### PR TITLE
[Enhancement] aws_msk_replicator: Add `log_delivery` configuration block

### DIFF
--- a/.changelog/48054.txt
+++ b/.changelog/48054.txt
@@ -1,0 +1,11 @@
+```release-note:enhancement
+resource/aws_msk_replicator: Add support for `log_delivery` configuration block
+```
+
+```release-note:bug
+resource/aws_msk_replicator: Mark `replication_info_list.consumer_group_replication.consumer_groups_to_exclude` as Computed
+```
+
+```release-note:bug
+resource/aws_msk_replicator: Mark `replication_info_list.topic_replication.topics_to_exclude` as Computed
+```

--- a/internal/service/kafka/replicator.go
+++ b/internal/service/kafka/replicator.go
@@ -340,21 +340,21 @@ func resourceReplicator() *schema.Resource {
 				cloudwatchLogsBlock := "log_delivery.0.replicator_log_delivery.0.cloudwatch_logs.0"
 				firehoseLogBlock := "log_delivery.0.replicator_log_delivery.0.firehose.0"
 				s3LogBlock := "log_delivery.0.replicator_log_delivery.0.s3.0"
-				if v, ok := d.Get(fmt.Sprintf("%s.%s", cloudwatchLogsBlock, "enabled")).(bool); ok && !v {
+				if v, ok := d.Get(fmt.Sprintf("%s.%s", cloudwatchLogsBlock, names.AttrEnabled)).(bool); ok && !v {
 					if _, ok := d.GetOk(fmt.Sprintf("%s.%s", cloudwatchLogsBlock, "log_group")); ok {
 						diags = sdkdiag.AppendErrorf(diags, "cannot specify log_group when CloudWatch Logs logging is disabled")
 					}
 				}
-				if v, ok := d.Get(fmt.Sprintf("%s.%s", firehoseLogBlock, "enabled")).(bool); ok && !v {
+				if v, ok := d.Get(fmt.Sprintf("%s.%s", firehoseLogBlock, names.AttrEnabled)).(bool); ok && !v {
 					if _, ok := d.GetOk(fmt.Sprintf("%s.%s", firehoseLogBlock, "delivery_stream")); ok {
 						diags = sdkdiag.AppendErrorf(diags, "cannot specify delivery_stream when Firehose logging is disabled")
 					}
 				}
-				if v, ok := d.Get(fmt.Sprintf("%s.%s", s3LogBlock, "enabled")).(bool); ok && !v {
-					if _, ok := d.GetOk(fmt.Sprintf("%s.%s", s3LogBlock, "bucket")); ok {
+				if v, ok := d.Get(fmt.Sprintf("%s.%s", s3LogBlock, names.AttrEnabled)).(bool); ok && !v {
+					if _, ok := d.GetOk(fmt.Sprintf("%s.%s", s3LogBlock, names.AttrBucket)); ok {
 						diags = sdkdiag.AppendErrorf(diags, "cannot specify bucket when S3 logging is disabled")
 					}
-					if _, ok := d.GetOk(fmt.Sprintf("%s.%s", s3LogBlock, "prefix")); ok {
+					if _, ok := d.GetOk(fmt.Sprintf("%s.%s", s3LogBlock, names.AttrPrefix)); ok {
 						diags = sdkdiag.AppendErrorf(diags, "cannot specify prefix when S3 logging is disabled")
 					}
 				}

--- a/internal/service/kafka/replicator.go
+++ b/internal/service/kafka/replicator.go
@@ -15,6 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/kafka"
 	"github.com/aws/aws-sdk-go-v2/service/kafka/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
@@ -102,6 +103,79 @@ func resourceReplicator() *schema.Resource {
 										ForceNew: true,
 										Elem: &schema.Schema{
 											Type: schema.TypeString,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"log_delivery": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"replicator_log_delivery": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									names.AttrCloudWatchLogs: {
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												names.AttrEnabled: {
+													Type:     schema.TypeBool,
+													Required: true,
+												},
+												"log_group": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+											},
+										},
+									},
+									"firehose": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"delivery_stream": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+												names.AttrEnabled: {
+													Type:     schema.TypeBool,
+													Required: true,
+												},
+											},
+										},
+									},
+									"s3": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												names.AttrBucket: {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+												names.AttrEnabled: {
+													Type:     schema.TypeBool,
+													Required: true,
+												},
+												names.AttrPrefix: {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+											},
 										},
 									},
 								},
@@ -258,6 +332,37 @@ func resourceReplicator() *schema.Resource {
 			names.AttrTags:    tftags.TagsSchema(),
 			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
+		CustomizeDiff: customdiff.Sequence(
+			func(ctx context.Context, d *schema.ResourceDiff, meta any) error {
+				var diags diag.Diagnostics
+				cloudwatchLogsBlock := "log_delivery.0.replicator_log_delivery.0.cloudwatch_logs.0"
+				firehoseLogBlock := "log_delivery.0.replicator_log_delivery.0.firehose.0"
+				s3LogBlock := "log_delivery.0.replicator_log_delivery.0.s3.0"
+				if v, ok := d.Get(fmt.Sprintf("%s.%s", cloudwatchLogsBlock, "enabled")).(bool); ok && !v {
+					if _, ok := d.GetOk(fmt.Sprintf("%s.%s", cloudwatchLogsBlock, "log_group")); ok {
+						diags = sdkdiag.AppendErrorf(diags, "cannot specify log_group when CloudWatch Logs logging is disabled")
+					}
+				}
+				if v, ok := d.Get(fmt.Sprintf("%s.%s", firehoseLogBlock, "enabled")).(bool); ok && !v {
+					if _, ok := d.GetOk(fmt.Sprintf("%s.%s", firehoseLogBlock, "delivery_stream")); ok {
+						diags = sdkdiag.AppendErrorf(diags, "cannot specify delivery_stream when Firehose logging is disabled")
+					}
+				}
+				if v, ok := d.Get(fmt.Sprintf("%s.%s", s3LogBlock, "enabled")).(bool); ok && !v {
+					if _, ok := d.GetOk(fmt.Sprintf("%s.%s", s3LogBlock, "bucket")); ok {
+						diags = sdkdiag.AppendErrorf(diags, "cannot specify bucket when S3 logging is disabled")
+					}
+					if _, ok := d.GetOk(fmt.Sprintf("%s.%s", s3LogBlock, "prefix")); ok {
+						diags = sdkdiag.AppendErrorf(diags, "cannot specify prefix when S3 logging is disabled")
+					}
+				}
+				if diags.HasError() {
+					return sdkdiag.DiagnosticsError(diags)
+				}
+
+				return nil
+			},
+		),
 	}
 }
 
