### PR TITLE
Corrects schema for `aws_secretsmanager_secret_version`

### DIFF
--- a/.changelog/48011.txt
+++ b/.changelog/48011.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_secretsmanager_secret_version: Deprecates `arn` in favor of `secret_arn`.
+```
+
+```release-note:enhancement
+data-source/aws_secretsmanager_secret_version: Deprecates `arn` in favor of `secret_arn`.
+```

--- a/internal/service/secretsmanager/secret_version.go
+++ b/internal/service/secretsmanager/secret_version.go
@@ -52,11 +52,16 @@ func resourceSecretVersion() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:       schema.TypeString,
+				Computed:   true,
+				Deprecated: "arn is deprecated. Use secret_arn instead.",
 			},
 			"has_secret_string_wo": {
 				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"secret_arn": {
+				Type:     schema.TypeString,
 				Computed: true,
 			},
 			"secret_id": {
@@ -216,6 +221,7 @@ func resourceSecretVersionRead(ctx context.Context, d *schema.ResourceData, meta
 		}
 
 		d.Set(names.AttrARN, arn)
+		d.Set("secret_arn", arn)
 		d.Set("secret_binary", nil)
 		d.Set("secret_string", nil)
 		d.Set("version_id", versionEntry.VersionId)
@@ -236,6 +242,7 @@ func resourceSecretVersionRead(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	d.Set(names.AttrARN, output.ARN)
+	d.Set("secret_arn", output.ARN)
 	d.Set("secret_binary", inttypes.Base64EncodeOnce(output.SecretBinary))
 	d.Set("secret_string", output.SecretString)
 	d.Set("version_id", output.VersionId)

--- a/internal/service/secretsmanager/secret_version_data_source.go
+++ b/internal/service/secretsmanager/secret_version_data_source.go
@@ -25,10 +25,15 @@ func dataSourceSecretVersion() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			names.AttrARN: {
+				Type:       schema.TypeString,
+				Computed:   true,
+				Deprecated: "arn is deprecated. Use secret_arn instead.",
+			},
+			names.AttrCreatedDate: {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			names.AttrCreatedDate: {
+			"secret_arn": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -95,6 +100,7 @@ func dataSourceSecretVersionRead(ctx context.Context, d *schema.ResourceData, me
 	d.SetId(id)
 	d.Set(names.AttrARN, output.ARN)
 	d.Set(names.AttrCreatedDate, aws.String(output.CreatedDate.Format(time.RFC3339)))
+	d.Set("secret_arn", output.ARN)
 	d.Set("secret_id", secretID)
 	d.Set("secret_binary", string(output.SecretBinary))
 	d.Set("secret_string", output.SecretString)

--- a/internal/service/secretsmanager/secret_version_data_source_test.go
+++ b/internal/service/secretsmanager/secret_version_data_source_test.go
@@ -8,8 +8,11 @@ import (
 	"testing"
 
 	"github.com/YakDriver/regexache"
+	"github.com/hashicorp/terraform-plugin-testing/compare"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -26,14 +29,30 @@ func TestAccSecretsManagerSecretVersionDataSource_basic(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccSecretVersionDataSourceConfig_nonExistent,
-				ExpectError: regexache.MustCompile(`couldn't find resource`),
-			},
-			{
 				Config: testAccSecretVersionDataSourceConfig_stageDefault(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccSecretVersionCheckDataSource(datasourceName, resourceName),
 				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.CompareValuePairs(datasourceName, tfjsonpath.New("secret_arn"), resourceName, tfjsonpath.New("secret_arn"), compare.ValuesSame()),
+					statecheck.CompareValuePairs(datasourceName, tfjsonpath.New(names.AttrARN), datasourceName, tfjsonpath.New("secret_arn"), compare.ValuesSame()),
+				},
+			},
+		},
+	})
+}
+
+func TestAccSecretsManagerSecretVersionDataSource_nonExistent(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SecretsManagerServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccSecretVersionDataSourceConfig_nonExistent,
+				ExpectError: regexache.MustCompile(`couldn't find resource`),
 			},
 		},
 	})
@@ -55,6 +74,10 @@ func TestAccSecretsManagerSecretVersionDataSource_versionID(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccSecretVersionCheckDataSource(datasourceName, resourceName),
 				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.CompareValuePairs(datasourceName, tfjsonpath.New("secret_arn"), resourceName, tfjsonpath.New("secret_arn"), compare.ValuesSame()),
+					statecheck.CompareValuePairs(datasourceName, tfjsonpath.New(names.AttrARN), datasourceName, tfjsonpath.New("secret_arn"), compare.ValuesSame()),
+				},
 			},
 		},
 	})
