### PR TITLE
Td semgrep schemafunc indentation

### DIFF
--- a/.ci/scripts/gofmtcheck.sh
+++ b/.ci/scripts/gofmtcheck.sh
@@ -4,7 +4,7 @@
 
 # Check gofmt
 echo "==> Checking that code complies with gofmt requirements..."
-gofmt_files=$(find . -name '*.go' | grep -v vendor | xargs gofmt -l -s)
+gofmt_files=$(find . -name '*.go' | grep -v vendor | grep -v semgrep | xargs gofmt -l -s)
 if [[ -n ${gofmt_files} ]]; then
     echo 'gofmt needs running on the following files:'
     echo "${gofmt_files}"

--- a/.ci/semgrep/pluginsdk/schema.fixed.go
+++ b/.ci/semgrep/pluginsdk/schema.fixed.go
@@ -1,6 +1,9 @@
 // Copyright IBM Corp. 2014, 2026
 // SPDX-License-Identifier: MPL-2.0
 
+// IMPORTANT: The "fixed" file must not be formatted with gofmt.
+// Semgrep does not handle formatting of multiline fixes in Goc orrectly.
+
 package main
 
 import (

--- a/.ci/semgrep/pluginsdk/schema.fixed.go
+++ b/.ci/semgrep/pluginsdk/schema.fixed.go
@@ -16,14 +16,14 @@ func resourceResource() *schema.Resource {
 
 		// ruleid: use-schema-func
 		SchemaFunc: func() map[string]*schema.Schema {
-			return map[string]*schema.Schema{
-				"name": {
-					Type:     schema.TypeString,
-					Required: true,
-					ForceNew: true,
-				},
-			}
-		},
+  	return map[string]*schema.Schema{
+  			"name": {
+  				Type:     schema.TypeString,
+  				Required: true,
+  				ForceNew: true,
+  			},
+  		}
+  },
 	}
 }
 
@@ -36,27 +36,27 @@ func resourceNested() *schema.Resource {
 
 		// ruleid: use-schema-func
 		SchemaFunc: func() map[string]*schema.Schema {
-			return map[string]*schema.Schema{
-				"name": {
-					Type:     schema.TypeString,
-					Required: true,
-					ForceNew: true,
-				},
-				"list": {
-					Type:     schema.TypeList,
-					Optional: true,
-					Elem: &schema.Resource{
-						// ok: use-schema-func
-						Schema: map[string]*schema.Schema{
-							"item": {
-								Type:     schema.TypeString,
-								Optional: true,
-							},
-						},
-					},
-				},
-			}
-		},
+  	return map[string]*schema.Schema{
+  			"name": {
+  				Type:     schema.TypeString,
+  				Required: true,
+  				ForceNew: true,
+  			},
+  			"list": {
+  				Type:     schema.TypeList,
+  				Optional: true,
+  				Elem: &schema.Resource{
+  					// ok: use-schema-func
+  					Schema: map[string]*schema.Schema{
+  						"item": {
+  							Type:     schema.TypeString,
+  							Optional: true,
+  						},
+  					},
+  				},
+  			},
+  		}
+  },
 	}
 }
 
@@ -71,13 +71,13 @@ func resourcePreamble() *schema.Resource {
 
 		// ruleid: use-schema-func
 		SchemaFunc: func() map[string]*schema.Schema {
-			return map[string]*schema.Schema{
-				"name": {
-					Type:     schema.TypeString,
-					Required: true,
-					ForceNew: true,
-				},
-			}
-		},
+  	return map[string]*schema.Schema{
+  			"name": {
+  				Type:     schema.TypeString,
+  				Required: true,
+  				ForceNew: true,
+  			},
+  		}
+  },
 	}
 }

--- a/.ci/semgrep/pluginsdk/schema.fixed.go
+++ b/.ci/semgrep/pluginsdk/schema.fixed.go
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 // IMPORTANT: The "fixed" file must not be formatted with gofmt.
-// Semgrep does not handle formatting of multiline fixes in Goc orrectly.
+// Semgrep does not handle formatting of multiline fixes in Go correctly.
 
 package main
 

--- a/.ci/semgrep/pluginsdk/schema.go
+++ b/.ci/semgrep/pluginsdk/schema.go
@@ -1,6 +1,9 @@
 // Copyright IBM Corp. 2014, 2026
 // SPDX-License-Identifier: MPL-2.0
 
+// IMPORTANT: The "fixed" file must not be formatted with gofmt.
+// Semgrep does not handle formatting of multiline fixes in Goc orrectly.
+
 package main
 
 import (

--- a/.ci/semgrep/pluginsdk/schema.go
+++ b/.ci/semgrep/pluginsdk/schema.go
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 // IMPORTANT: The "fixed" file must not be formatted with gofmt.
-// Semgrep does not handle formatting of multiline fixes in Goc orrectly.
+// Semgrep does not handle formatting of multiline fixes in Go correctly.
 
 package main
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Semgrep multi-line autofixes don't handle Go formatting well. To support testing of the `use-schema-func` Semgrep rule, the formatting of the "fixed" file must be invalid.

Once the rule has been applied to the entire provider, it can be removed as there will be no new Provider SDK resource types.