### PR TITLE
Fix format of .ci/ file

### DIFF
--- a/.ci/semgrep/pluginsdk/schema.fixed.go
+++ b/.ci/semgrep/pluginsdk/schema.fixed.go
@@ -16,14 +16,14 @@ func resourceResource() *schema.Resource {
 
 		// ruleid: use-schema-func
 		SchemaFunc: func() map[string]*schema.Schema {
-  	return map[string]*schema.Schema{
-  			"name": {
-  				Type:     schema.TypeString,
-  				Required: true,
-  				ForceNew: true,
-  			},
-  		}
-  },
+			return map[string]*schema.Schema{
+				"name": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+			}
+		},
 	}
 }
 
@@ -36,27 +36,27 @@ func resourceNested() *schema.Resource {
 
 		// ruleid: use-schema-func
 		SchemaFunc: func() map[string]*schema.Schema {
-  	return map[string]*schema.Schema{
-  			"name": {
-  				Type:     schema.TypeString,
-  				Required: true,
-  				ForceNew: true,
-  			},
-  			"list": {
-  				Type:     schema.TypeList,
-  				Optional: true,
-  				Elem: &schema.Resource{
-  					// ok: use-schema-func
-  					Schema: map[string]*schema.Schema{
-  						"item": {
-  							Type:     schema.TypeString,
-  							Optional: true,
-  						},
-  					},
-  				},
-  			},
-  		}
-  },
+			return map[string]*schema.Schema{
+				"name": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"list": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Elem: &schema.Resource{
+						// ok: use-schema-func
+						Schema: map[string]*schema.Schema{
+							"item": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+						},
+					},
+				},
+			}
+		},
 	}
 }
 
@@ -71,13 +71,13 @@ func resourcePreamble() *schema.Resource {
 
 		// ruleid: use-schema-func
 		SchemaFunc: func() map[string]*schema.Schema {
-  	return map[string]*schema.Schema{
-  			"name": {
-  				Type:     schema.TypeString,
-  				Required: true,
-  				ForceNew: true,
-  			},
-  		}
-  },
+			return map[string]*schema.Schema{
+				"name": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+			}
+		},
 	}
 }


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This is causing issues when running tests with:

```
make testacc
```

because it runs a format check first:

```
% make t T='TestAccElastiCacheReplicationGroup_Snapshot_ClusterModeDisabled_Redis7|TestAccElastiCacheReplicationGroup_Snapshot_ClusterModeDisabled_Valkey7|TestAccElastiCacheReplicationGroup_Snapshot_ClusterModeEnabled_Redis7|TestAccElastiCacheReplicationGroup_Snapshot_ClusterModeEnabled_Valkey7' K=elasticache
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
gofmt needs running on the following files:
./.ci/semgrep/pluginsdk/schema.fixed.go
You can use the command: `make fmt` to reformat code.
make: *** [fmt-check] Error 1
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
