### PR TITLE
r/aws_vpc_endpoint: Fix policy removal not resetting endpoint to default policy

### DIFF
--- a/.changelog/47940.txt
+++ b/.changelog/47940.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_vpc_endpoint: Fix policy removal not resetting endpoint to default policy
+```

--- a/internal/service/ec2/vpc_endpoint.go
+++ b/internal/service/ec2/vpc_endpoint.go
@@ -256,6 +256,42 @@ func resourceVPCEndpoint() *schema.Resource {
 			customdiff.ComputedIf("network_interface_ids", func(_ context.Context, diff *schema.ResourceDiff, meta any) bool {
 				return diff.HasChange("subnet_configuration") || diff.HasChange(names.AttrSubnetIDs)
 			}),
+			// Detect removal of the `policy` block from configuration.
+			//
+			// `policy` is `Optional + Computed` because the AWS API auto-assigns a
+			// default permissive policy at creation time. The Computed flag causes
+			// SDKv2 to silently keep the prior state value when the attribute is
+			// absent from configuration, which suppresses the diff and prevents the
+			// update path from emitting `ResetPolicy`. The result is that removing
+			// the `policy` block from a user's HCL is a no-op until the user also
+			// reapplies a default policy by hand.
+			//
+			// Inspecting the raw config (which reflects the user's HCL exactly,
+			// before any computed fill-in) lets us recognize the unset case and
+			// mark the attribute as changed, so the update path can call
+			// ModifyVpcEndpoint with `ResetPolicy: true`.
+			//
+			// Resolves https://github.com/hashicorp/terraform-provider-aws/issues/40973.
+			func(_ context.Context, diff *schema.ResourceDiff, meta any) error {
+				if diff.Id() == "" {
+					return nil
+				}
+				rawConfig := diff.GetRawConfig()
+				if !rawConfig.IsKnown() || rawConfig.IsNull() {
+					return nil
+				}
+				policyAttr := rawConfig.GetAttr(names.AttrPolicy)
+				if !policyAttr.IsKnown() {
+					return nil
+				}
+				stateHasPolicy := diff.Get(names.AttrPolicy).(string) != ""
+				if policyAttr.IsNull() && stateHasPolicy {
+					if err := diff.SetNew(names.AttrPolicy, ""); err != nil {
+						return err
+					}
+				}
+				return nil
+			},
 		),
 
 		Timeouts: &schema.ResourceTimeout{

--- a/internal/service/ec2/vpc_endpoint.go
+++ b/internal/service/ec2/vpc_endpoint.go
@@ -254,6 +254,42 @@ func resourceVPCEndpoint() *schema.Resource {
 			customdiff.ComputedIf("network_interface_ids", func(_ context.Context, diff *schema.ResourceDiff, meta any) bool {
 				return diff.HasChange("subnet_configuration") || diff.HasChange(names.AttrSubnetIDs)
 			}),
+			// Detect removal of the `policy` block from configuration.
+			//
+			// `policy` is `Optional + Computed` because the AWS API auto-assigns a
+			// default permissive policy at creation time. The Computed flag causes
+			// SDKv2 to silently keep the prior state value when the attribute is
+			// absent from configuration, which suppresses the diff and prevents the
+			// update path from emitting `ResetPolicy`. The result is that removing
+			// the `policy` block from a user's HCL is a no-op until the user also
+			// reapplies a default policy by hand.
+			//
+			// Inspecting the raw config (which reflects the user's HCL exactly,
+			// before any computed fill-in) lets us recognize the unset case and
+			// mark the attribute as changed, so the update path can call
+			// ModifyVpcEndpoint with `ResetPolicy: true`.
+			//
+			// Resolves https://github.com/hashicorp/terraform-provider-aws/issues/40973.
+			func(_ context.Context, diff *schema.ResourceDiff, meta any) error {
+				if diff.Id() == "" {
+					return nil
+				}
+				rawConfig := diff.GetRawConfig()
+				if !rawConfig.IsKnown() || rawConfig.IsNull() {
+					return nil
+				}
+				policyAttr := rawConfig.GetAttr(names.AttrPolicy)
+				if !policyAttr.IsKnown() {
+					return nil
+				}
+				stateHasPolicy := diff.Get(names.AttrPolicy).(string) != ""
+				if policyAttr.IsNull() && stateHasPolicy {
+					if err := diff.SetNew(names.AttrPolicy, ""); err != nil {
+						return err
+					}
+				}
+				return nil
+			},
 		),
 
 		Timeouts: &schema.ResourceTimeout{

--- a/internal/service/ec2/vpc_endpoint_test.go
+++ b/internal/service/ec2/vpc_endpoint_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/YakDriver/regexache"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/hashicorp/aws-sdk-go-base/v2/endpoints"
+	awspolicy "github.com/hashicorp/awspolicyequivalence"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
@@ -303,6 +304,77 @@ func TestAccVPCEndpoint_gatewayPolicy(t *testing.T) {
 				Config: testAccVPCEndpointConfig_gatewayPolicy(rName, policy2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVPCEndpointExists(ctx, t, resourceName, &endpoint),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+		},
+	})
+}
+
+// TestAccVPCEndpoint_gatewayPolicyRemoval verifies that removing the `policy`
+// attribute from configuration after creation triggers an update that resets
+// the endpoint to its default policy.
+//
+// Regression test for https://github.com/hashicorp/terraform-provider-aws/issues/40973.
+func TestAccVPCEndpoint_gatewayPolicyRemoval(t *testing.T) {
+	ctx := acctest.Context(t)
+	var endpoint awstypes.VpcEndpoint
+	policy := `
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "DenyAll",
+      "Effect": "Deny",
+      "Principal": "*",
+      "Action": "*",
+      "Resource": "*"
+    }
+  ]
+}
+`
+	resourceName := "aws_vpc_endpoint.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckVPCEndpointDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				// Step 1: create with custom policy.
+				Config: testAccVPCEndpointConfig_gatewayPolicy(rName, policy),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVPCEndpointExists(ctx, t, resourceName, &endpoint),
+					resource.TestCheckResourceAttrSet(resourceName, names.AttrPolicy),
+				),
+			},
+			{
+				// Step 2: remove `policy` from config. Plan must show an update,
+				// not a no-op, and apply must reset the endpoint to the default
+				// permissive policy returned by the API.
+				Config: testAccVPCEndpointConfig_gatewayNoPolicy(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVPCEndpointExists(ctx, t, resourceName, &endpoint),
+					// AWS returns its default policy (`{"Statement":[{"Action":"*","Effect":"Allow",...}]}`),
+					// which is not the user's custom DenyAll. Asserting non-empty
+					// is sufficient because the schema is Computed; asserting
+					// inequality with the original DenyAll policy is the
+					// behavior under test.
+					resource.TestCheckResourceAttrWith(resourceName, names.AttrPolicy, func(value string) error {
+						if value == "" {
+							return fmt.Errorf("expected default policy after removal, got empty")
+						}
+						if equivalent, _ := awspolicy.PoliciesAreEquivalent(value, policy); equivalent {
+							return fmt.Errorf("expected policy to be reset to default, got original custom policy")
+						}
+						return nil
+					}),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -1980,6 +2052,35 @@ POLICY
   }
 }
 `, rName, policy)
