### PR TITLE
[WIP] r/aws_instance : add `launch_time` 

### DIFF
--- a/internal/provider/framework/provider.go
+++ b/internal/provider/framework/provider.go
@@ -308,7 +308,7 @@ func (*frameworkProvider) Schema(ctx context.Context, request provider.SchemaReq
 						},
 						"web_identity_token": schema.StringAttribute{
 							Optional:    true,
-							Description: "Value of a web identity token from an OpenID Connect (OIDC) or OAuth provider. Can also be set with the `TF_AWS_IDENTITY_TOKEN` environment variable.",
+							Description: "Value of a web identity token. Can also be set with the `TF_AWS_IDENTITY_TOKEN` environment variable.",
 						},
 						"web_identity_token_file": schema.StringAttribute{
 							Optional: true,

--- a/internal/provider/framework/provider.go
+++ b/internal/provider/framework/provider.go
@@ -307,7 +307,8 @@ func (*frameworkProvider) Schema(ctx context.Context, request provider.SchemaReq
 							Description: "An identifier for the assumed role session.",
 						},
 						"web_identity_token": schema.StringAttribute{
-							Optional: true,
+							Optional:    true,
+							Description: "Value of a web identity token from an OpenID Connect (OIDC) or OAuth provider. Can also be set with the `TF_AWS_IDENTITY_TOKEN` environment variable.",
 						},
 						"web_identity_token_file": schema.StringAttribute{
 							Optional: true,

--- a/internal/provider/framework/provider.go
+++ b/internal/provider/framework/provider.go
@@ -308,7 +308,7 @@ func (*frameworkProvider) Schema(ctx context.Context, request provider.SchemaReq
 						},
 						"web_identity_token": schema.StringAttribute{
 							Optional:    true,
-							Description: "Value of a web identity token. Can also be set with the `TF_AWS_IDENTITY_TOKEN` environment variable.",
+							Description: "Value of a web identity token. Can also be set with the `TF_AWS_WEB_IDENTITY_TOKEN` environment variable.",
 						},
 						"web_identity_token_file": schema.StringAttribute{
 							Optional: true,

--- a/internal/provider/framework/provider.go
+++ b/internal/provider/framework/provider.go
@@ -311,7 +311,8 @@ func (*frameworkProvider) Schema(ctx context.Context, request provider.SchemaReq
 							Description: "Value of a web identity token. Can also be set with the `TF_AWS_WEB_IDENTITY_TOKEN` environment variable.",
 						},
 						"web_identity_token_file": schema.StringAttribute{
-							Optional: true,
+							Optional:    true,
+							Description: "Path to a file containing a web identity token. Can also be set with the `AWS_WEB_IDENTITY_TOKEN_FILE` environment variable.",
 						},
 					},
 				},

--- a/internal/provider/framework/provider.go
+++ b/internal/provider/framework/provider.go
@@ -307,12 +307,10 @@ func (*frameworkProvider) Schema(ctx context.Context, request provider.SchemaReq
 							Description: "An identifier for the assumed role session.",
 						},
 						"web_identity_token": schema.StringAttribute{
-							Optional:    true,
-							Description: "Value of a web identity token. Can also be set with the `TF_AWS_WEB_IDENTITY_TOKEN` environment variable.",
+							Optional: true,
 						},
 						"web_identity_token_file": schema.StringAttribute{
-							Optional:    true,
-							Description: "Path to a file containing a web identity token. Can also be set with the `AWS_WEB_IDENTITY_TOKEN_FILE` environment variable.",
+							Optional: true,
 						},
 					},
 				},

--- a/internal/provider/sdkv2/provider.go
+++ b/internal/provider/sdkv2/provider.go
@@ -456,8 +456,6 @@ func (p *sdkProvider) configure(ctx context.Context, d *schema.ResourceData) (an
 			"tf_aws.assume_role_with_web_identity.role_arn":     config.AssumeRoleWithWebIdentity.RoleARN,
 			"tf_aws.assume_role_with_web_identity.session_name": config.AssumeRoleWithWebIdentity.SessionName,
 		})
