### PR TITLE
lambda: Provisioned concurrency simultaneous change with Alias resource

### DIFF
--- a/.changelog/48116.txt
+++ b/.changelog/48116.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_lambda_provisioned_concurrency_config: Fix `InvalidParameterValueException: Alias with weights can not be used with Provisioned Concurrency` error when updating provisioned concurrency simultaneously with alias version change
+```
+
+```release-note:bug
+resource/aws_lambda_alias: Fix plan drift caused by transient routing weights appearing in state after updating `function_version`
+```

--- a/internal/service/lambda/alias.go
+++ b/internal/service/lambda/alias.go
@@ -157,7 +157,7 @@ func resourceAliasUpdate(ctx context.Context, d *schema.ResourceData, meta any) 
 	}
 
 	if len(input.RoutingConfig.AdditionalVersionWeights) == 0 {
-		if _, err := waitAliasRoutingWeightsCleared(ctx, conn, d.Get("function_name").(string), d.Get(names.AttrName).(string), 15*time.Minute); err != nil {
+		if err := waitAliasRoutingWeightsCleared(ctx, conn, d.Get("function_name").(string), d.Get(names.AttrName).(string), aliasRoutingWeightsTimeout); err != nil {
 			return sdkdiag.AppendErrorf(diags, "waiting for Lambda Alias (%s) routing weights to clear: %s", d.Id(), err)
 		}
 	}
@@ -269,9 +269,9 @@ func statusAliasRoutingWeights(conn *lambda.Client, functionName, aliasName stri
 	}
 }
 
-func waitAliasRoutingWeightsCleared(ctx context.Context, conn *lambda.Client, functionName, aliasName string, timeout time.Duration) (*lambda.GetAliasOutput, error) {
+func waitAliasRoutingWeightsCleared(ctx context.Context, conn *lambda.Client, functionName, aliasName string, timeout time.Duration) error {
 	if isNumericOnlyQualifier(aliasName) {
-		return nil, nil
+		return nil
 	}
 
 	stateConf := &retry.StateChangeConf{
@@ -281,13 +281,9 @@ func waitAliasRoutingWeightsCleared(ctx context.Context, conn *lambda.Client, fu
 		Timeout: timeout,
 	}
 
-	outputRaw, err := stateConf.WaitForStateContext(ctx)
+	_, err := stateConf.WaitForStateContext(ctx)
 
-	if output, ok := outputRaw.(*lambda.GetAliasOutput); ok {
-		return output, err
-	}
-
-	return nil, err
+	return err
 }
 
 func expandAliasRoutingConfiguration(tfList []any) *awstypes.AliasRoutingConfiguration {

--- a/internal/service/lambda/alias.go
+++ b/internal/service/lambda/alias.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/lambda"
@@ -155,6 +156,12 @@ func resourceAliasUpdate(ctx context.Context, d *schema.ResourceData, meta any) 
 		return sdkdiag.AppendErrorf(diags, "updating Lambda Alias (%s): %s", d.Id(), err)
 	}
 
+	if len(input.RoutingConfig.AdditionalVersionWeights) == 0 {
+		if _, err := waitAliasRoutingWeightsCleared(ctx, conn, d.Get("function_name").(string), d.Get(names.AttrName).(string), 15*time.Minute); err != nil {
+			return sdkdiag.AppendErrorf(diags, "waiting for Lambda Alias (%s) routing weights to clear: %s", d.Id(), err)
+		}
+	}
+
 	return append(diags, resourceAliasRead(ctx, d, meta)...)
 }
 
@@ -220,6 +227,67 @@ func findAlias(ctx context.Context, conn *lambda.Client, input *lambda.GetAliasI
 	}
 
 	return output, nil
+}
+
+// isNumericOnlyQualifier returns true if the qualifier is a published version number
+// (all digits). Alias names cannot be numeric-only per AWS validation rules.
+func isNumericOnlyQualifier(s string) bool {
+	if s == "" {
+		return false
+	}
+
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+
+	return true
+}
+
+func statusAliasRoutingWeights(conn *lambda.Client, functionName, aliasName string) retry.StateRefreshFunc {
+	return func(ctx context.Context) (any, string, error) {
+		if isNumericOnlyQualifier(aliasName) {
+			return nil, "stable", nil
+		}
+
+		output, err := findAliasByTwoPartKey(ctx, conn, functionName, aliasName)
+
+		if retry.NotFound(err) {
+			return nil, "stable", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		if output.RoutingConfig != nil && len(output.RoutingConfig.AdditionalVersionWeights) > 0 {
+			return output, "pending", nil
+		}
+
+		return output, "stable", nil
+	}
+}
+
+func waitAliasRoutingWeightsCleared(ctx context.Context, conn *lambda.Client, functionName, aliasName string, timeout time.Duration) (*lambda.GetAliasOutput, error) {
+	if isNumericOnlyQualifier(aliasName) {
+		return nil, nil
+	}
+
+	stateConf := &retry.StateChangeConf{
+		Pending: []string{"pending"},
+		Target:  []string{"stable"},
+		Refresh: statusAliasRoutingWeights(conn, functionName, aliasName),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+
+	if output, ok := outputRaw.(*lambda.GetAliasOutput); ok {
+		return output, err
+	}
+
+	return nil, err
 }
 
 func expandAliasRoutingConfiguration(tfList []any) *awstypes.AliasRoutingConfiguration {

--- a/internal/service/lambda/alias.go
+++ b/internal/service/lambda/alias.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strconv"
 	"strings"
 	"time"
 
@@ -36,6 +37,10 @@ func resourceAlias() *schema.Resource {
 
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceAliasImport,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Update: schema.DefaultTimeout(15 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -157,7 +162,7 @@ func resourceAliasUpdate(ctx context.Context, d *schema.ResourceData, meta any) 
 	}
 
 	if len(input.RoutingConfig.AdditionalVersionWeights) == 0 {
-		if err := waitAliasRoutingWeightsCleared(ctx, conn, d.Get("function_name").(string), d.Get(names.AttrName).(string), aliasRoutingWeightsTimeout); err != nil {
+		if err := waitAliasRoutingWeightsCleared(ctx, conn, d.Get("function_name").(string), d.Get(names.AttrName).(string), d.Timeout(schema.TimeoutUpdate)); err != nil {
 			return sdkdiag.AppendErrorf(diags, "waiting for Lambda Alias (%s) routing weights to clear: %s", d.Id(), err)
 		}
 	}
@@ -229,28 +234,8 @@ func findAlias(ctx context.Context, conn *lambda.Client, input *lambda.GetAliasI
 	return output, nil
 }
 
-// isNumericOnlyQualifier returns true if the qualifier is a published version number
-// (all digits). Alias names cannot be numeric-only per AWS validation rules.
-func isNumericOnlyQualifier(s string) bool {
-	if s == "" {
-		return false
-	}
-
-	for _, r := range s {
-		if r < '0' || r > '9' {
-			return false
-		}
-	}
-
-	return true
-}
-
 func statusAliasRoutingWeights(conn *lambda.Client, functionName, aliasName string) retry.StateRefreshFunc {
 	return func(ctx context.Context) (any, string, error) {
-		if isNumericOnlyQualifier(aliasName) {
-			return nil, "stable", nil
-		}
-
 		output, err := findAliasByTwoPartKey(ctx, conn, functionName, aliasName)
 
 		if retry.NotFound(err) {
@@ -270,7 +255,7 @@ func statusAliasRoutingWeights(conn *lambda.Client, functionName, aliasName stri
 }
 
 func waitAliasRoutingWeightsCleared(ctx context.Context, conn *lambda.Client, functionName, aliasName string, timeout time.Duration) error {
-	if isNumericOnlyQualifier(aliasName) {
+	if _, err := strconv.Atoi(aliasName); err == nil {
 		return nil
 	}
 

--- a/internal/service/lambda/alias_test.go
+++ b/internal/service/lambda/alias_test.go
@@ -412,7 +412,7 @@ resource "aws_lambda_function" "test" {
   function_name    = %[1]q
   role             = aws_iam_role.iam_for_lambda.arn
   handler          = "exports.example"
-  runtime          = "nodejs24.x"
+  runtime          = "nodejs22.x"
   source_code_hash = filebase64sha256("test-fixtures/lambdatest.zip")
   publish          = "true"
 }
@@ -435,7 +435,7 @@ resource "aws_lambda_function" "test" {
   function_name    = %[1]q
   role             = aws_iam_role.iam_for_lambda.arn
   handler          = "exports.example"
-  runtime          = "nodejs24.x"
+  runtime          = "nodejs22.x"
   source_code_hash = filebase64sha256("test-fixtures/lambdatest.zip")
   publish          = "true"
 }
@@ -458,7 +458,7 @@ resource "aws_lambda_function" "test" {
   function_name    = %[1]q
   role             = aws_iam_role.iam_for_lambda.arn
   handler          = "exports.example"
-  runtime          = "nodejs24.x"
+  runtime          = "nodejs22.x"
   source_code_hash = filebase64sha256("test-fixtures/lambdatest_modified.zip")
   publish          = "true"
 }

--- a/internal/service/lambda/consts.go
+++ b/internal/service/lambda/consts.go
@@ -18,8 +18,9 @@ const (
 )
 
 const (
-	iamPropagationTimeout    = 2 * time.Minute
-	lambdaPropagationTimeout = 5 * time.Minute // nosemgrep:ci.lambda-in-const-name, ci.lambda-in-var-name
+	aliasRoutingWeightsTimeout = 15 * time.Minute
+	iamPropagationTimeout      = 2 * time.Minute
+	lambdaPropagationTimeout   = 5 * time.Minute // nosemgrep:ci.lambda-in-const-name, ci.lambda-in-var-name
 )
 
 type invocationAction string

--- a/internal/service/lambda/consts.go
+++ b/internal/service/lambda/consts.go
@@ -18,9 +18,8 @@ const (
 )
 
 const (
-	aliasRoutingWeightsTimeout = 15 * time.Minute
-	iamPropagationTimeout      = 2 * time.Minute
-	lambdaPropagationTimeout   = 5 * time.Minute // nosemgrep:ci.lambda-in-const-name, ci.lambda-in-var-name
+	iamPropagationTimeout    = 2 * time.Minute
+	lambdaPropagationTimeout = 5 * time.Minute // nosemgrep:ci.lambda-in-const-name, ci.lambda-in-var-name
 )
 
 type invocationAction string

--- a/internal/service/lambda/provisioned_concurrency_config.go
+++ b/internal/service/lambda/provisioned_concurrency_config.go
@@ -100,7 +100,11 @@ func resourceProvisionedConcurrencyConfigCreate(ctx context.Context, d *schema.R
 		Qualifier:                       aws.String(qualifier),
 	}
 
-	if _, err := conn.PutProvisionedConcurrencyConfig(ctx, input); err != nil {
+	if _, err = waitAliasRoutingWeightsCleared(ctx, conn, functionName, qualifier, d.Timeout(schema.TimeoutCreate)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "creating Lambda Provisioned Concurrency Config (%s): %s", id, err)
+	}
+
+	if _, err = conn.PutProvisionedConcurrencyConfig(ctx, input); err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating Lambda Provisioned Concurrency Config (%s): %s", id, err)
 	}
 
@@ -160,9 +164,11 @@ func resourceProvisionedConcurrencyConfigUpdate(ctx context.Context, d *schema.R
 		Qualifier:                       aws.String(qualifier),
 	}
 
-	_, err = conn.PutProvisionedConcurrencyConfig(ctx, input)
+	if _, err = waitAliasRoutingWeightsCleared(ctx, conn, functionName, qualifier, d.Timeout(schema.TimeoutUpdate)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "updating Lambda Provisioned Concurrency Config (%s): %s", d.Id(), err)
+	}
 
-	if err != nil {
+	if _, err = conn.PutProvisionedConcurrencyConfig(ctx, input); err != nil {
 		return sdkdiag.AppendErrorf(diags, "updating Lambda Provisioned Concurrency Config (%s): %s", d.Id(), err)
 	}
 

--- a/internal/service/lambda/provisioned_concurrency_config.go
+++ b/internal/service/lambda/provisioned_concurrency_config.go
@@ -100,7 +100,7 @@ func resourceProvisionedConcurrencyConfigCreate(ctx context.Context, d *schema.R
 		Qualifier:                       aws.String(qualifier),
 	}
 
-	if _, err = waitAliasRoutingWeightsCleared(ctx, conn, functionName, qualifier, d.Timeout(schema.TimeoutCreate)); err != nil {
+	if err = waitAliasRoutingWeightsCleared(ctx, conn, functionName, qualifier, d.Timeout(schema.TimeoutCreate)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating Lambda Provisioned Concurrency Config (%s): %s", id, err)
 	}
 
@@ -164,7 +164,7 @@ func resourceProvisionedConcurrencyConfigUpdate(ctx context.Context, d *schema.R
 		Qualifier:                       aws.String(qualifier),
 	}
 
-	if _, err = waitAliasRoutingWeightsCleared(ctx, conn, functionName, qualifier, d.Timeout(schema.TimeoutUpdate)); err != nil {
+	if err = waitAliasRoutingWeightsCleared(ctx, conn, functionName, qualifier, d.Timeout(schema.TimeoutUpdate)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "updating Lambda Provisioned Concurrency Config (%s): %s", d.Id(), err)
 	}
 

--- a/internal/service/lambda/provisioned_concurrency_config_test.go
+++ b/internal/service/lambda/provisioned_concurrency_config_test.go
@@ -228,6 +228,49 @@ func TestAccLambdaProvisionedConcurrencyConfig_Qualifier_aliasName(t *testing.T)
 	})
 }
 
+func TestAccLabdaProvisionedConcurrencyConfig_Qualifier_NNaliasNameNN_versionUpdate(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	filename1 := "test-fixtures/lambdapinpoint.zip"
+	filename2 := "test-fixtures/lambdapinpoint_modified.zip"
+	lambdaAliasResourceName := "aws_lambda_alias.test"
+	resourceName := "aws_lambda_provisioned_concurrency_config.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.LambdaServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckProvisionedConcurrencyConfigDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProvisionedConcurrencyConfigConfig_qualifierAliasNameVersionUpdate(rName, filename1, 1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckProvisionedConcurrencyConfigExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "qualifier", lambdaAliasResourceName, names.AttrName),
+					resource.TestCheckResourceAttr(resourceName, "provisioned_concurrent_executions", "1"),
+				),
+			},
+			{
+				// Simultaneously updating the alias function_version and
+				// provisioned_concurrent_executions in the same apply should succeed.
+				// Before the fix this step fails with:
+				// InvalidParameterValueException: Alias with weights can not be used with Provisioned Concurrency
+				// See https://github.com/hashicorp/terraform-provider-aws/issues/13329
+				Config: testAccProvisionedConcurrencyConfigConfig_qualifierAliasNameVersionUpdate(rName, filename2, 2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckProvisionedConcurrencyConfigExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "qualifier", lambdaAliasResourceName, names.AttrName),
+					resource.TestCheckResourceAttr(resourceName, "provisioned_concurrent_executions", "2"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccLambdaProvisionedConcurrencyConfig_skipDestroy(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
@@ -463,6 +506,25 @@ resource "aws_lambda_provisioned_concurrency_config" "test" {
   qualifier                         = aws_lambda_alias.test.name
 }
 `,
