### PR TITLE
Fix `ignore_changes` tags reset by another tag with an empty value

### DIFF
--- a/.changelog/48008.txt
+++ b/.changelog/48008.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+provider: Fix `lifecycle.ignore_changes` for individual `tags` elements being bypassed when another tag in the same map is updated to an empty string, to avoid overwriting any out-of-band changes the lifecycle block was meant to preserve.
+```
+
+```release-note:bug
+resource/aws_instance: Fix `lifecycle.ignore_changes` for individual `tags` elements being bypassed when another tag in the same map is updated to an empty string, to avoid overwriting any out-of-band changes the lifecycle block was meant to preserve.
+```

--- a/internal/provider/sdkv2/tags_interceptor.go
+++ b/internal/provider/sdkv2/tags_interceptor.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 	"unique"
 
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -116,16 +117,44 @@ func (r tagsResourceCRUDInterceptor) run(ctx context.Context, opts crudIntercept
 			// Some old resources may not have the required attribute set after Read:
 			// https://github.com/hashicorp/terraform-provider-aws/issues/31180
 			if identifier := r.GetIdentifierSDKv2(ctx, d); identifier != "" && !d.GetRawPlan().GetAttr(names.AttrTagsAll).IsWhollyKnown() {
+				// Read the desired tags from the plan rather than the literal
+				// configuration so that lifecycle.ignore_changes is honored.
+				// Terraform Core resolves ignore_changes during planning, so the
+				// plan's `tags` attribute reflects the effective desired state;
+				// the raw config does not.
+				//
+				// This branch runs when `tags_all` is not wholly known in the
+				// plan (e.g., when `tags` contains an empty string value, which
+				// causes `setTagsAll` to mark `tags_all` as Computed). Without
+				// using the plan here, an unrelated tag change in the config
+				// would cause the API call to also include the value of any
+				// ignored tag, overwriting out-of-band changes. See
+				// https://github.com/hashicorp/terraform-provider-aws/issues/48007.
 				configTags := make(map[string]string)
-				if config := d.GetRawConfig(); !config.IsNull() && config.IsKnown() {
-					c := config.GetAttr(names.AttrTags)
-					if !c.IsNull() {
-						for k, v := range c.AsValueMap() {
-							if !v.IsNull() {
-								configTags[k] = v.AsString()
-							}
+				readTags := func(v cty.Value) bool {
+					if v.IsNull() || !v.IsKnown() {
+						return false
+					}
+					if !v.Type().IsObjectType() || !v.Type().HasAttribute(names.AttrTags) {
+						return false
+					}
+					t := v.GetAttr(names.AttrTags)
+					if t.IsNull() || !t.IsWhollyKnown() {
+						return false
+					}
+					for k, vv := range t.AsValueMap() {
+						if !vv.IsNull() {
+							configTags[k] = vv.AsString()
 						}
 					}
+					return true
+				}
+				if !readTags(d.GetRawPlan()) {
+					// Fall back to the raw config when the plan's tags aren't
+					// wholly known (e.g., values from unknown references). This
+					// preserves the prior behavior for scenarios that don't
+					// involve ignore_changes.
+					_ = readTags(d.GetRawConfig())
 				}
 
 				stateTags := make(map[string]string)

--- a/internal/provider/sdkv2/tags_interceptor_test.go
+++ b/internal/provider/sdkv2/tags_interceptor_test.go
@@ -123,6 +123,12 @@ func (d *resourceData) GetRawConfig() cty.Value {
 
 func (d *resourceData) GetRawPlan() cty.Value {
 	return cty.ObjectVal(map[string]cty.Value{
+		// `tags` is set from the user's configuration, while `tags_all` is
+		// computed (unknown) in the plan when, for example, an empty string
+		// tag value forces tags_all to be re-computed.
+		"tags": cty.MapVal(map[string]cty.Value{
+			"tag1": cty.StringVal("value1"),
+		}),
 		"tags_all": cty.MapVal(map[string]cty.Value{
 			"tag1": cty.UnknownVal(cty.String),
 		}),

--- a/internal/service/ec2/ec2_instance_test.go
+++ b/internal/service/ec2/ec2_instance_test.go
@@ -2542,6 +2542,11 @@ func TestAccEC2Instance_tagsIgnoreChangesEmptyValue(t *testing.T) {
 					}
 				},
 				Config: testAccInstanceConfig_tagsIgnoreChangesEmptyValue(rName, "UpdatedTag"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.Step", "UpdatedTag"),
@@ -2557,6 +2562,11 @@ func TestAccEC2Instance_tagsIgnoreChangesEmptyValue(t *testing.T) {
 					}
 				},
 				Config: testAccInstanceConfig_tagsIgnoreChangesEmptyValue(rName, ""),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(ctx, t, resourceName, &v),
 					testAccCheckInstanceAPITagValue(ctx, t, &v, "Step", ""),
@@ -7150,17 +7160,12 @@ func overrideInstanceTag(ctx context.Context, t *testing.T, instance *awstypes.I
 	}
 
 	conn := acctest.ProviderMeta(ctx, t).EC2Client(ctx)
-	input := ec2.CreateTagsInput{
-		Resources: []string{aws.ToString(instance.InstanceId)},
-		Tags: []awstypes.Tag{
-			{
-				Key:   aws.String(key),
-				Value: aws.String(value),
-			},
+	return tfec2.CreateTags(ctx, conn, aws.ToString(instance.InstanceId), []awstypes.Tag{
+		{
+			Key:   aws.String(key),
+			Value: aws.String(value),
 		},
-	}
-	_, err := conn.CreateTags(ctx, &input)
-	return err
+	})
 }
 
 // testAccCheckInstanceAPITagValue verifies that an EC2 instance has the

--- a/internal/service/ec2/ec2_instance_test.go
+++ b/internal/service/ec2/ec2_instance_test.go
@@ -2499,6 +2499,74 @@ func TestAccEC2Instance_forceNewAndTagsDrift(t *testing.T) {
 	})
 }
 
+// TestAccEC2Instance_tagsIgnoreChangesEmptyValue verifies that a tag listed in
+// lifecycle.ignore_changes is not overwritten when an unrelated tag in the
+// same map is updated to an empty string.
+//
+// See https://github.com/hashicorp/terraform-provider-aws/issues/48007 for the
+// root-cause analysis. In short: when a tag value is set to "", `setTagsAll`
+// marks `tags_all` as Computed, which causes `tagsResourceCRUDInterceptor`'s
+// `Finally/Update` branch to run. That branch reads desired tags from
+// `d.GetRawConfig()` (the literal user config) instead of the plan, bypassing
+// `ignore_changes` and overwriting any externally-modified tag value.
+func TestAccEC2Instance_tagsIgnoreChangesEmptyValue(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v awstypes.Instance
+	resourceName := "aws_instance.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheckHasDefaultVPCDefaultSubnets(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckInstanceDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				// Initial apply: instance with stagingState tag covered by ignore_changes.
+				Config: testAccInstanceConfig_tagsIgnoreChangesEmptyValue(rName, "InitialTag"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceExists(ctx, t, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.Step", "InitialTag"),
+					resource.TestCheckResourceAttr(resourceName, "tags.stagingState", "trigger"),
+				),
+			},
+			{
+				// Sanity case: changing Step to a non-empty value preserves the
+				// out-of-band stagingState change. ignore_changes works here.
+				PreConfig: func() {
+					if err := overrideInstanceTag(ctx, t, &v, "stagingState", "CHANGED"); err != nil {
+						t.Fatalf("setting external tag: %s", err)
+					}
+				},
+				Config: testAccInstanceConfig_tagsIgnoreChangesEmptyValue(rName, "UpdatedTag"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceExists(ctx, t, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.Step", "UpdatedTag"),
+					testAccCheckInstanceAPITagValue(ctx, t, &v, "stagingState", "CHANGED"),
+				),
+			},
+			{
+				// Bug case: changing Step to an empty string must not overwrite
+				// the externally modified stagingState tag.
+				PreConfig: func() {
+					if err := overrideInstanceTag(ctx, t, &v, "stagingState", "CHANGED"); err != nil {
+						t.Fatalf("setting external tag: %s", err)
+					}
+				},
+				Config: testAccInstanceConfig_tagsIgnoreChangesEmptyValue(rName, ""),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceExists(ctx, t, resourceName, &v),
+					testAccCheckInstanceAPITagValue(ctx, t, &v, "Step", ""),
+					testAccCheckInstanceAPITagValue(ctx, t, &v, "stagingState", "CHANGED"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccEC2Instance_changeInstanceType(t *testing.T) {
 	ctx := acctest.Context(t)
 	var before, after awstypes.Instance
@@ -7071,6 +7139,60 @@ func driftTags(ctx context.Context, t *testing.T, instance *awstypes.Instance) r
 	}
 }
 
+// overrideInstanceTag simulates an out-of-band modification of a single tag
+// on the EC2 instance, mimicking a change made directly via the AWS console
+// or another tool.
+func overrideInstanceTag(ctx context.Context, t *testing.T, instance *awstypes.Instance, key, value string) error {
+	t.Helper()
+
+	if instance == nil || instance.InstanceId == nil {
+		return fmt.Errorf("instance is nil or has no ID")
+	}
+
+	conn := acctest.ProviderMeta(ctx, t).EC2Client(ctx)
+	input := ec2.CreateTagsInput{
+		Resources: []string{aws.ToString(instance.InstanceId)},
+		Tags: []awstypes.Tag{
+			{
+				Key:   aws.String(key),
+				Value: aws.String(value),
+			},
+		},
+	}
+	_, err := conn.CreateTags(ctx, &input)
+	return err
+}
+
+// testAccCheckInstanceAPITagValue verifies that an EC2 instance has the
+// expected tag value as reported by the AWS API. This bypasses the Terraform
+// state to detect cases where the provider has overwritten an externally
+// modified tag despite ignore_changes.
+func testAccCheckInstanceAPITagValue(ctx context.Context, t *testing.T, instance *awstypes.Instance, key, want string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if instance == nil || instance.InstanceId == nil {
+			return fmt.Errorf("instance is nil or has no ID")
+		}
+
+		conn := acctest.ProviderMeta(ctx, t).EC2Client(ctx)
+		output, err := tfec2.FindInstanceByID(ctx, conn, aws.ToString(instance.InstanceId))
+		if err != nil {
+			return fmt.Errorf("reading EC2 Instance (%s): %w", aws.ToString(instance.InstanceId), err)
+		}
+
+		for _, tag := range output.Tags {
+			if aws.ToString(tag.Key) == key {
+				got := aws.ToString(tag.Value)
+				if got != want {
+					return fmt.Errorf("EC2 Instance (%s) tag %q: got %q, want %q", aws.ToString(instance.InstanceId), key, got, want)
+				}
+				return nil
+			}
+		}
+
+		return fmt.Errorf("EC2 Instance (%s) tag %q: not found", aws.ToString(instance.InstanceId), key)
+	}
+}
+
 // testAccPreCheckHasDefaultVPCDefaultSubnets checks that the test region has
 // - A default VPC with default subnets.
 // This check is useful to ensure that an instance can be launched without specifying a subnet.
@@ -9260,6 +9382,28 @@ resource "aws_instance" "test" {
   }
 }
 `, rName))
