### PR TITLE
elbv2: validate target group health check interval against timeout

### DIFF
--- a/internal/service/elbv2/target_group.go
+++ b/internal/service/elbv2/target_group.go
@@ -1091,6 +1091,14 @@ func resourceTargetGroupCustomizeDiff(_ context.Context, diff *schema.ResourceDi
 
 	healthCheckPath := cty.GetAttrPath(names.AttrHealthCheck).IndexInt(0)
 
+	if interval, ok := healthCheck[names.AttrInterval].(int); ok {
+		if timeout, ok := healthCheck[names.AttrTimeout].(int); ok {
+			if err := validateTargetGroupHealthCheckIntervalTimeout(healthCheckPath, interval, timeout); err != nil {
+				return err
+			}
+		}
+	}
+
 	if p, ok := healthCheck[names.AttrProtocol].(string); ok && strings.ToUpper(p) == string(awstypes.ProtocolEnumTcp) {
 		if m := healthCheck["matcher"].(string); m != "" {
 			return sdkdiag.DiagnosticError(errs.NewAttributeConflictsWhenError(
@@ -1125,6 +1133,27 @@ func resourceTargetGroupCustomizeDiff(_ context.Context, diff *schema.ResourceDi
 
 	if diff.Id() == "" {
 		return nil
+	}
+
+	return nil
+}
+
+func validateTargetGroupHealthCheckIntervalTimeout(healthCheckPath cty.Path, interval, timeout int) error {
+	if timeout == 0 {
+		return nil
+	}
+
+	if interval <= timeout {
+		intervalPath := healthCheckPath.GetAttr(names.AttrInterval)
+		timeoutPath := healthCheckPath.GetAttr(names.AttrTimeout)
+
+		return sdkdiag.DiagnosticError(errs.NewInvalidValueAttributeCombinationError(
+			intervalPath,
+			fmt.Sprintf("Attribute %q must be greater than %q.",
+				errs.PathString(intervalPath),
+				errs.PathString(timeoutPath),
+			),
+		))
 	}
 
 	return nil

--- a/internal/service/elbv2/validate_test.go
+++ b/internal/service/elbv2/validate_test.go
@@ -4,8 +4,10 @@
 package elbv2
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/hashicorp/go-cty/cty"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -126,5 +128,58 @@ func TestValidTargetGroupNamePrefix(t *testing.T) {
 		if len(errors) != tc.ErrCount {
 			t.Fatalf("Expected the AWS LB Target Group Name to trigger a validation error for %q", tc.Value)
 		}
+	}
+}
+
+func TestValidateTargetGroupHealthCheckIntervalTimeout(t *testing.T) {
+	t.Parallel()
+
+	healthCheckPath := cty.GetAttrPath(names.AttrHealthCheck).IndexInt(0)
+
+	testCases := []struct {
+		name     string
+		interval int
+		timeout  int
+		wantErr  string
+	}{
+		{
+			name:     "interval_greater_than_timeout",
+			interval: 6,
+			timeout:  5,
+		},
+		{
+			name:     "interval_equals_timeout",
+			interval: 5,
+			timeout:  5,
+			wantErr:  `Attribute "health_check[0].interval" must be greater than "health_check[0].timeout".`,
+		},
+		{
+			name:     "interval_less_than_timeout",
+			interval: 4,
+			timeout:  5,
+			wantErr:  `Attribute "health_check[0].interval" must be greater than "health_check[0].timeout".`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateTargetGroupHealthCheckIntervalTimeout(healthCheckPath, tc.interval, tc.timeout)
+
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("expected no error, got %v", err)
+				}
+
+				return
+			}
+
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+
+			if got := err.Error(); !strings.Contains(got, tc.wantErr) {
+				t.Fatalf("expected error containing %q, got %q", tc.wantErr, got)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Rollback plan

Revert this PR.

## Changes to security controls

None.

## Description

Add plan-time validation for `aws_lb_target_group.health_check` so `interval` must be greater than `timeout`.

AWS already rejects configurations where `interval <= timeout`, but the provider only validates the two fields independently today. This change moves that failure into provider validation and adds focused unit coverage for the helper.

## Relations

Closes #48070

## References

- AWS API error: `ValidationError: Health check interval must be greater than the timeout.`

## Output from Acceptance Testing

```console
$ go test ./internal/service/elbv2 -run TestValidateTargetGroupHealthCheckIntervalTimeout
ok   github.com/hashicorp/terraform-provider-aws/internal/service/elbv2 (cached)
```