-	} else if os.Getenv("TF_AWS_WEB_IDENTITY_TOKEN") != "" && os.Getenv("AWS_WEB_IDENTITY_TOKEN_FILE") != "" {
-		diags = append(diags, errs.NewAttributeConflictsWithError(cty.GetAttrPath("web_identity_token"), cty.GetAttrPath("web_identity_token_file")))
 	} else if v := os.Getenv("TF_AWS_WEB_IDENTITY_TOKEN"); v != "" {
 		config.AssumeRoleWithWebIdentity = expandAssumeRoleWithWebIdentity(ctx, nil)
 	}

--- a/internal/provider/sdkv2/provider.go
+++ b/internal/provider/sdkv2/provider.go
@@ -456,7 +456,7 @@ func (p *sdkProvider) configure(ctx context.Context, d *schema.ResourceData) (an
 			"tf_aws.assume_role_with_web_identity.role_arn":     config.AssumeRoleWithWebIdentity.RoleARN,
 			"tf_aws.assume_role_with_web_identity.session_name": config.AssumeRoleWithWebIdentity.SessionName,
 		})
-	} else if v := os.Getenv("TF_AWS_IDENTITY_TOKEN"); v != "" {
+	} else if v := os.Getenv("TF_AWS_WEB_IDENTITY_TOKEN"); v != "" {
 		config.AssumeRoleWithWebIdentity = expandAssumeRoleWithWebIdentity(ctx, nil)
 	}
 
