### PR TITLE
r/aws_rds_global_cluster: wait for source cluster promotion to complete

### DIFF
--- a/.changelog/48076.txt
+++ b/.changelog/48076.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_rds_global_cluster: Wait for source cluster promotion to complete when `source_db_cluster_identifier` is specified, fixing race condition with downstream resources
+```

--- a/internal/service/rds/consts.go
+++ b/internal/service/rds/consts.go
@@ -128,6 +128,7 @@ const (
 	globalClusterStatusCreating  = "creating"
 	globalClusterStatusDeleting  = "deleting"
 	globalClusterStatusModifying = "modifying"
+	globalClusterStatusPromoting = "promoting"
 	globalClusterStatusUpgrading = "upgrading"
 )
 

--- a/internal/service/rds/global_cluster.go
+++ b/internal/service/rds/global_cluster.go
@@ -204,6 +204,13 @@ func resourceGlobalClusterCreate(ctx context.Context, d *schema.ResourceData, me
 		return sdkdiag.AppendErrorf(diags, "waiting for RDS Global Cluster (%s) create: %s", d.Id(), err)
 	}
 
+	if v, ok := d.GetOk("source_db_cluster_identifier"); ok {
+		sourceARN := v.(string)
+		if _, err := waitGlobalClusterSourcePromoted(ctx, conn, d.Id(), sourceARN, d.Timeout(schema.TimeoutCreate)); err != nil {
+			return sdkdiag.AppendErrorf(diags, "waiting for RDS Global Cluster (%s) source cluster promotion: %s", d.Id(), err)
+		}
+	}
+
 	return append(diags, resourceGlobalClusterRead(ctx, d, meta)...)
 }
 
@@ -491,6 +498,58 @@ func waitGlobalClusterCreated(ctx context.Context, conn *rds.Client, id string, 
 	}
 
 	return nil, err
+}
+
+func waitGlobalClusterSourcePromoted(ctx context.Context, conn *rds.Client, id, sourceARN string, timeout time.Duration) (*types.GlobalCluster, error) {
+	const (
+		globalClusterStatusPromoting = "promoting"
+	)
+	stateConf := &retry.StateChangeConf{
+		Pending:    []string{globalClusterStatusPromoting},
+		Target:     []string{globalClusterStatusAvailable},
+		Refresh:    statusGlobalClusterSourcePromotion(conn, id, sourceARN),
+		Timeout:    timeout,
+		Delay:      10 * time.Second,
+		MinTimeout: 5 * time.Second,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+
+	if output, ok := outputRaw.(*types.GlobalCluster); ok {
+		return output, err
+	}
+
+	return nil, err
+}
+
+func statusGlobalClusterSourcePromotion(conn *rds.Client, id, sourceARN string) retry.StateRefreshFunc {
+	const (
+		globalClusterStatusPromoting = "promoting"
+	)
+	return func(ctx context.Context) (any, string, error) {
+		output, err := findGlobalClusterByID(ctx, conn, id)
+
+		if retry.NotFound(err) {
+			return nil, "", &retry.NotFoundError{LastError: err}
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		status := aws.ToString(output.Status)
+		if status != globalClusterStatusAvailable {
+			return output, status, nil
+		}
+
+		for _, m := range output.GlobalClusterMembers {
+			if aws.ToString(m.DBClusterArn) == sourceARN && aws.ToBool(m.IsWriter) {
+				return output, globalClusterStatusAvailable, nil
+			}
+		}
+
+		return output, globalClusterStatusPromoting, nil
+	}
 }
 
 func waitGlobalClusterUpdated(ctx context.Context, conn *rds.Client, id string, timeout time.Duration) (*types.GlobalCluster, error) {

--- a/internal/service/rds/global_cluster.go
+++ b/internal/service/rds/global_cluster.go
@@ -206,6 +206,13 @@ func resourceGlobalClusterCreate(ctx context.Context, d *schema.ResourceData, me
 		return sdkdiag.AppendErrorf(diags, "waiting for RDS Global Cluster (%s) create: %s", d.Id(), err)
 	}
 
+	if v, ok := d.GetOk("source_db_cluster_identifier"); ok {
+		sourceARN := v.(string)
+		if _, err := waitGlobalClusterSourcePromoted(ctx, conn, d.Id(), sourceARN, d.Timeout(schema.TimeoutCreate)); err != nil {
+			return sdkdiag.AppendErrorf(diags, "waiting for RDS Global Cluster (%s) source cluster promotion: %s", d.Id(), err)
+		}
+	}
+
 	return append(diags, resourceGlobalClusterRead(ctx, d, meta)...)
 }
 
@@ -493,6 +500,52 @@ func waitGlobalClusterCreated(ctx context.Context, conn *rds.Client, id string, 
 	}
 
 	return nil, err
+}
+
+func waitGlobalClusterSourcePromoted(ctx context.Context, conn *rds.Client, id, sourceARN string, timeout time.Duration) (*types.GlobalCluster, error) {
+	stateConf := &retry.StateChangeConf{
+		Pending:    []string{globalClusterStatusPromoting},
+		Target:     []string{globalClusterStatusAvailable},
+		Refresh:    statusGlobalClusterSourcePromotion(conn, id, sourceARN),
+		Timeout:    timeout,
+		Delay:      10 * time.Second,
+		MinTimeout: 5 * time.Second,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+
+	if output, ok := outputRaw.(*types.GlobalCluster); ok {
+		return output, err
+	}
+
+	return nil, err
+}
+
+func statusGlobalClusterSourcePromotion(conn *rds.Client, id, sourceARN string) retry.StateRefreshFunc {
+	return func(ctx context.Context) (any, string, error) {
+		output, err := findGlobalClusterByID(ctx, conn, id)
+
+		if retry.NotFound(err) {
+			return nil, "", &retry.NotFoundError{LastError: err}
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		status := aws.ToString(output.Status)
+		if status != globalClusterStatusAvailable {
+			return output, status, nil
+		}
+
+		for _, m := range output.GlobalClusterMembers {
+			if aws.ToString(m.DBClusterArn) == sourceARN && aws.ToBool(m.IsWriter) {
+				return output, globalClusterStatusAvailable, nil
+			}
+		}
+
+		return output, globalClusterStatusPromoting, nil
+	}
 }
 
 func waitGlobalClusterUpdated(ctx context.Context, conn *rds.Client, id string, timeout time.Duration) (*types.GlobalCluster, error) {

--- a/internal/service/rds/global_cluster_test.go
+++ b/internal/service/rds/global_cluster_test.go
@@ -579,6 +579,29 @@ func TestAccRDSGlobalCluster_sourceDBClusterIdentifier(t *testing.T) {
 	})
 }
 
+func TestAccRDSGlobalCluster_sourceDBClusterIdentifier_writerMemberPromoted(t *testing.T) {
+	ctx := acctest.Context(t)
+	var globalCluster1 types.GlobalCluster
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_rds_global_cluster.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckGlobalCluster(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckGlobalClusterDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGlobalClusterConfig_sourceClusterID(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGlobalClusterExists(ctx, t, resourceName, &globalCluster1),
+					testAccCheckGlobalClusterHasWriterMember(&globalCluster1),
+				),
+			},
+		},
+	})
+}
+
 func TestAccRDSGlobalCluster_SourceDBClusterIdentifier_storageEncrypted(t *testing.T) {
 	ctx := acctest.Context(t)
 	var globalCluster1 types.GlobalCluster
@@ -736,6 +759,17 @@ func testAccCheckGlobalClusterExists(ctx context.Context, t *testing.T, n string
 		*v = *output
 
 		return nil
+	}
+}
+
+func testAccCheckGlobalClusterHasWriterMember(globalCluster *types.GlobalCluster) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		for _, m := range globalCluster.GlobalClusterMembers {
+			if aws.ToBool(m.IsWriter) && aws.ToString(m.DBClusterArn) != "" {
+				return nil
+			}
+		}
+		return errors.New("expected global cluster to have a writer member after create, but none found")
 	}
 }
 

--- a/internal/service/rds/global_cluster_test.go
+++ b/internal/service/rds/global_cluster_test.go
@@ -5,10 +5,12 @@ package rds_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
 	"github.com/YakDriver/regexache"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/rds"
 	"github.com/aws/aws-sdk-go-v2/service/rds/types"
 	"github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
@@ -605,6 +607,67 @@ func TestAccRDSGlobalCluster_sourceDBClusterIdentifier(t *testing.T) {
 	})
 }
 
+func TestAccRDSGlobalCluster_sourceDBClusterIdentifier_writerMemberPromoted(t *testing.T) {
+	ctx := acctest.Context(t)
+	var globalCluster1 types.GlobalCluster
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_rds_global_cluster.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckGlobalCluster(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckGlobalClusterDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGlobalClusterConfig_sourceClusterID(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckGlobalClusterExists(ctx, t, resourceName, &globalCluster1),
+					testAccCheckGlobalClusterHasWriterMember(&globalCluster1),
+				),
+			},
+		},
+	})
+}
+
+// Regression test for the source promotion race: a cross-region secondary must
+// apply cleanly on top of a promote-existing global cluster, which only holds if
+// create waits for the source cluster to become a writer member first.
+func TestAccRDSGlobalCluster_sourceDBClusterIdentifier_crossRegionReplica(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var globalCluster types.GlobalCluster
+	rNameSource := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	rNameGlobal := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	rNameSecondary := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_rds_global_cluster.test"
+	secondaryResourceName := "aws_rds_cluster.secondary"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+			testAccPreCheckGlobalCluster(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5FactoriesAlternate(ctx, t),
+		CheckDestroy:             testAccCheckGlobalClusterDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGlobalClusterConfig_sourceClusterIDCrossRegionReplica(rNameSource, rNameGlobal, rNameSecondary, tfrds.ClusterEngineAuroraPostgreSQL),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckGlobalClusterExists(ctx, t, resourceName, &globalCluster),
+					testAccCheckGlobalClusterHasWriterMember(&globalCluster),
+					resource.TestCheckResourceAttrSet(secondaryResourceName, "replication_source_identifier"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccRDSGlobalCluster_SourceDBClusterIdentifier_storageEncrypted(t *testing.T) {
 	ctx := acctest.Context(t)
 	var globalCluster1 types.GlobalCluster
@@ -764,6 +827,17 @@ func testAccCheckGlobalClusterExists(ctx context.Context, t *testing.T, n string
 		*v = *output
 
 		return nil
+	}
+}
+
+func testAccCheckGlobalClusterHasWriterMember(globalCluster *types.GlobalCluster) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		for _, m := range globalCluster.GlobalClusterMembers {
+			if aws.ToBool(m.IsWriter) && aws.ToString(m.DBClusterArn) != "" {
+				return nil
+			}
+		}
+		return errors.New("expected global cluster to have a writer member after create, but none found")
 	}
 }
 
@@ -1316,6 +1390,113 @@ resource "aws_rds_global_cluster" "test" {
   source_db_cluster_identifier = aws_rds_cluster.test.arn
 }
 `, rName)
