### PR TITLE
`meta` service: Deprecate `id` attribute

### DIFF
--- a/.changelog/48036.txt
+++ b/.changelog/48036.txt
@@ -1,0 +1,27 @@
+```release-note:enhancement
+data-source/aws_arn: Deprecates `id` in favor of `arn`
+```
+
+```release-note:enhancement
+data-source/aws_default_tags: Deprecates `id`
+```
+
+```release-note:enhancement
+data-source/aws_ip_ranges: Deprecates `id`
+```
+
+```release-note:enhancement
+data-source/aws_partition: Deprecates `id` in favor of `partition`
+```
+
+```release-note:enhancement
+data-source/aws_region: Deprecates `id` in favor of `region`
+```
+
+```release-note:enhancement
+data-source/aws_regions: Deprecates `id`
+```
+
+```release-note:enhancement
+data-source/aws_service: Deprecates `id` in favor of `reverse_dns_name`
+```

--- a/internal/framework/datasourceattribute/attributes.go
+++ b/internal/framework/datasourceattribute/attributes.go
@@ -1,0 +1,35 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package datasourceattribute
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+)
+
+func IDAttribute() schema.StringAttribute {
+	return schema.StringAttribute{
+		Computed: true,
+	}
+}
+
+func IDAttributeDeprecatedWithAlternate(altPath path.Path) schema.StringAttribute {
+	return schema.StringAttribute{
+		Computed:           true,
+		DeprecationMessage: deprecatedWithAlternateMessage(altPath),
+	}
+}
+
+func IDAttributeDeprecatedNoReplacement() schema.StringAttribute {
+	return schema.StringAttribute{
+		Computed:           true,
+		DeprecationMessage: "This attribute will be removed in a future version of the provider.",
+	}
+}
+
+func deprecatedWithAlternateMessage(altPath path.Path) string {
+	return fmt.Sprintf("Use '%s' instead. This attribute will be removed in a future version of the provider.", altPath.String())
+}

--- a/internal/service/meta/arn_data_source.go
+++ b/internal/service/meta/arn_data_source.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
-	"github.com/hashicorp/terraform-provider-aws/internal/framework/datasourceattribute"
 	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
 	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -41,7 +40,7 @@ func (d *arnDataSource) Schema(ctx context.Context, request datasource.SchemaReq
 				CustomType: fwtypes.ARNType,
 				Required:   true,
 			},
-			names.AttrID: datasourceattribute.IDAttributeDeprecatedWithAlternate(path.Root(names.AttrARN)),
+			names.AttrID: idAttributeDeprecatedWithAlternate(path.Root(names.AttrARN)),
 			"partition": schema.StringAttribute{
 				Computed: true,
 			},

--- a/internal/service/meta/arn_data_source.go
+++ b/internal/service/meta/arn_data_source.go
@@ -10,8 +10,10 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/datasourceattribute"
 	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
 	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -39,10 +41,7 @@ func (d *arnDataSource) Schema(ctx context.Context, request datasource.SchemaReq
 				CustomType: fwtypes.ARNType,
 				Required:   true,
 			},
-			names.AttrID: schema.StringAttribute{
-				Optional: true,
-				Computed: true,
-			},
+			names.AttrID: datasourceattribute.IDAttributeDeprecatedWithAlternate(path.Root(names.AttrARN)),
 			"partition": schema.StringAttribute{
 				Computed: true,
 			},

--- a/internal/service/meta/arn_data_source_test.go
+++ b/internal/service/meta/arn_data_source_test.go
@@ -27,7 +27,8 @@ func TestAccMetaARNDataSource_basic(t *testing.T) {
 				Config: testAccARNDataSourceConfig_basic(arn),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "account", acctest.Ct12Digit),
-					resource.TestCheckResourceAttr(dataSourceName, names.AttrID, arn),
+					resource.TestCheckResourceAttr(dataSourceName, names.AttrARN, arn),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrID, dataSourceName, names.AttrARN),
 					resource.TestCheckResourceAttr(dataSourceName, "partition", "aws"),
 					resource.TestCheckResourceAttr(dataSourceName, names.AttrRegion, "eu-west-1"), // lintignore:AWSAT003
 					resource.TestCheckResourceAttr(dataSourceName, "resource", "db:mysql-db"),