+	)
+}
+
+func testAccProvisionedConcurrencyConfigConfig_qualifierAliasNameVersionUpdate(rName, filename string, provisionedConcurrentExecutions int) string {
+	return acctest.ConfigCompose(
+		testAccProvisionedConcurrencyConfigConfigBase_withFilename(rName, filename),
+		fmt.Sprintf(`
+resource "aws_lambda_alias" "test" {
+  function_name    = aws_lambda_function.test.function_name
+  function_version = aws_lambda_function.test.version
+  name             = "test"
+}
+
+resource "aws_lambda_provisioned_concurrency_config" "test" {
+  function_name                     = aws_lambda_function.test.function_name
+  provisioned_concurrent_executions = %[1]d
+  qualifier                         = aws_lambda_alias.test.name
+}
+`, provisionedConcurrentExecutions),
 	)
 }
 

--- a/internal/service/lambda/provisioned_concurrency_config_test.go
+++ b/internal/service/lambda/provisioned_concurrency_config_test.go
@@ -228,7 +228,7 @@ func TestAccLambdaProvisionedConcurrencyConfig_Qualifier_aliasName(t *testing.T)
 	})
 }
 
-func TestAccLabdaProvisionedConcurrencyConfig_Qualifier_NNaliasNameNN_versionUpdate(t *testing.T) {
+func TestAccLambdaProvisionedConcurrencyConfig_aliasChangeWithProvisionedConcurrency(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
@@ -255,11 +255,6 @@ func TestAccLabdaProvisionedConcurrencyConfig_Qualifier_NNaliasNameNN_versionUpd
 				),
 			},
 			{
-				// Simultaneously updating the alias function_version and
-				// provisioned_concurrent_executions in the same apply should succeed.
-				// Before the fix this step fails with:
-				// InvalidParameterValueException: Alias with weights can not be used with Provisioned Concurrency
-				// See https://github.com/hashicorp/terraform-provider-aws/issues/13329
 				Config: testAccProvisionedConcurrencyConfigConfig_qualifierAliasNameVersionUpdate(rName, filename2, 2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProvisionedConcurrencyConfigExists(ctx, t, resourceName),
@@ -457,7 +452,7 @@ resource "aws_lambda_function" "test" {
   role          = aws_iam_role.test.arn
   handler       = "lambdapinpoint.handler"
   publish       = true
-  runtime       = "nodejs24.x"
+  runtime       = "nodejs22.x"
 
   depends_on = [aws_iam_role_policy_attachment.test]
 }

--- a/website/docs/r/lambda_alias.html.markdown
+++ b/website/docs/r/lambda_alias.html.markdown
@@ -97,6 +97,12 @@ This resource exports the following attributes in addition to the arguments abov
 * `arn` - ARN identifying your Lambda function alias.
 * `invoke_arn` - ARN to be used for invoking Lambda Function from API Gateway - to be used in [`aws_api_gateway_integration`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/api_gateway_integration)'s `uri`.
 
+## Timeouts
+
+[Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
+
+* `update` - (Default `15m`)
+
 ## Import
 
 In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Lambda Function Aliases using the `function_name/alias`. For example:


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

AWS temporarily adds alias routing weights during alias version transitions. If Terraform updates provisioned concurrency at the same time, `PutProvisionedConcurrencyConfig` can fail (Alias with weights can not be used with Provisioned Concurrency), and alias state can be read mid-transition, causing drift.
Reproduced the same issue via acceptance testing.
Added a waiter which waits for the weights to be cleared before calling the relevant API.

When `aws_lambda_alias` updates function_version, AWS temporarily injects routing weights on the alias during the version transition. Without the waiter in alias Update, runs immediately and captures these transient weights into Terraform state. On the next plan, Terraform sees routing_config.additional_version_weights = {"1": 1} in state but nothing in config, producing a drift.

P.S. - Downgraded the tests lambda runtimes in `alias_test` and `provisioned_concurrency_config_test` to Nodejs22.x, because callback support was dropped for Nodejs24.x, which leads to most of the acc tests to fail with function init errors.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #13329 

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

Tests for `provisioned_concurrency_config`

```console
% make t T=TestAccLambdaProvisionedConcurrencyConfig_ K=lambda
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-fix-lambda-provisioned-concurrency 🌿...
TF_ACC=1 go1.26.3 test ./internal/service/lambda/... -v -count 1 -parallel 20 -run='TestAccLambdaProvisionedConcurrencyConfig_'  -timeout 360m -vet=off
2026/05/29 13:31:03 Creating Terraform AWS Provider (SDKv2-style)...
2026/05/29 13:31:03 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccLambdaProvisionedConcurrencyConfig_basic
=== PAUSE TestAccLambdaProvisionedConcurrencyConfig_basic
=== RUN   TestAccLambdaProvisionedConcurrencyConfig_disappears
=== PAUSE TestAccLambdaProvisionedConcurrencyConfig_disappears
=== RUN   TestAccLambdaProvisionedConcurrencyConfig_Disappears_lambdaFunction
=== PAUSE TestAccLambdaProvisionedConcurrencyConfig_Disappears_lambdaFunction
=== RUN   TestAccLambdaProvisionedConcurrencyConfig_provisionedConcurrentExecutions
=== PAUSE TestAccLambdaProvisionedConcurrencyConfig_provisionedConcurrentExecutions
=== RUN   TestAccLambdaProvisionedConcurrencyConfig_FunctionName_arn
=== PAUSE TestAccLambdaProvisionedConcurrencyConfig_FunctionName_arn
=== RUN   TestAccLambdaProvisionedConcurrencyConfig_Qualifier_aliasName
=== PAUSE TestAccLambdaProvisionedConcurrencyConfig_Qualifier_aliasName
=== RUN   TestAccLambdaProvisionedConcurrencyConfig_aliasChangeWithProvisionedConcurrency
=== PAUSE TestAccLambdaProvisionedConcurrencyConfig_aliasChangeWithProvisionedConcurrency
=== RUN   TestAccLambdaProvisionedConcurrencyConfig_skipDestroy
=== PAUSE TestAccLambdaProvisionedConcurrencyConfig_skipDestroy
=== RUN   TestAccLambdaProvisionedConcurrencyConfig_idMigration530
=== PAUSE TestAccLambdaProvisionedConcurrencyConfig_idMigration530
=== CONT  TestAccLambdaProvisionedConcurrencyConfig_basic
=== CONT  TestAccLambdaProvisionedConcurrencyConfig_Qualifier_aliasName
=== CONT  TestAccLambdaProvisionedConcurrencyConfig_provisionedConcurrentExecutions
=== CONT  TestAccLambdaProvisionedConcurrencyConfig_Disappears_lambdaFunction
=== CONT  TestAccLambdaProvisionedConcurrencyConfig_FunctionName_arn
=== CONT  TestAccLambdaProvisionedConcurrencyConfig_disappears
=== CONT  TestAccLambdaProvisionedConcurrencyConfig_skipDestroy
=== CONT  TestAccLambdaProvisionedConcurrencyConfig_idMigration530
=== CONT  TestAccLambdaProvisionedConcurrencyConfig_aliasChangeWithProvisionedConcurrency
=== NAME  TestAccLambdaProvisionedConcurrencyConfig_idMigration530
    provisioned_concurrency_config_test.go:321: Step 1/2 error: Check failed: Check 6/6 error: aws_lambda_provisioned_concurrency_config.test: Attribute 'id' expected "tf-acc-test-266951408855583663:1", got "tf-acc-test-266951408855583663,1"
--- PASS: TestAccLambdaProvisionedConcurrencyConfig_Qualifier_aliasName (215.95s)
--- FAIL: TestAccLambdaProvisionedConcurrencyConfig_idMigration530 (216.51s)
--- PASS: TestAccLambdaProvisionedConcurrencyConfig_basic (220.76s)
--- PASS: TestAccLambdaProvisionedConcurrencyConfig_disappears (232.15s)
--- PASS: TestAccLambdaProvisionedConcurrencyConfig_Disappears_lambdaFunction (249.16s)
--- PASS: TestAccLambdaProvisionedConcurrencyConfig_provisionedConcurrentExecutions (421.52s)
--- PASS: TestAccLambdaProvisionedConcurrencyConfig_FunctionName_arn (429.36s)
--- PASS: TestAccLambdaProvisionedConcurrencyConfig_skipDestroy (479.15s)
--- PASS: TestAccLambdaProvisionedConcurrencyConfig_aliasChangeWithProvisionedConcurrency (656.39s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/lambda     661.447s
```

The failing test fails in main as well, hence unrelated to this change.

```console
% make t T=TestAccLambdaProvisionedConcurrencyConfig_idMigration530 K=lambda
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: :herb: main :herb:...
TF_ACC=1 go1.26.3 test ./internal/service/lambda/... -v -count 1 -parallel 20 -run='TestAccLambdaProvisionedConcurrencyConfig_idMigration530'  -timeout 360m -vet=off
2026/05/29 13:56:51 Creating Terraform AWS Provider (SDKv2-style)...
2026/05/29 13:56:51 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccLambdaProvisionedConcurrencyConfig_idMigration530
=== PAUSE TestAccLambdaProvisionedConcurrencyConfig_idMigration530
=== CONT  TestAccLambdaProvisionedConcurrencyConfig_idMigration530
    provisioned_concurrency_config_test.go:283: Step 1/2 error: Check failed: Check 6/6 error: aws_lambda_provisioned_concurrency_config.test: Attribute 'id' expected "tf-acc-test-6706589439076223711:1", got "tf-acc-test-6706589439076223711,1"
--- FAIL: TestAccLambdaProvisionedConcurrencyConfig_idMigration530 (216.17s)
FAIL
FAIL    [github.com/hashicorp/terraform-provider-aws/internal/service/lambda](http://github.com/hashicorp/terraform-provider-aws/internal/service/lambda)     221.431s
```


Tests for `alias`

```console
% make t T=TestAccLambdaAlias_ K=lambda
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-fix-lambda-provisioned-concurrency 🌿...
TF_ACC=1 go1.26.3 test ./internal/service/lambda/... -v -count 1 -parallel 20 -run='TestAccLambdaAlias_'  -timeout 360m -vet=off
2026/05/29 14:07:19 Creating Terraform AWS Provider (SDKv2-style)...
2026/05/29 14:07:19 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccLambdaAlias_basic
=== PAUSE TestAccLambdaAlias_basic
=== RUN   TestAccLambdaAlias_disappears
=== PAUSE TestAccLambdaAlias_disappears
=== RUN   TestAccLambdaAlias_FunctionName_name
=== PAUSE TestAccLambdaAlias_FunctionName_name
=== RUN   TestAccLambdaAlias_nameUpdate
=== PAUSE TestAccLambdaAlias_nameUpdate
=== RUN   TestAccLambdaAlias_routing
=== PAUSE TestAccLambdaAlias_routing
=== CONT  TestAccLambdaAlias_basic
=== CONT  TestAccLambdaAlias_nameUpdate
=== CONT  TestAccLambdaAlias_FunctionName_name
=== CONT  TestAccLambdaAlias_routing
=== CONT  TestAccLambdaAlias_disappears
--- PASS: TestAccLambdaAlias_FunctionName_name (60.02s)
--- PASS: TestAccLambdaAlias_nameUpdate (71.39s)
--- PASS: TestAccLambdaAlias_disappears (72.15s)
--- PASS: TestAccLambdaAlias_basic (101.12s)
--- PASS: TestAccLambdaAlias_routing (130.78s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lambda     135.820s
```