+}
+
+func testAccInstanceConfig_tagsIgnoreChangesEmptyValue(rName, stepValue string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigLatestAmazonLinux2HVMEBSX8664AMI(),
+		acctest.AvailableEC2InstanceTypeForRegion("t3.micro", "t2.micro", "t1.micro", "m1.small"),
+		fmt.Sprintf(`
+resource "aws_instance" "test" {
+  ami           = data.aws_ami.amzn2-ami-minimal-hvm-ebs-x86_64.id
+  instance_type = data.aws_ec2_instance_type_offering.available.instance_type
+
+  tags = {
+    Name         = %[1]q
+    Step         = %[2]q
+    stagingState = "trigger"
+  }
+
+  lifecycle {
+    ignore_changes = [tags["stagingState"]]
+  }
+}
+`, rName, stepValue))
 }
 
 func testAccInstanceConfig_primaryNetworkInterface_basic(rName string) string {

--- a/internal/service/ec2/exports_test.go
+++ b/internal/service/ec2/exports_test.go
@@ -143,6 +143,7 @@ var (
 	ResourceVolumeAttachment                              = resourceVolumeAttachment
 
 	CheckMostRecentAndMissingFilters                            = checkMostRecentAndMissingFilters
+	CreateTags                                                  = createTags
 	CustomFiltersSchema                                         = customFiltersSchema
 	CustomerGatewayConfigurationToTunnelInfo                    = customerGatewayConfigurationToTunnelInfo
 	DefaultIPv6CIDRBlockAssociation                             = defaultIPv6CIDRBlockAssociation


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

**This fix impacts all plugin SDK resources with tags.** It was reported for `aws_instance` and so I added the repro/regression acceptance test to `ec2_instance_test.go`. For good measure, I also ran acceptances for SNS, Secrets Manager, and CloudWatch.

Fixes a bug where `lifecycle.ignore_changes` on individual `tags` elements (`tags["k"]`) was bypassed when another tag in the same map was updated to an empty string. The ignored tag's value from the user's configuration was sent to AWS during `Update`, overwriting any out-of-band changes the lifecycle block was meant to preserve.

Root cause is in the SDK v2 transparent tagging interceptor (`internal/provider/sdkv2/tags_interceptor.go`):

- `setTagsAll` marks `tags_all` as Computed whenever the tags map contains an empty-string value (`KeyValueTags.HasZeroValue()`).
- With `tags_all` not wholly known in the plan, the `Before/Update` branch (which uses `d.GetChange(tags_all)` and is plan-aware) is skipped.
- The `Finally/Update` branch ran instead and rebuilt the desired tag map from `d.GetRawConfig()` — the literal user configuration, in which `lifecycle.ignore_changes` is **not** applied. The resulting `UpdateTags` call therefore included every tag the user wrote, including ignored ones.

The fix reads the desired tags from `d.GetRawPlan()` (where Terraform Core has already applied `ignore_changes`) and falls back to `d.GetRawConfig()` only when the plan's `tags` attribute is itself not wholly known — preserving prior behavior for the unknown-references scenario the `Finally` branch was originally designed for. The `Before/Update` branch is unchanged, so the common case (no empty-string tag values) is unaffected.

A full root-cause walkthrough lives in the issue: see [issue #48007](https://github.com/hashicorp/terraform-provider-aws/issues/48007#issuecomment-4510210788).

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #48007

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

- The Plugin Framework tagging interceptor (`internal/provider/framework/tags_interceptor.go`) does not have this bug; it already reads `tags_all` from `request.Plan.GetAttribute(...)`.
- Not a duplicate of #39733, which is about the provider-level `ignore_tags` block (a different mechanism with a different documented contract).

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

#### Before changes

```console
=== CONT  TestAccEC2Instance_tagsIgnoreChangesEmptyValue
    ec2_instance_test.go:2533: Step 3/3 error: Check failed: Check 3/3 error: EC2 Instance (i-026719c1eebb6d07a) tag "stagingState": got "trigger", want "CHANGED"
--- FAIL: TestAccEC2Instance_tagsIgnoreChangesEmptyValue (75.07s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	81.963s
```

#### After changes

```console
--- PASS: TestAccEC2Instance_tagsIgnoreChangesEmptyValue (87.18s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	94.629s
```

#### Regression testing

```console
% make t T='^TestAccEC2Instance_.*[Tt]ags' K=ec2 P=10
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 b-explore-ec2-tags-reset 🌿...
TF_ACC=1 go1.26.3 test ./internal/service/ec2/... -v -count 1 -parallel 10 -run='^TestAccEC2Instance_.*[Tt]ags'  -timeout 360m -vet=off
2026/05/21 12:27:44 Creating Terraform AWS Provider (SDKv2-style)...
2026/05/21 12:27:44 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccEC2Instance_tags
=== PAUSE TestAccEC2Instance_tags
=== RUN   TestAccEC2Instance_Tags_null
=== PAUSE TestAccEC2Instance_Tags_null
=== RUN   TestAccEC2Instance_Tags_emptyMap
=== PAUSE TestAccEC2Instance_Tags_emptyMap
=== RUN   TestAccEC2Instance_Tags_addOnUpdate
=== PAUSE TestAccEC2Instance_Tags_addOnUpdate
=== RUN   TestAccEC2Instance_Tags_EmptyTag_onCreate
=== PAUSE TestAccEC2Instance_Tags_EmptyTag_onCreate
=== RUN   TestAccEC2Instance_Tags_EmptyTag_OnUpdate_add
=== PAUSE TestAccEC2Instance_Tags_EmptyTag_OnUpdate_add
=== RUN   TestAccEC2Instance_Tags_EmptyTag_OnUpdate_replace
=== PAUSE TestAccEC2Instance_Tags_EmptyTag_OnUpdate_replace
=== RUN   TestAccEC2Instance_Tags_DefaultTags_providerOnly
=== PAUSE TestAccEC2Instance_Tags_DefaultTags_providerOnly
=== RUN   TestAccEC2Instance_Tags_DefaultTags_nonOverlapping
=== PAUSE TestAccEC2Instance_Tags_DefaultTags_nonOverlapping
=== RUN   TestAccEC2Instance_Tags_DefaultTags_overlapping
=== PAUSE TestAccEC2Instance_Tags_DefaultTags_overlapping
=== RUN   TestAccEC2Instance_Tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccEC2Instance_Tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccEC2Instance_Tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccEC2Instance_Tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccEC2Instance_Tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccEC2Instance_Tags_DefaultTags_emptyResourceTag
=== RUN   TestAccEC2Instance_Tags_DefaultTags_emptyProviderOnlyTag
=== PAUSE TestAccEC2Instance_Tags_DefaultTags_emptyProviderOnlyTag
=== RUN   TestAccEC2Instance_Tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccEC2Instance_Tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccEC2Instance_Tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccEC2Instance_Tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccEC2Instance_Tags_ComputedTag_onCreate
=== PAUSE TestAccEC2Instance_Tags_ComputedTag_onCreate
=== RUN   TestAccEC2Instance_Tags_ComputedTag_OnUpdate_add
=== PAUSE TestAccEC2Instance_Tags_ComputedTag_OnUpdate_add
=== RUN   TestAccEC2Instance_Tags_ComputedTag_OnUpdate_replace
=== PAUSE TestAccEC2Instance_Tags_ComputedTag_OnUpdate_replace
=== RUN   TestAccEC2Instance_Tags_IgnoreTags_Overlap_defaultTag
=== PAUSE TestAccEC2Instance_Tags_IgnoreTags_Overlap_defaultTag
=== RUN   TestAccEC2Instance_Tags_IgnoreTags_Overlap_resourceTag
=== PAUSE TestAccEC2Instance_Tags_IgnoreTags_Overlap_resourceTag
=== RUN   TestAccEC2Instance_BlockDeviceTags_volumeTags
=== PAUSE TestAccEC2Instance_BlockDeviceTags_volumeTags
=== RUN   TestAccEC2Instance_BlockDeviceTags_attachedVolume
=== PAUSE TestAccEC2Instance_BlockDeviceTags_attachedVolume
=== RUN   TestAccEC2Instance_BlockDeviceTags_ebsAndRoot
=== PAUSE TestAccEC2Instance_BlockDeviceTags_ebsAndRoot
=== RUN   TestAccEC2Instance_BlockDeviceTags_defaultTagsVolumeTags
=== PAUSE TestAccEC2Instance_BlockDeviceTags_defaultTagsVolumeTags
=== RUN   TestAccEC2Instance_BlockDeviceTags_defaultTagsEBSRoot
=== PAUSE TestAccEC2Instance_BlockDeviceTags_defaultTagsEBSRoot
=== RUN   TestAccEC2Instance_BlockDeviceTags_defaultTagsRBDOverlap
=== PAUSE TestAccEC2Instance_BlockDeviceTags_defaultTagsRBDOverlap
=== RUN   TestAccEC2Instance_BlockDeviceTags_defaultTagsEBDOverlaps
=== PAUSE TestAccEC2Instance_BlockDeviceTags_defaultTagsEBDOverlaps
=== RUN   TestAccEC2Instance_BlockDeviceTags_defaultTagsVolumeTagsOverlap
=== PAUSE TestAccEC2Instance_BlockDeviceTags_defaultTagsVolumeTagsOverlap
=== RUN   TestAccEC2Instance_forceNewAndTagsDrift
=== PAUSE TestAccEC2Instance_forceNewAndTagsDrift
=== RUN   TestAccEC2Instance_tagsIgnoreChangesEmptyValue
=== PAUSE TestAccEC2Instance_tagsIgnoreChangesEmptyValue
=== CONT  TestAccEC2Instance_tags
=== CONT  TestAccEC2Instance_Tags_ComputedTag_onCreate
=== CONT  TestAccEC2Instance_BlockDeviceTags_defaultTagsVolumeTags
=== CONT  TestAccEC2Instance_Tags_IgnoreTags_Overlap_resourceTag
=== CONT  TestAccEC2Instance_BlockDeviceTags_attachedVolume
=== CONT  TestAccEC2Instance_BlockDeviceTags_defaultTagsVolumeTagsOverlap
=== CONT  TestAccEC2Instance_tagsIgnoreChangesEmptyValue
=== CONT  TestAccEC2Instance_forceNewAndTagsDrift
=== CONT  TestAccEC2Instance_Tags_DefaultTags_nonOverlapping
=== CONT  TestAccEC2Instance_BlockDeviceTags_ebsAndRoot
--- PASS: TestAccEC2Instance_Tags_ComputedTag_onCreate (76.73s)
=== CONT  TestAccEC2Instance_Tags_DefaultTags_nullNonOverlappingResourceTag
--- PASS: TestAccEC2Instance_tagsIgnoreChangesEmptyValue (86.64s)
=== CONT  TestAccEC2Instance_Tags_DefaultTags_nullOverlappingResourceTag
--- PASS: TestAccEC2Instance_Tags_IgnoreTags_Overlap_resourceTag (98.93s)
=== CONT  TestAccEC2Instance_Tags_DefaultTags_emptyProviderOnlyTag
--- PASS: TestAccEC2Instance_Tags_DefaultTags_nonOverlapping (111.78s)
=== CONT  TestAccEC2Instance_Tags_DefaultTags_emptyResourceTag
--- PASS: TestAccEC2Instance_BlockDeviceTags_ebsAndRoot (136.06s)
=== CONT  TestAccEC2Instance_Tags_DefaultTags_updateToResourceOnly
--- PASS: TestAccEC2Instance_tags (138.75s)
=== CONT  TestAccEC2Instance_Tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccEC2Instance_BlockDeviceTags_attachedVolume (146.89s)
=== CONT  TestAccEC2Instance_Tags_DefaultTags_overlapping
--- PASS: TestAccEC2Instance_Tags_DefaultTags_nullNonOverlappingResourceTag (71.09s)
=== CONT  TestAccEC2Instance_Tags_ComputedTag_OnUpdate_replace
--- PASS: TestAccEC2Instance_BlockDeviceTags_defaultTagsVolumeTagsOverlap (156.97s)
=== CONT  TestAccEC2Instance_Tags_IgnoreTags_Overlap_defaultTag
--- PASS: TestAccEC2Instance_Tags_DefaultTags_nullOverlappingResourceTag (79.65s)
=== CONT  TestAccEC2Instance_Tags_ComputedTag_OnUpdate_add
--- PASS: TestAccEC2Instance_BlockDeviceTags_defaultTagsVolumeTags (173.16s)
=== CONT  TestAccEC2Instance_BlockDeviceTags_volumeTags
--- PASS: TestAccEC2Instance_Tags_DefaultTags_emptyProviderOnlyTag (79.60s)
=== CONT  TestAccEC2Instance_BlockDeviceTags_defaultTagsEBSRoot
--- PASS: TestAccEC2Instance_Tags_DefaultTags_emptyResourceTag (69.59s)
=== CONT  TestAccEC2Instance_BlockDeviceTags_defaultTagsEBDOverlaps
--- PASS: TestAccEC2Instance_Tags_DefaultTags_updateToResourceOnly (68.30s)
=== CONT  TestAccEC2Instance_Tags_EmptyTag_onCreate
--- PASS: TestAccEC2Instance_Tags_DefaultTags_updateToProviderOnly (80.53s)
=== CONT  TestAccEC2Instance_Tags_DefaultTags_providerOnly
--- PASS: TestAccEC2Instance_forceNewAndTagsDrift (222.28s)
=== CONT  TestAccEC2Instance_Tags_EmptyTag_OnUpdate_replace
--- PASS: TestAccEC2Instance_Tags_ComputedTag_OnUpdate_replace (77.10s)
=== CONT  TestAccEC2Instance_Tags_EmptyTag_OnUpdate_add
--- PASS: TestAccEC2Instance_Tags_ComputedTag_OnUpdate_add (82.38s)
=== CONT  TestAccEC2Instance_Tags_emptyMap
--- PASS: TestAccEC2Instance_Tags_IgnoreTags_Overlap_defaultTag (93.04s)
=== CONT  TestAccEC2Instance_Tags_addOnUpdate
--- PASS: TestAccEC2Instance_Tags_DefaultTags_overlapping (115.22s)
=== CONT  TestAccEC2Instance_BlockDeviceTags_defaultTagsRBDOverlap
--- PASS: TestAccEC2Instance_BlockDeviceTags_defaultTagsEBDOverlaps (104.07s)
=== CONT  TestAccEC2Instance_Tags_null
--- PASS: TestAccEC2Instance_Tags_EmptyTag_onCreate (86.79s)
--- PASS: TestAccEC2Instance_Tags_EmptyTag_OnUpdate_replace (80.37s)
--- PASS: TestAccEC2Instance_Tags_emptyMap (69.85s)
--- PASS: TestAccEC2Instance_BlockDeviceTags_defaultTagsEBSRoot (145.79s)
--- PASS: TestAccEC2Instance_Tags_EmptyTag_OnUpdate_add (101.98s)
--- PASS: TestAccEC2Instance_BlockDeviceTags_volumeTags (156.22s)
--- PASS: TestAccEC2Instance_Tags_addOnUpdate (81.07s)
--- PASS: TestAccEC2Instance_Tags_null (73.04s)
--- PASS: TestAccEC2Instance_Tags_DefaultTags_providerOnly (142.52s)
--- PASS: TestAccEC2Instance_BlockDeviceTags_defaultTagsRBDOverlap (100.67s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	370.128s
% make t T='_Tags_(EmptyTag|ComputedTag|DefaultTags|null|emptyMap|addOnUpdate|IgnoreTags)' K=sns P=10
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 b-explore-ec2-tags-reset 🌿...
TF_ACC=1 go1.26.3 test ./internal/service/sns/... -v -count 1 -parallel 10 -run='_Tags_(EmptyTag|ComputedTag|DefaultTags|null|emptyMap|addOnUpdate|IgnoreTags)'  -timeout 360m -vet=off
2026/05/21 12:33:28 Creating Terraform AWS Provider (SDKv2-style)...
2026/05/21 12:33:28 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccSNSTopicDataSource_Tags_nullMap
=== PAUSE TestAccSNSTopicDataSource_Tags_nullMap
=== RUN   TestAccSNSTopicDataSource_Tags_emptyMap
=== PAUSE TestAccSNSTopicDataSource_Tags_emptyMap
=== RUN   TestAccSNSTopicDataSource_Tags_DefaultTags_nonOverlapping
=== PAUSE TestAccSNSTopicDataSource_Tags_DefaultTags_nonOverlapping
=== RUN   TestAccSNSTopicDataSource_Tags_IgnoreTags_Overlap_defaultTag
=== PAUSE TestAccSNSTopicDataSource_Tags_IgnoreTags_Overlap_defaultTag
=== RUN   TestAccSNSTopicDataSource_Tags_IgnoreTags_Overlap_resourceTag
=== PAUSE TestAccSNSTopicDataSource_Tags_IgnoreTags_Overlap_resourceTag
=== RUN   TestAccSNSTopic_Tags_null
=== PAUSE TestAccSNSTopic_Tags_null
=== RUN   TestAccSNSTopic_Tags_emptyMap
=== PAUSE TestAccSNSTopic_Tags_emptyMap
=== RUN   TestAccSNSTopic_Tags_addOnUpdate
=== PAUSE TestAccSNSTopic_Tags_addOnUpdate
=== RUN   TestAccSNSTopic_Tags_EmptyTag_onCreate
=== PAUSE TestAccSNSTopic_Tags_EmptyTag_onCreate
=== RUN   TestAccSNSTopic_Tags_EmptyTag_OnUpdate_add
=== PAUSE TestAccSNSTopic_Tags_EmptyTag_OnUpdate_add
=== RUN   TestAccSNSTopic_Tags_EmptyTag_OnUpdate_replace
=== PAUSE TestAccSNSTopic_Tags_EmptyTag_OnUpdate_replace
=== RUN   TestAccSNSTopic_Tags_DefaultTags_providerOnly
=== PAUSE TestAccSNSTopic_Tags_DefaultTags_providerOnly
=== RUN   TestAccSNSTopic_Tags_DefaultTags_nonOverlapping
=== PAUSE TestAccSNSTopic_Tags_DefaultTags_nonOverlapping
=== RUN   TestAccSNSTopic_Tags_DefaultTags_overlapping
=== PAUSE TestAccSNSTopic_Tags_DefaultTags_overlapping
=== RUN   TestAccSNSTopic_Tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccSNSTopic_Tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccSNSTopic_Tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccSNSTopic_Tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccSNSTopic_Tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccSNSTopic_Tags_DefaultTags_emptyResourceTag
=== RUN   TestAccSNSTopic_Tags_DefaultTags_emptyProviderOnlyTag
=== PAUSE TestAccSNSTopic_Tags_DefaultTags_emptyProviderOnlyTag
=== RUN   TestAccSNSTopic_Tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccSNSTopic_Tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccSNSTopic_Tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccSNSTopic_Tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccSNSTopic_Tags_ComputedTag_onCreate
=== PAUSE TestAccSNSTopic_Tags_ComputedTag_onCreate
=== RUN   TestAccSNSTopic_Tags_ComputedTag_OnUpdate_add
=== PAUSE TestAccSNSTopic_Tags_ComputedTag_OnUpdate_add
=== RUN   TestAccSNSTopic_Tags_ComputedTag_OnUpdate_replace
=== PAUSE TestAccSNSTopic_Tags_ComputedTag_OnUpdate_replace
=== RUN   TestAccSNSTopic_Tags_IgnoreTags_Overlap_defaultTag
=== PAUSE TestAccSNSTopic_Tags_IgnoreTags_Overlap_defaultTag
=== RUN   TestAccSNSTopic_Tags_IgnoreTags_Overlap_resourceTag
=== PAUSE TestAccSNSTopic_Tags_IgnoreTags_Overlap_resourceTag
=== CONT  TestAccSNSTopicDataSource_Tags_nullMap
=== CONT  TestAccSNSTopic_Tags_DefaultTags_overlapping
=== CONT  TestAccSNSTopic_Tags_addOnUpdate
=== CONT  TestAccSNSTopic_Tags_ComputedTag_OnUpdate_add
=== CONT  TestAccSNSTopic_Tags_EmptyTag_OnUpdate_replace
=== CONT  TestAccSNSTopic_Tags_EmptyTag_OnUpdate_add
=== CONT  TestAccSNSTopic_Tags_IgnoreTags_Overlap_resourceTag
=== CONT  TestAccSNSTopic_Tags_IgnoreTags_Overlap_defaultTag
=== CONT  TestAccSNSTopic_Tags_ComputedTag_OnUpdate_replace
=== CONT  TestAccSNSTopic_Tags_DefaultTags_nullNonOverlappingResourceTag
--- PASS: TestAccSNSTopicDataSource_Tags_nullMap (20.34s)
=== CONT  TestAccSNSTopicDataSource_Tags_IgnoreTags_Overlap_resourceTag
--- PASS: TestAccSNSTopic_Tags_DefaultTags_nullNonOverlappingResourceTag (28.10s)
=== CONT  TestAccSNSTopic_Tags_emptyMap
--- PASS: TestAccSNSTopicDataSource_Tags_IgnoreTags_Overlap_resourceTag (21.44s)
=== CONT  TestAccSNSTopic_Tags_null
--- PASS: TestAccSNSTopic_Tags_EmptyTag_OnUpdate_replace (43.93s)
=== CONT  TestAccSNSTopic_Tags_ComputedTag_onCreate
--- PASS: TestAccSNSTopic_Tags_addOnUpdate (45.69s)
=== CONT  TestAccSNSTopic_Tags_EmptyTag_onCreate
=== CONT  TestAccSNSTopicDataSource_Tags_IgnoreTags_Overlap_defaultTag
--- PASS: TestAccSNSTopic_Tags_ComputedTag_OnUpdate_add (47.01s)
--- PASS: TestAccSNSTopic_Tags_ComputedTag_OnUpdate_replace (48.48s)
=== CONT  TestAccSNSTopic_Tags_DefaultTags_nonOverlapping
--- PASS: TestAccSNSTopic_Tags_IgnoreTags_Overlap_defaultTag (55.01s)
=== CONT  TestAccSNSTopic_Tags_DefaultTags_providerOnly
--- PASS: TestAccSNSTopic_Tags_IgnoreTags_Overlap_resourceTag (66.02s)
=== CONT  TestAccSNSTopic_Tags_DefaultTags_emptyResourceTag
--- PASS: TestAccSNSTopic_Tags_emptyMap (38.92s)
=== CONT  TestAccSNSTopicDataSource_Tags_DefaultTags_nonOverlapping
--- PASS: TestAccSNSTopicDataSource_Tags_IgnoreTags_Overlap_defaultTag (20.20s)
=== CONT  TestAccSNSTopic_Tags_DefaultTags_nullOverlappingResourceTag
--- PASS: TestAccSNSTopic_Tags_EmptyTag_OnUpdate_add (68.75s)
=== CONT  TestAccSNSTopicDataSource_Tags_emptyMap
--- PASS: TestAccSNSTopic_Tags_DefaultTags_overlapping (73.89s)
=== CONT  TestAccSNSTopic_Tags_DefaultTags_emptyProviderOnlyTag
--- PASS: TestAccSNSTopic_Tags_ComputedTag_onCreate (30.06s)
=== CONT  TestAccSNSTopic_Tags_DefaultTags_updateToResourceOnly
--- PASS: TestAccSNSTopic_Tags_null (38.41s)
=== CONT  TestAccSNSTopic_Tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccSNSTopicDataSource_Tags_DefaultTags_nonOverlapping (19.91s)
--- PASS: TestAccSNSTopicDataSource_Tags_emptyMap (19.54s)
--- PASS: TestAccSNSTopic_Tags_DefaultTags_emptyResourceTag (26.74s)
--- PASS: TestAccSNSTopic_Tags_EmptyTag_onCreate (47.18s)
--- PASS: TestAccSNSTopic_Tags_DefaultTags_nullOverlappingResourceTag (26.09s)
--- PASS: TestAccSNSTopic_Tags_DefaultTags_emptyProviderOnlyTag (25.06s)
--- PASS: TestAccSNSTopic_Tags_DefaultTags_updateToResourceOnly (35.87s)
--- PASS: TestAccSNSTopic_Tags_DefaultTags_nonOverlapping (64.00s)
--- PASS: TestAccSNSTopic_Tags_DefaultTags_updateToProviderOnly (35.83s)
--- PASS: TestAccSNSTopic_Tags_DefaultTags_providerOnly (77.43s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sns	139.737s
% make t T='_Tags_(EmptyTag|ComputedTag|DefaultTags|null|emptyMap|addOnUpdate|IgnoreTags)' K=secretsmanager P=10
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 b-explore-ec2-tags-reset 🌿...
TF_ACC=1 go1.26.3 test ./internal/service/secretsmanager/... -v -count 1 -parallel 10 -run='_Tags_(EmptyTag|ComputedTag|DefaultTags|null|emptyMap|addOnUpdate|IgnoreTags)'  -timeout 360m -vet=off
2026/05/21 12:37:16 Creating Terraform AWS Provider (SDKv2-style)...
2026/05/21 12:37:16 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccSecretsManagerSecretDataSource_Tags_nullMap
=== PAUSE TestAccSecretsManagerSecretDataSource_Tags_nullMap
=== RUN   TestAccSecretsManagerSecretDataSource_Tags_emptyMap
=== PAUSE TestAccSecretsManagerSecretDataSource_Tags_emptyMap
=== RUN   TestAccSecretsManagerSecretDataSource_Tags_DefaultTags_nonOverlapping
=== PAUSE TestAccSecretsManagerSecretDataSource_Tags_DefaultTags_nonOverlapping
=== RUN   TestAccSecretsManagerSecretDataSource_Tags_IgnoreTags_Overlap_defaultTag
=== PAUSE TestAccSecretsManagerSecretDataSource_Tags_IgnoreTags_Overlap_defaultTag
=== RUN   TestAccSecretsManagerSecretDataSource_Tags_IgnoreTags_Overlap_resourceTag
=== PAUSE TestAccSecretsManagerSecretDataSource_Tags_IgnoreTags_Overlap_resourceTag
=== RUN   TestAccSecretsManagerSecret_Tags_null
=== PAUSE TestAccSecretsManagerSecret_Tags_null
=== RUN   TestAccSecretsManagerSecret_Tags_emptyMap
=== PAUSE TestAccSecretsManagerSecret_Tags_emptyMap
=== RUN   TestAccSecretsManagerSecret_Tags_addOnUpdate
=== PAUSE TestAccSecretsManagerSecret_Tags_addOnUpdate
=== RUN   TestAccSecretsManagerSecret_Tags_EmptyTag_onCreate
=== PAUSE TestAccSecretsManagerSecret_Tags_EmptyTag_onCreate
=== RUN   TestAccSecretsManagerSecret_Tags_EmptyTag_OnUpdate_add
=== PAUSE TestAccSecretsManagerSecret_Tags_EmptyTag_OnUpdate_add
=== RUN   TestAccSecretsManagerSecret_Tags_EmptyTag_OnUpdate_replace
=== PAUSE TestAccSecretsManagerSecret_Tags_EmptyTag_OnUpdate_replace
=== RUN   TestAccSecretsManagerSecret_Tags_DefaultTags_providerOnly
=== PAUSE TestAccSecretsManagerSecret_Tags_DefaultTags_providerOnly
=== RUN   TestAccSecretsManagerSecret_Tags_DefaultTags_nonOverlapping
=== PAUSE TestAccSecretsManagerSecret_Tags_DefaultTags_nonOverlapping
=== RUN   TestAccSecretsManagerSecret_Tags_DefaultTags_overlapping
=== PAUSE TestAccSecretsManagerSecret_Tags_DefaultTags_overlapping
=== RUN   TestAccSecretsManagerSecret_Tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccSecretsManagerSecret_Tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccSecretsManagerSecret_Tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccSecretsManagerSecret_Tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccSecretsManagerSecret_Tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccSecretsManagerSecret_Tags_DefaultTags_emptyResourceTag
=== RUN   TestAccSecretsManagerSecret_Tags_DefaultTags_emptyProviderOnlyTag
=== PAUSE TestAccSecretsManagerSecret_Tags_DefaultTags_emptyProviderOnlyTag
=== RUN   TestAccSecretsManagerSecret_Tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccSecretsManagerSecret_Tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccSecretsManagerSecret_Tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccSecretsManagerSecret_Tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccSecretsManagerSecret_Tags_ComputedTag_onCreate
=== PAUSE TestAccSecretsManagerSecret_Tags_ComputedTag_onCreate
=== RUN   TestAccSecretsManagerSecret_Tags_ComputedTag_OnUpdate_add
=== PAUSE TestAccSecretsManagerSecret_Tags_ComputedTag_OnUpdate_add
=== RUN   TestAccSecretsManagerSecret_Tags_ComputedTag_OnUpdate_replace
=== PAUSE TestAccSecretsManagerSecret_Tags_ComputedTag_OnUpdate_replace
=== RUN   TestAccSecretsManagerSecret_Tags_IgnoreTags_Overlap_defaultTag
=== PAUSE TestAccSecretsManagerSecret_Tags_IgnoreTags_Overlap_defaultTag
=== RUN   TestAccSecretsManagerSecret_Tags_IgnoreTags_Overlap_resourceTag
=== PAUSE TestAccSecretsManagerSecret_Tags_IgnoreTags_Overlap_resourceTag
=== CONT  TestAccSecretsManagerSecretDataSource_Tags_nullMap
=== CONT  TestAccSecretsManagerSecret_Tags_DefaultTags_overlapping
=== CONT  TestAccSecretsManagerSecret_Tags_addOnUpdate
=== CONT  TestAccSecretsManagerSecret_Tags_DefaultTags_nullNonOverlappingResourceTag
=== CONT  TestAccSecretsManagerSecret_Tags_ComputedTag_OnUpdate_replace
=== CONT  TestAccSecretsManagerSecret_Tags_IgnoreTags_Overlap_defaultTag
=== CONT  TestAccSecretsManagerSecret_Tags_DefaultTags_emptyResourceTag
=== CONT  TestAccSecretsManagerSecret_Tags_DefaultTags_nullOverlappingResourceTag
=== CONT  TestAccSecretsManagerSecret_Tags_DefaultTags_emptyProviderOnlyTag
=== CONT  TestAccSecretsManagerSecret_Tags_EmptyTag_OnUpdate_replace
--- PASS: TestAccSecretsManagerSecretDataSource_Tags_nullMap (25.57s)
=== CONT  TestAccSecretsManagerSecret_Tags_DefaultTags_nonOverlapping
--- PASS: TestAccSecretsManagerSecret_Tags_DefaultTags_nullNonOverlappingResourceTag (33.68s)
=== CONT  TestAccSecretsManagerSecret_Tags_DefaultTags_providerOnly
--- PASS: TestAccSecretsManagerSecret_Tags_DefaultTags_nullOverlappingResourceTag (36.05s)
=== CONT  TestAccSecretsManagerSecret_Tags_IgnoreTags_Overlap_resourceTag
--- PASS: TestAccSecretsManagerSecret_Tags_DefaultTags_emptyProviderOnlyTag (36.34s)
=== CONT  TestAccSecretsManagerSecret_Tags_DefaultTags_updateToResourceOnly
--- PASS: TestAccSecretsManagerSecret_Tags_DefaultTags_emptyResourceTag (36.41s)
=== CONT  TestAccSecretsManagerSecret_Tags_ComputedTag_OnUpdate_add
--- PASS: TestAccSecretsManagerSecret_Tags_EmptyTag_OnUpdate_replace (51.69s)
=== CONT  TestAccSecretsManagerSecret_Tags_EmptyTag_onCreate
--- PASS: TestAccSecretsManagerSecret_Tags_addOnUpdate (55.45s)
=== CONT  TestAccSecretsManagerSecret_Tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccSecretsManagerSecret_Tags_ComputedTag_OnUpdate_replace (58.37s)
=== CONT  TestAccSecretsManagerSecret_Tags_EmptyTag_OnUpdate_add
--- PASS: TestAccSecretsManagerSecret_Tags_IgnoreTags_Overlap_defaultTag (65.42s)
=== CONT  TestAccSecretsManagerSecretDataSource_Tags_DefaultTags_nonOverlapping
--- PASS: TestAccSecretsManagerSecret_Tags_DefaultTags_updateToResourceOnly (47.81s)
=== CONT  TestAccSecretsManagerSecretDataSource_Tags_IgnoreTags_Overlap_resourceTag
--- PASS: TestAccSecretsManagerSecret_Tags_DefaultTags_overlapping (88.87s)
=== CONT  TestAccSecretsManagerSecretDataSource_Tags_IgnoreTags_Overlap_defaultTag
--- PASS: TestAccSecretsManagerSecretDataSource_Tags_DefaultTags_nonOverlapping (24.67s)
=== CONT  TestAccSecretsManagerSecret_Tags_emptyMap
--- PASS: TestAccSecretsManagerSecret_Tags_ComputedTag_OnUpdate_add (54.48s)
=== CONT  TestAccSecretsManagerSecret_Tags_null
--- PASS: TestAccSecretsManagerSecret_Tags_DefaultTags_updateToProviderOnly (58.18s)
=== CONT  TestAccSecretsManagerSecret_Tags_ComputedTag_onCreate
--- PASS: TestAccSecretsManagerSecret_Tags_EmptyTag_onCreate (63.43s)
=== CONT  TestAccSecretsManagerSecretDataSource_Tags_emptyMap
--- PASS: TestAccSecretsManagerSecret_Tags_DefaultTags_nonOverlapping (90.82s)
--- PASS: TestAccSecretsManagerSecretDataSource_Tags_IgnoreTags_Overlap_defaultTag (28.65s)
--- PASS: TestAccSecretsManagerSecret_Tags_IgnoreTags_Overlap_resourceTag (82.16s)
--- PASS: TestAccSecretsManagerSecretDataSource_Tags_IgnoreTags_Overlap_resourceTag (34.37s)
--- PASS: TestAccSecretsManagerSecretDataSource_Tags_emptyMap (18.48s)
--- PASS: TestAccSecretsManagerSecret_Tags_null (45.94s)
--- PASS: TestAccSecretsManagerSecret_Tags_emptyMap (46.76s)
--- PASS: TestAccSecretsManagerSecret_Tags_EmptyTag_OnUpdate_add (79.27s)
--- PASS: TestAccSecretsManagerSecret_Tags_DefaultTags_providerOnly (106.92s)
--- PASS: TestAccSecretsManagerSecret_Tags_ComputedTag_onCreate (27.14s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/secretsmanager	148.026s
% make t T='_Tags_(EmptyTag|ComputedTag|DefaultTags|null|emptyMap|addOnUpdate|IgnoreTags)' K=cloudwatch P=10
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 b-explore-ec2-tags-reset 🌿...
TF_ACC=1 go1.26.3 test ./internal/service/cloudwatch/... -v -count 1 -parallel 10 -run='_Tags_(EmptyTag|ComputedTag|DefaultTags|null|emptyMap|addOnUpdate|IgnoreTags)'  -timeout 360m -vet=off
2026/05/21 12:37:29 Creating Terraform AWS Provider (SDKv2-style)...
2026/05/21 12:37:29 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccCloudWatchAlarmMuteRule_Tags_null
=== PAUSE TestAccCloudWatchAlarmMuteRule_Tags_null
=== RUN   TestAccCloudWatchAlarmMuteRule_Tags_emptyMap
=== PAUSE TestAccCloudWatchAlarmMuteRule_Tags_emptyMap
=== RUN   TestAccCloudWatchAlarmMuteRule_Tags_addOnUpdate
=== PAUSE TestAccCloudWatchAlarmMuteRule_Tags_addOnUpdate
=== RUN   TestAccCloudWatchAlarmMuteRule_Tags_EmptyTag_onCreate
=== PAUSE TestAccCloudWatchAlarmMuteRule_Tags_EmptyTag_onCreate
=== RUN   TestAccCloudWatchAlarmMuteRule_Tags_EmptyTag_OnUpdate_add
=== PAUSE TestAccCloudWatchAlarmMuteRule_Tags_EmptyTag_OnUpdate_add
=== RUN   TestAccCloudWatchAlarmMuteRule_Tags_EmptyTag_OnUpdate_replace
=== PAUSE TestAccCloudWatchAlarmMuteRule_Tags_EmptyTag_OnUpdate_replace
=== RUN   TestAccCloudWatchAlarmMuteRule_Tags_DefaultTags_providerOnly
=== PAUSE TestAccCloudWatchAlarmMuteRule_Tags_DefaultTags_providerOnly
=== RUN   TestAccCloudWatchAlarmMuteRule_Tags_DefaultTags_nonOverlapping
=== PAUSE TestAccCloudWatchAlarmMuteRule_Tags_DefaultTags_nonOverlapping
=== RUN   TestAccCloudWatchAlarmMuteRule_Tags_DefaultTags_overlapping
=== PAUSE TestAccCloudWatchAlarmMuteRule_Tags_DefaultTags_overlapping
=== RUN   TestAccCloudWatchAlarmMuteRule_Tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccCloudWatchAlarmMuteRule_Tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccCloudWatchAlarmMuteRule_Tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccCloudWatchAlarmMuteRule_Tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccCloudWatchAlarmMuteRule_Tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccCloudWatchAlarmMuteRule_Tags_DefaultTags_emptyResourceTag
=== RUN   TestAccCloudWatchAlarmMuteRule_Tags_DefaultTags_emptyProviderOnlyTag
=== PAUSE TestAccCloudWatchAlarmMuteRule_Tags_DefaultTags_emptyProviderOnlyTag
=== RUN   TestAccCloudWatchAlarmMuteRule_Tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccCloudWatchAlarmMuteRule_Tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccCloudWatchAlarmMuteRule_Tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccCloudWatchAlarmMuteRule_Tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccCloudWatchAlarmMuteRule_Tags_ComputedTag_onCreate
=== PAUSE TestAccCloudWatchAlarmMuteRule_Tags_ComputedTag_onCreate
=== RUN   TestAccCloudWatchAlarmMuteRule_Tags_ComputedTag_OnUpdate_add
=== PAUSE TestAccCloudWatchAlarmMuteRule_Tags_ComputedTag_OnUpdate_add
=== RUN   TestAccCloudWatchAlarmMuteRule_Tags_ComputedTag_OnUpdate_replace
=== PAUSE TestAccCloudWatchAlarmMuteRule_Tags_ComputedTag_OnUpdate_replace
=== RUN   TestAccCloudWatchAlarmMuteRule_Tags_IgnoreTags_Overlap_defaultTag
=== PAUSE TestAccCloudWatchAlarmMuteRule_Tags_IgnoreTags_Overlap_defaultTag
=== RUN   TestAccCloudWatchAlarmMuteRule_Tags_IgnoreTags_Overlap_resourceTag
=== PAUSE TestAccCloudWatchAlarmMuteRule_Tags_IgnoreTags_Overlap_resourceTag
=== RUN   TestAccCloudWatchCompositeAlarm_Tags_null
=== PAUSE TestAccCloudWatchCompositeAlarm_Tags_null
=== RUN   TestAccCloudWatchCompositeAlarm_Tags_emptyMap
=== PAUSE TestAccCloudWatchCompositeAlarm_Tags_emptyMap
=== RUN   TestAccCloudWatchCompositeAlarm_Tags_addOnUpdate
=== PAUSE TestAccCloudWatchCompositeAlarm_Tags_addOnUpdate
=== RUN   TestAccCloudWatchCompositeAlarm_Tags_EmptyTag_onCreate
=== PAUSE TestAccCloudWatchCompositeAlarm_Tags_EmptyTag_onCreate
=== RUN   TestAccCloudWatchCompositeAlarm_Tags_EmptyTag_OnUpdate_add
=== PAUSE TestAccCloudWatchCompositeAlarm_Tags_EmptyTag_OnUpdate_add
=== RUN   TestAccCloudWatchCompositeAlarm_Tags_EmptyTag_OnUpdate_replace
=== PAUSE TestAccCloudWatchCompositeAlarm_Tags_EmptyTag_OnUpdate_replace
=== RUN   TestAccCloudWatchCompositeAlarm_Tags_DefaultTags_providerOnly
=== PAUSE TestAccCloudWatchCompositeAlarm_Tags_DefaultTags_providerOnly
=== RUN   TestAccCloudWatchCompositeAlarm_Tags_DefaultTags_nonOverlapping
=== PAUSE TestAccCloudWatchCompositeAlarm_Tags_DefaultTags_nonOverlapping
=== RUN   TestAccCloudWatchCompositeAlarm_Tags_DefaultTags_overlapping
=== PAUSE TestAccCloudWatchCompositeAlarm_Tags_DefaultTags_overlapping
=== RUN   TestAccCloudWatchCompositeAlarm_Tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccCloudWatchCompositeAlarm_Tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccCloudWatchCompositeAlarm_Tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccCloudWatchCompositeAlarm_Tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccCloudWatchCompositeAlarm_Tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccCloudWatchCompositeAlarm_Tags_DefaultTags_emptyResourceTag
=== RUN   TestAccCloudWatchCompositeAlarm_Tags_DefaultTags_emptyProviderOnlyTag
=== PAUSE TestAccCloudWatchCompositeAlarm_Tags_DefaultTags_emptyProviderOnlyTag
=== RUN   TestAccCloudWatchCompositeAlarm_Tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccCloudWatchCompositeAlarm_Tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccCloudWatchCompositeAlarm_Tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccCloudWatchCompositeAlarm_Tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccCloudWatchCompositeAlarm_Tags_ComputedTag_onCreate
=== PAUSE TestAccCloudWatchCompositeAlarm_Tags_ComputedTag_onCreate
=== RUN   TestAccCloudWatchCompositeAlarm_Tags_ComputedTag_OnUpdate_add
=== PAUSE TestAccCloudWatchCompositeAlarm_Tags_ComputedTag_OnUpdate_add
=== RUN   TestAccCloudWatchCompositeAlarm_Tags_ComputedTag_OnUpdate_replace
=== PAUSE TestAccCloudWatchCompositeAlarm_Tags_ComputedTag_OnUpdate_replace
=== RUN   TestAccCloudWatchCompositeAlarm_Tags_IgnoreTags_Overlap_defaultTag
=== PAUSE TestAccCloudWatchCompositeAlarm_Tags_IgnoreTags_Overlap_defaultTag
=== RUN   TestAccCloudWatchCompositeAlarm_Tags_IgnoreTags_Overlap_resourceTag
=== PAUSE TestAccCloudWatchCompositeAlarm_Tags_IgnoreTags_Overlap_resourceTag
=== RUN   TestAccCloudWatchContributorInsightRule_Tags_null
=== PAUSE TestAccCloudWatchContributorInsightRule_Tags_null
=== RUN   TestAccCloudWatchContributorInsightRule_Tags_emptyMap
=== PAUSE TestAccCloudWatchContributorInsightRule_Tags_emptyMap
=== RUN   TestAccCloudWatchContributorInsightRule_Tags_addOnUpdate
=== PAUSE TestAccCloudWatchContributorInsightRule_Tags_addOnUpdate
=== RUN   TestAccCloudWatchContributorInsightRule_Tags_EmptyTag_onCreate
=== PAUSE TestAccCloudWatchContributorInsightRule_Tags_EmptyTag_onCreate
=== RUN   TestAccCloudWatchContributorInsightRule_Tags_EmptyTag_OnUpdate_add
=== PAUSE TestAccCloudWatchContributorInsightRule_Tags_EmptyTag_OnUpdate_add
=== RUN   TestAccCloudWatchContributorInsightRule_Tags_EmptyTag_OnUpdate_replace
=== PAUSE TestAccCloudWatchContributorInsightRule_Tags_EmptyTag_OnUpdate_replace
=== RUN   TestAccCloudWatchContributorInsightRule_Tags_DefaultTags_providerOnly
=== PAUSE TestAccCloudWatchContributorInsightRule_Tags_DefaultTags_providerOnly
=== RUN   TestAccCloudWatchContributorInsightRule_Tags_DefaultTags_nonOverlapping
=== PAUSE TestAccCloudWatchContributorInsightRule_Tags_DefaultTags_nonOverlapping
=== RUN   TestAccCloudWatchContributorInsightRule_Tags_DefaultTags_overlapping
=== PAUSE TestAccCloudWatchContributorInsightRule_Tags_DefaultTags_overlapping
=== RUN   TestAccCloudWatchContributorInsightRule_Tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccCloudWatchContributorInsightRule_Tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccCloudWatchContributorInsightRule_Tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccCloudWatchContributorInsightRule_Tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccCloudWatchContributorInsightRule_Tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccCloudWatchContributorInsightRule_Tags_DefaultTags_emptyResourceTag
=== RUN   TestAccCloudWatchContributorInsightRule_Tags_DefaultTags_emptyProviderOnlyTag
=== PAUSE TestAccCloudWatchContributorInsightRule_Tags_DefaultTags_emptyProviderOnlyTag
=== RUN   TestAccCloudWatchContributorInsightRule_Tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccCloudWatchContributorInsightRule_Tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccCloudWatchContributorInsightRule_Tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccCloudWatchContributorInsightRule_Tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccCloudWatchContributorInsightRule_Tags_ComputedTag_onCreate
=== PAUSE TestAccCloudWatchContributorInsightRule_Tags_ComputedTag_onCreate
=== RUN   TestAccCloudWatchContributorInsightRule_Tags_ComputedTag_OnUpdate_add
=== PAUSE TestAccCloudWatchContributorInsightRule_Tags_ComputedTag_OnUpdate_add
=== RUN   TestAccCloudWatchContributorInsightRule_Tags_ComputedTag_OnUpdate_replace
=== PAUSE TestAccCloudWatchContributorInsightRule_Tags_ComputedTag_OnUpdate_replace
=== RUN   TestAccCloudWatchContributorInsightRule_Tags_IgnoreTags_Overlap_defaultTag
=== PAUSE TestAccCloudWatchContributorInsightRule_Tags_IgnoreTags_Overlap_defaultTag
=== RUN   TestAccCloudWatchContributorInsightRule_Tags_IgnoreTags_Overlap_resourceTag
=== PAUSE TestAccCloudWatchContributorInsightRule_Tags_IgnoreTags_Overlap_resourceTag
=== RUN   TestAccCloudWatchMetricAlarm_Tags_null
=== PAUSE TestAccCloudWatchMetricAlarm_Tags_null
=== RUN   TestAccCloudWatchMetricAlarm_Tags_emptyMap
=== PAUSE TestAccCloudWatchMetricAlarm_Tags_emptyMap
=== RUN   TestAccCloudWatchMetricAlarm_Tags_addOnUpdate
=== PAUSE TestAccCloudWatchMetricAlarm_Tags_addOnUpdate
=== RUN   TestAccCloudWatchMetricAlarm_Tags_EmptyTag_onCreate
=== PAUSE TestAccCloudWatchMetricAlarm_Tags_EmptyTag_onCreate
=== RUN   TestAccCloudWatchMetricAlarm_Tags_EmptyTag_OnUpdate_add
=== PAUSE TestAccCloudWatchMetricAlarm_Tags_EmptyTag_OnUpdate_add
=== RUN   TestAccCloudWatchMetricAlarm_Tags_EmptyTag_OnUpdate_replace
=== PAUSE TestAccCloudWatchMetricAlarm_Tags_EmptyTag_OnUpdate_replace
=== RUN   TestAccCloudWatchMetricAlarm_Tags_DefaultTags_providerOnly
=== PAUSE TestAccCloudWatchMetricAlarm_Tags_DefaultTags_providerOnly
=== RUN   TestAccCloudWatchMetricAlarm_Tags_DefaultTags_nonOverlapping
=== PAUSE TestAccCloudWatchMetricAlarm_Tags_DefaultTags_nonOverlapping
=== RUN   TestAccCloudWatchMetricAlarm_Tags_DefaultTags_overlapping
=== PAUSE TestAccCloudWatchMetricAlarm_Tags_DefaultTags_overlapping
=== RUN   TestAccCloudWatchMetricAlarm_Tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccCloudWatchMetricAlarm_Tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccCloudWatchMetricAlarm_Tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccCloudWatchMetricAlarm_Tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccCloudWatchMetricAlarm_Tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccCloudWatchMetricAlarm_Tags_DefaultTags_emptyResourceTag
=== RUN   TestAccCloudWatchMetricAlarm_Tags_DefaultTags_emptyProviderOnlyTag
=== PAUSE TestAccCloudWatchMetricAlarm_Tags_DefaultTags_emptyProviderOnlyTag
=== RUN   TestAccCloudWatchMetricAlarm_Tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccCloudWatchMetricAlarm_Tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccCloudWatchMetricAlarm_Tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccCloudWatchMetricAlarm_Tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccCloudWatchMetricAlarm_Tags_ComputedTag_onCreate
=== PAUSE TestAccCloudWatchMetricAlarm_Tags_ComputedTag_onCreate
=== RUN   TestAccCloudWatchMetricAlarm_Tags_ComputedTag_OnUpdate_add
=== PAUSE TestAccCloudWatchMetricAlarm_Tags_ComputedTag_OnUpdate_add
=== RUN   TestAccCloudWatchMetricAlarm_Tags_ComputedTag_OnUpdate_replace
=== PAUSE TestAccCloudWatchMetricAlarm_Tags_ComputedTag_OnUpdate_replace
=== RUN   TestAccCloudWatchMetricAlarm_Tags_IgnoreTags_Overlap_defaultTag
=== PAUSE TestAccCloudWatchMetricAlarm_Tags_IgnoreTags_Overlap_defaultTag
=== RUN   TestAccCloudWatchMetricAlarm_Tags_IgnoreTags_Overlap_resourceTag
=== PAUSE TestAccCloudWatchMetricAlarm_Tags_IgnoreTags_Overlap_resourceTag
=== RUN   TestAccCloudWatchMetricStream_Tags_null
=== PAUSE TestAccCloudWatchMetricStream_Tags_null
=== RUN   TestAccCloudWatchMetricStream_Tags_emptyMap
=== PAUSE TestAccCloudWatchMetricStream_Tags_emptyMap
=== RUN   TestAccCloudWatchMetricStream_Tags_addOnUpdate
=== PAUSE TestAccCloudWatchMetricStream_Tags_addOnUpdate
=== RUN   TestAccCloudWatchMetricStream_Tags_EmptyTag_onCreate
=== PAUSE TestAccCloudWatchMetricStream_Tags_EmptyTag_onCreate
=== RUN   TestAccCloudWatchMetricStream_Tags_EmptyTag_OnUpdate_add
=== PAUSE TestAccCloudWatchMetricStream_Tags_EmptyTag_OnUpdate_add
=== RUN   TestAccCloudWatchMetricStream_Tags_EmptyTag_OnUpdate_replace
=== PAUSE TestAccCloudWatchMetricStream_Tags_EmptyTag_OnUpdate_replace
=== RUN   TestAccCloudWatchMetricStream_Tags_DefaultTags_providerOnly
=== PAUSE TestAccCloudWatchMetricStream_Tags_DefaultTags_providerOnly
=== RUN   TestAccCloudWatchMetricStream_Tags_DefaultTags_nonOverlapping
=== PAUSE TestAccCloudWatchMetricStream_Tags_DefaultTags_nonOverlapping
=== RUN   TestAccCloudWatchMetricStream_Tags_DefaultTags_overlapping
=== PAUSE TestAccCloudWatchMetricStream_Tags_DefaultTags_overlapping
=== RUN   TestAccCloudWatchMetricStream_Tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccCloudWatchMetricStream_Tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccCloudWatchMetricStream_Tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccCloudWatchMetricStream_Tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccCloudWatchMetricStream_Tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccCloudWatchMetricStream_Tags_DefaultTags_emptyResourceTag
=== RUN   TestAccCloudWatchMetricStream_Tags_DefaultTags_emptyProviderOnlyTag
=== PAUSE TestAccCloudWatchMetricStream_Tags_DefaultTags_emptyProviderOnlyTag
=== RUN   TestAccCloudWatchMetricStream_Tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccCloudWatchMetricStream_Tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccCloudWatchMetricStream_Tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccCloudWatchMetricStream_Tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccCloudWatchMetricStream_Tags_ComputedTag_onCreate
=== PAUSE TestAccCloudWatchMetricStream_Tags_ComputedTag_onCreate
=== RUN   TestAccCloudWatchMetricStream_Tags_ComputedTag_OnUpdate_add
=== PAUSE TestAccCloudWatchMetricStream_Tags_ComputedTag_OnUpdate_add
=== RUN   TestAccCloudWatchMetricStream_Tags_ComputedTag_OnUpdate_replace
=== PAUSE TestAccCloudWatchMetricStream_Tags_ComputedTag_OnUpdate_replace
=== RUN   TestAccCloudWatchMetricStream_Tags_IgnoreTags_Overlap_defaultTag
=== PAUSE TestAccCloudWatchMetricStream_Tags_IgnoreTags_Overlap_defaultTag
=== RUN   TestAccCloudWatchMetricStream_Tags_IgnoreTags_Overlap_resourceTag
=== PAUSE TestAccCloudWatchMetricStream_Tags_IgnoreTags_Overlap_resourceTag
=== CONT  TestAccCloudWatchAlarmMuteRule_Tags_null
=== CONT  TestAccCloudWatchMetricAlarm_Tags_DefaultTags_providerOnly
=== CONT  TestAccCloudWatchMetricStream_Tags_EmptyTag_onCreate
=== CONT  TestAccCloudWatchMetricStream_Tags_DefaultTags_emptyProviderOnlyTag
=== CONT  TestAccCloudWatchMetricStream_Tags_IgnoreTags_Overlap_resourceTag
=== CONT  TestAccCloudWatchMetricStream_Tags_IgnoreTags_Overlap_defaultTag
=== CONT  TestAccCloudWatchMetricStream_Tags_ComputedTag_OnUpdate_replace
=== CONT  TestAccCloudWatchMetricStream_Tags_ComputedTag_OnUpdate_add
=== CONT  TestAccCloudWatchMetricStream_Tags_ComputedTag_onCreate
=== CONT  TestAccCloudWatchMetricStream_Tags_DefaultTags_nullNonOverlappingResourceTag
--- PASS: TestAccCloudWatchAlarmMuteRule_Tags_null (29.62s)
=== CONT  TestAccCloudWatchMetricStream_Tags_DefaultTags_nullOverlappingResourceTag
--- PASS: TestAccCloudWatchMetricAlarm_Tags_DefaultTags_providerOnly (101.55s)
=== CONT  TestAccCloudWatchMetricStream_Tags_DefaultTags_overlapping
--- PASS: TestAccCloudWatchMetricStream_Tags_ComputedTag_onCreate (123.92s)
=== CONT  TestAccCloudWatchMetricStream_Tags_DefaultTags_emptyResourceTag
--- PASS: TestAccCloudWatchMetricStream_Tags_DefaultTags_nullOverlappingResourceTag (101.87s)
=== CONT  TestAccCloudWatchMetricStream_Tags_DefaultTags_updateToResourceOnly
--- PASS: TestAccCloudWatchMetricStream_Tags_DefaultTags_nullNonOverlappingResourceTag (143.33s)
=== CONT  TestAccCloudWatchMetricStream_Tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccCloudWatchMetricStream_Tags_DefaultTags_emptyProviderOnlyTag (145.04s)
=== CONT  TestAccCloudWatchCompositeAlarm_Tags_DefaultTags_nullOverlappingResourceTag
--- PASS: TestAccCloudWatchMetricStream_Tags_ComputedTag_OnUpdate_add (146.57s)
=== CONT  TestAccCloudWatchMetricAlarm_Tags_EmptyTag_OnUpdate_replace
--- PASS: TestAccCloudWatchMetricStream_Tags_ComputedTag_OnUpdate_replace (149.40s)
=== CONT  TestAccCloudWatchMetricAlarm_Tags_ComputedTag_onCreate
--- PASS: TestAccCloudWatchMetricStream_Tags_IgnoreTags_Overlap_defaultTag (150.37s)
=== CONT  TestAccCloudWatchMetricAlarm_Tags_EmptyTag_OnUpdate_add
--- PASS: TestAccCloudWatchMetricStream_Tags_EmptyTag_onCreate (151.26s)
=== CONT  TestAccCloudWatchMetricAlarm_Tags_EmptyTag_onCreate
--- PASS: TestAccCloudWatchCompositeAlarm_Tags_DefaultTags_nullOverlappingResourceTag (21.66s)
=== CONT  TestAccCloudWatchMetricStream_Tags_addOnUpdate
--- PASS: TestAccCloudWatchMetricAlarm_Tags_ComputedTag_onCreate (23.86s)
=== CONT  TestAccCloudWatchMetricAlarm_Tags_addOnUpdate
--- PASS: TestAccCloudWatchMetricStream_Tags_IgnoreTags_Overlap_resourceTag (174.98s)
=== CONT  TestAccCloudWatchMetricStream_Tags_emptyMap
--- PASS: TestAccCloudWatchMetricAlarm_Tags_EmptyTag_OnUpdate_replace (34.56s)
=== CONT  TestAccCloudWatchMetricAlarm_Tags_emptyMap
--- PASS: TestAccCloudWatchMetricAlarm_Tags_EmptyTag_onCreate (39.30s)
=== CONT  TestAccCloudWatchMetricStream_Tags_null
--- PASS: TestAccCloudWatchMetricAlarm_Tags_EmptyTag_OnUpdate_add (53.00s)
=== CONT  TestAccCloudWatchMetricAlarm_Tags_null
--- PASS: TestAccCloudWatchMetricAlarm_Tags_addOnUpdate (35.00s)
=== CONT  TestAccCloudWatchMetricAlarm_Tags_IgnoreTags_Overlap_resourceTag
--- PASS: TestAccCloudWatchMetricAlarm_Tags_emptyMap (31.68s)
=== CONT  TestAccCloudWatchContributorInsightRule_Tags_IgnoreTags_Overlap_resourceTag
--- PASS: TestAccCloudWatchMetricStream_Tags_DefaultTags_emptyResourceTag (92.55s)
=== CONT  TestAccCloudWatchMetricAlarm_Tags_IgnoreTags_Overlap_defaultTag
--- PASS: TestAccCloudWatchMetricAlarm_Tags_null (31.54s)
=== CONT  TestAccCloudWatchContributorInsightRule_Tags_IgnoreTags_Overlap_defaultTag
--- PASS: TestAccCloudWatchMetricStream_Tags_DefaultTags_updateToProviderOnly (93.69s)
=== CONT  TestAccCloudWatchMetricAlarm_Tags_ComputedTag_OnUpdate_replace
--- PASS: TestAccCloudWatchMetricStream_Tags_DefaultTags_overlapping (136.51s)
=== CONT  TestAccCloudWatchContributorInsightRule_Tags_ComputedTag_OnUpdate_replace
--- PASS: TestAccCloudWatchMetricStream_Tags_DefaultTags_updateToResourceOnly (114.90s)
=== CONT  TestAccCloudWatchMetricAlarm_Tags_ComputedTag_OnUpdate_add
--- PASS: TestAccCloudWatchMetricAlarm_Tags_IgnoreTags_Overlap_resourceTag (55.27s)
=== CONT  TestAccCloudWatchContributorInsightRule_Tags_ComputedTag_OnUpdate_add
--- PASS: TestAccCloudWatchMetricAlarm_Tags_IgnoreTags_Overlap_defaultTag (47.25s)
=== CONT  TestAccCloudWatchMetricStream_Tags_DefaultTags_providerOnly
--- PASS: TestAccCloudWatchContributorInsightRule_Tags_IgnoreTags_Overlap_resourceTag (51.93s)
=== CONT  TestAccCloudWatchContributorInsightRule_Tags_ComputedTag_onCreate
--- PASS: TestAccCloudWatchMetricStream_Tags_addOnUpdate (102.36s)
=== CONT  TestAccCloudWatchMetricStream_Tags_DefaultTags_nonOverlapping
--- PASS: TestAccCloudWatchMetricAlarm_Tags_ComputedTag_OnUpdate_replace (41.36s)
=== CONT  TestAccCloudWatchContributorInsightRule_Tags_DefaultTags_nullNonOverlappingResourceTag
--- PASS: TestAccCloudWatchContributorInsightRule_Tags_ComputedTag_OnUpdate_replace (41.28s)
=== CONT  TestAccCloudWatchContributorInsightRule_Tags_DefaultTags_nullOverlappingResourceTag
=== CONT  TestAccCloudWatchAlarmMuteRule_Tags_ComputedTag_OnUpdate_replace
--- PASS: TestAccCloudWatchContributorInsightRule_Tags_IgnoreTags_Overlap_defaultTag (46.75s)
--- PASS: TestAccCloudWatchMetricStream_Tags_emptyMap (110.47s)
=== CONT  TestAccCloudWatchContributorInsightRule_Tags_DefaultTags_emptyProviderOnlyTag
--- PASS: TestAccCloudWatchMetricAlarm_Tags_ComputedTag_OnUpdate_add (39.65s)
=== CONT  TestAccCloudWatchCompositeAlarm_Tags_DefaultTags_emptyProviderOnlyTag
--- PASS: TestAccCloudWatchContributorInsightRule_Tags_ComputedTag_onCreate (24.77s)
=== CONT  TestAccCloudWatchCompositeAlarm_Tags_DefaultTags_emptyResourceTag
--- PASS: TestAccCloudWatchMetricStream_Tags_null (99.43s)
=== CONT  TestAccCloudWatchCompositeAlarm_Tags_DefaultTags_updateToResourceOnly
--- PASS: TestAccCloudWatchContributorInsightRule_Tags_DefaultTags_nullNonOverlappingResourceTag (23.55s)
=== CONT  TestAccCloudWatchCompositeAlarm_Tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccCloudWatchContributorInsightRule_Tags_DefaultTags_nullOverlappingResourceTag (23.82s)
=== CONT  TestAccCloudWatchCompositeAlarm_Tags_DefaultTags_overlapping
--- PASS: TestAccCloudWatchContributorInsightRule_Tags_ComputedTag_OnUpdate_add (41.14s)
=== CONT  TestAccCloudWatchCompositeAlarm_Tags_DefaultTags_nonOverlapping
--- PASS: TestAccCloudWatchContributorInsightRule_Tags_DefaultTags_emptyProviderOnlyTag (24.62s)
=== CONT  TestAccCloudWatchCompositeAlarm_Tags_DefaultTags_providerOnly
--- PASS: TestAccCloudWatchCompositeAlarm_Tags_DefaultTags_emptyProviderOnlyTag (25.94s)
=== CONT  TestAccCloudWatchContributorInsightRule_Tags_addOnUpdate
--- PASS: TestAccCloudWatchCompositeAlarm_Tags_DefaultTags_emptyResourceTag (26.94s)
=== CONT  TestAccCloudWatchCompositeAlarm_Tags_EmptyTag_OnUpdate_replace
--- PASS: TestAccCloudWatchAlarmMuteRule_Tags_ComputedTag_OnUpdate_replace (43.27s)
=== CONT  TestAccCloudWatchContributorInsightRule_Tags_emptyMap
--- PASS: TestAccCloudWatchCompositeAlarm_Tags_DefaultTags_updateToResourceOnly (44.30s)
=== CONT  TestAccCloudWatchCompositeAlarm_Tags_EmptyTag_OnUpdate_add
--- PASS: TestAccCloudWatchCompositeAlarm_Tags_DefaultTags_updateToProviderOnly (44.22s)
=== CONT  TestAccCloudWatchContributorInsightRule_Tags_null
--- PASS: TestAccCloudWatchContributorInsightRule_Tags_emptyMap (25.32s)
=== CONT  TestAccCloudWatchCompositeAlarm_Tags_EmptyTag_onCreate
--- PASS: TestAccCloudWatchContributorInsightRule_Tags_addOnUpdate (42.30s)
=== CONT  TestAccCloudWatchContributorInsightRule_Tags_EmptyTag_onCreate
--- PASS: TestAccCloudWatchCompositeAlarm_Tags_EmptyTag_OnUpdate_replace (44.53s)
=== CONT  TestAccCloudWatchCompositeAlarm_Tags_IgnoreTags_Overlap_resourceTag
--- PASS: TestAccCloudWatchContributorInsightRule_Tags_null (26.21s)
=== CONT  TestAccCloudWatchCompositeAlarm_Tags_addOnUpdate
--- PASS: TestAccCloudWatchCompositeAlarm_Tags_DefaultTags_overlapping (72.56s)
=== CONT  TestAccCloudWatchContributorInsightRule_Tags_DefaultTags_emptyResourceTag
--- PASS: TestAccCloudWatchCompositeAlarm_Tags_DefaultTags_nonOverlapping (73.58s)
=== CONT  TestAccCloudWatchCompositeAlarm_Tags_IgnoreTags_Overlap_defaultTag
--- PASS: TestAccCloudWatchCompositeAlarm_Tags_EmptyTag_onCreate (50.62s)
=== CONT  TestAccCloudWatchContributorInsightRule_Tags_DefaultTags_updateToResourceOnly
--- PASS: TestAccCloudWatchContributorInsightRule_Tags_DefaultTags_emptyResourceTag (25.76s)
=== CONT  TestAccCloudWatchCompositeAlarm_Tags_ComputedTag_OnUpdate_replace
--- PASS: TestAccCloudWatchCompositeAlarm_Tags_EmptyTag_OnUpdate_add (67.74s)
=== CONT  TestAccCloudWatchContributorInsightRule_Tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccCloudWatchContributorInsightRule_Tags_EmptyTag_onCreate (48.16s)
=== CONT  TestAccCloudWatchCompositeAlarm_Tags_ComputedTag_OnUpdate_add
--- PASS: TestAccCloudWatchCompositeAlarm_Tags_DefaultTags_providerOnly (96.04s)
=== CONT  TestAccCloudWatchContributorInsightRule_Tags_DefaultTags_overlapping
--- PASS: TestAccCloudWatchCompositeAlarm_Tags_addOnUpdate (43.33s)
=== CONT  TestAccCloudWatchCompositeAlarm_Tags_ComputedTag_onCreate
--- PASS: TestAccCloudWatchCompositeAlarm_Tags_IgnoreTags_Overlap_resourceTag (63.87s)
=== CONT  TestAccCloudWatchContributorInsightRule_Tags_DefaultTags_nonOverlapping
--- PASS: TestAccCloudWatchMetricStream_Tags_DefaultTags_nonOverlapping (156.73s)
=== CONT  TestAccCloudWatchCompositeAlarm_Tags_DefaultTags_nullNonOverlappingResourceTag
--- PASS: TestAccCloudWatchMetricStream_Tags_DefaultTags_providerOnly (167.27s)
=== CONT  TestAccCloudWatchContributorInsightRule_Tags_DefaultTags_providerOnly
--- PASS: TestAccCloudWatchCompositeAlarm_Tags_IgnoreTags_Overlap_defaultTag (53.32s)
=== CONT  TestAccCloudWatchContributorInsightRule_Tags_EmptyTag_OnUpdate_replace
--- PASS: TestAccCloudWatchContributorInsightRule_Tags_DefaultTags_updateToResourceOnly (39.09s)
=== CONT  TestAccCloudWatchContributorInsightRule_Tags_EmptyTag_OnUpdate_add
--- PASS: TestAccCloudWatchContributorInsightRule_Tags_DefaultTags_updateToProviderOnly (42.11s)
=== CONT  TestAccCloudWatchAlarmMuteRule_Tags_IgnoreTags_Overlap_resourceTag
--- PASS: TestAccCloudWatchCompositeAlarm_Tags_ComputedTag_onCreate (30.67s)
=== CONT  TestAccCloudWatchCompositeAlarm_Tags_null
--- PASS: TestAccCloudWatchCompositeAlarm_Tags_ComputedTag_OnUpdate_add (46.35s)
=== CONT  TestAccCloudWatchMetricStream_Tags_EmptyTag_OnUpdate_replace
--- PASS: TestAccCloudWatchCompositeAlarm_Tags_ComputedTag_OnUpdate_replace (47.57s)
=== CONT  TestAccCloudWatchAlarmMuteRule_Tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccCloudWatchCompositeAlarm_Tags_DefaultTags_nullNonOverlappingResourceTag (28.36s)
=== CONT  TestAccCloudWatchAlarmMuteRule_Tags_ComputedTag_OnUpdate_add
--- PASS: TestAccCloudWatchContributorInsightRule_Tags_EmptyTag_OnUpdate_replace (42.54s)
=== CONT  TestAccCloudWatchAlarmMuteRule_Tags_ComputedTag_onCreate
--- PASS: TestAccCloudWatchContributorInsightRule_Tags_DefaultTags_overlapping (69.47s)
=== CONT  TestAccCloudWatchAlarmMuteRule_Tags_DefaultTags_nullNonOverlappingResourceTag
--- PASS: TestAccCloudWatchCompositeAlarm_Tags_null (38.83s)
=== CONT  TestAccCloudWatchAlarmMuteRule_Tags_DefaultTags_nullOverlappingResourceTag
--- PASS: TestAccCloudWatchAlarmMuteRule_Tags_DefaultTags_updateToProviderOnly (42.96s)
=== CONT  TestAccCloudWatchAlarmMuteRule_Tags_DefaultTags_emptyProviderOnlyTag
--- PASS: TestAccCloudWatchContributorInsightRule_Tags_DefaultTags_nonOverlapping (69.22s)
=== CONT  TestAccCloudWatchAlarmMuteRule_Tags_DefaultTags_emptyResourceTag
--- PASS: TestAccCloudWatchAlarmMuteRule_Tags_ComputedTag_OnUpdate_add (46.53s)
=== CONT  TestAccCloudWatchAlarmMuteRule_Tags_DefaultTags_updateToResourceOnly
--- PASS: TestAccCloudWatchAlarmMuteRule_Tags_DefaultTags_nullNonOverlappingResourceTag (26.09s)
=== CONT  TestAccCloudWatchMetricAlarm_Tags_DefaultTags_nullOverlappingResourceTag
--- PASS: TestAccCloudWatchAlarmMuteRule_Tags_IgnoreTags_Overlap_resourceTag (58.63s)
=== CONT  TestAccCloudWatchMetricAlarm_Tags_DefaultTags_nullNonOverlappingResourceTag
--- PASS: TestAccCloudWatchAlarmMuteRule_Tags_ComputedTag_onCreate (28.75s)
=== CONT  TestAccCloudWatchAlarmMuteRule_Tags_EmptyTag_onCreate
--- PASS: TestAccCloudWatchContributorInsightRule_Tags_EmptyTag_OnUpdate_add (65.46s)
=== CONT  TestAccCloudWatchAlarmMuteRule_Tags_EmptyTag_OnUpdate_add
--- PASS: TestAccCloudWatchAlarmMuteRule_Tags_DefaultTags_nullOverlappingResourceTag (27.05s)
=== CONT  TestAccCloudWatchMetricStream_Tags_EmptyTag_OnUpdate_add
--- PASS: TestAccCloudWatchAlarmMuteRule_Tags_DefaultTags_emptyProviderOnlyTag (26.79s)
=== CONT  TestAccCloudWatchAlarmMuteRule_Tags_addOnUpdate
--- PASS: TestAccCloudWatchAlarmMuteRule_Tags_DefaultTags_emptyResourceTag (27.63s)
=== CONT  TestAccCloudWatchAlarmMuteRule_Tags_EmptyTag_OnUpdate_replace
--- PASS: TestAccCloudWatchContributorInsightRule_Tags_DefaultTags_providerOnly (94.23s)
=== CONT  TestAccCloudWatchAlarmMuteRule_Tags_IgnoreTags_Overlap_defaultTag
--- PASS: TestAccCloudWatchMetricAlarm_Tags_DefaultTags_nullOverlappingResourceTag (27.07s)
=== CONT  TestAccCloudWatchAlarmMuteRule_Tags_DefaultTags_overlapping
--- PASS: TestAccCloudWatchMetricAlarm_Tags_DefaultTags_nullNonOverlappingResourceTag (27.48s)
=== CONT  TestAccCloudWatchAlarmMuteRule_Tags_DefaultTags_nonOverlapping
--- PASS: TestAccCloudWatchAlarmMuteRule_Tags_DefaultTags_updateToResourceOnly (40.68s)
=== CONT  TestAccCloudWatchMetricAlarm_Tags_DefaultTags_emptyProviderOnlyTag
--- PASS: TestAccCloudWatchAlarmMuteRule_Tags_EmptyTag_onCreate (48.33s)
=== CONT  TestAccCloudWatchAlarmMuteRule_Tags_DefaultTags_providerOnly
--- PASS: TestAccCloudWatchAlarmMuteRule_Tags_addOnUpdate (41.13s)
=== CONT  TestAccCloudWatchMetricAlarm_Tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccCloudWatchAlarmMuteRule_Tags_EmptyTag_OnUpdate_replace (43.02s)
=== CONT  TestAccCloudWatchCompositeAlarm_Tags_emptyMap
--- PASS: TestAccCloudWatchMetricAlarm_Tags_DefaultTags_emptyProviderOnlyTag (24.74s)
=== CONT  TestAccCloudWatchMetricAlarm_Tags_DefaultTags_overlapping
--- PASS: TestAccCloudWatchAlarmMuteRule_Tags_EmptyTag_OnUpdate_add (63.66s)
=== CONT  TestAccCloudWatchAlarmMuteRule_Tags_emptyMap
--- PASS: TestAccCloudWatchMetricStream_Tags_EmptyTag_OnUpdate_replace (120.67s)
=== CONT  TestAccCloudWatchMetricAlarm_Tags_DefaultTags_nonOverlapping
--- PASS: TestAccCloudWatchAlarmMuteRule_Tags_IgnoreTags_Overlap_defaultTag (52.61s)
=== CONT  TestAccCloudWatchMetricAlarm_Tags_DefaultTags_updateToResourceOnly
--- PASS: TestAccCloudWatchAlarmMuteRule_Tags_emptyMap (28.04s)
=== CONT  TestAccCloudWatchMetricAlarm_Tags_DefaultTags_emptyResourceTag
--- PASS: TestAccCloudWatchAlarmMuteRule_Tags_DefaultTags_overlapping (70.06s)
--- PASS: TestAccCloudWatchAlarmMuteRule_Tags_DefaultTags_nonOverlapping (71.13s)
--- PASS: TestAccCloudWatchMetricAlarm_Tags_DefaultTags_updateToProviderOnly (43.61s)
--- PASS: TestAccCloudWatchCompositeAlarm_Tags_emptyMap (40.84s)
--- PASS: TestAccCloudWatchMetricAlarm_Tags_DefaultTags_updateToResourceOnly (39.56s)
--- PASS: TestAccCloudWatchMetricAlarm_Tags_DefaultTags_emptyResourceTag (22.17s)
--- PASS: TestAccCloudWatchMetricAlarm_Tags_DefaultTags_overlapping (65.15s)
--- PASS: TestAccCloudWatchMetricAlarm_Tags_DefaultTags_nonOverlapping (63.47s)
--- PASS: TestAccCloudWatchAlarmMuteRule_Tags_DefaultTags_providerOnly (85.44s)
--- PASS: TestAccCloudWatchMetricStream_Tags_EmptyTag_OnUpdate_add (124.51s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudwatch	644.452s
```