@@ -52,7 +53,8 @@ func TestAccMetaARNDataSource_s3Bucket(t *testing.T) {
 				Config: testAccARNDataSourceConfig_basic(arn),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "account", ""),
-					resource.TestCheckResourceAttr(dataSourceName, names.AttrID, arn),
+					resource.TestCheckResourceAttr(dataSourceName, names.AttrARN, arn),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrID, dataSourceName, names.AttrARN),
 					resource.TestCheckResourceAttr(dataSourceName, "partition", "aws"),
 					resource.TestCheckResourceAttr(dataSourceName, names.AttrRegion, ""),
 					resource.TestCheckResourceAttr(dataSourceName, "resource", "my_corporate_bucket/Development/*"),

--- a/internal/service/meta/attributes.go
+++ b/internal/service/meta/attributes.go
@@ -1,0 +1,37 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+// DONOTCOPY: Copying old resources spreads bad habits. Use skaff instead.
+
+package meta
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+)
+
+// idAttributeDeprecatedWithAlternate is a variant of datasourceattribute.IDAttributeDeprecatedWithAlternate
+// that allows it to be set, preventing a breaking change.
+func idAttributeDeprecatedWithAlternate(altPath path.Path) schema.StringAttribute {
+	return schema.StringAttribute{
+		Optional:           true,
+		Computed:           true,
+		DeprecationMessage: deprecatedWithAlternateMessage(altPath),
+	}
+}
+
+// idAttributeDeprecatedNoReplacement is a variant of datasourceattribute.IDAttributeDeprecatedNoReplacement
+// that allows it to be set, preventing a breaking change.
+func idAttributeDeprecatedNoReplacement() schema.StringAttribute {
+	return schema.StringAttribute{
+		Optional:           true,
+		Computed:           true,
+		DeprecationMessage: "This attribute will be removed in a future version of the provider.",
+	}
+}
+
+func deprecatedWithAlternateMessage(altPath path.Path) string {
+	return fmt.Sprintf("Use '%s' instead. This attribute will be removed in a future version of the provider.", altPath.String())
+}

--- a/internal/service/meta/default_tags_data_source.go
+++ b/internal/service/meta/default_tags_data_source.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
-	"github.com/hashicorp/terraform-provider-aws/internal/framework/datasourceattribute"
 	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -33,7 +32,7 @@ type defaultTagsDataSource struct {
 func (d *defaultTagsDataSource) Schema(ctx context.Context, request datasource.SchemaRequest, response *datasource.SchemaResponse) {
 	response.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
-			names.AttrID:   datasourceattribute.IDAttributeDeprecatedNoReplacement(),
+			names.AttrID:   idAttributeDeprecatedNoReplacement(),
 			names.AttrTags: tftags.TagsAttributeComputedOnly(),
 		},
 	}

--- a/internal/service/meta/default_tags_data_source.go
+++ b/internal/service/meta/default_tags_data_source.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/datasourceattribute"
 	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -32,10 +33,7 @@ type defaultTagsDataSource struct {
 func (d *defaultTagsDataSource) Schema(ctx context.Context, request datasource.SchemaRequest, response *datasource.SchemaResponse) {
 	response.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
-			names.AttrID: schema.StringAttribute{
-				Optional: true,
-				Computed: true,
-			},
+			names.AttrID:   datasourceattribute.IDAttributeDeprecatedNoReplacement(),
 			names.AttrTags: tftags.TagsAttributeComputedOnly(),
 		},
 	}

--- a/internal/service/meta/default_tags_data_source_test.go
+++ b/internal/service/meta/default_tags_data_source_test.go
@@ -26,21 +26,17 @@ func TestAccMetaDefaultTagsDataSource_basic(t *testing.T) {
 		CheckDestroy:             nil,
 		Steps: []resource.TestStep{
 			{
-				Config: acctest.ConfigCompose(
-					acctest.ConfigDefaultTags_Tags1("first", acctest.CtValue1),
-					testAccDefaultTagsDataSourceConfig_basic(),
-				),
+				Config: testAccDefaultTagsDataSourceConfig_basic(),
 				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
-						"first": knownvalue.StringExact(acctest.CtValue1),
-					})),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrID), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
 				},
 			},
 		},
 	})
 }
 