@@ -76,6 +99,10 @@ func TestAccSecretsManagerSecretVersionDataSource_versionStage(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccSecretVersionCheckDataSource(datasourceName, resourceName),
 				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.CompareValuePairs(datasourceName, tfjsonpath.New("secret_arn"), resourceName, tfjsonpath.New("secret_arn"), compare.ValuesSame()),
+					statecheck.CompareValuePairs(datasourceName, tfjsonpath.New(names.AttrARN), datasourceName, tfjsonpath.New("secret_arn"), compare.ValuesSame()),
+				},
 			},
 		},
 	})

--- a/internal/service/secretsmanager/secret_version_data_source_test.go
+++ b/internal/service/secretsmanager/secret_version_data_source_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/YakDriver/regexache"
 	"github.com/hashicorp/terraform-plugin-testing/compare"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
@@ -32,10 +33,17 @@ func TestAccSecretsManagerSecretVersionDataSource_basic(t *testing.T) {
 				Config: testAccSecretVersionDataSourceConfig_stageDefault(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccSecretVersionCheckDataSource(datasourceName, resourceName),
+					acctest.CheckResourceAttrRFC3339(datasourceName, names.AttrCreatedDate),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.CompareValuePairs(datasourceName, tfjsonpath.New("secret_arn"), resourceName, tfjsonpath.New("secret_arn"), compare.ValuesSame()),
 					statecheck.CompareValuePairs(datasourceName, tfjsonpath.New(names.AttrARN), datasourceName, tfjsonpath.New("secret_arn"), compare.ValuesSame()),
+					statecheck.ExpectKnownValue(datasourceName, tfjsonpath.New("secret_binary"), knownvalue.StringExact("")),
+					statecheck.CompareValuePairs(datasourceName, tfjsonpath.New("secret_arn"), resourceName, tfjsonpath.New("secret_arn"), compare.ValuesSame()),
+					statecheck.CompareValuePairs(datasourceName, tfjsonpath.New("secret_id"), resourceName, tfjsonpath.New("secret_id"), compare.ValuesSame()),
+					statecheck.CompareValuePairs(datasourceName, tfjsonpath.New("secret_string"), resourceName, tfjsonpath.New("secret_string"), compare.ValuesSame()),
+					statecheck.CompareValuePairs(datasourceName, tfjsonpath.New("version_id"), resourceName, tfjsonpath.New("version_id"), compare.ValuesSame()),
+					statecheck.ExpectKnownValue(datasourceName, tfjsonpath.New("version_stage"), knownvalue.StringExact("AWSCURRENT")),
+					statecheck.CompareValuePairs(datasourceName, tfjsonpath.New("version_stages"), resourceName, tfjsonpath.New("version_stages"), compare.ValuesSame()),
 				},
 			},
 		},

