### PR TITLE
t/aws_s3_bucket: Add regression test for standalone policy deletion on v5→v6 upgrade

### DIFF
--- a/internal/service/s3/bucket_test.go
+++ b/internal/service/s3/bucket_test.go
@@ -546,6 +546,54 @@ func TestAccS3Bucket_Basic_upgradeFromV5(t *testing.T) {
 	})
 }
 
+// TestAccS3Bucket_Basic_upgradeFromV5WithStandalonePolicy is a regression test for the bug
+// where upgrading from provider v5 to v6 deletes a bucket policy managed by the standalone
+// aws_s3_bucket_policy resource. The aws_s3_bucket Read function unconditionally writes
+// the live policy into state even when the inline policy attribute is not configured,
+// causing HasChange("policy") to fire during the v6 update and call DeleteBucketPolicy.
+// Fixed in v6.46.0 by guarding the Update path with deprecatedAttributeInRawConfig.
+// See: https://github.com/hashicorp/terraform-provider-aws/issues/47962
+func TestAccS3Bucket_Basic_upgradeFromV5WithStandalonePolicy(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, "tf-test-bucket")
+	bucketResourceName := "aws_s3_bucket.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
+		CheckDestroy: testAccCheckBucketDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"aws": {
+						Source:            "hashicorp/aws",
+						VersionConstraint: "5.92.0",
+					},
+				},
+				Config: testAccBucketPolicyConfig_migrateNoChange(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckBucketExists(ctx, t, bucketResourceName),
+					testAccCheckBucketPolicyExists(ctx, t, bucketResourceName),
+				),
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				Config:                   testAccBucketPolicyConfig_migrateNoChange(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckBucketExists(ctx, t, bucketResourceName),
+					// Bug: policy is deleted by the v6 upgrade; this check should pass but fails.
+					testAccCheckBucketPolicyExists(ctx, t, bucketResourceName),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(bucketResourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+		},
+	})
+}
+
 // Test TestAccS3Bucket_disappears is designed to fail with a "plan
 // not empty" error in Terraform, to check against regressions.
 // See https://github.com/hashicorp/terraform/pull/2925


### PR DESCRIPTION
## Rollback Plan

This PR only adds a test — no functional code changes. There is nothing to roll back.

## Changes to Security Controls

No changes to security controls.

### Description

Adds a regression test for a specific failure mode where upgrading from provider v5 to v6 silently deletes a bucket policy managed by the standalone `aws_s3_bucket_policy` resource.

**Root cause:** The `aws_s3_bucket` `Read` function unconditionally writes the live bucket policy into state even when the deprecated inline `policy` attribute is not configured. When a provider upgrade triggered an `aws_s3_bucket` update (e.g. the `region` → `bucket_region` attribute rename in v6.0.0 with no state migration), `HasChange("policy")` evaluated to `true` — old state had the policy JSON, new config had empty string — and `DeleteBucketPolicy` was called, silently wiping the policy managed by the separate `aws_s3_bucket_policy` resource.

This scenario was fixed as a side effect of #47962 (which gated all deprecated attribute Update branches with `deprecatedAttributeInRawConfig`), but was not the reported issue and has no dedicated test coverage.

The test uses the existing `testAccBucketPolicyConfig_migrateNoChange` config and `testAccCheckBucketPolicyExists` helper, following the same two-step pattern as `TestAccS3Bucket_Basic_upgradeFromV5`.

### Relations

Relates #47962

### Output from Acceptance Testing

```console
% make testacc TESTS=TestAccS3Bucket_Basic_upgradeFromV5WithStandalonePolicy PKG=s3
```