-func TestAccMetaDefaultTagsDataSource_empty(t *testing.T) {
+func TestAccMetaDefaultTagsDataSource_single(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_default_tags.test"
 
@@ -51,9 +47,14 @@ func TestAccMetaDefaultTagsDataSource_empty(t *testing.T) {
 		CheckDestroy:             nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDefaultTagsDataSourceConfig_basic(),
+				Config: acctest.ConfigCompose(
+					acctest.ConfigDefaultTags_Tags1("first", acctest.CtValue1),
+					testAccDefaultTagsDataSourceConfig_basic(),
+				),
 				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
+						"first": knownvalue.StringExact(acctest.CtValue1),
+					})),
 				},
 			},
 		},

--- a/internal/service/meta/ip_ranges_data_source.go
+++ b/internal/service/meta/ip_ranges_data_source.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/datasourceattribute"
 	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
 	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
 	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
@@ -49,10 +50,7 @@ func (d *ipRangesDataSource) Schema(ctx context.Context, request datasource.Sche
 			"create_date": schema.StringAttribute{
 				Computed: true,
 			},
-			names.AttrID: schema.StringAttribute{
-				Optional: true,
-				Computed: true,
-			},
+			names.AttrID: datasourceattribute.IDAttributeDeprecatedNoReplacement(),
 			"ipv6_cidr_blocks": schema.ListAttribute{
 				ElementType: types.StringType,
 				CustomType:  fwtypes.ListOfStringType,

--- a/internal/service/meta/ip_ranges_data_source.go
+++ b/internal/service/meta/ip_ranges_data_source.go
@@ -20,7 +20,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
-	"github.com/hashicorp/terraform-provider-aws/internal/framework/datasourceattribute"
 	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
 	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
 	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
@@ -50,7 +49,7 @@ func (d *ipRangesDataSource) Schema(ctx context.Context, request datasource.Sche
 			"create_date": schema.StringAttribute{
 				Computed: true,
 			},
-			names.AttrID: datasourceattribute.IDAttributeDeprecatedNoReplacement(),
+			names.AttrID: idAttributeDeprecatedNoReplacement(),
 			"ipv6_cidr_blocks": schema.ListAttribute{
 				ElementType: types.StringType,
 				CustomType:  fwtypes.ListOfStringType,

--- a/internal/service/meta/ip_ranges_data_source_test.go
+++ b/internal/service/meta/ip_ranges_data_source_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	tfmeta "github.com/hashicorp/terraform-provider-aws/internal/service/meta"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func TestAccMetaIPRangesDataSource_basic(t *testing.T) {
@@ -33,6 +34,7 @@ func TestAccMetaIPRangesDataSource_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccIPRangesCheckAttributes(dataSourceName),
 					testAccIPRangesCheckCIDRBlocksAttribute(dataSourceName, "cidr_blocks"),
+					resource.TestCheckResourceAttrSet(dataSourceName, names.AttrID),
 					testAccIPRangesCheckCIDRBlocksAttribute(dataSourceName, "ipv6_cidr_blocks"),
 				),
 			},

--- a/internal/service/meta/partition_data_source.go
+++ b/internal/service/meta/partition_data_source.go
@@ -10,8 +10,10 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/datasourceattribute"
 	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -34,10 +36,7 @@ func (d *partitionDataSource) Schema(ctx context.Context, request datasource.Sch
 			"dns_suffix": schema.StringAttribute{
 				Computed: true,
 			},
-			names.AttrID: schema.StringAttribute{
-				Optional: true,
-				Computed: true,
-			},
+			names.AttrID: datasourceattribute.IDAttributeDeprecatedWithAlternate(path.Root("partition")),
 			"partition": schema.StringAttribute{
 				Computed: true,
 			},

--- a/internal/service/meta/partition_data_source.go
+++ b/internal/service/meta/partition_data_source.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
-	"github.com/hashicorp/terraform-provider-aws/internal/framework/datasourceattribute"
 	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -36,7 +35,7 @@ func (d *partitionDataSource) Schema(ctx context.Context, request datasource.Sch
 			"dns_suffix": schema.StringAttribute{
 				Computed: true,
 			},
-			names.AttrID: datasourceattribute.IDAttributeDeprecatedWithAlternate(path.Root("partition")),
+			names.AttrID: idAttributeDeprecatedWithAlternate(path.Root("partition")),
 			"partition": schema.StringAttribute{
 				Computed: true,
 			},

--- a/internal/service/meta/partition_data_source_test.go
+++ b/internal/service/meta/partition_data_source_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	tfmeta "github.com/hashicorp/terraform-provider-aws/internal/service/meta"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func TestAccMetaPartitionDataSource_basic(t *testing.T) {
@@ -24,6 +25,7 @@ func TestAccMetaPartitionDataSource_basic(t *testing.T) {
 			{
 				Config: testAccPartitionDataSourceConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrID, dataSourceName, "partition"),
 					resource.TestCheckResourceAttrWith(dataSourceName, "partition", func(value string) error {
 						expected := acctest.ProviderMeta(ctx, t).Partition(ctx)
 						if value != expected {

--- a/internal/service/meta/region_data_source.go
+++ b/internal/service/meta/region_data_source.go
@@ -47,8 +47,9 @@ func (d *regionDataSource) Schema(ctx context.Context, request datasource.Schema
 				Computed: true,
 			},
 			names.AttrID: schema.StringAttribute{
-				Optional: true,
-				Computed: true,
+				Optional:           true,
+				Computed:           true,
+				DeprecationMessage: "id is deprecated. Use region instead.",
 			},
 			names.AttrName: schema.StringAttribute{
 				Optional:           true,

--- a/internal/service/meta/region_data_source.go
+++ b/internal/service/meta/region_data_source.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
-	"github.com/hashicorp/terraform-provider-aws/internal/framework/datasourceattribute"
 	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -47,7 +46,7 @@ func (d *regionDataSource) Schema(ctx context.Context, request datasource.Schema
 				Optional: true,
 				Computed: true,
 			},
-			names.AttrID: datasourceattribute.IDAttributeDeprecatedWithAlternate(path.Root(names.AttrRegion)),
+			names.AttrID: idAttributeDeprecatedWithAlternate(path.Root(names.AttrRegion)),
 			names.AttrName: schema.StringAttribute{
 				Optional:           true,
 				Computed:           true,

--- a/internal/service/meta/region_data_source.go
+++ b/internal/service/meta/region_data_source.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/datasourceattribute"
 	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -46,11 +47,7 @@ func (d *regionDataSource) Schema(ctx context.Context, request datasource.Schema
 				Optional: true,
 				Computed: true,
 			},
-			names.AttrID: schema.StringAttribute{
-				Optional:           true,
-				Computed:           true,
-				DeprecationMessage: "id is deprecated. Use region instead.",
-			},
+			names.AttrID: datasourceattribute.IDAttributeDeprecatedWithAlternate(path.Root(names.AttrRegion)),
 			names.AttrName: schema.StringAttribute{
 				Optional:           true,
 				Computed:           true,

--- a/internal/service/meta/region_data_source_test.go
+++ b/internal/service/meta/region_data_source_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/aws-sdk-go-base/v2/endpoints"
+	"github.com/hashicorp/terraform-plugin-testing/compare"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -108,7 +109,8 @@ func TestAccMetaRegionDataSource_basic(t *testing.T) {
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrDescription), knownvalue.NotNull()),
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrEndpoint), knownvalue.NotNull()),
-					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrName), knownvalue.StringExact(acctest.Region())),
+					statecheck.CompareValuePairs(dataSourceName, tfjsonpath.New(names.AttrID), dataSourceName, tfjsonpath.New(names.AttrRegion), compare.ValuesSame()),
+					statecheck.CompareValuePairs(dataSourceName, tfjsonpath.New(names.AttrName), dataSourceName, tfjsonpath.New(names.AttrRegion), compare.ValuesSame()),
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.Region())),
 				},
 			},
@@ -130,7 +132,8 @@ func TestAccMetaRegionDataSource_endpoint(t *testing.T) {
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrDescription), knownvalue.NotNull()),
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrEndpoint), knownvalue.NotNull()),
-					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrName), knownvalue.StringExact(endpoints.EuWest1RegionID)),
+					statecheck.CompareValuePairs(dataSourceName, tfjsonpath.New(names.AttrID), dataSourceName, tfjsonpath.New(names.AttrRegion), compare.ValuesSame()),
+					statecheck.CompareValuePairs(dataSourceName, tfjsonpath.New(names.AttrName), dataSourceName, tfjsonpath.New(names.AttrRegion), compare.ValuesSame()),
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(endpoints.EuWest1RegionID)),
 				},
 			},
