### PR TITLE
resource/aws_cognito_user_pool: Add inbound_federation lambda trigger 🤖🤖🤖

### DIFF
--- a/.changelog/47954.txt
+++ b/.changelog/47954.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_cognito_user_pool: Add `lambda_config.inbound_federation` configuration block
+```

--- a/internal/service/cognitoidp/user_pool.go
+++ b/internal/service/cognitoidp/user_pool.go
@@ -321,6 +321,25 @@ func resourceUserPool() *schema.Resource {
 								Optional:     true,
 								ValidateFunc: verify.ValidARN,
 							},
+							"inbound_federation": {
+								Type:     schema.TypeList,
+								Optional: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"lambda_arn": {
+											Type:         schema.TypeString,
+											Required:     true,
+											ValidateFunc: verify.ValidARN,
+										},
+										"lambda_version": {
+											Type:             schema.TypeString,
+											Required:         true,
+											ValidateDiagFunc: enum.Validate[awstypes.InboundFederationLambdaVersionType](),
+										},
+									},
+								},
+							},
 							names.AttrKMSKeyID: {
 								Type:         schema.TypeString,
 								Optional:     true,
@@ -1697,6 +1716,12 @@ func expandLambdaConfigType(tfMap map[string]any) *awstypes.LambdaConfigType {
 		apiObject.DefineAuthChallenge = aws.String(v.(string))
 	}
 
+	if v, ok := tfMap["inbound_federation"].([]any); ok && len(v) > 0 {
+		if v, ok := v[0].(map[string]any); ok && v != nil {
+			apiObject.InboundFederation = expandInboundFederationLambdaType(v)
+		}
+	}
+
 	if v, ok := tfMap[names.AttrKMSKeyID]; ok && v.(string) != "" {
 		apiObject.KMSKeyID = aws.String(v.(string))
 	}
@@ -1763,6 +1788,10 @@ func flattenLambdaConfigType(apiObject *awstypes.LambdaConfigType) []any {
 
 	if apiObject.DefineAuthChallenge != nil {
 		tfMap["define_auth_challenge"] = aws.ToString(apiObject.DefineAuthChallenge)
+	}
+
+	if apiObject.InboundFederation != nil {
+		tfMap["inbound_federation"] = flattenInboundFederationLambdaType(apiObject.InboundFederation)
 	}
 
 	if apiObject.KMSKeyID != nil {
@@ -2214,6 +2243,28 @@ func expandPreTokenGenerationVersionConfigType(tfMap map[string]any) *awstypes.P
 }
 
 func flattenPreTokenGenerationVersionConfigType(apiObject *awstypes.PreTokenGenerationVersionConfigType) []any {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]any{}
+
+	tfMap["lambda_arn"] = aws.ToString(apiObject.LambdaArn)
+	tfMap["lambda_version"] = apiObject.LambdaVersion
+
+	return []any{tfMap}
+}
+
+func expandInboundFederationLambdaType(tfMap map[string]any) *awstypes.InboundFederationLambdaType {
+	apiObject := &awstypes.InboundFederationLambdaType{
+		LambdaArn:     aws.String(tfMap["lambda_arn"].(string)),
+		LambdaVersion: awstypes.InboundFederationLambdaVersionType(tfMap["lambda_version"].(string)),
+	}
+
+	return apiObject
+}
+
+func flattenInboundFederationLambdaType(apiObject *awstypes.InboundFederationLambdaType) []any {
 	if apiObject == nil {
 		return nil
 	}

--- a/internal/service/cognitoidp/user_pool_data_source.go
+++ b/internal/service/cognitoidp/user_pool_data_source.go
@@ -205,6 +205,7 @@ type lambdaConfigTypeModel struct {
 	CustomMessage               types.String                                                              `tfsdk:"custom_message"`
 	CustomSMSSender             fwtypes.ListNestedObjectValueOf[customSMSLambdaVersionConfigTypeModel]    `tfsdk:"custom_sms_sender"`
 	DefineAuthChallenge         types.String                                                              `tfsdk:"define_auth_challenge"`
+	InboundFederation           fwtypes.ListNestedObjectValueOf[inboundFederationLambdaTypeModel]         `tfsdk:"inbound_federation"`
 	KMSKeyID                    types.String                                                              `tfsdk:"kms_key_id"`
 	PostAuthentication          types.String                                                              `tfsdk:"post_authentication"`
 	PostConfirmation            types.String                                                              `tfsdk:"post_confirmation"`
@@ -227,6 +228,11 @@ type customSMSLambdaVersionConfigTypeModel struct {
 }
 
 type preTokenGenerationVersionConfigTypeModel struct {
+	LambdaARN     types.String `tfsdk:"lambda_arn"`
+	LambdaVersion types.String `tfsdk:"lambda_version"`
+}
+
+type inboundFederationLambdaTypeModel struct {
 	LambdaARN     types.String `tfsdk:"lambda_arn"`
 	LambdaVersion types.String `tfsdk:"lambda_version"`
 }

--- a/internal/service/cognitoidp/user_pool_test.go
+++ b/internal/service/cognitoidp/user_pool_test.go
@@ -1480,6 +1480,55 @@ func TestAccCognitoIDPUserPool_WithLambda_preGenerationTokenConfig(t *testing.T)
 	})
 }
 
+func TestAccCognitoIDPUserPool_WithLambda_inboundFederation(t *testing.T) {
+	ctx := acctest.Context(t)
+	var pool awstypes.UserPoolType
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_cognito_user_pool.test"
+	lambdaResourceName := "aws_lambda_function.test"
+	lambdaUpdatedResourceName := "aws_lambda_function.second"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckIdentityProvider(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CognitoIDPServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckUserPoolDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserPoolConfig_lambdaInboundFederation(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckUserPoolExists(ctx, t, resourceName, &pool),
+					resource.TestCheckResourceAttr(resourceName, "lambda_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "lambda_config.0.inbound_federation.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "lambda_config.0.inbound_federation.0.lambda_arn", lambdaResourceName, names.AttrARN),
+					resource.TestCheckResourceAttr(resourceName, "lambda_config.0.inbound_federation.0.lambda_version", "V1_0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccUserPoolConfig_lambdaInboundFederationUpdated(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "lambda_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "lambda_config.0.inbound_federation.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "lambda_config.0.inbound_federation.0.lambda_arn", lambdaUpdatedResourceName, names.AttrARN),
+					resource.TestCheckResourceAttr(resourceName, "lambda_config.0.inbound_federation.0.lambda_version", "V1_0"),
+				),
+			},
+			{
+				Config: testAccUserPoolConfig_lambdaInboundFederationRemove(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "lambda_config.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "lambda_config.0.inbound_federation.#", "0"),
+				),
+			},
+		},
+	})
+}
+
 // https://github.com/hashicorp/terraform-provider-aws/issues/38164.
 func TestAccCognitoIDPUserPool_addLambda(t *testing.T) {
 	ctx := acctest.Context(t)
@@ -3046,6 +3095,52 @@ resource "aws_cognito_user_pool" "test" {
     advanced_security_mode = "ENFORCED"
   }
 
+}
+`, name))
+}
+
+func testAccUserPoolConfig_lambdaInboundFederation(name string) string {
+	return acctest.ConfigCompose(testAccUserPoolLambdaConfig_base(name), fmt.Sprintf(`
+resource "aws_cognito_user_pool" "test" {
+  name = %[1]q
+
+  lambda_config {
+    inbound_federation {
+      lambda_arn     = aws_lambda_function.test.arn
+      lambda_version = "V1_0"
+    }
+  }
+}
+`, name))
+}
+
+func testAccUserPoolConfig_lambdaInboundFederationUpdated(name string) string {
+	return acctest.ConfigCompose(testAccUserPoolLambdaConfig_base(name), fmt.Sprintf(`
+resource "aws_lambda_function" "second" {
+  filename      = "test-fixtures/lambdatest.zip"
+  function_name = "%[1]s_second"
+  role          = aws_iam_role.test.arn
+  handler       = "exports.example"
+  runtime       = "nodejs24.x"
+}
+
+resource "aws_cognito_user_pool" "test" {
+  name = %[1]q
+
+  lambda_config {
+    inbound_federation {
+      lambda_arn     = aws_lambda_function.second.arn
+      lambda_version = "V1_0"
+    }
+  }
+}
+`, name))
+}
+
+func testAccUserPoolConfig_lambdaInboundFederationRemove(name string) string {
+	return acctest.ConfigCompose(testAccUserPoolLambdaConfig_base(name), fmt.Sprintf(`
+resource "aws_cognito_user_pool" "test" {
+  name = %[1]q
 }
 `, name))
 }

