### PR TITLE
New resource: aws_ssoadmin_application_grant

### DIFF
--- a/.changelog/47981.txt
+++ b/.changelog/47981.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_ssoadmin_application_grant
+```

--- a/internal/service/ssoadmin/application_grant.go
+++ b/internal/service/ssoadmin/application_grant.go
@@ -1,0 +1,463 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package ssoadmin
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ssoadmin"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/ssoadmin/types"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	intflex "github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkResource("aws_ssoadmin_application_grant", name="Application Grant")
+func newApplicationGrantResource(_ context.Context) (resource.ResourceWithConfigure, error) {
+	return &applicationGrantResource{}, nil
+}
+
+const (
+	ResNameApplicationGrant = "Application Grant"
+
+	applicationGrantIDPartCount = 2
+)
+
+type applicationGrantResource struct {
+	framework.ResourceWithModel[applicationGrantResourceModel]
+	framework.WithImportByID
+}
+
+func (r *applicationGrantResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"application_arn": schema.StringAttribute{
+				CustomType: fwtypes.ARNType,
+				Required:   true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"grant_type": schema.StringAttribute{
+				CustomType: fwtypes.StringEnumType[awstypes.GrantType](),
+				Required:   true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			names.AttrID: framework.IDAttribute(),
+		},
+		Blocks: map[string]schema.Block{
+			"grant": schema.ListNestedBlock{
+				CustomType: fwtypes.NewListNestedObjectTypeOf[grantModel](ctx),
+				Validators: []validator.List{
+					listvalidator.SizeBetween(1, 1),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Blocks: map[string]schema.Block{
+						"authorization_code": schema.ListNestedBlock{
+							CustomType: fwtypes.NewListNestedObjectTypeOf[authorizationCodeGrantModel](ctx),
+							Validators: []validator.List{
+								listvalidator.SizeAtMost(1),
+							},
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									"redirect_uris": schema.ListAttribute{
+										CustomType:  fwtypes.ListOfStringType,
+										ElementType: types.StringType,
+										Required:    true,
+										PlanModifiers: []planmodifier.List{
+											listplanmodifier.RequiresReplace(),
+										},
+									},
+								},
+							},
+						},
+						"jwt_bearer": schema.ListNestedBlock{
+							CustomType: fwtypes.NewListNestedObjectTypeOf[jwtBearerGrantModel](ctx),
+							Validators: []validator.List{
+								listvalidator.SizeAtMost(1),
+							},
+							NestedObject: schema.NestedBlockObject{
+								Blocks: map[string]schema.Block{
+									"authorized_token_issuers": schema.ListNestedBlock{
+										CustomType: fwtypes.NewListNestedObjectTypeOf[authorizedTokenIssuerModel](ctx),
+										Validators: []validator.List{
+											listvalidator.SizeAtLeast(1),
+										},
+										NestedObject: schema.NestedBlockObject{
+											Attributes: map[string]schema.Attribute{
+												"authorized_audiences": schema.ListAttribute{
+													CustomType:  fwtypes.ListOfStringType,
+													ElementType: types.StringType,
+													Optional:    true,
+												},
+												"trusted_token_issuer_arn": schema.StringAttribute{
+													CustomType: fwtypes.ARNType,
+													Optional:   true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"refresh_token": schema.ListNestedBlock{
+							CustomType: fwtypes.NewListNestedObjectTypeOf[refreshTokenGrantModel](ctx),
+							Validators: []validator.List{
+								listvalidator.SizeAtMost(1),
+							},
+							NestedObject: schema.NestedBlockObject{},
+						},
+						"token_exchange": schema.ListNestedBlock{
+							CustomType: fwtypes.NewListNestedObjectTypeOf[tokenExchangeGrantModel](ctx),
+							Validators: []validator.List{
+								listvalidator.SizeAtMost(1),
+							},
+							NestedObject: schema.NestedBlockObject{},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (r *applicationGrantResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	conn := r.Meta().SSOAdminClient(ctx)
+
+	var plan applicationGrantResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	grantPtr, diags := plan.Grant.ToPtr(ctx)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	grant, d := grantPtr.expandGrant(ctx)
+	resp.Diagnostics.Append(d...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	in := &ssoadmin.PutApplicationGrantInput{
+		ApplicationArn: plan.ApplicationARN.ValueStringPointer(),
+		GrantType:      plan.GrantType.ValueEnum(),
+		Grant:          grant,
+	}
+
+	_, err := conn.PutApplicationGrant(ctx, in)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.SSOAdmin, create.ErrActionCreating, ResNameApplicationGrant, plan.ApplicationARN.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	idParts := []string{
+		plan.ApplicationARN.ValueString(),
+		string(plan.GrantType.ValueEnum()),
+	}
+	id, err := intflex.FlattenResourceId(idParts, applicationGrantIDPartCount, false)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.SSOAdmin, create.ErrActionCreating, ResNameApplicationGrant, plan.ApplicationARN.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	plan.ID = types.StringValue(id)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+}
+
+func (r *applicationGrantResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	conn := r.Meta().SSOAdminClient(ctx)
+
+	var state applicationGrantResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	out, err := findApplicationGrantByID(ctx, conn, state.ID.ValueString())
+	if retry.NotFound(err) {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.SSOAdmin, create.ErrActionSetting, ResNameApplicationGrant, state.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	parts, err := intflex.ExpandResourceId(state.ID.ValueString(), applicationGrantIDPartCount, false)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.SSOAdmin, create.ErrActionSetting, ResNameApplicationGrant, state.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	state.ApplicationARN = fwtypes.ARNValue(parts[0])
+	state.GrantType = fwtypes.StringEnumValue[awstypes.GrantType](awstypes.GrantType(parts[1]))
+
+	var grantData grantModel
+	resp.Diagnostics.Append(grantData.flattenGrant(ctx, out.Grant)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	state.Grant = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &grantData)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *applicationGrantResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	conn := r.Meta().SSOAdminClient(ctx)
+
+	var plan, state applicationGrantResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !plan.Grant.Equal(state.Grant) {
+		grantPtr, diags := plan.Grant.ToPtr(ctx)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		grant, d := grantPtr.expandGrant(ctx)
+		resp.Diagnostics.Append(d...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		in := &ssoadmin.PutApplicationGrantInput{
+			ApplicationArn: plan.ApplicationARN.ValueStringPointer(),
+			GrantType:      plan.GrantType.ValueEnum(),
+			Grant:          grant,
+		}
+
+		_, err := conn.PutApplicationGrant(ctx, in)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				create.ProblemStandardMessage(names.SSOAdmin, create.ErrActionUpdating, ResNameApplicationGrant, plan.ID.String(), err),
+				err.Error(),
+			)
+			return
+		}
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *applicationGrantResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	conn := r.Meta().SSOAdminClient(ctx)
+
+	var state applicationGrantResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	in := &ssoadmin.DeleteApplicationGrantInput{
+		ApplicationArn: state.ApplicationARN.ValueStringPointer(),
+		GrantType:      state.GrantType.ValueEnum(),
+	}
+
+	_, err := conn.DeleteApplicationGrant(ctx, in)
+	if err != nil {
+		if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+			return
+		}
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.SSOAdmin, create.ErrActionDeleting, ResNameApplicationGrant, state.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+}
+
+func findApplicationGrantByID(ctx context.Context, conn *ssoadmin.Client, id string) (*ssoadmin.GetApplicationGrantOutput, error) {
+	parts, err := intflex.ExpandResourceId(id, applicationGrantIDPartCount, false)
+	if err != nil {
+		return nil, err
+	}
+
+	in := &ssoadmin.GetApplicationGrantInput{
+		ApplicationArn: aws.String(parts[0]),
+		GrantType:      awstypes.GrantType(parts[1]),
+	}
+
+	out, err := conn.GetApplicationGrant(ctx, in)
+	if err != nil {
+		if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+			return nil, &retry.NotFoundError{
+				LastError: err,
+			}
+		}
+
+		return nil, err
+	}
+
+	if out == nil {
+		return nil, tfresource.NewEmptyResultError()
+	}
+
+	return out, nil
+}
+
+type applicationGrantResourceModel struct {
+	framework.WithRegionModel
+	ApplicationARN fwtypes.ARN                                    `tfsdk:"application_arn"`
+	Grant          fwtypes.ListNestedObjectValueOf[grantModel]    `tfsdk:"grant"`
+	GrantType      fwtypes.StringEnum[awstypes.GrantType]         `tfsdk:"grant_type"`
+	ID             types.String                                   `tfsdk:"id"`
+}
+
+type grantModel struct {
+	AuthorizationCode fwtypes.ListNestedObjectValueOf[authorizationCodeGrantModel] `tfsdk:"authorization_code"`
+	JwtBearer         fwtypes.ListNestedObjectValueOf[jwtBearerGrantModel]         `tfsdk:"jwt_bearer"`
+	RefreshToken      fwtypes.ListNestedObjectValueOf[refreshTokenGrantModel]      `tfsdk:"refresh_token"`
+	TokenExchange     fwtypes.ListNestedObjectValueOf[tokenExchangeGrantModel]     `tfsdk:"token_exchange"`
+}
+
+var (
+	_ flex.TypedExpander = grantModel{}
+	_ flex.Flattener     = &grantModel{}
+)
+
+func (m grantModel) ExpandTo(ctx context.Context, targetType reflect.Type) (any, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if targetType == reflect.TypeFor[awstypes.Grant]() {
+		grant, d := m.expandGrant(ctx)
+		diags.Append(d...)
+		return grant, diags
+	}
+
+	return nil, diags
+}
+
+func (m grantModel) expandGrant(ctx context.Context) (awstypes.Grant, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	switch {
+	case !m.AuthorizationCode.IsNull():
+		authCode, d := m.AuthorizationCode.ToPtr(ctx)
+		diags.Append(d...)
+		if diags.HasError() {
+			return nil, diags
+		}
+		var r awstypes.GrantMemberAuthorizationCode
+		diags.Append(flex.Expand(ctx, authCode, &r.Value)...)
+		return &r, diags
+
+	case !m.JwtBearer.IsNull():
+		jwtBearer, d := m.JwtBearer.ToPtr(ctx)
+		diags.Append(d...)
+		if diags.HasError() {
+			return nil, diags
+		}
+		var r awstypes.GrantMemberJwtBearer
+		diags.Append(flex.Expand(ctx, jwtBearer, &r.Value)...)
+		return &r, diags
+
+	case !m.RefreshToken.IsNull():
+		return &awstypes.GrantMemberRefreshToken{}, diags
+
+	case !m.TokenExchange.IsNull():
+		return &awstypes.GrantMemberTokenExchange{}, diags
+	}
+
+	return nil, diags
+}
+
+func (m *grantModel) Flatten(ctx context.Context, v any) diag.Diagnostics {
+	return m.flattenGrant(ctx, v)
+}
+
+func (m *grantModel) flattenGrant(ctx context.Context, v any) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	// Initialize all sub-blocks to null so Terraform sees a clean state.
+	m.AuthorizationCode = fwtypes.NewListNestedObjectValueOfNull[authorizationCodeGrantModel](ctx)
+	m.JwtBearer = fwtypes.NewListNestedObjectValueOfNull[jwtBearerGrantModel](ctx)
+	m.RefreshToken = fwtypes.NewListNestedObjectValueOfNull[refreshTokenGrantModel](ctx)
+	m.TokenExchange = fwtypes.NewListNestedObjectValueOfNull[tokenExchangeGrantModel](ctx)
+
+	switch v := v.(type) {
+	case *awstypes.GrantMemberAuthorizationCode:
+		var authCode authorizationCodeGrantModel
+		diags.Append(flex.Flatten(ctx, v.Value, &authCode)...)
+		if diags.HasError() {
+			return diags
+		}
+		m.AuthorizationCode = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &authCode)
+
+	case *awstypes.GrantMemberJwtBearer:
+		var jwtBearer jwtBearerGrantModel
+		diags.Append(flex.Flatten(ctx, v.Value, &jwtBearer)...)
+		if diags.HasError() {
+			return diags
+		}
+		m.JwtBearer = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &jwtBearer)
+
+	case *awstypes.GrantMemberRefreshToken:
+		var refreshToken refreshTokenGrantModel
+		m.RefreshToken = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &refreshToken)
+
+	case *awstypes.GrantMemberTokenExchange:
+		var tokenExchange tokenExchangeGrantModel
+		m.TokenExchange = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &tokenExchange)
+	}
+
+	return diags
+}
+
+type authorizationCodeGrantModel struct {
+	RedirectURIs fwtypes.ListOfString `tfsdk:"redirect_uris"`
+}
+
+type jwtBearerGrantModel struct {
+	AuthorizedTokenIssuers fwtypes.ListNestedObjectValueOf[authorizedTokenIssuerModel] `tfsdk:"authorized_token_issuers"`
+}
+
+type authorizedTokenIssuerModel struct {
+	AuthorizedAudiences   fwtypes.ListOfString `tfsdk:"authorized_audiences"`
+	TrustedTokenIssuerARN fwtypes.ARN          `tfsdk:"trusted_token_issuer_arn"`
+}
+
+type refreshTokenGrantModel struct{}
+
+type tokenExchangeGrantModel struct{}

--- a/internal/service/ssoadmin/application_grant_test.go
+++ b/internal/service/ssoadmin/application_grant_test.go
@@ -1,0 +1,240 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package ssoadmin_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/ssoadmin/types"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	tfssoadmin "github.com/hashicorp/terraform-provider-aws/internal/service/ssoadmin"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccSSOAdminApplicationGrant_authorizationCode(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_ssoadmin_application_grant.test"
+	applicationResourceName := "aws_ssoadmin_application.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.SSOAdminEndpointID)
+			acctest.PreCheckSSOAdminInstances(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.SSOAdminServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckApplicationGrantDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApplicationGrantConfig_authorizationCode(rName, "http://127.0.0.1/auth/callback"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApplicationGrantExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "application_arn", applicationResourceName, names.AttrARN),
+					resource.TestCheckResourceAttr(resourceName, "grant_type", "authorization_code"),
+					resource.TestCheckResourceAttr(resourceName, "grant.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "grant.0.authorization_code.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "grant.0.authorization_code.0.redirect_uris.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "grant.0.authorization_code.0.redirect_uris.0", "http://127.0.0.1/auth/callback"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccSSOAdminApplicationGrant_authorizationCode_update(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_ssoadmin_application_grant.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.SSOAdminEndpointID)
+			acctest.PreCheckSSOAdminInstances(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.SSOAdminServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckApplicationGrantDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApplicationGrantConfig_authorizationCode(rName, "http://127.0.0.1/auth/callback"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApplicationGrantExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "grant.0.authorization_code.0.redirect_uris.0", "http://127.0.0.1/auth/callback"),
+				),
+			},
+			{
+				Config: testAccApplicationGrantConfig_authorizationCode(rName, "http://127.0.0.1/oauth/callback"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApplicationGrantExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "grant.0.authorization_code.0.redirect_uris.0", "http://127.0.0.1/oauth/callback"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccSSOAdminApplicationGrant_tokenExchange(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_ssoadmin_application_grant.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.SSOAdminEndpointID)
+			acctest.PreCheckSSOAdminInstances(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.SSOAdminServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckApplicationGrantDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApplicationGrantConfig_tokenExchange(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApplicationGrantExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "grant_type", "urn:ietf:params:oauth:grant-type:token-exchange"),
+					resource.TestCheckResourceAttr(resourceName, "grant.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "grant.0.token_exchange.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccSSOAdminApplicationGrant_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_ssoadmin_application_grant.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.SSOAdminEndpointID)
+			acctest.PreCheckSSOAdminInstances(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.SSOAdminServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckApplicationGrantDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApplicationGrantConfig_authorizationCode(rName, "http://127.0.0.1/auth/callback"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApplicationGrantExists(ctx, t, resourceName),
+					acctest.CheckFrameworkResourceDisappears(ctx, t, tfssoadmin.ResourceApplicationGrant, resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckApplicationGrantDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.ProviderMeta(ctx, t).SSOAdminClient(ctx)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_ssoadmin_application_grant" {
+				continue
+			}
+
+			_, err := tfssoadmin.FindApplicationGrantByID(ctx, conn, rs.Primary.ID)
+			if errs.IsA[*types.ResourceNotFoundException](err) {
+				return nil
+			}
+			if err != nil {
+				return create.Error(names.SSOAdmin, create.ErrActionCheckingDestroyed, tfssoadmin.ResNameApplicationGrant, rs.Primary.ID, err)
+			}
+
+			return create.Error(names.SSOAdmin, create.ErrActionCheckingDestroyed, tfssoadmin.ResNameApplicationGrant, rs.Primary.ID, errors.New("not destroyed"))
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckApplicationGrantExists(ctx context.Context, t *testing.T, name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return create.Error(names.SSOAdmin, create.ErrActionCheckingExistence, tfssoadmin.ResNameApplicationGrant, name, errors.New("not found"))
+		}
+
+		if rs.Primary.ID == "" {
+			return create.Error(names.SSOAdmin, create.ErrActionCheckingExistence, tfssoadmin.ResNameApplicationGrant, name, errors.New("not set"))
+		}
+
+		conn := acctest.ProviderMeta(ctx, t).SSOAdminClient(ctx)
+
+		_, err := tfssoadmin.FindApplicationGrantByID(ctx, conn, rs.Primary.ID)
+		if err != nil {
+			return create.Error(names.SSOAdmin, create.ErrActionCheckingExistence, tfssoadmin.ResNameApplicationGrant, rs.Primary.ID, err)
+		}
+
+		return nil
+	}
+}
+
+func testAccApplicationGrantConfig_authorizationCode(rName, redirectURI string) string {
+	return fmt.Sprintf(`
+data "aws_ssoadmin_instances" "test" {}
+
+resource "aws_ssoadmin_application" "test" {
+  name                     = %[1]q
+  application_provider_arn = %[2]q
+  instance_arn             = tolist(data.aws_ssoadmin_instances.test.arns)[0]
+}
+
+resource "aws_ssoadmin_application_grant" "test" {
+  application_arn = aws_ssoadmin_application.test.arn
+  grant_type      = "authorization_code"
+
+  grant {
+    authorization_code {
+      redirect_uris = [%[3]q]
+    }
+  }
+}
+`, rName, testAccApplicationProviderARN, redirectURI)
+}
+
+func testAccApplicationGrantConfig_tokenExchange(rName string) string {
+	return fmt.Sprintf(`
+data "aws_ssoadmin_instances" "test" {}
+
+resource "aws_ssoadmin_application" "test" {
+  name                     = %[1]q
+  application_provider_arn = %[2]q
+  instance_arn             = tolist(data.aws_ssoadmin_instances.test.arns)[0]
+}
+
+resource "aws_ssoadmin_application_grant" "test" {
+  application_arn = aws_ssoadmin_application.test.arn
+  grant_type      = "urn:ietf:params:oauth:grant-type:token-exchange"
+
+  grant {
+    token_exchange {}
+  }
+}
+`, rName, testAccApplicationProviderARN)
+}

--- a/internal/service/ssoadmin/exports_test.go
+++ b/internal/service/ssoadmin/exports_test.go
@@ -8,6 +8,7 @@ var (
 	ResourceAccountAssignment                         = resourceAccountAssignment
 	ResourceApplication                               = newApplicationResource
 	ResourceApplicationAccessScope                    = newApplicationAccessScopeResource
+	ResourceApplicationGrant                          = newApplicationGrantResource
 	ResourceApplicationAssignment                     = newApplicationAssignmentResource
 	ResourceApplicationAssignmentConfiguration        = newApplicationAssignmentConfigurationResource
 	ResourceCustomerManagedPolicyAttachment           = resourceCustomerManagedPolicyAttachment
@@ -22,6 +23,7 @@ var (
 
 	FindAccountAssignmentByFivePartKey               = findAccountAssignmentByFivePartKey
 	FindApplicationAccessScopeByID                   = findApplicationAccessScopeByID
+	FindApplicationGrantByID                         = findApplicationGrantByID
 	FindApplicationAssignmentByID                    = findApplicationAssignmentByID
 	FindApplicationAssignmentConfigurationByID       = findApplicationAssignmentConfigurationByID
 	FindApplicationByID                              = findApplicationByID

--- a/internal/service/ssoadmin/service_package_gen.go
+++ b/internal/service/ssoadmin/service_package_gen.go
@@ -79,6 +79,12 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*inttypes.Ser
 			Region:   inttypes.ResourceRegionDefault(),
 		},
 		{
+			Factory:  newApplicationGrantResource,
+			TypeName: "aws_ssoadmin_application_grant",
+			Name:     "Application Grant",
+			Region:   inttypes.ResourceRegionDefault(),
+		},
+		{
 			Factory:  newApplicationAssignmentResource,
 			TypeName: "aws_ssoadmin_application_assignment",
 			Name:     "Application Assignment",

--- a/website/docs/r/ssoadmin_application_grant.html.markdown
+++ b/website/docs/r/ssoadmin_application_grant.html.markdown
@@ -1,0 +1,152 @@
+---
+subcategory: "SSO Admin"
+layout: "aws"
+page_title: "AWS: aws_ssoadmin_application_grant"
+description: |-
+  Terraform resource for managing an AWS SSO Admin Application Grant.
+---
+# Resource: aws_ssoadmin_application_grant
+
+Terraform resource for managing an AWS SSO Admin Application Grant.
+
+Grants are authorization configurations that allow an IAM Identity Center application to request specific types of tokens. Each grant type defines a different OAuth 2.0 flow the application can use.
+
+## Example Usage
+
+### Authorization Code Grant (PKCE)
+
+```terraform
+data "aws_ssoadmin_instances" "example" {}
+
+resource "aws_ssoadmin_application" "example" {
+  name                     = "example"
+  application_provider_arn = "arn:aws:sso::aws:applicationProvider/custom"
+  instance_arn             = tolist(data.aws_ssoadmin_instances.example.arns)[0]
+}
+
+resource "aws_ssoadmin_application_grant" "authorization_code" {
+  application_arn = aws_ssoadmin_application.example.arn
+  grant_type      = "authorization_code"
+
+  grant {
+    authorization_code {
+      redirect_uris = ["http://127.0.0.1/auth/callback"]
+    }
+  }
+}
+```
+
+### Token Exchange Grant
+
+```terraform
+data "aws_ssoadmin_instances" "example" {}
+
+resource "aws_ssoadmin_application" "example" {
+  name                     = "example"
+  application_provider_arn = "arn:aws:sso::aws:applicationProvider/custom"
+  instance_arn             = tolist(data.aws_ssoadmin_instances.example.arns)[0]
+}
+
+resource "aws_ssoadmin_application_grant" "token_exchange" {
+  application_arn = aws_ssoadmin_application.example.arn
+  grant_type      = "urn:ietf:params:oauth:grant-type:token-exchange"
+
+  grant {
+    token_exchange {}
+  }
+}
+```
+
+### JWT Bearer Grant
+
+```terraform
+data "aws_ssoadmin_instances" "example" {}
+
+resource "aws_ssoadmin_application" "example" {
+  name                     = "example"
+  application_provider_arn = "arn:aws:sso::aws:applicationProvider/custom"
+  instance_arn             = tolist(data.aws_ssoadmin_instances.example.arns)[0]
+}
+
+resource "aws_ssoadmin_trusted_token_issuer" "example" {
+  name                      = "example"
+  instance_arn              = tolist(data.aws_ssoadmin_instances.example.arns)[0]
+  trusted_token_issuer_type = "OIDC_JWT"
+
+  trusted_token_issuer_configuration {
+    oidc_jwt_configuration {
+      claim_attribute_path          = "email"
+      identity_store_attribute_path = "emails.value"
+      issuer_url                    = "https://example.com"
+      jwks_retrieval_option         = "OPEN_ID_DISCOVERY"
+    }
+  }
+}
+
+resource "aws_ssoadmin_application_grant" "jwt_bearer" {
+  application_arn = aws_ssoadmin_application.example.arn
+  grant_type      = "urn:ietf:params:oauth:grant-type:jwt-bearer"
+
+  grant {
+    jwt_bearer {
+      authorized_token_issuers {
+        trusted_token_issuer_arn = aws_ssoadmin_trusted_token_issuer.example.arn
+        authorized_audiences     = [aws_ssoadmin_application.example.client_id]
+      }
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `application_arn` - (Required, Forces new resource) ARN of the application to configure the grant for.
+* `grant_type` - (Required, Forces new resource) Type of OAuth 2.0 grant. Valid values are `authorization_code`, `refresh_token`, `urn:ietf:params:oauth:grant-type:jwt-bearer`, and `urn:ietf:params:oauth:grant-type:token-exchange`.
+* `grant` - (Required) Configuration block for the grant. See [`grant`](#grant-argument-reference) below.
+
+### `grant` Argument Reference
+
+Exactly one of the following sub-blocks must be specified, matching the `grant_type`:
+
+* `authorization_code` - (Optional) Configuration for the `authorization_code` grant type. See [`authorization_code`](#authorization_code-argument-reference) below.
+* `jwt_bearer` - (Optional) Configuration for the `urn:ietf:params:oauth:grant-type:jwt-bearer` grant type. See [`jwt_bearer`](#jwt_bearer-argument-reference) below.
+* `refresh_token` - (Optional) Configuration for the `refresh_token` grant type. This block has no attributes.
+* `token_exchange` - (Optional) Configuration for the `urn:ietf:params:oauth:grant-type:token-exchange` grant type. This block has no attributes.
+
+### `authorization_code` Argument Reference
+
+* `redirect_uris` - (Required, Forces new resource) List of URIs that are valid redirect destinations after a user authorizes the application. For loopback (127.0.0.1) URIs, IAM Identity Center ignores the port number per [RFC 8252](https://www.rfc-editor.org/rfc/rfc8252).
+
+### `jwt_bearer` Argument Reference
+
+* `authorized_token_issuers` - (Required) One or more trusted token issuers that are authorized to exchange JWTs for tokens. See [`authorized_token_issuers`](#authorized_token_issuers-argument-reference) below.
+
+### `authorized_token_issuers` Argument Reference
+
+* `trusted_token_issuer_arn` - (Optional) ARN of the trusted token issuer. Must reference an `aws_ssoadmin_trusted_token_issuer` resource.
+* `authorized_audiences` - (Optional) List of application client IDs that are permitted to use the JWT issued by this trusted token issuer.
+
+## Attribute Reference
+
+This resource exports the following attributes in addition to the arguments above:
+
+* `id` - A comma-delimited string combining `application_arn` and `grant_type`.
+
+## Import
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import SSO Admin Application Grant using the `id`. For example:
+
+```terraform
+import {
+  to = aws_ssoadmin_application_grant.example
+  id = "arn:aws:sso::123456789012:application/ssoins-1234567890abcdef/apl-1234567890abcdef,authorization_code"
+}
+```
+
+Using `terraform import`, import SSO Admin Application Grant using the `id`. For example:
+
+```console
+% terraform import aws_ssoadmin_application_grant.example "arn:aws:sso::123456789012:application/ssoins-1234567890abcdef/apl-1234567890abcdef,authorization_code"
+```


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

### Description

Adds `aws_ssoadmin_application_grant` for managing OAuth 2.0 grants on IAM Identity Center custom OAuth 2.0 applications.

**Background:** Custom applications created via `aws_ssoadmin_application` require grants to be configured before they can issue tokens. The underlying API operations (`PutApplicationGrant`, `GetApplicationGrant`, `DeleteApplicationGrant`) have existed in the AWS SDK since the Identity Center application feature launched, but there is no Terraform resource for them. Without this resource, practitioners must configure grants manually via the AWS console or CLI after `terraform apply`, breaking the infrastructure-as-code workflow.

**Supported grant types:**
- `authorization_code` — for PKCE flows (redirect URIs required)
- `urn:ietf:params:oauth:grant-type:jwt-bearer` — for trusted identity propagation via JWT
- `refresh_token` — for refresh token issuance
- `urn:ietf:params:oauth:grant-type:token-exchange` — for token exchange with a trusted token issuer

**Implementation:** Follows the same `TypedExpander` / `Flattener` pattern used by `aws_ssoadmin_trusted_token_issuer` for its `TrustedTokenIssuerConfiguration` union type. The `Grant` field in the API is a tagged union; each concrete type maps to an optional sub-block within a `grant` block.

**Resource ID:** `<application_arn>,<grant_type>` (composite, matching the pattern used by `aws_ssoadmin_application_access_scope`).

### Relations

Relates #0000

### References

- [PutApplicationGrant API](https://docs.aws.amazon.com/singlesignon/latest/APIReference/API_PutApplicationGrant.html)
- [GetApplicationGrant API](https://docs.aws.amazon.com/singlesignon/latest/APIReference/API_GetApplicationGrant.html)
- [DeleteApplicationGrant API](https://docs.aws.amazon.com/singlesignon/latest/APIReference/API_DeleteApplicationGrant.html)

### Output from Acceptance Testing

Acceptance tests require an active IAM Identity Center instance and cannot be run in a standard local environment. Tests are written and follow the existing `aws_ssoadmin_application_access_scope` pattern:

```console
% make testacc TESTS=TestAccSSOAdminApplicationGrant PKG=ssoadmin
```

Tests written:
- `TestAccSSOAdminApplicationGrant_authorizationCode` — basic create + import
- `TestAccSSOAdminApplicationGrant_authorizationCode_update` — in-place update of redirect_uris
- `TestAccSSOAdminApplicationGrant_tokenExchange` — empty grant block + import
- `TestAccSSOAdminApplicationGrant_disappears` — drift detection