### PR TITLE
r/aws_db_instance: fix maintenance_window triggering unnecessary blue…

### DIFF
--- a/.changelog/48097.txt
+++ b/.changelog/48097.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_db_instance: Fix `maintenance_window` changes incorrectly triggering blue/green deployment when `blue_green_update` is enabled
+```

--- a/internal/service/rds/instance.go
+++ b/internal/service/rds/instance.go
@@ -2152,6 +2152,7 @@ func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta an
 			"blue_green_update",
 			"delete_automated_backups",
 			names.AttrFinalSnapshotIdentifier,
+			"maintenance_window",
 			"replicate_source_db",
 			"skip_final_snapshot",
 			names.AttrTags, names.AttrTagsAll,

--- a/internal/service/rds/instance_test.go
+++ b/internal/service/rds/instance_test.go
@@ -7055,6 +7055,45 @@ func TestAccRDSInstance_BlueGreenDeployment_passwordBypassesBlueGreen(t *testing
 	})
 }
 
+func TestAccRDSInstance_BlueGreenDeployment_maintenanceWindowBypassesBlueGreen(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var v1, v2 types.DBInstance
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_db_instance.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_11_0),
+		},
+		CheckDestroy: testAccCheckDBInstanceDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceConfig_BlueGreenDeployment_maintenanceWindow(rName, "sun:05:00-sun:06:00"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckDBInstanceExists(ctx, t, resourceName, &v1),
+					resource.TestCheckResourceAttr(resourceName, "maintenance_window", "sun:05:00-sun:06:00"),
+				),
+			},
+			{
+				Config: testAccInstanceConfig_BlueGreenDeployment_maintenanceWindow(rName, "mon:05:00-mon:06:00"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckDBInstanceExists(ctx, t, resourceName, &v2),
+					testAccCheckDBInstanceNotRecreated(&v1, &v2),
+					resource.TestCheckResourceAttr(resourceName, "maintenance_window", "mon:05:00-mon:06:00"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccRDSInstance_BlueGreenDeployment_updateWithDeletionProtection(t *testing.T) {
 	ctx := acctest.Context(t)
 
@@ -14599,6 +14638,31 @@ resource "aws_db_instance" "test" {
   }
 }
 `, rName, password))
+}
+
+func testAccInstanceConfig_BlueGreenDeployment_maintenanceWindow(rName, maintenanceWindow string) string {
+	return acctest.ConfigCompose(
+		testAccInstanceConfig_orderableClassMySQL(),
+		fmt.Sprintf(`
+resource "aws_db_instance" "test" {
+  identifier              = %[1]q
+  allocated_storage       = 10
+  backup_retention_period = 1
+  engine                  = data.aws_rds_orderable_db_instance.test.engine
+  engine_version          = data.aws_rds_orderable_db_instance.test.engine_version
+  instance_class          = data.aws_rds_orderable_db_instance.test.instance_class
+  db_name                 = "test"
+  parameter_group_name    = "default.${data.aws_rds_engine_version.default.parameter_group_family}"
+  skip_final_snapshot     = true
+  password                = "avoid-plaintext-passwords"
+  username                = "tfacctest"
+  maintenance_window      = %[2]q
+
+  blue_green_update {
+    enabled = true
+  }
+}
+`, rName, maintenanceWindow))
 }
 
 func testAccInstanceConfig_engineVersion(rName string, update bool) string {


### PR DESCRIPTION
---
  Description
  
  Changing maintenance_window on an aws_db_instance with blue_green_update enabled was incorrectly triggering a full blue/green deployment, causing
  unnecessary downtime. The maintenance_window attribute can be applied directly via ModifyDBInstance without any switchover, so it is now excluded from
  the list of changes that trigger blue/green — following the same pattern already used for deletion_protection and password.

  Relations

  Closes #46182

  References

  - Similar fix for deletion_protection and password: #33990
  - Original issue report: #46182

  Output from Acceptance Testing

  % make testacc TESTS=TestAccRDSInstance_BlueGreenDeployment_maintenanceWindowBypassesBlueGreen PKG=rds

  ▎ Acceptance tests require live AWS credentials and will be run by the HashiCorp CI pipeline. go build and go vet pass locally.

  Changes to Security Controls

  No changes to security controls.

  Rollback Plan

  If a change needs to be reverted, we will publish an updated version of the library.

  ---