### PR TITLE
[bugfx] aws_ecs_express_gateway_service: Exclude the automatically added ECS-managed security group from the state to fix "inconsistent result after apply"  error

### DIFF
--- a/.changelog/47944.txt
+++ b/.changelog/47944.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_ecs_express_gateway_service: Fix "inconsistent result after apply" error for `network_configuration[0].security_groups` when using `network_configuration`
+resource/aws_ecs_express_gateway_service: Fix "inconsistent result after apply" error for `network_configuration[0].security_groups` when using `network_configuration`. `ec2:DescribeSecurityGroups` IAM permission is newly required.
 ```

--- a/.changelog/47944.txt
+++ b/.changelog/47944.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ecs_express_gateway_service: Fix "inconsistent result after apply" error for `network_configuration[0].security_groups` when using `network_configuration`
+```

--- a/internal/service/ecs/express_gateway_service.go
+++ b/internal/service/ecs/express_gateway_service.go
@@ -16,6 +16,8 @@ import (
 	"github.com/YakDriver/smarterr"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
@@ -37,6 +39,7 @@ import (
 	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
 	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
+	tfec2 "github.com/hashicorp/terraform-provider-aws/internal/service/ec2"
 	"github.com/hashicorp/terraform-provider-aws/internal/smerr"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -278,6 +281,7 @@ func (r *expressGatewayServiceResource) Create(ctx context.Context, req resource
 	if len(waitOut.ActiveConfigurations) > 0 {
 		// Save plan's env/secret ordering before flattening (API may reorder).
 		planEnv, planSecrets := preservePlanContainerOrdering(ctx, plan.PrimaryContainer)
+		planNetworkConfiguration := plan.NetworkConfiguration
 
 		smerr.AddEnrich(ctx, &resp.Diagnostics, fwflex.Flatten(ctx, waitOut.ActiveConfigurations[0], &plan))
 		if resp.Diagnostics.HasError() {
@@ -285,6 +289,7 @@ func (r *expressGatewayServiceResource) Create(ctx context.Context, req resource
 		}
 
 		restorePlanContainerOrdering(ctx, &plan.PrimaryContainer, planEnv, planSecrets)
+		restorePlanNetworkConfigurationSecurityGroups(ctx, &plan.NetworkConfiguration, planNetworkConfiguration)
 	}
 
 	plan.Cluster = fwflex.StringValueToFramework(ctx, cluster)
@@ -303,6 +308,7 @@ func (r *expressGatewayServiceResource) Read(ctx context.Context, req resource.R
 	}
 
 	conn := r.Meta().ECSClient(ctx)
+	ec2Conn := r.Meta().EC2Client(ctx)
 
 	serviceARN := fwflex.StringValueFromFramework(ctx, state.ServiceARN)
 	out, err := findExpressGatewayServiceByARN(ctx, conn, serviceARN)
@@ -333,6 +339,8 @@ func (r *expressGatewayServiceResource) Read(ctx context.Context, req resource.R
 		if resp.Diagnostics.HasError() {
 			return
 		}
+
+		filterAmazonECSManagedSecurityGroups(ctx, ec2Conn, &state.NetworkConfiguration)
 
 		// Restore state ordering if env vars are unchanged (no-op during import).
 		restoreContainerOrderingIfUnchanged(ctx, &state.PrimaryContainer, stateEnv, stateSecrets)
@@ -440,6 +448,7 @@ func (r *expressGatewayServiceResource) Update(ctx context.Context, req resource
 	if len(waitOut.ActiveConfigurations) > 0 {
 		// Save plan's env/secret ordering before flattening (API may reorder).
 		planEnv, planSecrets := preservePlanContainerOrdering(ctx, plan.PrimaryContainer)
+		planNetworkConfiguration := plan.NetworkConfiguration
 
 		orderExpressGatewayContainerEnvironmentVariables(&waitOut.ActiveConfigurations[0])
 		smerr.AddEnrich(ctx, &resp.Diagnostics, fwflex.Flatten(ctx, waitOut.ActiveConfigurations[0], &plan))
@@ -448,6 +457,7 @@ func (r *expressGatewayServiceResource) Update(ctx context.Context, req resource
 		}
 
 		restorePlanContainerOrdering(ctx, &plan.PrimaryContainer, planEnv, planSecrets)
+		restorePlanNetworkConfigurationSecurityGroups(ctx, &plan.NetworkConfiguration, planNetworkConfiguration)
 	}
 
 	// Set Optional+Computed attributes from API response
@@ -859,6 +869,81 @@ func restoreContainerOrderingIfUnchanged(
 		return
 	}
 	*primaryContainer = updated
+}
+
+func restorePlanNetworkConfigurationSecurityGroups(
+	ctx context.Context,
+	networkConfiguration *fwtypes.ListNestedObjectValueOf[expressGatewayServiceNetworkConfigurationModel],
+	planNetworkConfiguration fwtypes.ListNestedObjectValueOf[expressGatewayServiceNetworkConfigurationModel],
+) {
+	planConfig, diags := planNetworkConfiguration.ToPtr(ctx)
+	if diags.HasError() || planConfig == nil || planConfig.SecurityGroups.IsUnknown() {
+		return
+	}
+
+	currentConfig, diags := networkConfiguration.ToPtr(ctx)
+	if diags.HasError() || currentConfig == nil {
+		return
+	}
+
+	currentConfig.SecurityGroups = planConfig.SecurityGroups
+
+	updated, diags := fwtypes.NewListNestedObjectValueOfPtr(ctx, currentConfig)
+	if diags.HasError() {
+		return
+	}
+
+	*networkConfiguration = updated
+}
+
+func filterAmazonECSManagedSecurityGroups(
+	ctx context.Context,
+	conn *ec2.Client,
+	networkConfiguration *fwtypes.ListNestedObjectValueOf[expressGatewayServiceNetworkConfigurationModel],
+) {
+	currentConfig, diags := networkConfiguration.ToPtr(ctx)
+	if diags.HasError() || currentConfig == nil || currentConfig.SecurityGroups.IsNull() || currentConfig.SecurityGroups.IsUnknown() {
+		return
+	}
+
+	securityGroups := fwflex.ExpandFrameworkStringValueSet(ctx, currentConfig.SecurityGroups)
+	if len(securityGroups) == 0 {
+		return
+	}
+
+	groups, err := tfec2.FindSecurityGroups(ctx, conn, &ec2.DescribeSecurityGroupsInput{
+		GroupIds: securityGroups,
+	})
+	if err != nil {
+		return
+	}
+
+	filteredGroupIDs := make([]string, 0, len(groups))
+	for _, group := range groups {
+		if !hasAmazonECSManagedTag(group.Tags) {
+			filteredGroupIDs = append(filteredGroupIDs, aws.ToString(group.GroupId))
+		}
+	}
+
+	slices.Sort(filteredGroupIDs)
+	currentConfig.SecurityGroups = fwflex.FlattenFrameworkStringValueSetOfString(ctx, filteredGroupIDs)
+
+	updated, diags := fwtypes.NewListNestedObjectValueOfPtr(ctx, currentConfig)
+	if diags.HasError() {
+		return
+	}
+
+	*networkConfiguration = updated
+}
+
+func hasAmazonECSManagedTag(tags []ec2types.Tag) bool {
+	for _, tag := range tags {
+		if aws.ToString(tag.Key) == "AmazonECSManaged" && aws.ToString(tag.Value) == "true" {
+			return true
+		}
+	}
+
+	return false
 }
 
 // envListsEquivalent returns true if two environment variable lists contain the same

--- a/internal/service/ecs/express_gateway_service.go
+++ b/internal/service/ecs/express_gateway_service.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/YakDriver/smarterr"
@@ -291,6 +292,7 @@ func (r *expressGatewayServiceResource) Create(ctx context.Context, req resource
 		restorePlanContainerOrdering(ctx, &plan.PrimaryContainer, planEnv, planSecrets)
 		restorePlanNetworkConfigurationSecurityGroups(ctx, &plan.NetworkConfiguration, planNetworkConfiguration)
 	}
+	normalizeIngressPathEndpoints(ctx, &plan.IngressPaths)
 
 	plan.Cluster = fwflex.StringValueToFramework(ctx, cluster)
 	plan.CurrentDeployment = fwflex.StringToFramework(ctx, waitOut.CurrentDeployment)
@@ -345,6 +347,7 @@ func (r *expressGatewayServiceResource) Read(ctx context.Context, req resource.R
 		// Restore state ordering if env vars are unchanged (no-op during import).
 		restoreContainerOrderingIfUnchanged(ctx, &state.PrimaryContainer, stateEnv, stateSecrets)
 	}
+	normalizeIngressPathEndpoints(ctx, &state.IngressPaths)
 
 	// Set Optional+Computed attributes from API response
 	if out.Cluster != nil {
@@ -459,6 +462,7 @@ func (r *expressGatewayServiceResource) Update(ctx context.Context, req resource
 		restorePlanContainerOrdering(ctx, &plan.PrimaryContainer, planEnv, planSecrets)
 		restorePlanNetworkConfigurationSecurityGroups(ctx, &plan.NetworkConfiguration, planNetworkConfiguration)
 	}
+	normalizeIngressPathEndpoints(ctx, &plan.IngressPaths)
 
 	// Set Optional+Computed attributes from API response
 	if waitOut.Cluster != nil {
@@ -944,6 +948,45 @@ func hasAmazonECSManagedTag(tags []ec2types.Tag) bool {
 	}
 
 	return false
+}
+
+func normalizeIngressPathEndpoints(ctx context.Context, ingressPaths *fwtypes.ListNestedObjectValueOf[ingressPathSummaryModel]) {
+	paths, diags := ingressPaths.ToSlice(ctx)
+	if diags.HasError() || len(paths) == 0 {
+		return
+	}
+
+	updatedPaths := make([]*ingressPathSummaryModel, 0, len(paths))
+	changed := false
+
+	for _, ingressPath := range paths {
+		if ingressPath == nil || ingressPath.Endpoint.IsNull() || ingressPath.Endpoint.IsUnknown() {
+			updatedPaths = append(updatedPaths, ingressPath)
+			continue
+		}
+
+		endpoint := ingressPath.Endpoint.ValueString()
+		if strings.HasPrefix(endpoint, "https://") || endpoint == "" {
+			updatedPaths = append(updatedPaths, ingressPath)
+			continue
+		}
+
+		clone := *ingressPath
+		clone.Endpoint = types.StringValue("https://" + endpoint)
+		updatedPaths = append(updatedPaths, &clone)
+		changed = true
+	}
+
+	if !changed {
+		return
+	}
+
+	updated, diags := fwtypes.NewListNestedObjectValueOfSlice(ctx, updatedPaths, nil)
+	if diags.HasError() {
+		return
+	}
+
+	*ingressPaths = updated
 }
 
 // envListsEquivalent returns true if two environment variable lists contain the same

--- a/internal/service/ecs/express_gateway_service.go
+++ b/internal/service/ecs/express_gateway_service.go
@@ -342,7 +342,7 @@ func (r *expressGatewayServiceResource) Read(ctx context.Context, req resource.R
 			return
 		}
 
-		filterAmazonECSManagedSecurityGroups(ctx, ec2Conn, &state.NetworkConfiguration)
+		filterManagedSecurityGroups(ctx, ec2Conn, &state.NetworkConfiguration)
 
 		// Restore state ordering if env vars are unchanged (no-op during import).
 		restoreContainerOrderingIfUnchanged(ctx, &state.PrimaryContainer, stateEnv, stateSecrets)
@@ -900,7 +900,7 @@ func restorePlanNetworkConfigurationSecurityGroups(
 	*networkConfiguration = updated
 }
 
-func filterAmazonECSManagedSecurityGroups(
+func filterManagedSecurityGroups(
 	ctx context.Context,
 	conn *ec2.Client,
 	networkConfiguration *fwtypes.ListNestedObjectValueOf[expressGatewayServiceNetworkConfigurationModel],
@@ -924,7 +924,7 @@ func filterAmazonECSManagedSecurityGroups(
 
 	filteredGroupIDs := make([]string, 0, len(groups))
 	for _, group := range groups {
-		if !hasAmazonECSManagedTag(group.Tags) {
+		if !hasManagedTag(group.Tags) {
 			filteredGroupIDs = append(filteredGroupIDs, aws.ToString(group.GroupId))
 		}
 	}
@@ -940,7 +940,7 @@ func filterAmazonECSManagedSecurityGroups(
 	*networkConfiguration = updated
 }
 
-func hasAmazonECSManagedTag(tags []ec2types.Tag) bool {
+func hasManagedTag(tags []ec2types.Tag) bool {
 	for _, tag := range tags {
 		if aws.ToString(tag.Key) == "AmazonECSManaged" && aws.ToString(tag.Value) == "true" {
 			return true

--- a/internal/service/ecs/express_gateway_service.go
+++ b/internal/service/ecs/express_gateway_service.go
@@ -971,9 +971,8 @@ func normalizeIngressPathEndpoints(ctx context.Context, ingressPaths *fwtypes.Li
 			continue
 		}
 
-		clone := *ingressPath
-		clone.Endpoint = types.StringValue("https://" + endpoint)
-		updatedPaths = append(updatedPaths, &clone)
+		ingressPath.Endpoint = types.StringValue("https://" + endpoint)
+		updatedPaths = append(updatedPaths, ingressPath)
 		changed = true
 	}
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

This PR fixes two state consistency issues for `aws_ecs_express_gateway_service`.

#### 1. Exclude ECS-managed Security Groups during refresh

  ECS can attach additional managed Security Groups that are tagged with:

  - `AmazonECSManaged=true`

  Previously, those managed Security Groups could be written into state during `Read`, causing refreshed state to diverge from configuration and leading to persistent diffs.

  This change updates `Read` to look up returned Security Groups in EC2 and exclude any tagged with `AmazonECSManaged=true` before writing them to state.

  The resource also preserves configured `security_groups` values after create/update so API-returned values do not leak back into state, by adding `restorePlanNetworkConfigurationSecurityGroups` function following the existing similar function such as `restorePlanContainerOrdering`.

#### 2. Normalize ingress path endpoints

`ingress_paths[*].endpoint` was not represented consistently across create/read/import flows.

Depending on the path, state could contain either:
  - `https://ng-...`
  - `ng-...`

This change normalizes ingress path endpoints so they are always stored with the `https://` prefix, avoiding import verification mismatches and inconsistent state representation.

Without this fix, the existing acceptance test failed due to the following error (not always but occasionally):

* The plan is going to remove the automatically added security group.

```console
   test_name=TestAccECSExpressGatewayService_networkConfiguration
    express_gateway_service_test.go:302: Step 1/1 error: After applying this test step, the refresh plan was not empty.
        stdout
        
        
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place
        
        Terraform will perform the following actions:
        
          # aws_ecs_express_gateway_service.test will be updated in-place
          ~ resource "aws_ecs_express_gateway_service" "test" {
              ~ current_deployment      = "arn:aws:ecs:us-west-2:123456789012:service-deployment/default/tf-acc-test-3698194443430916894-service/IX8GX3PONPE0ev1CYKdii" -> (known after apply)
              ~ ingress_paths           = [
                  - {
                      - access_type = "PRIVATE"
                      - endpoint    = "tf-140ea3792952409f89f92ce153a10311.ecs.us-west-2.on.aws"
                    },
                ] -> (known after apply)
              ~ network_configuration   = [
                  ~ {
                      ~ security_groups = [
                          - "sg-0922568de5cbf03c0",
                            # (1 unchanged element hidden)
                        ]
                        # (1 unchanged attribute hidden)
                    },
                ]
              ~ service_revision_arn    = "arn:aws:ecs:us-west-2:123456789012:service-revision/default/tf-acc-test-3698194443430916894-service/7098612735948506164" -> (known after apply)
                # (13 unchanged attributes hidden)
        
                # (1 unchanged block hidden)
            }
        
        Plan: 0 to add, 1 to change, 0 to destroy.
```

Also an acceptance test for import also failed:

* Inconsistent `ingress_paths.0.endpoint` values caused by differences in whether `https://` is attached.
* Inconsistent `network_configuration.0.security_groups.` due to the automatically added ECS-managed security group.
```console
=== NAME  TestAccECSExpressGatewayService_basic
    express_gateway_service_test.go:43: Step 2/2 error running import: ImportStateVerify attributes not equivalent. Difference is shown below. The - symbol indicates attributes missing after import.
        
          map[string]string{
                "ingress_paths.0.endpoint": strings.Join({
        -               "https://",
                        "ng-21df1f174b074205a68a0c97641fa4b6.ecs.us-west-2.on.aws",
                }, ""),
        +       "network_configuration.0.security_groups.#": "1",
        +       "network_configuration.0.security_groups.0": "sg-011e730be6f08b0b8",
          }
```


### Relations

Closes #47908.
Closes #47437.


### Output from Acceptance Testing
No fix is added to the existing acceptance test.
```console
$ make testacc TESTS='TestAccECSExpressGatewayService_' PKG=ecs
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     5.867s
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework 5.700s
make: Running acceptance tests on branch: 🌿 b-aws_ecs_express_gateway_service-suppress_diff_by_auto_sg 🌿...
TF_ACC=1 go1.26.3 test ./internal/service/ecs/... -v -count 1 -parallel 20 -run='TestAccECSExpressGatewayService_'  -timeout 360m -vet=off -buildvcs=false
2026/05/17 07:24:25 Creating Terraform AWS Provider (SDKv2-style)...
2026/05/17 07:24:25 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccECSExpressGatewayService_basic
=== PAUSE TestAccECSExpressGatewayService_basic
=== RUN   TestAccECSExpressGatewayService_disappears
=== PAUSE TestAccECSExpressGatewayService_disappears
=== RUN   TestAccECSExpressGatewayService_tags
=== PAUSE TestAccECSExpressGatewayService_tags
=== RUN   TestAccECSExpressGatewayService_update
=== PAUSE TestAccECSExpressGatewayService_update
=== RUN   TestAccECSExpressGatewayService_waitForSteadyState
    express_gateway_service_test.go:254: Times out when running with full suite
--- SKIP: TestAccECSExpressGatewayService_waitForSteadyState (0.00s)
=== RUN   TestAccECSExpressGatewayService_networkConfiguration
=== PAUSE TestAccECSExpressGatewayService_networkConfiguration
=== RUN   TestAccECSExpressGatewayService_checkIdempotency
=== PAUSE TestAccECSExpressGatewayService_checkIdempotency
=== RUN   TestAccECSExpressGatewayService_environmentVariableOrdering
=== PAUSE TestAccECSExpressGatewayService_environmentVariableOrdering
=== RUN   TestAccECSExpressGatewayService_recreateAfterDeleting
=== PAUSE TestAccECSExpressGatewayService_recreateAfterDeleting
=== CONT  TestAccECSExpressGatewayService_basic
=== CONT  TestAccECSExpressGatewayService_networkConfiguration
=== CONT  TestAccECSExpressGatewayService_tags
=== CONT  TestAccECSExpressGatewayService_environmentVariableOrdering
=== CONT  TestAccECSExpressGatewayService_update
=== CONT  TestAccECSExpressGatewayService_disappears
=== CONT  TestAccECSExpressGatewayService_recreateAfterDeleting
=== CONT  TestAccECSExpressGatewayService_checkIdempotency
--- PASS: TestAccECSExpressGatewayService_disappears (113.56s)
--- PASS: TestAccECSExpressGatewayService_networkConfiguration (148.81s)
--- PASS: TestAccECSExpressGatewayService_checkIdempotency (165.51s)
--- PASS: TestAccECSExpressGatewayService_basic (166.32s)
--- PASS: TestAccECSExpressGatewayService_update (175.73s)
--- PASS: TestAccECSExpressGatewayService_tags (263.29s)
--- PASS: TestAccECSExpressGatewayService_environmentVariableOrdering (295.29s)
--- PASS: TestAccECSExpressGatewayService_recreateAfterDeleting (309.58s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ecs        315.291s
?       github.com/hashicorp/terraform-provider-aws/internal/service/ecs/test-fixtures  [no test files]
```
