### PR TITLE
AutoFlex test fixes

### DIFF
--- a/internal/framework/flex/autoflex_args_test.go
+++ b/internal/framework/flex/autoflex_args_test.go
@@ -46,7 +46,7 @@ func TestExpandArgs_nilAndPointers(t *testing.T) {
 		},
 	}
 
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true})
+	runAutoExpandTestCases(t, testCases, runChecks{})
 }
 
 func TestExpandArgs_shapeCompatibility(t *testing.T) {
@@ -77,7 +77,7 @@ func TestExpandArgs_shapeCompatibility(t *testing.T) {
 		},
 	}
 
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true})
+	runAutoExpandTestCases(t, testCases, runChecks{})
 }
 
 func TestFlattenArgs_nilAndPointers(t *testing.T) {
@@ -114,7 +114,7 @@ func TestFlattenArgs_nilAndPointers(t *testing.T) {
 		},
 	}
 
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{})
 }
 
 func TestFlattenArgs_shapeCompatibility(t *testing.T) {
@@ -145,5 +145,5 @@ func TestFlattenArgs_shapeCompatibility(t *testing.T) {
 		},
 	}
 
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{})
 }

--- a/internal/framework/flex/autoflex_args_test.go
+++ b/internal/framework/flex/autoflex_args_test.go
@@ -46,7 +46,7 @@ func TestExpandArgs_nilAndPointers(t *testing.T) {
 		},
 	}
 
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true, CompareTarget: true})
+	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true})
 }
 
 func TestExpandArgs_shapeCompatibility(t *testing.T) {
@@ -77,7 +77,7 @@ func TestExpandArgs_shapeCompatibility(t *testing.T) {
 		},
 	}
 
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true, CompareTarget: true})
+	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true})
 }
 
 func TestFlattenArgs_nilAndPointers(t *testing.T) {
@@ -114,7 +114,7 @@ func TestFlattenArgs_nilAndPointers(t *testing.T) {
 		},
 	}
 
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true, CompareTarget: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true})
 }
 
 func TestFlattenArgs_shapeCompatibility(t *testing.T) {
@@ -145,5 +145,5 @@ func TestFlattenArgs_shapeCompatibility(t *testing.T) {
 		},
 	}
 
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true, CompareTarget: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true})
 }

--- a/internal/framework/flex/autoflex_collections_test.go
+++ b/internal/framework/flex/autoflex_collections_test.go
@@ -80,7 +80,7 @@ func TestExpandCollections(t *testing.T) {
 		},
 	}
 
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: false})
+	runAutoExpandTestCases(t, testCases, runChecks{})
 }
 
 func TestExpandListOfInt64(t *testing.T) {
@@ -160,7 +160,7 @@ func TestExpandListOfInt64(t *testing.T) {
 			WantTarget: &[]*int32{},
 		},
 	}
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: false})
+	runAutoExpandTestCases(t, testCases, runChecks{})
 }
 
 func TestExpandSetOfInt64(t *testing.T) {
@@ -240,7 +240,7 @@ func TestExpandSetOfInt64(t *testing.T) {
 			WantTarget: &[]*int32{},
 		},
 	}
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: false})
+	runAutoExpandTestCases(t, testCases, runChecks{})
 }
 
 func TestExpandListOfStringEnum(t *testing.T) {
@@ -266,7 +266,7 @@ func TestExpandListOfStringEnum(t *testing.T) {
 			WantTarget: &[]testEnum{},
 		},
 	}
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: false})
+	runAutoExpandTestCases(t, testCases, runChecks{})
 }
 
 func TestExpandSetOfStringEnum(t *testing.T) {
@@ -292,7 +292,7 @@ func TestExpandSetOfStringEnum(t *testing.T) {
 			WantTarget: &[]testEnum{},
 		},
 	}
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: false})
+	runAutoExpandTestCases(t, testCases, runChecks{})
 }
 
 type tfListOfStringEnum struct {
@@ -338,7 +338,7 @@ func TestExpandStructListOfStringEnum(t *testing.T) {
 			WantTarget: &awsSliceOfStringEnum{},
 		},
 	}
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: false})
+	runAutoExpandTestCases(t, testCases, runChecks{})
 }
 
 type tfSetOfStringEnum struct {
@@ -380,7 +380,7 @@ func TestExpandStructSetOfStringEnum(t *testing.T) {
 			WantTarget: &awsSliceOfStringEnum{},
 		},
 	}
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: false})
+	runAutoExpandTestCases(t, testCases, runChecks{})
 }
 
 type tfSingleStringFieldIgnore struct {
@@ -407,7 +407,7 @@ func TestExpandIgnoreStructTag(t *testing.T) {
 		},
 	}
 
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: false})
+	runAutoExpandTestCases(t, testCases, runChecks{})
 }
 
 type TFExportedStruct struct {
@@ -460,7 +460,7 @@ func TestExpandEmbeddedStruct(t *testing.T) {
 			},
 		},
 	}
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: false})
+	runAutoExpandTestCases(t, testCases, runChecks{})
 }
 
 // List/Set/Map of string types.
@@ -579,7 +579,7 @@ func TestFlattenCollections(t *testing.T) {
 		},
 	}
 
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: false})
+	runAutoFlattenTestCases(t, testCases, runChecks{})
 }
 
 type awsSimpleStringValueSlice struct {
@@ -673,7 +673,7 @@ func TestFlattenSimpleListOfPrimitiveValues(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			runAutoFlattenTestCases(t, cases, runChecks{CompareDiags: false})
+			runAutoFlattenTestCases(t, cases, runChecks{})
 		})
 	}
 }
@@ -765,7 +765,7 @@ func TestFlattenSimpleSetOfPrimitiveValues(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			runAutoFlattenTestCases(t, cases, runChecks{CompareDiags: false})
+			runAutoFlattenTestCases(t, cases, runChecks{})
 		})
 	}
 }
@@ -790,7 +790,7 @@ func TestFlattenIgnoreStructTag(t *testing.T) {
 		},
 	}
 
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: false})
+	runAutoFlattenTestCases(t, testCases, runChecks{})
 }
 
 func TestFlattenStructListOfStringEnum(t *testing.T) {
@@ -835,7 +835,7 @@ func TestFlattenStructListOfStringEnum(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			runAutoFlattenTestCases(t, cases, runChecks{CompareDiags: false})
+			runAutoFlattenTestCases(t, cases, runChecks{})
 		})
 	}
 }
@@ -882,7 +882,7 @@ func TestFlattenStructSetOfStringEnum(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			runAutoFlattenTestCases(t, cases, runChecks{CompareDiags: false})
+			runAutoFlattenTestCases(t, cases, runChecks{})
 		})
 	}
 }
@@ -919,5 +919,5 @@ func TestFlattenEmbeddedStruct(t *testing.T) {
 		},
 	}
 	// cmp.Diff cannot handle an unexported field
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: false}, cmpopts.EquateComparable(tfUnexportedEmbeddedStruct{}))
+	runAutoFlattenTestCases(t, testCases, runChecks{}, cmpopts.EquateComparable(tfUnexportedEmbeddedStruct{}))
 }

--- a/internal/framework/flex/autoflex_collections_test.go
+++ b/internal/framework/flex/autoflex_collections_test.go
@@ -80,7 +80,7 @@ func TestExpandCollections(t *testing.T) {
 		},
 	}
 
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: false, CompareTarget: true})
+	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: false})
 }
 
 func TestExpandListOfInt64(t *testing.T) {
@@ -160,7 +160,7 @@ func TestExpandListOfInt64(t *testing.T) {
 			WantTarget: &[]*int32{},
 		},
 	}
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: false, CompareTarget: true})
+	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: false})
 }
 
 func TestExpandSetOfInt64(t *testing.T) {
@@ -240,7 +240,7 @@ func TestExpandSetOfInt64(t *testing.T) {
 			WantTarget: &[]*int32{},
 		},
 	}
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: false, CompareTarget: true})
+	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: false})
 }
 
 func TestExpandListOfStringEnum(t *testing.T) {
@@ -266,7 +266,7 @@ func TestExpandListOfStringEnum(t *testing.T) {
 			WantTarget: &[]testEnum{},
 		},
 	}
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: false, CompareTarget: true})
+	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: false})
 }
 
 func TestExpandSetOfStringEnum(t *testing.T) {
@@ -292,7 +292,7 @@ func TestExpandSetOfStringEnum(t *testing.T) {
 			WantTarget: &[]testEnum{},
 		},
 	}
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: false, CompareTarget: true})
+	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: false})
 }
 
 type tfListOfStringEnum struct {
@@ -338,7 +338,7 @@ func TestExpandStructListOfStringEnum(t *testing.T) {
 			WantTarget: &awsSliceOfStringEnum{},
 		},
 	}
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: false, CompareTarget: true})
+	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: false})
 }
 
 type tfSetOfStringEnum struct {
@@ -380,7 +380,7 @@ func TestExpandStructSetOfStringEnum(t *testing.T) {
 			WantTarget: &awsSliceOfStringEnum{},
 		},
 	}
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: false, CompareTarget: true})
+	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: false})
 }
 
 type tfSingleStringFieldIgnore struct {
@@ -407,7 +407,7 @@ func TestExpandIgnoreStructTag(t *testing.T) {
 		},
 	}
 
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: false, CompareTarget: true})
+	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: false})
 }
 
 type TFExportedStruct struct {
@@ -460,7 +460,7 @@ func TestExpandEmbeddedStruct(t *testing.T) {
 			},
 		},
 	}
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: false, CompareTarget: true})
+	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: false})
 }
 
 // List/Set/Map of string types.
@@ -579,7 +579,7 @@ func TestFlattenCollections(t *testing.T) {
 		},
 	}
 
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: false, CompareTarget: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: false})
 }
 
 type awsSimpleStringValueSlice struct {
@@ -673,7 +673,7 @@ func TestFlattenSimpleListOfPrimitiveValues(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			runAutoFlattenTestCases(t, cases, runChecks{CompareDiags: false, CompareTarget: true})
+			runAutoFlattenTestCases(t, cases, runChecks{CompareDiags: false})
 		})
 	}
 }
@@ -765,7 +765,7 @@ func TestFlattenSimpleSetOfPrimitiveValues(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			runAutoFlattenTestCases(t, cases, runChecks{CompareDiags: false, CompareTarget: true})
+			runAutoFlattenTestCases(t, cases, runChecks{CompareDiags: false})
 		})
 	}
 }
@@ -790,7 +790,7 @@ func TestFlattenIgnoreStructTag(t *testing.T) {
 		},
 	}
 
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: false, CompareTarget: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: false})
 }
 
 func TestFlattenStructListOfStringEnum(t *testing.T) {
@@ -835,7 +835,7 @@ func TestFlattenStructListOfStringEnum(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			runAutoFlattenTestCases(t, cases, runChecks{CompareDiags: false, CompareTarget: true})
+			runAutoFlattenTestCases(t, cases, runChecks{CompareDiags: false})
 		})
 	}
 }