+}
+
+// testAccVPCEndpointConfig_gatewayNoPolicy is the same as
+// testAccVPCEndpointConfig_gatewayPolicy but omits the `policy` attribute,
+// used to test reverting to the API-default policy. See issue #40973.
+func testAccVPCEndpointConfig_gatewayNoPolicy(rName string) string {
+	return fmt.Sprintf(`
+data "aws_vpc_endpoint_service" "test" {
+  service      = "dynamodb"
+  service_type = "Gateway"
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_vpc_endpoint" "test" {
+  service_name = data.aws_vpc_endpoint_service.test.service_name
+  vpc_id       = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName)
 }
 
 func testAccVPCEndpointConfig_vpcBase(rName string) string {


### PR DESCRIPTION
### Description

Fix a long-standing bug where removing the \`policy\` attribute from an \`aws_vpc_endpoint\` configuration leaves the previously-applied custom policy in place forever. After this change, removing \`policy\` from configuration triggers an update that resets the endpoint to the AWS-default permissive policy, matching the behaviour of the AWS web console and the AWS CLI.

### Relations

Closes #40973.

### Root cause

The \`policy\` attribute is declared with \`sdkv2.IAMPolicyDocumentSchemaOptionalComputed()\`, which sets both \`Optional: true\` and \`Computed: true\`:

- [\`internal/service/ec2/vpc_endpoint.go\` line 143](https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/ec2/vpc_endpoint.go#L143)
- [\`internal/sdkv2/schema.go\` lines 112-124](https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/sdkv2/schema.go#L112-L124)

The \`Computed\` flag is required because the AWS API auto-assigns a default permissive policy when none is supplied at \`CreateVpcEndpoint\` time (see [\`ec2:ModifyVpcEndpoint\` API reference](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_ModifyVpcEndpoint.html), which exposes a \`ResetPolicy\` boolean for exactly this case). The side effect is that when an Optional+Computed attribute is removed from configuration, the SDKv2 plan layer fills the missing value from state, so \`d.HasChange(\"policy\")\` returns \`false\`. The existing update path (\`resourceVPCEndpointUpdate\`) is gated behind \`d.HasChanges(...names.AttrPolicy...)\`, so without a detected change, no \`ModifyVpcEndpoint\` call is made, and \`ResetPolicy\` is never sent.

The user-visible symptom: \`terraform plan\` reports \"No changes\" after removing the \`policy\` block, but the endpoint still enforces the old custom policy. Re-applying a different policy works correctly because that does generate a diff. Only **removal** is silently dropped.

### Fix

Add a third function to the existing \`CustomizeDiff: customdiff.All(...)\` block. It inspects the **raw config** via \`diff.GetRawConfig()\` -- the unmodified HCL representation, before SDKv2 fills computed values from state. When raw config has \`policy\` null and state holds a value, the function calls \`diff.SetNew(\"policy\", \"\")\` to surface the diff. The existing update path at [\`vpc_endpoint.go\` lines 458-473](https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/ec2/vpc_endpoint.go#L458-L473) already converts an empty policy string into \`ResetPolicy: aws.Bool(true)\`, so no change is needed there.

Why \`GetRawConfig\` rather than another mechanism: this is the canonical SDKv2 idiom for \`Optional+Computed\` removal detection. The same pattern is used elsewhere in this provider, including [\`vpc_nat_gateway.go\`](https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/ec2/vpc_nat_gateway.go#L478) and [\`transitgateway_vpc_attachment.go\`](https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/ec2/transitgateway_vpc_attachment.go#L152). Setting \`Computed: false\` would force-replace the resource on every existing config that omits \`policy\` at create time -- a breaking change. \`SetNew\` to empty string is non-breaking and routes through the existing reset code path.

### Test

\`TestAccVPCEndpoint_gatewayPolicyRemoval\` exercises the regression directly:

1. Create a gateway endpoint with a custom \`DenyAll\` policy. Assert \`policy\` is non-empty.
2. Remove the \`policy\` attribute from configuration. Assert via \`plancheck.ExpectResourceAction(... ResourceActionUpdate)\` that the plan is an update (not a no-op). After apply, assert that \`policy\` is non-empty (because the API repopulates with the default) AND that it is **not equivalent** to the original \`DenyAll\` policy.

The new test follows the same shape as the existing \`TestAccVPCEndpoint_gatewayPolicy\`, reuses \`testAccVPCEndpointConfig_gatewayPolicy\`, and adds one new helper, \`testAccVPCEndpointConfig_gatewayNoPolicy\`, that omits the \`policy\` attribute.

### Output from acceptance testing

Acceptance tests have not been run locally -- this PR is from a community contributor without access to the upstream test AWS account. Local verification:

\`\`\`
$ go vet ./internal/service/ec2/...
(no output)
\`\`\`

Please run on a maintainer-controlled environment:

\`\`\`
$ make testacc TESTS=TestAccVPCEndpoint_gatewayPolicyRemoval PKG=ec2
\`\`\`

### References

- Issue: #40973
- AWS \`ec2:ModifyVpcEndpoint\` API (note the \`ResetPolicy\` boolean): <https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_ModifyVpcEndpoint.html>
- AWS VPC Endpoint policy semantics: <https://docs.aws.amazon.com/vpc/latest/privatelink/vpc-endpoints-access.html>
- Terraform SDKv2 \`CustomizeDiff\` and \`GetRawConfig\` reference: <https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/customizing-differences>
- HashiCorp guidance on \`Optional+Computed\` semantics: <https://developer.hashicorp.com/terraform/plugin/sdkv2/schemas/schema-behaviors#optional>
- Prior art in this provider for raw-config inspection on Optional+Computed fields:
  - \`vpc_nat_gateway.go\` (\`secondary_allocation_ids\`): <https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/ec2/vpc_nat_gateway.go#L478>
  - \`transitgateway_vpc_attachment.go\` (\`transit_gateway_default_route_table_*\`): <https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/ec2/transitgateway_vpc_attachment.go#L152>
- Working precedent for \`ResetPolicy\` in the dedicated \`aws_vpc_endpoint_policy\` resource: <https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/ec2/vpc_endpoint_policy.go#L68-L72>

### Changelog entry

Will be added in a follow-up commit once this PR has a number assigned (\`.changelog/<PR-NUMBER>.txt\`):

\`\`\`
\`\`\`release-note:bug
resource/aws_vpc_endpoint: Fix policy removal not resetting endpoint to default policy
\`\`\`
\`\`\`