### PR TITLE
[Docs] aws_observabilityadmin_centralization_rule_for_organization: Add `data_source_selection_criteria`

### DIFF
--- a/website/docs/r/observabilityadmin_centralization_rule_for_organization.html.markdown
+++ b/website/docs/r/observabilityadmin_centralization_rule_for_organization.html.markdown
@@ -183,7 +183,8 @@ The following arguments are optional:
 #### source_logs_configuration
 
 * `encrypted_log_group_strategy` - (Required) Strategy for handling encrypted log groups. Valid values: `ALLOW`, `SKIP`.
-* `log_group_selection_criteria` - (Required) Criteria for selecting log groups. Use `*` for all log groups or OAM filter syntax like `LogGroupName LIKE '/aws/lambda%'`. Must be between 1 and 2000 characters.
+* `data_source_selection_criteria` - (Optional) Criteria for selecting data sources. Uses the same filter expression format as `log_group_selection_criteria`, but operates on Data Source Name and Data Source Type operands. When both `log_group_selection_criteria` and `data_source_selection_criteria` are specified, a log event must match both criteria to be centralized. Must be between 1 and 2000 characters.
+* `log_group_selection_criteria` - (Optional) Criteria for selecting log groups. Use `*` for all log groups or OAM filter syntax like `LogGroupName LIKE '/aws/lambda%'`. Must be between 1 and 2000 characters.
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

This PR updates the documentation for `aws_observabilityadmin_centralization_rule_for_organization` to include `data_source_selection_criteria`.

* This argument was added in #47154, where `log_group_selection_criteria` was changed to `Optional`.

### Relations
Closes #48045
Relates #47154

### References
https://docs.aws.amazon.com/cloudwatch/latest/observabilityadmin/API_SourceLogsConfiguration.html#cwoa-Type-SourceLogsConfiguration-DataSourceSelectionCriteria

https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/data-source-discovery-management.html