@@ -882,7 +882,7 @@ func TestFlattenStructSetOfStringEnum(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			runAutoFlattenTestCases(t, cases, runChecks{CompareDiags: false, CompareTarget: true})
+			runAutoFlattenTestCases(t, cases, runChecks{CompareDiags: false})
 		})
 	}
 }
@@ -919,5 +919,5 @@ func TestFlattenEmbeddedStruct(t *testing.T) {
 		},
 	}
 	// cmp.Diff cannot handle an unexported field
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: false, CompareTarget: true}, cmpopts.EquateComparable(tfUnexportedEmbeddedStruct{}))
+	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: false}, cmpopts.EquateComparable(tfUnexportedEmbeddedStruct{}))
 }

--- a/internal/framework/flex/autoflex_dispatch_test.go
+++ b/internal/framework/flex/autoflex_dispatch_test.go
@@ -282,7 +282,7 @@ func TestExpandLogging_collections(t *testing.T) {
 		},
 	}
 
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: false})
+	runAutoExpandTestCases(t, testCases, runChecks{})
 }
 
 func TestExpandInterfaceContract(t *testing.T) {
@@ -296,7 +296,7 @@ func TestExpandInterfaceContract(t *testing.T) {
 		},
 	}
 
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true})
+	runAutoExpandTestCases(t, testCases, runChecks{})
 }
 
 func TestExpandExpander(t *testing.T) {
@@ -557,7 +557,7 @@ func TestExpandExpander(t *testing.T) {
 			},
 		},
 	}
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true})
+	runAutoExpandTestCases(t, testCases, runChecks{})
 }
 
 func testFlexAWSInterfaceInterfacePtr(v awsInterfaceInterface) *awsInterfaceInterface { // nosemgrep:ci.aws-in-func-name
@@ -709,7 +709,7 @@ func TestExpandInterface(t *testing.T) {
 			},
 		},
 	}
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true})
+	runAutoExpandTestCases(t, testCases, runChecks{})
 }
 
 func TestExpandInterfaceTypedExpander(t *testing.T) {
@@ -857,7 +857,7 @@ func TestExpandInterfaceTypedExpander(t *testing.T) {
 			},
 		},
 	}
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true})
+	runAutoExpandTestCases(t, testCases, runChecks{})
 }
 
 func TestExpandTypedExpander(t *testing.T) {
@@ -1104,7 +1104,7 @@ func TestExpandTypedExpander(t *testing.T) {
 			},
 		},
 	}
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true})
+	runAutoExpandTestCases(t, testCases, runChecks{})
 }
 
 func TestFlattenLogging_collections(t *testing.T) {
@@ -1162,7 +1162,7 @@ func TestFlattenLogging_collections(t *testing.T) {
 		},
 	}
 
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: false})
+	runAutoFlattenTestCases(t, testCases, runChecks{})
 }
 
 func TestFlattenInterfaceContract(t *testing.T) {
@@ -1196,7 +1196,7 @@ func TestFlattenInterfaceContract(t *testing.T) {
 		},
 	}
 
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{})
 }
 
 func TestFlattenInterface(t *testing.T) {
@@ -1381,7 +1381,7 @@ func TestFlattenInterface(t *testing.T) {
 			},
 		},
 	}
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{})
 }
 
 func TestFlattenFlattener(t *testing.T) {
@@ -1642,7 +1642,7 @@ func TestFlattenFlattener(t *testing.T) {
 			},
 		},
 	}
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{})
 }
 
 // TestFlattenFlattener_PointerToListNestedObject tests that AutoFlex properly calls
@@ -1681,7 +1681,7 @@ func TestFlattenFlattener_PointerToListNestedObject(t *testing.T) {
 			},
 		},
 	}
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{})
 }
 
 // Test types for TestFlattenFlattener_PointerToListNestedObject
@@ -1753,7 +1753,7 @@ func TestFlattenFlattener_StructValue(t *testing.T) {
 			},
 		},
 	}
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{})
 }
 
 // tfFlattenerStructValueModel is a Flattener that strictly requires a struct value.

--- a/internal/framework/flex/autoflex_dispatch_test.go
+++ b/internal/framework/flex/autoflex_dispatch_test.go
@@ -282,7 +282,7 @@ func TestExpandLogging_collections(t *testing.T) {
 		},
 	}
 
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: false, CompareTarget: true})
+	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: false})
 }
 
 func TestExpandInterfaceContract(t *testing.T) {
@@ -296,7 +296,7 @@ func TestExpandInterfaceContract(t *testing.T) {
 		},
 	}
 
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true, CompareTarget: true})
+	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true})
 }
 
 func TestExpandExpander(t *testing.T) {
@@ -557,7 +557,7 @@ func TestExpandExpander(t *testing.T) {
 			},
 		},
 	}
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true, CompareTarget: true})
+	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true})
 }
 
 func testFlexAWSInterfaceInterfacePtr(v awsInterfaceInterface) *awsInterfaceInterface { // nosemgrep:ci.aws-in-func-name
@@ -709,7 +709,7 @@ func TestExpandInterface(t *testing.T) {
 			},
 		},
 	}
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true, CompareTarget: true})
+	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true})
 }
 
 func TestExpandInterfaceTypedExpander(t *testing.T) {
@@ -857,7 +857,7 @@ func TestExpandInterfaceTypedExpander(t *testing.T) {
 			},
 		},
 	}
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true, CompareTarget: true})
+	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true})
 }
 
 func TestExpandTypedExpander(t *testing.T) {
@@ -1104,7 +1104,7 @@ func TestExpandTypedExpander(t *testing.T) {
 			},
 		},
 	}
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true, CompareTarget: true})
+	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true})
 }
 
 func TestFlattenLogging_collections(t *testing.T) {
@@ -1162,7 +1162,7 @@ func TestFlattenLogging_collections(t *testing.T) {
 		},
 	}
 
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: false, CompareTarget: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: false})
 }
 
 func TestFlattenInterfaceContract(t *testing.T) {
@@ -1196,7 +1196,7 @@ func TestFlattenInterfaceContract(t *testing.T) {
 		},
 	}
 
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true, CompareTarget: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true})
 }
 
 func TestFlattenInterface(t *testing.T) {
@@ -1381,7 +1381,7 @@ func TestFlattenInterface(t *testing.T) {
 			},
 		},
 	}
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true, CompareTarget: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true})
 }
 
 func TestFlattenFlattener(t *testing.T) {
@@ -1642,7 +1642,7 @@ func TestFlattenFlattener(t *testing.T) {
 			},
 		},
 	}
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true, CompareTarget: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true})
 }
 
 // TestFlattenFlattener_PointerToListNestedObject tests that AutoFlex properly calls
@@ -1681,7 +1681,7 @@ func TestFlattenFlattener_PointerToListNestedObject(t *testing.T) {
 			},
 		},
 	}
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true, CompareTarget: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true})
 }
 
 // Test types for TestFlattenFlattener_PointerToListNestedObject
@@ -1753,7 +1753,7 @@ func TestFlattenFlattener_StructValue(t *testing.T) {
 			},
 		},
 	}
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true, CompareTarget: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true})
 }
 
 // tfFlattenerStructValueModel is a Flattener that strictly requires a struct value.

--- a/internal/framework/flex/autoflex_maps_test.go
+++ b/internal/framework/flex/autoflex_maps_test.go
@@ -193,7 +193,7 @@ func TestExpandMaps(t *testing.T) {
 		},
 	}
 
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true, CompareTarget: true})
+	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true})
 }
 
 func TestExpandMapBlock(t *testing.T) {
@@ -374,7 +374,7 @@ func TestExpandMapBlock(t *testing.T) {
 			ExpectedDiags: diagAF[tfMapBlockElementNoKey](diagExpandingNoMapBlockKey),
 		},
 	}
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true, CompareTarget: true})
+	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true})
 }
 
 func TestFlattenMaps(t *testing.T) {
@@ -462,7 +462,7 @@ func TestFlattenMaps(t *testing.T) {
 		},
 	}
 
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true, CompareTarget: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true})
 }
 
 func TestFlattenMapBlock(t *testing.T) {
@@ -603,5 +603,5 @@ func TestFlattenMapBlock(t *testing.T) {
 			ExpectedDiags: diagAF[tfMapBlockElementNoKey](diagFlatteningNoMapBlockKey),
 		},
 	}
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true, CompareTarget: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true})
 }

--- a/internal/framework/flex/autoflex_maps_test.go
+++ b/internal/framework/flex/autoflex_maps_test.go
@@ -193,7 +193,7 @@ func TestExpandMaps(t *testing.T) {
 		},
 	}
 
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true})
+	runAutoExpandTestCases(t, testCases, runChecks{})
 }
 
 func TestExpandMapBlock(t *testing.T) {
@@ -374,7 +374,7 @@ func TestExpandMapBlock(t *testing.T) {
 			ExpectedDiags: diagAF[tfMapBlockElementNoKey](diagExpandingNoMapBlockKey),
 		},
 	}
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true})
+	runAutoExpandTestCases(t, testCases, runChecks{})
 }
 
 func TestFlattenMaps(t *testing.T) {
@@ -462,7 +462,7 @@ func TestFlattenMaps(t *testing.T) {
 		},
 	}
 
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{})
 }
 
 func TestFlattenMapBlock(t *testing.T) {
@@ -603,5 +603,5 @@ func TestFlattenMapBlock(t *testing.T) {
 			ExpectedDiags: diagAF[tfMapBlockElementNoKey](diagFlatteningNoMapBlockKey),
 		},
 	}
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{})
 }

--- a/internal/framework/flex/autoflex_naming_test.go
+++ b/internal/framework/flex/autoflex_naming_test.go
@@ -181,7 +181,7 @@ func TestExpandNaming(t *testing.T) {
 		},
 	}
 
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true, CompareTarget: true})
+	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true})
 }
 
 func TestExpandOptions(t *testing.T) {
@@ -254,7 +254,7 @@ func TestExpandOptions(t *testing.T) {
 			},
 		},
 	}
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true, CompareTarget: true})
+	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true})
 }
 
 func TestFindFieldFuzzy_Combinations(t *testing.T) {
@@ -373,7 +373,7 @@ func TestExpandFieldNamePrefix(t *testing.T) {
 		},
 	}
 
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true, CompareTarget: true})
+	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true})
 }
 
 func TestFlattenNaming(t *testing.T) {
@@ -499,7 +499,7 @@ func TestFlattenNaming(t *testing.T) {
 		},
 	}
 
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true, CompareTarget: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true})
 }
 
 func TestFlattenOptions(t *testing.T) {
@@ -585,5 +585,5 @@ func TestFlattenOptions(t *testing.T) {
 			},
 		},
 	}
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true, CompareTarget: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true})
 }