--- a/internal/service/secretsmanager/secret_version_test.go
+++ b/internal/service/secretsmanager/secret_version_test.go
@@ -239,8 +239,9 @@ func TestAccSecretsManagerSecretVersion_basicString(t *testing.T) {
 				Config: testAccSecretVersionConfig_string(rName, "test-string"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSecretVersionExists(ctx, t, resourceName, &version),
-					resource.TestCheckResourceAttrPair(resourceName, names.AttrARN, secretResourceName, names.AttrARN),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrARN, resourceName, "secret_arn"),
 					resource.TestCheckNoResourceAttr(resourceName, "has_secret_string_wo"),
+					resource.TestCheckResourceAttrPair(resourceName, "secret_arn", secretResourceName, names.AttrARN),
 					resource.TestCheckResourceAttrPair(resourceName, "secret_id", secretResourceName, names.AttrID),
 					resource.TestCheckResourceAttr(resourceName, "secret_binary", ""),
 					resource.TestCheckResourceAttr(resourceName, "secret_string", "test-string"),
@@ -278,8 +279,9 @@ func TestAccSecretsManagerSecretVersion_base64Binary(t *testing.T) {
 				Config: testAccSecretVersionConfig_binary(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSecretVersionExists(ctx, t, resourceName, &version),
-					resource.TestCheckResourceAttrPair(resourceName, names.AttrARN, secretResourceName, names.AttrARN),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrARN, resourceName, "secret_arn"),
 					resource.TestCheckNoResourceAttr(resourceName, "has_secret_string_wo"),
+					resource.TestCheckResourceAttrPair(resourceName, "secret_arn", secretResourceName, names.AttrARN),
 					resource.TestCheckResourceAttrPair(resourceName, "secret_id", secretResourceName, names.AttrID),
 					resource.TestCheckResourceAttr(resourceName, "secret_binary", inttypes.Base64EncodeOnce([]byte("test-binary"))),
 					resource.TestCheckResourceAttr(resourceName, "secret_string", ""),
@@ -612,7 +614,8 @@ func TestAccSecretsManagerSecretVersion_StringWriteOnly_sameWOVersion(t *testing
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSecretVersionExists(ctx, t, resourceName, &version),
 					testAccCheckSecretVersionWriteOnlyValueEqual(t, &version, "test-secret"),
-					resource.TestCheckResourceAttrPair(resourceName, names.AttrARN, secretResourceName, names.AttrARN),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrARN, resourceName, "secret_arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "secret_arn", secretResourceName, names.AttrARN),
 				),
 			},
 			{
@@ -620,7 +623,7 @@ func TestAccSecretsManagerSecretVersion_StringWriteOnly_sameWOVersion(t *testing
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSecretVersionExists(ctx, t, resourceName, &version),
 					testAccCheckSecretVersionWriteOnlyValueEqual(t, &version, "test-secret"),
-					resource.TestCheckResourceAttrPair(resourceName, names.AttrARN, secretResourceName, names.AttrARN),
+					resource.TestCheckResourceAttrPair(resourceName, "secret_arn", secretResourceName, names.AttrARN),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -658,7 +661,7 @@ func TestAccSecretsManagerSecretVersion_stringWriteOnlyLimitedPermissions(t *tes
 					testAccCheckSecretVersionExists(ctx, t, resourceName, &version),
 					testAccCheckSecretVersionWriteOnlyValueEqual(t, &version, "test-secret"),
 					resource.TestCheckResourceAttr(resourceName, "has_secret_string_wo", acctest.CtTrue),
-					resource.TestCheckResourceAttrPair(resourceName, names.AttrARN, secretResourceName, names.AttrARN),
+					resource.TestCheckResourceAttrPair(resourceName, "secret_arn", secretResourceName, names.AttrARN),
 				),
 			},
 			{
@@ -666,7 +669,7 @@ func TestAccSecretsManagerSecretVersion_stringWriteOnlyLimitedPermissions(t *tes
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSecretVersionExists(ctx, t, resourceName, &version),
 					resource.TestCheckResourceAttr(resourceName, "secret_string", "test-string"),
-					resource.TestCheckResourceAttrPair(resourceName, names.AttrARN, secretResourceName, names.AttrARN),
+					resource.TestCheckResourceAttrPair(resourceName, "secret_arn", secretResourceName, names.AttrARN),
 				),
 			},
 		},
@@ -693,7 +696,7 @@ func TestAccSecretsManagerSecretVersion_stringWriteOnly_stages(t *testing.T) {
 				Config: testAccSecretVersionConfig_stringWriteOnly_stagesSingle(rName, "test-secret", 1),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSecretVersionExists(ctx, t, resourceName, &version),
-					resource.TestCheckResourceAttrPair(resourceName, names.AttrARN, secretResourceName, names.AttrARN),
+					resource.TestCheckResourceAttrPair(resourceName, "secret_arn", secretResourceName, names.AttrARN),
 					resource.TestCheckResourceAttr(resourceName, "version_stages.#", "2"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "version_stages.*", "AWSCURRENT"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "version_stages.*", "one"),
@@ -703,7 +706,7 @@ func TestAccSecretsManagerSecretVersion_stringWriteOnly_stages(t *testing.T) {
 				Config: testAccSecretVersionConfig_stringWriteOnly_stagesSingleUpdated(rName, "test-secret", 1),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSecretVersionExists(ctx, t, resourceName, &version),
-					resource.TestCheckResourceAttrPair(resourceName, names.AttrARN, secretResourceName, names.AttrARN),
+					resource.TestCheckResourceAttrPair(resourceName, "secret_arn", secretResourceName, names.AttrARN),
 					resource.TestCheckResourceAttr(resourceName, "version_stages.#", "2"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "version_stages.*", "AWSCURRENT"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "version_stages.*", "two"),
@@ -718,7 +721,7 @@ func TestAccSecretsManagerSecretVersion_stringWriteOnly_stages(t *testing.T) {
 				Config: testAccSecretVersionConfig_stringWriteOnly_stagesMultiple(rName, "test-secret", 1),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSecretVersionExists(ctx, t, resourceName, &version),
-					resource.TestCheckResourceAttrPair(resourceName, names.AttrARN, secretResourceName, names.AttrARN),
+					resource.TestCheckResourceAttrPair(resourceName, "secret_arn", secretResourceName, names.AttrARN),
 					resource.TestCheckResourceAttr(resourceName, "version_stages.#", "3"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "version_stages.*", "AWSCURRENT"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "version_stages.*", "two"),

--- a/website/docs/d/secretsmanager_secret_version.html.markdown
+++ b/website/docs/d/secretsmanager_secret_version.html.markdown
@@ -54,9 +54,10 @@ This data source supports the following arguments:
 
 This data source exports the following attributes in addition to the arguments above:
 
-* `arn` - ARN of the secret.
+* `arn` - (**Deprecated**) The ARN of the secret.
 * `created_date` - Created date of the secret in UTC.
 * `id` - Unique identifier of this version of the secret.
+* `secret_arn` - The ARN of the secret.
 * `secret_string` - Decrypted part of the protected secret information that was originally provided as a string.
 * `secret_binary` - Decrypted part of the protected secret information that was originally provided as a binary.
 * `version_id` - Unique identifier of this version of the secret.

--- a/website/docs/d/secretsmanager_secret_version.html.markdown
+++ b/website/docs/d/secretsmanager_secret_version.html.markdown
@@ -56,7 +56,6 @@ This data source exports the following attributes in addition to the arguments a
 
 * `arn` - (**Deprecated**) The ARN of the secret.
 * `created_date` - Created date of the secret in UTC.
-* `id` - Unique identifier of this version of the secret.
 * `secret_arn` - The ARN of the secret.
 * `secret_string` - Decrypted part of the protected secret information that was originally provided as a string.
 * `secret_binary` - Decrypted part of the protected secret information that was originally provided as a binary.

--- a/website/docs/r/secretsmanager_secret_version.html.markdown
+++ b/website/docs/r/secretsmanager_secret_version.html.markdown
@@ -75,8 +75,9 @@ This resource supports the following arguments:
 
 This resource exports the following attributes in addition to the arguments above:
 
-* `arn` - The ARN of the secret.
+* `arn` - (**Deprecated**) The ARN of the secret.
 * `id` - A pipe delimited combination of secret ID and version ID.
+* `secret_arn` - The ARN of the secret.
 * `version_id` - The unique identifier of the version of the secret.
 
 ## Import

--- a/website/docs/r/secretsmanager_secret_version.html.markdown
+++ b/website/docs/r/secretsmanager_secret_version.html.markdown
@@ -76,7 +76,6 @@ This resource supports the following arguments:
 This resource exports the following attributes in addition to the arguments above:
 
 * `arn` - (**Deprecated**) The ARN of the secret.
-* `id` - A pipe delimited combination of secret ID and version ID.
 * `secret_arn` - The ARN of the secret.
 * `version_id` - The unique identifier of the version of the secret.
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Corrects schema for `aws_secretsmanager_secret_version` resource type and data source type: adds `secret_arn` and deprecates `arn`.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc PKG=secretsmanager TESTS=TestAccSecretsManagerSecretVersion_

--- PASS: TestAccSecretsManagerSecretVersion_disappears (62.43s)
--- PASS: TestAccSecretsManagerSecretVersion_multipleVersions (63.25s)
--- PASS: TestAccSecretsManagerSecretVersion_Disappears_secret (65.79s)
--- PASS: TestAccSecretsManagerSecretVersion_List_basic (67.38s)
--- PASS: TestAccSecretsManagerSecretVersion_base64Binary (71.74s)
--- PASS: TestAccSecretsManagerSecretVersion_basicString (72.06s)
--- PASS: TestAccSecretsManagerSecretVersion_stringWriteOnly (84.43s)
--- PASS: TestAccSecretsManagerSecretVersion_versionStagesExternalUpdate (85.82s)
--- PASS: TestAccSecretsManagerSecretVersion_Identity_ExistingResource_noRefreshNoChange (91.13s)
--- PASS: TestAccSecretsManagerSecretVersion_Identity_ExistingResource_basic (91.38s)
--- PASS: TestAccSecretsManagerSecretVersion_Identity_basic (92.42s)
--- PASS: TestAccSecretsManagerSecretVersion_Identity_regionOverride (92.74s)
--- PASS: TestAccSecretsManagerSecretVersion_stringWriteOnly_stages (98.57s)
--- PASS: TestAccSecretsManagerSecretVersion_versionStages (102.93s)
```


```console
$ make testacc PKG=secretsmanager TESTS=TestAccSecretsManagerSecretVersionDataSource_

--- PASS: TestAccSecretsManagerSecretVersionDataSource_nonExistent (8.27s)
--- PASS: TestAccSecretsManagerSecretVersionDataSource_versionID (33.52s)
--- PASS: TestAccSecretsManagerSecretVersionDataSource_basic (33.72s)
--- PASS: TestAccSecretsManagerSecretVersionDataSource_versionStage (33.95s)
```
