### PR TITLE
Use `SchemaFunc` instead of `Schema` for `a` and `b` services

### DIFF
--- a/.ci/semgrep/pluginsdk/schema.yml
+++ b/.ci/semgrep/pluginsdk/schema.yml
@@ -28,25 +28,6 @@ rules:
     severity: WARNING
     paths:
       exclude:
-        - /internal/service/acmpca
-        - /internal/service/amp
-        - /internal/service/amplify
-        - /internal/service/apigateway
-        - /internal/service/apigatewayv2
-        - /internal/service/appautoscaling
-        - /internal/service/appconfig
-        - /internal/service/appflow
-        - /internal/service/appintegrations
-        - /internal/service/applicationinsights
-        - /internal/service/apprunner
-        - /internal/service/appstream
-        - /internal/service/appsync
-        - /internal/service/athena
-        - /internal/service/autoscaling
-        - /internal/service/autoscalingplans
-        - /internal/service/backup
-        - /internal/service/batch
-        - /internal/service/budgets
         - /internal/service/ce
         - /internal/service/chime
         - /internal/service/chimesdkmediapipelines

--- a/.ci/semgrep/pluginsdk/schema.yml
+++ b/.ci/semgrep/pluginsdk/schema.yml
@@ -28,9 +28,6 @@ rules:
     severity: WARNING
     paths:
       exclude:
-        - /internal/service/accessanalyzer
-        - /internal/service/account
-        - /internal/service/acm
         - /internal/service/acmpca
         - /internal/service/amp
         - /internal/service/amplify

--- a/internal/service/accessanalyzer/analyzer.go
+++ b/internal/service/accessanalyzer/analyzer.go
@@ -53,124 +53,74 @@ func resourceAnalyzer() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"analyzer_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-				ValidateFunc: validation.All(
-					validation.StringLenBetween(1, 255),
-					validation.StringMatch(regexache.MustCompile(`^[A-Za-z][0-9A-Za-z_.-]*$`), "must begin with a letter and contain only alphanumeric, underscore, period, or hyphen characters"),
-				),
-			},
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrConfiguration: {
-				Type:     schema.TypeList,
-				Optional: true,
-				ForceNew: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"internal_access": {
-							Type:          schema.TypeList,
-							Optional:      true,
-							ForceNew:      true,
-							MaxItems:      1,
-							ConflictsWith: []string{"configuration.0.unused_access"},
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"analysis_rule": {
-										Type:     schema.TypeList,
-										Optional: true,
-										ForceNew: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"inclusion": {
-													Type:     schema.TypeList,
-													Optional: true,
-													ForceNew: true,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															"account_ids": {
-																Type:     schema.TypeList,
-																Optional: true,
-																ForceNew: true,
-																Elem: &schema.Schema{
-																	Type:         schema.TypeString,
-																	ValidateFunc: verify.ValidAccountID,
-																},
-															},
-															"resource_arns": {
-																Type:     schema.TypeList,
-																Optional: true,
-																ForceNew: true,
-																Elem: &schema.Schema{
-																	Type:         schema.TypeString,
-																	ValidateFunc: verify.ValidARN,
-																},
-															},
-															"resource_types": {
-																Type:     schema.TypeList,
-																Optional: true,
-																ForceNew: true,
-																Elem: &schema.Schema{
-																	Type:             schema.TypeString,
-																	ValidateDiagFunc: enum.Validate[types.ResourceType](),
-																},
-															},
-														},
-													},
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-						"unused_access": {
-							Type:          schema.TypeList,
-							Optional:      true,
-							ForceNew:      true,
-							MaxItems:      1,
-							ConflictsWith: []string{"configuration.0.internal_access"},
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"analysis_rule": {
-										Type:     schema.TypeList,
-										Optional: true,
-										ForceNew: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"exclusion": {
-													Type:     schema.TypeList,
-													Optional: true,
-													ForceNew: true,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															"account_ids": {
-																Type:     schema.TypeList,
-																Optional: true,
-																ForceNew: true,
-																MaxItems: 2000,
-																Elem: &schema.Schema{
-																	Type:         schema.TypeString,
-																	ValidateFunc: verify.ValidAccountID,
-																},
-															},
-															names.AttrResourceTags: {
-																Type:     schema.TypeList,
-																Optional: true,
-																ForceNew: true,
-																Elem: &schema.Schema{
-																	Type: schema.TypeMap,
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"analyzer_name": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+					ValidateFunc: validation.All(
+						validation.StringLenBetween(1, 255),
+						validation.StringMatch(regexache.MustCompile(`^[A-Za-z][0-9A-Za-z_.-]*$`), "must begin with a letter and contain only alphanumeric, underscore, period, or hyphen characters"),
+					),
+				},
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrConfiguration: {
+					Type:     schema.TypeList,
+					Optional: true,
+					ForceNew: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"internal_access": {
+								Type:          schema.TypeList,
+								Optional:      true,
+								ForceNew:      true,
+								MaxItems:      1,
+								ConflictsWith: []string{"configuration.0.unused_access"},
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"analysis_rule": {
+											Type:     schema.TypeList,
+											Optional: true,
+											ForceNew: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"inclusion": {
+														Type:     schema.TypeList,
+														Optional: true,
+														ForceNew: true,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																"account_ids": {
+																	Type:     schema.TypeList,
+																	Optional: true,
+																	ForceNew: true,
 																	Elem: &schema.Schema{
 																		Type:         schema.TypeString,
-																		ValidateFunc: validation.StringLenBetween(0, 256),
+																		ValidateFunc: verify.ValidAccountID,
+																	},
+																},
+																"resource_arns": {
+																	Type:     schema.TypeList,
+																	Optional: true,
+																	ForceNew: true,
+																	Elem: &schema.Schema{
+																		Type:         schema.TypeString,
+																		ValidateFunc: verify.ValidARN,
+																	},
+																},
+																"resource_types": {
+																	Type:     schema.TypeList,
+																	Optional: true,
+																	ForceNew: true,
+																	Elem: &schema.Schema{
+																		Type:             schema.TypeString,
+																		ValidateDiagFunc: enum.Validate[types.ResourceType](),
 																	},
 																},
 															},
@@ -180,26 +130,78 @@ func resourceAnalyzer() *schema.Resource {
 											},
 										},
 									},
-									"unused_access_age": {
-										Type:     schema.TypeInt,
-										Optional: true,
-										ForceNew: true,
+								},
+							},
+							"unused_access": {
+								Type:          schema.TypeList,
+								Optional:      true,
+								ForceNew:      true,
+								MaxItems:      1,
+								ConflictsWith: []string{"configuration.0.internal_access"},
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"analysis_rule": {
+											Type:     schema.TypeList,
+											Optional: true,
+											ForceNew: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"exclusion": {
+														Type:     schema.TypeList,
+														Optional: true,
+														ForceNew: true,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																"account_ids": {
+																	Type:     schema.TypeList,
+																	Optional: true,
+																	ForceNew: true,
+																	MaxItems: 2000,
+																	Elem: &schema.Schema{
+																		Type:         schema.TypeString,
+																		ValidateFunc: verify.ValidAccountID,
+																	},
+																},
+																names.AttrResourceTags: {
+																	Type:     schema.TypeList,
+																	Optional: true,
+																	ForceNew: true,
+																	Elem: &schema.Schema{
+																		Type: schema.TypeMap,
+																		Elem: &schema.Schema{
+																			Type:         schema.TypeString,
+																			ValidateFunc: validation.StringLenBetween(0, 256),
+																		},
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+										"unused_access_age": {
+											Type:     schema.TypeInt,
+											Optional: true,
+											ForceNew: true,
+										},
 									},
 								},
 							},
 						},
 					},
 				},
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			names.AttrType: {
-				Type:             schema.TypeString,
-				Optional:         true,
-				ForceNew:         true,
-				Default:          types.TypeAccount,
-				ValidateDiagFunc: enum.Validate[types.Type](),
-			},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				names.AttrType: {
+					Type:             schema.TypeString,
+					Optional:         true,
+					ForceNew:         true,
+					Default:          types.TypeAccount,
+					ValidateDiagFunc: enum.Validate[types.Type](),
+				},
+			}
 		},
 	}
 }

--- a/internal/service/accessanalyzer/archive_rule.go
+++ b/internal/service/accessanalyzer/archive_rule.go
@@ -40,53 +40,55 @@ func resourceArchiveRule() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"analyzer_name": {
-				Type:     schema.TypeString,
-				ForceNew: true,
-				Required: true,
-			},
-			names.AttrFilter: {
-				Type:     schema.TypeSet,
-				Required: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"criteria": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"contains": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Computed: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-						"eq": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Computed: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-						"exists": {
-							Type:         nullable.TypeNullableBool,
-							Optional:     true,
-							Computed:     true,
-							ValidateFunc: nullable.ValidateTypeStringNullableBool,
-						},
-						"neq": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Computed: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"analyzer_name": {
+					Type:     schema.TypeString,
+					ForceNew: true,
+					Required: true,
+				},
+				names.AttrFilter: {
+					Type:     schema.TypeSet,
+					Required: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"criteria": {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+							"contains": {
+								Type:     schema.TypeList,
+								Optional: true,
+								Computed: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+							},
+							"eq": {
+								Type:     schema.TypeList,
+								Optional: true,
+								Computed: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+							},
+							"exists": {
+								Type:         nullable.TypeNullableBool,
+								Optional:     true,
+								Computed:     true,
+								ValidateFunc: nullable.ValidateTypeStringNullableBool,
+							},
+							"neq": {
+								Type:     schema.TypeList,
+								Optional: true,
+								Computed: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+							},
 						},
 					},
 				},
-			},
-			"rule_name": {
-				Type:     schema.TypeString,
-				ForceNew: true,
-				Required: true,
-			},
+				"rule_name": {
+					Type:     schema.TypeString,
+					ForceNew: true,
+					Required: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/account/alternate_contact.go
+++ b/internal/service/account/alternate_contact.go
@@ -47,39 +47,41 @@ func resourceAlternateContact() *schema.Resource {
 			Delete: schema.DefaultTimeout(5 * time.Minute),
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrAccountID: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidAccountID,
-			},
-			"alternate_contact_type": {
-				Type:             schema.TypeString,
-				Required:         true,
-				ForceNew:         true,
-				ValidateDiagFunc: enum.Validate[types.AlternateContactType](),
-			},
-			"email_address": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringMatch(regexache.MustCompile(`[\w+=,.-]+@[\w.-]+\.[\w]+`), "must be a valid email address"),
-			},
-			names.AttrName: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringLenBetween(1, 64),
-			},
-			"phone_number": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringMatch(regexache.MustCompile(`^[0-9\s()+-]+$`), "must be a valid phone number"),
-			},
-			"title": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringLenBetween(1, 50),
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrAccountID: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ForceNew:     true,
+					ValidateFunc: verify.ValidAccountID,
+				},
+				"alternate_contact_type": {
+					Type:             schema.TypeString,
+					Required:         true,
+					ForceNew:         true,
+					ValidateDiagFunc: enum.Validate[types.AlternateContactType](),
+				},
+				"email_address": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringMatch(regexache.MustCompile(`[\w+=,.-]+@[\w.-]+\.[\w]+`), "must be a valid email address"),
+				},
+				names.AttrName: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringLenBetween(1, 64),
+				},
+				"phone_number": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringMatch(regexache.MustCompile(`^[0-9\s()+-]+$`), "must be a valid phone number"),
+				},
+				"title": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringLenBetween(1, 50),
+				},
+			}
 		},
 	}
 }

--- a/internal/service/account/primary_contact.go
+++ b/internal/service/account/primary_contact.go
@@ -37,63 +37,65 @@ func resourcePrimaryContact() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrAccountID: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidAccountID,
-			},
-			"address_line_1": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"address_line_2": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"address_line_3": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"city": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"company_name": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"country_code": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"district_or_county": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"full_name": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringLenBetween(1, 64),
-			},
-			"phone_number": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringMatch(regexache.MustCompile(`^[+][0-9\s()-]+$`), "must be a valid phone number"),
-			},
-			"postal_code": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"state_or_region": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"website_url": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrAccountID: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ForceNew:     true,
+					ValidateFunc: verify.ValidAccountID,
+				},
+				"address_line_1": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"address_line_2": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"address_line_3": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"city": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"company_name": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"country_code": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"district_or_county": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"full_name": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringLenBetween(1, 64),
+				},
+				"phone_number": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringMatch(regexache.MustCompile(`^[+][0-9\s()-]+$`), "must be a valid phone number"),
+				},
+				"postal_code": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"state_or_region": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"website_url": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/account/region.go
+++ b/internal/service/account/region.go
@@ -37,26 +37,28 @@ func resourceRegion() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrAccountID: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidAccountID,
-			},
-			names.AttrEnabled: {
-				Type:     schema.TypeBool,
-				Required: true,
-			},
-			"opt_status": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"region_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrAccountID: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ForceNew:     true,
+					ValidateFunc: verify.ValidAccountID,
+				},
+				names.AttrEnabled: {
+					Type:     schema.TypeBool,
+					Required: true,
+				},
+				"opt_status": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"region_name": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+			}
 		},
 
 		Timeouts: &schema.ResourceTimeout{

--- a/internal/service/acm/certificate.go
+++ b/internal/service/acm/certificate.go
@@ -71,210 +71,212 @@ func resourceCertificate() *schema.Resource {
 		UpdateWithoutTimeout: resourceCertificateUpdate,
 		DeleteWithoutTimeout: resourceCertificateDelete,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"certificate_authority_arn": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				ForceNew:      true,
-				ValidateFunc:  verify.ValidARN,
-				ConflictsWith: []string{"certificate_body", names.AttrPrivateKey, "private_key_wo", "validation_method"},
-			},
-			"certificate_body": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				ConflictsWith: []string{"certificate_authority_arn", names.AttrDomainName, "validation_method"},
-			},
-			names.AttrCertificateChain: {
-				Type:          schema.TypeString,
-				Optional:      true,
-				ConflictsWith: []string{"certificate_authority_arn", names.AttrDomainName, "validation_method"},
-			},
-			names.AttrDomainName: {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				ForceNew:      true,
-				ValidateFunc:  validation.StringDoesNotMatch(regexache.MustCompile(`\.$`), "cannot end with a period"),
-				ExactlyOneOf:  []string{names.AttrDomainName, names.AttrPrivateKey, "private_key_wo"},
-				ConflictsWith: []string{"certificate_body", names.AttrCertificateChain, names.AttrPrivateKey},
-			},
-			"domain_validation_options": {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrDomainName: {
-							Type:     schema.TypeString,
-							Computed: true,
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"certificate_authority_arn": {
+					Type:          schema.TypeString,
+					Optional:      true,
+					ForceNew:      true,
+					ValidateFunc:  verify.ValidARN,
+					ConflictsWith: []string{"certificate_body", names.AttrPrivateKey, "private_key_wo", "validation_method"},
+				},
+				"certificate_body": {
+					Type:          schema.TypeString,
+					Optional:      true,
+					ConflictsWith: []string{"certificate_authority_arn", names.AttrDomainName, "validation_method"},
+				},
+				names.AttrCertificateChain: {
+					Type:          schema.TypeString,
+					Optional:      true,
+					ConflictsWith: []string{"certificate_authority_arn", names.AttrDomainName, "validation_method"},
+				},
+				names.AttrDomainName: {
+					Type:          schema.TypeString,
+					Optional:      true,
+					Computed:      true,
+					ForceNew:      true,
+					ValidateFunc:  validation.StringDoesNotMatch(regexache.MustCompile(`\.$`), "cannot end with a period"),
+					ExactlyOneOf:  []string{names.AttrDomainName, names.AttrPrivateKey, "private_key_wo"},
+					ConflictsWith: []string{"certificate_body", names.AttrCertificateChain, names.AttrPrivateKey},
+				},
+				"domain_validation_options": {
+					Type:     schema.TypeSet,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrDomainName: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"resource_record_name": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"resource_record_type": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"resource_record_value": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
 						},
-						"resource_record_name": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"resource_record_type": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"resource_record_value": {
-							Type:     schema.TypeString,
-							Computed: true,
+					},
+					Set: domainValidationOptionsHash,
+				},
+				"early_renewal_duration": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					ValidateDiagFunc: validateHybridDuration,
+					ConflictsWith:    []string{"certificate_body", names.AttrCertificateChain, names.AttrPrivateKey, "validation_method"},
+				},
+				"key_algorithm": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					Computed:         true,
+					ForceNew:         true,
+					ValidateDiagFunc: enum.Validate[types.KeyAlgorithm](),
+					ConflictsWith:    []string{"certificate_body", names.AttrCertificateChain, names.AttrPrivateKey},
+				},
+				"not_after": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"not_before": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"options": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Computed: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"certificate_transparency_logging_preference": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								Default:          types.CertificateTransparencyLoggingPreferenceEnabled,
+								ValidateDiagFunc: enum.Validate[types.CertificateTransparencyLoggingPreference](),
+								ConflictsWith:    []string{"certificate_body", names.AttrCertificateChain, names.AttrPrivateKey},
+							},
+							"export": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								Computed:         true,
+								ValidateDiagFunc: enum.Validate[types.CertificateExport](),
+							},
 						},
 					},
 				},
-				Set: domainValidationOptionsHash,
-			},
-			"early_renewal_duration": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				ValidateDiagFunc: validateHybridDuration,
-				ConflictsWith:    []string{"certificate_body", names.AttrCertificateChain, names.AttrPrivateKey, "validation_method"},
-			},
-			"key_algorithm": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Computed:         true,
-				ForceNew:         true,
-				ValidateDiagFunc: enum.Validate[types.KeyAlgorithm](),
-				ConflictsWith:    []string{"certificate_body", names.AttrCertificateChain, names.AttrPrivateKey},
-			},
-			"not_after": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"not_before": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"options": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Computed: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"certificate_transparency_logging_preference": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Default:          types.CertificateTransparencyLoggingPreferenceEnabled,
-							ValidateDiagFunc: enum.Validate[types.CertificateTransparencyLoggingPreference](),
-							ConflictsWith:    []string{"certificate_body", names.AttrCertificateChain, names.AttrPrivateKey},
-						},
-						"export": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Computed:         true,
-							ValidateDiagFunc: enum.Validate[types.CertificateExport](),
+				"pending_renewal": {
+					Type:     schema.TypeBool,
+					Computed: true,
+				},
+				names.AttrPrivateKey: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Sensitive:    true,
+					ExactlyOneOf: []string{names.AttrDomainName, names.AttrPrivateKey, "private_key_wo"},
+				},
+				"private_key_wo": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					WriteOnly:    true,
+					ExactlyOneOf: []string{names.AttrDomainName, names.AttrPrivateKey, "private_key_wo"},
+					RequiredWith: []string{"private_key_wo_version"},
+				},
+				"private_key_wo_version": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					RequiredWith: []string{"private_key_wo"},
+				},
+				"renewal_eligibility": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"renewal_summary": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"renewal_status": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"renewal_status_reason": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"updated_at": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
 						},
 					},
 				},
-			},
-			"pending_renewal": {
-				Type:     schema.TypeBool,
-				Computed: true,
-			},
-			names.AttrPrivateKey: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Sensitive:    true,
-				ExactlyOneOf: []string{names.AttrDomainName, names.AttrPrivateKey, "private_key_wo"},
-			},
-			"private_key_wo": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				WriteOnly:    true,
-				ExactlyOneOf: []string{names.AttrDomainName, names.AttrPrivateKey, "private_key_wo"},
-				RequiredWith: []string{"private_key_wo_version"},
-			},
-			"private_key_wo_version": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				RequiredWith: []string{"private_key_wo"},
-			},
-			"renewal_eligibility": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"renewal_summary": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"renewal_status": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"renewal_status_reason": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"updated_at": {
-							Type:     schema.TypeString,
-							Computed: true,
+				names.AttrStatus: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"subject_alternative_names": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+					Elem: &schema.Schema{
+						Type: schema.TypeString,
+						ValidateFunc: validation.All(
+							validation.StringLenBetween(1, 253),
+							validation.StringDoesNotMatch(regexache.MustCompile(`\.$`), "cannot end with a period"),
+						),
+					},
+					ConflictsWith: []string{"certificate_body", names.AttrCertificateChain, names.AttrPrivateKey},
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				names.AttrType: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"validation_emails": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"validation_method": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					Computed:         true,
+					ForceNew:         true,
+					ValidateDiagFunc: enum.Validate[types.ValidationMethod](),
+					ConflictsWith:    []string{"certificate_authority_arn", "certificate_body", names.AttrCertificateChain, names.AttrPrivateKey},
+				},
+				"validation_option": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					ForceNew: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrDomainName: {
+								Type:     schema.TypeString,
+								Required: true,
+								ForceNew: true,
+							},
+							"validation_domain": {
+								Type:     schema.TypeString,
+								Required: true,
+								ForceNew: true,
+							},
 						},
 					},
+					ConflictsWith: []string{"certificate_body", names.AttrCertificateChain, names.AttrPrivateKey},
 				},
-			},
-			names.AttrStatus: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"subject_alternative_names": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-					ValidateFunc: validation.All(
-						validation.StringLenBetween(1, 253),
-						validation.StringDoesNotMatch(regexache.MustCompile(`\.$`), "cannot end with a period"),
-					),
-				},
-				ConflictsWith: []string{"certificate_body", names.AttrCertificateChain, names.AttrPrivateKey},
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			names.AttrType: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"validation_emails": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			"validation_method": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Computed:         true,
-				ForceNew:         true,
-				ValidateDiagFunc: enum.Validate[types.ValidationMethod](),
-				ConflictsWith:    []string{"certificate_authority_arn", "certificate_body", names.AttrCertificateChain, names.AttrPrivateKey},
-			},
-			"validation_option": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				ForceNew: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrDomainName: {
-							Type:     schema.TypeString,
-							Required: true,
-							ForceNew: true,
-						},
-						"validation_domain": {
-							Type:     schema.TypeString,
-							Required: true,
-							ForceNew: true,
-						},
-					},
-				},
-				ConflictsWith: []string{"certificate_body", names.AttrCertificateChain, names.AttrPrivateKey},
-			},
+			}
 		},
 
 		CustomizeDiff: customdiff.Sequence(

--- a/internal/service/acm/certificate_data_source.go
+++ b/internal/service/acm/certificate_data_source.go
@@ -34,59 +34,61 @@ func dataSourceCertificate() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceCertificateRead,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrCertificate: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrCertificateChain: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrDomain: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				AtLeastOneOf: []string{names.AttrDomain, names.AttrTags},
-			},
-			"key_types": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem: &schema.Schema{
-					Type:             schema.TypeString,
-					ValidateDiagFunc: enum.Validate[awstypes.KeyAlgorithm](),
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
 				},
-			},
-			names.AttrMostRecent: {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-			names.AttrStatus: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"statuses": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			names.AttrTags: {
-				Type:         schema.TypeMap,
-				Optional:     true,
-				Computed:     true,
-				Elem:         &schema.Schema{Type: schema.TypeString},
-				AtLeastOneOf: []string{names.AttrDomain, names.AttrTags},
-			},
-			"types": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
+				names.AttrCertificate: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrCertificateChain: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrDomain: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Computed:     true,
+					AtLeastOneOf: []string{names.AttrDomain, names.AttrTags},
+				},
+				"key_types": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem: &schema.Schema{
+						Type:             schema.TypeString,
+						ValidateDiagFunc: enum.Validate[awstypes.KeyAlgorithm](),
+					},
+				},
+				names.AttrMostRecent: {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
+				names.AttrStatus: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"statuses": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				names.AttrTags: {
+					Type:         schema.TypeMap,
+					Optional:     true,
+					Computed:     true,
+					Elem:         &schema.Schema{Type: schema.TypeString},
+					AtLeastOneOf: []string{names.AttrDomain, names.AttrTags},
+				},
+				"types": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+			}
 		},
 	}
 }

--- a/internal/service/acm/certificate_validation.go
+++ b/internal/service/acm/certificate_validation.go
@@ -43,18 +43,20 @@ func resourceCertificateValidation() *schema.Resource {
 			Create: schema.DefaultTimeout(75 * time.Minute),
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrCertificateARN: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"validation_record_fqdns": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				ForceNew: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrCertificateARN: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"validation_record_fqdns": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					ForceNew: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+			}
 		},
 	}
 }

--- a/internal/service/acmpca/certificate.go
+++ b/internal/service/acmpca/certificate.go
@@ -71,66 +71,68 @@ func resourceCertificate() *schema.Resource {
 			},
 		},
 
-		Schema: map[string]*schema.Schema{
-			"api_passthrough": sdkv2.JSONDocumentSchemaOptionalForceNew(),
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrCertificate: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"certificate_authority_arn": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			names.AttrCertificateChain: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"certificate_signing_request": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"signing_algorithm": {
-				Type:             schema.TypeString,
-				Required:         true,
-				ForceNew:         true,
-				ValidateDiagFunc: enum.Validate[types.SigningAlgorithm](),
-			},
-			"template_arn": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: validTemplateARN,
-			},
-			"validity": {
-				Type:     schema.TypeList,
-				Required: true,
-				ForceNew: true,
-				MinItems: 1,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrType: {
-							Type:             schema.TypeString,
-							Required:         true,
-							ForceNew:         true,
-							ValidateDiagFunc: enum.Validate[types.ValidityPeriodType](),
-						},
-						names.AttrValue: {
-							Type:         schema.TypeString,
-							Required:     true,
-							ForceNew:     true,
-							ValidateFunc: verify.ValidStringDateOrPositiveInt,
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"api_passthrough": sdkv2.JSONDocumentSchemaOptionalForceNew(),
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrCertificate: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"certificate_authority_arn": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				names.AttrCertificateChain: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"certificate_signing_request": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"signing_algorithm": {
+					Type:             schema.TypeString,
+					Required:         true,
+					ForceNew:         true,
+					ValidateDiagFunc: enum.Validate[types.SigningAlgorithm](),
+				},
+				"template_arn": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ForceNew:     true,
+					ValidateFunc: validTemplateARN,
+				},
+				"validity": {
+					Type:     schema.TypeList,
+					Required: true,
+					ForceNew: true,
+					MinItems: 1,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrType: {
+								Type:             schema.TypeString,
+								Required:         true,
+								ForceNew:         true,
+								ValidateDiagFunc: enum.Validate[types.ValidityPeriodType](),
+							},
+							names.AttrValue: {
+								Type:         schema.TypeString,
+								Required:     true,
+								ForceNew:     true,
+								ValidateFunc: verify.ValidStringDateOrPositiveInt,
+							},
 						},
 					},
 				},
-			},
+			}
 		},
 	}
 }

--- a/internal/service/acmpca/certificate_authority.go
+++ b/internal/service/acmpca/certificate_authority.go
@@ -72,292 +72,294 @@ func resourceCertificateAuthority() *schema.Resource {
 		MigrateState:  resourceCertificateAuthorityMigrateState,
 		SchemaVersion: 1,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrCertificate: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			// https://docs.aws.amazon.com/privateca/latest/APIReference/API_CertificateAuthorityConfiguration.html
-			"certificate_authority_configuration": {
-				Type:     schema.TypeList,
-				Required: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"key_algorithm": {
-							Type:             schema.TypeString,
-							Required:         true,
-							ForceNew:         true,
-							ValidateDiagFunc: enum.Validate[types.KeyAlgorithm](),
-						},
-						"signing_algorithm": {
-							Type:             schema.TypeString,
-							Required:         true,
-							ForceNew:         true,
-							ValidateDiagFunc: enum.Validate[types.SigningAlgorithm](),
-						},
-						// https://docs.aws.amazon.com/privateca/latest/APIReference/API_ASN1Subject.html
-						"subject": {
-							Type:     schema.TypeList,
-							Required: true,
-							ForceNew: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"common_name": {
-										Type:         schema.TypeString,
-										Optional:     true,
-										ForceNew:     true,
-										ValidateFunc: validation.StringLenBetween(0, 64),
-									},
-									"country": {
-										Type:         schema.TypeString,
-										Optional:     true,
-										ForceNew:     true,
-										ValidateFunc: validation.StringLenBetween(0, 2),
-									},
-									"distinguished_name_qualifier": {
-										Type:         schema.TypeString,
-										Optional:     true,
-										ForceNew:     true,
-										ValidateFunc: validation.StringLenBetween(0, 64),
-									},
-									"generation_qualifier": {
-										Type:         schema.TypeString,
-										Optional:     true,
-										ForceNew:     true,
-										ValidateFunc: validation.StringLenBetween(0, 3),
-									},
-									"given_name": {
-										Type:         schema.TypeString,
-										Optional:     true,
-										ForceNew:     true,
-										ValidateFunc: validation.StringLenBetween(0, 16),
-									},
-									"initials": {
-										Type:         schema.TypeString,
-										Optional:     true,
-										ForceNew:     true,
-										ValidateFunc: validation.StringLenBetween(0, 5),
-									},
-									"locality": {
-										Type:         schema.TypeString,
-										Optional:     true,
-										ForceNew:     true,
-										ValidateFunc: validation.StringLenBetween(0, 128),
-									},
-									"organization": {
-										Type:         schema.TypeString,
-										Optional:     true,
-										ForceNew:     true,
-										ValidateFunc: validation.StringLenBetween(0, 64),
-									},
-									"organizational_unit": {
-										Type:         schema.TypeString,
-										Optional:     true,
-										ForceNew:     true,
-										ValidateFunc: validation.StringLenBetween(0, 64),
-									},
-									"pseudonym": {
-										Type:         schema.TypeString,
-										Optional:     true,
-										ForceNew:     true,
-										ValidateFunc: validation.StringLenBetween(0, 128),
-									},
-									names.AttrState: {
-										Type:         schema.TypeString,
-										Optional:     true,
-										ForceNew:     true,
-										ValidateFunc: validation.StringLenBetween(0, 128),
-									},
-									"surname": {
-										Type:         schema.TypeString,
-										Optional:     true,
-										ForceNew:     true,
-										ValidateFunc: validation.StringLenBetween(0, 40),
-									},
-									"title": {
-										Type:         schema.TypeString,
-										Optional:     true,
-										ForceNew:     true,
-										ValidateFunc: validation.StringLenBetween(0, 64),
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrCertificate: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				// https://docs.aws.amazon.com/privateca/latest/APIReference/API_CertificateAuthorityConfiguration.html
+				"certificate_authority_configuration": {
+					Type:     schema.TypeList,
+					Required: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"key_algorithm": {
+								Type:             schema.TypeString,
+								Required:         true,
+								ForceNew:         true,
+								ValidateDiagFunc: enum.Validate[types.KeyAlgorithm](),
+							},
+							"signing_algorithm": {
+								Type:             schema.TypeString,
+								Required:         true,
+								ForceNew:         true,
+								ValidateDiagFunc: enum.Validate[types.SigningAlgorithm](),
+							},
+							// https://docs.aws.amazon.com/privateca/latest/APIReference/API_ASN1Subject.html
+							"subject": {
+								Type:     schema.TypeList,
+								Required: true,
+								ForceNew: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"common_name": {
+											Type:         schema.TypeString,
+											Optional:     true,
+											ForceNew:     true,
+											ValidateFunc: validation.StringLenBetween(0, 64),
+										},
+										"country": {
+											Type:         schema.TypeString,
+											Optional:     true,
+											ForceNew:     true,
+											ValidateFunc: validation.StringLenBetween(0, 2),
+										},
+										"distinguished_name_qualifier": {
+											Type:         schema.TypeString,
+											Optional:     true,
+											ForceNew:     true,
+											ValidateFunc: validation.StringLenBetween(0, 64),
+										},
+										"generation_qualifier": {
+											Type:         schema.TypeString,
+											Optional:     true,
+											ForceNew:     true,
+											ValidateFunc: validation.StringLenBetween(0, 3),
+										},
+										"given_name": {
+											Type:         schema.TypeString,
+											Optional:     true,
+											ForceNew:     true,
+											ValidateFunc: validation.StringLenBetween(0, 16),
+										},
+										"initials": {
+											Type:         schema.TypeString,
+											Optional:     true,
+											ForceNew:     true,
+											ValidateFunc: validation.StringLenBetween(0, 5),
+										},
+										"locality": {
+											Type:         schema.TypeString,
+											Optional:     true,
+											ForceNew:     true,
+											ValidateFunc: validation.StringLenBetween(0, 128),
+										},
+										"organization": {
+											Type:         schema.TypeString,
+											Optional:     true,
+											ForceNew:     true,
+											ValidateFunc: validation.StringLenBetween(0, 64),
+										},
+										"organizational_unit": {
+											Type:         schema.TypeString,
+											Optional:     true,
+											ForceNew:     true,
+											ValidateFunc: validation.StringLenBetween(0, 64),
+										},
+										"pseudonym": {
+											Type:         schema.TypeString,
+											Optional:     true,
+											ForceNew:     true,
+											ValidateFunc: validation.StringLenBetween(0, 128),
+										},
+										names.AttrState: {
+											Type:         schema.TypeString,
+											Optional:     true,
+											ForceNew:     true,
+											ValidateFunc: validation.StringLenBetween(0, 128),
+										},
+										"surname": {
+											Type:         schema.TypeString,
+											Optional:     true,
+											ForceNew:     true,
+											ValidateFunc: validation.StringLenBetween(0, 40),
+										},
+										"title": {
+											Type:         schema.TypeString,
+											Optional:     true,
+											ForceNew:     true,
+											ValidateFunc: validation.StringLenBetween(0, 64),
+										},
 									},
 								},
 							},
 						},
 					},
 				},
-			},
-			names.AttrCertificateChain: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"certificate_signing_request": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrEnabled: {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
-			},
-			"key_storage_security_standard": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Computed:         true,
-				ForceNew:         true,
-				ValidateDiagFunc: enum.Validate[types.KeyStorageSecurityStandard](),
-			},
-			"not_after": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"not_before": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"permanent_deletion_time_in_days": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Default:  certificateAuthorityPermanentDeletionTimeInDaysDefault,
-				ValidateFunc: validation.IntBetween(
-					certificateAuthorityPermanentDeletionTimeInDaysMin,
-					certificateAuthorityPermanentDeletionTimeInDaysMax,
-				),
-			},
-			// https://docs.aws.amazon.com/privateca/latest/APIReference/API_RevocationConfiguration.html
-			"revocation_configuration": {
-				Type:             schema.TypeList,
-				Optional:         true,
-				MaxItems:         1,
-				DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						// https://docs.aws.amazon.com/privateca/latest/APIReference/API_CrlConfiguration.html
-						"crl_configuration": {
-							Type:             schema.TypeList,
-							Optional:         true,
-							MaxItems:         1,
-							DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"custom_cname": {
-										Type:         schema.TypeString,
-										Optional:     true,
-										ValidateFunc: validation.StringLenBetween(0, 253),
-										DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-											// Ignore attributes if CRL configuration is not enabled
-											if d.Get("revocation_configuration.0.crl_configuration.0.enabled").(bool) {
-												return old == new
-											}
-											return true
+				names.AttrCertificateChain: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"certificate_signing_request": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrEnabled: {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  true,
+				},
+				"key_storage_security_standard": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					Computed:         true,
+					ForceNew:         true,
+					ValidateDiagFunc: enum.Validate[types.KeyStorageSecurityStandard](),
+				},
+				"not_after": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"not_before": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"permanent_deletion_time_in_days": {
+					Type:     schema.TypeInt,
+					Optional: true,
+					Default:  certificateAuthorityPermanentDeletionTimeInDaysDefault,
+					ValidateFunc: validation.IntBetween(
+						certificateAuthorityPermanentDeletionTimeInDaysMin,
+						certificateAuthorityPermanentDeletionTimeInDaysMax,
+					),
+				},
+				// https://docs.aws.amazon.com/privateca/latest/APIReference/API_RevocationConfiguration.html
+				"revocation_configuration": {
+					Type:             schema.TypeList,
+					Optional:         true,
+					MaxItems:         1,
+					DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							// https://docs.aws.amazon.com/privateca/latest/APIReference/API_CrlConfiguration.html
+							"crl_configuration": {
+								Type:             schema.TypeList,
+								Optional:         true,
+								MaxItems:         1,
+								DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"custom_cname": {
+											Type:         schema.TypeString,
+											Optional:     true,
+											ValidateFunc: validation.StringLenBetween(0, 253),
+											DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+												// Ignore attributes if CRL configuration is not enabled
+												if d.Get("revocation_configuration.0.crl_configuration.0.enabled").(bool) {
+													return old == new
+												}
+												return true
+											},
 										},
-									},
-									"custom_path": {
-										Type:     schema.TypeString,
-										Optional: true,
-										ValidateFunc: validation.All(
-											validation.StringLenBetween(0, 253),
-											validation.StringMatch(regexache.MustCompile(`^[-a-zA-Z0-9;?:@&=+$,%_.!~*()']+(/[-a-zA-Z0-9;?:@&=+$,%_.!~*()']+)*$`), "must match pattern [-a-zA-Z0-9;?:@&=+$,%_.!~*()']+(/[-a-zA-Z0-9;?:@&=+$,%_.!~*()']+)*"),
-										),
-										DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-											// Ignore attributes if CRL configuration is not enabled
-											if d.Get("revocation_configuration.0.crl_configuration.0.enabled").(bool) {
-												return old == new
-											}
-											return true
+										"custom_path": {
+											Type:     schema.TypeString,
+											Optional: true,
+											ValidateFunc: validation.All(
+												validation.StringLenBetween(0, 253),
+												validation.StringMatch(regexache.MustCompile(`^[-a-zA-Z0-9;?:@&=+$,%_.!~*()']+(/[-a-zA-Z0-9;?:@&=+$,%_.!~*()']+)*$`), "must match pattern [-a-zA-Z0-9;?:@&=+$,%_.!~*()']+(/[-a-zA-Z0-9;?:@&=+$,%_.!~*()']+)*"),
+											),
+											DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+												// Ignore attributes if CRL configuration is not enabled
+												if d.Get("revocation_configuration.0.crl_configuration.0.enabled").(bool) {
+													return old == new
+												}
+												return true
+											},
 										},
-									},
-									names.AttrEnabled: {
-										Type:     schema.TypeBool,
-										Optional: true,
-									},
-									"expiration_in_days": {
-										Type:         schema.TypeInt,
-										Optional:     true,
-										ValidateFunc: validation.IntBetween(1, 5000),
-										DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-											// Ignore attributes if CRL configuration is not enabled
-											if d.Get("revocation_configuration.0.crl_configuration.0.enabled").(bool) {
-												return old == new
-											}
-											return true
+										names.AttrEnabled: {
+											Type:     schema.TypeBool,
+											Optional: true,
 										},
-									},
-									names.AttrS3BucketName: {
-										Type:         schema.TypeString,
-										Optional:     true,
-										ValidateFunc: validation.StringLenBetween(3, 255),
-										DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-											// Ignore attributes if CRL configuration is not enabled
-											if d.Get("revocation_configuration.0.crl_configuration.0.enabled").(bool) {
-												return old == new
-											}
-											return true
+										"expiration_in_days": {
+											Type:         schema.TypeInt,
+											Optional:     true,
+											ValidateFunc: validation.IntBetween(1, 5000),
+											DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+												// Ignore attributes if CRL configuration is not enabled
+												if d.Get("revocation_configuration.0.crl_configuration.0.enabled").(bool) {
+													return old == new
+												}
+												return true
+											},
 										},
-									},
-									"s3_object_acl": {
-										Type:             schema.TypeString,
-										Optional:         true,
-										Computed:         true,
-										ValidateDiagFunc: enum.Validate[types.S3ObjectAcl](),
-										DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-											// Ignore attributes if CRL configuration is not enabled
-											if d.Get("revocation_configuration.0.crl_configuration.0.enabled").(bool) {
-												return old == new
-											}
-											return true
+										names.AttrS3BucketName: {
+											Type:         schema.TypeString,
+											Optional:     true,
+											ValidateFunc: validation.StringLenBetween(3, 255),
+											DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+												// Ignore attributes if CRL configuration is not enabled
+												if d.Get("revocation_configuration.0.crl_configuration.0.enabled").(bool) {
+													return old == new
+												}
+												return true
+											},
+										},
+										"s3_object_acl": {
+											Type:             schema.TypeString,
+											Optional:         true,
+											Computed:         true,
+											ValidateDiagFunc: enum.Validate[types.S3ObjectAcl](),
+											DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+												// Ignore attributes if CRL configuration is not enabled
+												if d.Get("revocation_configuration.0.crl_configuration.0.enabled").(bool) {
+													return old == new
+												}
+												return true
+											},
 										},
 									},
 								},
 							},
-						},
-						// https://docs.aws.amazon.com/privateca/latest/APIReference/API_OcspConfiguration.html
-						"ocsp_configuration": {
-							Type:             schema.TypeList,
-							Optional:         true,
-							MaxItems:         1,
-							DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									names.AttrEnabled: {
-										Type:     schema.TypeBool,
-										Required: true,
-									},
-									"ocsp_custom_cname": {
-										Type:         schema.TypeString,
-										Optional:     true,
-										ValidateFunc: validation.StringLenBetween(0, 253),
+							// https://docs.aws.amazon.com/privateca/latest/APIReference/API_OcspConfiguration.html
+							"ocsp_configuration": {
+								Type:             schema.TypeList,
+								Optional:         true,
+								MaxItems:         1,
+								DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										names.AttrEnabled: {
+											Type:     schema.TypeBool,
+											Required: true,
+										},
+										"ocsp_custom_cname": {
+											Type:         schema.TypeString,
+											Optional:     true,
+											ValidateFunc: validation.StringLenBetween(0, 253),
+										},
 									},
 								},
 							},
 						},
 					},
 				},
-			},
-			"serial": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			names.AttrType: {
-				Type:             schema.TypeString,
-				Optional:         true,
-				ForceNew:         true,
-				Default:          types.CertificateAuthorityTypeSubordinate,
-				ValidateDiagFunc: enum.Validate[types.CertificateAuthorityType](),
-			},
-			"usage_mode": {
-				Type:             schema.TypeString,
-				Computed:         true,
-				Optional:         true,
-				ValidateDiagFunc: enum.Validate[types.CertificateAuthorityUsageMode](),
-			},
+				"serial": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				names.AttrType: {
+					Type:             schema.TypeString,
+					Optional:         true,
+					ForceNew:         true,
+					Default:          types.CertificateAuthorityTypeSubordinate,
+					ValidateDiagFunc: enum.Validate[types.CertificateAuthorityType](),
+				},
+				"usage_mode": {
+					Type:             schema.TypeString,
+					Computed:         true,
+					Optional:         true,
+					ValidateDiagFunc: enum.Validate[types.CertificateAuthorityUsageMode](),
+				},
+			}
 		},
 	}
 }

--- a/internal/service/acmpca/certificate_authority_certificate.go
+++ b/internal/service/acmpca/certificate_authority_certificate.go
@@ -36,25 +36,27 @@ func resourceCertificateAuthorityCertificate() *schema.Resource {
 		ReadWithoutTimeout:   resourceCertificateAuthorityCertificateRead,
 		DeleteWithoutTimeout: schema.NoopContext,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrCertificate: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(1, 32768),
-			},
-			"certificate_authority_arn": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			names.AttrCertificateChain: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(0, 2097152),
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrCertificate: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringLenBetween(1, 32768),
+				},
+				"certificate_authority_arn": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				names.AttrCertificateChain: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringLenBetween(0, 2097152),
+				},
+			}
 		},
 	}
 }

--- a/internal/service/acmpca/certificate_authority_data_source.go
+++ b/internal/service/acmpca/certificate_authority_data_source.go
@@ -28,111 +28,113 @@ func dataSourceCertificateAuthority() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceCertificateAuthorityRead,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			names.AttrCertificate: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrCertificateChain: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"certificate_signing_request": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"key_storage_security_standard": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"not_after": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"not_before": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			// https://docs.aws.amazon.com/privateca/latest/APIReference/API_RevocationConfiguration.html
-			"revocation_configuration": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						// https://docs.aws.amazon.com/privateca/latest/APIReference/API_CrlConfiguration.html
-						"crl_configuration": {
-							Type:     schema.TypeList,
-							Computed: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"custom_cname": {
-										Type:     schema.TypeString,
-										Computed: true,
-									},
-									"custom_path": {
-										Type:     schema.TypeString,
-										Computed: true,
-									},
-									names.AttrEnabled: {
-										Type:     schema.TypeBool,
-										Computed: true,
-									},
-									"expiration_in_days": {
-										Type:     schema.TypeInt,
-										Computed: true,
-									},
-									names.AttrS3BucketName: {
-										Type:     schema.TypeString,
-										Computed: true,
-									},
-									"s3_object_acl": {
-										Type:     schema.TypeString,
-										Computed: true,
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				names.AttrCertificate: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrCertificateChain: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"certificate_signing_request": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"key_storage_security_standard": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"not_after": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"not_before": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				// https://docs.aws.amazon.com/privateca/latest/APIReference/API_RevocationConfiguration.html
+				"revocation_configuration": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							// https://docs.aws.amazon.com/privateca/latest/APIReference/API_CrlConfiguration.html
+							"crl_configuration": {
+								Type:     schema.TypeList,
+								Computed: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"custom_cname": {
+											Type:     schema.TypeString,
+											Computed: true,
+										},
+										"custom_path": {
+											Type:     schema.TypeString,
+											Computed: true,
+										},
+										names.AttrEnabled: {
+											Type:     schema.TypeBool,
+											Computed: true,
+										},
+										"expiration_in_days": {
+											Type:     schema.TypeInt,
+											Computed: true,
+										},
+										names.AttrS3BucketName: {
+											Type:     schema.TypeString,
+											Computed: true,
+										},
+										"s3_object_acl": {
+											Type:     schema.TypeString,
+											Computed: true,
+										},
 									},
 								},
 							},
-						},
-						// https://docs.aws.amazon.com/privateca/latest/APIReference/API_OcspConfiguration.html
-						"ocsp_configuration": {
-							Type:     schema.TypeList,
-							Computed: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									names.AttrEnabled: {
-										Type:     schema.TypeBool,
-										Computed: true,
-									},
-									"ocsp_custom_cname": {
-										Type:     schema.TypeString,
-										Computed: true,
+							// https://docs.aws.amazon.com/privateca/latest/APIReference/API_OcspConfiguration.html
+							"ocsp_configuration": {
+								Type:     schema.TypeList,
+								Computed: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										names.AttrEnabled: {
+											Type:     schema.TypeBool,
+											Computed: true,
+										},
+										"ocsp_custom_cname": {
+											Type:     schema.TypeString,
+											Computed: true,
+										},
 									},
 								},
 							},
 						},
 					},
 				},
-			},
-			"serial": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrStatus: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrTags: tftags.TagsSchemaComputed(),
-			names.AttrType: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"usage_mode": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+				"serial": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrStatus: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrTags: tftags.TagsSchemaComputed(),
+				names.AttrType: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"usage_mode": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/acmpca/certificate_data_source.go
+++ b/internal/service/acmpca/certificate_data_source.go
@@ -21,25 +21,27 @@ func dataSourceCertificate() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceCertificateRead,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			names.AttrCertificate: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"certificate_authority_arn": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			names.AttrCertificateChain: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				names.AttrCertificate: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"certificate_authority_arn": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				names.AttrCertificateChain: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/acmpca/permission.go
+++ b/internal/service/acmpca/permission.go
@@ -38,40 +38,42 @@ func resourcePermission() *schema.Resource {
 		ReadWithoutTimeout:   resourcePermissionRead,
 		DeleteWithoutTimeout: resourcePermissionDelete,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrActions: {
-				Type:     schema.TypeSet,
-				Required: true,
-				ForceNew: true,
-				Elem: &schema.Schema{
-					Type:             schema.TypeString,
-					ValidateDiagFunc: enum.Validate[types.ActionType](),
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrActions: {
+					Type:     schema.TypeSet,
+					Required: true,
+					ForceNew: true,
+					Elem: &schema.Schema{
+						Type:             schema.TypeString,
+						ValidateDiagFunc: enum.Validate[types.ActionType](),
+					},
 				},
-			},
-			"certificate_authority_arn": {
-				Type:         schema.TypeString,
-				ForceNew:     true,
-				Required:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			names.AttrPolicy: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrPrincipal: {
-				Type:     schema.TypeString,
-				ForceNew: true,
-				Required: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					"acm.amazonaws.com",
-				}, false),
-			},
-			"source_account": {
-				Type:     schema.TypeString,
-				ForceNew: true,
-				Optional: true,
-				Computed: true,
-			},
+				"certificate_authority_arn": {
+					Type:         schema.TypeString,
+					ForceNew:     true,
+					Required:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				names.AttrPolicy: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrPrincipal: {
+					Type:     schema.TypeString,
+					ForceNew: true,
+					Required: true,
+					ValidateFunc: validation.StringInSlice([]string{
+						"acm.amazonaws.com",
+					}, false),
+				},
+				"source_account": {
+					Type:     schema.TypeString,
+					ForceNew: true,
+					Optional: true,
+					Computed: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/acmpca/policy.go
+++ b/internal/service/acmpca/policy.go
@@ -35,13 +35,15 @@ func resourcePolicy() *schema.Resource {
 		UpdateWithoutTimeout: resourcePolicyPut,
 		DeleteWithoutTimeout: resourcePolicyDelete,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrPolicy: sdkv2.IAMPolicyDocumentSchemaRequired(),
-			names.AttrResourceARN: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrPolicy: sdkv2.IAMPolicyDocumentSchemaRequired(),
+				names.AttrResourceARN: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/amp/alert_manager_definition.go
+++ b/internal/service/amp/alert_manager_definition.go
@@ -36,16 +36,18 @@ func resourceAlertManagerDefinition() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"definition": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"workspace_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"definition": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"workspace_id": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/amp/rule_group_namespace.go
+++ b/internal/service/amp/rule_group_namespace.go
@@ -40,27 +40,29 @@ func resourceRuleGroupNamespace() *schema.Resource {
 		UpdateWithoutTimeout: resourceRuleGroupNamespaceUpdate,
 		DeleteWithoutTimeout: resourceRuleGroupNamespaceDelete,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"data": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			"workspace_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"data": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				"workspace_id": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/amp/workspace.go
+++ b/internal/service/amp/workspace.go
@@ -52,44 +52,46 @@ func resourceWorkspace() *schema.Resource {
 			}),
 		),
 
-		Schema: map[string]*schema.Schema{
-			names.AttrAlias: {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrKMSKeyARN: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			names.AttrLoggingConfiguration: {
-				Type:     schema.TypeList,
-				MaxItems: 1,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"log_group_arn": {
-							Type:     schema.TypeString,
-							Required: true,
-							ValidateFunc: validation.All(
-								verify.ValidARN,
-								validation.StringMatch(regexache.MustCompile(`:\*$`), "ARN must end with `:*`"),
-							),
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrAlias: {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrKMSKeyARN: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ForceNew:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				names.AttrLoggingConfiguration: {
+					Type:     schema.TypeList,
+					MaxItems: 1,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"log_group_arn": {
+								Type:     schema.TypeString,
+								Required: true,
+								ValidateFunc: validation.All(
+									verify.ValidARN,
+									validation.StringMatch(regexache.MustCompile(`:\*$`), "ARN must end with `:*`"),
+								),
+							},
 						},
 					},
 				},
-			},
-			"prometheus_endpoint": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				"prometheus_endpoint": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			}
 		},
 	}
 }

--- a/internal/service/amp/workspace_data_source.go
+++ b/internal/service/amp/workspace_data_source.go
@@ -25,36 +25,38 @@ func dataSourceWorkspace() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceWorkspaceRead,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrAlias: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrCreatedDate: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrKMSKeyARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"prometheus_endpoint": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrStatus: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrTags: tftags.TagsSchemaComputed(),
-			"workspace_id": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrAlias: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrCreatedDate: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrKMSKeyARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"prometheus_endpoint": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrStatus: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrTags: tftags.TagsSchemaComputed(),
+				"workspace_id": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/amp/workspaces_data_source.go
+++ b/internal/service/amp/workspaces_data_source.go
@@ -23,26 +23,28 @@ func dataSourceWorkspaces() *schema.Resource { // nosemgrep:ci.caps0-in-func-nam
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceWorkspacesRead,
 
-		Schema: map[string]*schema.Schema{
-			"alias_prefix": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"aliases": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			names.AttrARNs: {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			"workspace_ids": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"alias_prefix": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"aliases": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				names.AttrARNs: {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"workspace_ids": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+			}
 		},
 	}
 }

--- a/internal/service/amplify/app.go
+++ b/internal/service/amplify/app.go
@@ -54,283 +54,285 @@ func resourceApp() *schema.Resource {
 			}),
 		),
 
-		Schema: map[string]*schema.Schema{
-			"access_token": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Sensitive:    true,
-				ValidateFunc: validation.StringLenBetween(1, 255),
-			},
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"auto_branch_creation_config": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Computed: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"basic_auth_credentials": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							Sensitive:    true,
-							ValidateFunc: validation.StringLenBetween(1, 2000),
-							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-								// These credentials are ignored if basic auth is not enabled.
-								if d.Get("auto_branch_creation_config.0.enable_basic_auth").(bool) {
-									return old == new
-								}
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"access_token": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Sensitive:    true,
+					ValidateFunc: validation.StringLenBetween(1, 255),
+				},
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"auto_branch_creation_config": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Computed: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"basic_auth_credentials": {
+								Type:         schema.TypeString,
+								Optional:     true,
+								Sensitive:    true,
+								ValidateFunc: validation.StringLenBetween(1, 2000),
+								DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+									// These credentials are ignored if basic auth is not enabled.
+									if d.Get("auto_branch_creation_config.0.enable_basic_auth").(bool) {
+										return old == new
+									}
 
-								return true
-							},
-						},
-						"build_spec": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							ValidateFunc: validation.StringLenBetween(1, 25000),
-						},
-						"enable_auto_build": {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
-						"enable_basic_auth": {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
-						"enable_performance_mode": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							ForceNew: true,
-						},
-						"enable_pull_request_preview": {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
-						"environment_variables": {
-							Type:     schema.TypeMap,
-							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-						"framework": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							ValidateFunc: validation.StringLenBetween(1, 255),
-						},
-						"pull_request_environment_name": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							ValidateFunc: validation.StringLenBetween(1, 255),
-						},
-						names.AttrStage: {
-							Type:             schema.TypeString,
-							Optional:         true,
-							ValidateDiagFunc: enum.Validate[types.Stage](),
-							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-								// API returns "NONE" by default.
-								if old == stageNone && new == "" {
 									return true
-								}
+								},
+							},
+							"build_spec": {
+								Type:         schema.TypeString,
+								Optional:     true,
+								ValidateFunc: validation.StringLenBetween(1, 25000),
+							},
+							"enable_auto_build": {
+								Type:     schema.TypeBool,
+								Optional: true,
+							},
+							"enable_basic_auth": {
+								Type:     schema.TypeBool,
+								Optional: true,
+							},
+							"enable_performance_mode": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								ForceNew: true,
+							},
+							"enable_pull_request_preview": {
+								Type:     schema.TypeBool,
+								Optional: true,
+							},
+							"environment_variables": {
+								Type:     schema.TypeMap,
+								Optional: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+							},
+							"framework": {
+								Type:         schema.TypeString,
+								Optional:     true,
+								ValidateFunc: validation.StringLenBetween(1, 255),
+							},
+							"pull_request_environment_name": {
+								Type:         schema.TypeString,
+								Optional:     true,
+								ValidateFunc: validation.StringLenBetween(1, 255),
+							},
+							names.AttrStage: {
+								Type:             schema.TypeString,
+								Optional:         true,
+								ValidateDiagFunc: enum.Validate[types.Stage](),
+								DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+									// API returns "NONE" by default.
+									if old == stageNone && new == "" {
+										return true
+									}
 
-								return old == new
+									return old == new
+								},
 							},
 						},
 					},
 				},
-			},
-			"auto_branch_creation_patterns": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					// These patterns are ignored if branch auto-creation is not enabled.
-					if d.Get("enable_auto_branch_creation").(bool) {
-						return old == new
-					}
+				"auto_branch_creation_patterns": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+					DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+						// These patterns are ignored if branch auto-creation is not enabled.
+						if d.Get("enable_auto_branch_creation").(bool) {
+							return old == new
+						}
 
-					return true
+						return true
+					},
 				},
-			},
-			"basic_auth_credentials": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Sensitive:    true,
-				ValidateFunc: validation.StringLenBetween(1, 2000),
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					// These credentials are ignored if basic auth is not enabled.
-					if d.Get("enable_basic_auth").(bool) {
-						return old == new
-					}
+				"basic_auth_credentials": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Sensitive:    true,
+					ValidateFunc: validation.StringLenBetween(1, 2000),
+					DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+						// These credentials are ignored if basic auth is not enabled.
+						if d.Get("enable_basic_auth").(bool) {
+							return old == new
+						}
 
-					return true
+						return true
+					},
 				},
-			},
-			"build_spec": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: validation.StringLenBetween(1, 25000),
-			},
-			"cache_config": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Computed: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrType: {
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: enum.Validate[types.CacheConfigType](),
+				"build_spec": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Computed:     true,
+					ValidateFunc: validation.StringLenBetween(1, 25000),
+				},
+				"cache_config": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Computed: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrType: {
+								Type:             schema.TypeString,
+								Required:         true,
+								ValidateDiagFunc: enum.Validate[types.CacheConfigType](),
+							},
 						},
 					},
 				},
-			},
-			"compute_role_arn": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			"custom_headers": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: validation.StringLenBetween(1, 25000),
-			},
-			"custom_rule": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrCondition: {
-							Type:         schema.TypeString,
-							Optional:     true,
-							ValidateFunc: validation.StringLenBetween(1, 2048),
-						},
-						names.AttrSource: {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validation.StringLenBetween(1, 2048),
-						},
-						names.AttrStatus: {
-							Type:     schema.TypeString,
-							Optional: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								"200",
-								"301",
-								"302",
-								"404",
-								"404-200",
-							}, false),
-						},
-						names.AttrTarget: {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validation.StringLenBetween(1, 2048),
+				"compute_role_arn": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				"custom_headers": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Computed:     true,
+					ValidateFunc: validation.StringLenBetween(1, 25000),
+				},
+				"custom_rule": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrCondition: {
+								Type:         schema.TypeString,
+								Optional:     true,
+								ValidateFunc: validation.StringLenBetween(1, 2048),
+							},
+							names.AttrSource: {
+								Type:         schema.TypeString,
+								Required:     true,
+								ValidateFunc: validation.StringLenBetween(1, 2048),
+							},
+							names.AttrStatus: {
+								Type:     schema.TypeString,
+								Optional: true,
+								ValidateFunc: validation.StringInSlice([]string{
+									"200",
+									"301",
+									"302",
+									"404",
+									"404-200",
+								}, false),
+							},
+							names.AttrTarget: {
+								Type:         schema.TypeString,
+								Required:     true,
+								ValidateFunc: validation.StringLenBetween(1, 2048),
+							},
 						},
 					},
 				},
-			},
-			"default_domain": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrDescription: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringLenBetween(1, 1000),
-			},
-			"enable_auto_branch_creation": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
-			"enable_basic_auth": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
-			"enable_branch_auto_build": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
-			"enable_branch_auto_deletion": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
-			"environment_variables": {
-				Type:     schema.TypeMap,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			"iam_service_role_arn": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			"job_config": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Computed: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"build_compute_type": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Computed:         true,
-							ValidateDiagFunc: enum.Validate[types.BuildComputeType](),
+				"default_domain": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrDescription: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringLenBetween(1, 1000),
+				},
+				"enable_auto_branch_creation": {
+					Type:     schema.TypeBool,
+					Optional: true,
+				},
+				"enable_basic_auth": {
+					Type:     schema.TypeBool,
+					Optional: true,
+				},
+				"enable_branch_auto_build": {
+					Type:     schema.TypeBool,
+					Optional: true,
+				},
+				"enable_branch_auto_deletion": {
+					Type:     schema.TypeBool,
+					Optional: true,
+				},
+				"environment_variables": {
+					Type:     schema.TypeMap,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"iam_service_role_arn": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				"job_config": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Computed: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"build_compute_type": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								Computed:         true,
+								ValidateDiagFunc: enum.Validate[types.BuildComputeType](),
+							},
 						},
 					},
 				},
-			},
-			names.AttrName: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringLenBetween(1, 255),
-			},
-			"oauth_token": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Sensitive:    true,
-				ValidateFunc: validation.StringLenBetween(1, 1000),
-			},
-			"platform": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Default:          types.PlatformWeb,
-				ValidateDiagFunc: enum.Validate[types.Platform](),
-			},
-			"production_branch": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"branch_name": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"last_deploy_time": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						names.AttrStatus: {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"thumbnail_url": {
-							Type:     schema.TypeString,
-							Computed: true,
+				names.AttrName: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringLenBetween(1, 255),
+				},
+				"oauth_token": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Sensitive:    true,
+					ValidateFunc: validation.StringLenBetween(1, 1000),
+				},
+				"platform": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					Default:          types.PlatformWeb,
+					ValidateDiagFunc: enum.Validate[types.Platform](),
+				},
+				"production_branch": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"branch_name": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"last_deploy_time": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							names.AttrStatus: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"thumbnail_url": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
 						},
 					},
 				},
-			},
-			"repository": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringLenBetween(1, 1000),
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				"repository": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringLenBetween(1, 1000),
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			}
 		},
 	}
 }

--- a/internal/service/amplify/backend_environment.go
+++ b/internal/service/amplify/backend_environment.go
@@ -37,36 +37,38 @@ func resourceBackendEnvironment() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"app_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"deployment_artifacts": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z-]{1,100}$`), "should be not be more than 100 alphanumeric or hyphen characters"),
-			},
-			"environment_name": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringMatch(regexache.MustCompile(`^[a-z]{2,10}$`), "should be between 2 and 10 characters (only lowercase alphabetic)"),
-			},
-			"stack_name": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z-]{1,100}$`), "should be not be more than 100 alphanumeric or hyphen characters"),
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"app_id": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"deployment_artifacts": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Computed:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z-]{1,100}$`), "should be not be more than 100 alphanumeric or hyphen characters"),
+				},
+				"environment_name": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringMatch(regexache.MustCompile(`^[a-z]{2,10}$`), "should be between 2 and 10 characters (only lowercase alphabetic)"),
+				},
+				"stack_name": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Computed:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z-]{1,100}$`), "should be not be more than 100 alphanumeric or hyphen characters"),
+				},
+			}
 		},
 	}
 }

--- a/internal/service/amplify/branch.go
+++ b/internal/service/amplify/branch.go
@@ -44,137 +44,139 @@ func resourceBranch() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"app_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"associated_resources": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			"backend_environment_arn": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			"basic_auth_credentials": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Sensitive:    true,
-				ValidateFunc: validation.StringLenBetween(1, 2000),
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					// These credentials are ignored if basic auth is not enabled.
-					if d.Get("enable_basic_auth").(bool) {
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"app_id": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"associated_resources": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"backend_environment_arn": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				"basic_auth_credentials": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Sensitive:    true,
+					ValidateFunc: validation.StringLenBetween(1, 2000),
+					DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+						// These credentials are ignored if basic auth is not enabled.
+						if d.Get("enable_basic_auth").(bool) {
+							return old == new
+						}
+
+						return true
+					},
+				},
+				"branch_name": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z/_.-]{1,255}$`), "should be not be more than 255 letters, numbers, and the symbols /_.-"),
+				},
+				"custom_domains": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				names.AttrDescription: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringLenBetween(1, 1000),
+				},
+				"destination_branch": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrDisplayName: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Computed:     true,
+					ValidateFunc: validation.StringMatch(regexache.MustCompile(`^[0-9a-z-]{1,255}$`), "should be not be more than 255 lowercase alphanumeric or hyphen characters"),
+				},
+				"enable_auto_build": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  true,
+				},
+				"enable_basic_auth": {
+					Type:     schema.TypeBool,
+					Optional: true,
+				},
+				"enable_notification": {
+					Type:     schema.TypeBool,
+					Optional: true,
+				},
+				"enable_performance_mode": {
+					Type:     schema.TypeBool,
+					Optional: true,
+				},
+				"enable_pull_request_preview": {
+					Type:     schema.TypeBool,
+					Optional: true,
+				},
+				"enable_skew_protection": {
+					Type:     schema.TypeBool,
+					Optional: true,
+				},
+				"environment_variables": {
+					Type:     schema.TypeMap,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"framework": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringLenBetween(1, 255),
+				},
+				"pull_request_environment_name": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringLenBetween(1, 20),
+				},
+				"source_branch": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrStage: {
+					Type:             schema.TypeString,
+					Optional:         true,
+					ValidateDiagFunc: enum.Validate[types.Stage](),
+					DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+						// API returns "NONE" by default.
+						if old == stageNone && new == "" {
+							return true
+						}
+
 						return old == new
-					}
-
-					return true
+					},
 				},
-			},
-			"branch_name": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z/_.-]{1,255}$`), "should be not be more than 255 letters, numbers, and the symbols /_.-"),
-			},
-			"custom_domains": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			names.AttrDescription: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringLenBetween(1, 1000),
-			},
-			"destination_branch": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrDisplayName: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: validation.StringMatch(regexache.MustCompile(`^[0-9a-z-]{1,255}$`), "should be not be more than 255 lowercase alphanumeric or hyphen characters"),
-			},
-			"enable_auto_build": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
-			},
-			"enable_basic_auth": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
-			"enable_notification": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
-			"enable_performance_mode": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
-			"enable_pull_request_preview": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
-			"enable_skew_protection": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
-			"environment_variables": {
-				Type:     schema.TypeMap,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			"framework": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringLenBetween(1, 255),
-			},
-			"pull_request_environment_name": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringLenBetween(1, 20),
-			},
-			"source_branch": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrStage: {
-				Type:             schema.TypeString,
-				Optional:         true,
-				ValidateDiagFunc: enum.Validate[types.Stage](),
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					// API returns "NONE" by default.
-					if old == stageNone && new == "" {
-						return true
-					}
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				"ttl": {
+					Type:     schema.TypeString,
+					Optional: true,
+					DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+						// API returns "5" by default.
+						if old == "5" && new == "" {
+							return true
+						}
 
-					return old == new
+						return old == new
+					},
 				},
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			"ttl": {
-				Type:     schema.TypeString,
-				Optional: true,
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					// API returns "5" by default.
-					if old == "5" && new == "" {
-						return true
-					}
-
-					return old == new
-				},
-			},
+			}
 		},
 	}
 }

--- a/internal/service/amplify/domain_association.go
+++ b/internal/service/amplify/domain_association.go
@@ -41,86 +41,88 @@ func resourceDomainAssociation() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"app_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"certificate_settings": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Computed: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"certificate_verification_dns_record": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						names.AttrType: {
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: enum.Validate[types.CertificateType](),
-						},
-						"custom_certificate_arn": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							ValidateFunc: verify.ValidARN,
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"app_id": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"certificate_settings": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Computed: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"certificate_verification_dns_record": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							names.AttrType: {
+								Type:             schema.TypeString,
+								Required:         true,
+								ValidateDiagFunc: enum.Validate[types.CertificateType](),
+							},
+							"custom_certificate_arn": {
+								Type:         schema.TypeString,
+								Optional:     true,
+								ValidateFunc: verify.ValidARN,
+							},
 						},
 					},
 				},
-			},
-			"certificate_verification_dns_record": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrDomainName: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(1, 255),
-			},
-			"enable_auto_sub_domain": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-			"sub_domain": {
-				Type:     schema.TypeSet,
-				Required: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"branch_name": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validation.StringLenBetween(1, 255),
-						},
-						"dns_record": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						names.AttrPrefix: {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validation.StringLenBetween(0, 255),
-						},
-						"verified": {
-							Type:     schema.TypeBool,
-							Computed: true,
+				"certificate_verification_dns_record": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrDomainName: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringLenBetween(1, 255),
+				},
+				"enable_auto_sub_domain": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
+				"sub_domain": {
+					Type:     schema.TypeSet,
+					Required: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"branch_name": {
+								Type:         schema.TypeString,
+								Required:     true,
+								ValidateFunc: validation.StringLenBetween(1, 255),
+							},
+							"dns_record": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							names.AttrPrefix: {
+								Type:         schema.TypeString,
+								Required:     true,
+								ValidateFunc: validation.StringLenBetween(0, 255),
+							},
+							"verified": {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
 						},
 					},
 				},
-			},
-			"wait_for_verification": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
-			},
+				"wait_for_verification": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/amplify/webhook.go
+++ b/internal/service/amplify/webhook.go
@@ -36,29 +36,31 @@ func resourceWebhook() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"app_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"branch_name": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z/_.-]{1,255}$`), "should be not be more than 255 letters, numbers, and the symbols /_.-"),
-			},
-			names.AttrDescription: {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			names.AttrURL: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"app_id": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"branch_name": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z/_.-]{1,255}$`), "should be not be more than 255 letters, numbers, and the symbols /_.-"),
+				},
+				names.AttrDescription: {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				names.AttrURL: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/apigateway/api_key.go
+++ b/internal/service/apigateway/api_key.go
@@ -40,47 +40,49 @@ func resourceAPIKey() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrCreatedDate: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"customer_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			names.AttrDescription: {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  "Managed by Terraform",
-			},
-			names.AttrEnabled: {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
-			},
-			names.AttrLastUpdatedDate: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			names.AttrValue: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ForceNew:     true,
-				Sensitive:    true,
-				ValidateFunc: validation.StringLenBetween(20, 128),
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrCreatedDate: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"customer_id": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				names.AttrDescription: {
+					Type:     schema.TypeString,
+					Optional: true,
+					Default:  "Managed by Terraform",
+				},
+				names.AttrEnabled: {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  true,
+				},
+				names.AttrLastUpdatedDate: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				names.AttrValue: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Computed:     true,
+					ForceNew:     true,
+					Sensitive:    true,
+					ValidateFunc: validation.StringLenBetween(20, 128),
+				},
+			}
 		},
 	}
 }

--- a/internal/service/apigateway/api_key_data_source.go
+++ b/internal/service/apigateway/api_key_data_source.go
@@ -25,45 +25,47 @@ func dataSourceAPIKey() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceAPIKeyRead,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrCreatedDate: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"customer_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrDescription: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrEnabled: {
-				Type:     schema.TypeBool,
-				Computed: true,
-			},
-			names.AttrID: {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			names.AttrLastUpdatedDate: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrTags: tftags.TagsSchemaComputed(),
-			names.AttrValue: {
-				Type:      schema.TypeString,
-				Computed:  true,
-				Sensitive: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrCreatedDate: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"customer_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrDescription: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrEnabled: {
+					Type:     schema.TypeBool,
+					Computed: true,
+				},
+				names.AttrID: {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				names.AttrLastUpdatedDate: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrTags: tftags.TagsSchemaComputed(),
+				names.AttrValue: {
+					Type:      schema.TypeString,
+					Computed:  true,
+					Sensitive: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/apigateway/authorizer.go
+++ b/internal/service/apigateway/authorizer.go
@@ -61,58 +61,60 @@ func resourceAuthorizer() *schema.Resource {
 			},
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"authorizer_credentials": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			"authorizer_result_ttl_in_seconds": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				ValidateFunc: validation.IntBetween(0, 3600),
-				Default:      defaultAuthorizerTTL,
-			},
-			"authorizer_uri": {
-				Type:     schema.TypeString,
-				Optional: true, // authorizer_uri is required for authorizer TOKEN/REQUEST
-			},
-			"identity_source": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  "method.request.header.Authorization",
-			},
-			"identity_validation_expression": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"provider_arns": {
-				Type:     schema.TypeSet,
-				Optional: true, // provider_arns is required for authorizer COGNITO_USER_POOLS.
-				Elem: &schema.Schema{
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"authorizer_credentials": {
 					Type:         schema.TypeString,
+					Optional:     true,
 					ValidateFunc: verify.ValidARN,
 				},
-			},
-			attrRestAPIID: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			names.AttrType: {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Default:          awstypes.AuthorizerTypeToken,
-				ValidateDiagFunc: enum.Validate[awstypes.AuthorizerType](),
-			},
+				"authorizer_result_ttl_in_seconds": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					ValidateFunc: validation.IntBetween(0, 3600),
+					Default:      defaultAuthorizerTTL,
+				},
+				"authorizer_uri": {
+					Type:     schema.TypeString,
+					Optional: true, // authorizer_uri is required for authorizer TOKEN/REQUEST
+				},
+				"identity_source": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Default:  "method.request.header.Authorization",
+				},
+				"identity_validation_expression": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"provider_arns": {
+					Type:     schema.TypeSet,
+					Optional: true, // provider_arns is required for authorizer COGNITO_USER_POOLS.
+					Elem: &schema.Schema{
+						Type:         schema.TypeString,
+						ValidateFunc: verify.ValidARN,
+					},
+				},
+				attrRestAPIID: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				names.AttrType: {
+					Type:             schema.TypeString,
+					Optional:         true,
+					Default:          awstypes.AuthorizerTypeToken,
+					ValidateDiagFunc: enum.Validate[awstypes.AuthorizerType](),
+				},
+			}
 		},
 	}
 }

--- a/internal/service/apigateway/authorizer_data_source.go
+++ b/internal/service/apigateway/authorizer_data_source.go
@@ -20,52 +20,54 @@ func dataSourceAuthorizer() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceAuthorizerRead,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"authorizer_credentials": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"authorizer_id": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"authorizer_result_ttl_in_seconds": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-			"authorizer_uri": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"identity_source": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"identity_validation_expression": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"provider_arns": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			attrRestAPIID: {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			names.AttrType: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"authorizer_credentials": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"authorizer_id": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"authorizer_result_ttl_in_seconds": {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
+				"authorizer_uri": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"identity_source": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"identity_validation_expression": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"provider_arns": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				attrRestAPIID: {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				names.AttrType: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/apigateway/authorizers_data_source.go
+++ b/internal/service/apigateway/authorizers_data_source.go
@@ -22,16 +22,18 @@ func dataSourceAuthorizers() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceAuthorizersRead,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrIDs: {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			attrRestAPIID: {
-				Type:     schema.TypeString,
-				Required: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrIDs: {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				attrRestAPIID: {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/apigateway/base_path_mapping.go
+++ b/internal/service/apigateway/base_path_mapping.go
@@ -39,28 +39,30 @@ func resourceBasePathMapping() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"api_id": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"base_path": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			names.AttrDomainName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"domain_name_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"stage_name": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"api_id": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"base_path": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				names.AttrDomainName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"domain_name_id": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"stage_name": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/apigateway/client_certificate.go
+++ b/internal/service/apigateway/client_certificate.go
@@ -38,29 +38,31 @@ func resourceClientCertificate() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrCreatedDate: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrDescription: {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"expiration_date": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"pem_encoded_certificate": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrCreatedDate: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrDescription: {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"expiration_date": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"pem_encoded_certificate": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			}
 		},
 	}
 }

--- a/internal/service/apigateway/deployment.go
+++ b/internal/service/apigateway/deployment.go
@@ -38,32 +38,34 @@ func resourceDeployment() *schema.Resource {
 			StateContext: resourceDeploymentImport,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrCreatedDate: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrDescription: {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			attrRestAPIID: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			names.AttrTriggers: {
-				Type:     schema.TypeMap,
-				Optional: true,
-				ForceNew: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			"variables": {
-				Type:     schema.TypeMap,
-				Optional: true,
-				ForceNew: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrCreatedDate: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrDescription: {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				attrRestAPIID: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				names.AttrTriggers: {
+					Type:     schema.TypeMap,
+					Optional: true,
+					ForceNew: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"variables": {
+					Type:     schema.TypeMap,
+					Optional: true,
+					ForceNew: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+			}
 		},
 	}
 }

--- a/internal/service/apigateway/documentation_part.go
+++ b/internal/service/apigateway/documentation_part.go
@@ -36,55 +36,57 @@ func resourceDocumentationPart() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"documentation_part_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrLocation: {
-				Type:     schema.TypeList,
-				Required: true,
-				ForceNew: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"method": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ForceNew: true,
-						},
-						names.AttrName: {
-							Type:     schema.TypeString,
-							Optional: true,
-							ForceNew: true,
-						},
-						names.AttrPath: {
-							Type:     schema.TypeString,
-							Optional: true,
-							ForceNew: true,
-						},
-						names.AttrStatusCode: {
-							Type:     schema.TypeString,
-							Optional: true,
-							ForceNew: true,
-						},
-						names.AttrType: {
-							Type:     schema.TypeString,
-							Required: true,
-							ForceNew: true,
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"documentation_part_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrLocation: {
+					Type:     schema.TypeList,
+					Required: true,
+					ForceNew: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"method": {
+								Type:     schema.TypeString,
+								Optional: true,
+								ForceNew: true,
+							},
+							names.AttrName: {
+								Type:     schema.TypeString,
+								Optional: true,
+								ForceNew: true,
+							},
+							names.AttrPath: {
+								Type:     schema.TypeString,
+								Optional: true,
+								ForceNew: true,
+							},
+							names.AttrStatusCode: {
+								Type:     schema.TypeString,
+								Optional: true,
+								ForceNew: true,
+							},
+							names.AttrType: {
+								Type:     schema.TypeString,
+								Required: true,
+								ForceNew: true,
+							},
 						},
 					},
 				},
-			},
-			names.AttrProperties: {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			attrRestAPIID: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+				names.AttrProperties: {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				attrRestAPIID: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/apigateway/documentation_version.go
+++ b/internal/service/apigateway/documentation_version.go
@@ -36,21 +36,23 @@ func resourceDocumentationVersion() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrDescription: {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			attrRestAPIID: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			names.AttrVersion: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrDescription: {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				attrRestAPIID: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				names.AttrVersion: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/apigateway/domain_name.go
+++ b/internal/service/apigateway/domain_name.go
@@ -51,153 +51,155 @@ func resourceDomainName() *schema.Resource {
 			Update: schema.DefaultTimeout(60 * time.Minute),
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			//According to AWS Documentation, ACM will be the only way to add certificates
-			//to ApiGateway DomainNames. When this happens, we will be deprecating all certificate methods
-			//except certificate_arn. We are not quite sure when this will happen.
-			names.AttrCertificateARN: {
-				Type:          schema.TypeString,
-				Optional:      true,
-				ConflictsWith: []string{"certificate_body", names.AttrCertificateChain, "certificate_name", "certificate_private_key", "regional_certificate_arn", "regional_certificate_name"},
-			},
-			"certificate_body": {
-				Type:          schema.TypeString,
-				ForceNew:      true,
-				Optional:      true,
-				ConflictsWith: []string{names.AttrCertificateARN, "regional_certificate_arn"},
-			},
-			names.AttrCertificateChain: {
-				Type:          schema.TypeString,
-				ForceNew:      true,
-				Optional:      true,
-				ConflictsWith: []string{names.AttrCertificateARN, "regional_certificate_arn"},
-			},
-			"certificate_name": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				ConflictsWith: []string{names.AttrCertificateARN, "regional_certificate_arn", "regional_certificate_name"},
-			},
-			"certificate_private_key": {
-				Type:          schema.TypeString,
-				ForceNew:      true,
-				Optional:      true,
-				Sensitive:     true,
-				ConflictsWith: []string{names.AttrCertificateARN, "regional_certificate_arn"},
-			},
-			"certificate_upload_date": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"cloudfront_domain_name": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"cloudfront_zone_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrDomainName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"domain_name_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"endpoint_access_mode": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				ValidateDiagFunc: enum.Validate[types.EndpointAccessMode](),
-			},
-			"endpoint_configuration": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Computed: true,
-				MinItems: 1,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrIPAddressType: {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Computed:         true,
-							ValidateDiagFunc: enum.Validate[types.IpAddressType](),
-						},
-						"types": {
-							Type:     schema.TypeList,
-							Required: true,
-							MinItems: 1,
-							// BadRequestException: Cannot create an api with multiple Endpoint Types
-							MaxItems: 1,
-							Elem: &schema.Schema{
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				//According to AWS Documentation, ACM will be the only way to add certificates
+				//to ApiGateway DomainNames. When this happens, we will be deprecating all certificate methods
+				//except certificate_arn. We are not quite sure when this will happen.
+				names.AttrCertificateARN: {
+					Type:          schema.TypeString,
+					Optional:      true,
+					ConflictsWith: []string{"certificate_body", names.AttrCertificateChain, "certificate_name", "certificate_private_key", "regional_certificate_arn", "regional_certificate_name"},
+				},
+				"certificate_body": {
+					Type:          schema.TypeString,
+					ForceNew:      true,
+					Optional:      true,
+					ConflictsWith: []string{names.AttrCertificateARN, "regional_certificate_arn"},
+				},
+				names.AttrCertificateChain: {
+					Type:          schema.TypeString,
+					ForceNew:      true,
+					Optional:      true,
+					ConflictsWith: []string{names.AttrCertificateARN, "regional_certificate_arn"},
+				},
+				"certificate_name": {
+					Type:          schema.TypeString,
+					Optional:      true,
+					ConflictsWith: []string{names.AttrCertificateARN, "regional_certificate_arn", "regional_certificate_name"},
+				},
+				"certificate_private_key": {
+					Type:          schema.TypeString,
+					ForceNew:      true,
+					Optional:      true,
+					Sensitive:     true,
+					ConflictsWith: []string{names.AttrCertificateARN, "regional_certificate_arn"},
+				},
+				"certificate_upload_date": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"cloudfront_domain_name": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"cloudfront_zone_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrDomainName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"domain_name_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"endpoint_access_mode": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					ValidateDiagFunc: enum.Validate[types.EndpointAccessMode](),
+				},
+				"endpoint_configuration": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Computed: true,
+					MinItems: 1,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrIPAddressType: {
 								Type:             schema.TypeString,
-								ValidateDiagFunc: enum.Validate[types.EndpointType](),
+								Optional:         true,
+								Computed:         true,
+								ValidateDiagFunc: enum.Validate[types.IpAddressType](),
+							},
+							"types": {
+								Type:     schema.TypeList,
+								Required: true,
+								MinItems: 1,
+								// BadRequestException: Cannot create an api with multiple Endpoint Types
+								MaxItems: 1,
+								Elem: &schema.Schema{
+									Type:             schema.TypeString,
+									ValidateDiagFunc: enum.Validate[types.EndpointType](),
+								},
 							},
 						},
 					},
 				},
-			},
-			"mutual_tls_authentication": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"truststore_uri": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"truststore_version": {
-							Type:     schema.TypeString,
-							Optional: true,
+				"mutual_tls_authentication": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"truststore_uri": {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+							"truststore_version": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
 						},
 					},
 				},
-			},
-			"ownership_verification_certificate_arn": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			names.AttrPolicy: sdkv2.IAMPolicyDocumentSchemaOptional(),
-			"regional_certificate_arn": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				ConflictsWith: []string{names.AttrCertificateARN, "certificate_body", names.AttrCertificateChain, "certificate_name", "certificate_private_key", "regional_certificate_name"},
-			},
-			"regional_certificate_name": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				ConflictsWith: []string{names.AttrCertificateARN, "certificate_name", "regional_certificate_arn"},
-			},
-			"regional_domain_name": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"regional_zone_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"routing_mode": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Computed:         true,
-				ValidateDiagFunc: enum.ValidateIgnoreCase[types.RoutingMode](),
-			},
-			"security_policy": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Computed:         true,
-				ValidateDiagFunc: enum.Validate[types.SecurityPolicy](),
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				"ownership_verification_certificate_arn": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Computed:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				names.AttrPolicy: sdkv2.IAMPolicyDocumentSchemaOptional(),
+				"regional_certificate_arn": {
+					Type:          schema.TypeString,
+					Optional:      true,
+					ConflictsWith: []string{names.AttrCertificateARN, "certificate_body", names.AttrCertificateChain, "certificate_name", "certificate_private_key", "regional_certificate_name"},
+				},
+				"regional_certificate_name": {
+					Type:          schema.TypeString,
+					Optional:      true,
+					ConflictsWith: []string{names.AttrCertificateARN, "certificate_name", "regional_certificate_arn"},
+				},
+				"regional_domain_name": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"regional_zone_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"routing_mode": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					Computed:         true,
+					ValidateDiagFunc: enum.ValidateIgnoreCase[types.RoutingMode](),
+				},
+				"security_policy": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					Computed:         true,
+					ValidateDiagFunc: enum.Validate[types.SecurityPolicy](),
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			}
 		},
 
 		CustomizeDiff: endpointConfigurationPlantimeValidate,

--- a/internal/service/apigateway/domain_name_data_source.go
+++ b/internal/service/apigateway/domain_name_data_source.go
@@ -27,86 +27,88 @@ func dataSourceDomainName() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceDomainNameRead,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrCertificateARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"certificate_name": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"certificate_upload_date": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"cloudfront_domain_name": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"cloudfront_zone_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrDomainName: {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"domain_name_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-			"endpoint_access_mode": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"endpoint_configuration": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrIPAddressType: {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"types": {
-							Type:     schema.TypeList,
-							Computed: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrCertificateARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"certificate_name": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"certificate_upload_date": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"cloudfront_domain_name": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"cloudfront_zone_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrDomainName: {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"domain_name_id": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+				},
+				"endpoint_access_mode": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"endpoint_configuration": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrIPAddressType: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"types": {
+								Type:     schema.TypeList,
+								Computed: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+							},
 						},
 					},
 				},
-			},
-			names.AttrPolicy: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"regional_certificate_arn": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"regional_certificate_name": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"regional_domain_name": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"regional_zone_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"security_policy": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrTags: tftags.TagsSchemaComputed(),
+				names.AttrPolicy: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"regional_certificate_arn": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"regional_certificate_name": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"regional_domain_name": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"regional_zone_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"security_policy": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrTags: tftags.TagsSchemaComputed(),
+			}
 		},
 	}
 }

--- a/internal/service/apigateway/export_data_source.go
+++ b/internal/service/apigateway/export_data_source.go
@@ -24,42 +24,44 @@ func dataSourceExport() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceExportRead,
 
-		Schema: map[string]*schema.Schema{
-			"accepts": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringInSlice([]string{"application/json", "application/yaml"}, false),
-			},
-			"body": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrContentType: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"content_disposition": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"export_type": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringInSlice([]string{"oas30", "swagger"}, false),
-			},
-			names.AttrParameters: {
-				Type:     schema.TypeMap,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			attrRestAPIID: {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"stage_name": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"accepts": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringInSlice([]string{"application/json", "application/yaml"}, false),
+				},
+				"body": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrContentType: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"content_disposition": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"export_type": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringInSlice([]string{"oas30", "swagger"}, false),
+				},
+				names.AttrParameters: {
+					Type:     schema.TypeMap,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				attrRestAPIID: {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"stage_name": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/apigateway/gateway_response.go
+++ b/internal/service/apigateway/gateway_response.go
@@ -48,31 +48,33 @@ func resourceGatewayResponse() *schema.Resource {
 			},
 		},
 
-		Schema: map[string]*schema.Schema{
-			"response_parameters": {
-				Type:     schema.TypeMap,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Optional: true,
-			},
-			"response_templates": {
-				Type:     schema.TypeMap,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Optional: true,
-			},
-			"response_type": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			attrRestAPIID: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			names.AttrStatusCode: {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"response_parameters": {
+					Type:     schema.TypeMap,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+					Optional: true,
+				},
+				"response_templates": {
+					Type:     schema.TypeMap,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+					Optional: true,
+				},
+				"response_type": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				attrRestAPIID: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				names.AttrStatusCode: {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/apigateway/integration.go
+++ b/internal/service/apigateway/integration.go
@@ -48,119 +48,121 @@ func resourceIntegration() *schema.Resource {
 		UpdateWithoutTimeout: resourceIntegrationUpdate,
 		DeleteWithoutTimeout: resourceIntegrationDelete,
 
-		Schema: map[string]*schema.Schema{
-			"cache_key_parameters": {
-				Type:     schema.TypeSet,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Optional: true,
-			},
-			"cache_namespace": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-			names.AttrConnectionID: {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"connection_type": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Default:          types.ConnectionTypeInternet,
-				ValidateDiagFunc: enum.Validate[types.ConnectionType](),
-			},
-			"content_handling": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				ValidateDiagFunc: validIntegrationContentHandling(),
-			},
-			"credentials": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
-			"http_method": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validHTTPMethod(),
-			},
-			"integration_http_method": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: validHTTPMethod(),
-			},
-			"integration_target": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			"passthrough_behavior": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					"WHEN_NO_MATCH",
-					"WHEN_NO_TEMPLATES",
-					"NEVER",
-				}, false),
-			},
-			"request_parameters": {
-				Type:     schema.TypeMap,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Optional: true,
-			},
-			"request_templates": {
-				Type:     schema.TypeMap,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			names.AttrResourceID: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"response_transfer_mode": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Computed:         true,
-				ValidateDiagFunc: enum.Validate[types.ResponseTransferMode](),
-			},
-			attrRestAPIID: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"timeout_milliseconds": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Default:  29000,
-			},
-			"tls_config": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"insecure_skip_verification": {
-							Type:     schema.TypeBool,
-							Optional: true,
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"cache_key_parameters": {
+					Type:     schema.TypeSet,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+					Optional: true,
+				},
+				"cache_namespace": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+				},
+				names.AttrConnectionID: {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"connection_type": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					Default:          types.ConnectionTypeInternet,
+					ValidateDiagFunc: enum.Validate[types.ConnectionType](),
+				},
+				"content_handling": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					ValidateDiagFunc: validIntegrationContentHandling(),
+				},
+				"credentials": {
+					Type:     schema.TypeString,
+					Optional: true,
+					ForceNew: true,
+				},
+				"http_method": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validHTTPMethod(),
+				},
+				"integration_http_method": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ForceNew:     true,
+					ValidateFunc: validHTTPMethod(),
+				},
+				"integration_target": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				"passthrough_behavior": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+					ValidateFunc: validation.StringInSlice([]string{
+						"WHEN_NO_MATCH",
+						"WHEN_NO_TEMPLATES",
+						"NEVER",
+					}, false),
+				},
+				"request_parameters": {
+					Type:     schema.TypeMap,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+					Optional: true,
+				},
+				"request_templates": {
+					Type:     schema.TypeMap,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				names.AttrResourceID: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"response_transfer_mode": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					Computed:         true,
+					ValidateDiagFunc: enum.Validate[types.ResponseTransferMode](),
+				},
+				attrRestAPIID: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"timeout_milliseconds": {
+					Type:     schema.TypeInt,
+					Optional: true,
+					Default:  29000,
+				},
+				"tls_config": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"insecure_skip_verification": {
+								Type:     schema.TypeBool,
+								Optional: true,
+							},
 						},
 					},
 				},
-			},
-			names.AttrType: {
-				Type:             schema.TypeString,
-				Required:         true,
-				ForceNew:         true,
-				ValidateDiagFunc: enum.Validate[types.IntegrationType](),
-			},
-			names.AttrURI: {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
+				names.AttrType: {
+					Type:             schema.TypeString,
+					Required:         true,
+					ForceNew:         true,
+					ValidateDiagFunc: enum.Validate[types.IntegrationType](),
+				},
+				names.AttrURI: {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+			}
 		},
 		CustomizeDiff: validateTimeoutMilliseconds,
 	}

--- a/internal/service/apigateway/integration_response.go
+++ b/internal/service/apigateway/integration_response.go
@@ -45,46 +45,48 @@ func resourceIntegrationResponse() *schema.Resource {
 		UpdateWithoutTimeout: resourceIntegrationResponsePut,
 		DeleteWithoutTimeout: resourceIntegrationResponseDelete,
 
-		Schema: map[string]*schema.Schema{
-			"content_handling": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				ValidateDiagFunc: validIntegrationContentHandling(),
-			},
-			"http_method": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validHTTPMethod(),
-			},
-			names.AttrResourceID: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"response_parameters": {
-				Type:     schema.TypeMap,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Optional: true,
-			},
-			"response_templates": {
-				Type:     schema.TypeMap,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			attrRestAPIID: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"selection_pattern": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			names.AttrStatusCode: {
-				Type:     schema.TypeString,
-				Required: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"content_handling": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					ValidateDiagFunc: validIntegrationContentHandling(),
+				},
+				"http_method": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validHTTPMethod(),
+				},
+				names.AttrResourceID: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"response_parameters": {
+					Type:     schema.TypeMap,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+					Optional: true,
+				},
+				"response_templates": {
+					Type:     schema.TypeMap,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				attrRestAPIID: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"selection_pattern": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				names.AttrStatusCode: {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/apigateway/method.go
+++ b/internal/service/apigateway/method.go
@@ -45,59 +45,61 @@ func resourceMethod() *schema.Resource {
 		UpdateWithoutTimeout: resourceMethodUpdate,
 		DeleteWithoutTimeout: resourceMethodDelete,
 
-		Schema: map[string]*schema.Schema{
-			"api_key_required": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-			"authorization": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"authorization_scopes": {
-				Type:     schema.TypeSet,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Optional: true,
-			},
-			"authorizer_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"http_method": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validHTTPMethod(),
-			},
-			"operation_name": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"request_models": {
-				Type:     schema.TypeMap,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			"request_parameters": {
-				Type:     schema.TypeMap,
-				Elem:     &schema.Schema{Type: schema.TypeBool},
-				Optional: true,
-			},
-			"request_validator_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			names.AttrResourceID: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			attrRestAPIID: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"api_key_required": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
+				"authorization": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"authorization_scopes": {
+					Type:     schema.TypeSet,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+					Optional: true,
+				},
+				"authorizer_id": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"http_method": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validHTTPMethod(),
+				},
+				"operation_name": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"request_models": {
+					Type:     schema.TypeMap,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"request_parameters": {
+					Type:     schema.TypeMap,
+					Elem:     &schema.Schema{Type: schema.TypeBool},
+					Optional: true,
+				},
+				"request_validator_id": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				names.AttrResourceID: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				attrRestAPIID: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/apigateway/method_response.go
+++ b/internal/service/apigateway/method_response.go
@@ -45,37 +45,39 @@ func resourceMethodResponse() *schema.Resource {
 		UpdateWithoutTimeout: resourceMethodResponseUpdate,
 		DeleteWithoutTimeout: resourceMethodResponseDelete,
 
-		Schema: map[string]*schema.Schema{
-			"http_method": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validHTTPMethod(),
-			},
-			names.AttrResourceID: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"response_models": {
-				Type:     schema.TypeMap,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			"response_parameters": {
-				Type:     schema.TypeMap,
-				Elem:     &schema.Schema{Type: schema.TypeBool},
-				Optional: true,
-			},
-			attrRestAPIID: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			names.AttrStatusCode: {
-				Type:     schema.TypeString,
-				Required: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"http_method": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validHTTPMethod(),
+				},
+				names.AttrResourceID: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"response_models": {
+					Type:     schema.TypeMap,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"response_parameters": {
+					Type:     schema.TypeMap,
+					Elem:     &schema.Schema{Type: schema.TypeBool},
+					Optional: true,
+				},
+				attrRestAPIID: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				names.AttrStatusCode: {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/apigateway/method_settings.go
+++ b/internal/service/apigateway/method_settings.go
@@ -38,87 +38,89 @@ func resourceMethodSettings() *schema.Resource {
 			StateContext: resourceMethodSettingsImport,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"method_path": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			attrRestAPIID: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"settings": {
-				Type:     schema.TypeList,
-				Required: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"cache_data_encrypted": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Computed: true,
-						},
-						"cache_ttl_in_seconds": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							Computed: true,
-						},
-						"caching_enabled": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Computed: true,
-						},
-						"data_trace_enabled": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Computed: true,
-						},
-						"logging_level": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Computed: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								"OFF",
-								"ERROR",
-								"INFO",
-							}, false),
-						},
-						"metrics_enabled": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Computed: true,
-						},
-						"require_authorization_for_cache_control": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Computed: true,
-						},
-						"throttling_burst_limit": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							Default:  -1,
-						},
-						"throttling_rate_limit": {
-							Type:     schema.TypeFloat,
-							Optional: true,
-							Default:  -1,
-						},
-						"unauthorized_cache_control_header_strategy": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							ValidateDiagFunc: enum.Validate[types.UnauthorizedCacheControlHeaderStrategy](),
-							Computed:         true,
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"method_path": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				attrRestAPIID: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"settings": {
+					Type:     schema.TypeList,
+					Required: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"cache_data_encrypted": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Computed: true,
+							},
+							"cache_ttl_in_seconds": {
+								Type:     schema.TypeInt,
+								Optional: true,
+								Computed: true,
+							},
+							"caching_enabled": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Computed: true,
+							},
+							"data_trace_enabled": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Computed: true,
+							},
+							"logging_level": {
+								Type:     schema.TypeString,
+								Optional: true,
+								Computed: true,
+								ValidateFunc: validation.StringInSlice([]string{
+									"OFF",
+									"ERROR",
+									"INFO",
+								}, false),
+							},
+							"metrics_enabled": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Computed: true,
+							},
+							"require_authorization_for_cache_control": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Computed: true,
+							},
+							"throttling_burst_limit": {
+								Type:     schema.TypeInt,
+								Optional: true,
+								Default:  -1,
+							},
+							"throttling_rate_limit": {
+								Type:     schema.TypeFloat,
+								Optional: true,
+								Default:  -1,
+							},
+							"unauthorized_cache_control_header_strategy": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								ValidateDiagFunc: enum.Validate[types.UnauthorizedCacheControlHeaderStrategy](),
+								Computed:         true,
+							},
 						},
 					},
 				},
-			},
-			"stage_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+				"stage_name": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/apigateway/model.go
+++ b/internal/service/apigateway/model.go
@@ -60,36 +60,38 @@ func resourceModel() *schema.Resource {
 			},
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrContentType: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			names.AttrDescription: {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			attrRestAPIID: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			names.AttrSchema: {
-				Type:             schema.TypeString,
-				Optional:         true,
-				ValidateFunc:     validation.StringIsJSON,
-				DiffSuppressFunc: verify.SuppressEquivalentJSONDiffs,
-				StateFunc: func(v any) string {
-					json, _ := structure.NormalizeJsonString(v)
-					return json
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrContentType: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
 				},
-			},
+				names.AttrDescription: {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				attrRestAPIID: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				names.AttrSchema: {
+					Type:             schema.TypeString,
+					Optional:         true,
+					ValidateFunc:     validation.StringIsJSON,
+					DiffSuppressFunc: verify.SuppressEquivalentJSONDiffs,
+					StateFunc: func(v any) string {
+						json, _ := structure.NormalizeJsonString(v)
+						return json
+					},
+				},
+			}
 		},
 	}
 }

--- a/internal/service/apigateway/request_validator.go
+++ b/internal/service/apigateway/request_validator.go
@@ -47,26 +47,28 @@ func resourceRequestValidator() *schema.Resource {
 			},
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			attrRestAPIID: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"validate_request_body": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-			"validate_request_parameters": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				attrRestAPIID: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"validate_request_body": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
+				"validate_request_parameters": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/apigateway/resource.go
+++ b/internal/service/apigateway/resource.go
@@ -41,24 +41,26 @@ func resourceResource() *schema.Resource {
 		UpdateWithoutTimeout: resourceResourceUpdate,
 		DeleteWithoutTimeout: resourceResourceDelete,
 
-		Schema: map[string]*schema.Schema{
-			"parent_id": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			names.AttrPath: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"path_part": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			attrRestAPIID: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"parent_id": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				names.AttrPath: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"path_part": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				attrRestAPIID: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+			}
 		},
 
 		CustomizeDiff: customdiff.All(

--- a/internal/service/apigateway/resource_data_source.go
+++ b/internal/service/apigateway/resource_data_source.go
@@ -27,23 +27,25 @@ func dataSourceResource() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceResourceRead,
 
-		Schema: map[string]*schema.Schema{
-			"parent_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrPath: {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"path_part": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			attrRestAPIID: {
-				Type:     schema.TypeString,
-				Required: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"parent_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrPath: {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"path_part": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				attrRestAPIID: {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/apigateway/rest_api.go
+++ b/internal/service/apigateway/rest_api.go
@@ -62,123 +62,125 @@ func resourceRestAPI() *schema.Resource {
 			},
 		},
 
-		Schema: map[string]*schema.Schema{
-			"api_key_source": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Computed:         true,
-				ValidateDiagFunc: enum.Validate[types.ApiKeySourceType](),
-			},
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"binary_media_types": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			"body": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			names.AttrCreatedDate: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrDescription: {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-			"disable_execute_api_endpoint": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Computed: true,
-			},
-			"endpoint_configuration": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Computed: true,
-				MinItems: 1,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrIPAddressType: {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Computed:         true,
-							ValidateDiagFunc: enum.Validate[types.IpAddressType](),
-						},
-						"types": {
-							Type:     schema.TypeList,
-							Required: true,
-							MinItems: 1,
-							MaxItems: 1,
-							Elem: &schema.Schema{
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"api_key_source": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					Computed:         true,
+					ValidateDiagFunc: enum.Validate[types.ApiKeySourceType](),
+				},
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"binary_media_types": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"body": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				names.AttrCreatedDate: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrDescription: {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+				},
+				"disable_execute_api_endpoint": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Computed: true,
+				},
+				"endpoint_configuration": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Computed: true,
+					MinItems: 1,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrIPAddressType: {
 								Type:             schema.TypeString,
-								ValidateDiagFunc: enum.Validate[types.EndpointType](),
+								Optional:         true,
+								Computed:         true,
+								ValidateDiagFunc: enum.Validate[types.IpAddressType](),
 							},
-						},
-						"vpc_endpoint_ids": {
-							Type:     schema.TypeSet,
-							Optional: true,
-							Computed: true,
-							MinItems: 1,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
+							"types": {
+								Type:     schema.TypeList,
+								Required: true,
+								MinItems: 1,
+								MaxItems: 1,
+								Elem: &schema.Schema{
+									Type:             schema.TypeString,
+									ValidateDiagFunc: enum.Validate[types.EndpointType](),
+								},
+							},
+							"vpc_endpoint_ids": {
+								Type:     schema.TypeSet,
+								Optional: true,
+								Computed: true,
+								MinItems: 1,
+								Elem: &schema.Schema{
+									Type: schema.TypeString,
+								},
 							},
 						},
 					},
 				},
-			},
-			"execution_arn": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"fail_on_warnings": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
-			"minimum_compression_size": {
-				Type:         nullable.TypeNullableInt,
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: nullable.ValidateTypeStringNullableIntBetween(-1, 10485760),
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					// suppress null trigger when value is already null
-					return old == "" && new == "-1"
+				"execution_arn": {
+					Type:     schema.TypeString,
+					Computed: true,
 				},
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			names.AttrParameters: {
-				Type:     schema.TypeMap,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			names.AttrPolicy: sdkv2.IAMPolicyDocumentSchemaOptionalComputed(),
-			"put_rest_api_mode": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Default:          types.PutModeOverwrite,
-				ValidateDiagFunc: enum.Validate[types.PutMode](),
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					if old == "" && new == string(types.PutModeOverwrite) {
-						return true
-					}
-					return false
+				"fail_on_warnings": {
+					Type:     schema.TypeBool,
+					Optional: true,
 				},
-			},
-			"root_resource_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				"minimum_compression_size": {
+					Type:         nullable.TypeNullableInt,
+					Optional:     true,
+					Computed:     true,
+					ValidateFunc: nullable.ValidateTypeStringNullableIntBetween(-1, 10485760),
+					DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+						// suppress null trigger when value is already null
+						return old == "" && new == "-1"
+					},
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				names.AttrParameters: {
+					Type:     schema.TypeMap,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				names.AttrPolicy: sdkv2.IAMPolicyDocumentSchemaOptionalComputed(),
+				"put_rest_api_mode": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					Default:          types.PutModeOverwrite,
+					ValidateDiagFunc: enum.Validate[types.PutMode](),
+					DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+						if old == "" && new == string(types.PutModeOverwrite) {
+							return true
+						}
+						return false
+					},
+				},
+				"root_resource_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			}
 		},
 
 		CustomizeDiff: endpointConfigurationPlantimeValidate,

--- a/internal/service/apigateway/rest_api_data_source.go
+++ b/internal/service/apigateway/rest_api_data_source.go
@@ -31,67 +31,69 @@ func dataSourceRestAPI() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceRestAPIRead,
 
-		Schema: map[string]*schema.Schema{
-			"api_key_source": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"binary_media_types": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			names.AttrDescription: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"endpoint_configuration": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrIPAddressType: {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"types": {
-							Type:     schema.TypeList,
-							Computed: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-						"vpc_endpoint_ids": {
-							Type:     schema.TypeSet,
-							Computed: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"api_key_source": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"binary_media_types": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				names.AttrDescription: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"endpoint_configuration": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrIPAddressType: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"types": {
+								Type:     schema.TypeList,
+								Computed: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+							},
+							"vpc_endpoint_ids": {
+								Type:     schema.TypeSet,
+								Computed: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+							},
 						},
 					},
 				},
-			},
-			"execution_arn": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"minimum_compression_size": {
-				Type:     nullable.TypeNullableInt,
-				Computed: true,
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			names.AttrPolicy: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"root_resource_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrTags: tftags.TagsSchemaComputed(),
+				"execution_arn": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"minimum_compression_size": {
+					Type:     nullable.TypeNullableInt,
+					Computed: true,
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				names.AttrPolicy: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"root_resource_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrTags: tftags.TagsSchemaComputed(),
+			}
 		},
 	}
 }

--- a/internal/service/apigateway/rest_api_policy.go
+++ b/internal/service/apigateway/rest_api_policy.go
@@ -36,23 +36,25 @@ func resourceRestAPIPolicy() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrPolicy: {
-				Type:                  schema.TypeString,
-				Required:              true,
-				ValidateFunc:          validation.StringIsJSON,
-				DiffSuppressFunc:      verify.SuppressEquivalentPolicyDiffs,
-				DiffSuppressOnRefresh: true,
-				StateFunc: func(v any) string {
-					json, _ := structure.NormalizeJsonString(v)
-					return json
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrPolicy: {
+					Type:                  schema.TypeString,
+					Required:              true,
+					ValidateFunc:          validation.StringIsJSON,
+					DiffSuppressFunc:      verify.SuppressEquivalentPolicyDiffs,
+					DiffSuppressOnRefresh: true,
+					StateFunc: func(v any) string {
+						json, _ := structure.NormalizeJsonString(v)
+						return json
+					},
 				},
-			},
-			attrRestAPIID: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+				attrRestAPIID: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/apigateway/sdk_data_source.go
+++ b/internal/service/apigateway/sdk_data_source.go
@@ -24,37 +24,39 @@ func dataSourceSDK() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceSDKRead,
 
-		Schema: map[string]*schema.Schema{
-			"body": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrContentType: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"content_disposition": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrParameters: {
-				Type:     schema.TypeMap,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			attrRestAPIID: {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"sdk_type": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringInSlice([]string{"java", "javascript", "android", "objectivec", "swift", "ruby"}, false),
-			},
-			"stage_name": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"body": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrContentType: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"content_disposition": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrParameters: {
+					Type:     schema.TypeMap,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				attrRestAPIID: {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"sdk_type": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringInSlice([]string{"java", "javascript", "android", "objectivec", "swift", "ruby"}, false),
+				},
+				"stage_name": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/apigateway/stage.go
+++ b/internal/service/apigateway/stage.go
@@ -57,114 +57,116 @@ func resourceStage() *schema.Resource {
 			},
 		},
 
-		Schema: map[string]*schema.Schema{
-			"access_log_settings": {
-				Type:     schema.TypeList,
-				MaxItems: 1,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrDestinationARN: {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: verify.ValidARN,
-						},
-						names.AttrFormat: {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-					},
-				},
-			},
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"cache_cluster_enabled": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
-			"cache_cluster_size": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				ValidateDiagFunc: enum.Validate[types.CacheClusterSize](),
-			},
-			"canary_settings": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"deployment_id": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"percent_traffic": {
-							Type:     schema.TypeFloat,
-							Optional: true,
-							Default:  0.0,
-						},
-						"stage_variable_overrides": {
-							Type:     schema.TypeMap,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-							Optional: true,
-						},
-						"use_stage_cache": {
-							Type:     schema.TypeBool,
-							Optional: true,
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"access_log_settings": {
+					Type:     schema.TypeList,
+					MaxItems: 1,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrDestinationARN: {
+								Type:         schema.TypeString,
+								Required:     true,
+								ValidateFunc: verify.ValidARN,
+							},
+							names.AttrFormat: {
+								Type:     schema.TypeString,
+								Required: true,
+							},
 						},
 					},
 				},
-			},
-			"client_certificate_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"deployment_id": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			names.AttrDescription: {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"documentation_version": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"execution_arn": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"invoke_url": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			attrRestAPIID: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"stage_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"variables": {
-				Type:     schema.TypeMap,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			"xray_tracing_enabled": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
-			"web_acl_arn": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"cache_cluster_enabled": {
+					Type:     schema.TypeBool,
+					Optional: true,
+				},
+				"cache_cluster_size": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					ValidateDiagFunc: enum.Validate[types.CacheClusterSize](),
+				},
+				"canary_settings": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"deployment_id": {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+							"percent_traffic": {
+								Type:     schema.TypeFloat,
+								Optional: true,
+								Default:  0.0,
+							},
+							"stage_variable_overrides": {
+								Type:     schema.TypeMap,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+								Optional: true,
+							},
+							"use_stage_cache": {
+								Type:     schema.TypeBool,
+								Optional: true,
+							},
+						},
+					},
+				},
+				"client_certificate_id": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"deployment_id": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				names.AttrDescription: {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"documentation_version": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"execution_arn": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"invoke_url": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				attrRestAPIID: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"stage_name": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"variables": {
+					Type:     schema.TypeMap,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				"xray_tracing_enabled": {
+					Type:     schema.TypeBool,
+					Optional: true,
+				},
+				"web_acl_arn": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/apigateway/usage_plan.go
+++ b/internal/service/apigateway/usage_plan.go
@@ -40,107 +40,109 @@ func resourceUsagePlan() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"api_stages": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"api_id": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						names.AttrStage: {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"throttle": {
-							Type:     schema.TypeSet,
-							Optional: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"burst_limit": {
-										Type:     schema.TypeInt,
-										Default:  0,
-										Optional: true,
-									},
-									names.AttrPath: {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-									"rate_limit": {
-										Type:     schema.TypeFloat,
-										Default:  0,
-										Optional: true,
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"api_stages": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"api_id": {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+							names.AttrStage: {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+							"throttle": {
+								Type:     schema.TypeSet,
+								Optional: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"burst_limit": {
+											Type:     schema.TypeInt,
+											Default:  0,
+											Optional: true,
+										},
+										names.AttrPath: {
+											Type:     schema.TypeString,
+											Required: true,
+										},
+										"rate_limit": {
+											Type:     schema.TypeFloat,
+											Default:  0,
+											Optional: true,
+										},
 									},
 								},
 							},
 						},
 					},
 				},
-			},
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrDescription: {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true, // Required since not addable nor removable afterwards
-			},
-			"product_code": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"quota_settings": {
-				Type:     schema.TypeList,
-				MaxItems: 1,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"limit": {
-							Type:     schema.TypeInt,
-							Required: true, // Required as not removable singularly
-						},
-						"offset": {
-							Type:     schema.TypeInt,
-							Default:  0,
-							Optional: true,
-						},
-						"period": {
-							Type:             schema.TypeString,
-							Required:         true, // Required as not removable
-							ValidateDiagFunc: enum.Validate[types.QuotaPeriodType](),
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrDescription: {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true, // Required since not addable nor removable afterwards
+				},
+				"product_code": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"quota_settings": {
+					Type:     schema.TypeList,
+					MaxItems: 1,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"limit": {
+								Type:     schema.TypeInt,
+								Required: true, // Required as not removable singularly
+							},
+							"offset": {
+								Type:     schema.TypeInt,
+								Default:  0,
+								Optional: true,
+							},
+							"period": {
+								Type:             schema.TypeString,
+								Required:         true, // Required as not removable
+								ValidateDiagFunc: enum.Validate[types.QuotaPeriodType](),
+							},
 						},
 					},
 				},
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			"throttle_settings": {
-				Type:     schema.TypeList,
-				MaxItems: 1,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"burst_limit": {
-							Type:         schema.TypeInt,
-							Default:      0,
-							Optional:     true,
-							AtLeastOneOf: []string{"throttle_settings.0.burst_limit", "throttle_settings.0.rate_limit"},
-						},
-						"rate_limit": {
-							Type:         schema.TypeFloat,
-							Default:      0,
-							Optional:     true,
-							AtLeastOneOf: []string{"throttle_settings.0.burst_limit", "throttle_settings.0.rate_limit"},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				"throttle_settings": {
+					Type:     schema.TypeList,
+					MaxItems: 1,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"burst_limit": {
+								Type:         schema.TypeInt,
+								Default:      0,
+								Optional:     true,
+								AtLeastOneOf: []string{"throttle_settings.0.burst_limit", "throttle_settings.0.rate_limit"},
+							},
+							"rate_limit": {
+								Type:         schema.TypeFloat,
+								Default:      0,
+								Optional:     true,
+								AtLeastOneOf: []string{"throttle_settings.0.burst_limit", "throttle_settings.0.rate_limit"},
+							},
 						},
 					},
 				},
-			},
+			}
 		},
 	}
 }

--- a/internal/service/apigateway/usage_plan_key.go
+++ b/internal/service/apigateway/usage_plan_key.go
@@ -46,30 +46,32 @@ func resourceUsagePlanKey() *schema.Resource {
 			},
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrKeyID: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"key_type": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"usage_plan_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			names.AttrValue: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrKeyID: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"key_type": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"usage_plan_id": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				names.AttrValue: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/apigateway/vpc_link.go
+++ b/internal/service/apigateway/vpc_link.go
@@ -41,28 +41,30 @@ func resourceVPCLink() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrDescription: {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			"target_arns": {
-				Type:     schema.TypeList,
-				MaxItems: 1,
-				Required: true,
-				ForceNew: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrDescription: {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				"target_arns": {
+					Type:     schema.TypeList,
+					MaxItems: 1,
+					Required: true,
+					ForceNew: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+			}
 		},
 	}
 }

--- a/internal/service/apigateway/vpc_link_data_source.go
+++ b/internal/service/apigateway/vpc_link_data_source.go
@@ -28,37 +28,39 @@ func dataSourceVPCLink() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceVPCLinkRead,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrDescription: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrID: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			names.AttrStatus: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrStatusMessage: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrTags: tftags.TagsSchemaComputed(),
-			"target_arns": {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrDescription: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrID: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				names.AttrStatus: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrStatusMessage: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrTags: tftags.TagsSchemaComputed(),
+				"target_arns": {
+					Type:     schema.TypeSet,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+			}
 		},
 	}
 }

--- a/internal/service/apigatewayv2/api.go
+++ b/internal/service/apigatewayv2/api.go
@@ -44,133 +44,135 @@ func resourceAPI() *schema.Resource {
 		UpdateWithoutTimeout: resourceAPIUpdate,
 		DeleteWithoutTimeout: resourceAPIDelete,
 
-		Schema: map[string]*schema.Schema{
-			"api_endpoint": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"api_key_selection_expression": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  "$request.header.x-api-key",
-				ValidateFunc: validation.StringInSlice([]string{
-					"$context.authorizer.usageIdentifierKey",
-					"$request.header.x-api-key",
-				}, false),
-			},
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"body": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				DiffSuppressFunc: verify.SuppressEquivalentJSONOrYAMLDiffs,
-				ValidateFunc:     verify.ValidStringIsJSONOrYAML,
-			},
-			"cors_configuration": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"allow_credentials": {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
-						"allow_headers": {
-							Type:     schema.TypeSet,
-							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-							Set:      sdkv2.StringCaseInsensitiveSetFunc,
-						},
-						"allow_methods": {
-							Type:     schema.TypeSet,
-							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-							Set:      sdkv2.StringCaseInsensitiveSetFunc,
-						},
-						"allow_origins": {
-							Type:     schema.TypeSet,
-							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-							Set:      sdkv2.StringCaseInsensitiveSetFunc,
-						},
-						"expose_headers": {
-							Type:     schema.TypeSet,
-							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-							Set:      sdkv2.StringCaseInsensitiveSetFunc,
-						},
-						"max_age": {
-							Type:     schema.TypeInt,
-							Optional: true,
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"api_endpoint": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"api_key_selection_expression": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Default:  "$request.header.x-api-key",
+					ValidateFunc: validation.StringInSlice([]string{
+						"$context.authorizer.usageIdentifierKey",
+						"$request.header.x-api-key",
+					}, false),
+				},
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"body": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					DiffSuppressFunc: verify.SuppressEquivalentJSONOrYAMLDiffs,
+					ValidateFunc:     verify.ValidStringIsJSONOrYAML,
+				},
+				"cors_configuration": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"allow_credentials": {
+								Type:     schema.TypeBool,
+								Optional: true,
+							},
+							"allow_headers": {
+								Type:     schema.TypeSet,
+								Optional: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+								Set:      sdkv2.StringCaseInsensitiveSetFunc,
+							},
+							"allow_methods": {
+								Type:     schema.TypeSet,
+								Optional: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+								Set:      sdkv2.StringCaseInsensitiveSetFunc,
+							},
+							"allow_origins": {
+								Type:     schema.TypeSet,
+								Optional: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+								Set:      sdkv2.StringCaseInsensitiveSetFunc,
+							},
+							"expose_headers": {
+								Type:     schema.TypeSet,
+								Optional: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+								Set:      sdkv2.StringCaseInsensitiveSetFunc,
+							},
+							"max_age": {
+								Type:     schema.TypeInt,
+								Optional: true,
+							},
 						},
 					},
 				},
-			},
-			"credentials_arn": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			names.AttrDescription: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringLenBetween(0, 1024),
-			},
-			"disable_execute_api_endpoint": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
-			"execution_arn": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"fail_on_warnings": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
-			names.AttrIPAddressType: {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Computed:         true,
-				ValidateDiagFunc: enum.Validate[awstypes.IpAddressType](),
-			},
-			names.AttrName: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringLenBetween(1, 128),
-			},
-			"protocol_type": {
-				Type:             schema.TypeString,
-				Required:         true,
-				ForceNew:         true,
-				ValidateDiagFunc: enum.Validate[awstypes.ProtocolType](),
-			},
-			"route_key": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
-			"route_selection_expression": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  "$request.method $request.path",
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			names.AttrTarget: {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
-			names.AttrVersion: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringLenBetween(1, 64),
-			},
+				"credentials_arn": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ForceNew:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				names.AttrDescription: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringLenBetween(0, 1024),
+				},
+				"disable_execute_api_endpoint": {
+					Type:     schema.TypeBool,
+					Optional: true,
+				},
+				"execution_arn": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"fail_on_warnings": {
+					Type:     schema.TypeBool,
+					Optional: true,
+				},
+				names.AttrIPAddressType: {
+					Type:             schema.TypeString,
+					Optional:         true,
+					Computed:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.IpAddressType](),
+				},
+				names.AttrName: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringLenBetween(1, 128),
+				},
+				"protocol_type": {
+					Type:             schema.TypeString,
+					Required:         true,
+					ForceNew:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.ProtocolType](),
+				},
+				"route_key": {
+					Type:     schema.TypeString,
+					Optional: true,
+					ForceNew: true,
+				},
+				"route_selection_expression": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Default:  "$request.method $request.path",
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				names.AttrTarget: {
+					Type:     schema.TypeString,
+					Optional: true,
+					ForceNew: true,
+				},
+				names.AttrVersion: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringLenBetween(1, 64),
+				},
+			}
 		},
 	}
 }

--- a/internal/service/apigatewayv2/api_data_source.go
+++ b/internal/service/apigatewayv2/api_data_source.go
@@ -24,92 +24,94 @@ func dataSourceAPI() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceAPIRead,
 
-		Schema: map[string]*schema.Schema{
-			"api_endpoint": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"api_id": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"api_key_selection_expression": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"cors_configuration": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"allow_credentials": {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
-						"allow_headers": {
-							Type:     schema.TypeSet,
-							Computed: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-						"allow_methods": {
-							Type:     schema.TypeSet,
-							Computed: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-						"allow_origins": {
-							Type:     schema.TypeSet,
-							Computed: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-						"expose_headers": {
-							Type:     schema.TypeSet,
-							Computed: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-						"max_age": {
-							Type:     schema.TypeInt,
-							Computed: true,
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"api_endpoint": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"api_id": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"api_key_selection_expression": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"cors_configuration": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"allow_credentials": {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
+							"allow_headers": {
+								Type:     schema.TypeSet,
+								Computed: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+							},
+							"allow_methods": {
+								Type:     schema.TypeSet,
+								Computed: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+							},
+							"allow_origins": {
+								Type:     schema.TypeSet,
+								Computed: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+							},
+							"expose_headers": {
+								Type:     schema.TypeSet,
+								Computed: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+							},
+							"max_age": {
+								Type:     schema.TypeInt,
+								Computed: true,
+							},
 						},
 					},
 				},
-			},
-			names.AttrDescription: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"disable_execute_api_endpoint": {
-				Type:     schema.TypeBool,
-				Computed: true,
-			},
-			"execution_arn": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrIPAddressType: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"protocol_type": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"route_selection_expression": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrTags: tftags.TagsSchemaComputed(),
-			names.AttrVersion: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+				names.AttrDescription: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"disable_execute_api_endpoint": {
+					Type:     schema.TypeBool,
+					Computed: true,
+				},
+				"execution_arn": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrIPAddressType: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"protocol_type": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"route_selection_expression": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrTags: tftags.TagsSchemaComputed(),
+				names.AttrVersion: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/apigatewayv2/api_mapping.go
+++ b/internal/service/apigatewayv2/api_mapping.go
@@ -36,25 +36,27 @@ func resourceAPIMapping() *schema.Resource {
 			StateContext: resourceAPIMappingImport,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"api_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"api_mapping_key": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			names.AttrDomainName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			names.AttrStage: {
-				Type:     schema.TypeString,
-				Required: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"api_id": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"api_mapping_key": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				names.AttrDomainName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				names.AttrStage: {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/apigatewayv2/apis_data_source.go
+++ b/internal/service/apigatewayv2/apis_data_source.go
@@ -25,22 +25,24 @@ func dataSourceAPIs() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceAPIsRead,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrIDs: {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Set:      schema.HashString,
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"protocol_type": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			names.AttrTags: tftags.TagsSchema(),
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrIDs: {
+					Type:     schema.TypeSet,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+					Set:      schema.HashString,
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"protocol_type": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				names.AttrTags: tftags.TagsSchema(),
+			}
 		},
 	}
 }

--- a/internal/service/apigatewayv2/authorizer.go
+++ b/internal/service/apigatewayv2/authorizer.go
@@ -45,71 +45,73 @@ func resourceAuthorizer() *schema.Resource {
 			Delete: schema.DefaultTimeout(30 * time.Minute),
 		},
 
-		Schema: map[string]*schema.Schema{
-			"api_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"authorizer_credentials_arn": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			"authorizer_payload_format_version": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringInSlice([]string{"1.0", "2.0"}, false),
-			},
-			"authorizer_result_ttl_in_seconds": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: validation.IntBetween(0, 3600),
-			},
-			"authorizer_type": {
-				Type:             schema.TypeString,
-				Required:         true,
-				ValidateDiagFunc: enum.Validate[awstypes.AuthorizerType](),
-			},
-			"authorizer_uri": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringLenBetween(1, 2048),
-			},
-			"enable_simple_responses": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
-			"identity_sources": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			"jwt_configuration": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MinItems: 0,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"audience": {
-							Type:     schema.TypeSet,
-							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-						names.AttrIssuer: {
-							Type:     schema.TypeString,
-							Optional: true,
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"api_id": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"authorizer_credentials_arn": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				"authorizer_payload_format_version": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringInSlice([]string{"1.0", "2.0"}, false),
+				},
+				"authorizer_result_ttl_in_seconds": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					Computed:     true,
+					ValidateFunc: validation.IntBetween(0, 3600),
+				},
+				"authorizer_type": {
+					Type:             schema.TypeString,
+					Required:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.AuthorizerType](),
+				},
+				"authorizer_uri": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringLenBetween(1, 2048),
+				},
+				"enable_simple_responses": {
+					Type:     schema.TypeBool,
+					Optional: true,
+				},
+				"identity_sources": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"jwt_configuration": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MinItems: 0,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"audience": {
+								Type:     schema.TypeSet,
+								Optional: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+							},
+							names.AttrIssuer: {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
 						},
 					},
 				},
-			},
-			names.AttrName: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringLenBetween(1, 128),
-			},
+				names.AttrName: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringLenBetween(1, 128),
+				},
+			}
 		},
 	}
 }

--- a/internal/service/apigatewayv2/deployment.go
+++ b/internal/service/apigatewayv2/deployment.go
@@ -40,27 +40,29 @@ func resourceDeployment() *schema.Resource {
 			StateContext: resourceDeploymentImport,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"api_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"auto_deployed": {
-				Type:     schema.TypeBool,
-				Computed: true,
-			},
-			names.AttrDescription: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringLenBetween(0, 1024),
-			},
-			names.AttrTriggers: {
-				Type:     schema.TypeMap,
-				Optional: true,
-				ForceNew: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"api_id": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"auto_deployed": {
+					Type:     schema.TypeBool,
+					Computed: true,
+				},
+				names.AttrDescription: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringLenBetween(0, 1024),
+				},
+				names.AttrTriggers: {
+					Type:     schema.TypeMap,
+					Optional: true,
+					ForceNew: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+			}
 		},
 	}
 }

--- a/internal/service/apigatewayv2/domain_name.go
+++ b/internal/service/apigatewayv2/domain_name.go
@@ -50,91 +50,93 @@ func resourceDomainName() *schema.Resource {
 			Update: schema.DefaultTimeout(60 * time.Minute),
 		},
 
-		Schema: map[string]*schema.Schema{
-			"api_mapping_selection_expression": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrDomainName: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(1, 512),
-			},
-			"domain_name_configuration": {
-				Type:     schema.TypeList,
-				Required: true,
-				MinItems: 1,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrCertificateARN: {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: verify.ValidARN,
-						},
-						names.AttrEndpointType: {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validation.StringInSlice(enum.Slice(awstypes.EndpointTypeRegional), true),
-						},
-						names.AttrHostedZoneID: {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						names.AttrIPAddressType: {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Computed:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.IpAddressType](),
-						},
-						"ownership_verification_certificate_arn": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							Computed:     true,
-							ValidateFunc: verify.ValidARN,
-						},
-						"security_policy": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validation.StringInSlice(enum.Slice(awstypes.SecurityPolicyTls12), true),
-						},
-						"target_domain_name": {
-							Type:     schema.TypeString,
-							Computed: true,
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"api_mapping_selection_expression": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrDomainName: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringLenBetween(1, 512),
+				},
+				"domain_name_configuration": {
+					Type:     schema.TypeList,
+					Required: true,
+					MinItems: 1,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrCertificateARN: {
+								Type:         schema.TypeString,
+								Required:     true,
+								ValidateFunc: verify.ValidARN,
+							},
+							names.AttrEndpointType: {
+								Type:         schema.TypeString,
+								Required:     true,
+								ValidateFunc: validation.StringInSlice(enum.Slice(awstypes.EndpointTypeRegional), true),
+							},
+							names.AttrHostedZoneID: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							names.AttrIPAddressType: {
+								Type:             schema.TypeString,
+								Optional:         true,
+								Computed:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.IpAddressType](),
+							},
+							"ownership_verification_certificate_arn": {
+								Type:         schema.TypeString,
+								Optional:     true,
+								Computed:     true,
+								ValidateFunc: verify.ValidARN,
+							},
+							"security_policy": {
+								Type:         schema.TypeString,
+								Required:     true,
+								ValidateFunc: validation.StringInSlice(enum.Slice(awstypes.SecurityPolicyTls12), true),
+							},
+							"target_domain_name": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
 						},
 					},
 				},
-			},
-			"mutual_tls_authentication": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"truststore_uri": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"truststore_version": {
-							Type:     schema.TypeString,
-							Optional: true,
+				"mutual_tls_authentication": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"truststore_uri": {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+							"truststore_version": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
 						},
 					},
 				},
-			},
-			"routing_mode": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Computed:         true,
-				ValidateDiagFunc: enum.ValidateIgnoreCase[awstypes.RoutingMode](),
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				"routing_mode": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					Computed:         true,
+					ValidateDiagFunc: enum.ValidateIgnoreCase[awstypes.RoutingMode](),
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			}
 		},
 	}
 }

--- a/internal/service/apigatewayv2/export_data_source.go
+++ b/internal/service/apigatewayv2/export_data_source.go
@@ -22,39 +22,41 @@ func dataSourceExport() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceExportRead,
 
-		Schema: map[string]*schema.Schema{
-			"api_id": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"body": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"export_version": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringInSlice([]string{"1.0"}, false),
-			},
-			"include_extensions": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
-			},
-			"specification": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringInSlice([]string{"OAS30"}, false),
-			},
-			"stage_name": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"output_type": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringInSlice([]string{"JSON", "YAML"}, false),
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"api_id": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"body": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"export_version": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringInSlice([]string{"1.0"}, false),
+				},
+				"include_extensions": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  true,
+				},
+				"specification": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringInSlice([]string{"OAS30"}, false),
+				},
+				"stage_name": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"output_type": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringInSlice([]string{"JSON", "YAML"}, false),
+				},
+			}
 		},
 	}
 }

--- a/internal/service/apigatewayv2/integration.go
+++ b/internal/service/apigatewayv2/integration.go
@@ -41,146 +41,148 @@ func resourceIntegration() *schema.Resource {
 			StateContext: resourceIntegrationImport,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"api_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			names.AttrConnectionID: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringLenBetween(1, 1024),
-			},
-			"connection_type": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Default:          awstypes.ConnectionTypeInternet,
-				ValidateDiagFunc: enum.Validate[awstypes.ConnectionType](),
-			},
-			"content_handling_strategy": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				ValidateDiagFunc: enum.Validate[awstypes.ContentHandlingStrategy](),
-			},
-			"credentials_arn": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			names.AttrDescription: {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"integration_method": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validHTTPMethod(),
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					// Default HTTP method for Lambda integration is POST.
-					if v := d.Get("integration_type").(string); (v == string(awstypes.IntegrationTypeAws) || v == string(awstypes.IntegrationTypeAwsProxy)) && old == "POST" && new == "" {
-						return true
-					}
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"api_id": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				names.AttrConnectionID: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringLenBetween(1, 1024),
+				},
+				"connection_type": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					Default:          awstypes.ConnectionTypeInternet,
+					ValidateDiagFunc: enum.Validate[awstypes.ConnectionType](),
+				},
+				"content_handling_strategy": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.ContentHandlingStrategy](),
+				},
+				"credentials_arn": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				names.AttrDescription: {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"integration_method": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validHTTPMethod(),
+					DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+						// Default HTTP method for Lambda integration is POST.
+						if v := d.Get("integration_type").(string); (v == string(awstypes.IntegrationTypeAws) || v == string(awstypes.IntegrationTypeAwsProxy)) && old == "POST" && new == "" {
+							return true
+						}
 
-					return false
+						return false
+					},
 				},
-			},
-			"integration_response_selection_expression": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"integration_subtype": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(1, 128),
-			},
-			"integration_type": {
-				Type:             schema.TypeString,
-				Required:         true,
-				ForceNew:         true,
-				ValidateDiagFunc: enum.Validate[awstypes.IntegrationType](),
-			},
-			"integration_uri": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"passthrough_behavior": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Default:          awstypes.PassthroughBehaviorWhenNoMatch,
-				ValidateDiagFunc: enum.Validate[awstypes.PassthroughBehavior](),
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					// Not set for HTTP APIs.
-					if old == "" && new == string(awstypes.PassthroughBehaviorWhenNoMatch) {
-						return true
-					}
-					return false
+				"integration_response_selection_expression": {
+					Type:     schema.TypeString,
+					Computed: true,
 				},
-			},
-			"payload_format_version": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  "1.0",
-				ValidateFunc: validation.StringInSlice([]string{
-					"1.0",
-					"2.0",
-				}, false),
-			},
-			"request_parameters": {
-				Type:     schema.TypeMap,
-				Optional: true,
-				// Length between [1-512].
-				Elem: &schema.Schema{Type: schema.TypeString},
-			},
-			"request_templates": {
-				Type:     schema.TypeMap,
-				Optional: true,
-				// Length between [0-32768].
-				Elem: &schema.Schema{Type: schema.TypeString},
-			},
-			"response_parameters": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				MinItems: 0,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"mappings": {
-							Type:     schema.TypeMap,
-							Required: true,
-							// Length between [1-512].
-							Elem: &schema.Schema{Type: schema.TypeString},
-						},
-						names.AttrStatusCode: {
-							Type:     schema.TypeString,
-							Required: true,
+				"integration_subtype": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringLenBetween(1, 128),
+				},
+				"integration_type": {
+					Type:             schema.TypeString,
+					Required:         true,
+					ForceNew:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.IntegrationType](),
+				},
+				"integration_uri": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"passthrough_behavior": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					Default:          awstypes.PassthroughBehaviorWhenNoMatch,
+					ValidateDiagFunc: enum.Validate[awstypes.PassthroughBehavior](),
+					DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+						// Not set for HTTP APIs.
+						if old == "" && new == string(awstypes.PassthroughBehaviorWhenNoMatch) {
+							return true
+						}
+						return false
+					},
+				},
+				"payload_format_version": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Default:  "1.0",
+					ValidateFunc: validation.StringInSlice([]string{
+						"1.0",
+						"2.0",
+					}, false),
+				},
+				"request_parameters": {
+					Type:     schema.TypeMap,
+					Optional: true,
+					// Length between [1-512].
+					Elem: &schema.Schema{Type: schema.TypeString},
+				},
+				"request_templates": {
+					Type:     schema.TypeMap,
+					Optional: true,
+					// Length between [0-32768].
+					Elem: &schema.Schema{Type: schema.TypeString},
+				},
+				"response_parameters": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					MinItems: 0,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"mappings": {
+								Type:     schema.TypeMap,
+								Required: true,
+								// Length between [1-512].
+								Elem: &schema.Schema{Type: schema.TypeString},
+							},
+							names.AttrStatusCode: {
+								Type:     schema.TypeString,
+								Required: true,
+							},
 						},
 					},
 				},
-			},
-			"template_selection_expression": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"timeout_milliseconds": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Computed: true,
-			},
-			"tls_config": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MinItems: 0,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"server_name_to_verify": {
-							Type:     schema.TypeString,
-							Optional: true,
+				"template_selection_expression": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"timeout_milliseconds": {
+					Type:     schema.TypeInt,
+					Optional: true,
+					Computed: true,
+				},
+				"tls_config": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MinItems: 0,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"server_name_to_verify": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
 						},
 					},
 				},
-			},
+			}
 		},
 	}
 }

--- a/internal/service/apigatewayv2/integration_response.go
+++ b/internal/service/apigatewayv2/integration_response.go
@@ -37,35 +37,37 @@ func resourceIntegrationResponse() *schema.Resource {
 			StateContext: resourceIntegrationResponseImport,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"api_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"content_handling_strategy": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				ValidateDiagFunc: enum.Validate[awstypes.ContentHandlingStrategy](),
-			},
-			"integration_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"integration_response_key": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"response_templates": {
-				Type:     schema.TypeMap,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			"template_selection_expression": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"api_id": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"content_handling_strategy": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.ContentHandlingStrategy](),
+				},
+				"integration_id": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"integration_response_key": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"response_templates": {
+					Type:     schema.TypeMap,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"template_selection_expression": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/apigatewayv2/model.go
+++ b/internal/service/apigatewayv2/model.go
@@ -40,44 +40,46 @@ func resourceModel() *schema.Resource {
 			StateContext: resourceModelImport,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"api_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			names.AttrContentType: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringLenBetween(1, 256),
-			},
-			names.AttrDescription: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringLenBetween(1, 128),
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ValidateFunc: validation.All(
-					validation.StringLenBetween(1, 128),
-					validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z]+$`), "must be alphanumeric"),
-				),
-			},
-			names.AttrSchema: {
-				Type:     schema.TypeString,
-				Required: true,
-				ValidateFunc: validation.All(
-					validation.StringLenBetween(0, 32768),
-					validation.StringIsJSON,
-				),
-				DiffSuppressFunc:      verify.SuppressEquivalentJSONDiffs,
-				DiffSuppressOnRefresh: true,
-				StateFunc: func(v any) string {
-					json, _ := structure.NormalizeJsonString(v)
-					return json
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"api_id": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
 				},
-			},
+				names.AttrContentType: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringLenBetween(1, 256),
+				},
+				names.AttrDescription: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringLenBetween(1, 128),
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ValidateFunc: validation.All(
+						validation.StringLenBetween(1, 128),
+						validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z]+$`), "must be alphanumeric"),
+					),
+				},
+				names.AttrSchema: {
+					Type:     schema.TypeString,
+					Required: true,
+					ValidateFunc: validation.All(
+						validation.StringLenBetween(0, 32768),
+						validation.StringIsJSON,
+					),
+					DiffSuppressFunc:      verify.SuppressEquivalentJSONDiffs,
+					DiffSuppressOnRefresh: true,
+					StateFunc: func(v any) string {
+						json, _ := structure.NormalizeJsonString(v)
+						return json
+					},
+				},
+			}
 		},
 	}
 }

--- a/internal/service/apigatewayv2/route.go
+++ b/internal/service/apigatewayv2/route.go
@@ -48,76 +48,78 @@ func resourceRoute() *schema.Resource {
 			StateContext: resourceRouteImport,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"api_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"api_key_required": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-			"authorization_scopes": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			"authorization_type": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Default:          awstypes.AuthorizationTypeNone,
-				ValidateDiagFunc: enum.Validate[awstypes.AuthorizationType](),
-			},
-			"authorizer_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"model_selection_expression": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"operation_name": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringLenBetween(1, 64),
-			},
-			"request_models": {
-				Type:     schema.TypeMap,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			"request_parameter": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				MinItems: 0,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"request_parameter_key": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"required": {
-							Type:     schema.TypeBool,
-							Required: true,
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"api_id": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"api_key_required": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
+				"authorization_scopes": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"authorization_type": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					Default:          awstypes.AuthorizationTypeNone,
+					ValidateDiagFunc: enum.Validate[awstypes.AuthorizationType](),
+				},
+				"authorizer_id": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"model_selection_expression": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"operation_name": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringLenBetween(1, 64),
+				},
+				"request_models": {
+					Type:     schema.TypeMap,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"request_parameter": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					MinItems: 0,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"request_parameter_key": {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+							"required": {
+								Type:     schema.TypeBool,
+								Required: true,
+							},
 						},
 					},
 				},
-			},
-			"route_key": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"route_response_selection_expression": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			names.AttrTarget: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringLenBetween(1, 128),
-			},
+				"route_key": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"route_response_selection_expression": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				names.AttrTarget: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringLenBetween(1, 128),
+				},
+			}
 		},
 	}
 }

--- a/internal/service/apigatewayv2/route_response.go
+++ b/internal/service/apigatewayv2/route_response.go
@@ -36,30 +36,32 @@ func resourceRouteResponse() *schema.Resource {
 			StateContext: resourceRouteResponseImport,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"api_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"model_selection_expression": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"response_models": {
-				Type:     schema.TypeMap,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			"route_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"route_response_key": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"api_id": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"model_selection_expression": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"response_models": {
+					Type:     schema.TypeMap,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"route_id": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"route_response_key": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/apigatewayv2/stage.go
+++ b/internal/service/apigatewayv2/stage.go
@@ -45,147 +45,149 @@ func resourceStage() *schema.Resource {
 			StateContext: resourceStageImport,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"access_log_settings": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MinItems: 0,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrDestinationARN: {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: verify.ValidARN,
-						},
-						names.AttrFormat: {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-					},
-				},
-			},
-			"api_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"auto_deploy": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-			"client_certificate_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"default_route_settings": {
-				Type:             schema.TypeList,
-				Optional:         true,
-				MinItems:         0,
-				MaxItems:         1,
-				DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"data_trace_enabled": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  false,
-						},
-						"detailed_metrics_enabled": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  false,
-						},
-						"logging_level": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Computed:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.LoggingLevel](),
-						},
-						"throttling_burst_limit": {
-							Type:     schema.TypeInt,
-							Optional: true,
-						},
-						"throttling_rate_limit": {
-							Type:     schema.TypeFloat,
-							Optional: true,
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"access_log_settings": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MinItems: 0,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrDestinationARN: {
+								Type:         schema.TypeString,
+								Required:     true,
+								ValidateFunc: verify.ValidARN,
+							},
+							names.AttrFormat: {
+								Type:     schema.TypeString,
+								Required: true,
+							},
 						},
 					},
 				},
-			},
-			"deployment_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-			names.AttrDescription: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringLenBetween(0, 1024),
-			},
-			"execution_arn": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"invoke_url": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrName: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(1, 128),
-			},
-			"route_settings": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				MinItems: 0,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"data_trace_enabled": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  false,
-						},
-						"detailed_metrics_enabled": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  false,
-						},
-						"logging_level": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Computed:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.LoggingLevel](),
-						},
-						"route_key": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"throttling_burst_limit": {
-							Type:     schema.TypeInt,
-							Optional: true,
-						},
-						"throttling_rate_limit": {
-							Type:     schema.TypeFloat,
-							Optional: true,
+				"api_id": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"auto_deploy": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
+				"client_certificate_id": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"default_route_settings": {
+					Type:             schema.TypeList,
+					Optional:         true,
+					MinItems:         0,
+					MaxItems:         1,
+					DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"data_trace_enabled": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Default:  false,
+							},
+							"detailed_metrics_enabled": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Default:  false,
+							},
+							"logging_level": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								Computed:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.LoggingLevel](),
+							},
+							"throttling_burst_limit": {
+								Type:     schema.TypeInt,
+								Optional: true,
+							},
+							"throttling_rate_limit": {
+								Type:     schema.TypeFloat,
+								Optional: true,
+							},
 						},
 					},
 				},
-			},
-			"stage_variables": {
-				Type:     schema.TypeMap,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				"deployment_id": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+				},
+				names.AttrDescription: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringLenBetween(0, 1024),
+				},
+				"execution_arn": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"invoke_url": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrName: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringLenBetween(1, 128),
+				},
+				"route_settings": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					MinItems: 0,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"data_trace_enabled": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Default:  false,
+							},
+							"detailed_metrics_enabled": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Default:  false,
+							},
+							"logging_level": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								Computed:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.LoggingLevel](),
+							},
+							"route_key": {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+							"throttling_burst_limit": {
+								Type:     schema.TypeInt,
+								Optional: true,
+							},
+							"throttling_rate_limit": {
+								Type:     schema.TypeFloat,
+								Optional: true,
+							},
+						},
+					},
+				},
+				"stage_variables": {
+					Type:     schema.TypeMap,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			}
 		},
 	}
 }

--- a/internal/service/apigatewayv2/vpc_link.go
+++ b/internal/service/apigatewayv2/vpc_link.go
@@ -42,30 +42,32 @@ func resourceVPCLink() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrName: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringLenBetween(1, 128),
-			},
-			names.AttrSecurityGroupIDs: {
-				Type:     schema.TypeSet,
-				Required: true,
-				ForceNew: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			names.AttrSubnetIDs: {
-				Type:     schema.TypeSet,
-				Required: true,
-				ForceNew: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrName: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringLenBetween(1, 128),
+				},
+				names.AttrSecurityGroupIDs: {
+					Type:     schema.TypeSet,
+					Required: true,
+					ForceNew: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				names.AttrSubnetIDs: {
+					Type:     schema.TypeSet,
+					Required: true,
+					ForceNew: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			}
 		},
 	}
 }

--- a/internal/service/apigatewayv2/vpc_link_data_source.go
+++ b/internal/service/apigatewayv2/vpc_link_data_source.go
@@ -23,30 +23,32 @@ func dataSourceVPCLink() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceVPCLinkRead,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrSecurityGroupIDs: {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			names.AttrSubnetIDs: {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			names.AttrTags: tftags.TagsSchemaComputed(),
-			"vpc_link_id": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrSecurityGroupIDs: {
+					Type:     schema.TypeSet,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				names.AttrSubnetIDs: {
+					Type:     schema.TypeSet,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				names.AttrTags: tftags.TagsSchemaComputed(),
+				"vpc_link_id": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/appautoscaling/scheduled_action.go
+++ b/internal/service/appautoscaling/scheduled_action.go
@@ -37,81 +37,83 @@ func resourceScheduledAction() *schema.Resource {
 		UpdateWithoutTimeout: resourceScheduledActionPut,
 		DeleteWithoutTimeout: resourceScheduledActionDelete,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"end_time": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				ValidateFunc:     validation.IsRFC3339Time,
-				DiffSuppressFunc: sdkv2.SuppressEquivalentTime,
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			names.AttrResourceID: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"scalable_dimension": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"scalable_target_action": {
-				Type:     schema.TypeList,
-				Required: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrMaxCapacity: {
-							Type:         nullable.TypeNullableInt,
-							Optional:     true,
-							ValidateFunc: nullable.ValidateTypeStringNullableIntAtLeast(0),
-							AtLeastOneOf: []string{
-								"scalable_target_action.0.max_capacity",
-								"scalable_target_action.0.min_capacity",
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"end_time": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					ValidateFunc:     validation.IsRFC3339Time,
+					DiffSuppressFunc: sdkv2.SuppressEquivalentTime,
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				names.AttrResourceID: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"scalable_dimension": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"scalable_target_action": {
+					Type:     schema.TypeList,
+					Required: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrMaxCapacity: {
+								Type:         nullable.TypeNullableInt,
+								Optional:     true,
+								ValidateFunc: nullable.ValidateTypeStringNullableIntAtLeast(0),
+								AtLeastOneOf: []string{
+									"scalable_target_action.0.max_capacity",
+									"scalable_target_action.0.min_capacity",
+								},
 							},
-						},
-						"min_capacity": {
-							Type:         nullable.TypeNullableInt,
-							Optional:     true,
-							ValidateFunc: nullable.ValidateTypeStringNullableIntAtLeast(0),
-							AtLeastOneOf: []string{
-								"scalable_target_action.0.max_capacity",
-								"scalable_target_action.0.min_capacity",
+							"min_capacity": {
+								Type:         nullable.TypeNullableInt,
+								Optional:     true,
+								ValidateFunc: nullable.ValidateTypeStringNullableIntAtLeast(0),
+								AtLeastOneOf: []string{
+									"scalable_target_action.0.max_capacity",
+									"scalable_target_action.0.min_capacity",
+								},
 							},
 						},
 					},
 				},
-			},
-			names.AttrSchedule: {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"service_namespace": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			// The AWS API normalizes start_time and end_time to UTC. Uses
-			// suppressEquivalentTime to allow any timezone to be used.
-			names.AttrStartTime: {
-				Type:             schema.TypeString,
-				Optional:         true,
-				ValidateFunc:     validation.IsRFC3339Time,
-				DiffSuppressFunc: sdkv2.SuppressEquivalentTime,
-			},
-			"timezone": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  "UTC",
-			},
+				names.AttrSchedule: {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"service_namespace": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				// The AWS API normalizes start_time and end_time to UTC. Uses
+				// suppressEquivalentTime to allow any timezone to be used.
+				names.AttrStartTime: {
+					Type:             schema.TypeString,
+					Optional:         true,
+					ValidateFunc:     validation.IsRFC3339Time,
+					DiffSuppressFunc: sdkv2.SuppressEquivalentTime,
+				},
+				"timezone": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Default:  "UTC",
+				},
+			}
 		},
 	}
 }

--- a/internal/service/appautoscaling/target.go
+++ b/internal/service/appautoscaling/target.go
@@ -42,66 +42,68 @@ func resourceTarget() *schema.Resource {
 			StateContext: resourceTargetImport,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrMaxCapacity: {
-				Type:     schema.TypeInt,
-				Required: true,
-			},
-			"min_capacity": {
-				Type:     schema.TypeInt,
-				Required: true,
-			},
-			names.AttrResourceID: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			names.AttrRoleARN: {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-			"scalable_dimension": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"service_namespace": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"suspended_state": {
-				Type:     schema.TypeList,
-				MaxItems: 1,
-				Optional: true,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"dynamic_scaling_in_suspended": {
-							Type:     schema.TypeBool,
-							Default:  false,
-							Optional: true,
-						},
-						"dynamic_scaling_out_suspended": {
-							Type:     schema.TypeBool,
-							Default:  false,
-							Optional: true,
-						},
-						"scheduled_scaling_suspended": {
-							Type:     schema.TypeBool,
-							Default:  false,
-							Optional: true,
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrMaxCapacity: {
+					Type:     schema.TypeInt,
+					Required: true,
+				},
+				"min_capacity": {
+					Type:     schema.TypeInt,
+					Required: true,
+				},
+				names.AttrResourceID: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				names.AttrRoleARN: {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+				},
+				"scalable_dimension": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"service_namespace": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"suspended_state": {
+					Type:     schema.TypeList,
+					MaxItems: 1,
+					Optional: true,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"dynamic_scaling_in_suspended": {
+								Type:     schema.TypeBool,
+								Default:  false,
+								Optional: true,
+							},
+							"dynamic_scaling_out_suspended": {
+								Type:     schema.TypeBool,
+								Default:  false,
+								Optional: true,
+							},
+							"scheduled_scaling_suspended": {
+								Type:     schema.TypeBool,
+								Default:  false,
+								Optional: true,
+							},
 						},
 					},
 				},
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			}
 		},
 	}
 }

--- a/internal/service/appconfig/application.go
+++ b/internal/service/appconfig/application.go
@@ -37,23 +37,25 @@ func resourceApplication() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrDescription: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringLenBetween(0, 1024),
-			},
-			names.AttrName: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringLenBetween(1, 64),
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrDescription: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringLenBetween(0, 1024),
+				},
+				names.AttrName: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringLenBetween(1, 64),
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			}
 		},
 	}
 }

--- a/internal/service/appconfig/configuration_profile.go
+++ b/internal/service/appconfig/configuration_profile.go
@@ -56,82 +56,84 @@ func resourceConfigurationProfile() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrApplicationID: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringMatch(regexache.MustCompile(`[0-9a-z]{4,7}`), ""),
-			},
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"configuration_profile_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrDescription: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringLenBetween(0, 1024),
-			},
-			"location_uri": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(1, 2048),
-			},
-			"kms_key_identifier": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ValidateFunc: validation.Any(
-					verify.ValidARN,
-					validation.StringLenBetween(1, 256)),
-			},
-			names.AttrName: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringLenBetween(1, 128),
-			},
-			"retrieval_role_arn": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			names.AttrType: {
-				Type:             schema.TypeString,
-				Optional:         true,
-				ForceNew:         true,
-				Default:          configurationProfileTypeFreeform,
-				ValidateDiagFunc: enum.Validate[configurationProfileType](),
-			},
-			"validator": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				MaxItems: 2,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrContent: {
-							Type:      schema.TypeString,
-							Optional:  true,
-							Sensitive: true,
-							ValidateFunc: validation.Any(
-								validation.StringIsJSON,
-								verify.ValidARN,
-							),
-							DiffSuppressFunc: verify.SuppressEquivalentJSONDiffs,
-						},
-						names.AttrType: {
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.ValidatorType](),
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrApplicationID: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringMatch(regexache.MustCompile(`[0-9a-z]{4,7}`), ""),
+				},
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"configuration_profile_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrDescription: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringLenBetween(0, 1024),
+				},
+				"location_uri": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringLenBetween(1, 2048),
+				},
+				"kms_key_identifier": {
+					Type:     schema.TypeString,
+					Optional: true,
+					ValidateFunc: validation.Any(
+						verify.ValidARN,
+						validation.StringLenBetween(1, 256)),
+				},
+				names.AttrName: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringLenBetween(1, 128),
+				},
+				"retrieval_role_arn": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				names.AttrType: {
+					Type:             schema.TypeString,
+					Optional:         true,
+					ForceNew:         true,
+					Default:          configurationProfileTypeFreeform,
+					ValidateDiagFunc: enum.Validate[configurationProfileType](),
+				},
+				"validator": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					MaxItems: 2,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrContent: {
+								Type:      schema.TypeString,
+								Optional:  true,
+								Sensitive: true,
+								ValidateFunc: validation.Any(
+									validation.StringIsJSON,
+									verify.ValidARN,
+								),
+								DiffSuppressFunc: verify.SuppressEquivalentJSONDiffs,
+							},
+							names.AttrType: {
+								Type:             schema.TypeString,
+								Required:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.ValidatorType](),
+							},
 						},
 					},
 				},
-			},
+			}
 		},
 	}
 }

--- a/internal/service/appconfig/configuration_profile_data_source.go
+++ b/internal/service/appconfig/configuration_profile_data_source.go
@@ -24,62 +24,64 @@ func dataSourceConfigurationProfile() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceConfigurationProfileRead,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrApplicationID: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringMatch(regexache.MustCompile(`[a-z\d]{4,7}`), ""),
-			},
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"configuration_profile_id": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringMatch(regexache.MustCompile(`[a-z\d]{4,7}`), ""),
-			},
-			names.AttrDescription: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"location_uri": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"kms_key_identifier": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"retrieval_role_arn": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrTags: tftags.TagsSchemaComputed(),
-			names.AttrType: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"validator": {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrContent: {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						names.AttrType: {
-							Type:     schema.TypeString,
-							Computed: true,
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrApplicationID: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringMatch(regexache.MustCompile(`[a-z\d]{4,7}`), ""),
+				},
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"configuration_profile_id": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringMatch(regexache.MustCompile(`[a-z\d]{4,7}`), ""),
+				},
+				names.AttrDescription: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"location_uri": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"kms_key_identifier": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"retrieval_role_arn": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrTags: tftags.TagsSchemaComputed(),
+				names.AttrType: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"validator": {
+					Type:     schema.TypeSet,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrContent: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							names.AttrType: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
 						},
 					},
 				},
-			},
+			}
 		},
 	}
 }

--- a/internal/service/appconfig/configuration_profiles_data_source.go
+++ b/internal/service/appconfig/configuration_profiles_data_source.go
@@ -26,16 +26,18 @@ func dataSourceConfigurationProfiles() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceConfigurationProfilesRead,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrApplicationID: {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"configuration_profile_ids": {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrApplicationID: {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"configuration_profile_ids": {
+					Type:     schema.TypeSet,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+			}
 		},
 	}
 }

--- a/internal/service/appconfig/deployment.go
+++ b/internal/service/appconfig/deployment.go
@@ -45,69 +45,71 @@ func resourceDeployment() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrApplicationID: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringMatch(regexache.MustCompile(`[0-9a-z]{4,7}`), ""),
-			},
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"configuration_profile_id": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringMatch(regexache.MustCompile(`[0-9a-z]{4,7}`), ""),
-			},
-			"configuration_version": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(1, 1024),
-			},
-			"deployment_number": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-			"deployment_strategy_id": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringMatch(regexache.MustCompile(`(^[0-9a-z]{4,7}$|^AppConfig\.[0-9A-Za-z]{9,40}$)`), ""),
-			},
-			names.AttrDescription: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(0, 1024),
-			},
-			"environment_id": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringMatch(regexache.MustCompile(`[0-9a-z]{4,7}`), ""),
-			},
-			names.AttrKMSKeyARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"kms_key_identifier": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				ValidateFunc: validation.Any(
-					verify.ValidARN,
-					validation.StringLenBetween(1, 256)),
-			},
-			names.AttrState: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrApplicationID: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringMatch(regexache.MustCompile(`[0-9a-z]{4,7}`), ""),
+				},
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"configuration_profile_id": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringMatch(regexache.MustCompile(`[0-9a-z]{4,7}`), ""),
+				},
+				"configuration_version": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringLenBetween(1, 1024),
+				},
+				"deployment_number": {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
+				"deployment_strategy_id": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringMatch(regexache.MustCompile(`(^[0-9a-z]{4,7}$|^AppConfig\.[0-9A-Za-z]{9,40}$)`), ""),
+				},
+				names.AttrDescription: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringLenBetween(0, 1024),
+				},
+				"environment_id": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringMatch(regexache.MustCompile(`[0-9a-z]{4,7}`), ""),
+				},
+				names.AttrKMSKeyARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"kms_key_identifier": {
+					Type:     schema.TypeString,
+					Optional: true,
+					ForceNew: true,
+					ValidateFunc: validation.Any(
+						verify.ValidARN,
+						validation.StringLenBetween(1, 256)),
+				},
+				names.AttrState: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			}
 		},
 	}
 }

--- a/internal/service/appconfig/deployment_strategy.go
+++ b/internal/service/appconfig/deployment_strategy.go
@@ -38,51 +38,53 @@ func resourceDeploymentStrategy() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"deployment_duration_in_minutes": {
-				Type:         schema.TypeInt,
-				Required:     true,
-				ValidateFunc: validation.IntBetween(0, 1440),
-			},
-			names.AttrDescription: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringLenBetween(0, 1024),
-			},
-			"final_bake_time_in_minutes": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				ValidateFunc: validation.IntBetween(0, 1440),
-			},
-			"growth_factor": {
-				Type:         schema.TypeFloat,
-				Required:     true,
-				ValidateFunc: validation.FloatBetween(1.0, 100.0),
-			},
-			"growth_type": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Default:          awstypes.GrowthTypeLinear,
-				ValidateDiagFunc: enum.Validate[awstypes.GrowthType](),
-			},
-			names.AttrName: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(1, 64),
-			},
-			"replicate_to": {
-				Type:             schema.TypeString,
-				Required:         true,
-				ForceNew:         true,
-				ValidateDiagFunc: enum.Validate[awstypes.ReplicateTo](),
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"deployment_duration_in_minutes": {
+					Type:         schema.TypeInt,
+					Required:     true,
+					ValidateFunc: validation.IntBetween(0, 1440),
+				},
+				names.AttrDescription: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringLenBetween(0, 1024),
+				},
+				"final_bake_time_in_minutes": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					ValidateFunc: validation.IntBetween(0, 1440),
+				},
+				"growth_factor": {
+					Type:         schema.TypeFloat,
+					Required:     true,
+					ValidateFunc: validation.FloatBetween(1.0, 100.0),
+				},
+				"growth_type": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					Default:          awstypes.GrowthTypeLinear,
+					ValidateDiagFunc: enum.Validate[awstypes.GrowthType](),
+				},
+				names.AttrName: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringLenBetween(1, 64),
+				},
+				"replicate_to": {
+					Type:             schema.TypeString,
+					Required:         true,
+					ForceNew:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.ReplicateTo](),
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			}
 		},
 	}
 }

--- a/internal/service/appconfig/environment_data_source.go
+++ b/internal/service/appconfig/environment_data_source.go
@@ -26,50 +26,52 @@ func dataSourceEnvironment() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceEnvironmentRead,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrApplicationID: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringMatch(regexache.MustCompile(`[a-z\d]{4,7}`), ""),
-			},
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrDescription: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"environment_id": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringMatch(regexache.MustCompile(`[a-z\d]{4,7}`), ""),
-			},
-			"monitor": {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"alarm_arn": {
-							Computed: true,
-							Type:     schema.TypeString,
-						},
-						"alarm_role_arn": {
-							Computed: true,
-							Type:     schema.TypeString,
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrApplicationID: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringMatch(regexache.MustCompile(`[a-z\d]{4,7}`), ""),
+				},
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrDescription: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"environment_id": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringMatch(regexache.MustCompile(`[a-z\d]{4,7}`), ""),
+				},
+				"monitor": {
+					Type:     schema.TypeSet,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"alarm_arn": {
+								Computed: true,
+								Type:     schema.TypeString,
+							},
+							"alarm_role_arn": {
+								Computed: true,
+								Type:     schema.TypeString,
+							},
 						},
 					},
 				},
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrState: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrTags: tftags.TagsSchemaComputed(),
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrState: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrTags: tftags.TagsSchemaComputed(),
+			}
 		},
 	}
 }

--- a/internal/service/appconfig/environments_data_source.go
+++ b/internal/service/appconfig/environments_data_source.go
@@ -26,17 +26,19 @@ func dataSourceEnvironments() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceEnvironmentsRead,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrApplicationID: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringMatch(regexache.MustCompile(`[a-z\d]{4,7}`), ""),
-			},
-			"environment_ids": {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrApplicationID: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringMatch(regexache.MustCompile(`[a-z\d]{4,7}`), ""),
+				},
+				"environment_ids": {
+					Type:     schema.TypeSet,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+			}
 		},
 	}
 }

--- a/internal/service/appconfig/extension.go
+++ b/internal/service/appconfig/extension.go
@@ -37,87 +37,89 @@ func resourceExtension() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"action_point": {
-				Type:     schema.TypeSet,
-				Required: true,
-				MinItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrAction: {
-							Type:     schema.TypeSet,
-							Required: true,
-							MinItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									names.AttrDescription: {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
-									names.AttrName: {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-									names.AttrRoleARN: {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
-									names.AttrURI: {
-										Type:     schema.TypeString,
-										Required: true,
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"action_point": {
+					Type:     schema.TypeSet,
+					Required: true,
+					MinItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrAction: {
+								Type:     schema.TypeSet,
+								Required: true,
+								MinItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										names.AttrDescription: {
+											Type:     schema.TypeString,
+											Optional: true,
+										},
+										names.AttrName: {
+											Type:     schema.TypeString,
+											Required: true,
+										},
+										names.AttrRoleARN: {
+											Type:     schema.TypeString,
+											Optional: true,
+										},
+										names.AttrURI: {
+											Type:     schema.TypeString,
+											Required: true,
+										},
 									},
 								},
 							},
-						},
-						"point": {
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.ActionPoint](),
-						},
-					},
-				},
-			},
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrDescription: {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			names.AttrParameter: {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrDescription: {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						names.AttrName: {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"required": {
-							Type:     schema.TypeBool,
-							Optional: true,
+							"point": {
+								Type:             schema.TypeString,
+								Required:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.ActionPoint](),
+							},
 						},
 					},
 				},
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			names.AttrVersion: {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrDescription: {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				names.AttrParameter: {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrDescription: {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+							names.AttrName: {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+							"required": {
+								Type:     schema.TypeBool,
+								Optional: true,
+							},
+						},
+					},
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				names.AttrVersion: {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/appconfig/extension_association.go
+++ b/internal/service/appconfig/extension_association.go
@@ -36,32 +36,34 @@ func resourceExtensionAssociation() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"extension_arn": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			"extension_version": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-			names.AttrParameters: {
-				Type:     schema.TypeMap,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			names.AttrResourceARN: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidARN,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"extension_arn": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				"extension_version": {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
+				names.AttrParameters: {
+					Type:     schema.TypeMap,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				names.AttrResourceARN: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/appconfig/hosted_configuration_version.go
+++ b/internal/service/appconfig/hosted_configuration_version.go
@@ -38,45 +38,47 @@ func resourceHostedConfigurationVersion() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrApplicationID: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringMatch(regexache.MustCompile(`[0-9a-z]{4,7}`), ""),
-			},
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"configuration_profile_id": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringMatch(regexache.MustCompile(`[0-9a-z]{4,7}`), ""),
-			},
-			names.AttrContent: {
-				Type:      schema.TypeString,
-				Required:  true,
-				ForceNew:  true,
-				Sensitive: true,
-			},
-			names.AttrContentType: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(1, 255),
-			},
-			names.AttrDescription: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(0, 1024),
-			},
-			"version_number": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrApplicationID: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringMatch(regexache.MustCompile(`[0-9a-z]{4,7}`), ""),
+				},
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"configuration_profile_id": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringMatch(regexache.MustCompile(`[0-9a-z]{4,7}`), ""),
+				},
+				names.AttrContent: {
+					Type:      schema.TypeString,
+					Required:  true,
+					ForceNew:  true,
+					Sensitive: true,
+				},
+				names.AttrContentType: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringLenBetween(1, 255),
+				},
+				names.AttrDescription: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringLenBetween(0, 1024),
+				},
+				"version_number": {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/appflow/connector_profile.go
+++ b/internal/service/appflow/connector_profile.go
@@ -41,888 +41,890 @@ func resourceConnectorProfile() *schema.Resource {
 		UpdateWithoutTimeout: resourceConnectorProfileUpdate,
 		DeleteWithoutTimeout: resourceConnectorProfileDelete,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"connector_label": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				ValidateFunc: validation.All(
-					validation.StringMatch(regexache.MustCompile(`[0-9A-Za-z][\w!@#.-]+`), "must contain only alphanumeric, exclamation point (!), at sign (@), number sign (#), period (.), and hyphen (-) characters"),
-					validation.StringLenBetween(1, 256),
-				),
-			},
-			"connection_mode": {
-				Type:             schema.TypeString,
-				Required:         true,
-				ValidateDiagFunc: enum.Validate[types.ConnectionMode](),
-			},
-			"connector_profile_config": {
-				Type:     schema.TypeList,
-				Required: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"connector_profile_credentials": {
-							Type:     schema.TypeList,
-							Required: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"amplitude": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"api_key": {
-													Type:     schema.TypeString,
-													Required: true,
-													ValidateFunc: validation.All(
-														validation.StringLenBetween(1, 256),
-														validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-													),
-												},
-												names.AttrSecretKey: {
-													Type:      schema.TypeString,
-													Required:  true,
-													Sensitive: true,
-													ValidateFunc: validation.All(
-														validation.StringLenBetween(1, 256),
-														validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-													),
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"connector_label": {
+					Type:     schema.TypeString,
+					Optional: true,
+					ForceNew: true,
+					ValidateFunc: validation.All(
+						validation.StringMatch(regexache.MustCompile(`[0-9A-Za-z][\w!@#.-]+`), "must contain only alphanumeric, exclamation point (!), at sign (@), number sign (#), period (.), and hyphen (-) characters"),
+						validation.StringLenBetween(1, 256),
+					),
+				},
+				"connection_mode": {
+					Type:             schema.TypeString,
+					Required:         true,
+					ValidateDiagFunc: enum.Validate[types.ConnectionMode](),
+				},
+				"connector_profile_config": {
+					Type:     schema.TypeList,
+					Required: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"connector_profile_credentials": {
+								Type:     schema.TypeList,
+								Required: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"amplitude": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"api_key": {
+														Type:     schema.TypeString,
+														Required: true,
+														ValidateFunc: validation.All(
+															validation.StringLenBetween(1, 256),
+															validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+														),
+													},
+													names.AttrSecretKey: {
+														Type:      schema.TypeString,
+														Required:  true,
+														Sensitive: true,
+														ValidateFunc: validation.All(
+															validation.StringLenBetween(1, 256),
+															validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+														),
+													},
 												},
 											},
 										},
-									},
-									"custom_connector": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"api_key": {
-													Type:     schema.TypeList,
-													Optional: true,
-													MaxItems: 1,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															"api_key": {
-																Type:     schema.TypeString,
-																Required: true,
-																ValidateFunc: validation.All(
-																	validation.StringLenBetween(1, 256),
-																	validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-																),
-															},
-															"api_secret_key": {
-																Type:     schema.TypeString,
-																Optional: true,
-																ValidateFunc: validation.All(
-																	validation.StringLenBetween(1, 256),
-																	validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-																),
-															},
-														},
-													},
-												},
-												"authentication_type": {
-													Type:             schema.TypeString,
-													Required:         true,
-													ValidateDiagFunc: enum.Validate[types.AuthenticationType](),
-												},
-												"basic": {
-													Type:     schema.TypeList,
-													Optional: true,
-													MaxItems: 1,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															names.AttrPassword: {
-																Type:         schema.TypeString,
-																Required:     true,
-																Sensitive:    true,
-																ValidateFunc: validation.StringLenBetween(0, 512),
-															},
-															names.AttrUsername: {
-																Type:         schema.TypeString,
-																Required:     true,
-																ValidateFunc: validation.StringLenBetween(0, 512),
-															},
-														},
-													},
-												},
-												"custom": {
-													Type:     schema.TypeList,
-													Optional: true,
-													MaxItems: 1,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															"credentials_map": {
-																Type:      schema.TypeMap,
-																Optional:  true,
-																Sensitive: true,
-																ValidateDiagFunc: validation.AllDiag(
-																	validation.MapKeyLenBetween(1, 128),
-																	validation.MapKeyMatch(regexache.MustCompile(`[\w]+`), "must contain only alphanumeric and underscore (_) characters"),
-																),
-																Elem: &schema.Schema{
-																	Type: schema.TypeString,
+										"custom_connector": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"api_key": {
+														Type:     schema.TypeList,
+														Optional: true,
+														MaxItems: 1,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																"api_key": {
+																	Type:     schema.TypeString,
+																	Required: true,
 																	ValidateFunc: validation.All(
-																		validation.StringLenBetween(0, 2048),
+																		validation.StringLenBetween(1, 256),
+																		validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+																	),
+																},
+																"api_secret_key": {
+																	Type:     schema.TypeString,
+																	Optional: true,
+																	ValidateFunc: validation.All(
+																		validation.StringLenBetween(1, 256),
 																		validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
 																	),
 																},
 															},
-															"custom_authentication_type": {
-																Type:         schema.TypeString,
-																Required:     true,
-																ValidateFunc: validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+														},
+													},
+													"authentication_type": {
+														Type:             schema.TypeString,
+														Required:         true,
+														ValidateDiagFunc: enum.Validate[types.AuthenticationType](),
+													},
+													"basic": {
+														Type:     schema.TypeList,
+														Optional: true,
+														MaxItems: 1,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																names.AttrPassword: {
+																	Type:         schema.TypeString,
+																	Required:     true,
+																	Sensitive:    true,
+																	ValidateFunc: validation.StringLenBetween(0, 512),
+																},
+																names.AttrUsername: {
+																	Type:         schema.TypeString,
+																	Required:     true,
+																	ValidateFunc: validation.StringLenBetween(0, 512),
+																},
 															},
 														},
 													},
-												},
-												"oauth2": {
-													Type:     schema.TypeList,
-													Optional: true,
-													MaxItems: 1,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															"access_token": {
-																Type:      schema.TypeString,
-																Optional:  true,
-																Sensitive: true,
-																ValidateFunc: validation.All(
-																	validation.StringLenBetween(1, 4096),
-																	validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-																),
+													"custom": {
+														Type:     schema.TypeList,
+														Optional: true,
+														MaxItems: 1,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																"credentials_map": {
+																	Type:      schema.TypeMap,
+																	Optional:  true,
+																	Sensitive: true,
+																	ValidateDiagFunc: validation.AllDiag(
+																		validation.MapKeyLenBetween(1, 128),
+																		validation.MapKeyMatch(regexache.MustCompile(`[\w]+`), "must contain only alphanumeric and underscore (_) characters"),
+																	),
+																	Elem: &schema.Schema{
+																		Type: schema.TypeString,
+																		ValidateFunc: validation.All(
+																			validation.StringLenBetween(0, 2048),
+																			validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+																		),
+																	},
+																},
+																"custom_authentication_type": {
+																	Type:         schema.TypeString,
+																	Required:     true,
+																	ValidateFunc: validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+																},
 															},
-															names.AttrClientID: {
-																Type:     schema.TypeString,
-																Optional: true,
-																ValidateFunc: validation.All(
-																	validation.StringLenBetween(1, 512),
-																	validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-																),
-															},
-															names.AttrClientSecret: {
-																Type:      schema.TypeString,
-																Optional:  true,
-																Sensitive: true,
-																ValidateFunc: validation.All(
-																	validation.StringLenBetween(1, 512),
-																	validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-																),
-															},
-															"oauth_request": {
-																Type:     schema.TypeList,
-																Optional: true,
-																MaxItems: 1,
-																Elem: &schema.Resource{
-																	Schema: map[string]*schema.Schema{
-																		"auth_code": {
-																			Type:     schema.TypeString,
-																			Optional: true,
-																			ValidateFunc: validation.All(
-																				validation.StringLenBetween(1, 4096),
-																				validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-																			),
-																		},
-																		"redirect_uri": {
-																			Type:     schema.TypeString,
-																			Optional: true,
-																			ValidateFunc: validation.All(
-																				validation.StringLenBetween(1, 512),
-																				validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-																			),
+														},
+													},
+													"oauth2": {
+														Type:     schema.TypeList,
+														Optional: true,
+														MaxItems: 1,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																"access_token": {
+																	Type:      schema.TypeString,
+																	Optional:  true,
+																	Sensitive: true,
+																	ValidateFunc: validation.All(
+																		validation.StringLenBetween(1, 4096),
+																		validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+																	),
+																},
+																names.AttrClientID: {
+																	Type:     schema.TypeString,
+																	Optional: true,
+																	ValidateFunc: validation.All(
+																		validation.StringLenBetween(1, 512),
+																		validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+																	),
+																},
+																names.AttrClientSecret: {
+																	Type:      schema.TypeString,
+																	Optional:  true,
+																	Sensitive: true,
+																	ValidateFunc: validation.All(
+																		validation.StringLenBetween(1, 512),
+																		validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+																	),
+																},
+																"oauth_request": {
+																	Type:     schema.TypeList,
+																	Optional: true,
+																	MaxItems: 1,
+																	Elem: &schema.Resource{
+																		Schema: map[string]*schema.Schema{
+																			"auth_code": {
+																				Type:     schema.TypeString,
+																				Optional: true,
+																				ValidateFunc: validation.All(
+																					validation.StringLenBetween(1, 4096),
+																					validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+																				),
+																			},
+																			"redirect_uri": {
+																				Type:     schema.TypeString,
+																				Optional: true,
+																				ValidateFunc: validation.All(
+																					validation.StringLenBetween(1, 512),
+																					validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+																				),
+																			},
 																		},
 																	},
 																},
-															},
-															"refresh_token": {
-																Type:     schema.TypeString,
-																Optional: true,
-																ValidateFunc: validation.All(
-																	validation.StringLenBetween(1, 4096),
-																	validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-																),
-															},
-														},
-													},
-												},
-											},
-										},
-									},
-									"datadog": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"api_key": {
-													Type:     schema.TypeString,
-													Required: true,
-													ValidateFunc: validation.All(
-														validation.StringLenBetween(1, 256),
-														validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-													),
-												},
-												"application_key": {
-													Type:     schema.TypeString,
-													Required: true,
-													ValidateFunc: validation.All(
-														validation.StringLenBetween(1, 512),
-														validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-													),
-												},
-											},
-										},
-									},
-									"dynatrace": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"api_token": {
-													Type:     schema.TypeString,
-													Required: true,
-													ValidateFunc: validation.All(
-														validation.StringLenBetween(1, 256),
-														validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-													),
-												},
-											},
-										},
-									},
-									"google_analytics": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"access_token": {
-													Type:      schema.TypeString,
-													Optional:  true,
-													Sensitive: true,
-													ValidateFunc: validation.All(
-														validation.StringLenBetween(1, 2048),
-														validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-													),
-												},
-												names.AttrClientID: {
-													Type:     schema.TypeString,
-													Required: true,
-													ValidateFunc: validation.All(
-														validation.StringLenBetween(1, 512),
-														validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-													),
-												},
-												names.AttrClientSecret: {
-													Type:      schema.TypeString,
-													Required:  true,
-													Sensitive: true,
-													ValidateFunc: validation.All(
-														validation.StringLenBetween(1, 512),
-														validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-													),
-												},
-												"oauth_request": {
-													Type:     schema.TypeList,
-													Optional: true,
-													MaxItems: 1,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															"auth_code": {
-																Type:     schema.TypeString,
-																Optional: true,
-																ValidateFunc: validation.All(
-																	validation.StringLenBetween(1, 2048),
-																	validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-																),
-															},
-															"redirect_uri": {
-																Type:     schema.TypeString,
-																Optional: true,
-																ValidateFunc: validation.All(
-																	validation.StringLenBetween(1, 512),
-																	validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-																),
-															},
-														},
-													},
-												},
-												"refresh_token": {
-													Type:     schema.TypeString,
-													Optional: true,
-													ValidateFunc: validation.All(
-														validation.StringLenBetween(1, 1024),
-														validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-													),
-												},
-											},
-										},
-									},
-									"honeycode": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"access_token": {
-													Type:      schema.TypeString,
-													Optional:  true,
-													Sensitive: true,
-													ValidateFunc: validation.All(
-														validation.StringLenBetween(1, 2048),
-														validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-													),
-												},
-												"oauth_request": {
-													Type:     schema.TypeList,
-													Optional: true,
-													MaxItems: 1,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															"auth_code": {
-																Type:     schema.TypeString,
-																Optional: true,
-																ValidateFunc: validation.All(
-																	validation.StringLenBetween(1, 2048),
-																	validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-																),
-															},
-															"redirect_uri": {
-																Type:     schema.TypeString,
-																Optional: true,
-																ValidateFunc: validation.All(
-																	validation.StringLenBetween(1, 512),
-																	validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-																),
-															},
-														},
-													},
-												},
-												"refresh_token": {
-													Type:     schema.TypeString,
-													Optional: true,
-													ValidateFunc: validation.All(
-														validation.StringLenBetween(1, 1024),
-														validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-													),
-												},
-											},
-										},
-									},
-									"infor_nexus": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"access_key_id": {
-													Type:     schema.TypeString,
-													Required: true,
-													ValidateFunc: validation.All(
-														validation.StringLenBetween(1, 256),
-														validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-													),
-												},
-												"datakey": {
-													Type:     schema.TypeString,
-													Required: true,
-													ValidateFunc: validation.All(
-														validation.StringLenBetween(1, 512),
-														validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-													),
-												},
-												"secret_access_key": {
-													Type:      schema.TypeString,
-													Required:  true,
-													Sensitive: true,
-													ValidateFunc: validation.All(
-														validation.StringLenBetween(1, 512),
-														validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-													),
-												},
-												"user_id": {
-													Type:     schema.TypeString,
-													Required: true,
-													ValidateFunc: validation.All(
-														validation.StringLenBetween(1, 512),
-														validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-													),
-												},
-											},
-										},
-									},
-									"marketo": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"access_token": {
-													Type:      schema.TypeString,
-													Optional:  true,
-													Sensitive: true,
-													ValidateFunc: validation.All(
-														validation.StringLenBetween(1, 2048),
-														validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-													),
-												},
-												names.AttrClientID: {
-													Type:     schema.TypeString,
-													Required: true,
-													ValidateFunc: validation.All(
-														validation.StringLenBetween(1, 512),
-														validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-													),
-												},
-												names.AttrClientSecret: {
-													Type:      schema.TypeString,
-													Required:  true,
-													Sensitive: true,
-													ValidateFunc: validation.All(
-														validation.StringLenBetween(1, 512),
-														validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-													),
-												},
-												"oauth_request": {
-													Type:     schema.TypeList,
-													Optional: true,
-													MaxItems: 1,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															"auth_code": {
-																Type:     schema.TypeString,
-																Optional: true,
-																ValidateFunc: validation.All(
-																	validation.StringLenBetween(1, 512),
-																	validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-																),
-															},
-															"redirect_uri": {
-																Type:     schema.TypeString,
-																Optional: true,
-																ValidateFunc: validation.All(
-																	validation.StringLenBetween(1, 512),
-																	validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-																),
+																"refresh_token": {
+																	Type:     schema.TypeString,
+																	Optional: true,
+																	ValidateFunc: validation.All(
+																		validation.StringLenBetween(1, 4096),
+																		validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+																	),
+																},
 															},
 														},
 													},
 												},
 											},
 										},
-									},
-									"redshift": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												names.AttrPassword: {
-													Type:         schema.TypeString,
-													Required:     true,
-													Sensitive:    true,
-													ValidateFunc: validation.StringLenBetween(0, 512),
-												},
-												names.AttrUsername: {
-													Type:     schema.TypeString,
-													Required: true,
-													ValidateFunc: validation.All(
-														validation.StringLenBetween(1, 512),
-														validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-													),
+										"datadog": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"api_key": {
+														Type:     schema.TypeString,
+														Required: true,
+														ValidateFunc: validation.All(
+															validation.StringLenBetween(1, 256),
+															validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+														),
+													},
+													"application_key": {
+														Type:     schema.TypeString,
+														Required: true,
+														ValidateFunc: validation.All(
+															validation.StringLenBetween(1, 512),
+															validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+														),
+													},
 												},
 											},
 										},
-									},
-									"salesforce": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"access_token": {
-													Type:      schema.TypeString,
-													Optional:  true,
-													Sensitive: true,
-													ValidateFunc: validation.All(
-														validation.StringLenBetween(1, 2048),
-														validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-													),
+										"dynatrace": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"api_token": {
+														Type:     schema.TypeString,
+														Required: true,
+														ValidateFunc: validation.All(
+															validation.StringLenBetween(1, 256),
+															validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+														),
+													},
 												},
-												"client_credentials_arn": {
-													Type:         schema.TypeString,
-													Optional:     true,
-													ValidateFunc: verify.ValidARN,
-												},
-												"jwt_token": {
-													Type:         schema.TypeString,
-													Optional:     true,
-													ValidateFunc: validation.StringLenBetween(1, 8000),
-												},
-												"oauth2_grant_type": {
-													Type:             schema.TypeString,
-													Optional:         true,
-													ValidateDiagFunc: enum.Validate[types.OAuth2GrantType](),
-												},
-												"oauth_request": {
-													Type:     schema.TypeList,
-													Optional: true,
-													MaxItems: 1,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															"auth_code": {
-																Type:     schema.TypeString,
-																Optional: true,
-																ValidateFunc: validation.All(
-																	validation.StringLenBetween(1, 2048),
-																	validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-																),
+											},
+										},
+										"google_analytics": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"access_token": {
+														Type:      schema.TypeString,
+														Optional:  true,
+														Sensitive: true,
+														ValidateFunc: validation.All(
+															validation.StringLenBetween(1, 2048),
+															validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+														),
+													},
+													names.AttrClientID: {
+														Type:     schema.TypeString,
+														Required: true,
+														ValidateFunc: validation.All(
+															validation.StringLenBetween(1, 512),
+															validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+														),
+													},
+													names.AttrClientSecret: {
+														Type:      schema.TypeString,
+														Required:  true,
+														Sensitive: true,
+														ValidateFunc: validation.All(
+															validation.StringLenBetween(1, 512),
+															validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+														),
+													},
+													"oauth_request": {
+														Type:     schema.TypeList,
+														Optional: true,
+														MaxItems: 1,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																"auth_code": {
+																	Type:     schema.TypeString,
+																	Optional: true,
+																	ValidateFunc: validation.All(
+																		validation.StringLenBetween(1, 2048),
+																		validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+																	),
+																},
+																"redirect_uri": {
+																	Type:     schema.TypeString,
+																	Optional: true,
+																	ValidateFunc: validation.All(
+																		validation.StringLenBetween(1, 512),
+																		validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+																	),
+																},
 															},
-															"redirect_uri": {
-																Type:     schema.TypeString,
-																Optional: true,
-																ValidateFunc: validation.All(
-																	validation.StringLenBetween(1, 512),
-																	validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-																),
+														},
+													},
+													"refresh_token": {
+														Type:     schema.TypeString,
+														Optional: true,
+														ValidateFunc: validation.All(
+															validation.StringLenBetween(1, 1024),
+															validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+														),
+													},
+												},
+											},
+										},
+										"honeycode": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"access_token": {
+														Type:      schema.TypeString,
+														Optional:  true,
+														Sensitive: true,
+														ValidateFunc: validation.All(
+															validation.StringLenBetween(1, 2048),
+															validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+														),
+													},
+													"oauth_request": {
+														Type:     schema.TypeList,
+														Optional: true,
+														MaxItems: 1,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																"auth_code": {
+																	Type:     schema.TypeString,
+																	Optional: true,
+																	ValidateFunc: validation.All(
+																		validation.StringLenBetween(1, 2048),
+																		validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+																	),
+																},
+																"redirect_uri": {
+																	Type:     schema.TypeString,
+																	Optional: true,
+																	ValidateFunc: validation.All(
+																		validation.StringLenBetween(1, 512),
+																		validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+																	),
+																},
+															},
+														},
+													},
+													"refresh_token": {
+														Type:     schema.TypeString,
+														Optional: true,
+														ValidateFunc: validation.All(
+															validation.StringLenBetween(1, 1024),
+															validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+														),
+													},
+												},
+											},
+										},
+										"infor_nexus": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"access_key_id": {
+														Type:     schema.TypeString,
+														Required: true,
+														ValidateFunc: validation.All(
+															validation.StringLenBetween(1, 256),
+															validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+														),
+													},
+													"datakey": {
+														Type:     schema.TypeString,
+														Required: true,
+														ValidateFunc: validation.All(
+															validation.StringLenBetween(1, 512),
+															validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+														),
+													},
+													"secret_access_key": {
+														Type:      schema.TypeString,
+														Required:  true,
+														Sensitive: true,
+														ValidateFunc: validation.All(
+															validation.StringLenBetween(1, 512),
+															validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+														),
+													},
+													"user_id": {
+														Type:     schema.TypeString,
+														Required: true,
+														ValidateFunc: validation.All(
+															validation.StringLenBetween(1, 512),
+															validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+														),
+													},
+												},
+											},
+										},
+										"marketo": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"access_token": {
+														Type:      schema.TypeString,
+														Optional:  true,
+														Sensitive: true,
+														ValidateFunc: validation.All(
+															validation.StringLenBetween(1, 2048),
+															validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+														),
+													},
+													names.AttrClientID: {
+														Type:     schema.TypeString,
+														Required: true,
+														ValidateFunc: validation.All(
+															validation.StringLenBetween(1, 512),
+															validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+														),
+													},
+													names.AttrClientSecret: {
+														Type:      schema.TypeString,
+														Required:  true,
+														Sensitive: true,
+														ValidateFunc: validation.All(
+															validation.StringLenBetween(1, 512),
+															validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+														),
+													},
+													"oauth_request": {
+														Type:     schema.TypeList,
+														Optional: true,
+														MaxItems: 1,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																"auth_code": {
+																	Type:     schema.TypeString,
+																	Optional: true,
+																	ValidateFunc: validation.All(
+																		validation.StringLenBetween(1, 512),
+																		validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+																	),
+																},
+																"redirect_uri": {
+																	Type:     schema.TypeString,
+																	Optional: true,
+																	ValidateFunc: validation.All(
+																		validation.StringLenBetween(1, 512),
+																		validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+																	),
+																},
 															},
 														},
 													},
 												},
-												"refresh_token": {
-													Type:     schema.TypeString,
-													Optional: true,
-													ValidateFunc: validation.All(
-														validation.StringLenBetween(1, 1024),
-														validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-													),
+											},
+										},
+										"redshift": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													names.AttrPassword: {
+														Type:         schema.TypeString,
+														Required:     true,
+														Sensitive:    true,
+														ValidateFunc: validation.StringLenBetween(0, 512),
+													},
+													names.AttrUsername: {
+														Type:     schema.TypeString,
+														Required: true,
+														ValidateFunc: validation.All(
+															validation.StringLenBetween(1, 512),
+															validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+														),
+													},
 												},
 											},
 										},
-									},
-									"sapo_data": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"basic_auth_credentials": {
-													Type:     schema.TypeList,
-													Optional: true,
-													MaxItems: 1,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															names.AttrPassword: {
-																Type:         schema.TypeString,
-																Required:     true,
-																Sensitive:    true,
-																ValidateFunc: validation.StringLenBetween(0, 512),
-															},
-															names.AttrUsername: {
-																Type:     schema.TypeString,
-																Required: true,
-																ValidateFunc: validation.All(
-																	validation.StringLenBetween(1, 512),
-																	validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-																),
+										"salesforce": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"access_token": {
+														Type:      schema.TypeString,
+														Optional:  true,
+														Sensitive: true,
+														ValidateFunc: validation.All(
+															validation.StringLenBetween(1, 2048),
+															validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+														),
+													},
+													"client_credentials_arn": {
+														Type:         schema.TypeString,
+														Optional:     true,
+														ValidateFunc: verify.ValidARN,
+													},
+													"jwt_token": {
+														Type:         schema.TypeString,
+														Optional:     true,
+														ValidateFunc: validation.StringLenBetween(1, 8000),
+													},
+													"oauth2_grant_type": {
+														Type:             schema.TypeString,
+														Optional:         true,
+														ValidateDiagFunc: enum.Validate[types.OAuth2GrantType](),
+													},
+													"oauth_request": {
+														Type:     schema.TypeList,
+														Optional: true,
+														MaxItems: 1,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																"auth_code": {
+																	Type:     schema.TypeString,
+																	Optional: true,
+																	ValidateFunc: validation.All(
+																		validation.StringLenBetween(1, 2048),
+																		validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+																	),
+																},
+																"redirect_uri": {
+																	Type:     schema.TypeString,
+																	Optional: true,
+																	ValidateFunc: validation.All(
+																		validation.StringLenBetween(1, 512),
+																		validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+																	),
+																},
 															},
 														},
 													},
+													"refresh_token": {
+														Type:     schema.TypeString,
+														Optional: true,
+														ValidateFunc: validation.All(
+															validation.StringLenBetween(1, 1024),
+															validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+														),
+													},
 												},
-												"oauth_credentials": {
-													Type:     schema.TypeList,
-													Optional: true,
-													MaxItems: 1,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															"access_token": {
-																Type:      schema.TypeString,
-																Optional:  true,
-																Sensitive: true,
-																ValidateFunc: validation.All(
-																	validation.StringLenBetween(1, 2048),
-																	validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-																),
+											},
+										},
+										"sapo_data": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"basic_auth_credentials": {
+														Type:     schema.TypeList,
+														Optional: true,
+														MaxItems: 1,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																names.AttrPassword: {
+																	Type:         schema.TypeString,
+																	Required:     true,
+																	Sensitive:    true,
+																	ValidateFunc: validation.StringLenBetween(0, 512),
+																},
+																names.AttrUsername: {
+																	Type:     schema.TypeString,
+																	Required: true,
+																	ValidateFunc: validation.All(
+																		validation.StringLenBetween(1, 512),
+																		validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+																	),
+																},
 															},
-															names.AttrClientID: {
-																Type:     schema.TypeString,
-																Required: true,
-																ValidateFunc: validation.All(
-																	validation.StringLenBetween(1, 512),
-																	validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-																),
-															},
-															names.AttrClientSecret: {
-																Type:     schema.TypeString,
-																Required: true,
-																ValidateFunc: validation.All(
-																	validation.StringLenBetween(1, 512),
-																	validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-																),
-															},
-															"oauth_request": {
-																Type:     schema.TypeList,
-																Optional: true,
-																MaxItems: 1,
-																Elem: &schema.Resource{
-																	Schema: map[string]*schema.Schema{
-																		"auth_code": {
-																			Type:     schema.TypeString,
-																			Optional: true,
-																			ValidateFunc: validation.All(
-																				validation.StringLenBetween(1, 2048),
-																				validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-																			),
-																		},
-																		"redirect_uri": {
-																			Type:     schema.TypeString,
-																			Optional: true,
-																			ValidateFunc: validation.All(
-																				validation.StringLenBetween(1, 512),
-																				validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-																			),
+														},
+													},
+													"oauth_credentials": {
+														Type:     schema.TypeList,
+														Optional: true,
+														MaxItems: 1,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																"access_token": {
+																	Type:      schema.TypeString,
+																	Optional:  true,
+																	Sensitive: true,
+																	ValidateFunc: validation.All(
+																		validation.StringLenBetween(1, 2048),
+																		validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+																	),
+																},
+																names.AttrClientID: {
+																	Type:     schema.TypeString,
+																	Required: true,
+																	ValidateFunc: validation.All(
+																		validation.StringLenBetween(1, 512),
+																		validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+																	),
+																},
+																names.AttrClientSecret: {
+																	Type:     schema.TypeString,
+																	Required: true,
+																	ValidateFunc: validation.All(
+																		validation.StringLenBetween(1, 512),
+																		validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+																	),
+																},
+																"oauth_request": {
+																	Type:     schema.TypeList,
+																	Optional: true,
+																	MaxItems: 1,
+																	Elem: &schema.Resource{
+																		Schema: map[string]*schema.Schema{
+																			"auth_code": {
+																				Type:     schema.TypeString,
+																				Optional: true,
+																				ValidateFunc: validation.All(
+																					validation.StringLenBetween(1, 2048),
+																					validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+																				),
+																			},
+																			"redirect_uri": {
+																				Type:     schema.TypeString,
+																				Optional: true,
+																				ValidateFunc: validation.All(
+																					validation.StringLenBetween(1, 512),
+																					validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+																				),
+																			},
 																		},
 																	},
 																},
-															},
-															"refresh_token": {
-																Type:     schema.TypeString,
-																Optional: true,
-																ValidateFunc: validation.All(
-																	validation.StringLenBetween(1, 1024),
-																	validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-																),
-															},
-														},
-													},
-												},
-											},
-										},
-									},
-									"service_now": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												names.AttrPassword: {
-													Type:         schema.TypeString,
-													Required:     true,
-													Sensitive:    true,
-													ValidateFunc: validation.StringLenBetween(0, 512),
-												},
-												names.AttrUsername: {
-													Type:     schema.TypeString,
-													Required: true,
-													ValidateFunc: validation.All(
-														validation.StringLenBetween(1, 512),
-														validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-													),
-												},
-											},
-										},
-									},
-									"singular": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"api_key": {
-													Type:     schema.TypeString,
-													Required: true,
-													ValidateFunc: validation.All(
-														validation.StringLenBetween(1, 256),
-														validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-													),
-												},
-											},
-										},
-									},
-									"slack": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"access_token": {
-													Type:      schema.TypeString,
-													Optional:  true,
-													Sensitive: true,
-													ValidateFunc: validation.All(
-														validation.StringLenBetween(1, 2048),
-														validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-													),
-												},
-												names.AttrClientID: {
-													Type:     schema.TypeString,
-													Required: true,
-													ValidateFunc: validation.All(
-														validation.StringLenBetween(1, 512),
-														validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-													),
-												},
-												names.AttrClientSecret: {
-													Type:      schema.TypeString,
-													Required:  true,
-													Sensitive: true,
-													ValidateFunc: validation.All(
-														validation.StringLenBetween(1, 512),
-														validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-													),
-												},
-												"oauth_request": {
-													Type:     schema.TypeList,
-													Optional: true,
-													MaxItems: 1,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															"auth_code": {
-																Type:     schema.TypeString,
-																Optional: true,
-																ValidateFunc: validation.All(
-																	validation.StringLenBetween(1, 2048),
-																	validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-																),
-															},
-															"redirect_uri": {
-																Type:     schema.TypeString,
-																Optional: true,
-																ValidateFunc: validation.All(
-																	validation.StringLenBetween(1, 512),
-																	validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-																),
+																"refresh_token": {
+																	Type:     schema.TypeString,
+																	Optional: true,
+																	ValidateFunc: validation.All(
+																		validation.StringLenBetween(1, 1024),
+																		validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+																	),
+																},
 															},
 														},
 													},
 												},
 											},
 										},
-									},
-									"snowflake": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												names.AttrPassword: {
-													Type:         schema.TypeString,
-													Required:     true,
-													Sensitive:    true,
-													ValidateFunc: validation.StringLenBetween(0, 512),
-												},
-												names.AttrUsername: {
-													Type:     schema.TypeString,
-													Required: true,
-													ValidateFunc: validation.All(
-														validation.StringLenBetween(1, 512),
-														validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-													),
-												},
-											},
-										},
-									},
-									"trendmicro": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"api_secret_key": {
-													Type:      schema.TypeString,
-													Required:  true,
-													Sensitive: true,
-													ValidateFunc: validation.All(
-														validation.StringLenBetween(1, 256),
-														validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-													),
+										"service_now": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													names.AttrPassword: {
+														Type:         schema.TypeString,
+														Required:     true,
+														Sensitive:    true,
+														ValidateFunc: validation.StringLenBetween(0, 512),
+													},
+													names.AttrUsername: {
+														Type:     schema.TypeString,
+														Required: true,
+														ValidateFunc: validation.All(
+															validation.StringLenBetween(1, 512),
+															validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+														),
+													},
 												},
 											},
 										},
-									},
-									"veeva": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												names.AttrPassword: {
-													Type:         schema.TypeString,
-													Required:     true,
-													Sensitive:    true,
-													ValidateFunc: validation.StringLenBetween(0, 512),
-												},
-												names.AttrUsername: {
-													Type:     schema.TypeString,
-													Required: true,
-													ValidateFunc: validation.All(
-														validation.StringLenBetween(1, 512),
-														validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-													),
+										"singular": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"api_key": {
+														Type:     schema.TypeString,
+														Required: true,
+														ValidateFunc: validation.All(
+															validation.StringLenBetween(1, 256),
+															validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+														),
+													},
 												},
 											},
 										},
-									},
-									"zendesk": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"access_token": {
-													Type:      schema.TypeString,
-													Optional:  true,
-													Sensitive: true,
-													ValidateFunc: validation.All(
-														validation.StringLenBetween(1, 2048),
-														validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-													),
-												},
-												names.AttrClientID: {
-													Type:     schema.TypeString,
-													Required: true,
-													ValidateFunc: validation.All(
-														validation.StringLenBetween(1, 512),
-														validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-													),
-												},
-												names.AttrClientSecret: {
-													Type:      schema.TypeString,
-													Required:  true,
-													Sensitive: true,
-													ValidateFunc: validation.All(
-														validation.StringLenBetween(1, 512),
-														validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-													),
-												},
-												"oauth_request": {
-													Type:     schema.TypeList,
-													Optional: true,
-													MaxItems: 1,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															"auth_code": {
-																Type:     schema.TypeString,
-																Optional: true,
-																ValidateFunc: validation.All(
-																	validation.StringLenBetween(1, 2048),
-																	validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-																),
+										"slack": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"access_token": {
+														Type:      schema.TypeString,
+														Optional:  true,
+														Sensitive: true,
+														ValidateFunc: validation.All(
+															validation.StringLenBetween(1, 2048),
+															validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+														),
+													},
+													names.AttrClientID: {
+														Type:     schema.TypeString,
+														Required: true,
+														ValidateFunc: validation.All(
+															validation.StringLenBetween(1, 512),
+															validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+														),
+													},
+													names.AttrClientSecret: {
+														Type:      schema.TypeString,
+														Required:  true,
+														Sensitive: true,
+														ValidateFunc: validation.All(
+															validation.StringLenBetween(1, 512),
+															validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+														),
+													},
+													"oauth_request": {
+														Type:     schema.TypeList,
+														Optional: true,
+														MaxItems: 1,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																"auth_code": {
+																	Type:     schema.TypeString,
+																	Optional: true,
+																	ValidateFunc: validation.All(
+																		validation.StringLenBetween(1, 2048),
+																		validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+																	),
+																},
+																"redirect_uri": {
+																	Type:     schema.TypeString,
+																	Optional: true,
+																	ValidateFunc: validation.All(
+																		validation.StringLenBetween(1, 512),
+																		validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+																	),
+																},
 															},
-															"redirect_uri": {
-																Type:     schema.TypeString,
-																Optional: true,
-																ValidateFunc: validation.All(
-																	validation.StringLenBetween(1, 512),
-																	validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-																),
+														},
+													},
+												},
+											},
+										},
+										"snowflake": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													names.AttrPassword: {
+														Type:         schema.TypeString,
+														Required:     true,
+														Sensitive:    true,
+														ValidateFunc: validation.StringLenBetween(0, 512),
+													},
+													names.AttrUsername: {
+														Type:     schema.TypeString,
+														Required: true,
+														ValidateFunc: validation.All(
+															validation.StringLenBetween(1, 512),
+															validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+														),
+													},
+												},
+											},
+										},
+										"trendmicro": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"api_secret_key": {
+														Type:      schema.TypeString,
+														Required:  true,
+														Sensitive: true,
+														ValidateFunc: validation.All(
+															validation.StringLenBetween(1, 256),
+															validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+														),
+													},
+												},
+											},
+										},
+										"veeva": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													names.AttrPassword: {
+														Type:         schema.TypeString,
+														Required:     true,
+														Sensitive:    true,
+														ValidateFunc: validation.StringLenBetween(0, 512),
+													},
+													names.AttrUsername: {
+														Type:     schema.TypeString,
+														Required: true,
+														ValidateFunc: validation.All(
+															validation.StringLenBetween(1, 512),
+															validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+														),
+													},
+												},
+											},
+										},
+										"zendesk": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"access_token": {
+														Type:      schema.TypeString,
+														Optional:  true,
+														Sensitive: true,
+														ValidateFunc: validation.All(
+															validation.StringLenBetween(1, 2048),
+															validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+														),
+													},
+													names.AttrClientID: {
+														Type:     schema.TypeString,
+														Required: true,
+														ValidateFunc: validation.All(
+															validation.StringLenBetween(1, 512),
+															validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+														),
+													},
+													names.AttrClientSecret: {
+														Type:      schema.TypeString,
+														Required:  true,
+														Sensitive: true,
+														ValidateFunc: validation.All(
+															validation.StringLenBetween(1, 512),
+															validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+														),
+													},
+													"oauth_request": {
+														Type:     schema.TypeList,
+														Optional: true,
+														MaxItems: 1,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																"auth_code": {
+																	Type:     schema.TypeString,
+																	Optional: true,
+																	ValidateFunc: validation.All(
+																		validation.StringLenBetween(1, 2048),
+																		validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+																	),
+																},
+																"redirect_uri": {
+																	Type:     schema.TypeString,
+																	Optional: true,
+																	ValidateFunc: validation.All(
+																		validation.StringLenBetween(1, 512),
+																		validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+																	),
+																},
 															},
 														},
 													},
@@ -932,471 +934,471 @@ func resourceConnectorProfile() *schema.Resource {
 									},
 								},
 							},
-						},
-						"connector_profile_properties": {
-							Type:     schema.TypeList,
-							Required: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"amplitude": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{},
+							"connector_profile_properties": {
+								Type:     schema.TypeList,
+								Required: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"amplitude": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{},
+											},
 										},
-									},
-									"custom_connector": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"oauth2_properties": {
-													Type:     schema.TypeList,
-													Optional: true,
-													MaxItems: 1,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															"oauth2_grant_type": {
-																Type:             schema.TypeString,
-																Required:         true,
-																ValidateDiagFunc: enum.Validate[types.OAuth2GrantType](),
-															},
-															"token_url": {
-																Type:     schema.TypeString,
-																Required: true,
-																ValidateFunc: validation.All(
-																	validation.StringLenBetween(1, 256),
-																	validation.StringMatch(regexache.MustCompile(`^(https?)://[0-9A-Za-z-+&@#/%?=~_|!:,.;]*[0-9A-Za-z-+&@#/%=~_|]`), "must provide a valid HTTPS url"),
-																),
-															},
-															"token_url_custom_properties": {
-																Type:     schema.TypeMap,
-																Optional: true,
-																ValidateDiagFunc: validation.AllDiag(
-																	validation.MapKeyLenBetween(1, 128),
-																	validation.MapKeyMatch(regexache.MustCompile(`[\w]+`), "must contain only alphanumeric and underscore (_) characters"),
-																),
-																Elem: &schema.Schema{
-																	Type: schema.TypeString,
+										"custom_connector": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"oauth2_properties": {
+														Type:     schema.TypeList,
+														Optional: true,
+														MaxItems: 1,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																"oauth2_grant_type": {
+																	Type:             schema.TypeString,
+																	Required:         true,
+																	ValidateDiagFunc: enum.Validate[types.OAuth2GrantType](),
+																},
+																"token_url": {
+																	Type:     schema.TypeString,
+																	Required: true,
 																	ValidateFunc: validation.All(
-																		validation.StringLenBetween(0, 2048),
-																		validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+																		validation.StringLenBetween(1, 256),
+																		validation.StringMatch(regexache.MustCompile(`^(https?)://[0-9A-Za-z-+&@#/%?=~_|!:,.;]*[0-9A-Za-z-+&@#/%=~_|]`), "must provide a valid HTTPS url"),
 																	),
+																},
+																"token_url_custom_properties": {
+																	Type:     schema.TypeMap,
+																	Optional: true,
+																	ValidateDiagFunc: validation.AllDiag(
+																		validation.MapKeyLenBetween(1, 128),
+																		validation.MapKeyMatch(regexache.MustCompile(`[\w]+`), "must contain only alphanumeric and underscore (_) characters"),
+																	),
+																	Elem: &schema.Schema{
+																		Type: schema.TypeString,
+																		ValidateFunc: validation.All(
+																			validation.StringLenBetween(0, 2048),
+																			validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+																		),
+																	},
 																},
 															},
 														},
 													},
+													"profile_properties": {
+														Type:     schema.TypeMap,
+														Optional: true,
+														ValidateDiagFunc: validation.AllDiag(
+															validation.MapKeyLenBetween(1, 128),
+															validation.MapKeyMatch(regexache.MustCompile(`[\w]+`), "must contain only alphanumeric and underscore (_) characters"),
+														),
+														Elem: &schema.Schema{
+															Type: schema.TypeString,
+															ValidateFunc: validation.All(
+																validation.StringLenBetween(0, 2048),
+																validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+															),
+														},
+													},
 												},
-												"profile_properties": {
-													Type:     schema.TypeMap,
-													Optional: true,
-													ValidateDiagFunc: validation.AllDiag(
-														validation.MapKeyLenBetween(1, 128),
-														validation.MapKeyMatch(regexache.MustCompile(`[\w]+`), "must contain only alphanumeric and underscore (_) characters"),
-													),
-													Elem: &schema.Schema{
-														Type: schema.TypeString,
+											},
+										},
+										"datadog": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"instance_url": {
+														Type:     schema.TypeString,
+														Required: true,
 														ValidateFunc: validation.All(
-															validation.StringLenBetween(0, 2048),
+															validation.StringLenBetween(1, 256),
 															validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
 														),
 													},
 												},
 											},
 										},
-									},
-									"datadog": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"instance_url": {
-													Type:     schema.TypeString,
-													Required: true,
-													ValidateFunc: validation.All(
-														validation.StringLenBetween(1, 256),
-														validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-													),
+										"dynatrace": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"instance_url": {
+														Type:     schema.TypeString,
+														Required: true,
+														ValidateFunc: validation.All(
+															validation.StringLenBetween(1, 256),
+															validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+														),
+													},
 												},
 											},
 										},
-									},
-									"dynatrace": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"instance_url": {
-													Type:     schema.TypeString,
-													Required: true,
-													ValidateFunc: validation.All(
-														validation.StringLenBetween(1, 256),
-														validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-													),
+										"google_analytics": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{},
+											},
+										},
+										"honeycode": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{},
+											},
+										},
+										"infor_nexus": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"instance_url": {
+														Type:     schema.TypeString,
+														Required: true,
+														ValidateFunc: validation.All(
+															validation.StringLenBetween(1, 256),
+															validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+														),
+													},
 												},
 											},
 										},
-									},
-									"google_analytics": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{},
-										},
-									},
-									"honeycode": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{},
-										},
-									},
-									"infor_nexus": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"instance_url": {
-													Type:     schema.TypeString,
-													Required: true,
-													ValidateFunc: validation.All(
-														validation.StringLenBetween(1, 256),
-														validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-													),
+										"marketo": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"instance_url": {
+														Type:     schema.TypeString,
+														Required: true,
+														ValidateFunc: validation.All(
+															validation.StringLenBetween(1, 256),
+															validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+														),
+													},
 												},
 											},
 										},
-									},
-									"marketo": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"instance_url": {
-													Type:     schema.TypeString,
-													Required: true,
-													ValidateFunc: validation.All(
-														validation.StringLenBetween(1, 256),
-														validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-													),
+										"redshift": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													names.AttrBucketName: {
+														Type:     schema.TypeString,
+														Required: true,
+														ValidateFunc: validation.All(
+															validation.StringLenBetween(3, 63),
+															validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+														),
+													},
+													names.AttrBucketPrefix: {
+														Type:         schema.TypeString,
+														Optional:     true,
+														ValidateFunc: validation.StringLenBetween(0, 512),
+													},
+													names.AttrClusterIdentifier: {
+														Type:     schema.TypeString,
+														Optional: true,
+													},
+													"data_api_role_arn": {
+														Type:         schema.TypeString,
+														Optional:     true,
+														ValidateFunc: verify.ValidARN,
+													},
+													names.AttrDatabaseName: {
+														Type:     schema.TypeString,
+														Optional: true,
+													},
+													"database_url": {
+														Type:         schema.TypeString,
+														Optional:     true,
+														ValidateFunc: validation.StringLenBetween(0, 512),
+													},
+													names.AttrRoleARN: {
+														Type:         schema.TypeString,
+														Required:     true,
+														ValidateFunc: verify.ValidARN,
+													},
 												},
 											},
 										},
-									},
-									"redshift": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												names.AttrBucketName: {
-													Type:     schema.TypeString,
-													Required: true,
-													ValidateFunc: validation.All(
-														validation.StringLenBetween(3, 63),
-														validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-													),
-												},
-												names.AttrBucketPrefix: {
-													Type:         schema.TypeString,
-													Optional:     true,
-													ValidateFunc: validation.StringLenBetween(0, 512),
-												},
-												names.AttrClusterIdentifier: {
-													Type:     schema.TypeString,
-													Optional: true,
-												},
-												"data_api_role_arn": {
-													Type:         schema.TypeString,
-													Optional:     true,
-													ValidateFunc: verify.ValidARN,
-												},
-												names.AttrDatabaseName: {
-													Type:     schema.TypeString,
-													Optional: true,
-												},
-												"database_url": {
-													Type:         schema.TypeString,
-													Optional:     true,
-													ValidateFunc: validation.StringLenBetween(0, 512),
-												},
-												names.AttrRoleARN: {
-													Type:         schema.TypeString,
-													Required:     true,
-													ValidateFunc: verify.ValidARN,
+										"salesforce": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"instance_url": {
+														Type:     schema.TypeString,
+														Optional: true,
+														ValidateFunc: validation.All(
+															validation.StringLenBetween(1, 256),
+															validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+														),
+													},
+													"is_sandbox_environment": {
+														Type:     schema.TypeBool,
+														Optional: true,
+													},
+													"use_privatelink_for_metadata_and_authorization": {
+														Type:     schema.TypeBool,
+														Optional: true,
+													},
 												},
 											},
 										},
-									},
-									"salesforce": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"instance_url": {
-													Type:     schema.TypeString,
-													Optional: true,
-													ValidateFunc: validation.All(
-														validation.StringLenBetween(1, 256),
-														validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-													),
-												},
-												"is_sandbox_environment": {
-													Type:     schema.TypeBool,
-													Optional: true,
-												},
-												"use_privatelink_for_metadata_and_authorization": {
-													Type:     schema.TypeBool,
-													Optional: true,
-												},
-											},
-										},
-									},
-									"sapo_data": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"application_host_url": {
-													Type:     schema.TypeString,
-													Required: true,
-													ValidateFunc: validation.All(
-														validation.StringLenBetween(1, 256),
-														validation.StringMatch(regexache.MustCompile(`^(https?)://[0-9A-Za-z-+&@#/%?=~_|!:,.;]*[0-9A-Za-z-+&@#/%=~_|]`), "must provide a valid HTTPS url"),
-													),
-												},
-												"application_service_path": {
-													Type:     schema.TypeString,
-													Required: true,
-													ValidateFunc: validation.All(
-														validation.StringLenBetween(1, 512),
-														validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-													),
-												},
-												"client_number": {
-													Type:     schema.TypeString,
-													Required: true,
-													ValidateFunc: validation.All(
-														validation.StringLenBetween(3, 3),
-														validation.StringMatch(regexache.MustCompile(`^\d{3}$`), "must consist of exactly three digits"),
-													),
-												},
-												"logon_language": {
-													Type:     schema.TypeString,
-													Optional: true,
-													ValidateFunc: validation.All(
-														validation.StringLenBetween(0, 2),
-														validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z_]*$`), "must contain only alphanumeric characters and the underscore (_) character"),
-													),
-												},
-												"oauth_properties": {
-													Type:     schema.TypeList,
-													Optional: true,
-													MaxItems: 1,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															"auth_code_url": {
-																Type:     schema.TypeString,
-																Required: true,
-																ValidateFunc: validation.All(
-																	validation.StringLenBetween(1, 256),
-																	validation.StringMatch(regexache.MustCompile(`^(https?)://[0-9A-Za-z-+&@#/%?=~_|!:,.;]*[0-9A-Za-z-+&@#/%=~_|]`), "must provide a valid HTTPS url"),
-																),
-															},
-															"oauth_scopes": {
-																Type:     schema.TypeList,
-																Required: true,
-																Elem: &schema.Schema{
-																	Type: schema.TypeString,
+										"sapo_data": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"application_host_url": {
+														Type:     schema.TypeString,
+														Required: true,
+														ValidateFunc: validation.All(
+															validation.StringLenBetween(1, 256),
+															validation.StringMatch(regexache.MustCompile(`^(https?)://[0-9A-Za-z-+&@#/%?=~_|!:,.;]*[0-9A-Za-z-+&@#/%=~_|]`), "must provide a valid HTTPS url"),
+														),
+													},
+													"application_service_path": {
+														Type:     schema.TypeString,
+														Required: true,
+														ValidateFunc: validation.All(
+															validation.StringLenBetween(1, 512),
+															validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+														),
+													},
+													"client_number": {
+														Type:     schema.TypeString,
+														Required: true,
+														ValidateFunc: validation.All(
+															validation.StringLenBetween(3, 3),
+															validation.StringMatch(regexache.MustCompile(`^\d{3}$`), "must consist of exactly three digits"),
+														),
+													},
+													"logon_language": {
+														Type:     schema.TypeString,
+														Optional: true,
+														ValidateFunc: validation.All(
+															validation.StringLenBetween(0, 2),
+															validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z_]*$`), "must contain only alphanumeric characters and the underscore (_) character"),
+														),
+													},
+													"oauth_properties": {
+														Type:     schema.TypeList,
+														Optional: true,
+														MaxItems: 1,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																"auth_code_url": {
+																	Type:     schema.TypeString,
+																	Required: true,
 																	ValidateFunc: validation.All(
-																		validation.StringLenBetween(1, 128),
-																		validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+																		validation.StringLenBetween(1, 256),
+																		validation.StringMatch(regexache.MustCompile(`^(https?)://[0-9A-Za-z-+&@#/%?=~_|!:,.;]*[0-9A-Za-z-+&@#/%=~_|]`), "must provide a valid HTTPS url"),
+																	),
+																},
+																"oauth_scopes": {
+																	Type:     schema.TypeList,
+																	Required: true,
+																	Elem: &schema.Schema{
+																		Type: schema.TypeString,
+																		ValidateFunc: validation.All(
+																			validation.StringLenBetween(1, 128),
+																			validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+																		),
+																	},
+																},
+																"token_url": {
+																	Type:     schema.TypeString,
+																	Required: true,
+																	ValidateFunc: validation.All(
+																		validation.StringLenBetween(1, 256),
+																		validation.StringMatch(regexache.MustCompile(`^(https?)://[0-9A-Za-z-+&@#/%?=~_|!:,.;]*[0-9A-Za-z-+&@#/%=~_|]`), "must provide a valid HTTPS url"),
 																	),
 																},
 															},
-															"token_url": {
-																Type:     schema.TypeString,
-																Required: true,
-																ValidateFunc: validation.All(
-																	validation.StringLenBetween(1, 256),
-																	validation.StringMatch(regexache.MustCompile(`^(https?)://[0-9A-Za-z-+&@#/%?=~_|!:,.;]*[0-9A-Za-z-+&@#/%=~_|]`), "must provide a valid HTTPS url"),
-																),
-															},
 														},
 													},
-												},
-												"port_number": {
-													Type:         schema.TypeInt,
-													Required:     true,
-													ValidateFunc: validation.IntBetween(1, 65535),
-												},
-												"private_link_service_name": {
-													Type:     schema.TypeString,
-													Optional: true,
-													ValidateFunc: validation.All(
-														validation.StringLenBetween(1, 512),
-														validation.StringMatch(regexache.MustCompile(`^$|com.amazonaws.vpce.[\w/!:@#.\-]+`), "must be a valid AWS VPC endpoint address"),
-													),
-												},
-											},
-										},
-									},
-									"service_now": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"instance_url": {
-													Type:     schema.TypeString,
-													Required: true,
-													ValidateFunc: validation.All(
-														validation.StringLenBetween(1, 256),
-														validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-													),
-												},
-											},
-										},
-									},
-									"singular": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{},
-										},
-									},
-									"slack": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"instance_url": {
-													Type:     schema.TypeString,
-													Required: true,
-													ValidateFunc: validation.All(
-														validation.StringLenBetween(1, 256),
-														validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-													),
-												},
-											},
-										},
-									},
-									"snowflake": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"account_name": {
-													Type:     schema.TypeString,
-													Optional: true,
-													ValidateFunc: validation.All(
-														validation.StringLenBetween(1, 512),
-														validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-													),
-												},
-												names.AttrBucketName: {
-													Type:     schema.TypeString,
-													Required: true,
-													ValidateFunc: validation.All(
-														validation.StringLenBetween(3, 63),
-														validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-													),
-												},
-												names.AttrBucketPrefix: {
-													Type:         schema.TypeString,
-													Optional:     true,
-													ValidateFunc: validation.StringLenBetween(0, 512),
-												},
-												"private_link_service_name": {
-													Type:     schema.TypeString,
-													Optional: true,
-													ValidateFunc: validation.All(
-														validation.StringLenBetween(1, 512),
-														validation.StringMatch(regexache.MustCompile(`^$|com.amazonaws.vpce.[\w/!:@#.\-]+`), "must be a valid AWS VPC endpoint address"),
-													),
-												},
-												names.AttrRegion: {
-													Type:     schema.TypeString,
-													Optional: true,
-													ValidateFunc: validation.All(
-														validation.StringLenBetween(1, 64),
-														validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-													),
-												},
-												names.AttrStage: {
-													Type:     schema.TypeString,
-													Required: true,
-													DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-														return old == new || old == "@"+new
+													"port_number": {
+														Type:         schema.TypeInt,
+														Required:     true,
+														ValidateFunc: validation.IntBetween(1, 65535),
 													},
-													ValidateFunc: validation.All(
-														validation.StringLenBetween(1, 512),
-														validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-													),
-												},
-												"warehouse": {
-													Type:     schema.TypeString,
-													Required: true,
-													ValidateFunc: validation.All(
-														validation.StringLenBetween(0, 512),
-														validation.StringMatch(regexache.MustCompile(`[\s\w/!@#+=.-]*`), "must match [\\s\\w/!@#+=.-]*"),
-													),
+													"private_link_service_name": {
+														Type:     schema.TypeString,
+														Optional: true,
+														ValidateFunc: validation.All(
+															validation.StringLenBetween(1, 512),
+															validation.StringMatch(regexache.MustCompile(`^$|com.amazonaws.vpce.[\w/!:@#.\-]+`), "must be a valid AWS VPC endpoint address"),
+														),
+													},
 												},
 											},
 										},
-									},
-									"trendmicro": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{},
-										},
-									},
-									"veeva": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"instance_url": {
-													Type:     schema.TypeString,
-													Required: true,
-													ValidateFunc: validation.All(
-														validation.StringLenBetween(1, 256),
-														validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-													),
+										"service_now": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"instance_url": {
+														Type:     schema.TypeString,
+														Required: true,
+														ValidateFunc: validation.All(
+															validation.StringLenBetween(1, 256),
+															validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+														),
+													},
 												},
 											},
 										},
-									},
-									"zendesk": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"instance_url": {
-													Type:     schema.TypeString,
-													Required: true,
-													ValidateFunc: validation.All(
-														validation.StringLenBetween(1, 256),
-														validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
-													),
+										"singular": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{},
+											},
+										},
+										"slack": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"instance_url": {
+														Type:     schema.TypeString,
+														Required: true,
+														ValidateFunc: validation.All(
+															validation.StringLenBetween(1, 256),
+															validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+														),
+													},
+												},
+											},
+										},
+										"snowflake": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"account_name": {
+														Type:     schema.TypeString,
+														Optional: true,
+														ValidateFunc: validation.All(
+															validation.StringLenBetween(1, 512),
+															validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+														),
+													},
+													names.AttrBucketName: {
+														Type:     schema.TypeString,
+														Required: true,
+														ValidateFunc: validation.All(
+															validation.StringLenBetween(3, 63),
+															validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+														),
+													},
+													names.AttrBucketPrefix: {
+														Type:         schema.TypeString,
+														Optional:     true,
+														ValidateFunc: validation.StringLenBetween(0, 512),
+													},
+													"private_link_service_name": {
+														Type:     schema.TypeString,
+														Optional: true,
+														ValidateFunc: validation.All(
+															validation.StringLenBetween(1, 512),
+															validation.StringMatch(regexache.MustCompile(`^$|com.amazonaws.vpce.[\w/!:@#.\-]+`), "must be a valid AWS VPC endpoint address"),
+														),
+													},
+													names.AttrRegion: {
+														Type:     schema.TypeString,
+														Optional: true,
+														ValidateFunc: validation.All(
+															validation.StringLenBetween(1, 64),
+															validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+														),
+													},
+													names.AttrStage: {
+														Type:     schema.TypeString,
+														Required: true,
+														DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+															return old == new || old == "@"+new
+														},
+														ValidateFunc: validation.All(
+															validation.StringLenBetween(1, 512),
+															validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+														),
+													},
+													"warehouse": {
+														Type:     schema.TypeString,
+														Required: true,
+														ValidateFunc: validation.All(
+															validation.StringLenBetween(0, 512),
+															validation.StringMatch(regexache.MustCompile(`[\s\w/!@#+=.-]*`), "must match [\\s\\w/!@#+=.-]*"),
+														),
+													},
+												},
+											},
+										},
+										"trendmicro": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{},
+											},
+										},
+										"veeva": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"instance_url": {
+														Type:     schema.TypeString,
+														Required: true,
+														ValidateFunc: validation.All(
+															validation.StringLenBetween(1, 256),
+															validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+														),
+													},
+												},
+											},
+										},
+										"zendesk": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"instance_url": {
+														Type:     schema.TypeString,
+														Required: true,
+														ValidateFunc: validation.All(
+															validation.StringLenBetween(1, 256),
+															validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"),
+														),
+													},
 												},
 											},
 										},
@@ -1406,33 +1408,33 @@ func resourceConnectorProfile() *schema.Resource {
 						},
 					},
 				},
-			},
-			"connector_type": {
-				Type:             schema.TypeString,
-				Required:         true,
-				ForceNew:         true,
-				ValidateDiagFunc: enum.Validate[types.ConnectorType](),
-			},
-			"credentials_arn": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"kms_arn": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-				ValidateFunc: validation.All(
-					validation.StringLenBetween(1, 256),
-					validation.StringMatch(regexache.MustCompile(`[\w/!@#+=.-]+`), "must match [\\w/!@#+=.-]+"),
-				),
-			},
+				"connector_type": {
+					Type:             schema.TypeString,
+					Required:         true,
+					ForceNew:         true,
+					ValidateDiagFunc: enum.Validate[types.ConnectorType](),
+				},
+				"credentials_arn": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"kms_arn": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Computed:     true,
+					ForceNew:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+					ValidateFunc: validation.All(
+						validation.StringLenBetween(1, 256),
+						validation.StringMatch(regexache.MustCompile(`[\w/!@#+=.-]+`), "must match [\\w/!@#+=.-]+"),
+					),
+				},
+			}
 		},
 	}
 }

--- a/internal/service/appflow/flow.go
+++ b/internal/service/appflow/flow.go
@@ -45,1299 +45,1301 @@ func resourceFlow() *schema.Resource {
 		UpdateWithoutTimeout: resourceFlowUpdate,
 		DeleteWithoutTimeout: resourceFlowDelete,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrDescription: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringMatch(regexache.MustCompile(`[\w!@#\-.?,\s]*`), "must contain only alphanumeric, underscore (_), exclamation point (!), at sign (@), number sign (#), hyphen (-), period (.), question mark (?), comma (,), and whitespace characters"),
-			},
-			"destination_flow_config": {
-				Type:     schema.TypeList,
-				Required: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"api_version": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(1, 256)),
-						},
-						"connector_profile_name": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`[\w\/!@#+=.-]+`), "must contain only alphanumeric, underscore (_), forward slash (/), exclamation point (!), at sign (@), number sign (#), plus sign (+), equals sign (=), period (.), and hyphen (-) characters"), validation.StringLenBetween(1, 256)),
-						},
-						"connector_type": {
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: enum.Validate[types.ConnectorType](),
-						},
-						"destination_connector_properties": {
-							Type:     schema.TypeList,
-							Required: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"custom_connector": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"custom_properties": {
-													Type:     schema.TypeMap,
-													Optional: true,
-													ValidateDiagFunc: validation.AllDiag(
-														validation.MapKeyLenBetween(1, 128),
-														validation.MapKeyMatch(regexache.MustCompile(`[\w]+`), "must contain only alphanumeric and underscore (_) characters"),
-													),
-													Elem: &schema.Schema{
-														Type:         schema.TypeString,
-														ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(0, 2048)),
-													},
-												},
-												"entity_name": {
-													Type:         schema.TypeString,
-													Required:     true,
-													ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(1, 1024)),
-												},
-												"error_handling_config": {
-													Type:     schema.TypeList,
-													Optional: true,
-													MaxItems: 1,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															names.AttrBucketName: {
-																Type:         schema.TypeString,
-																Optional:     true,
-																ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(3, 63)),
-															},
-															names.AttrBucketPrefix: {
-																Type:         schema.TypeString,
-																Optional:     true,
-																ValidateFunc: validation.StringLenBetween(0, 512),
-															},
-															"fail_on_first_destination_error": {
-																Type:     schema.TypeBool,
-																Optional: true,
-															},
-														},
-													},
-												},
-												"id_field_names": {
-													Type:     schema.TypeList,
-													Optional: true,
-													Elem: &schema.Schema{
-														Type:         schema.TypeString,
-														ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(0, 128)),
-													},
-												},
-												"write_operation_type": {
-													Type:             schema.TypeString,
-													Optional:         true,
-													ValidateDiagFunc: enum.Validate[types.WriteOperationType](),
-												},
-											},
-										},
-									},
-									"customer_profiles": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												names.AttrDomainName: {
-													Type:         schema.TypeString,
-													Required:     true,
-													ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(1, 64)),
-												},
-												"object_type_name": {
-													Type:         schema.TypeString,
-													Optional:     true,
-													ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(0, 255)),
-												},
-											},
-										},
-									},
-									"event_bridge": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"error_handling_config": {
-													Type:     schema.TypeList,
-													Optional: true,
-													MaxItems: 1,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															names.AttrBucketName: {
-																Type:         schema.TypeString,
-																Optional:     true,
-																ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(3, 63)),
-															},
-															names.AttrBucketPrefix: {
-																Type:         schema.TypeString,
-																Optional:     true,
-																ValidateFunc: validation.StringLenBetween(0, 512),
-															},
-															"fail_on_first_destination_error": {
-																Type:     schema.TypeBool,
-																Optional: true,
-															},
-														},
-													},
-												},
-												"object": {
-													Type:         schema.TypeString,
-													Required:     true,
-													ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(1, 512)),
-												},
-											},
-										},
-									},
-									"honeycode": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"error_handling_config": {
-													Type:     schema.TypeList,
-													Optional: true,
-													MaxItems: 1,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															names.AttrBucketName: {
-																Type:         schema.TypeString,
-																Optional:     true,
-																ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(3, 63)),
-															},
-															names.AttrBucketPrefix: {
-																Type:         schema.TypeString,
-																Optional:     true,
-																ValidateFunc: validation.StringLenBetween(0, 512),
-															},
-															"fail_on_first_destination_error": {
-																Type:     schema.TypeBool,
-																Optional: true,
-															},
-														},
-													},
-												},
-												"object": {
-													Type:         schema.TypeString,
-													Required:     true,
-													ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(1, 512)),
-												},
-											},
-										},
-									},
-									"lookout_metrics": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{},
-										},
-									},
-									"marketo": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"error_handling_config": {
-													Type:     schema.TypeList,
-													Optional: true,
-													MaxItems: 1,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															names.AttrBucketName: {
-																Type:         schema.TypeString,
-																Optional:     true,
-																ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(3, 63)),
-															},
-															names.AttrBucketPrefix: {
-																Type:         schema.TypeString,
-																Optional:     true,
-																ValidateFunc: validation.StringLenBetween(0, 512),
-															},
-															"fail_on_first_destination_error": {
-																Type:     schema.TypeBool,
-																Optional: true,
-															},
-														},
-													},
-												},
-												"object": {
-													Type:         schema.TypeString,
-													Required:     true,
-													ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(1, 512)),
-												},
-											},
-										},
-									},
-									"redshift": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												names.AttrBucketPrefix: {
-													Type:         schema.TypeString,
-													Optional:     true,
-													ValidateFunc: validation.StringLenBetween(0, 512),
-												},
-												"error_handling_config": {
-													Type:     schema.TypeList,
-													Optional: true,
-													MaxItems: 1,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															names.AttrBucketName: {
-																Type:         schema.TypeString,
-																Optional:     true,
-																ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(3, 63)),
-															},
-															names.AttrBucketPrefix: {
-																Type:         schema.TypeString,
-																Optional:     true,
-																ValidateFunc: validation.StringLenBetween(0, 512),
-															},
-															"fail_on_first_destination_error": {
-																Type:     schema.TypeBool,
-																Optional: true,
-															},
-														},
-													},
-												},
-												"intermediate_bucket_name": {
-													Type:         schema.TypeString,
-													Required:     true,
-													ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(3, 63)),
-												},
-												"object": {
-													Type:         schema.TypeString,
-													Required:     true,
-													ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(1, 512)),
-												},
-											},
-										},
-									},
-									"s3": {
-										Type:     schema.TypeList,
-										Optional: true,
-										Computed: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												names.AttrBucketName: {
-													Type:         schema.TypeString,
-													Required:     true,
-													ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(3, 63)),
-												},
-												names.AttrBucketPrefix: {
-													Type:         schema.TypeString,
-													Optional:     true,
-													Computed:     true,
-													ValidateFunc: validation.StringLenBetween(0, 512),
-												},
-												"s3_output_format_config": {
-													Type:     schema.TypeList,
-													Optional: true,
-													Computed: true,
-													MaxItems: 1,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															"aggregation_config": {
-																Type:     schema.TypeList,
-																Optional: true,
-																Computed: true,
-																MaxItems: 1,
-																Elem: &schema.Resource{
-																	Schema: map[string]*schema.Schema{
-																		"aggregation_type": {
-																			Type:             schema.TypeString,
-																			Optional:         true,
-																			Computed:         true,
-																			ValidateDiagFunc: enum.Validate[types.AggregationType](),
-																		},
-																		"target_file_size": {
-																			Type:     schema.TypeInt,
-																			Optional: true,
-																			Computed: true,
-																		},
-																	},
-																},
-															},
-															"file_type": {
-																Type:             schema.TypeString,
-																Optional:         true,
-																ValidateDiagFunc: enum.Validate[types.FileType](),
-															},
-															"prefix_config": {
-																Type:     schema.TypeList,
-																Optional: true,
-																Computed: true,
-																MaxItems: 1,
-																Elem: &schema.Resource{
-																	Schema: map[string]*schema.Schema{
-																		"prefix_hierarchy": {
-																			Type:     schema.TypeList,
-																			Optional: true,
-																			Computed: true,
-																			Elem: &schema.Schema{
-																				Type:             schema.TypeString,
-																				ValidateDiagFunc: enum.Validate[types.PathPrefix](),
-																			},
-																		},
-																		"prefix_format": {
-																			Type:             schema.TypeString,
-																			Optional:         true,
-																			ValidateDiagFunc: enum.Validate[types.PrefixFormat](),
-																		},
-																		"prefix_type": {
-																			Type:             schema.TypeString,
-																			Optional:         true,
-																			ValidateDiagFunc: enum.Validate[types.PrefixType](),
-																		},
-																	},
-																},
-															},
-															"preserve_source_data_typing": {
-																Type:     schema.TypeBool,
-																Optional: true,
-																Computed: true,
-															},
-														},
-													},
-												},
-											},
-										},
-									},
-									"salesforce": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"data_transfer_api": {
-													Type:             schema.TypeString,
-													Optional:         true,
-													ValidateDiagFunc: enum.Validate[types.SalesforceDataTransferApi](),
-												},
-												"error_handling_config": {
-													Type:     schema.TypeList,
-													Optional: true,
-													MaxItems: 1,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															names.AttrBucketName: {
-																Type:         schema.TypeString,
-																Optional:     true,
-																ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(3, 63)),
-															},
-															names.AttrBucketPrefix: {
-																Type:         schema.TypeString,
-																Optional:     true,
-																ValidateFunc: validation.StringLenBetween(0, 512),
-															},
-															"fail_on_first_destination_error": {
-																Type:     schema.TypeBool,
-																Optional: true,
-															},
-														},
-													},
-												},
-												"id_field_names": {
-													Type:     schema.TypeList,
-													Optional: true,
-													Elem: &schema.Schema{
-														Type:         schema.TypeString,
-														ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(0, 128)),
-													},
-												},
-												"object": {
-													Type:         schema.TypeString,
-													Required:     true,
-													ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(1, 512)),
-												},
-												"write_operation_type": {
-													Type:             schema.TypeString,
-													Optional:         true,
-													ValidateDiagFunc: enum.Validate[types.WriteOperationType](),
-												},
-											},
-										},
-									},
-									"sapo_data": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"error_handling_config": {
-													Type:     schema.TypeList,
-													Optional: true,
-													MaxItems: 1,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															names.AttrBucketName: {
-																Type:         schema.TypeString,
-																Optional:     true,
-																ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(3, 63)),
-															},
-															names.AttrBucketPrefix: {
-																Type:         schema.TypeString,
-																Optional:     true,
-																ValidateFunc: validation.StringLenBetween(0, 512),
-															},
-															"fail_on_first_destination_error": {
-																Type:     schema.TypeBool,
-																Optional: true,
-															},
-														},
-													},
-												},
-												"id_field_names": {
-													Type:     schema.TypeList,
-													Optional: true,
-													Elem: &schema.Schema{
-														Type:         schema.TypeString,
-														ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(0, 128)),
-													},
-												},
-												"object_path": {
-													Type:         schema.TypeString,
-													Required:     true,
-													ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(1, 512)),
-												},
-												"success_response_handling_config": {
-													Type:     schema.TypeList,
-													Optional: true,
-													MaxItems: 1,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															names.AttrBucketName: {
-																Type:         schema.TypeString,
-																Optional:     true,
-																ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(3, 63)),
-															},
-															names.AttrBucketPrefix: {
-																Type:         schema.TypeString,
-																Optional:     true,
-																ValidateFunc: validation.StringLenBetween(0, 512),
-															},
-														},
-													},
-												},
-												"write_operation_type": {
-													Type:             schema.TypeString,
-													Optional:         true,
-													ValidateDiagFunc: enum.Validate[types.WriteOperationType](),
-												},
-											},
-										},
-									},
-									"snowflake": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												names.AttrBucketPrefix: {
-													Type:         schema.TypeString,
-													Optional:     true,
-													ValidateFunc: validation.StringLenBetween(0, 512),
-												},
-												"error_handling_config": {
-													Type:     schema.TypeList,
-													Optional: true,
-													MaxItems: 1,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															names.AttrBucketName: {
-																Type:         schema.TypeString,
-																Optional:     true,
-																ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(3, 63)),
-															},
-															names.AttrBucketPrefix: {
-																Type:         schema.TypeString,
-																Optional:     true,
-																ValidateFunc: validation.StringLenBetween(0, 512),
-															},
-															"fail_on_first_destination_error": {
-																Type:     schema.TypeBool,
-																Optional: true,
-															},
-														},
-													},
-												},
-												"intermediate_bucket_name": {
-													Type:         schema.TypeString,
-													Required:     true,
-													ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(3, 63)),
-												},
-												"object": {
-													Type:         schema.TypeString,
-													Required:     true,
-													ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(1, 512)),
-												},
-											},
-										},
-									},
-									"upsolver": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												names.AttrBucketName: {
-													Type:         schema.TypeString,
-													Required:     true,
-													ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`^(upsolver-appflow)\S*`), "must start with 'upsolver-appflow' and can not contain any whitespace characters"), validation.StringLenBetween(3, 63)),
-												},
-												names.AttrBucketPrefix: {
-													Type:         schema.TypeString,
-													Optional:     true,
-													ValidateFunc: validation.StringLenBetween(0, 512),
-												},
-												"s3_output_format_config": {
-													Type:     schema.TypeList,
-													Required: true,
-													MaxItems: 1,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															"aggregation_config": {
-																Type:     schema.TypeList,
-																Optional: true,
-																MaxItems: 1,
-																Elem: &schema.Resource{
-																	Schema: map[string]*schema.Schema{
-																		"aggregation_type": {
-																			Type:             schema.TypeString,
-																			Optional:         true,
-																			ValidateDiagFunc: enum.Validate[types.AggregationType](),
-																		},
-																	},
-																},
-															},
-															"file_type": {
-																Type:             schema.TypeString,
-																Optional:         true,
-																ValidateDiagFunc: enum.Validate[types.FileType](),
-															},
-															"prefix_config": {
-																Type:     schema.TypeList,
-																Required: true,
-																MaxItems: 1,
-																Elem: &schema.Resource{
-																	Schema: map[string]*schema.Schema{
-																		"prefix_hierarchy": {
-																			Type:     schema.TypeList,
-																			Optional: true,
-																			Computed: true,
-																			Elem: &schema.Schema{
-																				Type:             schema.TypeString,
-																				ValidateDiagFunc: enum.Validate[types.PathPrefix](),
-																			},
-																		},
-																		"prefix_format": {
-																			Type:             schema.TypeString,
-																			Optional:         true,
-																			ValidateDiagFunc: enum.Validate[types.PrefixFormat](),
-																		},
-																		"prefix_type": {
-																			Type:             schema.TypeString,
-																			Required:         true,
-																			ValidateDiagFunc: enum.Validate[types.PrefixType](),
-																		},
-																	},
-																},
-															},
-														},
-													},
-												},
-											},
-										},
-									},
-									"zendesk": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"error_handling_config": {
-													Type:     schema.TypeList,
-													Optional: true,
-													MaxItems: 1,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															names.AttrBucketName: {
-																Type:         schema.TypeString,
-																Optional:     true,
-																ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(3, 63)),
-															},
-															names.AttrBucketPrefix: {
-																Type:         schema.TypeString,
-																Optional:     true,
-																ValidateFunc: validation.StringLenBetween(0, 512),
-															},
-															"fail_on_first_destination_error": {
-																Type:     schema.TypeBool,
-																Optional: true,
-															},
-														},
-													},
-												},
-												"id_field_names": {
-													Type:     schema.TypeList,
-													Optional: true,
-													Elem: &schema.Schema{
-														Type:         schema.TypeString,
-														ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(0, 128)),
-													},
-												},
-												"object": {
-													Type:         schema.TypeString,
-													Required:     true,
-													ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(1, 512)),
-												},
-												"write_operation_type": {
-													Type:             schema.TypeString,
-													Optional:         true,
-													ValidateDiagFunc: enum.Validate[types.WriteOperationType](),
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
 				},
-			},
-			"flow_status": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"kms_arn": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringMatch(regexache.MustCompile(`arn:.*:kms:.*:[0-9]+:.*`), "must be a valid ARN of a Key Management Services (KMS) key"),
-			},
-			names.AttrName: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`[0-9A-Za-z][\w!@#.-]+`), "must contain only alphanumeric, exclamation point (!), at sign (@), number sign (#), period (.), and hyphen (-) characters"), validation.StringLenBetween(1, 256)),
-			},
-			"source_flow_config": {
-				Type:     schema.TypeList,
-				Required: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"api_version": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(1, 256)),
-						},
-						"connector_profile_name": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`[\w\/!@#+=.-]+`), "must contain only alphanumeric, underscore (_), forward slash (/), exclamation point (!), at sign (@), number sign (#), plus sign (+), equals sign (=), period (.), and hyphen (-) characters"), validation.StringLenBetween(1, 256)),
-						},
-						"connector_type": {
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: enum.Validate[types.ConnectorType](),
-						},
-						"incremental_pull_config": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"datetime_type_field_name": {
-										Type:         schema.TypeString,
-										Optional:     true,
-										ValidateFunc: validation.StringLenBetween(0, 256),
-									},
-								},
-							},
-						},
-						"source_connector_properties": {
-							Type:     schema.TypeList,
-							Required: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"amplitude": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"object": {
-													Type:         schema.TypeString,
-													Required:     true,
-													ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(1, 512)),
-												},
-											},
-										},
-									},
-									"custom_connector": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"custom_properties": {
-													Type:     schema.TypeMap,
-													Optional: true,
-													ValidateDiagFunc: validation.AllDiag(
-														validation.MapKeyLenBetween(1, 128),
-														validation.MapKeyMatch(regexache.MustCompile(`[\w]+`), "must contain only alphanumeric and underscore (_) characters"),
-													),
-													Elem: &schema.Schema{
-														Type:         schema.TypeString,
-														ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(0, 2048)),
-													},
-												},
-												"entity_name": {
-													Type:         schema.TypeString,
-													Required:     true,
-													ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(1, 1024)),
-												},
-											},
-										},
-									},
-									"datadog": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"object": {
-													Type:         schema.TypeString,
-													Required:     true,
-													ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(1, 512)),
-												},
-											},
-										},
-									},
-									"dynatrace": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"object": {
-													Type:         schema.TypeString,
-													Required:     true,
-													ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(1, 512)),
-												},
-											},
-										},
-									},
-									"google_analytics": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"object": {
-													Type:         schema.TypeString,
-													Required:     true,
-													ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(1, 512)),
-												},
-											},
-										},
-									},
-									"infor_nexus": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"object": {
-													Type:         schema.TypeString,
-													Required:     true,
-													ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(1, 512)),
-												},
-											},
-										},
-									},
-									"marketo": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"object": {
-													Type:         schema.TypeString,
-													Required:     true,
-													ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(1, 512)),
-												},
-											},
-										},
-									},
-									"s3": {
-										Type:     schema.TypeList,
-										Optional: true,
-										Computed: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												names.AttrBucketName: {
-													Type:         schema.TypeString,
-													Required:     true,
-													ForceNew:     true,
-													ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(3, 63)),
-												},
-												names.AttrBucketPrefix: {
-													Type:         schema.TypeString,
-													Required:     true,
-													ForceNew:     true,
-													ValidateFunc: validation.StringLenBetween(0, 512),
-												},
-												"s3_input_format_config": {
-													Type:     schema.TypeList,
-													Optional: true,
-													MaxItems: 1,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															"s3_input_file_type": {
-																Type:             schema.TypeString,
-																Optional:         true,
-																ValidateDiagFunc: enum.Validate[types.S3InputFileType](),
-															},
-														},
-													},
-												},
-											},
-										},
-									},
-									"salesforce": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"data_transfer_api": {
-													Type:             schema.TypeString,
-													Optional:         true,
-													ValidateDiagFunc: enum.Validate[types.SalesforceDataTransferApi](),
-												},
-												"enable_dynamic_field_update": {
-													Type:     schema.TypeBool,
-													Optional: true,
-												},
-												"include_deleted_records": {
-													Type:     schema.TypeBool,
-													Optional: true,
-												},
-												"object": {
-													Type:         schema.TypeString,
-													Required:     true,
-													ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(1, 512)),
-												},
-											},
-										},
-									},
-									"sapo_data": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"object_path": {
-													Type:         schema.TypeString,
-													Required:     true,
-													ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(1, 512)),
-												},
-												"pagination_config": {
-													Type:     schema.TypeList,
-													Optional: true,
-													MaxItems: 1,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															"max_page_size": {
-																Type:         schema.TypeInt,
-																Required:     true,
-																ValidateFunc: validation.IntBetween(1, 10000),
-															},
-														},
-													},
-												},
-												"parallelism_config": {
-													Type:     schema.TypeList,
-													Optional: true,
-													MaxItems: 1,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															"max_page_size": {
-																Type:         schema.TypeInt,
-																Required:     true,
-																ValidateFunc: validation.IntBetween(1, 10),
-															},
-														},
-													},
-												},
-											},
-										},
-									},
-									"service_now": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"object": {
-													Type:         schema.TypeString,
-													Required:     true,
-													ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(1, 512)),
-												},
-											},
-										},
-									},
-									"singular": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"object": {
-													Type:         schema.TypeString,
-													Required:     true,
-													ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(1, 512)),
-												},
-											},
-										},
-									},
-									"slack": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"object": {
-													Type:         schema.TypeString,
-													Required:     true,
-													ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(1, 512)),
-												},
-											},
-										},
-									},
-									"trendmicro": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"object": {
-													Type:         schema.TypeString,
-													Required:     true,
-													ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(1, 512)),
-												},
-											},
-										},
-									},
-									"veeva": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"document_type": {
-													Type:         schema.TypeString,
-													Optional:     true,
-													ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`[\s\w_-]+`), "must contain only alphanumeric, underscore (_), and hyphen (-) characters"), validation.StringLenBetween(1, 512)),
-												},
-												"include_all_versions": {
-													Type:     schema.TypeBool,
-													Optional: true,
-												},
-												"include_renditions": {
-													Type:     schema.TypeBool,
-													Optional: true,
-												},
-												"include_source_files": {
-													Type:     schema.TypeBool,
-													Optional: true,
-												},
-												"object": {
-													Type:         schema.TypeString,
-													Required:     true,
-													ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(1, 512)),
-												},
-											},
-										},
-									},
-									"zendesk": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"object": {
-													Type:         schema.TypeString,
-													Required:     true,
-													ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(1, 512)),
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
+				names.AttrDescription: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringMatch(regexache.MustCompile(`[\w!@#\-.?,\s]*`), "must contain only alphanumeric, underscore (_), exclamation point (!), at sign (@), number sign (#), hyphen (-), period (.), question mark (?), comma (,), and whitespace characters"),
 				},
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			"task": {
-				Type:     schema.TypeSet,
-				Required: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"connector_operator": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"amplitude": {
-										Type:             schema.TypeString,
-										Optional:         true,
-										ValidateDiagFunc: enum.Validate[types.AmplitudeConnectorOperator](),
-									},
-									"custom_connector": {
-										Type:             schema.TypeString,
-										Optional:         true,
-										ValidateDiagFunc: enum.Validate[types.Operator](),
-									},
-									"datadog": {
-										Type:             schema.TypeString,
-										Optional:         true,
-										ValidateDiagFunc: enum.Validate[types.DatadogConnectorOperator](),
-									},
-									"dynatrace": {
-										Type:             schema.TypeString,
-										Optional:         true,
-										ValidateDiagFunc: enum.Validate[types.DynatraceConnectorOperator](),
-									},
-									"google_analytics": {
-										Type:             schema.TypeString,
-										Optional:         true,
-										ValidateDiagFunc: enum.Validate[types.GoogleAnalyticsConnectorOperator](),
-									},
-									"infor_nexus": {
-										Type:             schema.TypeString,
-										Optional:         true,
-										ValidateDiagFunc: enum.Validate[types.InforNexusConnectorOperator](),
-									},
-									"marketo": {
-										Type:             schema.TypeString,
-										Optional:         true,
-										ValidateDiagFunc: enum.Validate[types.MarketoConnectorOperator](),
-									},
-									"s3": {
-										Type:             schema.TypeString,
-										Optional:         true,
-										ValidateDiagFunc: enum.Validate[types.S3ConnectorOperator](),
-									},
-									"salesforce": {
-										Type:             schema.TypeString,
-										Optional:         true,
-										ValidateDiagFunc: enum.Validate[types.SalesforceConnectorOperator](),
-									},
-									"sapo_data": {
-										Type:             schema.TypeString,
-										Optional:         true,
-										ValidateDiagFunc: enum.Validate[types.SAPODataConnectorOperator](),
-									},
-									"service_now": {
-										Type:             schema.TypeString,
-										Optional:         true,
-										ValidateDiagFunc: enum.Validate[types.ServiceNowConnectorOperator](),
-									},
-									"singular": {
-										Type:             schema.TypeString,
-										Optional:         true,
-										ValidateDiagFunc: enum.Validate[types.SingularConnectorOperator](),
-									},
-									"slack": {
-										Type:             schema.TypeString,
-										Optional:         true,
-										ValidateDiagFunc: enum.Validate[types.SlackConnectorOperator](),
-									},
-									"trendmicro": {
-										Type:             schema.TypeString,
-										Optional:         true,
-										ValidateDiagFunc: enum.Validate[types.TrendmicroConnectorOperator](),
-									},
-									"veeva": {
-										Type:             schema.TypeString,
-										Optional:         true,
-										ValidateDiagFunc: enum.Validate[types.VeevaConnectorOperator](),
-									},
-									"zendesk": {
-										Type:             schema.TypeString,
-										Optional:         true,
-										ValidateDiagFunc: enum.Validate[types.ZendeskConnectorOperator](),
-									},
-								},
-							},
-						},
-						"destination_field": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							ValidateFunc: validation.StringLenBetween(0, 256),
-						},
-						"source_fields": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Computed: true,
-							Elem: &schema.Schema{
+				"destination_flow_config": {
+					Type:     schema.TypeList,
+					Required: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"api_version": {
 								Type:         schema.TypeString,
-								ValidateFunc: validation.StringLenBetween(0, 2048),
+								Optional:     true,
+								ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(1, 256)),
 							},
-							DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool {
-								if v, ok := d.Get("task").(*schema.Set); ok && v.Len() == 1 {
-									if tl, ok := v.List()[0].(map[string]any); ok && len(tl) > 0 {
-										if sf, ok := tl["source_fields"].([]any); ok && len(sf) == 1 {
-											if sf[0] == "" {
-												return oldValue == "0" && newValue == "1"
+							"connector_profile_name": {
+								Type:         schema.TypeString,
+								Optional:     true,
+								ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`[\w\/!@#+=.-]+`), "must contain only alphanumeric, underscore (_), forward slash (/), exclamation point (!), at sign (@), number sign (#), plus sign (+), equals sign (=), period (.), and hyphen (-) characters"), validation.StringLenBetween(1, 256)),
+							},
+							"connector_type": {
+								Type:             schema.TypeString,
+								Required:         true,
+								ValidateDiagFunc: enum.Validate[types.ConnectorType](),
+							},
+							"destination_connector_properties": {
+								Type:     schema.TypeList,
+								Required: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"custom_connector": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"custom_properties": {
+														Type:     schema.TypeMap,
+														Optional: true,
+														ValidateDiagFunc: validation.AllDiag(
+															validation.MapKeyLenBetween(1, 128),
+															validation.MapKeyMatch(regexache.MustCompile(`[\w]+`), "must contain only alphanumeric and underscore (_) characters"),
+														),
+														Elem: &schema.Schema{
+															Type:         schema.TypeString,
+															ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(0, 2048)),
+														},
+													},
+													"entity_name": {
+														Type:         schema.TypeString,
+														Required:     true,
+														ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(1, 1024)),
+													},
+													"error_handling_config": {
+														Type:     schema.TypeList,
+														Optional: true,
+														MaxItems: 1,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																names.AttrBucketName: {
+																	Type:         schema.TypeString,
+																	Optional:     true,
+																	ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(3, 63)),
+																},
+																names.AttrBucketPrefix: {
+																	Type:         schema.TypeString,
+																	Optional:     true,
+																	ValidateFunc: validation.StringLenBetween(0, 512),
+																},
+																"fail_on_first_destination_error": {
+																	Type:     schema.TypeBool,
+																	Optional: true,
+																},
+															},
+														},
+													},
+													"id_field_names": {
+														Type:     schema.TypeList,
+														Optional: true,
+														Elem: &schema.Schema{
+															Type:         schema.TypeString,
+															ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(0, 128)),
+														},
+													},
+													"write_operation_type": {
+														Type:             schema.TypeString,
+														Optional:         true,
+														ValidateDiagFunc: enum.Validate[types.WriteOperationType](),
+													},
+												},
+											},
+										},
+										"customer_profiles": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													names.AttrDomainName: {
+														Type:         schema.TypeString,
+														Required:     true,
+														ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(1, 64)),
+													},
+													"object_type_name": {
+														Type:         schema.TypeString,
+														Optional:     true,
+														ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(0, 255)),
+													},
+												},
+											},
+										},
+										"event_bridge": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"error_handling_config": {
+														Type:     schema.TypeList,
+														Optional: true,
+														MaxItems: 1,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																names.AttrBucketName: {
+																	Type:         schema.TypeString,
+																	Optional:     true,
+																	ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(3, 63)),
+																},
+																names.AttrBucketPrefix: {
+																	Type:         schema.TypeString,
+																	Optional:     true,
+																	ValidateFunc: validation.StringLenBetween(0, 512),
+																},
+																"fail_on_first_destination_error": {
+																	Type:     schema.TypeBool,
+																	Optional: true,
+																},
+															},
+														},
+													},
+													"object": {
+														Type:         schema.TypeString,
+														Required:     true,
+														ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(1, 512)),
+													},
+												},
+											},
+										},
+										"honeycode": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"error_handling_config": {
+														Type:     schema.TypeList,
+														Optional: true,
+														MaxItems: 1,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																names.AttrBucketName: {
+																	Type:         schema.TypeString,
+																	Optional:     true,
+																	ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(3, 63)),
+																},
+																names.AttrBucketPrefix: {
+																	Type:         schema.TypeString,
+																	Optional:     true,
+																	ValidateFunc: validation.StringLenBetween(0, 512),
+																},
+																"fail_on_first_destination_error": {
+																	Type:     schema.TypeBool,
+																	Optional: true,
+																},
+															},
+														},
+													},
+													"object": {
+														Type:         schema.TypeString,
+														Required:     true,
+														ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(1, 512)),
+													},
+												},
+											},
+										},
+										"lookout_metrics": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{},
+											},
+										},
+										"marketo": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"error_handling_config": {
+														Type:     schema.TypeList,
+														Optional: true,
+														MaxItems: 1,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																names.AttrBucketName: {
+																	Type:         schema.TypeString,
+																	Optional:     true,
+																	ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(3, 63)),
+																},
+																names.AttrBucketPrefix: {
+																	Type:         schema.TypeString,
+																	Optional:     true,
+																	ValidateFunc: validation.StringLenBetween(0, 512),
+																},
+																"fail_on_first_destination_error": {
+																	Type:     schema.TypeBool,
+																	Optional: true,
+																},
+															},
+														},
+													},
+													"object": {
+														Type:         schema.TypeString,
+														Required:     true,
+														ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(1, 512)),
+													},
+												},
+											},
+										},
+										"redshift": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													names.AttrBucketPrefix: {
+														Type:         schema.TypeString,
+														Optional:     true,
+														ValidateFunc: validation.StringLenBetween(0, 512),
+													},
+													"error_handling_config": {
+														Type:     schema.TypeList,
+														Optional: true,
+														MaxItems: 1,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																names.AttrBucketName: {
+																	Type:         schema.TypeString,
+																	Optional:     true,
+																	ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(3, 63)),
+																},
+																names.AttrBucketPrefix: {
+																	Type:         schema.TypeString,
+																	Optional:     true,
+																	ValidateFunc: validation.StringLenBetween(0, 512),
+																},
+																"fail_on_first_destination_error": {
+																	Type:     schema.TypeBool,
+																	Optional: true,
+																},
+															},
+														},
+													},
+													"intermediate_bucket_name": {
+														Type:         schema.TypeString,
+														Required:     true,
+														ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(3, 63)),
+													},
+													"object": {
+														Type:         schema.TypeString,
+														Required:     true,
+														ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(1, 512)),
+													},
+												},
+											},
+										},
+										"s3": {
+											Type:     schema.TypeList,
+											Optional: true,
+											Computed: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													names.AttrBucketName: {
+														Type:         schema.TypeString,
+														Required:     true,
+														ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(3, 63)),
+													},
+													names.AttrBucketPrefix: {
+														Type:         schema.TypeString,
+														Optional:     true,
+														Computed:     true,
+														ValidateFunc: validation.StringLenBetween(0, 512),
+													},
+													"s3_output_format_config": {
+														Type:     schema.TypeList,
+														Optional: true,
+														Computed: true,
+														MaxItems: 1,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																"aggregation_config": {
+																	Type:     schema.TypeList,
+																	Optional: true,
+																	Computed: true,
+																	MaxItems: 1,
+																	Elem: &schema.Resource{
+																		Schema: map[string]*schema.Schema{
+																			"aggregation_type": {
+																				Type:             schema.TypeString,
+																				Optional:         true,
+																				Computed:         true,
+																				ValidateDiagFunc: enum.Validate[types.AggregationType](),
+																			},
+																			"target_file_size": {
+																				Type:     schema.TypeInt,
+																				Optional: true,
+																				Computed: true,
+																			},
+																		},
+																	},
+																},
+																"file_type": {
+																	Type:             schema.TypeString,
+																	Optional:         true,
+																	ValidateDiagFunc: enum.Validate[types.FileType](),
+																},
+																"prefix_config": {
+																	Type:     schema.TypeList,
+																	Optional: true,
+																	Computed: true,
+																	MaxItems: 1,
+																	Elem: &schema.Resource{
+																		Schema: map[string]*schema.Schema{
+																			"prefix_hierarchy": {
+																				Type:     schema.TypeList,
+																				Optional: true,
+																				Computed: true,
+																				Elem: &schema.Schema{
+																					Type:             schema.TypeString,
+																					ValidateDiagFunc: enum.Validate[types.PathPrefix](),
+																				},
+																			},
+																			"prefix_format": {
+																				Type:             schema.TypeString,
+																				Optional:         true,
+																				ValidateDiagFunc: enum.Validate[types.PrefixFormat](),
+																			},
+																			"prefix_type": {
+																				Type:             schema.TypeString,
+																				Optional:         true,
+																				ValidateDiagFunc: enum.Validate[types.PrefixType](),
+																			},
+																		},
+																	},
+																},
+																"preserve_source_data_typing": {
+																	Type:     schema.TypeBool,
+																	Optional: true,
+																	Computed: true,
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+										"salesforce": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"data_transfer_api": {
+														Type:             schema.TypeString,
+														Optional:         true,
+														ValidateDiagFunc: enum.Validate[types.SalesforceDataTransferApi](),
+													},
+													"error_handling_config": {
+														Type:     schema.TypeList,
+														Optional: true,
+														MaxItems: 1,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																names.AttrBucketName: {
+																	Type:         schema.TypeString,
+																	Optional:     true,
+																	ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(3, 63)),
+																},
+																names.AttrBucketPrefix: {
+																	Type:         schema.TypeString,
+																	Optional:     true,
+																	ValidateFunc: validation.StringLenBetween(0, 512),
+																},
+																"fail_on_first_destination_error": {
+																	Type:     schema.TypeBool,
+																	Optional: true,
+																},
+															},
+														},
+													},
+													"id_field_names": {
+														Type:     schema.TypeList,
+														Optional: true,
+														Elem: &schema.Schema{
+															Type:         schema.TypeString,
+															ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(0, 128)),
+														},
+													},
+													"object": {
+														Type:         schema.TypeString,
+														Required:     true,
+														ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(1, 512)),
+													},
+													"write_operation_type": {
+														Type:             schema.TypeString,
+														Optional:         true,
+														ValidateDiagFunc: enum.Validate[types.WriteOperationType](),
+													},
+												},
+											},
+										},
+										"sapo_data": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"error_handling_config": {
+														Type:     schema.TypeList,
+														Optional: true,
+														MaxItems: 1,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																names.AttrBucketName: {
+																	Type:         schema.TypeString,
+																	Optional:     true,
+																	ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(3, 63)),
+																},
+																names.AttrBucketPrefix: {
+																	Type:         schema.TypeString,
+																	Optional:     true,
+																	ValidateFunc: validation.StringLenBetween(0, 512),
+																},
+																"fail_on_first_destination_error": {
+																	Type:     schema.TypeBool,
+																	Optional: true,
+																},
+															},
+														},
+													},
+													"id_field_names": {
+														Type:     schema.TypeList,
+														Optional: true,
+														Elem: &schema.Schema{
+															Type:         schema.TypeString,
+															ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(0, 128)),
+														},
+													},
+													"object_path": {
+														Type:         schema.TypeString,
+														Required:     true,
+														ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(1, 512)),
+													},
+													"success_response_handling_config": {
+														Type:     schema.TypeList,
+														Optional: true,
+														MaxItems: 1,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																names.AttrBucketName: {
+																	Type:         schema.TypeString,
+																	Optional:     true,
+																	ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(3, 63)),
+																},
+																names.AttrBucketPrefix: {
+																	Type:         schema.TypeString,
+																	Optional:     true,
+																	ValidateFunc: validation.StringLenBetween(0, 512),
+																},
+															},
+														},
+													},
+													"write_operation_type": {
+														Type:             schema.TypeString,
+														Optional:         true,
+														ValidateDiagFunc: enum.Validate[types.WriteOperationType](),
+													},
+												},
+											},
+										},
+										"snowflake": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													names.AttrBucketPrefix: {
+														Type:         schema.TypeString,
+														Optional:     true,
+														ValidateFunc: validation.StringLenBetween(0, 512),
+													},
+													"error_handling_config": {
+														Type:     schema.TypeList,
+														Optional: true,
+														MaxItems: 1,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																names.AttrBucketName: {
+																	Type:         schema.TypeString,
+																	Optional:     true,
+																	ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(3, 63)),
+																},
+																names.AttrBucketPrefix: {
+																	Type:         schema.TypeString,
+																	Optional:     true,
+																	ValidateFunc: validation.StringLenBetween(0, 512),
+																},
+																"fail_on_first_destination_error": {
+																	Type:     schema.TypeBool,
+																	Optional: true,
+																},
+															},
+														},
+													},
+													"intermediate_bucket_name": {
+														Type:         schema.TypeString,
+														Required:     true,
+														ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(3, 63)),
+													},
+													"object": {
+														Type:         schema.TypeString,
+														Required:     true,
+														ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(1, 512)),
+													},
+												},
+											},
+										},
+										"upsolver": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													names.AttrBucketName: {
+														Type:         schema.TypeString,
+														Required:     true,
+														ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`^(upsolver-appflow)\S*`), "must start with 'upsolver-appflow' and can not contain any whitespace characters"), validation.StringLenBetween(3, 63)),
+													},
+													names.AttrBucketPrefix: {
+														Type:         schema.TypeString,
+														Optional:     true,
+														ValidateFunc: validation.StringLenBetween(0, 512),
+													},
+													"s3_output_format_config": {
+														Type:     schema.TypeList,
+														Required: true,
+														MaxItems: 1,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																"aggregation_config": {
+																	Type:     schema.TypeList,
+																	Optional: true,
+																	MaxItems: 1,
+																	Elem: &schema.Resource{
+																		Schema: map[string]*schema.Schema{
+																			"aggregation_type": {
+																				Type:             schema.TypeString,
+																				Optional:         true,
+																				ValidateDiagFunc: enum.Validate[types.AggregationType](),
+																			},
+																		},
+																	},
+																},
+																"file_type": {
+																	Type:             schema.TypeString,
+																	Optional:         true,
+																	ValidateDiagFunc: enum.Validate[types.FileType](),
+																},
+																"prefix_config": {
+																	Type:     schema.TypeList,
+																	Required: true,
+																	MaxItems: 1,
+																	Elem: &schema.Resource{
+																		Schema: map[string]*schema.Schema{
+																			"prefix_hierarchy": {
+																				Type:     schema.TypeList,
+																				Optional: true,
+																				Computed: true,
+																				Elem: &schema.Schema{
+																					Type:             schema.TypeString,
+																					ValidateDiagFunc: enum.Validate[types.PathPrefix](),
+																				},
+																			},
+																			"prefix_format": {
+																				Type:             schema.TypeString,
+																				Optional:         true,
+																				ValidateDiagFunc: enum.Validate[types.PrefixFormat](),
+																			},
+																			"prefix_type": {
+																				Type:             schema.TypeString,
+																				Required:         true,
+																				ValidateDiagFunc: enum.Validate[types.PrefixType](),
+																			},
+																		},
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+										"zendesk": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"error_handling_config": {
+														Type:     schema.TypeList,
+														Optional: true,
+														MaxItems: 1,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																names.AttrBucketName: {
+																	Type:         schema.TypeString,
+																	Optional:     true,
+																	ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(3, 63)),
+																},
+																names.AttrBucketPrefix: {
+																	Type:         schema.TypeString,
+																	Optional:     true,
+																	ValidateFunc: validation.StringLenBetween(0, 512),
+																},
+																"fail_on_first_destination_error": {
+																	Type:     schema.TypeBool,
+																	Optional: true,
+																},
+															},
+														},
+													},
+													"id_field_names": {
+														Type:     schema.TypeList,
+														Optional: true,
+														Elem: &schema.Schema{
+															Type:         schema.TypeString,
+															ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(0, 128)),
+														},
+													},
+													"object": {
+														Type:         schema.TypeString,
+														Required:     true,
+														ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(1, 512)),
+													},
+													"write_operation_type": {
+														Type:             schema.TypeString,
+														Optional:         true,
+														ValidateDiagFunc: enum.Validate[types.WriteOperationType](),
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				"flow_status": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"kms_arn": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Computed:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringMatch(regexache.MustCompile(`arn:.*:kms:.*:[0-9]+:.*`), "must be a valid ARN of a Key Management Services (KMS) key"),
+				},
+				names.AttrName: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`[0-9A-Za-z][\w!@#.-]+`), "must contain only alphanumeric, exclamation point (!), at sign (@), number sign (#), period (.), and hyphen (-) characters"), validation.StringLenBetween(1, 256)),
+				},
+				"source_flow_config": {
+					Type:     schema.TypeList,
+					Required: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"api_version": {
+								Type:         schema.TypeString,
+								Optional:     true,
+								ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(1, 256)),
+							},
+							"connector_profile_name": {
+								Type:         schema.TypeString,
+								Optional:     true,
+								ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`[\w\/!@#+=.-]+`), "must contain only alphanumeric, underscore (_), forward slash (/), exclamation point (!), at sign (@), number sign (#), plus sign (+), equals sign (=), period (.), and hyphen (-) characters"), validation.StringLenBetween(1, 256)),
+							},
+							"connector_type": {
+								Type:             schema.TypeString,
+								Required:         true,
+								ValidateDiagFunc: enum.Validate[types.ConnectorType](),
+							},
+							"incremental_pull_config": {
+								Type:     schema.TypeList,
+								Optional: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"datetime_type_field_name": {
+											Type:         schema.TypeString,
+											Optional:     true,
+											ValidateFunc: validation.StringLenBetween(0, 256),
+										},
+									},
+								},
+							},
+							"source_connector_properties": {
+								Type:     schema.TypeList,
+								Required: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"amplitude": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"object": {
+														Type:         schema.TypeString,
+														Required:     true,
+														ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(1, 512)),
+													},
+												},
+											},
+										},
+										"custom_connector": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"custom_properties": {
+														Type:     schema.TypeMap,
+														Optional: true,
+														ValidateDiagFunc: validation.AllDiag(
+															validation.MapKeyLenBetween(1, 128),
+															validation.MapKeyMatch(regexache.MustCompile(`[\w]+`), "must contain only alphanumeric and underscore (_) characters"),
+														),
+														Elem: &schema.Schema{
+															Type:         schema.TypeString,
+															ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(0, 2048)),
+														},
+													},
+													"entity_name": {
+														Type:         schema.TypeString,
+														Required:     true,
+														ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(1, 1024)),
+													},
+												},
+											},
+										},
+										"datadog": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"object": {
+														Type:         schema.TypeString,
+														Required:     true,
+														ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(1, 512)),
+													},
+												},
+											},
+										},
+										"dynatrace": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"object": {
+														Type:         schema.TypeString,
+														Required:     true,
+														ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(1, 512)),
+													},
+												},
+											},
+										},
+										"google_analytics": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"object": {
+														Type:         schema.TypeString,
+														Required:     true,
+														ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(1, 512)),
+													},
+												},
+											},
+										},
+										"infor_nexus": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"object": {
+														Type:         schema.TypeString,
+														Required:     true,
+														ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(1, 512)),
+													},
+												},
+											},
+										},
+										"marketo": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"object": {
+														Type:         schema.TypeString,
+														Required:     true,
+														ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(1, 512)),
+													},
+												},
+											},
+										},
+										"s3": {
+											Type:     schema.TypeList,
+											Optional: true,
+											Computed: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													names.AttrBucketName: {
+														Type:         schema.TypeString,
+														Required:     true,
+														ForceNew:     true,
+														ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(3, 63)),
+													},
+													names.AttrBucketPrefix: {
+														Type:         schema.TypeString,
+														Required:     true,
+														ForceNew:     true,
+														ValidateFunc: validation.StringLenBetween(0, 512),
+													},
+													"s3_input_format_config": {
+														Type:     schema.TypeList,
+														Optional: true,
+														MaxItems: 1,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																"s3_input_file_type": {
+																	Type:             schema.TypeString,
+																	Optional:         true,
+																	ValidateDiagFunc: enum.Validate[types.S3InputFileType](),
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+										"salesforce": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"data_transfer_api": {
+														Type:             schema.TypeString,
+														Optional:         true,
+														ValidateDiagFunc: enum.Validate[types.SalesforceDataTransferApi](),
+													},
+													"enable_dynamic_field_update": {
+														Type:     schema.TypeBool,
+														Optional: true,
+													},
+													"include_deleted_records": {
+														Type:     schema.TypeBool,
+														Optional: true,
+													},
+													"object": {
+														Type:         schema.TypeString,
+														Required:     true,
+														ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(1, 512)),
+													},
+												},
+											},
+										},
+										"sapo_data": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"object_path": {
+														Type:         schema.TypeString,
+														Required:     true,
+														ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(1, 512)),
+													},
+													"pagination_config": {
+														Type:     schema.TypeList,
+														Optional: true,
+														MaxItems: 1,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																"max_page_size": {
+																	Type:         schema.TypeInt,
+																	Required:     true,
+																	ValidateFunc: validation.IntBetween(1, 10000),
+																},
+															},
+														},
+													},
+													"parallelism_config": {
+														Type:     schema.TypeList,
+														Optional: true,
+														MaxItems: 1,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																"max_page_size": {
+																	Type:         schema.TypeInt,
+																	Required:     true,
+																	ValidateFunc: validation.IntBetween(1, 10),
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+										"service_now": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"object": {
+														Type:         schema.TypeString,
+														Required:     true,
+														ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(1, 512)),
+													},
+												},
+											},
+										},
+										"singular": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"object": {
+														Type:         schema.TypeString,
+														Required:     true,
+														ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(1, 512)),
+													},
+												},
+											},
+										},
+										"slack": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"object": {
+														Type:         schema.TypeString,
+														Required:     true,
+														ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(1, 512)),
+													},
+												},
+											},
+										},
+										"trendmicro": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"object": {
+														Type:         schema.TypeString,
+														Required:     true,
+														ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(1, 512)),
+													},
+												},
+											},
+										},
+										"veeva": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"document_type": {
+														Type:         schema.TypeString,
+														Optional:     true,
+														ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`[\s\w_-]+`), "must contain only alphanumeric, underscore (_), and hyphen (-) characters"), validation.StringLenBetween(1, 512)),
+													},
+													"include_all_versions": {
+														Type:     schema.TypeBool,
+														Optional: true,
+													},
+													"include_renditions": {
+														Type:     schema.TypeBool,
+														Optional: true,
+													},
+													"include_source_files": {
+														Type:     schema.TypeBool,
+														Optional: true,
+													},
+													"object": {
+														Type:         schema.TypeString,
+														Required:     true,
+														ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(1, 512)),
+													},
+												},
+											},
+										},
+										"zendesk": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"object": {
+														Type:         schema.TypeString,
+														Required:     true,
+														ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(1, 512)),
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				"task": {
+					Type:     schema.TypeSet,
+					Required: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"connector_operator": {
+								Type:     schema.TypeList,
+								Optional: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"amplitude": {
+											Type:             schema.TypeString,
+											Optional:         true,
+											ValidateDiagFunc: enum.Validate[types.AmplitudeConnectorOperator](),
+										},
+										"custom_connector": {
+											Type:             schema.TypeString,
+											Optional:         true,
+											ValidateDiagFunc: enum.Validate[types.Operator](),
+										},
+										"datadog": {
+											Type:             schema.TypeString,
+											Optional:         true,
+											ValidateDiagFunc: enum.Validate[types.DatadogConnectorOperator](),
+										},
+										"dynatrace": {
+											Type:             schema.TypeString,
+											Optional:         true,
+											ValidateDiagFunc: enum.Validate[types.DynatraceConnectorOperator](),
+										},
+										"google_analytics": {
+											Type:             schema.TypeString,
+											Optional:         true,
+											ValidateDiagFunc: enum.Validate[types.GoogleAnalyticsConnectorOperator](),
+										},
+										"infor_nexus": {
+											Type:             schema.TypeString,
+											Optional:         true,
+											ValidateDiagFunc: enum.Validate[types.InforNexusConnectorOperator](),
+										},
+										"marketo": {
+											Type:             schema.TypeString,
+											Optional:         true,
+											ValidateDiagFunc: enum.Validate[types.MarketoConnectorOperator](),
+										},
+										"s3": {
+											Type:             schema.TypeString,
+											Optional:         true,
+											ValidateDiagFunc: enum.Validate[types.S3ConnectorOperator](),
+										},
+										"salesforce": {
+											Type:             schema.TypeString,
+											Optional:         true,
+											ValidateDiagFunc: enum.Validate[types.SalesforceConnectorOperator](),
+										},
+										"sapo_data": {
+											Type:             schema.TypeString,
+											Optional:         true,
+											ValidateDiagFunc: enum.Validate[types.SAPODataConnectorOperator](),
+										},
+										"service_now": {
+											Type:             schema.TypeString,
+											Optional:         true,
+											ValidateDiagFunc: enum.Validate[types.ServiceNowConnectorOperator](),
+										},
+										"singular": {
+											Type:             schema.TypeString,
+											Optional:         true,
+											ValidateDiagFunc: enum.Validate[types.SingularConnectorOperator](),
+										},
+										"slack": {
+											Type:             schema.TypeString,
+											Optional:         true,
+											ValidateDiagFunc: enum.Validate[types.SlackConnectorOperator](),
+										},
+										"trendmicro": {
+											Type:             schema.TypeString,
+											Optional:         true,
+											ValidateDiagFunc: enum.Validate[types.TrendmicroConnectorOperator](),
+										},
+										"veeva": {
+											Type:             schema.TypeString,
+											Optional:         true,
+											ValidateDiagFunc: enum.Validate[types.VeevaConnectorOperator](),
+										},
+										"zendesk": {
+											Type:             schema.TypeString,
+											Optional:         true,
+											ValidateDiagFunc: enum.Validate[types.ZendeskConnectorOperator](),
+										},
+									},
+								},
+							},
+							"destination_field": {
+								Type:         schema.TypeString,
+								Optional:     true,
+								ValidateFunc: validation.StringLenBetween(0, 256),
+							},
+							"source_fields": {
+								Type:     schema.TypeList,
+								Optional: true,
+								Computed: true,
+								Elem: &schema.Schema{
+									Type:         schema.TypeString,
+									ValidateFunc: validation.StringLenBetween(0, 2048),
+								},
+								DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool {
+									if v, ok := d.Get("task").(*schema.Set); ok && v.Len() == 1 {
+										if tl, ok := v.List()[0].(map[string]any); ok && len(tl) > 0 {
+											if sf, ok := tl["source_fields"].([]any); ok && len(sf) == 1 {
+												if sf[0] == "" {
+													return oldValue == "0" && newValue == "1"
+												}
 											}
 										}
 									}
-								}
-								return false
+									return false
+								},
 							},
-						},
-						"task_properties": {
-							Type:     schema.TypeMap,
-							Optional: true,
-							Elem: &schema.Schema{
-								Type:         schema.TypeString,
-								ValidateFunc: validation.StringLenBetween(0, 2048),
+							"task_properties": {
+								Type:     schema.TypeMap,
+								Optional: true,
+								Elem: &schema.Schema{
+									Type:         schema.TypeString,
+									ValidateFunc: validation.StringLenBetween(0, 2048),
+								},
 							},
-						},
-						"task_type": {
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: enum.Validate[types.TaskType](),
+							"task_type": {
+								Type:             schema.TypeString,
+								Required:         true,
+								ValidateDiagFunc: enum.Validate[types.TaskType](),
+							},
 						},
 					},
 				},
-			},
-			"trigger_config": {
-				Type:     schema.TypeList,
-				Required: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"trigger_properties": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Computed: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"scheduled": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"data_pull_mode": {
-													Type:             schema.TypeString,
-													Optional:         true,
-													ValidateDiagFunc: enum.Validate[types.DataPullMode](),
-												},
-												"first_execution_from": {
-													Type:         schema.TypeString,
-													Optional:     true,
-													ValidateFunc: validation.IsRFC3339Time,
-												},
-												"schedule_end_time": {
-													Type:         schema.TypeString,
-													Optional:     true,
-													ValidateFunc: validation.IsRFC3339Time,
-												},
-												names.AttrScheduleExpression: {
-													Type:         schema.TypeString,
-													Required:     true,
-													ValidateFunc: validation.StringLenBetween(1, 256),
-												},
-												"schedule_offset": {
-													Type:         schema.TypeInt,
-													Optional:     true,
-													ValidateFunc: validation.IntBetween(0, 36000),
-												},
-												"schedule_start_time": {
-													Type:         schema.TypeString,
-													Optional:     true,
-													ValidateFunc: validation.IsRFC3339Time,
-												},
-												"timezone": {
-													Type:         schema.TypeString,
-													Optional:     true,
-													ValidateFunc: validation.StringLenBetween(0, 256),
+				"trigger_config": {
+					Type:     schema.TypeList,
+					Required: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"trigger_properties": {
+								Type:     schema.TypeList,
+								Optional: true,
+								Computed: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"scheduled": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"data_pull_mode": {
+														Type:             schema.TypeString,
+														Optional:         true,
+														ValidateDiagFunc: enum.Validate[types.DataPullMode](),
+													},
+													"first_execution_from": {
+														Type:         schema.TypeString,
+														Optional:     true,
+														ValidateFunc: validation.IsRFC3339Time,
+													},
+													"schedule_end_time": {
+														Type:         schema.TypeString,
+														Optional:     true,
+														ValidateFunc: validation.IsRFC3339Time,
+													},
+													names.AttrScheduleExpression: {
+														Type:         schema.TypeString,
+														Required:     true,
+														ValidateFunc: validation.StringLenBetween(1, 256),
+													},
+													"schedule_offset": {
+														Type:         schema.TypeInt,
+														Optional:     true,
+														ValidateFunc: validation.IntBetween(0, 36000),
+													},
+													"schedule_start_time": {
+														Type:         schema.TypeString,
+														Optional:     true,
+														ValidateFunc: validation.IsRFC3339Time,
+													},
+													"timezone": {
+														Type:         schema.TypeString,
+														Optional:     true,
+														ValidateFunc: validation.StringLenBetween(0, 256),
+													},
 												},
 											},
 										},
 									},
 								},
 							},
-						},
-						"trigger_type": {
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: enum.Validate[types.TriggerType](),
+							"trigger_type": {
+								Type:             schema.TypeString,
+								Required:         true,
+								ValidateDiagFunc: enum.Validate[types.TriggerType](),
+							},
 						},
 					},
 				},
-			},
-			"metadata_catalog_config": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Computed: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"glue_data_catalog": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									names.AttrDatabaseName: {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-									names.AttrRoleARN: {
-										Type:             schema.TypeString,
-										Required:         true,
-										ValidateDiagFunc: validation.ToDiagFunc(verify.ValidARN),
-									},
-									"table_prefix": {
-										Type:     schema.TypeString,
-										Required: true,
+				"metadata_catalog_config": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Computed: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"glue_data_catalog": {
+								Type:     schema.TypeList,
+								Optional: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										names.AttrDatabaseName: {
+											Type:     schema.TypeString,
+											Required: true,
+										},
+										names.AttrRoleARN: {
+											Type:             schema.TypeString,
+											Required:         true,
+											ValidateDiagFunc: validation.ToDiagFunc(verify.ValidARN),
+										},
+										"table_prefix": {
+											Type:     schema.TypeString,
+											Required: true,
+										},
 									},
 								},
 							},
 						},
 					},
 				},
-			},
+			}
 		},
 	}
 }

--- a/internal/service/appintegrations/data_integration.go
+++ b/internal/service/appintegrations/data_integration.go
@@ -40,72 +40,74 @@ func resourceDataIntegration() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrDescription: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringLenBetween(1, 1000),
-			},
-			names.AttrKMSKey: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringLenBetween(1, 255),
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-				ValidateFunc: validation.All(
-					validation.StringLenBetween(1, 255),
-					validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z\/\._\-]+$`), "should be not be more than 255 alphanumeric, forward slashes, dots, underscores, or hyphen characters"),
-				),
-			},
-			"schedule_config": {
-				Type:     schema.TypeList,
-				MaxItems: 1,
-				Required: true,
-				ForceNew: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"first_execution_from": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ForceNew:     true,
-							ValidateFunc: validation.StringLenBetween(1, 255),
-						},
-						"object": {
-							Type:     schema.TypeString,
-							Required: true,
-							ForceNew: true,
-							ValidateFunc: validation.All(
-								validation.StringLenBetween(1, 255),
-								validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z\/\._\-]+$`), "should be not be more than 255 alphanumeric, forward slashes, dots, underscores, or hyphen characters"),
-							),
-						},
-						names.AttrScheduleExpression: {
-							Type:         schema.TypeString,
-							Required:     true,
-							ForceNew:     true,
-							ValidateFunc: validation.StringLenBetween(1, 255),
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrDescription: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringLenBetween(1, 1000),
+				},
+				names.AttrKMSKey: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringLenBetween(1, 255),
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+					ValidateFunc: validation.All(
+						validation.StringLenBetween(1, 255),
+						validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z\/\._\-]+$`), "should be not be more than 255 alphanumeric, forward slashes, dots, underscores, or hyphen characters"),
+					),
+				},
+				"schedule_config": {
+					Type:     schema.TypeList,
+					MaxItems: 1,
+					Required: true,
+					ForceNew: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"first_execution_from": {
+								Type:         schema.TypeString,
+								Required:     true,
+								ForceNew:     true,
+								ValidateFunc: validation.StringLenBetween(1, 255),
+							},
+							"object": {
+								Type:     schema.TypeString,
+								Required: true,
+								ForceNew: true,
+								ValidateFunc: validation.All(
+									validation.StringLenBetween(1, 255),
+									validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z\/\._\-]+$`), "should be not be more than 255 alphanumeric, forward slashes, dots, underscores, or hyphen characters"),
+								),
+							},
+							names.AttrScheduleExpression: {
+								Type:         schema.TypeString,
+								Required:     true,
+								ForceNew:     true,
+								ValidateFunc: validation.StringLenBetween(1, 255),
+							},
 						},
 					},
 				},
-			},
-			"source_uri": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-				ValidateFunc: validation.All(
-					validation.StringLenBetween(1, 1000),
-					validation.StringMatch(regexache.MustCompile(`^(\w+\:\/\/[\w.-]+[\w/!@#+=.-]+$)|(\w+\:\/\/[\w.-]+[\w/!@#+=.-]+[\w/!@#+=.-]+[\w/!@#+=.,-]+$)`), "should be a valid source uri"),
-				),
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				"source_uri": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+					ValidateFunc: validation.All(
+						validation.StringLenBetween(1, 1000),
+						validation.StringMatch(regexache.MustCompile(`^(\w+\:\/\/[\w.-]+[\w/!@#+=.-]+$)|(\w+\:\/\/[\w.-]+[\w/!@#+=.-]+[\w/!@#+=.-]+[\w/!@#+=.,-]+$)`), "should be a valid source uri"),
+					),
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			}
 		},
 	}
 }

--- a/internal/service/appintegrations/event_integration.go
+++ b/internal/service/appintegrations/event_integration.go
@@ -36,46 +36,48 @@ func resourceEventIntegration() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrDescription: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringLenBetween(1, 1000),
-			},
-			"eventbridge_bus": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z\/\._\-]{1,255}$`), "should be not be more than 255 alphanumeric, forward slashes, dots, underscores, or hyphen characters"),
-			},
-			"event_filter": {
-				Type:     schema.TypeList,
-				MaxItems: 1,
-				Required: true,
-				ForceNew: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrSource: {
-							Type:         schema.TypeString,
-							Required:     true,
-							ForceNew:     true,
-							ValidateFunc: validation.StringMatch(regexache.MustCompile(`^aws\.partner\/.*$`), "should be not be more than 255 alphanumeric, forward slashes, dots, underscores, or hyphen characters"),
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrDescription: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringLenBetween(1, 1000),
+				},
+				"eventbridge_bus": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z\/\._\-]{1,255}$`), "should be not be more than 255 alphanumeric, forward slashes, dots, underscores, or hyphen characters"),
+				},
+				"event_filter": {
+					Type:     schema.TypeList,
+					MaxItems: 1,
+					Required: true,
+					ForceNew: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrSource: {
+								Type:         schema.TypeString,
+								Required:     true,
+								ForceNew:     true,
+								ValidateFunc: validation.StringMatch(regexache.MustCompile(`^aws\.partner\/.*$`), "should be not be more than 255 alphanumeric, forward slashes, dots, underscores, or hyphen characters"),
+							},
 						},
 					},
 				},
-			},
-			names.AttrName: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z\/\._\-]{1,255}$`), "should be not be more than 255 alphanumeric, forward slashes, dots, underscores, or hyphen characters"),
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				names.AttrName: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z\/\._\-]{1,255}$`), "should be not be more than 255 alphanumeric, forward slashes, dots, underscores, or hyphen characters"),
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			}
 		},
 	}
 }

--- a/internal/service/appintegrations/event_integration_data_source.go
+++ b/internal/service/appintegrations/event_integration_data_source.go
@@ -25,36 +25,38 @@ func dataSourceEventIntegration() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceEventIntegrationRead,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrDescription: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"event_filter": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrSource: {
-							Type:     schema.TypeString,
-							Computed: true,
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrDescription: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"event_filter": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrSource: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
 						},
 					},
 				},
-			},
-			"eventbridge_bus": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			names.AttrTags: tftags.TagsSchemaComputed(),
+				"eventbridge_bus": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				names.AttrTags: tftags.TagsSchemaComputed(),
+			}
 		},
 	}
 }

--- a/internal/service/applicationinsights/application.go
+++ b/internal/service/applicationinsights/application.go
@@ -40,46 +40,48 @@ func resourceApplication() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"auto_config_enabled": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
-			"auto_create": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				ForceNew: true,
-			},
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"cwe_monitor_enabled": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
-			"grouping_type": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				ForceNew:         true,
-				ValidateDiagFunc: enum.Validate[awstypes.GroupingType](),
-			},
-			"ops_center_enabled": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
-			"ops_item_sns_topic_arn": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			"resource_group_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"auto_config_enabled": {
+					Type:     schema.TypeBool,
+					Optional: true,
+				},
+				"auto_create": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					ForceNew: true,
+				},
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"cwe_monitor_enabled": {
+					Type:     schema.TypeBool,
+					Optional: true,
+				},
+				"grouping_type": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					ForceNew:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.GroupingType](),
+				},
+				"ops_center_enabled": {
+					Type:     schema.TypeBool,
+					Optional: true,
+				},
+				"ops_item_sns_topic_arn": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				"resource_group_name": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			}
 		},
 	}
 }

--- a/internal/service/apprunner/auto_scaling_configuration_version.go
+++ b/internal/service/apprunner/auto_scaling_configuration_version.go
@@ -37,59 +37,61 @@ func resourceAutoScalingConfigurationVersion() *schema.Resource {
 		UpdateWithoutTimeout: resourceAutoScalingConfigurationUpdate,
 		DeleteWithoutTimeout: resourceAutoScalingConfigurationDelete,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"auto_scaling_configuration_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"auto_scaling_configuration_revision": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-			"has_associated_service": {
-				Type:     schema.TypeBool,
-				Computed: true,
-			},
-			"is_default": {
-				Type:     schema.TypeBool,
-				Computed: true,
-			},
-			"latest": {
-				Type:     schema.TypeBool,
-				Computed: true,
-			},
-			"max_concurrency": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				Default:      100,
-				ForceNew:     true,
-				ValidateFunc: validation.IntBetween(1, 200),
-			},
-			"max_size": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				Default:      25,
-				ForceNew:     true,
-				ValidateFunc: validation.IntAtLeast(1),
-			},
-			"min_size": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				Default:      1,
-				ForceNew:     true,
-				ValidateFunc: validation.IntAtLeast(1),
-			},
-			names.AttrStatus: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"auto_scaling_configuration_name": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"auto_scaling_configuration_revision": {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
+				"has_associated_service": {
+					Type:     schema.TypeBool,
+					Computed: true,
+				},
+				"is_default": {
+					Type:     schema.TypeBool,
+					Computed: true,
+				},
+				"latest": {
+					Type:     schema.TypeBool,
+					Computed: true,
+				},
+				"max_concurrency": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					Default:      100,
+					ForceNew:     true,
+					ValidateFunc: validation.IntBetween(1, 200),
+				},
+				"max_size": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					Default:      25,
+					ForceNew:     true,
+					ValidateFunc: validation.IntAtLeast(1),
+				},
+				"min_size": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					Default:      1,
+					ForceNew:     true,
+					ValidateFunc: validation.IntAtLeast(1),
+				},
+				names.AttrStatus: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			}
 		},
 	}
 }

--- a/internal/service/apprunner/connection.go
+++ b/internal/service/apprunner/connection.go
@@ -38,28 +38,30 @@ func resourceConnection() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"connection_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"provider_type": {
-				Type:             schema.TypeString,
-				Required:         true,
-				ForceNew:         true,
-				ValidateDiagFunc: enum.Validate[types.ProviderType](),
-			},
-			names.AttrStatus: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"connection_name": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"provider_type": {
+					Type:             schema.TypeString,
+					Required:         true,
+					ForceNew:         true,
+					ValidateDiagFunc: enum.Validate[types.ProviderType](),
+				},
+				names.AttrStatus: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			}
 		},
 	}
 }

--- a/internal/service/apprunner/custom_domain_association.go
+++ b/internal/service/apprunner/custom_domain_association.go
@@ -39,57 +39,59 @@ func resourceCustomDomainAssociation() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"certificate_validation_records": {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrName: {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						names.AttrStatus: {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						names.AttrType: {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						names.AttrValue: {
-							Type:     schema.TypeString,
-							Computed: true,
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"certificate_validation_records": {
+					Type:     schema.TypeSet,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrName: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							names.AttrStatus: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							names.AttrType: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							names.AttrValue: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
 						},
 					},
 				},
-			},
-			"dns_target": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrDomainName: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(1, 255),
-			},
-			"enable_www_subdomain": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
-				ForceNew: true,
-			},
-			"service_arn": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			names.AttrStatus: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+				"dns_target": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrDomainName: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringLenBetween(1, 255),
+				},
+				"enable_www_subdomain": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  true,
+					ForceNew: true,
+				},
+				"service_arn": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				names.AttrStatus: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/apprunner/observability_configuration.go
+++ b/internal/service/apprunner/observability_configuration.go
@@ -35,44 +35,46 @@ func resourceObservabilityConfiguration() *schema.Resource {
 		ReadWithoutTimeout:   resourceObservabilityConfigurationRead,
 		UpdateWithoutTimeout: resourceObservabilityConfigurationUpdate,
 		DeleteWithoutTimeout: resourceObservabilityConfigurationDelete,
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"latest": {
-				Type:     schema.TypeBool,
-				Computed: true,
-			},
-			"observability_configuration_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"observability_configuration_revision": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-			names.AttrStatus: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			"trace_configuration": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"vendor": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							ValidateDiagFunc: enum.Validate[types.TracingVendor](),
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"latest": {
+					Type:     schema.TypeBool,
+					Computed: true,
+				},
+				"observability_configuration_name": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"observability_configuration_revision": {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
+				names.AttrStatus: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				"trace_configuration": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"vendor": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								ValidateDiagFunc: enum.Validate[types.TracingVendor](),
+							},
 						},
 					},
 				},
-			},
+			}
 		},
 	}
 }

--- a/internal/service/apprunner/service.go
+++ b/internal/service/apprunner/service.go
@@ -40,391 +40,393 @@ func resourceService() *schema.Resource {
 		UpdateWithoutTimeout: resourceServiceUpdate,
 		DeleteWithoutTimeout: resourceServiceDelete,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"auto_scaling_configuration_arn": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			names.AttrEncryptionConfiguration: {
-				Type:     schema.TypeList,
-				Optional: true,
-				ForceNew: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrKMSKey: {
-							Type:         schema.TypeString,
-							Required:     true,
-							ForceNew:     true,
-							ValidateFunc: verify.ValidARN,
-						},
-					},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
 				},
-			},
-			"health_check_configuration": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Computed: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"healthy_threshold": {
-							Type:         schema.TypeInt,
-							Optional:     true,
-							Default:      1,
-							ValidateFunc: validation.IntBetween(1, 20),
-						},
-						names.AttrInterval: {
-							Type:         schema.TypeInt,
-							Optional:     true,
-							Default:      5,
-							ValidateFunc: validation.IntBetween(1, 20),
-						},
-						names.AttrPath: {
-							Type:         schema.TypeString,
-							Optional:     true,
-							Default:      "/",
-							ValidateFunc: validation.StringLenBetween(0, 51200),
-						},
-						names.AttrProtocol: {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Default:          types.HealthCheckProtocolTcp,
-							ValidateDiagFunc: enum.Validate[types.HealthCheckProtocol](),
-						},
-						names.AttrTimeout: {
-							Type:         schema.TypeInt,
-							Optional:     true,
-							Default:      2,
-							ValidateFunc: validation.IntBetween(1, 20),
-						},
-						"unhealthy_threshold": {
-							Type:         schema.TypeInt,
-							Optional:     true,
-							Default:      5,
-							ValidateFunc: validation.IntBetween(1, 20),
-						},
-					},
+				"auto_scaling_configuration_arn": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Computed:     true,
+					ValidateFunc: verify.ValidARN,
 				},
-			},
-			"instance_configuration": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Computed: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"cpu": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							Default:      "1024",
-							ValidateFunc: validation.StringMatch(regexache.MustCompile(`256|512|1024|2048|4096|(0.25|0.5|1|2|4) vCPU`), ""),
-							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-								// App Runner API always returns the amount in multiples of 1024 units
-								return (old == "256" && new == "0.25 vCPU") || (old == "512" && new == "0.5 vCPU") || (old == "1024" && new == "1 vCPU") || (old == "2048" && new == "2 vCPU") || (old == "4096" && new == "4 vCPU")
-							},
-						},
-						"instance_role_arn": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							ValidateFunc: verify.ValidARN,
-						},
-						"memory": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							Default:      "2048",
-							ValidateFunc: validation.StringMatch(regexache.MustCompile(`512|1024|2048|3072|4096|6144|8192|10240|12288|(0.5|1|2|3|4|6|8|10|12) GB`), ""),
-							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-								// App Runner API always returns the amount in MB
-								return (old == "512" && new == "0.5 GB") || (old == "1024" && new == "1 GB") || (old == "2048" && new == "2 GB") || (old == "3072" && new == "3 GB") || (old == "4096" && new == "4 GB") || (old == "6144" && new == "6 GB") || (old == "8192" && new == "8 GB") || (old == "10240" && new == "10 GB") || (old == "12288" && new == "12 GB")
+				names.AttrEncryptionConfiguration: {
+					Type:     schema.TypeList,
+					Optional: true,
+					ForceNew: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrKMSKey: {
+								Type:         schema.TypeString,
+								Required:     true,
+								ForceNew:     true,
+								ValidateFunc: verify.ValidARN,
 							},
 						},
 					},
 				},
-			},
-			names.AttrNetworkConfiguration: {
-				Type:     schema.TypeList,
-				Optional: true,
-				Computed: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"egress_configuration": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Computed: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"egress_type": {
-										Type:             schema.TypeString,
-										Optional:         true,
-										Computed:         true,
-										ValidateDiagFunc: enum.Validate[types.EgressType](),
-									},
-									"vpc_connector_arn": {
-										Type:         schema.TypeString,
-										Optional:     true,
-										ValidateFunc: verify.ValidARN,
-									},
+				"health_check_configuration": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Computed: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"healthy_threshold": {
+								Type:         schema.TypeInt,
+								Optional:     true,
+								Default:      1,
+								ValidateFunc: validation.IntBetween(1, 20),
+							},
+							names.AttrInterval: {
+								Type:         schema.TypeInt,
+								Optional:     true,
+								Default:      5,
+								ValidateFunc: validation.IntBetween(1, 20),
+							},
+							names.AttrPath: {
+								Type:         schema.TypeString,
+								Optional:     true,
+								Default:      "/",
+								ValidateFunc: validation.StringLenBetween(0, 51200),
+							},
+							names.AttrProtocol: {
+								Type:             schema.TypeString,
+								Optional:         true,
+								Default:          types.HealthCheckProtocolTcp,
+								ValidateDiagFunc: enum.Validate[types.HealthCheckProtocol](),
+							},
+							names.AttrTimeout: {
+								Type:         schema.TypeInt,
+								Optional:     true,
+								Default:      2,
+								ValidateFunc: validation.IntBetween(1, 20),
+							},
+							"unhealthy_threshold": {
+								Type:         schema.TypeInt,
+								Optional:     true,
+								Default:      5,
+								ValidateFunc: validation.IntBetween(1, 20),
+							},
+						},
+					},
+				},
+				"instance_configuration": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Computed: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"cpu": {
+								Type:         schema.TypeString,
+								Optional:     true,
+								Default:      "1024",
+								ValidateFunc: validation.StringMatch(regexache.MustCompile(`256|512|1024|2048|4096|(0.25|0.5|1|2|4) vCPU`), ""),
+								DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+									// App Runner API always returns the amount in multiples of 1024 units
+									return (old == "256" && new == "0.25 vCPU") || (old == "512" && new == "0.5 vCPU") || (old == "1024" && new == "1 vCPU") || (old == "2048" && new == "2 vCPU") || (old == "4096" && new == "4 vCPU")
+								},
+							},
+							"instance_role_arn": {
+								Type:         schema.TypeString,
+								Optional:     true,
+								ValidateFunc: verify.ValidARN,
+							},
+							"memory": {
+								Type:         schema.TypeString,
+								Optional:     true,
+								Default:      "2048",
+								ValidateFunc: validation.StringMatch(regexache.MustCompile(`512|1024|2048|3072|4096|6144|8192|10240|12288|(0.5|1|2|3|4|6|8|10|12) GB`), ""),
+								DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+									// App Runner API always returns the amount in MB
+									return (old == "512" && new == "0.5 GB") || (old == "1024" && new == "1 GB") || (old == "2048" && new == "2 GB") || (old == "3072" && new == "3 GB") || (old == "4096" && new == "4 GB") || (old == "6144" && new == "6 GB") || (old == "8192" && new == "8 GB") || (old == "10240" && new == "10 GB") || (old == "12288" && new == "12 GB")
 								},
 							},
 						},
-						"ingress_configuration": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Computed: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"is_publicly_accessible": {
-										Type:     schema.TypeBool,
-										Optional: true,
+					},
+				},
+				names.AttrNetworkConfiguration: {
+					Type:     schema.TypeList,
+					Optional: true,
+					Computed: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"egress_configuration": {
+								Type:     schema.TypeList,
+								Optional: true,
+								Computed: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"egress_type": {
+											Type:             schema.TypeString,
+											Optional:         true,
+											Computed:         true,
+											ValidateDiagFunc: enum.Validate[types.EgressType](),
+										},
+										"vpc_connector_arn": {
+											Type:         schema.TypeString,
+											Optional:     true,
+											ValidateFunc: verify.ValidARN,
+										},
 									},
 								},
 							},
-						},
-						names.AttrIPAddressType: {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Default:          types.IpAddressTypeIpv4,
-							ValidateDiagFunc: enum.Validate[types.IpAddressType](),
-						},
-					},
-				},
-			},
-			"observability_configuration": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"observability_configuration_arn": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							ValidateFunc: verify.ValidARN,
-						},
-						"observability_enabled": {
-							Type:     schema.TypeBool,
-							Required: true,
-						},
-					},
-				},
-			},
-			"service_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrServiceName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"service_url": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"source_configuration": {
-				Type:     schema.TypeList,
-				Required: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"authentication_configuration": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"access_role_arn": {
-										Type:         schema.TypeString,
-										Optional:     true,
-										ValidateFunc: verify.ValidARN,
-									},
-									"connection_arn": {
-										Type:         schema.TypeString,
-										Optional:     true,
-										ValidateFunc: verify.ValidARN,
+							"ingress_configuration": {
+								Type:     schema.TypeList,
+								Optional: true,
+								Computed: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"is_publicly_accessible": {
+											Type:     schema.TypeBool,
+											Optional: true,
+										},
 									},
 								},
 							},
+							names.AttrIPAddressType: {
+								Type:             schema.TypeString,
+								Optional:         true,
+								Default:          types.IpAddressTypeIpv4,
+								ValidateDiagFunc: enum.Validate[types.IpAddressType](),
+							},
 						},
-						"auto_deployments_enabled": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  true,
+					},
+				},
+				"observability_configuration": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"observability_configuration_arn": {
+								Type:         schema.TypeString,
+								Optional:     true,
+								ValidateFunc: verify.ValidARN,
+							},
+							"observability_enabled": {
+								Type:     schema.TypeBool,
+								Required: true,
+							},
 						},
-						"code_repository": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"code_configuration": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"code_configuration_values": {
-													Type:     schema.TypeList,
-													Optional: true,
-													MaxItems: 1,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															"build_command": {
-																Type:         schema.TypeString,
-																Optional:     true,
-																ValidateFunc: validation.StringLenBetween(0, 51200),
-															},
-															names.AttrPort: {
-																Type:         schema.TypeString,
-																Optional:     true,
-																Default:      "8080",
-																ValidateFunc: validation.StringLenBetween(0, 51200),
-															},
-															"runtime": {
-																Type:             schema.TypeString,
-																Required:         true,
-																ValidateDiagFunc: enum.Validate[types.Runtime](),
-															},
-															"runtime_environment_secrets": {
-																Type:     schema.TypeMap,
-																Optional: true,
-																Elem: &schema.Schema{
+					},
+				},
+				"service_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrServiceName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"service_url": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"source_configuration": {
+					Type:     schema.TypeList,
+					Required: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"authentication_configuration": {
+								Type:     schema.TypeList,
+								Optional: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"access_role_arn": {
+											Type:         schema.TypeString,
+											Optional:     true,
+											ValidateFunc: verify.ValidARN,
+										},
+										"connection_arn": {
+											Type:         schema.TypeString,
+											Optional:     true,
+											ValidateFunc: verify.ValidARN,
+										},
+									},
+								},
+							},
+							"auto_deployments_enabled": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Default:  true,
+							},
+							"code_repository": {
+								Type:     schema.TypeList,
+								Optional: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"code_configuration": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"code_configuration_values": {
+														Type:     schema.TypeList,
+														Optional: true,
+														MaxItems: 1,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																"build_command": {
 																	Type:         schema.TypeString,
-																	ValidateFunc: validation.StringLenBetween(0, 2048),
+																	Optional:     true,
+																	ValidateFunc: validation.StringLenBetween(0, 51200),
 																},
-															},
-															"runtime_environment_variables": {
-																Type:     schema.TypeMap,
-																Optional: true,
-																Elem: &schema.Schema{
+																names.AttrPort: {
 																	Type:         schema.TypeString,
+																	Optional:     true,
+																	Default:      "8080",
+																	ValidateFunc: validation.StringLenBetween(0, 51200),
+																},
+																"runtime": {
+																	Type:             schema.TypeString,
+																	Required:         true,
+																	ValidateDiagFunc: enum.Validate[types.Runtime](),
+																},
+																"runtime_environment_secrets": {
+																	Type:     schema.TypeMap,
+																	Optional: true,
+																	Elem: &schema.Schema{
+																		Type:         schema.TypeString,
+																		ValidateFunc: validation.StringLenBetween(0, 2048),
+																	},
+																},
+																"runtime_environment_variables": {
+																	Type:     schema.TypeMap,
+																	Optional: true,
+																	Elem: &schema.Schema{
+																		Type:         schema.TypeString,
+																		ValidateFunc: validation.StringLenBetween(0, 51200),
+																	},
+																},
+																"start_command": {
+																	Type:         schema.TypeString,
+																	Optional:     true,
 																	ValidateFunc: validation.StringLenBetween(0, 51200),
 																},
 															},
-															"start_command": {
-																Type:         schema.TypeString,
-																Optional:     true,
-																ValidateFunc: validation.StringLenBetween(0, 51200),
-															},
 														},
 													},
-												},
-												"configuration_source": {
-													Type:             schema.TypeString,
-													Required:         true,
-													ValidateDiagFunc: enum.Validate[types.ConfigurationSource](),
-												},
-											},
-										},
-									},
-									"repository_url": {
-										Type:         schema.TypeString,
-										Required:     true,
-										ValidateFunc: validation.StringLenBetween(0, 51200),
-									},
-									"source_code_version": {
-										Type:     schema.TypeList,
-										Required: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												names.AttrType: {
-													Type:             schema.TypeString,
-													Required:         true,
-													ValidateDiagFunc: enum.Validate[types.SourceCodeVersionType](),
-												},
-												names.AttrValue: {
-													Type:         schema.TypeString,
-													Required:     true,
-													ValidateFunc: validation.StringLenBetween(0, 51200),
-												},
-											},
-										},
-									},
-									"source_directory": {
-										Type:         schema.TypeString,
-										Optional:     true,
-										Computed:     true,
-										ValidateFunc: validation.StringLenBetween(0, 4096),
-									},
-								},
-							},
-							ExactlyOneOf: []string{"source_configuration.0.code_repository", "source_configuration.0.image_repository"},
-						},
-						"image_repository": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"image_configuration": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												names.AttrPort: {
-													Type:         schema.TypeString,
-													Optional:     true,
-													Default:      "8080",
-													ValidateFunc: validation.StringLenBetween(0, 51200),
-												},
-												"runtime_environment_secrets": {
-													Type:     schema.TypeMap,
-													Optional: true,
-													Elem: &schema.Schema{
-														Type:         schema.TypeString,
-														ValidateFunc: validation.StringLenBetween(0, 2048),
+													"configuration_source": {
+														Type:             schema.TypeString,
+														Required:         true,
+														ValidateDiagFunc: enum.Validate[types.ConfigurationSource](),
 													},
 												},
-												"runtime_environment_variables": {
-													Type:     schema.TypeMap,
-													Optional: true,
-													Elem: &schema.Schema{
+											},
+										},
+										"repository_url": {
+											Type:         schema.TypeString,
+											Required:     true,
+											ValidateFunc: validation.StringLenBetween(0, 51200),
+										},
+										"source_code_version": {
+											Type:     schema.TypeList,
+											Required: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													names.AttrType: {
+														Type:             schema.TypeString,
+														Required:         true,
+														ValidateDiagFunc: enum.Validate[types.SourceCodeVersionType](),
+													},
+													names.AttrValue: {
 														Type:         schema.TypeString,
+														Required:     true,
 														ValidateFunc: validation.StringLenBetween(0, 51200),
 													},
 												},
-												"start_command": {
-													Type:         schema.TypeString,
-													Optional:     true,
-													ValidateFunc: validation.StringLenBetween(0, 51200),
+											},
+										},
+										"source_directory": {
+											Type:         schema.TypeString,
+											Optional:     true,
+											Computed:     true,
+											ValidateFunc: validation.StringLenBetween(0, 4096),
+										},
+									},
+								},
+								ExactlyOneOf: []string{"source_configuration.0.code_repository", "source_configuration.0.image_repository"},
+							},
+							"image_repository": {
+								Type:     schema.TypeList,
+								Optional: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"image_configuration": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													names.AttrPort: {
+														Type:         schema.TypeString,
+														Optional:     true,
+														Default:      "8080",
+														ValidateFunc: validation.StringLenBetween(0, 51200),
+													},
+													"runtime_environment_secrets": {
+														Type:     schema.TypeMap,
+														Optional: true,
+														Elem: &schema.Schema{
+															Type:         schema.TypeString,
+															ValidateFunc: validation.StringLenBetween(0, 2048),
+														},
+													},
+													"runtime_environment_variables": {
+														Type:     schema.TypeMap,
+														Optional: true,
+														Elem: &schema.Schema{
+															Type:         schema.TypeString,
+															ValidateFunc: validation.StringLenBetween(0, 51200),
+														},
+													},
+													"start_command": {
+														Type:         schema.TypeString,
+														Optional:     true,
+														ValidateFunc: validation.StringLenBetween(0, 51200),
+													},
 												},
 											},
 										},
-									},
-									"image_identifier": {
-										Type:         schema.TypeString,
-										Required:     true,
-										ValidateFunc: validation.StringMatch(regexache.MustCompile(`([0-9]{12}\.dkr\.ecr\.[a-z\-]+-[0-9]{1,2}\.amazonaws\.com\/.*)|(^public\.ecr\.aws\/.+\/.+)`), ""),
-									},
-									"image_repository_type": {
-										Type:             schema.TypeString,
-										Required:         true,
-										ValidateDiagFunc: enum.Validate[types.ImageRepositoryType](),
+										"image_identifier": {
+											Type:         schema.TypeString,
+											Required:     true,
+											ValidateFunc: validation.StringMatch(regexache.MustCompile(`([0-9]{12}\.dkr\.ecr\.[a-z\-]+-[0-9]{1,2}\.amazonaws\.com\/.*)|(^public\.ecr\.aws\/.+\/.+)`), ""),
+										},
+										"image_repository_type": {
+											Type:             schema.TypeString,
+											Required:         true,
+											ValidateDiagFunc: enum.Validate[types.ImageRepositoryType](),
+										},
 									},
 								},
+								ExactlyOneOf: []string{"source_configuration.0.image_repository", "source_configuration.0.code_repository"},
 							},
-							ExactlyOneOf: []string{"source_configuration.0.image_repository", "source_configuration.0.code_repository"},
 						},
 					},
 				},
-			},
-			names.AttrStatus: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				names.AttrStatus: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			}
 		},
 	}
 }

--- a/internal/service/apprunner/vpc_connector.go
+++ b/internal/service/apprunner/vpc_connector.go
@@ -38,39 +38,41 @@ func resourceVPCConnector() *schema.Resource {
 		UpdateWithoutTimeout: resourceVPCConnectorUpdate,
 		DeleteWithoutTimeout: resourceVPCConnectorDelete,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrSecurityGroups: {
-				Type:     schema.TypeSet,
-				Required: true,
-				ForceNew: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			names.AttrStatus: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrSubnets: {
-				Type:     schema.TypeSet,
-				Required: true,
-				ForceNew: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			"vpc_connector_name": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(4, 40),
-			},
-			"vpc_connector_revision": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrSecurityGroups: {
+					Type:     schema.TypeSet,
+					Required: true,
+					ForceNew: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				names.AttrStatus: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrSubnets: {
+					Type:     schema.TypeSet,
+					Required: true,
+					ForceNew: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				"vpc_connector_name": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringLenBetween(4, 40),
+				},
+				"vpc_connector_revision": {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/apprunner/vpc_ingress_connection.go
+++ b/internal/service/apprunner/vpc_ingress_connection.go
@@ -37,52 +37,54 @@ func resourceVPCIngressConnection() *schema.Resource {
 		UpdateWithoutTimeout: resourceVPCIngressConnectionUpdate,
 		DeleteWithoutTimeout: resourceVPCIngressConnectionDelete,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrDomainName: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"ingress_vpc_configuration": {
-				Type:     schema.TypeList,
-				Required: true,
-				ForceNew: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrVPCEndpointID: {
-							Type:     schema.TypeString,
-							Optional: true,
-							ForceNew: true,
-						},
-						names.AttrVPCID: {
-							Type:     schema.TypeString,
-							Optional: true,
-							ForceNew: true,
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrDomainName: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"ingress_vpc_configuration": {
+					Type:     schema.TypeList,
+					Required: true,
+					ForceNew: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrVPCEndpointID: {
+								Type:     schema.TypeString,
+								Optional: true,
+								ForceNew: true,
+							},
+							names.AttrVPCID: {
+								Type:     schema.TypeString,
+								Optional: true,
+								ForceNew: true,
+							},
 						},
 					},
 				},
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"service_arn": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			names.AttrStatus: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"service_arn": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				names.AttrStatus: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			}
 		},
 	}
 }

--- a/internal/service/appstream/directory_config.go
+++ b/internal/service/appstream/directory_config.go
@@ -39,61 +39,63 @@ func resourceDirectoryConfig() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrCreatedTime: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"directory_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"organizational_unit_distinguished_names": {
-				Type:     schema.TypeSet,
-				Required: true,
-				Elem: &schema.Schema{
-					Type:         schema.TypeString,
-					ValidateFunc: validation.StringLenBetween(0, 2000),
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrCreatedTime: {
+					Type:     schema.TypeString,
+					Computed: true,
 				},
-			},
-			"service_account_credentials": {
-				Type:     schema.TypeList,
-				MaxItems: 1,
-				Required: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"account_name": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"account_password": {
-							Type:      schema.TypeString,
-							Required:  true,
-							Sensitive: true,
+				"directory_name": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"organizational_unit_distinguished_names": {
+					Type:     schema.TypeSet,
+					Required: true,
+					Elem: &schema.Schema{
+						Type:         schema.TypeString,
+						ValidateFunc: validation.StringLenBetween(0, 2000),
+					},
+				},
+				"service_account_credentials": {
+					Type:     schema.TypeList,
+					MaxItems: 1,
+					Required: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"account_name": {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+							"account_password": {
+								Type:      schema.TypeString,
+								Required:  true,
+								Sensitive: true,
+							},
 						},
 					},
 				},
-			},
-			"certificate_based_auth_properties": {
-				Type:     schema.TypeList,
-				MaxItems: 1,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"certificate_authority_arn": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							ValidateFunc: verify.ValidARN,
-						},
-						names.AttrStatus: {
-							Type:             schema.TypeString,
-							Optional:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.CertificateBasedAuthStatus](),
+				"certificate_based_auth_properties": {
+					Type:     schema.TypeList,
+					MaxItems: 1,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"certificate_authority_arn": {
+								Type:         schema.TypeString,
+								Optional:     true,
+								ValidateFunc: verify.ValidARN,
+							},
+							names.AttrStatus: {
+								Type:             schema.TypeString,
+								Optional:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.CertificateBasedAuthStatus](),
+							},
 						},
 					},
 				},
-			},
+			}
 		},
 	}
 }

--- a/internal/service/appstream/fleet.go
+++ b/internal/service/appstream/fleet.go
@@ -47,178 +47,180 @@ func resourceFleet() *schema.Resource {
 
 		CustomizeDiff: resourceFleetCustDiff,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"compute_capacity": {
-				Type:     schema.TypeList,
-				MaxItems: 1,
-				Required: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"available": {
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
-						"desired_instances": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							ExactlyOneOf: []string{
-								"compute_capacity.0.desired_sessions",
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"compute_capacity": {
+					Type:     schema.TypeList,
+					MaxItems: 1,
+					Required: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"available": {
+								Type:     schema.TypeInt,
+								Computed: true,
+							},
+							"desired_instances": {
+								Type:     schema.TypeInt,
+								Optional: true,
+								ExactlyOneOf: []string{
+									"compute_capacity.0.desired_sessions",
+								},
+							},
+							"desired_sessions": {
+								Type:     schema.TypeInt,
+								Optional: true,
+								ExactlyOneOf: []string{
+									"compute_capacity.0.desired_instances",
+								},
+							},
+							"in_use": {
+								Type:     schema.TypeInt,
+								Computed: true,
+							},
+							"running": {
+								Type:     schema.TypeInt,
+								Computed: true,
 							},
 						},
-						"desired_sessions": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							ExactlyOneOf: []string{
-								"compute_capacity.0.desired_instances",
+					},
+				},
+				names.AttrCreatedTime: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrDescription: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Computed:     true,
+					ValidateFunc: validation.StringLenBetween(0, 256),
+				},
+				"disconnect_timeout_in_seconds": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					Computed:     true,
+					ValidateFunc: validation.IntBetween(60, 360000),
+				},
+				names.AttrDisplayName: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Computed:     true,
+					ValidateFunc: validation.StringLenBetween(0, 100),
+				},
+				"domain_join_info": {
+					Type:     schema.TypeList,
+					MaxItems: 1,
+					Optional: true,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"directory_name": {
+								Type:     schema.TypeString,
+								Optional: true,
+								Computed: true,
+							},
+							"organizational_unit_distinguished_name": {
+								Type:     schema.TypeString,
+								Optional: true,
+								Computed: true,
 							},
 						},
-						"in_use": {
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
-						"running": {
-							Type:     schema.TypeInt,
-							Computed: true,
+					},
+				},
+				"enable_default_internet_access": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Computed: true,
+				},
+				"fleet_type": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					Computed:         true,
+					ForceNew:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.FleetType](),
+				},
+				names.AttrIAMRoleARN: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Computed:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				"idle_disconnect_timeout_in_seconds": {
+					Type:     schema.TypeInt,
+					Optional: true,
+					Default:  0,
+					ValidateFunc: validation.Any(
+						validation.IntBetween(60, 360000),
+						validation.IntInSlice([]int{0}),
+					),
+				},
+				"image_arn": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+				},
+				"image_name": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+				},
+				names.AttrInstanceType: {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"max_sessions_per_instance": {
+					Type:     schema.TypeInt,
+					Optional: true,
+				},
+				"max_user_duration_in_seconds": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					Computed:     true,
+					ValidateFunc: validation.IntBetween(600, 432000),
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"stream_view": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					Computed:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.StreamView](),
+				},
+				names.AttrState: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrVPCConfig: {
+					Type:     schema.TypeList,
+					MaxItems: 1,
+					Optional: true,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrSecurityGroupIDs: {
+								Type:     schema.TypeList,
+								Optional: true,
+								Computed: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+							},
+							names.AttrSubnetIDs: {
+								Type:     schema.TypeList,
+								Optional: true,
+								Computed: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+							},
 						},
 					},
 				},
-			},
-			names.AttrCreatedTime: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrDescription: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: validation.StringLenBetween(0, 256),
-			},
-			"disconnect_timeout_in_seconds": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: validation.IntBetween(60, 360000),
-			},
-			names.AttrDisplayName: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: validation.StringLenBetween(0, 100),
-			},
-			"domain_join_info": {
-				Type:     schema.TypeList,
-				MaxItems: 1,
-				Optional: true,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"directory_name": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Computed: true,
-						},
-						"organizational_unit_distinguished_name": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Computed: true,
-						},
-					},
-				},
-			},
-			"enable_default_internet_access": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Computed: true,
-			},
-			"fleet_type": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Computed:         true,
-				ForceNew:         true,
-				ValidateDiagFunc: enum.Validate[awstypes.FleetType](),
-			},
-			names.AttrIAMRoleARN: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			"idle_disconnect_timeout_in_seconds": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Default:  0,
-				ValidateFunc: validation.Any(
-					validation.IntBetween(60, 360000),
-					validation.IntInSlice([]int{0}),
-				),
-			},
-			"image_arn": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-			"image_name": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-			names.AttrInstanceType: {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"max_sessions_per_instance": {
-				Type:     schema.TypeInt,
-				Optional: true,
-			},
-			"max_user_duration_in_seconds": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: validation.IntBetween(600, 432000),
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"stream_view": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Computed:         true,
-				ValidateDiagFunc: enum.Validate[awstypes.StreamView](),
-			},
-			names.AttrState: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrVPCConfig: {
-				Type:     schema.TypeList,
-				MaxItems: 1,
-				Optional: true,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrSecurityGroupIDs: {
-							Type:     schema.TypeList,
-							Optional: true,
-							Computed: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-						names.AttrSubnetIDs: {
-							Type:     schema.TypeList,
-							Optional: true,
-							Computed: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-					},
-				},
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			}
 		},
 	}
 }

--- a/internal/service/appstream/fleet_stack_association.go
+++ b/internal/service/appstream/fleet_stack_association.go
@@ -36,17 +36,19 @@ func resourceFleetStackAssociation() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"fleet_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"stack_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"fleet_name": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"stack_name": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/appstream/image_builder.go
+++ b/internal/service/appstream/image_builder.go
@@ -42,143 +42,145 @@ func resourceImageBuilder() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"access_endpoint": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				ForceNew: true,
-				MinItems: 1,
-				MaxItems: 4,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrEndpointType: {
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.AccessEndpointType](),
-						},
-						"vpce_id": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Computed: true,
-						},
-					},
-				},
-			},
-			"appstream_agent_version": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(1, 100),
-			},
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrCreatedTime: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrDescription: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(0, 256),
-			},
-			names.AttrDisplayName: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(0, 100),
-			},
-			"domain_join_info": {
-				Type:     schema.TypeList,
-				MaxItems: 1,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"directory_name": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"organizational_unit_distinguished_name": {
-							Type:     schema.TypeString,
-							Optional: true,
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"access_endpoint": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					ForceNew: true,
+					MinItems: 1,
+					MaxItems: 4,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrEndpointType: {
+								Type:             schema.TypeString,
+								Required:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.AccessEndpointType](),
+							},
+							"vpce_id": {
+								Type:     schema.TypeString,
+								Optional: true,
+								Computed: true,
+							},
 						},
 					},
 				},
-			},
-			"enable_default_internet_access": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
-			names.AttrIAMRoleARN: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			"image_arn": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ForceNew:     true,
-				ExactlyOneOf: []string{"image_arn", "image_name"},
-				ValidateFunc: verify.ValidARN,
-			},
-			"image_name": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ForceNew:     true,
-				ExactlyOneOf: []string{"image_name", "image_arn"},
-			},
-			names.AttrInstanceType: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			names.AttrState: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			names.AttrVPCConfig: {
-				Type:     schema.TypeList,
-				MaxItems: 1,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrSecurityGroupIDs: {
-							Type:     schema.TypeSet,
-							Optional: true,
-							Computed: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-						names.AttrSubnetIDs: {
-							Type:     schema.TypeSet,
-							Optional: true,
-							Computed: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
+				"appstream_agent_version": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Computed:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringLenBetween(1, 100),
+				},
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrCreatedTime: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrDescription: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Computed:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringLenBetween(0, 256),
+				},
+				names.AttrDisplayName: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Computed:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringLenBetween(0, 100),
+				},
+				"domain_join_info": {
+					Type:     schema.TypeList,
+					MaxItems: 1,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"directory_name": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+							"organizational_unit_distinguished_name": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
 						},
 					},
 				},
-			},
+				"enable_default_internet_access": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+				},
+				names.AttrIAMRoleARN: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Computed:     true,
+					ForceNew:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				"image_arn": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Computed:     true,
+					ForceNew:     true,
+					ExactlyOneOf: []string{"image_arn", "image_name"},
+					ValidateFunc: verify.ValidARN,
+				},
+				"image_name": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Computed:     true,
+					ForceNew:     true,
+					ExactlyOneOf: []string{"image_name", "image_arn"},
+				},
+				names.AttrInstanceType: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				names.AttrState: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				names.AttrVPCConfig: {
+					Type:     schema.TypeList,
+					MaxItems: 1,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrSecurityGroupIDs: {
+								Type:     schema.TypeSet,
+								Optional: true,
+								Computed: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+							},
+							names.AttrSubnetIDs: {
+								Type:     schema.TypeSet,
+								Optional: true,
+								Computed: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+							},
+						},
+					},
+				},
+			}
 		},
 	}
 }

--- a/internal/service/appstream/stack.go
+++ b/internal/service/appstream/stack.go
@@ -48,161 +48,163 @@ func resourceStack() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"access_endpoints": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Computed: true,
-				MinItems: 1,
-				MaxItems: 4,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrEndpointType: {
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.AccessEndpointType](),
-						},
-						"vpce_id": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Computed: true,
-						},
-					},
-				},
-			},
-			"application_settings": {
-				Type:     schema.TypeList,
-				MaxItems: 1,
-				Optional: true,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrEnabled: {
-							Type:     schema.TypeBool,
-							Required: true,
-						},
-						"settings_group": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							ValidateFunc: validation.StringLenBetween(0, 100),
-						},
-					},
-				},
-			},
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrCreatedTime: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrDescription: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringLenBetween(0, 256),
-			},
-			names.AttrDisplayName: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringLenBetween(0, 100),
-			},
-			"embed_host_domains": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Computed: true,
-				MinItems: 1,
-				MaxItems: 20,
-				Elem: &schema.Schema{
-					Type:         schema.TypeString,
-					ValidateFunc: validation.StringLenBetween(0, 128),
-				},
-			},
-			"feedback_url": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: validation.StringLenBetween(0, 100),
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"redirect_url": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: validation.StringLenBetween(0, 1000),
-			},
-			"storage_connectors": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"connector_type": {
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.StorageConnectorType](),
-						},
-						"domains": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Computed: true,
-							MaxItems: 50,
-							Elem: &schema.Schema{
-								Type:         schema.TypeString,
-								ValidateFunc: validation.StringLenBetween(1, 64),
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"access_endpoints": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Computed: true,
+					MinItems: 1,
+					MaxItems: 4,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrEndpointType: {
+								Type:             schema.TypeString,
+								Required:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.AccessEndpointType](),
+							},
+							"vpce_id": {
+								Type:     schema.TypeString,
+								Optional: true,
+								Computed: true,
 							},
 						},
-						"resource_identifier": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							Computed:     true,
-							ValidateFunc: validation.StringLenBetween(1, 2048),
+					},
+				},
+				"application_settings": {
+					Type:     schema.TypeList,
+					MaxItems: 1,
+					Optional: true,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrEnabled: {
+								Type:     schema.TypeBool,
+								Required: true,
+							},
+							"settings_group": {
+								Type:         schema.TypeString,
+								Optional:     true,
+								ValidateFunc: validation.StringLenBetween(0, 100),
+							},
 						},
 					},
 				},
-			},
-			"streaming_experience_settings": {
-				Type:     schema.TypeList,
-				MaxItems: 1,
-				Optional: true,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"preferred_protocol": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.PreferredProtocol](),
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrCreatedTime: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrDescription: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringLenBetween(0, 256),
+				},
+				names.AttrDisplayName: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringLenBetween(0, 100),
+				},
+				"embed_host_domains": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Computed: true,
+					MinItems: 1,
+					MaxItems: 20,
+					Elem: &schema.Schema{
+						Type:         schema.TypeString,
+						ValidateFunc: validation.StringLenBetween(0, 128),
+					},
+				},
+				"feedback_url": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Computed:     true,
+					ValidateFunc: validation.StringLenBetween(0, 100),
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"redirect_url": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Computed:     true,
+					ValidateFunc: validation.StringLenBetween(0, 1000),
+				},
+				"storage_connectors": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"connector_type": {
+								Type:             schema.TypeString,
+								Required:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.StorageConnectorType](),
+							},
+							"domains": {
+								Type:     schema.TypeList,
+								Optional: true,
+								Computed: true,
+								MaxItems: 50,
+								Elem: &schema.Schema{
+									Type:         schema.TypeString,
+									ValidateFunc: validation.StringLenBetween(1, 64),
+								},
+							},
+							"resource_identifier": {
+								Type:         schema.TypeString,
+								Optional:     true,
+								Computed:     true,
+								ValidateFunc: validation.StringLenBetween(1, 2048),
+							},
 						},
 					},
 				},
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			"user_settings": {
-				Type:             schema.TypeSet,
-				Optional:         true,
-				Computed:         true,
-				MinItems:         1,
-				DiffSuppressFunc: suppressAppsStreamStackUserSettings,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrAction: {
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.Action](),
-						},
-						"permission": {
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.Permission](),
+				"streaming_experience_settings": {
+					Type:     schema.TypeList,
+					MaxItems: 1,
+					Optional: true,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"preferred_protocol": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.PreferredProtocol](),
+							},
 						},
 					},
 				},
-			},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				"user_settings": {
+					Type:             schema.TypeSet,
+					Optional:         true,
+					Computed:         true,
+					MinItems:         1,
+					DiffSuppressFunc: suppressAppsStreamStackUserSettings,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrAction: {
+								Type:             schema.TypeString,
+								Required:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.Action](),
+							},
+							"permission": {
+								Type:             schema.TypeString,
+								Required:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.Permission](),
+							},
+						},
+					},
+				},
+			}
 		},
 
 		CustomizeDiff: customdiff.All(

--- a/internal/service/appstream/user.go
+++ b/internal/service/appstream/user.go
@@ -40,49 +40,51 @@ func resourceUser() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"authentication_type": {
-				Type:             schema.TypeString,
-				Required:         true,
-				ForceNew:         true,
-				ValidateDiagFunc: enum.Validate[awstypes.AuthenticationType](),
-			},
-			names.AttrCreatedTime: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrEnabled: {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
-			},
-			"first_name": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(0, 2048),
-			},
-			"last_name": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(0, 2048),
-			},
-			"send_email_notification": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
-			},
-			names.AttrUserName: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(1, 128),
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"authentication_type": {
+					Type:             schema.TypeString,
+					Required:         true,
+					ForceNew:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.AuthenticationType](),
+				},
+				names.AttrCreatedTime: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrEnabled: {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  true,
+				},
+				"first_name": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringLenBetween(0, 2048),
+				},
+				"last_name": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringLenBetween(0, 2048),
+				},
+				"send_email_notification": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  true,
+				},
+				names.AttrUserName: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringLenBetween(1, 128),
+				},
+			}
 		},
 	}
 }

--- a/internal/service/appstream/user_stack_association.go
+++ b/internal/service/appstream/user_stack_association.go
@@ -39,28 +39,30 @@ func resourceUserStackAssociation() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"authentication_type": {
-				Type:             schema.TypeString,
-				Required:         true,
-				ForceNew:         true,
-				ValidateDiagFunc: enum.Validate[awstypes.AuthenticationType](),
-			},
-			"send_email_notification": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
-			"stack_name": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(1, 128),
-			},
-			names.AttrUserName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"authentication_type": {
+					Type:             schema.TypeString,
+					Required:         true,
+					ForceNew:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.AuthenticationType](),
+				},
+				"send_email_notification": {
+					Type:     schema.TypeBool,
+					Optional: true,
+				},
+				"stack_name": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringLenBetween(1, 128),
+				},
+				names.AttrUserName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/appsync/api_cache.go
+++ b/internal/service/appsync/api_cache.go
@@ -38,37 +38,39 @@ func resourceAPICache() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"api_caching_behavior": {
-				Type:             schema.TypeString,
-				Required:         true,
-				ValidateDiagFunc: enum.Validate[awstypes.ApiCachingBehavior](),
-			},
-			"api_id": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"at_rest_encryption_enabled": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
-			"transit_encryption_enabled": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
-			"ttl": {
-				Type:     schema.TypeInt,
-				Required: true,
-			},
-			names.AttrType: {
-				Type:             schema.TypeString,
-				Required:         true,
-				ValidateDiagFunc: enum.Validate[awstypes.ApiCacheType](),
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"api_caching_behavior": {
+					Type:             schema.TypeString,
+					Required:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.ApiCachingBehavior](),
+				},
+				"api_id": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"at_rest_encryption_enabled": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+				},
+				"transit_encryption_enabled": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+				},
+				"ttl": {
+					Type:     schema.TypeInt,
+					Required: true,
+				},
+				names.AttrType: {
+					Type:             schema.TypeString,
+					Required:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.ApiCacheType](),
+				},
+			}
 		},
 	}
 }

--- a/internal/service/appsync/api_key.go
+++ b/internal/service/appsync/api_key.go
@@ -41,37 +41,39 @@ func resourceAPIKey() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"api_id": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"api_key_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrDescription: {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  "Managed by Terraform",
-			},
-			"expires": {
-				Type:     schema.TypeString,
-				Optional: true,
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					// Ignore unsetting value.
-					if old != "" && new == "" {
-						return true
-					}
-					return false
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"api_id": {
+					Type:     schema.TypeString,
+					Required: true,
 				},
-				ValidateFunc: validation.IsRFC3339Time,
-			},
-			names.AttrKey: {
-				Type:      schema.TypeString,
-				Computed:  true,
-				Sensitive: true,
-			},
+				"api_key_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrDescription: {
+					Type:     schema.TypeString,
+					Optional: true,
+					Default:  "Managed by Terraform",
+				},
+				"expires": {
+					Type:     schema.TypeString,
+					Optional: true,
+					DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+						// Ignore unsetting value.
+						if old != "" && new == "" {
+							return true
+						}
+						return false
+					},
+					ValidateFunc: validation.IsRFC3339Time,
+				},
+				names.AttrKey: {
+					Type:      schema.TypeString,
+					Computed:  true,
+					Sensitive: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/appsync/datasource.go
+++ b/internal/service/appsync/datasource.go
@@ -43,244 +43,246 @@ func resourceDataSource() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"api_id": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrDescription: {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"dynamodb_config": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"delta_sync_config": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"base_table_ttl": {
-										Type:     schema.TypeInt,
-										Optional: true,
-									},
-									"delta_sync_table_name": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-									"delta_sync_table_ttl": {
-										Type:     schema.TypeInt,
-										Optional: true,
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"api_id": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrDescription: {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"dynamodb_config": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"delta_sync_config": {
+								Type:     schema.TypeList,
+								Optional: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"base_table_ttl": {
+											Type:     schema.TypeInt,
+											Optional: true,
+										},
+										"delta_sync_table_name": {
+											Type:     schema.TypeString,
+											Required: true,
+										},
+										"delta_sync_table_ttl": {
+											Type:     schema.TypeInt,
+											Optional: true,
+										},
 									},
 								},
 							},
-						},
-						names.AttrRegion: {
-							Type:     schema.TypeString,
-							Optional: true,
-							Computed: true,
-						},
-						names.AttrTableName: {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"use_caller_credentials": {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
-						"versioned": {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
-					},
-				},
-				ConflictsWith: []string{"elasticsearch_config", "http_config", "lambda_config", "relational_database_config", "opensearchservice_config"},
-			},
-			"elasticsearch_config": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrEndpoint: {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						names.AttrRegion: {
-							Type:     schema.TypeString,
-							Optional: true,
-							Computed: true,
+							names.AttrRegion: {
+								Type:     schema.TypeString,
+								Optional: true,
+								Computed: true,
+							},
+							names.AttrTableName: {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+							"use_caller_credentials": {
+								Type:     schema.TypeBool,
+								Optional: true,
+							},
+							"versioned": {
+								Type:     schema.TypeBool,
+								Optional: true,
+							},
 						},
 					},
+					ConflictsWith: []string{"elasticsearch_config", "http_config", "lambda_config", "relational_database_config", "opensearchservice_config"},
 				},
-				ConflictsWith: []string{"dynamodb_config", "http_config", "lambda_config", "opensearchservice_config"},
-			},
-			"event_bridge_config": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"event_bus_arn": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: verify.ValidARN,
+				"elasticsearch_config": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrEndpoint: {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+							names.AttrRegion: {
+								Type:     schema.TypeString,
+								Optional: true,
+								Computed: true,
+							},
 						},
 					},
+					ConflictsWith: []string{"dynamodb_config", "http_config", "lambda_config", "opensearchservice_config"},
 				},
-				ConflictsWith: []string{"dynamodb_config", "elasticsearch_config", "http_config", "lambda_config", "relational_database_config"},
-			},
-			"http_config": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"authorization_config": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"authorization_type": {
-										Type:             schema.TypeString,
-										Optional:         true,
-										Default:          awstypes.AuthorizationTypeAwsIam,
-										ValidateDiagFunc: enum.Validate[awstypes.AuthorizationType](),
-									},
-									"aws_iam_config": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"signing_region": {
-													Type:     schema.TypeString,
-													Optional: true,
-												},
-												"signing_service_name": {
-													Type:     schema.TypeString,
-													Optional: true,
+				"event_bridge_config": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"event_bus_arn": {
+								Type:         schema.TypeString,
+								Required:     true,
+								ValidateFunc: verify.ValidARN,
+							},
+						},
+					},
+					ConflictsWith: []string{"dynamodb_config", "elasticsearch_config", "http_config", "lambda_config", "relational_database_config"},
+				},
+				"http_config": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"authorization_config": {
+								Type:     schema.TypeList,
+								Optional: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"authorization_type": {
+											Type:             schema.TypeString,
+											Optional:         true,
+											Default:          awstypes.AuthorizationTypeAwsIam,
+											ValidateDiagFunc: enum.Validate[awstypes.AuthorizationType](),
+										},
+										"aws_iam_config": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"signing_region": {
+														Type:     schema.TypeString,
+														Optional: true,
+													},
+													"signing_service_name": {
+														Type:     schema.TypeString,
+														Optional: true,
+													},
 												},
 											},
 										},
 									},
 								},
 							},
-						},
-						names.AttrEndpoint: {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-					},
-				},
-				ConflictsWith: []string{"dynamodb_config", "elasticsearch_config", "opensearchservice_config", "lambda_config", "relational_database_config"},
-			},
-			"lambda_config": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrFunctionARN: {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: verify.ValidARN,
+							names.AttrEndpoint: {
+								Type:     schema.TypeString,
+								Required: true,
+							},
 						},
 					},
+					ConflictsWith: []string{"dynamodb_config", "elasticsearch_config", "opensearchservice_config", "lambda_config", "relational_database_config"},
 				},
-				ConflictsWith: []string{"dynamodb_config", "elasticsearch_config", "opensearchservice_config", "http_config", "relational_database_config"},
-			},
-			"opensearchservice_config": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrEndpoint: {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						names.AttrRegion: {
-							Type:     schema.TypeString,
-							Optional: true,
-							Computed: true,
+				"lambda_config": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrFunctionARN: {
+								Type:         schema.TypeString,
+								Required:     true,
+								ValidateFunc: verify.ValidARN,
+							},
 						},
 					},
+					ConflictsWith: []string{"dynamodb_config", "elasticsearch_config", "opensearchservice_config", "http_config", "relational_database_config"},
 				},
-				ConflictsWith: []string{"dynamodb_config", "http_config", "lambda_config", "elasticsearch_config"},
-			},
-			names.AttrName: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringMatch(regexache.MustCompile(`[A-Za-z_][0-9A-Za-z_]*`), "must match [A-Za-z_][0-9A-Za-z_]*"),
-			},
-			"relational_database_config": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"http_endpoint_config": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"aws_secret_store_arn": {
-										Type:         schema.TypeString,
-										Required:     true,
-										ValidateFunc: verify.ValidARN,
-									},
-									names.AttrDatabaseName: {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
-									"db_cluster_identifier": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-									names.AttrRegion: {
-										Type:     schema.TypeString,
-										Optional: true,
-										Computed: true,
-									},
-									names.AttrSchema: {
-										Type:     schema.TypeString,
-										Optional: true,
+				"opensearchservice_config": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrEndpoint: {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+							names.AttrRegion: {
+								Type:     schema.TypeString,
+								Optional: true,
+								Computed: true,
+							},
+						},
+					},
+					ConflictsWith: []string{"dynamodb_config", "http_config", "lambda_config", "elasticsearch_config"},
+				},
+				names.AttrName: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringMatch(regexache.MustCompile(`[A-Za-z_][0-9A-Za-z_]*`), "must match [A-Za-z_][0-9A-Za-z_]*"),
+				},
+				"relational_database_config": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"http_endpoint_config": {
+								Type:     schema.TypeList,
+								Optional: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"aws_secret_store_arn": {
+											Type:         schema.TypeString,
+											Required:     true,
+											ValidateFunc: verify.ValidARN,
+										},
+										names.AttrDatabaseName: {
+											Type:     schema.TypeString,
+											Optional: true,
+										},
+										"db_cluster_identifier": {
+											Type:     schema.TypeString,
+											Required: true,
+										},
+										names.AttrRegion: {
+											Type:     schema.TypeString,
+											Optional: true,
+											Computed: true,
+										},
+										names.AttrSchema: {
+											Type:     schema.TypeString,
+											Optional: true,
+										},
 									},
 								},
 							},
-						},
-						names.AttrSourceType: {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Default:          awstypes.RelationalDatabaseSourceTypeRdsHttpEndpoint,
-							ValidateDiagFunc: enum.Validate[awstypes.RelationalDatabaseSourceType](),
+							names.AttrSourceType: {
+								Type:             schema.TypeString,
+								Optional:         true,
+								Default:          awstypes.RelationalDatabaseSourceTypeRdsHttpEndpoint,
+								ValidateDiagFunc: enum.Validate[awstypes.RelationalDatabaseSourceType](),
+							},
 						},
 					},
+					ConflictsWith: []string{"dynamodb_config", "elasticsearch_config", "opensearchservice_config", "http_config", "lambda_config"},
 				},
-				ConflictsWith: []string{"dynamodb_config", "elasticsearch_config", "opensearchservice_config", "http_config", "lambda_config"},
-			},
-			names.AttrServiceRoleARN: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			names.AttrType: {
-				Type:             schema.TypeString,
-				Required:         true,
-				ValidateDiagFunc: enum.Validate[awstypes.DataSourceType](),
-				StateFunc:        sdkv2.ToUpperSchemaStateFunc,
-			},
+				names.AttrServiceRoleARN: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				names.AttrType: {
+					Type:             schema.TypeString,
+					Required:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.DataSourceType](),
+					StateFunc:        sdkv2.ToUpperSchemaStateFunc,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/appsync/domain_name.go
+++ b/internal/service/appsync/domain_name.go
@@ -38,30 +38,32 @@ func resourceDomainName() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"appsync_domain_name": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrCertificateARN: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			names.AttrDescription: {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			names.AttrDomainName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			names.AttrHostedZoneID: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"appsync_domain_name": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrCertificateARN: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				names.AttrDescription: {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				names.AttrDomainName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				names.AttrHostedZoneID: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/appsync/domain_name_api_association.go
+++ b/internal/service/appsync/domain_name_api_association.go
@@ -39,16 +39,18 @@ func resourceDomainNameAPIAssociation() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"api_id": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			names.AttrDomainName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"api_id": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				names.AttrDomainName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/appsync/function.go
+++ b/internal/service/appsync/function.go
@@ -46,112 +46,114 @@ func resourceFunction() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"api_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"code": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				RequiredWith: []string{"runtime"},
-				ValidateFunc: validation.StringLenBetween(1, 32768),
-			},
-			"data_source": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			names.AttrDescription: {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"function_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"function_version": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					functionVersion2018_05_29,
-				}, true),
-			},
-			"max_batch_size": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				ValidateFunc: validation.IntBetween(0, 2000),
-			},
-			names.AttrName: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringMatch(regexache.MustCompile(`[A-Za-z_][0-9A-Za-z_]*`), "must match [A-Za-z_][0-9A-Za-z_]*"),
-			},
-			"request_mapping_template": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"response_mapping_template": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"runtime": {
-				Type:         schema.TypeList,
-				Optional:     true,
-				MaxItems:     1,
-				RequiredWith: []string{"code"},
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrName: {
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.RuntimeName](),
-						},
-						"runtime_version": {
-							Type:     schema.TypeString,
-							Required: true,
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"api_id": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"code": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					RequiredWith: []string{"runtime"},
+					ValidateFunc: validation.StringLenBetween(1, 32768),
+				},
+				"data_source": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				names.AttrDescription: {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"function_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"function_version": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+					ValidateFunc: validation.StringInSlice([]string{
+						functionVersion2018_05_29,
+					}, true),
+				},
+				"max_batch_size": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					ValidateFunc: validation.IntBetween(0, 2000),
+				},
+				names.AttrName: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringMatch(regexache.MustCompile(`[A-Za-z_][0-9A-Za-z_]*`), "must match [A-Za-z_][0-9A-Za-z_]*"),
+				},
+				"request_mapping_template": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"response_mapping_template": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"runtime": {
+					Type:         schema.TypeList,
+					Optional:     true,
+					MaxItems:     1,
+					RequiredWith: []string{"code"},
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrName: {
+								Type:             schema.TypeString,
+								Required:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.RuntimeName](),
+							},
+							"runtime_version": {
+								Type:     schema.TypeString,
+								Required: true,
+							},
 						},
 					},
 				},
-			},
-			"sync_config": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"conflict_detection": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.ConflictDetectionType](),
-						},
-						"conflict_handler": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.ConflictHandlerType](),
-						},
-						"lambda_conflict_handler_config": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"lambda_conflict_handler_arn": {
-										Type:         schema.TypeString,
-										Optional:     true,
-										ValidateFunc: verify.ValidARN,
+				"sync_config": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"conflict_detection": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.ConflictDetectionType](),
+							},
+							"conflict_handler": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.ConflictHandlerType](),
+							},
+							"lambda_conflict_handler_config": {
+								Type:     schema.TypeList,
+								Optional: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"lambda_conflict_handler_arn": {
+											Type:         schema.TypeString,
+											Optional:     true,
+											ValidateFunc: verify.ValidARN,
+										},
 									},
 								},
 							},
 						},
 					},
 				},
-			},
+			}
 		},
 	}
 }

--- a/internal/service/appsync/graphql_api.go
+++ b/internal/service/appsync/graphql_api.go
@@ -51,278 +51,280 @@ func resourceGraphQLAPI() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"additional_authentication_provider": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"authentication_type": {
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.AuthenticationType](),
-						},
-						"lambda_authorizer_config": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"authorizer_result_ttl_in_seconds": {
-										Type:         schema.TypeInt,
-										Optional:     true,
-										Default:      defaultAuthorizerResultTTLInSeconds,
-										ValidateFunc: validateAuthorizerResultTTLInSeconds,
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"additional_authentication_provider": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"authentication_type": {
+								Type:             schema.TypeString,
+								Required:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.AuthenticationType](),
+							},
+							"lambda_authorizer_config": {
+								Type:     schema.TypeList,
+								Optional: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"authorizer_result_ttl_in_seconds": {
+											Type:         schema.TypeInt,
+											Optional:     true,
+											Default:      defaultAuthorizerResultTTLInSeconds,
+											ValidateFunc: validateAuthorizerResultTTLInSeconds,
+										},
+										"authorizer_uri": {
+											Type:     schema.TypeString,
+											Required: true,
+										},
+										"identity_validation_expression": {
+											Type:     schema.TypeString,
+											Optional: true,
+										},
 									},
-									"authorizer_uri": {
-										Type:     schema.TypeString,
-										Required: true,
+								},
+							},
+							"openid_connect_config": {
+								Type:     schema.TypeList,
+								Optional: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"auth_ttl": {
+											Type:     schema.TypeInt,
+											Optional: true,
+										},
+										names.AttrClientID: {
+											Type:     schema.TypeString,
+											Optional: true,
+										},
+										"iat_ttl": {
+											Type:     schema.TypeInt,
+											Optional: true,
+										},
+										names.AttrIssuer: {
+											Type:     schema.TypeString,
+											Required: true,
+										},
 									},
-									"identity_validation_expression": {
-										Type:     schema.TypeString,
-										Optional: true,
+								},
+							},
+							"user_pool_config": {
+								Type:     schema.TypeList,
+								Optional: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"app_id_client_regex": {
+											Type:     schema.TypeString,
+											Optional: true,
+										},
+										"aws_region": {
+											Type:     schema.TypeString,
+											Optional: true,
+											Computed: true,
+										},
+										names.AttrUserPoolID: {
+											Type:     schema.TypeString,
+											Required: true,
+										},
 									},
 								},
 							},
 						},
-						"openid_connect_config": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"auth_ttl": {
-										Type:     schema.TypeInt,
-										Optional: true,
-									},
-									names.AttrClientID: {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
-									"iat_ttl": {
-										Type:     schema.TypeInt,
-										Optional: true,
-									},
-									names.AttrIssuer: {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-								},
+					},
+				},
+				"api_type": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.GraphQLApiType](),
+					ForceNew:         true,
+					Default:          awstypes.GraphQLApiTypeGraphql,
+				},
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"authentication_type": {
+					Type:             schema.TypeString,
+					Required:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.AuthenticationType](),
+				},
+				"enhanced_metrics_config": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"data_source_level_metrics_behavior": {
+								Type:             schema.TypeString,
+								Required:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.DataSourceLevelMetricsBehavior](),
 							},
-						},
-						"user_pool_config": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"app_id_client_regex": {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
-									"aws_region": {
-										Type:     schema.TypeString,
-										Optional: true,
-										Computed: true,
-									},
-									names.AttrUserPoolID: {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-								},
+							"operation_level_metrics_config": {
+								Type:             schema.TypeString,
+								Required:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.OperationLevelMetricsConfig](),
+							},
+							"resolver_level_metrics_behavior": {
+								Type:             schema.TypeString,
+								Required:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.ResolverLevelMetricsBehavior](),
 							},
 						},
 					},
 				},
-			},
-			"api_type": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				ValidateDiagFunc: enum.Validate[awstypes.GraphQLApiType](),
-				ForceNew:         true,
-				Default:          awstypes.GraphQLApiTypeGraphql,
-			},
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"authentication_type": {
-				Type:             schema.TypeString,
-				Required:         true,
-				ValidateDiagFunc: enum.Validate[awstypes.AuthenticationType](),
-			},
-			"enhanced_metrics_config": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"data_source_level_metrics_behavior": {
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.DataSourceLevelMetricsBehavior](),
-						},
-						"operation_level_metrics_config": {
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.OperationLevelMetricsConfig](),
-						},
-						"resolver_level_metrics_behavior": {
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.ResolverLevelMetricsBehavior](),
+				"introspection_config": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					Default:          awstypes.GraphQLApiIntrospectionConfigEnabled,
+					ValidateDiagFunc: enum.Validate[awstypes.GraphQLApiIntrospectionConfig](),
+				},
+				"lambda_authorizer_config": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"authorizer_result_ttl_in_seconds": {
+								Type:         schema.TypeInt,
+								Optional:     true,
+								Default:      defaultAuthorizerResultTTLInSeconds,
+								ValidateFunc: validateAuthorizerResultTTLInSeconds,
+							},
+							"authorizer_uri": {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+							"identity_validation_expression": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
 						},
 					},
 				},
-			},
-			"introspection_config": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Default:          awstypes.GraphQLApiIntrospectionConfigEnabled,
-				ValidateDiagFunc: enum.Validate[awstypes.GraphQLApiIntrospectionConfig](),
-			},
-			"lambda_authorizer_config": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"authorizer_result_ttl_in_seconds": {
-							Type:         schema.TypeInt,
-							Optional:     true,
-							Default:      defaultAuthorizerResultTTLInSeconds,
-							ValidateFunc: validateAuthorizerResultTTLInSeconds,
-						},
-						"authorizer_uri": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"identity_validation_expression": {
-							Type:     schema.TypeString,
-							Optional: true,
+				"log_config": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"cloudwatch_logs_role_arn": {
+								Type:         schema.TypeString,
+								Required:     true,
+								ValidateFunc: verify.ValidARN,
+							},
+							"exclude_verbose_content": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Default:  false,
+							},
+							"field_log_level": {
+								Type:             schema.TypeString,
+								Required:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.FieldLogLevel](),
+							},
 						},
 					},
 				},
-			},
-			"log_config": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"cloudwatch_logs_role_arn": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: verify.ValidARN,
-						},
-						"exclude_verbose_content": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  false,
-						},
-						"field_log_level": {
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.FieldLogLevel](),
+				"merged_api_execution_role_arn": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				names.AttrName: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringMatch(regexache.MustCompile(`[A-Za-z_][0-9A-Za-z_]*`), ""),
+				},
+				"openid_connect_config": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"auth_ttl": {
+								Type:     schema.TypeInt,
+								Optional: true,
+							},
+							names.AttrClientID: {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+							"iat_ttl": {
+								Type:     schema.TypeInt,
+								Optional: true,
+							},
+							names.AttrIssuer: {
+								Type:     schema.TypeString,
+								Required: true,
+							},
 						},
 					},
 				},
-			},
-			"merged_api_execution_role_arn": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			names.AttrName: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringMatch(regexache.MustCompile(`[A-Za-z_][0-9A-Za-z_]*`), ""),
-			},
-			"openid_connect_config": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"auth_ttl": {
-							Type:     schema.TypeInt,
-							Optional: true,
-						},
-						names.AttrClientID: {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"iat_ttl": {
-							Type:     schema.TypeInt,
-							Optional: true,
-						},
-						names.AttrIssuer: {
-							Type:     schema.TypeString,
-							Required: true,
+				"query_depth_limit": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					Default:      0,
+					ValidateFunc: validation.IntBetween(0, 75),
+				},
+				"resolver_count_limit": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					Default:      0,
+					ValidateFunc: validation.IntBetween(0, 10000),
+				},
+				names.AttrSchema: {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				"uris": {
+					Type:     schema.TypeMap,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"user_pool_config": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"app_id_client_regex": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+							"aws_region": {
+								Type:     schema.TypeString,
+								Optional: true,
+								Computed: true,
+							},
+							names.AttrDefaultAction: {
+								Type:             schema.TypeString,
+								Required:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.DefaultAction](),
+							},
+							names.AttrUserPoolID: {
+								Type:     schema.TypeString,
+								Required: true,
+							},
 						},
 					},
 				},
-			},
-			"query_depth_limit": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				Default:      0,
-				ValidateFunc: validation.IntBetween(0, 75),
-			},
-			"resolver_count_limit": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				Default:      0,
-				ValidateFunc: validation.IntBetween(0, 10000),
-			},
-			names.AttrSchema: {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			"uris": {
-				Type:     schema.TypeMap,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			"user_pool_config": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"app_id_client_regex": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"aws_region": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Computed: true,
-						},
-						names.AttrDefaultAction: {
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.DefaultAction](),
-						},
-						names.AttrUserPoolID: {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-					},
+				"visibility": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					ForceNew:         true,
+					Default:          awstypes.GraphQLApiVisibilityGlobal,
+					ValidateDiagFunc: enum.Validate[awstypes.GraphQLApiVisibility](),
 				},
-			},
-			"visibility": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				ForceNew:         true,
-				Default:          awstypes.GraphQLApiVisibilityGlobal,
-				ValidateDiagFunc: enum.Validate[awstypes.GraphQLApiVisibility](),
-			},
-			"xray_enabled": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
+				"xray_enabled": {
+					Type:     schema.TypeBool,
+					Optional: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/appsync/resolver.go
+++ b/internal/service/appsync/resolver.go
@@ -43,146 +43,148 @@ func resourceResolver() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"api_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"caching_config": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"caching_keys": {
-							Type:     schema.TypeSet,
-							Optional: true,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-						},
-						"ttl": {
-							Type:         schema.TypeInt,
-							Optional:     true,
-							ValidateFunc: validation.IntBetween(1, 3600),
-						},
-					},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"api_id": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
 				},
-			},
-			"code": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				RequiredWith: []string{"runtime"},
-				ValidateFunc: validation.StringLenBetween(1, 32768),
-			},
-			"data_source": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				ConflictsWith: []string{"pipeline_config"},
-			},
-			names.AttrField: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"kind": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Default:          awstypes.ResolverKindUnit,
-				ValidateDiagFunc: enum.Validate[awstypes.ResolverKind](),
-			},
-			"max_batch_size": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				ValidateFunc: validation.IntBetween(0, 2000),
-			},
-			"pipeline_config": {
-				Type:          schema.TypeList,
-				Optional:      true,
-				MaxItems:      1,
-				ConflictsWith: []string{"data_source"},
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"functions": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"caching_config": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"caching_keys": {
+								Type:     schema.TypeSet,
+								Optional: true,
+								Elem: &schema.Schema{
+									Type: schema.TypeString,
+								},
+							},
+							"ttl": {
+								Type:         schema.TypeInt,
+								Optional:     true,
+								ValidateFunc: validation.IntBetween(1, 3600),
 							},
 						},
 					},
 				},
-			},
-			"request_template": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"response_template": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"runtime": {
-				Type:         schema.TypeList,
-				Optional:     true,
-				MaxItems:     1,
-				RequiredWith: []string{"code"},
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrName: {
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.RuntimeName](),
-						},
-						"runtime_version": {
-							Type:     schema.TypeString,
-							Required: true,
+				"code": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					RequiredWith: []string{"runtime"},
+					ValidateFunc: validation.StringLenBetween(1, 32768),
+				},
+				"data_source": {
+					Type:          schema.TypeString,
+					Optional:      true,
+					ConflictsWith: []string{"pipeline_config"},
+				},
+				names.AttrField: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"kind": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					Default:          awstypes.ResolverKindUnit,
+					ValidateDiagFunc: enum.Validate[awstypes.ResolverKind](),
+				},
+				"max_batch_size": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					ValidateFunc: validation.IntBetween(0, 2000),
+				},
+				"pipeline_config": {
+					Type:          schema.TypeList,
+					Optional:      true,
+					MaxItems:      1,
+					ConflictsWith: []string{"data_source"},
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"functions": {
+								Type:     schema.TypeList,
+								Optional: true,
+								Elem: &schema.Schema{
+									Type: schema.TypeString,
+								},
+							},
 						},
 					},
 				},
-			},
-			"sync_config": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"conflict_detection": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.ConflictDetectionType](),
+				"request_template": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"response_template": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"runtime": {
+					Type:         schema.TypeList,
+					Optional:     true,
+					MaxItems:     1,
+					RequiredWith: []string{"code"},
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrName: {
+								Type:             schema.TypeString,
+								Required:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.RuntimeName](),
+							},
+							"runtime_version": {
+								Type:     schema.TypeString,
+								Required: true,
+							},
 						},
-						"conflict_handler": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.ConflictHandlerType](),
-						},
-						"lambda_conflict_handler_config": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"lambda_conflict_handler_arn": {
-										Type:         schema.TypeString,
-										Optional:     true,
-										ValidateFunc: verify.ValidARN,
+					},
+				},
+				"sync_config": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"conflict_detection": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.ConflictDetectionType](),
+							},
+							"conflict_handler": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.ConflictHandlerType](),
+							},
+							"lambda_conflict_handler_config": {
+								Type:     schema.TypeList,
+								Optional: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"lambda_conflict_handler_arn": {
+											Type:         schema.TypeString,
+											Optional:     true,
+											ValidateFunc: verify.ValidARN,
+										},
 									},
 								},
 							},
 						},
 					},
 				},
-			},
-			names.AttrType: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+				names.AttrType: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/appsync/type.go
+++ b/internal/service/appsync/type.go
@@ -39,33 +39,35 @@ func resourceType() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"api_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrDescription: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"definition": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			names.AttrFormat: {
-				Type:             schema.TypeString,
-				Required:         true,
-				ValidateDiagFunc: enum.Validate[awstypes.TypeDefinitionFormat](),
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"api_id": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrDescription: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"definition": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				names.AttrFormat: {
+					Type:             schema.TypeString,
+					Required:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.TypeDefinitionFormat](),
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/athena/data_catalog.go
+++ b/internal/service/athena/data_catalog.go
@@ -41,40 +41,42 @@ func resourceDataCatalog() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrDescription: {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-				ValidateFunc: validation.All(
-					validation.StringLenBetween(1, 129),
-					validation.StringMatch(regexache.MustCompile(`[\w@-]*`), ""),
-				),
-			},
-			names.AttrParameters: {
-				Type:     schema.TypeMap,
-				Required: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				ValidateDiagFunc: validation.AllDiag(
-					validation.MapKeyLenBetween(1, 255),
-					validation.MapValueLenBetween(0, 51200),
-				),
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			names.AttrType: {
-				Type:             schema.TypeString,
-				Required:         true,
-				ValidateDiagFunc: enum.Validate[types.DataCatalogType](),
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrDescription: {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+					ValidateFunc: validation.All(
+						validation.StringLenBetween(1, 129),
+						validation.StringMatch(regexache.MustCompile(`[\w@-]*`), ""),
+					),
+				},
+				names.AttrParameters: {
+					Type:     schema.TypeMap,
+					Required: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+					ValidateDiagFunc: validation.AllDiag(
+						validation.MapKeyLenBetween(1, 255),
+						validation.MapValueLenBetween(0, 51200),
+					),
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				names.AttrType: {
+					Type:             schema.TypeString,
+					Required:         true,
+					ValidateDiagFunc: enum.Validate[types.DataCatalogType](),
+				},
+			}
 		},
 	}
 }

--- a/internal/service/athena/database.go
+++ b/internal/service/athena/database.go
@@ -41,80 +41,82 @@ func resourceDatabase() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"acl_configuration": {
-				Type:     schema.TypeList,
-				Optional: true,
-				ForceNew: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"s3_acl_option": {
-							Type:             schema.TypeString,
-							Required:         true,
-							ForceNew:         true,
-							ValidateDiagFunc: enum.Validate[types.S3AclOption](),
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"acl_configuration": {
+					Type:     schema.TypeList,
+					Optional: true,
+					ForceNew: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"s3_acl_option": {
+								Type:             schema.TypeString,
+								Required:         true,
+								ForceNew:         true,
+								ValidateDiagFunc: enum.Validate[types.S3AclOption](),
+							},
 						},
 					},
 				},
-			},
-			names.AttrBucket: {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			names.AttrComment: {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
-			names.AttrEncryptionConfiguration: {
-				Type:     schema.TypeList,
-				Optional: true,
-				ForceNew: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"encryption_option": {
-							Type:             schema.TypeString,
-							Required:         true,
-							ForceNew:         true,
-							ValidateDiagFunc: enum.Validate[types.EncryptionOption](),
-						},
-						names.AttrKMSKey: {
-							Type:     schema.TypeString,
-							Optional: true,
-							ForceNew: true,
+				names.AttrBucket: {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				names.AttrComment: {
+					Type:     schema.TypeString,
+					Optional: true,
+					ForceNew: true,
+				},
+				names.AttrEncryptionConfiguration: {
+					Type:     schema.TypeList,
+					Optional: true,
+					ForceNew: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"encryption_option": {
+								Type:             schema.TypeString,
+								Required:         true,
+								ForceNew:         true,
+								ValidateDiagFunc: enum.Validate[types.EncryptionOption](),
+							},
+							names.AttrKMSKey: {
+								Type:     schema.TypeString,
+								Optional: true,
+								ForceNew: true,
+							},
 						},
 					},
 				},
-			},
-			names.AttrExpectedBucketOwner: {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
-			names.AttrForceDestroy: {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-			names.AttrName: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringMatch(regexache.MustCompile("^[0-9a-z_]+$"), "must be lowercase letters, numbers, or underscore ('_')"),
-			},
-			names.AttrProperties: {
-				Type:     schema.TypeMap,
-				Optional: true,
-				ForceNew: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			"workgroup": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
+				names.AttrExpectedBucketOwner: {
+					Type:     schema.TypeString,
+					Optional: true,
+					ForceNew: true,
+				},
+				names.AttrForceDestroy: {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
+				names.AttrName: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringMatch(regexache.MustCompile("^[0-9a-z_]+$"), "must be lowercase letters, numbers, or underscore ('_')"),
+				},
+				names.AttrProperties: {
+					Type:     schema.TypeMap,
+					Optional: true,
+					ForceNew: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"workgroup": {
+					Type:     schema.TypeString,
+					Optional: true,
+					ForceNew: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/athena/named_query.go
+++ b/internal/service/athena/named_query.go
@@ -33,33 +33,35 @@ func resourceNamedQuery() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrDatabase: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			names.AttrDescription: {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"query": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"workgroup": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Default:  "primary",
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrDatabase: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				names.AttrDescription: {
+					Type:     schema.TypeString,
+					Optional: true,
+					ForceNew: true,
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"query": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"workgroup": {
+					Type:     schema.TypeString,
+					Optional: true,
+					ForceNew: true,
+					Default:  "primary",
+				},
+			}
 		},
 	}
 }

--- a/internal/service/athena/named_query_data_source.go
+++ b/internal/service/athena/named_query_data_source.go
@@ -25,28 +25,30 @@ func dataSourceNamedQuery() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceNamedQueryRead,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrDatabase: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrDescription: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"querystring": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"workgroup": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  "primary",
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrDatabase: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrDescription: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"querystring": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"workgroup": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Default:  "primary",
+				},
+			}
 		},
 	}
 }

--- a/internal/service/athena/prepared_statement.go
+++ b/internal/service/athena/prepared_statement.go
@@ -45,29 +45,31 @@ func resourcePreparedStatement() *schema.Resource {
 			Delete: schema.DefaultTimeout(30 * time.Minute),
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrDescription: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringLenBetween(1, 1024),
-			},
-			names.AttrName: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringMatch(regexache.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_@:]{1,256}$`), ""),
-			},
-			"query_statement": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringLenBetween(1, 262144),
-			},
-			"workgroup": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringMatch(regexache.MustCompile(`^[a-zA-Z0-9._-]{1,128}$`), ""),
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrDescription: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringLenBetween(1, 1024),
+				},
+				names.AttrName: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringMatch(regexache.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_@:]{1,256}$`), ""),
+				},
+				"query_statement": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringLenBetween(1, 262144),
+				},
+				"workgroup": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringMatch(regexache.MustCompile(`^[a-zA-Z0-9._-]{1,128}$`), ""),
+				},
+			}
 		},
 	}
 }

--- a/internal/service/athena/workgroup.go
+++ b/internal/service/athena/workgroup.go
@@ -46,211 +46,213 @@ func resourceWorkGroup() *schema.Resource {
 
 		CustomizeDiff: managedQueryResultsValidation,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrConfiguration: {
-				Type:             schema.TypeList,
-				Optional:         true,
-				MaxItems:         1,
-				DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"bytes_scanned_cutoff_per_query": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							ValidateFunc: validation.Any(
-								validation.IntAtLeast(10485760),
-								validation.IntInSlice([]int{0}),
-							),
-						},
-						"customer_content_encryption_configuration": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									names.AttrKMSKey: {
-										Type:         schema.TypeString,
-										Optional:     true,
-										ValidateFunc: validation.StringMatch(regexache.MustCompile(`^arn:aws[a-z\-]*:kms:([a-z0-9\-]+):\d{12}:key/?[a-zA-Z_0-9+=,.@\-_/]+$|^arn:aws[a-z\-]*:kms:([a-z0-9\-]+):\d{12}:alias/?[a-zA-Z_0-9+=,.@\-_/]+$|^alias/[a-zA-Z0-9/_-]+$|[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}`), "must be a valid KMS Key ARN or Alias"),
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrConfiguration: {
+					Type:             schema.TypeList,
+					Optional:         true,
+					MaxItems:         1,
+					DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"bytes_scanned_cutoff_per_query": {
+								Type:     schema.TypeInt,
+								Optional: true,
+								ValidateFunc: validation.Any(
+									validation.IntAtLeast(10485760),
+									validation.IntInSlice([]int{0}),
+								),
+							},
+							"customer_content_encryption_configuration": {
+								Type:     schema.TypeList,
+								Optional: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										names.AttrKMSKey: {
+											Type:         schema.TypeString,
+											Optional:     true,
+											ValidateFunc: validation.StringMatch(regexache.MustCompile(`^arn:aws[a-z\-]*:kms:([a-z0-9\-]+):\d{12}:key/?[a-zA-Z_0-9+=,.@\-_/]+$|^arn:aws[a-z\-]*:kms:([a-z0-9\-]+):\d{12}:alias/?[a-zA-Z_0-9+=,.@\-_/]+$|^alias/[a-zA-Z0-9/_-]+$|[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}`), "must be a valid KMS Key ARN or Alias"),
+										},
 									},
 								},
 							},
-						},
-						"enable_minimum_encryption_configuration": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Computed: true,
-						},
-						"enforce_workgroup_configuration": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  true,
-						},
-						names.AttrEngineVersion: {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"effective_engine_version": {
-										Type:     schema.TypeString,
-										Computed: true,
-									},
-									"selected_engine_version": {
-										Type:     schema.TypeString,
-										Optional: true,
-										Default:  "AUTO",
+							"enable_minimum_encryption_configuration": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Computed: true,
+							},
+							"enforce_workgroup_configuration": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Default:  true,
+							},
+							names.AttrEngineVersion: {
+								Type:     schema.TypeList,
+								Optional: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"effective_engine_version": {
+											Type:     schema.TypeString,
+											Computed: true,
+										},
+										"selected_engine_version": {
+											Type:     schema.TypeString,
+											Optional: true,
+											Default:  "AUTO",
+										},
 									},
 								},
 							},
-						},
-						"execution_role": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							ValidateFunc: verify.ValidARN,
-						},
-						"identity_center_configuration": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"enable_identity_center": {
-										Type:     schema.TypeBool,
-										Optional: true,
-									},
-									"identity_center_instance_arn": {
-										Type:         schema.TypeString,
-										Optional:     true,
-										ValidateFunc: verify.ValidARN,
+							"execution_role": {
+								Type:         schema.TypeString,
+								Optional:     true,
+								ValidateFunc: verify.ValidARN,
+							},
+							"identity_center_configuration": {
+								Type:     schema.TypeList,
+								Optional: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"enable_identity_center": {
+											Type:     schema.TypeBool,
+											Optional: true,
+										},
+										"identity_center_instance_arn": {
+											Type:         schema.TypeString,
+											Optional:     true,
+											ValidateFunc: verify.ValidARN,
+										},
 									},
 								},
 							},
-						},
-						"query_results_s3_access_grants_configuration": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"authentication_type": {
-										Type:             schema.TypeString,
-										Required:         true,
-										ValidateDiagFunc: enum.Validate[types.AuthenticationType](),
-									},
-									"create_user_level_prefix": {
-										Type:     schema.TypeBool,
-										Optional: true,
-									},
-									"enable_s3_access_grants": {
-										Type:     schema.TypeBool,
-										Required: true,
+							"query_results_s3_access_grants_configuration": {
+								Type:     schema.TypeList,
+								Optional: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"authentication_type": {
+											Type:             schema.TypeString,
+											Required:         true,
+											ValidateDiagFunc: enum.Validate[types.AuthenticationType](),
+										},
+										"create_user_level_prefix": {
+											Type:     schema.TypeBool,
+											Optional: true,
+										},
+										"enable_s3_access_grants": {
+											Type:     schema.TypeBool,
+											Required: true,
+										},
 									},
 								},
 							},
-						},
-						"managed_query_results_configuration": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									names.AttrEnabled: {
-										Type:     schema.TypeBool,
-										Optional: true,
-									},
-									names.AttrEncryptionConfiguration: {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												names.AttrKMSKey: {
-													Type:         schema.TypeString,
-													Optional:     true,
-													ValidateFunc: verify.ValidARN,
+							"managed_query_results_configuration": {
+								Type:     schema.TypeList,
+								Optional: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										names.AttrEnabled: {
+											Type:     schema.TypeBool,
+											Optional: true,
+										},
+										names.AttrEncryptionConfiguration: {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													names.AttrKMSKey: {
+														Type:         schema.TypeString,
+														Optional:     true,
+														ValidateFunc: verify.ValidARN,
+													},
 												},
 											},
 										},
 									},
 								},
 							},
-						},
-						"monitoring_configuration": {
-							Type:             schema.TypeList,
-							Optional:         true,
-							MaxItems:         1,
-							DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"cloud_watch_logging_configuration": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										DiffSuppressFunc: func(_, old, new string, d *schema.ResourceData) bool {
-											// Empty block and enabled = false is equivalent
-											o, n := d.GetChange("configuration.0.monitoring_configuration.0.cloud_watch_logging_configuration")
-											if o != nil && n != nil {
-												if v, ok := o.([]any); ok && len(v) == 0 {
-													if v, ok := n.([]any); ok && len(v) > 0 && v[0] != nil {
-														vm := v[0].(map[string]any)
-														if v, ok := vm[names.AttrEnabled].(bool); ok && !v {
-															return true
+							"monitoring_configuration": {
+								Type:             schema.TypeList,
+								Optional:         true,
+								MaxItems:         1,
+								DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"cloud_watch_logging_configuration": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											DiffSuppressFunc: func(_, old, new string, d *schema.ResourceData) bool {
+												// Empty block and enabled = false is equivalent
+												o, n := d.GetChange("configuration.0.monitoring_configuration.0.cloud_watch_logging_configuration")
+												if o != nil && n != nil {
+													if v, ok := o.([]any); ok && len(v) == 0 {
+														if v, ok := n.([]any); ok && len(v) > 0 && v[0] != nil {
+															vm := v[0].(map[string]any)
+															if v, ok := vm[names.AttrEnabled].(bool); ok && !v {
+																return true
+															}
 														}
 													}
 												}
-											}
-											return false
-										},
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												names.AttrEnabled: {
-													Type:     schema.TypeBool,
-													Required: true,
-													DiffSuppressFunc: func(_, old, new string, d *schema.ResourceData) bool {
-														if old == "" && new == "false" {
-															return true
-														}
-														return false
+												return false
+											},
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													names.AttrEnabled: {
+														Type:     schema.TypeBool,
+														Required: true,
+														DiffSuppressFunc: func(_, old, new string, d *schema.ResourceData) bool {
+															if old == "" && new == "false" {
+																return true
+															}
+															return false
+														},
 													},
-												},
-												"log_group": {
-													Type:             schema.TypeString,
-													Optional:         true,
-													DiffSuppressFunc: diffSuppressWorkGroupConfigurationMonitoringCloudWatchLogging,
-													ValidateFunc: validation.All(
-														validation.StringMatch(regexache.MustCompile(`^[a-zA-Z0-9._/-]+$`), "must contain only alphanumeric characters, periods, underscores, hyphens, and slashes"),
-														validation.StringLenBetween(1, 512),
-													),
-												},
-												"log_stream_name_prefix": {
-													Type:             schema.TypeString,
-													Optional:         true,
-													DiffSuppressFunc: diffSuppressWorkGroupConfigurationMonitoringCloudWatchLogging,
-													ValidateFunc: validation.All(
-														validation.StringMatch(regexache.MustCompile(`^[a-zA-Z0-9._/-]+$`), "must contain only alphanumeric characters, periods, underscores, hyphens, and slashes"),
-														validation.StringLenBetween(1, 512),
-													),
-												},
-												"log_type": {
-													Type:             schema.TypeSet,
-													Optional:         true,
-													DiffSuppressFunc: diffSuppressWorkGroupConfigurationMonitoringCloudWatchLogging,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															names.AttrKey: {
-																Type:     schema.TypeString,
-																Required: true,
-															},
-															names.AttrValues: {
-																Type:     schema.TypeSet,
-																Required: true,
-																Elem: &schema.Schema{
-																	Type: schema.TypeString,
+													"log_group": {
+														Type:             schema.TypeString,
+														Optional:         true,
+														DiffSuppressFunc: diffSuppressWorkGroupConfigurationMonitoringCloudWatchLogging,
+														ValidateFunc: validation.All(
+															validation.StringMatch(regexache.MustCompile(`^[a-zA-Z0-9._/-]+$`), "must contain only alphanumeric characters, periods, underscores, hyphens, and slashes"),
+															validation.StringLenBetween(1, 512),
+														),
+													},
+													"log_stream_name_prefix": {
+														Type:             schema.TypeString,
+														Optional:         true,
+														DiffSuppressFunc: diffSuppressWorkGroupConfigurationMonitoringCloudWatchLogging,
+														ValidateFunc: validation.All(
+															validation.StringMatch(regexache.MustCompile(`^[a-zA-Z0-9._/-]+$`), "must contain only alphanumeric characters, periods, underscores, hyphens, and slashes"),
+															validation.StringLenBetween(1, 512),
+														),
+													},
+													"log_type": {
+														Type:             schema.TypeSet,
+														Optional:         true,
+														DiffSuppressFunc: diffSuppressWorkGroupConfigurationMonitoringCloudWatchLogging,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																names.AttrKey: {
+																	Type:     schema.TypeString,
+																	Required: true,
+																},
+																names.AttrValues: {
+																	Type:     schema.TypeSet,
+																	Required: true,
+																	Elem: &schema.Schema{
+																		Type: schema.TypeString,
+																	},
 																},
 															},
 														},
@@ -258,189 +260,189 @@ func resourceWorkGroup() *schema.Resource {
 												},
 											},
 										},
-									},
-									"managed_logging_configuration": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										DiffSuppressFunc: func(_, old, new string, d *schema.ResourceData) bool {
-											// Empty block and enabled = false is equivalent
-											o, n := d.GetChange("configuration.0.monitoring_configuration.0.managed_logging_configuration")
-											if o != nil && n != nil {
-												if v, ok := o.([]any); ok && len(v) == 0 {
-													if v, ok := n.([]any); ok && len(v) > 0 && v[0] != nil {
-														vm := v[0].(map[string]any)
-														if v, ok := vm[names.AttrEnabled].(bool); ok && !v {
-															return true
+										"managed_logging_configuration": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											DiffSuppressFunc: func(_, old, new string, d *schema.ResourceData) bool {
+												// Empty block and enabled = false is equivalent
+												o, n := d.GetChange("configuration.0.monitoring_configuration.0.managed_logging_configuration")
+												if o != nil && n != nil {
+													if v, ok := o.([]any); ok && len(v) == 0 {
+														if v, ok := n.([]any); ok && len(v) > 0 && v[0] != nil {
+															vm := v[0].(map[string]any)
+															if v, ok := vm[names.AttrEnabled].(bool); ok && !v {
+																return true
+															}
 														}
 													}
 												}
-											}
-											return false
-										},
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												names.AttrEnabled: {
-													Type:     schema.TypeBool,
-													Required: true,
-													DiffSuppressFunc: func(_, old, new string, d *schema.ResourceData) bool {
-														if old == "" && new == "false" {
-															return true
-														}
-														return false
+												return false
+											},
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													names.AttrEnabled: {
+														Type:     schema.TypeBool,
+														Required: true,
+														DiffSuppressFunc: func(_, old, new string, d *schema.ResourceData) bool {
+															if old == "" && new == "false" {
+																return true
+															}
+															return false
+														},
 													},
-												},
-												names.AttrKMSKey: {
-													Type:             schema.TypeString,
-													Optional:         true,
-													DiffSuppressFunc: diffSuppressWorkGroupConfigurationMonitoringManagedLogging,
-													ValidateFunc:     validation.StringMatch(regexache.MustCompile(`^arn:aws[a-z\-]*:kms:([a-z0-9\-]+):\d{12}:key/?[a-zA-Z_0-9+=,.@\-_/]+$|^arn:aws[a-z\-]*:kms:([a-z0-9\-]+):\d{12}:alias/?[a-zA-Z_0-9+=,.@\-_/]+$|^alias/[a-zA-Z0-9/_-]+$|[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}`), "must be a valid KMS Key ARN or Alias"),
+													names.AttrKMSKey: {
+														Type:             schema.TypeString,
+														Optional:         true,
+														DiffSuppressFunc: diffSuppressWorkGroupConfigurationMonitoringManagedLogging,
+														ValidateFunc:     validation.StringMatch(regexache.MustCompile(`^arn:aws[a-z\-]*:kms:([a-z0-9\-]+):\d{12}:key/?[a-zA-Z_0-9+=,.@\-_/]+$|^arn:aws[a-z\-]*:kms:([a-z0-9\-]+):\d{12}:alias/?[a-zA-Z_0-9+=,.@\-_/]+$|^alias/[a-zA-Z0-9/_-]+$|[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}`), "must be a valid KMS Key ARN or Alias"),
+													},
 												},
 											},
 										},
-									},
-									"s3_logging_configuration": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										DiffSuppressFunc: func(_, old, new string, d *schema.ResourceData) bool {
-											// Empty block and enabled = false is equivalent
-											o, n := d.GetChange("configuration.0.monitoring_configuration.0.s3_logging_configuration")
-											if o != nil && n != nil {
-												if v, ok := o.([]any); ok && len(v) == 0 {
-													if v, ok := n.([]any); ok && len(v) > 0 && v[0] != nil {
-														vm := v[0].(map[string]any)
-														if v, ok := vm[names.AttrEnabled].(bool); ok && !v {
-															return true
+										"s3_logging_configuration": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											DiffSuppressFunc: func(_, old, new string, d *schema.ResourceData) bool {
+												// Empty block and enabled = false is equivalent
+												o, n := d.GetChange("configuration.0.monitoring_configuration.0.s3_logging_configuration")
+												if o != nil && n != nil {
+													if v, ok := o.([]any); ok && len(v) == 0 {
+														if v, ok := n.([]any); ok && len(v) > 0 && v[0] != nil {
+															vm := v[0].(map[string]any)
+															if v, ok := vm[names.AttrEnabled].(bool); ok && !v {
+																return true
+															}
 														}
 													}
 												}
-											}
-											return false
-										},
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												names.AttrEnabled: {
-													Type:     schema.TypeBool,
-													Required: true,
-													DiffSuppressFunc: func(_, old, new string, d *schema.ResourceData) bool {
-														if old == "" && new == "false" {
-															return true
-														}
-														return false
+												return false
+											},
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													names.AttrEnabled: {
+														Type:     schema.TypeBool,
+														Required: true,
+														DiffSuppressFunc: func(_, old, new string, d *schema.ResourceData) bool {
+															if old == "" && new == "false" {
+																return true
+															}
+															return false
+														},
 													},
-												},
-												names.AttrKMSKey: {
-													Type:             schema.TypeString,
-													Optional:         true,
-													DiffSuppressFunc: diffSuppressWorkGroupConfigurationMonitoringS3Logging,
-													ValidateFunc:     validation.StringMatch(regexache.MustCompile(`^arn:aws[a-z\-]*:kms:([a-z0-9\-]+):\d{12}:key/?[a-zA-Z_0-9+=,.@\-_/]+$|^arn:aws[a-z\-]*:kms:([a-z0-9\-]+):\d{12}:alias/?[a-zA-Z_0-9+=,.@\-_/]+$|^alias/[a-zA-Z0-9/_-]+$|[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}`), "must be a valid KMS Key ARN or Alias"),
-												},
-												"log_location": {
-													Type:             schema.TypeString,
-													Optional:         true,
-													DiffSuppressFunc: diffSuppressWorkGroupConfigurationMonitoringS3Logging,
-													ValidateFunc: validation.All(
-														validation.StringLenBetween(1, 1024),
-														validation.StringMatch(regexache.MustCompile(`^s3://[a-z0-9][a-z0-9\-]*[a-z0-9](/.*)?$`), "must be a valid S3 URI starting with s3://"),
-													),
+													names.AttrKMSKey: {
+														Type:             schema.TypeString,
+														Optional:         true,
+														DiffSuppressFunc: diffSuppressWorkGroupConfigurationMonitoringS3Logging,
+														ValidateFunc:     validation.StringMatch(regexache.MustCompile(`^arn:aws[a-z\-]*:kms:([a-z0-9\-]+):\d{12}:key/?[a-zA-Z_0-9+=,.@\-_/]+$|^arn:aws[a-z\-]*:kms:([a-z0-9\-]+):\d{12}:alias/?[a-zA-Z_0-9+=,.@\-_/]+$|^alias/[a-zA-Z0-9/_-]+$|[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}`), "must be a valid KMS Key ARN or Alias"),
+													},
+													"log_location": {
+														Type:             schema.TypeString,
+														Optional:         true,
+														DiffSuppressFunc: diffSuppressWorkGroupConfigurationMonitoringS3Logging,
+														ValidateFunc: validation.All(
+															validation.StringLenBetween(1, 1024),
+															validation.StringMatch(regexache.MustCompile(`^s3://[a-z0-9][a-z0-9\-]*[a-z0-9](/.*)?$`), "must be a valid S3 URI starting with s3://"),
+														),
+													},
 												},
 											},
 										},
 									},
 								},
 							},
-						},
-						"publish_cloudwatch_metrics_enabled": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  true,
-						},
-						"result_configuration": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"acl_configuration": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"s3_acl_option": {
-													Type:             schema.TypeString,
-													Required:         true,
-													ValidateDiagFunc: enum.Validate[types.S3AclOption](),
+							"publish_cloudwatch_metrics_enabled": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Default:  true,
+							},
+							"result_configuration": {
+								Type:     schema.TypeList,
+								Optional: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"acl_configuration": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"s3_acl_option": {
+														Type:             schema.TypeString,
+														Required:         true,
+														ValidateDiagFunc: enum.Validate[types.S3AclOption](),
+													},
 												},
 											},
 										},
-									},
-									names.AttrEncryptionConfiguration: {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"encryption_option": {
-													Type:             schema.TypeString,
-													Optional:         true,
-													ValidateDiagFunc: enum.Validate[types.EncryptionOption](),
-												},
-												names.AttrKMSKeyARN: {
-													Type:         schema.TypeString,
-													Optional:     true,
-													ValidateFunc: verify.ValidARN,
+										names.AttrEncryptionConfiguration: {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"encryption_option": {
+														Type:             schema.TypeString,
+														Optional:         true,
+														ValidateDiagFunc: enum.Validate[types.EncryptionOption](),
+													},
+													names.AttrKMSKeyARN: {
+														Type:         schema.TypeString,
+														Optional:     true,
+														ValidateFunc: verify.ValidARN,
+													},
 												},
 											},
 										},
-									},
-									names.AttrExpectedBucketOwner: {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
-									"output_location": {
-										Type:     schema.TypeString,
-										Optional: true,
+										names.AttrExpectedBucketOwner: {
+											Type:     schema.TypeString,
+											Optional: true,
+										},
+										"output_location": {
+											Type:     schema.TypeString,
+											Optional: true,
+										},
 									},
 								},
 							},
-						},
-						"requester_pays_enabled": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  false,
+							"requester_pays_enabled": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Default:  false,
+							},
 						},
 					},
 				},
-			},
-			names.AttrDescription: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringLenBetween(0, 1024),
-			},
-			names.AttrForceDestroy: {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-				ValidateFunc: validation.All(
-					validation.StringLenBetween(1, 128),
-					validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z_.-]+$`), "must contain only alphanumeric characters, periods, underscores, and hyphens"),
-				),
-			},
-			names.AttrState: {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Default:          types.WorkGroupStateEnabled,
-				ValidateDiagFunc: enum.Validate[types.WorkGroupState](),
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				names.AttrDescription: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringLenBetween(0, 1024),
+				},
+				names.AttrForceDestroy: {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+					ValidateFunc: validation.All(
+						validation.StringLenBetween(1, 128),
+						validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z_.-]+$`), "must contain only alphanumeric characters, periods, underscores, and hyphens"),
+					),
+				},
+				names.AttrState: {
+					Type:             schema.TypeString,
+					Optional:         true,
+					Default:          types.WorkGroupStateEnabled,
+					ValidateDiagFunc: enum.Validate[types.WorkGroupState](),
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			}
 		},
 	}
 }

--- a/internal/service/autoscaling/attachment.go
+++ b/internal/service/autoscaling/attachment.go
@@ -30,24 +30,26 @@ func resourceAttachment() *schema.Resource {
 		ReadWithoutTimeout:   resourceAttachmentRead,
 		DeleteWithoutTimeout: resourceAttachmentDelete,
 
-		Schema: map[string]*schema.Schema{
-			"autoscaling_group_name": {
-				Type:     schema.TypeString,
-				ForceNew: true,
-				Required: true,
-			},
-			"elb": {
-				Type:         schema.TypeString,
-				ForceNew:     true,
-				Optional:     true,
-				ExactlyOneOf: []string{"elb", "lb_target_group_arn"},
-			},
-			"lb_target_group_arn": {
-				Type:         schema.TypeString,
-				ForceNew:     true,
-				Optional:     true,
-				ExactlyOneOf: []string{"elb", "lb_target_group_arn"},
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"autoscaling_group_name": {
+					Type:     schema.TypeString,
+					ForceNew: true,
+					Required: true,
+				},
+				"elb": {
+					Type:         schema.TypeString,
+					ForceNew:     true,
+					Optional:     true,
+					ExactlyOneOf: []string{"elb", "lb_target_group_arn"},
+				},
+				"lb_target_group_arn": {
+					Type:         schema.TypeString,
+					ForceNew:     true,
+					Optional:     true,
+					ExactlyOneOf: []string{"elb", "lb_target_group_arn"},
+				},
+			}
 		},
 	}
 }

--- a/internal/service/autoscaling/group.go
+++ b/internal/service/autoscaling/group.go
@@ -69,783 +69,74 @@ func resourceGroup() *schema.Resource {
 			},
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrAvailabilityZones: {
-				Type:          schema.TypeSet,
-				Optional:      true,
-				Computed:      true,
-				Elem:          &schema.Schema{Type: schema.TypeString},
-				ConflictsWith: []string{"vpc_zone_identifier"},
-			},
-			"availability_zone_distribution": {
-				Type:     schema.TypeList,
-				MaxItems: 1,
-				Optional: true,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"capacity_distribution_strategy": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Default:          awstypes.CapacityDistributionStrategyBalancedBestEffort,
-							ValidateDiagFunc: enum.Validate[awstypes.CapacityDistributionStrategy](),
-						},
-					},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
 				},
-			},
-			"capacity_rebalance": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
-			"capacity_reservation_specification": {
-				Type:     schema.TypeList,
-				MaxItems: 1,
-				Optional: true,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"capacity_reservation_preference": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Computed:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.CapacityReservationPreference](),
-						},
-						"capacity_reservation_target": {
-							Type:     schema.TypeList,
-							MaxItems: 1,
-							Optional: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"capacity_reservation_ids": {
-										Type:     schema.TypeList,
-										Optional: true,
-										Elem: &schema.Schema{
-											Type: schema.TypeString,
-										},
-										ConflictsWith: []string{"capacity_reservation_specification.0.capacity_reservation_target.0.capacity_reservation_resource_group_arns"},
-									},
-									"capacity_reservation_resource_group_arns": {
-										Type:     schema.TypeList,
-										Optional: true,
-										Elem: &schema.Schema{
-											Type:         schema.TypeString,
-											ValidateFunc: verify.ValidARN,
-										},
-										ConflictsWith: []string{"capacity_reservation_specification.0.capacity_reservation_target.0.capacity_reservation_ids"},
-									},
-								},
-							},
-						},
-					},
+				names.AttrAvailabilityZones: {
+					Type:          schema.TypeSet,
+					Optional:      true,
+					Computed:      true,
+					Elem:          &schema.Schema{Type: schema.TypeString},
+					ConflictsWith: []string{"vpc_zone_identifier"},
 				},
-			},
-			"context": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"default_cooldown": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Computed: true,
-			},
-			"default_instance_warmup": {
-				Type:     schema.TypeInt,
-				Optional: true,
-			},
-			"desired_capacity": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Computed: true,
-			},
-			"desired_capacity_type": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				ValidateDiagFunc: enum.Validate[desiredCapacityType](),
-			},
-			"enabled_metrics": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			names.AttrForceDelete: {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-			"force_delete_warm_pool": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-			"health_check_grace_period": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Default:  300,
-			},
-			"health_check_type": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-			"ignore_failed_scaling_activities": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-			"initial_lifecycle_hook": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				ForceNew: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"default_result": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Computed:         true,
-							ForceNew:         true,
-							ValidateDiagFunc: enum.Validate[lifecycleHookDefaultResult](),
-						},
-						"heartbeat_timeout": {
-							Type:         schema.TypeInt,
-							Optional:     true,
-							ForceNew:     true,
-							ValidateFunc: validation.IntBetween(30, 7200),
-						},
-						"lifecycle_transition": {
-							Type:             schema.TypeString,
-							Required:         true,
-							ForceNew:         true,
-							ValidateDiagFunc: enum.Validate[lifecycleHookLifecycleTransition](),
-						},
-						names.AttrName: {
-							Type:     schema.TypeString,
-							Required: true,
-							ForceNew: true,
-							ValidateFunc: validation.All(
-								validation.StringLenBetween(1, 255),
-								validation.StringMatch(regexache.MustCompile(`[A-Za-z0-9\-_\/]+`),
-									`no spaces or special characters except "-", "_", and "/"`),
-							),
-						},
-						"notification_metadata": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ForceNew: true,
-						},
-						"notification_target_arn": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							ForceNew:     true,
-							ValidateFunc: verify.ValidARN,
-						},
-						names.AttrRoleARN: {
-							Type:         schema.TypeString,
-							Optional:     true,
-							ForceNew:     true,
-							ValidateFunc: verify.ValidARN,
-						},
-					},
-				},
-			},
-			"instance_maintenance_policy": {
-				Type:             schema.TypeList,
-				MaxItems:         1,
-				Optional:         true,
-				DiffSuppressFunc: instanceMaintenancePolicyDiffSupress,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"max_healthy_percentage": {
-							Type:     schema.TypeInt,
-							Required: true,
-							ValidateFunc: validation.Any(
-								validation.IntBetween(100, 200),
-								validation.IntBetween(-1, -1),
-							),
-							// When value is -1, instance maintenance policy is removed, state file will not contain any value.
-							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-								return old == "" && new == "-1"
-							},
-						},
-						"min_healthy_percentage": {
-							Type:         schema.TypeInt,
-							Required:     true,
-							ValidateFunc: validation.IntBetween(-1, 100),
-							// When value is -1, instance maintenance policy is removed, state file will not contain any value.
-							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-								return old == "" && new == "-1"
-							},
-						},
-					},
-				},
-			},
-			"instance_refresh": {
-				Type:     schema.TypeList,
-				MaxItems: 1,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"preferences": {
-							Type:     schema.TypeList,
-							MaxItems: 1,
-							Optional: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"alarm_specification": {
-										Type:     schema.TypeList,
-										MaxItems: 1,
-										Optional: true,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"alarms": {
-													Type:     schema.TypeList,
-													Optional: true,
-													Elem: &schema.Schema{
-														Type: schema.TypeString,
-													},
-												},
-											},
-										},
-									},
-									"auto_rollback": {
-										Type:     schema.TypeBool,
-										Optional: true,
-									},
-									"checkpoint_delay": {
-										Type:         nullable.TypeNullableInt,
-										Optional:     true,
-										ValidateFunc: nullable.ValidateTypeStringNullableIntAtLeast(0),
-									},
-									"checkpoint_percentages": {
-										Type:     schema.TypeList,
-										Optional: true,
-										Elem: &schema.Schema{
-											Type: schema.TypeInt,
-										},
-									},
-									"instance_warmup": {
-										Type:         nullable.TypeNullableInt,
-										Optional:     true,
-										ValidateFunc: nullable.ValidateTypeStringNullableIntAtLeast(0),
-									},
-									"max_healthy_percentage": {
-										Type:         schema.TypeInt,
-										Optional:     true,
-										Default:      100,
-										ValidateFunc: validation.IntBetween(100, 200),
-									},
-									"min_healthy_percentage": {
-										Type:         schema.TypeInt,
-										Optional:     true,
-										Default:      90,
-										ValidateFunc: validation.IntBetween(0, 100),
-									},
-									"scale_in_protected_instances": {
-										Type:             schema.TypeString,
-										Optional:         true,
-										Default:          awstypes.ScaleInProtectedInstancesIgnore,
-										ValidateDiagFunc: enum.Validate[awstypes.ScaleInProtectedInstances](),
-									},
-									"skip_matching": {
-										Type:     schema.TypeBool,
-										Optional: true,
-										Default:  false,
-									},
-									"standby_instances": {
-										Type:             schema.TypeString,
-										Optional:         true,
-										Default:          awstypes.StandbyInstancesIgnore,
-										ValidateDiagFunc: enum.Validate[awstypes.StandbyInstances](),
-									},
-								},
-							},
-						},
-						"strategy": {
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.RefreshStrategy](),
-						},
-						names.AttrTriggers: {
-							Type:     schema.TypeSet,
-							Optional: true,
-							Elem: &schema.Schema{
+				"availability_zone_distribution": {
+					Type:     schema.TypeList,
+					MaxItems: 1,
+					Optional: true,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"capacity_distribution_strategy": {
 								Type:             schema.TypeString,
-								ValidateDiagFunc: validateGroupInstanceRefreshTriggerFields,
+								Optional:         true,
+								Default:          awstypes.CapacityDistributionStrategyBalancedBestEffort,
+								ValidateDiagFunc: enum.Validate[awstypes.CapacityDistributionStrategy](),
 							},
 						},
 					},
 				},
-			},
-			"launch_configuration": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ExactlyOneOf: []string{"launch_configuration", names.AttrLaunchTemplate, "mixed_instances_policy"},
-			},
-			names.AttrLaunchTemplate: {
-				Type:     schema.TypeList,
-				MaxItems: 1,
-				Optional: true,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrID: {
-							Type:          schema.TypeString,
-							Optional:      true,
-							Computed:      true,
-							ValidateFunc:  verify.ValidLaunchTemplateID,
-							ConflictsWith: []string{"launch_template.0.name"},
-						},
-						names.AttrName: {
-							Type:          schema.TypeString,
-							Optional:      true,
-							Computed:      true,
-							ValidateFunc:  verify.ValidLaunchTemplateName,
-							ConflictsWith: []string{"launch_template.0.id"},
-						},
-						names.AttrVersion: {
-							Type:         schema.TypeString,
-							Optional:     true,
-							Computed:     true,
-							ValidateFunc: validation.StringLenBetween(1, 255),
-						},
-					},
+				"capacity_rebalance": {
+					Type:     schema.TypeBool,
+					Optional: true,
 				},
-				ExactlyOneOf: []string{"launch_configuration", names.AttrLaunchTemplate, "mixed_instances_policy"},
-			},
-			"load_balancers": {
-				Type:          schema.TypeSet,
-				Optional:      true,
-				Computed:      true,
-				Elem:          &schema.Schema{Type: schema.TypeString},
-				ConflictsWith: []string{"traffic_source"},
-			},
-			"max_instance_lifetime": {
-				Type:     schema.TypeInt,
-				Optional: true,
-			},
-			"max_size": {
-				Type:     schema.TypeInt,
-				Required: true,
-			},
-			"metrics_granularity": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  defaultEnabledMetricsGranularity,
-			},
-			"min_elb_capacity": {
-				Type:     schema.TypeInt,
-				Optional: true,
-			},
-			"min_size": {
-				Type:     schema.TypeInt,
-				Required: true,
-			},
-			"mixed_instances_policy": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Computed: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"instances_distribution": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Computed: true,
-							// Ideally we'd want to detect drift detection,
-							// but a DiffSuppressFunc here does not behave nicely
-							// for detecting missing configuration blocks
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									// These fields are returned from calls to the API
-									// even if not provided at input time and can be omitted in requests;
-									// thus, to prevent non-empty plans, we set these
-									// to Computed and remove Defaults
-									"on_demand_allocation_strategy": {
-										Type:     schema.TypeString,
-										Optional: true,
-										Computed: true,
-									},
-									"on_demand_base_capacity": {
-										Type:         schema.TypeInt,
-										Optional:     true,
-										Computed:     true,
-										ValidateFunc: validation.IntAtLeast(0),
-									},
-									"on_demand_percentage_above_base_capacity": {
-										Type:         schema.TypeInt,
-										Optional:     true,
-										Computed:     true,
-										ValidateFunc: validation.IntBetween(0, 100),
-									},
-									"spot_allocation_strategy": {
-										Type:     schema.TypeString,
-										Optional: true,
-										Computed: true,
-									},
-									"spot_instance_pools": {
-										Type:         schema.TypeInt,
-										Optional:     true,
-										Computed:     true,
-										ValidateFunc: validation.IntAtLeast(0),
-									},
-									"spot_max_price": {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
-								},
+				"capacity_reservation_specification": {
+					Type:     schema.TypeList,
+					MaxItems: 1,
+					Optional: true,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"capacity_reservation_preference": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								Computed:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.CapacityReservationPreference](),
 							},
-						},
-						names.AttrLaunchTemplate: {
-							Type:     schema.TypeList,
-							Required: true,
-							MinItems: 1,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"launch_template_specification": {
-										Type:     schema.TypeList,
-										Required: true,
-										MinItems: 1,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"launch_template_id": {
-													Type:     schema.TypeString,
-													Optional: true,
-													Computed: true,
-												},
-												"launch_template_name": {
-													Type:     schema.TypeString,
-													Optional: true,
-													Computed: true,
-												},
-												names.AttrVersion: {
-													Type:     schema.TypeString,
-													Optional: true,
-													Computed: true,
-												},
+							"capacity_reservation_target": {
+								Type:     schema.TypeList,
+								MaxItems: 1,
+								Optional: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"capacity_reservation_ids": {
+											Type:     schema.TypeList,
+											Optional: true,
+											Elem: &schema.Schema{
+												Type: schema.TypeString,
 											},
+											ConflictsWith: []string{"capacity_reservation_specification.0.capacity_reservation_target.0.capacity_reservation_resource_group_arns"},
 										},
-									},
-									"override": {
-										Type:     schema.TypeList,
-										Optional: true,
-										Computed: true,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"instance_requirements": {
-													Type:     schema.TypeList,
-													Optional: true,
-													MaxItems: 1,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															"accelerator_count": {
-																Type:     schema.TypeList,
-																Optional: true,
-																MaxItems: 1,
-																Elem: &schema.Resource{
-																	Schema: map[string]*schema.Schema{
-																		names.AttrMax: {
-																			Type:         schema.TypeInt,
-																			Optional:     true,
-																			ValidateFunc: validation.IntAtLeast(0),
-																		},
-																		names.AttrMin: {
-																			Type:         schema.TypeInt,
-																			Optional:     true,
-																			ValidateFunc: validation.IntAtLeast(1),
-																		},
-																	},
-																},
-															},
-															"accelerator_manufacturers": {
-																Type:     schema.TypeSet,
-																Optional: true,
-																Elem: &schema.Schema{
-																	Type:             schema.TypeString,
-																	ValidateDiagFunc: enum.Validate[awstypes.AcceleratorManufacturer](),
-																},
-															},
-															"accelerator_names": {
-																Type:     schema.TypeSet,
-																Optional: true,
-																Elem: &schema.Schema{
-																	Type:             schema.TypeString,
-																	ValidateDiagFunc: enum.Validate[awstypes.AcceleratorName](),
-																},
-															},
-															"accelerator_total_memory_mib": {
-																Type:     schema.TypeList,
-																Optional: true,
-																MaxItems: 1,
-																Elem: &schema.Resource{
-																	Schema: map[string]*schema.Schema{
-																		names.AttrMax: {
-																			Type:         schema.TypeInt,
-																			Optional:     true,
-																			ValidateFunc: validation.IntAtLeast(1),
-																		},
-																		names.AttrMin: {
-																			Type:         schema.TypeInt,
-																			Optional:     true,
-																			ValidateFunc: validation.IntAtLeast(1),
-																		},
-																	},
-																},
-															},
-															"accelerator_types": {
-																Type:     schema.TypeSet,
-																Optional: true,
-																Elem: &schema.Schema{
-																	Type:             schema.TypeString,
-																	ValidateDiagFunc: enum.Validate[awstypes.AcceleratorType](),
-																},
-															},
-															"allowed_instance_types": {
-																Type:     schema.TypeSet,
-																Optional: true,
-																MaxItems: 400,
-																Elem:     &schema.Schema{Type: schema.TypeString},
-															},
-															"bare_metal": {
-																Type:             schema.TypeString,
-																Optional:         true,
-																ValidateDiagFunc: enum.Validate[awstypes.BareMetal](),
-															},
-															"baseline_ebs_bandwidth_mbps": {
-																Type:     schema.TypeList,
-																Optional: true,
-																MaxItems: 1,
-																Elem: &schema.Resource{
-																	Schema: map[string]*schema.Schema{
-																		names.AttrMax: {
-																			Type:         schema.TypeInt,
-																			Optional:     true,
-																			ValidateFunc: validation.IntAtLeast(1),
-																		},
-																		names.AttrMin: {
-																			Type:         schema.TypeInt,
-																			Optional:     true,
-																			ValidateFunc: validation.IntAtLeast(1),
-																		},
-																	},
-																},
-															},
-															"burstable_performance": {
-																Type:             schema.TypeString,
-																Optional:         true,
-																ValidateDiagFunc: enum.Validate[awstypes.BurstablePerformance](),
-															},
-															"cpu_manufacturers": {
-																Type:     schema.TypeSet,
-																Optional: true,
-																Elem: &schema.Schema{
-																	Type:             schema.TypeString,
-																	ValidateDiagFunc: enum.Validate[awstypes.CpuManufacturer](),
-																},
-															},
-															"excluded_instance_types": {
-																Type:     schema.TypeSet,
-																Optional: true,
-																MaxItems: 400,
-																Elem:     &schema.Schema{Type: schema.TypeString},
-															},
-															"instance_generations": {
-																Type:     schema.TypeSet,
-																Optional: true,
-																Elem: &schema.Schema{
-																	Type:             schema.TypeString,
-																	ValidateDiagFunc: enum.Validate[awstypes.InstanceGeneration](),
-																},
-															},
-															"local_storage": {
-																Type:             schema.TypeString,
-																Optional:         true,
-																ValidateDiagFunc: enum.Validate[awstypes.LocalStorage](),
-															},
-															"local_storage_types": {
-																Type:     schema.TypeSet,
-																Optional: true,
-																Elem: &schema.Schema{
-																	Type:             schema.TypeString,
-																	ValidateDiagFunc: enum.Validate[awstypes.LocalStorageType](),
-																},
-															},
-															"max_spot_price_as_percentage_of_optimal_on_demand_price": {
-																Type:         schema.TypeInt,
-																Optional:     true,
-																ValidateFunc: validation.IntAtLeast(1),
-															},
-															"memory_gib_per_vcpu": {
-																Type:     schema.TypeList,
-																Optional: true,
-																MaxItems: 1,
-																Elem: &schema.Resource{
-																	Schema: map[string]*schema.Schema{
-																		names.AttrMax: {
-																			Type:         schema.TypeFloat,
-																			Optional:     true,
-																			ValidateFunc: verify.FloatGreaterThan(0.0),
-																		},
-																		names.AttrMin: {
-																			Type:         schema.TypeFloat,
-																			Optional:     true,
-																			ValidateFunc: verify.FloatGreaterThan(0.0),
-																		},
-																	},
-																},
-															},
-															"memory_mib": {
-																Type:     schema.TypeList,
-																Optional: true,
-																MaxItems: 1,
-																Elem: &schema.Resource{
-																	Schema: map[string]*schema.Schema{
-																		names.AttrMax: {
-																			Type:         schema.TypeInt,
-																			Optional:     true,
-																			ValidateFunc: validation.IntAtLeast(1),
-																		},
-																		names.AttrMin: {
-																			Type:         schema.TypeInt,
-																			Optional:     true,
-																			ValidateFunc: validation.IntAtLeast(1),
-																		},
-																	},
-																},
-															},
-															"network_bandwidth_gbps": {
-																Type:     schema.TypeList,
-																Optional: true,
-																MaxItems: 1,
-																Elem: &schema.Resource{
-																	Schema: map[string]*schema.Schema{
-																		names.AttrMax: {
-																			Type:         schema.TypeFloat,
-																			Optional:     true,
-																			ValidateFunc: verify.FloatGreaterThan(0.0),
-																		},
-																		names.AttrMin: {
-																			Type:         schema.TypeFloat,
-																			Optional:     true,
-																			ValidateFunc: verify.FloatGreaterThan(0.0),
-																		},
-																	},
-																},
-															},
-															"network_interface_count": {
-																Type:     schema.TypeList,
-																Optional: true,
-																MaxItems: 1,
-																Elem: &schema.Resource{
-																	Schema: map[string]*schema.Schema{
-																		names.AttrMax: {
-																			Type:         schema.TypeInt,
-																			Optional:     true,
-																			ValidateFunc: validation.IntAtLeast(1),
-																		},
-																		names.AttrMin: {
-																			Type:         schema.TypeInt,
-																			Optional:     true,
-																			ValidateFunc: validation.IntAtLeast(1),
-																		},
-																	},
-																},
-															},
-															"on_demand_max_price_percentage_over_lowest_price": {
-																Type:         schema.TypeInt,
-																Optional:     true,
-																ValidateFunc: validation.IntAtLeast(1),
-															},
-															"require_hibernate_support": {
-																Type:     schema.TypeBool,
-																Optional: true,
-															},
-															"spot_max_price_percentage_over_lowest_price": {
-																Type:         schema.TypeInt,
-																Optional:     true,
-																ValidateFunc: validation.IntAtLeast(1),
-															},
-															"total_local_storage_gb": {
-																Type:     schema.TypeList,
-																Optional: true,
-																MaxItems: 1,
-																Elem: &schema.Resource{
-																	Schema: map[string]*schema.Schema{
-																		names.AttrMax: {
-																			Type:         schema.TypeFloat,
-																			Optional:     true,
-																			ValidateFunc: verify.FloatGreaterThan(0.0),
-																		},
-																		names.AttrMin: {
-																			Type:         schema.TypeFloat,
-																			Optional:     true,
-																			ValidateFunc: verify.FloatGreaterThan(0.0),
-																		},
-																	},
-																},
-															},
-															"vcpu_count": {
-																Type:     schema.TypeList,
-																Optional: true,
-																MaxItems: 1,
-																Elem: &schema.Resource{
-																	Schema: map[string]*schema.Schema{
-																		names.AttrMax: {
-																			Type:         schema.TypeInt,
-																			Optional:     true,
-																			ValidateFunc: validation.IntAtLeast(1),
-																		},
-																		names.AttrMin: {
-																			Type:         schema.TypeInt,
-																			Optional:     true,
-																			ValidateFunc: validation.IntAtLeast(1),
-																		},
-																	},
-																},
-															},
-														},
-													},
-												},
-												names.AttrInstanceType: {
-													Type:     schema.TypeString,
-													Optional: true,
-												},
-												"launch_template_specification": {
-													Type:     schema.TypeList,
-													Optional: true,
-													MinItems: 0,
-													MaxItems: 1,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															"launch_template_id": {
-																Type:     schema.TypeString,
-																Optional: true,
-																Computed: true,
-															},
-															"launch_template_name": {
-																Type:     schema.TypeString,
-																Optional: true,
-																Computed: true,
-															},
-															names.AttrVersion: {
-																Type:     schema.TypeString,
-																Optional: true,
-																Computed: true,
-															},
-														},
-													},
-												},
-												"weighted_capacity": {
-													Type:         schema.TypeString,
-													Optional:     true,
-													ValidateFunc: validation.StringMatch(regexache.MustCompile(`^[1-9][0-9]{0,2}$`), "see https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_LaunchTemplateOverrides.html"),
-												},
+										"capacity_reservation_resource_group_arns": {
+											Type:     schema.TypeList,
+											Optional: true,
+											Elem: &schema.Schema{
+												Type:         schema.TypeString,
+												ValidateFunc: verify.ValidARN,
 											},
+											ConflictsWith: []string{"capacity_reservation_specification.0.capacity_reservation_target.0.capacity_reservation_ids"},
 										},
 									},
 								},
@@ -853,161 +144,872 @@ func resourceGroup() *schema.Resource {
 						},
 					},
 				},
-				ExactlyOneOf: []string{"launch_configuration", names.AttrLaunchTemplate, "mixed_instances_policy"},
-			},
-			names.AttrName: {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				ForceNew:      true,
-				ValidateFunc:  validation.StringLenBetween(0, 255),
-				ConflictsWith: []string{names.AttrNamePrefix},
-			},
-			names.AttrNamePrefix: {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				ForceNew:      true,
-				ValidateFunc:  validation.StringLenBetween(0, 255-sdkid.UniqueIDSuffixLength),
-				ConflictsWith: []string{names.AttrName},
-			},
-			"placement_group": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"predicted_capacity": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-			"protect_from_scale_in": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-			"service_linked_role_arn": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-			"suspended_processes": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			"tag": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrKey: {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"propagate_at_launch": {
-							Type:     schema.TypeBool,
-							Required: true,
-						},
-						names.AttrValue: {
-							Type:     schema.TypeString,
-							Required: true,
+				"context": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"default_cooldown": {
+					Type:     schema.TypeInt,
+					Optional: true,
+					Computed: true,
+				},
+				"default_instance_warmup": {
+					Type:     schema.TypeInt,
+					Optional: true,
+				},
+				"desired_capacity": {
+					Type:     schema.TypeInt,
+					Optional: true,
+					Computed: true,
+				},
+				"desired_capacity_type": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					ValidateDiagFunc: enum.Validate[desiredCapacityType](),
+				},
+				"enabled_metrics": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				names.AttrForceDelete: {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
+				"force_delete_warm_pool": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
+				"health_check_grace_period": {
+					Type:     schema.TypeInt,
+					Optional: true,
+					Default:  300,
+				},
+				"health_check_type": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+				},
+				"ignore_failed_scaling_activities": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
+				"initial_lifecycle_hook": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					ForceNew: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"default_result": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								Computed:         true,
+								ForceNew:         true,
+								ValidateDiagFunc: enum.Validate[lifecycleHookDefaultResult](),
+							},
+							"heartbeat_timeout": {
+								Type:         schema.TypeInt,
+								Optional:     true,
+								ForceNew:     true,
+								ValidateFunc: validation.IntBetween(30, 7200),
+							},
+							"lifecycle_transition": {
+								Type:             schema.TypeString,
+								Required:         true,
+								ForceNew:         true,
+								ValidateDiagFunc: enum.Validate[lifecycleHookLifecycleTransition](),
+							},
+							names.AttrName: {
+								Type:     schema.TypeString,
+								Required: true,
+								ForceNew: true,
+								ValidateFunc: validation.All(
+									validation.StringLenBetween(1, 255),
+									validation.StringMatch(regexache.MustCompile(`[A-Za-z0-9\-_\/]+`),
+										`no spaces or special characters except "-", "_", and "/"`),
+								),
+							},
+							"notification_metadata": {
+								Type:     schema.TypeString,
+								Optional: true,
+								ForceNew: true,
+							},
+							"notification_target_arn": {
+								Type:         schema.TypeString,
+								Optional:     true,
+								ForceNew:     true,
+								ValidateFunc: verify.ValidARN,
+							},
+							names.AttrRoleARN: {
+								Type:         schema.TypeString,
+								Optional:     true,
+								ForceNew:     true,
+								ValidateFunc: verify.ValidARN,
+							},
 						},
 					},
 				},
-			},
-			"target_group_arns": {
-				Type:          schema.TypeSet,
-				Optional:      true,
-				Computed:      true,
-				Elem:          &schema.Schema{Type: schema.TypeString},
-				ConflictsWith: []string{"traffic_source"},
-			},
-			"termination_policies": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			"traffic_source": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrIdentifier: {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validation.StringLenBetween(1, 2048),
-						},
-						names.AttrType: {
-							Type:         schema.TypeString,
-							Optional:     true,
-							ValidateFunc: validation.StringLenBetween(1, 2048),
+				"instance_maintenance_policy": {
+					Type:             schema.TypeList,
+					MaxItems:         1,
+					Optional:         true,
+					DiffSuppressFunc: instanceMaintenancePolicyDiffSupress,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"max_healthy_percentage": {
+								Type:     schema.TypeInt,
+								Required: true,
+								ValidateFunc: validation.Any(
+									validation.IntBetween(100, 200),
+									validation.IntBetween(-1, -1),
+								),
+								// When value is -1, instance maintenance policy is removed, state file will not contain any value.
+								DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+									return old == "" && new == "-1"
+								},
+							},
+							"min_healthy_percentage": {
+								Type:         schema.TypeInt,
+								Required:     true,
+								ValidateFunc: validation.IntBetween(-1, 100),
+								// When value is -1, instance maintenance policy is removed, state file will not contain any value.
+								DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+									return old == "" && new == "-1"
+								},
+							},
 						},
 					},
 				},
-				ConflictsWith: []string{"load_balancers", "target_group_arns"},
-			},
-			"vpc_zone_identifier": {
-				Type:          schema.TypeSet,
-				Optional:      true,
-				Computed:      true,
-				Elem:          &schema.Schema{Type: schema.TypeString},
-				ConflictsWith: []string{names.AttrAvailabilityZones},
-			},
-			"wait_for_capacity_timeout": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Default:      "10m",
-				ValidateFunc: verify.ValidDuration,
-			},
-			"wait_for_elb_capacity": {
-				Type:     schema.TypeInt,
-				Optional: true,
-			},
-			"warm_pool": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"instance_reuse_policy": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"reuse_on_scale_in": {
-										Type:     schema.TypeBool,
-										Optional: true,
-										Default:  false,
+				"instance_refresh": {
+					Type:     schema.TypeList,
+					MaxItems: 1,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"preferences": {
+								Type:     schema.TypeList,
+								MaxItems: 1,
+								Optional: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"alarm_specification": {
+											Type:     schema.TypeList,
+											MaxItems: 1,
+											Optional: true,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"alarms": {
+														Type:     schema.TypeList,
+														Optional: true,
+														Elem: &schema.Schema{
+															Type: schema.TypeString,
+														},
+													},
+												},
+											},
+										},
+										"auto_rollback": {
+											Type:     schema.TypeBool,
+											Optional: true,
+										},
+										"checkpoint_delay": {
+											Type:         nullable.TypeNullableInt,
+											Optional:     true,
+											ValidateFunc: nullable.ValidateTypeStringNullableIntAtLeast(0),
+										},
+										"checkpoint_percentages": {
+											Type:     schema.TypeList,
+											Optional: true,
+											Elem: &schema.Schema{
+												Type: schema.TypeInt,
+											},
+										},
+										"instance_warmup": {
+											Type:         nullable.TypeNullableInt,
+											Optional:     true,
+											ValidateFunc: nullable.ValidateTypeStringNullableIntAtLeast(0),
+										},
+										"max_healthy_percentage": {
+											Type:         schema.TypeInt,
+											Optional:     true,
+											Default:      100,
+											ValidateFunc: validation.IntBetween(100, 200),
+										},
+										"min_healthy_percentage": {
+											Type:         schema.TypeInt,
+											Optional:     true,
+											Default:      90,
+											ValidateFunc: validation.IntBetween(0, 100),
+										},
+										"scale_in_protected_instances": {
+											Type:             schema.TypeString,
+											Optional:         true,
+											Default:          awstypes.ScaleInProtectedInstancesIgnore,
+											ValidateDiagFunc: enum.Validate[awstypes.ScaleInProtectedInstances](),
+										},
+										"skip_matching": {
+											Type:     schema.TypeBool,
+											Optional: true,
+											Default:  false,
+										},
+										"standby_instances": {
+											Type:             schema.TypeString,
+											Optional:         true,
+											Default:          awstypes.StandbyInstancesIgnore,
+											ValidateDiagFunc: enum.Validate[awstypes.StandbyInstances](),
+										},
+									},
+								},
+							},
+							"strategy": {
+								Type:             schema.TypeString,
+								Required:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.RefreshStrategy](),
+							},
+							names.AttrTriggers: {
+								Type:     schema.TypeSet,
+								Optional: true,
+								Elem: &schema.Schema{
+									Type:             schema.TypeString,
+									ValidateDiagFunc: validateGroupInstanceRefreshTriggerFields,
+								},
+							},
+						},
+					},
+				},
+				"launch_configuration": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ExactlyOneOf: []string{"launch_configuration", names.AttrLaunchTemplate, "mixed_instances_policy"},
+				},
+				names.AttrLaunchTemplate: {
+					Type:     schema.TypeList,
+					MaxItems: 1,
+					Optional: true,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrID: {
+								Type:          schema.TypeString,
+								Optional:      true,
+								Computed:      true,
+								ValidateFunc:  verify.ValidLaunchTemplateID,
+								ConflictsWith: []string{"launch_template.0.name"},
+							},
+							names.AttrName: {
+								Type:          schema.TypeString,
+								Optional:      true,
+								Computed:      true,
+								ValidateFunc:  verify.ValidLaunchTemplateName,
+								ConflictsWith: []string{"launch_template.0.id"},
+							},
+							names.AttrVersion: {
+								Type:         schema.TypeString,
+								Optional:     true,
+								Computed:     true,
+								ValidateFunc: validation.StringLenBetween(1, 255),
+							},
+						},
+					},
+					ExactlyOneOf: []string{"launch_configuration", names.AttrLaunchTemplate, "mixed_instances_policy"},
+				},
+				"load_balancers": {
+					Type:          schema.TypeSet,
+					Optional:      true,
+					Computed:      true,
+					Elem:          &schema.Schema{Type: schema.TypeString},
+					ConflictsWith: []string{"traffic_source"},
+				},
+				"max_instance_lifetime": {
+					Type:     schema.TypeInt,
+					Optional: true,
+				},
+				"max_size": {
+					Type:     schema.TypeInt,
+					Required: true,
+				},
+				"metrics_granularity": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Default:  defaultEnabledMetricsGranularity,
+				},
+				"min_elb_capacity": {
+					Type:     schema.TypeInt,
+					Optional: true,
+				},
+				"min_size": {
+					Type:     schema.TypeInt,
+					Required: true,
+				},
+				"mixed_instances_policy": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Computed: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"instances_distribution": {
+								Type:     schema.TypeList,
+								Optional: true,
+								MaxItems: 1,
+								Computed: true,
+								// Ideally we'd want to detect drift detection,
+								// but a DiffSuppressFunc here does not behave nicely
+								// for detecting missing configuration blocks
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										// These fields are returned from calls to the API
+										// even if not provided at input time and can be omitted in requests;
+										// thus, to prevent non-empty plans, we set these
+										// to Computed and remove Defaults
+										"on_demand_allocation_strategy": {
+											Type:     schema.TypeString,
+											Optional: true,
+											Computed: true,
+										},
+										"on_demand_base_capacity": {
+											Type:         schema.TypeInt,
+											Optional:     true,
+											Computed:     true,
+											ValidateFunc: validation.IntAtLeast(0),
+										},
+										"on_demand_percentage_above_base_capacity": {
+											Type:         schema.TypeInt,
+											Optional:     true,
+											Computed:     true,
+											ValidateFunc: validation.IntBetween(0, 100),
+										},
+										"spot_allocation_strategy": {
+											Type:     schema.TypeString,
+											Optional: true,
+											Computed: true,
+										},
+										"spot_instance_pools": {
+											Type:         schema.TypeInt,
+											Optional:     true,
+											Computed:     true,
+											ValidateFunc: validation.IntAtLeast(0),
+										},
+										"spot_max_price": {
+											Type:     schema.TypeString,
+											Optional: true,
+										},
+									},
+								},
+							},
+							names.AttrLaunchTemplate: {
+								Type:     schema.TypeList,
+								Required: true,
+								MinItems: 1,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"launch_template_specification": {
+											Type:     schema.TypeList,
+											Required: true,
+											MinItems: 1,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"launch_template_id": {
+														Type:     schema.TypeString,
+														Optional: true,
+														Computed: true,
+													},
+													"launch_template_name": {
+														Type:     schema.TypeString,
+														Optional: true,
+														Computed: true,
+													},
+													names.AttrVersion: {
+														Type:     schema.TypeString,
+														Optional: true,
+														Computed: true,
+													},
+												},
+											},
+										},
+										"override": {
+											Type:     schema.TypeList,
+											Optional: true,
+											Computed: true,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"instance_requirements": {
+														Type:     schema.TypeList,
+														Optional: true,
+														MaxItems: 1,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																"accelerator_count": {
+																	Type:     schema.TypeList,
+																	Optional: true,
+																	MaxItems: 1,
+																	Elem: &schema.Resource{
+																		Schema: map[string]*schema.Schema{
+																			names.AttrMax: {
+																				Type:         schema.TypeInt,
+																				Optional:     true,
+																				ValidateFunc: validation.IntAtLeast(0),
+																			},
+																			names.AttrMin: {
+																				Type:         schema.TypeInt,
+																				Optional:     true,
+																				ValidateFunc: validation.IntAtLeast(1),
+																			},
+																		},
+																	},
+																},
+																"accelerator_manufacturers": {
+																	Type:     schema.TypeSet,
+																	Optional: true,
+																	Elem: &schema.Schema{
+																		Type:             schema.TypeString,
+																		ValidateDiagFunc: enum.Validate[awstypes.AcceleratorManufacturer](),
+																	},
+																},
+																"accelerator_names": {
+																	Type:     schema.TypeSet,
+																	Optional: true,
+																	Elem: &schema.Schema{
+																		Type:             schema.TypeString,
+																		ValidateDiagFunc: enum.Validate[awstypes.AcceleratorName](),
+																	},
+																},
+																"accelerator_total_memory_mib": {
+																	Type:     schema.TypeList,
+																	Optional: true,
+																	MaxItems: 1,
+																	Elem: &schema.Resource{
+																		Schema: map[string]*schema.Schema{
+																			names.AttrMax: {
+																				Type:         schema.TypeInt,
+																				Optional:     true,
+																				ValidateFunc: validation.IntAtLeast(1),
+																			},
+																			names.AttrMin: {
+																				Type:         schema.TypeInt,
+																				Optional:     true,
+																				ValidateFunc: validation.IntAtLeast(1),
+																			},
+																		},
+																	},
+																},
+																"accelerator_types": {
+																	Type:     schema.TypeSet,
+																	Optional: true,
+																	Elem: &schema.Schema{
+																		Type:             schema.TypeString,
+																		ValidateDiagFunc: enum.Validate[awstypes.AcceleratorType](),
+																	},
+																},
+																"allowed_instance_types": {
+																	Type:     schema.TypeSet,
+																	Optional: true,
+																	MaxItems: 400,
+																	Elem:     &schema.Schema{Type: schema.TypeString},
+																},
+																"bare_metal": {
+																	Type:             schema.TypeString,
+																	Optional:         true,
+																	ValidateDiagFunc: enum.Validate[awstypes.BareMetal](),
+																},
+																"baseline_ebs_bandwidth_mbps": {
+																	Type:     schema.TypeList,
+																	Optional: true,
+																	MaxItems: 1,
+																	Elem: &schema.Resource{
+																		Schema: map[string]*schema.Schema{
+																			names.AttrMax: {
+																				Type:         schema.TypeInt,
+																				Optional:     true,
+																				ValidateFunc: validation.IntAtLeast(1),
+																			},
+																			names.AttrMin: {
+																				Type:         schema.TypeInt,
+																				Optional:     true,
+																				ValidateFunc: validation.IntAtLeast(1),
+																			},
+																		},
+																	},
+																},
+																"burstable_performance": {
+																	Type:             schema.TypeString,
+																	Optional:         true,
+																	ValidateDiagFunc: enum.Validate[awstypes.BurstablePerformance](),
+																},
+																"cpu_manufacturers": {
+																	Type:     schema.TypeSet,
+																	Optional: true,
+																	Elem: &schema.Schema{
+																		Type:             schema.TypeString,
+																		ValidateDiagFunc: enum.Validate[awstypes.CpuManufacturer](),
+																	},
+																},
+																"excluded_instance_types": {
+																	Type:     schema.TypeSet,
+																	Optional: true,
+																	MaxItems: 400,
+																	Elem:     &schema.Schema{Type: schema.TypeString},
+																},
+																"instance_generations": {
+																	Type:     schema.TypeSet,
+																	Optional: true,
+																	Elem: &schema.Schema{
+																		Type:             schema.TypeString,
+																		ValidateDiagFunc: enum.Validate[awstypes.InstanceGeneration](),
+																	},
+																},
+																"local_storage": {
+																	Type:             schema.TypeString,
+																	Optional:         true,
+																	ValidateDiagFunc: enum.Validate[awstypes.LocalStorage](),
+																},
+																"local_storage_types": {
+																	Type:     schema.TypeSet,
+																	Optional: true,
+																	Elem: &schema.Schema{
+																		Type:             schema.TypeString,
+																		ValidateDiagFunc: enum.Validate[awstypes.LocalStorageType](),
+																	},
+																},
+																"max_spot_price_as_percentage_of_optimal_on_demand_price": {
+																	Type:         schema.TypeInt,
+																	Optional:     true,
+																	ValidateFunc: validation.IntAtLeast(1),
+																},
+																"memory_gib_per_vcpu": {
+																	Type:     schema.TypeList,
+																	Optional: true,
+																	MaxItems: 1,
+																	Elem: &schema.Resource{
+																		Schema: map[string]*schema.Schema{
+																			names.AttrMax: {
+																				Type:         schema.TypeFloat,
+																				Optional:     true,
+																				ValidateFunc: verify.FloatGreaterThan(0.0),
+																			},
+																			names.AttrMin: {
+																				Type:         schema.TypeFloat,
+																				Optional:     true,
+																				ValidateFunc: verify.FloatGreaterThan(0.0),
+																			},
+																		},
+																	},
+																},
+																"memory_mib": {
+																	Type:     schema.TypeList,
+																	Optional: true,
+																	MaxItems: 1,
+																	Elem: &schema.Resource{
+																		Schema: map[string]*schema.Schema{
+																			names.AttrMax: {
+																				Type:         schema.TypeInt,
+																				Optional:     true,
+																				ValidateFunc: validation.IntAtLeast(1),
+																			},
+																			names.AttrMin: {
+																				Type:         schema.TypeInt,
+																				Optional:     true,
+																				ValidateFunc: validation.IntAtLeast(1),
+																			},
+																		},
+																	},
+																},
+																"network_bandwidth_gbps": {
+																	Type:     schema.TypeList,
+																	Optional: true,
+																	MaxItems: 1,
+																	Elem: &schema.Resource{
+																		Schema: map[string]*schema.Schema{
+																			names.AttrMax: {
+																				Type:         schema.TypeFloat,
+																				Optional:     true,
+																				ValidateFunc: verify.FloatGreaterThan(0.0),
+																			},
+																			names.AttrMin: {
+																				Type:         schema.TypeFloat,
+																				Optional:     true,
+																				ValidateFunc: verify.FloatGreaterThan(0.0),
+																			},
+																		},
+																	},
+																},
+																"network_interface_count": {
+																	Type:     schema.TypeList,
+																	Optional: true,
+																	MaxItems: 1,
+																	Elem: &schema.Resource{
+																		Schema: map[string]*schema.Schema{
+																			names.AttrMax: {
+																				Type:         schema.TypeInt,
+																				Optional:     true,
+																				ValidateFunc: validation.IntAtLeast(1),
+																			},
+																			names.AttrMin: {
+																				Type:         schema.TypeInt,
+																				Optional:     true,
+																				ValidateFunc: validation.IntAtLeast(1),
+																			},
+																		},
+																	},
+																},
+																"on_demand_max_price_percentage_over_lowest_price": {
+																	Type:         schema.TypeInt,
+																	Optional:     true,
+																	ValidateFunc: validation.IntAtLeast(1),
+																},
+																"require_hibernate_support": {
+																	Type:     schema.TypeBool,
+																	Optional: true,
+																},
+																"spot_max_price_percentage_over_lowest_price": {
+																	Type:         schema.TypeInt,
+																	Optional:     true,
+																	ValidateFunc: validation.IntAtLeast(1),
+																},
+																"total_local_storage_gb": {
+																	Type:     schema.TypeList,
+																	Optional: true,
+																	MaxItems: 1,
+																	Elem: &schema.Resource{
+																		Schema: map[string]*schema.Schema{
+																			names.AttrMax: {
+																				Type:         schema.TypeFloat,
+																				Optional:     true,
+																				ValidateFunc: verify.FloatGreaterThan(0.0),
+																			},
+																			names.AttrMin: {
+																				Type:         schema.TypeFloat,
+																				Optional:     true,
+																				ValidateFunc: verify.FloatGreaterThan(0.0),
+																			},
+																		},
+																	},
+																},
+																"vcpu_count": {
+																	Type:     schema.TypeList,
+																	Optional: true,
+																	MaxItems: 1,
+																	Elem: &schema.Resource{
+																		Schema: map[string]*schema.Schema{
+																			names.AttrMax: {
+																				Type:         schema.TypeInt,
+																				Optional:     true,
+																				ValidateFunc: validation.IntAtLeast(1),
+																			},
+																			names.AttrMin: {
+																				Type:         schema.TypeInt,
+																				Optional:     true,
+																				ValidateFunc: validation.IntAtLeast(1),
+																			},
+																		},
+																	},
+																},
+															},
+														},
+													},
+													names.AttrInstanceType: {
+														Type:     schema.TypeString,
+														Optional: true,
+													},
+													"launch_template_specification": {
+														Type:     schema.TypeList,
+														Optional: true,
+														MinItems: 0,
+														MaxItems: 1,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																"launch_template_id": {
+																	Type:     schema.TypeString,
+																	Optional: true,
+																	Computed: true,
+																},
+																"launch_template_name": {
+																	Type:     schema.TypeString,
+																	Optional: true,
+																	Computed: true,
+																},
+																names.AttrVersion: {
+																	Type:     schema.TypeString,
+																	Optional: true,
+																	Computed: true,
+																},
+															},
+														},
+													},
+													"weighted_capacity": {
+														Type:         schema.TypeString,
+														Optional:     true,
+														ValidateFunc: validation.StringMatch(regexache.MustCompile(`^[1-9][0-9]{0,2}$`), "see https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_LaunchTemplateOverrides.html"),
+													},
+												},
+											},
+										},
 									},
 								},
 							},
 						},
-						"max_group_prepared_capacity": {
-							Type:         schema.TypeInt,
-							Optional:     true,
-							Default:      defaultWarmPoolMaxGroupPreparedCapacity,
-							ValidateFunc: validation.IntAtLeast(defaultWarmPoolMaxGroupPreparedCapacity),
-						},
-						"min_size": {
-							Type:         schema.TypeInt,
-							Optional:     true,
-							Default:      0,
-							ValidateFunc: validation.IntAtLeast(0),
-						},
-						"pool_state": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Default:          awstypes.WarmPoolStateStopped,
-							ValidateDiagFunc: enum.Validate[awstypes.WarmPoolState](),
+					},
+					ExactlyOneOf: []string{"launch_configuration", names.AttrLaunchTemplate, "mixed_instances_policy"},
+				},
+				names.AttrName: {
+					Type:          schema.TypeString,
+					Optional:      true,
+					Computed:      true,
+					ForceNew:      true,
+					ValidateFunc:  validation.StringLenBetween(0, 255),
+					ConflictsWith: []string{names.AttrNamePrefix},
+				},
+				names.AttrNamePrefix: {
+					Type:          schema.TypeString,
+					Optional:      true,
+					Computed:      true,
+					ForceNew:      true,
+					ValidateFunc:  validation.StringLenBetween(0, 255-sdkid.UniqueIDSuffixLength),
+					ConflictsWith: []string{names.AttrName},
+				},
+				"placement_group": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"predicted_capacity": {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
+				"protect_from_scale_in": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
+				"service_linked_role_arn": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+				},
+				"suspended_processes": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"tag": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrKey: {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+							"propagate_at_launch": {
+								Type:     schema.TypeBool,
+								Required: true,
+							},
+							names.AttrValue: {
+								Type:     schema.TypeString,
+								Required: true,
+							},
 						},
 					},
 				},
-			},
-			"warm_pool_size": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
+				"target_group_arns": {
+					Type:          schema.TypeSet,
+					Optional:      true,
+					Computed:      true,
+					Elem:          &schema.Schema{Type: schema.TypeString},
+					ConflictsWith: []string{"traffic_source"},
+				},
+				"termination_policies": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"traffic_source": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrIdentifier: {
+								Type:         schema.TypeString,
+								Required:     true,
+								ValidateFunc: validation.StringLenBetween(1, 2048),
+							},
+							names.AttrType: {
+								Type:         schema.TypeString,
+								Optional:     true,
+								ValidateFunc: validation.StringLenBetween(1, 2048),
+							},
+						},
+					},
+					ConflictsWith: []string{"load_balancers", "target_group_arns"},
+				},
+				"vpc_zone_identifier": {
+					Type:          schema.TypeSet,
+					Optional:      true,
+					Computed:      true,
+					Elem:          &schema.Schema{Type: schema.TypeString},
+					ConflictsWith: []string{names.AttrAvailabilityZones},
+				},
+				"wait_for_capacity_timeout": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Default:      "10m",
+					ValidateFunc: verify.ValidDuration,
+				},
+				"wait_for_elb_capacity": {
+					Type:     schema.TypeInt,
+					Optional: true,
+				},
+				"warm_pool": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"instance_reuse_policy": {
+								Type:     schema.TypeList,
+								Optional: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"reuse_on_scale_in": {
+											Type:     schema.TypeBool,
+											Optional: true,
+											Default:  false,
+										},
+									},
+								},
+							},
+							"max_group_prepared_capacity": {
+								Type:         schema.TypeInt,
+								Optional:     true,
+								Default:      defaultWarmPoolMaxGroupPreparedCapacity,
+								ValidateFunc: validation.IntAtLeast(defaultWarmPoolMaxGroupPreparedCapacity),
+							},
+							"min_size": {
+								Type:         schema.TypeInt,
+								Optional:     true,
+								Default:      0,
+								ValidateFunc: validation.IntAtLeast(0),
+							},
+							"pool_state": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								Default:          awstypes.WarmPoolStateStopped,
+								ValidateDiagFunc: enum.Validate[awstypes.WarmPoolState](),
+							},
+						},
+					},
+				},
+				"warm_pool_size": {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
+			}
 		},
 
 		CustomizeDiff: customdiff.Sequence(

--- a/internal/service/autoscaling/group_data_source.go
+++ b/internal/service/autoscaling/group_data_source.go
@@ -21,418 +21,420 @@ func dataSourceGroup() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceGroupRead,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrAvailabilityZones: {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
 				},
-			},
-			"default_cooldown": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-			"desired_capacity": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-			"desired_capacity_type": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"enabled_metrics": {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
+				names.AttrAvailabilityZones: {
+					Type:     schema.TypeSet,
+					Computed: true,
+					Elem: &schema.Schema{
+						Type: schema.TypeString,
+					},
 				},
-			},
-			"health_check_grace_period": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-			"health_check_type": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"instance_maintenance_policy": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"max_healthy_percentage": {
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
-						"min_healthy_percentage": {
-							Type:     schema.TypeInt,
-							Computed: true,
+				"default_cooldown": {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
+				"desired_capacity": {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
+				"desired_capacity_type": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"enabled_metrics": {
+					Type:     schema.TypeSet,
+					Computed: true,
+					Elem: &schema.Schema{
+						Type: schema.TypeString,
+					},
+				},
+				"health_check_grace_period": {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
+				"health_check_type": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"instance_maintenance_policy": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"max_healthy_percentage": {
+								Type:     schema.TypeInt,
+								Computed: true,
+							},
+							"min_healthy_percentage": {
+								Type:     schema.TypeInt,
+								Computed: true,
+							},
 						},
 					},
 				},
-			},
-			"launch_configuration": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrLaunchTemplate: {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrID: {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						names.AttrName: {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						names.AttrVersion: {
-							Type:     schema.TypeString,
-							Computed: true,
+				"launch_configuration": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrLaunchTemplate: {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrID: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							names.AttrName: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							names.AttrVersion: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
 						},
 					},
 				},
-			},
-			"load_balancers": {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
+				"load_balancers": {
+					Type:     schema.TypeSet,
+					Computed: true,
+					Elem: &schema.Schema{
+						Type: schema.TypeString,
+					},
 				},
-			},
-			"max_instance_lifetime": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-			"max_size": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-			"min_size": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-			"mixed_instances_policy": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"instances_distribution": {
-							Type:     schema.TypeList,
-							Computed: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"on_demand_allocation_strategy": {
-										Type:     schema.TypeString,
-										Computed: true,
-									},
-									"on_demand_base_capacity": {
-										Type:     schema.TypeInt,
-										Computed: true,
-									},
-									"on_demand_percentage_above_base_capacity": {
-										Type:     schema.TypeInt,
-										Computed: true,
-									},
-									"spot_allocation_strategy": {
-										Type:     schema.TypeString,
-										Computed: true,
-									},
-									"spot_instance_pools": {
-										Type:     schema.TypeInt,
-										Computed: true,
-									},
-									"spot_max_price": {
-										Type:     schema.TypeString,
-										Computed: true,
+				"max_instance_lifetime": {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
+				"max_size": {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
+				"min_size": {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
+				"mixed_instances_policy": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"instances_distribution": {
+								Type:     schema.TypeList,
+								Computed: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"on_demand_allocation_strategy": {
+											Type:     schema.TypeString,
+											Computed: true,
+										},
+										"on_demand_base_capacity": {
+											Type:     schema.TypeInt,
+											Computed: true,
+										},
+										"on_demand_percentage_above_base_capacity": {
+											Type:     schema.TypeInt,
+											Computed: true,
+										},
+										"spot_allocation_strategy": {
+											Type:     schema.TypeString,
+											Computed: true,
+										},
+										"spot_instance_pools": {
+											Type:     schema.TypeInt,
+											Computed: true,
+										},
+										"spot_max_price": {
+											Type:     schema.TypeString,
+											Computed: true,
+										},
 									},
 								},
 							},
-						},
-						names.AttrLaunchTemplate: {
-							Type:     schema.TypeList,
-							Computed: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"launch_template_specification": {
-										Type:     schema.TypeList,
-										Computed: true,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"launch_template_id": {
-													Type:     schema.TypeString,
-													Computed: true,
-												},
-												"launch_template_name": {
-													Type:     schema.TypeString,
-													Computed: true,
-												},
-												names.AttrVersion: {
-													Type:     schema.TypeString,
-													Computed: true,
+							names.AttrLaunchTemplate: {
+								Type:     schema.TypeList,
+								Computed: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"launch_template_specification": {
+											Type:     schema.TypeList,
+											Computed: true,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"launch_template_id": {
+														Type:     schema.TypeString,
+														Computed: true,
+													},
+													"launch_template_name": {
+														Type:     schema.TypeString,
+														Computed: true,
+													},
+													names.AttrVersion: {
+														Type:     schema.TypeString,
+														Computed: true,
+													},
 												},
 											},
 										},
-									},
-									"override": {
-										Type:     schema.TypeList,
-										Computed: true,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"instance_requirements": {
-													Type:     schema.TypeList,
-													Computed: true,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															"accelerator_count": {
-																Type:     schema.TypeList,
-																Computed: true,
-																Elem: &schema.Resource{
-																	Schema: map[string]*schema.Schema{
-																		names.AttrMax: {
-																			Type:     schema.TypeInt,
-																			Computed: true,
-																		},
-																		names.AttrMin: {
-																			Type:     schema.TypeInt,
-																			Computed: true,
-																		},
-																	},
-																},
-															},
-															"accelerator_manufacturers": {
-																Type:     schema.TypeSet,
-																Computed: true,
-																Elem:     &schema.Schema{Type: schema.TypeString},
-															},
-															"accelerator_names": {
-																Type:     schema.TypeSet,
-																Computed: true,
-																Elem:     &schema.Schema{Type: schema.TypeString},
-															},
-															"accelerator_total_memory_mib": {
-																Type:     schema.TypeList,
-																Computed: true,
-																Elem: &schema.Resource{
-																	Schema: map[string]*schema.Schema{
-																		names.AttrMax: {
-																			Type:     schema.TypeInt,
-																			Computed: true,
-																		},
-																		names.AttrMin: {
-																			Type:     schema.TypeInt,
-																			Computed: true,
+										"override": {
+											Type:     schema.TypeList,
+											Computed: true,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"instance_requirements": {
+														Type:     schema.TypeList,
+														Computed: true,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																"accelerator_count": {
+																	Type:     schema.TypeList,
+																	Computed: true,
+																	Elem: &schema.Resource{
+																		Schema: map[string]*schema.Schema{
+																			names.AttrMax: {
+																				Type:     schema.TypeInt,
+																				Computed: true,
+																			},
+																			names.AttrMin: {
+																				Type:     schema.TypeInt,
+																				Computed: true,
+																			},
 																		},
 																	},
 																},
-															},
-															"accelerator_types": {
-																Type:     schema.TypeSet,
-																Computed: true,
-																Elem:     &schema.Schema{Type: schema.TypeString},
-															},
-															"allowed_instance_types": {
-																Type:     schema.TypeSet,
-																Computed: true,
-																Elem:     &schema.Schema{Type: schema.TypeString},
-															},
-															"bare_metal": {
-																Type:     schema.TypeString,
-																Computed: true,
-															},
-															"baseline_ebs_bandwidth_mbps": {
-																Type:     schema.TypeList,
-																Computed: true,
-																Elem: &schema.Resource{
-																	Schema: map[string]*schema.Schema{
-																		names.AttrMax: {
-																			Type:     schema.TypeInt,
-																			Computed: true,
-																		},
-																		names.AttrMin: {
-																			Type:     schema.TypeInt,
-																			Computed: true,
+																"accelerator_manufacturers": {
+																	Type:     schema.TypeSet,
+																	Computed: true,
+																	Elem:     &schema.Schema{Type: schema.TypeString},
+																},
+																"accelerator_names": {
+																	Type:     schema.TypeSet,
+																	Computed: true,
+																	Elem:     &schema.Schema{Type: schema.TypeString},
+																},
+																"accelerator_total_memory_mib": {
+																	Type:     schema.TypeList,
+																	Computed: true,
+																	Elem: &schema.Resource{
+																		Schema: map[string]*schema.Schema{
+																			names.AttrMax: {
+																				Type:     schema.TypeInt,
+																				Computed: true,
+																			},
+																			names.AttrMin: {
+																				Type:     schema.TypeInt,
+																				Computed: true,
+																			},
 																		},
 																	},
 																},
-															},
-															"burstable_performance": {
-																Type:     schema.TypeString,
-																Computed: true,
-															},
-															"cpu_manufacturers": {
-																Type:     schema.TypeSet,
-																Computed: true,
-																Elem:     &schema.Schema{Type: schema.TypeString},
-															},
-															"excluded_instance_types": {
-																Type:     schema.TypeSet,
-																Computed: true,
-																Elem:     &schema.Schema{Type: schema.TypeString},
-															},
-															"instance_generations": {
-																Type:     schema.TypeSet,
-																Computed: true,
-																Elem:     &schema.Schema{Type: schema.TypeString},
-															},
-															"local_storage": {
-																Type:     schema.TypeString,
-																Computed: true,
-															},
-															"local_storage_types": {
-																Type:     schema.TypeSet,
-																Computed: true,
-																Elem:     &schema.Schema{Type: schema.TypeString},
-															},
-															"max_spot_price_as_percentage_of_optimal_on_demand_price": {
-																Type:     schema.TypeInt,
-																Computed: true,
-															},
-															"memory_gib_per_vcpu": {
-																Type:     schema.TypeList,
-																Computed: true,
-																Elem: &schema.Resource{
-																	Schema: map[string]*schema.Schema{
-																		names.AttrMax: {
-																			Type:     schema.TypeFloat,
-																			Computed: true,
-																		},
-																		names.AttrMin: {
-																			Type:     schema.TypeFloat,
-																			Computed: true,
+																"accelerator_types": {
+																	Type:     schema.TypeSet,
+																	Computed: true,
+																	Elem:     &schema.Schema{Type: schema.TypeString},
+																},
+																"allowed_instance_types": {
+																	Type:     schema.TypeSet,
+																	Computed: true,
+																	Elem:     &schema.Schema{Type: schema.TypeString},
+																},
+																"bare_metal": {
+																	Type:     schema.TypeString,
+																	Computed: true,
+																},
+																"baseline_ebs_bandwidth_mbps": {
+																	Type:     schema.TypeList,
+																	Computed: true,
+																	Elem: &schema.Resource{
+																		Schema: map[string]*schema.Schema{
+																			names.AttrMax: {
+																				Type:     schema.TypeInt,
+																				Computed: true,
+																			},
+																			names.AttrMin: {
+																				Type:     schema.TypeInt,
+																				Computed: true,
+																			},
 																		},
 																	},
 																},
-															},
-															"memory_mib": {
-																Type:     schema.TypeList,
-																Computed: true,
-																Elem: &schema.Resource{
-																	Schema: map[string]*schema.Schema{
-																		names.AttrMax: {
-																			Type:     schema.TypeInt,
-																			Computed: true,
-																		},
-																		names.AttrMin: {
-																			Type:     schema.TypeInt,
-																			Computed: true,
+																"burstable_performance": {
+																	Type:     schema.TypeString,
+																	Computed: true,
+																},
+																"cpu_manufacturers": {
+																	Type:     schema.TypeSet,
+																	Computed: true,
+																	Elem:     &schema.Schema{Type: schema.TypeString},
+																},
+																"excluded_instance_types": {
+																	Type:     schema.TypeSet,
+																	Computed: true,
+																	Elem:     &schema.Schema{Type: schema.TypeString},
+																},
+																"instance_generations": {
+																	Type:     schema.TypeSet,
+																	Computed: true,
+																	Elem:     &schema.Schema{Type: schema.TypeString},
+																},
+																"local_storage": {
+																	Type:     schema.TypeString,
+																	Computed: true,
+																},
+																"local_storage_types": {
+																	Type:     schema.TypeSet,
+																	Computed: true,
+																	Elem:     &schema.Schema{Type: schema.TypeString},
+																},
+																"max_spot_price_as_percentage_of_optimal_on_demand_price": {
+																	Type:     schema.TypeInt,
+																	Computed: true,
+																},
+																"memory_gib_per_vcpu": {
+																	Type:     schema.TypeList,
+																	Computed: true,
+																	Elem: &schema.Resource{
+																		Schema: map[string]*schema.Schema{
+																			names.AttrMax: {
+																				Type:     schema.TypeFloat,
+																				Computed: true,
+																			},
+																			names.AttrMin: {
+																				Type:     schema.TypeFloat,
+																				Computed: true,
+																			},
 																		},
 																	},
 																},
-															},
-															"network_bandwidth_gbps": {
-																Type:     schema.TypeList,
-																Computed: true,
-																Elem: &schema.Resource{
-																	Schema: map[string]*schema.Schema{
-																		names.AttrMax: {
-																			Type:     schema.TypeFloat,
-																			Computed: true,
-																		},
-																		names.AttrMin: {
-																			Type:     schema.TypeFloat,
-																			Computed: true,
-																		},
-																	},
-																},
-															},
-															"network_interface_count": {
-																Type:     schema.TypeList,
-																Computed: true,
-																Elem: &schema.Resource{
-																	Schema: map[string]*schema.Schema{
-																		names.AttrMax: {
-																			Type:     schema.TypeInt,
-																			Computed: true,
-																		},
-																		names.AttrMin: {
-																			Type:     schema.TypeInt,
-																			Computed: true,
+																"memory_mib": {
+																	Type:     schema.TypeList,
+																	Computed: true,
+																	Elem: &schema.Resource{
+																		Schema: map[string]*schema.Schema{
+																			names.AttrMax: {
+																				Type:     schema.TypeInt,
+																				Computed: true,
+																			},
+																			names.AttrMin: {
+																				Type:     schema.TypeInt,
+																				Computed: true,
+																			},
 																		},
 																	},
 																},
-															},
-															"on_demand_max_price_percentage_over_lowest_price": {
-																Type:     schema.TypeInt,
-																Computed: true,
-															},
-															"require_hibernate_support": {
-																Type:     schema.TypeBool,
-																Computed: true,
-															},
-															"spot_max_price_percentage_over_lowest_price": {
-																Type:     schema.TypeInt,
-																Computed: true,
-															},
-															"total_local_storage_gb": {
-																Type:     schema.TypeList,
-																Computed: true,
-																Elem: &schema.Resource{
-																	Schema: map[string]*schema.Schema{
-																		names.AttrMax: {
-																			Type:     schema.TypeFloat,
-																			Computed: true,
-																		},
-																		names.AttrMin: {
-																			Type:     schema.TypeFloat,
-																			Computed: true,
+																"network_bandwidth_gbps": {
+																	Type:     schema.TypeList,
+																	Computed: true,
+																	Elem: &schema.Resource{
+																		Schema: map[string]*schema.Schema{
+																			names.AttrMax: {
+																				Type:     schema.TypeFloat,
+																				Computed: true,
+																			},
+																			names.AttrMin: {
+																				Type:     schema.TypeFloat,
+																				Computed: true,
+																			},
 																		},
 																	},
 																},
-															},
-															"vcpu_count": {
-																Type:     schema.TypeList,
-																Computed: true,
-																Elem: &schema.Resource{
-																	Schema: map[string]*schema.Schema{
-																		names.AttrMax: {
-																			Type:     schema.TypeInt,
-																			Computed: true,
+																"network_interface_count": {
+																	Type:     schema.TypeList,
+																	Computed: true,
+																	Elem: &schema.Resource{
+																		Schema: map[string]*schema.Schema{
+																			names.AttrMax: {
+																				Type:     schema.TypeInt,
+																				Computed: true,
+																			},
+																			names.AttrMin: {
+																				Type:     schema.TypeInt,
+																				Computed: true,
+																			},
 																		},
-																		names.AttrMin: {
-																			Type:     schema.TypeInt,
-																			Computed: true,
+																	},
+																},
+																"on_demand_max_price_percentage_over_lowest_price": {
+																	Type:     schema.TypeInt,
+																	Computed: true,
+																},
+																"require_hibernate_support": {
+																	Type:     schema.TypeBool,
+																	Computed: true,
+																},
+																"spot_max_price_percentage_over_lowest_price": {
+																	Type:     schema.TypeInt,
+																	Computed: true,
+																},
+																"total_local_storage_gb": {
+																	Type:     schema.TypeList,
+																	Computed: true,
+																	Elem: &schema.Resource{
+																		Schema: map[string]*schema.Schema{
+																			names.AttrMax: {
+																				Type:     schema.TypeFloat,
+																				Computed: true,
+																			},
+																			names.AttrMin: {
+																				Type:     schema.TypeFloat,
+																				Computed: true,
+																			},
+																		},
+																	},
+																},
+																"vcpu_count": {
+																	Type:     schema.TypeList,
+																	Computed: true,
+																	Elem: &schema.Resource{
+																		Schema: map[string]*schema.Schema{
+																			names.AttrMax: {
+																				Type:     schema.TypeInt,
+																				Computed: true,
+																			},
+																			names.AttrMin: {
+																				Type:     schema.TypeInt,
+																				Computed: true,
+																			},
 																		},
 																	},
 																},
 															},
 														},
 													},
-												},
-												names.AttrInstanceType: {
-													Type:     schema.TypeString,
-													Computed: true,
-												},
-												"launch_template_specification": {
-													Type:     schema.TypeList,
-													Computed: true,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															"launch_template_id": {
-																Type:     schema.TypeString,
-																Computed: true,
-															},
-															"launch_template_name": {
-																Type:     schema.TypeString,
-																Computed: true,
-															},
-															names.AttrVersion: {
-																Type:     schema.TypeString,
-																Computed: true,
+													names.AttrInstanceType: {
+														Type:     schema.TypeString,
+														Computed: true,
+													},
+													"launch_template_specification": {
+														Type:     schema.TypeList,
+														Computed: true,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																"launch_template_id": {
+																	Type:     schema.TypeString,
+																	Computed: true,
+																},
+																"launch_template_name": {
+																	Type:     schema.TypeString,
+																	Computed: true,
+																},
+																names.AttrVersion: {
+																	Type:     schema.TypeString,
+																	Computed: true,
+																},
 															},
 														},
 													},
-												},
-												"weighted_capacity": {
-													Type:     schema.TypeString,
-													Computed: true,
+													"weighted_capacity": {
+														Type:     schema.TypeString,
+														Computed: true,
+													},
 												},
 											},
 										},
@@ -442,126 +444,126 @@ func dataSourceGroup() *schema.Resource {
 						},
 					},
 				},
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"new_instances_protected_from_scale_in": {
-				Type:     schema.TypeBool,
-				Computed: true,
-			},
-			"placement_group": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"predicted_capacity": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-			"service_linked_role_arn": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrStatus: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"suspended_processes": {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			"tag": {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrKey: {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"propagate_at_launch": {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
-						names.AttrValue: {
-							Type:     schema.TypeString,
-							Computed: true,
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"new_instances_protected_from_scale_in": {
+					Type:     schema.TypeBool,
+					Computed: true,
+				},
+				"placement_group": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"predicted_capacity": {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
+				"service_linked_role_arn": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrStatus: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"suspended_processes": {
+					Type:     schema.TypeSet,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"tag": {
+					Type:     schema.TypeSet,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrKey: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"propagate_at_launch": {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
+							names.AttrValue: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
 						},
 					},
 				},
-			},
-			"target_group_arns": {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
+				"target_group_arns": {
+					Type:     schema.TypeSet,
+					Computed: true,
+					Elem: &schema.Schema{
+						Type: schema.TypeString,
+					},
 				},
-			},
-			"termination_policies": {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
+				"termination_policies": {
+					Type:     schema.TypeSet,
+					Computed: true,
+					Elem: &schema.Schema{
+						Type: schema.TypeString,
+					},
 				},
-			},
-			"traffic_source": {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrIdentifier: {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						names.AttrType: {
-							Type:     schema.TypeString,
-							Computed: true,
+				"traffic_source": {
+					Type:     schema.TypeSet,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrIdentifier: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							names.AttrType: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
 						},
 					},
 				},
-			},
-			"vpc_zone_identifier": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"warm_pool": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"instance_reuse_policy": {
-							Type:     schema.TypeList,
-							Computed: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"reuse_on_scale_in": {
-										Type:     schema.TypeBool,
-										Computed: true,
+				"vpc_zone_identifier": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"warm_pool": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"instance_reuse_policy": {
+								Type:     schema.TypeList,
+								Computed: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"reuse_on_scale_in": {
+											Type:     schema.TypeBool,
+											Computed: true,
+										},
 									},
 								},
 							},
-						},
-						"max_group_prepared_capacity": {
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
-						"min_size": {
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
-						"pool_state": {
-							Type:     schema.TypeString,
-							Computed: true,
+							"max_group_prepared_capacity": {
+								Type:     schema.TypeInt,
+								Computed: true,
+							},
+							"min_size": {
+								Type:     schema.TypeInt,
+								Computed: true,
+							},
+							"pool_state": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
 						},
 					},
 				},
-			},
-			"warm_pool_size": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
+				"warm_pool_size": {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/autoscaling/group_migrate.go
+++ b/internal/service/autoscaling/group_migrate.go
@@ -15,579 +15,581 @@ import (
 // aws_autoscaling_group resource's Schema @v5.11.0 minus validators.
 func resourceGroupV0() *schema.Resource {
 	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrAvailabilityZones: {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			"capacity_rebalance": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
-			"context": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"default_cooldown": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Computed: true,
-			},
-			"default_instance_warmup": {
-				Type:     schema.TypeInt,
-				Optional: true,
-			},
-			"desired_capacity": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Computed: true,
-			},
-			"desired_capacity_type": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"enabled_metrics": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			names.AttrForceDelete: {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-			"force_delete_warm_pool": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-			"health_check_grace_period": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Default:  300,
-			},
-			"health_check_type": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-			"initial_lifecycle_hook": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				ForceNew: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"default_result": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Computed: true,
-						},
-						"heartbeat_timeout": {
-							Type:     schema.TypeInt,
-							Optional: true,
-						},
-						"lifecycle_transition": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						names.AttrName: {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"notification_metadata": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"notification_target_arn": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						names.AttrRoleARN: {
-							Type:     schema.TypeString,
-							Optional: true,
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrAvailabilityZones: {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"capacity_rebalance": {
+					Type:     schema.TypeBool,
+					Optional: true,
+				},
+				"context": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"default_cooldown": {
+					Type:     schema.TypeInt,
+					Optional: true,
+					Computed: true,
+				},
+				"default_instance_warmup": {
+					Type:     schema.TypeInt,
+					Optional: true,
+				},
+				"desired_capacity": {
+					Type:     schema.TypeInt,
+					Optional: true,
+					Computed: true,
+				},
+				"desired_capacity_type": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"enabled_metrics": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				names.AttrForceDelete: {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
+				"force_delete_warm_pool": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
+				"health_check_grace_period": {
+					Type:     schema.TypeInt,
+					Optional: true,
+					Default:  300,
+				},
+				"health_check_type": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+				},
+				"initial_lifecycle_hook": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					ForceNew: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"default_result": {
+								Type:     schema.TypeString,
+								Optional: true,
+								Computed: true,
+							},
+							"heartbeat_timeout": {
+								Type:     schema.TypeInt,
+								Optional: true,
+							},
+							"lifecycle_transition": {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+							names.AttrName: {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+							"notification_metadata": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+							"notification_target_arn": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+							names.AttrRoleARN: {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
 						},
 					},
 				},
-			},
-			"instance_refresh": {
-				Type:     schema.TypeList,
-				MaxItems: 1,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"preferences": {
-							Type:     schema.TypeList,
-							MaxItems: 1,
-							Optional: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"auto_rollback": {
-										Type:     schema.TypeBool,
-										Optional: true,
-									},
-									"checkpoint_delay": {
-										Type:     nullable.TypeNullableInt,
-										Optional: true,
-									},
-									"checkpoint_percentages": {
-										Type:     schema.TypeList,
-										Optional: true,
-										Elem: &schema.Schema{
-											Type: schema.TypeInt,
+				"instance_refresh": {
+					Type:     schema.TypeList,
+					MaxItems: 1,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"preferences": {
+								Type:     schema.TypeList,
+								MaxItems: 1,
+								Optional: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"auto_rollback": {
+											Type:     schema.TypeBool,
+											Optional: true,
+										},
+										"checkpoint_delay": {
+											Type:     nullable.TypeNullableInt,
+											Optional: true,
+										},
+										"checkpoint_percentages": {
+											Type:     schema.TypeList,
+											Optional: true,
+											Elem: &schema.Schema{
+												Type: schema.TypeInt,
+											},
+										},
+										"instance_warmup": {
+											Type:     nullable.TypeNullableInt,
+											Optional: true,
+										},
+										"min_healthy_percentage": {
+											Type:     schema.TypeInt,
+											Optional: true,
+											Default:  90,
+										},
+										"skip_matching": {
+											Type:     schema.TypeBool,
+											Optional: true,
+											Default:  false,
 										},
 									},
-									"instance_warmup": {
-										Type:     nullable.TypeNullableInt,
-										Optional: true,
-									},
-									"min_healthy_percentage": {
-										Type:     schema.TypeInt,
-										Optional: true,
-										Default:  90,
-									},
-									"skip_matching": {
-										Type:     schema.TypeBool,
-										Optional: true,
-										Default:  false,
-									},
 								},
 							},
-						},
-						"strategy": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						names.AttrTriggers: {
-							Type:     schema.TypeSet,
-							Optional: true,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
+							"strategy": {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+							names.AttrTriggers: {
+								Type:     schema.TypeSet,
+								Optional: true,
+								Elem: &schema.Schema{
+									Type: schema.TypeString,
+								},
 							},
 						},
 					},
 				},
-			},
-			"launch_configuration": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			names.AttrLaunchTemplate: {
-				Type:     schema.TypeList,
-				MaxItems: 1,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrID: {
-							Type:     schema.TypeString,
-							Optional: true,
-							Computed: true,
-						},
-						names.AttrName: {
-							Type:     schema.TypeString,
-							Optional: true,
-							Computed: true,
-						},
-						names.AttrVersion: {
-							Type:     schema.TypeString,
-							Optional: true,
+				"launch_configuration": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				names.AttrLaunchTemplate: {
+					Type:     schema.TypeList,
+					MaxItems: 1,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrID: {
+								Type:     schema.TypeString,
+								Optional: true,
+								Computed: true,
+							},
+							names.AttrName: {
+								Type:     schema.TypeString,
+								Optional: true,
+								Computed: true,
+							},
+							names.AttrVersion: {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
 						},
 					},
 				},
-			},
-			"load_balancers": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			"max_instance_lifetime": {
-				Type:     schema.TypeInt,
-				Optional: true,
-			},
-			"max_size": {
-				Type:     schema.TypeInt,
-				Required: true,
-			},
-			"metrics_granularity": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  defaultEnabledMetricsGranularity,
-			},
-			"min_elb_capacity": {
-				Type:     schema.TypeInt,
-				Optional: true,
-			},
-			"min_size": {
-				Type:     schema.TypeInt,
-				Required: true,
-			},
-			"mixed_instances_policy": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"instances_distribution": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Computed: true,
-							// Ideally we'd want to detect drift detection,
-							// but a DiffSuppressFunc here does not behave nicely
-							// for detecting missing configuration blocks
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									// These fields are returned from calls to the API
-									// even if not provided at input time and can be omitted in requests;
-									// thus, to prevent non-empty plans, we set these
-									// to Computed and remove Defaults
-									"on_demand_allocation_strategy": {
-										Type:     schema.TypeString,
-										Optional: true,
-										Computed: true,
-									},
-									"on_demand_base_capacity": {
-										Type:     schema.TypeInt,
-										Optional: true,
-										Computed: true,
-									},
-									"on_demand_percentage_above_base_capacity": {
-										Type:     schema.TypeInt,
-										Optional: true,
-										Computed: true,
-									},
-									"spot_allocation_strategy": {
-										Type:     schema.TypeString,
-										Optional: true,
-										Computed: true,
-									},
-									"spot_instance_pools": {
-										Type:     schema.TypeInt,
-										Optional: true,
-										Computed: true,
-									},
-									"spot_max_price": {
-										Type:     schema.TypeString,
-										Optional: true,
+				"load_balancers": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"max_instance_lifetime": {
+					Type:     schema.TypeInt,
+					Optional: true,
+				},
+				"max_size": {
+					Type:     schema.TypeInt,
+					Required: true,
+				},
+				"metrics_granularity": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Default:  defaultEnabledMetricsGranularity,
+				},
+				"min_elb_capacity": {
+					Type:     schema.TypeInt,
+					Optional: true,
+				},
+				"min_size": {
+					Type:     schema.TypeInt,
+					Required: true,
+				},
+				"mixed_instances_policy": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"instances_distribution": {
+								Type:     schema.TypeList,
+								Optional: true,
+								MaxItems: 1,
+								Computed: true,
+								// Ideally we'd want to detect drift detection,
+								// but a DiffSuppressFunc here does not behave nicely
+								// for detecting missing configuration blocks
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										// These fields are returned from calls to the API
+										// even if not provided at input time and can be omitted in requests;
+										// thus, to prevent non-empty plans, we set these
+										// to Computed and remove Defaults
+										"on_demand_allocation_strategy": {
+											Type:     schema.TypeString,
+											Optional: true,
+											Computed: true,
+										},
+										"on_demand_base_capacity": {
+											Type:     schema.TypeInt,
+											Optional: true,
+											Computed: true,
+										},
+										"on_demand_percentage_above_base_capacity": {
+											Type:     schema.TypeInt,
+											Optional: true,
+											Computed: true,
+										},
+										"spot_allocation_strategy": {
+											Type:     schema.TypeString,
+											Optional: true,
+											Computed: true,
+										},
+										"spot_instance_pools": {
+											Type:     schema.TypeInt,
+											Optional: true,
+											Computed: true,
+										},
+										"spot_max_price": {
+											Type:     schema.TypeString,
+											Optional: true,
+										},
 									},
 								},
 							},
-						},
-						names.AttrLaunchTemplate: {
-							Type:     schema.TypeList,
-							Required: true,
-							MinItems: 1,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"launch_template_specification": {
-										Type:     schema.TypeList,
-										Required: true,
-										MinItems: 1,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"launch_template_id": {
-													Type:     schema.TypeString,
-													Optional: true,
-													Computed: true,
-												},
-												"launch_template_name": {
-													Type:     schema.TypeString,
-													Optional: true,
-													Computed: true,
-												},
-												names.AttrVersion: {
-													Type:     schema.TypeString,
-													Optional: true,
-													Default:  "$Default",
+							names.AttrLaunchTemplate: {
+								Type:     schema.TypeList,
+								Required: true,
+								MinItems: 1,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"launch_template_specification": {
+											Type:     schema.TypeList,
+											Required: true,
+											MinItems: 1,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"launch_template_id": {
+														Type:     schema.TypeString,
+														Optional: true,
+														Computed: true,
+													},
+													"launch_template_name": {
+														Type:     schema.TypeString,
+														Optional: true,
+														Computed: true,
+													},
+													names.AttrVersion: {
+														Type:     schema.TypeString,
+														Optional: true,
+														Default:  "$Default",
+													},
 												},
 											},
 										},
-									},
-									"override": {
-										Type:     schema.TypeList,
-										Optional: true,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"instance_requirements": {
-													Type:     schema.TypeList,
-													Optional: true,
-													MaxItems: 1,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															"accelerator_count": {
-																Type:     schema.TypeList,
-																Optional: true,
-																MaxItems: 1,
-																Elem: &schema.Resource{
-																	Schema: map[string]*schema.Schema{
-																		names.AttrMax: {
-																			Type:     schema.TypeInt,
-																			Optional: true,
-																		},
-																		names.AttrMin: {
-																			Type:     schema.TypeInt,
-																			Optional: true,
-																		},
-																	},
-																},
-															},
-															"accelerator_manufacturers": {
-																Type:     schema.TypeSet,
-																Optional: true,
-																Elem: &schema.Schema{
-																	Type: schema.TypeString,
-																},
-															},
-															"accelerator_names": {
-																Type:     schema.TypeSet,
-																Optional: true,
-																Elem: &schema.Schema{
-																	Type: schema.TypeString,
-																},
-															},
-															"accelerator_total_memory_mib": {
-																Type:     schema.TypeList,
-																Optional: true,
-																MaxItems: 1,
-																Elem: &schema.Resource{
-																	Schema: map[string]*schema.Schema{
-																		names.AttrMax: {
-																			Type:     schema.TypeInt,
-																			Optional: true,
-																		},
-																		names.AttrMin: {
-																			Type:     schema.TypeInt,
-																			Optional: true,
+										"override": {
+											Type:     schema.TypeList,
+											Optional: true,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"instance_requirements": {
+														Type:     schema.TypeList,
+														Optional: true,
+														MaxItems: 1,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																"accelerator_count": {
+																	Type:     schema.TypeList,
+																	Optional: true,
+																	MaxItems: 1,
+																	Elem: &schema.Resource{
+																		Schema: map[string]*schema.Schema{
+																			names.AttrMax: {
+																				Type:     schema.TypeInt,
+																				Optional: true,
+																			},
+																			names.AttrMin: {
+																				Type:     schema.TypeInt,
+																				Optional: true,
+																			},
 																		},
 																	},
 																},
-															},
-															"accelerator_types": {
-																Type:     schema.TypeSet,
-																Optional: true,
-																Elem: &schema.Schema{
-																	Type: schema.TypeString,
+																"accelerator_manufacturers": {
+																	Type:     schema.TypeSet,
+																	Optional: true,
+																	Elem: &schema.Schema{
+																		Type: schema.TypeString,
+																	},
 																},
-															},
-															"allowed_instance_types": {
-																Type:     schema.TypeSet,
-																Optional: true,
-																MaxItems: 400,
-																Elem:     &schema.Schema{Type: schema.TypeString},
-															},
-															"bare_metal": {
-																Type:     schema.TypeString,
-																Optional: true,
-															},
-															"baseline_ebs_bandwidth_mbps": {
-																Type:     schema.TypeList,
-																Optional: true,
-																MaxItems: 1,
-																Elem: &schema.Resource{
-																	Schema: map[string]*schema.Schema{
-																		names.AttrMax: {
-																			Type:     schema.TypeInt,
-																			Optional: true,
-																		},
-																		names.AttrMin: {
-																			Type:     schema.TypeInt,
-																			Optional: true,
+																"accelerator_names": {
+																	Type:     schema.TypeSet,
+																	Optional: true,
+																	Elem: &schema.Schema{
+																		Type: schema.TypeString,
+																	},
+																},
+																"accelerator_total_memory_mib": {
+																	Type:     schema.TypeList,
+																	Optional: true,
+																	MaxItems: 1,
+																	Elem: &schema.Resource{
+																		Schema: map[string]*schema.Schema{
+																			names.AttrMax: {
+																				Type:     schema.TypeInt,
+																				Optional: true,
+																			},
+																			names.AttrMin: {
+																				Type:     schema.TypeInt,
+																				Optional: true,
+																			},
 																		},
 																	},
 																},
-															},
-															"burstable_performance": {
-																Type:     schema.TypeString,
-																Optional: true,
-															},
-															"cpu_manufacturers": {
-																Type:     schema.TypeSet,
-																Optional: true,
-																Elem: &schema.Schema{
-																	Type: schema.TypeString,
+																"accelerator_types": {
+																	Type:     schema.TypeSet,
+																	Optional: true,
+																	Elem: &schema.Schema{
+																		Type: schema.TypeString,
+																	},
 																},
-															},
-															"excluded_instance_types": {
-																Type:     schema.TypeSet,
-																Optional: true,
-																MaxItems: 400,
-																Elem:     &schema.Schema{Type: schema.TypeString},
-															},
-															"instance_generations": {
-																Type:     schema.TypeSet,
-																Optional: true,
-																Elem: &schema.Schema{
-																	Type: schema.TypeString,
+																"allowed_instance_types": {
+																	Type:     schema.TypeSet,
+																	Optional: true,
+																	MaxItems: 400,
+																	Elem:     &schema.Schema{Type: schema.TypeString},
 																},
-															},
-															"local_storage": {
-																Type:     schema.TypeString,
-																Optional: true,
-															},
-															"local_storage_types": {
-																Type:     schema.TypeSet,
-																Optional: true,
-																Elem: &schema.Schema{
-																	Type: schema.TypeString,
+																"bare_metal": {
+																	Type:     schema.TypeString,
+																	Optional: true,
 																},
-															},
-															"memory_gib_per_vcpu": {
-																Type:     schema.TypeList,
-																Optional: true,
-																MaxItems: 1,
-																Elem: &schema.Resource{
-																	Schema: map[string]*schema.Schema{
-																		names.AttrMax: {
-																			Type:     schema.TypeFloat,
-																			Optional: true,
-																		},
-																		names.AttrMin: {
-																			Type:     schema.TypeFloat,
-																			Optional: true,
+																"baseline_ebs_bandwidth_mbps": {
+																	Type:     schema.TypeList,
+																	Optional: true,
+																	MaxItems: 1,
+																	Elem: &schema.Resource{
+																		Schema: map[string]*schema.Schema{
+																			names.AttrMax: {
+																				Type:     schema.TypeInt,
+																				Optional: true,
+																			},
+																			names.AttrMin: {
+																				Type:     schema.TypeInt,
+																				Optional: true,
+																			},
 																		},
 																	},
 																},
-															},
-															"memory_mib": {
-																Type:     schema.TypeList,
-																Optional: true,
-																MaxItems: 1,
-																Elem: &schema.Resource{
-																	Schema: map[string]*schema.Schema{
-																		names.AttrMax: {
-																			Type:     schema.TypeInt,
-																			Optional: true,
-																		},
-																		names.AttrMin: {
-																			Type:     schema.TypeInt,
-																			Optional: true,
+																"burstable_performance": {
+																	Type:     schema.TypeString,
+																	Optional: true,
+																},
+																"cpu_manufacturers": {
+																	Type:     schema.TypeSet,
+																	Optional: true,
+																	Elem: &schema.Schema{
+																		Type: schema.TypeString,
+																	},
+																},
+																"excluded_instance_types": {
+																	Type:     schema.TypeSet,
+																	Optional: true,
+																	MaxItems: 400,
+																	Elem:     &schema.Schema{Type: schema.TypeString},
+																},
+																"instance_generations": {
+																	Type:     schema.TypeSet,
+																	Optional: true,
+																	Elem: &schema.Schema{
+																		Type: schema.TypeString,
+																	},
+																},
+																"local_storage": {
+																	Type:     schema.TypeString,
+																	Optional: true,
+																},
+																"local_storage_types": {
+																	Type:     schema.TypeSet,
+																	Optional: true,
+																	Elem: &schema.Schema{
+																		Type: schema.TypeString,
+																	},
+																},
+																"memory_gib_per_vcpu": {
+																	Type:     schema.TypeList,
+																	Optional: true,
+																	MaxItems: 1,
+																	Elem: &schema.Resource{
+																		Schema: map[string]*schema.Schema{
+																			names.AttrMax: {
+																				Type:     schema.TypeFloat,
+																				Optional: true,
+																			},
+																			names.AttrMin: {
+																				Type:     schema.TypeFloat,
+																				Optional: true,
+																			},
 																		},
 																	},
 																},
-															},
-															"network_bandwidth_gbps": {
-																Type:     schema.TypeList,
-																Optional: true,
-																MaxItems: 1,
-																Elem: &schema.Resource{
-																	Schema: map[string]*schema.Schema{
-																		names.AttrMax: {
-																			Type:     schema.TypeFloat,
-																			Optional: true,
-																		},
-																		names.AttrMin: {
-																			Type:     schema.TypeFloat,
-																			Optional: true,
-																		},
-																	},
-																},
-															},
-															"network_interface_count": {
-																Type:     schema.TypeList,
-																Optional: true,
-																MaxItems: 1,
-																Elem: &schema.Resource{
-																	Schema: map[string]*schema.Schema{
-																		names.AttrMax: {
-																			Type:     schema.TypeInt,
-																			Optional: true,
-																		},
-																		names.AttrMin: {
-																			Type:     schema.TypeInt,
-																			Optional: true,
+																"memory_mib": {
+																	Type:     schema.TypeList,
+																	Optional: true,
+																	MaxItems: 1,
+																	Elem: &schema.Resource{
+																		Schema: map[string]*schema.Schema{
+																			names.AttrMax: {
+																				Type:     schema.TypeInt,
+																				Optional: true,
+																			},
+																			names.AttrMin: {
+																				Type:     schema.TypeInt,
+																				Optional: true,
+																			},
 																		},
 																	},
 																},
-															},
-															"on_demand_max_price_percentage_over_lowest_price": {
-																Type:     schema.TypeInt,
-																Optional: true,
-															},
-															"require_hibernate_support": {
-																Type:     schema.TypeBool,
-																Optional: true,
-															},
-															"spot_max_price_percentage_over_lowest_price": {
-																Type:     schema.TypeInt,
-																Optional: true,
-															},
-															"total_local_storage_gb": {
-																Type:     schema.TypeList,
-																Optional: true,
-																MaxItems: 1,
-																Elem: &schema.Resource{
-																	Schema: map[string]*schema.Schema{
-																		names.AttrMax: {
-																			Type:     schema.TypeFloat,
-																			Optional: true,
-																		},
-																		names.AttrMin: {
-																			Type:     schema.TypeFloat,
-																			Optional: true,
+																"network_bandwidth_gbps": {
+																	Type:     schema.TypeList,
+																	Optional: true,
+																	MaxItems: 1,
+																	Elem: &schema.Resource{
+																		Schema: map[string]*schema.Schema{
+																			names.AttrMax: {
+																				Type:     schema.TypeFloat,
+																				Optional: true,
+																			},
+																			names.AttrMin: {
+																				Type:     schema.TypeFloat,
+																				Optional: true,
+																			},
 																		},
 																	},
 																},
-															},
-															"vcpu_count": {
-																Type:     schema.TypeList,
-																Optional: true,
-																MaxItems: 1,
-																Elem: &schema.Resource{
-																	Schema: map[string]*schema.Schema{
-																		names.AttrMax: {
-																			Type:     schema.TypeInt,
-																			Optional: true,
+																"network_interface_count": {
+																	Type:     schema.TypeList,
+																	Optional: true,
+																	MaxItems: 1,
+																	Elem: &schema.Resource{
+																		Schema: map[string]*schema.Schema{
+																			names.AttrMax: {
+																				Type:     schema.TypeInt,
+																				Optional: true,
+																			},
+																			names.AttrMin: {
+																				Type:     schema.TypeInt,
+																				Optional: true,
+																			},
 																		},
-																		names.AttrMin: {
-																			Type:     schema.TypeInt,
-																			Optional: true,
+																	},
+																},
+																"on_demand_max_price_percentage_over_lowest_price": {
+																	Type:     schema.TypeInt,
+																	Optional: true,
+																},
+																"require_hibernate_support": {
+																	Type:     schema.TypeBool,
+																	Optional: true,
+																},
+																"spot_max_price_percentage_over_lowest_price": {
+																	Type:     schema.TypeInt,
+																	Optional: true,
+																},
+																"total_local_storage_gb": {
+																	Type:     schema.TypeList,
+																	Optional: true,
+																	MaxItems: 1,
+																	Elem: &schema.Resource{
+																		Schema: map[string]*schema.Schema{
+																			names.AttrMax: {
+																				Type:     schema.TypeFloat,
+																				Optional: true,
+																			},
+																			names.AttrMin: {
+																				Type:     schema.TypeFloat,
+																				Optional: true,
+																			},
+																		},
+																	},
+																},
+																"vcpu_count": {
+																	Type:     schema.TypeList,
+																	Optional: true,
+																	MaxItems: 1,
+																	Elem: &schema.Resource{
+																		Schema: map[string]*schema.Schema{
+																			names.AttrMax: {
+																				Type:     schema.TypeInt,
+																				Optional: true,
+																			},
+																			names.AttrMin: {
+																				Type:     schema.TypeInt,
+																				Optional: true,
+																			},
 																		},
 																	},
 																},
 															},
 														},
 													},
-												},
-												names.AttrInstanceType: {
-													Type:     schema.TypeString,
-													Optional: true,
-												},
-												"launch_template_specification": {
-													Type:     schema.TypeList,
-													Optional: true,
-													MinItems: 0,
-													MaxItems: 1,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															"launch_template_id": {
-																Type:     schema.TypeString,
-																Optional: true,
-																Computed: true,
-															},
-															"launch_template_name": {
-																Type:     schema.TypeString,
-																Optional: true,
-																Computed: true,
-															},
-															names.AttrVersion: {
-																Type:     schema.TypeString,
-																Optional: true,
-																Default:  "$Default",
+													names.AttrInstanceType: {
+														Type:     schema.TypeString,
+														Optional: true,
+													},
+													"launch_template_specification": {
+														Type:     schema.TypeList,
+														Optional: true,
+														MinItems: 0,
+														MaxItems: 1,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																"launch_template_id": {
+																	Type:     schema.TypeString,
+																	Optional: true,
+																	Computed: true,
+																},
+																"launch_template_name": {
+																	Type:     schema.TypeString,
+																	Optional: true,
+																	Computed: true,
+																},
+																names.AttrVersion: {
+																	Type:     schema.TypeString,
+																	Optional: true,
+																	Default:  "$Default",
+																},
 															},
 														},
 													},
-												},
-												"weighted_capacity": {
-													Type:     schema.TypeString,
-													Optional: true,
+													"weighted_capacity": {
+														Type:     schema.TypeString,
+														Optional: true,
+													},
 												},
 											},
 										},
@@ -597,147 +599,147 @@ func resourceGroupV0() *schema.Resource {
 						},
 					},
 				},
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
-			names.AttrNamePrefix: {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
-			"placement_group": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"predicted_capacity": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-			"protect_from_scale_in": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-			"service_linked_role_arn": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-			"suspended_processes": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			"tag": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrKey: {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"propagate_at_launch": {
-							Type:     schema.TypeBool,
-							Required: true,
-						},
-						names.AttrValue: {
-							Type:     schema.TypeString,
-							Required: true,
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+				},
+				names.AttrNamePrefix: {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+				},
+				"placement_group": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"predicted_capacity": {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
+				"protect_from_scale_in": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
+				"service_linked_role_arn": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+				},
+				"suspended_processes": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"tag": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrKey: {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+							"propagate_at_launch": {
+								Type:     schema.TypeBool,
+								Required: true,
+							},
+							names.AttrValue: {
+								Type:     schema.TypeString,
+								Required: true,
+							},
 						},
 					},
 				},
-			},
-			"target_group_arns": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			"termination_policies": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			"traffic_source": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrIdentifier: {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						names.AttrType: {
-							Type:     schema.TypeString,
-							Optional: true,
+				"target_group_arns": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"termination_policies": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"traffic_source": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrIdentifier: {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+							names.AttrType: {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
 						},
 					},
 				},
-			},
-			"vpc_zone_identifier": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			"wait_for_capacity_timeout": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  "10m",
-			},
-			"wait_for_elb_capacity": {
-				Type:     schema.TypeInt,
-				Optional: true,
-			},
-			"warm_pool": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"instance_reuse_policy": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"reuse_on_scale_in": {
-										Type:     schema.TypeBool,
-										Optional: true,
-										Default:  false,
+				"vpc_zone_identifier": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"wait_for_capacity_timeout": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Default:  "10m",
+				},
+				"wait_for_elb_capacity": {
+					Type:     schema.TypeInt,
+					Optional: true,
+				},
+				"warm_pool": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"instance_reuse_policy": {
+								Type:     schema.TypeList,
+								Optional: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"reuse_on_scale_in": {
+											Type:     schema.TypeBool,
+											Optional: true,
+											Default:  false,
+										},
 									},
 								},
 							},
-						},
-						"max_group_prepared_capacity": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							Default:  defaultWarmPoolMaxGroupPreparedCapacity,
-						},
-						"min_size": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							Default:  0,
-						},
-						"pool_state": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Default:  awstypes.WarmPoolStateStopped,
+							"max_group_prepared_capacity": {
+								Type:     schema.TypeInt,
+								Optional: true,
+								Default:  defaultWarmPoolMaxGroupPreparedCapacity,
+							},
+							"min_size": {
+								Type:     schema.TypeInt,
+								Optional: true,
+								Default:  0,
+							},
+							"pool_state": {
+								Type:     schema.TypeString,
+								Optional: true,
+								Default:  awstypes.WarmPoolStateStopped,
+							},
 						},
 					},
 				},
-			},
-			"warm_pool_size": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
+				"warm_pool_size": {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/autoscaling/group_tag.go
+++ b/internal/service/autoscaling/group_tag.go
@@ -30,34 +30,36 @@ func resourceGroupTag() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"autoscaling_group_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"tag": {
-				Type:     schema.TypeList,
-				MaxItems: 1,
-				Required: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrKey: {
-							Type:     schema.TypeString,
-							Required: true,
-							ForceNew: true,
-						},
-						names.AttrValue: {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"propagate_at_launch": {
-							Type:     schema.TypeBool,
-							Required: true,
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"autoscaling_group_name": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"tag": {
+					Type:     schema.TypeList,
+					MaxItems: 1,
+					Required: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrKey: {
+								Type:     schema.TypeString,
+								Required: true,
+								ForceNew: true,
+							},
+							names.AttrValue: {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+							"propagate_at_launch": {
+								Type:     schema.TypeBool,
+								Required: true,
+							},
 						},
 					},
 				},
-			},
+			}
 		},
 	}
 }

--- a/internal/service/autoscaling/groups_data_source.go
+++ b/internal/service/autoscaling/groups_data_source.go
@@ -25,35 +25,37 @@ func dataSourceGroups() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceGroupsRead,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARNs: {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			names.AttrFilter: {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrName: {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						names.AttrValues: {
-							Type:     schema.TypeList,
-							Required: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARNs: {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				names.AttrFilter: {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrName: {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+							names.AttrValues: {
+								Type:     schema.TypeList,
+								Required: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+							},
 						},
 					},
 				},
-			},
-			names.AttrNames: {
-				Type:     schema.TypeList,
-				Optional: true,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
+				names.AttrNames: {
+					Type:     schema.TypeList,
+					Optional: true,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+			}
 		},
 	}
 }

--- a/internal/service/autoscaling/launch_configuration.go
+++ b/internal/service/autoscaling/launch_configuration.go
@@ -45,270 +45,272 @@ func resourceLaunchConfiguration() *schema.Resource {
 		ReadWithoutTimeout:   resourceLaunchConfigurationRead,
 		DeleteWithoutTimeout: resourceLaunchConfigurationDelete,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"associate_public_ip_address": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
-			"ebs_block_device": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrDeleteOnTermination: {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  true,
-							ForceNew: true,
-						},
-						names.AttrDeviceName: {
-							Type:     schema.TypeString,
-							Required: true,
-							ForceNew: true,
-						},
-						names.AttrEncrypted: {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Computed: true,
-							ForceNew: true,
-						},
-						names.AttrIOPS: {
-							Type:     schema.TypeInt,
-							Optional: true,
-							Computed: true,
-							ForceNew: true,
-						},
-						"no_device": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							ForceNew: true,
-						},
-						names.AttrSnapshotID: {
-							Type:     schema.TypeString,
-							Optional: true,
-							Computed: true,
-							ForceNew: true,
-						},
-						names.AttrThroughput: {
-							Type:     schema.TypeInt,
-							Optional: true,
-							Computed: true,
-							ForceNew: true,
-						},
-						names.AttrVolumeSize: {
-							Type:     schema.TypeInt,
-							Optional: true,
-							Computed: true,
-							ForceNew: true,
-						},
-						names.AttrVolumeType: {
-							Type:     schema.TypeString,
-							Optional: true,
-							Computed: true,
-							ForceNew: true,
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"associate_public_ip_address": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+				},
+				"ebs_block_device": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrDeleteOnTermination: {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Default:  true,
+								ForceNew: true,
+							},
+							names.AttrDeviceName: {
+								Type:     schema.TypeString,
+								Required: true,
+								ForceNew: true,
+							},
+							names.AttrEncrypted: {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Computed: true,
+								ForceNew: true,
+							},
+							names.AttrIOPS: {
+								Type:     schema.TypeInt,
+								Optional: true,
+								Computed: true,
+								ForceNew: true,
+							},
+							"no_device": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								ForceNew: true,
+							},
+							names.AttrSnapshotID: {
+								Type:     schema.TypeString,
+								Optional: true,
+								Computed: true,
+								ForceNew: true,
+							},
+							names.AttrThroughput: {
+								Type:     schema.TypeInt,
+								Optional: true,
+								Computed: true,
+								ForceNew: true,
+							},
+							names.AttrVolumeSize: {
+								Type:     schema.TypeInt,
+								Optional: true,
+								Computed: true,
+								ForceNew: true,
+							},
+							names.AttrVolumeType: {
+								Type:     schema.TypeString,
+								Optional: true,
+								Computed: true,
+								ForceNew: true,
+							},
 						},
 					},
 				},
-			},
-			"ebs_optimized": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				ForceNew: true,
-				Computed: true,
-			},
-			"enable_monitoring": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				ForceNew: true,
-				Default:  true,
-			},
-			"ephemeral_block_device": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				ForceNew: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrDeviceName: {
-							Type:     schema.TypeString,
-							Required: true,
-							ForceNew: true,
-						},
-						"no_device": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							ForceNew: true,
-						},
-						names.AttrVirtualName: {
-							Type:     schema.TypeString,
-							Optional: true,
-							ForceNew: true,
+				"ebs_optimized": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					ForceNew: true,
+					Computed: true,
+				},
+				"enable_monitoring": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					ForceNew: true,
+					Default:  true,
+				},
+				"ephemeral_block_device": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					ForceNew: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrDeviceName: {
+								Type:     schema.TypeString,
+								Required: true,
+								ForceNew: true,
+							},
+							"no_device": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								ForceNew: true,
+							},
+							names.AttrVirtualName: {
+								Type:     schema.TypeString,
+								Optional: true,
+								ForceNew: true,
+							},
 						},
 					},
 				},
-			},
-			"iam_instance_profile": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
-			"image_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			names.AttrInstanceType: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"key_name": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
-			"metadata_options": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"http_endpoint": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							Computed:     true,
-							ForceNew:     true,
-							ValidateFunc: validation.StringInSlice(enum.Slice(awstypes.InstanceMetadataEndpointStateEnabled, awstypes.InstanceMetadataEndpointStateDisabled), false),
-						},
-						"http_put_response_hop_limit": {
-							Type:         schema.TypeInt,
-							Optional:     true,
-							Computed:     true,
-							ForceNew:     true,
-							ValidateFunc: validation.IntBetween(1, 64),
-						},
-						"http_tokens": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							Computed:     true,
-							ForceNew:     true,
-							ValidateFunc: validation.StringInSlice(enum.Slice(awstypes.InstanceMetadataHttpTokensStateOptional, awstypes.InstanceMetadataHttpTokensStateRequired), false),
+				"iam_instance_profile": {
+					Type:     schema.TypeString,
+					Optional: true,
+					ForceNew: true,
+				},
+				"image_id": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				names.AttrInstanceType: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"key_name": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+				},
+				"metadata_options": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"http_endpoint": {
+								Type:         schema.TypeString,
+								Optional:     true,
+								Computed:     true,
+								ForceNew:     true,
+								ValidateFunc: validation.StringInSlice(enum.Slice(awstypes.InstanceMetadataEndpointStateEnabled, awstypes.InstanceMetadataEndpointStateDisabled), false),
+							},
+							"http_put_response_hop_limit": {
+								Type:         schema.TypeInt,
+								Optional:     true,
+								Computed:     true,
+								ForceNew:     true,
+								ValidateFunc: validation.IntBetween(1, 64),
+							},
+							"http_tokens": {
+								Type:         schema.TypeString,
+								Optional:     true,
+								Computed:     true,
+								ForceNew:     true,
+								ValidateFunc: validation.StringInSlice(enum.Slice(awstypes.InstanceMetadataHttpTokensStateOptional, awstypes.InstanceMetadataHttpTokensStateRequired), false),
+							},
 						},
 					},
 				},
-			},
-			names.AttrName: {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				ForceNew:      true,
-				ConflictsWith: []string{names.AttrNamePrefix},
-				ValidateFunc:  validation.StringLenBetween(1, 255),
-			},
-			names.AttrNamePrefix: {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				ForceNew:      true,
-				ConflictsWith: []string{names.AttrName},
-				ValidateFunc:  validation.StringLenBetween(1, 255-sdkid.UniqueIDSuffixLength),
-			},
-			"placement_tenancy": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
-			"root_block_device": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Computed: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					// "You can only modify the volume size, volume type, and Delete on
-					// Termination flag on the block device mapping entry for the root
-					// device volume." - bit.ly/ec2bdmap
-					Schema: map[string]*schema.Schema{
-						names.AttrDeleteOnTermination: {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  true,
-							ForceNew: true,
-						},
-						names.AttrEncrypted: {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Computed: true,
-							ForceNew: true,
-						},
-						names.AttrIOPS: {
-							Type:     schema.TypeInt,
-							Optional: true,
-							Computed: true,
-							ForceNew: true,
-						},
-						names.AttrThroughput: {
-							Type:     schema.TypeInt,
-							Optional: true,
-							Computed: true,
-							ForceNew: true,
-						},
-						names.AttrVolumeSize: {
-							Type:     schema.TypeInt,
-							Optional: true,
-							Computed: true,
-							ForceNew: true,
-						},
-						names.AttrVolumeType: {
-							Type:     schema.TypeString,
-							Optional: true,
-							Computed: true,
-							ForceNew: true,
+				names.AttrName: {
+					Type:          schema.TypeString,
+					Optional:      true,
+					Computed:      true,
+					ForceNew:      true,
+					ConflictsWith: []string{names.AttrNamePrefix},
+					ValidateFunc:  validation.StringLenBetween(1, 255),
+				},
+				names.AttrNamePrefix: {
+					Type:          schema.TypeString,
+					Optional:      true,
+					Computed:      true,
+					ForceNew:      true,
+					ConflictsWith: []string{names.AttrName},
+					ValidateFunc:  validation.StringLenBetween(1, 255-sdkid.UniqueIDSuffixLength),
+				},
+				"placement_tenancy": {
+					Type:     schema.TypeString,
+					Optional: true,
+					ForceNew: true,
+				},
+				"root_block_device": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Computed: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						// "You can only modify the volume size, volume type, and Delete on
+						// Termination flag on the block device mapping entry for the root
+						// device volume." - bit.ly/ec2bdmap
+						Schema: map[string]*schema.Schema{
+							names.AttrDeleteOnTermination: {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Default:  true,
+								ForceNew: true,
+							},
+							names.AttrEncrypted: {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Computed: true,
+								ForceNew: true,
+							},
+							names.AttrIOPS: {
+								Type:     schema.TypeInt,
+								Optional: true,
+								Computed: true,
+								ForceNew: true,
+							},
+							names.AttrThroughput: {
+								Type:     schema.TypeInt,
+								Optional: true,
+								Computed: true,
+								ForceNew: true,
+							},
+							names.AttrVolumeSize: {
+								Type:     schema.TypeInt,
+								Optional: true,
+								Computed: true,
+								ForceNew: true,
+							},
+							names.AttrVolumeType: {
+								Type:     schema.TypeString,
+								Optional: true,
+								Computed: true,
+								ForceNew: true,
+							},
 						},
 					},
 				},
-			},
-			names.AttrSecurityGroups: {
-				Type:     schema.TypeSet,
-				Optional: true,
-				ForceNew: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			"spot_price": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
-			"user_data": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				ForceNew:      true,
-				ConflictsWith: []string{"user_data_base64"},
-				StateFunc: func(v any) string {
-					switch v := v.(type) {
-					case string:
-						return userDataHashSum(v)
-					default:
-						return ""
-					}
+				names.AttrSecurityGroups: {
+					Type:     schema.TypeSet,
+					Optional: true,
+					ForceNew: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
 				},
-				ValidateFunc: validation.StringLenBetween(1, 16384),
-			},
-			"user_data_base64": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				ForceNew:      true,
-				ConflictsWith: []string{"user_data"},
-				ValidateFunc:  verify.ValidBase64String,
-			},
+				"spot_price": {
+					Type:     schema.TypeString,
+					Optional: true,
+					ForceNew: true,
+				},
+				"user_data": {
+					Type:          schema.TypeString,
+					Optional:      true,
+					ForceNew:      true,
+					ConflictsWith: []string{"user_data_base64"},
+					StateFunc: func(v any) string {
+						switch v := v.(type) {
+						case string:
+							return userDataHashSum(v)
+						default:
+							return ""
+						}
+					},
+					ValidateFunc: validation.StringLenBetween(1, 16384),
+				},
+				"user_data_base64": {
+					Type:          schema.TypeString,
+					Optional:      true,
+					ForceNew:      true,
+					ConflictsWith: []string{"user_data"},
+					ValidateFunc:  verify.ValidBase64String,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/autoscaling/launch_configuration_data_source.go
+++ b/internal/service/autoscaling/launch_configuration_data_source.go
@@ -20,172 +20,174 @@ func dataSourceLaunchConfiguration() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceLaunchConfigurationRead,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"associate_public_ip_address": {
-				Type:     schema.TypeBool,
-				Computed: true,
-			},
-			"ebs_block_device": {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrDeleteOnTermination: {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
-						names.AttrDeviceName: {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						names.AttrEncrypted: {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
-						names.AttrIOPS: {
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
-						"no_device": {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
-						names.AttrSnapshotID: {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						names.AttrThroughput: {
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
-						names.AttrVolumeSize: {
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
-						names.AttrVolumeType: {
-							Type:     schema.TypeString,
-							Computed: true,
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"associate_public_ip_address": {
+					Type:     schema.TypeBool,
+					Computed: true,
+				},
+				"ebs_block_device": {
+					Type:     schema.TypeSet,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrDeleteOnTermination: {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
+							names.AttrDeviceName: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							names.AttrEncrypted: {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
+							names.AttrIOPS: {
+								Type:     schema.TypeInt,
+								Computed: true,
+							},
+							"no_device": {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
+							names.AttrSnapshotID: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							names.AttrThroughput: {
+								Type:     schema.TypeInt,
+								Computed: true,
+							},
+							names.AttrVolumeSize: {
+								Type:     schema.TypeInt,
+								Computed: true,
+							},
+							names.AttrVolumeType: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
 						},
 					},
 				},
-			},
-			"ebs_optimized": {
-				Type:     schema.TypeBool,
-				Computed: true,
-			},
-			"enable_monitoring": {
-				Type:     schema.TypeBool,
-				Computed: true,
-			},
-			"ephemeral_block_device": {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrDeviceName: {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						names.AttrVirtualName: {
-							Type:     schema.TypeString,
-							Computed: true,
+				"ebs_optimized": {
+					Type:     schema.TypeBool,
+					Computed: true,
+				},
+				"enable_monitoring": {
+					Type:     schema.TypeBool,
+					Computed: true,
+				},
+				"ephemeral_block_device": {
+					Type:     schema.TypeSet,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrDeviceName: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							names.AttrVirtualName: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
 						},
 					},
 				},
-			},
-			"iam_instance_profile": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"image_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrInstanceType: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"key_name": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"metadata_options": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"http_endpoint": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"http_put_response_hop_limit": {
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
-						"http_tokens": {
-							Type:     schema.TypeString,
-							Computed: true,
+				"iam_instance_profile": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"image_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrInstanceType: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"key_name": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"metadata_options": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"http_endpoint": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"http_put_response_hop_limit": {
+								Type:     schema.TypeInt,
+								Computed: true,
+							},
+							"http_tokens": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
 						},
 					},
 				},
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"placement_tenancy": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"root_block_device": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrDeleteOnTermination: {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
-						names.AttrEncrypted: {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
-						names.AttrIOPS: {
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
-						names.AttrThroughput: {
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
-						names.AttrVolumeSize: {
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
-						names.AttrVolumeType: {
-							Type:     schema.TypeString,
-							Computed: true,
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"placement_tenancy": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"root_block_device": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrDeleteOnTermination: {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
+							names.AttrEncrypted: {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
+							names.AttrIOPS: {
+								Type:     schema.TypeInt,
+								Computed: true,
+							},
+							names.AttrThroughput: {
+								Type:     schema.TypeInt,
+								Computed: true,
+							},
+							names.AttrVolumeSize: {
+								Type:     schema.TypeInt,
+								Computed: true,
+							},
+							names.AttrVolumeType: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
 						},
 					},
 				},
-			},
-			names.AttrSecurityGroups: {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			"spot_price": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"user_data": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+				names.AttrSecurityGroups: {
+					Type:     schema.TypeSet,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"spot_price": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"user_data": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/autoscaling/lifecycle_hook.go
+++ b/internal/service/autoscaling/lifecycle_hook.go
@@ -43,51 +43,53 @@ func resourceLifecycleHook() *schema.Resource {
 		UpdateWithoutTimeout: resourceLifecycleHookPut,
 		DeleteWithoutTimeout: resourceLifecycleHookDelete,
 
-		Schema: map[string]*schema.Schema{
-			"autoscaling_group_name": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"default_result": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Computed:         true,
-				ValidateDiagFunc: enum.Validate[lifecycleHookDefaultResult](),
-			},
-			"heartbeat_timeout": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				ValidateFunc: validation.IntBetween(30, 7200),
-			},
-			"lifecycle_transition": {
-				Type:             schema.TypeString,
-				Required:         true,
-				ValidateDiagFunc: enum.Validate[lifecycleHookLifecycleTransition](),
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-				ValidateFunc: validation.All(
-					validation.StringLenBetween(1, 255),
-					validation.StringMatch(regexache.MustCompile(`[A-Za-z0-9\-_\/]+`),
-						`no spaces or special characters except "-", "_", and "/"`),
-				),
-			},
-			"notification_metadata": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"notification_target_arn": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			names.AttrRoleARN: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: verify.ValidARN,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"autoscaling_group_name": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"default_result": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					Computed:         true,
+					ValidateDiagFunc: enum.Validate[lifecycleHookDefaultResult](),
+				},
+				"heartbeat_timeout": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					ValidateFunc: validation.IntBetween(30, 7200),
+				},
+				"lifecycle_transition": {
+					Type:             schema.TypeString,
+					Required:         true,
+					ValidateDiagFunc: enum.Validate[lifecycleHookLifecycleTransition](),
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+					ValidateFunc: validation.All(
+						validation.StringLenBetween(1, 255),
+						validation.StringMatch(regexache.MustCompile(`[A-Za-z0-9\-_\/]+`),
+							`no spaces or special characters except "-", "_", and "/"`),
+					),
+				},
+				"notification_metadata": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"notification_target_arn": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				names.AttrRoleARN: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/autoscaling/notification.go
+++ b/internal/service/autoscaling/notification.go
@@ -34,23 +34,25 @@ func resourceNotification() *schema.Resource {
 		UpdateWithoutTimeout: resourceNotificationUpdate,
 		DeleteWithoutTimeout: resourceNotificationDelete,
 
-		Schema: map[string]*schema.Schema{
-			"group_names": {
-				Type:     schema.TypeSet,
-				Required: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			"notifications": {
-				Type:     schema.TypeSet,
-				Required: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			names.AttrTopicARN: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidARN,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"group_names": {
+					Type:     schema.TypeSet,
+					Required: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"notifications": {
+					Type:     schema.TypeSet,
+					Required: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				names.AttrTopicARN: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/autoscaling/schedule.go
+++ b/internal/service/autoscaling/schedule.go
@@ -44,58 +44,60 @@ func resourceSchedule() *schema.Resource {
 		UpdateWithoutTimeout: resourceSchedulePut,
 		DeleteWithoutTimeout: resourceScheduleDelete,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"autoscaling_group_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"desired_capacity": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Computed: true,
-			},
-			"end_time": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: validScheduleTimestamp,
-			},
-			"max_size": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Computed: true,
-			},
-			"min_size": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Computed: true,
-			},
-			"recurrence": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-			"scheduled_action_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			names.AttrStartTime: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: validScheduleTimestamp,
-			},
-			"time_zone": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"autoscaling_group_name": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"desired_capacity": {
+					Type:     schema.TypeInt,
+					Optional: true,
+					Computed: true,
+				},
+				"end_time": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Computed:     true,
+					ValidateFunc: validScheduleTimestamp,
+				},
+				"max_size": {
+					Type:     schema.TypeInt,
+					Optional: true,
+					Computed: true,
+				},
+				"min_size": {
+					Type:     schema.TypeInt,
+					Optional: true,
+					Computed: true,
+				},
+				"recurrence": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+				},
+				"scheduled_action_name": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				names.AttrStartTime: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Computed:     true,
+					ValidateFunc: validScheduleTimestamp,
+				},
+				"time_zone": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/autoscaling/traffic_source_attachment.go
+++ b/internal/service/autoscaling/traffic_source_attachment.go
@@ -43,34 +43,36 @@ func resourceTrafficSourceAttachment() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"autoscaling_group_name": {
-				Type:     schema.TypeString,
-				ForceNew: true,
-				Required: true,
-			},
-			"traffic_source": {
-				Type:     schema.TypeList,
-				Optional: true,
-				ForceNew: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrIdentifier: {
-							Type:         schema.TypeString,
-							Required:     true,
-							ForceNew:     true,
-							ValidateFunc: validation.StringLenBetween(1, 2048),
-						},
-						names.AttrType: {
-							Type:         schema.TypeString,
-							Required:     true,
-							ForceNew:     true,
-							ValidateFunc: validation.StringLenBetween(1, 2048),
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"autoscaling_group_name": {
+					Type:     schema.TypeString,
+					ForceNew: true,
+					Required: true,
+				},
+				"traffic_source": {
+					Type:     schema.TypeList,
+					Optional: true,
+					ForceNew: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrIdentifier: {
+								Type:         schema.TypeString,
+								Required:     true,
+								ForceNew:     true,
+								ValidateFunc: validation.StringLenBetween(1, 2048),
+							},
+							names.AttrType: {
+								Type:         schema.TypeString,
+								Required:     true,
+								ForceNew:     true,
+								ValidateFunc: validation.StringLenBetween(1, 2048),
+							},
 						},
 					},
 				},
-			},
+			}
 		},
 	}
 }

--- a/internal/service/autoscalingplans/scaling_plan.go
+++ b/internal/service/autoscalingplans/scaling_plan.go
@@ -43,293 +43,295 @@ func ResourceScalingPlan() *schema.Resource {
 			StateContext: resourceScalingPlanImport,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"application_source": {
-				Type:     schema.TypeList,
-				Required: true,
-				MinItems: 1,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"cloudformation_stack_arn": {
-							Type:          schema.TypeString,
-							Optional:      true,
-							ValidateFunc:  verify.ValidARN,
-							ConflictsWith: []string{"application_source.0.tag_filter"},
-						},
-
-						"tag_filter": {
-							Type:     schema.TypeSet,
-							Optional: true,
-							MinItems: 0,
-							MaxItems: 50,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									names.AttrKey: {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-
-									names.AttrValues: {
-										Type:     schema.TypeSet,
-										Optional: true,
-										MinItems: 0,
-										MaxItems: 50,
-										Elem:     &schema.Schema{Type: schema.TypeString},
-									},
-								},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"application_source": {
+					Type:     schema.TypeList,
+					Required: true,
+					MinItems: 1,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"cloudformation_stack_arn": {
+								Type:          schema.TypeString,
+								Optional:      true,
+								ValidateFunc:  verify.ValidARN,
+								ConflictsWith: []string{"application_source.0.tag_filter"},
 							},
-							ConflictsWith: []string{"application_source.0.cloudformation_stack_arn"},
-						},
-					},
-				},
-			},
 
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-				ValidateFunc: validation.All(
-					validation.StringLenBetween(1, 128),
-					validation.StringMatch(regexache.MustCompile(`^[[:print:]]+$`), "must be printable"),
-					validation.StringDoesNotContainAny("|:/"),
-				),
-			},
+							"tag_filter": {
+								Type:     schema.TypeSet,
+								Optional: true,
+								MinItems: 0,
+								MaxItems: 50,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										names.AttrKey: {
+											Type:     schema.TypeString,
+											Required: true,
+										},
 
-			"scaling_instruction": {
-				Type:     schema.TypeSet,
-				Required: true,
-				MinItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"customized_load_metric_specification": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MinItems: 0,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"dimensions": {
-										Type:     schema.TypeMap,
-										Optional: true,
-										Elem:     &schema.Schema{Type: schema.TypeString},
-									},
-
-									names.AttrMetricName: {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-
-									names.AttrNamespace: {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-
-									"statistic": {
-										Type:         schema.TypeString,
-										Required:     true,
-										ValidateFunc: validation.StringInSlice(enum.Slice(awstypes.MetricStatisticSum), false),
-									},
-
-									names.AttrUnit: {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
-								},
-							},
-						},
-
-						"disable_dynamic_scaling": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  false,
-						},
-
-						names.AttrMaxCapacity: {
-							Type:     schema.TypeInt,
-							Required: true,
-						},
-
-						"min_capacity": {
-							Type:     schema.TypeInt,
-							Required: true,
-						},
-
-						"predefined_load_metric_specification": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MinItems: 0,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"predefined_load_metric_type": {
-										Type:             schema.TypeString,
-										Required:         true,
-										ValidateDiagFunc: enum.Validate[awstypes.LoadMetricType](),
-									},
-
-									"resource_label": {
-										Type:         schema.TypeString,
-										Optional:     true,
-										ValidateFunc: validation.StringLenBetween(1, 1023),
-									},
-								},
-							},
-						},
-
-						"predictive_scaling_max_capacity_behavior": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.PredictiveScalingMaxCapacityBehavior](),
-						},
-
-						"predictive_scaling_max_capacity_buffer": {
-							Type:         schema.TypeInt,
-							Optional:     true,
-							Computed:     true,
-							ValidateFunc: validation.IntBetween(1, 100),
-						},
-
-						"predictive_scaling_mode": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.PredictiveScalingMode](),
-						},
-
-						names.AttrResourceID: {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validation.StringLenBetween(1, 1600),
-						},
-
-						"scalable_dimension": {
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.ScalableDimension](),
-						},
-
-						"scaling_policy_update_behavior": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Default:          awstypes.ScalingPolicyUpdateBehaviorKeepExternalPolicies,
-							ValidateDiagFunc: enum.Validate[awstypes.ScalingPolicyUpdateBehavior](),
-						},
-
-						"scheduled_action_buffer_time": {
-							Type:         schema.TypeInt,
-							Optional:     true,
-							ValidateFunc: validation.IntAtLeast(0),
-						},
-
-						"service_namespace": {
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.ServiceNamespace](),
-						},
-
-						"target_tracking_configuration": {
-							Type:     schema.TypeSet,
-							Required: true,
-							MinItems: 1,
-							MaxItems: 10,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"customized_scaling_metric_specification": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MinItems: 0,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"dimensions": {
-													Type:     schema.TypeMap,
-													Optional: true,
-													Elem:     &schema.Schema{Type: schema.TypeString},
-												},
-
-												names.AttrMetricName: {
-													Type:     schema.TypeString,
-													Required: true,
-												},
-
-												names.AttrNamespace: {
-													Type:     schema.TypeString,
-													Required: true,
-												},
-
-												"statistic": {
-													Type:             schema.TypeString,
-													Required:         true,
-													ValidateDiagFunc: enum.Validate[awstypes.MetricStatistic](),
-												},
-
-												names.AttrUnit: {
-													Type:     schema.TypeString,
-													Optional: true,
-												},
-											},
+										names.AttrValues: {
+											Type:     schema.TypeSet,
+											Optional: true,
+											MinItems: 0,
+											MaxItems: 50,
+											Elem:     &schema.Schema{Type: schema.TypeString},
 										},
 									},
-
-									"disable_scale_in": {
-										Type:     schema.TypeBool,
-										Optional: true,
-										Default:  false,
-									},
-
-									"estimated_instance_warmup": {
-										Type:     schema.TypeInt,
-										Optional: true,
-									},
-
-									"predefined_scaling_metric_specification": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MinItems: 0,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"predefined_scaling_metric_type": {
-													Type:             schema.TypeString,
-													Required:         true,
-													ValidateDiagFunc: enum.Validate[awstypes.ScalingMetricType](),
-												},
-
-												"resource_label": {
-													Type:         schema.TypeString,
-													Optional:     true,
-													ValidateFunc: validation.StringLenBetween(1, 1023),
-												},
-											},
-										},
-									},
-
-									"scale_in_cooldown": {
-										Type:     schema.TypeInt,
-										Optional: true,
-									},
-
-									"scale_out_cooldown": {
-										Type:     schema.TypeInt,
-										Optional: true,
-									},
-
-									"target_value": {
-										Type:         schema.TypeFloat,
-										Required:     true,
-										ValidateFunc: validation.FloatBetween(8.515920e-109, 1.174271e+108),
-									},
 								},
+								ConflictsWith: []string{"application_source.0.cloudformation_stack_arn"},
 							},
 						},
 					},
 				},
-			},
 
-			"scaling_plan_version": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+					ValidateFunc: validation.All(
+						validation.StringLenBetween(1, 128),
+						validation.StringMatch(regexache.MustCompile(`^[[:print:]]+$`), "must be printable"),
+						validation.StringDoesNotContainAny("|:/"),
+					),
+				},
+
+				"scaling_instruction": {
+					Type:     schema.TypeSet,
+					Required: true,
+					MinItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"customized_load_metric_specification": {
+								Type:     schema.TypeList,
+								Optional: true,
+								MinItems: 0,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"dimensions": {
+											Type:     schema.TypeMap,
+											Optional: true,
+											Elem:     &schema.Schema{Type: schema.TypeString},
+										},
+
+										names.AttrMetricName: {
+											Type:     schema.TypeString,
+											Required: true,
+										},
+
+										names.AttrNamespace: {
+											Type:     schema.TypeString,
+											Required: true,
+										},
+
+										"statistic": {
+											Type:         schema.TypeString,
+											Required:     true,
+											ValidateFunc: validation.StringInSlice(enum.Slice(awstypes.MetricStatisticSum), false),
+										},
+
+										names.AttrUnit: {
+											Type:     schema.TypeString,
+											Optional: true,
+										},
+									},
+								},
+							},
+
+							"disable_dynamic_scaling": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Default:  false,
+							},
+
+							names.AttrMaxCapacity: {
+								Type:     schema.TypeInt,
+								Required: true,
+							},
+
+							"min_capacity": {
+								Type:     schema.TypeInt,
+								Required: true,
+							},
+
+							"predefined_load_metric_specification": {
+								Type:     schema.TypeList,
+								Optional: true,
+								MinItems: 0,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"predefined_load_metric_type": {
+											Type:             schema.TypeString,
+											Required:         true,
+											ValidateDiagFunc: enum.Validate[awstypes.LoadMetricType](),
+										},
+
+										"resource_label": {
+											Type:         schema.TypeString,
+											Optional:     true,
+											ValidateFunc: validation.StringLenBetween(1, 1023),
+										},
+									},
+								},
+							},
+
+							"predictive_scaling_max_capacity_behavior": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.PredictiveScalingMaxCapacityBehavior](),
+							},
+
+							"predictive_scaling_max_capacity_buffer": {
+								Type:         schema.TypeInt,
+								Optional:     true,
+								Computed:     true,
+								ValidateFunc: validation.IntBetween(1, 100),
+							},
+
+							"predictive_scaling_mode": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.PredictiveScalingMode](),
+							},
+
+							names.AttrResourceID: {
+								Type:         schema.TypeString,
+								Required:     true,
+								ValidateFunc: validation.StringLenBetween(1, 1600),
+							},
+
+							"scalable_dimension": {
+								Type:             schema.TypeString,
+								Required:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.ScalableDimension](),
+							},
+
+							"scaling_policy_update_behavior": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								Default:          awstypes.ScalingPolicyUpdateBehaviorKeepExternalPolicies,
+								ValidateDiagFunc: enum.Validate[awstypes.ScalingPolicyUpdateBehavior](),
+							},
+
+							"scheduled_action_buffer_time": {
+								Type:         schema.TypeInt,
+								Optional:     true,
+								ValidateFunc: validation.IntAtLeast(0),
+							},
+
+							"service_namespace": {
+								Type:             schema.TypeString,
+								Required:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.ServiceNamespace](),
+							},
+
+							"target_tracking_configuration": {
+								Type:     schema.TypeSet,
+								Required: true,
+								MinItems: 1,
+								MaxItems: 10,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"customized_scaling_metric_specification": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MinItems: 0,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"dimensions": {
+														Type:     schema.TypeMap,
+														Optional: true,
+														Elem:     &schema.Schema{Type: schema.TypeString},
+													},
+
+													names.AttrMetricName: {
+														Type:     schema.TypeString,
+														Required: true,
+													},
+
+													names.AttrNamespace: {
+														Type:     schema.TypeString,
+														Required: true,
+													},
+
+													"statistic": {
+														Type:             schema.TypeString,
+														Required:         true,
+														ValidateDiagFunc: enum.Validate[awstypes.MetricStatistic](),
+													},
+
+													names.AttrUnit: {
+														Type:     schema.TypeString,
+														Optional: true,
+													},
+												},
+											},
+										},
+
+										"disable_scale_in": {
+											Type:     schema.TypeBool,
+											Optional: true,
+											Default:  false,
+										},
+
+										"estimated_instance_warmup": {
+											Type:     schema.TypeInt,
+											Optional: true,
+										},
+
+										"predefined_scaling_metric_specification": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MinItems: 0,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"predefined_scaling_metric_type": {
+														Type:             schema.TypeString,
+														Required:         true,
+														ValidateDiagFunc: enum.Validate[awstypes.ScalingMetricType](),
+													},
+
+													"resource_label": {
+														Type:         schema.TypeString,
+														Optional:     true,
+														ValidateFunc: validation.StringLenBetween(1, 1023),
+													},
+												},
+											},
+										},
+
+										"scale_in_cooldown": {
+											Type:     schema.TypeInt,
+											Optional: true,
+										},
+
+										"scale_out_cooldown": {
+											Type:     schema.TypeInt,
+											Optional: true,
+										},
+
+										"target_value": {
+											Type:         schema.TypeFloat,
+											Required:     true,
+											ValidateFunc: validation.FloatBetween(8.515920e-109, 1.174271e+108),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+
+				"scaling_plan_version": {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/backup/framework.go
+++ b/internal/service/backup/framework.go
@@ -49,100 +49,102 @@ func resourceFramework() *schema.Resource {
 			Delete: schema.DefaultTimeout(3 * time.Minute),
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"control": {
-				Type:     schema.TypeSet,
-				Required: true,
-				MinItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"input_parameter": {
-							Type:     schema.TypeSet,
-							Optional: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									names.AttrName: {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
-									names.AttrValue: {
-										Type:     schema.TypeString,
-										Optional: true,
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"control": {
+					Type:     schema.TypeSet,
+					Required: true,
+					MinItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"input_parameter": {
+								Type:     schema.TypeSet,
+								Optional: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										names.AttrName: {
+											Type:     schema.TypeString,
+											Optional: true,
+										},
+										names.AttrValue: {
+											Type:     schema.TypeString,
+											Optional: true,
+										},
 									},
 								},
 							},
-						},
-						names.AttrName: {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validation.StringLenBetween(1, 256),
-						},
-						names.AttrScope: {
-							// The control scope can include
-							// one or more resource types,
-							// a combination of a tag key and value,
-							// or a combination of one resource type and one resource ID.
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"compliance_resource_ids": {
-										Type:     schema.TypeSet,
-										Optional: true,
-										Computed: true,
-										MinItems: 1,
-										MaxItems: 100,
-										Elem: &schema.Schema{
-											Type: schema.TypeString,
+							names.AttrName: {
+								Type:         schema.TypeString,
+								Required:     true,
+								ValidateFunc: validation.StringLenBetween(1, 256),
+							},
+							names.AttrScope: {
+								// The control scope can include
+								// one or more resource types,
+								// a combination of a tag key and value,
+								// or a combination of one resource type and one resource ID.
+								Type:     schema.TypeList,
+								Optional: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"compliance_resource_ids": {
+											Type:     schema.TypeSet,
+											Optional: true,
+											Computed: true,
+											MinItems: 1,
+											MaxItems: 100,
+											Elem: &schema.Schema{
+												Type: schema.TypeString,
+											},
 										},
-									},
-									"compliance_resource_types": {
-										Type:     schema.TypeSet,
-										Optional: true,
-										Computed: true,
-										Elem: &schema.Schema{
-											Type: schema.TypeString,
+										"compliance_resource_types": {
+											Type:     schema.TypeSet,
+											Optional: true,
+											Computed: true,
+											Elem: &schema.Schema{
+												Type: schema.TypeString,
+											},
 										},
+										// A maximum of one key-value pair can be provided.
+										// The tag value is optional, but it cannot be an empty string
+										names.AttrTags: tftags.TagsSchema(),
 									},
-									// A maximum of one key-value pair can be provided.
-									// The tag value is optional, but it cannot be an empty string
-									names.AttrTags: tftags.TagsSchema(),
 								},
 							},
 						},
 					},
 				},
-			},
-			names.AttrCreationTime: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"deployment_status": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrDescription: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringLenBetween(0, 1024),
-			},
-			names.AttrName: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validFrameworkName,
-			},
-			names.AttrStatus: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				names.AttrCreationTime: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"deployment_status": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrDescription: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringLenBetween(0, 1024),
+				},
+				names.AttrName: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validFrameworkName,
+				},
+				names.AttrStatus: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			}
 		},
 	}
 }

--- a/internal/service/backup/framework_data_source.go
+++ b/internal/service/backup/framework_data_source.go
@@ -25,83 +25,85 @@ func dataSourceFramework() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceFrameworkRead,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"control": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"input_parameter": {
-							Type:     schema.TypeList,
-							Computed: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									names.AttrName: {
-										Type:     schema.TypeString,
-										Computed: true,
-									},
-									names.AttrValue: {
-										Type:     schema.TypeString,
-										Computed: true,
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"control": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"input_parameter": {
+								Type:     schema.TypeList,
+								Computed: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										names.AttrName: {
+											Type:     schema.TypeString,
+											Computed: true,
+										},
+										names.AttrValue: {
+											Type:     schema.TypeString,
+											Computed: true,
+										},
 									},
 								},
 							},
-						},
-						names.AttrName: {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						names.AttrScope: {
-							Type:     schema.TypeList,
-							Computed: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"compliance_resource_ids": {
-										Type:     schema.TypeList,
-										Computed: true,
-										Elem: &schema.Schema{
-											Type: schema.TypeString,
+							names.AttrName: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							names.AttrScope: {
+								Type:     schema.TypeList,
+								Computed: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"compliance_resource_ids": {
+											Type:     schema.TypeList,
+											Computed: true,
+											Elem: &schema.Schema{
+												Type: schema.TypeString,
+											},
 										},
-									},
-									"compliance_resource_types": {
-										Type:     schema.TypeList,
-										Computed: true,
-										Elem: &schema.Schema{
-											Type: schema.TypeString,
+										"compliance_resource_types": {
+											Type:     schema.TypeList,
+											Computed: true,
+											Elem: &schema.Schema{
+												Type: schema.TypeString,
+											},
 										},
+										names.AttrTags: tftags.TagsSchemaComputed(),
 									},
-									names.AttrTags: tftags.TagsSchemaComputed(),
 								},
 							},
 						},
 					},
 				},
-			},
-			names.AttrCreationTime: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"deployment_status": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrDescription: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			names.AttrStatus: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrTags: tftags.TagsSchemaComputed(),
+				names.AttrCreationTime: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"deployment_status": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrDescription: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				names.AttrStatus: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrTags: tftags.TagsSchemaComputed(),
+			}
 		},
 	}
 }

--- a/internal/service/backup/global_settings.go
+++ b/internal/service/backup/global_settings.go
@@ -32,12 +32,14 @@ func resourceGlobalSettings() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"global_settings": {
-				Type:     schema.TypeMap,
-				Required: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"global_settings": {
+					Type:     schema.TypeMap,
+					Required: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+			}
 		},
 	}
 }

--- a/internal/service/backup/plan.go
+++ b/internal/service/backup/plan.go
@@ -56,198 +56,200 @@ func resourcePlan() *schema.Resource {
 			},
 		},
 
-		Schema: map[string]*schema.Schema{
-			"advanced_backup_setting": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"backup_options": {
-							Type:     schema.TypeMap,
-							Required: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-						names.AttrResourceType: {
-							Type:     schema.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								"EC2",
-							}, false),
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"advanced_backup_setting": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"backup_options": {
+								Type:     schema.TypeMap,
+								Required: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+							},
+							names.AttrResourceType: {
+								Type:     schema.TypeString,
+								Required: true,
+								ValidateFunc: validation.StringInSlice([]string{
+									"EC2",
+								}, false),
+							},
 						},
 					},
 				},
-			},
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			names.AttrRule: {
-				Type:     schema.TypeSet,
-				Required: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"completion_window": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							Default:  180,
-						},
-						"copy_action": {
-							Type:     schema.TypeSet,
-							Optional: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"destination_vault_arn": {
-										Type:         schema.TypeString,
-										Required:     true,
-										ValidateFunc: verify.ValidARN,
-									},
-									"lifecycle": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"cold_storage_after": {
-													Type:     schema.TypeInt,
-													Optional: true,
-												},
-												"delete_after": {
-													Type:     schema.TypeInt,
-													Optional: true,
-												},
-												"opt_in_to_archive_for_supported_resources": {
-													Type:     schema.TypeBool,
-													Optional: true,
-													Computed: true,
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				names.AttrRule: {
+					Type:     schema.TypeSet,
+					Required: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"completion_window": {
+								Type:     schema.TypeInt,
+								Optional: true,
+								Default:  180,
+							},
+							"copy_action": {
+								Type:     schema.TypeSet,
+								Optional: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"destination_vault_arn": {
+											Type:         schema.TypeString,
+											Required:     true,
+											ValidateFunc: verify.ValidARN,
+										},
+										"lifecycle": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"cold_storage_after": {
+														Type:     schema.TypeInt,
+														Optional: true,
+													},
+													"delete_after": {
+														Type:     schema.TypeInt,
+														Optional: true,
+													},
+													"opt_in_to_archive_for_supported_resources": {
+														Type:     schema.TypeBool,
+														Optional: true,
+														Computed: true,
+													},
 												},
 											},
 										},
 									},
 								},
 							},
-						},
-						"enable_continuous_backup": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  false,
-						},
-						"lifecycle": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"cold_storage_after": {
-										Type:     schema.TypeInt,
-										Optional: true,
-									},
-									"delete_after": {
-										Type:     schema.TypeInt,
-										Optional: true,
-									},
-									"opt_in_to_archive_for_supported_resources": {
-										Type:     schema.TypeBool,
-										Optional: true,
-										Computed: true,
+							"enable_continuous_backup": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Default:  false,
+							},
+							"lifecycle": {
+								Type:     schema.TypeList,
+								Optional: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"cold_storage_after": {
+											Type:     schema.TypeInt,
+											Optional: true,
+										},
+										"delete_after": {
+											Type:     schema.TypeInt,
+											Optional: true,
+										},
+										"opt_in_to_archive_for_supported_resources": {
+											Type:     schema.TypeBool,
+											Optional: true,
+											Computed: true,
+										},
 									},
 								},
 							},
-						},
-						"recovery_point_tags": tftags.TagsSchema(),
-						"rule_name": {
-							Type:     schema.TypeString,
-							Required: true,
-							ValidateFunc: validation.All(
-								validation.StringLenBetween(1, 50),
-								validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z_.-]+$`), "must contain only alphanumeric characters, hyphens, underscores, and periods"),
-							),
-						},
-						names.AttrSchedule: {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"scan_action": {
-							Type:     schema.TypeSet,
-							Optional: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"malware_scanner": {
-										Type:             schema.TypeString,
-										Required:         true,
-										ValidateDiagFunc: enum.Validate[awstypes.MalwareScanner](),
-									},
-									"scan_mode": {
-										Type:             schema.TypeString,
-										Required:         true,
-										ValidateDiagFunc: enum.Validate[awstypes.ScanMode](),
+							"recovery_point_tags": tftags.TagsSchema(),
+							"rule_name": {
+								Type:     schema.TypeString,
+								Required: true,
+								ValidateFunc: validation.All(
+									validation.StringLenBetween(1, 50),
+									validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z_.-]+$`), "must contain only alphanumeric characters, hyphens, underscores, and periods"),
+								),
+							},
+							names.AttrSchedule: {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+							"scan_action": {
+								Type:     schema.TypeSet,
+								Optional: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"malware_scanner": {
+											Type:             schema.TypeString,
+											Required:         true,
+											ValidateDiagFunc: enum.Validate[awstypes.MalwareScanner](),
+										},
+										"scan_mode": {
+											Type:             schema.TypeString,
+											Required:         true,
+											ValidateDiagFunc: enum.Validate[awstypes.ScanMode](),
+										},
 									},
 								},
 							},
-						},
-						"schedule_expression_timezone": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Default:  defaultPlanRuleScheduleExpressionTimezone,
-						},
-						"start_window": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							Default:  60,
-						},
-						"target_logically_air_gapped_backup_vault_arn": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							ValidateFunc: verify.ValidARN,
-						},
-						"target_vault_name": {
-							Type:     schema.TypeString,
-							Required: true,
-							ValidateFunc: validation.All(
-								validation.StringLenBetween(2, 50),
-								validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z_-]+$`), "must contain only alphanumeric characters, hyphens, and underscores"),
-							),
-						},
-					},
-				},
-			},
-			"scan_setting": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"malware_scanner": {
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.MalwareScanner](),
-						},
-						"resource_types": {
-							Type:     schema.TypeSet,
-							Required: true,
-							MinItems: 1,
-							Elem: &schema.Schema{
+							"schedule_expression_timezone": {
+								Type:     schema.TypeString,
+								Optional: true,
+								Default:  defaultPlanRuleScheduleExpressionTimezone,
+							},
+							"start_window": {
+								Type:     schema.TypeInt,
+								Optional: true,
+								Default:  60,
+							},
+							"target_logically_air_gapped_backup_vault_arn": {
 								Type:         schema.TypeString,
-								ValidateFunc: validation.StringMatch(regexache.MustCompile(`^[a-zA-Z0-9\-\_\.]{1,50}$`), "must contain only alphanumeric characters, hyphens, underscores, and periods"),
+								Optional:     true,
+								ValidateFunc: verify.ValidARN,
 							},
-						},
-						"scanner_role_arn": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: verify.ValidARN,
+							"target_vault_name": {
+								Type:     schema.TypeString,
+								Required: true,
+								ValidateFunc: validation.All(
+									validation.StringLenBetween(2, 50),
+									validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z_-]+$`), "must contain only alphanumeric characters, hyphens, and underscores"),
+								),
+							},
 						},
 					},
 				},
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			names.AttrVersion: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+				"scan_setting": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"malware_scanner": {
+								Type:             schema.TypeString,
+								Required:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.MalwareScanner](),
+							},
+							"resource_types": {
+								Type:     schema.TypeSet,
+								Required: true,
+								MinItems: 1,
+								Elem: &schema.Schema{
+									Type:         schema.TypeString,
+									ValidateFunc: validation.StringMatch(regexache.MustCompile(`^[a-zA-Z0-9\-\_\.]{1,50}$`), "must contain only alphanumeric characters, hyphens, underscores, and periods"),
+								},
+							},
+							"scanner_role_arn": {
+								Type:         schema.TypeString,
+								Required:     true,
+								ValidateFunc: verify.ValidARN,
+							},
+						},
+					},
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				names.AttrVersion: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/backup/plan_data_source.go
+++ b/internal/service/backup/plan_data_source.go
@@ -23,156 +23,158 @@ func dataSourcePlan() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourcePlanRead,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"plan_id": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			names.AttrRule: {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"completion_window": {
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
-						"copy_action": {
-							Type:     schema.TypeSet,
-							Computed: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"destination_vault_arn": {
-										Type:     schema.TypeString,
-										Computed: true,
-									},
-									"lifecycle": {
-										Type:     schema.TypeList,
-										Computed: true,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"cold_storage_after": {
-													Type:     schema.TypeInt,
-													Computed: true,
-												},
-												"delete_after": {
-													Type:     schema.TypeInt,
-													Computed: true,
-												},
-												"opt_in_to_archive_for_supported_resources": {
-													Type:     schema.TypeBool,
-													Computed: true,
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"plan_id": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				names.AttrRule: {
+					Type:     schema.TypeSet,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"completion_window": {
+								Type:     schema.TypeInt,
+								Computed: true,
+							},
+							"copy_action": {
+								Type:     schema.TypeSet,
+								Computed: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"destination_vault_arn": {
+											Type:     schema.TypeString,
+											Computed: true,
+										},
+										"lifecycle": {
+											Type:     schema.TypeList,
+											Computed: true,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"cold_storage_after": {
+														Type:     schema.TypeInt,
+														Computed: true,
+													},
+													"delete_after": {
+														Type:     schema.TypeInt,
+														Computed: true,
+													},
+													"opt_in_to_archive_for_supported_resources": {
+														Type:     schema.TypeBool,
+														Computed: true,
+													},
 												},
 											},
 										},
 									},
 								},
 							},
-						},
-						"enable_continuous_backup": {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
-						"lifecycle": {
-							Type:     schema.TypeList,
-							Computed: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"cold_storage_after": {
-										Type:     schema.TypeInt,
-										Computed: true,
-									},
-									"delete_after": {
-										Type:     schema.TypeInt,
-										Computed: true,
-									},
-									"opt_in_to_archive_for_supported_resources": {
-										Type:     schema.TypeBool,
-										Computed: true,
+							"enable_continuous_backup": {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
+							"lifecycle": {
+								Type:     schema.TypeList,
+								Computed: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"cold_storage_after": {
+											Type:     schema.TypeInt,
+											Computed: true,
+										},
+										"delete_after": {
+											Type:     schema.TypeInt,
+											Computed: true,
+										},
+										"opt_in_to_archive_for_supported_resources": {
+											Type:     schema.TypeBool,
+											Computed: true,
+										},
 									},
 								},
 							},
-						},
-						"recovery_point_tags": tftags.TagsSchema(),
-						"rule_name": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"scan_action": {
-							Type:     schema.TypeSet,
-							Computed: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"malware_scanner": {
-										Type:     schema.TypeString,
-										Computed: true,
-									},
-									"scan_mode": {
-										Type:     schema.TypeString,
-										Computed: true,
+							"recovery_point_tags": tftags.TagsSchema(),
+							"rule_name": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"scan_action": {
+								Type:     schema.TypeSet,
+								Computed: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"malware_scanner": {
+											Type:     schema.TypeString,
+											Computed: true,
+										},
+										"scan_mode": {
+											Type:     schema.TypeString,
+											Computed: true,
+										},
 									},
 								},
 							},
-						},
-						names.AttrSchedule: {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"schedule_expression_timezone": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"start_window": {
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
-						"target_logically_air_gapped_backup_vault_arn": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"target_vault_name": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-					},
-				},
-			},
-			"scan_setting": {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"malware_scanner": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"resource_types": {
-							Type:     schema.TypeSet,
-							Computed: true,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
+							names.AttrSchedule: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"schedule_expression_timezone": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"start_window": {
+								Type:     schema.TypeInt,
+								Computed: true,
+							},
+							"target_logically_air_gapped_backup_vault_arn": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"target_vault_name": {
+								Type:     schema.TypeString,
+								Computed: true,
 							},
 						},
-						"scanner_role_arn": {
-							Type:     schema.TypeString,
-							Computed: true,
+					},
+				},
+				"scan_setting": {
+					Type:     schema.TypeSet,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"malware_scanner": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"resource_types": {
+								Type:     schema.TypeSet,
+								Computed: true,
+								Elem: &schema.Schema{
+									Type: schema.TypeString,
+								},
+							},
+							"scanner_role_arn": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
 						},
 					},
 				},
-			},
-			names.AttrTags: tftags.TagsSchemaComputed(),
-			names.AttrVersion: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+				names.AttrTags: tftags.TagsSchemaComputed(),
+				names.AttrVersion: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/backup/plan_migrate.go
+++ b/internal/service/backup/plan_migrate.go
@@ -27,131 +27,133 @@ func planStateUpgradeV0(ctx context.Context, rawState map[string]any, meta any) 
 
 func planResourceV0() *schema.Resource {
 	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"advanced_backup_setting": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"backup_options": {
-							Type:     schema.TypeMap,
-							Required: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-						names.AttrResourceType: {
-							Type:     schema.TypeString,
-							Required: true,
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"advanced_backup_setting": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"backup_options": {
+								Type:     schema.TypeMap,
+								Required: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+							},
+							names.AttrResourceType: {
+								Type:     schema.TypeString,
+								Required: true,
+							},
 						},
 					},
 				},
-			},
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			names.AttrRule: {
-				Type:     schema.TypeSet,
-				Required: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"completion_window": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							Default:  180,
-						},
-						"copy_action": {
-							Type:     schema.TypeSet,
-							Optional: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"destination_vault_arn": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-									"lifecycle": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"cold_storage_after": {
-													Type:     schema.TypeInt,
-													Optional: true,
-												},
-												"delete_after": {
-													Type:     schema.TypeInt,
-													Optional: true,
-												},
-												"opt_in_to_archive_for_supported_resources": {
-													Type:     schema.TypeBool,
-													Optional: true,
-													Computed: true,
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				names.AttrRule: {
+					Type:     schema.TypeSet,
+					Required: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"completion_window": {
+								Type:     schema.TypeInt,
+								Optional: true,
+								Default:  180,
+							},
+							"copy_action": {
+								Type:     schema.TypeSet,
+								Optional: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"destination_vault_arn": {
+											Type:     schema.TypeString,
+											Required: true,
+										},
+										"lifecycle": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"cold_storage_after": {
+														Type:     schema.TypeInt,
+														Optional: true,
+													},
+													"delete_after": {
+														Type:     schema.TypeInt,
+														Optional: true,
+													},
+													"opt_in_to_archive_for_supported_resources": {
+														Type:     schema.TypeBool,
+														Optional: true,
+														Computed: true,
+													},
 												},
 											},
 										},
 									},
 								},
 							},
-						},
-						"enable_continuous_backup": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  false,
-						},
-						"lifecycle": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"cold_storage_after": {
-										Type:     schema.TypeInt,
-										Optional: true,
-									},
-									"delete_after": {
-										Type:     schema.TypeInt,
-										Optional: true,
-									},
-									"opt_in_to_archive_for_supported_resources": {
-										Type:     schema.TypeBool,
-										Optional: true,
-										Computed: true,
+							"enable_continuous_backup": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Default:  false,
+							},
+							"lifecycle": {
+								Type:     schema.TypeList,
+								Optional: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"cold_storage_after": {
+											Type:     schema.TypeInt,
+											Optional: true,
+										},
+										"delete_after": {
+											Type:     schema.TypeInt,
+											Optional: true,
+										},
+										"opt_in_to_archive_for_supported_resources": {
+											Type:     schema.TypeBool,
+											Optional: true,
+											Computed: true,
+										},
 									},
 								},
 							},
-						},
-						"recovery_point_tags": tftags.TagsSchema(),
-						"rule_name": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						names.AttrSchedule: {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"start_window": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							Default:  60,
-						},
-						"target_vault_name": {
-							Type:     schema.TypeString,
-							Required: true,
+							"recovery_point_tags": tftags.TagsSchema(),
+							"rule_name": {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+							names.AttrSchedule: {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+							"start_window": {
+								Type:     schema.TypeInt,
+								Optional: true,
+								Default:  60,
+							},
+							"target_vault_name": {
+								Type:     schema.TypeString,
+								Required: true,
+							},
 						},
 					},
 				},
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			names.AttrVersion: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				names.AttrVersion: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/backup/region_settings.go
+++ b/internal/service/backup/region_settings.go
@@ -33,18 +33,20 @@ func resourceRegionSettings() *schema.Resource {
 		ReadWithoutTimeout:   resourceRegionSettingsRead,
 		DeleteWithoutTimeout: schema.NoopContext,
 
-		Schema: map[string]*schema.Schema{
-			"resource_type_management_preference": {
-				Type:     schema.TypeMap,
-				Optional: true,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeBool},
-			},
-			"resource_type_opt_in_preference": {
-				Type:     schema.TypeMap,
-				Required: true,
-				Elem:     &schema.Schema{Type: schema.TypeBool},
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"resource_type_management_preference": {
+					Type:     schema.TypeMap,
+					Optional: true,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeBool},
+				},
+				"resource_type_opt_in_preference": {
+					Type:     schema.TypeMap,
+					Required: true,
+					Elem:     &schema.Schema{Type: schema.TypeBool},
+				},
+			}
 		},
 	}
 }

--- a/internal/service/backup/report_plan.go
+++ b/internal/service/backup/report_plan.go
@@ -42,105 +42,107 @@ func resourceReportPlan() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrCreationTime: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"deployment_status": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrDescription: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringLenBetween(0, 1024),
-			},
-			names.AttrName: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validReportPlanName,
-			},
-			"report_delivery_channel": {
-				Type:     schema.TypeList,
-				Required: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"formats": {
-							Type:     schema.TypeSet,
-							Optional: true,
-							Elem: &schema.Schema{
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrCreationTime: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"deployment_status": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrDescription: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringLenBetween(0, 1024),
+				},
+				names.AttrName: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validReportPlanName,
+				},
+				"report_delivery_channel": {
+					Type:     schema.TypeList,
+					Required: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"formats": {
+								Type:     schema.TypeSet,
+								Optional: true,
+								Elem: &schema.Schema{
+									Type:         schema.TypeString,
+									ValidateFunc: validation.StringInSlice(reportDeliveryChannelFormat_Values(), false),
+								},
+							},
+							names.AttrS3BucketName: {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+							names.AttrS3KeyPrefix: {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+						},
+					},
+				},
+				"report_setting": {
+					Type:     schema.TypeList,
+					Required: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"accounts": {
+								Type:     schema.TypeSet,
+								Optional: true,
+								Elem: &schema.Schema{
+									Type: schema.TypeString,
+								},
+							},
+							"framework_arns": {
+								Type:     schema.TypeSet,
+								Optional: true,
+								Elem: &schema.Schema{
+									Type: schema.TypeString,
+								},
+							},
+							"number_of_frameworks": {
+								Type:     schema.TypeInt,
+								Optional: true,
+							},
+							"organization_units": {
+								Type:     schema.TypeSet,
+								Optional: true,
+								Elem: &schema.Schema{
+									Type: schema.TypeString,
+								},
+							},
+							"regions": {
+								Type:     schema.TypeSet,
+								Optional: true,
+								Elem: &schema.Schema{
+									Type: schema.TypeString,
+								},
+							},
+							// A report plan template cannot be updated
+							"report_template": {
 								Type:         schema.TypeString,
-								ValidateFunc: validation.StringInSlice(reportDeliveryChannelFormat_Values(), false),
+								Required:     true,
+								ForceNew:     true,
+								ValidateFunc: validation.StringInSlice(reportSettingTemplate_Values(), false),
 							},
-						},
-						names.AttrS3BucketName: {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						names.AttrS3KeyPrefix: {
-							Type:     schema.TypeString,
-							Optional: true,
 						},
 					},
 				},
-			},
-			"report_setting": {
-				Type:     schema.TypeList,
-				Required: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"accounts": {
-							Type:     schema.TypeSet,
-							Optional: true,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-						},
-						"framework_arns": {
-							Type:     schema.TypeSet,
-							Optional: true,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-						},
-						"number_of_frameworks": {
-							Type:     schema.TypeInt,
-							Optional: true,
-						},
-						"organization_units": {
-							Type:     schema.TypeSet,
-							Optional: true,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-						},
-						"regions": {
-							Type:     schema.TypeSet,
-							Optional: true,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-						},
-						// A report plan template cannot be updated
-						"report_template": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ForceNew:     true,
-							ValidateFunc: validation.StringInSlice(reportSettingTemplate_Values(), false),
-						},
-					},
-				},
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			}
 		},
 	}
 }

--- a/internal/service/backup/report_plan_data_source.go
+++ b/internal/service/backup/report_plan_data_source.go
@@ -24,95 +24,97 @@ func dataSourceReportPlan() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceReportPlanRead,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrCreationTime: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"deployment_status": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrDescription: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"report_delivery_channel": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"formats": {
-							Type:     schema.TypeSet,
-							Computed: true,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrCreationTime: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"deployment_status": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrDescription: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"report_delivery_channel": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"formats": {
+								Type:     schema.TypeSet,
+								Computed: true,
+								Elem: &schema.Schema{
+									Type: schema.TypeString,
+								},
 							},
-						},
-						names.AttrS3BucketName: {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						names.AttrS3KeyPrefix: {
-							Type:     schema.TypeString,
-							Computed: true,
+							names.AttrS3BucketName: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							names.AttrS3KeyPrefix: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
 						},
 					},
 				},
-			},
-			"report_setting": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"accounts": {
-							Type:     schema.TypeSet,
-							Computed: true,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
+				"report_setting": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"accounts": {
+								Type:     schema.TypeSet,
+								Computed: true,
+								Elem: &schema.Schema{
+									Type: schema.TypeString,
+								},
 							},
-						},
-						"framework_arns": {
-							Type:     schema.TypeSet,
-							Computed: true,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
+							"framework_arns": {
+								Type:     schema.TypeSet,
+								Computed: true,
+								Elem: &schema.Schema{
+									Type: schema.TypeString,
+								},
 							},
-						},
-						"number_of_frameworks": {
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
-						"organization_units": {
-							Type:     schema.TypeSet,
-							Computed: true,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
+							"number_of_frameworks": {
+								Type:     schema.TypeInt,
+								Computed: true,
 							},
-						},
-						"regions": {
-							Type:     schema.TypeSet,
-							Computed: true,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
+							"organization_units": {
+								Type:     schema.TypeSet,
+								Computed: true,
+								Elem: &schema.Schema{
+									Type: schema.TypeString,
+								},
 							},
-						},
-						"report_template": {
-							Type:     schema.TypeString,
-							Computed: true,
+							"regions": {
+								Type:     schema.TypeSet,
+								Computed: true,
+								Elem: &schema.Schema{
+									Type: schema.TypeString,
+								},
+							},
+							"report_template": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
 						},
 					},
 				},
-			},
-			names.AttrTags: tftags.TagsSchemaComputed(),
+				names.AttrTags: tftags.TagsSchemaComputed(),
+			}
 		},
 	}
 }

--- a/internal/service/backup/selection.go
+++ b/internal/service/backup/selection.go
@@ -40,151 +40,153 @@ func resourceSelection() *schema.Resource {
 			StateContext: resourceSelectionImportState,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-				ValidateFunc: validation.All(
-					validation.StringLenBetween(1, 50),
-					validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z_.-]+$`), "must contain only alphanumeric, hyphen, underscore, and period characters"),
-				),
-			},
-			names.AttrCondition: {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"string_equals": {
-							Type:     schema.TypeSet,
-							Optional: true,
-							ForceNew: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									names.AttrKey: {
-										Type:     schema.TypeString,
-										Required: true,
-										ForceNew: true,
-									},
-									names.AttrValue: {
-										Type:     schema.TypeString,
-										Required: true,
-										ForceNew: true,
-									},
-								},
-							},
-						},
-						"string_like": {
-							Type:     schema.TypeSet,
-							Optional: true,
-							ForceNew: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									names.AttrKey: {
-										Type:     schema.TypeString,
-										Required: true,
-										ForceNew: true,
-									},
-									names.AttrValue: {
-										Type:     schema.TypeString,
-										Required: true,
-										ForceNew: true,
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+					ValidateFunc: validation.All(
+						validation.StringLenBetween(1, 50),
+						validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z_.-]+$`), "must contain only alphanumeric, hyphen, underscore, and period characters"),
+					),
+				},
+				names.AttrCondition: {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"string_equals": {
+								Type:     schema.TypeSet,
+								Optional: true,
+								ForceNew: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										names.AttrKey: {
+											Type:     schema.TypeString,
+											Required: true,
+											ForceNew: true,
+										},
+										names.AttrValue: {
+											Type:     schema.TypeString,
+											Required: true,
+											ForceNew: true,
+										},
 									},
 								},
 							},
-						},
-						"string_not_equals": {
-							Type:     schema.TypeSet,
-							Optional: true,
-							ForceNew: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									names.AttrKey: {
-										Type:     schema.TypeString,
-										Required: true,
-										ForceNew: true,
-									},
-									names.AttrValue: {
-										Type:     schema.TypeString,
-										Required: true,
-										ForceNew: true,
+							"string_like": {
+								Type:     schema.TypeSet,
+								Optional: true,
+								ForceNew: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										names.AttrKey: {
+											Type:     schema.TypeString,
+											Required: true,
+											ForceNew: true,
+										},
+										names.AttrValue: {
+											Type:     schema.TypeString,
+											Required: true,
+											ForceNew: true,
+										},
 									},
 								},
 							},
-						},
-						"string_not_like": {
-							Type:     schema.TypeSet,
-							Optional: true,
-							ForceNew: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									names.AttrKey: {
-										Type:     schema.TypeString,
-										Required: true,
-										ForceNew: true,
+							"string_not_equals": {
+								Type:     schema.TypeSet,
+								Optional: true,
+								ForceNew: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										names.AttrKey: {
+											Type:     schema.TypeString,
+											Required: true,
+											ForceNew: true,
+										},
+										names.AttrValue: {
+											Type:     schema.TypeString,
+											Required: true,
+											ForceNew: true,
+										},
 									},
-									names.AttrValue: {
-										Type:     schema.TypeString,
-										Required: true,
-										ForceNew: true,
+								},
+							},
+							"string_not_like": {
+								Type:     schema.TypeSet,
+								Optional: true,
+								ForceNew: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										names.AttrKey: {
+											Type:     schema.TypeString,
+											Required: true,
+											ForceNew: true,
+										},
+										names.AttrValue: {
+											Type:     schema.TypeString,
+											Required: true,
+											ForceNew: true,
+										},
 									},
 								},
 							},
 						},
 					},
 				},
-			},
-			names.AttrIAMRoleARN: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			"not_resources": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			"plan_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"selection_tag": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				ForceNew: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrKey: {
-							Type:     schema.TypeString,
-							Required: true,
-							ForceNew: true,
-						},
-						names.AttrType: {
-							Type:             schema.TypeString,
-							Required:         true,
-							ForceNew:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.ConditionType](),
-						},
-						names.AttrValue: {
-							Type:     schema.TypeString,
-							Required: true,
-							ForceNew: true,
+				names.AttrIAMRoleARN: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				"not_resources": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"plan_id": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"selection_tag": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					ForceNew: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrKey: {
+								Type:     schema.TypeString,
+								Required: true,
+								ForceNew: true,
+							},
+							names.AttrType: {
+								Type:             schema.TypeString,
+								Required:         true,
+								ForceNew:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.ConditionType](),
+							},
+							names.AttrValue: {
+								Type:     schema.TypeString,
+								Required: true,
+								ForceNew: true,
+							},
 						},
 					},
 				},
-			},
-			names.AttrResources: {
-				Type:     schema.TypeSet,
-				Optional: true,
-				ForceNew: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
+				names.AttrResources: {
+					Type:     schema.TypeSet,
+					Optional: true,
+					ForceNew: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+			}
 		},
 	}
 }

--- a/internal/service/backup/selection_data_source.go
+++ b/internal/service/backup/selection_data_source.go
@@ -20,28 +20,30 @@ func dataSourceSelection() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceSelectionRead,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrIAMRoleARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"plan_id": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			names.AttrResources: {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			"selection_id": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrIAMRoleARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"plan_id": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				names.AttrResources: {
+					Type:     schema.TypeSet,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"selection_id": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/backup/vault.go
+++ b/internal/service/backup/vault.go
@@ -50,38 +50,40 @@ func resourceVault() *schema.Resource {
 			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrForceDestroy: {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-			names.AttrKMSKeyARN: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-				ValidateFunc: validation.All(
-					validation.StringLenBetween(2, 50),
-					validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z_-]*$`), "must consist of letters, numbers, and hyphens."),
-				),
-			},
-			"recovery_points": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrForceDestroy: {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
+				names.AttrKMSKeyARN: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Computed:     true,
+					ForceNew:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+					ValidateFunc: validation.All(
+						validation.StringLenBetween(2, 50),
+						validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z_-]*$`), "must consist of letters, numbers, and hyphens."),
+					),
+				},
+				"recovery_points": {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			}
 		},
 	}
 }

--- a/internal/service/backup/vault_data_source.go
+++ b/internal/service/backup/vault_data_source.go
@@ -22,24 +22,26 @@ func dataSourceVault() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceVaultRead,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrKMSKeyARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"recovery_points": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-			names.AttrTags: tftags.TagsSchemaComputed(),
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrKMSKeyARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"recovery_points": {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
+				names.AttrTags: tftags.TagsSchemaComputed(),
+			}
 		},
 	}
 }

--- a/internal/service/backup/vault_lock_configuration.go
+++ b/internal/service/backup/vault_lock_configuration.go
@@ -33,33 +33,35 @@ func resourceVaultLockConfiguration() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"backup_vault_name": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z_.-]{1,50}$`), "must consist of lowercase letters, numbers, and hyphens."),
-			},
-			"backup_vault_arn": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"changeable_for_days": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.IntAtLeast(3),
-			},
-			"max_retention_days": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				ForceNew: true,
-			},
-			"min_retention_days": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				ForceNew: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"backup_vault_name": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z_.-]{1,50}$`), "must consist of lowercase letters, numbers, and hyphens."),
+				},
+				"backup_vault_arn": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"changeable_for_days": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.IntAtLeast(3),
+				},
+				"max_retention_days": {
+					Type:     schema.TypeInt,
+					Optional: true,
+					ForceNew: true,
+				},
+				"min_retention_days": {
+					Type:     schema.TypeInt,
+					Optional: true,
+					ForceNew: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/backup/vault_notifications.go
+++ b/internal/service/backup/vault_notifications.go
@@ -39,32 +39,34 @@ func resourceVaultNotifications() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"backup_vault_arn": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"backup_vault_events": {
-				Type:     schema.TypeSet,
-				Required: true,
-				ForceNew: true,
-				Elem: &schema.Schema{
-					Type:             schema.TypeString,
-					ValidateDiagFunc: enum.Validate[awstypes.BackupVaultEvent](),
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"backup_vault_arn": {
+					Type:     schema.TypeString,
+					Computed: true,
 				},
-			},
-			"backup_vault_name": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z_.-]{1,50}$`), "must consist of lowercase letters, numbers, and hyphens."),
-			},
-			names.AttrSNSTopicARN: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidARN,
-			},
+				"backup_vault_events": {
+					Type:     schema.TypeSet,
+					Required: true,
+					ForceNew: true,
+					Elem: &schema.Schema{
+						Type:             schema.TypeString,
+						ValidateDiagFunc: enum.Validate[awstypes.BackupVaultEvent](),
+					},
+				},
+				"backup_vault_name": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z_.-]{1,50}$`), "must consist of lowercase letters, numbers, and hyphens."),
+				},
+				names.AttrSNSTopicARN: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/backup/vault_policy.go
+++ b/internal/service/backup/vault_policy.go
@@ -38,17 +38,19 @@ func resourceVaultPolicy() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"backup_vault_arn": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"backup_vault_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			names.AttrPolicy: sdkv2.IAMPolicyDocumentSchemaRequired(),
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"backup_vault_arn": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"backup_vault_name": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				names.AttrPolicy: sdkv2.IAMPolicyDocumentSchemaRequired(),
+			}
 		},
 	}
 }

--- a/internal/service/batch/compute_environment.go
+++ b/internal/service/batch/compute_environment.go
@@ -59,237 +59,239 @@ func resourceComputeEnvironment() *schema.Resource {
 			},
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrName: {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				ForceNew:      true,
-				ConflictsWith: []string{names.AttrNamePrefix},
-				ValidateFunc:  validName,
-			},
-			names.AttrNamePrefix: {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				ForceNew:      true,
-				ConflictsWith: []string{names.AttrName},
-				ValidateFunc:  validPrefix,
-			},
-			"compute_resources": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Computed: true,
-				MinItems: 0,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"allocation_strategy": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							StateFunc:        sdkv2.ToUpperSchemaStateFunc,
-							ValidateDiagFunc: enum.ValidateIgnoreCase[awstypes.CRAllocationStrategy](),
-						},
-						"bid_percentage": {
-							Type:     schema.TypeInt,
-							Optional: true,
-						},
-						"desired_vcpus": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							Computed: true,
-						},
-						"ec2_configuration": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Computed: true,
-							ForceNew: true,
-							MaxItems: 2,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"image_id_override": {
-										Type:         schema.TypeString,
-										Optional:     true,
-										Computed:     true,
-										ValidateFunc: validation.StringLenBetween(1, 256),
-									},
-									"image_kubernetes_version": {
-										Type:         schema.TypeString,
-										Optional:     true,
-										ValidateFunc: validation.StringLenBetween(1, 256),
-									},
-									"image_type": {
-										Type:         schema.TypeString,
-										Optional:     true,
-										ValidateFunc: validation.StringLenBetween(1, 256),
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrName: {
+					Type:          schema.TypeString,
+					Optional:      true,
+					Computed:      true,
+					ForceNew:      true,
+					ConflictsWith: []string{names.AttrNamePrefix},
+					ValidateFunc:  validName,
+				},
+				names.AttrNamePrefix: {
+					Type:          schema.TypeString,
+					Optional:      true,
+					Computed:      true,
+					ForceNew:      true,
+					ConflictsWith: []string{names.AttrName},
+					ValidateFunc:  validPrefix,
+				},
+				"compute_resources": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Computed: true,
+					MinItems: 0,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"allocation_strategy": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								StateFunc:        sdkv2.ToUpperSchemaStateFunc,
+								ValidateDiagFunc: enum.ValidateIgnoreCase[awstypes.CRAllocationStrategy](),
+							},
+							"bid_percentage": {
+								Type:     schema.TypeInt,
+								Optional: true,
+							},
+							"desired_vcpus": {
+								Type:     schema.TypeInt,
+								Optional: true,
+								Computed: true,
+							},
+							"ec2_configuration": {
+								Type:     schema.TypeList,
+								Optional: true,
+								Computed: true,
+								ForceNew: true,
+								MaxItems: 2,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"image_id_override": {
+											Type:         schema.TypeString,
+											Optional:     true,
+											Computed:     true,
+											ValidateFunc: validation.StringLenBetween(1, 256),
+										},
+										"image_kubernetes_version": {
+											Type:         schema.TypeString,
+											Optional:     true,
+											ValidateFunc: validation.StringLenBetween(1, 256),
+										},
+										"image_type": {
+											Type:         schema.TypeString,
+											Optional:     true,
+											ValidateFunc: validation.StringLenBetween(1, 256),
+										},
 									},
 								},
 							},
-						},
-						"ec2_key_pair": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"image_id": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"instance_role": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							ValidateFunc: verify.ValidARN,
-						},
-						names.AttrInstanceType: {
-							Type:     schema.TypeSet,
-							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-						names.AttrLaunchTemplate: {
-							Type:     schema.TypeList,
-							Optional: true,
-							ForceNew: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"launch_template_id": {
-										Type:          schema.TypeString,
-										Optional:      true,
-										ConflictsWith: []string{"compute_resources.0.launch_template.0.launch_template_name"},
-									},
-									"launch_template_name": {
-										Type:          schema.TypeString,
-										Optional:      true,
-										ConflictsWith: []string{"compute_resources.0.launch_template.0.launch_template_id"},
-									},
-									names.AttrVersion: {
-										Type:     schema.TypeString,
-										Optional: true,
-										Computed: true,
+							"ec2_key_pair": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+							"image_id": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+							"instance_role": {
+								Type:         schema.TypeString,
+								Optional:     true,
+								ValidateFunc: verify.ValidARN,
+							},
+							names.AttrInstanceType: {
+								Type:     schema.TypeSet,
+								Optional: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+							},
+							names.AttrLaunchTemplate: {
+								Type:     schema.TypeList,
+								Optional: true,
+								ForceNew: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"launch_template_id": {
+											Type:          schema.TypeString,
+											Optional:      true,
+											ConflictsWith: []string{"compute_resources.0.launch_template.0.launch_template_name"},
+										},
+										"launch_template_name": {
+											Type:          schema.TypeString,
+											Optional:      true,
+											ConflictsWith: []string{"compute_resources.0.launch_template.0.launch_template_id"},
+										},
+										names.AttrVersion: {
+											Type:     schema.TypeString,
+											Optional: true,
+											Computed: true,
+										},
 									},
 								},
 							},
-						},
-						"max_vcpus": {
-							Type:     schema.TypeInt,
-							Required: true,
-						},
-						"min_vcpus": {
-							Type:     schema.TypeInt,
-							Optional: true,
-						},
-						"placement_group": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ForceNew: true,
-						},
-						names.AttrSecurityGroupIDs: {
-							Type:     schema.TypeSet,
-							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-						"spot_iam_fleet_role": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							ForceNew:     true,
-							ValidateFunc: verify.ValidARN,
-						},
-						names.AttrSubnets: {
-							Type:     schema.TypeSet,
-							Required: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-						names.AttrTags: tftags.TagsSchema(),
-						names.AttrType: {
-							Type:             schema.TypeString,
-							Required:         true,
-							StateFunc:        sdkv2.ToUpperSchemaStateFunc,
-							ValidateDiagFunc: enum.ValidateIgnoreCase[awstypes.CRType](),
-						},
-					},
-				},
-			},
-			"ecs_cluster_arn": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"eks_configuration": {
-				Type:     schema.TypeList,
-				Optional: true,
-				ForceNew: true,
-				MinItems: 0,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"eks_cluster_arn": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ForceNew:     true,
-							ValidateFunc: verify.ValidARN,
-						},
-						"kubernetes_namespace": {
-							Type:     schema.TypeString,
-							Required: true,
-							ForceNew: true,
+							"max_vcpus": {
+								Type:     schema.TypeInt,
+								Required: true,
+							},
+							"min_vcpus": {
+								Type:     schema.TypeInt,
+								Optional: true,
+							},
+							"placement_group": {
+								Type:     schema.TypeString,
+								Optional: true,
+								ForceNew: true,
+							},
+							names.AttrSecurityGroupIDs: {
+								Type:     schema.TypeSet,
+								Optional: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+							},
+							"spot_iam_fleet_role": {
+								Type:         schema.TypeString,
+								Optional:     true,
+								ForceNew:     true,
+								ValidateFunc: verify.ValidARN,
+							},
+							names.AttrSubnets: {
+								Type:     schema.TypeSet,
+								Required: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+							},
+							names.AttrTags: tftags.TagsSchema(),
+							names.AttrType: {
+								Type:             schema.TypeString,
+								Required:         true,
+								StateFunc:        sdkv2.ToUpperSchemaStateFunc,
+								ValidateDiagFunc: enum.ValidateIgnoreCase[awstypes.CRType](),
+							},
 						},
 					},
 				},
-			},
-			names.AttrServiceRole: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			names.AttrState: {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Default:          awstypes.CEStateEnabled,
-				StateFunc:        sdkv2.ToUpperSchemaStateFunc,
-				ValidateDiagFunc: enum.ValidateIgnoreCase[awstypes.CEState](),
-			},
-			names.AttrStatus: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrStatusReason: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			names.AttrType: {
-				Type:             schema.TypeString,
-				Required:         true,
-				ForceNew:         true,
-				StateFunc:        sdkv2.ToUpperSchemaStateFunc,
-				ValidateDiagFunc: enum.ValidateIgnoreCase[awstypes.CEType](),
-			},
-			"update_policy": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Computed: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					// https://docs.aws.amazon.com/batch/latest/APIReference/API_UpdatePolicy.html
-					Schema: map[string]*schema.Schema{
-						"job_execution_timeout_minutes": {
-							Type:         schema.TypeInt,
-							Optional:     true,
-							Computed:     true,
-							ValidateFunc: validation.IntBetween(1, 360),
-						},
-						"terminate_jobs_on_update": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Computed: true,
+				"ecs_cluster_arn": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"eks_configuration": {
+					Type:     schema.TypeList,
+					Optional: true,
+					ForceNew: true,
+					MinItems: 0,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"eks_cluster_arn": {
+								Type:         schema.TypeString,
+								Required:     true,
+								ForceNew:     true,
+								ValidateFunc: verify.ValidARN,
+							},
+							"kubernetes_namespace": {
+								Type:     schema.TypeString,
+								Required: true,
+								ForceNew: true,
+							},
 						},
 					},
 				},
-			},
+				names.AttrServiceRole: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Computed:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				names.AttrState: {
+					Type:             schema.TypeString,
+					Optional:         true,
+					Default:          awstypes.CEStateEnabled,
+					StateFunc:        sdkv2.ToUpperSchemaStateFunc,
+					ValidateDiagFunc: enum.ValidateIgnoreCase[awstypes.CEState](),
+				},
+				names.AttrStatus: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrStatusReason: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				names.AttrType: {
+					Type:             schema.TypeString,
+					Required:         true,
+					ForceNew:         true,
+					StateFunc:        sdkv2.ToUpperSchemaStateFunc,
+					ValidateDiagFunc: enum.ValidateIgnoreCase[awstypes.CEType](),
+				},
+				"update_policy": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Computed: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						// https://docs.aws.amazon.com/batch/latest/APIReference/API_UpdatePolicy.html
+						Schema: map[string]*schema.Schema{
+							"job_execution_timeout_minutes": {
+								Type:         schema.TypeInt,
+								Optional:     true,
+								Computed:     true,
+								ValidateFunc: validation.IntBetween(1, 360),
+							},
+							"terminate_jobs_on_update": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Computed: true,
+							},
+						},
+					},
+				},
+			}
 		},
 	}
 }

--- a/internal/service/batch/compute_environment_data_source.go
+++ b/internal/service/batch/compute_environment_data_source.go
@@ -24,57 +24,59 @@ func dataSourceComputeEnvironment() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceComputeEnvironmentRead,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+				},
 
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"ecs_cluster_arn": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrServiceRole: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrState: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrStatus: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrStatusReason: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrTags: tftags.TagsSchemaComputed(),
-			names.AttrType: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"update_policy": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"job_execution_timeout_minutes": {
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
-						"terminate_jobs_on_update": {
-							Type:     schema.TypeBool,
-							Computed: true,
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"ecs_cluster_arn": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrServiceRole: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrState: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrStatus: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrStatusReason: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrTags: tftags.TagsSchemaComputed(),
+				names.AttrType: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"update_policy": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"job_execution_timeout_minutes": {
+								Type:     schema.TypeInt,
+								Computed: true,
+							},
+							"terminate_jobs_on_update": {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
 						},
 					},
 				},
-			},
+			}
 		},
 	}
 }

--- a/internal/service/batch/compute_environment_migrate.go
+++ b/internal/service/batch/compute_environment_migrate.go
@@ -15,215 +15,217 @@ import (
 
 func computeEnvironmentSchemaV0() *schema.Resource {
 	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"compute_environment_name": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				ForceNew:      true,
-				ConflictsWith: []string{"compute_environment_name_prefix"},
-			},
-			"compute_environment_name_prefix": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				ForceNew:      true,
-				ConflictsWith: []string{"compute_environment_name"},
-			},
-			"compute_resources": {
-				Type:     schema.TypeList,
-				Optional: true,
-				ForceNew: true,
-				MinItems: 0,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"allocation_strategy": {
-							Type:      schema.TypeString,
-							Optional:  true,
-							StateFunc: sdkv2.ToUpperSchemaStateFunc,
-						},
-						"bid_percentage": {
-							Type:     schema.TypeInt,
-							Optional: true,
-						},
-						"desired_vcpus": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							Computed: true,
-						},
-						"ec2_configuration": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Computed: true,
-							ForceNew: true,
-							MaxItems: 2,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"image_id_override": {
-										Type:     schema.TypeString,
-										Optional: true,
-										Computed: true,
-									},
-									"image_type": {
-										Type:     schema.TypeString,
-										Optional: true,
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"compute_environment_name": {
+					Type:          schema.TypeString,
+					Optional:      true,
+					Computed:      true,
+					ForceNew:      true,
+					ConflictsWith: []string{"compute_environment_name_prefix"},
+				},
+				"compute_environment_name_prefix": {
+					Type:          schema.TypeString,
+					Optional:      true,
+					Computed:      true,
+					ForceNew:      true,
+					ConflictsWith: []string{"compute_environment_name"},
+				},
+				"compute_resources": {
+					Type:     schema.TypeList,
+					Optional: true,
+					ForceNew: true,
+					MinItems: 0,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"allocation_strategy": {
+								Type:      schema.TypeString,
+								Optional:  true,
+								StateFunc: sdkv2.ToUpperSchemaStateFunc,
+							},
+							"bid_percentage": {
+								Type:     schema.TypeInt,
+								Optional: true,
+							},
+							"desired_vcpus": {
+								Type:     schema.TypeInt,
+								Optional: true,
+								Computed: true,
+							},
+							"ec2_configuration": {
+								Type:     schema.TypeList,
+								Optional: true,
+								Computed: true,
+								ForceNew: true,
+								MaxItems: 2,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"image_id_override": {
+											Type:     schema.TypeString,
+											Optional: true,
+											Computed: true,
+										},
+										"image_type": {
+											Type:     schema.TypeString,
+											Optional: true,
+										},
 									},
 								},
 							},
-						},
-						"ec2_key_pair": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"image_id": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"instance_role": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						names.AttrInstanceType: {
-							Type:     schema.TypeSet,
-							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-						names.AttrLaunchTemplate: {
-							Type:     schema.TypeList,
-							Optional: true,
-							ForceNew: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"launch_template_id": {
-										Type:          schema.TypeString,
-										Optional:      true,
-										ConflictsWith: []string{"compute_resources.0.launch_template.0.launch_template_name"},
-									},
-									"launch_template_name": {
-										Type:          schema.TypeString,
-										Optional:      true,
-										ConflictsWith: []string{"compute_resources.0.launch_template.0.launch_template_id"},
-									},
-									names.AttrVersion: {
-										Type:     schema.TypeString,
-										Optional: true,
-										Computed: true,
+							"ec2_key_pair": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+							"image_id": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+							"instance_role": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+							names.AttrInstanceType: {
+								Type:     schema.TypeSet,
+								Optional: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+							},
+							names.AttrLaunchTemplate: {
+								Type:     schema.TypeList,
+								Optional: true,
+								ForceNew: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"launch_template_id": {
+											Type:          schema.TypeString,
+											Optional:      true,
+											ConflictsWith: []string{"compute_resources.0.launch_template.0.launch_template_name"},
+										},
+										"launch_template_name": {
+											Type:          schema.TypeString,
+											Optional:      true,
+											ConflictsWith: []string{"compute_resources.0.launch_template.0.launch_template_id"},
+										},
+										names.AttrVersion: {
+											Type:     schema.TypeString,
+											Optional: true,
+											Computed: true,
+										},
 									},
 								},
 							},
-						},
-						"max_vcpus": {
-							Type:     schema.TypeInt,
-							Required: true,
-						},
-						"min_vcpus": {
-							Type:     schema.TypeInt,
-							Optional: true,
-						},
-						"placement_group": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ForceNew: true,
-						},
-						names.AttrSecurityGroupIDs: {
-							Type:     schema.TypeSet,
-							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-						"spot_iam_fleet_role": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ForceNew: true,
-						},
-						names.AttrSubnets: {
-							Type:     schema.TypeSet,
-							Required: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-						names.AttrTags: tftags.TagsSchema(),
-						names.AttrType: {
-							Type:      schema.TypeString,
-							Required:  true,
-							StateFunc: sdkv2.ToUpperSchemaStateFunc,
-						},
-					},
-				},
-			},
-			"ecs_cluster_arn": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"eks_configuration": {
-				Type:     schema.TypeList,
-				Optional: true,
-				ForceNew: true,
-				MinItems: 0,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"eks_cluster_arn": {
-							Type:     schema.TypeString,
-							Required: true,
-							ForceNew: true,
-						},
-						"kubernetes_namespace": {
-							Type:     schema.TypeString,
-							Required: true,
-							ForceNew: true,
+							"max_vcpus": {
+								Type:     schema.TypeInt,
+								Required: true,
+							},
+							"min_vcpus": {
+								Type:     schema.TypeInt,
+								Optional: true,
+							},
+							"placement_group": {
+								Type:     schema.TypeString,
+								Optional: true,
+								ForceNew: true,
+							},
+							names.AttrSecurityGroupIDs: {
+								Type:     schema.TypeSet,
+								Optional: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+							},
+							"spot_iam_fleet_role": {
+								Type:     schema.TypeString,
+								Optional: true,
+								ForceNew: true,
+							},
+							names.AttrSubnets: {
+								Type:     schema.TypeSet,
+								Required: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+							},
+							names.AttrTags: tftags.TagsSchema(),
+							names.AttrType: {
+								Type:      schema.TypeString,
+								Required:  true,
+								StateFunc: sdkv2.ToUpperSchemaStateFunc,
+							},
 						},
 					},
 				},
-			},
-			names.AttrServiceRole: {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-			names.AttrState: {
-				Type:      schema.TypeString,
-				Optional:  true,
-				Default:   awstypes.CEStateEnabled,
-				StateFunc: sdkv2.ToUpperSchemaStateFunc,
-			},
-			names.AttrStatus: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrStatusReason: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			names.AttrType: {
-				Type:      schema.TypeString,
-				Required:  true,
-				ForceNew:  true,
-				StateFunc: sdkv2.ToUpperSchemaStateFunc,
-			},
-			"update_policy": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"job_execution_timeout_minutes": {
-							Type:     schema.TypeInt,
-							Required: true,
-						},
-						"terminate_jobs_on_update": {
-							Type:     schema.TypeBool,
-							Required: true,
+				"ecs_cluster_arn": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"eks_configuration": {
+					Type:     schema.TypeList,
+					Optional: true,
+					ForceNew: true,
+					MinItems: 0,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"eks_cluster_arn": {
+								Type:     schema.TypeString,
+								Required: true,
+								ForceNew: true,
+							},
+							"kubernetes_namespace": {
+								Type:     schema.TypeString,
+								Required: true,
+								ForceNew: true,
+							},
 						},
 					},
 				},
-			},
+				names.AttrServiceRole: {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+				},
+				names.AttrState: {
+					Type:      schema.TypeString,
+					Optional:  true,
+					Default:   awstypes.CEStateEnabled,
+					StateFunc: sdkv2.ToUpperSchemaStateFunc,
+				},
+				names.AttrStatus: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrStatusReason: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				names.AttrType: {
+					Type:      schema.TypeString,
+					Required:  true,
+					ForceNew:  true,
+					StateFunc: sdkv2.ToUpperSchemaStateFunc,
+				},
+				"update_policy": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"job_execution_timeout_minutes": {
+								Type:     schema.TypeInt,
+								Required: true,
+							},
+							"terminate_jobs_on_update": {
+								Type:     schema.TypeBool,
+								Required: true,
+							},
+						},
+					},
+				},
+			}
 		},
 	}
 }

--- a/internal/service/batch/job_definition.go
+++ b/internal/service/batch/job_definition.go
@@ -61,402 +61,404 @@ func resourceJobDefinition() *schema.Resource {
 			},
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"arn_prefix": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"container_properties": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				ConflictsWith: []string{"ecs_properties", "eks_properties", "node_properties"},
-				StateFunc: func(v any) string {
-					json, _ := structure.NormalizeJsonString(v)
-					return json
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
 				},
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					equal, _ := equivalentContainerPropertiesJSON(old, new)
-					return equal
+				"arn_prefix": {
+					Type:     schema.TypeString,
+					Computed: true,
 				},
-				DiffSuppressOnRefresh: true,
-				ValidateFunc:          validJobContainerProperties,
-			},
-			"deregister_on_new_revision": {
-				Type:     schema.TypeBool,
-				Default:  true,
-				Optional: true,
-			},
-			"ecs_properties": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				ConflictsWith: []string{"container_properties", "eks_properties", "node_properties"},
-				StateFunc: func(v any) string {
-					json, _ := structure.NormalizeJsonString(v)
-					return json
+				"container_properties": {
+					Type:          schema.TypeString,
+					Optional:      true,
+					ConflictsWith: []string{"ecs_properties", "eks_properties", "node_properties"},
+					StateFunc: func(v any) string {
+						json, _ := structure.NormalizeJsonString(v)
+						return json
+					},
+					DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+						equal, _ := equivalentContainerPropertiesJSON(old, new)
+						return equal
+					},
+					DiffSuppressOnRefresh: true,
+					ValidateFunc:          validJobContainerProperties,
 				},
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					equal, _ := equivalentECSPropertiesJSON(old, new)
-					return equal
+				"deregister_on_new_revision": {
+					Type:     schema.TypeBool,
+					Default:  true,
+					Optional: true,
 				},
-				DiffSuppressOnRefresh: true,
-				ValidateFunc:          validJobECSProperties,
-			},
-			"eks_properties": {
-				Type:          schema.TypeList,
-				MaxItems:      1,
-				Optional:      true,
-				ConflictsWith: []string{"ecs_properties", "container_properties", "node_properties"},
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"pod_properties": {
-							Type:     schema.TypeList,
-							MaxItems: 1,
-							Required: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"containers": {
-										Type:     schema.TypeList,
-										Required: true,
-										MaxItems: 10,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"args": {
-													Type:     schema.TypeList,
-													Optional: true,
-													Elem:     &schema.Schema{Type: schema.TypeString},
-												},
-												"command": {
-													Type:     schema.TypeList,
-													Optional: true,
-													Elem:     &schema.Schema{Type: schema.TypeString},
-												},
-												"env": {
-													Type:     schema.TypeSet,
-													Optional: true,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															names.AttrName: {
-																Type:     schema.TypeString,
-																Required: true,
-															},
-															names.AttrValue: {
-																Type:     schema.TypeString,
-																Required: true,
+				"ecs_properties": {
+					Type:          schema.TypeString,
+					Optional:      true,
+					ConflictsWith: []string{"container_properties", "eks_properties", "node_properties"},
+					StateFunc: func(v any) string {
+						json, _ := structure.NormalizeJsonString(v)
+						return json
+					},
+					DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+						equal, _ := equivalentECSPropertiesJSON(old, new)
+						return equal
+					},
+					DiffSuppressOnRefresh: true,
+					ValidateFunc:          validJobECSProperties,
+				},
+				"eks_properties": {
+					Type:          schema.TypeList,
+					MaxItems:      1,
+					Optional:      true,
+					ConflictsWith: []string{"ecs_properties", "container_properties", "node_properties"},
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"pod_properties": {
+								Type:     schema.TypeList,
+								MaxItems: 1,
+								Required: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"containers": {
+											Type:     schema.TypeList,
+											Required: true,
+											MaxItems: 10,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"args": {
+														Type:     schema.TypeList,
+														Optional: true,
+														Elem:     &schema.Schema{Type: schema.TypeString},
+													},
+													"command": {
+														Type:     schema.TypeList,
+														Optional: true,
+														Elem:     &schema.Schema{Type: schema.TypeString},
+													},
+													"env": {
+														Type:     schema.TypeSet,
+														Optional: true,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																names.AttrName: {
+																	Type:     schema.TypeString,
+																	Required: true,
+																},
+																names.AttrValue: {
+																	Type:     schema.TypeString,
+																	Required: true,
+																},
 															},
 														},
 													},
-												},
-												"image": {
-													Type:     schema.TypeString,
-													Required: true,
-												},
-												"image_pull_policy": {
-													Type:         schema.TypeString,
-													Optional:     true,
-													ValidateFunc: validation.StringInSlice(imagePullPolicy_Values(), false),
-												},
-												names.AttrName: {
-													Type:     schema.TypeString,
-													Optional: true,
-												},
-												names.AttrResources: {
-													Type:     schema.TypeList,
-													Optional: true,
-													MaxItems: 1,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															"limits": {
-																Type:     schema.TypeMap,
-																Optional: true,
-																Elem:     &schema.Schema{Type: schema.TypeString},
-															},
-															"requests": {
-																Type:     schema.TypeMap,
-																Optional: true,
-																Elem:     &schema.Schema{Type: schema.TypeString},
+													"image": {
+														Type:     schema.TypeString,
+														Required: true,
+													},
+													"image_pull_policy": {
+														Type:         schema.TypeString,
+														Optional:     true,
+														ValidateFunc: validation.StringInSlice(imagePullPolicy_Values(), false),
+													},
+													names.AttrName: {
+														Type:     schema.TypeString,
+														Optional: true,
+													},
+													names.AttrResources: {
+														Type:     schema.TypeList,
+														Optional: true,
+														MaxItems: 1,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																"limits": {
+																	Type:     schema.TypeMap,
+																	Optional: true,
+																	Elem:     &schema.Schema{Type: schema.TypeString},
+																},
+																"requests": {
+																	Type:     schema.TypeMap,
+																	Optional: true,
+																	Elem:     &schema.Schema{Type: schema.TypeString},
+																},
 															},
 														},
 													},
-												},
-												"security_context": {
-													Type:     schema.TypeList,
-													Optional: true,
-													MaxItems: 1,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															"allow_privilege_escalation": {
-																Type:     schema.TypeBool,
-																Optional: true,
-															},
-															"privileged": {
-																Type:     schema.TypeBool,
-																Optional: true,
-															},
-															"read_only_root_file_system": {
-																Type:     schema.TypeBool,
-																Optional: true,
-															},
-															"run_as_group": {
-																Type:     schema.TypeInt,
-																Optional: true,
-															},
-															"run_as_non_root": {
-																Type:     schema.TypeBool,
-																Optional: true,
-															},
-															"run_as_user": {
-																Type:     schema.TypeInt,
-																Optional: true,
+													"security_context": {
+														Type:     schema.TypeList,
+														Optional: true,
+														MaxItems: 1,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																"allow_privilege_escalation": {
+																	Type:     schema.TypeBool,
+																	Optional: true,
+																},
+																"privileged": {
+																	Type:     schema.TypeBool,
+																	Optional: true,
+																},
+																"read_only_root_file_system": {
+																	Type:     schema.TypeBool,
+																	Optional: true,
+																},
+																"run_as_group": {
+																	Type:     schema.TypeInt,
+																	Optional: true,
+																},
+																"run_as_non_root": {
+																	Type:     schema.TypeBool,
+																	Optional: true,
+																},
+																"run_as_user": {
+																	Type:     schema.TypeInt,
+																	Optional: true,
+																},
 															},
 														},
 													},
-												},
-												"volume_mounts": {
-													Type:     schema.TypeList,
-													Optional: true,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															"mount_path": {
-																Type:     schema.TypeString,
-																Required: true,
-															},
-															names.AttrName: {
-																Type:     schema.TypeString,
-																Required: true,
-															},
-															"read_only": {
-																Type:     schema.TypeBool,
-																Optional: true,
+													"volume_mounts": {
+														Type:     schema.TypeList,
+														Optional: true,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																"mount_path": {
+																	Type:     schema.TypeString,
+																	Required: true,
+																},
+																names.AttrName: {
+																	Type:     schema.TypeString,
+																	Required: true,
+																},
+																"read_only": {
+																	Type:     schema.TypeBool,
+																	Optional: true,
+																},
 															},
 														},
 													},
 												},
 											},
 										},
-									},
-									"dns_policy": {
-										Type:         schema.TypeString,
-										Optional:     true,
-										ValidateFunc: validation.StringInSlice(dnsPolicy_Values(), false),
-									},
-									"host_network": {
-										Type:     schema.TypeBool,
-										Optional: true,
-										Default:  true,
-									},
-									"image_pull_secret": {
-										Type:     schema.TypeList,
-										Optional: true,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												names.AttrName: {
-													Type:     schema.TypeString,
-													Required: true,
-												},
-											},
+										"dns_policy": {
+											Type:         schema.TypeString,
+											Optional:     true,
+											ValidateFunc: validation.StringInSlice(dnsPolicy_Values(), false),
 										},
-									},
-									"init_containers": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 10,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"args": {
-													Type:     schema.TypeList,
-													Optional: true,
-													Elem:     &schema.Schema{Type: schema.TypeString},
-												},
-												"command": {
-													Type:     schema.TypeList,
-													Optional: true,
-													Elem:     &schema.Schema{Type: schema.TypeString},
-												},
-												"env": {
-													Type:     schema.TypeSet,
-													Optional: true,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															names.AttrName: {
-																Type:     schema.TypeString,
-																Required: true,
-															},
-															names.AttrValue: {
-																Type:     schema.TypeString,
-																Required: true,
-															},
-														},
-													},
-												},
-												"image": {
-													Type:     schema.TypeString,
-													Required: true,
-												},
-												"image_pull_policy": {
-													Type:         schema.TypeString,
-													Optional:     true,
-													ValidateFunc: validation.StringInSlice(imagePullPolicy_Values(), false),
-												},
-												names.AttrName: {
-													Type:     schema.TypeString,
-													Optional: true,
-												},
-												names.AttrResources: {
-													Type:     schema.TypeList,
-													Optional: true,
-													MaxItems: 1,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															"limits": {
-																Type:     schema.TypeMap,
-																Optional: true,
-																Elem:     &schema.Schema{Type: schema.TypeString},
-															},
-															"requests": {
-																Type:     schema.TypeMap,
-																Optional: true,
-																Elem:     &schema.Schema{Type: schema.TypeString},
-															},
-														},
-													},
-												},
-												"security_context": {
-													Type:     schema.TypeList,
-													Optional: true,
-													MaxItems: 1,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															"allow_privilege_escalation": {
-																Type:     schema.TypeBool,
-																Optional: true,
-															},
-															"privileged": {
-																Type:     schema.TypeBool,
-																Optional: true,
-															},
-															"read_only_root_file_system": {
-																Type:     schema.TypeBool,
-																Optional: true,
-															},
-															"run_as_group": {
-																Type:     schema.TypeInt,
-																Optional: true,
-															},
-															"run_as_non_root": {
-																Type:     schema.TypeBool,
-																Optional: true,
-															},
-															"run_as_user": {
-																Type:     schema.TypeInt,
-																Optional: true,
-															},
-														},
-													},
-												},
-												"volume_mounts": {
-													Type:     schema.TypeList,
-													Optional: true,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															"mount_path": {
-																Type:     schema.TypeString,
-																Required: true,
-															},
-															names.AttrName: {
-																Type:     schema.TypeString,
-																Required: true,
-															},
-															"read_only": {
-																Type:     schema.TypeBool,
-																Optional: true,
-															},
-														},
+										"host_network": {
+											Type:     schema.TypeBool,
+											Optional: true,
+											Default:  true,
+										},
+										"image_pull_secret": {
+											Type:     schema.TypeList,
+											Optional: true,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													names.AttrName: {
+														Type:     schema.TypeString,
+														Required: true,
 													},
 												},
 											},
 										},
-									},
-									"metadata": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"labels": {
-													Type:     schema.TypeMap,
-													Optional: true,
-													Elem:     &schema.Schema{Type: schema.TypeString},
+										"init_containers": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 10,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"args": {
+														Type:     schema.TypeList,
+														Optional: true,
+														Elem:     &schema.Schema{Type: schema.TypeString},
+													},
+													"command": {
+														Type:     schema.TypeList,
+														Optional: true,
+														Elem:     &schema.Schema{Type: schema.TypeString},
+													},
+													"env": {
+														Type:     schema.TypeSet,
+														Optional: true,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																names.AttrName: {
+																	Type:     schema.TypeString,
+																	Required: true,
+																},
+																names.AttrValue: {
+																	Type:     schema.TypeString,
+																	Required: true,
+																},
+															},
+														},
+													},
+													"image": {
+														Type:     schema.TypeString,
+														Required: true,
+													},
+													"image_pull_policy": {
+														Type:         schema.TypeString,
+														Optional:     true,
+														ValidateFunc: validation.StringInSlice(imagePullPolicy_Values(), false),
+													},
+													names.AttrName: {
+														Type:     schema.TypeString,
+														Optional: true,
+													},
+													names.AttrResources: {
+														Type:     schema.TypeList,
+														Optional: true,
+														MaxItems: 1,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																"limits": {
+																	Type:     schema.TypeMap,
+																	Optional: true,
+																	Elem:     &schema.Schema{Type: schema.TypeString},
+																},
+																"requests": {
+																	Type:     schema.TypeMap,
+																	Optional: true,
+																	Elem:     &schema.Schema{Type: schema.TypeString},
+																},
+															},
+														},
+													},
+													"security_context": {
+														Type:     schema.TypeList,
+														Optional: true,
+														MaxItems: 1,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																"allow_privilege_escalation": {
+																	Type:     schema.TypeBool,
+																	Optional: true,
+																},
+																"privileged": {
+																	Type:     schema.TypeBool,
+																	Optional: true,
+																},
+																"read_only_root_file_system": {
+																	Type:     schema.TypeBool,
+																	Optional: true,
+																},
+																"run_as_group": {
+																	Type:     schema.TypeInt,
+																	Optional: true,
+																},
+																"run_as_non_root": {
+																	Type:     schema.TypeBool,
+																	Optional: true,
+																},
+																"run_as_user": {
+																	Type:     schema.TypeInt,
+																	Optional: true,
+																},
+															},
+														},
+													},
+													"volume_mounts": {
+														Type:     schema.TypeList,
+														Optional: true,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																"mount_path": {
+																	Type:     schema.TypeString,
+																	Required: true,
+																},
+																names.AttrName: {
+																	Type:     schema.TypeString,
+																	Required: true,
+																},
+																"read_only": {
+																	Type:     schema.TypeBool,
+																	Optional: true,
+																},
+															},
+														},
+													},
 												},
 											},
 										},
-									},
-									"service_account_name": {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
-									"share_process_namespace": {
-										Type:     schema.TypeBool,
-										Optional: true,
-									},
-									"volumes": {
-										Type:     schema.TypeList,
-										Optional: true,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"empty_dir": {
-													Type:     schema.TypeList,
-													MaxItems: 1,
-													Optional: true,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															"medium": {
-																Type:         schema.TypeString,
-																Optional:     true,
-																Default:      "",
-																ValidateFunc: validation.StringInSlice([]string{"", "Memory"}, true),
-															},
-															"size_limit": {
-																Type:     schema.TypeString,
-																Required: true,
+										"metadata": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"labels": {
+														Type:     schema.TypeMap,
+														Optional: true,
+														Elem:     &schema.Schema{Type: schema.TypeString},
+													},
+												},
+											},
+										},
+										"service_account_name": {
+											Type:     schema.TypeString,
+											Optional: true,
+										},
+										"share_process_namespace": {
+											Type:     schema.TypeBool,
+											Optional: true,
+										},
+										"volumes": {
+											Type:     schema.TypeList,
+											Optional: true,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"empty_dir": {
+														Type:     schema.TypeList,
+														MaxItems: 1,
+														Optional: true,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																"medium": {
+																	Type:         schema.TypeString,
+																	Optional:     true,
+																	Default:      "",
+																	ValidateFunc: validation.StringInSlice([]string{"", "Memory"}, true),
+																},
+																"size_limit": {
+																	Type:     schema.TypeString,
+																	Required: true,
+																},
 															},
 														},
 													},
-												},
-												"host_path": {
-													Type:     schema.TypeList,
-													Optional: true,
-													MaxItems: 1,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															names.AttrPath: {
-																Type:     schema.TypeString,
-																Required: true,
+													"host_path": {
+														Type:     schema.TypeList,
+														Optional: true,
+														MaxItems: 1,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																names.AttrPath: {
+																	Type:     schema.TypeString,
+																	Required: true,
+																},
 															},
 														},
 													},
-												},
-												names.AttrName: {
-													Type:     schema.TypeString,
-													Optional: true,
-													Default:  "Default",
-												},
-												"secret": {
-													Type:     schema.TypeList,
-													Optional: true,
-													MaxItems: 1,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															"optional": {
-																Type:     schema.TypeBool,
-																Optional: true,
-															},
-															"secret_name": {
-																Type:     schema.TypeString,
-																Required: true,
+													names.AttrName: {
+														Type:     schema.TypeString,
+														Optional: true,
+														Default:  "Default",
+													},
+													"secret": {
+														Type:     schema.TypeList,
+														Optional: true,
+														MaxItems: 1,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																"optional": {
+																	Type:     schema.TypeBool,
+																	Optional: true,
+																},
+																"secret_name": {
+																	Type:     schema.TypeString,
+																	Required: true,
+																},
 															},
 														},
 													},
@@ -469,130 +471,130 @@ func resourceJobDefinition() *schema.Resource {
 						},
 					},
 				},
-			},
-			names.AttrName: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validName,
-			},
-			"node_properties": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				ConflictsWith: []string{"container_properties", "ecs_properties", "eks_properties"},
-				StateFunc: func(v any) string {
-					json, _ := structure.NormalizeJsonString(v)
-					return json
+				names.AttrName: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validName,
 				},
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					equal, _ := equivalentNodePropertiesJSON(old, new)
-					return equal
+				"node_properties": {
+					Type:          schema.TypeString,
+					Optional:      true,
+					ConflictsWith: []string{"container_properties", "ecs_properties", "eks_properties"},
+					StateFunc: func(v any) string {
+						json, _ := structure.NormalizeJsonString(v)
+						return json
+					},
+					DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+						equal, _ := equivalentNodePropertiesJSON(old, new)
+						return equal
+					},
+					DiffSuppressOnRefresh: true,
+					ValidateFunc:          validJobNodeProperties,
 				},
-				DiffSuppressOnRefresh: true,
-				ValidateFunc:          validJobNodeProperties,
-			},
-			names.AttrParameters: {
-				Type:     schema.TypeMap,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			"platform_capabilities": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem: &schema.Schema{
+				names.AttrParameters: {
+					Type:     schema.TypeMap,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"platform_capabilities": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem: &schema.Schema{
+						Type:             schema.TypeString,
+						ValidateDiagFunc: enum.Validate[awstypes.PlatformCapability](),
+					},
+				},
+				names.AttrPropagateTags: {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
+				"retry_strategy": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"attempts": {
+								Type:         schema.TypeInt,
+								Optional:     true,
+								ValidateFunc: validation.IntBetween(1, 10),
+							},
+							"evaluate_on_exit": {
+								Type:     schema.TypeList,
+								Optional: true,
+								ForceNew: true,
+								MinItems: 0,
+								MaxItems: 5,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										names.AttrAction: {
+											Type:             schema.TypeString,
+											Required:         true,
+											StateFunc:        sdkv2.ToLowerSchemaStateFunc,
+											ValidateDiagFunc: enum.ValidateIgnoreCase[awstypes.RetryAction](),
+										},
+										"on_exit_code": {
+											Type:     schema.TypeString,
+											Optional: true,
+											ValidateFunc: validation.All(
+												validation.StringLenBetween(1, 512),
+												validation.StringMatch(regexache.MustCompile(`^[0-9]*\*?$`), "must contain only numbers, and can optionally end with an asterisk"),
+											),
+										},
+										"on_reason": {
+											Type:     schema.TypeString,
+											Optional: true,
+											ValidateFunc: validation.All(
+												validation.StringLenBetween(1, 512),
+												validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z.:\s]*\*?$`), "must contain letters, numbers, periods, colons, and white space, and can optionally end with an asterisk"),
+											),
+										},
+										"on_status_reason": {
+											Type:     schema.TypeString,
+											Optional: true,
+											ValidateFunc: validation.All(
+												validation.StringLenBetween(1, 512),
+												validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z.:\s]*\*?$`), "must contain letters, numbers, periods, colons, and white space, and can optionally end with an asterisk"),
+											),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				"revision": {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
+				"scheduling_priority": {
+					Type:     schema.TypeInt,
+					Optional: true,
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				names.AttrTimeout: {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"attempt_duration_seconds": {
+								Type:         schema.TypeInt,
+								Optional:     true,
+								ValidateFunc: validation.IntAtLeast(60),
+							},
+						},
+					},
+				},
+				names.AttrType: {
 					Type:             schema.TypeString,
-					ValidateDiagFunc: enum.Validate[awstypes.PlatformCapability](),
+					Required:         true,
+					ValidateDiagFunc: enum.ValidateIgnoreCase[awstypes.JobDefinitionType](),
 				},
-			},
-			names.AttrPropagateTags: {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-			"retry_strategy": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"attempts": {
-							Type:         schema.TypeInt,
-							Optional:     true,
-							ValidateFunc: validation.IntBetween(1, 10),
-						},
-						"evaluate_on_exit": {
-							Type:     schema.TypeList,
-							Optional: true,
-							ForceNew: true,
-							MinItems: 0,
-							MaxItems: 5,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									names.AttrAction: {
-										Type:             schema.TypeString,
-										Required:         true,
-										StateFunc:        sdkv2.ToLowerSchemaStateFunc,
-										ValidateDiagFunc: enum.ValidateIgnoreCase[awstypes.RetryAction](),
-									},
-									"on_exit_code": {
-										Type:     schema.TypeString,
-										Optional: true,
-										ValidateFunc: validation.All(
-											validation.StringLenBetween(1, 512),
-											validation.StringMatch(regexache.MustCompile(`^[0-9]*\*?$`), "must contain only numbers, and can optionally end with an asterisk"),
-										),
-									},
-									"on_reason": {
-										Type:     schema.TypeString,
-										Optional: true,
-										ValidateFunc: validation.All(
-											validation.StringLenBetween(1, 512),
-											validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z.:\s]*\*?$`), "must contain letters, numbers, periods, colons, and white space, and can optionally end with an asterisk"),
-										),
-									},
-									"on_status_reason": {
-										Type:     schema.TypeString,
-										Optional: true,
-										ValidateFunc: validation.All(
-											validation.StringLenBetween(1, 512),
-											validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z.:\s]*\*?$`), "must contain letters, numbers, periods, colons, and white space, and can optionally end with an asterisk"),
-										),
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			"revision": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-			"scheduling_priority": {
-				Type:     schema.TypeInt,
-				Optional: true,
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			names.AttrTimeout: {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"attempt_duration_seconds": {
-							Type:         schema.TypeInt,
-							Optional:     true,
-							ValidateFunc: validation.IntAtLeast(60),
-						},
-					},
-				},
-			},
-			names.AttrType: {
-				Type:             schema.TypeString,
-				Required:         true,
-				ValidateDiagFunc: enum.ValidateIgnoreCase[awstypes.JobDefinitionType](),
-			},
+			}
 		},
 
 		CustomizeDiff: jobDefinitionCustomizeDiff,

--- a/internal/service/batch/job_queue_data_source.go
+++ b/internal/service/batch/job_queue_data_source.go
@@ -25,76 +25,78 @@ func dataSourceJobQueue() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceJobQueueRead,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"compute_environment_order": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"compute_environment": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"order": {
-							Type:     schema.TypeInt,
-							Computed: true,
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"compute_environment_order": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"compute_environment": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"order": {
+								Type:     schema.TypeInt,
+								Computed: true,
+							},
 						},
 					},
 				},
-			},
-			"job_state_time_limit_action": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrAction: {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"max_time_seconds": {
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
-						"reason": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						names.AttrState: {
-							Type:     schema.TypeString,
-							Computed: true,
+				"job_state_time_limit_action": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrAction: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"max_time_seconds": {
+								Type:     schema.TypeInt,
+								Computed: true,
+							},
+							"reason": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							names.AttrState: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
 						},
 					},
 				},
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			names.AttrPriority: {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-			"scheduling_policy_arn": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrState: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrStatus: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrStatusReason: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrTags: tftags.TagsSchemaComputed(),
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				names.AttrPriority: {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
+				"scheduling_policy_arn": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrState: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrStatus: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrStatusReason: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrTags: tftags.TagsSchemaComputed(),
+			}
 		},
 	}
 }

--- a/internal/service/batch/scheduling_policy.go
+++ b/internal/service/batch/scheduling_policy.go
@@ -38,58 +38,60 @@ func resourceSchedulingPolicy() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"fair_share_policy": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"compute_reservation": {
-							Type:         schema.TypeInt,
-							Optional:     true,
-							ValidateFunc: validation.IntBetween(0, 99),
-						},
-						"share_decay_seconds": {
-							Type:         schema.TypeInt,
-							Optional:     true,
-							ValidateFunc: validation.IntBetween(0, 604800),
-						},
-						"share_distribution": {
-							Type: schema.TypeSet,
-							// There can be no more than 500 fair share identifiers active in a job queue.
-							MaxItems: 500,
-							Optional: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"share_identifier": {
-										Type:         schema.TypeString,
-										Required:     true,
-										ValidateFunc: validShareIdentifier,
-									},
-									"weight_factor": {
-										Type:         schema.TypeFloat,
-										Optional:     true,
-										ValidateFunc: validation.FloatBetween(0.0001, 999.9999),
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"fair_share_policy": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"compute_reservation": {
+								Type:         schema.TypeInt,
+								Optional:     true,
+								ValidateFunc: validation.IntBetween(0, 99),
+							},
+							"share_decay_seconds": {
+								Type:         schema.TypeInt,
+								Optional:     true,
+								ValidateFunc: validation.IntBetween(0, 604800),
+							},
+							"share_distribution": {
+								Type: schema.TypeSet,
+								// There can be no more than 500 fair share identifiers active in a job queue.
+								MaxItems: 500,
+								Optional: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"share_identifier": {
+											Type:         schema.TypeString,
+											Required:     true,
+											ValidateFunc: validShareIdentifier,
+										},
+										"weight_factor": {
+											Type:         schema.TypeFloat,
+											Optional:     true,
+											ValidateFunc: validation.FloatBetween(0.0001, 999.9999),
+										},
 									},
 								},
 							},
 						},
 					},
 				},
-			},
-			names.AttrName: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validName,
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				names.AttrName: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validName,
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			}
 		},
 	}
 }

--- a/internal/service/batch/scheduling_policy_data_source.go
+++ b/internal/service/batch/scheduling_policy_data_source.go
@@ -25,48 +25,50 @@ func dataSourceSchedulingPolicy() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceSchedulingPolicyRead,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"fair_share_policy": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"compute_reservation": {
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
-						"share_decay_seconds": {
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
-						"share_distribution": {
-							Type:     schema.TypeSet,
-							Computed: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"share_identifier": {
-										Type:     schema.TypeString,
-										Computed: true,
-									},
-									"weight_factor": {
-										Type:     schema.TypeFloat,
-										Computed: true,
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"fair_share_policy": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"compute_reservation": {
+								Type:     schema.TypeInt,
+								Computed: true,
+							},
+							"share_decay_seconds": {
+								Type:     schema.TypeInt,
+								Computed: true,
+							},
+							"share_distribution": {
+								Type:     schema.TypeSet,
+								Computed: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"share_identifier": {
+											Type:     schema.TypeString,
+											Computed: true,
+										},
+										"weight_factor": {
+											Type:     schema.TypeFloat,
+											Computed: true,
+										},
 									},
 								},
 							},
 						},
 					},
 				},
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrTags: tftags.TagsSchemaComputed(),
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrTags: tftags.TagsSchemaComputed(),
+			}
 		},
 	}
 }

--- a/internal/service/budgets/budget.go
+++ b/internal/service/budgets/budget.go
@@ -54,281 +54,283 @@ func resourceBudget() *schema.Resource {
 
 		CustomizeDiff: validateFilterExpressionDiff,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrAccountID: {
-				Type:         schema.TypeString,
-				Computed:     true,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidAccountID,
-			},
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"auto_adjust_data": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"auto_adjust_type": {
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.AutoAdjustType](),
-						},
-						"historical_options": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"budget_adjustment_period": {
-										Type:         schema.TypeInt,
-										Required:     true,
-										ValidateFunc: validation.IntBetween(1, 60),
-									},
-									"lookback_available_periods": {
-										Type:     schema.TypeInt,
-										Computed: true,
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrAccountID: {
+					Type:         schema.TypeString,
+					Computed:     true,
+					Optional:     true,
+					ForceNew:     true,
+					ValidateFunc: verify.ValidAccountID,
+				},
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"auto_adjust_data": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"auto_adjust_type": {
+								Type:             schema.TypeString,
+								Required:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.AutoAdjustType](),
+							},
+							"historical_options": {
+								Type:     schema.TypeList,
+								Optional: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"budget_adjustment_period": {
+											Type:         schema.TypeInt,
+											Required:     true,
+											ValidateFunc: validation.IntBetween(1, 60),
+										},
+										"lookback_available_periods": {
+											Type:     schema.TypeInt,
+											Computed: true,
+										},
 									},
 								},
 							},
-						},
-						"last_auto_adjust_time": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-					},
-				},
-			},
-			"billing_view_arn": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			"budget_type": {
-				Type:             schema.TypeString,
-				Required:         true,
-				ValidateDiagFunc: enum.Validate[awstypes.BudgetType](),
-			},
-			"cost_filter": {
-				Type:          schema.TypeSet,
-				Optional:      true,
-				Computed:      true,
-				ConflictsWith: []string{"filter_expression"},
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrName: {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						names.AttrValues: {
-							Type:     schema.TypeList,
-							Required: true,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
+							"last_auto_adjust_time": {
+								Type:     schema.TypeString,
+								Computed: true,
 							},
 						},
 					},
 				},
-			},
-			"cost_types": {
-				Type:          schema.TypeList,
-				Computed:      true,
-				Optional:      true,
-				MaxItems:      1,
-				ConflictsWith: []string{"metrics"},
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"include_credit": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  true,
-						},
-						"include_discount": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  true,
-						},
-						"include_other_subscription": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  true,
-						},
-						"include_recurring": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  true,
-						},
-						"include_refund": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  true,
-						},
-						"include_subscription": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  true,
-						},
-						"include_support": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  true,
-						},
-						"include_tax": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  true,
-						},
-						"include_upfront": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  true,
-						},
-						"use_amortized": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  false,
-						},
-						"use_blended": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  false,
-						},
-					},
+				"billing_view_arn": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: verify.ValidARN,
 				},
-			},
-			"limit_amount": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Computed:         true,
-				DiffSuppressFunc: suppressEquivalentBudgetLimitAmount,
-				ConflictsWith:    []string{"planned_limit"},
-			},
-			"limit_unit": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				ConflictsWith: []string{"planned_limit"},
-			},
-			names.AttrName: {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				ForceNew:      true,
-				ConflictsWith: []string{names.AttrNamePrefix},
-			},
-			names.AttrNamePrefix: {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				ForceNew:      true,
-				ConflictsWith: []string{names.AttrName},
-			},
-			"notification": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"comparison_operator": {
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.ComparisonOperator](),
-						},
-						"notification_type": {
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.NotificationType](),
-						},
-						"subscriber_email_addresses": {
-							Type:     schema.TypeSet,
-							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-						"subscriber_sns_topic_arns": {
-							Type:     schema.TypeSet,
-							Optional: true,
-							Elem: &schema.Schema{
-								Type:         schema.TypeString,
-								ValidateFunc: verify.ValidARN,
-							},
-						},
-						"threshold": {
-							Type:     schema.TypeFloat,
-							Required: true,
-						},
-						"threshold_type": {
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.ThresholdType](),
-						},
-					},
-				},
-			},
-			"planned_limit": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"amount": {
-							Type:             schema.TypeString,
-							Required:         true,
-							DiffSuppressFunc: suppressEquivalentBudgetLimitAmount,
-						},
-						names.AttrStartTime: {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validTimePeriodTimestamp,
-						},
-						names.AttrUnit: {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-					},
-				},
-				ConflictsWith: []string{"limit_amount", "limit_unit"},
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			"time_period_end": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Default:      "2087-06-15_00:00",
-				ValidateFunc: validTimePeriodTimestamp,
-			},
-			"time_period_start": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: validTimePeriodTimestamp,
-			},
-			"time_unit": {
-				Type:             schema.TypeString,
-				Required:         true,
-				ValidateDiagFunc: enum.Validate[awstypes.TimeUnit](),
-			},
-			"filter_expression": {
-				Type:          schema.TypeList,
-				Optional:      true,
-				MaxItems:      1,
-				ConflictsWith: []string{"cost_filter"},
-				RequiredWith:  []string{"metrics"},
-				// AWS Budgets API enforces: "Expression nested depth cannot be more than 2" which is not mentioned in docs
-				// Schema level 3 = AWS depth 2 (because operators added when level > 1)
-				Elem: filterExpressionElem(filterExpressionDepth),
-			},
-			"metrics": {
-				Type:          schema.TypeList,
-				Optional:      true,
-				MaxItems:      1,
-				ConflictsWith: []string{"cost_types"},
-				RequiredWith:  []string{"filter_expression"},
-				Elem: &schema.Schema{
+				"budget_type": {
 					Type:             schema.TypeString,
-					ValidateDiagFunc: enum.Validate[awstypes.Metric](),
+					Required:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.BudgetType](),
 				},
-			},
+				"cost_filter": {
+					Type:          schema.TypeSet,
+					Optional:      true,
+					Computed:      true,
+					ConflictsWith: []string{"filter_expression"},
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrName: {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+							names.AttrValues: {
+								Type:     schema.TypeList,
+								Required: true,
+								Elem: &schema.Schema{
+									Type: schema.TypeString,
+								},
+							},
+						},
+					},
+				},
+				"cost_types": {
+					Type:          schema.TypeList,
+					Computed:      true,
+					Optional:      true,
+					MaxItems:      1,
+					ConflictsWith: []string{"metrics"},
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"include_credit": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Default:  true,
+							},
+							"include_discount": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Default:  true,
+							},
+							"include_other_subscription": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Default:  true,
+							},
+							"include_recurring": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Default:  true,
+							},
+							"include_refund": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Default:  true,
+							},
+							"include_subscription": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Default:  true,
+							},
+							"include_support": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Default:  true,
+							},
+							"include_tax": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Default:  true,
+							},
+							"include_upfront": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Default:  true,
+							},
+							"use_amortized": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Default:  false,
+							},
+							"use_blended": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Default:  false,
+							},
+						},
+					},
+				},
+				"limit_amount": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					Computed:         true,
+					DiffSuppressFunc: suppressEquivalentBudgetLimitAmount,
+					ConflictsWith:    []string{"planned_limit"},
+				},
+				"limit_unit": {
+					Type:          schema.TypeString,
+					Optional:      true,
+					Computed:      true,
+					ConflictsWith: []string{"planned_limit"},
+				},
+				names.AttrName: {
+					Type:          schema.TypeString,
+					Optional:      true,
+					Computed:      true,
+					ForceNew:      true,
+					ConflictsWith: []string{names.AttrNamePrefix},
+				},
+				names.AttrNamePrefix: {
+					Type:          schema.TypeString,
+					Optional:      true,
+					Computed:      true,
+					ForceNew:      true,
+					ConflictsWith: []string{names.AttrName},
+				},
+				"notification": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"comparison_operator": {
+								Type:             schema.TypeString,
+								Required:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.ComparisonOperator](),
+							},
+							"notification_type": {
+								Type:             schema.TypeString,
+								Required:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.NotificationType](),
+							},
+							"subscriber_email_addresses": {
+								Type:     schema.TypeSet,
+								Optional: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+							},
+							"subscriber_sns_topic_arns": {
+								Type:     schema.TypeSet,
+								Optional: true,
+								Elem: &schema.Schema{
+									Type:         schema.TypeString,
+									ValidateFunc: verify.ValidARN,
+								},
+							},
+							"threshold": {
+								Type:     schema.TypeFloat,
+								Required: true,
+							},
+							"threshold_type": {
+								Type:             schema.TypeString,
+								Required:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.ThresholdType](),
+							},
+						},
+					},
+				},
+				"planned_limit": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"amount": {
+								Type:             schema.TypeString,
+								Required:         true,
+								DiffSuppressFunc: suppressEquivalentBudgetLimitAmount,
+							},
+							names.AttrStartTime: {
+								Type:         schema.TypeString,
+								Required:     true,
+								ValidateFunc: validTimePeriodTimestamp,
+							},
+							names.AttrUnit: {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+						},
+					},
+					ConflictsWith: []string{"limit_amount", "limit_unit"},
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				"time_period_end": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Default:      "2087-06-15_00:00",
+					ValidateFunc: validTimePeriodTimestamp,
+				},
+				"time_period_start": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Computed:     true,
+					ValidateFunc: validTimePeriodTimestamp,
+				},
+				"time_unit": {
+					Type:             schema.TypeString,
+					Required:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.TimeUnit](),
+				},
+				"filter_expression": {
+					Type:          schema.TypeList,
+					Optional:      true,
+					MaxItems:      1,
+					ConflictsWith: []string{"cost_filter"},
+					RequiredWith:  []string{"metrics"},
+					// AWS Budgets API enforces: "Expression nested depth cannot be more than 2" which is not mentioned in docs
+					// Schema level 3 = AWS depth 2 (because operators added when level > 1)
+					Elem: filterExpressionElem(filterExpressionDepth),
+				},
+				"metrics": {
+					Type:          schema.TypeList,
+					Optional:      true,
+					MaxItems:      1,
+					ConflictsWith: []string{"cost_types"},
+					RequiredWith:  []string{"filter_expression"},
+					Elem: &schema.Schema{
+						Type:             schema.TypeString,
+						ValidateDiagFunc: enum.Validate[awstypes.Metric](),
+					},
+				},
+			}
 		},
 	}
 }

--- a/internal/service/budgets/budget_action.go
+++ b/internal/service/budgets/budget_action.go
@@ -52,182 +52,184 @@ func resourceBudgetAction() *schema.Resource {
 			Delete: schema.DefaultTimeout(5 * time.Minute),
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrAccountID: {
-				Type:         schema.TypeString,
-				Computed:     true,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidAccountID,
-			},
-			"action_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"action_threshold": {
-				Type:     schema.TypeList,
-				Required: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"action_threshold_type": {
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.ThresholdType](),
-						},
-						"action_threshold_value": {
-							Type:         schema.TypeFloat,
-							Required:     true,
-							ValidateFunc: validation.FloatBetween(0, 40000000000),
-						},
-					},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrAccountID: {
+					Type:         schema.TypeString,
+					Computed:     true,
+					Optional:     true,
+					ForceNew:     true,
+					ValidateFunc: verify.ValidAccountID,
 				},
-			},
-			"action_type": {
-				Type:             schema.TypeString,
-				Required:         true,
-				ForceNew:         true,
-				ValidateDiagFunc: enum.Validate[awstypes.ActionType](),
-			},
-			"approval_model": {
-				Type:             schema.TypeString,
-				Required:         true,
-				ValidateDiagFunc: enum.Validate[awstypes.ApprovalModel](),
-			},
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"budget_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-				ValidateFunc: validation.All(
-					validation.StringLenBetween(1, 100),
-					validation.StringMatch(regexache.MustCompile(`[^:\\]+`), "The ':' and '\\' characters aren't allowed."),
-				),
-			},
-			"definition": {
-				Type:     schema.TypeList,
-				Required: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"iam_action_definition": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"groups": {
-										Type:     schema.TypeSet,
-										Optional: true,
-										MaxItems: 100,
-										Elem:     &schema.Schema{Type: schema.TypeString},
-									},
-									"policy_arn": {
-										Type:         schema.TypeString,
-										Required:     true,
-										ValidateFunc: verify.ValidARN,
-									},
-									"roles": {
-										Type:     schema.TypeSet,
-										Optional: true,
-										MaxItems: 100,
-										Elem:     &schema.Schema{Type: schema.TypeString},
-									},
-									"users": {
-										Type:     schema.TypeSet,
-										Optional: true,
-										MaxItems: 100,
-										Elem:     &schema.Schema{Type: schema.TypeString},
-									},
-								},
+				"action_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"action_threshold": {
+					Type:     schema.TypeList,
+					Required: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"action_threshold_type": {
+								Type:             schema.TypeString,
+								Required:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.ThresholdType](),
 							},
-						},
-						"scp_action_definition": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"policy_id": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-									"target_ids": {
-										Type:     schema.TypeSet,
-										Required: true,
-										MaxItems: 100,
-										Elem:     &schema.Schema{Type: schema.TypeString},
-									},
-								},
-							},
-						},
-						"ssm_action_definition": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"action_sub_type": {
-										Type:             schema.TypeString,
-										Required:         true,
-										ValidateDiagFunc: enum.Validate[awstypes.ActionSubType](),
-									},
-									"instance_ids": {
-										Type:     schema.TypeSet,
-										Required: true,
-										MaxItems: 100,
-										Elem:     &schema.Schema{Type: schema.TypeString},
-									},
-									names.AttrRegion: {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-								},
+							"action_threshold_value": {
+								Type:         schema.TypeFloat,
+								Required:     true,
+								ValidateFunc: validation.FloatBetween(0, 40000000000),
 							},
 						},
 					},
 				},
-			},
-			names.AttrExecutionRoleARN: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			"notification_type": {
-				Type:             schema.TypeString,
-				Required:         true,
-				ValidateDiagFunc: enum.Validate[awstypes.NotificationType](),
-			},
-			names.AttrStatus: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"subscriber": {
-				Type:     schema.TypeSet,
-				Required: true,
-				MaxItems: 11,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrAddress: {
-							Type:     schema.TypeString,
-							Required: true,
-							ValidateFunc: validation.All(
-								validation.StringLenBetween(1, 2147483647),
-								validation.StringMatch(regexache.MustCompile(`(.*[\n\r\t\f\ ]?)*`), "Can't contain line breaks."),
-							)},
-						"subscription_type": {
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.SubscriptionType](),
+				"action_type": {
+					Type:             schema.TypeString,
+					Required:         true,
+					ForceNew:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.ActionType](),
+				},
+				"approval_model": {
+					Type:             schema.TypeString,
+					Required:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.ApprovalModel](),
+				},
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"budget_name": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+					ValidateFunc: validation.All(
+						validation.StringLenBetween(1, 100),
+						validation.StringMatch(regexache.MustCompile(`[^:\\]+`), "The ':' and '\\' characters aren't allowed."),
+					),
+				},
+				"definition": {
+					Type:     schema.TypeList,
+					Required: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"iam_action_definition": {
+								Type:     schema.TypeList,
+								Optional: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"groups": {
+											Type:     schema.TypeSet,
+											Optional: true,
+											MaxItems: 100,
+											Elem:     &schema.Schema{Type: schema.TypeString},
+										},
+										"policy_arn": {
+											Type:         schema.TypeString,
+											Required:     true,
+											ValidateFunc: verify.ValidARN,
+										},
+										"roles": {
+											Type:     schema.TypeSet,
+											Optional: true,
+											MaxItems: 100,
+											Elem:     &schema.Schema{Type: schema.TypeString},
+										},
+										"users": {
+											Type:     schema.TypeSet,
+											Optional: true,
+											MaxItems: 100,
+											Elem:     &schema.Schema{Type: schema.TypeString},
+										},
+									},
+								},
+							},
+							"scp_action_definition": {
+								Type:     schema.TypeList,
+								Optional: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"policy_id": {
+											Type:     schema.TypeString,
+											Required: true,
+										},
+										"target_ids": {
+											Type:     schema.TypeSet,
+											Required: true,
+											MaxItems: 100,
+											Elem:     &schema.Schema{Type: schema.TypeString},
+										},
+									},
+								},
+							},
+							"ssm_action_definition": {
+								Type:     schema.TypeList,
+								Optional: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"action_sub_type": {
+											Type:             schema.TypeString,
+											Required:         true,
+											ValidateDiagFunc: enum.Validate[awstypes.ActionSubType](),
+										},
+										"instance_ids": {
+											Type:     schema.TypeSet,
+											Required: true,
+											MaxItems: 100,
+											Elem:     &schema.Schema{Type: schema.TypeString},
+										},
+										names.AttrRegion: {
+											Type:     schema.TypeString,
+											Required: true,
+										},
+									},
+								},
+							},
 						},
 					},
 				},
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				names.AttrExecutionRoleARN: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				"notification_type": {
+					Type:             schema.TypeString,
+					Required:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.NotificationType](),
+				},
+				names.AttrStatus: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"subscriber": {
+					Type:     schema.TypeSet,
+					Required: true,
+					MaxItems: 11,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrAddress: {
+								Type:     schema.TypeString,
+								Required: true,
+								ValidateFunc: validation.All(
+									validation.StringLenBetween(1, 2147483647),
+									validation.StringMatch(regexache.MustCompile(`(.*[\n\r\t\f\ ]?)*`), "Can't contain line breaks."),
+								)},
+							"subscription_type": {
+								Type:             schema.TypeString,
+								Required:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.SubscriptionType](),
+							},
+						},
+					},
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			}
 		},
 	}
 }

--- a/internal/service/budgets/budget_data_source.go
+++ b/internal/service/budgets/budget_data_source.go
@@ -27,248 +27,250 @@ func dataSourceBudget() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceBudgetRead,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrAccountID: {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"auto_adjust_data": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"auto_adjust_type": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"historical_options": {
-							Type:     schema.TypeList,
-							Computed: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"budget_adjustment_period": {
-										Type:     schema.TypeInt,
-										Computed: true,
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrAccountID: {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+				},
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"auto_adjust_data": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"auto_adjust_type": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"historical_options": {
+								Type:     schema.TypeList,
+								Computed: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"budget_adjustment_period": {
+											Type:     schema.TypeInt,
+											Computed: true,
+										},
+										"lookback_available_periods": {
+											Type:     schema.TypeInt,
+											Computed: true,
+										},
 									},
-									"lookback_available_periods": {
-										Type:     schema.TypeInt,
-										Computed: true,
+								},
+							},
+							"last_auto_adjust_time": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+						},
+					},
+				},
+				"billing_view_arn": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"budget_type": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"budget_limit": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"amount": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							names.AttrUnit: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+						},
+					},
+				},
+				"calculated_spend": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"actual_spend": {
+								Type:     schema.TypeList,
+								Computed: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"amount": {
+											Type:     schema.TypeString,
+											Computed: true,
+										},
+										names.AttrUnit: {
+											Type:     schema.TypeString,
+											Computed: true,
+										},
 									},
 								},
 							},
 						},
-						"last_auto_adjust_time": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
 					},
 				},
-			},
-			"billing_view_arn": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"budget_type": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"budget_limit": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"amount": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						names.AttrUnit: {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-					},
-				},
-			},
-			"calculated_spend": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"actual_spend": {
-							Type:     schema.TypeList,
-							Computed: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"amount": {
-										Type:     schema.TypeString,
-										Computed: true,
-									},
-									names.AttrUnit: {
-										Type:     schema.TypeString,
-										Computed: true,
-									},
+				"cost_filter": {
+					Type:     schema.TypeSet,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrName: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							names.AttrValues: {
+								Type:     schema.TypeList,
+								Computed: true,
+								Elem: &schema.Schema{
+									Type: schema.TypeString,
 								},
 							},
 						},
 					},
 				},
-			},
-			"cost_filter": {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrName: {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						names.AttrValues: {
-							Type:     schema.TypeList,
-							Computed: true,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
+				"cost_types": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"include_credit": {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
+							"include_discount": {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
+							"include_other_subscription": {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
+							"include_recurring": {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
+							"include_refund": {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
+							"include_subscription": {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
+							"include_support": {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
+							"include_tax": {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
+							"include_upfront": {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
+							"use_amortized": {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
+							"use_blended": {
+								Type:     schema.TypeBool,
+								Computed: true,
 							},
 						},
 					},
 				},
-			},
-			"cost_types": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"include_credit": {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
-						"include_discount": {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
-						"include_other_subscription": {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
-						"include_recurring": {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
-						"include_refund": {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
-						"include_subscription": {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
-						"include_support": {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
-						"include_tax": {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
-						"include_upfront": {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
-						"use_amortized": {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
-						"use_blended": {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
-					},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
 				},
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			names.AttrNamePrefix: {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"notification": {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"comparison_operator": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"notification_type": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"subscriber_email_addresses": {
-							Type:     schema.TypeSet,
-							Computed: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-						"subscriber_sns_topic_arns": {
-							Type:     schema.TypeSet,
-							Computed: true,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
+				names.AttrNamePrefix: {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"notification": {
+					Type:     schema.TypeSet,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"comparison_operator": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"notification_type": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"subscriber_email_addresses": {
+								Type:     schema.TypeSet,
+								Computed: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+							},
+							"subscriber_sns_topic_arns": {
+								Type:     schema.TypeSet,
+								Computed: true,
+								Elem: &schema.Schema{
+									Type: schema.TypeString,
+								},
+							},
+							"threshold": {
+								Type:     schema.TypeFloat,
+								Computed: true,
+							},
+							"threshold_type": {
+								Type:     schema.TypeString,
+								Computed: true,
 							},
 						},
-						"threshold": {
-							Type:     schema.TypeFloat,
-							Computed: true,
-						},
-						"threshold_type": {
-							Type:     schema.TypeString,
-							Computed: true,
+					},
+				},
+				"planned_limit": {
+					Type:     schema.TypeSet,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"amount": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							names.AttrStartTime: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							names.AttrUnit: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
 						},
 					},
 				},
-			},
-			"planned_limit": {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"amount": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						names.AttrStartTime: {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						names.AttrUnit: {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-					},
+				names.AttrTags: tftags.TagsSchemaComputed(),
+				"time_period_end": {
+					Type:     schema.TypeString,
+					Computed: true,
 				},
-			},
-			names.AttrTags: tftags.TagsSchemaComputed(),
-			"time_period_end": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"time_period_start": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"time_unit": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"budget_exceeded": {
-				Type:     schema.TypeBool,
-				Computed: true,
-			},
+				"time_period_start": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"time_unit": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"budget_exceeded": {
+					Type:     schema.TypeBool,
+					Computed: true,
+				},
+			}
 		},
 	}
 }


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Use `SchemaFunc` instead of `Schema` for `a` and `b` services

Relates #47758