@@ -276,6 +381,10 @@ func resourceReplicatorCreate(ctx context.Context, d *schema.ResourceData, meta 
 
 	if v, ok := d.GetOk(names.AttrDescription); ok {
 		input.Description = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("log_delivery"); ok {
+		input.LogDelivery = expandLogDelivery(v.([]any))
 	}
 
 	output, err := conn.CreateReplicator(ctx, input)
@@ -326,6 +435,9 @@ func resourceReplicatorRead(ctx context.Context, d *schema.ResourceData, meta an
 	d.Set("current_version", output.CurrentVersion)
 	d.Set(names.AttrDescription, output.ReplicatorDescription)
 	d.Set("kafka_cluster", flattenKafkaClusterDescriptions(output.KafkaClusters))
+	if err := d.Set("log_delivery", flattenLogDelivery(output.LogDelivery)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting log_delivery for MSK Replicator (%s): %s", d.Id(), err)
+	}
 	d.Set("replication_info_list", flattenReplicationInfoDescriptions(output.ReplicationInfoList, sourceARN, targetARN))
 	d.Set("replicator_name", output.ReplicatorName)
 	d.Set("service_execution_role_arn", output.ServiceExecutionRoleArn)
@@ -346,6 +458,10 @@ func resourceReplicatorUpdate(ctx context.Context, d *schema.ResourceData, meta 
 			ReplicatorArn:         aws.String(d.Id()),
 			SourceKafkaClusterArn: aws.String(d.Get("replication_info_list.0.source_kafka_cluster_arn").(string)),
 			TargetKafkaClusterArn: aws.String(d.Get("replication_info_list.0.target_kafka_cluster_arn").(string)),
+		}
+
+		if d.HasChanges("log_delivery") {
+			input.LogDelivery = expandLogDelivery(d.Get("log_delivery").([]any))
 		}
 
 		if d.HasChanges("replication_info_list.0.consumer_group_replication") {
@@ -696,6 +812,94 @@ func flattenAmazonMSKCluster(apiObject *types.AmazonMskCluster) map[string]any {
 	return tfMap
 }
 
+func flattenLogDelivery(apiObject *types.LogDelivery) []any {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]any{}
+
+	if v := apiObject.ReplicatorLogDelivery; v != nil {
+		tfMap["replicator_log_delivery"] = flattenReplicatorLogDelivery(v)
+	}
+
+	return []any{tfMap}
+}
+
+func flattenReplicatorLogDelivery(apiObject *types.ReplicatorLogDelivery) []any {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]any{}
+
+	if v := apiObject.CloudWatchLogs; v != nil {
+		tfMap[names.AttrCloudWatchLogs] = flattenReplicatorLogDeliveryCloudWatchLogs(v)
+	}
+
+	if v := apiObject.Firehose; v != nil {
+		tfMap["firehose"] = flattenReplicatorLogDeliveryFirehose(v)
+	}
+
+	if v := apiObject.S3; v != nil {
+		tfMap["s3"] = flattenReplicatorLogDeliveryS3(v)
+	}
+
+	return []any{tfMap}
+}
+
+func flattenReplicatorLogDeliveryCloudWatchLogs(apiObject *types.ReplicatorCloudWatchLogs) []any {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]any{
+		names.AttrEnabled: apiObject.Enabled,
+	}
+
+	if v := apiObject.LogGroup; v != nil {
+		tfMap["log_group"] = aws.ToString(v)
+	}
+
+	return []any{tfMap}
+}
+
+func flattenReplicatorLogDeliveryFirehose(apiObject *types.ReplicatorFirehose) []any {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]any{
+		names.AttrEnabled: apiObject.Enabled,
+	}
+
+	if v := apiObject.DeliveryStream; v != nil {
+		tfMap["delivery_stream"] = aws.ToString(v)
+	}
+
+	return []any{tfMap}
+}
+
+func flattenReplicatorLogDeliveryS3(apiObject *types.ReplicatorS3) []any {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]any{
+		names.AttrEnabled: apiObject.Enabled,
+	}
+
+	if v := apiObject.Bucket; v != nil {
+		tfMap[names.AttrBucket] = aws.ToString(v)
+	}
+
+	if v := apiObject.Prefix; v != nil {
+		tfMap[names.AttrPrefix] = aws.ToString(v)
+	}
+
+	return []any{tfMap}
+}
+
 func expandConsumerGroupReplicationUpdate(tfMap map[string]any) *types.ConsumerGroupReplicationUpdate {
 	apiObject := &types.ConsumerGroupReplicationUpdate{}
 
@@ -923,6 +1127,125 @@ func expandAmazonMSKCluster(tfMap map[string]any) *types.AmazonMskCluster { // n
 
 	if v, ok := tfMap["msk_cluster_arn"].(string); ok && v != "" {
 		apiObject.MskClusterArn = aws.String(v)
+	}
+
+	return apiObject
+}
+
+func expandLogDelivery(tfList []any) *types.LogDelivery {
+	if len(tfList) == 0 {
+		return nil
+	}
+
+	tfMap, ok := tfList[0].(map[string]any)
+
+	if !ok {
+		return nil
+	}
+
+	apiObject := &types.LogDelivery{}
+
+	if v, ok := tfMap["replicator_log_delivery"].([]any); ok {
+		apiObject.ReplicatorLogDelivery = expandReplicatorLogDelivery(v)
+	}
+
+	return apiObject
+}
+
+func expandReplicatorLogDelivery(tfList []any) *types.ReplicatorLogDelivery {
+	if len(tfList) == 0 || tfList[0] == nil {
+		return nil
+	}
+
+	tfMap, ok := tfList[0].(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	apiObject := &types.ReplicatorLogDelivery{}
+
+	if v, ok := tfMap[names.AttrCloudWatchLogs].([]any); ok {
+		apiObject.CloudWatchLogs = expandReplicatorLogDeliveryCloudWatchLogs(v)
+	}
+
+	if v, ok := tfMap["firehose"].([]any); ok {
+		apiObject.Firehose = expandReplicatorLogDeliveryFirehose(v)
+	}
+
+	if v, ok := tfMap["s3"].([]any); ok {
+		apiObject.S3 = expandReplicatorLogDeliveryS3(v)
+	}
+
+	return apiObject
+}
+
+func expandReplicatorLogDeliveryCloudWatchLogs(tfList []any) *types.ReplicatorCloudWatchLogs {
+	if len(tfList) == 0 || tfList[0] == nil {
+		return nil
+	}
+
+	tfMap, ok := tfList[0].(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	apiObject := &types.ReplicatorCloudWatchLogs{}
+
+	if v, ok := tfMap[names.AttrEnabled].(bool); ok {
+		apiObject.Enabled = aws.Bool(v)
+	}
+
+	if v, ok := tfMap["log_group"].(string); ok && v != "" {
+		apiObject.LogGroup = aws.String(v)
+	}
+
+	return apiObject
+}
+
+func expandReplicatorLogDeliveryFirehose(tfList []any) *types.ReplicatorFirehose {
+	if len(tfList) == 0 || tfList[0] == nil {
+		return nil
+	}
+
+	tfMap, ok := tfList[0].(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	apiObject := &types.ReplicatorFirehose{}
+
+	if v, ok := tfMap[names.AttrEnabled].(bool); ok {
+		apiObject.Enabled = aws.Bool(v)
+	}
+
+	if v, ok := tfMap["delivery_stream"].(string); ok && v != "" {
+		apiObject.DeliveryStream = aws.String(v)
+	}
+
+	return apiObject
+}
+
+func expandReplicatorLogDeliveryS3(tfList []any) *types.ReplicatorS3 {
+	if len(tfList) == 0 || tfList[0] == nil {
+		return nil
+	}
+	tfMap, ok := tfList[0].(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	apiObject := &types.ReplicatorS3{}
+
+	if v, ok := tfMap[names.AttrEnabled].(bool); ok {
+		apiObject.Enabled = aws.Bool(v)
+	}
+
+	if v, ok := tfMap[names.AttrBucket].(string); ok && v != "" {
+		apiObject.Bucket = aws.String(v)
+	}
+
+	if v, ok := tfMap[names.AttrPrefix].(string); ok && v != "" {
+		apiObject.Prefix = aws.String(v)
 	}
 
 	return apiObject

--- a/internal/service/kafka/replicator.go
+++ b/internal/service/kafka/replicator.go
@@ -271,6 +271,7 @@ func resourceReplicator() *schema.Resource {
 									"topics_to_exclude": {
 										Type:     schema.TypeSet,
 										Optional: true,
+										Computed: true,
 										Elem: &schema.Schema{
 											Type: schema.TypeString,
 										},
@@ -293,6 +294,7 @@ func resourceReplicator() *schema.Resource {
 									"consumer_groups_to_exclude": {
 										Type:     schema.TypeSet,
 										Optional: true,
+										Computed: true,
 										Elem: &schema.Schema{
 											Type: schema.TypeString,
 										},

--- a/internal/service/kafka/replicator_test.go
+++ b/internal/service/kafka/replicator_test.go
@@ -854,23 +854,23 @@ resource "aws_msk_replicator" "test" {
 func testAccReplicatorConfig_logDeliveryBase(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_cloudwatch_log_group" "test" {
- name = %[1]q
+  name = %[1]q
 }
 
 resource "aws_s3_bucket" "test" {
- bucket        = "%[1]s-log-delivery"
- force_destroy = true
+  bucket        = "%[1]s-log-delivery"
+  force_destroy = true
 }
 
 resource "aws_s3_bucket" "test_firehose" {
- bucket        = "%[1]s-firehose"
- force_destroy = true
+  bucket        = "%[1]s-firehose"
+  force_destroy = true
 }
 
 resource "aws_iam_role" "firehose_role" {
- name = %[1]q
+  name = %[1]q
 
- assume_role_policy = <<EOF
+  assume_role_policy = <<EOF
 {
  "Version": "2012-10-17",
  "Statement": [
@@ -888,24 +888,24 @@ EOF
 }
 
 resource "aws_kinesis_firehose_delivery_stream" "test" {
- name        = %[1]q
- destination = "extended_s3"
+  name        = %[1]q
+  destination = "extended_s3"
 
- extended_s3_configuration {
-   role_arn   = aws_iam_role.firehose_role.arn
-   bucket_arn = aws_s3_bucket.test_firehose.arn
- }
+  extended_s3_configuration {
+    role_arn   = aws_iam_role.firehose_role.arn
+    bucket_arn = aws_s3_bucket.test_firehose.arn
+  }
 
- tags = {
-   LogDeliveryEnabled = "placeholder"
- }
+  tags = {
+    LogDeliveryEnabled = "placeholder"
+  }
 
- lifecycle {
-   ignore_changes = [
-     # Ignore changes to LogDeliveryEnabled tag as API adds this tag when broker log delivery is enabled
-     tags["LogDeliveryEnabled"],
-   ]
- }
+  lifecycle {
+    ignore_changes = [
+      # Ignore changes to LogDeliveryEnabled tag as API adds this tag when broker log delivery is enabled
+      tags["LogDeliveryEnabled"],
+    ]
+  }
 }
 `, rName)
 }
@@ -917,64 +917,64 @@ func testAccReplicatorConfig_logDelivery(rName, sourceCluster, targetCluster str
 		testAccReplicatorConfig_logDeliveryBase(rName),
 		fmt.Sprintf(`
 resource "aws_msk_replicator" "test" {
- replicator_name            = %[1]q
- description                = "test-description"
- service_execution_role_arn = aws_iam_role.source.arn
+  replicator_name            = %[1]q
+  description                = "test-description"
+  service_execution_role_arn = aws_iam_role.source.arn
 
- log_delivery {
-   replicator_log_delivery {
-     cloudwatch_logs {
-       enabled   = %[2]t
-       log_group = aws_cloudwatch_log_group.test.name
-     }
-     s3 {
-       enabled   = %[2]t
-       bucket    = aws_s3_bucket.test.bucket
-       prefix    = "test/"
-     }
-     firehose {
-       enabled         = %[2]t
-       delivery_stream = aws_kinesis_firehose_delivery_stream.test.name
-     }
-   }
- }
+  log_delivery {
+    replicator_log_delivery {
+      cloudwatch_logs {
+        enabled   = %[2]t
+        log_group = aws_cloudwatch_log_group.test.name
+      }
+      s3 {
+        enabled = %[2]t
+        bucket  = aws_s3_bucket.test.bucket
+        prefix  = "test/"
+      }
+      firehose {
+        enabled         = %[2]t
+        delivery_stream = aws_kinesis_firehose_delivery_stream.test.name
+      }
+    }
+  }
 
- kafka_cluster {
-   amazon_msk_cluster {
-     msk_cluster_arn = aws_msk_cluster.source.arn
-   }
+  kafka_cluster {
+    amazon_msk_cluster {
+      msk_cluster_arn = aws_msk_cluster.source.arn
+    }
 
-   vpc_config {
-     subnet_ids          = aws_subnet.source[*].id
-     security_groups_ids = [aws_security_group.source.id]
-   }
- }
+    vpc_config {
+      subnet_ids          = aws_subnet.source[*].id
+      security_groups_ids = [aws_security_group.source.id]
+    }
+  }
 
- kafka_cluster {
-   amazon_msk_cluster {
-     msk_cluster_arn = aws_msk_cluster.target.arn
-   }
+  kafka_cluster {
+    amazon_msk_cluster {
+      msk_cluster_arn = aws_msk_cluster.target.arn
+    }
 
-   vpc_config {
-     subnet_ids          = aws_subnet.target[*].id
-     security_groups_ids = [aws_security_group.target.id]
-   }
- }
+    vpc_config {
+      subnet_ids          = aws_subnet.target[*].id
+      security_groups_ids = [aws_security_group.target.id]
+    }
+  }
 
- replication_info_list {
-   source_kafka_cluster_arn = aws_msk_cluster.source.arn
-   target_kafka_cluster_arn = aws_msk_cluster.target.arn
-   target_compression_type  = "NONE"
+  replication_info_list {
+    source_kafka_cluster_arn = aws_msk_cluster.source.arn
+    target_kafka_cluster_arn = aws_msk_cluster.target.arn
+    target_compression_type  = "NONE"
 
 
-   topic_replication {
-     topics_to_replicate = [".*"]
-   }
+    topic_replication {
+      topics_to_replicate = [".*"]
+    }
 
-   consumer_group_replication {
-     consumer_groups_to_replicate = [".*"]
-   }
- }
+    consumer_group_replication {
+      consumer_groups_to_replicate = [".*"]
+    }
+  }
 }
 `, rName, logDeliveryEnabled))
 }
@@ -986,60 +986,60 @@ func testAccReplicatorConfig_logDeliveryDisabled(rName, sourceCluster, targetClu
 		testAccReplicatorConfig_logDeliveryBase(rName),
 		fmt.Sprintf(`
 resource "aws_msk_replicator" "test" {
- replicator_name            = %[1]q
- description                = "test-description"
- service_execution_role_arn = aws_iam_role.source.arn
+  replicator_name            = %[1]q
+  description                = "test-description"
+  service_execution_role_arn = aws_iam_role.source.arn
 
- log_delivery {
-   replicator_log_delivery {
-     cloudwatch_logs {
-       enabled = false
-     }
-     s3 {
-       enabled = false
-     }
-     firehose {
-       enabled = false
-     }
-   }
- }
+  log_delivery {
+    replicator_log_delivery {
+      cloudwatch_logs {
+        enabled = false
+      }
+      s3 {
+        enabled = false
+      }
+      firehose {
+        enabled = false
+      }
+    }
+  }
 
- kafka_cluster {
-   amazon_msk_cluster {
-     msk_cluster_arn = aws_msk_cluster.source.arn
-   }
+  kafka_cluster {
+    amazon_msk_cluster {
+      msk_cluster_arn = aws_msk_cluster.source.arn
+    }
 
-   vpc_config {
-     subnet_ids          = aws_subnet.source[*].id
-     security_groups_ids = [aws_security_group.source.id]
-   }
- }
+    vpc_config {
+      subnet_ids          = aws_subnet.source[*].id
+      security_groups_ids = [aws_security_group.source.id]
+    }
+  }
 
- kafka_cluster {
-   amazon_msk_cluster {
-     msk_cluster_arn = aws_msk_cluster.target.arn
-   }
+  kafka_cluster {
+    amazon_msk_cluster {
+      msk_cluster_arn = aws_msk_cluster.target.arn
+    }
 
-   vpc_config {
-     subnet_ids          = aws_subnet.target[*].id
-     security_groups_ids = [aws_security_group.target.id]
-   }
- }
+    vpc_config {
+      subnet_ids          = aws_subnet.target[*].id
+      security_groups_ids = [aws_security_group.target.id]
+    }
+  }
 
- replication_info_list {
-   source_kafka_cluster_arn = aws_msk_cluster.source.arn
-   target_kafka_cluster_arn = aws_msk_cluster.target.arn
-   target_compression_type  = "NONE"
+  replication_info_list {
+    source_kafka_cluster_arn = aws_msk_cluster.source.arn
+    target_kafka_cluster_arn = aws_msk_cluster.target.arn
+    target_compression_type  = "NONE"
 
 
-   topic_replication {
-     topics_to_replicate = [".*"]
-   }
+    topic_replication {
+      topics_to_replicate = [".*"]
+    }
 
-   consumer_group_replication {
-     consumer_groups_to_replicate = [".*"]
-   }
- }
+    consumer_group_replication {
+      consumer_groups_to_replicate = [".*"]
+    }
+  }
 }
 `, rName))
 }

--- a/internal/service/kafka/replicator_test.go
+++ b/internal/service/kafka/replicator_test.go
@@ -160,6 +160,81 @@ func TestAccKafkaReplicator_update(t *testing.T) {
 	})
 }
 
+func TestAccKafkaReplicator_logDelivery(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var replicator kafka.DescribeReplicatorOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	sourceCluster := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	targetCluster := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_msk_replicator.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.Kafka)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.Kafka),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckReplicatorDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccReplicatorConfig_logDelivery(rName, sourceCluster, targetCluster, false),
+				ExpectError: regexache.MustCompile(`Error: cannot specify log_group when CloudWatch Logs logging is disabled\n\s*cannot specify delivery_stream when Firehose logging is disabled\n\s*cannot specify bucket when S3 logging is disabled\n\s*cannot specify prefix when S3 logging is disabled`),
+			},
+			{
+				Config: testAccReplicatorConfig_logDelivery(rName, sourceCluster, targetCluster, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckReplicatorExists(ctx, t, resourceName, &replicator),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery.0.replicator_log_delivery.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery.0.replicator_log_delivery.0.cloudwatch_logs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery.0.replicator_log_delivery.0.cloudwatch_logs.0.enabled", acctest.CtTrue),
+					resource.TestCheckResourceAttrPair(
+						resourceName, "log_delivery.0.replicator_log_delivery.0.cloudwatch_logs.0.log_group",
+						"aws_cloudwatch_log_group.test", names.AttrName,
+					),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery.0.replicator_log_delivery.0.firehose.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery.0.replicator_log_delivery.0.firehose.0.enabled", acctest.CtTrue),
+					resource.TestCheckResourceAttrPair(
+						resourceName, "log_delivery.0.replicator_log_delivery.0.firehose.0.delivery_stream",
+						"aws_kinesis_firehose_delivery_stream.test", names.AttrName,
+					),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery.0.replicator_log_delivery.0.s3.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery.0.replicator_log_delivery.0.s3.0.enabled", acctest.CtTrue),
+					resource.TestCheckResourceAttrPair(
+						resourceName, "log_delivery.0.replicator_log_delivery.0.s3.0.bucket",
+						"aws_s3_bucket.test", names.AttrBucket,
+					),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccReplicatorConfig_logDeliveryDisabled(rName, sourceCluster, targetCluster),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckReplicatorExists(ctx, t, resourceName, &replicator),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery.0.replicator_log_delivery.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery.0.replicator_log_delivery.0.cloudwatch_logs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery.0.replicator_log_delivery.0.cloudwatch_logs.0.enabled", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery.0.replicator_log_delivery.0.firehose.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery.0.replicator_log_delivery.0.firehose.0.enabled", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery.0.replicator_log_delivery.0.s3.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery.0.replicator_log_delivery.0.s3.0.enabled", acctest.CtFalse),
+				),
+			},
+		},
+	})
+}
+
 func TestAccKafkaReplicator_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
@@ -774,4 +849,197 @@ resource "aws_msk_replicator" "test" {
   }
 }
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2, sourceCluster, targetCluster))
+}
+
+func testAccReplicatorConfig_logDeliveryBase(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_cloudwatch_log_group" "test" {
+ name = %[1]q
+}
+
+resource "aws_s3_bucket" "test" {
+ bucket        = "%[1]s-log-delivery"
+ force_destroy = true
+}
+
+resource "aws_s3_bucket" "test_firehose" {
+ bucket        = "%[1]s-firehose"
+ force_destroy = true
+}
+
+resource "aws_iam_role" "firehose_role" {
+ name = %[1]q
+
+ assume_role_policy = <<EOF
+{
+ "Version": "2012-10-17",
+ "Statement": [
+   {
+     "Action": "sts:AssumeRole",
+     "Principal": {
+       "Service": "firehose.amazonaws.com"
+     },
+     "Effect": "Allow",
+     "Sid": ""
+   }
+ ]
+}
+EOF
+}
+
+resource "aws_kinesis_firehose_delivery_stream" "test" {
+ name        = %[1]q
+ destination = "extended_s3"
+
+ extended_s3_configuration {
+   role_arn   = aws_iam_role.firehose_role.arn
+   bucket_arn = aws_s3_bucket.test_firehose.arn
+ }
+
+ tags = {
+   LogDeliveryEnabled = "placeholder"
+ }
+
+ lifecycle {
+   ignore_changes = [
+     # Ignore changes to LogDeliveryEnabled tag as API adds this tag when broker log delivery is enabled
+     tags["LogDeliveryEnabled"],
+   ]
+ }
+}
+`, rName)
+}
+
+func testAccReplicatorConfig_logDelivery(rName, sourceCluster, targetCluster string, logDeliveryEnabled bool) string {
+	return acctest.ConfigCompose(
+		testAccReplicatorConfig_source(sourceCluster),
+		testAccReplicatorConfig_target(targetCluster),
+		testAccReplicatorConfig_logDeliveryBase(rName),
+		fmt.Sprintf(`
+resource "aws_msk_replicator" "test" {
+ replicator_name            = %[1]q
+ description                = "test-description"
+ service_execution_role_arn = aws_iam_role.source.arn
+
+ log_delivery {
+   replicator_log_delivery {
+     cloudwatch_logs {
+       enabled   = %[2]t
+       log_group = aws_cloudwatch_log_group.test.name
+     }
+     s3 {
+       enabled   = %[2]t
+       bucket    = aws_s3_bucket.test.bucket
+       prefix    = "test/"
+     }
+     firehose {
+       enabled         = %[2]t
+       delivery_stream = aws_kinesis_firehose_delivery_stream.test.name
+     }
+   }
+ }
+
+ kafka_cluster {
+   amazon_msk_cluster {
+     msk_cluster_arn = aws_msk_cluster.source.arn
+   }
+
+   vpc_config {
+     subnet_ids          = aws_subnet.source[*].id
+     security_groups_ids = [aws_security_group.source.id]
+   }
+ }
+
+ kafka_cluster {
+   amazon_msk_cluster {
+     msk_cluster_arn = aws_msk_cluster.target.arn
+   }
+
+   vpc_config {
+     subnet_ids          = aws_subnet.target[*].id
+     security_groups_ids = [aws_security_group.target.id]
+   }
+ }
+
+ replication_info_list {
+   source_kafka_cluster_arn = aws_msk_cluster.source.arn
+   target_kafka_cluster_arn = aws_msk_cluster.target.arn
+   target_compression_type  = "NONE"
+
+
+   topic_replication {
+     topics_to_replicate = [".*"]
+   }
+
+   consumer_group_replication {
+     consumer_groups_to_replicate = [".*"]
+   }
+ }
+}
+`, rName, logDeliveryEnabled))
+}
+
+func testAccReplicatorConfig_logDeliveryDisabled(rName, sourceCluster, targetCluster string) string {
+	return acctest.ConfigCompose(
+		testAccReplicatorConfig_source(sourceCluster),
+		testAccReplicatorConfig_target(targetCluster),
+		testAccReplicatorConfig_logDeliveryBase(rName),
+		fmt.Sprintf(`
+resource "aws_msk_replicator" "test" {
+ replicator_name            = %[1]q
+ description                = "test-description"
+ service_execution_role_arn = aws_iam_role.source.arn
+
+ log_delivery {
+   replicator_log_delivery {
+     cloudwatch_logs {
+       enabled = false
+     }
+     s3 {
+       enabled = false
+     }
+     firehose {
+       enabled = false
+     }
+   }
+ }
+
+ kafka_cluster {
+   amazon_msk_cluster {
+     msk_cluster_arn = aws_msk_cluster.source.arn
+   }
+
+   vpc_config {
+     subnet_ids          = aws_subnet.source[*].id
+     security_groups_ids = [aws_security_group.source.id]
+   }
+ }
+
+ kafka_cluster {
+   amazon_msk_cluster {
+     msk_cluster_arn = aws_msk_cluster.target.arn
+   }
+
+   vpc_config {
+     subnet_ids          = aws_subnet.target[*].id
+     security_groups_ids = [aws_security_group.target.id]
+   }
+ }
+
+ replication_info_list {
+   source_kafka_cluster_arn = aws_msk_cluster.source.arn
+   target_kafka_cluster_arn = aws_msk_cluster.target.arn
+   target_compression_type  = "NONE"
+
+
+   topic_replication {
+     topics_to_replicate = [".*"]
+   }
+
+   consumer_group_replication {
+     consumer_groups_to_replicate = [".*"]
+   }
+ }
+}
+`, rName))
 }

--- a/website/docs/r/msk_replicator.html.markdown
+++ b/website/docs/r/msk_replicator.html.markdown
@@ -75,6 +75,7 @@ This resource supports the following arguments:
 * `service_execution_role_arn` - (Required) The ARN of the IAM role used by the replicator to access resources in the customer's account (e.g source and target clusters).
 * `replication_info_list` - (Required) A list of replication configurations, where each configuration targets a given source cluster to target cluster replication flow.
 * `description` - (Optional) A summary description of the replicator.
+* `log_delivery` - (Optional) Configuration block for delivering replicator logs to customer destinations. Detailed below.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ### kafka_cluster Argument Reference
@@ -123,6 +124,32 @@ This resource supports the following arguments:
 ### starting_position
 
 * `type` - (Optional) The type of replication starting position. Supports `LATEST` and `EARLIEST`.
+
+### log_delivery
+
+* `replicator_log_delivery` - (Optional) Configuration block for replicator log delivery. Detailed below.
+
+### replicator_log_delivery
+
+* `cloudwatch_logs` - (Optional) Configuration block for replicator log delivery to Amazon CloudWatch Logs. Detailed below.
+* `firehose` - (Optional) Configuration block for replicator log delivery to Amazon Data Firehose. Detailed below.
+* `s3` - (Optional) Configuration block for replicator log delivery to Amazon S3. Detailed below.
+
+### cloudwatch_logs
+
+* `enabled` - (Required) Boolean whether to enable log delivery to CloudWatch Logs.
+* `log_group` - (Optional) Name of CloudWatch Logs log group. Required if `enabled` is `true`. If `enabled` is `false`, this value must not be set.
+
+### firehose
+
+* `enabled` - (Required) Boolean whether to enable log delivery to Firehose.
+* `delivery_stream` - (Optional) Name of the Firehose delivery stream. Required if `enabled` is `true`. If `enabled` is `false`, this value must not be set.
+
+### s3
+
+* `enabled` - (Required) Boolean whether to enable log delivery to S3.
+* `bucket` - (Optional) Name of the S3 bucket. Required if `enabled` is `true`. If `enabled` is `false`, this value must not be set.
+* `prefix` - (Optional) Prefix to use when storing replicator logs in S3. If `enabled` is `false`, this value must not be set.
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

This PR adds the `log_delivery` configuration block to the `aws_msk_replicator` resource.

#### AWS API behavior and AWS Provider implementation

* When `enabled` is set to `false`, specifying other arguments such as `log_group` for CloudWatch Logs, `delivery_stream` for Data Firehose, or `bucket` and `prefix` for S3 causes the AWS API to return an error. The newly added `CustomizeDiff` function validates that these arguments are not specified when `enabled` is `false`.
* Although not the main focus of this PR, some existing arguments are also updated to be marked as `Computed`. Without these fixes, the basic acceptance test fails as follows:

```console
=== NAME  TestAccKafkaReplicator_basic
    replicator_test.go:41: Step 1/2 error: After applying this test step, the non-refresh plan was not empty.
        stdout:
        
        
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place
        
        Terraform will perform the following actions:
        
          # aws_msk_replicator.test will be updated in-place
          ~ resource "aws_msk_replicator" "test" {
                id                         = "arn:aws:kafka:us-west-2:123456789012:replicator/tf-acc-test-9193745927902875833/678c7ed9-e81e-4684-97c7-6d0cc3e2dc35-2"
                # (7 unchanged attributes hidden)
        
              ~ replication_info_list {
                    # (5 unchanged attributes hidden)
        
                  ~ consumer_group_replication {
                      + consumer_groups_to_exclude          = []
                        # (3 unchanged attributes hidden)
                    }
        
                  ~ topic_replication {
                      + topics_to_exclude                    = []
                        # (4 unchanged attributes hidden)
        
                        # (2 unchanged blocks hidden)
                    }
                }
        
                # (2 unchanged blocks hidden)
            }
        
        Plan: 0 to add, 1 to change, 0 to destroy.
--- FAIL: TestAccKafkaReplicator_basic (6071.05s)
```

### Relations
Closes #48024.
Closes https://github.com/hashicorp/terraform-provider-aws/pull/47720.

### References
https://docs.aws.amazon.com/ja_jp/msk/1.0/apireference-replicator/v1-replicators.html#v1-replicators-schemas


### Output from Acceptance Testing

It takes too log time to complete the tests

```console
$ make testacc TESTS='TestAccKafkaReplicator_(basic|update|logDelivery)' PKG=kafka
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     5.952s
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework 5.990s
make: Running acceptance tests on branch: 🌿 f-aws_msk_replicator-add_log_delivery 🌿...
TF_ACC=1 go1.26.3 test ./internal/service/kafka/... -v -count 1 -parallel 20 -run='TestAccKafkaReplicator_(basic|update|logDelivery)'  -timeout 360m -vet=off -buildvcs=false
2026/05/26 13:20:57 Creating Terraform AWS Provider (SDKv2-style)...
2026/05/26 13:20:57 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccKafkaReplicator_basic
=== PAUSE TestAccKafkaReplicator_basic
=== RUN   TestAccKafkaReplicator_update
=== PAUSE TestAccKafkaReplicator_update
=== RUN   TestAccKafkaReplicator_logDelivery
=== PAUSE TestAccKafkaReplicator_logDelivery
=== CONT  TestAccKafkaReplicator_basic
=== CONT  TestAccKafkaReplicator_logDelivery
=== CONT  TestAccKafkaReplicator_update
--- PASS: TestAccKafkaReplicator_logDelivery (6230.35s)
--- PASS: TestAccKafkaReplicator_update (6645.42s)
--- PASS: TestAccKafkaReplicator_basic (7718.13s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/kafka      7723.777s

```
