### PR TITLE
[Enhancement] aws_backup_plan: Add `rule.index_action` configuration block

### DIFF
--- a/.changelog/48041.txt
+++ b/.changelog/48041.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_backup_plan: Add `rule.index_action` configuration block
+```
+
+```release-note:enhancement
+data-source/aws_backup_plan: Add `rule.index_action` attribute
+```

--- a/internal/service/backup/plan.go
+++ b/internal/service/backup/plan.go
@@ -137,6 +137,24 @@ func resourcePlan() *schema.Resource {
 								Optional: true,
 								Default:  false,
 							},
+							"index_action": {
+								Type:     schema.TypeList,
+								Optional: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"resource_types": {
+											Type:     schema.TypeSet,
+											MinItems: 1,
+											Required: true,
+											Elem: &schema.Schema{
+												Type:         schema.TypeString,
+												ValidateFunc: validation.StringInSlice([]string{"EBS", "S3"}, false),
+											},
+										},
+									},
+								},
+							},
 							"lifecycle": {
 								Type:     schema.TypeList,
 								Optional: true,
@@ -411,6 +429,9 @@ func expandBackupRuleInputs(ctx context.Context, tfList []any) []awstypes.Backup
 		if v, ok := tfMap["enable_continuous_backup"].(bool); ok {
 			apiObject.EnableContinuousBackup = aws.Bool(v)
 		}
+		if v, ok := tfMap["index_action"].([]any); ok && len(v) > 0 {
+			apiObject.IndexActions = expandIndexActions(v)
+		}
 		if v, ok := tfMap["lifecycle"].([]any); ok && len(v) > 0 && v[0] != nil {
 			apiObject.Lifecycle = expandLifecycle(v[0].(map[string]any))
 		}
@@ -488,6 +509,23 @@ func expandCopyActions(tfList []any) []awstypes.CopyAction {
 
 		if v, ok := tfMap["lifecycle"].([]any); ok && len(v) > 0 && v[0] != nil {
 			apiObject.Lifecycle = expandLifecycle(v[0].(map[string]any))
+		}
+
+		apiObjects = append(apiObjects, apiObject)
+	}
+
+	return apiObjects
+}
+
+func expandIndexActions(tfList []any) []awstypes.IndexAction {
+	apiObjects := []awstypes.IndexAction{}
+
+	for _, tfMapRaw := range tfList {
+		tfMap := tfMapRaw.(map[string]any)
+		apiObject := awstypes.IndexAction{}
+
+		if v, ok := tfMap["resource_types"].(*schema.Set); ok && v.Len() > 0 && v.List()[0] != nil {
+			apiObject.ResourceTypes = flex.ExpandStringValueSet(v)
 		}
 
 		apiObjects = append(apiObjects, apiObject)
@@ -591,6 +629,10 @@ func flattenBackupRules(ctx context.Context, apiObjects []awstypes.BackupRule) [
 			tfMap["copy_action"] = flattenCopyActions(v)
 		}
 
+		if v := apiObject.IndexActions; v != nil {
+			tfMap["index_action"] = flattenIndexActions(v)
+		}
+
 		if v := apiObject.Lifecycle; v != nil {
 			tfMap["lifecycle"] = flattenLifecycle(v)
 		}
@@ -643,6 +685,25 @@ func flattenCopyActions(apiObjects []awstypes.CopyAction) []any {
 		tfList = append(tfList, tfMap)
 	}
 
+	return tfList
+}
+
+func flattenIndexActions(apiObject []awstypes.IndexAction) []any {
+	if len(apiObject) == 0 {
+		return nil
+	}
+
+	var tfList []any
+
+	for _, indexAction := range apiObject {
+		tfMap := map[string]any{}
+
+		if v := indexAction.ResourceTypes; len(v) > 0 {
+			tfMap["resource_types"] = flex.FlattenStringValueSet(v)
+		}
+
+		tfList = append(tfList, tfMap)
+	}
 	return tfList
 }
 

--- a/internal/service/backup/plan_data_source.go
+++ b/internal/service/backup/plan_data_source.go
@@ -82,6 +82,21 @@ func dataSourcePlan() *schema.Resource {
 								Type:     schema.TypeBool,
 								Computed: true,
 							},
+							"index_action": {
+								Type:     schema.TypeList,
+								Computed: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"resource_types": {
+											Type:     schema.TypeSet,
+											Computed: true,
+											Elem: &schema.Schema{
+												Type: schema.TypeString,
+											},
+										},
+									},
+								},
+							},
 							"lifecycle": {
 								Type:     schema.TypeList,
 								Computed: true,

--- a/internal/service/backup/plan_test.go
+++ b/internal/service/backup/plan_test.go
@@ -6,6 +6,7 @@ package backup_test
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/YakDriver/regexache"
@@ -45,6 +46,7 @@ func TestAccBackupPlan_basic(t *testing.T) {
 						names.AttrSchedule:             "cron(0 12 * * ? *)",
 						"schedule_expression_timezone": "Etc/UTC",
 						"lifecycle.#":                  "0",
+						"index_action.#":               "0",
 					}),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "0"),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrVersion),
@@ -807,6 +809,73 @@ func TestAccBackupPlan_malwareScan(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "scan_setting.#", "0"),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrVersion),
 				),
+			},
+		},
+	})
+}
+
+func TestAccBackupPlan_withIndexAction(t *testing.T) {
+	ctx := acctest.Context(t)
+	var plan backup.GetBackupPlanOutput
+	resourceName := "aws_backup_plan.test"
+	rName := fmt.Sprintf("tf-testacc-backup-%s", acctest.RandString(t, 14))
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.BackupServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckPlanDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPlanConfig_withIndexAction(rName, []string{"EBS"}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPlanExists(ctx, t, resourceName, &plan),
+					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rule.0.index_action.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rule.0.index_action.0.resource_types.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "rule.0.index_action.0.resource_types.*", "EBS"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				// Update index_action.resource_types from ["EBS"] to ["EBS", "S3"]
+				Config: testAccPlanConfig_withIndexAction(rName, []string{"EBS", "S3"}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPlanExists(ctx, t, resourceName, &plan),
+					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rule.0.index_action.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rule.0.index_action.0.resource_types.#", "2"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "rule.0.index_action.0.resource_types.*", "EBS"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "rule.0.index_action.0.resource_types.*", "S3"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				// Remove index_action block
+				Config: testAccPlanConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPlanExists(ctx, t, resourceName, &plan),
+					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rule.0.index_action.#", "0"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
 			},
 		},
 	})
@@ -1596,4 +1665,26 @@ resource "aws_backup_plan" "test" {
   }
 }
 `, rName))