--- a/internal/framework/flex/autoflex_naming_test.go
+++ b/internal/framework/flex/autoflex_naming_test.go
@@ -181,7 +181,7 @@ func TestExpandNaming(t *testing.T) {
 		},
 	}
 
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true})
+	runAutoExpandTestCases(t, testCases, runChecks{})
 }
 
 func TestExpandOptions(t *testing.T) {
@@ -254,7 +254,7 @@ func TestExpandOptions(t *testing.T) {
 			},
 		},
 	}
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true})
+	runAutoExpandTestCases(t, testCases, runChecks{})
 }
 
 func TestFindFieldFuzzy_Combinations(t *testing.T) {
@@ -373,7 +373,7 @@ func TestExpandFieldNamePrefix(t *testing.T) {
 		},
 	}
 
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true})
+	runAutoExpandTestCases(t, testCases, runChecks{})
 }
 
 func TestFlattenNaming(t *testing.T) {
@@ -499,7 +499,7 @@ func TestFlattenNaming(t *testing.T) {
 		},
 	}
 
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{})
 }
 
 func TestFlattenOptions(t *testing.T) {
@@ -585,5 +585,5 @@ func TestFlattenOptions(t *testing.T) {
 			},
 		},
 	}
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{})
 }

--- a/internal/framework/flex/autoflex_nested_test.go
+++ b/internal/framework/flex/autoflex_nested_test.go
@@ -90,7 +90,7 @@ func TestExpandSimpleSingleNestedBlock(t *testing.T) {
 			WantTarget: &aws03{Field1: aws01{Field1: aws.String("a"), Field2: 1}},
 		},
 	}
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true, CompareTarget: true})
+	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true})
 }
 
 func TestExpandNestedComplex(t *testing.T) {
@@ -138,7 +138,7 @@ func TestExpandNestedComplex(t *testing.T) {
 		},
 	}
 
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true, CompareTarget: true})
+	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true})
 }
 
 func TestExpandComplexSingleNestedBlock(t *testing.T) {
@@ -195,7 +195,7 @@ func TestExpandComplexSingleNestedBlock(t *testing.T) {
 			},
 		},
 	}
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true, CompareTarget: true})
+	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true})
 }
 
 func TestExpandTopLevelListOfNestedObject(t *testing.T) {
@@ -286,7 +286,7 @@ func TestExpandTopLevelListOfNestedObject(t *testing.T) {
 			WantTarget: &awsSingleStringValue{},
 		},
 	}
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true, CompareTarget: true})
+	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true})
 }
 
 func TestExpandSetOfNestedObject(t *testing.T) {
@@ -377,7 +377,7 @@ func TestExpandSetOfNestedObject(t *testing.T) {
 			WantTarget: &awsSingleStringValue{},
 		},
 	}
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true, CompareTarget: true})
+	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true})
 }
 
 func TestExpandSimpleNestedBlockWithStringEnum(t *testing.T) {
@@ -416,7 +416,7 @@ func TestExpandSimpleNestedBlockWithStringEnum(t *testing.T) {
 			},
 		},
 	}
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true, CompareTarget: true})
+	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true})
 }
 
 func TestExpandComplexNestedBlockWithStringEnum(t *testing.T) {
@@ -470,7 +470,7 @@ func TestExpandComplexNestedBlockWithStringEnum(t *testing.T) {
 			},
 		},
 	}
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true, CompareTarget: true})
+	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true})
 }
 
 func TestExpandListOfNestedObjectField(t *testing.T) {
@@ -550,7 +550,7 @@ func TestExpandListOfNestedObjectField(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			runAutoExpandTestCases(t, cases, runChecks{CompareDiags: true, CompareTarget: true})
+			runAutoExpandTestCases(t, cases, runChecks{CompareDiags: true})
 		})
 	}
 }
@@ -615,7 +615,7 @@ func TestExpandSetOfNestedObjectField(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			runAutoExpandTestCases(t, cases, runChecks{CompareDiags: true, CompareTarget: true})
+			runAutoExpandTestCases(t, cases, runChecks{CompareDiags: true})
 		})
 	}
 }
@@ -654,7 +654,7 @@ func TestFlattenNestedComplex(t *testing.T) {
 		},
 	}
 
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true, CompareTarget: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true})
 }
 
 func TestFlattenSimpleNestedBlockWithStringEnum(t *testing.T) {
@@ -693,7 +693,7 @@ func TestFlattenSimpleNestedBlockWithStringEnum(t *testing.T) {
 			},
 		},
 	}
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true, CompareTarget: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true})
 }
 
 func TestFlattenComplexNestedBlockWithStringEnum(t *testing.T) {
@@ -760,7 +760,7 @@ func TestFlattenComplexNestedBlockWithStringEnum(t *testing.T) {
 			},
 		},
 	}
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true, CompareTarget: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true})
 }
 
 func TestFlattenSimpleSingleNestedBlock(t *testing.T) {
@@ -824,7 +824,7 @@ func TestFlattenSimpleSingleNestedBlock(t *testing.T) {
 			},
 		},
 	}
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true, CompareTarget: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true})
 }
 
 func TestFlattenComplexSingleNestedBlock(t *testing.T) {
@@ -878,7 +878,7 @@ func TestFlattenComplexSingleNestedBlock(t *testing.T) {
 			},
 		},
 	}
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true, CompareTarget: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true})
 }
 
 func TestFlattenSimpleNestedBlockWithFloat32(t *testing.T) {
@@ -900,7 +900,7 @@ func TestFlattenSimpleNestedBlockWithFloat32(t *testing.T) {
 			WantTarget: &tf01{Field1: types.Int64Value(1), Field2: types.Float64Value(0.01)},
 		},
 	}
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true, CompareTarget: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true})
 }
 
 func TestFlattenComplexNestedBlockWithFloat32(t *testing.T) {
@@ -943,7 +943,7 @@ func TestFlattenComplexNestedBlockWithFloat32(t *testing.T) {
 			},
 		},
 	}
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true, CompareTarget: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true})
 }
 
 func TestFlattenSimpleNestedBlockWithFloat64(t *testing.T) {
@@ -971,7 +971,7 @@ func TestFlattenSimpleNestedBlockWithFloat64(t *testing.T) {
 			},
 		},
 	}
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true, CompareTarget: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true})
 }
 
 func TestFlattenComplexNestedBlockWithFloat64(t *testing.T) {
@@ -1008,7 +1008,7 @@ func TestFlattenComplexNestedBlockWithFloat64(t *testing.T) {
 			WantTarget: &tf02{Field1: types.Int64Value(1), Field2: fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &tf01{Field1: types.Float64Value(1.11), Field2: types.Float64Value(-2.22)})},
 		},
 	}
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true, CompareTarget: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true})
 }
 
 func TestFlattenObjectValueField(t *testing.T) {
@@ -1045,7 +1045,7 @@ func TestFlattenObjectValueField(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			runAutoFlattenTestCases(t, cases, runChecks{CompareDiags: true, CompareTarget: true})
+			runAutoFlattenTestCases(t, cases, runChecks{CompareDiags: true})
 		})
 	}
 }
@@ -1243,7 +1243,7 @@ func TestFlattenListOfNestedObjectField(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			runAutoFlattenTestCases(t, cases, runChecks{CompareDiags: true, CompareTarget: true})
+			runAutoFlattenTestCases(t, cases, runChecks{CompareDiags: true})
 		})
 	}
 }
@@ -1284,7 +1284,7 @@ func TestFlattenTopLevelListOfNestedObject(t *testing.T) {
 		},
 	}
 
-	runTopLevelTestCases(t, testCases, runChecks{CompareDiags: true, CompareTarget: true})
+	runTopLevelTestCases(t, testCases, runChecks{CompareDiags: true})
 }
 
 func TestFlattenSetOfNestedObjectField(t *testing.T) {
@@ -1455,7 +1455,7 @@ func TestFlattenSetOfNestedObjectField(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			runAutoFlattenTestCases(t, cases, runChecks{CompareDiags: true, CompareTarget: true})
+			runAutoFlattenTestCases(t, cases, runChecks{CompareDiags: true})
 		})
 	}
 }

--- a/internal/framework/flex/autoflex_nested_test.go
+++ b/internal/framework/flex/autoflex_nested_test.go
@@ -90,7 +90,7 @@ func TestExpandSimpleSingleNestedBlock(t *testing.T) {
 			WantTarget: &aws03{Field1: aws01{Field1: aws.String("a"), Field2: 1}},
 		},
 	}
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true})
+	runAutoExpandTestCases(t, testCases, runChecks{})
 }
 
 func TestExpandNestedComplex(t *testing.T) {
@@ -138,7 +138,7 @@ func TestExpandNestedComplex(t *testing.T) {
 		},
 	}
 
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true})
+	runAutoExpandTestCases(t, testCases, runChecks{})
 }
 
 func TestExpandComplexSingleNestedBlock(t *testing.T) {
@@ -195,7 +195,7 @@ func TestExpandComplexSingleNestedBlock(t *testing.T) {
 			},
 		},
 	}
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true})
+	runAutoExpandTestCases(t, testCases, runChecks{})
 }
 
 func TestExpandTopLevelListOfNestedObject(t *testing.T) {
@@ -286,7 +286,7 @@ func TestExpandTopLevelListOfNestedObject(t *testing.T) {
 			WantTarget: &awsSingleStringValue{},
 		},
 	}
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true})
+	runAutoExpandTestCases(t, testCases, runChecks{})
 }
 
 func TestExpandSetOfNestedObject(t *testing.T) {
@@ -377,7 +377,7 @@ func TestExpandSetOfNestedObject(t *testing.T) {
 			WantTarget: &awsSingleStringValue{},
 		},
 	}
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true})
+	runAutoExpandTestCases(t, testCases, runChecks{})
 }
 
 func TestExpandSimpleNestedBlockWithStringEnum(t *testing.T) {
@@ -416,7 +416,7 @@ func TestExpandSimpleNestedBlockWithStringEnum(t *testing.T) {
 			},
 		},
 	}
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true})
+	runAutoExpandTestCases(t, testCases, runChecks{})
 }
 
 func TestExpandComplexNestedBlockWithStringEnum(t *testing.T) {
@@ -470,7 +470,7 @@ func TestExpandComplexNestedBlockWithStringEnum(t *testing.T) {
 			},
 		},
 	}
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true})
+	runAutoExpandTestCases(t, testCases, runChecks{})
 }
 
 func TestExpandListOfNestedObjectField(t *testing.T) {
@@ -550,7 +550,7 @@ func TestExpandListOfNestedObjectField(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			runAutoExpandTestCases(t, cases, runChecks{CompareDiags: true})
+			runAutoExpandTestCases(t, cases, runChecks{})
 		})
 	}
 }
