### PR TITLE
Add wait_for_deployment to CloudFront multitenant distribution

### DIFF
--- a/.changelog/48112.txt
+++ b/.changelog/48112.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_cloudfront_multitenant_distribution: Add `wait_for_deployment` attribute
+```

--- a/internal/service/cloudfront/multitenant_distribution.go
+++ b/internal/service/cloudfront/multitenant_distribution.go
@@ -127,6 +127,11 @@ func (r *multiTenantDistributionResource) Schema(ctx context.Context, request re
 			},
 			names.AttrTags:    tftags.TagsAttribute(),
 			names.AttrTagsAll: tftags.TagsAttributeComputedOnly(),
+			"wait_for_deployment": schema.BoolAttribute{
+				Optional: true,
+				Computed: true,
+				Default:  booldefault.StaticBool(true),
+			},
 			"web_acl_id": schema.StringAttribute{
 				Optional: true,
 				// Note: For multi-tenant distributions, this must be a WAF V2 web ACL if specified
@@ -726,12 +731,21 @@ func (r *multiTenantDistributionResource) Create(ctx context.Context, request re
 	data.ID = types.StringValue(aws.ToString(output.Distribution.Id))
 	data.ARN = types.StringValue(aws.ToString(output.Distribution.ARN))
 
-	// Wait for distribution to be deployed
-	distro, err := waitDistributionDeployed(ctx, conn, data.ID.ValueString())
-	if err != nil {
-		response.State.SetAttribute(ctx, path.Root(names.AttrID), data.ID) // Set 'id' so as to taint the resource.
-		response.Diagnostics.AddError(fmt.Sprintf("waiting for CloudFront Multi-tenant Distribution (%s) create", data.ID.ValueString()), err.Error())
-		return
+	var distro *cloudfront.GetDistributionOutput
+
+	if data.WaitForDeployment.ValueBool() {
+		distro, err = waitDistributionDeployed(ctx, conn, data.ID.ValueString())
+		if err != nil {
+			response.State.SetAttribute(ctx, path.Root(names.AttrID), data.ID) // Set 'id' so as to taint the resource.
+			response.Diagnostics.AddError(fmt.Sprintf("waiting for CloudFront Multi-tenant Distribution (%s) create", data.ID.ValueString()), err.Error())
+			return
+		}
+	} else {
+		distro, err = findDistributionByID(ctx, conn, data.ID.ValueString())
+		if err != nil {
+			response.Diagnostics.AddError(fmt.Sprintf("reading CloudFront Multi-tenant Distribution (%s)", data.ID.ValueString()), err.Error())
+			return
+		}
 	}
 
 	// Read the distribution to get consistent state
@@ -847,7 +861,7 @@ func (r *multiTenantDistributionResource) Update(ctx context.Context, request re
 		}
 
 		// Wait for deployment if enabled
-		if new.Enabled.ValueBool() {
+		if new.WaitForDeployment.ValueBool() {
 			_, err = waitDistributionDeployed(ctx, conn, new.ID.ValueString())
 			if err != nil {
 				response.Diagnostics.AddError(fmt.Sprintf("waiting for CloudFront Multi-tenant Distribution (%s) update", new.ID.ValueString()), err.Error())
@@ -1058,6 +1072,7 @@ type multiTenantDistributionResourceModel struct {
 	TagsAll                       tftags.Map                                                   `tfsdk:"tags_all"`
 	TenantConfig                  fwtypes.ListNestedObjectValueOf[tenantConfigModel]           `tfsdk:"tenant_config"`
 	Timeouts                      timeouts.Value                                               `tfsdk:"timeouts"`
+	WaitForDeployment             types.Bool                                                   `tfsdk:"wait_for_deployment"`
 	ViewerCertificate             fwtypes.ListNestedObjectValueOf[viewerCertificateModel]      `tfsdk:"viewer_certificate"`
 	WebACLID                      types.String                                                 `tfsdk:"web_acl_id" autoflex:",omitempty"`
 }

--- a/internal/service/cloudfront/multitenant_distribution_test.go
+++ b/internal/service/cloudfront/multitenant_distribution_test.go
@@ -36,6 +36,7 @@ func TestAccCloudFrontMultiTenantDistribution_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMultiTenantDistributionExists(ctx, t, resourceName, &distribution),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEnabled, acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, "wait_for_deployment", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "tenant_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tenant_config.0.parameter_definition.0.definition.0.string_schema.0.required", acctest.CtTrue),
 
@@ -47,7 +48,61 @@ func TestAccCloudFrontMultiTenantDistribution_basic(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"etag"},
+				ImportStateVerifyIgnore: []string{"etag", "wait_for_deployment"},
+			},
+		},
+	})
+}
+
+func TestAccCloudFrontMultiTenantDistribution_waitForDeployment(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var distribution awstypes.Distribution
+	resourceName := "aws_cloudfront_multitenant_distribution.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.CloudFrontEndpointID) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CloudFrontServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckMultiTenantDistributionDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMultiTenantDistributionConfig_waitForDeployment(false, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMultiTenantDistributionExists(ctx, t, resourceName, &distribution),
+					testAccCheckDistributionStatusInProgress(&distribution),
+					testAccCheckDistributionWaitForDeployment(ctx, t, &distribution),
+					resource.TestCheckResourceAttr(resourceName, "wait_for_deployment", acctest.CtFalse),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"etag",
+					names.AttrStatus,
+					"wait_for_deployment",
+				},
+			},
+			{
+				Config: testAccMultiTenantDistributionConfig_waitForDeployment(true, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMultiTenantDistributionExists(ctx, t, resourceName, &distribution),
+					testAccCheckDistributionStatusInProgress(&distribution),
+					resource.TestCheckResourceAttr(resourceName, "wait_for_deployment", acctest.CtFalse),
+				),
+			},
+			{
+				Config: testAccMultiTenantDistributionConfig_waitForDeployment(false, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMultiTenantDistributionExists(ctx, t, resourceName, &distribution),
+					testAccCheckDistributionStatusDeployed(&distribution),
+					resource.TestCheckResourceAttr(resourceName, "wait_for_deployment", acctest.CtTrue),
+				),
 			},
 		},
 	})
@@ -156,7 +211,7 @@ func TestAccCloudFrontMultiTenantDistribution_comprehensive(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"etag"},
+				ImportStateVerifyIgnore: []string{"etag", "wait_for_deployment"},
 			},
 		},
 	})
@@ -187,7 +242,7 @@ func TestAccCloudFrontMultiTenantDistribution_s3OriginWithOAC(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"etag"},
+				ImportStateVerifyIgnore: []string{"etag", "wait_for_deployment"},
 			},
 		},
 	})
@@ -222,7 +277,7 @@ func TestAccCloudFrontMultiTenantDistribution_customErrorResponseWithoutResponse
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"etag"},
+				ImportStateVerifyIgnore: []string{"etag", "wait_for_deployment"},
 			},
 		},
 	})
@@ -251,7 +306,7 @@ func TestAccCloudFrontMultiTenantDistribution_tags(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"etag"},
+				ImportStateVerifyIgnore: []string{"etag", "wait_for_deployment"},
 			},
 			{
 				Config: testAccMultiTenantDistributionConfig_tags(map[string]string{acctest.CtKey1: acctest.CtValue1Updated, acctest.CtKey2: acctest.CtValue2}),
@@ -345,7 +400,7 @@ func TestAccCloudFrontMultiTenantDistribution_update(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"etag"},
+				ImportStateVerifyIgnore: []string{"etag", "wait_for_deployment"},
 			},
 		},
 	})
@@ -387,7 +442,7 @@ func TestAccCloudFrontMultiTenantDistribution_functionAssociationSwapBlocks(t *t
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"etag"},
+				ImportStateVerifyIgnore: []string{"etag", "wait_for_deployment"},
 			},
 		},
 	})
@@ -536,6 +591,61 @@ resource "aws_cloudfront_multitenant_distribution" "test" {
   }
 }
 `
