### PR TITLE
New data source: `aws_rds_global_clusters`

### DIFF
--- a/.changelog/48074.txt
+++ b/.changelog/48074.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_rds_global_clusters
+```

--- a/internal/service/rds/global_clusters_data_source.go
+++ b/internal/service/rds/global_clusters_data_source.go
@@ -1,0 +1,164 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package rds
+
+import (
+	"context"
+	"slices"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/rds"
+	"github.com/aws/aws-sdk-go-v2/service/rds/types"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	fwtypes "github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwflextypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkDataSource("aws_rds_global_clusters", name="Global Clusters")
+func newDataSourceGlobalClusters(context.Context) (datasource.DataSourceWithConfigure, error) {
+	return &dataSourceGlobalClusters{}, nil
+}
+
+type dataSourceGlobalClusters struct {
+	framework.DataSourceWithModel[dataSourceGlobalClustersModel]
+}
+
+func (d *dataSourceGlobalClusters) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			names.AttrID: framework.IDAttribute(),
+			"global_cluster_identifiers": schema.ListAttribute{
+				CustomType:  fwflextypes.ListOfStringType,
+				ElementType: fwtypes.StringType,
+				Computed:    true,
+			},
+			"global_cluster_arns": schema.ListAttribute{
+				CustomType:  fwflextypes.ListOfStringType,
+				ElementType: fwtypes.StringType,
+				Computed:    true,
+			},
+		},
+		Blocks: map[string]schema.Block{
+			names.AttrFilter: schema.SetNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						names.AttrName: schema.StringAttribute{
+							Required: true,
+						},
+						names.AttrValues: schema.ListAttribute{
+							Required:    true,
+							ElementType: fwtypes.StringType,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *dataSourceGlobalClusters) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data dataSourceGlobalClustersModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	conn := d.Meta().RDSClient(ctx)
+	input := &rds.DescribeGlobalClustersInput{}
+
+	var filters []globalClustersFilterModel
+	resp.Diagnostics.Append(data.Filter.ElementsAs(ctx, &filters, false)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	predicate := globalClustersPredicate(filters)
+
+	clusters, err := findGlobalClusters(ctx, conn, input, predicate)
+	if err != nil {
+		resp.Diagnostics.AddError("listing RDS Global Clusters", err.Error())
+		return
+	}
+
+	var identifiers []string
+	var arns []string
+	for _, cluster := range clusters {
+		identifiers = append(identifiers, aws.ToString(cluster.GlobalClusterIdentifier))
+		arns = append(arns, aws.ToString(cluster.GlobalClusterArn))
+	}
+
+	data.GlobalClusterIdentifiers = fwflex.FlattenFrameworkStringValueListOfString(ctx, identifiers)
+	data.GlobalClusterArns = fwflex.FlattenFrameworkStringValueListOfString(ctx, arns)
+	data.ID = fwtypes.StringValue(d.Meta().Region(ctx))
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func globalClustersPredicate(filters []globalClustersFilterModel) tfslices.Predicate[*types.GlobalCluster] {
+	if len(filters) == 0 {
+		return tfslices.PredicateTrue[*types.GlobalCluster]()
+	}
+
+	return func(cluster *types.GlobalCluster) bool {
+		for _, f := range filters {
+			name := f.Name.ValueString()
+
+			var values []string
+			for _, v := range f.Values.Elements() {
+				values = append(values, v.(fwtypes.String).ValueString())
+			}
+
+			var fieldValue string
+			switch name {
+			case "engine":
+				fieldValue = aws.ToString(cluster.Engine)
+			case "engine_version":
+				fieldValue = aws.ToString(cluster.EngineVersion)
+			case "status":
+				fieldValue = aws.ToString(cluster.Status)
+			case "global_cluster_identifier":
+				fieldValue = aws.ToString(cluster.GlobalClusterIdentifier)
+			case "database_name":
+				fieldValue = aws.ToString(cluster.DatabaseName)
+			case "storage_encrypted":
+				if aws.ToBool(cluster.StorageEncrypted) {
+					fieldValue = "true"
+				} else {
+					fieldValue = "false"
+				}
+			case "deletion_protection":
+				if aws.ToBool(cluster.DeletionProtection) {
+					fieldValue = "true"
+				} else {
+					fieldValue = "false"
+				}
+			default:
+				return false
+			}
+
+			if !slices.Contains(values, fieldValue) {
+				return false
+			}
+		}
+		return true
+	}
+}
+
+type dataSourceGlobalClustersModel struct {
+	framework.WithRegionModel
+	ID                       fwtypes.String       `tfsdk:"id"`
+	Filter                   fwtypes.Set          `tfsdk:"filter"`
+	GlobalClusterIdentifiers fwflextypes.ListOfString `tfsdk:"global_cluster_identifiers"`
+	GlobalClusterArns        fwflextypes.ListOfString `tfsdk:"global_cluster_arns"`
+}
+
+type globalClustersFilterModel struct {
+	Name   fwtypes.String `tfsdk:"name"`
+	Values fwtypes.List   `tfsdk:"values"`
+}

--- a/internal/service/rds/global_clusters_data_source.go
+++ b/internal/service/rds/global_clusters_data_source.go
@@ -1,0 +1,181 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package rds
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/rds"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkDataSource("aws_rds_global_clusters", name="Global Clusters")
+func newGlobalClustersDataSource(context.Context) (datasource.DataSourceWithConfigure, error) {
+	return &globalClustersDataSource{}, nil
+}
+
+type globalClustersDataSource struct {
+	framework.DataSourceWithModel[globalClustersDataSourceModel]
+}
+
+func (d *globalClustersDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			names.AttrID: framework.IDAttribute(),
+			"global_cluster_identifiers": schema.ListAttribute{
+				CustomType:  fwtypes.ListOfStringType,
+				ElementType: types.StringType,
+				Computed:    true,
+			},
+			"global_cluster_arns": schema.ListAttribute{
+				CustomType:  fwtypes.ListOfStringType,
+				ElementType: types.StringType,
+				Computed:    true,
+			},
+		},
+		Blocks: map[string]schema.Block{
+			names.AttrFilter: schema.SetNestedBlock{
+				CustomType: fwtypes.NewSetNestedObjectTypeOf[globalClustersFilterModel](ctx),
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						names.AttrName: schema.StringAttribute{
+							Required: true,
+						},
+						names.AttrValues: schema.ListAttribute{
+							CustomType:  fwtypes.ListOfStringType,
+							ElementType: types.StringType,
+							Required:    true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *globalClustersDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data globalClustersDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	filters, diags := data.Filter.ToSlice(ctx)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Validate filter names up front so a typo surfaces an error instead of
+	// silently returning no results.
+	for _, f := range filters {
+		if _, ok := globalClusterFilterFields[f.Name.ValueString()]; !ok {
+			resp.Diagnostics.AddError(
+				"Invalid Filter Name",
+				fmt.Sprintf("%q is not a supported filter name. Valid names are: %s.", f.Name.ValueString(), strings.Join(globalClusterFilterNames(), ", ")),
+			)
+		}
+	}
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	conn := d.Meta().RDSClient(ctx)
+	input := &rds.DescribeGlobalClustersInput{}
+
+	clusters, err := findGlobalClusters(ctx, conn, input, globalClustersPredicate(ctx, filters))
+	if err != nil {
+		resp.Diagnostics.AddError("listing RDS Global Clusters", err.Error())
+		return
+	}
+
+	identifiers := tfslices.ApplyToAll(clusters, func(c awstypes.GlobalCluster) string {
+		return aws.ToString(c.GlobalClusterIdentifier)
+	})
+	arns := tfslices.ApplyToAll(clusters, func(c awstypes.GlobalCluster) string {
+		return aws.ToString(c.GlobalClusterArn)
+	})
+
+	data.GlobalClusterIdentifiers = fwflex.FlattenFrameworkStringValueListOfString(ctx, identifiers)
+	data.GlobalClusterArns = fwflex.FlattenFrameworkStringValueListOfString(ctx, arns)
+	data.ID = types.StringValue(d.Meta().Region(ctx))
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+// globalClusterFilterFields maps a supported filter name to the corresponding
+// value on a global cluster. The DescribeGlobalClusters API does not support
+// server-side filtering (other than by identifier), so filtering is client-side.
+var globalClusterFilterFields = map[string]func(*awstypes.GlobalCluster) string{
+	names.AttrDatabaseName:       func(c *awstypes.GlobalCluster) string { return aws.ToString(c.DatabaseName) },
+	names.AttrDeletionProtection: func(c *awstypes.GlobalCluster) string { return strconv.FormatBool(aws.ToBool(c.DeletionProtection)) },
+	names.AttrEngine:             func(c *awstypes.GlobalCluster) string { return aws.ToString(c.Engine) },
+	names.AttrEngineVersion:      func(c *awstypes.GlobalCluster) string { return aws.ToString(c.EngineVersion) },
+	"global_cluster_identifier":  func(c *awstypes.GlobalCluster) string { return aws.ToString(c.GlobalClusterIdentifier) },
+	names.AttrStatus:             func(c *awstypes.GlobalCluster) string { return aws.ToString(c.Status) },
+	names.AttrStorageEncrypted:   func(c *awstypes.GlobalCluster) string { return strconv.FormatBool(aws.ToBool(c.StorageEncrypted)) },
+}
+
+func globalClusterFilterNames() []string {
+	filterNames := make([]string, 0, len(globalClusterFilterFields))
+	for name := range globalClusterFilterFields {
+		filterNames = append(filterNames, name)
+	}
+	slices.Sort(filterNames)
+	return filterNames
+}
+
+func globalClustersPredicate(ctx context.Context, filters []*globalClustersFilterModel) tfslices.Predicate[*awstypes.GlobalCluster] {
+	if len(filters) == 0 {
+		return tfslices.PredicateTrue[*awstypes.GlobalCluster]()
+	}
+
+	// Extract each filter's field accessor and values once, rather than per cluster.
+	type compiledFilter struct {
+		field  func(*awstypes.GlobalCluster) string
+		values []string
+	}
+	compiled := make([]compiledFilter, 0, len(filters))
+	for _, f := range filters {
+		compiled = append(compiled, compiledFilter{
+			field:  globalClusterFilterFields[f.Name.ValueString()], // name validated in Read
+			values: fwflex.ExpandFrameworkStringValueList(ctx, f.Values),
+		})
+	}
+
+	return func(cluster *awstypes.GlobalCluster) bool {
+		for _, cf := range compiled {
+			if !slices.Contains(cf.values, cf.field(cluster)) {
+				return false
+			}
+		}
+		return true
+	}
+}
+
+type globalClustersDataSourceModel struct {
+	framework.WithRegionModel
+	ID                       types.String                                              `tfsdk:"id"`
+	Filter                   fwtypes.SetNestedObjectValueOf[globalClustersFilterModel] `tfsdk:"filter"`
+	GlobalClusterIdentifiers fwtypes.ListOfString                                      `tfsdk:"global_cluster_identifiers"`
+	GlobalClusterArns        fwtypes.ListOfString                                      `tfsdk:"global_cluster_arns"`
+}
+
+type globalClustersFilterModel struct {
+	Name   types.String         `tfsdk:"name"`
+	Values fwtypes.ListOfString `tfsdk:"values"`
+}

--- a/internal/service/rds/global_clusters_data_source_test.go
+++ b/internal/service/rds/global_clusters_data_source_test.go
@@ -1,0 +1,114 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package rds_test
+
+import (
+	"fmt"
+	"testing"
+
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccRDSGlobalClustersDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_rds_global_clusters.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckGlobalCluster(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGlobalClustersDataSourceConfig_basic(rName1, rName2),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "global_cluster_identifiers.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "global_cluster_arns.#"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRDSGlobalClustersDataSource_filter(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_rds_global_clusters.test"
+	resourceName := "aws_rds_global_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckGlobalCluster(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGlobalClustersDataSourceConfig_filter(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "global_cluster_identifiers.#", "1"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "global_cluster_identifiers.0", resourceName, "global_cluster_identifier"),
+				),
+			},
+		},
+	})
+}
+
+func testAccGlobalClustersDataSourceConfig_basic(rName1, rName2 string) string {
+	return fmt.Sprintf(`
+resource "aws_rds_global_cluster" "test1" {
+  global_cluster_identifier = %[1]q
+  engine                    = "aurora-postgresql"
+  engine_version            = "16.4"
+}
+
+resource "aws_rds_global_cluster" "test2" {
+  global_cluster_identifier = %[2]q
+  engine                    = "aurora-postgresql"
+  engine_version            = "16.4"
+}
+
+data "aws_rds_global_clusters" "test" {
+  depends_on = [
+    aws_rds_global_cluster.test1,
+    aws_rds_global_cluster.test2,
+  ]
+}
+`, rName1, rName2)
+}
+
+func testAccGlobalClustersDataSourceConfig_filter(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_rds_global_cluster" "test" {
+  global_cluster_identifier = %[1]q
+  engine                    = "aurora-postgresql"
+  engine_version            = "16.4"
+}
+
+resource "aws_rds_global_cluster" "decoy" {
+  global_cluster_identifier = "%[1]s-decoy"
+  engine                    = "aurora-mysql"
+  engine_version            = "8.0.mysql_aurora.3.07.1"
+}
+
+data "aws_rds_global_clusters" "test" {
+  filter {
+    name   = "engine"
+    values = ["aurora-postgresql"]
+  }
+
+  filter {
+    name   = "global_cluster_identifier"
+    values = [%[1]q]
+  }
+
+  depends_on = [
+    aws_rds_global_cluster.test,
+    aws_rds_global_cluster.decoy,
+  ]
+}
+`, rName)
+}