+}
+
+func testAccPlanConfig_withIndexAction(rName string, resourceTypes []string) string {
+	return fmt.Sprintf(`
+resource "aws_backup_vault" "test" {
+  name = %[1]q
+}
+
+resource "aws_backup_plan" "test" {
+  name = %[1]q
+
+  rule {
+    rule_name         = %[1]q
+    target_vault_name = aws_backup_vault.test.name
+    schedule          = "cron(0 12 * * ? *)"
+
+    index_action {
+      resource_types = ["%[2]s"]
+    }
+  }
+}
+`, rName, strings.Join(resourceTypes, `","`))
 }

--- a/internal/service/backup/plan_test.go
+++ b/internal/service/backup/plan_test.go
@@ -830,7 +830,7 @@ func TestAccBackupPlan_withIndexAction(t *testing.T) {
 				Config: testAccPlanConfig_withIndexAction(rName, []string{"EBS"}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPlanExists(ctx, t, resourceName, &plan),
-					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtRulePound, "1"),
 					resource.TestCheckResourceAttr(resourceName, "rule.0.index_action.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "rule.0.index_action.0.resource_types.#", "1"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "rule.0.index_action.0.resource_types.*", "EBS"),
@@ -851,7 +851,7 @@ func TestAccBackupPlan_withIndexAction(t *testing.T) {
 				Config: testAccPlanConfig_withIndexAction(rName, []string{"EBS", "S3"}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPlanExists(ctx, t, resourceName, &plan),
-					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtRulePound, "1"),
 					resource.TestCheckResourceAttr(resourceName, "rule.0.index_action.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "rule.0.index_action.0.resource_types.#", "2"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "rule.0.index_action.0.resource_types.*", "EBS"),
@@ -868,7 +868,7 @@ func TestAccBackupPlan_withIndexAction(t *testing.T) {
 				Config: testAccPlanConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPlanExists(ctx, t, resourceName, &plan),
-					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtRulePound, "1"),
 					resource.TestCheckResourceAttr(resourceName, "rule.0.index_action.#", "0"),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{

--- a/website/docs/r/backup_plan.html.markdown
+++ b/website/docs/r/backup_plan.html.markdown
@@ -55,6 +55,7 @@ This resource supports the following arguments:
 * `completion_window` - (Optional) The amount of time in minutes AWS Backup attempts a backup before canceling the job and returning an error.
 * `copy_action` - (Optional) Configuration block(s) with copy operation settings. Detailed below.
 * `enable_continuous_backup` - (Optional) Enable continuous backups for supported resources.
+* `index_action` - (Optional) Configuration block for a backup index of Amazon EBS snapshots and/or Amazon S3 backups. Details below.
 * `lifecycle` - (Optional) The lifecycle defines when a protected resource is transitioned to cold storage and when it expires.  Fields documented below.
 * `recovery_point_tags` - (Optional) Metadata that you can assign to help organize the resources that you create.
 * `scan_action` - (Optional) Block for scanning configuration for the backup rule and includes the malware scanner, and scan mode of either full or incremental.
@@ -69,6 +70,12 @@ This resource supports the following arguments:
 
 * `destination_vault_arn` - (Required) An Amazon Resource Name (ARN) that uniquely identifies the destination backup vault for the copied backup.
 * `lifecycle` - (Optional) The lifecycle defines when a protected resource is copied over to a backup vault and when it expires.  Fields documented above.
+
+### Index Action Arguments
+
+`index_action` supports the following attributes:
+
+* `resource_types` - (Required) List of resource types to include in the backup index. Valid values are `EBS` and `S3`. At least one of these values must be included in the list.
 
 ### Lifecycle Arguments
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

This PR adds the `rule.index_action` block to the `aws_backup_plan` resource and data source.

#### AWS API behavior and AWS Provider implementation

* Since `index_action` is an array containing zero or one element, it is defined as `TypeList` with `MaxItems: 1`.
* `rule.index_action.resource_types` is defined as `TypeSet` with `MinItems: 1`.
  * If an empty array is passed to the AWS API, the API returns an `InvalidParameter` error.

* `rule.index_action.resource_types` is described as `Optional` in the [AWS API reference](https://docs.aws.amazon.com/aws-backup/latest/devguide/API_IndexAction.html). However, it was confirmed that the API returns an error when `resource_types` is omitted from the request parameters, meaning that it is effectively required. Therefore, `rule.index_action.resource_types` is marked as `Required`.

* The newly added acceptance test covers CRUD operations for the `rule.index_action` block.

#### Data source

* The `rule.index_action` block is also added to the data source.
  * Updating the acceptance tests and documentation is unnecessary because:
    * The data source acceptance tests compare the `rule` block between the resource and the data source.
    * The current data source documentation does not describe block details.

### Relations

Closes #48029
Relates #40672

### References
https://docs.aws.amazon.com/aws-backup/latest/devguide/API_BackupRuleInput.html#Backup-Type-BackupRuleInput-IndexActions

https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_backup_syntax.html


### Output from Acceptance Testing

```console
$ make testacc TESTS='TestAccBackupPlan(|DataSource)_' PKG=backup  
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     5.735s
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework 5.724s
make: Running acceptance tests on branch: 🌿 f-aws_backup_plan-add_index_action 🌿...
TF_ACC=1 go1.26.3 test ./internal/service/backup/... -v -count 1 -parallel 20 -run='TestAccBackupPlan(|DataSource)_'  -timeout 360m -vet=off -buildvcs=false
2026/05/24 19:57:33 Creating Terraform AWS Provider (SDKv2-style)...
2026/05/24 19:57:33 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccBackupPlanDataSource_tags
=== PAUSE TestAccBackupPlanDataSource_tags
=== RUN   TestAccBackupPlanDataSource_Tags_nullMap
=== PAUSE TestAccBackupPlanDataSource_Tags_nullMap
=== RUN   TestAccBackupPlanDataSource_Tags_emptyMap
=== PAUSE TestAccBackupPlanDataSource_Tags_emptyMap
=== RUN   TestAccBackupPlanDataSource_Tags_DefaultTags_nonOverlapping
=== PAUSE TestAccBackupPlanDataSource_Tags_DefaultTags_nonOverlapping
=== RUN   TestAccBackupPlanDataSource_Tags_IgnoreTags_Overlap_defaultTag
=== PAUSE TestAccBackupPlanDataSource_Tags_IgnoreTags_Overlap_defaultTag
=== RUN   TestAccBackupPlanDataSource_Tags_IgnoreTags_Overlap_resourceTag
=== PAUSE TestAccBackupPlanDataSource_Tags_IgnoreTags_Overlap_resourceTag
=== RUN   TestAccBackupPlanDataSource_basic
=== PAUSE TestAccBackupPlanDataSource_basic
=== RUN   TestAccBackupPlan_tags
=== PAUSE TestAccBackupPlan_tags
=== RUN   TestAccBackupPlan_Tags_null
=== PAUSE TestAccBackupPlan_Tags_null
=== RUN   TestAccBackupPlan_Tags_emptyMap
=== PAUSE TestAccBackupPlan_Tags_emptyMap
=== RUN   TestAccBackupPlan_Tags_addOnUpdate
=== PAUSE TestAccBackupPlan_Tags_addOnUpdate
=== RUN   TestAccBackupPlan_Tags_EmptyTag_onCreate
=== PAUSE TestAccBackupPlan_Tags_EmptyTag_onCreate
=== RUN   TestAccBackupPlan_Tags_EmptyTag_OnUpdate_add
=== PAUSE TestAccBackupPlan_Tags_EmptyTag_OnUpdate_add
=== RUN   TestAccBackupPlan_Tags_EmptyTag_OnUpdate_replace
=== PAUSE TestAccBackupPlan_Tags_EmptyTag_OnUpdate_replace
=== RUN   TestAccBackupPlan_Tags_DefaultTags_providerOnly
=== PAUSE TestAccBackupPlan_Tags_DefaultTags_providerOnly
=== RUN   TestAccBackupPlan_Tags_DefaultTags_nonOverlapping
=== PAUSE TestAccBackupPlan_Tags_DefaultTags_nonOverlapping
=== RUN   TestAccBackupPlan_Tags_DefaultTags_overlapping
=== PAUSE TestAccBackupPlan_Tags_DefaultTags_overlapping
=== RUN   TestAccBackupPlan_Tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccBackupPlan_Tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccBackupPlan_Tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccBackupPlan_Tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccBackupPlan_Tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccBackupPlan_Tags_DefaultTags_emptyResourceTag
=== RUN   TestAccBackupPlan_Tags_DefaultTags_emptyProviderOnlyTag
=== PAUSE TestAccBackupPlan_Tags_DefaultTags_emptyProviderOnlyTag
=== RUN   TestAccBackupPlan_Tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccBackupPlan_Tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccBackupPlan_Tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccBackupPlan_Tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccBackupPlan_Tags_ComputedTag_onCreate
=== PAUSE TestAccBackupPlan_Tags_ComputedTag_onCreate
=== RUN   TestAccBackupPlan_Tags_ComputedTag_OnUpdate_add
=== PAUSE TestAccBackupPlan_Tags_ComputedTag_OnUpdate_add
=== RUN   TestAccBackupPlan_Tags_ComputedTag_OnUpdate_replace
=== PAUSE TestAccBackupPlan_Tags_ComputedTag_OnUpdate_replace
=== RUN   TestAccBackupPlan_Tags_IgnoreTags_Overlap_defaultTag
=== PAUSE TestAccBackupPlan_Tags_IgnoreTags_Overlap_defaultTag
=== RUN   TestAccBackupPlan_Tags_IgnoreTags_Overlap_resourceTag
=== PAUSE TestAccBackupPlan_Tags_IgnoreTags_Overlap_resourceTag
=== RUN   TestAccBackupPlan_basic
=== PAUSE TestAccBackupPlan_basic
=== RUN   TestAccBackupPlan_disappears
=== PAUSE TestAccBackupPlan_disappears
=== RUN   TestAccBackupPlan_withRules
=== PAUSE TestAccBackupPlan_withRules
=== RUN   TestAccBackupPlan_withLifecycle
=== PAUSE TestAccBackupPlan_withLifecycle
=== RUN   TestAccBackupPlan_withRecoveryPointTags
=== PAUSE TestAccBackupPlan_withRecoveryPointTags
=== RUN   TestAccBackupPlan_RuleCopyAction_sameRegion
=== PAUSE TestAccBackupPlan_RuleCopyAction_sameRegion
=== RUN   TestAccBackupPlan_RuleCopyAction_noLifecycle
=== PAUSE TestAccBackupPlan_RuleCopyAction_noLifecycle
=== RUN   TestAccBackupPlan_RuleCopyAction_multiple
=== PAUSE TestAccBackupPlan_RuleCopyAction_multiple
=== RUN   TestAccBackupPlan_RuleCopyAction_crossRegion
=== PAUSE TestAccBackupPlan_RuleCopyAction_crossRegion
=== RUN   TestAccBackupPlan_advancedBackupSetting
=== PAUSE TestAccBackupPlan_advancedBackupSetting
=== RUN   TestAccBackupPlan_enableContinuousBackup
=== PAUSE TestAccBackupPlan_enableContinuousBackup
=== RUN   TestAccBackupPlan_upgradeScheduleExpressionTimezone
=== PAUSE TestAccBackupPlan_upgradeScheduleExpressionTimezone
=== RUN   TestAccBackupPlan_scheduleExpressionTimezone
=== PAUSE TestAccBackupPlan_scheduleExpressionTimezone
=== RUN   TestAccBackupPlan_targetLogicallyAirGappedVaultARN
=== PAUSE TestAccBackupPlan_targetLogicallyAirGappedVaultARN
=== RUN   TestAccBackupPlan_malwareScan
=== PAUSE TestAccBackupPlan_malwareScan
=== RUN   TestAccBackupPlan_withIndexAction
=== PAUSE TestAccBackupPlan_withIndexAction
=== CONT  TestAccBackupPlanDataSource_tags
=== CONT  TestAccBackupPlan_Tags_DefaultTags_nullNonOverlappingResourceTag
=== CONT  TestAccBackupPlan_RuleCopyAction_sameRegion
=== CONT  TestAccBackupPlan_basic
=== CONT  TestAccBackupPlan_withRecoveryPointTags
=== CONT  TestAccBackupPlan_withLifecycle
=== CONT  TestAccBackupPlan_withRules
=== CONT  TestAccBackupPlan_disappears
=== CONT  TestAccBackupPlan_Tags_ComputedTag_OnUpdate_replace
=== CONT  TestAccBackupPlan_Tags_IgnoreTags_Overlap_resourceTag
=== CONT  TestAccBackupPlan_Tags_IgnoreTags_Overlap_defaultTag
=== CONT  TestAccBackupPlan_upgradeScheduleExpressionTimezone
=== CONT  TestAccBackupPlan_withIndexAction
=== CONT  TestAccBackupPlan_malwareScan
=== CONT  TestAccBackupPlan_targetLogicallyAirGappedVaultARN
=== CONT  TestAccBackupPlan_scheduleExpressionTimezone
=== CONT  TestAccBackupPlan_RuleCopyAction_crossRegion
=== CONT  TestAccBackupPlan_enableContinuousBackup
=== CONT  TestAccBackupPlan_advancedBackupSetting
=== CONT  TestAccBackupPlan_Tags_ComputedTag_OnUpdate_add
--- PASS: TestAccBackupPlanDataSource_tags (72.52s)
=== CONT  TestAccBackupPlan_RuleCopyAction_multiple
--- PASS: TestAccBackupPlan_disappears (77.31s)
=== CONT  TestAccBackupPlan_RuleCopyAction_noLifecycle
--- PASS: TestAccBackupPlan_enableContinuousBackup (90.07s)
=== CONT  TestAccBackupPlan_Tags_EmptyTag_onCreate
--- PASS: TestAccBackupPlan_basic (91.68s)
=== CONT  TestAccBackupPlan_Tags_DefaultTags_nullOverlappingResourceTag
--- PASS: TestAccBackupPlan_Tags_DefaultTags_nullNonOverlappingResourceTag (103.17s)
=== CONT  TestAccBackupPlan_Tags_DefaultTags_emptyProviderOnlyTag
--- PASS: TestAccBackupPlan_upgradeScheduleExpressionTimezone (112.67s)
=== CONT  TestAccBackupPlan_Tags_DefaultTags_emptyResourceTag
--- PASS: TestAccBackupPlan_scheduleExpressionTimezone (152.76s)
=== CONT  TestAccBackupPlan_Tags_DefaultTags_updateToResourceOnly
--- PASS: TestAccBackupPlan_advancedBackupSetting (158.27s)
=== CONT  TestAccBackupPlan_Tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccBackupPlan_RuleCopyAction_crossRegion (158.93s)
=== CONT  TestAccBackupPlan_Tags_DefaultTags_overlapping
--- PASS: TestAccBackupPlan_RuleCopyAction_multiple (108.01s)
=== CONT  TestAccBackupPlan_Tags_DefaultTags_nonOverlapping
--- PASS: TestAccBackupPlan_Tags_ComputedTag_OnUpdate_replace (193.43s)
=== CONT  TestAccBackupPlan_Tags_DefaultTags_providerOnly
--- PASS: TestAccBackupPlan_Tags_ComputedTag_OnUpdate_add (193.96s)
=== CONT  TestAccBackupPlan_Tags_EmptyTag_OnUpdate_replace
--- PASS: TestAccBackupPlan_Tags_DefaultTags_nullOverlappingResourceTag (140.56s)
=== CONT  TestAccBackupPlan_Tags_EmptyTag_OnUpdate_add
--- PASS: TestAccBackupPlan_withRecoveryPointTags (238.93s)
=== CONT  TestAccBackupPlan_Tags_ComputedTag_onCreate
--- PASS: TestAccBackupPlan_RuleCopyAction_sameRegion (239.48s)
=== CONT  TestAccBackupPlanDataSource_basic
--- PASS: TestAccBackupPlan_withRules (240.18s)
=== CONT  TestAccBackupPlan_Tags_addOnUpdate
--- PASS: TestAccBackupPlan_Tags_IgnoreTags_Overlap_defaultTag (245.85s)
=== CONT  TestAccBackupPlan_Tags_emptyMap
--- PASS: TestAccBackupPlan_Tags_DefaultTags_emptyProviderOnlyTag (143.16s)
=== CONT  TestAccBackupPlan_Tags_null
--- PASS: TestAccBackupPlan_withIndexAction (261.11s)
=== CONT  TestAccBackupPlan_tags
--- PASS: TestAccBackupPlan_malwareScan (261.33s)
=== CONT  TestAccBackupPlanDataSource_Tags_DefaultTags_nonOverlapping
--- PASS: TestAccBackupPlan_Tags_DefaultTags_emptyResourceTag (148.93s)
=== CONT  TestAccBackupPlanDataSource_Tags_IgnoreTags_Overlap_resourceTag
--- PASS: TestAccBackupPlan_targetLogicallyAirGappedVaultARN (270.72s)
=== CONT  TestAccBackupPlanDataSource_Tags_IgnoreTags_Overlap_defaultTag
--- PASS: TestAccBackupPlan_Tags_IgnoreTags_Overlap_resourceTag (315.30s)
=== CONT  TestAccBackupPlanDataSource_Tags_emptyMap
--- PASS: TestAccBackupPlanDataSource_basic (101.70s)
=== CONT  TestAccBackupPlanDataSource_Tags_nullMap
--- PASS: TestAccBackupPlan_RuleCopyAction_noLifecycle (274.17s)
--- PASS: TestAccBackupPlan_Tags_EmptyTag_onCreate (271.62s)
--- PASS: TestAccBackupPlanDataSource_Tags_DefaultTags_nonOverlapping (104.83s)
--- PASS: TestAccBackupPlanDataSource_Tags_IgnoreTags_Overlap_defaultTag (108.20s)
--- PASS: TestAccBackupPlanDataSource_Tags_IgnoreTags_Overlap_resourceTag (117.32s)
--- PASS: TestAccBackupPlan_Tags_DefaultTags_updateToResourceOnly (230.06s)
--- PASS: TestAccBackupPlan_Tags_ComputedTag_onCreate (144.74s)
--- PASS: TestAccBackupPlan_withLifecycle (392.10s)
--- PASS: TestAccBackupPlan_Tags_DefaultTags_updateToProviderOnly (237.74s)
--- PASS: TestAccBackupPlanDataSource_Tags_emptyMap (86.81s)
--- PASS: TestAccBackupPlanDataSource_Tags_nullMap (72.49s)
--- PASS: TestAccBackupPlan_Tags_EmptyTag_OnUpdate_replace (224.82s)
--- PASS: TestAccBackupPlan_Tags_null (176.42s)
--- PASS: TestAccBackupPlan_Tags_emptyMap (179.70s)
--- PASS: TestAccBackupPlan_Tags_addOnUpdate (190.15s)
--- PASS: TestAccBackupPlan_Tags_DefaultTags_overlapping (295.55s)
--- PASS: TestAccBackupPlan_Tags_DefaultTags_nonOverlapping (280.67s)
--- PASS: TestAccBackupPlan_Tags_EmptyTag_OnUpdate_add (230.17s)
--- PASS: TestAccBackupPlan_Tags_DefaultTags_providerOnly (296.10s)
--- PASS: TestAccBackupPlan_tags (235.77s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/backup     502.713s

```