@@ -152,7 +155,8 @@ func TestAccMetaRegionDataSource_endpointAndName(t *testing.T) {
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrDescription), knownvalue.NotNull()),
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrEndpoint), knownvalue.NotNull()),
-					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrName), knownvalue.StringExact(endpoints.ApNortheast1RegionID)),
+					statecheck.CompareValuePairs(dataSourceName, tfjsonpath.New(names.AttrID), dataSourceName, tfjsonpath.New(names.AttrRegion), compare.ValuesSame()),
+					statecheck.CompareValuePairs(dataSourceName, tfjsonpath.New(names.AttrName), dataSourceName, tfjsonpath.New(names.AttrRegion), compare.ValuesSame()),
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(endpoints.ApNortheast1RegionID)),
 				},
 			},
@@ -174,7 +178,8 @@ func TestAccMetaRegionDataSource_name(t *testing.T) {
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrDescription), knownvalue.NotNull()),
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrEndpoint), knownvalue.NotNull()),
-					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrName), knownvalue.StringExact(endpoints.UsWest1RegionID)),
+					statecheck.CompareValuePairs(dataSourceName, tfjsonpath.New(names.AttrID), dataSourceName, tfjsonpath.New(names.AttrRegion), compare.ValuesSame()),
+					statecheck.CompareValuePairs(dataSourceName, tfjsonpath.New(names.AttrName), dataSourceName, tfjsonpath.New(names.AttrRegion), compare.ValuesSame()),
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(endpoints.UsWest1RegionID)),
 				},
 			},
