### PR TITLE
[Enhancement] aws_vpc_ipam_pool_cidr_allocation: Add tagging support

### DIFF
--- a/.changelog/48084.txt
+++ b/.changelog/48084.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_vpc_ipam_pool_cidr_allocation: Add tagging support
+```

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -1950,7 +1950,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*inttypes.ServicePa
 			Factory:  resourceIPAMPoolCIDRAllocation,
 			TypeName: "aws_vpc_ipam_pool_cidr_allocation",
 			Name:     "IPAM Pool CIDR Allocation",
-			Region:   inttypes.ResourceRegionDefault(),
+			Tags: unique.Make(inttypes.ServicePackageResourceTags{
+				IdentifierAttribute: "ipam_pool_allocation_id",
+			}),
+			Region: inttypes.ResourceRegionDefault(),
 		},
 		{
 			Factory:  resourceIPAMPreviewNextCIDR,

--- a/internal/service/ec2/vpc_ipam_pool_cidr_allocation.go
+++ b/internal/service/ec2/vpc_ipam_pool_cidr_allocation.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -23,16 +24,20 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 // @SDKResource("aws_vpc_ipam_pool_cidr_allocation", name="IPAM Pool CIDR Allocation")
+// @Tags(identifierAttribute="ipam_pool_allocation_id")
+// @Testing(tagsTest=false)
 func resourceIPAMPoolCIDRAllocation() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceIPAMPoolCIDRAllocationCreate,
 		ReadWithoutTimeout:   resourceIPAMPoolCIDRAllocationRead,
+		UpdateWithoutTimeout: resourceIPAMPoolCIDRAllocationUpdate,
 		DeleteWithoutTimeout: resourceIPAMPoolCIDRAllocationDelete,
 
 		Importer: &schema.ResourceImporter{
@@ -98,6 +103,8 @@ func resourceIPAMPoolCIDRAllocation() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 	}
 }
@@ -108,8 +115,9 @@ func resourceIPAMPoolCIDRAllocationCreate(ctx context.Context, d *schema.Resourc
 
 	ipamPoolID := d.Get("ipam_pool_id").(string)
 	input := &ec2.AllocateIpamPoolCidrInput{
-		ClientToken: aws.String(create.UniqueId(ctx)),
-		IpamPoolId:  aws.String(ipamPoolID),
+		ClientToken:       aws.String(create.UniqueId(ctx)),
+		IpamPoolId:        aws.String(ipamPoolID),
+		TagSpecifications: getTagSpecificationsIn(ctx, awstypes.ResourceTypeIpamPoolAllocation),
 	}
 
 	if v, ok := d.GetOk("cidr"); ok {
@@ -189,7 +197,15 @@ func resourceIPAMPoolCIDRAllocationRead(ctx context.Context, d *schema.ResourceD
 	d.Set(names.AttrResourceOwner, allocation.ResourceOwner)
 	d.Set(names.AttrResourceType, allocation.ResourceType)
 
+	setTagsOut(ctx, allocation.Tags)
+
 	return diags
+}
+
+func resourceIPAMPoolCIDRAllocationUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	// Only tags can be updated; transparent tagging handles the update
+	var diags diag.Diagnostics
+	return append(diags, resourceIPAMPoolCIDRAllocationRead(ctx, d, meta)...)
 }
 
 func resourceIPAMPoolCIDRAllocationDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/internal/service/ec2/vpc_ipam_pool_cidr_allocation_test.go
+++ b/internal/service/ec2/vpc_ipam_pool_cidr_allocation_test.go
@@ -269,6 +269,52 @@ func TestAccIPAMPoolCIDRAllocation_differentRegion(t *testing.T) { // nosemgrep:
 	})
 }
 
+func TestAccIPAMPoolCIDRAllocation_tags(t *testing.T) { // nosemgrep:ci.vpc-in-test-name
+	ctx := acctest.Context(t)
+	var allocation awstypes.IpamPoolAllocation
+	resourceName := "aws_vpc_ipam_pool_cidr_allocation.test"
+	cidr := "172.2.0.0/28"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckIPAMPoolAllocationDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIPAMPoolCIDRAllocationConfig_tags(cidr, acctest.CtKey1, acctest.CtValue1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIPAMPoolCIDRAllocationExists(ctx, t, resourceName, &allocation),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey1, acctest.CtValue1),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccIPAMPoolCIDRAllocationConfig_tags2(cidr, acctest.CtKey1, acctest.CtValue1Updated, acctest.CtKey2, acctest.CtValue2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIPAMPoolCIDRAllocationExists(ctx, t, resourceName, &allocation),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "2"),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey1, acctest.CtValue1Updated),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey2, acctest.CtValue2),
+				),
+			},
+			{
+				Config: testAccIPAMPoolCIDRAllocationConfig_tags(cidr, acctest.CtKey2, acctest.CtValue2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIPAMPoolCIDRAllocationExists(ctx, t, resourceName, &allocation),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey2, acctest.CtValue2),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckIPAMCIDRPrefix(allocation *awstypes.IpamPoolAllocation, expected string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if strings.Split(aws.ToString(allocation.Cidr), "/")[1] != expected {
@@ -494,4 +540,39 @@ resource "aws_vpc_ipam_pool_cidr_allocation" "test" {
   ]
 }
 `, cidr, acctest.Region(), acctest.AlternateRegion()))
