### PR TITLE
.ci: lint for `TIP:` comments

### DIFF
--- a/.ci/.golangci3.yml
+++ b/.ci/.golangci3.yml
@@ -8,6 +8,7 @@ linters:
     # !! only add f-m linters here
     - goconst
     - gocritic
+    - godox
     - govet
     - importas
     - ineffassign
@@ -26,6 +27,10 @@ linters:
         - opinionated
         - performance
         - style
+    godox:
+      keywords:
+        # for lingering skaff TIP comments
+        - TIP
     importas:
       no-unaliased: true
       alias:

--- a/internal/service/chatbot/slack_workspace_data_source_test.go
+++ b/internal/service/chatbot/slack_workspace_data_source_test.go
@@ -15,8 +15,6 @@ import (
 
 func TestAccChatbotSlackWorkspaceDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	// TIP: This is a long-running test guard for tests that run longer than
-	// 300s (5 min) generally.
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}

--- a/internal/service/logs/metric_filter_list.go
+++ b/internal/service/logs/metric_filter_list.go
@@ -64,7 +64,6 @@ func (l *metricFilterListResource) List(ctx context.Context, request list.ListRe
 		logging.ResourceAttributeKey(names.AttrLogGroupName): logGroupName,
 	})
 
-	// TIP: -- 4. Get information about a resource from AWS
 	stream.Results = func(yield func(list.ListResult) bool) {
 		input := cloudwatchlogs.DescribeMetricFiltersInput{
 			LogGroupName: aws.String(logGroupName),


### PR DESCRIPTION


<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
These comments are typically left over when `skaff` is used to outline an initial resource, data source, or list resource. Uses the [`godox`](https://golangci-lint.run/docs/linters/configuration/#godox) linter rather than rolling our own custom analyzer or using semgrep for a simple regexp search.