@@ -196,7 +201,8 @@ func TestAccMetaRegionDataSource_endpointAndRegion(t *testing.T) {
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrDescription), knownvalue.NotNull()),
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrEndpoint), knownvalue.NotNull()),
-					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrName), knownvalue.StringExact(endpoints.ApSoutheast2RegionID)),
+					statecheck.CompareValuePairs(dataSourceName, tfjsonpath.New(names.AttrID), dataSourceName, tfjsonpath.New(names.AttrRegion), compare.ValuesSame()),
+					statecheck.CompareValuePairs(dataSourceName, tfjsonpath.New(names.AttrName), dataSourceName, tfjsonpath.New(names.AttrRegion), compare.ValuesSame()),
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(endpoints.ApSoutheast2RegionID)),
 				},
 			},
@@ -218,7 +224,8 @@ func TestAccMetaRegionDataSource_region(t *testing.T) {
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrDescription), knownvalue.NotNull()),
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrEndpoint), knownvalue.NotNull()),
-					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrName), knownvalue.StringExact(endpoints.UsGovEast1RegionID)),
+					statecheck.CompareValuePairs(dataSourceName, tfjsonpath.New(names.AttrID), dataSourceName, tfjsonpath.New(names.AttrRegion), compare.ValuesSame()),
+					statecheck.CompareValuePairs(dataSourceName, tfjsonpath.New(names.AttrName), dataSourceName, tfjsonpath.New(names.AttrRegion), compare.ValuesSame()),
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(endpoints.UsGovEast1RegionID)),
 				},
 			},

--- a/internal/service/meta/regions_data_source.go
+++ b/internal/service/meta/regions_data_source.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/datasourceattribute"
 	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
 	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
 	tfec2 "github.com/hashicorp/terraform-provider-aws/internal/service/ec2"