+}
+
+func testAccGlobalClusterConfig_sourceClusterIDCrossRegionReplica(rNameSource, rNameGlobal, rNameSecondary, engine string) string {
+	return acctest.ConfigCompose(acctest.ConfigMultipleRegionProvider(2), fmt.Sprintf(`
+data "aws_availability_zones" "alternate" {
+  provider = "awsalternate"
+  state    = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
+data "aws_rds_engine_version" "test" {
+  engine = %[4]q
+  latest = true
+}
+
+data "aws_rds_orderable_db_instance" "test" {
+  engine                     = data.aws_rds_engine_version.test.engine
+  engine_version             = data.aws_rds_engine_version.test.version_actual
+  preferred_instance_classes = [%[5]s]
+  supports_clusters          = true
+  supports_global_databases  = true
+}
+
+resource "aws_rds_cluster" "source" {
+  cluster_identifier  = %[1]q
+  engine              = data.aws_rds_engine_version.test.engine
+  engine_version      = data.aws_rds_engine_version.test.version_actual
+  master_password     = "avoid-plaintext-passwords"
+  master_username     = "tfacctest"
+  skip_final_snapshot = true
+
+  lifecycle {
+    ignore_changes = [global_cluster_identifier]
+  }
+}
+
+resource "aws_rds_cluster_instance" "source" {
+  identifier         = %[1]q
+  cluster_identifier = aws_rds_cluster.source.id
+  engine             = aws_rds_cluster.source.engine
+  engine_version     = aws_rds_cluster.source.engine_version
+  instance_class     = data.aws_rds_orderable_db_instance.test.instance_class
+}
+
+resource "aws_rds_global_cluster" "test" {
+  force_destroy                = true
+  global_cluster_identifier    = %[2]q
+  source_db_cluster_identifier = aws_rds_cluster.source.arn
+
+  depends_on = [aws_rds_cluster_instance.source]
+}
+
+resource "aws_vpc" "alternate" {
+  provider   = "awsalternate"
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = %[3]q
+  }
+}
+
+resource "aws_subnet" "alternate" {
+  provider          = "awsalternate"
+  count             = 3
+  vpc_id            = aws_vpc.alternate.id
+  availability_zone = data.aws_availability_zones.alternate.names[count.index]
+  cidr_block        = "10.0.${count.index}.0/24"
+
+  tags = {
+    Name = %[3]q
+  }
+}
+
+resource "aws_db_subnet_group" "alternate" {
+  provider   = "awsalternate"
+  name       = %[3]q
+  subnet_ids = aws_subnet.alternate[*].id
+}
+
+# Fails with InvalidDBClusterStateFault if the source has not finished promoting.
+resource "aws_rds_cluster" "secondary" {
+  provider                  = "awsalternate"
+  cluster_identifier        = %[3]q
+  engine                    = aws_rds_global_cluster.test.engine
+  engine_version            = aws_rds_global_cluster.test.engine_version
+  global_cluster_identifier = aws_rds_global_cluster.test.id
+  db_subnet_group_name      = aws_db_subnet_group.alternate.name
+  skip_final_snapshot       = true
+
+  lifecycle {
+    ignore_changes = [replication_source_identifier]
+  }
+}
+
+resource "aws_rds_cluster_instance" "secondary" {
+  provider           = "awsalternate"
+  identifier         = %[3]q
+  cluster_identifier = aws_rds_cluster.secondary.id
+  engine             = aws_rds_cluster.secondary.engine
+  engine_version     = aws_rds_cluster.secondary.engine_version
+  instance_class     = data.aws_rds_orderable_db_instance.test.instance_class
+}
+`, rNameSource, rNameGlobal, rNameSecondary, engine, mainInstanceClasses))
 }
 
 func testAccGlobalClusterConfig_sourceClusterIDStorageEncrypted(rName string) string {


### PR DESCRIPTION
## Summary

Fixes a race condition in `aws_rds_global_cluster` when using the **promote-existing** pattern (`source_db_cluster_identifier`). The `CreateGlobalCluster` API returns in ~1s, but AWS asynchronously promotes the source cluster into the global cluster's primary over ~30-60s. Without waiting for this promotion, downstream resources (e.g., cross-region secondary `aws_rds_cluster` with `replication_source_identifier`) race against the promotion and fail with:

```
InvalidDBClusterStateFault: Source cluster ... is in a state which is not valid for physical replication
```

After this change, `aws_rds_global_cluster` create blocks until the source cluster appears in `GlobalClusterMembers` as a writer — matching users' reasonable expectation that the global cluster is ready for replication when create completes.

**Greenfield behavior (no `source_db_cluster_identifier`) is unchanged.**

## Changes

- Added `waitGlobalClusterSourcePromoted` — polls `DescribeGlobalClusters` until the source ARN is listed as a writer member
- Added `statusGlobalClusterSourcePromotion` — refresh function returning a synthetic `"promoting"` state while waiting
- Added the `globalClusterStatusPromoting` constant to `consts.go` alongside the other `globalClusterStatus*` values
- Wired into `resourceGlobalClusterCreate` conditionally (only when `source_db_cluster_identifier` is set)
- Added acceptance tests `TestAccRDSGlobalCluster_sourceDBClusterIdentifier_writerMemberPromoted` and `TestAccRDSGlobalCluster_sourceDBClusterIdentifier_crossRegionReplica` (the latter applies a cross-region secondary on top of the promoted source, reproducing the race)

## Test plan

Acceptance tests pass against AWS (`us-west-2` primary, `us-east-1` alternate):

```
$ make testacc PKG=rds TESTS='TestAccRDSGlobalCluster_sourceDBClusterIdentifier|TestAccRDSGlobalCluster_sourceDBClusterIdentifier_writerMemberPromoted'
--- PASS: TestAccRDSGlobalCluster_sourceDBClusterIdentifier_writerMemberPromoted (197.59s)
--- PASS: TestAccRDSGlobalCluster_sourceDBClusterIdentifier (201.26s)
ok  github.com/hashicorp/terraform-provider-aws/internal/service/rds  207.691s

$ make testacc PKG=rds TESTS='TestAccRDSGlobalCluster_sourceDBClusterIdentifier_crossRegionReplica'
--- PASS: TestAccRDSGlobalCluster_sourceDBClusterIdentifier_crossRegionReplica (2561.87s)
ok  github.com/hashicorp/terraform-provider-aws/internal/service/rds  2568.129s
```

Closes #48769
