### PR TITLE
service/ec2: Improve error message for recently deregistered AMIs

### DIFF
--- a/.changelog/47945.txt
+++ b/.changelog/47945.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+service/ec2: Improve error message for recently deregistered AMIs
+```

--- a/internal/service/ec2/find.go
+++ b/internal/service/ec2/find.go
@@ -5,6 +5,7 @@ package ec2
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"iter"
 	"slices"
@@ -4608,6 +4609,11 @@ func findImageByID(ctx context.Context, conn *ec2.Client, id string) (*awstypes.
 	output, err := findImage(ctx, conn, &input)
 
 	if err != nil {
+		if errors.Is(err, tfresource.ErrEmptyResult) {
+			return nil, &retry.NotFoundError{
+				Message: fmt.Sprintf("AMI (%s) not found; the AMI may have been recently deregistered", id),
+			}
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
## Description

When creating an `aws_instance` with an AMI ID that was recently deregistered, `DescribeImages` returns an empty result instead of a clear "not found" error. The provider previously returned `tfresource.NewEmptyResultError()` which produced the cryptic message: `empty result`.

This change intercepts the empty result error in `findImageByID` and returns a `retry.NotFoundError` with a descriptive message indicating the AMI may have been recently deregistered.

## Relations

Closes #26046

## References

- https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeImages.html