--- a/internal/service/rds/global_clusters_data_source_test.go
+++ b/internal/service/rds/global_clusters_data_source_test.go
@@ -1,0 +1,125 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package rds_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccRDSGlobalClustersDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName1 := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	rName2 := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	dataSourceName := "data.aws_rds_global_clusters.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckGlobalCluster(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGlobalClustersDataSourceConfig_basic(rName1, rName2),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "global_cluster_identifiers.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "global_cluster_arns.#"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRDSGlobalClustersDataSource_filter(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	dataSourceName := "data.aws_rds_global_clusters.test"
+	resourceName := "aws_rds_global_cluster.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckGlobalCluster(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGlobalClustersDataSourceConfig_filter(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "global_cluster_identifiers.#", "1"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "global_cluster_identifiers.0", resourceName, "global_cluster_identifier"),
+				),
+			},
+		},
+	})
+}
+
+func testAccGlobalClustersDataSourceConfig_basic(rName1, rName2 string) string {
+	return fmt.Sprintf(`
+data "aws_rds_engine_version" "default" {
+  engine = "aurora-postgresql"
+}
+
+resource "aws_rds_global_cluster" "test1" {
+  global_cluster_identifier = %[1]q
+  engine                    = data.aws_rds_engine_version.default.engine
+  engine_version            = data.aws_rds_engine_version.default.version
+}
+
+resource "aws_rds_global_cluster" "test2" {
+  global_cluster_identifier = %[2]q
+  engine                    = data.aws_rds_engine_version.default.engine
+  engine_version            = data.aws_rds_engine_version.default.version
+}
+
+data "aws_rds_global_clusters" "test" {
+  depends_on = [
+    aws_rds_global_cluster.test1,
+    aws_rds_global_cluster.test2,
+  ]
+}
+`, rName1, rName2)
+}
+
+func testAccGlobalClustersDataSourceConfig_filter(rName string) string {
+	return fmt.Sprintf(`
+data "aws_rds_engine_version" "postgresql" {
+  engine = "aurora-postgresql"
+}
+
+data "aws_rds_engine_version" "mysql" {
+  engine = "aurora-mysql"
+}
+
+resource "aws_rds_global_cluster" "test" {
+  global_cluster_identifier = %[1]q
+  engine                    = data.aws_rds_engine_version.postgresql.engine
+  engine_version            = data.aws_rds_engine_version.postgresql.version
+}
+
+resource "aws_rds_global_cluster" "decoy" {
+  global_cluster_identifier = "%[1]s-decoy"
+  engine                    = data.aws_rds_engine_version.mysql.engine
+  engine_version            = data.aws_rds_engine_version.mysql.version
+}
+
+data "aws_rds_global_clusters" "test" {
+  filter {
+    name   = "engine"
+    values = [data.aws_rds_engine_version.postgresql.engine]
+  }
+
+  filter {
+    name   = "global_cluster_identifier"
+    values = [%[1]q]
+  }
+
+  depends_on = [
+    aws_rds_global_cluster.test,
+    aws_rds_global_cluster.decoy,
+  ]
+}
+`, rName)
+}

