### PR TITLE
resource/aws_fms_policy: default resource tag logical operator

### DIFF
--- a/.changelog/47771.txt
+++ b/.changelog/47771.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_fms_policy: Default `resource_tag_logical_operator` to `AND` so drift from remote `OR` values is shown in plans when the argument is omitted
+```

--- a/internal/service/fms/policy.go
+++ b/internal/service/fms/policy.go
@@ -212,7 +212,7 @@ func resourcePolicy() *schema.Resource {
 				"resource_tag_logical_operator": {
 					Type:             schema.TypeString,
 					Optional:         true,
-					Computed:         true,
+					Default:          string(awstypes.ResourceTagLogicalOperatorAnd),
 					ValidateDiagFunc: enum.Validate[awstypes.ResourceTagLogicalOperator](),
 				},
 				"resource_type_list": {
@@ -501,8 +501,9 @@ func expandPolicy(d *schema.ResourceData) *awstypes.Policy {
 				Key:   aws.String(k),
 				Value: aws.String(v),
 			})
-			apiObject.ResourceTagLogicalOperator = awstypes.ResourceTagLogicalOperator(d.Get("resource_tag_logical_operator").(string))
 		}
+
+		apiObject.ResourceTagLogicalOperator = awstypes.ResourceTagLogicalOperator(d.Get("resource_tag_logical_operator").(string))
 	}
 
 	tfMap := d.Get("security_service_policy_data").([]any)[0].(map[string]any)

--- a/internal/service/fms/policy_test.go
+++ b/internal/service/fms/policy_test.go
@@ -285,7 +285,7 @@ func testAccPolicy_resourceTagLogicalOperator(t *testing.T) {
 			{
 				Config: testAccPolicyConfig_resourceTagLogicalOperator_default(rName, acctest.CtKey1, acctest.CtValue1),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "resource_tag_logical_operator", ""),
+					resource.TestCheckResourceAttr(resourceName, "resource_tag_logical_operator", "AND"),
 				),
 			},
 			{


### PR DESCRIPTION
## Summary
- Default `resource_tag_logical_operator` to `AND` so omitted configuration has the same explicit value AWS applies by default.
- Set `ResourceTagLogicalOperator` once when expanding resource tags.
- Update the existing FMS policy acceptance test expectation and add a changelog entry.

Closes #47771

## Testing
- `gofmt -w internal/service/fms/policy.go internal/service/fms/policy_test.go`
- `git diff --check`
- `go test ./internal/service/fms -run '^$'`