@@ -615,7 +615,7 @@ func TestExpandSetOfNestedObjectField(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			runAutoExpandTestCases(t, cases, runChecks{CompareDiags: true})
+			runAutoExpandTestCases(t, cases, runChecks{})
 		})
 	}
 }
@@ -654,7 +654,7 @@ func TestFlattenNestedComplex(t *testing.T) {
 		},
 	}
 
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{})
 }
 
 func TestFlattenSimpleNestedBlockWithStringEnum(t *testing.T) {
@@ -693,7 +693,7 @@ func TestFlattenSimpleNestedBlockWithStringEnum(t *testing.T) {
 			},
 		},
 	}
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{})
 }
 
 func TestFlattenComplexNestedBlockWithStringEnum(t *testing.T) {
@@ -760,7 +760,7 @@ func TestFlattenComplexNestedBlockWithStringEnum(t *testing.T) {
 			},
 		},
 	}
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{})
 }
 
 func TestFlattenSimpleSingleNestedBlock(t *testing.T) {
@@ -824,7 +824,7 @@ func TestFlattenSimpleSingleNestedBlock(t *testing.T) {
 			},
 		},
 	}
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{})
 }
 
 func TestFlattenComplexSingleNestedBlock(t *testing.T) {
@@ -878,7 +878,7 @@ func TestFlattenComplexSingleNestedBlock(t *testing.T) {
 			},
 		},
 	}
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{})
 }
 
 func TestFlattenSimpleNestedBlockWithFloat32(t *testing.T) {
@@ -900,7 +900,7 @@ func TestFlattenSimpleNestedBlockWithFloat32(t *testing.T) {
 			WantTarget: &tf01{Field1: types.Int64Value(1), Field2: types.Float64Value(0.01)},
 		},
 	}
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{})
 }
 
 func TestFlattenComplexNestedBlockWithFloat32(t *testing.T) {
@@ -943,7 +943,7 @@ func TestFlattenComplexNestedBlockWithFloat32(t *testing.T) {
 			},
 		},
 	}
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{})
 }
 
 func TestFlattenSimpleNestedBlockWithFloat64(t *testing.T) {
@@ -971,7 +971,7 @@ func TestFlattenSimpleNestedBlockWithFloat64(t *testing.T) {
 			},
 		},
 	}
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{})
 }
 
 func TestFlattenComplexNestedBlockWithFloat64(t *testing.T) {
@@ -1008,7 +1008,7 @@ func TestFlattenComplexNestedBlockWithFloat64(t *testing.T) {
 			WantTarget: &tf02{Field1: types.Int64Value(1), Field2: fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &tf01{Field1: types.Float64Value(1.11), Field2: types.Float64Value(-2.22)})},
 		},
 	}
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{})
 }
 
 func TestFlattenObjectValueField(t *testing.T) {
@@ -1045,7 +1045,7 @@ func TestFlattenObjectValueField(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			runAutoFlattenTestCases(t, cases, runChecks{CompareDiags: true})
+			runAutoFlattenTestCases(t, cases, runChecks{})
 		})
 	}
 }
@@ -1243,7 +1243,7 @@ func TestFlattenListOfNestedObjectField(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			runAutoFlattenTestCases(t, cases, runChecks{CompareDiags: true})
+			runAutoFlattenTestCases(t, cases, runChecks{})
 		})
 	}
 }
@@ -1284,7 +1284,7 @@ func TestFlattenTopLevelListOfNestedObject(t *testing.T) {
 		},
 	}
 
-	runTopLevelTestCases(t, testCases, runChecks{CompareDiags: true})
+	runTopLevelTestCases(t, testCases, runChecks{})
 }
 
 func TestFlattenSetOfNestedObjectField(t *testing.T) {
@@ -1455,7 +1455,7 @@ func TestFlattenSetOfNestedObjectField(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			runAutoFlattenTestCases(t, cases, runChecks{CompareDiags: true})
+			runAutoFlattenTestCases(t, cases, runChecks{})
 		})
 	}
 }

--- a/internal/framework/flex/autoflex_nums_test.go
+++ b/internal/framework/flex/autoflex_nums_test.go
@@ -174,7 +174,7 @@ func TestExpandPrimitives(t *testing.T) {
 		},
 	}
 
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true})
+	runAutoExpandTestCases(t, testCases, runChecks{})
 }
 
 func TestExpandFloat64toFloat32(t *testing.T) {
@@ -307,7 +307,7 @@ func TestExpandFloat64toFloat32(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			runAutoExpandTestCases(t, cases, runChecks{CompareDiags: true})
+			runAutoExpandTestCases(t, cases, runChecks{})
 		})
 	}
 }
@@ -430,7 +430,7 @@ func TestExpandFloat32toFloat64(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			runAutoExpandTestCases(t, cases, runChecks{CompareDiags: true})
+			runAutoExpandTestCases(t, cases, runChecks{})
 		})
 	}
 }
@@ -565,7 +565,7 @@ func TestExpandInt64toInt32(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			runAutoExpandTestCases(t, cases, runChecks{CompareDiags: true})
+			runAutoExpandTestCases(t, cases, runChecks{})
 		})
 	}
 }
@@ -680,7 +680,7 @@ func TestExpandInt32toInt64(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			runAutoExpandTestCases(t, cases, runChecks{CompareDiags: true})
+			runAutoExpandTestCases(t, cases, runChecks{})
 		})
 	}
 }
@@ -740,7 +740,7 @@ func TestFlattenPrimitivePack(t *testing.T) {
 		},
 	}
 
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{})
 }
 
 func TestFlattenFloat64(t *testing.T) {
@@ -894,7 +894,7 @@ func TestFlattenFloat64(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			runAutoFlattenTestCases(t, cases, runChecks{CompareDiags: true})
+			runAutoFlattenTestCases(t, cases, runChecks{})
 		})
 	}
 }
@@ -1010,7 +1010,7 @@ func TestFlattenFloat32(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			runAutoFlattenTestCases(t, cases, runChecks{CompareDiags: true})
+			runAutoFlattenTestCases(t, cases, runChecks{})
 		})
 	}
 }
@@ -1166,7 +1166,7 @@ func TestFlattenInt64(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			runAutoFlattenTestCases(t, cases, runChecks{CompareDiags: true})
+			runAutoFlattenTestCases(t, cases, runChecks{})
 		})
 	}
 }
@@ -1282,7 +1282,7 @@ func TestFlattenInt32(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			runAutoFlattenTestCases(t, cases, runChecks{CompareDiags: true})
+			runAutoFlattenTestCases(t, cases, runChecks{})
 		})
 	}
 }
@@ -1310,5 +1310,5 @@ func TestFlattenTopLevelInt64Ptr(t *testing.T) {
 		},
 	}
 
-	runTopLevelTestCases(t, testCases, runChecks{CompareDiags: true})
+	runTopLevelTestCases(t, testCases, runChecks{})
 }

--- a/internal/framework/flex/autoflex_nums_test.go
+++ b/internal/framework/flex/autoflex_nums_test.go
@@ -174,7 +174,7 @@ func TestExpandPrimitives(t *testing.T) {
 		},
 	}
 
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true, CompareTarget: true})
+	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true})
 }
 
 func TestExpandFloat64toFloat32(t *testing.T) {
@@ -307,7 +307,7 @@ func TestExpandFloat64toFloat32(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			runAutoExpandTestCases(t, cases, runChecks{CompareDiags: true, CompareTarget: true})
+			runAutoExpandTestCases(t, cases, runChecks{CompareDiags: true})
 		})
 	}
 }
@@ -430,7 +430,7 @@ func TestExpandFloat32toFloat64(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			runAutoExpandTestCases(t, cases, runChecks{CompareDiags: true, CompareTarget: true})
+			runAutoExpandTestCases(t, cases, runChecks{CompareDiags: true})
 		})
 	}
 }
@@ -565,7 +565,7 @@ func TestExpandInt64toInt32(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			runAutoExpandTestCases(t, cases, runChecks{CompareDiags: true, CompareTarget: true})
+			runAutoExpandTestCases(t, cases, runChecks{CompareDiags: true})
 		})
 	}
 }
@@ -680,7 +680,7 @@ func TestExpandInt32toInt64(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			runAutoExpandTestCases(t, cases, runChecks{CompareDiags: true, CompareTarget: true})
+			runAutoExpandTestCases(t, cases, runChecks{CompareDiags: true})
 		})
 	}
 }
@@ -740,7 +740,7 @@ func TestFlattenPrimitivePack(t *testing.T) {
 		},
 	}
 
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true, CompareTarget: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true})
 }
 
 func TestFlattenFloat64(t *testing.T) {
@@ -894,7 +894,7 @@ func TestFlattenFloat64(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			runAutoFlattenTestCases(t, cases, runChecks{CompareDiags: true, CompareTarget: true})
+			runAutoFlattenTestCases(t, cases, runChecks{CompareDiags: true})
 		})
 	}
 }
@@ -1010,7 +1010,7 @@ func TestFlattenFloat32(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			runAutoFlattenTestCases(t, cases, runChecks{CompareDiags: true, CompareTarget: true})
+			runAutoFlattenTestCases(t, cases, runChecks{CompareDiags: true})
 		})
 	}
 }
@@ -1166,7 +1166,7 @@ func TestFlattenInt64(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			runAutoFlattenTestCases(t, cases, runChecks{CompareDiags: true, CompareTarget: true})
+			runAutoFlattenTestCases(t, cases, runChecks{CompareDiags: true})
 		})
 	}
 }
@@ -1282,7 +1282,7 @@ func TestFlattenInt32(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			runAutoFlattenTestCases(t, cases, runChecks{CompareDiags: true, CompareTarget: true})
+			runAutoFlattenTestCases(t, cases, runChecks{CompareDiags: true})
 		})
 	}
 }
@@ -1310,5 +1310,5 @@ func TestFlattenTopLevelInt64Ptr(t *testing.T) {
 		},
 	}
 
-	runTopLevelTestCases(t, testCases, runChecks{CompareDiags: true, CompareTarget: true})
+	runTopLevelTestCases(t, testCases, runChecks{CompareDiags: true})
 }

