### PR TITLE
Update EKS cluster version from 1.31 to 1.35

### DIFF
--- a/website/docs/r/eks_cluster.html.markdown
+++ b/website/docs/r/eks_cluster.html.markdown
@@ -25,7 +25,7 @@ resource "aws_eks_cluster" "example" {
   }
 
   role_arn = aws_iam_role.cluster.arn
-  version  = "1.31"
+  version  = "1.35"
 
   vpc_config {
     subnet_ids = [
@@ -81,7 +81,7 @@ resource "aws_eks_cluster" "example" {
   }
 
   role_arn = aws_iam_role.cluster.arn
-  version  = "1.31"
+  version  = "1.35"
 
   bootstrap_self_managed_addons = false
 
@@ -208,7 +208,7 @@ resource "aws_eks_cluster" "example" {
   }
 
   role_arn = aws_iam_role.cluster.arn
-  version  = "1.31"
+  version  = "1.35"
 
   remote_network_config {
     remote_node_networks {
@@ -276,7 +276,7 @@ resource "aws_eks_cluster" "example" {
   }
 
   role_arn = aws_iam_role.cluster.arn
-  version  = "1.31"
+  version  = "1.35"
 
   vpc_config {
     endpoint_private_access = true


### PR DESCRIPTION
## Description

Updates the EKS cluster version referenced in the `aws_eks_cluster` documentation example from `1.31` to `1.35`, reflecting the latest stable Amazon EKS release.

## Motivation

Keeping documentation examples up to date with current EKS versions helps users avoid deploying outdated cluster versions and ensures the examples reflect AWS best practices.

## Changes

- Updated EKS cluster version in the `aws_eks_cluster` example from `1.31` to `1.35`

## Testing

- Verified that the example configuration is valid with the updated version
- No functional changes to the resource behavior or arguments