--- a/internal/service/rds/service_package_gen.go
+++ b/internal/service/rds/service_package_gen.go
@@ -39,6 +39,12 @@ func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*inttypes.S
 			}),
 			Region: inttypes.ResourceRegionDefault(),
 		},
+		{
+			Factory:  newDataSourceGlobalClusters,
+			TypeName: "aws_rds_global_clusters",
+			Name:     "Global Clusters",
+			Region:   inttypes.ResourceRegionDefault(),
+		},
 	}
 }
 

--- a/internal/service/rds/service_package_gen.go
+++ b/internal/service/rds/service_package_gen.go
@@ -40,6 +40,12 @@ func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*inttypes.S
 			Region: inttypes.ResourceRegionDefault(),
 		},
 		{
+			Factory:  newGlobalClustersDataSource,
+			TypeName: "aws_rds_global_clusters",
+			Name:     "Global Clusters",
+			Region:   inttypes.ResourceRegionDefault(),
+		},
+		{
 			Factory:  newSnapshotsDataSource,
 			TypeName: "aws_rds_snapshots",
 			Name:     "Snapshots",

--- a/website/docs/d/rds_global_clusters.html.markdown
+++ b/website/docs/d/rds_global_clusters.html.markdown
@@ -1,0 +1,69 @@
+---
+subcategory: "RDS (Relational Database)"
+layout: "aws"
+page_title: "AWS: aws_rds_global_clusters"
+description: |-
+  Terraform data source for listing AWS RDS Global Clusters.
+---
+
+# Data Source: aws_rds_global_clusters
+
+Use this data source to discover all RDS Global Clusters in the current AWS account.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_rds_global_clusters" "all" {}
+```
+
+### Filter by Engine
+
+```terraform
+data "aws_rds_global_clusters" "postgresql" {
+  filter {
+    name   = "engine"
+    values = ["aurora-postgresql"]
+  }
+}
+```
+
+### Chain with Singular Data Source
+
+```terraform
+data "aws_rds_global_clusters" "discovered" {
+  filter {
+    name   = "engine"
+    values = ["aurora-postgresql"]
+  }
+}
+
+data "aws_rds_global_cluster" "detailed" {
+  for_each   = toset(data.aws_rds_global_clusters.discovered.global_cluster_identifiers)
+  identifier = each.value
+}
+
+output "all_global_endpoints" {
+  value = { for k, v in data.aws_rds_global_cluster.detailed : k => v.endpoint }
+}
+```
+
+## Argument Reference
+
+The following arguments are optional:
+
+* `filter` - (Optional) One or more configuration blocks for client-side filtering. Detailed below.
+
+### filter Argument Reference
+
+* `name` - (Required) Name of the field to filter by. Supported values: `engine`, `engine_version`, `status`, `global_cluster_identifier`, `database_name`, `storage_encrypted`, `deletion_protection`.
+* `values` - (Required) List of values to match against.
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `id` - AWS region.
+* `global_cluster_identifiers` - List of user-defined global cluster identifiers.
+* `global_cluster_arns` - List of ARNs for the global clusters.

--- a/website/docs/d/rds_global_clusters.html.markdown
+++ b/website/docs/d/rds_global_clusters.html.markdown
@@ -1,0 +1,70 @@
+---
+subcategory: "RDS (Relational Database)"
+layout: "aws"
+page_title: "AWS: aws_rds_global_clusters"
+description: |-
+  Terraform data source for listing AWS RDS Global Clusters.
+---
+
+# Data Source: aws_rds_global_clusters
+
+Use this data source to discover all RDS Global Clusters in the current AWS account.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_rds_global_clusters" "all" {}
+```
+
+### Filter by Engine
+
+```terraform
+data "aws_rds_global_clusters" "postgresql" {
+  filter {
+    name   = "engine"
+    values = ["aurora-postgresql"]
+  }
+}
+```
+
+### Chain with Singular Data Source
+
+```terraform
+data "aws_rds_global_clusters" "discovered" {
+  filter {
+    name   = "engine"
+    values = ["aurora-postgresql"]
+  }
+}
+
+data "aws_rds_global_cluster" "detailed" {
+  for_each   = toset(data.aws_rds_global_clusters.discovered.global_cluster_identifiers)
+  identifier = each.value
+}
+
+output "all_global_endpoints" {
+  value = { for k, v in data.aws_rds_global_cluster.detailed : k => v.endpoint }
+}
+```
+
+## Argument Reference
+
+The following arguments are optional:
+
+* `filter` - (Optional) One or more configuration blocks for client-side filtering. Detailed below.
+* `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
+
+### `filter` Block
+
+* `name` - (Required) Name of the field to filter by. Supported values: `database_name`, `deletion_protection`, `engine`, `engine_version`, `global_cluster_identifier`, `status`, `storage_encrypted`.
+* `values` - (Required) List of values to match against.
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `global_cluster_arns` - List of ARNs for the global clusters.
+* `global_cluster_identifiers` - List of user-defined global cluster identifiers.
+* `id` - AWS Region.


### PR DESCRIPTION
## Summary

Adds a plural data source `aws_rds_global_clusters` for discovering all RDS Global Clusters in the current AWS account.

- Uses `DescribeGlobalClusters` API with SDK v2 paginator
- Implements client-side filtering (the API does not support server-side `Filter` params beyond `GlobalClusterIdentifier`)
- Returns `global_cluster_identifiers` and `global_cluster_arns` for chaining with `aws_rds_global_cluster`

### Motivation

A plural data source enables programmatic discovery and conditional state validation, to get around singular data source lookup `aws_rds_global_cluster` failure when cluster does not exist.

- [Issue #29372](https://github.com/hashicorp/terraform-provider-aws/issues/29372): highlighted the data gap for global architecture state management
- [Issue #34203](https://github.com/hashicorp/terraform-provider-aws/issues/34203): orchestration hurdles in complex configurations involving global cluster dependencies
- [Issue #43214](https://github.com/hashicorp/terraform-provider-aws/issues/43214): requires setting `replication_source_identifier` dynamically to avoid error after initial cluster creation from snapshot

### Supported Filter Fields

| Field | Type |
|---|---|
| `engine` | string |
| `engine_version` | string |
| `status` | string |
| `global_cluster_identifier` | string |
| `database_name` | string |
| `storage_encrypted` | "true"/"false" |
| `deletion_protection` | "true"/"false" |

## Usage Example

```hcl
data "aws_rds_global_clusters" "postgresql" {
  filter {
    name   = "engine"
    values = ["aurora-postgresql"]
  }
}

data "aws_rds_global_cluster" "detailed" {
  for_each   = toset(data.aws_rds_global_clusters.postgresql.global_cluster_identifiers)
  identifier = each.value
}
```

## Test plan

Acceptance tests pass against AWS (`us-west-2`):

```
$ make testacc PKG=rds TESTS='TestAccRDSGlobalClustersDataSource_'
--- PASS: TestAccRDSGlobalClustersDataSource_filter (21.23s)
--- PASS: TestAccRDSGlobalClustersDataSource_basic (21.23s)
ok  github.com/hashicorp/terraform-provider-aws/internal/service/rds  27.736s
```

- `TestAccRDSGlobalClustersDataSource_basic` — creates two global clusters, verifies the data source returns identifiers/arns
- `TestAccRDSGlobalClustersDataSource_filter` — creates a target (aurora-postgresql) + decoy (aurora-mysql), verifies the filter returns only the matching cluster

## New or Affected Resource(s)

- `aws_rds_global_clusters` (new data source)

Closes #48770