--- a/internal/framework/flex/autoflex_primitives_test.go
+++ b/internal/framework/flex/autoflex_primitives_test.go
@@ -176,7 +176,7 @@ func testStringRoundtrip(t *testing.T) {
 					runFlattenOnlyTest(t, testName, awsStruct, expectedTFResult)
 				} else {
 					// Use helper for all standard roundtrip cases
-					runBasicRoundtripTest(t, testName, variant, stringTypeInfo, tc.stringValue, tc.isNull, false, tc.isEmpty, runChecks{CompareTarget: true})
+					runBasicRoundtripTest(t, testName, variant, stringTypeInfo, tc.stringValue, tc.isNull, false, tc.isEmpty, runChecks{})
 				}
 			})
 		}
@@ -231,7 +231,7 @@ func testBoolRoundtrip(t *testing.T) {
 				// Use helper for all standard roundtrip cases
 				// Note: false value should be treated as "zero" for legacy mode
 				isZero := !tc.boolValue && !tc.isNull
-				runBasicRoundtripTest(t, testName, variant, boolTypeInfo, tc.boolValue, tc.isNull, isZero, false, runChecks{CompareTarget: true})
+				runBasicRoundtripTest(t, testName, variant, boolTypeInfo, tc.boolValue, tc.isNull, isZero, false, runChecks{})
 			})
 		}
 	}
@@ -279,7 +279,7 @@ func testInt64Roundtrip(t *testing.T) {
 			testName := tc.name + "_" + variant
 			t.Run(testName, func(t *testing.T) {
 				// Use helper for all roundtrip cases
-				runBasicRoundtripTest(t, testName, variant, int64TypeInfo, tc.int64Value, tc.isNull, tc.isZero, false, runChecks{CompareTarget: true})
+				runBasicRoundtripTest(t, testName, variant, int64TypeInfo, tc.int64Value, tc.isNull, tc.isZero, false, runChecks{})
 			})
 		}
 	}
@@ -327,7 +327,7 @@ func testInt32Roundtrip(t *testing.T) {
 			testName := tc.name + "_" + variant
 			t.Run(testName, func(t *testing.T) {
 				// Use helper for all roundtrip cases
-				runBasicRoundtripTest(t, testName, variant, int32TypeInfo, tc.int32Value, tc.isNull, tc.isZero, false, runChecks{CompareTarget: true})
+				runBasicRoundtripTest(t, testName, variant, int32TypeInfo, tc.int32Value, tc.isNull, tc.isZero, false, runChecks{})
 			})
 		}
 	}
@@ -381,7 +381,7 @@ func testFloat64Roundtrip(t *testing.T) {
 				}
 
 				// Use helper for all roundtrip cases
-				runBasicRoundtripTest(t, testName, variant, float64TypeInfo, tc.float64Value, tc.isNull, tc.isZero, false, runChecks{CompareTarget: true})
+				runBasicRoundtripTest(t, testName, variant, float64TypeInfo, tc.float64Value, tc.isNull, tc.isZero, false, runChecks{})
 			})
 		}
 	}
@@ -435,7 +435,7 @@ func testFloat32Roundtrip(t *testing.T) {
 				}
 
 				// Use helper for all roundtrip cases
-				runBasicRoundtripTest(t, testName, variant, float32TypeInfo, tc.float32Value, tc.isNull, tc.isZero, false, runChecks{CompareTarget: true})
+				runBasicRoundtripTest(t, testName, variant, float32TypeInfo, tc.float32Value, tc.isNull, tc.isZero, false, runChecks{})
 			})
 		}
 	}
@@ -695,15 +695,13 @@ func runRoundtripTest[T any](t *testing.T, tc RoundtripTestCase[T], checks runCh
 		}
 	}
 
-	if checks.CompareTarget {
-		if diff := cmp.Diff(expectedTF, flattenedTF); diff != "" {
-			t.Errorf("Roundtrip mismatch for %s (+got, -want): %s", tc.Name, diff)
-		}
+	if diff := cmp.Diff(expectedTF, flattenedTF); diff != "" {
+		t.Errorf("Roundtrip mismatch for %s (+got, -want): %s", tc.Name, diff)
+	}
 
-		// Step 4: Verify AWS structure matches expected
-		if diff := cmp.Diff(tc.AWSStruct, expandedAWS); diff != "" {
-			t.Errorf("AWS structure mismatch for %s (+got, -want): %s", tc.Name, diff)
-		}
+	// Step 4: Verify AWS structure matches expected
+	if diff := cmp.Diff(tc.AWSStruct, expandedAWS); diff != "" {
+		t.Errorf("AWS structure mismatch for %s (+got, -want): %s", tc.Name, diff)
 	}
 
 	// Golden log validation (if requested)

--- a/internal/framework/flex/autoflex_primitives_test.go
+++ b/internal/framework/flex/autoflex_primitives_test.go
@@ -614,11 +614,8 @@ func runRoundtripTest[T any](t *testing.T, tc RoundtripTestCase[T], checks runCh
 	expandedAWS := reflect.New(reflect.TypeOf(tc.AWSStruct).Elem()).Interface()
 	expandDiags := Expand(ctx, tc.TFStruct, expandedAWS, tc.Options...)
 
-	// Check diagnostics if requested
-	if checks.CompareDiags {
-		if diff := cmp.Diff(expandDiags, tc.ExpectedDiags); diff != "" {
-			t.Errorf("unexpected expand diagnostics difference: %s", diff)
-		}
+	if diff := cmp.Diff(expandDiags, tc.ExpectedDiags); diff != "" {
+		t.Errorf("unexpected expand diagnostics difference: %s", diff)
 	}
 
 	if tc.ExpectError {

--- a/internal/framework/flex/autoflex_special_types_test.go
+++ b/internal/framework/flex/autoflex_special_types_test.go
@@ -149,7 +149,7 @@ func TestExpandSpecialTypes(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			runAutoExpandTestCases(t, cases, runChecks{CompareDiags: true})
+			runAutoExpandTestCases(t, cases, runChecks{})
 		})
 	}
 }
@@ -221,7 +221,7 @@ func TestFlattenSpecialTypes(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			runAutoFlattenTestCases(t, cases, runChecks{CompareDiags: true})
+			runAutoFlattenTestCases(t, cases, runChecks{})
 		})
 	}
 }
@@ -311,5 +311,5 @@ func TestFlattenJSONInterfaceToStringTypable(t *testing.T) {
 		},
 	}
 
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{})
 }

--- a/internal/framework/flex/autoflex_special_types_test.go
+++ b/internal/framework/flex/autoflex_special_types_test.go
@@ -221,7 +221,7 @@ func TestFlattenSpecialTypes(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			runAutoExpandTestCases(t, cases, runChecks{CompareDiags: false})
+			runAutoFlattenTestCases(t, cases, runChecks{CompareDiags: true})
 		})
 	}
 }

--- a/internal/framework/flex/autoflex_special_types_test.go
+++ b/internal/framework/flex/autoflex_special_types_test.go
@@ -149,7 +149,7 @@ func TestExpandSpecialTypes(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			runAutoExpandTestCases(t, cases, runChecks{CompareDiags: true, CompareTarget: true})
+			runAutoExpandTestCases(t, cases, runChecks{CompareDiags: true})
 		})
 	}
 }
@@ -221,7 +221,7 @@ func TestFlattenSpecialTypes(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			runAutoExpandTestCases(t, cases, runChecks{CompareDiags: false, CompareTarget: true})
+			runAutoExpandTestCases(t, cases, runChecks{CompareDiags: false})
 		})
 	}
 }
@@ -311,5 +311,5 @@ func TestFlattenJSONInterfaceToStringTypable(t *testing.T) {
 		},
 	}
 
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true, CompareTarget: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true})
 }

--- a/internal/framework/flex/autoflex_strings_test.go
+++ b/internal/framework/flex/autoflex_strings_test.go
@@ -94,7 +94,7 @@ func TestExpandString(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			runAutoExpandTestCases(t, cases, runChecks{CompareDiags: true, CompareTarget: true})
+			runAutoExpandTestCases(t, cases, runChecks{CompareDiags: true})
 		})
 	}
 }
@@ -117,7 +117,7 @@ func TestExpandStringEnum(t *testing.T) {
 			WantTarget: &enum,
 		},
 	}
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true, CompareTarget: true})
+	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true})
 }
 
 type tfSingleStringFieldOmitEmpty struct {
@@ -244,7 +244,7 @@ func TestFlattenString(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			runAutoFlattenTestCases(t, cases, runChecks{CompareDiags: true, CompareTarget: true})
+			runAutoFlattenTestCases(t, cases, runChecks{CompareDiags: true})
 		})
 	}
 }
@@ -290,7 +290,7 @@ func TestFlattenStringSpecial(t *testing.T) {
 		},
 	}
 
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true, CompareTarget: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true})
 }
 
 func TestFlattenTopLevelStringPtr(t *testing.T) {
@@ -316,5 +316,5 @@ func TestFlattenTopLevelStringPtr(t *testing.T) {
 		},
 	}
 
-	runTopLevelTestCases(t, testCases, runChecks{CompareDiags: true, CompareTarget: true})
+	runTopLevelTestCases(t, testCases, runChecks{CompareDiags: true})
 }

--- a/internal/framework/flex/autoflex_strings_test.go
+++ b/internal/framework/flex/autoflex_strings_test.go
@@ -94,7 +94,7 @@ func TestExpandString(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			runAutoExpandTestCases(t, cases, runChecks{CompareDiags: true})
+			runAutoExpandTestCases(t, cases, runChecks{})
 		})
 	}
 }
@@ -117,7 +117,7 @@ func TestExpandStringEnum(t *testing.T) {
 			WantTarget: &enum,
 		},
 	}
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true})
+	runAutoExpandTestCases(t, testCases, runChecks{})
 }
 
 type tfSingleStringFieldOmitEmpty struct {
@@ -244,7 +244,7 @@ func TestFlattenString(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			runAutoFlattenTestCases(t, cases, runChecks{CompareDiags: true})
+			runAutoFlattenTestCases(t, cases, runChecks{})
 		})
 	}
 }
@@ -290,7 +290,7 @@ func TestFlattenStringSpecial(t *testing.T) {
 		},
 	}
 
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{})
 }
 
 func TestFlattenTopLevelStringPtr(t *testing.T) {
@@ -316,5 +316,5 @@ func TestFlattenTopLevelStringPtr(t *testing.T) {
 		},
 	}
 
-	runTopLevelTestCases(t, testCases, runChecks{CompareDiags: true})
+	runTopLevelTestCases(t, testCases, runChecks{})
 }

--- a/internal/framework/flex/autoflex_test.go
+++ b/internal/framework/flex/autoflex_test.go
@@ -32,7 +32,6 @@ type autoFlexTestCases map[string]autoFlexTestCase
 
 type runChecks struct {
 	CompareDiags   bool
-	CompareTarget  bool
 	SkipGoldenLogs bool // skip golden snapshots for log comparison
 	PrintLogs      bool // print logs to test output
 }