@@ -1038,7 +1038,7 @@ func assumeRoleWithWebIdentitySchema() *schema.Schema {
 				"web_identity_token": {
 					Type:         schema.TypeString,
 					Optional:     true,
-					Description:  "Value of a web identity token. Can also be set with the `TF_AWS_IDENTITY_TOKEN` environment variable.",
+					Description:  "Value of a web identity token. Can also be set with the `TF_AWS_WEB_IDENTITY_TOKEN` environment variable.",
 					ValidateFunc: validation.StringLenBetween(4, 20000),
 				},
 				"web_identity_token_file": {
@@ -1121,7 +1121,7 @@ func expandAssumeRole(_ context.Context, path cty.Path, tfMap map[string]any) (r
 }
 
 func expandAssumeRoleWithWebIdentity(_ context.Context, tfMap map[string]any) *awsbase.AssumeRoleWithWebIdentity {
-	if tfMap == nil && os.Getenv("TF_AWS_IDENTITY_TOKEN") == "" {
+	if tfMap == nil && os.Getenv("TF_AWS_WEB_IDENTITY_TOKEN") == "" {
 		return nil
 	}
 
@@ -1150,7 +1150,7 @@ func expandAssumeRoleWithWebIdentity(_ context.Context, tfMap map[string]any) *a
 
 	if v, ok := tfMap["web_identity_token"].(string); ok && v != "" {
 		assumeRole.WebIdentityToken = v
-	} else if v := os.Getenv("TF_AWS_IDENTITY_TOKEN"); v != "" {
+	} else if v := os.Getenv("TF_AWS_WEB_IDENTITY_TOKEN"); v != "" {
 		assumeRole.WebIdentityToken = v
 	}
 

--- a/internal/provider/sdkv2/provider.go
+++ b/internal/provider/sdkv2/provider.go
@@ -1038,13 +1038,11 @@ func assumeRoleWithWebIdentitySchema() *schema.Schema {
 				"web_identity_token": {
 					Type:         schema.TypeString,
 					Optional:     true,
-					Description:  "Value of a web identity token. Can also be set with the `TF_AWS_WEB_IDENTITY_TOKEN` environment variable.",
 					ValidateFunc: validation.StringLenBetween(4, 20000),
 				},
 				"web_identity_token_file": {
-					Type:        schema.TypeString,
-					Optional:    true,
-					Description: "Path to a file containing a web identity token. Can also be set with the `AWS_WEB_IDENTITY_TOKEN_FILE` environment variable.",
+					Type:     schema.TypeString,
+					Optional: true,
 				},
 			},
 		},

--- a/internal/provider/sdkv2/provider.go
+++ b/internal/provider/sdkv2/provider.go
@@ -1038,14 +1038,12 @@ func assumeRoleWithWebIdentitySchema() *schema.Schema {
 				"web_identity_token": {
 					Type:         schema.TypeString,
 					Optional:     true,
-					Description:  "Value of a web identity token from an OpenID Connect (OIDC) or OAuth provider. Can also be set with the `TF_AWS_IDENTITY_TOKEN` environment variable.",
+					Description:  "Value of a web identity token. Can also be set with the `TF_AWS_IDENTITY_TOKEN` environment variable.",
 					ValidateFunc: validation.StringLenBetween(4, 20000),
-					ExactlyOneOf: []string{"assume_role_with_web_identity.0.web_identity_token", "assume_role_with_web_identity.0.web_identity_token_file"},
 				},
 				"web_identity_token_file": {
-					Type:         schema.TypeString,
-					Optional:     true,
-					ExactlyOneOf: []string{"assume_role_with_web_identity.0.web_identity_token", "assume_role_with_web_identity.0.web_identity_token_file"},
+					Type:     schema.TypeString,
+					Optional: true,
 				},
 			},
 		},

--- a/internal/provider/sdkv2/provider.go
+++ b/internal/provider/sdkv2/provider.go
@@ -456,6 +456,8 @@ func (p *sdkProvider) configure(ctx context.Context, d *schema.ResourceData) (an
 			"tf_aws.assume_role_with_web_identity.role_arn":     config.AssumeRoleWithWebIdentity.RoleARN,
 			"tf_aws.assume_role_with_web_identity.session_name": config.AssumeRoleWithWebIdentity.SessionName,
 		})
+	} else if v := os.Getenv("TF_AWS_IDENTITY_TOKEN"); v != "" {
+		config.AssumeRoleWithWebIdentity = expandAssumeRoleWithWebIdentity(ctx, nil)
 	}
 
 	if v, ok := d.GetOk("default_tags"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
@@ -1036,6 +1038,7 @@ func assumeRoleWithWebIdentitySchema() *schema.Schema {
 				"web_identity_token": {
 					Type:         schema.TypeString,
 					Optional:     true,
+					Description:  "Value of a web identity token from an OpenID Connect (OIDC) or OAuth provider. Can also be set with the `TF_AWS_IDENTITY_TOKEN` environment variable.",
 					ValidateFunc: validation.StringLenBetween(4, 20000),
 					ExactlyOneOf: []string{"assume_role_with_web_identity.0.web_identity_token", "assume_role_with_web_identity.0.web_identity_token_file"},
 				},
@@ -1120,7 +1123,7 @@ func expandAssumeRole(_ context.Context, path cty.Path, tfMap map[string]any) (r
 }
 
 func expandAssumeRoleWithWebIdentity(_ context.Context, tfMap map[string]any) *awsbase.AssumeRoleWithWebIdentity {
-	if tfMap == nil {
+	if tfMap == nil && os.Getenv("TF_AWS_IDENTITY_TOKEN") == "" {
 		return nil
 	}
 
@@ -1148,6 +1151,8 @@ func expandAssumeRoleWithWebIdentity(_ context.Context, tfMap map[string]any) *a
 	}
 
 	if v, ok := tfMap["web_identity_token"].(string); ok && v != "" {
+		assumeRole.WebIdentityToken = v
+	} else if v := os.Getenv("TF_AWS_IDENTITY_TOKEN"); v != "" {
 		assumeRole.WebIdentityToken = v
 	}
 

--- a/internal/provider/sdkv2/provider.go
+++ b/internal/provider/sdkv2/provider.go
@@ -456,6 +456,8 @@ func (p *sdkProvider) configure(ctx context.Context, d *schema.ResourceData) (an
 			"tf_aws.assume_role_with_web_identity.role_arn":     config.AssumeRoleWithWebIdentity.RoleARN,
 			"tf_aws.assume_role_with_web_identity.session_name": config.AssumeRoleWithWebIdentity.SessionName,
 		})
+	} else if os.Getenv("TF_AWS_WEB_IDENTITY_TOKEN") != "" && os.Getenv("AWS_WEB_IDENTITY_TOKEN_FILE") != "" {
+		diags = append(diags, errs.NewAttributeConflictsWithError(cty.GetAttrPath("web_identity_token"), cty.GetAttrPath("web_identity_token_file")))
 	} else if v := os.Getenv("TF_AWS_WEB_IDENTITY_TOKEN"); v != "" {
 		config.AssumeRoleWithWebIdentity = expandAssumeRoleWithWebIdentity(ctx, nil)
 	}

--- a/internal/provider/sdkv2/provider.go
+++ b/internal/provider/sdkv2/provider.go
@@ -1044,8 +1044,9 @@ func assumeRoleWithWebIdentitySchema() *schema.Schema {
 					ValidateFunc: validation.StringLenBetween(4, 20000),
 				},
 				"web_identity_token_file": {
-					Type:     schema.TypeString,
-					Optional: true,
+					Type:        schema.TypeString,
+					Optional:    true,
+					Description: "Path to a file containing a web identity token. Can also be set with the `AWS_WEB_IDENTITY_TOKEN_FILE` environment variable.",
 				},
 			},
 		},