--- a/website/docs/d/cognito_user_pool.html.markdown
+++ b/website/docs/d/cognito_user_pool.html.markdown
@@ -93,6 +93,7 @@ This data source exports the following attributes in addition to the arguments a
 
 * [custom_email_sender](#lambda-function) - Configuration for a custom email sender Lambda function.
 * [custom_sms_sender](#lambda-function) - Configuration for a custom SMS sender Lambda function
+* [inbound_federation](#lambda-function) - Configuration for an inbound federation Lambda function that transforms federated user attributes during authentication with external identity providers.
 * [pre_token_generation_config](#lambda-function) - Configuration for a Lambda function that executes before token generation.
 
 ### lambda function

--- a/website/docs/r/cognito_user_pool.html.markdown
+++ b/website/docs/r/cognito_user_pool.html.markdown
@@ -135,6 +135,7 @@ This resource supports the following arguments:
 * `create_auth_challenge` - (Optional) ARN of the lambda creating an authentication challenge.
 * `custom_message` - (Optional) Custom Message AWS Lambda trigger.
 * `define_auth_challenge` - (Optional) Defines the authentication challenge.
+* `inbound_federation` - (Optional) Inbound federation AWS Lambda trigger that transforms federated user attributes during authentication. See [inbound_federation](#inbound_federation) below.
 * `post_authentication` - (Optional) Post-authentication AWS Lambda trigger.
 * `post_confirmation` - (Optional) Post-confirmation AWS Lambda trigger.
 * `pre_authentication` - (Optional) Pre-authentication AWS Lambda trigger.
@@ -161,6 +162,11 @@ This resource supports the following arguments:
 
 * `lambda_arn` - (Required) The Lambda Amazon Resource Name of the Lambda function that Amazon Cognito triggers to customize access tokens. If you also set an ARN in `pre_token_generation`, its value must be identical to this one.
 * `lambda_version` - (Required) The Lambda version represents the signature of the "version" attribute in the "event" information Amazon Cognito passes to your pre Token Generation Lambda function. The supported values are `V1_0`, `V2_0`, `V3_0`.
+
+#### inbound_federation
+
+* `lambda_arn` - (Required) The Lambda Amazon Resource Name of the Lambda function that Amazon Cognito triggers to transform federated user attributes during authentication with external identity providers.
+* `lambda_version` - (Required) The Lambda version represents the signature of the "request" attribute in the "event" information Amazon Cognito passes to your inbound federation Lambda function. The only supported value is `V1_0`.
 
 ### password_policy
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No. This change exposes an existing AWS-side feature (the Cognito User Pool inbound federation Lambda trigger) through a new optional configuration block on `aws_cognito_user_pool`. It does not introduce new access controls, encryption, or logging on the provider side. Authentication, authorization, and key management for the configured Lambda continue to be handled by AWS Cognito and AWS Lambda exactly as today.

### Description

AWS released the Cognito User Pool inbound federation Lambda trigger on 2026-01-29. The trigger lets a Lambda function transform federated user attributes during authentication with external identity providers (SAML / OIDC). The provider did not yet expose a way to configure it.

This PR adds an `inbound_federation` nested block under `aws_cognito_user_pool.lambda_config`, mirroring the existing `pre_token_generation_config` shape:

```hcl
resource "aws_cognito_user_pool" "example" {
  lambda_config {
    inbound_federation {
      lambda_arn     = aws_lambda_function.example.arn
      lambda_version = "V1_0"
    }
    # ...other triggers like pre_sign_up, post_authentication, etc.
  }
}
```

Both fields are `Required`. `lambda_version` is validated against the SDK enum `awstypes.InboundFederationLambdaVersionType`, which currently only accepts `V1_0` (per AWS SDK docs: *"You must use a LambdaVersion of V1_0 with an inbound federation function"*). When AWS adds future versions, an SDK bump alone will widen acceptance.

#### Why a new `inbound_federation` block rather than reusing/repurposing an existing one

It maps 1:1 to the new SDK field `LambdaConfigType.InboundFederation *InboundFederationLambdaType`, which is its own type rather than a variant of `PreTokenGenerationVersionConfigType`. Following the pattern of `custom_email_sender`, `custom_sms_sender`, and `pre_token_generation_config` keeps the schema flat and predictable. The block name matches the spelling used in #46216 and in the AWS documentation.

#### Companion data source

The Plugin Framework `aws_cognito_user_pool` data source uses an AutoFlex model (`lambdaConfigTypeModel`). A new `inboundFederationLambdaTypeModel` struct and a corresponding `InboundFederation` field were added so reads on user pools that have the trigger configured do not silently drop the field.

#### What's in this PR

- `internal/service/cognitoidp/user_pool.go` — schema block, `expandInboundFederationLambdaType` / `flattenInboundFederationLambdaType` helpers, and integration into `expandLambdaConfigType` / `flattenLambdaConfigType`.
- `internal/service/cognitoidp/user_pool_data_source.go` — `InboundFederation` field on `lambdaConfigTypeModel` and a new `inboundFederationLambdaTypeModel` struct.
- `internal/service/cognitoidp/user_pool_test.go` — `TestAccCognitoIDPUserPool_WithLambda_inboundFederation` plus three HCL fixtures (create, update, remove). Covers create, `ImportStateVerify`, update with a swapped Lambda, and removal.
- `website/docs/r/cognito_user_pool.html.markdown` — argument entry under `lambda_config` and a new `inbound_federation` subsection.
- `website/docs/d/cognito_user_pool.html.markdown` — entry under the data source's `lambda config` section.
- `.changelog/46216.txt` — `release-note:enhancement`. Filename will be renamed to the PR number in a follow-up commit on this branch once GitHub assigns it.

The `aws-sdk-go-v2/service/cognitoidentityprovider` types are already present at the currently pinned version (`v1.60.2`); no SDK bump is required.

#### AI usage disclosure

This PR was prepared with Claude (Anthropic) acting as a coding assistant under human direction. The human author reviewed every line and is accountable for the change. AI was used to: read the existing `pre_token_generation_config` pattern, draft the schema/expand/flatten/test code in that exact shape, and write the docs/changelog. The 🤖🤖🤖 marker in the title follows the project's AI usage policy.

### Relations

Closes #46216

### References

- AWS feature announcement (2026-01-29): https://aws.amazon.com/about-aws/whats-new/2026/01/amazon-cognito-inbound-federation-lambda-trigger/
- AWS Cognito developer guide — inbound federation Lambda trigger: https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-inbound-federation.html
- AWS SDK type — `InboundFederationLambdaType`: https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider/types#InboundFederationLambdaType
- AWS SDK type — `LambdaConfigType.InboundFederation`: https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider/types#LambdaConfigType

### Output from Acceptance Testing

Unit tests in the package:

```console
% go test -count=1 ./internal/service/cognitoidp/...
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cognitoidp	(46 tests passed)
```

`go vet` clean on the package.

Acceptance test against real AWS (us-east-1):

<details>
<summary><code>make testacc TESTS='TestAccCognitoIDPUserPool_WithLambda_inboundFederation' PKG=cognitoidp</code></summary>

```console
% TF_ACC=1 go test -v -count=1 -timeout=30m \
    -run='^TestAccCognitoIDPUserPool_WithLambda_inboundFederation$' \
    ./internal/service/cognitoidp/
2026/05/18 20:06:55 Creating Terraform AWS Provider (SDKv2-style)...
2026/05/18 20:06:55 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccCognitoIDPUserPool_WithLambda_inboundFederation
=== PAUSE TestAccCognitoIDPUserPool_WithLambda_inboundFederation
=== CONT  TestAccCognitoIDPUserPool_WithLambda_inboundFederation
--- PASS: TestAccCognitoIDPUserPool_WithLambda_inboundFederation (200.56s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cognitoidp    200.947s
```

</details>