@@ -130,7 +129,7 @@ func runAutoExpandTestCases(t *testing.T, testCases autoFlexTestCases, checks ru
 				}
 			}
 
-			if checks.CompareTarget && !diags.HasError() {
+			if !diags.HasError() {
 				if diff := cmp.Diff(tc.Target, tc.WantTarget, opts...); diff != "" {
 					t.Errorf("unexpected diff (+wanted, -got): %s", diff)
 				}
@@ -183,7 +182,7 @@ func runAutoFlattenTestCases(t *testing.T, testCases autoFlexTestCases, checks r
 				}
 			}
 
-			if checks.CompareTarget && !diags.HasError() {
+			if !diags.HasError() {
 				less := func(a, b any) bool { return fmt.Sprintf("%+v", a) < fmt.Sprintf("%+v", b) }
 				if diff := cmp.Diff(testCase.Target, testCase.WantTarget, append(opts, cmpopts.SortSlices(less))...); diff != "" {
 					if !testCase.WantDiff {
@@ -239,7 +238,7 @@ func runTopLevelTestCases[Tsource, Ttarget any](t *testing.T, testCases toplevel
 				compareWithGolden(t, goldenPath, normalizedLines)
 			}
 
-			if checks.CompareTarget && !diags.HasError() {
+			if !diags.HasError() {
 				less := func(a, b any) bool { return fmt.Sprintf("%+v", a) < fmt.Sprintf("%+v", b) }
 				if diff := cmp.Diff(target, testCase.expectedValue, cmpopts.SortSlices(less)); diff != "" {
 					t.Errorf("unexpected diff (+wanted, -got): %s", diff)

--- a/internal/framework/flex/autoflex_test.go
+++ b/internal/framework/flex/autoflex_test.go
@@ -31,7 +31,6 @@ type autoFlexTestCase struct {
 type autoFlexTestCases map[string]autoFlexTestCase
 
 type runChecks struct {
-	CompareDiags   bool
 	SkipGoldenLogs bool // skip golden snapshots for log comparison
 	PrintLogs      bool // print logs to test output
 }
@@ -99,10 +98,8 @@ func runAutoExpandTestCases(t *testing.T, testCases autoFlexTestCases, checks ru
 
 			diags := Expand(ctx, tc.Source, tc.Target, tc.Options...)
 
-			if checks.CompareDiags {
-				if diff := cmp.Diff(diags, tc.ExpectedDiags); diff != "" {
-					t.Errorf("unexpected diagnostics difference: %s", diff)
-				}
+			if diff := cmp.Diff(diags, tc.ExpectedDiags); diff != "" {
+				t.Errorf("unexpected diagnostics difference: %s", diff)
 			}
 
 			if !checks.SkipGoldenLogs {
@@ -152,10 +149,8 @@ func runAutoFlattenTestCases(t *testing.T, testCases autoFlexTestCases, checks r
 
 			diags := Flatten(ctx, testCase.Source, testCase.Target, testCase.Options...)
 
-			if checks.CompareDiags {
-				if diff := cmp.Diff(diags, testCase.ExpectedDiags); diff != "" {
-					t.Errorf("unexpected diagnostics difference: %s", diff)
-				}
+			if diff := cmp.Diff(diags, testCase.ExpectedDiags); diff != "" {
+				t.Errorf("unexpected diagnostics difference: %s", diff)
 			}
 
 			if !checks.SkipGoldenLogs {
@@ -220,10 +215,8 @@ func runTopLevelTestCases[Tsource, Ttarget any](t *testing.T, testCases toplevel
 			var target Ttarget
 			diags := Flatten(ctx, testCase.source, &target)
 
-			if checks.CompareDiags {
-				if diff := cmp.Diff(diags, testCase.ExpectedDiags); diff != "" {
-					t.Errorf("unexpected diagnostics difference: %s", diff)
-				}
+			if diff := cmp.Diff(diags, testCase.ExpectedDiags); diff != "" {
+				t.Errorf("unexpected diagnostics difference: %s", diff)
 			}
 
 			if !checks.SkipGoldenLogs {

--- a/internal/framework/flex/autoflex_xml_compat_test.go
+++ b/internal/framework/flex/autoflex_xml_compat_test.go
@@ -122,7 +122,7 @@ func TestExpandXMLWrapper(t *testing.T) {
 		},
 	}
 
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true})
+	runAutoExpandTestCases(t, testCases, runChecks{})
 }
 
 // Test XML wrapper expansion for direct struct (not pointer to struct)
@@ -352,7 +352,7 @@ func TestFlattenXMLWrapper(t *testing.T) {
 		},
 	}
 
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{})
 }
 
 type FunctionAssociationsTF struct {
@@ -408,7 +408,7 @@ func TestExpandNoXMLWrapper(t *testing.T) {
 		},
 	}
 
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true})
+	runAutoExpandTestCases(t, testCases, runChecks{})
 }
 
 func TestFlattenNoXMLWrapper(t *testing.T) {
@@ -464,5 +464,5 @@ func TestFlattenNoXMLWrapper(t *testing.T) {
 		},
 	}
 
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{})
 }

--- a/internal/framework/flex/autoflex_xml_compat_test.go
+++ b/internal/framework/flex/autoflex_xml_compat_test.go
@@ -122,7 +122,7 @@ func TestExpandXMLWrapper(t *testing.T) {
 		},
 	}
 
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true, CompareTarget: true})
+	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true})
 }
 
 // Test XML wrapper expansion for direct struct (not pointer to struct)
@@ -352,7 +352,7 @@ func TestFlattenXMLWrapper(t *testing.T) {
 		},
 	}
 
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true, CompareTarget: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true})
 }
 
 type FunctionAssociationsTF struct {
@@ -408,7 +408,7 @@ func TestExpandNoXMLWrapper(t *testing.T) {
 		},
 	}
 
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true, CompareTarget: true})
+	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true})
 }
 
 func TestFlattenNoXMLWrapper(t *testing.T) {
@@ -464,5 +464,5 @@ func TestFlattenNoXMLWrapper(t *testing.T) {
 		},
 	}
 
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true, CompareTarget: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true})
 }

--- a/internal/framework/flex/autoflex_xml_wrapper_basic_test.go
+++ b/internal/framework/flex/autoflex_xml_wrapper_basic_test.go
@@ -60,7 +60,7 @@ func TestExpandXMLWrapperRule1SimpleType(t *testing.T) {
 		},
 	}
 
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true})
+	runAutoExpandTestCases(t, testCases, runChecks{})
 }
 
 // Rule 1 + Complex Type: Fruits/Apples/Apple example from context
@@ -113,7 +113,7 @@ func TestExpandXMLWrapperRule1ComplexType(t *testing.T) {
 		},
 	}
 
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true})
+	runAutoExpandTestCases(t, testCases, runChecks{})
 }
 
 // Rule 2 + Simple Type: Birds/Parrots example from context
@@ -178,7 +178,7 @@ func TestExpandXMLWrapperRule2SimpleType(t *testing.T) {
 		},
 	}
 
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true})
+	runAutoExpandTestCases(t, testCases, runChecks{})
 }
 
 func TestExpandXMLWrapperRule2SimpleTypeNoOmitEmpty(t *testing.T) {
@@ -214,7 +214,7 @@ func TestExpandXMLWrapperRule2SimpleTypeNoOmitEmpty(t *testing.T) {
 		},
 	}
 
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true})
+	runAutoExpandTestCases(t, testCases, runChecks{})
 }
 
 // Rule 2 + Complex Type: Trees/Oaks/Oak example from context
@@ -287,7 +287,7 @@ func TestExpandXMLWrapperRule2ComplexType(t *testing.T) {
 		},
 	}
 
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true})
+	runAutoExpandTestCases(t, testCases, runChecks{})
 }
 
 // Flatten tests for Rule 1 + Simple Type
@@ -335,7 +335,7 @@ func TestFlattenXMLWrapperRule1SimpleType(t *testing.T) {
 		},
 	}
 
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{})
 }
 
 // Flatten tests for Rule 1 + Complex Type
@@ -388,7 +388,7 @@ func TestFlattenXMLWrapperRule1ComplexType(t *testing.T) {
 		},
 	}
 
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: false, PrintLogs: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{PrintLogs: true})
 }
 
 // Flatten tests for Rule 2 + Simple Type
@@ -464,7 +464,7 @@ func TestFlattenXMLWrapperRule2SimpleType(t *testing.T) {
 		},
 	}
 
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{})
 }
 
 func TestFlattenXMLWrapperRule2SimpleTypeNoOmitEmpty(t *testing.T) {
@@ -508,7 +508,7 @@ func TestFlattenXMLWrapperRule2SimpleTypeNoOmitEmpty(t *testing.T) {
 		},
 	}
 
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{})
 }
 
 // Flatten tests for Rule 2 + Complex Type
@@ -592,5 +592,5 @@ func TestFlattenXMLWrapperRule2ComplexType(t *testing.T) {
 		},
 	}
 
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{})
 }

--- a/internal/framework/flex/autoflex_xml_wrapper_basic_test.go
+++ b/internal/framework/flex/autoflex_xml_wrapper_basic_test.go
@@ -60,7 +60,7 @@ func TestExpandXMLWrapperRule1SimpleType(t *testing.T) {
 		},
 	}
 
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true, CompareTarget: true})
+	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true})
 }
 
 // Rule 1 + Complex Type: Fruits/Apples/Apple example from context
@@ -113,7 +113,7 @@ func TestExpandXMLWrapperRule1ComplexType(t *testing.T) {
 		},
 	}
 
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true, CompareTarget: true})
+	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true})
 }
 
 // Rule 2 + Simple Type: Birds/Parrots example from context
@@ -178,7 +178,7 @@ func TestExpandXMLWrapperRule2SimpleType(t *testing.T) {
 		},
 	}
 
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true, CompareTarget: true})
+	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true})
 }
 
 func TestExpandXMLWrapperRule2SimpleTypeNoOmitEmpty(t *testing.T) {
@@ -214,7 +214,7 @@ func TestExpandXMLWrapperRule2SimpleTypeNoOmitEmpty(t *testing.T) {
 		},
 	}
 
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true, CompareTarget: true})
+	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true})
 }
 
 // Rule 2 + Complex Type: Trees/Oaks/Oak example from context
@@ -287,7 +287,7 @@ func TestExpandXMLWrapperRule2ComplexType(t *testing.T) {
 		},
 	}
 
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true, CompareTarget: true})
+	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true})
 }
 
 // Flatten tests for Rule 1 + Simple Type
@@ -335,7 +335,7 @@ func TestFlattenXMLWrapperRule1SimpleType(t *testing.T) {
 		},
 	}
 
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true, CompareTarget: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true})
 }
 
 // Flatten tests for Rule 1 + Complex Type
