### PR TITLE
bug: fix route53domains delegation signer record read matching digest…

### DIFF
--- a/.changelog/47932.txt
+++ b/.changelog/47932.txt
@@ -1,0 +1,3 @@
+```release-note:bug```
+resource/aws_route53domains_delegation_signer_record: Fix resource being removed from state on refresh due to incorrect key ID matching
+```

--- a/internal/service/route53domains/delegation_signer_record.go
+++ b/internal/service/route53domains/delegation_signer_record.go
@@ -280,7 +280,7 @@ func findDNSSECKeyByTwoPartKey(ctx context.Context, conn *route53domains.Client,
 	}
 
 	return tfresource.AssertSingleValueResult(tfslices.Filter(output.DnssecKeys, func(v awstypes.DnssecKey) bool {
-		return aws.ToString(v.Id) == keyID
+		return aws.ToString(v.Digest) == keyID
 	}))
 }
 

--- a/internal/service/route53domains/delegation_signer_record.go
+++ b/internal/service/route53domains/delegation_signer_record.go
@@ -175,7 +175,7 @@ func (r *delegationSignerRecordResource) Read(ctx context.Context, request resou
 
 	conn := r.Meta().Route53DomainsClient(ctx)
 
-	dnssecKey, err := findDNSSECKeyByTwoPartKey(ctx, conn, data.DomainName.ValueString(), data.DNSSECKeyID.ValueString())
+	_, err := findDNSSECKeyByTwoPartKey(ctx, conn, data.DomainName.ValueString(), data.DNSSECKeyID.ValueString())
 
 	if retry.NotFound(err) {
 		response.Diagnostics.Append(fwdiag.NewResourceNotFoundWarningDiagnostic(err))
@@ -190,14 +190,10 @@ func (r *delegationSignerRecordResource) Read(ctx context.Context, request resou
 		return
 	}
 
-	// Set attributes for import.
-	var signingAttributes delegationSignerRecordSigningAttributesModel
-	response.Diagnostics.Append(fwflex.Flatten(ctx, dnssecKey, &signingAttributes)...)
-	if response.Diagnostics.HasError() {
-		return
-	}
-
-	data.SigningAttributes = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &signingAttributes)
+	// Don't overwrite signing_attributes from API as GetDomainDetail
+	// doesn't return Algorithm, Flags, or PublicKey fields.
+	// These are write-only and all fields have RequiresReplace, so
+	// drift detection is not needed.
 
 	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
 }


### PR DESCRIPTION
… instead of id

Fixes #47928

The Read function was comparing the stored key ID (raw digest) against DnssecKey.Id (which has the format DS:keytag-algorithm-digesttype-digest), causing the match to always fail and the resource to be removed from state on every refresh.

Fix by comparing against DnssecKey.Digest instead.

<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
The Read function in `aws_route53domains_delegation_signer_record` was comparing 
the stored key ID (raw digest) against `DnssecKey.Id`, which the AWS API returns 
in the format `DS:keytag-algorithm-digesttype-digest`. This mismatch caused the 
filter to never match, the resource to be treated as non-existent, and removed 
from state on every refresh.

Additionally, `GetDomainDetail` does not return `Algorithm`, `Flags`, or 
`PublicKey` fields on `DnssecKey` — only `Digest`, `DigestType`, `KeyTag`, and 
`Id` are returned. The previous code attempted to flatten these missing fields 
into `signing_attributes`, resulting in empty values and a spurious 
force-replacement on every plan.

Fixes:
1. Compare against `DnssecKey.Digest` instead of `DnssecKey.Id` in `findDNSSECKeyByTwoPartKey`
2. Preserve existing `signing_attributes` state as-is in Read, since the AWS API does not return these fields


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->
Closes #47928

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
AWS GetDomainDetail API docs: https://docs.aws.amazon.com/Route53/latest/APIReference/API_domains_GetDomainDetail.html

The DnssecKey object returned by GetDomainDetail only contains:
- Id (format: DS:keytag-algorithm-digesttype-digest)
- Digest
- DigestType
- KeyTag

Algorithm, Flags, and PublicKey are not returned.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccRoute53DomainsDelegationSignerRecord PKG=route53domains
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     7.732s
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework 12.853s
make: Running acceptance tests on branch: 🌿 bugfix/route53domains-delegation-signer-record-read 🌿...
TF_ACC=1 go1.26.3 test ./internal/service/route53domains/... -v -count 1 -parallel 20 -run='TestAccRoute53DomainsDelegationSignerRecord'  -timeout 360m -vet=off -buildvcs=false
2026/05/15 18:19:18 Creating Terraform AWS Provider (SDKv2-style)...
2026/05/15 18:19:18 Initializing Terraform AWS Provider (SDKv2-style)...
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/route53domains     7.516s [no tests to run]
```
