### PR TITLE
resource/aws_cloudfront_distribution: support mTLS passthrough mode

### DIFF
--- a/internal/service/cloudfront/distribution_test.go
+++ b/internal/service/cloudfront/distribution_test.go
@@ -1960,6 +1960,39 @@ func TestAccCloudFrontDistribution_viewerMtlsConfig(t *testing.T) {
 	})
 }
 
+func TestAccCloudFrontDistribution_viewerMtlsConfigPassthrough(t *testing.T) {
+	ctx := acctest.Context(t)
+	var distribution awstypes.Distribution
+	resourceName := "aws_cloudfront_distribution.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.CloudFrontEndpointID) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CloudFrontServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDistributionDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDistributionConfig_viewerMtlsConfigPassthrough(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDistributionExists(ctx, t, resourceName, &distribution),
+					resource.TestCheckResourceAttr(resourceName, "viewer_mtls_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "viewer_mtls_config.0.mode", string(awstypes.ViewerMtlsModePassthrough)),
+					resource.TestCheckResourceAttr(resourceName, "viewer_mtls_config.0.trust_store_config.#", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"retain_on_delete",
+					"wait_for_deployment",
+				},
+			},
+		},
+	})
+}
+
 func TestAccCloudFrontDistribution_cacheTagConfig(t *testing.T) {
 	ctx := acctest.Context(t)
 	var distribution awstypes.Distribution
@@ -5774,6 +5807,56 @@ resource "aws_cloudfront_distribution" "test" {
 
 }
 `)
+}
+
+func testAccDistributionConfig_viewerMtlsConfigPassthrough() string {
+	return `
+resource "aws_cloudfront_distribution" "test" {
+  enabled          = false
+  retain_on_delete = false
+
+  default_cache_behavior {
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    target_origin_id       = "test"
+    viewer_protocol_policy = "https-only"
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "all"
+      }
+    }
+  }
+
+  origin {
+    domain_name = "www.example.com"
+    origin_id   = "test"
+
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "https-only"
+      origin_ssl_protocols   = ["TLSv1.2"]
+    }
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+
+  viewer_mtls_config {
+    mode = "passthrough"
+  }
+}
+`
 }
 
 func testAccDistributionConfig_cacheTagConfig(enabled, retainOnDelete bool, cacheTagConfigHeaderName string) string {

--- a/internal/service/cloudfront/distribution_test.go
+++ b/internal/service/cloudfront/distribution_test.go
@@ -1945,6 +1945,39 @@ func TestAccCloudFrontDistribution_viewerMtlsConfig(t *testing.T) {
 	})
 }
 
+func TestAccCloudFrontDistribution_viewerMtlsConfigPassthrough(t *testing.T) {
+	ctx := acctest.Context(t)
+	var distribution awstypes.Distribution
+	resourceName := "aws_cloudfront_distribution.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.CloudFrontEndpointID) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CloudFrontServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDistributionDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDistributionConfig_viewerMtlsConfigPassthrough(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDistributionExists(ctx, t, resourceName, &distribution),
+					resource.TestCheckResourceAttr(resourceName, "viewer_mtls_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "viewer_mtls_config.0.mode", string(awstypes.ViewerMtlsModePassthrough)),
+					resource.TestCheckResourceAttr(resourceName, "viewer_mtls_config.0.trust_store_config.#", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"retain_on_delete",
+					"wait_for_deployment",
+				},
+			},
+		},
+	})
+}
+
 func TestAccCloudFrontDistribution_cacheTagConfig(t *testing.T) {
 	ctx := acctest.Context(t)
 	var distribution awstypes.Distribution
@@ -5788,6 +5821,56 @@ resource "aws_cloudfront_distribution" "test" {
 
 }
 `)
