### PR TITLE
Fix API Gateway REST API body policy updates

### DIFF
--- a/.changelog/48118.txt
+++ b/.changelog/48118.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_api_gateway_rest_api: Fix OpenAPI body-managed `x-amazon-apigateway-policy` updates being overwritten by prior policy state
+```

--- a/internal/service/apigateway/rest_api.go
+++ b/internal/service/apigateway/rest_api.go
@@ -747,7 +747,10 @@ func resourceRestAPIWithBodyUpdateOperations(d *schema.ResourceData, output *api
 		})
 	}
 
-	if v, ok := d.GetOk(names.AttrPolicy); ok {
+	// Only re-apply policy after OpenAPI import when policy was configured
+	// explicitly. For Optional+Computed policy, GetOk can be true for a
+	// value that was read from the prior API state.
+	if v, ok := d.GetOk(names.AttrPolicy); ok && resourceRestAPIPolicyConfigured(d) {
 		if equivalent, err := awspolicy.PoliciesAreEquivalent(v.(string), aws.ToString(output.Policy)); err != nil || !equivalent {
 			policy, _ := structure.NormalizeJsonString(v.(string)) // validation covers error
 
@@ -760,6 +763,15 @@ func resourceRestAPIWithBodyUpdateOperations(d *schema.ResourceData, output *api
 	}
 
 	return operations
+}
+
+func resourceRestAPIPolicyConfigured(d *schema.ResourceData) bool {
+	rawConfig := d.GetRawConfig()
+	if rawConfig.IsNull() || !rawConfig.Type().IsObjectType() || !rawConfig.Type().HasAttribute(names.AttrPolicy) {
+		return false
+	}
+
+	return !rawConfig.GetAttr(names.AttrPolicy).IsNull()
 }
 
 // escapeJSONPointer escapes string per RFC 6901

--- a/internal/service/apigateway/rest_api_test.go
+++ b/internal/service/apigateway/rest_api_test.go
@@ -1483,6 +1483,13 @@ func TestAccAPIGatewayRestAPI_Policy_setByBody(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccRestAPIConfig_policySetByBody(rName, "Deny"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
+					resource.TestMatchResourceAttr(resourceName, names.AttrPolicy, regexache.MustCompile(`"Deny"`)),
+				),
+			},
+			{
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

This affects API Gateway REST API resource policy updates when the policy is configured through the OpenAPI `body` via `x-amazon-apigateway-policy`. It does not introduce new security controls; it prevents a stale state-derived policy value from being re-applied over the newly imported OpenAPI policy.

### Description

When an `aws_api_gateway_rest_api` resource uses `body` to configure `x-amazon-apigateway-policy`, updates to that embedded policy can be lost.

During `PutRestApi`, API Gateway imports the new OpenAPI document and updates the REST API policy. Immediately afterward, the provider checks the top-level `policy` attribute and may append a `Replace` patch operation for `/policy`. Because `policy` is `Optional` + `Computed`, `GetOk("policy")` can be true for a value read from prior remote state even when the user did not configure `policy` explicitly. In that case, the provider re-applies the old policy and overwrites the policy that came from the updated OpenAPI body.

This change only performs the follow-up `/policy` patch when `policy` is explicitly present in raw user configuration. That preserves the existing explicit top-level `policy` override behavior while allowing body-owned policies to update through OpenAPI import.

The acceptance test for `TestAccAPIGatewayRestAPI_Policy_setByBody` now updates the embedded OpenAPI policy from `Allow` to `Deny` to cover the regression.

### Relations

Closes #38515

### References

Relates pulumi/pulumi-aws#2321

### Output from Acceptance Testing

```console
% make testacc PKG=apigateway TESTS='TestAccAPIGatewayRestAPI_(Policy_|body)'

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2	6.009s
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider/framework	5.856s
make: Running acceptance tests on branch: fix-apigateway-restapi-body-policy
TF_ACC=1 go1.26.3 test ./internal/service/apigateway/... -v -count 1 -parallel 20 -run='TestAccAPIGatewayRestAPI_(Policy_|body)'  -timeout 360m -vet=off -buildvcs=false
--- PASS: TestAccAPIGatewayRestAPI_Policy_basic (29.13s)
--- PASS: TestAccAPIGatewayRestAPI_Policy_setByBody (60.08s)
--- PASS: TestAccAPIGatewayRestAPI_Policy_order (125.71s)
--- PASS: TestAccAPIGatewayRestAPI_Policy_overrideBody (138.99s)
--- PASS: TestAccAPIGatewayRestAPI_body (245.23s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/apigateway	251.102s
```