@@ -388,7 +388,7 @@ func TestFlattenXMLWrapperRule1ComplexType(t *testing.T) {
 		},
 	}
 
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: false, CompareTarget: true, PrintLogs: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: false, PrintLogs: true})
 }
 
 // Flatten tests for Rule 2 + Simple Type
@@ -464,7 +464,7 @@ func TestFlattenXMLWrapperRule2SimpleType(t *testing.T) {
 		},
 	}
 
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true, CompareTarget: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true})
 }
 
 func TestFlattenXMLWrapperRule2SimpleTypeNoOmitEmpty(t *testing.T) {
@@ -508,7 +508,7 @@ func TestFlattenXMLWrapperRule2SimpleTypeNoOmitEmpty(t *testing.T) {
 		},
 	}
 
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true, CompareTarget: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true})
 }
 
 // Flatten tests for Rule 2 + Complex Type
@@ -592,5 +592,5 @@ func TestFlattenXMLWrapperRule2ComplexType(t *testing.T) {
 		},
 	}
 
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true, CompareTarget: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true})
 }

--- a/internal/framework/flex/autoflex_xml_wrapper_test.go
+++ b/internal/framework/flex/autoflex_xml_wrapper_test.go
@@ -168,7 +168,7 @@ func TestExpandXMLWrapperRule1ScalarElements(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			runAutoExpandTestCases(t, cases, runChecks{CompareDiags: true})
+			runAutoExpandTestCases(t, cases, runChecks{})
 		})
 	}
 }
@@ -223,7 +223,7 @@ func TestExpandXMLWrapperRule1StructElements(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			runAutoExpandTestCases(t, cases, runChecks{CompareDiags: true})
+			runAutoExpandTestCases(t, cases, runChecks{})
 		})
 	}
 }
@@ -268,7 +268,7 @@ func TestFlattenXMLWrapperRule1ScalarElements(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			runAutoFlattenTestCases(t, cases, runChecks{CompareDiags: true})
+			runAutoFlattenTestCases(t, cases, runChecks{})
 		})
 	}
 }
@@ -324,7 +324,7 @@ func TestFlattenXMLWrapperRule1StructElements(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			runAutoFlattenTestCases(t, cases, runChecks{CompareDiags: true})
+			runAutoFlattenTestCases(t, cases, runChecks{})
 		})
 	}
 }
@@ -512,7 +512,7 @@ func TestExpandXMLWrapperRule2(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			runAutoExpandTestCases(t, cases, runChecks{CompareDiags: true})
+			runAutoExpandTestCases(t, cases, runChecks{})
 		})
 	}
 }
@@ -555,7 +555,7 @@ func TestFlattenXMLWrapperRule2(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			runAutoFlattenTestCases(t, cases, runChecks{CompareDiags: true})
+			runAutoFlattenTestCases(t, cases, runChecks{})
 		})
 	}
 }
@@ -1177,7 +1177,7 @@ func TestFlattenXMLWrapperSplitNested(t *testing.T) {
 		},
 	}
 
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{})
 }
 
 func TestFlattenXMLWrapperSplit(t *testing.T) {
@@ -1307,7 +1307,7 @@ func TestFlattenXMLWrapperSplit(t *testing.T) {
 		},
 	}
 
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{})
 }
 
 func TestExpandXMLWrapperSplit(t *testing.T) {
@@ -1448,7 +1448,7 @@ func TestExpandXMLWrapperSplit(t *testing.T) {
 		},
 	}
 
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true}, cmpopts.IgnoreUnexported(
+	runAutoExpandTestCases(t, testCases, runChecks{}, cmpopts.IgnoreUnexported(
 		awstypes.AllowedMethods{},
 		awstypes.CachedMethods{},
 	))

--- a/internal/framework/flex/autoflex_xml_wrapper_test.go
+++ b/internal/framework/flex/autoflex_xml_wrapper_test.go
@@ -168,7 +168,7 @@ func TestExpandXMLWrapperRule1ScalarElements(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			runAutoExpandTestCases(t, cases, runChecks{CompareDiags: true, CompareTarget: true})
+			runAutoExpandTestCases(t, cases, runChecks{CompareDiags: true})
 		})
 	}
 }
@@ -223,7 +223,7 @@ func TestExpandXMLWrapperRule1StructElements(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			runAutoExpandTestCases(t, cases, runChecks{CompareDiags: true, CompareTarget: true})
+			runAutoExpandTestCases(t, cases, runChecks{CompareDiags: true})
 		})
 	}
 }
@@ -268,7 +268,7 @@ func TestFlattenXMLWrapperRule1ScalarElements(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			runAutoFlattenTestCases(t, cases, runChecks{CompareDiags: true, CompareTarget: true})
+			runAutoFlattenTestCases(t, cases, runChecks{CompareDiags: true})
 		})
 	}
 }
@@ -324,7 +324,7 @@ func TestFlattenXMLWrapperRule1StructElements(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			runAutoFlattenTestCases(t, cases, runChecks{CompareDiags: true, CompareTarget: true})
+			runAutoFlattenTestCases(t, cases, runChecks{CompareDiags: true})
 		})
 	}
 }
@@ -512,7 +512,7 @@ func TestExpandXMLWrapperRule2(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			runAutoExpandTestCases(t, cases, runChecks{CompareDiags: true, CompareTarget: true})
+			runAutoExpandTestCases(t, cases, runChecks{CompareDiags: true})
 		})
 	}
 }
@@ -555,7 +555,7 @@ func TestFlattenXMLWrapperRule2(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			runAutoFlattenTestCases(t, cases, runChecks{CompareDiags: true, CompareTarget: true})
+			runAutoFlattenTestCases(t, cases, runChecks{CompareDiags: true})
 		})
 	}
 }
@@ -1177,7 +1177,7 @@ func TestFlattenXMLWrapperSplitNested(t *testing.T) {
 		},
 	}
 
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true, CompareTarget: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true})
 }
 
 func TestFlattenXMLWrapperSplit(t *testing.T) {
@@ -1307,7 +1307,7 @@ func TestFlattenXMLWrapperSplit(t *testing.T) {
 		},
 	}
 
-	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true, CompareTarget: true})
+	runAutoFlattenTestCases(t, testCases, runChecks{CompareDiags: true})
 }
 
 func TestExpandXMLWrapperSplit(t *testing.T) {
@@ -1448,7 +1448,7 @@ func TestExpandXMLWrapperSplit(t *testing.T) {
 		},
 	}
 