@@ -40,10 +41,7 @@ func (d *regionsDataSource) Schema(ctx context.Context, request datasource.Schem
 			"all_regions": schema.BoolAttribute{
 				Optional: true,
 			},
-			names.AttrID: schema.StringAttribute{
-				Optional: true,
-				Computed: true,
-			},
+			names.AttrID: datasourceattribute.IDAttributeDeprecatedNoReplacement(),
 			names.AttrNames: schema.SetAttribute{
 				CustomType:  fwtypes.SetOfStringType,
 				ElementType: types.StringType,

--- a/internal/service/meta/regions_data_source.go
+++ b/internal/service/meta/regions_data_source.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
-	"github.com/hashicorp/terraform-provider-aws/internal/framework/datasourceattribute"
 	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
 	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
 	tfec2 "github.com/hashicorp/terraform-provider-aws/internal/service/ec2"
@@ -41,7 +40,7 @@ func (d *regionsDataSource) Schema(ctx context.Context, request datasource.Schem
 			"all_regions": schema.BoolAttribute{
 				Optional: true,
 			},
-			names.AttrID: datasourceattribute.IDAttributeDeprecatedNoReplacement(),
+			names.AttrID: idAttributeDeprecatedNoReplacement(),
 			names.AttrNames: schema.SetAttribute{
 				CustomType:  fwtypes.SetOfStringType,
 				ElementType: types.StringType,

--- a/internal/service/meta/regions_data_source_test.go
+++ b/internal/service/meta/regions_data_source_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	tfmeta "github.com/hashicorp/terraform-provider-aws/internal/service/meta"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func TestAccMetaRegionsDataSource_basic(t *testing.T) {
@@ -24,6 +25,7 @@ func TestAccMetaRegionsDataSource_basic(t *testing.T) {
 			{
 				Config: testAccRegionsDataSourceConfig_empty(),
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, names.AttrID),
 					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "names.#", 0),
 				),
 			},

--- a/internal/service/meta/service_data_source.go
+++ b/internal/service/meta/service_data_source.go
@@ -13,8 +13,10 @@ import (
 	"github.com/hashicorp/aws-sdk-go-base/v2/endpoints"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/datasourceattribute"
 	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
 	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -38,10 +40,7 @@ func (d *serviceDataSource) Schema(ctx context.Context, request datasource.Schem
 				Optional: true,
 				Computed: true,
 			},
-			names.AttrID: schema.StringAttribute{
-				Optional: true,
-				Computed: true,
-			},
+			names.AttrID: datasourceattribute.IDAttributeDeprecatedWithAlternate(path.Root("reverse_dns_name")),
 			"partition": schema.StringAttribute{
 				Computed: true,
 			},

--- a/internal/service/meta/service_data_source.go
+++ b/internal/service/meta/service_data_source.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
-	"github.com/hashicorp/terraform-provider-aws/internal/framework/datasourceattribute"
 	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
 	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -40,7 +39,7 @@ func (d *serviceDataSource) Schema(ctx context.Context, request datasource.Schem
 				Optional: true,
 				Computed: true,
 			},
-			names.AttrID: datasourceattribute.IDAttributeDeprecatedWithAlternate(path.Root("reverse_dns_name")),
+			names.AttrID: idAttributeDeprecatedWithAlternate(path.Root("reverse_dns_name")),
 			"partition": schema.StringAttribute{
 				Computed: true,
 			},

--- a/internal/service/meta/service_data_source_test.go
+++ b/internal/service/meta/service_data_source_test.go
@@ -28,6 +28,7 @@ func TestAccMetaServiceDataSource_basic(t *testing.T) {
 				Config: testAccServiceDataSourceConfig_serviceID(serviceID),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, names.AttrDNSName, fmt.Sprintf("%s.%s.%s", serviceID, acctest.Region(), "amazonaws.com")),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrID, dataSourceName, "reverse_dns_name"),
 					resource.TestCheckResourceAttr(dataSourceName, "partition", acctest.Partition()),
 					resource.TestCheckResourceAttr(dataSourceName, "reverse_dns_prefix", "com.amazonaws"),
 					resource.TestCheckResourceAttr(dataSourceName, names.AttrRegion, acctest.Region()),

--- a/internal/service/meta/service_principal_data_source.go
+++ b/internal/service/meta/service_principal_data_source.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/datasourceattribute"
 	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -33,9 +34,7 @@ type servicePrincipalDataSource struct {
 func (d *servicePrincipalDataSource) Schema(ctx context.Context, request datasource.SchemaRequest, response *datasource.SchemaResponse) {
 	response.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
-			names.AttrID: schema.StringAttribute{
-				Computed: true,
-			},
+			names.AttrID: datasourceattribute.IDAttribute(),
 			names.AttrName: schema.StringAttribute{
 				Computed: true,
 			},

--- a/website/docs/d/arn.html.markdown
+++ b/website/docs/d/arn.html.markdown
@@ -30,6 +30,8 @@ This data source exports the following attributes in addition to the arguments a
 
 * `partition` - Partition that the resource is in.
 * `service` - The [service namespace](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#genref-aws-service-namespaces) that identifies the AWS product.
-* `region` - Region the resource resides in. Note that the ARNs for some resources do not include a Region, so this component might be omitted.
+* `region` - Region the resource resides in.
+  Note that the ARNs for some resources do not include a Region, so this component might be omitted.
 * `account` - The [ID](https://docs.aws.amazon.com/general/latest/gr/acct-identifiers.html) of the AWS account that owns the resource, without the hyphens.
-* `resource` - Content of this part of the ARN varies by service. It often includes an indicator of the type of resource—for example, an IAM user or Amazon RDS database —followed by a slash (/) or a colon (:), followed by the resource name itself.
+* `resource` - Content of this part of the ARN varies by service.
+  It often includes an indicator of the type of resource—for example, an IAM user or Amazon RDS database —followed by a slash (/) or a colon (:), followed by the resource name itself.

--- a/website/docs/d/partition.html.markdown
+++ b/website/docs/d/partition.html.markdown
@@ -40,6 +40,7 @@ This data source does not support any arguments.
 This data source exports the following attributes in addition to the arguments above:
 
 * `dns_suffix` - Base DNS domain name for the current partition (e.g., `amazonaws.com` in AWS Commercial, `amazonaws.com.cn` in AWS China).
-* `id` - Identifier of the current partition (e.g., `aws` in AWS Commercial, `aws-cn` in AWS China).
+* `id` - (**Deprecated**) Identifier of the current partition (e.g., `aws` in AWS Commercial, `aws-cn` in AWS China).
+  Use `partition` instead.
 * `partition` - Identifier of the current partition (e.g., `aws` in AWS Commercial, `aws-cn` in AWS China).
 * `reverse_dns_prefix` - Prefix of service names (e.g., `com.amazonaws` in AWS Commercial, `cn.com.amazonaws` in AWS China).

--- a/website/docs/d/region.html.markdown
+++ b/website/docs/d/region.html.markdown
@@ -36,5 +36,5 @@ This data source supports the following arguments:
 
 This data source exports the following attributes in addition to the arguments above:
 
-* `id` - Region's name (e.g. `us-east-1`).
+* `id` - (**Deprecated**) Region's name (e.g. `us-east-1`).
 * `description` - Region's description in this format: "Location (Region name)".

--- a/website/docs/d/regions.html.markdown
+++ b/website/docs/d/regions.html.markdown
@@ -44,7 +44,6 @@ data "aws_regions" "current" {
 This data source supports the following arguments:
 
 * `all_regions` - (Optional) If true the source will query all regions regardless of availability.
-
 * `filter` - (Optional) Configuration block(s) to use as filters. Detailed below.
 
 ### filter Configuration Block
@@ -58,7 +57,7 @@ The `filter` configuration block supports the following arguments:
 
 This data source exports the following attributes in addition to the arguments above:
 
-* `id` - Identifier of the current partition (e.g., `aws` in AWS Commercial, `aws-cn` in AWS China).
+* `id` - (**Deprecated**) Identifier of the current partition (e.g., `aws` in AWS Commercial, `aws-cn` in AWS China).
 * `names` - Names of regions that meets the criteria.
 
 [1]: https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-regions.html


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Deprecates the `id` attribute for:

* `data.aws_arn`
* `data.aws_default_tags`
* `data.aws_ip_ranges`
* `data.aws_partition`
* `data.aws_region`
* `data.aws_regions`
* `data.aws_service`
