### PR TITLE
🤖🤖🤖 d/aws_ec2_hosts: New data source

### DIFF
--- a/.changelog/47986.txt
+++ b/.changelog/47986.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_ec2_hosts
+```

--- a/internal/service/ec2/ec2_hosts_data_source.go
+++ b/internal/service/ec2/ec2_hosts_data_source.go
@@ -1,0 +1,98 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+// DONOTCOPY: Copying old resources spreads bad habits. Use skaff instead.
+
+package ec2
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkDataSource("aws_ec2_hosts", name="Hosts")
+func newHostsDataSource(context.Context) (datasource.DataSourceWithConfigure, error) {
+	return &hostsDataSource{}, nil
+}
+
+type hostsDataSource struct {
+	framework.DataSourceWithModel[hostsDataSourceModel]
+}
+
+func (d *hostsDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			names.AttrIDs: schema.ListAttribute{
+				CustomType:  fwtypes.ListOfStringType,
+				ElementType: types.StringType,
+				Computed:    true,
+			},
+			"outpost_arn": schema.StringAttribute{
+				Optional: true,
+			},
+			names.AttrTags: tftags.TagsAttribute(),
+		},
+		Blocks: map[string]schema.Block{
+			names.AttrFilter: customFiltersBlock(ctx),
+		},
+	}
+}
+
+func (d *hostsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data hostsDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	conn := d.Meta().EC2Client(ctx)
+
+	input := ec2.DescribeHostsInput{
+		Filter: append(newCustomFilterListFramework(ctx, data.Filters), newTagFilterList(svcTags(tftags.New(ctx, data.Tags)))...),
+	}
+
+	if len(input.Filter) == 0 {
+		input.Filter = nil
+	}
+
+	output, err := findHosts(ctx, conn, &input)
+
+	if err != nil {
+		resp.Diagnostics.AddError("reading EC2 Hosts", err.Error())
+		return
+	}
+
+	// Client-side filter on OutpostArn since the API does not support it as a server-side filter.
+	if !data.OutpostARN.IsNull() && !data.OutpostARN.IsUnknown() {
+		outpostARN := data.OutpostARN.ValueString()
+		output = tfslices.Filter(output, func(v awstypes.Host) bool {
+			return aws.ToString(v.OutpostArn) == outpostARN
+		})
+	}
+
+	data.IDs = fwflex.FlattenFrameworkStringValueListOfString(ctx, tfslices.ApplyToAll(output, func(v awstypes.Host) string {
+		return aws.ToString(v.HostId)
+	}))
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+type hostsDataSourceModel struct {
+	framework.WithRegionModel
+	Filters    customFilters        `tfsdk:"filter"`
+	IDs        fwtypes.ListOfString `tfsdk:"ids"`
+	OutpostARN types.String         `tfsdk:"outpost_arn"`
+	Tags       tftags.Map           `tfsdk:"tags"`
+}

--- a/internal/service/ec2/ec2_hosts_data_source_test.go
+++ b/internal/service/ec2/ec2_hosts_data_source_test.go
@@ -1,0 +1,97 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package ec2_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccEC2HostsDataSource_filter(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_ec2_hosts.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccHostsDataSourceConfig_filter(rName),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "ids.#", 0),
+				),
+			},
+		},
+	})
+}
+
+func TestAccEC2HostsDataSource_tags(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_ec2_hosts.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccHostsDataSourceConfig_tags(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "ids.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccHostsDataSourceConfig_filter(rName string) string {
+	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
+resource "aws_ec2_host" "test" {
+  availability_zone = data.aws_availability_zones.available.names[0]
+  instance_type     = "c5.large"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+data "aws_ec2_hosts" "test" {
+  filter {
+    name   = "instance-type"
+    values = ["c5.large"]
+  }
+
+  filter {
+    name   = "availability-zone"
+    values = [aws_ec2_host.test.availability_zone]
+  }
+}
+`, rName))
+}
+
+func testAccHostsDataSourceConfig_tags(rName string) string {
+	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
+resource "aws_ec2_host" "test" {
+  availability_zone = data.aws_availability_zones.available.names[0]
+  instance_type     = "c5.large"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+data "aws_ec2_hosts" "test" {
+  tags = {
+    Name = aws_ec2_host.test.tags["Name"]
+  }
+}
+`, rName))
+}

--- a/internal/service/ec2/ec2_hosts_data_source_test.go
+++ b/internal/service/ec2/ec2_hosts_data_source_test.go
@@ -32,6 +32,26 @@ func TestAccEC2HostsDataSource_filter(t *testing.T) {
 	})
 }
 
+func TestAccEC2HostsDataSource_outpostARN(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_ec2_hosts.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckOutpostsOutposts(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccHostsDataSourceConfig_outpostARN(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "ids.#", "1"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccEC2HostsDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_ec2_hosts.test"
@@ -50,6 +70,37 @@ func TestAccEC2HostsDataSource_tags(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testAccHostsDataSourceConfig_outpostARN(rName string) string {
+	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
+data "aws_outposts_outposts" "test" {}
+
+data "aws_outposts_outpost" "test" {
+  id = tolist(data.aws_outposts_outposts.test.ids)[0]
+}
+
+resource "aws_ec2_host" "test" {
+  instance_family   = "r5d"
+  availability_zone = data.aws_availability_zones.available.names[1]
+  outpost_arn       = data.aws_outposts_outpost.test.arn
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+data "aws_ec2_hosts" "test" {
+  outpost_arn = data.aws_outposts_outpost.test.arn
+
+  filter {
+    name   = "instance-type"
+    values = ["r5d.*"]
+  }
+
+  depends_on = [aws_ec2_host.test]
+}
+`, rName))
 }
 
 func testAccHostsDataSourceConfig_filter(rName string) string {

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -42,6 +42,12 @@ func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*inttypes.S
 			Region:   inttypes.ResourceRegionDefault(),
 		},
 		{
+			Factory:  newHostsDataSource,
+			TypeName: "aws_ec2_hosts",
+			Name:     "Hosts",
+			Region:   inttypes.ResourceRegionDefault(),
+		},
+		{
 			Factory:  newServiceLinkVirtualInterfaceDataSource,
 			TypeName: "aws_ec2_service_link_virtual_interface",
 			Name:     "Service Link Virtual Interface",

--- a/website/docs/d/ec2_hosts.html.markdown
+++ b/website/docs/d/ec2_hosts.html.markdown
@@ -1,0 +1,66 @@
+---
+subcategory: "EC2 (Elastic Compute Cloud)"
+layout: "aws"
+page_title: "AWS: aws_ec2_hosts"
+description: |-
+    Provides details about multiple EC2 Dedicated Hosts
+---
+
+# Data Source: aws_ec2_hosts
+
+Provides a list of EC2 Dedicated Host IDs matching the provided filters. More information about Dedicated Hosts can be found in the [EC2 User Guide](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/dedicated-hosts-overview.html).
+
+## Example Usage
+
+### Filter by instance type
+
+```terraform
+data "aws_ec2_hosts" "example" {
+  filter {
+    name   = "instance-type"
+    values = ["c5.large"]
+  }
+
+  filter {
+    name   = "state"
+    values = ["available"]
+  }
+}
+```
+
+### Filter by Outpost ARN
+
+The `outpost_arn` argument applies a client-side filter because the `DescribeHosts` API does not support `outpost-arn` as a server-side filter.
+
+```terraform
+data "aws_ec2_hosts" "outpost" {
+  outpost_arn = data.aws_outposts_outpost.example.arn
+
+  filter {
+    name   = "state"
+    values = ["available"]
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are optional:
+
+* `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
+* `filter` - (Optional) One or more configuration blocks containing name-values filters. See the [EC2 API Reference](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeHosts.html) for supported filters. Detailed below.
+* `outpost_arn` - (Optional) ARN of the AWS Outpost. Filters results client-side to only include hosts allocated on this Outpost.
+* `tags` - (Optional) Key-value map of resource tags, each pair of which must exactly match a pair on the desired Dedicated Hosts.
+
+### filter Argument Reference
+
+The `filter` configuration block supports the following arguments:
+
+* `name` - (Required) Name of the filter.
+* `values` - (Required) List of one or more values for the filter.
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `ids` - List of EC2 Dedicated Host identifiers.

--- a/website/docs/d/ec2_hosts.html.markdown
+++ b/website/docs/d/ec2_hosts.html.markdown
@@ -47,12 +47,12 @@ data "aws_ec2_hosts" "outpost" {
 
 The following arguments are optional:
 
-* `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `filter` - (Optional) One or more configuration blocks containing name-values filters. See the [EC2 API Reference](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeHosts.html) for supported filters. Detailed below.
 * `outpost_arn` - (Optional) ARN of the AWS Outpost. Filters results client-side to only include hosts allocated on this Outpost.
+* `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `tags` - (Optional) Key-value map of resource tags, each pair of which must exactly match a pair on the desired Dedicated Hosts.
 
-### filter Argument Reference
+### `filter` Block
 
 The `filter` configuration block supports the following arguments:
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No. This PR adds a read-only data source only.

### Description

Adds a new plural data source `aws_ec2_hosts` that returns a list of Dedicated Host IDs matching the supplied criteria.

- Accepts standard `DescribeHosts` API filters via the `filter` block (e.g. `instance-type`, `availability-zone`, `state`, `auto-placement`, `tag-key`).
- Accepts `outpost_arn` as a top-level argument with **client-side** filtering on `Host.OutpostArn`, since the API does not support it as a server-side filter.
- Accepts `tags` for tag-based filtering (converted to tag-filter at the API level).
- Returns `ids` (list of host IDs).
- Uses `terraform-plugin-framework` + `aws-sdk-go-v2`.
- Reuses the existing `findHosts` paginator helper in `internal/service/ec2/find.go`.
- Pattern follows `aws_ec2_service_link_virtual_interfaces` (same package, same plural shape).

### Relations

Closes #47941

### References

- AWS SDK Go v2 `DescribeHosts`: https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/ec2#Client.DescribeHosts
- AWS SDK Go v2 `Host` type: https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/ec2/types#Host
- AWS API Reference: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeHosts.html
- Existing singular data source: `internal/service/ec2/ec2_host_data_source.go`
- Existing paginator helper: `findHosts` in `internal/service/ec2/find.go`

### Output from Acceptance Testing

```console
% make testacc TESTS=TestAccEC2HostsDataSource PKG=ec2

Tests compile successfully. Acceptance tests require Dedicated Host capacity (not available in standard CI accounts).
```

---

### AI Usage Disclosure

This pull request was prepared with assistance from an AI agent — specifically, a custom agent running inside [Claude Code](https://docs.anthropic.com/en/docs/claude-code). The agent was configured for this repository (branching conventions, `make gen` awareness, no manual edits to `_gen.go`, Framework patterns, acceptance-test scaffolding) and used for code generation, test authoring, and documentation. Every line has been reviewed by the human contributor, who has verified the code compiles and understands each design decision. Per the project's AI Usage Policy, "🤖🤖🤖" is included in the PR title.