### PR TITLE
🤖🤖🤖 resource/aws_ecs_express_gateway_service: Fix recreate after deletion

### DIFF
--- a/.changelog/48098.txt
+++ b/.changelog/48098.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ecs_express_gateway_service: Fix `Resource Already Exists` error when recreating a service after deletion
+```

--- a/internal/service/ecs/express_gateway_service.go
+++ b/internal/service/ecs/express_gateway_service.go
@@ -664,8 +664,11 @@ func checkExpressGatewayServiceExists(ctx context.Context, conn *ecs.Client, ser
 		clusterName = "default"
 	}
 
-	_, err := findServiceNoTagsByTwoPartKey(ctx, conn, serviceName.ValueString(), clusterName)
+	svc, err := findServiceNoTagsByTwoPartKey(ctx, conn, serviceName.ValueString(), clusterName)
 	if err == nil {
+		if aws.ToString(svc.Status) == serviceStatusInactive {
+			return nil
+		}
 		return fmt.Errorf("Express Gateway Service %s already exists in cluster %s", serviceName.ValueString(), clusterName)
 	}
 	if retry.NotFound(err) {

--- a/internal/service/ecs/express_gateway_service_test.go
+++ b/internal/service/ecs/express_gateway_service_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/YakDriver/regexache"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
@@ -514,6 +515,90 @@ func TestAccECSExpressGatewayService_recreateAfterDeleting(t *testing.T) {
 			},
 		},
 	})
+}
+
+// TestAccECSExpressGatewayService_inactiveServiceDoesNotBlockCreate verifies that
+// an INACTIVE service returned by DescribeServices does not block recreation.
+// Regression test for https://github.com/hashicorp/terraform-provider-aws/issues/47438
+func TestAccECSExpressGatewayService_inactiveServiceDoesNotBlockCreate(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var service1, service2 awstypes.ECSExpressGatewayService
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_ecs_express_gateway_service.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.ECSEndpointID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ECSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckExpressGatewayServiceDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccExpressGatewayServiceConfig_named(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckExpressGatewayServiceExists(ctx, t, resourceName, &service1),
+				),
+			},
+			{
+				Config: testAccExpressGatewayServiceConfig_base(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckExpressGatewayServiceNotInState(ctx, t, resourceName),
+					testAccCheckServiceInactiveViaDescribeServices(ctx, t, rName, "default"),
+				),
+			},
+			{
+				Config: testAccExpressGatewayServiceConfig_named(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckExpressGatewayServiceExists(ctx, t, resourceName, &service2),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckServiceInactiveViaDescribeServices(ctx context.Context, t *testing.T, serviceName, cluster string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.ProviderMeta(ctx, t).ECSClient(ctx)
+
+		svc, err := tfecs.FindServiceNoTagsByTwoPartKey(ctx, conn, serviceName, cluster)
+		if err != nil {
+			t.Logf("Service %s not found via DescribeServices (may have been fully removed): %s", serviceName, err)
+			return nil
+		}
+
+		status := aws.ToString(svc.Status)
+		if status != "INACTIVE" {
+			return fmt.Errorf("expected service %s to be INACTIVE via DescribeServices, got %s", serviceName, status)
+		}
+
+		t.Logf("Service %s is INACTIVE but still discoverable via DescribeServices", serviceName)
+		return nil
+	}
+}
+
+func testAccExpressGatewayServiceConfig_named(rName string) string {
+	return acctest.ConfigCompose(testAccExpressGatewayServiceConfig_base(rName, false), fmt.Sprintf(`
+resource "aws_ecs_express_gateway_service" "test" {
+  service_name            = %[1]q
+  execution_role_arn      = aws_iam_role.execution.arn
+  infrastructure_role_arn = aws_iam_role.infrastructure.arn
+
+  primary_container {
+    image = "public.ecr.aws/nginx/nginx:1.28-alpine3.21-slim"
+  }
+
+  depends_on = [
+    aws_iam_role_policy_attachment.execution,
+    aws_iam_role_policy_attachment.infrastructure,
+  ]
+}
+`, rName))
 }
 
 func testAccCheckExpressGatewayServiceDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

  ### Description

  Fixes the `Resource Already Exists` error when recreating an `aws_ecs_express_gateway_service` after deletion.

**Root cause**: `checkExpressGatewayServiceExists` calls `findServiceNoTagsByTwoPartKey` (which uses `DescribeServices`) and treats any found service as "already exists". After a destroy, the ECS API still returns the service in `INACTIVE` state, causing a false conflict.

**Fix**: Check `svc.Status` and allow creation when the existing service is `INACTIVE`, since INACTIVE services are fully deleted and their names can be reused.

**Note**: PR #47568 fixed the delete waiter (waiting for INACTIVE instead of returning at DRAINING), and PR #47701 added a test for this scenario, but neither addressed the existence check — leaving the issue unresolved despite being marked as fixed in v6.43.0.

### Relations

Closes #47438
Closes #48098
Closes #48057

### References

- #47568 — Fixed delete waiter but not existence check
- #47701 — Added recreate test but bug still present
- [ECS DescribeServices API](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_DescribeServices.html) — Returns services in `INACTIVE` status
- [ECS Service lifecycle](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_Service.html) — Documents `ACTIVE`, `DRAINING`, `INACTIVE` status values

### Output from Acceptance Testing

```
2026/05/29 09:53:38 Creating Terraform AWS Provider (SDKv2-style)...
2026/05/29 09:53:38 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccECSExpressGatewayService_inactiveServiceDoesNotBlockCreate
=== PAUSE TestAccECSExpressGatewayService_inactiveServiceDoesNotBlockCreate
=== CONT  TestAccECSExpressGatewayService_inactiveServiceDoesNotBlockCreate
    express_gateway_service_test.go:580: Service tf-acc-test-3200380183907123977 is INACTIVE but still discoverable via DescribeServices
--- PASS: TestAccECSExpressGatewayService_inactiveServiceDoesNotBlockCreate (239.17s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecs	248.752s
?   	github.com/hashicorp/terraform-provider-aws/internal/service/ecs/test-fixtures	[no test files]
```

### AI Disclosure

AI (Claude) was used to identify the root cause and generate the fix. All code has been reviewed and understood by the submitter.