### PR TITLE
r/aws_instance : add `launch_time`

### DIFF
--- a/.changelog/48018.txt
+++ b/.changelog/48018.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_instance: Add `launch_time` attribute
+```

--- a/internal/service/ec2/ec2_instance.go
+++ b/internal/service/ec2/ec2_instance.go
@@ -648,6 +648,10 @@ func resourceInstanceSchema() map[string]*schema.Schema {
 			ForceNew: true,
 			Computed: true,
 		},
+		"launch_time": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
 		names.AttrLaunchTemplate: {
 			Type:         schema.TypeList,
 			MaxItems:     1,
@@ -3265,6 +3269,7 @@ func resourceInstanceFlatten(ctx context.Context, client *conns.AWSClient, insta
 	rd.Set("ami", instance.ImageId)
 	rd.Set(names.AttrInstanceType, instanceType)
 	rd.Set("key_name", instance.KeyName)
+	rd.Set("launch_time", instance.LaunchTime.Format(time.RFC3339))
 	rd.Set("public_dns", instance.PublicDnsName)
 	rd.Set("public_ip", instance.PublicIpAddress)
 	rd.Set("private_dns", instance.PrivateDnsName)

--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -467,6 +467,7 @@ This resource exports the following attributes in addition to the arguments abov
 
 * `arn` - ARN of the instance.
 * `capacity_reservation_specification` - Capacity reservation specification of the instance.
+* `launch_time` - Time the instance was launched.
 * `id` - ID of the instance.
 * `instance_state` - State of the instance. One of: `pending`, `running`, `shutting-down`, `terminated`, `stopping`, `stopped`. See [Instance Lifecycle](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-lifecycle.html) for more information.
 * `outpost_arn` - ARN of the Outpost the instance is assigned to.


### PR DESCRIPTION
## Rollback Plan
If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls
n/a

### Description
Adding parity with the `aws_instance` data source. When resources get created, they do not pull the launch time of the instance. 


### Relations
No active issues, but an issue was opened and close due to staleness. 
Relates: #34548 

Original data source request: 
Relates: #36977

### References
Mainly mirroring the data source setup...

https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/ec2/ec2_instance_data_source.go#L216-L219

https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/ec2/ec2_instance_data_source.go#L491C1-L491C64

Tested and adding to state: 

```json
    "instance_state": "running",
    "instance_type": "t3.micro",
    "ipv6_address_count": 0,
    "ipv6_addresses": [],
    "key_name": "tf-ec2-demo-oypnbf-key",
    "launch_template": [],
    "launch_time": "2026-05-21T19:57:23Z",
    "maintenance_options": [
      {
        "auto_recovery": "default"
      }
    ],
```

### Output from Acceptance Testing
```console
➜  terraform-provider-aws git:(f-resource-aws-instance-launch-time) make testacc TESTS=TestAccEC2Instance_basic PKG=ec2                         
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-resource-aws-instance-launch-time 🌿...
TF_ACC=1 go1.25.7 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2Instance_basic'  -timeout 360m -vet=off
2026/05/21 16:36:57 Creating Terraform AWS Provider (SDKv2-style)...
2026/05/21 16:36:57 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccEC2Instance_basic
=== PAUSE TestAccEC2Instance_basic
=== RUN   TestAccEC2Instance_basicWithSpot
=== PAUSE TestAccEC2Instance_basicWithSpot
=== CONT  TestAccEC2Instance_basic
=== CONT  TestAccEC2Instance_basicWithSpot
--- PASS: TestAccEC2Instance_basic (50.23s)
--- PASS: TestAccEC2Instance_basicWithSpot (155.43s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        163.933s
```