+}
+
+func testAccMultiTenantDistributionConfig_waitForDeployment(enabled, waitForDeployment bool) string {
+	return fmt.Sprintf(`
+resource "aws_cloudfront_multitenant_distribution" "test" {
+  comment             = "Test multi-tenant distribution"
+  enabled             = %[1]t
+  wait_for_deployment = %[2]t
+
+  origin {
+    domain_name = "example.com"
+    id          = "example"
+
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "https-only"
+      origin_ssl_protocols   = ["TLSv1.2"]
+    }
+  }
+
+  default_cache_behavior {
+    target_origin_id       = "example"
+    viewer_protocol_policy = "redirect-to-https"
+    cache_policy_id        = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad" # AWS Managed CachingDisabled policy
+
+    allowed_methods {
+      items          = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+      cached_methods = ["GET", "HEAD", "OPTIONS"]
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  tenant_config {
+    parameter_definition {
+      name = "origin_domain"
+      definition {
+        string_schema {
+          required = true
+          comment  = "Origin domain parameter for tenants"
+        }
+      }
+    }
+  }
+}
+`, enabled, waitForDeployment)
 }
 
 func testAccMultiTenantDistributionConfig_comprehensive(rName, comment, defaultRootObject string, compress bool) string {

--- a/website/docs/r/cloudfront_multitenant_distribution.html.markdown
+++ b/website/docs/r/cloudfront_multitenant_distribution.html.markdown
@@ -119,6 +119,7 @@ This resource supports the following arguments:
 * `tags` - (Optional) Map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `tenant_config` - (Required) Tenant configuration that contains parameter definitions for multi-tenant distributions. See [Tenant Config](#tenant-config) below.
 * `viewer_certificate` - (Required) SSL configuration for this distribution. See [Viewer Certificate](#viewer-certificate) below.
+* `wait_for_deployment` - (Optional) If enabled, the resource will wait for the distribution status to change from `InProgress` to `Deployed`. Setting this to `false` will skip the process. Default: `true`.
 * `web_acl_id` - (Optional) Unique identifier that specifies the AWS WAF v2 web ACL to associate with this distribution.
 
 ### Cache Behavior


### PR DESCRIPTION
Closes #47652

I used copilot to duplicate the implementation from `aws_cloudfront_distribution`.

---

`aws_cloudfront_multitenant_distribution` always waited for CloudFront deployment to complete, unlike `aws_cloudfront_distribution`, which already exposes `wait_for_deployment`. This change brings the multi-tenant resource to parity so applies can skip the 10–15 minute deployment wait when desired.

- **Resource behavior**
  - Adds `wait_for_deployment` to `aws_cloudfront_multitenant_distribution` with the same default and semantics as `aws_cloudfront_distribution`
  - Gates the create/update deployment wait on that attribute instead of always blocking until `Deployed`

- **State and import**
  - Preserves the virtual attribute in resource state
  - Updates import expectations for the new non-API-backed field

- **Acceptance coverage**
  - Adds coverage for both modes:
    - `wait_for_deployment = false` leaves the distribution `InProgress`
    - `wait_for_deployment = true` waits for `Deployed`
  - Verifies behavior across create, update, and import flows

- **Documentation**
  - Documents the new argument on the multi-tenant distribution resource page

Example:

```hcl
resource "aws_cloudfront_multitenant_distribution" "example" {
  comment             = "app distribution"
  enabled             = true
  wait_for_deployment = false

  # ...
}
```