### PR TITLE
docs: update description of map_long_varchar_as

### DIFF
--- a/website/docs/r/dms_endpoint.html.markdown
+++ b/website/docs/r/dms_endpoint.html.markdown
@@ -210,7 +210,7 @@ The following arguments are optional:
 * `heartbeat_schema` - (Optional) Sets the schema in which the heartbeat artifacts are created. Default value is `public`.
 * `map_boolean_as_boolean` - (Optional) You can use PostgreSQL endpoint settings to map a boolean as a boolean from your PostgreSQL source to a Amazon Redshift target. Default value is `false`.
 * `map_jsonb_as_clob` - Optional When true, DMS migrates JSONB values as CLOB.
-* `map_long_varchar_as` - Optional When true, DMS migrates LONG values as VARCHAR.
+* `map_long_varchar_as` - (Optional) Specifies how DMS maps LONG VARCHAR values. Valid values are `wstring`, `clob`, and `nclob`.
 * `max_file_size` - (Optional) Specifies the maximum size (in KB) of any .csv file used to transfer data to PostgreSQL. Default is `32,768 KB`.
 * `plugin_name` - (Optional) Specifies the plugin to use to create a replication slot. Valid values: `pglogical`, `test-decoding`.
 * `service_access_role_arn` - (Optional) Specifies the IAM role to use to authenticate the connection.


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls implemented.

### Description

Update description for [`map_long_varchar_as`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dms_endpoint#map_long_varchar_as-1) of [`aws_dms_endpoint`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dms_endpoint)

The current explanation

> When true, DMS migrates LONG values as VARCHAR.

 is not correct .Instead you need to pick from `wstring, `clob`, and `nclob`.


### Relations

Closes #48005 

### References

Copied from #48005

- https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/dms/endpoint.go#L700-L703
- https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/dms/endpoint.go#L19
- https://github.com/aws/aws-sdk-go-v2/blob/main/service/databasemigrationservice/types/types.go#L2984
- https://docs.aws.amazon.com/sdk-for-swift/latest/api/awsdatabasemigrationservice/documentation/awsdatabasemigrationservice/databasemigrationclienttypes/longvarcharmappingtype/
- https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/databasemigrationservice/types#LongVarcharMappingType

### Output from Acceptance Testing

Not applicable. Only documentation is updated.