+}
+
+func testAccDistributionConfig_viewerMtlsConfigPassthrough() string {
+	return `
+resource "aws_cloudfront_distribution" "test" {
+  enabled          = false
+  retain_on_delete = false
+
+  default_cache_behavior {
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    target_origin_id       = "test"
+    viewer_protocol_policy = "https-only"
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "all"
+      }
+    }
+  }
+
+  origin {
+    domain_name = "www.example.com"
+    origin_id   = "test"
+
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "https-only"
+      origin_ssl_protocols   = ["TLSv1.2"]
+    }
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+
+  viewer_mtls_config {
+    mode = "passthrough"
+  }
+}
+`
 }
 
 func testAccDistributionConfig_cacheTagConfig(enabled, retainOnDelete bool, cacheTagConfigHeaderName string) string {

--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -656,8 +656,8 @@ The arguments of `geo_restriction` are:
 
 #### Viewer mTLS Config Arguments
 
-* `mode` (Required) - The mode for viewer mTLS. Valid values: `required`, `optional`.
-* `trust_store_config` (Required) - The [trust store configuration](#trust-store-config-arguments) for viewer mTLS (maximum one).
+* `mode` (Required) - The mode for viewer mTLS. Valid values: `required`, `optional`, `passthrough`. In `passthrough` mode, CloudFront does not validate the client certificate against a trust store and instead forwards the certificate to the origin for validation.
+* `trust_store_config` (Optional) - The [trust store configuration](#trust-store-config-arguments) for viewer mTLS (maximum one). Required when `mode` is `required` or `optional`. Must be omitted when `mode` is `passthrough`.
 
 ##### Trust Store Config Arguments
 

--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -651,8 +651,8 @@ The arguments of `geo_restriction` are:
 
 #### Viewer mTLS Config Arguments
 
-* `mode` (Required) - The mode for viewer mTLS. Valid values: `required`, `optional`.
-* `trust_store_config` (Required) - The [trust store configuration](#trust-store-config-arguments) for viewer mTLS (maximum one).
+* `mode` (Required) - The mode for viewer mTLS. Valid values: `required`, `optional`, `passthrough`. In `passthrough` mode, CloudFront does not validate the client certificate against a trust store and instead forwards the certificate to the origin for validation.
+* `trust_store_config` (Optional) - The [trust store configuration](#trust-store-config-arguments) for viewer mTLS (maximum one). Required when `mode` is `required` or `optional`. Must be omitted when `mode` is `passthrough`.
 
 ##### Trust Store Config Arguments
 


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls. This change adds a new viewer mTLS validation mode (`passthrough`) that delegates client certificate validation from CloudFront to the origin. Operators opting into `passthrough` are responsible for performing certificate validation at their origin; the change does not alter the behavior of existing `required` or `optional` modes.

### Description

AWS [announced CloudFront mTLS passthrough mode](https://aws.amazon.com/about-aws/whats-new/2026/05/amazon-cloudfront-mtls-passthrough/) on 2026-05-14. In passthrough mode CloudFront does not validate the client certificate against a trust store and instead forwards the certificate to the origin for validation, so no `trust_store_config` is required.

This PR:

- Bumps `github.com/aws/aws-sdk-go-v2/service/cloudfront` from `v1.63.0` to `v1.64.0`, which adds the `passthrough` constant to `ViewerMtlsMode`. The existing schema validator (`enum.Validate[awstypes.ViewerMtlsMode]()`) picks this up automatically.
- Updates the `aws_cloudfront_distribution` documentation to list `passthrough` as a valid value for `viewer_mtls_config.mode` and clarifies that `trust_store_config` is only required for `required`/`optional` modes.
- Adds `TestAccCloudFrontDistribution_viewerMtlsConfigPassthrough`, exercising a configuration with `mode = "passthrough"` and no `trust_store_config`.

Example configuration:

```hcl
resource "aws_cloudfront_distribution" "example" {
  # ... other configuration ...

  viewer_mtls_config {
    mode = "passthrough"
  }
}
```

### Relations

Closes #47929
Closes #47926

### References

- AWS announcement: https://aws.amazon.com/about-aws/whats-new/2026/05/amazon-cloudfront-mtls-passthrough/
- CloudFront developer guide (mTLS): https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/mtls-authentication.html
- aws-sdk-go-v2 cloudfront v1.64.0 changelog entry: "Adding a new boolean for OCSP Revocations in Viewer mTLS Create and Update APIs, and adding a new 'Passthrough' option for TrustStore modes"

### Output from Acceptance Testing

Acceptance tests for this change require `TF_ACC=1` and live CloudFront resources. I have not run the full mTLS acceptance suite myself; the new test compiles and the package builds cleanly.

```console
% go test -count=1 -run "TestAccCloudFrontDistribution_viewerMtlsConfigPassthrough" -short ./internal/service/cloudfront/
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudfront	9.061s
```

Per the [CloudFront contribution note in `docs/dependency-updates.md`](https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/dependency-updates.md#cloudfront-changes), running the full `TestAccCloudFront` suite is recommended before merging the SDK bump.