### PR TITLE
# 🤖🤖🤖 resource/aws_dynamodb_table: Add create_async for GSI

### DIFF
--- a/.changelog/48101.txt
+++ b/.changelog/48101.txt
@@ -1,0 +1,4 @@
+```release-note:enhancement
+resource/aws_dynamodb_table: Add `create_async` argument to `global_secondary_index` to skip waiting for a new index to become `ACTIVE`
+resource/aws_dynamodb_global_secondary_index: Add `create_async` argument to skip waiting for a new index to become `ACTIVE`
+```

--- a/internal/service/dynamodb/exports_test.go
+++ b/internal/service/dynamodb/exports_test.go
@@ -37,4 +37,8 @@ var (
 	TableReplicaParseResourceID                  = tableReplicaParseResourceID
 	UpdateDiffGSI                                = updateDiffGSI
 	CheckIfGSIRecreateAttributesChanged          = checkIfGSIRecreateAttributesChanged
+	GSICreateAsyncByName                         = gsiCreateAsyncByName
+	FlattenTableGlobalSecondaryIndex             = flattenTableGlobalSecondaryIndex
+	GSIModificationsBlockedByCreating            = gsiModificationsBlockedByCreating
+	SortGSICreatesAsyncLast                      = sortGSICreatesAsyncLast
 )

