### PR TITLE
feat: add support for S3 bucket owner in S3 destination configuration

### DIFF
--- a/.changelog/47958.txt
+++ b/.changelog/47958.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_bcmdataexports_export: Add `s3_bucket_owner` to `destination_configurations.s3_destination`
+```

--- a/internal/service/bcmdataexports/export.go
+++ b/internal/service/bcmdataexports/export.go
@@ -30,6 +30,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
 	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	fwvalidators "github.com/hashicorp/terraform-provider-aws/internal/framework/validators"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -189,6 +190,9 @@ func exportS3DestinationSchema(ctx context.Context) schema.ListNestedBlock {
 					Optional: true,
 					PlanModifiers: []planmodifier.String{
 						stringplanmodifier.RequiresReplace(),
+					},
+					Validators: []validator.String{
+						fwvalidators.AWSAccountID(),
 					},
 				},
 				"s3_prefix": schema.StringAttribute{

--- a/internal/service/bcmdataexports/export.go
+++ b/internal/service/bcmdataexports/export.go
@@ -185,6 +185,12 @@ func exportS3DestinationSchema(ctx context.Context) schema.ListNestedBlock {
 						stringplanmodifier.RequiresReplace(),
 					},
 				},
+				"s3_bucket_owner": schema.StringAttribute{
+					Optional: true,
+					PlanModifiers: []planmodifier.String{
+						stringplanmodifier.RequiresReplace(),
+					},
+				},
 				"s3_prefix": schema.StringAttribute{
 					Required: true,
 					PlanModifiers: []planmodifier.String{
@@ -518,6 +524,7 @@ type s3OutputConfigurations struct {
 
 type s3Destination struct {
 	S3Bucket               types.String                                            `tfsdk:"s3_bucket"`
+	S3BucketOwner          types.String                                            `tfsdk:"s3_bucket_owner"`
 	S3Prefix               types.String                                            `tfsdk:"s3_prefix"`
 	S3Region               types.String                                            `tfsdk:"s3_region"`
 	S3OutputConfigurations fwtypes.ListNestedObjectValueOf[s3OutputConfigurations] `tfsdk:"s3_output_configurations"`

--- a/internal/service/bcmdataexports/export_test.go
+++ b/internal/service/bcmdataexports/export_test.go
@@ -170,7 +170,7 @@ func TestAccBCMDataExportsExport_s3BucketOwner(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "export.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "export.0.destination_configurations.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "export.0.destination_configurations.0.s3_destination.#", "1"),
-					resource.TestCheckResourceAttrPair(resourceName, "export.0.destination_configurations.0.s3_destination.0.s3_bucket_owner", "data.aws_caller_identity.current", "account_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "export.0.destination_configurations.0.s3_destination.0.s3_bucket_owner", "data.aws_caller_identity.current", names.AttrAccountID),
 				),
 			},
 			{

--- a/internal/service/bcmdataexports/export_test.go
+++ b/internal/service/bcmdataexports/export_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/aws-sdk-go-base/v2/endpoints"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
@@ -170,6 +171,53 @@ func TestAccBCMDataExportsExport_s3BucketOwner(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "export.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "export.0.destination_configurations.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "export.0.destination_configurations.0.s3_destination.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "export.0.destination_configurations.0.s3_destination.0.s3_bucket_owner", "data.aws_caller_identity.current", names.AttrAccountID),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccBCMDataExportsExport_s3BucketOwner_update(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var export1, export2 bcmdataexports.GetExportOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_bcmdataexports_export.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionNot(t, endpoints.AwsUsGovPartitionID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BCMDataExportsServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckExportDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccExportConfig_CUR_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckExportExists(ctx, t, resourceName, &export1),
+					resource.TestCheckNoResourceAttr(resourceName, "export.0.destination_configurations.0.s3_destination.0.s3_bucket_owner"),
+				),
+			},
+			{
+				Config: testAccExportConfig_s3BucketOwner(rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionDestroyBeforeCreate),
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckExportExists(ctx, t, resourceName, &export2),
 					resource.TestCheckResourceAttrPair(resourceName, "export.0.destination_configurations.0.s3_destination.0.s3_bucket_owner", "data.aws_caller_identity.current", names.AttrAccountID),
 				),
 			},

--- a/internal/service/bcmdataexports/export_test.go
+++ b/internal/service/bcmdataexports/export_test.go
@@ -144,6 +144,44 @@ func TestAccBCMDataExportsExport_CUR_tableConfigurations(t *testing.T) {
 	})
 }
 
+func TestAccBCMDataExportsExport_s3BucketOwner(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var export bcmdataexports.GetExportOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_bcmdataexports_export.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionNot(t, endpoints.AwsUsGovPartitionID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BCMDataExportsServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckExportDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccExportConfig_s3BucketOwner(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckExportExists(ctx, t, resourceName, &export),
+					resource.TestCheckResourceAttr(resourceName, "export.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "export.0.destination_configurations.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "export.0.destination_configurations.0.s3_destination.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "export.0.destination_configurations.0.s3_destination.0.s3_bucket_owner", "data.aws_caller_identity.current", "account_id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccBCMDataExportsExport_CarbonEmissions_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
@@ -663,6 +701,41 @@ resource "aws_bcmdataexports_export" "test" {
         s3_bucket = aws_s3_bucket.test.bucket
         s3_prefix = aws_s3_bucket.test.bucket_prefix
         s3_region = aws_s3_bucket.test.region
+        s3_output_configurations {
+          overwrite   = "OVERWRITE_REPORT"
+          format      = "TEXT_OR_CSV"
+          compression = "GZIP"
+          output_type = "CUSTOM"
+        }
+      }
+    }
+
+    refresh_cadence {
+      frequency = "SYNCHRONOUS"
+    }
+  }
+}
+`, rName))
+}
+
+func testAccExportConfig_s3BucketOwner(rName string) string {
+	return acctest.ConfigCompose(
+		testAccExportConfigBase(rName),
+		fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+
+resource "aws_bcmdataexports_export" "test" {
+  export {
+    name = %[1]q
+    data_query {
+      query_statement = "SELECT identity_line_item_id, identity_time_interval, line_item_product_code,line_item_unblended_cost FROM COST_AND_USAGE_REPORT"
+    }
+    destination_configurations {
+      s3_destination {
+        s3_bucket       = aws_s3_bucket.test.bucket
+        s3_bucket_owner = data.aws_caller_identity.current.account_id
+        s3_prefix       = aws_s3_bucket.test.bucket_prefix
+        s3_region       = aws_s3_bucket.test.region
         s3_output_configurations {
           overwrite   = "OVERWRITE_REPORT"
           format      = "TEXT_OR_CSV"

--- a/website/docs/r/bcmdataexports_export.html.markdown
+++ b/website/docs/r/bcmdataexports_export.html.markdown
@@ -85,6 +85,7 @@ This resource supports the following arguments:
 ### `s3_destination` Argument Reference
 
 * `s3_bucket` - (Required) Name of the Amazon S3 bucket used as the destination of a data export file.
+* `s3_bucket_owner` - (Optional) AWS account ID of the bucket owner. Set this for cross-account S3 delivery.
 * `s3_output_configurations` - (Required) Output configuration for the data export. See the [`s3_output_configurations` argument reference](#s3_output_configurations-argument-reference) below.
 * `s3_prefix` - (Required) S3 path prefix you want prepended to the name of your data export.
 * `s3_region` - (Required) S3 bucket region.


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls implemented.

### Description

Allow to configure the S3 Bucket owner in [`destination_configurations.s3_destination`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/bcmdataexports_export#s3_destination-argument-reference) of resource [`aws_bcmdataexports_export`](https://registry.terraform.io/providers/hashicorp/aws/6.45.0/docs/resources/bcmdataexports_export)

### Relations

Closes #47613

### References

- [AWS Docs - Cloudformation AWS::BCMDataExports::Export S3Destination](https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-properties-bcmdataexports-export-s3destination.html)
- [AWS CLI Docs - aws bcm-data-exports create-export](https://docs.aws.amazon.com/cli/latest/reference/bcm-data-exports/create-export.html)

### Output from Acceptance Testing

Executing all tests fails at the moment - hitting a service quota limit. 

```console
make testacc T=TestAccBCMDataExportsExport_s3BucketOwner K=bcmdataexports
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework (cached)
make: Running acceptance tests on branch: 🌿 f-aws_bcmdataexports_export-add-s3-bucket-owner 🌿...
TF_ACC=1 go1.26.3 test ./internal/service/bcmdataexports/... -v -count 1 -parallel 20 -run='TestAccBCMDataExportsExport_s3BucketOwner'  -timeout 360m -vet=off -buildvcs=false
2026/05/18 21:28:36 Creating Terraform AWS Provider (SDKv2-style)...
2026/05/18 21:28:36 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccBCMDataExportsExport_s3BucketOwner
=== PAUSE TestAccBCMDataExportsExport_s3BucketOwner
=== RUN   TestAccBCMDataExportsExport_s3BucketOwner_update
=== PAUSE TestAccBCMDataExportsExport_s3BucketOwner_update
=== CONT  TestAccBCMDataExportsExport_s3BucketOwner
=== CONT  TestAccBCMDataExportsExport_s3BucketOwner_update
--- PASS: TestAccBCMDataExportsExport_s3BucketOwner (40.80s)
--- PASS: TestAccBCMDataExportsExport_s3BucketOwner_update (67.01s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/bcmdataexports     67.156s
```
