### PR TITLE
 docs: aws_instance: Document `interruptible-capacity-reservation` as supported a `market_type`

### DIFF
--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -373,7 +373,7 @@ The `maintenance_options` block supports the following:
 
 The `instance_market_options` block supports the following:
 
-* `market_type` - (Optional) Type of market for the instance. Valid values are `spot` and `capacity-block`. Defaults to `spot`. Required if `spot_options` is specified.
+* `market_type` - (Optional) Type of market for the instance. Valid values are `spot`, `capacity-block`, and `interruptible-capacity-reservation`. Use `interruptible-capacity-reservation` to launch instances into [interruptible Capacity Reservations](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/capacity-consumer-procedures.html). Defaults to `spot`. Required if `spot_options` is specified.
 * `spot_options` - (Optional) Block to configure the options for Spot Instances. See [Spot Options](#spot-options) below for details on attributes.
 
 ### Metadata Options


### PR DESCRIPTION


### Description
Add `interruptible-capacity-reservation` as a supported `market-type` for r/aws_instance in docs

The aws_instance resource's `instance_market_options.market_type` field is validated dynamically against the `awstypes.MarketType` enum from the aws-sdk-go-v2 EC2 service, which has supported
`interruptible-capacity-reservation` since the EC2 SDK bump late 2025 (around provider v6.23.0). The user-facing docs only listed `spot` and `capacity-block`. This adds the missing value.

The `interruptible-capacity-reservation` value is used to launch instances from interruptible On-Demand Capacity Reservations (iODCRs) and uses the same `instance_market_options` setup as Capacity Blocks.



### References
[AWS user guide — Launch instances into interruptible reservations](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/capacity-consumer-procedures.html)
SDK enum source: [aws-sdk-go-v2/service/ec2/types/enums.go](https://github.com/aws/aws-sdk-go-v2/blob/main/service/ec2/types/enums.go) — MarketTypeInterruptibleCapacityReservation