+}
+
+func testAccIPAMPoolCIDRAllocationConfig_tags(cidr, tagKey1, tagValue1 string) string {
+	return acctest.ConfigCompose(testAccIPAMPoolCIDRAllocationConfig_base, fmt.Sprintf(`
+resource "aws_vpc_ipam_pool_cidr_allocation" "test" {
+  ipam_pool_id = aws_vpc_ipam_pool.test.id
+  cidr         = %[1]q
+
+  tags = {
+    %[2]q = %[3]q
+  }
+
+  depends_on = [
+    aws_vpc_ipam_pool_cidr.test
+  ]
+}
+`, cidr, tagKey1, tagValue1))
+}
+
+func testAccIPAMPoolCIDRAllocationConfig_tags2(cidr, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return acctest.ConfigCompose(testAccIPAMPoolCIDRAllocationConfig_base, fmt.Sprintf(`
+resource "aws_vpc_ipam_pool_cidr_allocation" "test" {
+  ipam_pool_id = aws_vpc_ipam_pool.test.id
+  cidr         = %[1]q
+
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+
+  depends_on = [
+    aws_vpc_ipam_pool_cidr.test
+  ]
+}
+`, cidr, tagKey1, tagValue1, tagKey2, tagValue2))
 }

--- a/internal/service/ec2/vpc_ipam_pool_cidr_allocation_test.go
+++ b/internal/service/ec2/vpc_ipam_pool_cidr_allocation_test.go
@@ -288,6 +288,11 @@ func TestAccIPAMPoolCIDRAllocation_tags(t *testing.T) { // nosemgrep:ci.vpc-in-t
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey1, acctest.CtValue1),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
 			},
 			{
 				ResourceName:      resourceName,
@@ -302,6 +307,11 @@ func TestAccIPAMPoolCIDRAllocation_tags(t *testing.T) { // nosemgrep:ci.vpc-in-t
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey1, acctest.CtValue1Updated),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey2, acctest.CtValue2),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
 			},
 			{
 				Config: testAccIPAMPoolCIDRAllocationConfig_tags(cidr, acctest.CtKey2, acctest.CtValue2),
@@ -310,6 +320,11 @@ func TestAccIPAMPoolCIDRAllocation_tags(t *testing.T) { // nosemgrep:ci.vpc-in-t
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey2, acctest.CtValue2),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
 			},
 		},
 	})

--- a/website/docs/r/vpc_ipam_pool_cidr_allocation.html.markdown
+++ b/website/docs/r/vpc_ipam_pool_cidr_allocation.html.markdown
@@ -99,6 +99,7 @@ This resource exports the following attributes in addition to the arguments abov
 * `resource_id` - The ID of the resource.
 * `resource_owner` - The owner of the resource.
 * `resource_type` - The type of the resource.
+* `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 
 ## Import
 

--- a/website/docs/r/vpc_ipam_pool_cidr_allocation.html.markdown
+++ b/website/docs/r/vpc_ipam_pool_cidr_allocation.html.markdown
@@ -89,6 +89,7 @@ This resource supports the following arguments:
 * `disallowed_cidrs` - (Optional, Forces new resource) Exclude a particular CIDR range from being returned by the pool.
 * `ipam_pool_id` - (Required, Forces new resource) The ID of the pool to which you want to assign a CIDR.
 * `netmask_length` - (Optional, Forces new resource) The netmask length of the CIDR you would like to allocate to the IPAM pool. Valid Values: `0-128`.
+* `tags` - (Optional) Map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

This PR adds tagging support to the `aws_vpc_ipam_pool_cidr_allocation` resource using the transparent tagging mechanism.

Since the resource previously did not implement an `Update` function, an `Update` function is added to support tag updates through transparent tagging.

### Relations

Closes #48069

### References
Announcement
https://aws.amazon.com/jp/about-aws/whats-new/2026/05/amazon-vpc-ipam-tags/

### Output from Acceptance Testing
```console
$ make testacc TESTS='TestAccIPAMPoolCIDRAllocation_ipv4Basic$$' PKG=ec2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     5.715s
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework 5.297s
make: Running acceptance tests on branch: 🌿 f-aws_vpc_ipam_pool_cidr_allocation-support_tagging 🌿...
TF_ACC=1 go1.26.3 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccIPAMPoolCIDRAllocation_ipv4Basic$'  -timeout 360m -vet=off -buildvcs=false
2026/05/28 02:45:33 Creating Terraform AWS Provider (SDKv2-style)...
2026/05/28 02:45:33 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccIPAMPoolCIDRAllocation_ipv4Basic
=== PAUSE TestAccIPAMPoolCIDRAllocation_ipv4Basic
=== CONT  TestAccIPAMPoolCIDRAllocation_ipv4Basic
--- PASS: TestAccIPAMPoolCIDRAllocation_ipv4Basic (88.13s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        93.968s
```

```console
$ make testacc TESTS='TestAccIPAMPoolCIDRAllocation_tags' PKG=ec2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework (cached)
make: Running acceptance tests on branch: 🌿 f-aws_vpc_ipam_pool_cidr_allocation-support_tagging 🌿...
TF_ACC=1 go1.26.3 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccIPAMPoolCIDRAllocation_tags'  -timeout 360m -vet=off -buildvcs=false
2026/05/28 02:33:09 Creating Terraform AWS Provider (SDKv2-style)...
2026/05/28 02:33:09 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccIPAMPoolCIDRAllocation_tags
=== PAUSE TestAccIPAMPoolCIDRAllocation_tags
=== CONT  TestAccIPAMPoolCIDRAllocation_tags
--- PASS: TestAccIPAMPoolCIDRAllocation_tags (152.03s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        157.863s
```
