### PR TITLE
[Docs] aws_dms_s3_endpoint: Fix typos in the valid values for `encoding_type`

### DIFF
--- a/website/docs/r/dms_s3_endpoint.html.markdown
+++ b/website/docs/r/dms_s3_endpoint.html.markdown
@@ -127,7 +127,7 @@ The following arguments are optional:
 * `detach_target_on_lob_lookup_failure_parquet` - (Optional) Undocumented argument for use as directed by AWS Support.
 * `dict_page_size_limit` - (Optional) Maximum size in bytes of an encoded dictionary page of a column. (AWS default is 1 MiB, _i.e._, `1048576`.)
 * `enable_statistics` - (Optional) Whether to enable statistics for Parquet pages and row groups. Default is `true`.
-* `encoding_type` - (Optional) Type of encoding to use. Value values are `rle_dictionary`, `plain`, and `plain_dictionary`. (AWS default is `rle_dictionary`.)
+* `encoding_type` - (Optional) Type of encoding to use. Value values are `rle-dictionary`, `plain`, and `plain-dictionary`. (AWS default is `rle-dictionary`.)
 * `encryption_mode` - (Optional) Server-side encryption mode that you want to encrypt your .csv or .parquet object files copied to S3. Valid values are `SSE_S3` and `SSE_KMS`. (AWS default is `SSE_S3`.) (Ignored for source endpoints -- only `SSE_S3` is valid.)
 * `expected_bucket_owner` - (Optional) Bucket owner to prevent sniping. Value is an AWS account ID.
 * `external_table_definition` - (Optional) JSON document that describes how AWS DMS should interpret the data. Required for `source` endpoints.


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

This PR fixes the documentation for the `aws_dms_s3_endpoint` resource.

* Fix typos in the valid values for `encoding_type`
  * `rle_dictionary` -> `rle-dictionary`
  * `plain_dictionary` -> `plain-dictionary`

The corrected values are consistent with the [enum definitions in AWS SDK for Go v2](https://github.com/aws/aws-sdk-go-v2/blob/db9f4e546dfe2f62a6bc3bf54b9da42ebace6372/service/databasemigrationservice/types/enums.go#L265-L270).

### Relations
Closes #48030 

### References
https://github.com/aws/aws-sdk-go-v2/blob/db9f4e546dfe2f62a6bc3bf54b9da42ebace6372/service/databasemigrationservice/types/enums.go#L265-L270