--- a/internal/service/ec2/ec2_instance.go
+++ b/internal/service/ec2/ec2_instance.go
@@ -508,6 +508,10 @@ func resourceInstance() *schema.Resource {
 				ForceNew: true,
 				Computed: true,
 			},
+			"launch_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			names.AttrLaunchTemplate: {
 				Type:         schema.TypeList,
 				MaxItems:     1,
@@ -3226,6 +3230,7 @@ func resourceInstanceFlatten(ctx context.Context, client *conns.AWSClient, insta
 	rd.Set("ami", instance.ImageId)
 	rd.Set(names.AttrInstanceType, instanceType)
 	rd.Set("key_name", instance.KeyName)
+	rd.Set("launch_time", instance.LaunchTime.Format(time.RFC3339))
 	rd.Set("public_dns", instance.PublicDnsName)
 	rd.Set("public_ip", instance.PublicIpAddress)
 	rd.Set("private_dns", instance.PrivateDnsName)


### PR DESCRIPTION
## Rollback Plan
If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls
n/a

### Description
Adding parity with the `aws_instance` data source. When resources get created, they do not pull the launch time of the instance. 


### Relations
No active issues, but an issue was opened and close due to staleness. 
Relates: #34548 

Original data source request: 
Relates: #36977

### References
Mainly mirroring the data source setup...

https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/ec2/ec2_instance_data_source.go#L216-L219

https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/ec2/ec2_instance_data_source.go#L491C1-L491C64



### Output from Acceptance Testing
```console
➜  terraform-provider-aws git:(f-resource-aws-instance-launch-time) make testacc TESTS=TestAccEC2Instance_basic PKG=ec2                         
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-resource-aws-instance-launch-time 🌿...
TF_ACC=1 go1.25.7 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2Instance_basic'  -timeout 360m -vet=off
2026/05/21 16:36:57 Creating Terraform AWS Provider (SDKv2-style)...
2026/05/21 16:36:57 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccEC2Instance_basic
=== PAUSE TestAccEC2Instance_basic
=== RUN   TestAccEC2Instance_basicWithSpot
=== PAUSE TestAccEC2Instance_basicWithSpot
=== CONT  TestAccEC2Instance_basic
=== CONT  TestAccEC2Instance_basicWithSpot
--- PASS: TestAccEC2Instance_basic (50.23s)
--- PASS: TestAccEC2Instance_basicWithSpot (155.43s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        163.933s
```