-	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true, CompareTarget: true}, cmpopts.IgnoreUnexported(
+	runAutoExpandTestCases(t, testCases, runChecks{CompareDiags: true}, cmpopts.IgnoreUnexported(
 		awstypes.AllowedMethods{},
 		awstypes.CachedMethods{},
 	))

--- a/internal/framework/flex/autoflex_xml_wrapper_test.go
+++ b/internal/framework/flex/autoflex_xml_wrapper_test.go
@@ -87,20 +87,6 @@ func TestExpandXMLWrapperRule1ScalarElements(t *testing.T) {
 	ctx := context.Background()
 
 	testCases := map[string]autoFlexTestCases{
-		"OriginSslProtocols": {
-			"null set": {
-				Source:     fwtypes.NewSetValueOfNull[fwtypes.StringEnum[awstypes.SslProtocol]](ctx),
-				Target:     &awstypes.OriginSslProtocols{},
-				WantTarget: (*awstypes.OriginSslProtocols)(nil),
-			},
-			"single protocol": {
-				Source: fwtypes.NewSetValueOfMust[fwtypes.StringEnum[awstypes.SslProtocol]](ctx, []attr.Value{
-					fwtypes.StringEnumValue(awstypes.SslProtocolTLSv12),
-				}),
-				Target:     &awstypes.OriginSslProtocols{},
-				WantTarget: &awstypes.OriginSslProtocols{Items: []awstypes.SslProtocol{awstypes.SslProtocolTLSv12}, Quantity: aws.Int32(1)},
-			},
-		},
 		"TestXMLWrapperScalar": func() autoFlexTestCases {
 			type tfModel struct {
 				Field fwtypes.SetValueOf[types.String] `tfsdk:"field" autoflex:",xmlwrapper=Items,omitempty"`
@@ -182,11 +168,7 @@ func TestExpandXMLWrapperRule1ScalarElements(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			if testName == "OriginSslProtocols" {
-				runAutoExpandTestCases(t, cases, runChecks{CompareDiags: true, CompareTarget: false})
-			} else {
-				runAutoExpandTestCases(t, cases, runChecks{CompareDiags: true, CompareTarget: true})
-			}
+			runAutoExpandTestCases(t, cases, runChecks{CompareDiags: true, CompareTarget: true})
 		})
 	}
 }

--- a/internal/framework/flex/testdata/autoflex/special_types/flatten_special_types/single_arn/single_nil_pointer_string_source_and_single_arn_target.golden
+++ b/internal/framework/flex/testdata/autoflex/special_types/flatten_special_types/single_arn/single_nil_pointer_string_source_and_single_arn_target.golden
@@ -1,9 +1,18 @@
 [
   {
     "@level": "info",
-    "@message": "Expanding",
+    "@message": "Flattening",
     "@module": "provider.autoflex",
     "autoflex.source.type": "*github.com/hashicorp/terraform-provider-aws/internal/framework/flex.awsSingleStringPointer",
+    "autoflex.target.type": "*github.com/hashicorp/terraform-provider-aws/internal/framework/flex.tfSingleARNField"
+  },
+  {
+    "@level": "trace",
+    "@message": "Source is not XML wrapper struct",
+    "@module": "provider.autoflex",
+    "autoflex.source.path": "",
+    "autoflex.source.type": "github.com/hashicorp/terraform-provider-aws/internal/framework/flex.awsSingleStringPointer",
+    "autoflex.target.path": "",
     "autoflex.target.type": "*github.com/hashicorp/terraform-provider-aws/internal/framework/flex.tfSingleARNField"
   },
   {
@@ -29,15 +38,6 @@
   {
     "@level": "info",
     "@message": "Converting",
-    "@module": "provider.autoflex",
-    "autoflex.source.path": "Field1",
-    "autoflex.source.type": "*string",
-    "autoflex.target.path": "Field1",
-    "autoflex.target.type": "github.com/hashicorp/terraform-provider-aws/internal/framework/types.ARN"
-  },
-  {
-    "@level": "error",
-    "@message": "Source does not implement attr.Value",
     "@module": "provider.autoflex",
     "autoflex.source.path": "Field1",
     "autoflex.source.type": "*string",

--- a/internal/framework/flex/testdata/autoflex/special_types/flatten_special_types/single_arn/single_pointer_string_source_and_single_arn_target.golden
+++ b/internal/framework/flex/testdata/autoflex/special_types/flatten_special_types/single_arn/single_pointer_string_source_and_single_arn_target.golden
@@ -1,9 +1,18 @@
 [
   {
     "@level": "info",
-    "@message": "Expanding",
+    "@message": "Flattening",
     "@module": "provider.autoflex",
     "autoflex.source.type": "*github.com/hashicorp/terraform-provider-aws/internal/framework/flex.awsSingleStringPointer",
+    "autoflex.target.type": "*github.com/hashicorp/terraform-provider-aws/internal/framework/flex.tfSingleARNField"
+  },
+  {
+    "@level": "trace",
+    "@message": "Source is not XML wrapper struct",
+    "@module": "provider.autoflex",
+    "autoflex.source.path": "",
+    "autoflex.source.type": "github.com/hashicorp/terraform-provider-aws/internal/framework/flex.awsSingleStringPointer",
+    "autoflex.target.path": "",
     "autoflex.target.type": "*github.com/hashicorp/terraform-provider-aws/internal/framework/flex.tfSingleARNField"
   },
   {
@@ -29,15 +38,6 @@
   {
     "@level": "info",
     "@message": "Converting",
-    "@module": "provider.autoflex",
-    "autoflex.source.path": "Field1",
-    "autoflex.source.type": "*string",
-    "autoflex.target.path": "Field1",
-    "autoflex.target.type": "github.com/hashicorp/terraform-provider-aws/internal/framework/types.ARN"
-  },
-  {
-    "@level": "error",
-    "@message": "Source does not implement attr.Value",
     "@module": "provider.autoflex",
     "autoflex.source.path": "Field1",
     "autoflex.source.type": "*string",

--- a/internal/framework/flex/testdata/autoflex/special_types/flatten_special_types/single_arn/single_string_source_and_single_arn_target.golden
+++ b/internal/framework/flex/testdata/autoflex/special_types/flatten_special_types/single_arn/single_string_source_and_single_arn_target.golden
@@ -1,9 +1,18 @@
 [
   {
     "@level": "info",
-    "@message": "Expanding",
+    "@message": "Flattening",
     "@module": "provider.autoflex",
     "autoflex.source.type": "*github.com/hashicorp/terraform-provider-aws/internal/framework/flex.awsSingleStringValue",
+    "autoflex.target.type": "*github.com/hashicorp/terraform-provider-aws/internal/framework/flex.tfSingleARNField"
+  },
+  {
+    "@level": "trace",
+    "@message": "Source is not XML wrapper struct",
+    "@module": "provider.autoflex",
+    "autoflex.source.path": "",
+    "autoflex.source.type": "github.com/hashicorp/terraform-provider-aws/internal/framework/flex.awsSingleStringValue",
+    "autoflex.target.path": "",
     "autoflex.target.type": "*github.com/hashicorp/terraform-provider-aws/internal/framework/flex.tfSingleARNField"
   },
   {
@@ -29,15 +38,6 @@
   {
     "@level": "info",
     "@message": "Converting",
-    "@module": "provider.autoflex",
-    "autoflex.source.path": "Field1",
-    "autoflex.source.type": "string",
-    "autoflex.target.path": "Field1",
-    "autoflex.target.type": "github.com/hashicorp/terraform-provider-aws/internal/framework/types.ARN"
-  },
-  {
-    "@level": "error",
-    "@message": "Source does not implement attr.Value",
     "@module": "provider.autoflex",
     "autoflex.source.path": "Field1",
     "autoflex.source.type": "string",

--- a/internal/framework/flex/testdata/autoflex/special_types/flatten_special_types/timestamp/timestamp.golden
+++ b/internal/framework/flex/testdata/autoflex/special_types/flatten_special_types/timestamp/timestamp.golden
@@ -1,9 +1,18 @@
 [
   {
     "@level": "info",
-    "@message": "Expanding",
+    "@message": "Flattening",
     "@module": "provider.autoflex",
     "autoflex.source.type": "*github.com/hashicorp/terraform-provider-aws/internal/framework/flex.awsRFC3339TimeValue",
+    "autoflex.target.type": "*github.com/hashicorp/terraform-provider-aws/internal/framework/flex.tfRFC3339Time"
+  },
+  {
+    "@level": "trace",
+    "@message": "Source is not XML wrapper struct",
+    "@module": "provider.autoflex",
+    "autoflex.source.path": "",
+    "autoflex.source.type": "github.com/hashicorp/terraform-provider-aws/internal/framework/flex.awsRFC3339TimeValue",
+    "autoflex.target.path": "",
     "autoflex.target.type": "*github.com/hashicorp/terraform-provider-aws/internal/framework/flex.tfRFC3339Time"
   },
   {
@@ -29,15 +38,6 @@
   {
     "@level": "info",
     "@message": "Converting",
-    "@module": "provider.autoflex",
-    "autoflex.source.path": "CreationDateTime",
-    "autoflex.source.type": "time.Time",
-    "autoflex.target.path": "CreationDateTime",
-    "autoflex.target.type": "github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes.RFC3339"
-  },
-  {
-    "@level": "error",
-    "@message": "Source does not implement attr.Value",
     "@module": "provider.autoflex",
     "autoflex.source.path": "CreationDateTime",
     "autoflex.source.type": "time.Time",

--- a/internal/framework/flex/testdata/autoflex/special_types/flatten_special_types/timestamp/timestamp_empty.golden
+++ b/internal/framework/flex/testdata/autoflex/special_types/flatten_special_types/timestamp/timestamp_empty.golden
@@ -1,9 +1,18 @@
 [
   {
     "@level": "info",
-    "@message": "Expanding",
+    "@message": "Flattening",
     "@module": "provider.autoflex",
     "autoflex.source.type": "*github.com/hashicorp/terraform-provider-aws/internal/framework/flex.awsRFC3339TimeValue",
+    "autoflex.target.type": "*github.com/hashicorp/terraform-provider-aws/internal/framework/flex.tfRFC3339Time"
+  },
+  {
+    "@level": "trace",
+    "@message": "Source is not XML wrapper struct",
+    "@module": "provider.autoflex",
+    "autoflex.source.path": "",
+    "autoflex.source.type": "github.com/hashicorp/terraform-provider-aws/internal/framework/flex.awsRFC3339TimeValue",
+    "autoflex.target.path": "",
     "autoflex.target.type": "*github.com/hashicorp/terraform-provider-aws/internal/framework/flex.tfRFC3339Time"
   },
   {
@@ -29,15 +38,6 @@
   {
     "@level": "info",
     "@message": "Converting",
-    "@module": "provider.autoflex",
-    "autoflex.source.path": "CreationDateTime",
-    "autoflex.source.type": "time.Time",
-    "autoflex.target.path": "CreationDateTime",
-    "autoflex.target.type": "github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes.RFC3339"
-  },
-  {
-    "@level": "error",
-    "@message": "Source does not implement attr.Value",
     "@module": "provider.autoflex",
     "autoflex.source.path": "CreationDateTime",
     "autoflex.source.type": "time.Time",

--- a/internal/framework/flex/testdata/autoflex/special_types/flatten_special_types/timestamp/timestamp_nil.golden
+++ b/internal/framework/flex/testdata/autoflex/special_types/flatten_special_types/timestamp/timestamp_nil.golden
@@ -1,9 +1,18 @@
 [
   {
     "@level": "info",
-    "@message": "Expanding",
+    "@message": "Flattening",
     "@module": "provider.autoflex",
     "autoflex.source.type": "*github.com/hashicorp/terraform-provider-aws/internal/framework/flex.awsRFC3339TimePointer",
+    "autoflex.target.type": "*github.com/hashicorp/terraform-provider-aws/internal/framework/flex.tfRFC3339Time"
+  },
+  {
+    "@level": "trace",
+    "@message": "Source is not XML wrapper struct",
+    "@module": "provider.autoflex",
+    "autoflex.source.path": "",
+    "autoflex.source.type": "github.com/hashicorp/terraform-provider-aws/internal/framework/flex.awsRFC3339TimePointer",
+    "autoflex.target.path": "",
     "autoflex.target.type": "*github.com/hashicorp/terraform-provider-aws/internal/framework/flex.tfRFC3339Time"
   },
   {
@@ -29,15 +38,6 @@
   {
     "@level": "info",
     "@message": "Converting",
-    "@module": "provider.autoflex",
-    "autoflex.source.path": "CreationDateTime",
-    "autoflex.source.type": "*time.Time",
-    "autoflex.target.path": "CreationDateTime",
-    "autoflex.target.type": "github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes.RFC3339"
-  },
-  {
-    "@level": "error",
-    "@message": "Source does not implement attr.Value",
     "@module": "provider.autoflex",
     "autoflex.source.path": "CreationDateTime",
     "autoflex.source.type": "*time.Time",

--- a/internal/framework/flex/testdata/autoflex/special_types/flatten_special_types/timestamp/timestamp_pointer.golden
+++ b/internal/framework/flex/testdata/autoflex/special_types/flatten_special_types/timestamp/timestamp_pointer.golden
@@ -1,9 +1,18 @@
 [
   {
     "@level": "info",
-    "@message": "Expanding",
+    "@message": "Flattening",
     "@module": "provider.autoflex",
     "autoflex.source.type": "*github.com/hashicorp/terraform-provider-aws/internal/framework/flex.awsRFC3339TimePointer",
+    "autoflex.target.type": "*github.com/hashicorp/terraform-provider-aws/internal/framework/flex.tfRFC3339Time"
+  },
+  {
+    "@level": "trace",
+    "@message": "Source is not XML wrapper struct",
+    "@module": "provider.autoflex",
+    "autoflex.source.path": "",
+    "autoflex.source.type": "github.com/hashicorp/terraform-provider-aws/internal/framework/flex.awsRFC3339TimePointer",
+    "autoflex.target.path": "",
     "autoflex.target.type": "*github.com/hashicorp/terraform-provider-aws/internal/framework/flex.tfRFC3339Time"
   },
   {
@@ -29,15 +38,6 @@
   {
     "@level": "info",
     "@message": "Converting",
-    "@module": "provider.autoflex",
-    "autoflex.source.path": "CreationDateTime",
-    "autoflex.source.type": "*time.Time",
-    "autoflex.target.path": "CreationDateTime",
-    "autoflex.target.type": "github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes.RFC3339"
-  },
-  {
-    "@level": "error",
-    "@message": "Source does not implement attr.Value",
     "@module": "provider.autoflex",
     "autoflex.source.path": "CreationDateTime",
     "autoflex.source.type": "*time.Time",


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Now always checks `diags` and compares expected result.

Fixes direction of test `TestFlattenSpecialTypes`