### PR TITLE
data-source/aws_secretsmanager_secret_versions: Fixes flattening

### DIFF
--- a/.changelog/48033.txt
+++ b/.changelog/48033.txt
@@ -5,3 +5,7 @@ data-source/aws_secretsmanager_secret_versions: Polulates `versions.*.last_acces
 ```release-note:enhancement
 data-source/aws_secretsmanager_secret_versions: Deprecates `arn` in favor of `secret_arn`.
 ```
+
+```release-note:enhancement
+data-source/aws_secretsmanager_secret_versions: Deprecates `name` in favor of `secret_name`.
+```

--- a/.changelog/placeholder.txt
+++ b/.changelog/placeholder.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+data-source/aws_secretsmanager_secret_versions: Polulates `versions.*.last_accessed_date`.
+```
+
+```release-note:enhancement
+data-source/aws_secretsmanager_secret_versions: Deprecates `arn` in favor of `secret_arn`.
+```

--- a/internal/service/secretsmanager/secret_versions_data_source.go
+++ b/internal/service/secretsmanager/secret_versions_data_source.go
@@ -20,7 +20,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @FrameworkDataSource("aws_secretsmanager_secret_versions, name="Secret Versions")
+// @FrameworkDataSource("aws_secretsmanager_secret_versions", name="Secret Versions")
 func newSecretVersionsDataSource(context.Context) (datasource.DataSourceWithConfigure, error) {
 	return &secretVersionsDataSource{}, nil
 }

--- a/internal/service/secretsmanager/secret_versions_data_source.go
+++ b/internal/service/secretsmanager/secret_versions_data_source.go
@@ -113,7 +113,7 @@ type secretVersionsDataSourceModel struct {
 
 type dsVersionsData struct {
 	CreatedDate      timetypes.RFC3339                 `tfsdk:"created_time"`
-	LastAccessedDate types.String                      `tfsdk:"last_accessed_date"`
+	LastAccessedDate timetypes.RFC3339                 `tfsdk:"last_accessed_date"`
 	VersionID        types.String                      `tfsdk:"version_id"`
 	VersionStages    fwtypes.ListValueOf[types.String] `tfsdk:"version_stages"`
 }

--- a/internal/service/secretsmanager/secret_versions_data_source.go
+++ b/internal/service/secretsmanager/secret_versions_data_source.go
@@ -41,7 +41,8 @@ func (d *secretVersionsDataSource) Schema(ctx context.Context, req datasource.Sc
 				DeprecationMessage: "arn is deprecated. Use secret_arn instead.",
 			},
 			names.AttrName: schema.StringAttribute{
-				Computed: true,
+				Computed:           true,
+				DeprecationMessage: "name is deprecated. Use secret_name instead.",
 			},
 			"include_deprecated": schema.BoolAttribute{
 				Optional: true,
@@ -51,6 +52,9 @@ func (d *secretVersionsDataSource) Schema(ctx context.Context, req datasource.Sc
 			},
 			"secret_id": schema.StringAttribute{
 				Required: true,
+			},
+			"secret_name": schema.StringAttribute{
+				Computed: true,
 			},
 			"versions": framework.DataSourceComputedListOfObjectAttribute[dsVersionsData](ctx),
 		},
@@ -97,6 +101,7 @@ func (d *secretVersionsDataSource) Read(ctx context.Context, req datasource.Read
 		return
 	}
 	data.SecretARN = data.ARN
+	data.SecretName = data.Name
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -108,6 +113,7 @@ type secretVersionsDataSourceModel struct {
 	IncludeDeprecated types.Bool                                      `tfsdk:"include_deprecated"`
 	SecretARN         types.String                                    `tfsdk:"secret_arn"`
 	SecretID          types.String                                    `tfsdk:"secret_id"`
+	SecretName        types.String                                    `tfsdk:"secret_name"`
 	Versions          fwtypes.ListNestedObjectValueOf[dsVersionsData] `tfsdk:"versions"`
 }
 

--- a/internal/service/secretsmanager/secret_versions_data_source.go
+++ b/internal/service/secretsmanager/secret_versions_data_source.go
@@ -10,10 +10,8 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
-	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
@@ -39,16 +37,17 @@ func (d *secretVersionsDataSource) Schema(ctx context.Context, req datasource.Sc
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			names.AttrARN: schema.StringAttribute{
-				Computed: true,
-				Validators: []validator.String{
-					stringvalidator.LengthBetween(20, 2048),
-				},
+				Computed:           true,
+				DeprecationMessage: "arn is deprecated. Use secret_arn instead.",
 			},
 			names.AttrName: schema.StringAttribute{
 				Computed: true,
 			},
 			"include_deprecated": schema.BoolAttribute{
 				Optional: true,
+			},
+			"secret_arn": schema.StringAttribute{
+				Computed: true,
 			},
 			"secret_id": schema.StringAttribute{
 				Required: true,
@@ -77,7 +76,7 @@ func (d *secretVersionsDataSource) Read(ctx context.Context, req datasource.Read
 		page, err := paginator.NextPage(ctx)
 		if err != nil {
 			resp.Diagnostics.AddError(
-				create.ProblemStandardMessage(names.SecretsManager, create.ErrActionReading, DSNameSecretVersions, data.ARN.String(), err),
+				create.ProblemStandardMessage(names.SecretsManager, create.ErrActionReading, DSNameSecretVersions, data.SecretID.String(), err),
 				err.Error(),
 			)
 			return
@@ -97,6 +96,7 @@ func (d *secretVersionsDataSource) Read(ctx context.Context, req datasource.Read
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	data.SecretARN = data.ARN
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -106,6 +106,7 @@ type secretVersionsDataSourceModel struct {
 	ARN               types.String                                    `tfsdk:"arn"`
 	Name              types.String                                    `tfsdk:"name"`
 	IncludeDeprecated types.Bool                                      `tfsdk:"include_deprecated"`
+	SecretARN         types.String                                    `tfsdk:"secret_arn"`
 	SecretID          types.String                                    `tfsdk:"secret_id"`
 	Versions          fwtypes.ListNestedObjectValueOf[dsVersionsData] `tfsdk:"versions"`
 }

--- a/internal/service/secretsmanager/secret_versions_data_source_test.go
+++ b/internal/service/secretsmanager/secret_versions_data_source_test.go
@@ -35,6 +35,10 @@ func TestAccSecretsManagerSecretVersionsDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(dataSourceName, "versions.0.created_time"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "versions.0.version_id"),
 				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.CompareValuePairs(dataSourceName, tfjsonpath.New(names.AttrARN), dataSourceName, tfjsonpath.New("secret_arn"), compare.ValuesSame()),
+					statecheck.CompareValuePairs(dataSourceName, tfjsonpath.New("secret_arn"), resource1Name, tfjsonpath.New("secret_arn"), compare.ValuesSame()),
+				},
 			},
 		},
 	})

--- a/internal/service/secretsmanager/secret_versions_data_source_test.go
+++ b/internal/service/secretsmanager/secret_versions_data_source_test.go
@@ -38,9 +38,10 @@ func TestAccSecretsManagerSecretVersionsDataSource_basic(t *testing.T) {
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.CompareValuePairs(dataSourceName, tfjsonpath.New(names.AttrARN), dataSourceName, tfjsonpath.New("secret_arn"), compare.ValuesSame()),
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("include_deprecated"), knownvalue.Null()),
-					statecheck.CompareValuePairs(dataSourceName, tfjsonpath.New(names.AttrName), secretName, tfjsonpath.New(names.AttrName), compare.ValuesSame()),
+					statecheck.CompareValuePairs(dataSourceName, tfjsonpath.New(names.AttrName), dataSourceName, tfjsonpath.New("secret_name"), compare.ValuesSame()),
 					statecheck.CompareValuePairs(dataSourceName, tfjsonpath.New("secret_arn"), resource1Name, tfjsonpath.New("secret_arn"), compare.ValuesSame()),
 					statecheck.CompareValuePairs(dataSourceName, tfjsonpath.New("secret_id"), resource1Name, tfjsonpath.New("secret_id"), compare.ValuesSame()),
+					statecheck.CompareValuePairs(dataSourceName, tfjsonpath.New("secret_name"), secretName, tfjsonpath.New(names.AttrName), compare.ValuesSame()),
 					// Order is not guaranteed for `versions`
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("versions"), knownvalue.ListExact([]knownvalue.Check{
 						knownvalue.ObjectExact(map[string]knownvalue.Check{

--- a/internal/service/secretsmanager/secret_versions_data_source_test.go
+++ b/internal/service/secretsmanager/secret_versions_data_source_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/YakDriver/regexache"
 	"github.com/hashicorp/terraform-plugin-testing/compare"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
@@ -20,6 +21,7 @@ func TestAccSecretsManagerSecretVersionsDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resource1Name := "aws_secretsmanager_secret_version.test"
+	resource2Name := "aws_secretsmanager_secret_version.test2"
 	secretName := "aws_secretsmanager_secret.test"
 	dataSourceName := "data.aws_secretsmanager_secret_versions.test"
 
@@ -39,20 +41,23 @@ func TestAccSecretsManagerSecretVersionsDataSource_basic(t *testing.T) {
 					statecheck.CompareValuePairs(dataSourceName, tfjsonpath.New(names.AttrName), secretName, tfjsonpath.New(names.AttrName), compare.ValuesSame()),
 					statecheck.CompareValuePairs(dataSourceName, tfjsonpath.New("secret_arn"), resource1Name, tfjsonpath.New("secret_arn"), compare.ValuesSame()),
 					statecheck.CompareValuePairs(dataSourceName, tfjsonpath.New("secret_id"), resource1Name, tfjsonpath.New("secret_id"), compare.ValuesSame()),
+					// Order is not guaranteed for `versions`
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("versions"), knownvalue.ListExact([]knownvalue.Check{
-						knownvalue.ObjectPartial(map[string]knownvalue.Check{
-							"created_time":       knownvalue.NotNull(),
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"created_time":       knownvalue.StringRegexp(regexache.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$`)),
 							"last_accessed_date": knownvalue.Null(),
 							"version_id":         knownvalue.NotNull(),
-							"version_stages":     knownvalue.NotNull(),
+							"version_stages":     knownvalue.ListSizeExact(1),
 						}),
-						knownvalue.ObjectPartial(map[string]knownvalue.Check{
-							"created_time":       knownvalue.NotNull(),
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"created_time":       knownvalue.StringRegexp(regexache.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$`)),
 							"last_accessed_date": knownvalue.Null(),
 							"version_id":         knownvalue.NotNull(),
-							"version_stages":     knownvalue.NotNull(),
+							"version_stages":     knownvalue.ListSizeExact(1),
 						}),
 					})),
+					statecheck.CompareValueCollection(dataSourceName, []tfjsonpath.Path{tfjsonpath.New("versions"), tfjsonpath.New("version_id")}, resource1Name, tfjsonpath.New("version_id"), compare.ValuesSame()),
+					statecheck.CompareValueCollection(dataSourceName, []tfjsonpath.Path{tfjsonpath.New("versions"), tfjsonpath.New("version_id")}, resource2Name, tfjsonpath.New("version_id"), compare.ValuesSame()),
 				},
 			},
 		},

--- a/internal/service/secretsmanager/secret_versions_data_source_test.go
+++ b/internal/service/secretsmanager/secret_versions_data_source_test.go
@@ -45,13 +45,13 @@ func TestAccSecretsManagerSecretVersionsDataSource_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("versions"), knownvalue.ListExact([]knownvalue.Check{
 						knownvalue.ObjectExact(map[string]knownvalue.Check{
 							"created_time":       knownvalue.StringRegexp(regexache.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$`)),
-							"last_accessed_date": knownvalue.Null(),
+							"last_accessed_date": knownvalue.StringRegexp(regexache.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$`)),
 							"version_id":         knownvalue.NotNull(),
 							"version_stages":     knownvalue.ListSizeExact(1),
 						}),
 						knownvalue.ObjectExact(map[string]knownvalue.Check{
 							"created_time":       knownvalue.StringRegexp(regexache.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$`)),
-							"last_accessed_date": knownvalue.Null(),
+							"last_accessed_date": knownvalue.StringRegexp(regexache.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$`)),
 							"version_id":         knownvalue.NotNull(),
 							"version_stages":     knownvalue.ListSizeExact(1),
 						}),

--- a/internal/service/secretsmanager/secret_versions_data_source_test.go
+++ b/internal/service/secretsmanager/secret_versions_data_source_test.go
@@ -91,7 +91,7 @@ func TestAccSecretsManagerSecretVersionsDataSource_emptyVer(t *testing.T) {
 func testAccSecretVersionsDataSourceConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 data "aws_secretsmanager_secret_versions" "test" {
-  secret_id  = aws_secretsmanager_secret.test.id
+  secret_id = aws_secretsmanager_secret.test.id
 
   depends_on = [
     aws_secretsmanager_secret_version.test,
@@ -112,7 +112,7 @@ resource "aws_secretsmanager_secret_version" "test2" {
   secret_id     = aws_secretsmanager_secret.test.id
   secret_string = "test-string2"
 
-  depends_on    = [aws_secretsmanager_secret_version.test]
+  depends_on = [aws_secretsmanager_secret_version.test]
 }
 `, rName)
 }

--- a/internal/service/secretsmanager/secret_versions_data_source_test.go
+++ b/internal/service/secretsmanager/secret_versions_data_source_test.go
@@ -7,7 +7,11 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-testing/compare"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -16,6 +20,7 @@ func TestAccSecretsManagerSecretVersionsDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resource1Name := "aws_secretsmanager_secret_version.test"
+	secretName := "aws_secretsmanager_secret.test"
 	dataSourceName := "data.aws_secretsmanager_secret_versions.test"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -28,16 +33,26 @@ func TestAccSecretsManagerSecretVersionsDataSource_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSecretVersionsDataSourceConfig_basic(rName),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrPair(dataSourceName, "secret_id", resource1Name, "secret_id"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "versions.#"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "versions.0.%"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "versions.0.created_time"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "versions.0.version_id"),
-				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.CompareValuePairs(dataSourceName, tfjsonpath.New(names.AttrARN), dataSourceName, tfjsonpath.New("secret_arn"), compare.ValuesSame()),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("include_deprecated"), knownvalue.Null()),
+					statecheck.CompareValuePairs(dataSourceName, tfjsonpath.New(names.AttrName), secretName, tfjsonpath.New(names.AttrName), compare.ValuesSame()),
 					statecheck.CompareValuePairs(dataSourceName, tfjsonpath.New("secret_arn"), resource1Name, tfjsonpath.New("secret_arn"), compare.ValuesSame()),
+					statecheck.CompareValuePairs(dataSourceName, tfjsonpath.New("secret_id"), resource1Name, tfjsonpath.New("secret_id"), compare.ValuesSame()),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("versions"), knownvalue.ListExact([]knownvalue.Check{
+						knownvalue.ObjectPartial(map[string]knownvalue.Check{
+							"created_time":       knownvalue.NotNull(),
+							"last_accessed_date": knownvalue.Null(),
+							"version_id":         knownvalue.NotNull(),
+							"version_stages":     knownvalue.NotNull(),
+						}),
+						knownvalue.ObjectPartial(map[string]knownvalue.Check{
+							"created_time":       knownvalue.NotNull(),
+							"last_accessed_date": knownvalue.Null(),
+							"version_id":         knownvalue.NotNull(),
+							"version_stages":     knownvalue.NotNull(),
+						}),
+					})),
 				},
 			},
 		},
@@ -69,6 +84,15 @@ func TestAccSecretsManagerSecretVersionsDataSource_emptyVer(t *testing.T) {
 
 func testAccSecretVersionsDataSourceConfig_basic(rName string) string {
 	return fmt.Sprintf(`
+data "aws_secretsmanager_secret_versions" "test" {
+  secret_id  = aws_secretsmanager_secret.test.id
+
+  depends_on = [
+    aws_secretsmanager_secret_version.test,
+    aws_secretsmanager_secret_version.test2,
+  ]
+}
+
 resource "aws_secretsmanager_secret" "test" {
   name = %[1]q
 }
@@ -79,14 +103,10 @@ resource "aws_secretsmanager_secret_version" "test" {
 }
 
 resource "aws_secretsmanager_secret_version" "test2" {
-  depends_on    = [aws_secretsmanager_secret_version.test]
   secret_id     = aws_secretsmanager_secret.test.id
   secret_string = "test-string2"
-}
 
-data "aws_secretsmanager_secret_versions" "test" {
-  depends_on = [aws_secretsmanager_secret_version.test]
-  secret_id  = aws_secretsmanager_secret.test.id
+  depends_on    = [aws_secretsmanager_secret_version.test]
 }
 `, rName)
 }

--- a/internal/service/secretsmanager/secret_versions_data_source_test.go
+++ b/internal/service/secretsmanager/secret_versions_data_source_test.go
@@ -45,16 +45,16 @@ func TestAccSecretsManagerSecretVersionsDataSource_basic(t *testing.T) {
 					// Order is not guaranteed for `versions`
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("versions"), knownvalue.ListExact([]knownvalue.Check{
 						knownvalue.ObjectExact(map[string]knownvalue.Check{
-							"created_time":       knownvalue.StringRegexp(regexache.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$`)),
-							"last_accessed_date": knownvalue.StringRegexp(regexache.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$`)),
-							"version_id":         knownvalue.NotNull(),
-							"version_stages":     knownvalue.ListSizeExact(1),
+							names.AttrCreatedTime: knownvalue.StringRegexp(regexache.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$`)),
+							"last_accessed_date":  knownvalue.StringRegexp(regexache.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$`)),
+							"version_id":          knownvalue.NotNull(),
+							"version_stages":      knownvalue.ListSizeExact(1),
 						}),
 						knownvalue.ObjectExact(map[string]knownvalue.Check{
-							"created_time":       knownvalue.StringRegexp(regexache.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$`)),
-							"last_accessed_date": knownvalue.StringRegexp(regexache.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$`)),
-							"version_id":         knownvalue.NotNull(),
-							"version_stages":     knownvalue.ListSizeExact(1),
+							names.AttrCreatedTime: knownvalue.StringRegexp(regexache.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$`)),
+							"last_accessed_date":  knownvalue.StringRegexp(regexache.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$`)),
+							"version_id":          knownvalue.NotNull(),
+							"version_stages":      knownvalue.ListSizeExact(1),
 						}),
 					})),
 					statecheck.CompareValueCollection(dataSourceName, []tfjsonpath.Path{tfjsonpath.New("versions"), tfjsonpath.New("version_id")}, resource1Name, tfjsonpath.New("version_id"), compare.ValuesSame()),

--- a/website/docs/d/secretsmanager_secret_version.html.markdown
+++ b/website/docs/d/secretsmanager_secret_version.html.markdown
@@ -55,6 +55,7 @@ This data source supports the following arguments:
 This data source exports the following attributes in addition to the arguments above:
 
 * `arn` - (**Deprecated**) The ARN of the secret.
+  Use `secret_arn` instead.
 * `created_date` - Created date of the secret in UTC.
 * `secret_arn` - The ARN of the secret.
 * `secret_string` - Decrypted part of the protected secret information that was originally provided as a string.

--- a/website/docs/d/secretsmanager_secret_versions.html.markdown
+++ b/website/docs/d/secretsmanager_secret_versions.html.markdown
@@ -48,14 +48,15 @@ This data source supports the following arguments:
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `secret_id` - (Required) Specifies the secret containing the version that you want to retrieve. You can specify either the ARN or the friendly name of the secret.
 * `include_deprecated` - (Optional) If true, all deprecated secret versions are included in the response.
-If false, no deprecated secret versions are included in the response. If no value is specified, the default value is `false`.
+  If false, no deprecated secret versions are included in the response.
+  If no value is specified, the default value is `false`.
 
 ## Attribute Reference
 
 This data source exports the following attributes in addition to the arguments above:
 
-* `arn` - ARN of the secret.
-* `id` - Secret id.
+* `arn` - (**Deprecated**) The ARN of the secret.
+  Use `secret_arn` instead.
 * `versions` - List of the versions of the secret. Attributes are specified below.
 
 ### versions

--- a/website/docs/d/secretsmanager_secret_versions.html.markdown
+++ b/website/docs/d/secretsmanager_secret_versions.html.markdown
@@ -57,6 +57,10 @@ This data source exports the following attributes in addition to the arguments a
 
 * `arn` - (**Deprecated**) The ARN of the secret.
   Use `secret_arn` instead.
+* `name` - (**Deprecated**) Name of the secret.
+  Use `secret_name` instead.
+* `secret_arn` - The ARN of the secret.
+* `secret_name` - Name of the secret.
 * `versions` - List of the versions of the secret. Attributes are specified below.
 
 ### versions

--- a/website/docs/r/secretsmanager_secret_version.html.markdown
+++ b/website/docs/r/secretsmanager_secret_version.html.markdown
@@ -76,6 +76,7 @@ This resource supports the following arguments:
 This resource exports the following attributes in addition to the arguments above:
 
 * `arn` - (**Deprecated**) The ARN of the secret.
+  Use `secret_arn` instead.
 * `secret_arn` - The ARN of the secret.
 * `version_id` - The unique identifier of the version of the secret.
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Previously, the value of `versions.*.last_accessed_date` was not populated and the AutoFlex log contained error messages. Corrects model data type from `types.String` to `timetypes.RFC3339`.

Also deprecates `arn` in favour of `secret_arn` and `name` in favour of `secret_name`.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=secretsmanager TESTS=TestAccSecretsManagerSecretVersionsDataSource_

--- PASS: TestAccSecretsManagerSecretVersionsDataSource_emptyVer (14.96s)
--- PASS: TestAccSecretsManagerSecretVersionsDataSource_basic (15.31s)
```
