### PR TITLE
fix(bedrockagent): preserve PreparedAt and GuardrailConfiguration during agent updates

### DIFF
--- a/.changelog/47967.txt
+++ b/.changelog/47967.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_bedrockagent_agent: Fix `Provider produced inconsistent result after apply` error during updates by preserving `PreparedAt` and `GuardrailConfiguration` values
+```

--- a/internal/service/bedrockagent/agent.go
+++ b/internal/service/bedrockagent/agent.go
@@ -367,6 +367,13 @@ func (r *agentResource) Update(ctx context.Context, request resource.UpdateReque
 		if response.Diagnostics.HasError() {
 			return
 		}
+
+		// Preserve fields not returned by UpdateAgent API to avoid inconsistent result errors.
+		// See: https://github.com/hashicorp/terraform-provider-aws/issues/43849
+		new.PreparedAt = old.PreparedAt
+		if new.GuardrailConfiguration.IsNull() && !old.GuardrailConfiguration.IsNull() {
+			new.GuardrailConfiguration = old.GuardrailConfiguration
+		}
 	} else {
 		new.AgentVersion = old.AgentVersion
 	}


### PR DESCRIPTION
Fixes #43849

### Description

The `UpdateAgent` API doesn't return `PreparedAt` or `GuardrailConfiguration` in its response. When `fwflex.Flatten` maps the response back to the model, these fields become null, causing Terraform to report "Provider produced inconsistent result after apply".

This fix preserves the original values after the `Flatten` call, following the same pattern used in #43654 for `aws_bedrockagent_flow`.

### Changes

- Preserve `PreparedAt` from old state after flattening the API response
- Preserve `GuardrailConfiguration` if it becomes null after flattening but was previously set

### Testing

- [ ] Acceptance tests pass locally
- [ ] Manual verification that updates no longer produce inconsistent results

### References

- Similar fix: #43654 (Bedrock Flow `created_at`)
- Root cause analysis in issue comment: #43849