### PR TITLE
[Test] aws_db_instance_automated_backups_replication: Fix a lint issue to resolve a Semgrep CI error

### DIFF
--- a/internal/service/rds/instance_automated_backups_replication_test.go
+++ b/internal/service/rds/instance_automated_backups_replication_test.go
@@ -197,7 +197,7 @@ func TestAccRDSInstanceAutomatedBackupsReplication_withFinalSnapshot(t *testing.
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceAutomatedBackupsReplicationExist(ctx, t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrRetentionPeriod, "7"),
-					resource.TestCheckResourceAttr(instanceResourceName, "skip_final_snapshot", "false"),
+					resource.TestCheckResourceAttr(instanceResourceName, "skip_final_snapshot", acctest.CtFalse),
 					resource.TestCheckResourceAttr(instanceResourceName, names.AttrFinalSnapshotIdentifier, rName),
 				),
 			},


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

This PR fixes a lint issue in `internal/service/rds/instance_automated_backups_replication_test.go` to resolve a Semgrep CI error.

* Replaces `"false"` with `acctest.CtFalse`.


### Relations

Relates #46687