--- a/internal/service/dynamodb/forge.go
+++ b/internal/service/dynamodb/forge.go
@@ -14,6 +14,7 @@ func stripGSIUpdatableAttributes(in map[string]any) map[string]any {
 	attrs = stripNonKeyAttributes(attrs)
 	attrs = stripOnDemandThroughputAttributes(attrs)
 	attrs = stripWarmThroughputAttributes(attrs)
+	attrs = stripCreateAsyncAttributes(attrs)
 	// Remove empty hash_keys/range_keys to avoid false positive diffs
 	if hks, ok := attrs["hash_keys"]; ok {
 		if l, ok := hks.([]any); ok && len(l) == 0 {
@@ -58,6 +59,14 @@ func stripWarmThroughputAttributes(in map[string]any) map[string]any {
 	mapCopy := maps.Clone(in)
 
 	delete(mapCopy, "warm_throughput")
+
+	return mapCopy
+}
+
+func stripCreateAsyncAttributes(in map[string]any) map[string]any {
+	mapCopy := maps.Clone(in)
+
+	delete(mapCopy, "create_async")
 
 	return mapCopy
 }

--- a/internal/service/dynamodb/global_secondary_index.go
+++ b/internal/service/dynamodb/global_secondary_index.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
@@ -74,6 +75,11 @@ func (r *resourceGlobalSecondaryIndex) Schema(ctx context.Context, request resou
 	s := schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			names.AttrARN: framework.ARNAttributeComputedOnly(),
+			"create_async": schema.BoolAttribute{
+				Optional: true,
+				Computed: true,
+				Default:  booldefault.StaticBool(false),
+			},
 			"index_name": schema.StringAttribute{
 				Required: true,
 				PlanModifiers: []planmodifier.String{
@@ -313,6 +319,38 @@ func (r *resourceGlobalSecondaryIndex) Create(ctx context.Context, request resou
 	_, err = conn.UpdateTable(ctx, &input)
 	if err != nil {
 		smerr.AddError(ctx, &response.Diagnostics, err, names.AttrTableName, data.TableName.ValueString(), "index_name", data.IndexName.ValueString())
+		return
+	}
+
+	if data.CreateAsync.ValueBool() {
+		if _, err = waitGSIExists(ctx, conn, data.TableName.ValueString(), data.IndexName.ValueString(), createTimeout); err != nil {
+			response.Diagnostics.AddError(
+				fmt.Sprintf(`Error while waiting for GSI "%s" on table "%s" to be created`, data.IndexName.ValueString(), data.TableName.ValueString()),
+				err.Error(),
+			)
+
+			return
+		}
+
+		table, err = findTableByName(ctx, conn, data.TableName.ValueString())
+		if err != nil {
+			smerr.AddError(ctx, &response.Diagnostics, err, names.AttrTableName, data.TableName.ValueString(), "index_name", data.IndexName.ValueString())
+			return
+		}
+
+		index, err := findGSIFromTable(table, data.IndexName.ValueString())
+		if err != nil {
+			smerr.AddError(ctx, &response.Diagnostics, err, names.AttrTableName, data.TableName.ValueString(), "index_name", data.IndexName.ValueString())
+			return
+		}
+
+		response.Diagnostics.Append(flattenGlobalSecondaryIndex(ctx, &data, index, table)...)
+		if response.Diagnostics.HasError() {
+			return
+		}
+
+		response.Diagnostics.Append(response.State.Set(ctx, &data)...)
+
 		return
 	}
 
@@ -609,6 +647,9 @@ func flattenGlobalSecondaryIndex(ctx context.Context, data *resourceGlobalSecond
 	)...)
 
 	data.TableName = fwflex.StringToFramework(ctx, table.TableName)
+	if data.CreateAsync.IsNull() || data.CreateAsync.IsUnknown() {
+		data.CreateAsync = types.BoolValue(false)
+	}
 
 	attributeTypes := make(map[string]awstypes.ScalarAttributeType, len(table.AttributeDefinitions))
 	for _, attribute := range table.AttributeDefinitions {
@@ -647,6 +688,7 @@ type resourceGlobalSecondaryIndexModel struct {
 	framework.WithRegionModel
 
 	ARN                   types.String                                                `tfsdk:"arn"`
+	CreateAsync           types.Bool                                                  `tfsdk:"create_async"`
 	IndexName             types.String                                                `tfsdk:"index_name"`
 	KeySchema             fwtypes.ListNestedObjectValueOf[keySchemaModel]             `tfsdk:"key_schema"`
 	TableName             types.String                                                `tfsdk:"table_name"`

--- a/internal/service/dynamodb/global_secondary_index_test.go
+++ b/internal/service/dynamodb/global_secondary_index_test.go
@@ -96,6 +96,42 @@ func TestAccDynamoDBGlobalSecondaryIndex_basic(t *testing.T) {
 	})
 }
 
+func TestAccDynamoDBGlobalSecondaryIndex_createAsync(t *testing.T) {
+	ctx := acctest.Context(t)
+	var conf awstypes.TableDescription
+	var gsi awstypes.GlobalSecondaryIndexDescription
+
+	resourceNameTable := "aws_dynamodb_table.test"
+	resourceName := "aws_dynamodb_global_secondary_index.test"
+
+	rNameTable := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.DynamoDBServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckGlobalSecondaryIndexDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGlobalSecondaryIndexConfig_createAsync(rNameTable, rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckTableExists(ctx, t, resourceNameTable, &conf),
+					testAccCheckGlobalSecondaryIndexExists(ctx, t, resourceName, &gsi),
+					resource.TestCheckResourceAttr(resourceName, "create_async", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "index_name", rName),
+					resource.TestCheckResourceAttr(resourceName, names.AttrTableName, rNameTable),
+					testAccCheckGSIStatusReached(ctx, t, rNameTable, rName,
+						awstypes.IndexStatusCreating, awstypes.IndexStatusActive),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("create_async"), knownvalue.Bool(true)),
+				},
+			},
+		},
+	})
+}
+
 func TestAccDynamoDBGlobalSecondaryIndex_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf awstypes.TableDescription
@@ -2984,6 +3020,43 @@ resource "aws_dynamodb_global_secondary_index" "test" {
   index_name = %[2]q
   projection {
     projection_type = "ALL"
+  }
+
+  provisioned_throughput {
+    read_capacity_units  = 1
+    write_capacity_units = 1
+  }
+
+  key_schema {
+    attribute_name = %[1]q
+    attribute_type = "S"
+    key_type       = "HASH"
+  }
+}
+
+resource "aws_dynamodb_table" "test" {
+  name           = %[1]q
+  hash_key       = %[1]q
+  read_capacity  = 1
+  write_capacity = 1
+
+  attribute {
+    name = %[1]q
+    type = "S"
+  }
+}
+`, tableName, indexName)
+}
+
+func testAccGlobalSecondaryIndexConfig_createAsync(tableName, indexName string) string {
+	return fmt.Sprintf(`
+resource "aws_dynamodb_global_secondary_index" "test" {
+  table_name   = aws_dynamodb_table.test.name
+  index_name   = %[2]q
+  create_async = true
+
+  projection {
+    projection_type = "KEYS_ONLY"
   }
 
   provisioned_throughput {

--- a/internal/service/dynamodb/table.go
+++ b/internal/service/dynamodb/table.go
@@ -187,6 +187,11 @@ func resourceTable() *schema.Resource {
 					Computed: true,
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{
+							"create_async": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Default:  false,
+							},
 							"hash_key": {
 								Type:         schema.TypeString,
 								Optional:     true,
@@ -983,6 +988,14 @@ func resourceTableCreate(ctx context.Context, d *schema.ResourceData, meta any) 
 		for _, gsiObject := range gsiSet.List() {
 			gsi := gsiObject.(map[string]any)
 
+			if async, _ := gsi["create_async"].(bool); async {
+				if _, err := waitGSIExists(ctx, conn, d.Id(), gsi[names.AttrName].(string), d.Timeout(schema.TimeoutUpdate)); err != nil {
+					return create.AppendDiagError(diags, names.DynamoDB, create.ErrActionWaitingForCreation, resNameTable, d.Id(), fmt.Errorf("GSI (%s): %w", gsi[names.AttrName].(string), err))
+				}
+
+				continue
+			}
+
 			if _, err := waitGSIActive(ctx, conn, d.Id(), gsi[names.AttrName].(string), d.Timeout(schema.TimeoutUpdate)); err != nil {
 				return create.AppendDiagError(diags, names.DynamoDB, create.ErrActionWaitingForCreation, resNameTable, d.Id(), fmt.Errorf("GSI (%s): %w", gsi[names.AttrName].(string), err))
 			}
@@ -1072,7 +1085,8 @@ func resourceTableFlatten(ctx context.Context, c *conns.AWSClient, d *schema.Res
 		return create.AppendDiagSettingError(diags, names.DynamoDB, resNameTable, d.Id(), "local_secondary_index", err)
 	}
 
-	if err := d.Set("global_secondary_index", flattenTableGlobalSecondaryIndex(table.GlobalSecondaryIndexes)); err != nil {
+	priorCreateAsync := gsiCreateAsyncByName(d.Get("global_secondary_index").(*schema.Set).List())
+	if err := d.Set("global_secondary_index", flattenTableGlobalSecondaryIndex(table.GlobalSecondaryIndexes, priorCreateAsync)); err != nil {
 		return create.AppendDiagSettingError(diags, names.DynamoDB, resNameTable, d.Id(), "global_secondary_index", err)
 	}
 
@@ -1198,6 +1212,22 @@ func resourceTableUpdate(ctx context.Context, d *schema.ResourceData, meta any) 
 		gsiUpdates, err = updateDiffGSI(oldGSI.(*schema.Set).List(), newGSI.(*schema.Set).List(), newBillingMode, oldAttrTypes, newAttrTypes)
 		if err != nil {
 			return create.AppendDiagError(diags, names.DynamoDB, create.ErrActionUpdating, resNameTable, d.Id(), fmt.Errorf("computing GSI difference: %w", err))
+		}
+	}
+
+	// Fail fast if any GSI update or delete targets an index that is still
+	// backfilling (CREATING), e.g. one previously created with create_async.
+	// Create-only updates can never be blocked, so skip the extra DescribeTable.
+	if slices.ContainsFunc(gsiUpdates, func(op awstypes.GlobalSecondaryIndexUpdate) bool {
+		return op.Update != nil || op.Delete != nil
+	}) {
+		table, err := findTableByName(ctx, conn, d.Id())
+		if err != nil {
+			return create.AppendDiagError(diags, names.DynamoDB, create.ErrActionReading, resNameTable, d.Id(), err)
+		}
+
+		if err := gsiModificationsBlockedByCreating(table.GlobalSecondaryIndexes, gsiUpdates); err != nil {
+			return create.AppendDiagError(diags, names.DynamoDB, create.ErrActionUpdating, resNameTable, d.Id(), err)
 		}
 	}
 
@@ -1380,12 +1410,17 @@ func resourceTableUpdate(ctx context.Context, d *schema.ResourceData, meta any) 
 	}
 
 	// Phase 3 of Global Secondary Index Operations: Create Only
-	// Only 1 online index can be created simultaneously per table
-	for _, gsiUpdate := range gsiUpdates {
-		if gsiUpdate.Create == nil {
-			continue
-		}
+	// Only 1 online index can be created simultaneously per table, so creates
+	// are processed sequentially. Async-marked creates are reordered last so
+	// the user's intent to skip the ACTIVE wait is honored for at least one
+	// create when mixed with synchronous ones (AWS still requires waiting on
+	// prior creates to reach ACTIVE before submitting the next one).
+	createAsyncByName := gsiCreateAsyncByName(d.Get("global_secondary_index").(*schema.Set).List())
+	createOps := sortGSICreatesAsyncLast(gsiUpdates, createAsyncByName)
+	remainingCreates := len(createOps)
 
+	for _, gsiUpdate := range createOps {
+		remainingCreates--
 		idxName := aws.ToString(gsiUpdate.Create.IndexName)
 		input := &dynamodb.UpdateTableInput{
 			AttributeDefinitions:        expandAttributes(d.Get("attribute").(*schema.Set).List()),
@@ -1395,6 +1430,14 @@ func resourceTableUpdate(ctx context.Context, d *schema.ResourceData, meta any) 
 
 		if _, err := conn.UpdateTable(ctx, input); err != nil {
 			return create.AppendDiagError(diags, names.DynamoDB, create.ErrActionUpdating, resNameTable, d.Id(), fmt.Errorf("creating GSI (%s): %w", idxName, err))
+		}
+
+		if createAsyncByName[idxName] && remainingCreates == 0 {
+			if _, err := waitGSIExists(ctx, conn, d.Id(), idxName, d.Timeout(schema.TimeoutUpdate)); err != nil {
+				return create.AppendDiagError(diags, names.DynamoDB, create.ErrActionUpdating, resNameTable, d.Id(), fmt.Errorf("%s GSI (%s): %w", create.ErrActionWaitingForCreation, idxName, err))
+			}
+
+			continue // create_async: no later GSI create depends on this index becoming ACTIVE.
 		}
 
 		if _, err := waitGSIActive(ctx, conn, d.Id(), idxName, d.Timeout(schema.TimeoutUpdate)); err != nil {
@@ -2105,6 +2148,83 @@ func updateWarmThroughput(ctx context.Context, conn *dynamodb.Client, warmList [
 	return nil
 }
 
+// gsiCreateAsyncByName maps a GSI config list to index name -> create_async.
+func gsiCreateAsyncByName(gsi []any) map[string]bool {
+	m := make(map[string]bool, len(gsi))
+	for _, g := range gsi {
+		gm, ok := g.(map[string]any)
+		if !ok {
+			continue
+		}
+		name, _ := gm[names.AttrName].(string)
+		if name == "" {
+			continue
+		}
+		async, _ := gm["create_async"].(bool)
+		m[name] = async
+	}
+	return m
+}
+
+// sortGSICreatesAsyncLast filters GSI updates to Create ops and stable-sorts
+// them so async-marked creates come after synchronous ones. AWS serializes GSI
+// creates per table; only the last create in the loop can safely skip the
+// ACTIVE wait, so sorting async last maximizes the chance that user intent is
+// honored. Relative order within each group is preserved.
+func sortGSICreatesAsyncLast(gsiUpdates []awstypes.GlobalSecondaryIndexUpdate, createAsyncByName map[string]bool) []awstypes.GlobalSecondaryIndexUpdate {
+	createOps := make([]awstypes.GlobalSecondaryIndexUpdate, 0, len(gsiUpdates))
+	for _, op := range gsiUpdates {
+		if op.Create != nil {
+			createOps = append(createOps, op)
+		}
+	}
+
+	slices.SortStableFunc(createOps, func(a, b awstypes.GlobalSecondaryIndexUpdate) int {
+		aAsync := createAsyncByName[aws.ToString(a.Create.IndexName)]
+		bAsync := createAsyncByName[aws.ToString(b.Create.IndexName)]
+		switch {
+		case aAsync == bAsync:
+			return 0
+		case aAsync:
+			return 1
+		default:
+			return -1
+		}
+	})
+
+	return createOps
+}
+
+// gsiModificationsBlockedByCreating returns an error if any op modifies or
+// deletes an index that is currently in CREATING state. This produces an
+// actionable message instead of AWS's opaque ValidationException.
+func gsiModificationsBlockedByCreating(gsis []awstypes.GlobalSecondaryIndexDescription, ops []awstypes.GlobalSecondaryIndexUpdate) error {
+	creating := make(map[string]bool)
+	for _, g := range gsis {
+		if g.IndexStatus == awstypes.IndexStatusCreating {
+			creating[aws.ToString(g.IndexName)] = true
+		}
+	}
+
+	for _, op := range ops {
+		var name string
+		switch {
+		case op.Update != nil:
+			name = aws.ToString(op.Update.IndexName)
+		case op.Delete != nil:
+			name = aws.ToString(op.Delete.IndexName)
+		default:
+			continue // Create ops are allowed.
+		}
+
+		if creating[name] {
+			return fmt.Errorf("GSI (%s) is still backfilling (CREATING) and cannot be modified or deleted yet; wait for it to become ACTIVE", name)
+		}
+	}
+
+	return nil
+}
+
 func updateDiffGSI(oldGsi, newGsi []any, billingMode awstypes.BillingMode, oldAttrTypes, newAttrTypes map[string]string) ([]awstypes.GlobalSecondaryIndexUpdate, error) {
 	// Transform slices into maps
 	oldGsis := make(map[string]any)
@@ -2765,7 +2885,7 @@ func flattenTableLocalSecondaryIndex(lsi []awstypes.LocalSecondaryIndexDescripti
 	return output
 }
 
-func flattenTableGlobalSecondaryIndex(gsi []awstypes.GlobalSecondaryIndexDescription) []any {
+func flattenTableGlobalSecondaryIndex(gsi []awstypes.GlobalSecondaryIndexDescription, createAsync map[string]bool) []any {
 	if len(gsi) == 0 {
 		return []any{}
 	}
@@ -2776,6 +2896,10 @@ func flattenTableGlobalSecondaryIndex(gsi []awstypes.GlobalSecondaryIndexDescrip
 		gsi := make(map[string]any)
 
 		gsi[names.AttrName] = aws.ToString(g.IndexName)
+
+		if createAsync != nil {
+			gsi["create_async"] = createAsync[aws.ToString(g.IndexName)]
+		}
 
 		if g.ProvisionedThroughput != nil {
 			gsi["write_capacity"] = aws.ToInt64(g.ProvisionedThroughput.WriteCapacityUnits)

--- a/internal/service/dynamodb/table_data_source.go
+++ b/internal/service/dynamodb/table_data_source.go
@@ -310,7 +310,7 @@ func dataSourceTableRead(ctx context.Context, d *schema.ResourceData, meta any) 
 		return sdkdiag.AppendErrorf(diags, "setting local_secondary_index: %s", err)
 	}
 
-	if err := d.Set("global_secondary_index", flattenTableGlobalSecondaryIndex(table.GlobalSecondaryIndexes)); err != nil {
+	if err := d.Set("global_secondary_index", flattenTableGlobalSecondaryIndex(table.GlobalSecondaryIndexes, nil)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting global_secondary_index: %s", err)
 	}
 

--- a/internal/service/dynamodb/table_test.go
+++ b/internal/service/dynamodb/table_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"maps"
 	"regexp"
+	"slices"
 	"testing"
 	"time"
 
@@ -71,6 +72,29 @@ func TestUpdateDiffGSI_Provisioned(t *testing.T) {
 			New: []any{
 				map[string]any{
 					names.AttrName:    "att1-index",
+					"hash_key":        "att1",
+					"write_capacity":  10,
+					"read_capacity":   10,
+					"projection_type": "ALL",
+				},
+			},
+			ExpectedUpdates: nil,
+		},
+		"create_async changed": { // No-op => provider-only metadata
+			Old: []any{
+				map[string]any{
+					names.AttrName:    "att1-index",
+					"create_async":    true,
+					"hash_key":        "att1",
+					"write_capacity":  10,
+					"read_capacity":   10,
+					"projection_type": "ALL",
+				},
+			},
+			New: []any{
+				map[string]any{
+					names.AttrName:    "att1-index",
+					"create_async":    false,
 					"hash_key":        "att1",
 					"write_capacity":  10,
 					"read_capacity":   10,
@@ -1842,6 +1866,29 @@ func TestCheckIfGSIRecreateAttributesChanged(t *testing.T) {
 			},
 			New: map[string]any{
 				names.AttrName:    "gsi1",
+				"hash_key":        "pk",
+				"range_key":       "",
+				"projection_type": "ALL",
+				"key_schema": []any{
+					map[string]any{"attribute_name": "pk", "key_type": "HASH"},
+				},
+			},
+			Expected: false,
+		},
+		"create_async changed": {
+			Old: map[string]any{
+				names.AttrName:    "gsi1",
+				"create_async":    true,
+				"hash_key":        "pk",
+				"range_key":       "",
+				"projection_type": "ALL",
+				"key_schema": []any{
+					map[string]any{"attribute_name": "pk", "key_type": "HASH"},
+				},
+			},
+			New: map[string]any{
+				names.AttrName:    "gsi1",
+				"create_async":    false,
 				"hash_key":        "pk",
 				"range_key":       "",
 				"projection_type": "ALL",
@@ -9002,6 +9049,27 @@ func testAccCheckTableExists(ctx context.Context, t *testing.T, n string, v *aws
 	return testAccCheckInitialTableExists(ctx, t, n, v)
 }
 
+// testAccCheckGSIStatusReached asserts that a GSI is in one of the allowed
+// IndexStatus values immediately after apply. For create_async coverage,
+// callers should allow both CREATING (the expected state when the wait is
+// correctly skipped) and ACTIVE (in case backfill on a small test table
+// completes before the check runs).
+func testAccCheckGSIStatusReached(ctx context.Context, t *testing.T, tableName, indexName string, allowed ...awstypes.IndexStatus) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.ProviderMeta(ctx, t).DynamoDBClient(ctx)
+		gsi, err := tfdynamodb.FindGSIByTwoPartKey(ctx, conn, tableName, indexName)
+		if err != nil {
+			return err
+		}
+
+		if slices.Contains(allowed, gsi.IndexStatus) {
+			return nil
+		}
+
+		return fmt.Errorf("GSI %s: got status %s, want one of %v", indexName, gsi.IndexStatus, allowed)
+	}
+}
+
 func testAccCheckTableNotRecreated(i, j *awstypes.TableDescription) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if !i.CreationDateTime.Equal(aws.ToTime(j.CreationDateTime)) {
@@ -13427,6 +13495,259 @@ variable "global_secondary_index" {
     read_capacity      = 1
     write_capacity     = 1
   }]
+}
+`, rName)
+}
+
+func TestGSICreateAsyncByName(t *testing.T) {
+	t.Parallel()
+
+	input := []any{
+		map[string]any{names.AttrName: "idx1", "create_async": true},
+		map[string]any{names.AttrName: "idx2", "create_async": false},
+		map[string]any{names.AttrName: "idx3"}, // missing key -> false
+	}
+
+	got := tfdynamodb.GSICreateAsyncByName(input)
+	want := map[string]bool{"idx1": true, "idx2": false, "idx3": false}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("unexpected diff (-want +got):\n%s", diff)
+	}
+}
+
+func TestFlattenTableGlobalSecondaryIndex_createAsync(t *testing.T) {
+	t.Parallel()
+
+	gsis := []awstypes.GlobalSecondaryIndexDescription{
+		{IndexName: aws.String("idx1")},
+		{IndexName: aws.String("idx2")},
+	}
+
+	// nil map -> no create_async key emitted (data source path)
+	for _, e := range tfdynamodb.FlattenTableGlobalSecondaryIndex(gsis, nil) {
+		m := e.(map[string]any)
+		if _, ok := m["create_async"]; ok {
+			t.Errorf("expected no create_async key when map is nil, got %v", m["create_async"])
+		}
+	}
+
+	// non-nil map -> stamp values, default false when absent
+	got := map[string]bool{}
+	for _, e := range tfdynamodb.FlattenTableGlobalSecondaryIndex(gsis, map[string]bool{"idx1": true}) {
+		m := e.(map[string]any)
+		got[m[names.AttrName].(string)] = m["create_async"].(bool)
+	}
+	want := map[string]bool{"idx1": true, "idx2": false}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("unexpected diff (-want +got):\n%s", diff)
+	}
+}
+
+func TestGSIModificationsBlockedByCreating(t *testing.T) {
+	t.Parallel()
+
+	gsis := []awstypes.GlobalSecondaryIndexDescription{
+		{IndexName: aws.String("creating-idx"), IndexStatus: awstypes.IndexStatusCreating},
+		{IndexName: aws.String("active-idx"), IndexStatus: awstypes.IndexStatusActive},
+	}
+
+	testCases := map[string]struct {
+		ops     []awstypes.GlobalSecondaryIndexUpdate
+		wantErr bool
+	}{
+		"update creating index": {
+			ops:     []awstypes.GlobalSecondaryIndexUpdate{{Update: &awstypes.UpdateGlobalSecondaryIndexAction{IndexName: aws.String("creating-idx")}}},
+			wantErr: true,
+		},
+		"delete creating index": {
+			ops:     []awstypes.GlobalSecondaryIndexUpdate{{Delete: &awstypes.DeleteGlobalSecondaryIndexAction{IndexName: aws.String("creating-idx")}}},
+			wantErr: true,
+		},
+		"create new index": {
+			ops:     []awstypes.GlobalSecondaryIndexUpdate{{Create: &awstypes.CreateGlobalSecondaryIndexAction{IndexName: aws.String("new-idx")}}},
+			wantErr: false,
+		},
+		"update active index": {
+			ops:     []awstypes.GlobalSecondaryIndexUpdate{{Update: &awstypes.UpdateGlobalSecondaryIndexAction{IndexName: aws.String("active-idx")}}},
+			wantErr: false,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			err := tfdynamodb.GSIModificationsBlockedByCreating(gsis, tc.ops)
+			if got := err != nil; got != tc.wantErr {
+				t.Errorf("wantErr %t, got err: %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestSortGSICreatesAsyncLast(t *testing.T) {
+	t.Parallel()
+
+	createOp := func(name string) awstypes.GlobalSecondaryIndexUpdate {
+		return awstypes.GlobalSecondaryIndexUpdate{
+			Create: &awstypes.CreateGlobalSecondaryIndexAction{IndexName: aws.String(name)},
+		}
+	}
+	deleteOp := awstypes.GlobalSecondaryIndexUpdate{
+		Delete: &awstypes.DeleteGlobalSecondaryIndexAction{IndexName: aws.String("ignored-delete")},
+	}
+	updateOp := awstypes.GlobalSecondaryIndexUpdate{
+		Update: &awstypes.UpdateGlobalSecondaryIndexAction{IndexName: aws.String("ignored-update")},
+	}
+
+	extractCreateNames := func(ops []awstypes.GlobalSecondaryIndexUpdate) []string {
+		out := make([]string, 0, len(ops))
+		for _, op := range ops {
+			out = append(out, aws.ToString(op.Create.IndexName))
+		}
+		return out
+	}
+
+	testCases := map[string]struct {
+		input    []awstypes.GlobalSecondaryIndexUpdate
+		async    map[string]bool
+		expected []string
+	}{
+		"single sync": {
+			input:    []awstypes.GlobalSecondaryIndexUpdate{createOp("a")},
+			async:    map[string]bool{"a": false},
+			expected: []string{"a"},
+		},
+		"single async": {
+			input:    []awstypes.GlobalSecondaryIndexUpdate{createOp("a")},
+			async:    map[string]bool{"a": true},
+			expected: []string{"a"},
+		},
+		"sync then async preserved": {
+			input:    []awstypes.GlobalSecondaryIndexUpdate{createOp("sync"), createOp("async")},
+			async:    map[string]bool{"sync": false, "async": true},
+			expected: []string{"sync", "async"},
+		},
+		"async first reordered last": {
+			input:    []awstypes.GlobalSecondaryIndexUpdate{createOp("async"), createOp("sync")},
+			async:    map[string]bool{"async": true, "sync": false},
+			expected: []string{"sync", "async"},
+		},
+		"two sync one async": {
+			input:    []awstypes.GlobalSecondaryIndexUpdate{createOp("s1"), createOp("async"), createOp("s2")},
+			async:    map[string]bool{"s1": false, "async": true, "s2": false},
+			expected: []string{"s1", "s2", "async"},
+		},
+		"all async preserves relative order": {
+			input:    []awstypes.GlobalSecondaryIndexUpdate{createOp("a1"), createOp("a2"), createOp("a3")},
+			async:    map[string]bool{"a1": true, "a2": true, "a3": true},
+			expected: []string{"a1", "a2", "a3"},
+		},
+		"non-create ops filtered out": {
+			input:    []awstypes.GlobalSecondaryIndexUpdate{deleteOp, createOp("async"), updateOp, createOp("sync")},
+			async:    map[string]bool{"async": true, "sync": false},
+			expected: []string{"sync", "async"},
+		},
+		"empty input": {
+			input:    nil,
+			async:    nil,
+			expected: []string{},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got := tfdynamodb.SortGSICreatesAsyncLast(tc.input, tc.async)
+			gotNames := extractCreateNames(got)
+			if diff := cmp.Diff(tc.expected, gotNames); diff != "" {
+				t.Errorf("unexpected order (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestAccDynamoDBTable_gsiCreateAsync(t *testing.T) {
+	ctx := acctest.Context(t)
+	var conf awstypes.TableDescription
+	resourceName := "aws_dynamodb_table.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.DynamoDBServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTableDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTableConfig_gsiCreateAsyncBase(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInitialTableExists(ctx, t, resourceName, &conf),
+				),
+			},
+			{
+				Config: testAccTableConfig_gsiCreateAsync(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTableExists(ctx, t, resourceName, &conf),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "global_secondary_index.*", map[string]string{
+						names.AttrName: "AsyncGSI",
+						"create_async": acctest.CtTrue,
+					}),
+					testAccCheckGSIStatusReached(ctx, t, rName, "AsyncGSI",
+						awstypes.IndexStatusCreating, awstypes.IndexStatusActive),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccTableConfig_gsiCreateAsyncBase(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_dynamodb_table" "test" {
+  name           = %[1]q
+  read_capacity  = 1
+  write_capacity = 1
+  hash_key       = "TestTableHashKey"
+
+  attribute {
+    name = "TestTableHashKey"
+    type = "S"
+  }
+}
+`, rName)
+}
+
+func testAccTableConfig_gsiCreateAsync(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_dynamodb_table" "test" {
+  name           = %[1]q
+  read_capacity  = 1
+  write_capacity = 1
+  hash_key       = "TestTableHashKey"
+
+  attribute {
+    name = "TestTableHashKey"
+    type = "S"
+  }
+
+  attribute {
+    name = "AsyncGSIHashKey"
+    type = "S"
+  }
+
+  global_secondary_index {
+    name            = "AsyncGSI"
+    hash_key        = "AsyncGSIHashKey"
+    write_capacity  = 1
+    read_capacity   = 1
+    projection_type = "KEYS_ONLY"
+    create_async    = true
+  }
 }
 `, rName)
 }

--- a/internal/service/dynamodb/wait.go
+++ b/internal/service/dynamodb/wait.go
@@ -150,6 +150,23 @@ func waitGSIActive(ctx context.Context, conn *dynamodb.Client, tableName, indexN
 	return nil, err
 }
 
+func waitGSIExists(ctx context.Context, conn *dynamodb.Client, tableName, indexName string, timeout time.Duration) (*awstypes.GlobalSecondaryIndexDescription, error) { //nolint:unparam
+	stateConf := &retry.StateChangeConf{
+		Pending: enum.Slice(awstypes.IndexStatusUpdating),
+		Target:  enum.Slice(awstypes.IndexStatusCreating, awstypes.IndexStatusActive),
+		Refresh: statusGSI(conn, tableName, indexName),
+		Timeout: max(updateTableTimeout, timeout),
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+
+	if output, ok := outputRaw.(*awstypes.GlobalSecondaryIndexDescription); ok {
+		return output, err
+	}
+
+	return nil, err
+}
+
 func waitAllGSIActive(ctx context.Context, conn *dynamodb.Client, tableName string, timeout time.Duration) (*awstypes.TableDescription, error) { //nolint:unparam
 	stateConf := &retry.StateChangeConf{
 		Pending: enum.Slice(awstypes.IndexStatusCreating, awstypes.IndexStatusUpdating),

--- a/website/docs/r/dynamodb_global_secondary_index.html.markdown
+++ b/website/docs/r/dynamodb_global_secondary_index.html.markdown
@@ -186,6 +186,10 @@ The following arguments are required:
 
 The following arguments are optional:
 
+* `create_async` - (Optional) Whether to return as soon as the index enters the `CREATING` state instead of waiting for it to become `ACTIVE`. Defaults to `false`. Useful when adding a GSI to a large existing table, where backfilling the index can take hours.
+  The provider still waits briefly for AWS to acknowledge the create (so a subsequent `terraform refresh` succeeds), but does not block on backfill.
+  While the index is still backfilling, attempting to modify or delete it returns an error until it becomes `ACTIVE`, and other operations against the parent table that touch GSIs may fail.
+  If downstream resources need the GSI to be queryable, guard them with an explicit `depends_on` and a [`time_sleep`](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) (or equivalent) sized for the expected backfill duration.
 * `on_demand_throughput` - (Optional) Sets the maximum number of read and write units for the index.
   See [`on_demand_throughput` below](#on_demand_throughput).
   Only valid if the table's `billing_mode` is `PAY_PER_REQUEST`.

--- a/website/docs/r/dynamodb_table.html.markdown
+++ b/website/docs/r/dynamodb_table.html.markdown
@@ -412,6 +412,9 @@ The following arguments are optional:
 
 ### `global_secondary_index`
 
+* `create_async` - (Optional) Whether to return as soon as the index enters the `CREATING` state instead of waiting for it to become `ACTIVE`. Defaults to `false`. Useful when adding a GSI to a large existing table, where backfilling the index can take hours. While the index is still backfilling, other operations against the table may fail, and attempting to modify or delete the still-`CREATING` index returns an error until it becomes `ACTIVE`.
+
+    ~> **Multi-GSI limitation:** AWS DynamoDB allows only one GSI per table to be in the `CREATING` state at a time, so the provider serializes GSI creates. When multiple GSIs are added in a single apply, async-marked GSIs are processed after synchronous ones, and only the last GSI processed can actually skip the wait for `ACTIVE`. If you mark several GSIs as `create_async = true` in the same apply, all but one will still be waited on. To get the full benefit of `create_async` for several GSIs, either add them in separate applies or manage them with the [`aws_dynamodb_global_secondary_index`](dynamodb_global_secondary_index.html.markdown) resource (one resource per GSI).
 * `hash_key` - (Optional, **Deprecated**) Name of the hash key in the index; must be defined as an attribute in the resource. Mutually exclusive with `key_schema`. Use `key_schema` instead.
 * `key_schema` - (Optional) Configuration block(s) for the key schema. Mutually exclusive with `hash_key` and `range_key`. Required if `hash_key` is not specified. Supports multi-attribute keys for the [Multi-Attribute Keys design pattern](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/GSI.DesignPattern.MultiAttributeKeys.html). See below.
 * `name` - (Required) Name of the index.


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

### Description

Adds a Terraform-only `create_async` argument to the `aws_dynamodb_table` `global_secondary_index` block. When set to `true`, the provider issues the DynamoDB table/index creation request but does not wait for that new GSI to become `ACTIVE`, which allows applies adding an index to a large existing table to return while AWS continues backfilling.

The implementation preserves the flag across read round-trips by carrying it forward from prior state, avoids sending the flag to AWS, and blocks later modify/delete operations against a still-`CREATING` GSI with an actionable error. Multi-GSI updates still respect DynamoDB's one-online-index-create limit by waiting before starting any later GSI creates.

AI usage disclosure: Codex was used to implement, review, and verify this change. The generated code and tests were reviewed and adjusted against the repository's contribution guidance and the local design/spec.

### Relations

Closes #38721

### References

N/A

### Output from Acceptance Testing

Acceptance testing was not run locally because it creates real AWS resources.

```console
% make testacc TESTS=TestAccDynamoDBTable_gsiCreateAsync PKG=dynamodb

not run
```

Additional local verification:

```console
% make build

...
```

```console
% make test PKG=dynamodb

ok  	github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb	0.884s
```

```console
% make testacc-lint PKG=dynamodb

...
```

```console
% make website-misspell

...
```

```console
% make website-terrafmt

...
```

```console
% make changelog-misspell

...
```

```console
% git diff --check

```