### PR TITLE
`aws-sdk-go-v2` updates (Release 2026-05-28)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -138,7 +138,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/groundstation v1.42.0
 	github.com/aws/aws-sdk-go-v2/service/guardduty v1.78.1
 	github.com/aws/aws-sdk-go-v2/service/healthlake v1.37.1
-	github.com/aws/aws-sdk-go-v2/service/iam v1.53.10
+	github.com/aws/aws-sdk-go-v2/service/iam v1.53.11
 	github.com/aws/aws-sdk-go-v2/service/identitystore v1.37.0
 	github.com/aws/aws-sdk-go-v2/service/imagebuilder v1.54.0
 	github.com/aws/aws-sdk-go-v2/service/inspector v1.30.22

--- a/go.mod
+++ b/go.mod
@@ -153,7 +153,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/kendra v1.60.24
 	github.com/aws/aws-sdk-go-v2/service/keyspaces v1.26.0
 	github.com/aws/aws-sdk-go-v2/service/kinesis v1.43.8
-	github.com/aws/aws-sdk-go-v2/service/kinesisanalytics v1.30.25
+	github.com/aws/aws-sdk-go-v2/service/kinesisanalytics v1.30.26
 	github.com/aws/aws-sdk-go-v2/service/kinesisanalyticsv2 v1.37.2
 	github.com/aws/aws-sdk-go-v2/service/kinesisvideo v1.33.10
 	github.com/aws/aws-sdk-go-v2/service/kms v1.52.0

--- a/go.mod
+++ b/go.mod
@@ -164,7 +164,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/lexmodelsv2 v1.61.1
 	github.com/aws/aws-sdk-go-v2/service/licensemanager v1.37.13
 	github.com/aws/aws-sdk-go-v2/service/lightsail v1.54.1
-	github.com/aws/aws-sdk-go-v2/service/location v1.51.1
+	github.com/aws/aws-sdk-go-v2/service/location v1.52.1
 	github.com/aws/aws-sdk-go-v2/service/m2 v1.26.16
 	github.com/aws/aws-sdk-go-v2/service/macie2 v1.51.2
 	github.com/aws/aws-sdk-go-v2/service/mediaconnect v1.49.0

--- a/go.mod
+++ b/go.mod
@@ -170,7 +170,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/mediaconnect v1.49.1
 	github.com/aws/aws-sdk-go-v2/service/mediaconvert v1.91.3
 	github.com/aws/aws-sdk-go-v2/service/medialive v1.97.1
-	github.com/aws/aws-sdk-go-v2/service/mediapackage v1.39.23
+	github.com/aws/aws-sdk-go-v2/service/mediapackage v1.39.24
 	github.com/aws/aws-sdk-go-v2/service/mediapackagev2 v1.39.0
 	github.com/aws/aws-sdk-go-v2/service/mediapackagevod v1.39.23
 	github.com/aws/aws-sdk-go-v2/service/mediastore v1.29.23

--- a/go.mod
+++ b/go.mod
@@ -256,7 +256,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssmcontacts v1.32.1
 	github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.40.0
 	github.com/aws/aws-sdk-go-v2/service/ssmquicksetup v1.9.1
-	github.com/aws/aws-sdk-go-v2/service/ssmsap v1.26.7
+	github.com/aws/aws-sdk-go-v2/service/ssmsap v1.27.1
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.18
 	github.com/aws/aws-sdk-go-v2/service/ssoadmin v1.39.0
 	github.com/aws/aws-sdk-go-v2/service/storagegateway v1.43.16

--- a/go.mod
+++ b/go.mod
@@ -166,7 +166,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/lightsail v1.54.1
 	github.com/aws/aws-sdk-go-v2/service/location v1.52.1
 	github.com/aws/aws-sdk-go-v2/service/m2 v1.27.1
-	github.com/aws/aws-sdk-go-v2/service/macie2 v1.51.2
+	github.com/aws/aws-sdk-go-v2/service/macie2 v1.51.3
 	github.com/aws/aws-sdk-go-v2/service/mediaconnect v1.49.0
 	github.com/aws/aws-sdk-go-v2/service/mediaconvert v1.91.2
 	github.com/aws/aws-sdk-go-v2/service/medialive v1.96.0

--- a/go.mod
+++ b/go.mod
@@ -214,7 +214,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/redshift v1.62.9
 	github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.40.0
 	github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.35.1
-	github.com/aws/aws-sdk-go-v2/service/rekognition v1.51.24
+	github.com/aws/aws-sdk-go-v2/service/rekognition v1.51.25
 	github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.36.0
 	github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.23.6
 	github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.33.26

--- a/go.mod
+++ b/go.mod
@@ -89,7 +89,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/customerprofiles v1.62.0
 	github.com/aws/aws-sdk-go-v2/service/databasemigrationservice v1.63.1
 	github.com/aws/aws-sdk-go-v2/service/databrew v1.40.1
-	github.com/aws/aws-sdk-go-v2/service/dataexchange v1.41.2
+	github.com/aws/aws-sdk-go-v2/service/dataexchange v1.42.1
 	github.com/aws/aws-sdk-go-v2/service/datapipeline v1.30.22
 	github.com/aws/aws-sdk-go-v2/service/datasync v1.59.0
 	github.com/aws/aws-sdk-go-v2/service/datazone v1.62.0

--- a/go.mod
+++ b/go.mod
@@ -187,7 +187,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/networkmanager v1.42.1
 	github.com/aws/aws-sdk-go-v2/service/networkmonitor v1.14.0
 	github.com/aws/aws-sdk-go-v2/service/notifications v1.8.1
-	github.com/aws/aws-sdk-go-v2/service/notificationscontacts v1.6.0
+	github.com/aws/aws-sdk-go-v2/service/notificationscontacts v1.6.1
 	github.com/aws/aws-sdk-go-v2/service/oam v1.24.0
 	github.com/aws/aws-sdk-go-v2/service/observabilityadmin v1.16.0
 	github.com/aws/aws-sdk-go-v2/service/odb v1.11.0

--- a/go.mod
+++ b/go.mod
@@ -207,7 +207,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/qbusiness v1.34.9
 	github.com/aws/aws-sdk-go-v2/service/qldb v1.32.2
 	github.com/aws/aws-sdk-go-v2/service/quicksight v1.111.1
-	github.com/aws/aws-sdk-go-v2/service/ram v1.36.5
+	github.com/aws/aws-sdk-go-v2/service/ram v1.36.6
 	github.com/aws/aws-sdk-go-v2/service/rbin v1.28.0
 	github.com/aws/aws-sdk-go-v2/service/rds v1.118.2
 	github.com/aws/aws-sdk-go-v2/service/rdsdata v1.32.23

--- a/go.mod
+++ b/go.mod
@@ -217,7 +217,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/rekognition v1.51.25
 	github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.36.1
 	github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.24.1
-	github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.33.26
+	github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.33.27
 	github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.32.0
 	github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.23.0
 	github.com/aws/aws-sdk-go-v2/service/route53 v1.62.7

--- a/go.mod
+++ b/go.mod
@@ -238,7 +238,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/scheduler v1.18.1
 	github.com/aws/aws-sdk-go-v2/service/schemas v1.35.1
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.8
-	github.com/aws/aws-sdk-go-v2/service/securityhub v1.71.0
+	github.com/aws/aws-sdk-go-v2/service/securityhub v1.71.1
 	github.com/aws/aws-sdk-go-v2/service/securitylake v1.25.15
 	github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.31.0
 	github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.39.15

--- a/go.mod
+++ b/go.mod
@@ -255,7 +255,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.68.7
 	github.com/aws/aws-sdk-go-v2/service/ssmcontacts v1.32.1
 	github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.40.0
-	github.com/aws/aws-sdk-go-v2/service/ssmquicksetup v1.9.0
+	github.com/aws/aws-sdk-go-v2/service/ssmquicksetup v1.9.1
 	github.com/aws/aws-sdk-go-v2/service/ssmsap v1.26.7
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.18
 	github.com/aws/aws-sdk-go-v2/service/ssoadmin v1.39.0

--- a/go.mod
+++ b/go.mod
@@ -179,7 +179,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/mpa v1.8.1
 	github.com/aws/aws-sdk-go-v2/service/mq v1.34.23
 	github.com/aws/aws-sdk-go-v2/service/mwaa v1.40.2
-	github.com/aws/aws-sdk-go-v2/service/mwaaserverless v1.0.11
+	github.com/aws/aws-sdk-go-v2/service/mwaaserverless v1.0.12
 	github.com/aws/aws-sdk-go-v2/service/neptune v1.44.5
 	github.com/aws/aws-sdk-go-v2/service/neptunegraph v1.21.23
 	github.com/aws/aws-sdk-go-v2/service/networkfirewall v1.61.0

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/applicationautoscaling v1.41.17
 	github.com/aws/aws-sdk-go-v2/service/applicationinsights v1.34.23
 	github.com/aws/aws-sdk-go-v2/service/applicationsignals v1.22.1
-	github.com/aws/aws-sdk-go-v2/service/appmesh v1.35.14
+	github.com/aws/aws-sdk-go-v2/service/appmesh v1.35.15
 	github.com/aws/aws-sdk-go-v2/service/apprunner v1.40.0
 	github.com/aws/aws-sdk-go-v2/service/appstream v1.59.0
 	github.com/aws/aws-sdk-go-v2/service/appsync v1.53.7

--- a/go.mod
+++ b/go.mod
@@ -197,7 +197,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/osis v1.22.1
 	github.com/aws/aws-sdk-go-v2/service/outposts v1.60.1
 	github.com/aws/aws-sdk-go-v2/service/paymentcryptography v1.30.1
-	github.com/aws/aws-sdk-go-v2/service/pcaconnectorad v1.15.23
+	github.com/aws/aws-sdk-go-v2/service/pcaconnectorad v1.16.1
 	github.com/aws/aws-sdk-go-v2/service/pcs v1.18.0
 	github.com/aws/aws-sdk-go-v2/service/pinpoint v1.39.23
 	github.com/aws/aws-sdk-go-v2/service/pinpointsmsvoicev2 v1.28.2

--- a/go.mod
+++ b/go.mod
@@ -106,7 +106,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/drs v1.38.3
 	github.com/aws/aws-sdk-go-v2/service/dsql v1.14.1
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.5
-	github.com/aws/aws-sdk-go-v2/service/ec2 v1.304.0
+	github.com/aws/aws-sdk-go-v2/service/ec2 v1.304.1
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.57.2
 	github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.38.15
 	github.com/aws/aws-sdk-go-v2/service/ecs v1.80.0

--- a/go.mod
+++ b/go.mod
@@ -79,7 +79,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.60.3
 	github.com/aws/aws-sdk-go-v2/service/comprehend v1.41.1
 	github.com/aws/aws-sdk-go-v2/service/computeoptimizer v1.51.1
-	github.com/aws/aws-sdk-go-v2/service/configservice v1.62.3
+	github.com/aws/aws-sdk-go-v2/service/configservice v1.62.4
 	github.com/aws/aws-sdk-go-v2/service/connect v1.175.0
 	github.com/aws/aws-sdk-go-v2/service/connectcases v1.41.0
 	github.com/aws/aws-sdk-go-v2/service/controltower v1.29.0

--- a/go.mod
+++ b/go.mod
@@ -142,7 +142,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/identitystore v1.37.1
 	github.com/aws/aws-sdk-go-v2/service/imagebuilder v1.55.1
 	github.com/aws/aws-sdk-go-v2/service/inspector v1.30.23
-	github.com/aws/aws-sdk-go-v2/service/inspector2 v1.47.7
+	github.com/aws/aws-sdk-go-v2/service/inspector2 v1.48.1
 	github.com/aws/aws-sdk-go-v2/service/internetmonitor v1.27.0
 	github.com/aws/aws-sdk-go-v2/service/invoicing v1.11.0
 	github.com/aws/aws-sdk-go-v2/service/iot v1.73.0

--- a/go.mod
+++ b/go.mod
@@ -167,7 +167,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/location v1.52.1
 	github.com/aws/aws-sdk-go-v2/service/m2 v1.27.1
 	github.com/aws/aws-sdk-go-v2/service/macie2 v1.51.3
-	github.com/aws/aws-sdk-go-v2/service/mediaconnect v1.49.0
+	github.com/aws/aws-sdk-go-v2/service/mediaconnect v1.49.1
 	github.com/aws/aws-sdk-go-v2/service/mediaconvert v1.91.2
 	github.com/aws/aws-sdk-go-v2/service/medialive v1.96.0
 	github.com/aws/aws-sdk-go-v2/service/mediapackage v1.39.23

--- a/go.mod
+++ b/go.mod
@@ -109,7 +109,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.304.1
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.57.3
 	github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.39.1
-	github.com/aws/aws-sdk-go-v2/service/ecs v1.80.0
+	github.com/aws/aws-sdk-go-v2/service/ecs v1.81.1
 	github.com/aws/aws-sdk-go-v2/service/efs v1.41.16
 	github.com/aws/aws-sdk-go-v2/service/eks v1.84.0
 	github.com/aws/aws-sdk-go-v2/service/elasticache v1.52.2

--- a/go.mod
+++ b/go.mod
@@ -58,7 +58,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/cloudcontrol v1.30.1
 	github.com/aws/aws-sdk-go-v2/service/cloudformation v1.71.12
 	github.com/aws/aws-sdk-go-v2/service/cloudfront v1.64.1
-	github.com/aws/aws-sdk-go-v2/service/cloudfrontkeyvaluestore v1.12.26
+	github.com/aws/aws-sdk-go-v2/service/cloudfrontkeyvaluestore v1.13.0
 	github.com/aws/aws-sdk-go-v2/service/cloudhsmv2 v1.34.25
 	github.com/aws/aws-sdk-go-v2/service/cloudsearch v1.32.14
 	github.com/aws/aws-sdk-go-v2/service/cloudtrail v1.55.11

--- a/go.mod
+++ b/go.mod
@@ -171,7 +171,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/mediaconvert v1.91.3
 	github.com/aws/aws-sdk-go-v2/service/medialive v1.97.1
 	github.com/aws/aws-sdk-go-v2/service/mediapackage v1.39.24
-	github.com/aws/aws-sdk-go-v2/service/mediapackagev2 v1.39.0
+	github.com/aws/aws-sdk-go-v2/service/mediapackagev2 v1.39.1
 	github.com/aws/aws-sdk-go-v2/service/mediapackagevod v1.39.23
 	github.com/aws/aws-sdk-go-v2/service/mediastore v1.29.23
 	github.com/aws/aws-sdk-go-v2/service/memorydb v1.33.16

--- a/go.mod
+++ b/go.mod
@@ -278,7 +278,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.40.1
 	github.com/aws/aws-sdk-go-v2/service/workmail v1.37.1
 	github.com/aws/aws-sdk-go-v2/service/workspaces v1.68.2
-	github.com/aws/aws-sdk-go-v2/service/workspacesweb v1.39.0
+	github.com/aws/aws-sdk-go-v2/service/workspacesweb v1.40.1
 	github.com/aws/aws-sdk-go-v2/service/xray v1.36.23
 	github.com/aws/smithy-go v1.26.0
 	github.com/beevik/etree v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -107,7 +107,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/dsql v1.14.1
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.5
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.304.1
-	github.com/aws/aws-sdk-go-v2/service/ecr v1.57.2
+	github.com/aws/aws-sdk-go-v2/service/ecr v1.57.3
 	github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.38.15
 	github.com/aws/aws-sdk-go-v2/service/ecs v1.80.0
 	github.com/aws/aws-sdk-go-v2/service/efs v1.41.16

--- a/go.mod
+++ b/go.mod
@@ -253,7 +253,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sns v1.39.18
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.42.28
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.68.7
-	github.com/aws/aws-sdk-go-v2/service/ssmcontacts v1.31.16
+	github.com/aws/aws-sdk-go-v2/service/ssmcontacts v1.32.1
 	github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.39.22
 	github.com/aws/aws-sdk-go-v2/service/ssmquicksetup v1.9.0
 	github.com/aws/aws-sdk-go-v2/service/ssmsap v1.26.7

--- a/go.mod
+++ b/go.mod
@@ -195,7 +195,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/opensearchserverless v1.31.0
 	github.com/aws/aws-sdk-go-v2/service/organizations v1.51.5
 	github.com/aws/aws-sdk-go-v2/service/osis v1.22.1
-	github.com/aws/aws-sdk-go-v2/service/outposts v1.60.0
+	github.com/aws/aws-sdk-go-v2/service/outposts v1.60.1
 	github.com/aws/aws-sdk-go-v2/service/paymentcryptography v1.29.0
 	github.com/aws/aws-sdk-go-v2/service/pcaconnectorad v1.15.23
 	github.com/aws/aws-sdk-go-v2/service/pcs v1.18.0

--- a/go.mod
+++ b/go.mod
@@ -190,7 +190,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/notificationscontacts v1.6.1
 	github.com/aws/aws-sdk-go-v2/service/oam v1.24.1
 	github.com/aws/aws-sdk-go-v2/service/observabilityadmin v1.16.1
-	github.com/aws/aws-sdk-go-v2/service/odb v1.11.0
+	github.com/aws/aws-sdk-go-v2/service/odb v1.11.1
 	github.com/aws/aws-sdk-go-v2/service/opensearch v1.69.0
 	github.com/aws/aws-sdk-go-v2/service/opensearchserverless v1.30.3
 	github.com/aws/aws-sdk-go-v2/service/organizations v1.51.3

--- a/go.mod
+++ b/go.mod
@@ -196,7 +196,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/organizations v1.51.5
 	github.com/aws/aws-sdk-go-v2/service/osis v1.22.1
 	github.com/aws/aws-sdk-go-v2/service/outposts v1.60.1
-	github.com/aws/aws-sdk-go-v2/service/paymentcryptography v1.29.0
+	github.com/aws/aws-sdk-go-v2/service/paymentcryptography v1.30.1
 	github.com/aws/aws-sdk-go-v2/service/pcaconnectorad v1.15.23
 	github.com/aws/aws-sdk-go-v2/service/pcs v1.18.0
 	github.com/aws/aws-sdk-go-v2/service/pinpoint v1.39.23

--- a/go.mod
+++ b/go.mod
@@ -172,7 +172,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/medialive v1.97.1
 	github.com/aws/aws-sdk-go-v2/service/mediapackage v1.39.24
 	github.com/aws/aws-sdk-go-v2/service/mediapackagev2 v1.39.1
-	github.com/aws/aws-sdk-go-v2/service/mediapackagevod v1.39.23
+	github.com/aws/aws-sdk-go-v2/service/mediapackagevod v1.39.24
 	github.com/aws/aws-sdk-go-v2/service/mediastore v1.29.23
 	github.com/aws/aws-sdk-go-v2/service/memorydb v1.33.16
 	github.com/aws/aws-sdk-go-v2/service/mgn v1.43.0

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/appstream v1.60.0
 	github.com/aws/aws-sdk-go-v2/service/appsync v1.53.8
 	github.com/aws/aws-sdk-go-v2/service/arcregionswitch v1.8.0
-	github.com/aws/aws-sdk-go-v2/service/arczonalshift v1.22.25
+	github.com/aws/aws-sdk-go-v2/service/arczonalshift v1.22.26
 	github.com/aws/aws-sdk-go-v2/service/athena v1.57.6
 	github.com/aws/aws-sdk-go-v2/service/auditmanager v1.46.14
 	github.com/aws/aws-sdk-go-v2/service/autoscaling v1.66.2

--- a/go.mod
+++ b/go.mod
@@ -54,7 +54,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/chimesdkmediapipelines v1.27.1
 	github.com/aws/aws-sdk-go-v2/service/chimesdkvoice v1.28.16
 	github.com/aws/aws-sdk-go-v2/service/cleanrooms v1.45.1
-	github.com/aws/aws-sdk-go-v2/service/cloud9 v1.34.0
+	github.com/aws/aws-sdk-go-v2/service/cloud9 v1.34.1
 	github.com/aws/aws-sdk-go-v2/service/cloudcontrol v1.30.0
 	github.com/aws/aws-sdk-go-v2/service/cloudformation v1.71.11
 	github.com/aws/aws-sdk-go-v2/service/cloudfront v1.64.0

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/applicationsignals v1.22.1
 	github.com/aws/aws-sdk-go-v2/service/appmesh v1.35.15
 	github.com/aws/aws-sdk-go-v2/service/apprunner v1.40.1
-	github.com/aws/aws-sdk-go-v2/service/appstream v1.59.0
+	github.com/aws/aws-sdk-go-v2/service/appstream v1.60.0
 	github.com/aws/aws-sdk-go-v2/service/appsync v1.53.7
 	github.com/aws/aws-sdk-go-v2/service/arcregionswitch v1.7.0
 	github.com/aws/aws-sdk-go-v2/service/arczonalshift v1.22.25

--- a/go.mod
+++ b/go.mod
@@ -188,7 +188,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/networkmonitor v1.14.0
 	github.com/aws/aws-sdk-go-v2/service/notifications v1.8.1
 	github.com/aws/aws-sdk-go-v2/service/notificationscontacts v1.6.1
-	github.com/aws/aws-sdk-go-v2/service/oam v1.24.0
+	github.com/aws/aws-sdk-go-v2/service/oam v1.24.1
 	github.com/aws/aws-sdk-go-v2/service/observabilityadmin v1.16.0
 	github.com/aws/aws-sdk-go-v2/service/odb v1.11.0
 	github.com/aws/aws-sdk-go-v2/service/opensearch v1.69.0

--- a/go.mod
+++ b/go.mod
@@ -102,7 +102,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/directoryservice v1.38.19
 	github.com/aws/aws-sdk-go-v2/service/dlm v1.37.1
 	github.com/aws/aws-sdk-go-v2/service/docdb v1.48.16
-	github.com/aws/aws-sdk-go-v2/service/docdbelastic v1.20.15
+	github.com/aws/aws-sdk-go-v2/service/docdbelastic v1.21.1
 	github.com/aws/aws-sdk-go-v2/service/drs v1.38.2
 	github.com/aws/aws-sdk-go-v2/service/dsql v1.14.0
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.4

--- a/go.mod
+++ b/go.mod
@@ -86,7 +86,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/costandusagereportservice v1.34.16
 	github.com/aws/aws-sdk-go-v2/service/costexplorer v1.63.9
 	github.com/aws/aws-sdk-go-v2/service/costoptimizationhub v1.23.0
-	github.com/aws/aws-sdk-go-v2/service/customerprofiles v1.61.0
+	github.com/aws/aws-sdk-go-v2/service/customerprofiles v1.62.0
 	github.com/aws/aws-sdk-go-v2/service/databasemigrationservice v1.63.0
 	github.com/aws/aws-sdk-go-v2/service/databrew v1.40.0
 	github.com/aws/aws-sdk-go-v2/service/dataexchange v1.41.2

--- a/go.mod
+++ b/go.mod
@@ -226,7 +226,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.33.0
 	github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.26.24
 	github.com/aws/aws-sdk-go-v2/service/route53resolver v1.44.1
-	github.com/aws/aws-sdk-go-v2/service/rum v1.30.12
+	github.com/aws/aws-sdk-go-v2/service/rum v1.31.1
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.102.1
 	github.com/aws/aws-sdk-go-v2/service/s3control v1.70.1
 	github.com/aws/aws-sdk-go-v2/service/s3files v1.0.2

--- a/go.mod
+++ b/go.mod
@@ -276,7 +276,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/wafregional v1.30.24
 	github.com/aws/aws-sdk-go-v2/service/wafv2 v1.71.6
 	github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.40.1
-	github.com/aws/aws-sdk-go-v2/service/workmail v1.37.0
+	github.com/aws/aws-sdk-go-v2/service/workmail v1.37.1
 	github.com/aws/aws-sdk-go-v2/service/workspaces v1.68.1
 	github.com/aws/aws-sdk-go-v2/service/workspacesweb v1.39.0
 	github.com/aws/aws-sdk-go-v2/service/xray v1.36.23

--- a/go.mod
+++ b/go.mod
@@ -120,7 +120,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/elastictranscoder v1.33.0
 	github.com/aws/aws-sdk-go-v2/service/emr v1.59.3
 	github.com/aws/aws-sdk-go-v2/service/emrcontainers v1.41.1
-	github.com/aws/aws-sdk-go-v2/service/emrserverless v1.41.0
+	github.com/aws/aws-sdk-go-v2/service/emrserverless v1.41.1
 	github.com/aws/aws-sdk-go-v2/service/eventbridge v1.45.25
 	github.com/aws/aws-sdk-go-v2/service/evidently v1.30.0
 	github.com/aws/aws-sdk-go-v2/service/evs v1.10.0

--- a/go.mod
+++ b/go.mod
@@ -87,7 +87,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/costexplorer v1.63.9
 	github.com/aws/aws-sdk-go-v2/service/costoptimizationhub v1.23.0
 	github.com/aws/aws-sdk-go-v2/service/customerprofiles v1.62.0
-	github.com/aws/aws-sdk-go-v2/service/databasemigrationservice v1.63.0
+	github.com/aws/aws-sdk-go-v2/service/databasemigrationservice v1.63.1
 	github.com/aws/aws-sdk-go-v2/service/databrew v1.40.0
 	github.com/aws/aws-sdk-go-v2/service/dataexchange v1.41.2
 	github.com/aws/aws-sdk-go-v2/service/datapipeline v1.30.22

--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.74.1
 	github.com/aws/aws-sdk-go-v2/service/codeartifact v1.39.1
 	github.com/aws/aws-sdk-go-v2/service/codebuild v1.68.17
-	github.com/aws/aws-sdk-go-v2/service/codecatalyst v1.21.14
+	github.com/aws/aws-sdk-go-v2/service/codecatalyst v1.21.15
 	github.com/aws/aws-sdk-go-v2/service/codecommit v1.33.14
 	github.com/aws/aws-sdk-go-v2/service/codeconnections v1.11.0
 	github.com/aws/aws-sdk-go-v2/service/codedeploy v1.35.15

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/appintegrations v1.37.10
 	github.com/aws/aws-sdk-go-v2/service/applicationautoscaling v1.41.17
 	github.com/aws/aws-sdk-go-v2/service/applicationinsights v1.34.23
-	github.com/aws/aws-sdk-go-v2/service/applicationsignals v1.22.0
+	github.com/aws/aws-sdk-go-v2/service/applicationsignals v1.22.1
 	github.com/aws/aws-sdk-go-v2/service/appmesh v1.35.14
 	github.com/aws/aws-sdk-go-v2/service/apprunner v1.40.0
 	github.com/aws/aws-sdk-go-v2/service/appstream v1.59.0

--- a/go.mod
+++ b/go.mod
@@ -139,7 +139,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/guardduty v1.78.1
 	github.com/aws/aws-sdk-go-v2/service/healthlake v1.37.1
 	github.com/aws/aws-sdk-go-v2/service/iam v1.53.11
-	github.com/aws/aws-sdk-go-v2/service/identitystore v1.37.0
+	github.com/aws/aws-sdk-go-v2/service/identitystore v1.37.1
 	github.com/aws/aws-sdk-go-v2/service/imagebuilder v1.54.0
 	github.com/aws/aws-sdk-go-v2/service/inspector v1.30.22
 	github.com/aws/aws-sdk-go-v2/service/inspector2 v1.47.7

--- a/go.mod
+++ b/go.mod
@@ -115,7 +115,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/elasticache v1.52.3
 	github.com/aws/aws-sdk-go-v2/service/elasticbeanstalk v1.34.5
 	github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing v1.33.26
-	github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.54.12
+	github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.54.13
 	github.com/aws/aws-sdk-go-v2/service/elasticsearchservice v1.41.0
 	github.com/aws/aws-sdk-go-v2/service/elastictranscoder v1.33.0
 	github.com/aws/aws-sdk-go-v2/service/emr v1.59.2

--- a/go.mod
+++ b/go.mod
@@ -148,7 +148,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/iot v1.74.0
 	github.com/aws/aws-sdk-go-v2/service/ivs v1.51.0
 	github.com/aws/aws-sdk-go-v2/service/ivschat v1.22.1
-	github.com/aws/aws-sdk-go-v2/service/kafka v1.52.0
+	github.com/aws/aws-sdk-go-v2/service/kafka v1.52.1
 	github.com/aws/aws-sdk-go-v2/service/kafkaconnect v1.31.0
 	github.com/aws/aws-sdk-go-v2/service/kendra v1.60.23
 	github.com/aws/aws-sdk-go-v2/service/keyspaces v1.25.7

--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol v1.41.0
 	github.com/aws/aws-sdk-go-v2/service/billing v1.11.1
 	github.com/aws/aws-sdk-go-v2/service/budgets v1.43.8
-	github.com/aws/aws-sdk-go-v2/service/chatbot v1.14.23
+	github.com/aws/aws-sdk-go-v2/service/chatbot v1.15.0
 	github.com/aws/aws-sdk-go-v2/service/chime v1.41.14
 	github.com/aws/aws-sdk-go-v2/service/chimesdkmediapipelines v1.27.0
 	github.com/aws/aws-sdk-go-v2/service/chimesdkvoice v1.28.15

--- a/go.mod
+++ b/go.mod
@@ -67,7 +67,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/codeartifact v1.39.1
 	github.com/aws/aws-sdk-go-v2/service/codebuild v1.68.17
 	github.com/aws/aws-sdk-go-v2/service/codecatalyst v1.21.15
-	github.com/aws/aws-sdk-go-v2/service/codecommit v1.33.14
+	github.com/aws/aws-sdk-go-v2/service/codecommit v1.33.15
 	github.com/aws/aws-sdk-go-v2/service/codeconnections v1.11.0
 	github.com/aws/aws-sdk-go-v2/service/codedeploy v1.35.15
 	github.com/aws/aws-sdk-go-v2/service/codeguruprofiler v1.30.0

--- a/go.mod
+++ b/go.mod
@@ -121,7 +121,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/emr v1.59.3
 	github.com/aws/aws-sdk-go-v2/service/emrcontainers v1.41.1
 	github.com/aws/aws-sdk-go-v2/service/emrserverless v1.41.1
-	github.com/aws/aws-sdk-go-v2/service/eventbridge v1.45.25
+	github.com/aws/aws-sdk-go-v2/service/eventbridge v1.46.1
 	github.com/aws/aws-sdk-go-v2/service/evidently v1.30.0
 	github.com/aws/aws-sdk-go-v2/service/evs v1.10.0
 	github.com/aws/aws-sdk-go-v2/service/finspace v1.33.23

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/autoscalingplans v1.30.17
 	github.com/aws/aws-sdk-go-v2/service/backup v1.57.1
 	github.com/aws/aws-sdk-go-v2/service/batch v1.65.1
-	github.com/aws/aws-sdk-go-v2/service/bcmdataexports v1.16.0
+	github.com/aws/aws-sdk-go-v2/service/bcmdataexports v1.16.1
 	github.com/aws/aws-sdk-go-v2/service/bedrock v1.61.0
 	github.com/aws/aws-sdk-go-v2/service/bedrockagent v1.54.0
 	github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol v1.40.0

--- a/go.mod
+++ b/go.mod
@@ -218,7 +218,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.36.1
 	github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.24.1
 	github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.33.27
-	github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.32.0
+	github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.32.1
 	github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.23.0
 	github.com/aws/aws-sdk-go-v2/service/route53 v1.62.7
 	github.com/aws/aws-sdk-go-v2/service/route53domains v1.35.0

--- a/go.mod
+++ b/go.mod
@@ -123,7 +123,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/emrserverless v1.41.1
 	github.com/aws/aws-sdk-go-v2/service/eventbridge v1.46.1
 	github.com/aws/aws-sdk-go-v2/service/evidently v1.30.0
-	github.com/aws/aws-sdk-go-v2/service/evs v1.10.0
+	github.com/aws/aws-sdk-go-v2/service/evs v1.10.1
 	github.com/aws/aws-sdk-go-v2/service/finspace v1.33.23
 	github.com/aws/aws-sdk-go-v2/service/firehose v1.42.16
 	github.com/aws/aws-sdk-go-v2/service/fis v1.37.22

--- a/go.mod
+++ b/go.mod
@@ -269,7 +269,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.35.24
 	github.com/aws/aws-sdk-go-v2/service/transcribe v1.55.1
 	github.com/aws/aws-sdk-go-v2/service/transfer v1.72.1
-	github.com/aws/aws-sdk-go-v2/service/uxc v1.0.3
+	github.com/aws/aws-sdk-go-v2/service/uxc v1.0.4
 	github.com/aws/aws-sdk-go-v2/service/verifiedpermissions v1.33.0
 	github.com/aws/aws-sdk-go-v2/service/vpclattice v1.21.0
 	github.com/aws/aws-sdk-go-v2/service/waf v1.30.22

--- a/go.mod
+++ b/go.mod
@@ -77,7 +77,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/codestarnotifications v1.32.1
 	github.com/aws/aws-sdk-go-v2/service/cognitoidentity v1.33.25
 	github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.60.3
-	github.com/aws/aws-sdk-go-v2/service/comprehend v1.41.0
+	github.com/aws/aws-sdk-go-v2/service/comprehend v1.41.1
 	github.com/aws/aws-sdk-go-v2/service/computeoptimizer v1.50.1
 	github.com/aws/aws-sdk-go-v2/service/configservice v1.62.3
 	github.com/aws/aws-sdk-go-v2/service/connect v1.175.0

--- a/go.mod
+++ b/go.mod
@@ -239,7 +239,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/schemas v1.35.1
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.8
 	github.com/aws/aws-sdk-go-v2/service/securityhub v1.71.1
-	github.com/aws/aws-sdk-go-v2/service/securitylake v1.25.15
+	github.com/aws/aws-sdk-go-v2/service/securitylake v1.25.16
 	github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.31.0
 	github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.39.15
 	github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry v1.36.0

--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/budgets v1.43.8
 	github.com/aws/aws-sdk-go-v2/service/chatbot v1.15.0
 	github.com/aws/aws-sdk-go-v2/service/chime v1.41.15
-	github.com/aws/aws-sdk-go-v2/service/chimesdkmediapipelines v1.27.0
+	github.com/aws/aws-sdk-go-v2/service/chimesdkmediapipelines v1.27.1
 	github.com/aws/aws-sdk-go-v2/service/chimesdkvoice v1.28.15
 	github.com/aws/aws-sdk-go-v2/service/cleanrooms v1.45.0
 	github.com/aws/aws-sdk-go-v2/service/cloud9 v1.34.0

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/applicationinsights v1.34.23
 	github.com/aws/aws-sdk-go-v2/service/applicationsignals v1.22.1
 	github.com/aws/aws-sdk-go-v2/service/appmesh v1.35.15
-	github.com/aws/aws-sdk-go-v2/service/apprunner v1.40.0
+	github.com/aws/aws-sdk-go-v2/service/apprunner v1.40.1
 	github.com/aws/aws-sdk-go-v2/service/appstream v1.59.0
 	github.com/aws/aws-sdk-go-v2/service/appsync v1.53.7
 	github.com/aws/aws-sdk-go-v2/service/arcregionswitch v1.7.0

--- a/go.mod
+++ b/go.mod
@@ -128,7 +128,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/firehose v1.42.17
 	github.com/aws/aws-sdk-go-v2/service/fis v1.38.1
 	github.com/aws/aws-sdk-go-v2/service/fms v1.45.1
-	github.com/aws/aws-sdk-go-v2/service/fsx v1.66.0
+	github.com/aws/aws-sdk-go-v2/service/fsx v1.66.1
 	github.com/aws/aws-sdk-go-v2/service/gamelift v1.54.0
 	github.com/aws/aws-sdk-go-v2/service/glacier v1.32.8
 	github.com/aws/aws-sdk-go-v2/service/globalaccelerator v1.36.0

--- a/go.mod
+++ b/go.mod
@@ -96,7 +96,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/dax v1.29.19
 	github.com/aws/aws-sdk-go-v2/service/detective v1.39.0
 	github.com/aws/aws-sdk-go-v2/service/devicefarm v1.38.11
-	github.com/aws/aws-sdk-go-v2/service/devopsagent v1.4.0
+	github.com/aws/aws-sdk-go-v2/service/devopsagent v1.5.1
 	github.com/aws/aws-sdk-go-v2/service/devopsguru v1.41.0
 	github.com/aws/aws-sdk-go-v2/service/directconnect v1.38.17
 	github.com/aws/aws-sdk-go-v2/service/directoryservice v1.38.18

--- a/go.mod
+++ b/go.mod
@@ -111,7 +111,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.39.1
 	github.com/aws/aws-sdk-go-v2/service/ecs v1.81.1
 	github.com/aws/aws-sdk-go-v2/service/efs v1.41.17
-	github.com/aws/aws-sdk-go-v2/service/eks v1.84.0
+	github.com/aws/aws-sdk-go-v2/service/eks v1.84.1
 	github.com/aws/aws-sdk-go-v2/service/elasticache v1.52.2
 	github.com/aws/aws-sdk-go-v2/service/elasticbeanstalk v1.34.4
 	github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing v1.33.25

--- a/go.mod
+++ b/go.mod
@@ -83,7 +83,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/connect v1.175.1
 	github.com/aws/aws-sdk-go-v2/service/connectcases v1.42.1
 	github.com/aws/aws-sdk-go-v2/service/controltower v1.29.1
-	github.com/aws/aws-sdk-go-v2/service/costandusagereportservice v1.34.15
+	github.com/aws/aws-sdk-go-v2/service/costandusagereportservice v1.34.16
 	github.com/aws/aws-sdk-go-v2/service/costexplorer v1.63.8
 	github.com/aws/aws-sdk-go-v2/service/costoptimizationhub v1.22.10
 	github.com/aws/aws-sdk-go-v2/service/customerprofiles v1.61.0

--- a/go.mod
+++ b/go.mod
@@ -220,7 +220,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.33.27
 	github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.32.1
 	github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.23.1
-	github.com/aws/aws-sdk-go-v2/service/route53 v1.62.7
+	github.com/aws/aws-sdk-go-v2/service/route53 v1.62.8
 	github.com/aws/aws-sdk-go-v2/service/route53domains v1.35.0
 	github.com/aws/aws-sdk-go-v2/service/route53profiles v1.9.25
 	github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.32.16

--- a/go.mod
+++ b/go.mod
@@ -216,7 +216,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.35.1
 	github.com/aws/aws-sdk-go-v2/service/rekognition v1.51.25
 	github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.36.1
-	github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.23.6
+	github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.24.1
 	github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.33.26
 	github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.32.0
 	github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.23.0

--- a/go.mod
+++ b/go.mod
@@ -97,7 +97,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/detective v1.39.0
 	github.com/aws/aws-sdk-go-v2/service/devicefarm v1.38.11
 	github.com/aws/aws-sdk-go-v2/service/devopsagent v1.5.1
-	github.com/aws/aws-sdk-go-v2/service/devopsguru v1.41.0
+	github.com/aws/aws-sdk-go-v2/service/devopsguru v1.41.1
 	github.com/aws/aws-sdk-go-v2/service/directconnect v1.38.17
 	github.com/aws/aws-sdk-go-v2/service/directoryservice v1.38.18
 	github.com/aws/aws-sdk-go-v2/service/dlm v1.37.0

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/apigatewayv2 v1.35.1
 	github.com/aws/aws-sdk-go-v2/service/appconfig v1.44.1
 	github.com/aws/aws-sdk-go-v2/service/appfabric v1.16.24
-	github.com/aws/aws-sdk-go-v2/service/appflow v1.51.14
+	github.com/aws/aws-sdk-go-v2/service/appflow v1.51.15
 	github.com/aws/aws-sdk-go-v2/service/appintegrations v1.37.9
 	github.com/aws/aws-sdk-go-v2/service/applicationautoscaling v1.41.16
 	github.com/aws/aws-sdk-go-v2/service/applicationinsights v1.34.22

--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/cloudformation v1.71.12
 	github.com/aws/aws-sdk-go-v2/service/cloudfront v1.64.1
 	github.com/aws/aws-sdk-go-v2/service/cloudfrontkeyvaluestore v1.13.0
-	github.com/aws/aws-sdk-go-v2/service/cloudhsmv2 v1.34.25
+	github.com/aws/aws-sdk-go-v2/service/cloudhsmv2 v1.34.26
 	github.com/aws/aws-sdk-go-v2/service/cloudsearch v1.32.14
 	github.com/aws/aws-sdk-go-v2/service/cloudtrail v1.55.11
 	github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.57.0

--- a/go.mod
+++ b/go.mod
@@ -241,7 +241,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/securityhub v1.71.1
 	github.com/aws/aws-sdk-go-v2/service/securitylake v1.25.16
 	github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.31.1
-	github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.39.15
+	github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.39.16
 	github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry v1.36.0
 	github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.40.0
 	github.com/aws/aws-sdk-go-v2/service/servicequotas v1.35.0

--- a/go.mod
+++ b/go.mod
@@ -177,7 +177,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/memorydb v1.34.1
 	github.com/aws/aws-sdk-go-v2/service/mgn v1.44.1
 	github.com/aws/aws-sdk-go-v2/service/mpa v1.8.1
-	github.com/aws/aws-sdk-go-v2/service/mq v1.34.22
+	github.com/aws/aws-sdk-go-v2/service/mq v1.34.23
 	github.com/aws/aws-sdk-go-v2/service/mwaa v1.40.1
 	github.com/aws/aws-sdk-go-v2/service/mwaaserverless v1.0.11
 	github.com/aws/aws-sdk-go-v2/service/neptune v1.44.5

--- a/go.mod
+++ b/go.mod
@@ -191,7 +191,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/oam v1.24.1
 	github.com/aws/aws-sdk-go-v2/service/observabilityadmin v1.16.1
 	github.com/aws/aws-sdk-go-v2/service/odb v1.11.1
-	github.com/aws/aws-sdk-go-v2/service/opensearch v1.69.0
+	github.com/aws/aws-sdk-go-v2/service/opensearch v1.70.1
 	github.com/aws/aws-sdk-go-v2/service/opensearchserverless v1.30.3
 	github.com/aws/aws-sdk-go-v2/service/organizations v1.51.3
 	github.com/aws/aws-sdk-go-v2/service/osis v1.22.0

--- a/go.mod
+++ b/go.mod
@@ -225,7 +225,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/route53profiles v1.9.26
 	github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.33.0
 	github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.26.24
-	github.com/aws/aws-sdk-go-v2/service/route53resolver v1.44.0
+	github.com/aws/aws-sdk-go-v2/service/route53resolver v1.44.1
 	github.com/aws/aws-sdk-go-v2/service/rum v1.30.12
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.102.1
 	github.com/aws/aws-sdk-go-v2/service/s3control v1.70.1

--- a/go.mod
+++ b/go.mod
@@ -243,7 +243,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.31.1
 	github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.39.16
 	github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry v1.36.1
-	github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.40.0
+	github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.40.1
 	github.com/aws/aws-sdk-go-v2/service/servicequotas v1.35.0
 	github.com/aws/aws-sdk-go-v2/service/ses v1.34.24
 	github.com/aws/aws-sdk-go-v2/service/sesv2 v1.61.0

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/appflow v1.51.15
 	github.com/aws/aws-sdk-go-v2/service/appintegrations v1.37.10
 	github.com/aws/aws-sdk-go-v2/service/applicationautoscaling v1.41.17
-	github.com/aws/aws-sdk-go-v2/service/applicationinsights v1.34.22
+	github.com/aws/aws-sdk-go-v2/service/applicationinsights v1.34.23
 	github.com/aws/aws-sdk-go-v2/service/applicationsignals v1.22.0
 	github.com/aws/aws-sdk-go-v2/service/appmesh v1.35.14
 	github.com/aws/aws-sdk-go-v2/service/apprunner v1.40.0

--- a/go.mod
+++ b/go.mod
@@ -90,7 +90,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/databasemigrationservice v1.63.1
 	github.com/aws/aws-sdk-go-v2/service/databrew v1.40.1
 	github.com/aws/aws-sdk-go-v2/service/dataexchange v1.42.1
-	github.com/aws/aws-sdk-go-v2/service/datapipeline v1.30.22
+	github.com/aws/aws-sdk-go-v2/service/datapipeline v1.30.23
 	github.com/aws/aws-sdk-go-v2/service/datasync v1.59.0
 	github.com/aws/aws-sdk-go-v2/service/datazone v1.62.0
 	github.com/aws/aws-sdk-go-v2/service/dax v1.29.18

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/arczonalshift v1.22.26
 	github.com/aws/aws-sdk-go-v2/service/athena v1.57.7
 	github.com/aws/aws-sdk-go-v2/service/auditmanager v1.46.15
-	github.com/aws/aws-sdk-go-v2/service/autoscaling v1.66.2
+	github.com/aws/aws-sdk-go-v2/service/autoscaling v1.66.3
 	github.com/aws/aws-sdk-go-v2/service/autoscalingplans v1.30.16
 	github.com/aws/aws-sdk-go-v2/service/backup v1.57.0
 	github.com/aws/aws-sdk-go-v2/service/batch v1.65.0

--- a/go.mod
+++ b/go.mod
@@ -233,7 +233,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3outposts v1.34.15
 	github.com/aws/aws-sdk-go-v2/service/s3tables v1.16.1
 	github.com/aws/aws-sdk-go-v2/service/s3vectors v1.7.1
-	github.com/aws/aws-sdk-go-v2/service/sagemaker v1.249.0
+	github.com/aws/aws-sdk-go-v2/service/sagemaker v1.250.1
 	github.com/aws/aws-sdk-go-v2/service/savingsplans v1.32.4
 	github.com/aws/aws-sdk-go-v2/service/scheduler v1.18.0
 	github.com/aws/aws-sdk-go-v2/service/schemas v1.35.0

--- a/go.mod
+++ b/go.mod
@@ -180,7 +180,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/mq v1.34.23
 	github.com/aws/aws-sdk-go-v2/service/mwaa v1.40.2
 	github.com/aws/aws-sdk-go-v2/service/mwaaserverless v1.0.12
-	github.com/aws/aws-sdk-go-v2/service/neptune v1.44.5
+	github.com/aws/aws-sdk-go-v2/service/neptune v1.44.6
 	github.com/aws/aws-sdk-go-v2/service/neptunegraph v1.21.23
 	github.com/aws/aws-sdk-go-v2/service/networkfirewall v1.61.0
 	github.com/aws/aws-sdk-go-v2/service/networkflowmonitor v1.11.11

--- a/go.mod
+++ b/go.mod
@@ -145,7 +145,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/inspector2 v1.48.1
 	github.com/aws/aws-sdk-go-v2/service/internetmonitor v1.27.1
 	github.com/aws/aws-sdk-go-v2/service/invoicing v1.11.1
-	github.com/aws/aws-sdk-go-v2/service/iot v1.73.0
+	github.com/aws/aws-sdk-go-v2/service/iot v1.74.0
 	github.com/aws/aws-sdk-go-v2/service/ivs v1.50.1
 	github.com/aws/aws-sdk-go-v2/service/ivschat v1.22.0
 	github.com/aws/aws-sdk-go-v2/service/kafka v1.52.0

--- a/go.mod
+++ b/go.mod
@@ -156,7 +156,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/kinesisanalytics v1.30.26
 	github.com/aws/aws-sdk-go-v2/service/kinesisanalyticsv2 v1.38.0
 	github.com/aws/aws-sdk-go-v2/service/kinesisvideo v1.33.11
-	github.com/aws/aws-sdk-go-v2/service/kms v1.52.0
+	github.com/aws/aws-sdk-go-v2/service/kms v1.52.1
 	github.com/aws/aws-sdk-go-v2/service/lakeformation v1.47.8
 	github.com/aws/aws-sdk-go-v2/service/lambda v1.90.1
 	github.com/aws/aws-sdk-go-v2/service/launchwizard v1.14.6

--- a/go.mod
+++ b/go.mod
@@ -100,7 +100,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/devopsguru v1.41.1
 	github.com/aws/aws-sdk-go-v2/service/directconnect v1.38.18
 	github.com/aws/aws-sdk-go-v2/service/directoryservice v1.38.19
-	github.com/aws/aws-sdk-go-v2/service/dlm v1.37.0
+	github.com/aws/aws-sdk-go-v2/service/dlm v1.37.1
 	github.com/aws/aws-sdk-go-v2/service/docdb v1.48.15
 	github.com/aws/aws-sdk-go-v2/service/docdbelastic v1.20.15
 	github.com/aws/aws-sdk-go-v2/service/drs v1.38.2

--- a/go.mod
+++ b/go.mod
@@ -99,7 +99,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/devopsagent v1.5.1
 	github.com/aws/aws-sdk-go-v2/service/devopsguru v1.41.1
 	github.com/aws/aws-sdk-go-v2/service/directconnect v1.38.18
-	github.com/aws/aws-sdk-go-v2/service/directoryservice v1.38.18
+	github.com/aws/aws-sdk-go-v2/service/directoryservice v1.38.19
 	github.com/aws/aws-sdk-go-v2/service/dlm v1.37.0
 	github.com/aws/aws-sdk-go-v2/service/docdb v1.48.15
 	github.com/aws/aws-sdk-go-v2/service/docdbelastic v1.20.15

--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/billing v1.11.1
 	github.com/aws/aws-sdk-go-v2/service/budgets v1.43.8
 	github.com/aws/aws-sdk-go-v2/service/chatbot v1.15.0
-	github.com/aws/aws-sdk-go-v2/service/chime v1.41.14
+	github.com/aws/aws-sdk-go-v2/service/chime v1.41.15
 	github.com/aws/aws-sdk-go-v2/service/chimesdkmediapipelines v1.27.0
 	github.com/aws/aws-sdk-go-v2/service/chimesdkvoice v1.28.15
 	github.com/aws/aws-sdk-go-v2/service/cleanrooms v1.45.0

--- a/go.mod
+++ b/go.mod
@@ -130,7 +130,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/fms v1.45.1
 	github.com/aws/aws-sdk-go-v2/service/fsx v1.66.1
 	github.com/aws/aws-sdk-go-v2/service/gamelift v1.54.1
-	github.com/aws/aws-sdk-go-v2/service/glacier v1.32.8
+	github.com/aws/aws-sdk-go-v2/service/glacier v1.32.9
 	github.com/aws/aws-sdk-go-v2/service/globalaccelerator v1.36.0
 	github.com/aws/aws-sdk-go-v2/service/glue v1.142.0
 	github.com/aws/aws-sdk-go-v2/service/grafana v1.35.0

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/autoscaling v1.66.3
 	github.com/aws/aws-sdk-go-v2/service/autoscalingplans v1.30.17
 	github.com/aws/aws-sdk-go-v2/service/backup v1.57.1
-	github.com/aws/aws-sdk-go-v2/service/batch v1.65.0
+	github.com/aws/aws-sdk-go-v2/service/batch v1.65.1
 	github.com/aws/aws-sdk-go-v2/service/bcmdataexports v1.16.0
 	github.com/aws/aws-sdk-go-v2/service/bedrock v1.61.0
 	github.com/aws/aws-sdk-go-v2/service/bedrockagent v1.54.0

--- a/go.mod
+++ b/go.mod
@@ -129,7 +129,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/fis v1.38.1
 	github.com/aws/aws-sdk-go-v2/service/fms v1.45.1
 	github.com/aws/aws-sdk-go-v2/service/fsx v1.66.1
-	github.com/aws/aws-sdk-go-v2/service/gamelift v1.54.0
+	github.com/aws/aws-sdk-go-v2/service/gamelift v1.54.1
 	github.com/aws/aws-sdk-go-v2/service/glacier v1.32.8
 	github.com/aws/aws-sdk-go-v2/service/globalaccelerator v1.36.0
 	github.com/aws/aws-sdk-go-v2/service/glue v1.142.0

--- a/go.mod
+++ b/go.mod
@@ -176,7 +176,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/mediastore v1.29.24
 	github.com/aws/aws-sdk-go-v2/service/memorydb v1.34.1
 	github.com/aws/aws-sdk-go-v2/service/mgn v1.44.1
-	github.com/aws/aws-sdk-go-v2/service/mpa v1.7.4
+	github.com/aws/aws-sdk-go-v2/service/mpa v1.8.1
 	github.com/aws/aws-sdk-go-v2/service/mq v1.34.22
 	github.com/aws/aws-sdk-go-v2/service/mwaa v1.40.1
 	github.com/aws/aws-sdk-go-v2/service/mwaaserverless v1.0.11

--- a/go.mod
+++ b/go.mod
@@ -70,7 +70,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/codecommit v1.33.15
 	github.com/aws/aws-sdk-go-v2/service/codeconnections v1.11.1
 	github.com/aws/aws-sdk-go-v2/service/codedeploy v1.35.16
-	github.com/aws/aws-sdk-go-v2/service/codeguruprofiler v1.30.0
+	github.com/aws/aws-sdk-go-v2/service/codeguruprofiler v1.30.1
 	github.com/aws/aws-sdk-go-v2/service/codegurureviewer v1.34.22
 	github.com/aws/aws-sdk-go-v2/service/codepipeline v1.46.23
 	github.com/aws/aws-sdk-go-v2/service/codestarconnections v1.35.15

--- a/go.mod
+++ b/go.mod
@@ -73,7 +73,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/codeguruprofiler v1.30.1
 	github.com/aws/aws-sdk-go-v2/service/codegurureviewer v1.35.0
 	github.com/aws/aws-sdk-go-v2/service/codepipeline v1.46.24
-	github.com/aws/aws-sdk-go-v2/service/codestarconnections v1.35.15
+	github.com/aws/aws-sdk-go-v2/service/codestarconnections v1.36.0
 	github.com/aws/aws-sdk-go-v2/service/codestarnotifications v1.32.0
 	github.com/aws/aws-sdk-go-v2/service/cognitoidentity v1.33.24
 	github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.60.2

--- a/go.mod
+++ b/go.mod
@@ -71,7 +71,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/codeconnections v1.11.1
 	github.com/aws/aws-sdk-go-v2/service/codedeploy v1.35.16
 	github.com/aws/aws-sdk-go-v2/service/codeguruprofiler v1.30.1
-	github.com/aws/aws-sdk-go-v2/service/codegurureviewer v1.34.22
+	github.com/aws/aws-sdk-go-v2/service/codegurureviewer v1.35.0
 	github.com/aws/aws-sdk-go-v2/service/codepipeline v1.46.23
 	github.com/aws/aws-sdk-go-v2/service/codestarconnections v1.35.15
 	github.com/aws/aws-sdk-go-v2/service/codestarnotifications v1.32.0

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/backup v1.57.1
 	github.com/aws/aws-sdk-go-v2/service/batch v1.65.1
 	github.com/aws/aws-sdk-go-v2/service/bcmdataexports v1.16.1
-	github.com/aws/aws-sdk-go-v2/service/bedrock v1.61.0
+	github.com/aws/aws-sdk-go-v2/service/bedrock v1.62.0
 	github.com/aws/aws-sdk-go-v2/service/bedrockagent v1.54.0
 	github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol v1.40.0
 	github.com/aws/aws-sdk-go-v2/service/billing v1.11.0

--- a/go.mod
+++ b/go.mod
@@ -105,7 +105,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/docdbelastic v1.21.1
 	github.com/aws/aws-sdk-go-v2/service/drs v1.38.3
 	github.com/aws/aws-sdk-go-v2/service/dsql v1.14.1
-	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.4
+	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.5
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.304.0
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.57.2
 	github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.38.15
@@ -341,7 +341,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.25 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.17 // indirect
-	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.12.0 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.12.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.24 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.24 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -211,7 +211,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/rbin v1.28.1
 	github.com/aws/aws-sdk-go-v2/service/rds v1.118.3
 	github.com/aws/aws-sdk-go-v2/service/rdsdata v1.32.24
-	github.com/aws/aws-sdk-go-v2/service/redshift v1.62.8
+	github.com/aws/aws-sdk-go-v2/service/redshift v1.62.9
 	github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.39.2
 	github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.35.0
 	github.com/aws/aws-sdk-go-v2/service/rekognition v1.51.24

--- a/go.mod
+++ b/go.mod
@@ -68,7 +68,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/codebuild v1.68.17
 	github.com/aws/aws-sdk-go-v2/service/codecatalyst v1.21.15
 	github.com/aws/aws-sdk-go-v2/service/codecommit v1.33.15
-	github.com/aws/aws-sdk-go-v2/service/codeconnections v1.11.0
+	github.com/aws/aws-sdk-go-v2/service/codeconnections v1.11.1
 	github.com/aws/aws-sdk-go-v2/service/codedeploy v1.35.15
 	github.com/aws/aws-sdk-go-v2/service/codeguruprofiler v1.30.0
 	github.com/aws/aws-sdk-go-v2/service/codegurureviewer v1.34.22

--- a/go.mod
+++ b/go.mod
@@ -224,7 +224,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/route53domains v1.35.1
 	github.com/aws/aws-sdk-go-v2/service/route53profiles v1.9.26
 	github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.33.0
-	github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.26.23
+	github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.26.24
 	github.com/aws/aws-sdk-go-v2/service/route53resolver v1.44.0
 	github.com/aws/aws-sdk-go-v2/service/rum v1.30.12
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.102.1

--- a/go.mod
+++ b/go.mod
@@ -252,7 +252,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/signer v1.33.1
 	github.com/aws/aws-sdk-go-v2/service/sns v1.39.18
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.42.28
-	github.com/aws/aws-sdk-go-v2/service/ssm v1.68.6
+	github.com/aws/aws-sdk-go-v2/service/ssm v1.68.7
 	github.com/aws/aws-sdk-go-v2/service/ssmcontacts v1.31.16
 	github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.39.22
 	github.com/aws/aws-sdk-go-v2/service/ssmquicksetup v1.9.0

--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/cloudsearch v1.32.15
 	github.com/aws/aws-sdk-go-v2/service/cloudtrail v1.55.12
 	github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.57.1
-	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.74.0
+	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.74.1
 	github.com/aws/aws-sdk-go-v2/service/codeartifact v1.39.0
 	github.com/aws/aws-sdk-go-v2/service/codebuild v1.68.16
 	github.com/aws/aws-sdk-go-v2/service/codecatalyst v1.21.14

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/amplify v1.38.17
 	github.com/aws/aws-sdk-go-v2/service/apigateway v1.40.1
 	github.com/aws/aws-sdk-go-v2/service/apigatewayv2 v1.35.1
-	github.com/aws/aws-sdk-go-v2/service/appconfig v1.44.0
+	github.com/aws/aws-sdk-go-v2/service/appconfig v1.44.1
 	github.com/aws/aws-sdk-go-v2/service/appfabric v1.16.23
 	github.com/aws/aws-sdk-go-v2/service/appflow v1.51.14
 	github.com/aws/aws-sdk-go-v2/service/appintegrations v1.37.9

--- a/go.mod
+++ b/go.mod
@@ -141,7 +141,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/iam v1.53.11
 	github.com/aws/aws-sdk-go-v2/service/identitystore v1.37.1
 	github.com/aws/aws-sdk-go-v2/service/imagebuilder v1.55.1
-	github.com/aws/aws-sdk-go-v2/service/inspector v1.30.22
+	github.com/aws/aws-sdk-go-v2/service/inspector v1.30.23
 	github.com/aws/aws-sdk-go-v2/service/inspector2 v1.47.7
 	github.com/aws/aws-sdk-go-v2/service/internetmonitor v1.27.0
 	github.com/aws/aws-sdk-go-v2/service/invoicing v1.11.0

--- a/go.mod
+++ b/go.mod
@@ -175,7 +175,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/mediapackagevod v1.39.24
 	github.com/aws/aws-sdk-go-v2/service/mediastore v1.29.24
 	github.com/aws/aws-sdk-go-v2/service/memorydb v1.34.1
-	github.com/aws/aws-sdk-go-v2/service/mgn v1.43.0
+	github.com/aws/aws-sdk-go-v2/service/mgn v1.44.1
 	github.com/aws/aws-sdk-go-v2/service/mpa v1.7.4
 	github.com/aws/aws-sdk-go-v2/service/mq v1.34.22
 	github.com/aws/aws-sdk-go-v2/service/mwaa v1.40.1

--- a/go.mod
+++ b/go.mod
@@ -92,7 +92,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/dataexchange v1.42.1
 	github.com/aws/aws-sdk-go-v2/service/datapipeline v1.30.23
 	github.com/aws/aws-sdk-go-v2/service/datasync v1.59.1
-	github.com/aws/aws-sdk-go-v2/service/datazone v1.62.0
+	github.com/aws/aws-sdk-go-v2/service/datazone v1.62.1
 	github.com/aws/aws-sdk-go-v2/service/dax v1.29.18
 	github.com/aws/aws-sdk-go-v2/service/detective v1.38.15
 	github.com/aws/aws-sdk-go-v2/service/devicefarm v1.38.10

--- a/go.mod
+++ b/go.mod
@@ -124,7 +124,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/eventbridge v1.46.1
 	github.com/aws/aws-sdk-go-v2/service/evidently v1.30.0
 	github.com/aws/aws-sdk-go-v2/service/evs v1.10.1
-	github.com/aws/aws-sdk-go-v2/service/finspace v1.33.23
+	github.com/aws/aws-sdk-go-v2/service/finspace v1.34.1
 	github.com/aws/aws-sdk-go-v2/service/firehose v1.42.16
 	github.com/aws/aws-sdk-go-v2/service/fis v1.37.22
 	github.com/aws/aws-sdk-go-v2/service/fms v1.45.0

--- a/go.mod
+++ b/go.mod
@@ -136,7 +136,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/grafana v1.35.1
 	github.com/aws/aws-sdk-go-v2/service/greengrass v1.32.24
 	github.com/aws/aws-sdk-go-v2/service/groundstation v1.42.0
-	github.com/aws/aws-sdk-go-v2/service/guardduty v1.78.0
+	github.com/aws/aws-sdk-go-v2/service/guardduty v1.78.1
 	github.com/aws/aws-sdk-go-v2/service/healthlake v1.37.0
 	github.com/aws/aws-sdk-go-v2/service/iam v1.53.10
 	github.com/aws/aws-sdk-go-v2/service/identitystore v1.37.0

--- a/go.mod
+++ b/go.mod
@@ -165,7 +165,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/licensemanager v1.37.13
 	github.com/aws/aws-sdk-go-v2/service/lightsail v1.54.1
 	github.com/aws/aws-sdk-go-v2/service/location v1.52.1
-	github.com/aws/aws-sdk-go-v2/service/m2 v1.26.16
+	github.com/aws/aws-sdk-go-v2/service/m2 v1.27.1
 	github.com/aws/aws-sdk-go-v2/service/macie2 v1.51.2
 	github.com/aws/aws-sdk-go-v2/service/mediaconnect v1.49.0
 	github.com/aws/aws-sdk-go-v2/service/mediaconvert v1.91.2

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/appfabric v1.16.24
 	github.com/aws/aws-sdk-go-v2/service/appflow v1.51.15
 	github.com/aws/aws-sdk-go-v2/service/appintegrations v1.37.10
-	github.com/aws/aws-sdk-go-v2/service/applicationautoscaling v1.41.16
+	github.com/aws/aws-sdk-go-v2/service/applicationautoscaling v1.41.17
 	github.com/aws/aws-sdk-go-v2/service/applicationinsights v1.34.22
 	github.com/aws/aws-sdk-go-v2/service/applicationsignals v1.22.0
 	github.com/aws/aws-sdk-go-v2/service/appmesh v1.35.14

--- a/go.mod
+++ b/go.mod
@@ -236,7 +236,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sagemaker v1.250.1
 	github.com/aws/aws-sdk-go-v2/service/savingsplans v1.33.1
 	github.com/aws/aws-sdk-go-v2/service/scheduler v1.18.1
-	github.com/aws/aws-sdk-go-v2/service/schemas v1.35.0
+	github.com/aws/aws-sdk-go-v2/service/schemas v1.35.1
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.7
 	github.com/aws/aws-sdk-go-v2/service/securityhub v1.71.0
 	github.com/aws/aws-sdk-go-v2/service/securitylake v1.25.15

--- a/go.mod
+++ b/go.mod
@@ -266,7 +266,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/taxsettings v1.16.24
 	github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.20.0
 	github.com/aws/aws-sdk-go-v2/service/timestreamquery v1.36.18
-	github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.35.23
+	github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.35.24
 	github.com/aws/aws-sdk-go-v2/service/transcribe v1.55.0
 	github.com/aws/aws-sdk-go-v2/service/transfer v1.72.0
 	github.com/aws/aws-sdk-go-v2/service/uxc v1.0.3

--- a/go.mod
+++ b/go.mod
@@ -162,7 +162,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/launchwizard v1.15.1
 	github.com/aws/aws-sdk-go-v2/service/lexmodelbuildingservice v1.35.1
 	github.com/aws/aws-sdk-go-v2/service/lexmodelsv2 v1.61.1
-	github.com/aws/aws-sdk-go-v2/service/licensemanager v1.37.12
+	github.com/aws/aws-sdk-go-v2/service/licensemanager v1.37.13
 	github.com/aws/aws-sdk-go-v2/service/lightsail v1.54.0
 	github.com/aws/aws-sdk-go-v2/service/location v1.51.1
 	github.com/aws/aws-sdk-go-v2/service/m2 v1.26.16

--- a/go.mod
+++ b/go.mod
@@ -146,7 +146,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internetmonitor v1.27.1
 	github.com/aws/aws-sdk-go-v2/service/invoicing v1.11.1
 	github.com/aws/aws-sdk-go-v2/service/iot v1.74.0
-	github.com/aws/aws-sdk-go-v2/service/ivs v1.50.1
+	github.com/aws/aws-sdk-go-v2/service/ivs v1.51.0
 	github.com/aws/aws-sdk-go-v2/service/ivschat v1.22.0
 	github.com/aws/aws-sdk-go-v2/service/kafka v1.52.0
 	github.com/aws/aws-sdk-go-v2/service/kafkaconnect v1.31.0

--- a/go.mod
+++ b/go.mod
@@ -268,7 +268,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/timestreamquery v1.36.18
 	github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.35.24
 	github.com/aws/aws-sdk-go-v2/service/transcribe v1.55.1
-	github.com/aws/aws-sdk-go-v2/service/transfer v1.72.0
+	github.com/aws/aws-sdk-go-v2/service/transfer v1.72.1
 	github.com/aws/aws-sdk-go-v2/service/uxc v1.0.3
 	github.com/aws/aws-sdk-go-v2/service/verifiedpermissions v1.33.0
 	github.com/aws/aws-sdk-go-v2/service/vpclattice v1.21.0

--- a/go.mod
+++ b/go.mod
@@ -262,7 +262,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/storagegateway v1.43.17
 	github.com/aws/aws-sdk-go-v2/service/sts v1.42.2
 	github.com/aws/aws-sdk-go-v2/service/swf v1.33.19
-	github.com/aws/aws-sdk-go-v2/service/synthetics v1.42.16
+	github.com/aws/aws-sdk-go-v2/service/synthetics v1.42.17
 	github.com/aws/aws-sdk-go-v2/service/taxsettings v1.16.23
 	github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.19.2
 	github.com/aws/aws-sdk-go-v2/service/timestreamquery v1.36.17

--- a/go.mod
+++ b/go.mod
@@ -88,7 +88,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/costoptimizationhub v1.23.0
 	github.com/aws/aws-sdk-go-v2/service/customerprofiles v1.62.0
 	github.com/aws/aws-sdk-go-v2/service/databasemigrationservice v1.63.1
-	github.com/aws/aws-sdk-go-v2/service/databrew v1.40.0
+	github.com/aws/aws-sdk-go-v2/service/databrew v1.40.1
 	github.com/aws/aws-sdk-go-v2/service/dataexchange v1.41.2
 	github.com/aws/aws-sdk-go-v2/service/datapipeline v1.30.22
 	github.com/aws/aws-sdk-go-v2/service/datasync v1.59.0

--- a/go.mod
+++ b/go.mod
@@ -150,7 +150,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ivschat v1.22.1
 	github.com/aws/aws-sdk-go-v2/service/kafka v1.52.1
 	github.com/aws/aws-sdk-go-v2/service/kafkaconnect v1.31.1
-	github.com/aws/aws-sdk-go-v2/service/kendra v1.60.23
+	github.com/aws/aws-sdk-go-v2/service/kendra v1.60.24
 	github.com/aws/aws-sdk-go-v2/service/keyspaces v1.25.7
 	github.com/aws/aws-sdk-go-v2/service/kinesis v1.43.7
 	github.com/aws/aws-sdk-go-v2/service/kinesisanalytics v1.30.25

--- a/go.mod
+++ b/go.mod
@@ -228,7 +228,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/route53resolver v1.44.1
 	github.com/aws/aws-sdk-go-v2/service/rum v1.31.1
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.102.1
-	github.com/aws/aws-sdk-go-v2/service/s3control v1.70.1
+	github.com/aws/aws-sdk-go-v2/service/s3control v1.71.0
 	github.com/aws/aws-sdk-go-v2/service/s3files v1.0.2
 	github.com/aws/aws-sdk-go-v2/service/s3outposts v1.34.14
 	github.com/aws/aws-sdk-go-v2/service/s3tables v1.16.0

--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/cloud9 v1.34.1
 	github.com/aws/aws-sdk-go-v2/service/cloudcontrol v1.30.1
 	github.com/aws/aws-sdk-go-v2/service/cloudformation v1.71.12
-	github.com/aws/aws-sdk-go-v2/service/cloudfront v1.64.0
+	github.com/aws/aws-sdk-go-v2/service/cloudfront v1.64.1
 	github.com/aws/aws-sdk-go-v2/service/cloudfrontkeyvaluestore v1.12.26
 	github.com/aws/aws-sdk-go-v2/service/cloudhsmv2 v1.34.25
 	github.com/aws/aws-sdk-go-v2/service/cloudsearch v1.32.14

--- a/go.mod
+++ b/go.mod
@@ -270,7 +270,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/transcribe v1.55.1
 	github.com/aws/aws-sdk-go-v2/service/transfer v1.72.1
 	github.com/aws/aws-sdk-go-v2/service/uxc v1.0.4
-	github.com/aws/aws-sdk-go-v2/service/verifiedpermissions v1.33.0
+	github.com/aws/aws-sdk-go-v2/service/verifiedpermissions v1.34.0
 	github.com/aws/aws-sdk-go-v2/service/vpclattice v1.21.0
 	github.com/aws/aws-sdk-go-v2/service/waf v1.30.22
 	github.com/aws/aws-sdk-go-v2/service/wafregional v1.30.23

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/bcmdataexports v1.16.1
 	github.com/aws/aws-sdk-go-v2/service/bedrock v1.62.0
 	github.com/aws/aws-sdk-go-v2/service/bedrockagent v1.54.1
-	github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol v1.40.0
+	github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol v1.41.0
 	github.com/aws/aws-sdk-go-v2/service/billing v1.11.0
 	github.com/aws/aws-sdk-go-v2/service/budgets v1.43.7
 	github.com/aws/aws-sdk-go-v2/service/chatbot v1.14.23

--- a/go.mod
+++ b/go.mod
@@ -127,7 +127,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/finspace v1.34.1
 	github.com/aws/aws-sdk-go-v2/service/firehose v1.42.17
 	github.com/aws/aws-sdk-go-v2/service/fis v1.38.1
-	github.com/aws/aws-sdk-go-v2/service/fms v1.45.0
+	github.com/aws/aws-sdk-go-v2/service/fms v1.45.1
 	github.com/aws/aws-sdk-go-v2/service/fsx v1.66.0
 	github.com/aws/aws-sdk-go-v2/service/gamelift v1.54.0
 	github.com/aws/aws-sdk-go-v2/service/glacier v1.32.8

--- a/go.mod
+++ b/go.mod
@@ -134,7 +134,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/globalaccelerator v1.36.1
 	github.com/aws/aws-sdk-go-v2/service/glue v1.142.1
 	github.com/aws/aws-sdk-go-v2/service/grafana v1.35.1
-	github.com/aws/aws-sdk-go-v2/service/greengrass v1.32.23
+	github.com/aws/aws-sdk-go-v2/service/greengrass v1.32.24
 	github.com/aws/aws-sdk-go-v2/service/groundstation v1.41.1
 	github.com/aws/aws-sdk-go-v2/service/guardduty v1.78.0
 	github.com/aws/aws-sdk-go-v2/service/healthlake v1.37.0

--- a/go.mod
+++ b/go.mod
@@ -95,7 +95,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/datazone v1.62.1
 	github.com/aws/aws-sdk-go-v2/service/dax v1.29.19
 	github.com/aws/aws-sdk-go-v2/service/detective v1.39.0
-	github.com/aws/aws-sdk-go-v2/service/devicefarm v1.38.10
+	github.com/aws/aws-sdk-go-v2/service/devicefarm v1.38.11
 	github.com/aws/aws-sdk-go-v2/service/devopsagent v1.4.0
 	github.com/aws/aws-sdk-go-v2/service/devopsguru v1.41.0
 	github.com/aws/aws-sdk-go-v2/service/directconnect v1.38.17

--- a/go.mod
+++ b/go.mod
@@ -272,7 +272,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/uxc v1.0.4
 	github.com/aws/aws-sdk-go-v2/service/verifiedpermissions v1.34.0
 	github.com/aws/aws-sdk-go-v2/service/vpclattice v1.21.1
-	github.com/aws/aws-sdk-go-v2/service/waf v1.30.22
+	github.com/aws/aws-sdk-go-v2/service/waf v1.30.23
 	github.com/aws/aws-sdk-go-v2/service/wafregional v1.30.23
 	github.com/aws/aws-sdk-go-v2/service/wafv2 v1.71.5
 	github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.39.23

--- a/go.mod
+++ b/go.mod
@@ -259,7 +259,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssmsap v1.27.1
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.18
 	github.com/aws/aws-sdk-go-v2/service/ssoadmin v1.39.1
-	github.com/aws/aws-sdk-go-v2/service/storagegateway v1.43.16
+	github.com/aws/aws-sdk-go-v2/service/storagegateway v1.43.17
 	github.com/aws/aws-sdk-go-v2/service/sts v1.42.2
 	github.com/aws/aws-sdk-go-v2/service/swf v1.33.18
 	github.com/aws/aws-sdk-go-v2/service/synthetics v1.42.16

--- a/go.mod
+++ b/go.mod
@@ -245,7 +245,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry v1.36.1
 	github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.40.1
 	github.com/aws/aws-sdk-go-v2/service/servicequotas v1.35.1
-	github.com/aws/aws-sdk-go-v2/service/ses v1.34.24
+	github.com/aws/aws-sdk-go-v2/service/ses v1.34.25
 	github.com/aws/aws-sdk-go-v2/service/sesv2 v1.61.0
 	github.com/aws/aws-sdk-go-v2/service/sfn v1.41.0
 	github.com/aws/aws-sdk-go-v2/service/shield v1.34.23

--- a/go.mod
+++ b/go.mod
@@ -85,7 +85,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/controltower v1.29.1
 	github.com/aws/aws-sdk-go-v2/service/costandusagereportservice v1.34.16
 	github.com/aws/aws-sdk-go-v2/service/costexplorer v1.63.9
-	github.com/aws/aws-sdk-go-v2/service/costoptimizationhub v1.22.10
+	github.com/aws/aws-sdk-go-v2/service/costoptimizationhub v1.23.0
 	github.com/aws/aws-sdk-go-v2/service/customerprofiles v1.61.0
 	github.com/aws/aws-sdk-go-v2/service/databasemigrationservice v1.63.0
 	github.com/aws/aws-sdk-go-v2/service/databrew v1.40.0

--- a/go.mod
+++ b/go.mod
@@ -198,7 +198,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/outposts v1.60.1
 	github.com/aws/aws-sdk-go-v2/service/paymentcryptography v1.30.1
 	github.com/aws/aws-sdk-go-v2/service/pcaconnectorad v1.16.1
-	github.com/aws/aws-sdk-go-v2/service/pcs v1.18.0
+	github.com/aws/aws-sdk-go-v2/service/pcs v1.19.0
 	github.com/aws/aws-sdk-go-v2/service/pinpoint v1.39.23
 	github.com/aws/aws-sdk-go-v2/service/pinpointsmsvoicev2 v1.28.2
 	github.com/aws/aws-sdk-go-v2/service/pipes v1.24.0

--- a/go.mod
+++ b/go.mod
@@ -244,7 +244,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.39.16
 	github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry v1.36.1
 	github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.40.1
-	github.com/aws/aws-sdk-go-v2/service/servicequotas v1.35.0
+	github.com/aws/aws-sdk-go-v2/service/servicequotas v1.35.1
 	github.com/aws/aws-sdk-go-v2/service/ses v1.34.24
 	github.com/aws/aws-sdk-go-v2/service/sesv2 v1.61.0
 	github.com/aws/aws-sdk-go-v2/service/sfn v1.41.0

--- a/go.mod
+++ b/go.mod
@@ -78,7 +78,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/cognitoidentity v1.33.25
 	github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.60.3
 	github.com/aws/aws-sdk-go-v2/service/comprehend v1.41.1
-	github.com/aws/aws-sdk-go-v2/service/computeoptimizer v1.50.1
+	github.com/aws/aws-sdk-go-v2/service/computeoptimizer v1.51.1
 	github.com/aws/aws-sdk-go-v2/service/configservice v1.62.3
 	github.com/aws/aws-sdk-go-v2/service/connect v1.175.0
 	github.com/aws/aws-sdk-go-v2/service/connectcases v1.41.0

--- a/go.mod
+++ b/go.mod
@@ -185,7 +185,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/networkfirewall v1.61.1
 	github.com/aws/aws-sdk-go-v2/service/networkflowmonitor v1.11.12
 	github.com/aws/aws-sdk-go-v2/service/networkmanager v1.42.1
-	github.com/aws/aws-sdk-go-v2/service/networkmonitor v1.13.15
+	github.com/aws/aws-sdk-go-v2/service/networkmonitor v1.14.0
 	github.com/aws/aws-sdk-go-v2/service/notifications v1.8.0
 	github.com/aws/aws-sdk-go-v2/service/notificationscontacts v1.6.0
 	github.com/aws/aws-sdk-go-v2/service/oam v1.24.0

--- a/go.mod
+++ b/go.mod
@@ -173,7 +173,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/mediapackage v1.39.24
 	github.com/aws/aws-sdk-go-v2/service/mediapackagev2 v1.39.1
 	github.com/aws/aws-sdk-go-v2/service/mediapackagevod v1.39.24
-	github.com/aws/aws-sdk-go-v2/service/mediastore v1.29.23
+	github.com/aws/aws-sdk-go-v2/service/mediastore v1.29.24
 	github.com/aws/aws-sdk-go-v2/service/memorydb v1.33.16
 	github.com/aws/aws-sdk-go-v2/service/mgn v1.43.0
 	github.com/aws/aws-sdk-go-v2/service/mpa v1.7.4

--- a/go.mod
+++ b/go.mod
@@ -193,7 +193,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/odb v1.11.1
 	github.com/aws/aws-sdk-go-v2/service/opensearch v1.70.1
 	github.com/aws/aws-sdk-go-v2/service/opensearchserverless v1.31.0
-	github.com/aws/aws-sdk-go-v2/service/organizations v1.51.3
+	github.com/aws/aws-sdk-go-v2/service/organizations v1.51.5
 	github.com/aws/aws-sdk-go-v2/service/osis v1.22.0
 	github.com/aws/aws-sdk-go-v2/service/outposts v1.60.0
 	github.com/aws/aws-sdk-go-v2/service/paymentcryptography v1.29.0

--- a/go.mod
+++ b/go.mod
@@ -274,7 +274,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/vpclattice v1.21.1
 	github.com/aws/aws-sdk-go-v2/service/waf v1.30.23
 	github.com/aws/aws-sdk-go-v2/service/wafregional v1.30.24
-	github.com/aws/aws-sdk-go-v2/service/wafv2 v1.71.5
+	github.com/aws/aws-sdk-go-v2/service/wafv2 v1.71.6
 	github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.39.23
 	github.com/aws/aws-sdk-go-v2/service/workmail v1.37.0
 	github.com/aws/aws-sdk-go-v2/service/workspaces v1.68.1

--- a/go.mod
+++ b/go.mod
@@ -213,7 +213,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/rdsdata v1.32.24
 	github.com/aws/aws-sdk-go-v2/service/redshift v1.62.9
 	github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.40.0
-	github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.35.0
+	github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.35.1
 	github.com/aws/aws-sdk-go-v2/service/rekognition v1.51.24
 	github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.36.0
 	github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.23.6

--- a/go.mod
+++ b/go.mod
@@ -194,7 +194,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/opensearch v1.70.1
 	github.com/aws/aws-sdk-go-v2/service/opensearchserverless v1.31.0
 	github.com/aws/aws-sdk-go-v2/service/organizations v1.51.5
-	github.com/aws/aws-sdk-go-v2/service/osis v1.22.0
+	github.com/aws/aws-sdk-go-v2/service/osis v1.22.1
 	github.com/aws/aws-sdk-go-v2/service/outposts v1.60.0
 	github.com/aws/aws-sdk-go-v2/service/paymentcryptography v1.29.0
 	github.com/aws/aws-sdk-go-v2/service/pcaconnectorad v1.15.23

--- a/go.mod
+++ b/go.mod
@@ -263,7 +263,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.42.2
 	github.com/aws/aws-sdk-go-v2/service/swf v1.33.19
 	github.com/aws/aws-sdk-go-v2/service/synthetics v1.42.17
-	github.com/aws/aws-sdk-go-v2/service/taxsettings v1.16.23
+	github.com/aws/aws-sdk-go-v2/service/taxsettings v1.16.24
 	github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.19.2
 	github.com/aws/aws-sdk-go-v2/service/timestreamquery v1.36.17
 	github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.35.23

--- a/go.mod
+++ b/go.mod
@@ -184,7 +184,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/neptunegraph v1.22.0
 	github.com/aws/aws-sdk-go-v2/service/networkfirewall v1.61.1
 	github.com/aws/aws-sdk-go-v2/service/networkflowmonitor v1.11.12
-	github.com/aws/aws-sdk-go-v2/service/networkmanager v1.42.0
+	github.com/aws/aws-sdk-go-v2/service/networkmanager v1.42.1
 	github.com/aws/aws-sdk-go-v2/service/networkmonitor v1.13.15
 	github.com/aws/aws-sdk-go-v2/service/notifications v1.8.0
 	github.com/aws/aws-sdk-go-v2/service/notificationscontacts v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -132,7 +132,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/gamelift v1.54.1
 	github.com/aws/aws-sdk-go-v2/service/glacier v1.32.9
 	github.com/aws/aws-sdk-go-v2/service/globalaccelerator v1.36.1
-	github.com/aws/aws-sdk-go-v2/service/glue v1.142.0
+	github.com/aws/aws-sdk-go-v2/service/glue v1.142.1
 	github.com/aws/aws-sdk-go-v2/service/grafana v1.35.0
 	github.com/aws/aws-sdk-go-v2/service/greengrass v1.32.23
 	github.com/aws/aws-sdk-go-v2/service/groundstation v1.41.1

--- a/go.mod
+++ b/go.mod
@@ -163,7 +163,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/lexmodelbuildingservice v1.35.1
 	github.com/aws/aws-sdk-go-v2/service/lexmodelsv2 v1.61.1
 	github.com/aws/aws-sdk-go-v2/service/licensemanager v1.37.13
-	github.com/aws/aws-sdk-go-v2/service/lightsail v1.54.0
+	github.com/aws/aws-sdk-go-v2/service/lightsail v1.54.1
 	github.com/aws/aws-sdk-go-v2/service/location v1.51.1
 	github.com/aws/aws-sdk-go-v2/service/m2 v1.26.16
 	github.com/aws/aws-sdk-go-v2/service/macie2 v1.51.2

--- a/go.mod
+++ b/go.mod
@@ -110,7 +110,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.57.3
 	github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.39.1
 	github.com/aws/aws-sdk-go-v2/service/ecs v1.81.1
-	github.com/aws/aws-sdk-go-v2/service/efs v1.41.16
+	github.com/aws/aws-sdk-go-v2/service/efs v1.41.17
 	github.com/aws/aws-sdk-go-v2/service/eks v1.84.0
 	github.com/aws/aws-sdk-go-v2/service/elasticache v1.52.2
 	github.com/aws/aws-sdk-go-v2/service/elasticbeanstalk v1.34.4

--- a/go.mod
+++ b/go.mod
@@ -186,7 +186,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/networkflowmonitor v1.11.12
 	github.com/aws/aws-sdk-go-v2/service/networkmanager v1.42.1
 	github.com/aws/aws-sdk-go-v2/service/networkmonitor v1.14.0
-	github.com/aws/aws-sdk-go-v2/service/notifications v1.8.0
+	github.com/aws/aws-sdk-go-v2/service/notifications v1.8.1
 	github.com/aws/aws-sdk-go-v2/service/notificationscontacts v1.6.0
 	github.com/aws/aws-sdk-go-v2/service/oam v1.24.0
 	github.com/aws/aws-sdk-go-v2/service/observabilityadmin v1.16.0

--- a/go.mod
+++ b/go.mod
@@ -157,7 +157,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/kinesisanalyticsv2 v1.38.0
 	github.com/aws/aws-sdk-go-v2/service/kinesisvideo v1.33.11
 	github.com/aws/aws-sdk-go-v2/service/kms v1.52.1
-	github.com/aws/aws-sdk-go-v2/service/lakeformation v1.47.8
+	github.com/aws/aws-sdk-go-v2/service/lakeformation v1.47.9
 	github.com/aws/aws-sdk-go-v2/service/lambda v1.90.1
 	github.com/aws/aws-sdk-go-v2/service/launchwizard v1.14.6
 	github.com/aws/aws-sdk-go-v2/service/lexmodelbuildingservice v1.35.0

--- a/go.mod
+++ b/go.mod
@@ -76,7 +76,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/codestarconnections v1.36.0
 	github.com/aws/aws-sdk-go-v2/service/codestarnotifications v1.32.1
 	github.com/aws/aws-sdk-go-v2/service/cognitoidentity v1.33.25
-	github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.60.2
+	github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.60.3
 	github.com/aws/aws-sdk-go-v2/service/comprehend v1.41.0
 	github.com/aws/aws-sdk-go-v2/service/computeoptimizer v1.50.1
 	github.com/aws/aws-sdk-go-v2/service/configservice v1.62.3

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/appconfig v1.44.1
 	github.com/aws/aws-sdk-go-v2/service/appfabric v1.16.24
 	github.com/aws/aws-sdk-go-v2/service/appflow v1.51.15
-	github.com/aws/aws-sdk-go-v2/service/appintegrations v1.37.9
+	github.com/aws/aws-sdk-go-v2/service/appintegrations v1.37.10
 	github.com/aws/aws-sdk-go-v2/service/applicationautoscaling v1.41.16
 	github.com/aws/aws-sdk-go-v2/service/applicationinsights v1.34.22
 	github.com/aws/aws-sdk-go-v2/service/applicationsignals v1.22.0

--- a/go.mod
+++ b/go.mod
@@ -279,7 +279,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/workmail v1.37.1
 	github.com/aws/aws-sdk-go-v2/service/workspaces v1.68.2
 	github.com/aws/aws-sdk-go-v2/service/workspacesweb v1.40.1
-	github.com/aws/aws-sdk-go-v2/service/xray v1.36.23
+	github.com/aws/aws-sdk-go-v2/service/xray v1.36.24
 	github.com/aws/smithy-go v1.26.0
 	github.com/beevik/etree v1.6.0
 	github.com/cedar-policy/cedar-go v1.7.0

--- a/go.mod
+++ b/go.mod
@@ -210,7 +210,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ram v1.36.6
 	github.com/aws/aws-sdk-go-v2/service/rbin v1.28.1
 	github.com/aws/aws-sdk-go-v2/service/rds v1.118.3
-	github.com/aws/aws-sdk-go-v2/service/rdsdata v1.32.23
+	github.com/aws/aws-sdk-go-v2/service/rdsdata v1.32.24
 	github.com/aws/aws-sdk-go-v2/service/redshift v1.62.8
 	github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.39.2
 	github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.35.0

--- a/go.mod
+++ b/go.mod
@@ -249,7 +249,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sesv2 v1.61.1
 	github.com/aws/aws-sdk-go-v2/service/sfn v1.41.1
 	github.com/aws/aws-sdk-go-v2/service/shield v1.34.24
-	github.com/aws/aws-sdk-go-v2/service/signer v1.33.0
+	github.com/aws/aws-sdk-go-v2/service/signer v1.33.1
 	github.com/aws/aws-sdk-go-v2/service/sns v1.39.17
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.42.27
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.68.6

--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/batch v1.65.1
 	github.com/aws/aws-sdk-go-v2/service/bcmdataexports v1.16.1
 	github.com/aws/aws-sdk-go-v2/service/bedrock v1.62.0
-	github.com/aws/aws-sdk-go-v2/service/bedrockagent v1.54.0
+	github.com/aws/aws-sdk-go-v2/service/bedrockagent v1.54.1
 	github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol v1.40.0
 	github.com/aws/aws-sdk-go-v2/service/billing v1.11.0
 	github.com/aws/aws-sdk-go-v2/service/budgets v1.43.7

--- a/go.mod
+++ b/go.mod
@@ -125,7 +125,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/evidently v1.30.0
 	github.com/aws/aws-sdk-go-v2/service/evs v1.10.1
 	github.com/aws/aws-sdk-go-v2/service/finspace v1.34.1
-	github.com/aws/aws-sdk-go-v2/service/firehose v1.42.16
+	github.com/aws/aws-sdk-go-v2/service/firehose v1.42.17
 	github.com/aws/aws-sdk-go-v2/service/fis v1.37.22
 	github.com/aws/aws-sdk-go-v2/service/fms v1.45.0
 	github.com/aws/aws-sdk-go-v2/service/fsx v1.66.0

--- a/go.mod
+++ b/go.mod
@@ -204,7 +204,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/pipes v1.24.1
 	github.com/aws/aws-sdk-go-v2/service/polly v1.57.6
 	github.com/aws/aws-sdk-go-v2/service/pricing v1.42.1
-	github.com/aws/aws-sdk-go-v2/service/qbusiness v1.34.8
+	github.com/aws/aws-sdk-go-v2/service/qbusiness v1.34.9
 	github.com/aws/aws-sdk-go-v2/service/qldb v1.32.2
 	github.com/aws/aws-sdk-go-v2/service/quicksight v1.111.0
 	github.com/aws/aws-sdk-go-v2/service/ram v1.36.5

--- a/go.mod
+++ b/go.mod
@@ -119,7 +119,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/elasticsearchservice v1.41.1
 	github.com/aws/aws-sdk-go-v2/service/elastictranscoder v1.33.0
 	github.com/aws/aws-sdk-go-v2/service/emr v1.59.3
-	github.com/aws/aws-sdk-go-v2/service/emrcontainers v1.41.0
+	github.com/aws/aws-sdk-go-v2/service/emrcontainers v1.41.1
 	github.com/aws/aws-sdk-go-v2/service/emrserverless v1.41.0
 	github.com/aws/aws-sdk-go-v2/service/eventbridge v1.45.25
 	github.com/aws/aws-sdk-go-v2/service/evidently v1.30.0

--- a/go.mod
+++ b/go.mod
@@ -101,7 +101,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/directconnect v1.38.18
 	github.com/aws/aws-sdk-go-v2/service/directoryservice v1.38.19
 	github.com/aws/aws-sdk-go-v2/service/dlm v1.37.1
-	github.com/aws/aws-sdk-go-v2/service/docdb v1.48.15
+	github.com/aws/aws-sdk-go-v2/service/docdb v1.48.16
 	github.com/aws/aws-sdk-go-v2/service/docdbelastic v1.20.15
 	github.com/aws/aws-sdk-go-v2/service/drs v1.38.2
 	github.com/aws/aws-sdk-go-v2/service/dsql v1.14.0

--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/auditmanager v1.46.15
 	github.com/aws/aws-sdk-go-v2/service/autoscaling v1.66.3
 	github.com/aws/aws-sdk-go-v2/service/autoscalingplans v1.30.17
-	github.com/aws/aws-sdk-go-v2/service/backup v1.57.0
+	github.com/aws/aws-sdk-go-v2/service/backup v1.57.1
 	github.com/aws/aws-sdk-go-v2/service/batch v1.65.0
 	github.com/aws/aws-sdk-go-v2/service/bcmdataexports v1.16.0
 	github.com/aws/aws-sdk-go-v2/service/bedrock v1.61.0

--- a/go.mod
+++ b/go.mod
@@ -135,7 +135,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/glue v1.142.1
 	github.com/aws/aws-sdk-go-v2/service/grafana v1.35.1
 	github.com/aws/aws-sdk-go-v2/service/greengrass v1.32.24
-	github.com/aws/aws-sdk-go-v2/service/groundstation v1.41.1
+	github.com/aws/aws-sdk-go-v2/service/groundstation v1.42.0
 	github.com/aws/aws-sdk-go-v2/service/guardduty v1.78.0
 	github.com/aws/aws-sdk-go-v2/service/healthlake v1.37.0
 	github.com/aws/aws-sdk-go-v2/service/iam v1.53.10

--- a/go.mod
+++ b/go.mod
@@ -154,7 +154,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/keyspaces v1.26.0
 	github.com/aws/aws-sdk-go-v2/service/kinesis v1.43.8
 	github.com/aws/aws-sdk-go-v2/service/kinesisanalytics v1.30.26
-	github.com/aws/aws-sdk-go-v2/service/kinesisanalyticsv2 v1.37.2
+	github.com/aws/aws-sdk-go-v2/service/kinesisanalyticsv2 v1.38.0
 	github.com/aws/aws-sdk-go-v2/service/kinesisvideo v1.33.10
 	github.com/aws/aws-sdk-go-v2/service/kms v1.52.0
 	github.com/aws/aws-sdk-go-v2/service/lakeformation v1.47.8

--- a/go.mod
+++ b/go.mod
@@ -250,7 +250,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sfn v1.41.1
 	github.com/aws/aws-sdk-go-v2/service/shield v1.34.24
 	github.com/aws/aws-sdk-go-v2/service/signer v1.33.1
-	github.com/aws/aws-sdk-go-v2/service/sns v1.39.17
+	github.com/aws/aws-sdk-go-v2/service/sns v1.39.18
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.42.27
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.68.6
 	github.com/aws/aws-sdk-go-v2/service/ssmcontacts v1.31.16

--- a/go.mod
+++ b/go.mod
@@ -251,7 +251,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/shield v1.34.24
 	github.com/aws/aws-sdk-go-v2/service/signer v1.33.1
 	github.com/aws/aws-sdk-go-v2/service/sns v1.39.18
-	github.com/aws/aws-sdk-go-v2/service/sqs v1.42.27
+	github.com/aws/aws-sdk-go-v2/service/sqs v1.42.28
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.68.6
 	github.com/aws/aws-sdk-go-v2/service/ssmcontacts v1.31.16
 	github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.39.22

--- a/go.mod
+++ b/go.mod
@@ -82,7 +82,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/configservice v1.62.4
 	github.com/aws/aws-sdk-go-v2/service/connect v1.175.1
 	github.com/aws/aws-sdk-go-v2/service/connectcases v1.42.1
-	github.com/aws/aws-sdk-go-v2/service/controltower v1.29.0
+	github.com/aws/aws-sdk-go-v2/service/controltower v1.29.1
 	github.com/aws/aws-sdk-go-v2/service/costandusagereportservice v1.34.15
 	github.com/aws/aws-sdk-go-v2/service/costexplorer v1.63.8
 	github.com/aws/aws-sdk-go-v2/service/costoptimizationhub v1.22.10

--- a/go.mod
+++ b/go.mod
@@ -235,7 +235,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3vectors v1.7.1
 	github.com/aws/aws-sdk-go-v2/service/sagemaker v1.250.1
 	github.com/aws/aws-sdk-go-v2/service/savingsplans v1.33.1
-	github.com/aws/aws-sdk-go-v2/service/scheduler v1.18.0
+	github.com/aws/aws-sdk-go-v2/service/scheduler v1.18.1
 	github.com/aws/aws-sdk-go-v2/service/schemas v1.35.0
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.7
 	github.com/aws/aws-sdk-go-v2/service/securityhub v1.71.0

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/appmesh v1.35.15
 	github.com/aws/aws-sdk-go-v2/service/apprunner v1.40.1
 	github.com/aws/aws-sdk-go-v2/service/appstream v1.60.0
-	github.com/aws/aws-sdk-go-v2/service/appsync v1.53.7
+	github.com/aws/aws-sdk-go-v2/service/appsync v1.53.8
 	github.com/aws/aws-sdk-go-v2/service/arcregionswitch v1.7.0
 	github.com/aws/aws-sdk-go-v2/service/arczonalshift v1.22.25
 	github.com/aws/aws-sdk-go-v2/service/athena v1.57.6

--- a/go.mod
+++ b/go.mod
@@ -140,7 +140,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/healthlake v1.37.1
 	github.com/aws/aws-sdk-go-v2/service/iam v1.53.11
 	github.com/aws/aws-sdk-go-v2/service/identitystore v1.37.1
-	github.com/aws/aws-sdk-go-v2/service/imagebuilder v1.54.0
+	github.com/aws/aws-sdk-go-v2/service/imagebuilder v1.55.1
 	github.com/aws/aws-sdk-go-v2/service/inspector v1.30.22
 	github.com/aws/aws-sdk-go-v2/service/inspector2 v1.47.7
 	github.com/aws/aws-sdk-go-v2/service/internetmonitor v1.27.0

--- a/go.mod
+++ b/go.mod
@@ -242,7 +242,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/securitylake v1.25.16
 	github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.31.1
 	github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.39.16
-	github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry v1.36.0
+	github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry v1.36.1
 	github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.40.0
 	github.com/aws/aws-sdk-go-v2/service/servicequotas v1.35.0
 	github.com/aws/aws-sdk-go-v2/service/ses v1.34.24

--- a/go.mod
+++ b/go.mod
@@ -137,7 +137,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/greengrass v1.32.24
 	github.com/aws/aws-sdk-go-v2/service/groundstation v1.42.0
 	github.com/aws/aws-sdk-go-v2/service/guardduty v1.78.1
-	github.com/aws/aws-sdk-go-v2/service/healthlake v1.37.0
+	github.com/aws/aws-sdk-go-v2/service/healthlake v1.37.1
 	github.com/aws/aws-sdk-go-v2/service/iam v1.53.10
 	github.com/aws/aws-sdk-go-v2/service/identitystore v1.37.0
 	github.com/aws/aws-sdk-go-v2/service/imagebuilder v1.54.0

--- a/go.mod
+++ b/go.mod
@@ -240,7 +240,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.8
 	github.com/aws/aws-sdk-go-v2/service/securityhub v1.71.1
 	github.com/aws/aws-sdk-go-v2/service/securitylake v1.25.16
-	github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.31.0
+	github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.31.1
 	github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.39.15
 	github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry v1.36.0
 	github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.40.0

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/apprunner v1.40.1
 	github.com/aws/aws-sdk-go-v2/service/appstream v1.60.0
 	github.com/aws/aws-sdk-go-v2/service/appsync v1.53.8
-	github.com/aws/aws-sdk-go-v2/service/arcregionswitch v1.7.0
+	github.com/aws/aws-sdk-go-v2/service/arcregionswitch v1.8.0
 	github.com/aws/aws-sdk-go-v2/service/arczonalshift v1.22.25
 	github.com/aws/aws-sdk-go-v2/service/athena v1.57.6
 	github.com/aws/aws-sdk-go-v2/service/auditmanager v1.46.14

--- a/go.mod
+++ b/go.mod
@@ -69,7 +69,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/codecatalyst v1.21.15
 	github.com/aws/aws-sdk-go-v2/service/codecommit v1.33.15
 	github.com/aws/aws-sdk-go-v2/service/codeconnections v1.11.1
-	github.com/aws/aws-sdk-go-v2/service/codedeploy v1.35.15
+	github.com/aws/aws-sdk-go-v2/service/codedeploy v1.35.16
 	github.com/aws/aws-sdk-go-v2/service/codeguruprofiler v1.30.0
 	github.com/aws/aws-sdk-go-v2/service/codegurureviewer v1.34.22
 	github.com/aws/aws-sdk-go-v2/service/codepipeline v1.46.23

--- a/go.mod
+++ b/go.mod
@@ -61,7 +61,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/cloudfrontkeyvaluestore v1.13.0
 	github.com/aws/aws-sdk-go-v2/service/cloudhsmv2 v1.34.26
 	github.com/aws/aws-sdk-go-v2/service/cloudsearch v1.32.15
-	github.com/aws/aws-sdk-go-v2/service/cloudtrail v1.55.11
+	github.com/aws/aws-sdk-go-v2/service/cloudtrail v1.55.12
 	github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.57.0
 	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.74.0
 	github.com/aws/aws-sdk-go-v2/service/codeartifact v1.39.0

--- a/go.mod
+++ b/go.mod
@@ -182,7 +182,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/mwaaserverless v1.0.12
 	github.com/aws/aws-sdk-go-v2/service/neptune v1.44.6
 	github.com/aws/aws-sdk-go-v2/service/neptunegraph v1.22.0
-	github.com/aws/aws-sdk-go-v2/service/networkfirewall v1.61.0
+	github.com/aws/aws-sdk-go-v2/service/networkfirewall v1.61.1
 	github.com/aws/aws-sdk-go-v2/service/networkflowmonitor v1.11.11
 	github.com/aws/aws-sdk-go-v2/service/networkmanager v1.42.0
 	github.com/aws/aws-sdk-go-v2/service/networkmonitor v1.13.15

--- a/go.mod
+++ b/go.mod
@@ -94,7 +94,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/datasync v1.59.1
 	github.com/aws/aws-sdk-go-v2/service/datazone v1.62.1
 	github.com/aws/aws-sdk-go-v2/service/dax v1.29.19
-	github.com/aws/aws-sdk-go-v2/service/detective v1.38.15
+	github.com/aws/aws-sdk-go-v2/service/detective v1.39.0
 	github.com/aws/aws-sdk-go-v2/service/devicefarm v1.38.10
 	github.com/aws/aws-sdk-go-v2/service/devopsagent v1.4.0
 	github.com/aws/aws-sdk-go-v2/service/devopsguru v1.41.0

--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/bedrock v1.62.0
 	github.com/aws/aws-sdk-go-v2/service/bedrockagent v1.54.1
 	github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol v1.41.0
-	github.com/aws/aws-sdk-go-v2/service/billing v1.11.0
+	github.com/aws/aws-sdk-go-v2/service/billing v1.11.1
 	github.com/aws/aws-sdk-go-v2/service/budgets v1.43.7
 	github.com/aws/aws-sdk-go-v2/service/chatbot v1.14.23
 	github.com/aws/aws-sdk-go-v2/service/chime v1.41.14

--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/chatbot v1.15.0
 	github.com/aws/aws-sdk-go-v2/service/chime v1.41.15
 	github.com/aws/aws-sdk-go-v2/service/chimesdkmediapipelines v1.27.1
-	github.com/aws/aws-sdk-go-v2/service/chimesdkvoice v1.28.15
+	github.com/aws/aws-sdk-go-v2/service/chimesdkvoice v1.28.16
 	github.com/aws/aws-sdk-go-v2/service/cleanrooms v1.45.0
 	github.com/aws/aws-sdk-go-v2/service/cloud9 v1.34.0
 	github.com/aws/aws-sdk-go-v2/service/cloudcontrol v1.30.0

--- a/go.mod
+++ b/go.mod
@@ -91,7 +91,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/databrew v1.40.1
 	github.com/aws/aws-sdk-go-v2/service/dataexchange v1.42.1
 	github.com/aws/aws-sdk-go-v2/service/datapipeline v1.30.23
-	github.com/aws/aws-sdk-go-v2/service/datasync v1.59.0
+	github.com/aws/aws-sdk-go-v2/service/datasync v1.59.1
 	github.com/aws/aws-sdk-go-v2/service/datazone v1.62.0
 	github.com/aws/aws-sdk-go-v2/service/dax v1.29.18
 	github.com/aws/aws-sdk-go-v2/service/detective v1.38.15

--- a/go.mod
+++ b/go.mod
@@ -246,7 +246,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.40.1
 	github.com/aws/aws-sdk-go-v2/service/servicequotas v1.35.1
 	github.com/aws/aws-sdk-go-v2/service/ses v1.34.25
-	github.com/aws/aws-sdk-go-v2/service/sesv2 v1.61.0
+	github.com/aws/aws-sdk-go-v2/service/sesv2 v1.61.1
 	github.com/aws/aws-sdk-go-v2/service/sfn v1.41.0
 	github.com/aws/aws-sdk-go-v2/service/shield v1.34.23
 	github.com/aws/aws-sdk-go-v2/service/signer v1.33.0

--- a/go.mod
+++ b/go.mod
@@ -80,7 +80,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/comprehend v1.41.1
 	github.com/aws/aws-sdk-go-v2/service/computeoptimizer v1.51.1
 	github.com/aws/aws-sdk-go-v2/service/configservice v1.62.4
-	github.com/aws/aws-sdk-go-v2/service/connect v1.175.0
+	github.com/aws/aws-sdk-go-v2/service/connect v1.175.1
 	github.com/aws/aws-sdk-go-v2/service/connectcases v1.41.0
 	github.com/aws/aws-sdk-go-v2/service/controltower v1.29.0
 	github.com/aws/aws-sdk-go-v2/service/costandusagereportservice v1.34.15

--- a/go.mod
+++ b/go.mod
@@ -131,7 +131,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/fsx v1.66.1
 	github.com/aws/aws-sdk-go-v2/service/gamelift v1.54.1
 	github.com/aws/aws-sdk-go-v2/service/glacier v1.32.9
-	github.com/aws/aws-sdk-go-v2/service/globalaccelerator v1.36.0
+	github.com/aws/aws-sdk-go-v2/service/globalaccelerator v1.36.1
 	github.com/aws/aws-sdk-go-v2/service/glue v1.142.0
 	github.com/aws/aws-sdk-go-v2/service/grafana v1.35.0
 	github.com/aws/aws-sdk-go-v2/service/greengrass v1.32.23

--- a/go.mod
+++ b/go.mod
@@ -183,7 +183,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/neptune v1.44.6
 	github.com/aws/aws-sdk-go-v2/service/neptunegraph v1.22.0
 	github.com/aws/aws-sdk-go-v2/service/networkfirewall v1.61.1
-	github.com/aws/aws-sdk-go-v2/service/networkflowmonitor v1.11.11
+	github.com/aws/aws-sdk-go-v2/service/networkflowmonitor v1.11.12
 	github.com/aws/aws-sdk-go-v2/service/networkmanager v1.42.0
 	github.com/aws/aws-sdk-go-v2/service/networkmonitor v1.13.15
 	github.com/aws/aws-sdk-go-v2/service/notifications v1.8.0

--- a/go.mod
+++ b/go.mod
@@ -206,7 +206,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/pricing v1.42.1
 	github.com/aws/aws-sdk-go-v2/service/qbusiness v1.34.9
 	github.com/aws/aws-sdk-go-v2/service/qldb v1.32.2
-	github.com/aws/aws-sdk-go-v2/service/quicksight v1.111.0
+	github.com/aws/aws-sdk-go-v2/service/quicksight v1.111.1
 	github.com/aws/aws-sdk-go-v2/service/ram v1.36.5
 	github.com/aws/aws-sdk-go-v2/service/rbin v1.28.0
 	github.com/aws/aws-sdk-go-v2/service/rds v1.118.2

--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/cleanrooms v1.45.1
 	github.com/aws/aws-sdk-go-v2/service/cloud9 v1.34.1
 	github.com/aws/aws-sdk-go-v2/service/cloudcontrol v1.30.1
-	github.com/aws/aws-sdk-go-v2/service/cloudformation v1.71.11
+	github.com/aws/aws-sdk-go-v2/service/cloudformation v1.71.12
 	github.com/aws/aws-sdk-go-v2/service/cloudfront v1.64.0
 	github.com/aws/aws-sdk-go-v2/service/cloudfrontkeyvaluestore v1.12.26
 	github.com/aws/aws-sdk-go-v2/service/cloudhsmv2 v1.34.25

--- a/go.mod
+++ b/go.mod
@@ -103,7 +103,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/dlm v1.37.1
 	github.com/aws/aws-sdk-go-v2/service/docdb v1.48.16
 	github.com/aws/aws-sdk-go-v2/service/docdbelastic v1.21.1
-	github.com/aws/aws-sdk-go-v2/service/drs v1.38.2
+	github.com/aws/aws-sdk-go-v2/service/drs v1.38.3
 	github.com/aws/aws-sdk-go-v2/service/dsql v1.14.0
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.4
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.304.0

--- a/go.mod
+++ b/go.mod
@@ -221,7 +221,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.32.1
 	github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.23.1
 	github.com/aws/aws-sdk-go-v2/service/route53 v1.62.8
-	github.com/aws/aws-sdk-go-v2/service/route53domains v1.35.0
+	github.com/aws/aws-sdk-go-v2/service/route53domains v1.35.1
 	github.com/aws/aws-sdk-go-v2/service/route53profiles v1.9.25
 	github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.32.16
 	github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.26.23

--- a/go.mod
+++ b/go.mod
@@ -159,7 +159,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/kms v1.52.1
 	github.com/aws/aws-sdk-go-v2/service/lakeformation v1.47.9
 	github.com/aws/aws-sdk-go-v2/service/lambda v1.90.2
-	github.com/aws/aws-sdk-go-v2/service/launchwizard v1.14.6
+	github.com/aws/aws-sdk-go-v2/service/launchwizard v1.15.1
 	github.com/aws/aws-sdk-go-v2/service/lexmodelbuildingservice v1.35.0
 	github.com/aws/aws-sdk-go-v2/service/lexmodelsv2 v1.61.0
 	github.com/aws/aws-sdk-go-v2/service/licensemanager v1.37.12

--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/chimesdkvoice v1.28.16
 	github.com/aws/aws-sdk-go-v2/service/cleanrooms v1.45.1
 	github.com/aws/aws-sdk-go-v2/service/cloud9 v1.34.1
-	github.com/aws/aws-sdk-go-v2/service/cloudcontrol v1.30.0
+	github.com/aws/aws-sdk-go-v2/service/cloudcontrol v1.30.1
 	github.com/aws/aws-sdk-go-v2/service/cloudformation v1.71.11
 	github.com/aws/aws-sdk-go-v2/service/cloudfront v1.64.0
 	github.com/aws/aws-sdk-go-v2/service/cloudfrontkeyvaluestore v1.12.26

--- a/go.mod
+++ b/go.mod
@@ -219,7 +219,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.24.1
 	github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.33.27
 	github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.32.1
-	github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.23.0
+	github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.23.1
 	github.com/aws/aws-sdk-go-v2/service/route53 v1.62.7
 	github.com/aws/aws-sdk-go-v2/service/route53domains v1.35.0
 	github.com/aws/aws-sdk-go-v2/service/route53profiles v1.9.25

--- a/go.mod
+++ b/go.mod
@@ -126,7 +126,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/evs v1.10.1
 	github.com/aws/aws-sdk-go-v2/service/finspace v1.34.1
 	github.com/aws/aws-sdk-go-v2/service/firehose v1.42.17
-	github.com/aws/aws-sdk-go-v2/service/fis v1.37.22
+	github.com/aws/aws-sdk-go-v2/service/fis v1.38.1
 	github.com/aws/aws-sdk-go-v2/service/fms v1.45.0
 	github.com/aws/aws-sdk-go-v2/service/fsx v1.66.0
 	github.com/aws/aws-sdk-go-v2/service/gamelift v1.54.0

--- a/go.mod
+++ b/go.mod
@@ -149,7 +149,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ivs v1.51.0
 	github.com/aws/aws-sdk-go-v2/service/ivschat v1.22.1
 	github.com/aws/aws-sdk-go-v2/service/kafka v1.52.1
-	github.com/aws/aws-sdk-go-v2/service/kafkaconnect v1.31.0
+	github.com/aws/aws-sdk-go-v2/service/kafkaconnect v1.31.1
 	github.com/aws/aws-sdk-go-v2/service/kendra v1.60.23
 	github.com/aws/aws-sdk-go-v2/service/keyspaces v1.25.7
 	github.com/aws/aws-sdk-go-v2/service/kinesis v1.43.7

--- a/go.mod
+++ b/go.mod
@@ -254,7 +254,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.42.28
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.68.7
 	github.com/aws/aws-sdk-go-v2/service/ssmcontacts v1.32.1
-	github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.39.22
+	github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.40.0
 	github.com/aws/aws-sdk-go-v2/service/ssmquicksetup v1.9.0
 	github.com/aws/aws-sdk-go-v2/service/ssmsap v1.26.7
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.18

--- a/go.mod
+++ b/go.mod
@@ -133,7 +133,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/glacier v1.32.9
 	github.com/aws/aws-sdk-go-v2/service/globalaccelerator v1.36.1
 	github.com/aws/aws-sdk-go-v2/service/glue v1.142.1
-	github.com/aws/aws-sdk-go-v2/service/grafana v1.35.0
+	github.com/aws/aws-sdk-go-v2/service/grafana v1.35.1
 	github.com/aws/aws-sdk-go-v2/service/greengrass v1.32.23
 	github.com/aws/aws-sdk-go-v2/service/groundstation v1.41.1
 	github.com/aws/aws-sdk-go-v2/service/guardduty v1.78.0

--- a/go.mod
+++ b/go.mod
@@ -168,7 +168,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/m2 v1.27.1
 	github.com/aws/aws-sdk-go-v2/service/macie2 v1.51.3
 	github.com/aws/aws-sdk-go-v2/service/mediaconnect v1.49.1
-	github.com/aws/aws-sdk-go-v2/service/mediaconvert v1.91.2
+	github.com/aws/aws-sdk-go-v2/service/mediaconvert v1.91.3
 	github.com/aws/aws-sdk-go-v2/service/medialive v1.96.0
 	github.com/aws/aws-sdk-go-v2/service/mediapackage v1.39.23
 	github.com/aws/aws-sdk-go-v2/service/mediapackagev2 v1.39.0

--- a/go.mod
+++ b/go.mod
@@ -116,7 +116,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/elasticbeanstalk v1.34.5
 	github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing v1.33.26
 	github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.54.13
-	github.com/aws/aws-sdk-go-v2/service/elasticsearchservice v1.41.0
+	github.com/aws/aws-sdk-go-v2/service/elasticsearchservice v1.41.1
 	github.com/aws/aws-sdk-go-v2/service/elastictranscoder v1.33.0
 	github.com/aws/aws-sdk-go-v2/service/emr v1.59.2
 	github.com/aws/aws-sdk-go-v2/service/emrcontainers v1.41.0

--- a/go.mod
+++ b/go.mod
@@ -234,7 +234,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3tables v1.16.1
 	github.com/aws/aws-sdk-go-v2/service/s3vectors v1.7.1
 	github.com/aws/aws-sdk-go-v2/service/sagemaker v1.250.1
-	github.com/aws/aws-sdk-go-v2/service/savingsplans v1.32.4
+	github.com/aws/aws-sdk-go-v2/service/savingsplans v1.33.1
 	github.com/aws/aws-sdk-go-v2/service/scheduler v1.18.0
 	github.com/aws/aws-sdk-go-v2/service/schemas v1.35.0
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.7

--- a/go.mod
+++ b/go.mod
@@ -223,7 +223,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/route53 v1.62.8
 	github.com/aws/aws-sdk-go-v2/service/route53domains v1.35.1
 	github.com/aws/aws-sdk-go-v2/service/route53profiles v1.9.26
-	github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.32.16
+	github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.33.0
 	github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.26.23
 	github.com/aws/aws-sdk-go-v2/service/route53resolver v1.44.0
 	github.com/aws/aws-sdk-go-v2/service/rum v1.30.12

--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/chime v1.41.15
 	github.com/aws/aws-sdk-go-v2/service/chimesdkmediapipelines v1.27.1
 	github.com/aws/aws-sdk-go-v2/service/chimesdkvoice v1.28.16
-	github.com/aws/aws-sdk-go-v2/service/cleanrooms v1.45.0
+	github.com/aws/aws-sdk-go-v2/service/cleanrooms v1.45.1
 	github.com/aws/aws-sdk-go-v2/service/cloud9 v1.34.0
 	github.com/aws/aws-sdk-go-v2/service/cloudcontrol v1.30.0
 	github.com/aws/aws-sdk-go-v2/service/cloudformation v1.71.11

--- a/go.mod
+++ b/go.mod
@@ -98,7 +98,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/devicefarm v1.38.11
 	github.com/aws/aws-sdk-go-v2/service/devopsagent v1.5.1
 	github.com/aws/aws-sdk-go-v2/service/devopsguru v1.41.1
-	github.com/aws/aws-sdk-go-v2/service/directconnect v1.38.17
+	github.com/aws/aws-sdk-go-v2/service/directconnect v1.38.18
 	github.com/aws/aws-sdk-go-v2/service/directoryservice v1.38.18
 	github.com/aws/aws-sdk-go-v2/service/dlm v1.37.0
 	github.com/aws/aws-sdk-go-v2/service/docdb v1.48.15

--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/cloudhsmv2 v1.34.26
 	github.com/aws/aws-sdk-go-v2/service/cloudsearch v1.32.15
 	github.com/aws/aws-sdk-go-v2/service/cloudtrail v1.55.12
-	github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.57.0
+	github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.57.1
 	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.74.0
 	github.com/aws/aws-sdk-go-v2/service/codeartifact v1.39.0
 	github.com/aws/aws-sdk-go-v2/service/codebuild v1.68.16

--- a/go.mod
+++ b/go.mod
@@ -273,7 +273,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/verifiedpermissions v1.34.0
 	github.com/aws/aws-sdk-go-v2/service/vpclattice v1.21.1
 	github.com/aws/aws-sdk-go-v2/service/waf v1.30.23
-	github.com/aws/aws-sdk-go-v2/service/wafregional v1.30.23
+	github.com/aws/aws-sdk-go-v2/service/wafregional v1.30.24
 	github.com/aws/aws-sdk-go-v2/service/wafv2 v1.71.5
 	github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.39.23
 	github.com/aws/aws-sdk-go-v2/service/workmail v1.37.0

--- a/go.mod
+++ b/go.mod
@@ -144,7 +144,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/inspector v1.30.23
 	github.com/aws/aws-sdk-go-v2/service/inspector2 v1.48.1
 	github.com/aws/aws-sdk-go-v2/service/internetmonitor v1.27.1
-	github.com/aws/aws-sdk-go-v2/service/invoicing v1.11.0
+	github.com/aws/aws-sdk-go-v2/service/invoicing v1.11.1
 	github.com/aws/aws-sdk-go-v2/service/iot v1.73.0
 	github.com/aws/aws-sdk-go-v2/service/ivs v1.50.1
 	github.com/aws/aws-sdk-go-v2/service/ivschat v1.22.0

--- a/go.mod
+++ b/go.mod
@@ -112,7 +112,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ecs v1.81.1
 	github.com/aws/aws-sdk-go-v2/service/efs v1.41.17
 	github.com/aws/aws-sdk-go-v2/service/eks v1.84.1
-	github.com/aws/aws-sdk-go-v2/service/elasticache v1.52.2
+	github.com/aws/aws-sdk-go-v2/service/elasticache v1.52.3
 	github.com/aws/aws-sdk-go-v2/service/elasticbeanstalk v1.34.4
 	github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing v1.33.25
 	github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.54.12

--- a/go.mod
+++ b/go.mod
@@ -108,7 +108,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.5
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.304.1
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.57.3
-	github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.38.15
+	github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.39.1
 	github.com/aws/aws-sdk-go-v2/service/ecs v1.80.0
 	github.com/aws/aws-sdk-go-v2/service/efs v1.41.16
 	github.com/aws/aws-sdk-go-v2/service/eks v1.84.0

--- a/go.mod
+++ b/go.mod
@@ -267,7 +267,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.20.0
 	github.com/aws/aws-sdk-go-v2/service/timestreamquery v1.36.18
 	github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.35.24
-	github.com/aws/aws-sdk-go-v2/service/transcribe v1.55.0
+	github.com/aws/aws-sdk-go-v2/service/transcribe v1.55.1
 	github.com/aws/aws-sdk-go-v2/service/transfer v1.72.0
 	github.com/aws/aws-sdk-go-v2/service/uxc v1.0.3
 	github.com/aws/aws-sdk-go-v2/service/verifiedpermissions v1.33.0

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/arcregionswitch v1.8.0
 	github.com/aws/aws-sdk-go-v2/service/arczonalshift v1.22.26
 	github.com/aws/aws-sdk-go-v2/service/athena v1.57.7
-	github.com/aws/aws-sdk-go-v2/service/auditmanager v1.46.14
+	github.com/aws/aws-sdk-go-v2/service/auditmanager v1.46.15
 	github.com/aws/aws-sdk-go-v2/service/autoscaling v1.66.2
 	github.com/aws/aws-sdk-go-v2/service/autoscalingplans v1.30.16
 	github.com/aws/aws-sdk-go-v2/service/backup v1.57.0

--- a/go.mod
+++ b/go.mod
@@ -230,7 +230,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.102.1
 	github.com/aws/aws-sdk-go-v2/service/s3control v1.71.0
 	github.com/aws/aws-sdk-go-v2/service/s3files v1.0.3
-	github.com/aws/aws-sdk-go-v2/service/s3outposts v1.34.14
+	github.com/aws/aws-sdk-go-v2/service/s3outposts v1.34.15
 	github.com/aws/aws-sdk-go-v2/service/s3tables v1.16.0
 	github.com/aws/aws-sdk-go-v2/service/s3vectors v1.7.0
 	github.com/aws/aws-sdk-go-v2/service/sagemaker v1.249.0

--- a/go.mod
+++ b/go.mod
@@ -215,7 +215,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.40.0
 	github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.35.1
 	github.com/aws/aws-sdk-go-v2/service/rekognition v1.51.25
-	github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.36.0
+	github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.36.1
 	github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.23.6
 	github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.33.26
 	github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.32.0

--- a/go.mod
+++ b/go.mod
@@ -201,7 +201,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/pcs v1.19.0
 	github.com/aws/aws-sdk-go-v2/service/pinpoint v1.39.24
 	github.com/aws/aws-sdk-go-v2/service/pinpointsmsvoicev2 v1.29.0
-	github.com/aws/aws-sdk-go-v2/service/pipes v1.24.0
+	github.com/aws/aws-sdk-go-v2/service/pipes v1.24.1
 	github.com/aws/aws-sdk-go-v2/service/polly v1.57.5
 	github.com/aws/aws-sdk-go-v2/service/pricing v1.42.0
 	github.com/aws/aws-sdk-go-v2/service/qbusiness v1.34.8

--- a/go.mod
+++ b/go.mod
@@ -181,7 +181,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/mwaa v1.40.2
 	github.com/aws/aws-sdk-go-v2/service/mwaaserverless v1.0.12
 	github.com/aws/aws-sdk-go-v2/service/neptune v1.44.6
-	github.com/aws/aws-sdk-go-v2/service/neptunegraph v1.21.23
+	github.com/aws/aws-sdk-go-v2/service/neptunegraph v1.22.0
 	github.com/aws/aws-sdk-go-v2/service/networkfirewall v1.61.0
 	github.com/aws/aws-sdk-go-v2/service/networkflowmonitor v1.11.11
 	github.com/aws/aws-sdk-go-v2/service/networkmanager v1.42.0

--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/cloudfront v1.64.1
 	github.com/aws/aws-sdk-go-v2/service/cloudfrontkeyvaluestore v1.13.0
 	github.com/aws/aws-sdk-go-v2/service/cloudhsmv2 v1.34.26
-	github.com/aws/aws-sdk-go-v2/service/cloudsearch v1.32.14
+	github.com/aws/aws-sdk-go-v2/service/cloudsearch v1.32.15
 	github.com/aws/aws-sdk-go-v2/service/cloudtrail v1.55.11
 	github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.57.0
 	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.74.0

--- a/go.mod
+++ b/go.mod
@@ -74,7 +74,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/codegurureviewer v1.35.0
 	github.com/aws/aws-sdk-go-v2/service/codepipeline v1.46.24
 	github.com/aws/aws-sdk-go-v2/service/codestarconnections v1.36.0
-	github.com/aws/aws-sdk-go-v2/service/codestarnotifications v1.32.0
+	github.com/aws/aws-sdk-go-v2/service/codestarnotifications v1.32.1
 	github.com/aws/aws-sdk-go-v2/service/cognitoidentity v1.33.24
 	github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.60.2
 	github.com/aws/aws-sdk-go-v2/service/comprehend v1.41.0

--- a/go.mod
+++ b/go.mod
@@ -199,7 +199,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/paymentcryptography v1.30.1
 	github.com/aws/aws-sdk-go-v2/service/pcaconnectorad v1.16.1
 	github.com/aws/aws-sdk-go-v2/service/pcs v1.19.0
-	github.com/aws/aws-sdk-go-v2/service/pinpoint v1.39.23
+	github.com/aws/aws-sdk-go-v2/service/pinpoint v1.39.24
 	github.com/aws/aws-sdk-go-v2/service/pinpointsmsvoicev2 v1.28.2
 	github.com/aws/aws-sdk-go-v2/service/pipes v1.24.0
 	github.com/aws/aws-sdk-go-v2/service/polly v1.57.5

--- a/go.mod
+++ b/go.mod
@@ -264,7 +264,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/swf v1.33.19
 	github.com/aws/aws-sdk-go-v2/service/synthetics v1.42.17
 	github.com/aws/aws-sdk-go-v2/service/taxsettings v1.16.24
-	github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.19.2
+	github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.20.0
 	github.com/aws/aws-sdk-go-v2/service/timestreamquery v1.36.17
 	github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.35.23
 	github.com/aws/aws-sdk-go-v2/service/transcribe v1.55.0

--- a/go.mod
+++ b/go.mod
@@ -160,7 +160,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/lakeformation v1.47.9
 	github.com/aws/aws-sdk-go-v2/service/lambda v1.90.2
 	github.com/aws/aws-sdk-go-v2/service/launchwizard v1.15.1
-	github.com/aws/aws-sdk-go-v2/service/lexmodelbuildingservice v1.35.0
+	github.com/aws/aws-sdk-go-v2/service/lexmodelbuildingservice v1.35.1
 	github.com/aws/aws-sdk-go-v2/service/lexmodelsv2 v1.61.0
 	github.com/aws/aws-sdk-go-v2/service/licensemanager v1.37.12
 	github.com/aws/aws-sdk-go-v2/service/lightsail v1.54.0

--- a/go.mod
+++ b/go.mod
@@ -84,7 +84,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/connectcases v1.42.1
 	github.com/aws/aws-sdk-go-v2/service/controltower v1.29.1
 	github.com/aws/aws-sdk-go-v2/service/costandusagereportservice v1.34.16
-	github.com/aws/aws-sdk-go-v2/service/costexplorer v1.63.8
+	github.com/aws/aws-sdk-go-v2/service/costexplorer v1.63.9
 	github.com/aws/aws-sdk-go-v2/service/costoptimizationhub v1.22.10
 	github.com/aws/aws-sdk-go-v2/service/customerprofiles v1.61.0
 	github.com/aws/aws-sdk-go-v2/service/databasemigrationservice v1.63.0

--- a/go.mod
+++ b/go.mod
@@ -232,7 +232,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3files v1.0.3
 	github.com/aws/aws-sdk-go-v2/service/s3outposts v1.34.15
 	github.com/aws/aws-sdk-go-v2/service/s3tables v1.16.1
-	github.com/aws/aws-sdk-go-v2/service/s3vectors v1.7.0
+	github.com/aws/aws-sdk-go-v2/service/s3vectors v1.7.1
 	github.com/aws/aws-sdk-go-v2/service/sagemaker v1.249.0
 	github.com/aws/aws-sdk-go-v2/service/savingsplans v1.32.4
 	github.com/aws/aws-sdk-go-v2/service/scheduler v1.18.0

--- a/go.mod
+++ b/go.mod
@@ -247,7 +247,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/servicequotas v1.35.1
 	github.com/aws/aws-sdk-go-v2/service/ses v1.34.25
 	github.com/aws/aws-sdk-go-v2/service/sesv2 v1.61.1
-	github.com/aws/aws-sdk-go-v2/service/sfn v1.41.0
+	github.com/aws/aws-sdk-go-v2/service/sfn v1.41.1
 	github.com/aws/aws-sdk-go-v2/service/shield v1.34.23
 	github.com/aws/aws-sdk-go-v2/service/signer v1.33.0
 	github.com/aws/aws-sdk-go-v2/service/sns v1.39.17

--- a/go.mod
+++ b/go.mod
@@ -155,7 +155,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/kinesis v1.43.8
 	github.com/aws/aws-sdk-go-v2/service/kinesisanalytics v1.30.26
 	github.com/aws/aws-sdk-go-v2/service/kinesisanalyticsv2 v1.38.0
-	github.com/aws/aws-sdk-go-v2/service/kinesisvideo v1.33.10
+	github.com/aws/aws-sdk-go-v2/service/kinesisvideo v1.33.11
 	github.com/aws/aws-sdk-go-v2/service/kms v1.52.0
 	github.com/aws/aws-sdk-go-v2/service/lakeformation v1.47.8
 	github.com/aws/aws-sdk-go-v2/service/lambda v1.90.1

--- a/go.mod
+++ b/go.mod
@@ -275,7 +275,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/waf v1.30.23
 	github.com/aws/aws-sdk-go-v2/service/wafregional v1.30.24
 	github.com/aws/aws-sdk-go-v2/service/wafv2 v1.71.6
-	github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.39.23
+	github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.40.1
 	github.com/aws/aws-sdk-go-v2/service/workmail v1.37.0
 	github.com/aws/aws-sdk-go-v2/service/workspaces v1.68.1
 	github.com/aws/aws-sdk-go-v2/service/workspacesweb v1.39.0

--- a/go.mod
+++ b/go.mod
@@ -261,7 +261,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssoadmin v1.39.1
 	github.com/aws/aws-sdk-go-v2/service/storagegateway v1.43.17
 	github.com/aws/aws-sdk-go-v2/service/sts v1.42.2
-	github.com/aws/aws-sdk-go-v2/service/swf v1.33.18
+	github.com/aws/aws-sdk-go-v2/service/swf v1.33.19
 	github.com/aws/aws-sdk-go-v2/service/synthetics v1.42.16
 	github.com/aws/aws-sdk-go-v2/service/taxsettings v1.16.23
 	github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.19.2

--- a/go.mod
+++ b/go.mod
@@ -72,7 +72,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/codedeploy v1.35.16
 	github.com/aws/aws-sdk-go-v2/service/codeguruprofiler v1.30.1
 	github.com/aws/aws-sdk-go-v2/service/codegurureviewer v1.35.0
-	github.com/aws/aws-sdk-go-v2/service/codepipeline v1.46.23
+	github.com/aws/aws-sdk-go-v2/service/codepipeline v1.46.24
 	github.com/aws/aws-sdk-go-v2/service/codestarconnections v1.35.15
 	github.com/aws/aws-sdk-go-v2/service/codestarnotifications v1.32.0
 	github.com/aws/aws-sdk-go-v2/service/cognitoidentity v1.33.24

--- a/go.mod
+++ b/go.mod
@@ -248,7 +248,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ses v1.34.25
 	github.com/aws/aws-sdk-go-v2/service/sesv2 v1.61.1
 	github.com/aws/aws-sdk-go-v2/service/sfn v1.41.1
-	github.com/aws/aws-sdk-go-v2/service/shield v1.34.23
+	github.com/aws/aws-sdk-go-v2/service/shield v1.34.24
 	github.com/aws/aws-sdk-go-v2/service/signer v1.33.0
 	github.com/aws/aws-sdk-go-v2/service/sns v1.39.17
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.42.27

--- a/go.mod
+++ b/go.mod
@@ -81,7 +81,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/computeoptimizer v1.51.1
 	github.com/aws/aws-sdk-go-v2/service/configservice v1.62.4
 	github.com/aws/aws-sdk-go-v2/service/connect v1.175.1
-	github.com/aws/aws-sdk-go-v2/service/connectcases v1.41.0
+	github.com/aws/aws-sdk-go-v2/service/connectcases v1.42.1
 	github.com/aws/aws-sdk-go-v2/service/controltower v1.29.0
 	github.com/aws/aws-sdk-go-v2/service/costandusagereportservice v1.34.15
 	github.com/aws/aws-sdk-go-v2/service/costexplorer v1.63.8

--- a/go.mod
+++ b/go.mod
@@ -192,7 +192,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/observabilityadmin v1.16.1
 	github.com/aws/aws-sdk-go-v2/service/odb v1.11.1
 	github.com/aws/aws-sdk-go-v2/service/opensearch v1.70.1
-	github.com/aws/aws-sdk-go-v2/service/opensearchserverless v1.30.3
+	github.com/aws/aws-sdk-go-v2/service/opensearchserverless v1.31.0
 	github.com/aws/aws-sdk-go-v2/service/organizations v1.51.3
 	github.com/aws/aws-sdk-go-v2/service/osis v1.22.0
 	github.com/aws/aws-sdk-go-v2/service/outposts v1.60.0

--- a/go.mod
+++ b/go.mod
@@ -202,7 +202,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/pinpoint v1.39.24
 	github.com/aws/aws-sdk-go-v2/service/pinpointsmsvoicev2 v1.29.0
 	github.com/aws/aws-sdk-go-v2/service/pipes v1.24.1
-	github.com/aws/aws-sdk-go-v2/service/polly v1.57.5
+	github.com/aws/aws-sdk-go-v2/service/polly v1.57.6
 	github.com/aws/aws-sdk-go-v2/service/pricing v1.42.0
 	github.com/aws/aws-sdk-go-v2/service/qbusiness v1.34.8
 	github.com/aws/aws-sdk-go-v2/service/qldb v1.32.2

--- a/go.mod
+++ b/go.mod
@@ -161,7 +161,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/lambda v1.90.2
 	github.com/aws/aws-sdk-go-v2/service/launchwizard v1.15.1
 	github.com/aws/aws-sdk-go-v2/service/lexmodelbuildingservice v1.35.1
-	github.com/aws/aws-sdk-go-v2/service/lexmodelsv2 v1.61.0
+	github.com/aws/aws-sdk-go-v2/service/lexmodelsv2 v1.61.1
 	github.com/aws/aws-sdk-go-v2/service/licensemanager v1.37.12
 	github.com/aws/aws-sdk-go-v2/service/lightsail v1.54.0
 	github.com/aws/aws-sdk-go-v2/service/location v1.51.1

--- a/go.mod
+++ b/go.mod
@@ -147,7 +147,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/invoicing v1.11.1
 	github.com/aws/aws-sdk-go-v2/service/iot v1.74.0
 	github.com/aws/aws-sdk-go-v2/service/ivs v1.51.0
-	github.com/aws/aws-sdk-go-v2/service/ivschat v1.22.0
+	github.com/aws/aws-sdk-go-v2/service/ivschat v1.22.1
 	github.com/aws/aws-sdk-go-v2/service/kafka v1.52.0
 	github.com/aws/aws-sdk-go-v2/service/kafkaconnect v1.31.0
 	github.com/aws/aws-sdk-go-v2/service/kendra v1.60.23

--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.57.1
 	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.74.1
 	github.com/aws/aws-sdk-go-v2/service/codeartifact v1.39.1
-	github.com/aws/aws-sdk-go-v2/service/codebuild v1.68.16
+	github.com/aws/aws-sdk-go-v2/service/codebuild v1.68.17
 	github.com/aws/aws-sdk-go-v2/service/codecatalyst v1.21.14
 	github.com/aws/aws-sdk-go-v2/service/codecommit v1.33.14
 	github.com/aws/aws-sdk-go-v2/service/codeconnections v1.11.0

--- a/go.mod
+++ b/go.mod
@@ -75,7 +75,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/codepipeline v1.46.24
 	github.com/aws/aws-sdk-go-v2/service/codestarconnections v1.36.0
 	github.com/aws/aws-sdk-go-v2/service/codestarnotifications v1.32.1
-	github.com/aws/aws-sdk-go-v2/service/cognitoidentity v1.33.24
+	github.com/aws/aws-sdk-go-v2/service/cognitoidentity v1.33.25
 	github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.60.2
 	github.com/aws/aws-sdk-go-v2/service/comprehend v1.41.0
 	github.com/aws/aws-sdk-go-v2/service/computeoptimizer v1.50.1

--- a/go.mod
+++ b/go.mod
@@ -271,7 +271,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/transfer v1.72.1
 	github.com/aws/aws-sdk-go-v2/service/uxc v1.0.4
 	github.com/aws/aws-sdk-go-v2/service/verifiedpermissions v1.34.0
-	github.com/aws/aws-sdk-go-v2/service/vpclattice v1.21.0
+	github.com/aws/aws-sdk-go-v2/service/vpclattice v1.21.1
 	github.com/aws/aws-sdk-go-v2/service/waf v1.30.22
 	github.com/aws/aws-sdk-go-v2/service/wafregional v1.30.23
 	github.com/aws/aws-sdk-go-v2/service/wafv2 v1.71.5

--- a/go.mod
+++ b/go.mod
@@ -229,7 +229,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/rum v1.31.1
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.102.1
 	github.com/aws/aws-sdk-go-v2/service/s3control v1.71.0
-	github.com/aws/aws-sdk-go-v2/service/s3files v1.0.2
+	github.com/aws/aws-sdk-go-v2/service/s3files v1.0.3
 	github.com/aws/aws-sdk-go-v2/service/s3outposts v1.34.14
 	github.com/aws/aws-sdk-go-v2/service/s3tables v1.16.0
 	github.com/aws/aws-sdk-go-v2/service/s3vectors v1.7.0

--- a/go.mod
+++ b/go.mod
@@ -174,7 +174,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/mediapackagev2 v1.39.1
 	github.com/aws/aws-sdk-go-v2/service/mediapackagevod v1.39.24
 	github.com/aws/aws-sdk-go-v2/service/mediastore v1.29.24
-	github.com/aws/aws-sdk-go-v2/service/memorydb v1.33.16
+	github.com/aws/aws-sdk-go-v2/service/memorydb v1.34.1
 	github.com/aws/aws-sdk-go-v2/service/mgn v1.43.0
 	github.com/aws/aws-sdk-go-v2/service/mpa v1.7.4
 	github.com/aws/aws-sdk-go-v2/service/mq v1.34.22

--- a/go.mod
+++ b/go.mod
@@ -151,7 +151,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/kafka v1.52.1
 	github.com/aws/aws-sdk-go-v2/service/kafkaconnect v1.31.1
 	github.com/aws/aws-sdk-go-v2/service/kendra v1.60.24
-	github.com/aws/aws-sdk-go-v2/service/keyspaces v1.25.7
+	github.com/aws/aws-sdk-go-v2/service/keyspaces v1.26.0
 	github.com/aws/aws-sdk-go-v2/service/kinesis v1.43.7
 	github.com/aws/aws-sdk-go-v2/service/kinesisanalytics v1.30.25
 	github.com/aws/aws-sdk-go-v2/service/kinesisanalyticsv2 v1.37.2

--- a/go.mod
+++ b/go.mod
@@ -152,7 +152,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/kafkaconnect v1.31.1
 	github.com/aws/aws-sdk-go-v2/service/kendra v1.60.24
 	github.com/aws/aws-sdk-go-v2/service/keyspaces v1.26.0
-	github.com/aws/aws-sdk-go-v2/service/kinesis v1.43.7
+	github.com/aws/aws-sdk-go-v2/service/kinesis v1.43.8
 	github.com/aws/aws-sdk-go-v2/service/kinesisanalytics v1.30.25
 	github.com/aws/aws-sdk-go-v2/service/kinesisanalyticsv2 v1.37.2
 	github.com/aws/aws-sdk-go-v2/service/kinesisvideo v1.33.10

--- a/go.mod
+++ b/go.mod
@@ -169,7 +169,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/macie2 v1.51.3
 	github.com/aws/aws-sdk-go-v2/service/mediaconnect v1.49.1
 	github.com/aws/aws-sdk-go-v2/service/mediaconvert v1.91.3
-	github.com/aws/aws-sdk-go-v2/service/medialive v1.96.0
+	github.com/aws/aws-sdk-go-v2/service/medialive v1.97.1
 	github.com/aws/aws-sdk-go-v2/service/mediapackage v1.39.23
 	github.com/aws/aws-sdk-go-v2/service/mediapackagev2 v1.39.0
 	github.com/aws/aws-sdk-go-v2/service/mediapackagevod v1.39.23

--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/cloudtrail v1.55.12
 	github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.57.1
 	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.74.1
-	github.com/aws/aws-sdk-go-v2/service/codeartifact v1.39.0
+	github.com/aws/aws-sdk-go-v2/service/codeartifact v1.39.1
 	github.com/aws/aws-sdk-go-v2/service/codebuild v1.68.16
 	github.com/aws/aws-sdk-go-v2/service/codecatalyst v1.21.14
 	github.com/aws/aws-sdk-go-v2/service/codecommit v1.33.14

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/appsync v1.53.8
 	github.com/aws/aws-sdk-go-v2/service/arcregionswitch v1.8.0
 	github.com/aws/aws-sdk-go-v2/service/arczonalshift v1.22.26
-	github.com/aws/aws-sdk-go-v2/service/athena v1.57.6
+	github.com/aws/aws-sdk-go-v2/service/athena v1.57.7
 	github.com/aws/aws-sdk-go-v2/service/auditmanager v1.46.14
 	github.com/aws/aws-sdk-go-v2/service/autoscaling v1.66.2
 	github.com/aws/aws-sdk-go-v2/service/autoscalingplans v1.30.16

--- a/go.mod
+++ b/go.mod
@@ -277,7 +277,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/wafv2 v1.71.6
 	github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.40.1
 	github.com/aws/aws-sdk-go-v2/service/workmail v1.37.1
-	github.com/aws/aws-sdk-go-v2/service/workspaces v1.68.1
+	github.com/aws/aws-sdk-go-v2/service/workspaces v1.68.2
 	github.com/aws/aws-sdk-go-v2/service/workspacesweb v1.39.0
 	github.com/aws/aws-sdk-go-v2/service/xray v1.36.23
 	github.com/aws/smithy-go v1.26.0

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/apigateway v1.40.1
 	github.com/aws/aws-sdk-go-v2/service/apigatewayv2 v1.35.1
 	github.com/aws/aws-sdk-go-v2/service/appconfig v1.44.1
-	github.com/aws/aws-sdk-go-v2/service/appfabric v1.16.23
+	github.com/aws/aws-sdk-go-v2/service/appfabric v1.16.24
 	github.com/aws/aws-sdk-go-v2/service/appflow v1.51.14
 	github.com/aws/aws-sdk-go-v2/service/appintegrations v1.37.9
 	github.com/aws/aws-sdk-go-v2/service/applicationautoscaling v1.41.16

--- a/go.mod
+++ b/go.mod
@@ -104,7 +104,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/docdb v1.48.16
 	github.com/aws/aws-sdk-go-v2/service/docdbelastic v1.21.1
 	github.com/aws/aws-sdk-go-v2/service/drs v1.38.3
-	github.com/aws/aws-sdk-go-v2/service/dsql v1.14.0
+	github.com/aws/aws-sdk-go-v2/service/dsql v1.14.1
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.4
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.304.0
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.57.2

--- a/go.mod
+++ b/go.mod
@@ -203,7 +203,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/pinpointsmsvoicev2 v1.29.0
 	github.com/aws/aws-sdk-go-v2/service/pipes v1.24.1
 	github.com/aws/aws-sdk-go-v2/service/polly v1.57.6
-	github.com/aws/aws-sdk-go-v2/service/pricing v1.42.0
+	github.com/aws/aws-sdk-go-v2/service/pricing v1.42.1
 	github.com/aws/aws-sdk-go-v2/service/qbusiness v1.34.8
 	github.com/aws/aws-sdk-go-v2/service/qldb v1.32.2
 	github.com/aws/aws-sdk-go-v2/service/quicksight v1.111.0

--- a/go.mod
+++ b/go.mod
@@ -189,7 +189,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/notifications v1.8.1
 	github.com/aws/aws-sdk-go-v2/service/notificationscontacts v1.6.1
 	github.com/aws/aws-sdk-go-v2/service/oam v1.24.1
-	github.com/aws/aws-sdk-go-v2/service/observabilityadmin v1.16.0
+	github.com/aws/aws-sdk-go-v2/service/observabilityadmin v1.16.1
 	github.com/aws/aws-sdk-go-v2/service/odb v1.11.0
 	github.com/aws/aws-sdk-go-v2/service/opensearch v1.69.0
 	github.com/aws/aws-sdk-go-v2/service/opensearchserverless v1.30.3

--- a/go.mod
+++ b/go.mod
@@ -143,7 +143,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/imagebuilder v1.55.1
 	github.com/aws/aws-sdk-go-v2/service/inspector v1.30.23
 	github.com/aws/aws-sdk-go-v2/service/inspector2 v1.48.1
-	github.com/aws/aws-sdk-go-v2/service/internetmonitor v1.27.0
+	github.com/aws/aws-sdk-go-v2/service/internetmonitor v1.27.1
 	github.com/aws/aws-sdk-go-v2/service/invoicing v1.11.0
 	github.com/aws/aws-sdk-go-v2/service/iot v1.73.0
 	github.com/aws/aws-sdk-go-v2/service/ivs v1.50.1

--- a/go.mod
+++ b/go.mod
@@ -93,7 +93,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/datapipeline v1.30.23
 	github.com/aws/aws-sdk-go-v2/service/datasync v1.59.1
 	github.com/aws/aws-sdk-go-v2/service/datazone v1.62.1
-	github.com/aws/aws-sdk-go-v2/service/dax v1.29.18
+	github.com/aws/aws-sdk-go-v2/service/dax v1.29.19
 	github.com/aws/aws-sdk-go-v2/service/detective v1.38.15
 	github.com/aws/aws-sdk-go-v2/service/devicefarm v1.38.10
 	github.com/aws/aws-sdk-go-v2/service/devopsagent v1.4.0

--- a/go.mod
+++ b/go.mod
@@ -209,7 +209,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/quicksight v1.111.1
 	github.com/aws/aws-sdk-go-v2/service/ram v1.36.6
 	github.com/aws/aws-sdk-go-v2/service/rbin v1.28.1
-	github.com/aws/aws-sdk-go-v2/service/rds v1.118.2
+	github.com/aws/aws-sdk-go-v2/service/rds v1.118.3
 	github.com/aws/aws-sdk-go-v2/service/rdsdata v1.32.23
 	github.com/aws/aws-sdk-go-v2/service/redshift v1.62.8
 	github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.39.2

--- a/go.mod
+++ b/go.mod
@@ -222,7 +222,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.23.1
 	github.com/aws/aws-sdk-go-v2/service/route53 v1.62.8
 	github.com/aws/aws-sdk-go-v2/service/route53domains v1.35.1
-	github.com/aws/aws-sdk-go-v2/service/route53profiles v1.9.25
+	github.com/aws/aws-sdk-go-v2/service/route53profiles v1.9.26
 	github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.32.16
 	github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.26.23
 	github.com/aws/aws-sdk-go-v2/service/route53resolver v1.44.0

--- a/go.mod
+++ b/go.mod
@@ -265,7 +265,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/synthetics v1.42.17
 	github.com/aws/aws-sdk-go-v2/service/taxsettings v1.16.24
 	github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.20.0
-	github.com/aws/aws-sdk-go-v2/service/timestreamquery v1.36.17
+	github.com/aws/aws-sdk-go-v2/service/timestreamquery v1.36.18
 	github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.35.23
 	github.com/aws/aws-sdk-go-v2/service/transcribe v1.55.0
 	github.com/aws/aws-sdk-go-v2/service/transfer v1.72.0

--- a/go.mod
+++ b/go.mod
@@ -178,7 +178,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/mgn v1.44.1
 	github.com/aws/aws-sdk-go-v2/service/mpa v1.8.1
 	github.com/aws/aws-sdk-go-v2/service/mq v1.34.23
-	github.com/aws/aws-sdk-go-v2/service/mwaa v1.40.1
+	github.com/aws/aws-sdk-go-v2/service/mwaa v1.40.2
 	github.com/aws/aws-sdk-go-v2/service/mwaaserverless v1.0.11
 	github.com/aws/aws-sdk-go-v2/service/neptune v1.44.5
 	github.com/aws/aws-sdk-go-v2/service/neptunegraph v1.21.23

--- a/go.mod
+++ b/go.mod
@@ -237,7 +237,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/savingsplans v1.33.1
 	github.com/aws/aws-sdk-go-v2/service/scheduler v1.18.1
 	github.com/aws/aws-sdk-go-v2/service/schemas v1.35.1
-	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.7
+	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.8
 	github.com/aws/aws-sdk-go-v2/service/securityhub v1.71.0
 	github.com/aws/aws-sdk-go-v2/service/securitylake v1.25.15
 	github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.31.0

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/bedrockagent v1.54.1
 	github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol v1.41.0
 	github.com/aws/aws-sdk-go-v2/service/billing v1.11.1
-	github.com/aws/aws-sdk-go-v2/service/budgets v1.43.7
+	github.com/aws/aws-sdk-go-v2/service/budgets v1.43.8
 	github.com/aws/aws-sdk-go-v2/service/chatbot v1.14.23
 	github.com/aws/aws-sdk-go-v2/service/chime v1.41.14
 	github.com/aws/aws-sdk-go-v2/service/chimesdkmediapipelines v1.27.0

--- a/go.mod
+++ b/go.mod
@@ -212,7 +212,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/rds v1.118.3
 	github.com/aws/aws-sdk-go-v2/service/rdsdata v1.32.24
 	github.com/aws/aws-sdk-go-v2/service/redshift v1.62.9
-	github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.39.2
+	github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.40.0
 	github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.35.0
 	github.com/aws/aws-sdk-go-v2/service/rekognition v1.51.24
 	github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.36.0

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/athena v1.57.7
 	github.com/aws/aws-sdk-go-v2/service/auditmanager v1.46.15
 	github.com/aws/aws-sdk-go-v2/service/autoscaling v1.66.3
-	github.com/aws/aws-sdk-go-v2/service/autoscalingplans v1.30.16
+	github.com/aws/aws-sdk-go-v2/service/autoscalingplans v1.30.17
 	github.com/aws/aws-sdk-go-v2/service/backup v1.57.0
 	github.com/aws/aws-sdk-go-v2/service/batch v1.65.0
 	github.com/aws/aws-sdk-go-v2/service/bcmdataexports v1.16.0

--- a/go.mod
+++ b/go.mod
@@ -200,7 +200,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/pcaconnectorad v1.16.1
 	github.com/aws/aws-sdk-go-v2/service/pcs v1.19.0
 	github.com/aws/aws-sdk-go-v2/service/pinpoint v1.39.24
-	github.com/aws/aws-sdk-go-v2/service/pinpointsmsvoicev2 v1.28.2
+	github.com/aws/aws-sdk-go-v2/service/pinpointsmsvoicev2 v1.29.0
 	github.com/aws/aws-sdk-go-v2/service/pipes v1.24.0
 	github.com/aws/aws-sdk-go-v2/service/polly v1.57.5
 	github.com/aws/aws-sdk-go-v2/service/pricing v1.42.0

--- a/go.mod
+++ b/go.mod
@@ -208,7 +208,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/qldb v1.32.2
 	github.com/aws/aws-sdk-go-v2/service/quicksight v1.111.1
 	github.com/aws/aws-sdk-go-v2/service/ram v1.36.6
-	github.com/aws/aws-sdk-go-v2/service/rbin v1.28.0
+	github.com/aws/aws-sdk-go-v2/service/rbin v1.28.1
 	github.com/aws/aws-sdk-go-v2/service/rds v1.118.2
 	github.com/aws/aws-sdk-go-v2/service/rdsdata v1.32.23
 	github.com/aws/aws-sdk-go-v2/service/redshift v1.62.8

--- a/go.mod
+++ b/go.mod
@@ -113,7 +113,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/efs v1.41.17
 	github.com/aws/aws-sdk-go-v2/service/eks v1.84.1
 	github.com/aws/aws-sdk-go-v2/service/elasticache v1.52.3
-	github.com/aws/aws-sdk-go-v2/service/elasticbeanstalk v1.34.4
+	github.com/aws/aws-sdk-go-v2/service/elasticbeanstalk v1.34.5
 	github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing v1.33.25
 	github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.54.12
 	github.com/aws/aws-sdk-go-v2/service/elasticsearchservice v1.41.0

--- a/go.mod
+++ b/go.mod
@@ -118,7 +118,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.54.13
 	github.com/aws/aws-sdk-go-v2/service/elasticsearchservice v1.41.1
 	github.com/aws/aws-sdk-go-v2/service/elastictranscoder v1.33.0
-	github.com/aws/aws-sdk-go-v2/service/emr v1.59.2
+	github.com/aws/aws-sdk-go-v2/service/emr v1.59.3
 	github.com/aws/aws-sdk-go-v2/service/emrcontainers v1.41.0
 	github.com/aws/aws-sdk-go-v2/service/emrserverless v1.41.0
 	github.com/aws/aws-sdk-go-v2/service/eventbridge v1.45.25

--- a/go.mod
+++ b/go.mod
@@ -231,7 +231,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3control v1.71.0
 	github.com/aws/aws-sdk-go-v2/service/s3files v1.0.3
 	github.com/aws/aws-sdk-go-v2/service/s3outposts v1.34.15
-	github.com/aws/aws-sdk-go-v2/service/s3tables v1.16.0
+	github.com/aws/aws-sdk-go-v2/service/s3tables v1.16.1
 	github.com/aws/aws-sdk-go-v2/service/s3vectors v1.7.0
 	github.com/aws/aws-sdk-go-v2/service/sagemaker v1.249.0
 	github.com/aws/aws-sdk-go-v2/service/savingsplans v1.32.4

--- a/go.mod
+++ b/go.mod
@@ -258,7 +258,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssmquicksetup v1.9.1
 	github.com/aws/aws-sdk-go-v2/service/ssmsap v1.27.1
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.18
-	github.com/aws/aws-sdk-go-v2/service/ssoadmin v1.39.0
+	github.com/aws/aws-sdk-go-v2/service/ssoadmin v1.39.1
 	github.com/aws/aws-sdk-go-v2/service/storagegateway v1.43.16
 	github.com/aws/aws-sdk-go-v2/service/sts v1.42.2
 	github.com/aws/aws-sdk-go-v2/service/swf v1.33.18

--- a/go.mod
+++ b/go.mod
@@ -114,7 +114,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/eks v1.84.1
 	github.com/aws/aws-sdk-go-v2/service/elasticache v1.52.3
 	github.com/aws/aws-sdk-go-v2/service/elasticbeanstalk v1.34.5
-	github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing v1.33.25
+	github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing v1.33.26
 	github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.54.12
 	github.com/aws/aws-sdk-go-v2/service/elasticsearchservice v1.41.0
 	github.com/aws/aws-sdk-go-v2/service/elastictranscoder v1.33.0

--- a/go.mod
+++ b/go.mod
@@ -158,7 +158,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/kinesisvideo v1.33.11
 	github.com/aws/aws-sdk-go-v2/service/kms v1.52.1
 	github.com/aws/aws-sdk-go-v2/service/lakeformation v1.47.9
-	github.com/aws/aws-sdk-go-v2/service/lambda v1.90.1
+	github.com/aws/aws-sdk-go-v2/service/lambda v1.90.2
 	github.com/aws/aws-sdk-go-v2/service/launchwizard v1.14.6
 	github.com/aws/aws-sdk-go-v2/service/lexmodelbuildingservice v1.35.0
 	github.com/aws/aws-sdk-go-v2/service/lexmodelsv2 v1.61.0

--- a/go.sum
+++ b/go.sum
@@ -177,8 +177,8 @@ github.com/aws/aws-sdk-go-v2/service/controltower v1.29.1 h1:FG7qE3bUC6XqHY2lQ/B
 github.com/aws/aws-sdk-go-v2/service/controltower v1.29.1/go.mod h1:2pnXa7KVMMvd+KdNWGiVuS7Fs4FNtWu+j9Oe9XyQs3U=
 github.com/aws/aws-sdk-go-v2/service/costandusagereportservice v1.34.16 h1:w20+cJBkusCGMM+eBMpuId8tPKi7xQMU+oewJyUU5vc=
 github.com/aws/aws-sdk-go-v2/service/costandusagereportservice v1.34.16/go.mod h1:9FEyLTz1kOG0l/DWCCbvpAuJUlawnKJPaSA+xO0jpfg=
-github.com/aws/aws-sdk-go-v2/service/costexplorer v1.63.8 h1:rUg81vwoGgCmnQxsVl+B65QF8Qh+zYCluhyAcxsk79o=
-github.com/aws/aws-sdk-go-v2/service/costexplorer v1.63.8/go.mod h1:V+bKJ05kIC6K0LH8TB3D5boy7F8BhrZeecoXLz1NlB4=
+github.com/aws/aws-sdk-go-v2/service/costexplorer v1.63.9 h1:cVSd0kgTG+dvJlglPapLihiYNM69k+ZJxb2OqGY73BQ=
+github.com/aws/aws-sdk-go-v2/service/costexplorer v1.63.9/go.mod h1:bm12cXeoasdLU/Ra6PdxnbE8YZsbXDYHfLU4Z9yGBDc=
 github.com/aws/aws-sdk-go-v2/service/costoptimizationhub v1.22.10 h1:ZbXEmYQ2SuF9LXqdHAgcx5ThxphG2OxiiVsnQ7TrHAQ=
 github.com/aws/aws-sdk-go-v2/service/costoptimizationhub v1.22.10/go.mod h1:deL+2XD+z69IsKSRyxo+9/4xlRVdg9uL+B4RJW+t4RY=
 github.com/aws/aws-sdk-go-v2/service/customerprofiles v1.61.0 h1:rfU1DhRBbNg9f8uh9L4dJNZYSYRjrgqTxSI4aPkkzvE=

--- a/go.sum
+++ b/go.sum
@@ -215,8 +215,8 @@ github.com/aws/aws-sdk-go-v2/service/docdb v1.48.16 h1:JVfVNI1W7geUmJuyTPVKDdym3
 github.com/aws/aws-sdk-go-v2/service/docdb v1.48.16/go.mod h1:qzkOzKUNO8ZzfMCC8gTh2uxD/7UmpS9scLHfAZ696i4=
 github.com/aws/aws-sdk-go-v2/service/docdbelastic v1.21.1 h1:h/8yW1Qh78RTRmT1WOhe9vxF/lOSk1A3nASDopWIJLY=
 github.com/aws/aws-sdk-go-v2/service/docdbelastic v1.21.1/go.mod h1:BoVuSamInxADdfbPKk92a5ozopz1pjGnm+iv82rxj44=
-github.com/aws/aws-sdk-go-v2/service/drs v1.38.2 h1:lGGi8jgwirRgq3AicTFBr5u1nqkE/y3bJuhjQQI3e1o=
-github.com/aws/aws-sdk-go-v2/service/drs v1.38.2/go.mod h1:d6uN12uV8zw/mkR7EiIfuEs18rny1ZpGmw2IbFCc5Ec=
+github.com/aws/aws-sdk-go-v2/service/drs v1.38.3 h1:HwQ821+/yd6GSmIWHU2cSUUEcTp2NWN4PjoCFGw6VMM=
+github.com/aws/aws-sdk-go-v2/service/drs v1.38.3/go.mod h1:iq+Z1AOHKY/yRRUtgxQjCKjAEuHNiQcYsULuGHZKJLA=
 github.com/aws/aws-sdk-go-v2/service/dsql v1.14.0 h1:g/vNRzoxAtEEImkLqL9Nfi/meauKiOvj9XJjTjRA2XQ=
 github.com/aws/aws-sdk-go-v2/service/dsql v1.14.0/go.mod h1:Urak1kEuxp8VUQySLI4kL/hnRfYUOpvgSTyKTx7+Fh4=
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.4 h1:0E3bfw1Va3vfCrmtATvKRnGojY4oIlLl0u0xRDDUgfY=

--- a/go.sum
+++ b/go.sum
@@ -237,8 +237,8 @@ github.com/aws/aws-sdk-go-v2/service/elasticache v1.52.3 h1:l6i/86M1/beEHPdxcj/8
 github.com/aws/aws-sdk-go-v2/service/elasticache v1.52.3/go.mod h1:hpwaNXHNAM4EP+m38yzQI4hOgVwnjlNfK7Iq9GXYl04=
 github.com/aws/aws-sdk-go-v2/service/elasticbeanstalk v1.34.5 h1:lngZe4LXmP9FlF9LQ0YhNdRpLJi65oN/Mc41VQoxSJM=
 github.com/aws/aws-sdk-go-v2/service/elasticbeanstalk v1.34.5/go.mod h1:lxzT/1L6i9X/yAAE1zArAoFjWao/tjlfwo38zFp+RI0=
-github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing v1.33.25 h1:VzmoYPRbNSUqk3pA04ZyGZUg52yfX259XXRqwr1lns4=
-github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing v1.33.25/go.mod h1:r7chQGimOmFs4oqawhO+i+o3ez2l69rzAco5KTb7bjY=
+github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing v1.33.26 h1:4dwPvA64UPjLWC7m3yrdWeRVdvPDKPbqyBrH5n9NJKM=
+github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing v1.33.26/go.mod h1:Xct3NIOlINw4osqGbz1ryjxo5+Hro1YpY2xyZ426JYc=
 github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.54.12 h1:TJXv7kZjdXA2maPDaJFFEQPBrPmvPtMybN3qYDOpJ4Y=
 github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.54.12/go.mod h1:lwjtb9DHOAmNt7EUW68Zd1Qd+cPyFxacXHN5c9JZ2VY=
 github.com/aws/aws-sdk-go-v2/service/elasticsearchservice v1.41.0 h1:+2UoP7IQFeATSuXiv4REnMSNIIQVEhG3yNIypruQoa8=

--- a/go.sum
+++ b/go.sum
@@ -373,8 +373,8 @@ github.com/aws/aws-sdk-go-v2/service/mgn v1.44.1 h1:5Etw8C5flLuINUJNlE9HanIDd6Z6
 github.com/aws/aws-sdk-go-v2/service/mgn v1.44.1/go.mod h1:KR2PuoyY3PpsnMaQ7F+6EnvsUUSVbSwNwrQxBjUy7eU=
 github.com/aws/aws-sdk-go-v2/service/mpa v1.8.1 h1:w72sLJK6Oqa4kKmBCtrYxvcUqoGACcQ51ePjrAtMi2s=
 github.com/aws/aws-sdk-go-v2/service/mpa v1.8.1/go.mod h1:hKfTw6IUWyrVbmuHu9fouTshz1KJdPFLE3SDpXgtF4o=
-github.com/aws/aws-sdk-go-v2/service/mq v1.34.22 h1:l7nzDTuFH15cvRIFo5cFokN5g+9sA/ZYUsiffFBTObk=
-github.com/aws/aws-sdk-go-v2/service/mq v1.34.22/go.mod h1:aWvcRNyk/LFb3R6xIJE1o4MDwJcLjXhpdlg8X4kW57k=
+github.com/aws/aws-sdk-go-v2/service/mq v1.34.23 h1:W65gsIOHWb1jwqkILta3uVormtrgYKVdef0U9BHTJ54=
+github.com/aws/aws-sdk-go-v2/service/mq v1.34.23/go.mod h1:8neGcEvd8ny7TLfOT9be0HUx+jA7w46g2QM6JHl4Ptk=
 github.com/aws/aws-sdk-go-v2/service/mwaa v1.40.1 h1:fVJ6uZsjHWiMbT4tPsNPmA5VElniNCKj1pE4nb1J9gg=
 github.com/aws/aws-sdk-go-v2/service/mwaa v1.40.1/go.mod h1:O2kdYrYDkdHdUpvYcrWQoYaJgPJCGHdaLF06ep3HzKI=
 github.com/aws/aws-sdk-go-v2/service/mwaaserverless v1.0.11 h1:F6jhTASJH6ekrt1mbD/KKxVcA4cZYOLEWLHuPedAw88=

--- a/go.sum
+++ b/go.sum
@@ -385,8 +385,8 @@ github.com/aws/aws-sdk-go-v2/service/neptunegraph v1.22.0 h1:iTnqzV7TNmSlH+wpUsz
 github.com/aws/aws-sdk-go-v2/service/neptunegraph v1.22.0/go.mod h1:PMRZaSonQvYX8d0u6JciqToJh3JHIcNDU8JwpLeFiT0=
 github.com/aws/aws-sdk-go-v2/service/networkfirewall v1.61.1 h1:ewqow8gclzOTZRvgxkynXFaj9h8YQE8wJTRpyMMjtqw=
 github.com/aws/aws-sdk-go-v2/service/networkfirewall v1.61.1/go.mod h1:7bRBjeRP7pMQOX2qP8d7kEO1FV1WekbuMq5ZJXQpxCo=
-github.com/aws/aws-sdk-go-v2/service/networkflowmonitor v1.11.11 h1:/FfmXTc20Nc4NWFdAd0o5tekmtQ+M1Tr2xOqCdRp9GQ=
-github.com/aws/aws-sdk-go-v2/service/networkflowmonitor v1.11.11/go.mod h1:WNVP52DRoC0YOaS3EFfQ6VAat21xbwCtn4KaKr00vow=
+github.com/aws/aws-sdk-go-v2/service/networkflowmonitor v1.11.12 h1:wjAGQwXknovXHWsomCz7sOCdSMVlRc9mD/J7ut2GCEI=
+github.com/aws/aws-sdk-go-v2/service/networkflowmonitor v1.11.12/go.mod h1:LXVPCQiyrT5jBtZwCrzCxTomfsy+W/ZYzy2VmDlorn0=
 github.com/aws/aws-sdk-go-v2/service/networkmanager v1.42.0 h1:xWEOUBxKqNCR3qkUsmYOPUyW7ZlyWzKX6s0f81PW60A=
 github.com/aws/aws-sdk-go-v2/service/networkmanager v1.42.0/go.mod h1:x0O7AHep2gwquyfW6gmNql2OM4LEloyJGFflJfEJV+U=
 github.com/aws/aws-sdk-go-v2/service/networkmonitor v1.13.15 h1:Ji9P/9srs4/zg76hJP1117SuDZXDQ/ooeETlNPmhXcM=

--- a/go.sum
+++ b/go.sum
@@ -511,8 +511,8 @@ github.com/aws/aws-sdk-go-v2/service/servicequotas v1.35.1 h1:ixj7b/LEZAuNWwORvR
 github.com/aws/aws-sdk-go-v2/service/servicequotas v1.35.1/go.mod h1:OLExSerzvmddN8vnbNcW1AgvpMHE3LtU/hh4CYLsZXY=
 github.com/aws/aws-sdk-go-v2/service/ses v1.34.25 h1:DTpjLExwQKSSWO0Q0zmFRWJTL2zG4QW/7jtxcKribwc=
 github.com/aws/aws-sdk-go-v2/service/ses v1.34.25/go.mod h1:AGkPDUK1aHopltzewQ2M125cJ5LfNGq3UNAvSRqyFUE=
-github.com/aws/aws-sdk-go-v2/service/sesv2 v1.61.0 h1:d5valptgkxExUHAnyFp4iswYAoTqDD5g32tmTwj18j8=
-github.com/aws/aws-sdk-go-v2/service/sesv2 v1.61.0/go.mod h1:l5cTwZSX9kzxDHz9IpgZC0XIJ/cc43JL6hZzCd0iTwI=
+github.com/aws/aws-sdk-go-v2/service/sesv2 v1.61.1 h1:hwZmof1yhUHQkNDx8RrhX0CMNMFP6HNYCIMgc+R5O3I=
+github.com/aws/aws-sdk-go-v2/service/sesv2 v1.61.1/go.mod h1:5NtZCuE27gANW013bfdrXxD58KB4fr7Lgxub8TS4c6I=
 github.com/aws/aws-sdk-go-v2/service/sfn v1.41.0 h1:DjtJU3mUbj3Q6ggWmiCZuBfOf1k89O55knWuLABRUYs=
 github.com/aws/aws-sdk-go-v2/service/sfn v1.41.0/go.mod h1:4FYhQ/fQeVDlW53MUOevhxGhJ9RYOYV8HSwyVmFCer0=
 github.com/aws/aws-sdk-go-v2/service/shield v1.34.23 h1:J/F0GdRt3gHtS7U5IGq37+dBQR3OCXzDFgAkCRJw//k=

--- a/go.sum
+++ b/go.sum
@@ -149,8 +149,8 @@ github.com/aws/aws-sdk-go-v2/service/codeconnections v1.11.1 h1:IkztdxEx9jg3mtcn
 github.com/aws/aws-sdk-go-v2/service/codeconnections v1.11.1/go.mod h1:4Txe845x0NmXze3vzvVAw9Iy/Cb4dyVnxvk+qTceMJI=
 github.com/aws/aws-sdk-go-v2/service/codedeploy v1.35.16 h1:SWw60uVRCfmuw11uZVKz8gXaNSONa4KcgtK7jUy8yXY=
 github.com/aws/aws-sdk-go-v2/service/codedeploy v1.35.16/go.mod h1:BQ4gZJB6Cu71Aft0Dp5nal9mwlLGJIrYy3X36Zu1giY=
-github.com/aws/aws-sdk-go-v2/service/codeguruprofiler v1.30.0 h1:h9gG2F8LkS6IICbMUKVNquYeNYKTzNOZBkLx6NSlFN8=
-github.com/aws/aws-sdk-go-v2/service/codeguruprofiler v1.30.0/go.mod h1:fheDmr63trGw/27X+o9ZpPBN4GCOBCghaZBLoCO0NIo=
+github.com/aws/aws-sdk-go-v2/service/codeguruprofiler v1.30.1 h1:zoQt0M9PoeUxEDSVgN//BuRoRKh/9UFjgC5Atg1wrZ0=
+github.com/aws/aws-sdk-go-v2/service/codeguruprofiler v1.30.1/go.mod h1:UpiP4zJee3P/NTiH6mUFBuaEJpGZS39OjEZ1nYBE/sE=
 github.com/aws/aws-sdk-go-v2/service/codegurureviewer v1.34.22 h1:3SujyqCjZ0WFkwhReUv6bWvVzoqQeS//pQT7ByeqXiE=
 github.com/aws/aws-sdk-go-v2/service/codegurureviewer v1.34.22/go.mod h1:Wt9LWJboCaH1z4Jq6TJr/DahjcenYatyFDdGXCQ++ro=
 github.com/aws/aws-sdk-go-v2/service/codepipeline v1.46.23 h1:T1CJQxFSFH/74qHb6h02V7oJBCcNlWoBZj+ZM1C/+0I=

--- a/go.sum
+++ b/go.sum
@@ -433,8 +433,8 @@ github.com/aws/aws-sdk-go-v2/service/qldb v1.32.2 h1:tSctQisNHgXnDmyoOdLXkSQmHYo
 github.com/aws/aws-sdk-go-v2/service/qldb v1.32.2/go.mod h1:m6bmXbLs5XiGnTLcgKn9eNk5+GCO5e/wHQsIuN7d1Tw=
 github.com/aws/aws-sdk-go-v2/service/quicksight v1.111.1 h1:/HUZnYW1sHZBAtdTGwuWtVnNjRCixSrvQGxpHHlRrhw=
 github.com/aws/aws-sdk-go-v2/service/quicksight v1.111.1/go.mod h1:pEHxeKThX/zJkHjgLu0WvrODRLYMws3C/K+7pQLkQfo=
-github.com/aws/aws-sdk-go-v2/service/ram v1.36.5 h1:/fBlF6QctcMLhErPd/TzSV41wihdQKVhbrC2zxFtOn4=
-github.com/aws/aws-sdk-go-v2/service/ram v1.36.5/go.mod h1:YRX/UBxAWvjuN/UKBcIgaVcV4L343rUxOifybaw0eFM=
+github.com/aws/aws-sdk-go-v2/service/ram v1.36.6 h1:JTIlCNJMmjA1Z2JqVEEBeGQhVNkUwrkkJTkkVYY2vFQ=
+github.com/aws/aws-sdk-go-v2/service/ram v1.36.6/go.mod h1:mIXcD41n1f5BvqKUWB4GX99CfQgiW6Z07LfNPr6UKvQ=
 github.com/aws/aws-sdk-go-v2/service/rbin v1.28.0 h1:Mg/mflO6s0/a2zgtuqR2KGatzJyE+kSwURNfrzCfEBQ=
 github.com/aws/aws-sdk-go-v2/service/rbin v1.28.0/go.mod h1:KFURpoF+P8TBsEUL1nQcOVBhLk02WPccK5a0MulJ5AA=
 github.com/aws/aws-sdk-go-v2/service/rds v1.118.2 h1:pkEeQneYFpTAnGhyqSbyp/DlCPPJTGt0GkWahlLYzMA=

--- a/go.sum
+++ b/go.sum
@@ -467,8 +467,8 @@ github.com/aws/aws-sdk-go-v2/service/route53profiles v1.9.26 h1:pOuwLgdmVItzpEeB
 github.com/aws/aws-sdk-go-v2/service/route53profiles v1.9.26/go.mod h1:8i70SZ5M4kJPd7ny98C+Grl48iD3wdj2oE0Y8YO2yIo=
 github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.33.0 h1:PN25XBeAbUCrM6pfmUwNamch/CG1+jJAmVA+x6PJuTE=
 github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.33.0/go.mod h1:B2YQF5Mu9cs5J5TTYvSMcdATZLaOkoYVZ8lc3sfDsIU=
-github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.26.23 h1:l3nd7TS+byZcGFC7bPhcsoeLhgq2SQLitCUAIwSS7BA=
-github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.26.23/go.mod h1:f5QgeBGg2Esj0mWwdUDxQAsN00GJnfIKqQeS9oaBO6M=
+github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.26.24 h1:Fz0FkqtkuAaY9y1t3BkJiLkFQ18rIZp/aezHn7SCf8U=
+github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.26.24/go.mod h1:MPhW9xnKREEBarsR9trTTga2QPWIpNVh0DdSYqIXRxM=
 github.com/aws/aws-sdk-go-v2/service/route53resolver v1.44.0 h1:9VLmITeTm+jTiL48ZSll0A4KW3AD/IcRENQG2s3jxMc=
 github.com/aws/aws-sdk-go-v2/service/route53resolver v1.44.0/go.mod h1:OAvZZokn38D2+MY88EllrzDyl6MyEHTRAx0u5WvqBAI=
 github.com/aws/aws-sdk-go-v2/service/rum v1.30.12 h1:WO4GCFUbqUPMZ7ICqGtqqT60aVIosYeVKl3cdeiil/s=

--- a/go.sum
+++ b/go.sum
@@ -445,8 +445,8 @@ github.com/aws/aws-sdk-go-v2/service/redshift v1.62.9 h1:YHFGMgQa2zDRUTzvD8GtrOJ
 github.com/aws/aws-sdk-go-v2/service/redshift v1.62.9/go.mod h1://ALEpBVXJfV8saFPor8HMJ74xERWhrOYaPd+pNWUdk=
 github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.40.0 h1:jbRyKYbNrEnRd+nphrUIH345qpOGDqOfxjNpz3oZEJk=
 github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.40.0/go.mod h1:WPZLtD9otyFLcz+ZxS3QUuCd67f+7kAJaPjJ31ahO3M=
-github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.35.0 h1:4bhy+oTqgUdtw8IvWcc1pPL4DCH5ZT4rkV9a1eggQGY=
-github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.35.0/go.mod h1:24tWvrWAt7wxYpXYPSmDyfyRWKGdz2glsgnLV9MSRq4=
+github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.35.1 h1:q4W7YdDkLlrIjhk9zKEuGSIinADL6G/qZMNQBD6LNcg=
+github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.35.1/go.mod h1:qmN3dNnbhFHpwkQbpqbjjDH4co6/ETmKavalziNWLLs=
 github.com/aws/aws-sdk-go-v2/service/rekognition v1.51.24 h1:TjTpw5c4Z5DFHRHMZqL+rR/Jk9zlsGW4/gQxCqgWiHY=
 github.com/aws/aws-sdk-go-v2/service/rekognition v1.51.24/go.mod h1:1j7mu8NwhHLrAB43agCDAv4BsncoE0Ld+JWpDgUKH6w=
 github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.36.0 h1:1Nsy4eFGYxZqGfDA6+X23ngP1QiXmqjititE5quiVX0=

--- a/go.sum
+++ b/go.sum
@@ -157,8 +157,8 @@ github.com/aws/aws-sdk-go-v2/service/codepipeline v1.46.24 h1:DZR12e2R+OdulGzxcG
 github.com/aws/aws-sdk-go-v2/service/codepipeline v1.46.24/go.mod h1:K4x180hh43u6yepGq4lMqpU/KVtN9TwM8Rlfqo1XiWQ=
 github.com/aws/aws-sdk-go-v2/service/codestarconnections v1.36.0 h1:/dOf5ugZheZRQpKVetyzEbjmfiEexAADSrSf/RgiSx8=
 github.com/aws/aws-sdk-go-v2/service/codestarconnections v1.36.0/go.mod h1:IuvHlOzVFdseyeqMUZ5GSXg33+H8YdZjJI0wJ1McDyg=
-github.com/aws/aws-sdk-go-v2/service/codestarnotifications v1.32.0 h1:ZhPhn5tFRF/7XeoH24D/JGsXHuOPRjp9Ri5+BNkB7GQ=
-github.com/aws/aws-sdk-go-v2/service/codestarnotifications v1.32.0/go.mod h1:e/u0po2zsCdMWrenoCgTJ1vyctChUnm8m+zNN3WeBk8=
+github.com/aws/aws-sdk-go-v2/service/codestarnotifications v1.32.1 h1:MkB0/DJ8XCCQR5PZvUiWt5HgOa+75Q4K+QxOT6UnHko=
+github.com/aws/aws-sdk-go-v2/service/codestarnotifications v1.32.1/go.mod h1:def5w+aEKHpEosI+xJ9FGKJElmu/RRL2xjd+adgaZCg=
 github.com/aws/aws-sdk-go-v2/service/cognitoidentity v1.33.24 h1:DLQWli3xz20zXXwMahVJ7xVgAZTmYLfMx7bB2Blwx18=
 github.com/aws/aws-sdk-go-v2/service/cognitoidentity v1.33.24/go.mod h1:D9DtGGYo4Fp2t1UwtaoTKuemugfwy5VG5aQLCqan5yk=
 github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.60.2 h1:pZxE29WAHgnk0jGj1P4UOOJnNPHXfltkfnK4F1Tg8jU=

--- a/go.sum
+++ b/go.sum
@@ -575,8 +575,8 @@ github.com/aws/aws-sdk-go-v2/service/wafv2 v1.71.6 h1:SKPs3pBnHGs4hAKW1I3CoH8Gff
 github.com/aws/aws-sdk-go-v2/service/wafv2 v1.71.6/go.mod h1:L30J3rRiVI9inT2rOU6xD5ysqmbwwmj+ng1rReS0Xt0=
 github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.40.1 h1:1P2yEK/4l3aMcpfnwHGVYs5BlbsF9LtnYWaypkdgxLg=
 github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.40.1/go.mod h1:qlP/IKEhKywBy4iHYWPgGnhVZ43ns08vpl3GpPC+D2Y=
-github.com/aws/aws-sdk-go-v2/service/workmail v1.37.0 h1:JLmbQeUOmgc1k14QJyxO+goWW0fePbGaT/g0haIiSNk=
-github.com/aws/aws-sdk-go-v2/service/workmail v1.37.0/go.mod h1:1dIDHNIcmjGLavibuIO54qfx1GreVSr0msbVVvtxAoA=
+github.com/aws/aws-sdk-go-v2/service/workmail v1.37.1 h1:kkW+177cM7iuWX5VYUR4BOyPre4K/fGNLR/WEhYy7ag=
+github.com/aws/aws-sdk-go-v2/service/workmail v1.37.1/go.mod h1:UcDqAbgkZdXt7qiHgrC5qSUIGPaV35b0L2/2Nt/EcY0=
 github.com/aws/aws-sdk-go-v2/service/workspaces v1.68.1 h1:Jf5Hb+1UABUn01BGk6vwPFtnyX51wgvqo97bNogM1kI=
 github.com/aws/aws-sdk-go-v2/service/workspaces v1.68.1/go.mod h1:SXw3pS4ayjTIy1oEauZCWMXOUQG/ukxFH23G0kxjRbA=
 github.com/aws/aws-sdk-go-v2/service/workspacesweb v1.39.0 h1:oieTfrV3d0D/00Q7T8zc7vxnnz89M6Ux02Ocaw2qu50=

--- a/go.sum
+++ b/go.sum
@@ -435,8 +435,8 @@ github.com/aws/aws-sdk-go-v2/service/quicksight v1.111.1 h1:/HUZnYW1sHZBAtdTGwuW
 github.com/aws/aws-sdk-go-v2/service/quicksight v1.111.1/go.mod h1:pEHxeKThX/zJkHjgLu0WvrODRLYMws3C/K+7pQLkQfo=
 github.com/aws/aws-sdk-go-v2/service/ram v1.36.6 h1:JTIlCNJMmjA1Z2JqVEEBeGQhVNkUwrkkJTkkVYY2vFQ=
 github.com/aws/aws-sdk-go-v2/service/ram v1.36.6/go.mod h1:mIXcD41n1f5BvqKUWB4GX99CfQgiW6Z07LfNPr6UKvQ=
-github.com/aws/aws-sdk-go-v2/service/rbin v1.28.0 h1:Mg/mflO6s0/a2zgtuqR2KGatzJyE+kSwURNfrzCfEBQ=
-github.com/aws/aws-sdk-go-v2/service/rbin v1.28.0/go.mod h1:KFURpoF+P8TBsEUL1nQcOVBhLk02WPccK5a0MulJ5AA=
+github.com/aws/aws-sdk-go-v2/service/rbin v1.28.1 h1:vrR/SGBj/uCiJVUHPIxcqK+wt4ZeN20ZFznY3LNsSEk=
+github.com/aws/aws-sdk-go-v2/service/rbin v1.28.1/go.mod h1:OET1iQb9KlgKiRcT4rqsG5EbcGIAZu6+sptNIOO7mUg=
 github.com/aws/aws-sdk-go-v2/service/rds v1.118.2 h1:pkEeQneYFpTAnGhyqSbyp/DlCPPJTGt0GkWahlLYzMA=
 github.com/aws/aws-sdk-go-v2/service/rds v1.118.2/go.mod h1:7gS+cGrKF0mH253QHFlStmx79ws+DlNk+04ZRfmw3U0=
 github.com/aws/aws-sdk-go-v2/service/rdsdata v1.32.23 h1:CrpsWnO5yFYIBEqqOO70hbwJWHtipXd8bWHpfPxz0sk=

--- a/go.sum
+++ b/go.sum
@@ -287,8 +287,8 @@ github.com/aws/aws-sdk-go-v2/service/healthlake v1.37.1 h1:40UHAoml+Isk+Tp2+kaoK
 github.com/aws/aws-sdk-go-v2/service/healthlake v1.37.1/go.mod h1:q3E7DgMX7FNV9Q1Fqv/E6aLa7fcDqOK50zVinEKeRyU=
 github.com/aws/aws-sdk-go-v2/service/iam v1.53.11 h1:xt4JHLHBQonQXApaYfS0FvdIeALRuaN/aUWxM+4RNSo=
 github.com/aws/aws-sdk-go-v2/service/iam v1.53.11/go.mod h1:VkuYu8oSpQAx+hKNFvJqqei6/PACzkpqVdM6ylo0scg=
-github.com/aws/aws-sdk-go-v2/service/identitystore v1.37.0 h1:iVXnOYef3NmG72qZt525K8H2gdYJ03MTw/QaeTiKl0E=
-github.com/aws/aws-sdk-go-v2/service/identitystore v1.37.0/go.mod h1:9xdQ3N06kOdsL2JVtw8HhtpFA+bnTCoKhfBY4oKi8kM=
+github.com/aws/aws-sdk-go-v2/service/identitystore v1.37.1 h1:hNsPPU6m/Hi0p2QXm42tqPQugl3lALolEZ9DLgx/p0s=
+github.com/aws/aws-sdk-go-v2/service/identitystore v1.37.1/go.mod h1:STQWDynKsiZADmYxFBQ+hUx9VBMxGu5ZhdN6PPIrBXU=
 github.com/aws/aws-sdk-go-v2/service/imagebuilder v1.54.0 h1:MlFy3L3RStulK0LNyq9LzrRf45nsCYsIK6fw3M4St8s=
 github.com/aws/aws-sdk-go-v2/service/imagebuilder v1.54.0/go.mod h1:qaCPaUpUwFeeqaeG4x0eNKkPt5fINOh4YEoSLLcxdjc=
 github.com/aws/aws-sdk-go-v2/service/inspector v1.30.22 h1:phWl4pu6OSvB8xRF14eTKWrvk7hQspQqz1YqyV++fmA=

--- a/go.sum
+++ b/go.sum
@@ -107,8 +107,8 @@ github.com/aws/aws-sdk-go-v2/service/billing v1.11.1 h1:20TUeXiZAAngesBpuyvxz+d0
 github.com/aws/aws-sdk-go-v2/service/billing v1.11.1/go.mod h1:R2U4hP2CSLK5UseLbHUFKFNFF4U/7HMfcrJ3zyxV4I0=
 github.com/aws/aws-sdk-go-v2/service/budgets v1.43.8 h1:R4H5x5/neeXximWnr2RyM4BYLl47reWVMxbGW0qQSmA=
 github.com/aws/aws-sdk-go-v2/service/budgets v1.43.8/go.mod h1:WrxNwTTCRAEHvIU8Y5/EUpfcrHy7nlm8+DN9edSeqI4=
-github.com/aws/aws-sdk-go-v2/service/chatbot v1.14.23 h1:eVFe0spV/qN307E9M7EWomXBx20d6iSCRU9uhZnbbEM=
-github.com/aws/aws-sdk-go-v2/service/chatbot v1.14.23/go.mod h1:gDe8Q0Jr8+z3yoGmU38eVPCWGA3iBR9hJF8osx2Th5A=
+github.com/aws/aws-sdk-go-v2/service/chatbot v1.15.0 h1:e3QPlLAzchSC98C/Fk89qi9TBirQohTII7WWjvfOX4M=
+github.com/aws/aws-sdk-go-v2/service/chatbot v1.15.0/go.mod h1:2+T3ZzaxQ6rV/CImS72BNVHIyazppxtblF1xJTXjgIg=
 github.com/aws/aws-sdk-go-v2/service/chime v1.41.14 h1:1dS2RRGAELUPmXaNFZYgkxnOmYbMj5Uu4JETv8OwgxA=
 github.com/aws/aws-sdk-go-v2/service/chime v1.41.14/go.mod h1:QY1xYS2flCUbVr0o+AVrlEagk4KyLux3VyDeiem8eZU=
 github.com/aws/aws-sdk-go-v2/service/chimesdkmediapipelines v1.27.0 h1:slEpXPwuTojX3xQ3Xv0Haxa6ykicD9bVdhQ/j4DLkMg=

--- a/go.sum
+++ b/go.sum
@@ -205,8 +205,8 @@ github.com/aws/aws-sdk-go-v2/service/devopsagent v1.5.1 h1:c6K2TLSv75lt2R3+jKyDR
 github.com/aws/aws-sdk-go-v2/service/devopsagent v1.5.1/go.mod h1:geVmKDQ6LzByWVYJYlwKg249rG1mWlZ8gmKlPARovWk=
 github.com/aws/aws-sdk-go-v2/service/devopsguru v1.41.1 h1:qwR2AmbqAwfSx2x76tVK8mEggiGy8fUTd/+aVUWC+OI=
 github.com/aws/aws-sdk-go-v2/service/devopsguru v1.41.1/go.mod h1:BpdOA90ZcqzAMXfUlxUd1dMn8fdiaeEZIcLarZ+flu8=
-github.com/aws/aws-sdk-go-v2/service/directconnect v1.38.17 h1:fkeDjhbAy9ddanOVlxP2vnY2dbTxA8HL+DdV9HezVSs=
-github.com/aws/aws-sdk-go-v2/service/directconnect v1.38.17/go.mod h1:kzj2OFWYl3uGXBkincAArVPtSG8QwXJRfCL8+Ztsw9o=
+github.com/aws/aws-sdk-go-v2/service/directconnect v1.38.18 h1:aaZ+da2nGV0D4iSHdb36I7gqY354gfKXh/RItrHfLOE=
+github.com/aws/aws-sdk-go-v2/service/directconnect v1.38.18/go.mod h1:7+LEXCl28CUDCuRgcmXUCL2G335G1zmXjOnmkQDKH2Q=
 github.com/aws/aws-sdk-go-v2/service/directoryservice v1.38.18 h1:jj7CHRntkLMhurirvfbf1jUhQznjn28U2cTVzXhsFlc=
 github.com/aws/aws-sdk-go-v2/service/directoryservice v1.38.18/go.mod h1:7CWZoIlHKM1nPFm2nqSeoYJIjY+oyBnkQLrLiEIkctY=
 github.com/aws/aws-sdk-go-v2/service/dlm v1.37.0 h1:VtpZW9fiSg/nTc0g63un8Udl53RM1LNbkbc7vWQ7fwk=

--- a/go.sum
+++ b/go.sum
@@ -369,8 +369,8 @@ github.com/aws/aws-sdk-go-v2/service/mediastore v1.29.24 h1:m2irBJGMbk8sMSwzib4p
 github.com/aws/aws-sdk-go-v2/service/mediastore v1.29.24/go.mod h1:LYq03oKrNcnkcLLtcg0EXBUWZ5JXx1a+f3eZiwh77DQ=
 github.com/aws/aws-sdk-go-v2/service/memorydb v1.34.1 h1:RhXEEuM4OcMbRSMIqxNjFYwys+T3QYRf0PqzplaqtfY=
 github.com/aws/aws-sdk-go-v2/service/memorydb v1.34.1/go.mod h1:p2VcxOL4NmPRJW3Nl20lghEqJFVhWjZpT5uP46mhM44=
-github.com/aws/aws-sdk-go-v2/service/mgn v1.43.0 h1:/kOYSCEHwgu4rk9mvd/7Dc2G0jfv3sHMcFkOLHphOjs=
-github.com/aws/aws-sdk-go-v2/service/mgn v1.43.0/go.mod h1:fv/GNkmJYpQaKqCiuOcekqutnbRkr5LIPpp5U3u3veQ=
+github.com/aws/aws-sdk-go-v2/service/mgn v1.44.1 h1:5Etw8C5flLuINUJNlE9HanIDd6Z6+3FCAEO1Z827dOI=
+github.com/aws/aws-sdk-go-v2/service/mgn v1.44.1/go.mod h1:KR2PuoyY3PpsnMaQ7F+6EnvsUUSVbSwNwrQxBjUy7eU=
 github.com/aws/aws-sdk-go-v2/service/mpa v1.7.4 h1:ZaNccmns5TnxUasTmyma6Z8nwy70A54OyNwxvFXFLhI=
 github.com/aws/aws-sdk-go-v2/service/mpa v1.7.4/go.mod h1:Ap++P+Jq969tV8X0Vf9jkLuCZ3ssdLBHovSsmL0+CHU=
 github.com/aws/aws-sdk-go-v2/service/mq v1.34.22 h1:l7nzDTuFH15cvRIFo5cFokN5g+9sA/ZYUsiffFBTObk=

--- a/go.sum
+++ b/go.sum
@@ -207,8 +207,8 @@ github.com/aws/aws-sdk-go-v2/service/devopsguru v1.41.1 h1:qwR2AmbqAwfSx2x76tVK8
 github.com/aws/aws-sdk-go-v2/service/devopsguru v1.41.1/go.mod h1:BpdOA90ZcqzAMXfUlxUd1dMn8fdiaeEZIcLarZ+flu8=
 github.com/aws/aws-sdk-go-v2/service/directconnect v1.38.18 h1:aaZ+da2nGV0D4iSHdb36I7gqY354gfKXh/RItrHfLOE=
 github.com/aws/aws-sdk-go-v2/service/directconnect v1.38.18/go.mod h1:7+LEXCl28CUDCuRgcmXUCL2G335G1zmXjOnmkQDKH2Q=
-github.com/aws/aws-sdk-go-v2/service/directoryservice v1.38.18 h1:jj7CHRntkLMhurirvfbf1jUhQznjn28U2cTVzXhsFlc=
-github.com/aws/aws-sdk-go-v2/service/directoryservice v1.38.18/go.mod h1:7CWZoIlHKM1nPFm2nqSeoYJIjY+oyBnkQLrLiEIkctY=
+github.com/aws/aws-sdk-go-v2/service/directoryservice v1.38.19 h1:7uzyDjdMN99ALP0QI/ZaDQ+1kwF6skNZU8AqUMZf4uo=
+github.com/aws/aws-sdk-go-v2/service/directoryservice v1.38.19/go.mod h1:QmDYiedOfdgvQk6gtAHwa8yAgYSZXqiB6dHUxJ1CVBM=
 github.com/aws/aws-sdk-go-v2/service/dlm v1.37.0 h1:VtpZW9fiSg/nTc0g63un8Udl53RM1LNbkbc7vWQ7fwk=
 github.com/aws/aws-sdk-go-v2/service/dlm v1.37.0/go.mod h1:lZvlQUrRwgTdL3Bh/iyLf/z7XdBBowEAvbZXzgPg4/s=
 github.com/aws/aws-sdk-go-v2/service/docdb v1.48.15 h1:jvP746CYJno9fSBqvPMShLPVu+P9wetNsSb+xYk52ag=

--- a/go.sum
+++ b/go.sum
@@ -365,8 +365,8 @@ github.com/aws/aws-sdk-go-v2/service/mediapackagev2 v1.39.1 h1:2vjqeQHRqh/ILzIff
 github.com/aws/aws-sdk-go-v2/service/mediapackagev2 v1.39.1/go.mod h1:uzIN1W4NqMdy0yFFyRBihyGYAGzvtyPzrEfodrDqCLs=
 github.com/aws/aws-sdk-go-v2/service/mediapackagevod v1.39.24 h1:frq+4ymwr6AvyAvm3FXH0hxg9Oj7o+ISkqX+/ZRiO4k=
 github.com/aws/aws-sdk-go-v2/service/mediapackagevod v1.39.24/go.mod h1:8onlaKcsWCncSk0syNzxl2FWeurmeqDOciE387GEjQw=
-github.com/aws/aws-sdk-go-v2/service/mediastore v1.29.23 h1:yxt0mlXvIz6tBqE6tE+8nT4HInWgEjzwnHDI6TxKm7E=
-github.com/aws/aws-sdk-go-v2/service/mediastore v1.29.23/go.mod h1:8nxl+cuTs2USuUurU51GknJf37qAFtSRsrpSomYqqsA=
+github.com/aws/aws-sdk-go-v2/service/mediastore v1.29.24 h1:m2irBJGMbk8sMSwzib4pAFNrNqlTtVLgKZIVVQt3lRk=
+github.com/aws/aws-sdk-go-v2/service/mediastore v1.29.24/go.mod h1:LYq03oKrNcnkcLLtcg0EXBUWZ5JXx1a+f3eZiwh77DQ=
 github.com/aws/aws-sdk-go-v2/service/memorydb v1.33.16 h1:sFFA8VBMMksHbFaV689agmYNnKeP162vtYg+4U/Orks=
 github.com/aws/aws-sdk-go-v2/service/memorydb v1.33.16/go.mod h1:Iv+M4ZOQuUzzM7MeyFi/qBZRejA9vi689eZ//Zdxbac=
 github.com/aws/aws-sdk-go-v2/service/mgn v1.43.0 h1:/kOYSCEHwgu4rk9mvd/7Dc2G0jfv3sHMcFkOLHphOjs=

--- a/go.sum
+++ b/go.sum
@@ -119,8 +119,8 @@ github.com/aws/aws-sdk-go-v2/service/cleanrooms v1.45.1 h1:NJCoe6Vj3l8MqvWDcgJr8
 github.com/aws/aws-sdk-go-v2/service/cleanrooms v1.45.1/go.mod h1:2d8vMUOBBXQ7b5iUZKMAduQZOgDYp75ICcXRXm/NnKc=
 github.com/aws/aws-sdk-go-v2/service/cloud9 v1.34.1 h1:Ggr0UznpMf8Bs5VP6k7CqxohKYIcHkXwAbq428cJ79A=
 github.com/aws/aws-sdk-go-v2/service/cloud9 v1.34.1/go.mod h1:GVumurfBCSPfjp0Nq5zyQsFkwxm0u5JpG/1ltIeGyEI=
-github.com/aws/aws-sdk-go-v2/service/cloudcontrol v1.30.0 h1:2Ov1YcFJZktFa5ah08gyktZjEjkbLA0g0sbG6ZxV/G4=
-github.com/aws/aws-sdk-go-v2/service/cloudcontrol v1.30.0/go.mod h1:qdsQO5+urrlkcsolFWgiNQ0lpFB0UCQbTKK9j79b1Wg=
+github.com/aws/aws-sdk-go-v2/service/cloudcontrol v1.30.1 h1:AGb453LNQkxO5AJaQhIu7xRHTJjYI9xwi2LSdcTtBn8=
+github.com/aws/aws-sdk-go-v2/service/cloudcontrol v1.30.1/go.mod h1:0yYjIDvv3b9RHChdAEotH9RQNjQAJxyvFRpvTZMJJ0M=
 github.com/aws/aws-sdk-go-v2/service/cloudformation v1.71.11 h1:gIRdzLv98ugE0nvMkub5yp4uziPFHF66ERrQ9JN+D54=
 github.com/aws/aws-sdk-go-v2/service/cloudformation v1.71.11/go.mod h1:BMpnKVWK+343lUuI2ZM5bm282z+p61ZK9kwRg6/wBm4=
 github.com/aws/aws-sdk-go-v2/service/cloudfront v1.64.0 h1:a6XmNe8cAvfrXVKwjXzWl9HHtuyE/n4kBroNm2mSOyo=

--- a/go.sum
+++ b/go.sum
@@ -67,8 +67,8 @@ github.com/aws/aws-sdk-go-v2/service/appintegrations v1.37.10 h1:1KCD21KPp0HrEKX
 github.com/aws/aws-sdk-go-v2/service/appintegrations v1.37.10/go.mod h1:aRi8xw3Xl/McDp/yDbgzZsr10xVgG/iYYOath9LvooQ=
 github.com/aws/aws-sdk-go-v2/service/applicationautoscaling v1.41.17 h1:W47YuCgU/hJJIr3q32qDmFfPgzRFAqa4rRMZzBI9o/4=
 github.com/aws/aws-sdk-go-v2/service/applicationautoscaling v1.41.17/go.mod h1:76qbqOwmn5GX0Oo/7Qz/RyZX+vMwkQqpW46d+MGpwHY=
-github.com/aws/aws-sdk-go-v2/service/applicationinsights v1.34.22 h1:Efp05vChZXL5og/ix/bjwIB8Yea0Kge//pGnbQk22Mc=
-github.com/aws/aws-sdk-go-v2/service/applicationinsights v1.34.22/go.mod h1:pm+LG2M+wklS+qMReaKBWmEwR8vkUwWbUIVEjIkZnuw=
+github.com/aws/aws-sdk-go-v2/service/applicationinsights v1.34.23 h1:s/zG75mlE08UEIDv85gH8gOKQXwNENLgOhLmwxEYEOA=
+github.com/aws/aws-sdk-go-v2/service/applicationinsights v1.34.23/go.mod h1:ioZ050CgtUShNUI4TQ5bnYMCBhS8k/nDZn9+Hj6aF3I=
 github.com/aws/aws-sdk-go-v2/service/applicationsignals v1.22.0 h1:o9KsVNy6vQcytangT1DMYgz2AXJ/NRGB+TswhVJc3yw=
 github.com/aws/aws-sdk-go-v2/service/applicationsignals v1.22.0/go.mod h1:pK5zExLS4u5kh2swzrGKTQHbexXeIzKW/Cz2hjgl9q4=
 github.com/aws/aws-sdk-go-v2/service/appmesh v1.35.14 h1:31mnzduRd3FyuGCwgdMfPAu6MG1XnQf4zJrPjpZvnbM=

--- a/go.sum
+++ b/go.sum
@@ -163,8 +163,8 @@ github.com/aws/aws-sdk-go-v2/service/cognitoidentity v1.33.25 h1:XXa5oulvKVj4jTL
 github.com/aws/aws-sdk-go-v2/service/cognitoidentity v1.33.25/go.mod h1:jgO0hOeOmaYby7RvK4EXrSAwchb4KgSiM/+V5WchNgE=
 github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.60.3 h1:X3qB+VaAA66Na9aieVR3ziXJ83tVcLiHdEq3FldjmT4=
 github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.60.3/go.mod h1:8IfDUcBSJboFS3Az4MX8Oh1ik/P/X7jyFf5Q2UZLtrk=
-github.com/aws/aws-sdk-go-v2/service/comprehend v1.41.0 h1:eAzz571JckxP387G0vRwoDS4xARluclKYt5pGUaR6+I=
-github.com/aws/aws-sdk-go-v2/service/comprehend v1.41.0/go.mod h1:XdcHFOF8Kvzv6Ng37wgQgw59AMMxLT/sHrdZc2lLEK0=
+github.com/aws/aws-sdk-go-v2/service/comprehend v1.41.1 h1:qh4h+vi4SQ1EoFYQ1M+hBUMxMdbPw2bibMOIbd3yCwA=
+github.com/aws/aws-sdk-go-v2/service/comprehend v1.41.1/go.mod h1:ZGajmgEyhNgAzoGgVuBUn4CRkCZ+bi4tACWf8HHmgLo=
 github.com/aws/aws-sdk-go-v2/service/computeoptimizer v1.50.1 h1:FyZGfF3X2uzNSZjIxXgiW/5va1HcJKueMIXEbEhVa78=
 github.com/aws/aws-sdk-go-v2/service/computeoptimizer v1.50.1/go.mod h1:ypZFNO3viD/a8tii9vlzKCOPxRuDMidRNIadJf7eJ1Y=
 github.com/aws/aws-sdk-go-v2/service/configservice v1.62.3 h1:8rcAUMhCUuQe7kVBTBLPqMsJWFSVDPSFdpFexVQEEdU=

--- a/go.sum
+++ b/go.sum
@@ -527,8 +527,8 @@ github.com/aws/aws-sdk-go-v2/service/sqs v1.42.28 h1:CsLiNChqRvXWtIjyjUaqg9vq+0m
 github.com/aws/aws-sdk-go-v2/service/sqs v1.42.28/go.mod h1:ZhBg8NNBEs+UuIILtpcUaX8iV4yU/sF7vBiS+U9P83A=
 github.com/aws/aws-sdk-go-v2/service/ssm v1.68.7 h1:mKVjTrV40syRvcLfenT75nY8MTr6Nz3UyXSNxUaANRA=
 github.com/aws/aws-sdk-go-v2/service/ssm v1.68.7/go.mod h1:67nfKysKquQ5VKZOPfxI8+0FCa18Vj8Ojy2nKjPHkR4=
-github.com/aws/aws-sdk-go-v2/service/ssmcontacts v1.31.16 h1:8cOU6CwAoKHYdcKNvkQklc+QAFAMCOdKItfLkvKmmNc=
-github.com/aws/aws-sdk-go-v2/service/ssmcontacts v1.31.16/go.mod h1:F2vkPqylPCcAAM3xi+OClxWIHeOPPdnzfb60WVHFq8A=
+github.com/aws/aws-sdk-go-v2/service/ssmcontacts v1.32.1 h1:9+NviqMk6eedRqjIunBE7qBMHRc4y93vSqUIv3Lscc8=
+github.com/aws/aws-sdk-go-v2/service/ssmcontacts v1.32.1/go.mod h1:WEp0tvxt+uqTOpSjr1rfUUYGlVOCCA76QDfeIVqDF3A=
 github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.39.22 h1:xAMqo7ys/lr5jCxK922v755qklNno+aZHFxOXkYCcU8=
 github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.39.22/go.mod h1:0stvZYPGvcszNKhhvEeSjOEYhJSI+Z938KUDmiu+Ngs=
 github.com/aws/aws-sdk-go-v2/service/ssmquicksetup v1.9.0 h1:A63P9VmIvEwpkJ2t9kQwij/bY4NC6i09S+wVl8HU5RM=

--- a/go.sum
+++ b/go.sum
@@ -461,8 +461,8 @@ github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.23.1 h1:Qrebotu1g1iw4P+huw
 github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.23.1/go.mod h1:BNimlkjkBkiYd1OzVjX74gX5rt/H3kBfElrth3FpE4o=
 github.com/aws/aws-sdk-go-v2/service/route53 v1.62.8 h1:1QC1xoZg5XSes1CXQ20Y0qTaaeDj12e7bB0/Yw9sQwI=
 github.com/aws/aws-sdk-go-v2/service/route53 v1.62.8/go.mod h1:+GpgmfX7rnzQ8WMbMCMnI+VOjPZCf9yaUlBmRTvQgFE=
-github.com/aws/aws-sdk-go-v2/service/route53domains v1.35.0 h1:9WcucZLCnH5OLj6PO+smG3ityqw7OrHa/SkCUmnk7Kw=
-github.com/aws/aws-sdk-go-v2/service/route53domains v1.35.0/go.mod h1:oitnZaE7dxuIbSC08U6C7PgSSXjvs1LF4D0oMFFJiIU=
+github.com/aws/aws-sdk-go-v2/service/route53domains v1.35.1 h1:QGVZNUY+DruxL+81m7FNtAnvb6iib0GC/ltGUhNVE7w=
+github.com/aws/aws-sdk-go-v2/service/route53domains v1.35.1/go.mod h1:lMw0EGa0akP4Fx/x4sfjkj1lQ43imlfy68NuTA21Chg=
 github.com/aws/aws-sdk-go-v2/service/route53profiles v1.9.25 h1:YJM60kSq17CZWAni+v2LSOI++oO+UfjL8ShOZvCHwck=
 github.com/aws/aws-sdk-go-v2/service/route53profiles v1.9.25/go.mod h1:STkjS3eZb74bddkstwMTNn0qDubyajJcmrUEVL6OpvQ=
 github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.32.16 h1:SAgKT1K00J9Dr1w7rMzsX31mNG1yrlo/tV9VDH/DirA=

--- a/go.sum
+++ b/go.sum
@@ -463,8 +463,8 @@ github.com/aws/aws-sdk-go-v2/service/route53 v1.62.8 h1:1QC1xoZg5XSes1CXQ20Y0qTa
 github.com/aws/aws-sdk-go-v2/service/route53 v1.62.8/go.mod h1:+GpgmfX7rnzQ8WMbMCMnI+VOjPZCf9yaUlBmRTvQgFE=
 github.com/aws/aws-sdk-go-v2/service/route53domains v1.35.1 h1:QGVZNUY+DruxL+81m7FNtAnvb6iib0GC/ltGUhNVE7w=
 github.com/aws/aws-sdk-go-v2/service/route53domains v1.35.1/go.mod h1:lMw0EGa0akP4Fx/x4sfjkj1lQ43imlfy68NuTA21Chg=
-github.com/aws/aws-sdk-go-v2/service/route53profiles v1.9.25 h1:YJM60kSq17CZWAni+v2LSOI++oO+UfjL8ShOZvCHwck=
-github.com/aws/aws-sdk-go-v2/service/route53profiles v1.9.25/go.mod h1:STkjS3eZb74bddkstwMTNn0qDubyajJcmrUEVL6OpvQ=
+github.com/aws/aws-sdk-go-v2/service/route53profiles v1.9.26 h1:pOuwLgdmVItzpEeBu/hD/33jc+XTYVliNsMadl6bQr4=
+github.com/aws/aws-sdk-go-v2/service/route53profiles v1.9.26/go.mod h1:8i70SZ5M4kJPd7ny98C+Grl48iD3wdj2oE0Y8YO2yIo=
 github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.32.16 h1:SAgKT1K00J9Dr1w7rMzsX31mNG1yrlo/tV9VDH/DirA=
 github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.32.16/go.mod h1:AjooguU3fvv9uEJ6Tz5EPfOrjNMiDea3odumJyTFYK0=
 github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.26.23 h1:l3nd7TS+byZcGFC7bPhcsoeLhgq2SQLitCUAIwSS7BA=

--- a/go.sum
+++ b/go.sum
@@ -75,8 +75,8 @@ github.com/aws/aws-sdk-go-v2/service/appmesh v1.35.15 h1:vmTlolVTemGK//2CRSsX9es
 github.com/aws/aws-sdk-go-v2/service/appmesh v1.35.15/go.mod h1:IohdJ/2Kiag9GMPP2Uxq8V9qhmrIS7vsGG/+gduSJYE=
 github.com/aws/aws-sdk-go-v2/service/apprunner v1.40.1 h1:o/4DSr4gIe+PBGbAIG0SSZrix7MKh7B2m3P3t0dkjCM=
 github.com/aws/aws-sdk-go-v2/service/apprunner v1.40.1/go.mod h1:24gjDeb/xEFpfIfkxh5T1JTDd/f9Gtbada7V52Q401I=
-github.com/aws/aws-sdk-go-v2/service/appstream v1.59.0 h1:9EuZwqW8tDPZQwt2nGnXDBrcHY4CND/Fk7L50P6wV20=
-github.com/aws/aws-sdk-go-v2/service/appstream v1.59.0/go.mod h1:E5vrX7/8w/HM5rhk2LQyuzF+PKECUmE44tp6xvuNYTc=
+github.com/aws/aws-sdk-go-v2/service/appstream v1.60.0 h1:JuwEfGyAHpofgXhxNy5jIGaiUulBlH1/5KPb6mTnjtc=
+github.com/aws/aws-sdk-go-v2/service/appstream v1.60.0/go.mod h1:NgdOdv2hoXmENwpqqLtyFC8MTcjqRpR9khOl2s1uWyU=
 github.com/aws/aws-sdk-go-v2/service/appsync v1.53.7 h1:SjkXYNc15FoovS9k6ML7dO7pkXE3ns66RXwL+rfQVl8=
 github.com/aws/aws-sdk-go-v2/service/appsync v1.53.7/go.mod h1:RcoBov7Pw38ViMxlthKRr1GLgHPPseA+kY2bupWVm10=
 github.com/aws/aws-sdk-go-v2/service/arcregionswitch v1.7.0 h1:z4HLC7u07UaaxClNTRsSt4Gy+AAOynoJZMMLijRHoAk=

--- a/go.sum
+++ b/go.sum
@@ -403,8 +403,8 @@ github.com/aws/aws-sdk-go-v2/service/odb v1.11.1 h1:PMrQsLY8KqDizjsK3Mn+GhXIplc6
 github.com/aws/aws-sdk-go-v2/service/odb v1.11.1/go.mod h1:hyWPzIu5qQyr7VBqZa/Y3gyrnsEsYbjvdd5d3IKKWvc=
 github.com/aws/aws-sdk-go-v2/service/opensearch v1.70.1 h1:bvmcxzp/PGDLScBLcJHG5WSoChkALP20Xhem54dUaKc=
 github.com/aws/aws-sdk-go-v2/service/opensearch v1.70.1/go.mod h1:VKcO88AHkSJsp7pQeHNr5VVcs1t/0snyD+e0ppd4oE0=
-github.com/aws/aws-sdk-go-v2/service/opensearchserverless v1.30.3 h1:47FPswEE4RKBY0sUivfFCqBS5PVAfg2iiNaSl9rHOX4=
-github.com/aws/aws-sdk-go-v2/service/opensearchserverless v1.30.3/go.mod h1:w/kwwh/dzVFrXLKUCj3M73lYUl+LrVn9gQ7RyiPNkZU=
+github.com/aws/aws-sdk-go-v2/service/opensearchserverless v1.31.0 h1:0uBe/bKUfzbhZqzjDv1dqiTTSEOPEC6UY3wfZWZ3DBc=
+github.com/aws/aws-sdk-go-v2/service/opensearchserverless v1.31.0/go.mod h1:WHaDEfICNQgRbrEEeLRKTkFbA0l4oVKE4mXDobZxVJ8=
 github.com/aws/aws-sdk-go-v2/service/organizations v1.51.3 h1:LWSmXWwYzR9yRcszxyqaKuPCO4E6g/iknZv1kQIkD7I=
 github.com/aws/aws-sdk-go-v2/service/organizations v1.51.3/go.mod h1:DGpC4BVQ1zS8X/nFYfHGiHyAhrsb8gZ8pPxn+Jf0iPY=
 github.com/aws/aws-sdk-go-v2/service/osis v1.22.0 h1:ZEoUbJcXPB6NxHLOjgggCfuVSOphoDeRpoJlBF+ILb0=

--- a/go.sum
+++ b/go.sum
@@ -309,8 +309,8 @@ github.com/aws/aws-sdk-go-v2/service/internetmonitor v1.27.1 h1:5FWxiFSsPmdUC3Xk
 github.com/aws/aws-sdk-go-v2/service/internetmonitor v1.27.1/go.mod h1:1qUwGVZnLhCkPkQ3SM6RqunW4kyuEmZJsoNjmUx5Q9c=
 github.com/aws/aws-sdk-go-v2/service/invoicing v1.11.1 h1:kTiy0bkxsbkzBwZkwYDo8W+vhdqZFqYvEkrRiO9oF/A=
 github.com/aws/aws-sdk-go-v2/service/invoicing v1.11.1/go.mod h1:iCJX4vAw5TUZz+IbcrxugeF03bK/2VrAKUV7wguQIUo=
-github.com/aws/aws-sdk-go-v2/service/iot v1.73.0 h1:7ZI147ei1koJE5dnfus8cfMOp2CRxsMgORp6hmewV9I=
-github.com/aws/aws-sdk-go-v2/service/iot v1.73.0/go.mod h1:9OGjPSOz2OZbObVfBcn110WPW/XZ1k6rSCpky8EvfHQ=
+github.com/aws/aws-sdk-go-v2/service/iot v1.74.0 h1:02uKsDppeZVALHa2majKLYoo2bULbNCmAA3iD+iSL64=
+github.com/aws/aws-sdk-go-v2/service/iot v1.74.0/go.mod h1:1/NELumOZj42LnUNYQRZVlu0D/q1p389umYs+1YKqBM=
 github.com/aws/aws-sdk-go-v2/service/ivs v1.50.1 h1:H/tTA4a7nmiFacIKeQjK/S8m7Ah/OXzSSLwPXEtD3l8=
 github.com/aws/aws-sdk-go-v2/service/ivs v1.50.1/go.mod h1:bu+KAqMu3i8tSo+e5AT3LriDJ6miYVK1E3hVqBXFA/k=
 github.com/aws/aws-sdk-go-v2/service/ivschat v1.22.0 h1:NKO0cWPKFhn94H6SGpwd6aSS/ASc3PqNm8K7JUljXvI=

--- a/go.sum
+++ b/go.sum
@@ -577,8 +577,8 @@ github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.40.1 h1:1P2yEK/4l3aMcpfn
 github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.40.1/go.mod h1:qlP/IKEhKywBy4iHYWPgGnhVZ43ns08vpl3GpPC+D2Y=
 github.com/aws/aws-sdk-go-v2/service/workmail v1.37.1 h1:kkW+177cM7iuWX5VYUR4BOyPre4K/fGNLR/WEhYy7ag=
 github.com/aws/aws-sdk-go-v2/service/workmail v1.37.1/go.mod h1:UcDqAbgkZdXt7qiHgrC5qSUIGPaV35b0L2/2Nt/EcY0=
-github.com/aws/aws-sdk-go-v2/service/workspaces v1.68.1 h1:Jf5Hb+1UABUn01BGk6vwPFtnyX51wgvqo97bNogM1kI=
-github.com/aws/aws-sdk-go-v2/service/workspaces v1.68.1/go.mod h1:SXw3pS4ayjTIy1oEauZCWMXOUQG/ukxFH23G0kxjRbA=
+github.com/aws/aws-sdk-go-v2/service/workspaces v1.68.2 h1:tDCxiS3qmTHTnLj88M4UjFRHdp3x+CCfpwBiOPiBZTk=
+github.com/aws/aws-sdk-go-v2/service/workspaces v1.68.2/go.mod h1:zkyqZ/TcuMeIkKVmI0DdC3k7VMj649AQScJSq9yvbb0=
 github.com/aws/aws-sdk-go-v2/service/workspacesweb v1.39.0 h1:oieTfrV3d0D/00Q7T8zc7vxnnz89M6Ux02Ocaw2qu50=
 github.com/aws/aws-sdk-go-v2/service/workspacesweb v1.39.0/go.mod h1:5d3WGmJnZy7o8uLL4hAGEcj1aDM1UkP1+rVPOhSe6cw=
 github.com/aws/aws-sdk-go-v2/service/xray v1.36.23 h1:23UXC4h6nNZqOmk+xaXcfyTH/IIvqWycQk154GaSiE8=

--- a/go.sum
+++ b/go.sum
@@ -81,8 +81,8 @@ github.com/aws/aws-sdk-go-v2/service/appsync v1.53.8 h1:CwHQQiBhvXbsEiDS3GERuVE4
 github.com/aws/aws-sdk-go-v2/service/appsync v1.53.8/go.mod h1:gXYrh3UXmGd/XYsWikBgcjSLs1BAbxqzutFe8JZSuzU=
 github.com/aws/aws-sdk-go-v2/service/arcregionswitch v1.8.0 h1:clvHruzXl4C4/fDACW9chjs5YFMAmh+fZ/J+hk24jlY=
 github.com/aws/aws-sdk-go-v2/service/arcregionswitch v1.8.0/go.mod h1:hnvcKnh9kG1cJrZ/3fxXPEC9Bd/ck3mwXl9je2Kwo1Y=
-github.com/aws/aws-sdk-go-v2/service/arczonalshift v1.22.25 h1:K3E2d85dSlIfC+cZox0Bg1fjUeYtoOglDDYNqECA30w=
-github.com/aws/aws-sdk-go-v2/service/arczonalshift v1.22.25/go.mod h1:RYzavF/LbpmQlQ4VwiYJqYHAWErI5y+/MKrdgyd0AvM=
+github.com/aws/aws-sdk-go-v2/service/arczonalshift v1.22.26 h1:nv0oX1ZZ+6ny92QDpjPP9lfYTlZh4EUFyeJmng++Ous=
+github.com/aws/aws-sdk-go-v2/service/arczonalshift v1.22.26/go.mod h1:+REsC19JcG05zJBgsR87rXVWwfBgdKXmmibQOrEmtok=
 github.com/aws/aws-sdk-go-v2/service/athena v1.57.6 h1:QPDxHlfHmozXUj9rmUyxQiOLVEJL3qX4x56CrwAtytM=
 github.com/aws/aws-sdk-go-v2/service/athena v1.57.6/go.mod h1:3QLTFWWkK+tGp4LD0ClX5Ib75MWE5H66vBat1N9f8Os=
 github.com/aws/aws-sdk-go-v2/service/auditmanager v1.46.14 h1:JUaGgEfBSS1ok2Fmd6tUkNJviWk3NzgnS+zEbo2mMKo=

--- a/go.sum
+++ b/go.sum
@@ -221,8 +221,8 @@ github.com/aws/aws-sdk-go-v2/service/dsql v1.14.1 h1:RmsuXZWU4Ij5fN7ODA7DIJxX36z
 github.com/aws/aws-sdk-go-v2/service/dsql v1.14.1/go.mod h1:gyjbYTqyg94CBANbsuY+rBFxHCt1On5N6NdTQkUiIAk=
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.5 h1:8dBj9DoTg1rNP/n5FC13c7zc97hx6Urc+jT+iSC7PVA=
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.5/go.mod h1:cFa8ItF/dcfex+Op4D0oWbZePIq1ljmrAOAGlEQyGHo=
-github.com/aws/aws-sdk-go-v2/service/ec2 v1.304.0 h1:wZthLlYdKxBo7NpWLbl0A/8DB/QNDB+8RJa9WboK9Q0=
-github.com/aws/aws-sdk-go-v2/service/ec2 v1.304.0/go.mod h1:Y95W0Hm6FYLPa6o0hbnJ+sWgmdc4ifcLFjGkdobWVhY=
+github.com/aws/aws-sdk-go-v2/service/ec2 v1.304.1 h1:ViHXq1M38VYp2KuxM9Gcwohp9fwlpJ1noliwTmHcRFk=
+github.com/aws/aws-sdk-go-v2/service/ec2 v1.304.1/go.mod h1:+AkYu92PhPD3Utfj3ruK5hGpQF0OHm8ffj10X2T+ufE=
 github.com/aws/aws-sdk-go-v2/service/ecr v1.57.2 h1:rHEW02JFJUV2/ttjzyPIvbD0YraqpyU2w6m6DfQUmdg=
 github.com/aws/aws-sdk-go-v2/service/ecr v1.57.2/go.mod h1:gNS8pNht4VMzPd4UtQUL3NTUQbjEPLLmb9MqmqrqsCM=
 github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.38.15 h1:nW/zPIjkAgHV1xv8NHdLQtGMoHVj2toMj8/H6SMqjVw=

--- a/go.sum
+++ b/go.sum
@@ -213,8 +213,8 @@ github.com/aws/aws-sdk-go-v2/service/dlm v1.37.1 h1:m0/eWYy9aNesQr7fjtWzLWhiHZTu
 github.com/aws/aws-sdk-go-v2/service/dlm v1.37.1/go.mod h1:lxtBECY+gv9fB14kFslHOFV28Pj6RJEem6kPZdCrVZw=
 github.com/aws/aws-sdk-go-v2/service/docdb v1.48.16 h1:JVfVNI1W7geUmJuyTPVKDdym3cpOXfxWKfGdRhm5O6k=
 github.com/aws/aws-sdk-go-v2/service/docdb v1.48.16/go.mod h1:qzkOzKUNO8ZzfMCC8gTh2uxD/7UmpS9scLHfAZ696i4=
-github.com/aws/aws-sdk-go-v2/service/docdbelastic v1.20.15 h1:7yp69z1AGCHUznyl4At8SUYZHd5tDu+IMfqMqzGOBqM=
-github.com/aws/aws-sdk-go-v2/service/docdbelastic v1.20.15/go.mod h1:kzaI5ZnKnaKp6p8rK2jPBR16sonsZ7UysOUywcjCz+A=
+github.com/aws/aws-sdk-go-v2/service/docdbelastic v1.21.1 h1:h/8yW1Qh78RTRmT1WOhe9vxF/lOSk1A3nASDopWIJLY=
+github.com/aws/aws-sdk-go-v2/service/docdbelastic v1.21.1/go.mod h1:BoVuSamInxADdfbPKk92a5ozopz1pjGnm+iv82rxj44=
 github.com/aws/aws-sdk-go-v2/service/drs v1.38.2 h1:lGGi8jgwirRgq3AicTFBr5u1nqkE/y3bJuhjQQI3e1o=
 github.com/aws/aws-sdk-go-v2/service/drs v1.38.2/go.mod h1:d6uN12uV8zw/mkR7EiIfuEs18rny1ZpGmw2IbFCc5Ec=
 github.com/aws/aws-sdk-go-v2/service/dsql v1.14.0 h1:g/vNRzoxAtEEImkLqL9Nfi/meauKiOvj9XJjTjRA2XQ=

--- a/go.sum
+++ b/go.sum
@@ -223,8 +223,8 @@ github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.5 h1:8dBj9DoTg1rNP/n5FC13c7z
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.5/go.mod h1:cFa8ItF/dcfex+Op4D0oWbZePIq1ljmrAOAGlEQyGHo=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.304.1 h1:ViHXq1M38VYp2KuxM9Gcwohp9fwlpJ1noliwTmHcRFk=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.304.1/go.mod h1:+AkYu92PhPD3Utfj3ruK5hGpQF0OHm8ffj10X2T+ufE=
-github.com/aws/aws-sdk-go-v2/service/ecr v1.57.2 h1:rHEW02JFJUV2/ttjzyPIvbD0YraqpyU2w6m6DfQUmdg=
-github.com/aws/aws-sdk-go-v2/service/ecr v1.57.2/go.mod h1:gNS8pNht4VMzPd4UtQUL3NTUQbjEPLLmb9MqmqrqsCM=
+github.com/aws/aws-sdk-go-v2/service/ecr v1.57.3 h1:A96oesTgxeuq40H9PKkPXQDvqeLy8fzSXaMxjTVWdsc=
+github.com/aws/aws-sdk-go-v2/service/ecr v1.57.3/go.mod h1:wig6P1dEk+MIgducD7hX+RcnnRBSvk9S/4J398XJ+sE=
 github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.38.15 h1:nW/zPIjkAgHV1xv8NHdLQtGMoHVj2toMj8/H6SMqjVw=
 github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.38.15/go.mod h1:FXDXpYy2PKdkQQr4ERMoRzVKcga0O/hmtRbMaQSpe8U=
 github.com/aws/aws-sdk-go-v2/service/ecs v1.80.0 h1:orZYOYtvYU7A45XTWC/UchWSkkdWjOyXi8MYksnmQf0=

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,8 @@ github.com/aws/aws-sdk-go-v2/service/chatbot v1.15.0 h1:e3QPlLAzchSC98C/Fk89qi9T
 github.com/aws/aws-sdk-go-v2/service/chatbot v1.15.0/go.mod h1:2+T3ZzaxQ6rV/CImS72BNVHIyazppxtblF1xJTXjgIg=
 github.com/aws/aws-sdk-go-v2/service/chime v1.41.15 h1:NjDzXghqrmE5KFPedLuioRk08v+lr6ijiUasvhuiSFc=
 github.com/aws/aws-sdk-go-v2/service/chime v1.41.15/go.mod h1:T11rZ8NkCnMjuSu72hcd6sIS5drVGfAv8xJx8n2Hg3I=
-github.com/aws/aws-sdk-go-v2/service/chimesdkmediapipelines v1.27.0 h1:slEpXPwuTojX3xQ3Xv0Haxa6ykicD9bVdhQ/j4DLkMg=
-github.com/aws/aws-sdk-go-v2/service/chimesdkmediapipelines v1.27.0/go.mod h1:xGNDWxgYbjfyg7dRB5zhzXtad+8o839xZKMY3jVl9KE=
+github.com/aws/aws-sdk-go-v2/service/chimesdkmediapipelines v1.27.1 h1:JP5Jz9OCnqownQNBKTPxH89eAx5wZcMzWiKWw1gRiCg=
+github.com/aws/aws-sdk-go-v2/service/chimesdkmediapipelines v1.27.1/go.mod h1:/4racxzJ7S4x0j6EkPl7YpBqncHL2v85hchmoY+JnB8=
 github.com/aws/aws-sdk-go-v2/service/chimesdkvoice v1.28.15 h1:21vkPfPLTrzWnp3c+d5NJu9om1sLHg2tS1p72bxU+3A=
 github.com/aws/aws-sdk-go-v2/service/chimesdkvoice v1.28.15/go.mod h1:C6UVSmolomJa9uw9VAgIBVKx92I5jZ+vW24yeVvyXqs=
 github.com/aws/aws-sdk-go-v2/service/cleanrooms v1.45.0 h1:kBzMXsg/R1N25ylMalFU29HdrQotblZgDcenVwvgWZo=

--- a/go.sum
+++ b/go.sum
@@ -209,8 +209,8 @@ github.com/aws/aws-sdk-go-v2/service/directconnect v1.38.18 h1:aaZ+da2nGV0D4iSHd
 github.com/aws/aws-sdk-go-v2/service/directconnect v1.38.18/go.mod h1:7+LEXCl28CUDCuRgcmXUCL2G335G1zmXjOnmkQDKH2Q=
 github.com/aws/aws-sdk-go-v2/service/directoryservice v1.38.19 h1:7uzyDjdMN99ALP0QI/ZaDQ+1kwF6skNZU8AqUMZf4uo=
 github.com/aws/aws-sdk-go-v2/service/directoryservice v1.38.19/go.mod h1:QmDYiedOfdgvQk6gtAHwa8yAgYSZXqiB6dHUxJ1CVBM=
-github.com/aws/aws-sdk-go-v2/service/dlm v1.37.0 h1:VtpZW9fiSg/nTc0g63un8Udl53RM1LNbkbc7vWQ7fwk=
-github.com/aws/aws-sdk-go-v2/service/dlm v1.37.0/go.mod h1:lZvlQUrRwgTdL3Bh/iyLf/z7XdBBowEAvbZXzgPg4/s=
+github.com/aws/aws-sdk-go-v2/service/dlm v1.37.1 h1:m0/eWYy9aNesQr7fjtWzLWhiHZTuhcE7rn0wryW0PGE=
+github.com/aws/aws-sdk-go-v2/service/dlm v1.37.1/go.mod h1:lxtBECY+gv9fB14kFslHOFV28Pj6RJEem6kPZdCrVZw=
 github.com/aws/aws-sdk-go-v2/service/docdb v1.48.15 h1:jvP746CYJno9fSBqvPMShLPVu+P9wetNsSb+xYk52ag=
 github.com/aws/aws-sdk-go-v2/service/docdb v1.48.15/go.mod h1:wMMgRe7xZVJu58h7CI06EV6n/QUOILSk53/3EYzkorg=
 github.com/aws/aws-sdk-go-v2/service/docdbelastic v1.20.15 h1:7yp69z1AGCHUznyl4At8SUYZHd5tDu+IMfqMqzGOBqM=

--- a/go.sum
+++ b/go.sum
@@ -279,8 +279,8 @@ github.com/aws/aws-sdk-go-v2/service/grafana v1.35.1 h1:FmwZf8Zab+T2eOzl8zUxrnZi
 github.com/aws/aws-sdk-go-v2/service/grafana v1.35.1/go.mod h1:ZaE4XEcA7/Gi4Jf9vDpiiIE2zbuy3+bx1tpw0RdWJ/c=
 github.com/aws/aws-sdk-go-v2/service/greengrass v1.32.24 h1:2IcMPOpDsVIfaj9YFKuH1USw0hWvf1n6ZSL2V+y49Do=
 github.com/aws/aws-sdk-go-v2/service/greengrass v1.32.24/go.mod h1:3c1oObcY5EL5WcU6TIwyhWQ4yySFUdtJzskkINO0Ryw=
-github.com/aws/aws-sdk-go-v2/service/groundstation v1.41.1 h1:IQAuKMncZtYlrMX4N61s08EVJvllV2mBdNZJF1FAT6g=
-github.com/aws/aws-sdk-go-v2/service/groundstation v1.41.1/go.mod h1:qPVSrGBE5s3TSsN81w3aMrnFVN5hZkg4T/oW92/2m1I=
+github.com/aws/aws-sdk-go-v2/service/groundstation v1.42.0 h1:lFg4tM2tx+FQNy36hxl9oFNgntLzFxYlS+4fd6pjGnU=
+github.com/aws/aws-sdk-go-v2/service/groundstation v1.42.0/go.mod h1:q65bYfAuFmMS7zdSgFFs7FRygyzMfKtAnbqMF1H23YY=
 github.com/aws/aws-sdk-go-v2/service/guardduty v1.78.0 h1:G+ZbdL3onjVLfReu4piSAdE/Q9GOH89oNEXekFM+LUk=
 github.com/aws/aws-sdk-go-v2/service/guardduty v1.78.0/go.mod h1:kCpMuo4vLtzUaugNCZGCkVtdehl2YvoSd73Jmiuh1M0=
 github.com/aws/aws-sdk-go-v2/service/healthlake v1.37.0 h1:/y3MPNKd8QvlnCAltxWg9rflfbWgF8XH6ehX8xD4OFE=

--- a/go.sum
+++ b/go.sum
@@ -555,8 +555,8 @@ github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.20.0 h1:4zRcgn5fbavj1
 github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.20.0/go.mod h1:HuKojo4zKYq6UOvPeorfcmR6BlOxIjZx9/6mXVV5C5M=
 github.com/aws/aws-sdk-go-v2/service/timestreamquery v1.36.18 h1:cYAZklvpeCttnJeiG6b0ouYxy1fdzG52svDhllRF9c0=
 github.com/aws/aws-sdk-go-v2/service/timestreamquery v1.36.18/go.mod h1:D9Xer57g8BV+0T+to7RZ5U1aOd4cdTFVVK6OUH1pvHw=
-github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.35.23 h1:ibF4VUUnR8kveX/3pURldl1bTaEEAin8mjnmtzQGuzw=
-github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.35.23/go.mod h1:A9LLxRTZsFAoe66dPqfgMIB8bZeoo7Jzg5ZGzKRxFkc=
+github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.35.24 h1:9qHHrg3FTH+APkpY0DeKvpvO/XLmkYtWZJw2ENc9lts=
+github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.35.24/go.mod h1:E0ZDPhSKPaocAmHmVX6lr4QsTOn/FFi39uTb2Y2sSrg=
 github.com/aws/aws-sdk-go-v2/service/transcribe v1.55.0 h1:RKV4MScftqxaWNft0S5MqGgz78zyFU6IK/pxNlH6MJs=
 github.com/aws/aws-sdk-go-v2/service/transcribe v1.55.0/go.mod h1:z29t64Pva4oeaYboSZrJhhYJDZu80VCV/AnMnqhNvwE=
 github.com/aws/aws-sdk-go-v2/service/transfer v1.72.0 h1:RbzzKZwU/fPSDpO731YSRDQqbp/h6IycNV5pgVCbJVk=

--- a/go.sum
+++ b/go.sum
@@ -289,8 +289,8 @@ github.com/aws/aws-sdk-go-v2/service/iam v1.53.11 h1:xt4JHLHBQonQXApaYfS0FvdIeAL
 github.com/aws/aws-sdk-go-v2/service/iam v1.53.11/go.mod h1:VkuYu8oSpQAx+hKNFvJqqei6/PACzkpqVdM6ylo0scg=
 github.com/aws/aws-sdk-go-v2/service/identitystore v1.37.1 h1:hNsPPU6m/Hi0p2QXm42tqPQugl3lALolEZ9DLgx/p0s=
 github.com/aws/aws-sdk-go-v2/service/identitystore v1.37.1/go.mod h1:STQWDynKsiZADmYxFBQ+hUx9VBMxGu5ZhdN6PPIrBXU=
-github.com/aws/aws-sdk-go-v2/service/imagebuilder v1.54.0 h1:MlFy3L3RStulK0LNyq9LzrRf45nsCYsIK6fw3M4St8s=
-github.com/aws/aws-sdk-go-v2/service/imagebuilder v1.54.0/go.mod h1:qaCPaUpUwFeeqaeG4x0eNKkPt5fINOh4YEoSLLcxdjc=
+github.com/aws/aws-sdk-go-v2/service/imagebuilder v1.55.1 h1:BatfYeFcs220jnKlxrPE+mMtBOiiszLousw5jSVGClw=
+github.com/aws/aws-sdk-go-v2/service/imagebuilder v1.55.1/go.mod h1:IjRdS2Ybudj2D7Vpt5OPcJax5JEFOrhmviv9aesTuds=
 github.com/aws/aws-sdk-go-v2/service/inspector v1.30.22 h1:phWl4pu6OSvB8xRF14eTKWrvk7hQspQqz1YqyV++fmA=
 github.com/aws/aws-sdk-go-v2/service/inspector v1.30.22/go.mod h1:BRKeLwlPqToFLwqO3GcIETzktr5QvnWprfI/iICeyJ0=
 github.com/aws/aws-sdk-go-v2/service/inspector2 v1.47.7 h1:vHOhsldnj34FLcf4Vhruf4rXjuS/h2+rVq7g/Ff2Z1E=

--- a/go.sum
+++ b/go.sum
@@ -457,8 +457,8 @@ github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.33.27 h1:PBuU5HO0JhThHHOZ
 github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.33.27/go.mod h1:rqCOOEEd3ofM5Lltmv7IehmpnyXCDzxlydqXc6Sx35k=
 github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.32.1 h1:3VYXjxI8ZDW5h3yDaSXNpGW86quViQatLNNclkypnfM=
 github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.32.1/go.mod h1:FPN5JcyM3LRy070DtXbb+8eT53HR/cSP/yt/fmvdL4U=
-github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.23.0 h1:BD6q8KEiom1qJpDC7kmBrKwMXCRkuSy7JXWPhQThFkI=
-github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.23.0/go.mod h1:kJgqmGmlOPqTe9cntPrSgMdIQ3cAama8TAW+NKaDCzE=
+github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.23.1 h1:Qrebotu1g1iw4P+huw7lYnIN/qcZtIO3giD+f2dlwM4=
+github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.23.1/go.mod h1:BNimlkjkBkiYd1OzVjX74gX5rt/H3kBfElrth3FpE4o=
 github.com/aws/aws-sdk-go-v2/service/route53 v1.62.7 h1:twRRMmtSITnt/rrp+D7UDLzE5pKMZe759aalkUdN+OY=
 github.com/aws/aws-sdk-go-v2/service/route53 v1.62.7/go.mod h1:ztM1lr+sRoCAI8336ZUvlRPbToue0d3gE/wd6jomSJ8=
 github.com/aws/aws-sdk-go-v2/service/route53domains v1.35.0 h1:9WcucZLCnH5OLj6PO+smG3ityqw7OrHa/SkCUmnk7Kw=

--- a/go.sum
+++ b/go.sum
@@ -409,8 +409,8 @@ github.com/aws/aws-sdk-go-v2/service/organizations v1.51.5 h1:687d4GNItnbdTQDIru
 github.com/aws/aws-sdk-go-v2/service/organizations v1.51.5/go.mod h1:3x9U6Kuj/KbdofHwSr72N8ioLjo2+FwHSWhCxsSULks=
 github.com/aws/aws-sdk-go-v2/service/osis v1.22.1 h1:pQiTQtB/V1rnUIy11EcmYf5FEzkPea2812gA6/Y5UFM=
 github.com/aws/aws-sdk-go-v2/service/osis v1.22.1/go.mod h1:L8Tvf0GshqlZ1nUIK+TdPmxXz379eRT3R+EtCyPLqgU=
-github.com/aws/aws-sdk-go-v2/service/outposts v1.60.0 h1:hwyvhS06b2EkMwxkIoIu2xQDBkFTtRDjA2hR1pbi3VM=
-github.com/aws/aws-sdk-go-v2/service/outposts v1.60.0/go.mod h1:ba7mdkcZTuIb/Vr3exajZcLWIOtJJMdfOPiX8caoOl8=
+github.com/aws/aws-sdk-go-v2/service/outposts v1.60.1 h1:8UCOqAoJ68CU5YqSZ0inZuYkLnkk1nyjQa1tLf9C+68=
+github.com/aws/aws-sdk-go-v2/service/outposts v1.60.1/go.mod h1:Yfs4XytNgJNBYeO9VK37ln5SUViyyDQosIZU+JykOnc=
 github.com/aws/aws-sdk-go-v2/service/paymentcryptography v1.29.0 h1:lRe1Q5Rz1xFQlov+KkOm10XK/t1Mfe65lOA68hfZoBo=
 github.com/aws/aws-sdk-go-v2/service/paymentcryptography v1.29.0/go.mod h1:kZX+7Aq8eBUcO5qf8BNrFw9nsP3VZoXWK39sC79bwoc=
 github.com/aws/aws-sdk-go-v2/service/pcaconnectorad v1.15.23 h1:CtTEAf/iYhq8G9KLBJH0T3GOZQ6/Ejjt0+J66jdSfKk=

--- a/go.sum
+++ b/go.sum
@@ -181,8 +181,8 @@ github.com/aws/aws-sdk-go-v2/service/costexplorer v1.63.9 h1:cVSd0kgTG+dvJlglPap
 github.com/aws/aws-sdk-go-v2/service/costexplorer v1.63.9/go.mod h1:bm12cXeoasdLU/Ra6PdxnbE8YZsbXDYHfLU4Z9yGBDc=
 github.com/aws/aws-sdk-go-v2/service/costoptimizationhub v1.23.0 h1:H5zZyEmWfUUAlgIpkCl9UlCoTYsl9KdsoMBRPGTei9I=
 github.com/aws/aws-sdk-go-v2/service/costoptimizationhub v1.23.0/go.mod h1:+/F97SyLRVhK+fM3dQge1DWIrhhr/bNEzMCvixl0VRs=
-github.com/aws/aws-sdk-go-v2/service/customerprofiles v1.61.0 h1:rfU1DhRBbNg9f8uh9L4dJNZYSYRjrgqTxSI4aPkkzvE=
-github.com/aws/aws-sdk-go-v2/service/customerprofiles v1.61.0/go.mod h1:P8xXL2qstcrbxBXjHnL3VVBIWqGrHIn6YA+XSd4S8rA=
+github.com/aws/aws-sdk-go-v2/service/customerprofiles v1.62.0 h1:+5UR/UaODIBy0e1nJJZr7h+sg5PiWRZyO2d7PWpcAk0=
+github.com/aws/aws-sdk-go-v2/service/customerprofiles v1.62.0/go.mod h1:wssUdi0eG5acDhEjKWq11oP1X49rSMJ7ztO0hHFLIOk=
 github.com/aws/aws-sdk-go-v2/service/databasemigrationservice v1.63.0 h1:n80jw/JxEyeeZo9Df9fHUFVIrPmY5WRZSo9u6WkbWKk=
 github.com/aws/aws-sdk-go-v2/service/databasemigrationservice v1.63.0/go.mod h1:Qa7SOwwtaE9VticcY52FgDIXJZLS1jz+Y6fiCdLUdRU=
 github.com/aws/aws-sdk-go-v2/service/databrew v1.40.0 h1:wuMzTtsMNVfR954WDxxuTSxE84uBjbUZpkHzl8FGEzY=

--- a/go.sum
+++ b/go.sum
@@ -175,8 +175,8 @@ github.com/aws/aws-sdk-go-v2/service/connectcases v1.42.1 h1:GU/QQUClfsIpr8AiTzW
 github.com/aws/aws-sdk-go-v2/service/connectcases v1.42.1/go.mod h1:Jd2ciDlob6BwGJIU/VpmdQoOPtrFmpJ9gCePVnjH7jE=
 github.com/aws/aws-sdk-go-v2/service/controltower v1.29.1 h1:FG7qE3bUC6XqHY2lQ/BV65q3F8dJea/dW2uLUZYFQyY=
 github.com/aws/aws-sdk-go-v2/service/controltower v1.29.1/go.mod h1:2pnXa7KVMMvd+KdNWGiVuS7Fs4FNtWu+j9Oe9XyQs3U=
-github.com/aws/aws-sdk-go-v2/service/costandusagereportservice v1.34.15 h1:iI5WGYZl5mU9OWa0EBj6TOY0NQ4JLvevo0txMpdq20g=
-github.com/aws/aws-sdk-go-v2/service/costandusagereportservice v1.34.15/go.mod h1:3oLucoNB1dcG76JxzFFsSSnmpwl0BfX7CT1r0BgWavc=
+github.com/aws/aws-sdk-go-v2/service/costandusagereportservice v1.34.16 h1:w20+cJBkusCGMM+eBMpuId8tPKi7xQMU+oewJyUU5vc=
+github.com/aws/aws-sdk-go-v2/service/costandusagereportservice v1.34.16/go.mod h1:9FEyLTz1kOG0l/DWCCbvpAuJUlawnKJPaSA+xO0jpfg=
 github.com/aws/aws-sdk-go-v2/service/costexplorer v1.63.8 h1:rUg81vwoGgCmnQxsVl+B65QF8Qh+zYCluhyAcxsk79o=
 github.com/aws/aws-sdk-go-v2/service/costexplorer v1.63.8/go.mod h1:V+bKJ05kIC6K0LH8TB3D5boy7F8BhrZeecoXLz1NlB4=
 github.com/aws/aws-sdk-go-v2/service/costoptimizationhub v1.22.10 h1:ZbXEmYQ2SuF9LXqdHAgcx5ThxphG2OxiiVsnQ7TrHAQ=

--- a/go.sum
+++ b/go.sum
@@ -407,8 +407,8 @@ github.com/aws/aws-sdk-go-v2/service/opensearchserverless v1.31.0 h1:0uBe/bKUfzb
 github.com/aws/aws-sdk-go-v2/service/opensearchserverless v1.31.0/go.mod h1:WHaDEfICNQgRbrEEeLRKTkFbA0l4oVKE4mXDobZxVJ8=
 github.com/aws/aws-sdk-go-v2/service/organizations v1.51.5 h1:687d4GNItnbdTQDIrujejwYIiXpG+yFehtGhOEQ9yDU=
 github.com/aws/aws-sdk-go-v2/service/organizations v1.51.5/go.mod h1:3x9U6Kuj/KbdofHwSr72N8ioLjo2+FwHSWhCxsSULks=
-github.com/aws/aws-sdk-go-v2/service/osis v1.22.0 h1:ZEoUbJcXPB6NxHLOjgggCfuVSOphoDeRpoJlBF+ILb0=
-github.com/aws/aws-sdk-go-v2/service/osis v1.22.0/go.mod h1:SBHR/fdFyQMH3OeYAPR/HQWipbwm/xFR+x5vQg8imHU=
+github.com/aws/aws-sdk-go-v2/service/osis v1.22.1 h1:pQiTQtB/V1rnUIy11EcmYf5FEzkPea2812gA6/Y5UFM=
+github.com/aws/aws-sdk-go-v2/service/osis v1.22.1/go.mod h1:L8Tvf0GshqlZ1nUIK+TdPmxXz379eRT3R+EtCyPLqgU=
 github.com/aws/aws-sdk-go-v2/service/outposts v1.60.0 h1:hwyvhS06b2EkMwxkIoIu2xQDBkFTtRDjA2hR1pbi3VM=
 github.com/aws/aws-sdk-go-v2/service/outposts v1.60.0/go.mod h1:ba7mdkcZTuIb/Vr3exajZcLWIOtJJMdfOPiX8caoOl8=
 github.com/aws/aws-sdk-go-v2/service/paymentcryptography v1.29.0 h1:lRe1Q5Rz1xFQlov+KkOm10XK/t1Mfe65lOA68hfZoBo=

--- a/go.sum
+++ b/go.sum
@@ -203,8 +203,8 @@ github.com/aws/aws-sdk-go-v2/service/devicefarm v1.38.11 h1:71pCfxH8KVqP34bsmmDw
 github.com/aws/aws-sdk-go-v2/service/devicefarm v1.38.11/go.mod h1:I/md2ejJNL/3hWXi+iAkbiNPrhQq0cqMWPd7c0NOiVg=
 github.com/aws/aws-sdk-go-v2/service/devopsagent v1.5.1 h1:c6K2TLSv75lt2R3+jKyDRDzZo1rINjidrngfuHXGoN4=
 github.com/aws/aws-sdk-go-v2/service/devopsagent v1.5.1/go.mod h1:geVmKDQ6LzByWVYJYlwKg249rG1mWlZ8gmKlPARovWk=
-github.com/aws/aws-sdk-go-v2/service/devopsguru v1.41.0 h1:oivWpWrQ2iwG9uQIcwJfEwi+FgDD8weBrTG5/CnS8qY=
-github.com/aws/aws-sdk-go-v2/service/devopsguru v1.41.0/go.mod h1:7M6Y0kEPcla1JcdHe5IO+kq1XcmblIPgLAOerkiPXf8=
+github.com/aws/aws-sdk-go-v2/service/devopsguru v1.41.1 h1:qwR2AmbqAwfSx2x76tVK8mEggiGy8fUTd/+aVUWC+OI=
+github.com/aws/aws-sdk-go-v2/service/devopsguru v1.41.1/go.mod h1:BpdOA90ZcqzAMXfUlxUd1dMn8fdiaeEZIcLarZ+flu8=
 github.com/aws/aws-sdk-go-v2/service/directconnect v1.38.17 h1:fkeDjhbAy9ddanOVlxP2vnY2dbTxA8HL+DdV9HezVSs=
 github.com/aws/aws-sdk-go-v2/service/directconnect v1.38.17/go.mod h1:kzj2OFWYl3uGXBkincAArVPtSG8QwXJRfCL8+Ztsw9o=
 github.com/aws/aws-sdk-go-v2/service/directoryservice v1.38.18 h1:jj7CHRntkLMhurirvfbf1jUhQznjn28U2cTVzXhsFlc=

--- a/go.sum
+++ b/go.sum
@@ -581,8 +581,8 @@ github.com/aws/aws-sdk-go-v2/service/workspaces v1.68.2 h1:tDCxiS3qmTHTnLj88M4Uj
 github.com/aws/aws-sdk-go-v2/service/workspaces v1.68.2/go.mod h1:zkyqZ/TcuMeIkKVmI0DdC3k7VMj649AQScJSq9yvbb0=
 github.com/aws/aws-sdk-go-v2/service/workspacesweb v1.40.1 h1:AqfLNl9FpoH6stsFchZPaUuinb+CpbjF+jQdrCrOxO0=
 github.com/aws/aws-sdk-go-v2/service/workspacesweb v1.40.1/go.mod h1:LkpCj8zttwGuTuSM/Lkq7DGsrFx3asPdj9rKyAJekiw=
-github.com/aws/aws-sdk-go-v2/service/xray v1.36.23 h1:23UXC4h6nNZqOmk+xaXcfyTH/IIvqWycQk154GaSiE8=
-github.com/aws/aws-sdk-go-v2/service/xray v1.36.23/go.mod h1:XEYnz2YYwBDEDHrfBWjv31kK8vCTrvCcnS7K7vyrDA0=
+github.com/aws/aws-sdk-go-v2/service/xray v1.36.24 h1:yY22xMqs3gDtHp8l5w+nP2pah9k9YyeIc306TnqniUg=
+github.com/aws/aws-sdk-go-v2/service/xray v1.36.24/go.mod h1:FgYbZTox3hRI8ljPoemYdybZGKDHz0JP7fXFoIdqMYE=
 github.com/aws/smithy-go v1.26.0 h1:9ouqbi+NyKP7fV3Te7UElCwdAb6Y8uk7LGwPE5tVe/s=
 github.com/aws/smithy-go v1.26.0/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/beevik/etree v1.6.0 h1:u8Kwy8pp9D9XeITj2Z0XtA5qqZEmtJtuXZRQi+j03eE=

--- a/go.sum
+++ b/go.sum
@@ -521,8 +521,8 @@ github.com/aws/aws-sdk-go-v2/service/signer v1.33.1 h1:DNU6RZIbz7rEP0H1YErn1ElWN
 github.com/aws/aws-sdk-go-v2/service/signer v1.33.1/go.mod h1:31a60A8v7+SYksLgSpOPcSbgexJw5dS9gGiXbbS1CMY=
 github.com/aws/aws-sdk-go-v2/service/signin v1.1.0 h1:yQo3eZ5qFaL1sJWqs1nL6j3yPHA2/R7c6tQ4T+0IO10=
 github.com/aws/aws-sdk-go-v2/service/signin v1.1.0/go.mod h1:3Zzou41Qt/ueXfIzHvTEjDNuR5IjCUBVF01SNhrt1e8=
-github.com/aws/aws-sdk-go-v2/service/sns v1.39.17 h1:synXIPC/L4Cc489P0XDcrVJzHSLj7krKRpFLalbGM2k=
-github.com/aws/aws-sdk-go-v2/service/sns v1.39.17/go.mod h1:4ABZnI23uNK37waIjGwkubnCwGhepIt9x1GvASfljJA=
+github.com/aws/aws-sdk-go-v2/service/sns v1.39.18 h1:z5zzs1HGWZX1PVs7DcnjSuuuoKx0tkM9RfU+5hLoKAE=
+github.com/aws/aws-sdk-go-v2/service/sns v1.39.18/go.mod h1:OtbHWFTJ/cJHF/3t+H7ZJpMY43NbngwFrt0xq5u/28c=
 github.com/aws/aws-sdk-go-v2/service/sqs v1.42.27 h1:QgaWXVmNDxv/U/3UIHfGb7ohvtFgerf/bYcYylj4i8E=
 github.com/aws/aws-sdk-go-v2/service/sqs v1.42.27/go.mod h1:8S6ExnLprS0oIeA8ZlHkJUJ0BMpKqnRPws/S0jegTqQ=
 github.com/aws/aws-sdk-go-v2/service/ssm v1.68.6 h1:0LPJjbSNEDHidGOXa0LfvSVbdn9/GdlJUQTgE0kFpso=

--- a/go.sum
+++ b/go.sum
@@ -405,8 +405,8 @@ github.com/aws/aws-sdk-go-v2/service/opensearch v1.70.1 h1:bvmcxzp/PGDLScBLcJHG5
 github.com/aws/aws-sdk-go-v2/service/opensearch v1.70.1/go.mod h1:VKcO88AHkSJsp7pQeHNr5VVcs1t/0snyD+e0ppd4oE0=
 github.com/aws/aws-sdk-go-v2/service/opensearchserverless v1.31.0 h1:0uBe/bKUfzbhZqzjDv1dqiTTSEOPEC6UY3wfZWZ3DBc=
 github.com/aws/aws-sdk-go-v2/service/opensearchserverless v1.31.0/go.mod h1:WHaDEfICNQgRbrEEeLRKTkFbA0l4oVKE4mXDobZxVJ8=
-github.com/aws/aws-sdk-go-v2/service/organizations v1.51.3 h1:LWSmXWwYzR9yRcszxyqaKuPCO4E6g/iknZv1kQIkD7I=
-github.com/aws/aws-sdk-go-v2/service/organizations v1.51.3/go.mod h1:DGpC4BVQ1zS8X/nFYfHGiHyAhrsb8gZ8pPxn+Jf0iPY=
+github.com/aws/aws-sdk-go-v2/service/organizations v1.51.5 h1:687d4GNItnbdTQDIrujejwYIiXpG+yFehtGhOEQ9yDU=
+github.com/aws/aws-sdk-go-v2/service/organizations v1.51.5/go.mod h1:3x9U6Kuj/KbdofHwSr72N8ioLjo2+FwHSWhCxsSULks=
 github.com/aws/aws-sdk-go-v2/service/osis v1.22.0 h1:ZEoUbJcXPB6NxHLOjgggCfuVSOphoDeRpoJlBF+ILb0=
 github.com/aws/aws-sdk-go-v2/service/osis v1.22.0/go.mod h1:SBHR/fdFyQMH3OeYAPR/HQWipbwm/xFR+x5vQg8imHU=
 github.com/aws/aws-sdk-go-v2/service/outposts v1.60.0 h1:hwyvhS06b2EkMwxkIoIu2xQDBkFTtRDjA2hR1pbi3VM=

--- a/go.sum
+++ b/go.sum
@@ -465,8 +465,8 @@ github.com/aws/aws-sdk-go-v2/service/route53domains v1.35.1 h1:QGVZNUY+DruxL+81m
 github.com/aws/aws-sdk-go-v2/service/route53domains v1.35.1/go.mod h1:lMw0EGa0akP4Fx/x4sfjkj1lQ43imlfy68NuTA21Chg=
 github.com/aws/aws-sdk-go-v2/service/route53profiles v1.9.26 h1:pOuwLgdmVItzpEeBu/hD/33jc+XTYVliNsMadl6bQr4=
 github.com/aws/aws-sdk-go-v2/service/route53profiles v1.9.26/go.mod h1:8i70SZ5M4kJPd7ny98C+Grl48iD3wdj2oE0Y8YO2yIo=
-github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.32.16 h1:SAgKT1K00J9Dr1w7rMzsX31mNG1yrlo/tV9VDH/DirA=
-github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.32.16/go.mod h1:AjooguU3fvv9uEJ6Tz5EPfOrjNMiDea3odumJyTFYK0=
+github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.33.0 h1:PN25XBeAbUCrM6pfmUwNamch/CG1+jJAmVA+x6PJuTE=
+github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.33.0/go.mod h1:B2YQF5Mu9cs5J5TTYvSMcdATZLaOkoYVZ8lc3sfDsIU=
 github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.26.23 h1:l3nd7TS+byZcGFC7bPhcsoeLhgq2SQLitCUAIwSS7BA=
 github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.26.23/go.mod h1:f5QgeBGg2Esj0mWwdUDxQAsN00GJnfIKqQeS9oaBO6M=
 github.com/aws/aws-sdk-go-v2/service/route53resolver v1.44.0 h1:9VLmITeTm+jTiL48ZSll0A4KW3AD/IcRENQG2s3jxMc=

--- a/go.sum
+++ b/go.sum
@@ -383,8 +383,8 @@ github.com/aws/aws-sdk-go-v2/service/neptune v1.44.6 h1:fEiBIUr6UVYs6LxASES6m8a6
 github.com/aws/aws-sdk-go-v2/service/neptune v1.44.6/go.mod h1:+UvGeb9YQ093vXXr5/GM8AcOcLeXsO/zejCbna5zZQo=
 github.com/aws/aws-sdk-go-v2/service/neptunegraph v1.22.0 h1:iTnqzV7TNmSlH+wpUszaDtNPK6xANHW8wQIbuGPO1kI=
 github.com/aws/aws-sdk-go-v2/service/neptunegraph v1.22.0/go.mod h1:PMRZaSonQvYX8d0u6JciqToJh3JHIcNDU8JwpLeFiT0=
-github.com/aws/aws-sdk-go-v2/service/networkfirewall v1.61.0 h1:/cxzydSADiL23o7Z8ZYdNTDGSx2RuJZr3mJa67MtBOc=
-github.com/aws/aws-sdk-go-v2/service/networkfirewall v1.61.0/go.mod h1:oWCet/AjsuKhMkvcXOGEeS2QmssLJX1UmX2SiKCEsFM=
+github.com/aws/aws-sdk-go-v2/service/networkfirewall v1.61.1 h1:ewqow8gclzOTZRvgxkynXFaj9h8YQE8wJTRpyMMjtqw=
+github.com/aws/aws-sdk-go-v2/service/networkfirewall v1.61.1/go.mod h1:7bRBjeRP7pMQOX2qP8d7kEO1FV1WekbuMq5ZJXQpxCo=
 github.com/aws/aws-sdk-go-v2/service/networkflowmonitor v1.11.11 h1:/FfmXTc20Nc4NWFdAd0o5tekmtQ+M1Tr2xOqCdRp9GQ=
 github.com/aws/aws-sdk-go-v2/service/networkflowmonitor v1.11.11/go.mod h1:WNVP52DRoC0YOaS3EFfQ6VAat21xbwCtn4KaKr00vow=
 github.com/aws/aws-sdk-go-v2/service/networkmanager v1.42.0 h1:xWEOUBxKqNCR3qkUsmYOPUyW7ZlyWzKX6s0f81PW60A=

--- a/go.sum
+++ b/go.sum
@@ -121,8 +121,8 @@ github.com/aws/aws-sdk-go-v2/service/cloud9 v1.34.1 h1:Ggr0UznpMf8Bs5VP6k7CqxohK
 github.com/aws/aws-sdk-go-v2/service/cloud9 v1.34.1/go.mod h1:GVumurfBCSPfjp0Nq5zyQsFkwxm0u5JpG/1ltIeGyEI=
 github.com/aws/aws-sdk-go-v2/service/cloudcontrol v1.30.1 h1:AGb453LNQkxO5AJaQhIu7xRHTJjYI9xwi2LSdcTtBn8=
 github.com/aws/aws-sdk-go-v2/service/cloudcontrol v1.30.1/go.mod h1:0yYjIDvv3b9RHChdAEotH9RQNjQAJxyvFRpvTZMJJ0M=
-github.com/aws/aws-sdk-go-v2/service/cloudformation v1.71.11 h1:gIRdzLv98ugE0nvMkub5yp4uziPFHF66ERrQ9JN+D54=
-github.com/aws/aws-sdk-go-v2/service/cloudformation v1.71.11/go.mod h1:BMpnKVWK+343lUuI2ZM5bm282z+p61ZK9kwRg6/wBm4=
+github.com/aws/aws-sdk-go-v2/service/cloudformation v1.71.12 h1:XS2aRt1R1+ioudqhFIWLHhi8LoXobIIIx9zfoUrRLYE=
+github.com/aws/aws-sdk-go-v2/service/cloudformation v1.71.12/go.mod h1:QnZX1r0jQrYXnTlpne1T04aGFjbeFtmvY38o+fsVlvU=
 github.com/aws/aws-sdk-go-v2/service/cloudfront v1.64.0 h1:a6XmNe8cAvfrXVKwjXzWl9HHtuyE/n4kBroNm2mSOyo=
 github.com/aws/aws-sdk-go-v2/service/cloudfront v1.64.0/go.mod h1:brhMG/gR2xEB5lezxL2Cx+hqsEzGUn4LhNUtu7+ePFE=
 github.com/aws/aws-sdk-go-v2/service/cloudfrontkeyvaluestore v1.12.26 h1:nHUJWEa2oFFRWJpTVjxZp2QiaQl89Z8O7rmHW/yeu+0=

--- a/go.sum
+++ b/go.sum
@@ -331,8 +331,8 @@ github.com/aws/aws-sdk-go-v2/service/kinesisanalyticsv2 v1.38.0 h1:lTH3x76PDEV1a
 github.com/aws/aws-sdk-go-v2/service/kinesisanalyticsv2 v1.38.0/go.mod h1:8OH7Tvb6KDFKpID8pkeCo668eGLAe7VsipQtcF7ktLI=
 github.com/aws/aws-sdk-go-v2/service/kinesisvideo v1.33.11 h1:sYHiMglkBZbIVCZEoCjse08cMqLu/9lytB3keV0muGY=
 github.com/aws/aws-sdk-go-v2/service/kinesisvideo v1.33.11/go.mod h1:7kyj3hyFDn4o32dEeQf+XVF73rvJzu2VIrIn31u3imE=
-github.com/aws/aws-sdk-go-v2/service/kms v1.52.0 h1:QNtg+Mtj1zmepk568+UKBD5DFfqh+ESTUUqQT27JkQc=
-github.com/aws/aws-sdk-go-v2/service/kms v1.52.0/go.mod h1:Y0+uxvxz6ib4KktRdK0V4X45Vcs/JyYoz8H71pO8xeI=
+github.com/aws/aws-sdk-go-v2/service/kms v1.52.1 h1:qBc+5ZvMjb+Y+Ho+0wwyBYBITH1Wm5M1RJpt8DELPVU=
+github.com/aws/aws-sdk-go-v2/service/kms v1.52.1/go.mod h1:bWSG4E0FxeeDdfXseEnPfkFv4MqTY/6fDFGUHu/Wkb0=
 github.com/aws/aws-sdk-go-v2/service/lakeformation v1.47.8 h1:BtZujlNIGZJpz/6ZbhF6sNZf/B7qzjrO/L+U4ZImNbY=
 github.com/aws/aws-sdk-go-v2/service/lakeformation v1.47.8/go.mod h1:8ztA+uewolt+oJ2VEVUPIxhK5IW+4AVuDou6ju6wAAE=
 github.com/aws/aws-sdk-go-v2/service/lambda v1.90.1 h1:odCeJgHXfQoXEWQUIzPkKvsJTWcLMsaOWowNpovPFFw=

--- a/go.sum
+++ b/go.sum
@@ -321,8 +321,8 @@ github.com/aws/aws-sdk-go-v2/service/kafkaconnect v1.31.1 h1:ArCnvm+dkW5eThfz1P9
 github.com/aws/aws-sdk-go-v2/service/kafkaconnect v1.31.1/go.mod h1:71UZVNa0zpSvliXmaOVhFTa7YDQePW6AxyWV1F29PDo=
 github.com/aws/aws-sdk-go-v2/service/kendra v1.60.24 h1:rEo4jyDWChQCAHo55ryGSIrQYNbr/ZglWZQ1UIXHcks=
 github.com/aws/aws-sdk-go-v2/service/kendra v1.60.24/go.mod h1:zu/m6Ap5qItkBSIDoQlRFo6BNwZ145tpGmr0N2HwRqs=
-github.com/aws/aws-sdk-go-v2/service/keyspaces v1.25.7 h1:uQF+sXd/0Y1bIci9KCyxdDhbgI8O5JWea2VUukicctg=
-github.com/aws/aws-sdk-go-v2/service/keyspaces v1.25.7/go.mod h1:+666D+0+cFuzSwavezjOcMMxDuASZpb0f6kXSNxQ4A0=
+github.com/aws/aws-sdk-go-v2/service/keyspaces v1.26.0 h1:XzWibdCvfAdFtmEfoYe+gGS5qmZFsCSf/OuzmqOmtjI=
+github.com/aws/aws-sdk-go-v2/service/keyspaces v1.26.0/go.mod h1:GANMXCrbHQ3PXkymiJZLCwICRitWb7AVOnrwb8N2d/A=
 github.com/aws/aws-sdk-go-v2/service/kinesis v1.43.7 h1:9FvrpWzkSPbm995UGQ4jOdRDuhQLmwgh/5t8UoosTdY=
 github.com/aws/aws-sdk-go-v2/service/kinesis v1.43.7/go.mod h1:A7b/tv2nIcdfLY6EfH9fklY+L/wpVo6PtDJ6KA43PKg=
 github.com/aws/aws-sdk-go-v2/service/kinesisanalytics v1.30.25 h1:OBjINDp8xhZjliKWnidzagqyHpNIRPDm4jeP/173WkI=

--- a/go.sum
+++ b/go.sum
@@ -135,8 +135,8 @@ github.com/aws/aws-sdk-go-v2/service/cloudtrail v1.55.12 h1:vEtY+NJKYmCBjFrMQob5
 github.com/aws/aws-sdk-go-v2/service/cloudtrail v1.55.12/go.mod h1:3M8MhO9Z7Ev065eLAkInHs4vZABsa/SBMNg0m7NoVyI=
 github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.57.1 h1:i4i1wpCbEiFsge84hmvuLHpBCdhgfoAJTfDpPMr+sZA=
 github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.57.1/go.mod h1:751oDslfSNqbjCBSZYZKOvXl8Pbx9soAk2nISFo9sN0=
-github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.74.0 h1:6TqDeYdvJJEIJGg5ICy7nzC7/UuHk2Eg3wrpb5bWKPM=
-github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.74.0/go.mod h1:MLJu3PUd8fp5Qvj4CiLvyY5H8y7kxHKlTp060Wsd+Vc=
+github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.74.1 h1:8jNx+q40WGu+oYvW9bAo4wA/5P4RwKcMgInblHVRFhM=
+github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.74.1/go.mod h1:fzoRhw/rzt5X9EPA8fjbhZ/Ph0tChldiC/kPIFAGI7A=
 github.com/aws/aws-sdk-go-v2/service/codeartifact v1.39.0 h1:Fn9GARyT8xa81y8sYE5pvIjIRpYdUlbFyEuMadrkgoE=
 github.com/aws/aws-sdk-go-v2/service/codeartifact v1.39.0/go.mod h1:eyySIoSU4Mj4Ya1HD5Mf1EuzWvXAGaAS4mjSuGiBF4A=
 github.com/aws/aws-sdk-go-v2/service/codebuild v1.68.16 h1:ocvG4uGirVVBVsDQZGNlFPcKghtC/rxLW4y0jcwBp1I=

--- a/go.sum
+++ b/go.sum
@@ -313,8 +313,8 @@ github.com/aws/aws-sdk-go-v2/service/iot v1.74.0 h1:02uKsDppeZVALHa2majKLYoo2bUL
 github.com/aws/aws-sdk-go-v2/service/iot v1.74.0/go.mod h1:1/NELumOZj42LnUNYQRZVlu0D/q1p389umYs+1YKqBM=
 github.com/aws/aws-sdk-go-v2/service/ivs v1.51.0 h1:j9mf27acqCoQYGgOyMnXdofsai5Z0swskp5F1h6zJzc=
 github.com/aws/aws-sdk-go-v2/service/ivs v1.51.0/go.mod h1:jQ4K6GQ00jAI+UzNdil6lG9bBD6+loFAd2S4GoZAzD4=
-github.com/aws/aws-sdk-go-v2/service/ivschat v1.22.0 h1:NKO0cWPKFhn94H6SGpwd6aSS/ASc3PqNm8K7JUljXvI=
-github.com/aws/aws-sdk-go-v2/service/ivschat v1.22.0/go.mod h1:YtV5J3V6kO+ZIYpVSbdQhq3lrEFxQLDtqRNptC+rlGg=
+github.com/aws/aws-sdk-go-v2/service/ivschat v1.22.1 h1:VDLXIapXxzqeVeN1y2F1Ac/HjErc7ZPTz+dD0EfiKSg=
+github.com/aws/aws-sdk-go-v2/service/ivschat v1.22.1/go.mod h1:WohHsJOzPsHz8PmhizkZdExh0UbxG1P7zaIyV02Y4xQ=
 github.com/aws/aws-sdk-go-v2/service/kafka v1.52.0 h1:jalIJqKvZMvJRvs6ABLX+FhHz8E9pjU03Pyml4D9r3k=
 github.com/aws/aws-sdk-go-v2/service/kafka v1.52.0/go.mod h1:pW4pYNuVeScl13yqwsjLY0F/7g2YD8E0AvR6SOQsJZE=
 github.com/aws/aws-sdk-go-v2/service/kafkaconnect v1.31.0 h1:M0d76RXXSr320mhbr91xGraQX5qZHyjqaa0TR+FQkzg=

--- a/go.sum
+++ b/go.sum
@@ -529,8 +529,8 @@ github.com/aws/aws-sdk-go-v2/service/ssm v1.68.7 h1:mKVjTrV40syRvcLfenT75nY8MTr6
 github.com/aws/aws-sdk-go-v2/service/ssm v1.68.7/go.mod h1:67nfKysKquQ5VKZOPfxI8+0FCa18Vj8Ojy2nKjPHkR4=
 github.com/aws/aws-sdk-go-v2/service/ssmcontacts v1.32.1 h1:9+NviqMk6eedRqjIunBE7qBMHRc4y93vSqUIv3Lscc8=
 github.com/aws/aws-sdk-go-v2/service/ssmcontacts v1.32.1/go.mod h1:WEp0tvxt+uqTOpSjr1rfUUYGlVOCCA76QDfeIVqDF3A=
-github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.39.22 h1:xAMqo7ys/lr5jCxK922v755qklNno+aZHFxOXkYCcU8=
-github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.39.22/go.mod h1:0stvZYPGvcszNKhhvEeSjOEYhJSI+Z938KUDmiu+Ngs=
+github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.40.0 h1:AfdrW6qwJZL1/8Dg7HMpClcWi0rHh602En+4ij6gP2g=
+github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.40.0/go.mod h1:yl7ZtmrnHOFyzM7r0uGx2H8oLuwmPXyrYATZCHvU4Tg=
 github.com/aws/aws-sdk-go-v2/service/ssmquicksetup v1.9.0 h1:A63P9VmIvEwpkJ2t9kQwij/bY4NC6i09S+wVl8HU5RM=
 github.com/aws/aws-sdk-go-v2/service/ssmquicksetup v1.9.0/go.mod h1:L30rbC4sTiR0uIBkLk23p6AzjvwyfpWMo69IRCqdbIE=
 github.com/aws/aws-sdk-go-v2/service/ssmsap v1.26.7 h1:wbBhjngfYJsVongNhlt63l3YhHvbiljTtSyqI8QpNu4=

--- a/go.sum
+++ b/go.sum
@@ -569,8 +569,8 @@ github.com/aws/aws-sdk-go-v2/service/vpclattice v1.21.1 h1:XNrEJtc7gbo+UK9Otbyy/
 github.com/aws/aws-sdk-go-v2/service/vpclattice v1.21.1/go.mod h1:+6bxeMVFiKF9DbsnlPWSZZc09qvkEJAPaC9dZQvABYU=
 github.com/aws/aws-sdk-go-v2/service/waf v1.30.23 h1:haJSEMjnZSN06jrA3EtdHtYrzKZOmeaUtZ/jM3iIk18=
 github.com/aws/aws-sdk-go-v2/service/waf v1.30.23/go.mod h1:UU4sTEqsR0ymj69LvuxKBtneEvqnxkAnoRT58mJAF4U=
-github.com/aws/aws-sdk-go-v2/service/wafregional v1.30.23 h1:nSMoPH2GSzNREwCcUNgUuTT5fbN/NRlLXmF4ozCWXmw=
-github.com/aws/aws-sdk-go-v2/service/wafregional v1.30.23/go.mod h1:4z6g4XTbZ0xEwM6sJYBDn4YTkC7IItBYBBXMtcQzLAo=
+github.com/aws/aws-sdk-go-v2/service/wafregional v1.30.24 h1:rYfUYezU29dhNnX0ufDAiqLkuAqCigquygJogheO3iU=
+github.com/aws/aws-sdk-go-v2/service/wafregional v1.30.24/go.mod h1:X7/MWb1tXmdavn712tp+wPf4gC/zl6H4MHGOD8sZD7s=
 github.com/aws/aws-sdk-go-v2/service/wafv2 v1.71.5 h1:IMqwkBHrf3RjjNl+Xw0hkWz4WjB0ypcyNnRqOGiT7J0=
 github.com/aws/aws-sdk-go-v2/service/wafv2 v1.71.5/go.mod h1:4PHOazTWE3wBq/xYohRMnO7vv3H0WgBYAvR8hyeZCfI=
 github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.39.23 h1:5xJQfmla2mUX3vaYBMBTzF31Db4UWqKIjtcjZ3+rOnc=

--- a/go.sum
+++ b/go.sum
@@ -551,8 +551,8 @@ github.com/aws/aws-sdk-go-v2/service/synthetics v1.42.17 h1:laIoRwwPASaSQl/U+8mr
 github.com/aws/aws-sdk-go-v2/service/synthetics v1.42.17/go.mod h1:OnocIS6UzQdU0bC/tP7vNkB/6Lb3jwgEqO1bhQhbpco=
 github.com/aws/aws-sdk-go-v2/service/taxsettings v1.16.24 h1:jLJ3xMWjeHbmilHerEyVMILfQ/imOFAslNgHswpPXdo=
 github.com/aws/aws-sdk-go-v2/service/taxsettings v1.16.24/go.mod h1:Ufi/y8T3Yuj3w05IDIvevtz+wxQjrXeBIroAGjCKJtQ=
-github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.19.2 h1:D9z71BkiK5Xa6ibHU/3bkIAyGRwfqnn3jH8EWGhuzxs=
-github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.19.2/go.mod h1:hMTWUZs9ne9yqIiqHuMc0UcdNA6gYiA4VPyJ0jK7YJs=
+github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.20.0 h1:4zRcgn5fbavj1H4EaQzsK5cqe7HJhdh+2zsS6Qpnscc=
+github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.20.0/go.mod h1:HuKojo4zKYq6UOvPeorfcmR6BlOxIjZx9/6mXVV5C5M=
 github.com/aws/aws-sdk-go-v2/service/timestreamquery v1.36.17 h1:PAw0bg4Vw9G19+ozW3uJQXxxNYqk8J3jztJxZBCU71g=
 github.com/aws/aws-sdk-go-v2/service/timestreamquery v1.36.17/go.mod h1:/LTHgqxCcbaCh1QLp/uclq79iOFiauvra1lUNb4Co40=
 github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.35.23 h1:ibF4VUUnR8kveX/3pURldl1bTaEEAin8mjnmtzQGuzw=

--- a/go.sum
+++ b/go.sum
@@ -193,8 +193,8 @@ github.com/aws/aws-sdk-go-v2/service/datapipeline v1.30.23 h1:6YmSGnneMPxn3l3mHC
 github.com/aws/aws-sdk-go-v2/service/datapipeline v1.30.23/go.mod h1:98PrkTTHhKEp4uYhBYynJxNeuui1KXR6WvtT1mQGH3U=
 github.com/aws/aws-sdk-go-v2/service/datasync v1.59.1 h1:0rV9cHprMcB05StCAiqt1ZarbSDMst1wzMIDX6fxX5I=
 github.com/aws/aws-sdk-go-v2/service/datasync v1.59.1/go.mod h1:sQV6i+7URqrZCc8IsjVS75RVYdSB9+P31uY6dt7sUqY=
-github.com/aws/aws-sdk-go-v2/service/datazone v1.62.0 h1:ThT7AGMBPcBhDgXVOwiZyJ3x63X4NfruC63Ij4hnFjI=
-github.com/aws/aws-sdk-go-v2/service/datazone v1.62.0/go.mod h1:XdP77XvH2J7MVHRA+i7JSxpEqDC0TeXEfbXPHMQLEFw=
+github.com/aws/aws-sdk-go-v2/service/datazone v1.62.1 h1:RAGYoo2eV8cCmeFpDpAJzG0wHiPRFrx8EN3XtyxdTkc=
+github.com/aws/aws-sdk-go-v2/service/datazone v1.62.1/go.mod h1:ywdC/CddVikMtG/IoiGw9t2ZEdWQcFJ4PdeOie3M5KY=
 github.com/aws/aws-sdk-go-v2/service/dax v1.29.18 h1:sZwTAlW7WiDiLBjDk6OvmbOBjXQPooArNkUbTzCupOU=
 github.com/aws/aws-sdk-go-v2/service/dax v1.29.18/go.mod h1:zAdYaGSQXmr+LwBX8pp5vHvcToXC5SEOKPlDUhZMMRc=
 github.com/aws/aws-sdk-go-v2/service/detective v1.38.15 h1:H5v+Sro9ZL5OQGOoxuZz8RTzvO23VkOJ1LjKqXbank8=

--- a/go.sum
+++ b/go.sum
@@ -233,8 +233,8 @@ github.com/aws/aws-sdk-go-v2/service/efs v1.41.17 h1:0RViZJ5P2Tpm8OSTGFMVRJHDP6d
 github.com/aws/aws-sdk-go-v2/service/efs v1.41.17/go.mod h1:epIbYreyUL7HvPdLyEGpao66ZKaeafXHAXuWdB3Oass=
 github.com/aws/aws-sdk-go-v2/service/eks v1.84.1 h1:v3IeM72tqpk3LGx+PCPEP2IP8SsBwdIimDRpk+RcAvc=
 github.com/aws/aws-sdk-go-v2/service/eks v1.84.1/go.mod h1:4KiCxT4w134foeUz8N5tKJBNaKMBw62nYTsr9ewDVP4=
-github.com/aws/aws-sdk-go-v2/service/elasticache v1.52.2 h1:5wbCUfyxXcjIqesyVfJBBJs0bDMyejthtHyy48mfZCI=
-github.com/aws/aws-sdk-go-v2/service/elasticache v1.52.2/go.mod h1:o4vQxDt6oteknUjkXIEskp0ccy+93NRTPKXw3HlVMFE=
+github.com/aws/aws-sdk-go-v2/service/elasticache v1.52.3 h1:l6i/86M1/beEHPdxcj/85RuUH0egKZ2m8F8eMA+ejPE=
+github.com/aws/aws-sdk-go-v2/service/elasticache v1.52.3/go.mod h1:hpwaNXHNAM4EP+m38yzQI4hOgVwnjlNfK7Iq9GXYl04=
 github.com/aws/aws-sdk-go-v2/service/elasticbeanstalk v1.34.4 h1:0lWGw/CCacFJ97IBwi25huydqDogkF+aX0cnluiTsNA=
 github.com/aws/aws-sdk-go-v2/service/elasticbeanstalk v1.34.4/go.mod h1:DVDotsaHVCjF12bvBnytGoD5VU+eRYpAuaKdB9US49Q=
 github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing v1.33.25 h1:VzmoYPRbNSUqk3pA04ZyGZUg52yfX259XXRqwr1lns4=

--- a/go.sum
+++ b/go.sum
@@ -423,8 +423,8 @@ github.com/aws/aws-sdk-go-v2/service/pinpointsmsvoicev2 v1.29.0 h1:QZcwdS7MHOTFy
 github.com/aws/aws-sdk-go-v2/service/pinpointsmsvoicev2 v1.29.0/go.mod h1:3JW0jAoKkJsjUJuSbCDFyra1qIR0PRJfmPQWwe3lT04=
 github.com/aws/aws-sdk-go-v2/service/pipes v1.24.1 h1:0s9bqePCk0ViKJ4xlLRAG5gm/mc2h6gFU5dbA9Ij3lY=
 github.com/aws/aws-sdk-go-v2/service/pipes v1.24.1/go.mod h1:4wuEBSaANzxEjG58fcQeVmB2zV8m+iXQTV1phQdX/sE=
-github.com/aws/aws-sdk-go-v2/service/polly v1.57.5 h1:6pvU6R++AiWb3+NNgpoMjYnPNu2hsEEXJLK5V8BQ1G4=
-github.com/aws/aws-sdk-go-v2/service/polly v1.57.5/go.mod h1:PHlrCWacL+SBBUZ/wmgWl+gYOC4kPvRod1c7MHV+RVI=
+github.com/aws/aws-sdk-go-v2/service/polly v1.57.6 h1:TqNFnSXqL6eKmMiUCyX+EEQfa3omsM8NUjNaSBSH1Zo=
+github.com/aws/aws-sdk-go-v2/service/polly v1.57.6/go.mod h1:TdxNyiJawW7TwVxHULA7Rg3MStnSgBIBF6S+XiF0o4A=
 github.com/aws/aws-sdk-go-v2/service/pricing v1.42.0 h1:SsLM4EzFcuoHCTOnoldpRLUnJQJ/6/UfxwW33atxrwA=
 github.com/aws/aws-sdk-go-v2/service/pricing v1.42.0/go.mod h1:zXv2YjVkSugNoBHG8WrHHNqCyTFplsE8B8hCAV9riRA=
 github.com/aws/aws-sdk-go-v2/service/qbusiness v1.34.8 h1:fMFheeWMyC7aGeTIz+GJAaKanfOtOzOg78q/v0jKA4E=

--- a/go.sum
+++ b/go.sum
@@ -183,8 +183,8 @@ github.com/aws/aws-sdk-go-v2/service/costoptimizationhub v1.23.0 h1:H5zZyEmWfUUA
 github.com/aws/aws-sdk-go-v2/service/costoptimizationhub v1.23.0/go.mod h1:+/F97SyLRVhK+fM3dQge1DWIrhhr/bNEzMCvixl0VRs=
 github.com/aws/aws-sdk-go-v2/service/customerprofiles v1.62.0 h1:+5UR/UaODIBy0e1nJJZr7h+sg5PiWRZyO2d7PWpcAk0=
 github.com/aws/aws-sdk-go-v2/service/customerprofiles v1.62.0/go.mod h1:wssUdi0eG5acDhEjKWq11oP1X49rSMJ7ztO0hHFLIOk=
-github.com/aws/aws-sdk-go-v2/service/databasemigrationservice v1.63.0 h1:n80jw/JxEyeeZo9Df9fHUFVIrPmY5WRZSo9u6WkbWKk=
-github.com/aws/aws-sdk-go-v2/service/databasemigrationservice v1.63.0/go.mod h1:Qa7SOwwtaE9VticcY52FgDIXJZLS1jz+Y6fiCdLUdRU=
+github.com/aws/aws-sdk-go-v2/service/databasemigrationservice v1.63.1 h1:A3ZPi0AHJvhq4OiBFqjGkCW/OV0n0bYJnubWyUKwyhs=
+github.com/aws/aws-sdk-go-v2/service/databasemigrationservice v1.63.1/go.mod h1:+5VgeIKl82hc3J8/Z6rZpGLaNMrRYkHdR7n4pWhaNOo=
 github.com/aws/aws-sdk-go-v2/service/databrew v1.40.0 h1:wuMzTtsMNVfR954WDxxuTSxE84uBjbUZpkHzl8FGEzY=
 github.com/aws/aws-sdk-go-v2/service/databrew v1.40.0/go.mod h1:JR6djN/YtdK6R03KYsrMoh/GzmFsIDAdtzjl1RjqqSQ=
 github.com/aws/aws-sdk-go-v2/service/dataexchange v1.41.2 h1:kO0lpy2o5+OFc7RA2u0xHQvf7gFmVxuljgbe9xt5d/M=

--- a/go.sum
+++ b/go.sum
@@ -333,8 +333,8 @@ github.com/aws/aws-sdk-go-v2/service/kinesisvideo v1.33.11 h1:sYHiMglkBZbIVCZEoC
 github.com/aws/aws-sdk-go-v2/service/kinesisvideo v1.33.11/go.mod h1:7kyj3hyFDn4o32dEeQf+XVF73rvJzu2VIrIn31u3imE=
 github.com/aws/aws-sdk-go-v2/service/kms v1.52.1 h1:qBc+5ZvMjb+Y+Ho+0wwyBYBITH1Wm5M1RJpt8DELPVU=
 github.com/aws/aws-sdk-go-v2/service/kms v1.52.1/go.mod h1:bWSG4E0FxeeDdfXseEnPfkFv4MqTY/6fDFGUHu/Wkb0=
-github.com/aws/aws-sdk-go-v2/service/lakeformation v1.47.8 h1:BtZujlNIGZJpz/6ZbhF6sNZf/B7qzjrO/L+U4ZImNbY=
-github.com/aws/aws-sdk-go-v2/service/lakeformation v1.47.8/go.mod h1:8ztA+uewolt+oJ2VEVUPIxhK5IW+4AVuDou6ju6wAAE=
+github.com/aws/aws-sdk-go-v2/service/lakeformation v1.47.9 h1:pLP0jbhZSUY3T8LPHWJ9BWbJPKE2i6TAW5l2emgZM9o=
+github.com/aws/aws-sdk-go-v2/service/lakeformation v1.47.9/go.mod h1:ZHQuEeYF365Q5ASJDbYzg/4ZxaTTyWmfBGyXaKxZw9A=
 github.com/aws/aws-sdk-go-v2/service/lambda v1.90.1 h1:odCeJgHXfQoXEWQUIzPkKvsJTWcLMsaOWowNpovPFFw=
 github.com/aws/aws-sdk-go-v2/service/lambda v1.90.1/go.mod h1:NbtJVztitG7JkuoI4GSrDUlsB32zeXqKBvXj6bUxcMo=
 github.com/aws/aws-sdk-go-v2/service/launchwizard v1.14.6 h1:csDiL1/b79JOn9c02M5l3COsSPsUVFM4Q0TT9BEbkYk=

--- a/go.sum
+++ b/go.sum
@@ -541,8 +541,8 @@ github.com/aws/aws-sdk-go-v2/service/ssoadmin v1.39.1 h1:ZxRj1EQomXSjmgiNbiz9UPy
 github.com/aws/aws-sdk-go-v2/service/ssoadmin v1.39.1/go.mod h1:AgTMuGgg8LytG0uA525B9XzcoQVX5EXEXgsulpvQuqU=
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.36.1 h1:4VD7TIZOGzehrgQ8vDE+1c6BQW4ErZPGY8ohZT5LXEE=
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.36.1/go.mod h1:er0SFJfdV89Rit5hIJu/EXtv+qC2XMnxoksLmcUFkqM=
-github.com/aws/aws-sdk-go-v2/service/storagegateway v1.43.16 h1:wqoUsLBMsGMd91z4j7rN0pIV3+5DHDviVJh/R+XOen4=
-github.com/aws/aws-sdk-go-v2/service/storagegateway v1.43.16/go.mod h1:EYZjMeckp4X2MSyeaHcM4KqJDxdBVXoU/a6u3WQoB1s=
+github.com/aws/aws-sdk-go-v2/service/storagegateway v1.43.17 h1:XM4scnJ3RN5rGZ6liN3NfrhPiOGyGHTjxNySSwqbcxQ=
+github.com/aws/aws-sdk-go-v2/service/storagegateway v1.43.17/go.mod h1:IjPL178wNElOmXpaCHIqoNWQBZoCnDx/oX5N1Xu3gNA=
 github.com/aws/aws-sdk-go-v2/service/sts v1.42.2 h1:XKnxlM4KZH1gktcsh3zSWc7GW4KivEv/OkifmHOhCUY=
 github.com/aws/aws-sdk-go-v2/service/sts v1.42.2/go.mod h1:KJYmkQaFB3SUW2j3aBkPsxNmAb4ZsSOvbvCpuxzHJA0=
 github.com/aws/aws-sdk-go-v2/service/swf v1.33.18 h1:SjWST41D98QAQs/S2wDlH8zts5SgngDd0qkKG9WUX6M=

--- a/go.sum
+++ b/go.sum
@@ -499,8 +499,8 @@ github.com/aws/aws-sdk-go-v2/service/securityhub v1.71.1 h1:hbs1hLreR86SPC4wRp3G
 github.com/aws/aws-sdk-go-v2/service/securityhub v1.71.1/go.mod h1:agWYh3l/L9DfbvSKZBRlOYWhhl0ItrwmNzAbJLHvpPs=
 github.com/aws/aws-sdk-go-v2/service/securitylake v1.25.16 h1:fw1BIyWJrpjLhkdyiCDEBX9QRrIc1y40TBNxigvLSgg=
 github.com/aws/aws-sdk-go-v2/service/securitylake v1.25.16/go.mod h1:l/xI6VzP6fKQLvJi9rAbYym6ba/BI6Xl4GWM9IsyWdE=
-github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.31.0 h1:3qMdhh0sw7j73U82bj5PXXm4QVo23ANHsWF0JnmW5ls=
-github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.31.0/go.mod h1:QTf9w87F4wL2Ob5LgJETQcQTl03fqBr/N2rQlCQyYlc=
+github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.31.1 h1:dViX67zSP0rzdE8o4JW+Ttnm12+P+dwlgKnR48acSQI=
+github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.31.1/go.mod h1:J2Tcq2gsS7odqtAtMBWjcqnvh0Iz2l1SCowpzMBO0xE=
 github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.39.15 h1:ZCxvNcAKhyoOtNcBOTWMK9SzgMWf9TUlsx/pX5SqcTc=
 github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.39.15/go.mod h1:Ava9lSQtC5dJqB/H+usuyndF17h2o4YWEVF1MYxGss0=
 github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry v1.36.0 h1:kXEL4NsZt/JUCMOzQFi5qSD2CcfkzuZba4bvPdNsgtY=

--- a/go.sum
+++ b/go.sum
@@ -427,8 +427,8 @@ github.com/aws/aws-sdk-go-v2/service/polly v1.57.6 h1:TqNFnSXqL6eKmMiUCyX+EEQfa3
 github.com/aws/aws-sdk-go-v2/service/polly v1.57.6/go.mod h1:TdxNyiJawW7TwVxHULA7Rg3MStnSgBIBF6S+XiF0o4A=
 github.com/aws/aws-sdk-go-v2/service/pricing v1.42.1 h1:jjVDmqf3S3+KmHR24xJUR5ih2JPH3Hh/mG1r1Sejl28=
 github.com/aws/aws-sdk-go-v2/service/pricing v1.42.1/go.mod h1:lNpZkF5CiauLI0irg40hCRrPRP2Y9Cu9yGTxnSNZh/o=
-github.com/aws/aws-sdk-go-v2/service/qbusiness v1.34.8 h1:fMFheeWMyC7aGeTIz+GJAaKanfOtOzOg78q/v0jKA4E=
-github.com/aws/aws-sdk-go-v2/service/qbusiness v1.34.8/go.mod h1:S8/FKYPSm2WEEGMs5gmbrOrULz0zvJ1CYkf2UEnYzYw=
+github.com/aws/aws-sdk-go-v2/service/qbusiness v1.34.9 h1:rmjAYwOYrhNeK5RTBMcr84TOSODs5k5zh83Lbsh72dk=
+github.com/aws/aws-sdk-go-v2/service/qbusiness v1.34.9/go.mod h1:DTnIR42C7d8ubYOZWmTiBLKP2xxvCQCRYNBkTdhE/7I=
 github.com/aws/aws-sdk-go-v2/service/qldb v1.32.2 h1:tSctQisNHgXnDmyoOdLXkSQmHYo5yPQuvYK+4c4QiNI=
 github.com/aws/aws-sdk-go-v2/service/qldb v1.32.2/go.mod h1:m6bmXbLs5XiGnTLcgKn9eNk5+GCO5e/wHQsIuN7d1Tw=
 github.com/aws/aws-sdk-go-v2/service/quicksight v1.111.0 h1:9lnHJnuRb9o7UXtPNwdOUHjnSuBKuw5RNXG98EiZQdw=

--- a/go.sum
+++ b/go.sum
@@ -397,8 +397,8 @@ github.com/aws/aws-sdk-go-v2/service/notificationscontacts v1.6.1 h1:/+83sWWF9wz
 github.com/aws/aws-sdk-go-v2/service/notificationscontacts v1.6.1/go.mod h1:CgMKkMvi8mRoRFbjbhGj/tuYvhIp5wmiHkC4aYwCQAo=
 github.com/aws/aws-sdk-go-v2/service/oam v1.24.1 h1:QrXBn2Al2hSKd7iuncZwBh3Sm/M4w/AJqJwbUB/bcKo=
 github.com/aws/aws-sdk-go-v2/service/oam v1.24.1/go.mod h1:eQpqFnDbhCA78FU2Z5ZHyQ/x8mxPJMfWms/BnyB3POc=
-github.com/aws/aws-sdk-go-v2/service/observabilityadmin v1.16.0 h1:Ys/ZOm9bowwjJRkkv8iVjz6tRTnx1yAWknsdydNKnJU=
-github.com/aws/aws-sdk-go-v2/service/observabilityadmin v1.16.0/go.mod h1:BXfyXkrz+WDrJkHfWlj/+/WtVS2mKDUsWc2UcgcvVLY=
+github.com/aws/aws-sdk-go-v2/service/observabilityadmin v1.16.1 h1:UuKlVsiBejuh5sXgRRPPP0NcuDf5CArVCw4IBBEwwpM=
+github.com/aws/aws-sdk-go-v2/service/observabilityadmin v1.16.1/go.mod h1:krmgFpcpTaoPQlNgbliWg/O+UxC/jXn26a0NKKldCnY=
 github.com/aws/aws-sdk-go-v2/service/odb v1.11.0 h1:ugOElkAyu12xSVwgBZc4kK/bydeJpo7HVeWOqHFLSJ8=
 github.com/aws/aws-sdk-go-v2/service/odb v1.11.0/go.mod h1:2e7052lsNNzRF38Ogopkj2dlzFlSOQi3yX+uO8056pQ=
 github.com/aws/aws-sdk-go-v2/service/opensearch v1.69.0 h1:ogIqeUpD0k00Jr7DwaaO6VIR0o6aqnLiLetBVLgYt/4=

--- a/go.sum
+++ b/go.sum
@@ -533,8 +533,8 @@ github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.40.0 h1:AfdrW6qwJZL1/8Dg7HM
 github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.40.0/go.mod h1:yl7ZtmrnHOFyzM7r0uGx2H8oLuwmPXyrYATZCHvU4Tg=
 github.com/aws/aws-sdk-go-v2/service/ssmquicksetup v1.9.1 h1:WXPqjvJRG2hH/RLX0lM9myjhC8kHFKmJ+KRWSjQ7ZRY=
 github.com/aws/aws-sdk-go-v2/service/ssmquicksetup v1.9.1/go.mod h1:gInfq0wttvoOxb9nB0UH2RjahPb/PYWJD2IItOlv6Hs=
-github.com/aws/aws-sdk-go-v2/service/ssmsap v1.26.7 h1:wbBhjngfYJsVongNhlt63l3YhHvbiljTtSyqI8QpNu4=
-github.com/aws/aws-sdk-go-v2/service/ssmsap v1.26.7/go.mod h1:KI9kx0878kbUTCw3zXCf2JvuswE0GzwgFSQtzCd1qHM=
+github.com/aws/aws-sdk-go-v2/service/ssmsap v1.27.1 h1:h4lRgHktVhGZzjKpEsYTs/nSdU9gCC6jPOG++pMxhC0=
+github.com/aws/aws-sdk-go-v2/service/ssmsap v1.27.1/go.mod h1:+TPOmtCm13tG8EQuTY5t5WfCX3OBbchS5WzrWfcMPgA=
 github.com/aws/aws-sdk-go-v2/service/sso v1.30.18 h1:ApLTFdAZfDhZSiY5uskwECKHkSNNF83y2Ru2r7SezWA=
 github.com/aws/aws-sdk-go-v2/service/sso v1.30.18/go.mod h1:A9K9qx2l6nK89hp+a350FdGfRkrkH5HdiEjHbiy/Q/c=
 github.com/aws/aws-sdk-go-v2/service/ssoadmin v1.39.0 h1:tYMyan5oUI4EtkBUO+lCzc1aRboQQZ26V+GC3WEEiHk=

--- a/go.sum
+++ b/go.sum
@@ -497,8 +497,8 @@ github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.8 h1:1+cxbGx12HXmXlJnU
 github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.8/go.mod h1:OoxL3xzUUjYMDWPxth/zM+wlgmYOKAU5qY4BKit3u8U=
 github.com/aws/aws-sdk-go-v2/service/securityhub v1.71.1 h1:hbs1hLreR86SPC4wRp3GglTvNlqrhEZUFvEbuhYzUGs=
 github.com/aws/aws-sdk-go-v2/service/securityhub v1.71.1/go.mod h1:agWYh3l/L9DfbvSKZBRlOYWhhl0ItrwmNzAbJLHvpPs=
-github.com/aws/aws-sdk-go-v2/service/securitylake v1.25.15 h1:s92UU/ju1C28XiBmf4nmCRYnWLOpbxuLJ/iCDPC0RLg=
-github.com/aws/aws-sdk-go-v2/service/securitylake v1.25.15/go.mod h1:JgTWGploCcj5G0rPdcYDR3Ao3T4J4kPMEB5hPv6IGBk=
+github.com/aws/aws-sdk-go-v2/service/securitylake v1.25.16 h1:fw1BIyWJrpjLhkdyiCDEBX9QRrIc1y40TBNxigvLSgg=
+github.com/aws/aws-sdk-go-v2/service/securitylake v1.25.16/go.mod h1:l/xI6VzP6fKQLvJi9rAbYym6ba/BI6Xl4GWM9IsyWdE=
 github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.31.0 h1:3qMdhh0sw7j73U82bj5PXXm4QVo23ANHsWF0JnmW5ls=
 github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.31.0/go.mod h1:QTf9w87F4wL2Ob5LgJETQcQTl03fqBr/N2rQlCQyYlc=
 github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.39.15 h1:ZCxvNcAKhyoOtNcBOTWMK9SzgMWf9TUlsx/pX5SqcTc=

--- a/go.sum
+++ b/go.sum
@@ -359,8 +359,8 @@ github.com/aws/aws-sdk-go-v2/service/mediaconvert v1.91.3 h1:8/TuAc1vhYA4Woy7Tfq
 github.com/aws/aws-sdk-go-v2/service/mediaconvert v1.91.3/go.mod h1:K7xRA32242aLotLpG35AptbkKgBuSWfCQvSuflTRURI=
 github.com/aws/aws-sdk-go-v2/service/medialive v1.97.1 h1:CaaGyFVpZGGydt4vkFFx2rUNw8wg2zlwYlNcweLBLpM=
 github.com/aws/aws-sdk-go-v2/service/medialive v1.97.1/go.mod h1:7imY/+11Qy5wkFLlDbgclEzsCRM3kkJaxx2E7oPFtwI=
-github.com/aws/aws-sdk-go-v2/service/mediapackage v1.39.23 h1:ztbUtcql2vd65yqnEz/k+bTX8PBP1J4to32/ck5hLAA=
-github.com/aws/aws-sdk-go-v2/service/mediapackage v1.39.23/go.mod h1:3+LhO1Y/ZUTvLmnBsWJyMs4qBBUQJ9dAe8/DqutP+48=
+github.com/aws/aws-sdk-go-v2/service/mediapackage v1.39.24 h1:fyFyHZcBKpyUsppI5nxHf/uHZobtBjn39l1EFRQfHJA=
+github.com/aws/aws-sdk-go-v2/service/mediapackage v1.39.24/go.mod h1:/QFYcNuiSprNSxlGHsb9nZwzYgCnIhi9j4BlEQvZtZU=
 github.com/aws/aws-sdk-go-v2/service/mediapackagev2 v1.39.0 h1:+rIQceAbYT97OKasPK7f8E/wwh/3wAdABV0fSs+CUhU=
 github.com/aws/aws-sdk-go-v2/service/mediapackagev2 v1.39.0/go.mod h1:lmYE+EShgxxI35+UwVCbE8Z3OsutViSOMNNx3Y3/Y3c=
 github.com/aws/aws-sdk-go-v2/service/mediapackagevod v1.39.23 h1:3D0AdP2dlAuyS8+bI32nwWeVElqpum5x57qd7gnv0/g=

--- a/go.sum
+++ b/go.sum
@@ -311,8 +311,8 @@ github.com/aws/aws-sdk-go-v2/service/invoicing v1.11.1 h1:kTiy0bkxsbkzBwZkwYDo8W
 github.com/aws/aws-sdk-go-v2/service/invoicing v1.11.1/go.mod h1:iCJX4vAw5TUZz+IbcrxugeF03bK/2VrAKUV7wguQIUo=
 github.com/aws/aws-sdk-go-v2/service/iot v1.74.0 h1:02uKsDppeZVALHa2majKLYoo2bULbNCmAA3iD+iSL64=
 github.com/aws/aws-sdk-go-v2/service/iot v1.74.0/go.mod h1:1/NELumOZj42LnUNYQRZVlu0D/q1p389umYs+1YKqBM=
-github.com/aws/aws-sdk-go-v2/service/ivs v1.50.1 h1:H/tTA4a7nmiFacIKeQjK/S8m7Ah/OXzSSLwPXEtD3l8=
-github.com/aws/aws-sdk-go-v2/service/ivs v1.50.1/go.mod h1:bu+KAqMu3i8tSo+e5AT3LriDJ6miYVK1E3hVqBXFA/k=
+github.com/aws/aws-sdk-go-v2/service/ivs v1.51.0 h1:j9mf27acqCoQYGgOyMnXdofsai5Z0swskp5F1h6zJzc=
+github.com/aws/aws-sdk-go-v2/service/ivs v1.51.0/go.mod h1:jQ4K6GQ00jAI+UzNdil6lG9bBD6+loFAd2S4GoZAzD4=
 github.com/aws/aws-sdk-go-v2/service/ivschat v1.22.0 h1:NKO0cWPKFhn94H6SGpwd6aSS/ASc3PqNm8K7JUljXvI=
 github.com/aws/aws-sdk-go-v2/service/ivschat v1.22.0/go.mod h1:YtV5J3V6kO+ZIYpVSbdQhq3lrEFxQLDtqRNptC+rlGg=
 github.com/aws/aws-sdk-go-v2/service/kafka v1.52.0 h1:jalIJqKvZMvJRvs6ABLX+FhHz8E9pjU03Pyml4D9r3k=

--- a/go.sum
+++ b/go.sum
@@ -391,8 +391,8 @@ github.com/aws/aws-sdk-go-v2/service/networkmanager v1.42.1 h1:9o2GTfTTFQtorK/GU
 github.com/aws/aws-sdk-go-v2/service/networkmanager v1.42.1/go.mod h1:jWEPRVbipvd1/BZHOIgQjBN0RjPX+VE+vi7EbO52gkI=
 github.com/aws/aws-sdk-go-v2/service/networkmonitor v1.14.0 h1:kRw49kdziIuc5pz2+dPb9sYNf+1WCd10/pYl437M0bA=
 github.com/aws/aws-sdk-go-v2/service/networkmonitor v1.14.0/go.mod h1:G7P74BfTAeAp1qmfBe4NOlcz28e0L1a6xkjm/cdLGb4=
-github.com/aws/aws-sdk-go-v2/service/notifications v1.8.0 h1:TjLraX0tvsqAN1CgkQkQbl3ga91FhAXRPsPvQf+dp6I=
-github.com/aws/aws-sdk-go-v2/service/notifications v1.8.0/go.mod h1:2ShOanXPWp9GRHTHQP4gV2+YCrfiXL5gpchgRJzfdf4=
+github.com/aws/aws-sdk-go-v2/service/notifications v1.8.1 h1:p3fifBWnYwYZDl4dWnYH5jDOnIH+JpNVbj4RgSJEhc4=
+github.com/aws/aws-sdk-go-v2/service/notifications v1.8.1/go.mod h1:BFR5AGKy6wApHVrQzMGzAIIhu9XHLsC9Vr4Dhrr8MhU=
 github.com/aws/aws-sdk-go-v2/service/notificationscontacts v1.6.0 h1:3Roxg1ro+M11PFgPTmAuc4WnaD6B57s+Uur5l9Od/ck=
 github.com/aws/aws-sdk-go-v2/service/notificationscontacts v1.6.0/go.mod h1:OC9ulnk7D/U4pJ8aF5yc5E5UDNTUYeVYNorOytuPL+g=
 github.com/aws/aws-sdk-go-v2/service/oam v1.24.0 h1:O0sFLaMTd2qQHtU8HFH9hgnTcJCzEoGNmxdE7P1yuSo=

--- a/go.sum
+++ b/go.sum
@@ -437,8 +437,8 @@ github.com/aws/aws-sdk-go-v2/service/ram v1.36.6 h1:JTIlCNJMmjA1Z2JqVEEBeGQhVNkU
 github.com/aws/aws-sdk-go-v2/service/ram v1.36.6/go.mod h1:mIXcD41n1f5BvqKUWB4GX99CfQgiW6Z07LfNPr6UKvQ=
 github.com/aws/aws-sdk-go-v2/service/rbin v1.28.1 h1:vrR/SGBj/uCiJVUHPIxcqK+wt4ZeN20ZFznY3LNsSEk=
 github.com/aws/aws-sdk-go-v2/service/rbin v1.28.1/go.mod h1:OET1iQb9KlgKiRcT4rqsG5EbcGIAZu6+sptNIOO7mUg=
-github.com/aws/aws-sdk-go-v2/service/rds v1.118.2 h1:pkEeQneYFpTAnGhyqSbyp/DlCPPJTGt0GkWahlLYzMA=
-github.com/aws/aws-sdk-go-v2/service/rds v1.118.2/go.mod h1:7gS+cGrKF0mH253QHFlStmx79ws+DlNk+04ZRfmw3U0=
+github.com/aws/aws-sdk-go-v2/service/rds v1.118.3 h1:Q6o5SuzC3+T1WjA6y/+vxPkFRFXPiGilPCdhdQZ4qp8=
+github.com/aws/aws-sdk-go-v2/service/rds v1.118.3/go.mod h1:Fjbrf3IlJCagXHMf1GRBLmpcBXK60g3y9laWG2lgUmg=
 github.com/aws/aws-sdk-go-v2/service/rdsdata v1.32.23 h1:CrpsWnO5yFYIBEqqOO70hbwJWHtipXd8bWHpfPxz0sk=
 github.com/aws/aws-sdk-go-v2/service/rdsdata v1.32.23/go.mod h1:USBiT9IyJ5Qi32+1al0yNYuAcwTjGMi0s/4ksO9MjdE=
 github.com/aws/aws-sdk-go-v2/service/redshift v1.62.8 h1:5Wg38ZauCqmomDAGTCDbA/t4vR5fUqIBTEwAOAswdng=

--- a/go.sum
+++ b/go.sum
@@ -421,8 +421,8 @@ github.com/aws/aws-sdk-go-v2/service/pinpoint v1.39.24 h1:67Y2jqLLj6en/ZCG8ISz0L
 github.com/aws/aws-sdk-go-v2/service/pinpoint v1.39.24/go.mod h1:k9ZdOPKJWrh5bFUnC0K4A0omUyGp0zFAcnPUX2/1v2o=
 github.com/aws/aws-sdk-go-v2/service/pinpointsmsvoicev2 v1.29.0 h1:QZcwdS7MHOTFy3kcEO/88Ql3sOmjRhCIAzIVdeZUum8=
 github.com/aws/aws-sdk-go-v2/service/pinpointsmsvoicev2 v1.29.0/go.mod h1:3JW0jAoKkJsjUJuSbCDFyra1qIR0PRJfmPQWwe3lT04=
-github.com/aws/aws-sdk-go-v2/service/pipes v1.24.0 h1:NlxDsdecMTXaqjwym1Bvfq5SkIvcowO5BfDouo3nLIE=
-github.com/aws/aws-sdk-go-v2/service/pipes v1.24.0/go.mod h1:zpfI78kzmseqeSDG1tA4++Y8TKMDDTBQcFiwNoPgjgU=
+github.com/aws/aws-sdk-go-v2/service/pipes v1.24.1 h1:0s9bqePCk0ViKJ4xlLRAG5gm/mc2h6gFU5dbA9Ij3lY=
+github.com/aws/aws-sdk-go-v2/service/pipes v1.24.1/go.mod h1:4wuEBSaANzxEjG58fcQeVmB2zV8m+iXQTV1phQdX/sE=
 github.com/aws/aws-sdk-go-v2/service/polly v1.57.5 h1:6pvU6R++AiWb3+NNgpoMjYnPNu2hsEEXJLK5V8BQ1G4=
 github.com/aws/aws-sdk-go-v2/service/polly v1.57.5/go.mod h1:PHlrCWacL+SBBUZ/wmgWl+gYOC4kPvRod1c7MHV+RVI=
 github.com/aws/aws-sdk-go-v2/service/pricing v1.42.0 h1:SsLM4EzFcuoHCTOnoldpRLUnJQJ/6/UfxwW33atxrwA=

--- a/go.sum
+++ b/go.sum
@@ -537,8 +537,8 @@ github.com/aws/aws-sdk-go-v2/service/ssmsap v1.27.1 h1:h4lRgHktVhGZzjKpEsYTs/nSd
 github.com/aws/aws-sdk-go-v2/service/ssmsap v1.27.1/go.mod h1:+TPOmtCm13tG8EQuTY5t5WfCX3OBbchS5WzrWfcMPgA=
 github.com/aws/aws-sdk-go-v2/service/sso v1.30.18 h1:ApLTFdAZfDhZSiY5uskwECKHkSNNF83y2Ru2r7SezWA=
 github.com/aws/aws-sdk-go-v2/service/sso v1.30.18/go.mod h1:A9K9qx2l6nK89hp+a350FdGfRkrkH5HdiEjHbiy/Q/c=
-github.com/aws/aws-sdk-go-v2/service/ssoadmin v1.39.0 h1:tYMyan5oUI4EtkBUO+lCzc1aRboQQZ26V+GC3WEEiHk=
-github.com/aws/aws-sdk-go-v2/service/ssoadmin v1.39.0/go.mod h1:pGysVP4s+vO9KUV2n8dpmO/IfDflX0WOz4WKdHJWvQw=
+github.com/aws/aws-sdk-go-v2/service/ssoadmin v1.39.1 h1:ZxRj1EQomXSjmgiNbiz9UPyydqwDnjB55hT/lll9nXI=
+github.com/aws/aws-sdk-go-v2/service/ssoadmin v1.39.1/go.mod h1:AgTMuGgg8LytG0uA525B9XzcoQVX5EXEXgsulpvQuqU=
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.36.1 h1:4VD7TIZOGzehrgQ8vDE+1c6BQW4ErZPGY8ohZT5LXEE=
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.36.1/go.mod h1:er0SFJfdV89Rit5hIJu/EXtv+qC2XMnxoksLmcUFkqM=
 github.com/aws/aws-sdk-go-v2/service/storagegateway v1.43.16 h1:wqoUsLBMsGMd91z4j7rN0pIV3+5DHDviVJh/R+XOen4=

--- a/go.sum
+++ b/go.sum
@@ -487,8 +487,8 @@ github.com/aws/aws-sdk-go-v2/service/s3vectors v1.7.1 h1:kS5jiMR5DgHoBHKyTZerpQj
 github.com/aws/aws-sdk-go-v2/service/s3vectors v1.7.1/go.mod h1:EbboPnapUuRZyMud+453TcE1BKQ9QJYP77RmGmT2CUM=
 github.com/aws/aws-sdk-go-v2/service/sagemaker v1.250.1 h1:KoMKWfzAftZzto69IkrRnilMJtmso3B+szOBp0gM2M4=
 github.com/aws/aws-sdk-go-v2/service/sagemaker v1.250.1/go.mod h1:5Rogcr8mhSUah+AoYFZvB10D3qPtqa3GbbxSx+pW3yI=
-github.com/aws/aws-sdk-go-v2/service/savingsplans v1.32.4 h1:BWmdjmP8sWqe0eICMM+2X2jic2S41bJ7xDhz3Wfd8/0=
-github.com/aws/aws-sdk-go-v2/service/savingsplans v1.32.4/go.mod h1:r/jBjd7QFGv9fsk0EFMjHKMPV6El60e4pa+BU4oyjBI=
+github.com/aws/aws-sdk-go-v2/service/savingsplans v1.33.1 h1:g4IDAQgDNOn6XAGdQgv9zpDTtPlAZmWM9NgBgEvoiG0=
+github.com/aws/aws-sdk-go-v2/service/savingsplans v1.33.1/go.mod h1:M+v5amm+fIixMXUd9D6XLsNeNOHhnj7R7y8sVKuPku4=
 github.com/aws/aws-sdk-go-v2/service/scheduler v1.18.0 h1:Qq2vBd/eezmHlfkaINHdzS3+r6B+1d+NJXYj4iVZ3rE=
 github.com/aws/aws-sdk-go-v2/service/scheduler v1.18.0/go.mod h1:0/mvOL++cUfpS4KgHigHDo+x8KLYG/grOTyIOw3KCPM=
 github.com/aws/aws-sdk-go-v2/service/schemas v1.35.0 h1:SWK85nZP86S/uwIqQ54G81PYLuATBaPxKEmRFDoP35o=

--- a/go.sum
+++ b/go.sum
@@ -85,8 +85,8 @@ github.com/aws/aws-sdk-go-v2/service/arczonalshift v1.22.26 h1:nv0oX1ZZ+6ny92QDp
 github.com/aws/aws-sdk-go-v2/service/arczonalshift v1.22.26/go.mod h1:+REsC19JcG05zJBgsR87rXVWwfBgdKXmmibQOrEmtok=
 github.com/aws/aws-sdk-go-v2/service/athena v1.57.7 h1:LqflSmquSJVH5UYG0oW+YPWMOo/zWTv84fFyZmiMkuc=
 github.com/aws/aws-sdk-go-v2/service/athena v1.57.7/go.mod h1:EI9CjMXiFy6pqdEWf4zhEcu06Xpr1Mxt+Lf+XAznpIE=
-github.com/aws/aws-sdk-go-v2/service/auditmanager v1.46.14 h1:JUaGgEfBSS1ok2Fmd6tUkNJviWk3NzgnS+zEbo2mMKo=
-github.com/aws/aws-sdk-go-v2/service/auditmanager v1.46.14/go.mod h1:KXqDl2so93n0kVWxXJm+oesedc5WfxVS6coPV7orpiA=
+github.com/aws/aws-sdk-go-v2/service/auditmanager v1.46.15 h1:dTNrl3E7ODY2PwCBnkamxnPUpDtSOq9wSuUGN+9FUmE=
+github.com/aws/aws-sdk-go-v2/service/auditmanager v1.46.15/go.mod h1:MCSrmKum8NXNs+tl3yS7obnDNdZX/TAqG8ooqmc6j3U=
 github.com/aws/aws-sdk-go-v2/service/autoscaling v1.66.2 h1:pPd+/Ujqf2+DmPOdB47EN7ox1iC21lu2zlOccUlfHeo=
 github.com/aws/aws-sdk-go-v2/service/autoscaling v1.66.2/go.mod h1:b3XHAIEe5I9cmeZ9MLvUqj5DRWcBuh1/hpKDPb7T6KE=
 github.com/aws/aws-sdk-go-v2/service/autoscalingplans v1.30.16 h1:NHXI8e2fGE30FviOO2x5M0sKc94E0uWLe+S4tG1ulBs=

--- a/go.sum
+++ b/go.sum
@@ -79,8 +79,8 @@ github.com/aws/aws-sdk-go-v2/service/appstream v1.60.0 h1:JuwEfGyAHpofgXhxNy5jIG
 github.com/aws/aws-sdk-go-v2/service/appstream v1.60.0/go.mod h1:NgdOdv2hoXmENwpqqLtyFC8MTcjqRpR9khOl2s1uWyU=
 github.com/aws/aws-sdk-go-v2/service/appsync v1.53.8 h1:CwHQQiBhvXbsEiDS3GERuVE4dRoH8S02jiMIf+Vcihw=
 github.com/aws/aws-sdk-go-v2/service/appsync v1.53.8/go.mod h1:gXYrh3UXmGd/XYsWikBgcjSLs1BAbxqzutFe8JZSuzU=
-github.com/aws/aws-sdk-go-v2/service/arcregionswitch v1.7.0 h1:z4HLC7u07UaaxClNTRsSt4Gy+AAOynoJZMMLijRHoAk=
-github.com/aws/aws-sdk-go-v2/service/arcregionswitch v1.7.0/go.mod h1:5RPh0JZSLageN5/FN0TUGaU+BjEyuXayyOtOo2DMvnU=
+github.com/aws/aws-sdk-go-v2/service/arcregionswitch v1.8.0 h1:clvHruzXl4C4/fDACW9chjs5YFMAmh+fZ/J+hk24jlY=
+github.com/aws/aws-sdk-go-v2/service/arcregionswitch v1.8.0/go.mod h1:hnvcKnh9kG1cJrZ/3fxXPEC9Bd/ck3mwXl9je2Kwo1Y=
 github.com/aws/aws-sdk-go-v2/service/arczonalshift v1.22.25 h1:K3E2d85dSlIfC+cZox0Bg1fjUeYtoOglDDYNqECA30w=
 github.com/aws/aws-sdk-go-v2/service/arczonalshift v1.22.25/go.mod h1:RYzavF/LbpmQlQ4VwiYJqYHAWErI5y+/MKrdgyd0AvM=
 github.com/aws/aws-sdk-go-v2/service/athena v1.57.6 h1:QPDxHlfHmozXUj9rmUyxQiOLVEJL3qX4x56CrwAtytM=

--- a/go.sum
+++ b/go.sum
@@ -559,8 +559,8 @@ github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.35.24 h1:9qHHrg3FTH+APkp
 github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.35.24/go.mod h1:E0ZDPhSKPaocAmHmVX6lr4QsTOn/FFi39uTb2Y2sSrg=
 github.com/aws/aws-sdk-go-v2/service/transcribe v1.55.1 h1:bEAU9OOwAyEOJF8cq94ysE/D9jQeWJRapb9Vo5RIE58=
 github.com/aws/aws-sdk-go-v2/service/transcribe v1.55.1/go.mod h1:l8fV0et8V7he/M+q43fNHvzN2jwxUqwBQjP4lJsnf8k=
-github.com/aws/aws-sdk-go-v2/service/transfer v1.72.0 h1:RbzzKZwU/fPSDpO731YSRDQqbp/h6IycNV5pgVCbJVk=
-github.com/aws/aws-sdk-go-v2/service/transfer v1.72.0/go.mod h1:NuALErcQ4g5s7KJef/5aoMwFmWn6deuczObKXYnuVRg=
+github.com/aws/aws-sdk-go-v2/service/transfer v1.72.1 h1:Pj3ornr6k2QZco8JXnwzqBQ4xjnsCE7zuG18Wd3b7pw=
+github.com/aws/aws-sdk-go-v2/service/transfer v1.72.1/go.mod h1:XzQPYzVLZiYqzySF5BqMEDZG8888AzZXVMzq4qdIZm0=
 github.com/aws/aws-sdk-go-v2/service/uxc v1.0.3 h1:IITkqJoAxK9qNzDXCAOisBMcUVhHM5AgUkAXHKu1JwY=
 github.com/aws/aws-sdk-go-v2/service/uxc v1.0.3/go.mod h1:sD2byZmMTGnne1H+za5t3bdPCicEknO9MIqMy0wlR8o=
 github.com/aws/aws-sdk-go-v2/service/verifiedpermissions v1.33.0 h1:iqCdhY/fp+khS49n07W3t5A4BnA1De5J7539g99IdMk=

--- a/go.sum
+++ b/go.sum
@@ -251,8 +251,8 @@ github.com/aws/aws-sdk-go-v2/service/emrcontainers v1.41.1 h1:zYb59S5qlJPP0UKwfN
 github.com/aws/aws-sdk-go-v2/service/emrcontainers v1.41.1/go.mod h1:D2r6LGoC8ROaN5xH6MFNdmLX70Xskt6zEarzRiqgX+Q=
 github.com/aws/aws-sdk-go-v2/service/emrserverless v1.41.1 h1:uSr4AROQTSlhF+NLQwiY48S47K4BrkscrKy0Mge0yo8=
 github.com/aws/aws-sdk-go-v2/service/emrserverless v1.41.1/go.mod h1:0hsO5tjvol21vzxO2fvw6XmrTAzEVVnKqG9O/dqNoMc=
-github.com/aws/aws-sdk-go-v2/service/eventbridge v1.45.25 h1:9PZbyFSCN/E0TnqXqnvYJRhu7yQJv31vHG/vyuirbCY=
-github.com/aws/aws-sdk-go-v2/service/eventbridge v1.45.25/go.mod h1:ZJ1LBykgykfLqmsP2pBUesSd24sL6SebSEeXzzJ2hhE=
+github.com/aws/aws-sdk-go-v2/service/eventbridge v1.46.1 h1:L+gdqhYUoNwwmJQyrvD1gZeSFt+Dcq8FVMJA5asgv3M=
+github.com/aws/aws-sdk-go-v2/service/eventbridge v1.46.1/go.mod h1:seQW28L9RT5hICfCQG7s/N+Tlfe5Q7lb4gyombZqo+U=
 github.com/aws/aws-sdk-go-v2/service/evidently v1.30.0 h1:XzLucuWDJKFGR2+krY+ZOfs5fjC9BpeDaHYEf+VIBiA=
 github.com/aws/aws-sdk-go-v2/service/evidently v1.30.0/go.mod h1:C2rE4PiwysyiqCWqQbc0kmO1Jnr4UlpXWEZG18yruSA=
 github.com/aws/aws-sdk-go-v2/service/evs v1.10.0 h1:n2SZEQalw3m6TR8sAuEKm8f10Jb+0gqxhpEEpEaTuIs=

--- a/go.sum
+++ b/go.sum
@@ -165,8 +165,8 @@ github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.60.3 h1:X3qB+VaA
 github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.60.3/go.mod h1:8IfDUcBSJboFS3Az4MX8Oh1ik/P/X7jyFf5Q2UZLtrk=
 github.com/aws/aws-sdk-go-v2/service/comprehend v1.41.1 h1:qh4h+vi4SQ1EoFYQ1M+hBUMxMdbPw2bibMOIbd3yCwA=
 github.com/aws/aws-sdk-go-v2/service/comprehend v1.41.1/go.mod h1:ZGajmgEyhNgAzoGgVuBUn4CRkCZ+bi4tACWf8HHmgLo=
-github.com/aws/aws-sdk-go-v2/service/computeoptimizer v1.50.1 h1:FyZGfF3X2uzNSZjIxXgiW/5va1HcJKueMIXEbEhVa78=
-github.com/aws/aws-sdk-go-v2/service/computeoptimizer v1.50.1/go.mod h1:ypZFNO3viD/a8tii9vlzKCOPxRuDMidRNIadJf7eJ1Y=
+github.com/aws/aws-sdk-go-v2/service/computeoptimizer v1.51.1 h1:Cy3+tJvG/0K2TlzO+H0MYrIUdwTfkKvOH/9n1yp11Jg=
+github.com/aws/aws-sdk-go-v2/service/computeoptimizer v1.51.1/go.mod h1:y5HaCvXXAcgvjkHvPCrq1FFeHQ7VQnvS8wg8idHVX5k=
 github.com/aws/aws-sdk-go-v2/service/configservice v1.62.3 h1:8rcAUMhCUuQe7kVBTBLPqMsJWFSVDPSFdpFexVQEEdU=
 github.com/aws/aws-sdk-go-v2/service/configservice v1.62.3/go.mod h1:PvCpYWzh0/jwa8v3jYJOaDobKiKQzFm1hI7+4Ms3J90=
 github.com/aws/aws-sdk-go-v2/service/connect v1.175.0 h1:ryfwFSnLovIyJd6xX4M9CToQbaa3YZjOkt+wyRuPiPs=

--- a/go.sum
+++ b/go.sum
@@ -545,8 +545,8 @@ github.com/aws/aws-sdk-go-v2/service/storagegateway v1.43.17 h1:XM4scnJ3RN5rGZ6l
 github.com/aws/aws-sdk-go-v2/service/storagegateway v1.43.17/go.mod h1:IjPL178wNElOmXpaCHIqoNWQBZoCnDx/oX5N1Xu3gNA=
 github.com/aws/aws-sdk-go-v2/service/sts v1.42.2 h1:XKnxlM4KZH1gktcsh3zSWc7GW4KivEv/OkifmHOhCUY=
 github.com/aws/aws-sdk-go-v2/service/sts v1.42.2/go.mod h1:KJYmkQaFB3SUW2j3aBkPsxNmAb4ZsSOvbvCpuxzHJA0=
-github.com/aws/aws-sdk-go-v2/service/swf v1.33.18 h1:SjWST41D98QAQs/S2wDlH8zts5SgngDd0qkKG9WUX6M=
-github.com/aws/aws-sdk-go-v2/service/swf v1.33.18/go.mod h1:6JHjVMsfOip9vyH0U/aS0+eGLIE9Ha1PebQFseCG/fU=
+github.com/aws/aws-sdk-go-v2/service/swf v1.33.19 h1:H/an3wyJhN77u6RLkzG4cief0EpFc/N/Ef86NfIQGkA=
+github.com/aws/aws-sdk-go-v2/service/swf v1.33.19/go.mod h1:4eZKh8JaPvMXUmTf4wHl7S30oumGXWpFCF1pfLR9ico=
 github.com/aws/aws-sdk-go-v2/service/synthetics v1.42.16 h1:NPqq0MBc8eiNrKNZrxy8DySFx4KnUb4fBv93eoSs+aQ=
 github.com/aws/aws-sdk-go-v2/service/synthetics v1.42.16/go.mod h1:/32XVvh7KNCpp6JI+v6iOK2uopE6vpwoxBV+/WduEJM=
 github.com/aws/aws-sdk-go-v2/service/taxsettings v1.16.23 h1:39DCdgj7earBK4aIN7iON1PjoyduoTIxwkW3O+LyAfk=

--- a/go.sum
+++ b/go.sum
@@ -89,8 +89,8 @@ github.com/aws/aws-sdk-go-v2/service/auditmanager v1.46.15 h1:dTNrl3E7ODY2PwCBnk
 github.com/aws/aws-sdk-go-v2/service/auditmanager v1.46.15/go.mod h1:MCSrmKum8NXNs+tl3yS7obnDNdZX/TAqG8ooqmc6j3U=
 github.com/aws/aws-sdk-go-v2/service/autoscaling v1.66.3 h1:3ZLIDyYYWWxnxdt4EjbgHL6PQlnkiwKAJV4eSQv03ZY=
 github.com/aws/aws-sdk-go-v2/service/autoscaling v1.66.3/go.mod h1:H5gqqRutsdQYgHMlFiqf6t3cmm98xRJwB0zzHc6vqzQ=
-github.com/aws/aws-sdk-go-v2/service/autoscalingplans v1.30.16 h1:NHXI8e2fGE30FviOO2x5M0sKc94E0uWLe+S4tG1ulBs=
-github.com/aws/aws-sdk-go-v2/service/autoscalingplans v1.30.16/go.mod h1:OxmESzY5G8tAzVcQZE10oKW3LS6JXf3HXjzWF/zUEE0=
+github.com/aws/aws-sdk-go-v2/service/autoscalingplans v1.30.17 h1:fB+sNF4xqcysho/KeJHOF1YnizXYrOxN4FvTbdx9vEU=
+github.com/aws/aws-sdk-go-v2/service/autoscalingplans v1.30.17/go.mod h1:D13yDn18/1mh7ptciNt6Nxt8DEmcGeubZSe5LyZoZtE=
 github.com/aws/aws-sdk-go-v2/service/backup v1.57.0 h1:MK5y/qUq8I4OD7JEF1LDjkmLTfAonyiE+6N6i4asdwk=
 github.com/aws/aws-sdk-go-v2/service/backup v1.57.0/go.mod h1:uMh3ZDoLKhXldYL1qcBYy1HsNQfKgL/w8iF2onOyoKY=
 github.com/aws/aws-sdk-go-v2/service/batch v1.65.0 h1:F2G4oJT5uJyJ/brhUl/NcMDlB9krWdAfqTUhSM41S/k=

--- a/go.sum
+++ b/go.sum
@@ -197,8 +197,8 @@ github.com/aws/aws-sdk-go-v2/service/datazone v1.62.1 h1:RAGYoo2eV8cCmeFpDpAJzG0
 github.com/aws/aws-sdk-go-v2/service/datazone v1.62.1/go.mod h1:ywdC/CddVikMtG/IoiGw9t2ZEdWQcFJ4PdeOie3M5KY=
 github.com/aws/aws-sdk-go-v2/service/dax v1.29.19 h1:s+l4YYZcDuYI8EvhxV+66xj7mKwq4mthpuwTEeCuRDA=
 github.com/aws/aws-sdk-go-v2/service/dax v1.29.19/go.mod h1:hIn61FGs/Ju7NY+Hf8OwNAxMo1v83/eBkH+AuqCk8dc=
-github.com/aws/aws-sdk-go-v2/service/detective v1.38.15 h1:H5v+Sro9ZL5OQGOoxuZz8RTzvO23VkOJ1LjKqXbank8=
-github.com/aws/aws-sdk-go-v2/service/detective v1.38.15/go.mod h1:/DN1zJ/OloIC8JwOVgOjbSDpl0S56cnu5Qnf9D/sXc8=
+github.com/aws/aws-sdk-go-v2/service/detective v1.39.0 h1:YfhUgn/USIV3sTmMeHdpQn4VTCLSYMtNzbX6gX3zkdY=
+github.com/aws/aws-sdk-go-v2/service/detective v1.39.0/go.mod h1:2PAHITEaW85PWDdqe3TuSny3o+BD4uoystdaH/EYJdE=
 github.com/aws/aws-sdk-go-v2/service/devicefarm v1.38.10 h1:57LpTN6FaBV417EbwvNC0/rdFRhZm/nrf01XEXPy+nI=
 github.com/aws/aws-sdk-go-v2/service/devicefarm v1.38.10/go.mod h1:PrGKZECbjGdAFagZ+UlbXV2Gw9B287/VJ/Y48YmmAQQ=
 github.com/aws/aws-sdk-go-v2/service/devopsagent v1.4.0 h1:XaP6w9oxccwZ5ycXQD7WNsKI+rPGrh9u4jzugPR+1mE=

--- a/go.sum
+++ b/go.sum
@@ -401,8 +401,8 @@ github.com/aws/aws-sdk-go-v2/service/observabilityadmin v1.16.1 h1:UuKlVsiBejuh5
 github.com/aws/aws-sdk-go-v2/service/observabilityadmin v1.16.1/go.mod h1:krmgFpcpTaoPQlNgbliWg/O+UxC/jXn26a0NKKldCnY=
 github.com/aws/aws-sdk-go-v2/service/odb v1.11.1 h1:PMrQsLY8KqDizjsK3Mn+GhXIplc6xLPSyww17jzFJV0=
 github.com/aws/aws-sdk-go-v2/service/odb v1.11.1/go.mod h1:hyWPzIu5qQyr7VBqZa/Y3gyrnsEsYbjvdd5d3IKKWvc=
-github.com/aws/aws-sdk-go-v2/service/opensearch v1.69.0 h1:ogIqeUpD0k00Jr7DwaaO6VIR0o6aqnLiLetBVLgYt/4=
-github.com/aws/aws-sdk-go-v2/service/opensearch v1.69.0/go.mod h1:m6jcW6ksKQtM4f/AsUbYdfbyM9xv4jjrBnRWWh1q0VQ=
+github.com/aws/aws-sdk-go-v2/service/opensearch v1.70.1 h1:bvmcxzp/PGDLScBLcJHG5WSoChkALP20Xhem54dUaKc=
+github.com/aws/aws-sdk-go-v2/service/opensearch v1.70.1/go.mod h1:VKcO88AHkSJsp7pQeHNr5VVcs1t/0snyD+e0ppd4oE0=
 github.com/aws/aws-sdk-go-v2/service/opensearchserverless v1.30.3 h1:47FPswEE4RKBY0sUivfFCqBS5PVAfg2iiNaSl9rHOX4=
 github.com/aws/aws-sdk-go-v2/service/opensearchserverless v1.30.3/go.mod h1:w/kwwh/dzVFrXLKUCj3M73lYUl+LrVn9gQ7RyiPNkZU=
 github.com/aws/aws-sdk-go-v2/service/organizations v1.51.3 h1:LWSmXWwYzR9yRcszxyqaKuPCO4E6g/iknZv1kQIkD7I=

--- a/go.sum
+++ b/go.sum
@@ -293,8 +293,8 @@ github.com/aws/aws-sdk-go-v2/service/imagebuilder v1.55.1 h1:BatfYeFcs220jnKlxrP
 github.com/aws/aws-sdk-go-v2/service/imagebuilder v1.55.1/go.mod h1:IjRdS2Ybudj2D7Vpt5OPcJax5JEFOrhmviv9aesTuds=
 github.com/aws/aws-sdk-go-v2/service/inspector v1.30.23 h1:xZpQfU8tqiHpQ3bW3XvZAaKh2nGWCOnQ33AN9rToWYo=
 github.com/aws/aws-sdk-go-v2/service/inspector v1.30.23/go.mod h1:1QT2AJ4rehmxv/05zIB2PUqDF5I9J1g0scaNE78H2QA=
-github.com/aws/aws-sdk-go-v2/service/inspector2 v1.47.7 h1:vHOhsldnj34FLcf4Vhruf4rXjuS/h2+rVq7g/Ff2Z1E=
-github.com/aws/aws-sdk-go-v2/service/inspector2 v1.47.7/go.mod h1:LuywkZEbCgj1aB3Ij62TrWfPThhx6GHJqZSO1ZDj2cM=
+github.com/aws/aws-sdk-go-v2/service/inspector2 v1.48.1 h1:kqweiozR959YwuEPKThkhpG8PJ2eO1a228jpSn4JS1E=
+github.com/aws/aws-sdk-go-v2/service/inspector2 v1.48.1/go.mod h1:721Z4fzObLFGKS7zSRiWLRSnVLx6xjnF4zJXXGqNdLk=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.9 h1:FLudkZLt5ci0ozzgkVo8BJGwvqNaZbTWb3UcucAateA=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.9/go.mod h1:w7wZ/s9qK7c8g4al+UyoF1Sp/Z45UwMGcqIzLWVQHWk=
 github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.17 h1:Zma31M1f9bbD/bsl6haTxupA0+z72L3l2ujKAH37zuI=

--- a/go.sum
+++ b/go.sum
@@ -329,8 +329,8 @@ github.com/aws/aws-sdk-go-v2/service/kinesisanalytics v1.30.26 h1:bWGA6teid64RQu
 github.com/aws/aws-sdk-go-v2/service/kinesisanalytics v1.30.26/go.mod h1:F1D1LL8hXSfe0VKDA89e0TvAFFp3slFHMv3C5FaRU50=
 github.com/aws/aws-sdk-go-v2/service/kinesisanalyticsv2 v1.38.0 h1:lTH3x76PDEV1aMnPjfCnSFh9FJmrRUFE1ipPBhjq9Lg=
 github.com/aws/aws-sdk-go-v2/service/kinesisanalyticsv2 v1.38.0/go.mod h1:8OH7Tvb6KDFKpID8pkeCo668eGLAe7VsipQtcF7ktLI=
-github.com/aws/aws-sdk-go-v2/service/kinesisvideo v1.33.10 h1:Z3xoYyzvZa3YmIzTdUctjgEEvuE6NMcJqEKHAZkJxns=
-github.com/aws/aws-sdk-go-v2/service/kinesisvideo v1.33.10/go.mod h1:EgB0GBJpnq1xEuoeXnpRixPx2kwaWWMkl5JKMXx43f0=
+github.com/aws/aws-sdk-go-v2/service/kinesisvideo v1.33.11 h1:sYHiMglkBZbIVCZEoCjse08cMqLu/9lytB3keV0muGY=
+github.com/aws/aws-sdk-go-v2/service/kinesisvideo v1.33.11/go.mod h1:7kyj3hyFDn4o32dEeQf+XVF73rvJzu2VIrIn31u3imE=
 github.com/aws/aws-sdk-go-v2/service/kms v1.52.0 h1:QNtg+Mtj1zmepk568+UKBD5DFfqh+ESTUUqQT27JkQc=
 github.com/aws/aws-sdk-go-v2/service/kms v1.52.0/go.mod h1:Y0+uxvxz6ib4KktRdK0V4X45Vcs/JyYoz8H71pO8xeI=
 github.com/aws/aws-sdk-go-v2/service/lakeformation v1.47.8 h1:BtZujlNIGZJpz/6ZbhF6sNZf/B7qzjrO/L+U4ZImNbY=

--- a/go.sum
+++ b/go.sum
@@ -109,8 +109,8 @@ github.com/aws/aws-sdk-go-v2/service/budgets v1.43.8 h1:R4H5x5/neeXximWnr2RyM4BY
 github.com/aws/aws-sdk-go-v2/service/budgets v1.43.8/go.mod h1:WrxNwTTCRAEHvIU8Y5/EUpfcrHy7nlm8+DN9edSeqI4=
 github.com/aws/aws-sdk-go-v2/service/chatbot v1.15.0 h1:e3QPlLAzchSC98C/Fk89qi9TBirQohTII7WWjvfOX4M=
 github.com/aws/aws-sdk-go-v2/service/chatbot v1.15.0/go.mod h1:2+T3ZzaxQ6rV/CImS72BNVHIyazppxtblF1xJTXjgIg=
-github.com/aws/aws-sdk-go-v2/service/chime v1.41.14 h1:1dS2RRGAELUPmXaNFZYgkxnOmYbMj5Uu4JETv8OwgxA=
-github.com/aws/aws-sdk-go-v2/service/chime v1.41.14/go.mod h1:QY1xYS2flCUbVr0o+AVrlEagk4KyLux3VyDeiem8eZU=
+github.com/aws/aws-sdk-go-v2/service/chime v1.41.15 h1:NjDzXghqrmE5KFPedLuioRk08v+lr6ijiUasvhuiSFc=
+github.com/aws/aws-sdk-go-v2/service/chime v1.41.15/go.mod h1:T11rZ8NkCnMjuSu72hcd6sIS5drVGfAv8xJx8n2Hg3I=
 github.com/aws/aws-sdk-go-v2/service/chimesdkmediapipelines v1.27.0 h1:slEpXPwuTojX3xQ3Xv0Haxa6ykicD9bVdhQ/j4DLkMg=
 github.com/aws/aws-sdk-go-v2/service/chimesdkmediapipelines v1.27.0/go.mod h1:xGNDWxgYbjfyg7dRB5zhzXtad+8o839xZKMY3jVl9KE=
 github.com/aws/aws-sdk-go-v2/service/chimesdkvoice v1.28.15 h1:21vkPfPLTrzWnp3c+d5NJu9om1sLHg2tS1p72bxU+3A=

--- a/go.sum
+++ b/go.sum
@@ -491,8 +491,8 @@ github.com/aws/aws-sdk-go-v2/service/savingsplans v1.33.1 h1:g4IDAQgDNOn6XAGdQgv
 github.com/aws/aws-sdk-go-v2/service/savingsplans v1.33.1/go.mod h1:M+v5amm+fIixMXUd9D6XLsNeNOHhnj7R7y8sVKuPku4=
 github.com/aws/aws-sdk-go-v2/service/scheduler v1.18.1 h1:Bnd6NBK0dffch1jzoLW5kY1IseJgKhK7bKWK9CDIwls=
 github.com/aws/aws-sdk-go-v2/service/scheduler v1.18.1/go.mod h1:WxEyYX1IGwN35IsEOicEvOwTG32yu33kYcc+gHanyYQ=
-github.com/aws/aws-sdk-go-v2/service/schemas v1.35.0 h1:SWK85nZP86S/uwIqQ54G81PYLuATBaPxKEmRFDoP35o=
-github.com/aws/aws-sdk-go-v2/service/schemas v1.35.0/go.mod h1:/EC2ZUKZo8m/Pws9YuzgBSL8GZE7alyCYaYJyyZDah4=
+github.com/aws/aws-sdk-go-v2/service/schemas v1.35.1 h1:WVrl+FWZ3d7uOzZ/Vz7IzVWd0kc+7yi//DNFO1rEpVg=
+github.com/aws/aws-sdk-go-v2/service/schemas v1.35.1/go.mod h1:Q5TGR5yNtrh/lEtpz4YeyYyXh3Aahx3BT/fPPEtUcfM=
 github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.7 h1:JUGKqUnJHbXpS8uyuICP/zpQ+vXUIXW2zTEqjMLCqrY=
 github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.7/go.mod h1:l/cqI7ujYqBuTR6Ll13d9/gG/uUdlVzJ1UDltEEBTOo=
 github.com/aws/aws-sdk-go-v2/service/securityhub v1.71.0 h1:cWBwwMRfARTheeY+g3ykiyoQdR48Hb8S6qVCysB87/I=

--- a/go.sum
+++ b/go.sum
@@ -393,8 +393,8 @@ github.com/aws/aws-sdk-go-v2/service/networkmonitor v1.14.0 h1:kRw49kdziIuc5pz2+
 github.com/aws/aws-sdk-go-v2/service/networkmonitor v1.14.0/go.mod h1:G7P74BfTAeAp1qmfBe4NOlcz28e0L1a6xkjm/cdLGb4=
 github.com/aws/aws-sdk-go-v2/service/notifications v1.8.1 h1:p3fifBWnYwYZDl4dWnYH5jDOnIH+JpNVbj4RgSJEhc4=
 github.com/aws/aws-sdk-go-v2/service/notifications v1.8.1/go.mod h1:BFR5AGKy6wApHVrQzMGzAIIhu9XHLsC9Vr4Dhrr8MhU=
-github.com/aws/aws-sdk-go-v2/service/notificationscontacts v1.6.0 h1:3Roxg1ro+M11PFgPTmAuc4WnaD6B57s+Uur5l9Od/ck=
-github.com/aws/aws-sdk-go-v2/service/notificationscontacts v1.6.0/go.mod h1:OC9ulnk7D/U4pJ8aF5yc5E5UDNTUYeVYNorOytuPL+g=
+github.com/aws/aws-sdk-go-v2/service/notificationscontacts v1.6.1 h1:/+83sWWF9wzvNZrS2JuVTk2rz9x1eH2jM7JcFcfiCYA=
+github.com/aws/aws-sdk-go-v2/service/notificationscontacts v1.6.1/go.mod h1:CgMKkMvi8mRoRFbjbhGj/tuYvhIp5wmiHkC4aYwCQAo=
 github.com/aws/aws-sdk-go-v2/service/oam v1.24.0 h1:O0sFLaMTd2qQHtU8HFH9hgnTcJCzEoGNmxdE7P1yuSo=
 github.com/aws/aws-sdk-go-v2/service/oam v1.24.0/go.mod h1:RxA073SQ1NzTBNrAs1N2iQ1WACFWdUxIL+pmvw9Ih9U=
 github.com/aws/aws-sdk-go-v2/service/observabilityadmin v1.16.0 h1:Ys/ZOm9bowwjJRkkv8iVjz6tRTnx1yAWknsdydNKnJU=

--- a/go.sum
+++ b/go.sum
@@ -547,8 +547,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.42.2 h1:XKnxlM4KZH1gktcsh3zSWc7GW4Ki
 github.com/aws/aws-sdk-go-v2/service/sts v1.42.2/go.mod h1:KJYmkQaFB3SUW2j3aBkPsxNmAb4ZsSOvbvCpuxzHJA0=
 github.com/aws/aws-sdk-go-v2/service/swf v1.33.19 h1:H/an3wyJhN77u6RLkzG4cief0EpFc/N/Ef86NfIQGkA=
 github.com/aws/aws-sdk-go-v2/service/swf v1.33.19/go.mod h1:4eZKh8JaPvMXUmTf4wHl7S30oumGXWpFCF1pfLR9ico=
-github.com/aws/aws-sdk-go-v2/service/synthetics v1.42.16 h1:NPqq0MBc8eiNrKNZrxy8DySFx4KnUb4fBv93eoSs+aQ=
-github.com/aws/aws-sdk-go-v2/service/synthetics v1.42.16/go.mod h1:/32XVvh7KNCpp6JI+v6iOK2uopE6vpwoxBV+/WduEJM=
+github.com/aws/aws-sdk-go-v2/service/synthetics v1.42.17 h1:laIoRwwPASaSQl/U+8mratWJ5IK2mzl/7nhyFA9+4jg=
+github.com/aws/aws-sdk-go-v2/service/synthetics v1.42.17/go.mod h1:OnocIS6UzQdU0bC/tP7vNkB/6Lb3jwgEqO1bhQhbpco=
 github.com/aws/aws-sdk-go-v2/service/taxsettings v1.16.23 h1:39DCdgj7earBK4aIN7iON1PjoyduoTIxwkW3O+LyAfk=
 github.com/aws/aws-sdk-go-v2/service/taxsettings v1.16.23/go.mod h1:/U0lhg35wBZFmjijdF3imRoXuoDwM2KjCkSE2GlWnzU=
 github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.19.2 h1:D9z71BkiK5Xa6ibHU/3bkIAyGRwfqnn3jH8EWGhuzxs=

--- a/go.sum
+++ b/go.sum
@@ -563,8 +563,8 @@ github.com/aws/aws-sdk-go-v2/service/transfer v1.72.1 h1:Pj3ornr6k2QZco8JXnwzqBQ
 github.com/aws/aws-sdk-go-v2/service/transfer v1.72.1/go.mod h1:XzQPYzVLZiYqzySF5BqMEDZG8888AzZXVMzq4qdIZm0=
 github.com/aws/aws-sdk-go-v2/service/uxc v1.0.4 h1:f3FKLPhloiQRS0ImgXLmwjhBTplqBxBiUEUDQEVLjbk=
 github.com/aws/aws-sdk-go-v2/service/uxc v1.0.4/go.mod h1:/rKEAGJenQXrxXXPvxlYBBD5hS4qbQIzoTMKfgeo9do=
-github.com/aws/aws-sdk-go-v2/service/verifiedpermissions v1.33.0 h1:iqCdhY/fp+khS49n07W3t5A4BnA1De5J7539g99IdMk=
-github.com/aws/aws-sdk-go-v2/service/verifiedpermissions v1.33.0/go.mod h1:lQ9Sg9AKiZ7OE/MdjWWN6V6PQS1Sv4Yzf1gj8Usuakc=
+github.com/aws/aws-sdk-go-v2/service/verifiedpermissions v1.34.0 h1:LqkQfCt37IEbUtvi8hJpJOBSOwZSDOMYNr2jH6/Vk2o=
+github.com/aws/aws-sdk-go-v2/service/verifiedpermissions v1.34.0/go.mod h1:ujqEP1vFTIBsr/Fn2iZiaM3fHvlrfFfXkikWaZaU5aQ=
 github.com/aws/aws-sdk-go-v2/service/vpclattice v1.21.0 h1:5ZVG7gGUYgKTeHYr56h1tyc/9zQNGQaDqCvz4cUTM3c=
 github.com/aws/aws-sdk-go-v2/service/vpclattice v1.21.0/go.mod h1:GMCAnmnB2tlV0CrzwpowxpLb2H+MCp0mvW5A1DvwIKI=
 github.com/aws/aws-sdk-go-v2/service/waf v1.30.22 h1:EI78jKQQi/G+HRZeopJFSPSyG1/GzjCTeGd/1HPLHw8=

--- a/go.sum
+++ b/go.sum
@@ -475,8 +475,8 @@ github.com/aws/aws-sdk-go-v2/service/rum v1.31.1 h1:4uWoRB+WRGc5z6Anztw3qwdGLCpC
 github.com/aws/aws-sdk-go-v2/service/rum v1.31.1/go.mod h1:AsDtKeq5z+QO+OE5mnxaHqy+KCrjZDyc1F4QUkCUx3w=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.102.1 h1:vttIo8BQwfnhimKRBZBBF3Y38SAIxif72B/M91m9hDk=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.102.1/go.mod h1:2qjInACJr84m/Tm4XXCcVNpejmbKy9kz7TEa6viQHSk=
-github.com/aws/aws-sdk-go-v2/service/s3control v1.70.1 h1:jbMg6zIdFawDnLhbzaLGUxaMN2H42wP4hKsjG0OuLmA=
-github.com/aws/aws-sdk-go-v2/service/s3control v1.70.1/go.mod h1:BJiTF1ijkh2XHYqan51v2pmnHyVFp1H31vqEuC/wEFw=
+github.com/aws/aws-sdk-go-v2/service/s3control v1.71.0 h1:WLG6J5K6u5wY6rRt/H/9bdx0mPFd0yDiooVLktIGodg=
+github.com/aws/aws-sdk-go-v2/service/s3control v1.71.0/go.mod h1:XDxWqWcbRTSEjyGQ11yXnlrSvyacvuA/r00Xw7XqxTo=
 github.com/aws/aws-sdk-go-v2/service/s3files v1.0.2 h1:DQle06mhK+kiLv2fMzDW3gS0D0hAXSRM5CdWnHjM1BI=
 github.com/aws/aws-sdk-go-v2/service/s3files v1.0.2/go.mod h1:V9cqxfwLPBIb1bnB5bSCp/O7Nzqmd965WXByJa8GXcI=
 github.com/aws/aws-sdk-go-v2/service/s3outposts v1.34.14 h1:+Kd3/zK8ivdwLKtMeqXcPPU+v2X7juW73BgRDKqMD8o=

--- a/go.sum
+++ b/go.sum
@@ -131,8 +131,8 @@ github.com/aws/aws-sdk-go-v2/service/cloudhsmv2 v1.34.26 h1:lyAQbQ0pkqvAg4reG1Jj
 github.com/aws/aws-sdk-go-v2/service/cloudhsmv2 v1.34.26/go.mod h1:sDedonK8Lz6fMf4q1vEjzyyO3jskCECWosEhNS40sro=
 github.com/aws/aws-sdk-go-v2/service/cloudsearch v1.32.15 h1:ETNqwiPFuwQQbqoVhcwb+L9lmkjZmGHxmEOUo9SkYLw=
 github.com/aws/aws-sdk-go-v2/service/cloudsearch v1.32.15/go.mod h1:7ThInmcOZindokcAKJxcStdW2I6jl0heM7OMe5ukQZI=
-github.com/aws/aws-sdk-go-v2/service/cloudtrail v1.55.11 h1:3IDx7ybn7pyrLgVShEfGmEXec1xsqgoD1ADI1SxqKT0=
-github.com/aws/aws-sdk-go-v2/service/cloudtrail v1.55.11/go.mod h1:iSArc5uhvz1S3EICNNvRzPksb6HPAUhltzMvoCrGyfM=
+github.com/aws/aws-sdk-go-v2/service/cloudtrail v1.55.12 h1:vEtY+NJKYmCBjFrMQob5ex4mDKQgCW2v4NWfufAg9YA=
+github.com/aws/aws-sdk-go-v2/service/cloudtrail v1.55.12/go.mod h1:3M8MhO9Z7Ev065eLAkInHs4vZABsa/SBMNg0m7NoVyI=
 github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.57.0 h1:dlkFtYOrwOuM7IIBD6FPLtt0Xvnph+8hqmmbzyowkCk=
 github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.57.0/go.mod h1:7900IH3EvTrwNGLNx3QDKnQwPF/Cw+pD9cuvBDQ4org=
 github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.74.0 h1:6TqDeYdvJJEIJGg5ICy7nzC7/UuHk2Eg3wrpb5bWKPM=

--- a/go.sum
+++ b/go.sum
@@ -531,8 +531,8 @@ github.com/aws/aws-sdk-go-v2/service/ssmcontacts v1.32.1 h1:9+NviqMk6eedRqjIunBE
 github.com/aws/aws-sdk-go-v2/service/ssmcontacts v1.32.1/go.mod h1:WEp0tvxt+uqTOpSjr1rfUUYGlVOCCA76QDfeIVqDF3A=
 github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.40.0 h1:AfdrW6qwJZL1/8Dg7HMpClcWi0rHh602En+4ij6gP2g=
 github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.40.0/go.mod h1:yl7ZtmrnHOFyzM7r0uGx2H8oLuwmPXyrYATZCHvU4Tg=
-github.com/aws/aws-sdk-go-v2/service/ssmquicksetup v1.9.0 h1:A63P9VmIvEwpkJ2t9kQwij/bY4NC6i09S+wVl8HU5RM=
-github.com/aws/aws-sdk-go-v2/service/ssmquicksetup v1.9.0/go.mod h1:L30rbC4sTiR0uIBkLk23p6AzjvwyfpWMo69IRCqdbIE=
+github.com/aws/aws-sdk-go-v2/service/ssmquicksetup v1.9.1 h1:WXPqjvJRG2hH/RLX0lM9myjhC8kHFKmJ+KRWSjQ7ZRY=
+github.com/aws/aws-sdk-go-v2/service/ssmquicksetup v1.9.1/go.mod h1:gInfq0wttvoOxb9nB0UH2RjahPb/PYWJD2IItOlv6Hs=
 github.com/aws/aws-sdk-go-v2/service/ssmsap v1.26.7 h1:wbBhjngfYJsVongNhlt63l3YhHvbiljTtSyqI8QpNu4=
 github.com/aws/aws-sdk-go-v2/service/ssmsap v1.26.7/go.mod h1:KI9kx0878kbUTCw3zXCf2JvuswE0GzwgFSQtzCd1qHM=
 github.com/aws/aws-sdk-go-v2/service/sso v1.30.18 h1:ApLTFdAZfDhZSiY5uskwECKHkSNNF83y2Ru2r7SezWA=

--- a/go.sum
+++ b/go.sum
@@ -347,8 +347,8 @@ github.com/aws/aws-sdk-go-v2/service/licensemanager v1.37.13 h1:111XpjGyREF2grOT
 github.com/aws/aws-sdk-go-v2/service/licensemanager v1.37.13/go.mod h1:8GKUM7OrtYiizLA72d3799YulE9YYd1LBjitI9gni6U=
 github.com/aws/aws-sdk-go-v2/service/lightsail v1.54.1 h1:TA/8uCWJQzeNy8fTf8ojFxZuvWA+R20CMu0b7IxYcp0=
 github.com/aws/aws-sdk-go-v2/service/lightsail v1.54.1/go.mod h1:F0RbBQMzN+pD4BswikBhagVqSQWqjMnmx14plgRsxKA=
-github.com/aws/aws-sdk-go-v2/service/location v1.51.1 h1:V2YRh41kS0i5lzJqEJlpnv5ljKUKBPQl0WJ8p8MEYU8=
-github.com/aws/aws-sdk-go-v2/service/location v1.51.1/go.mod h1:vItA3+XI99kmKXC2ILRMsBVOLB6lNUg5E5Jn01JGE78=
+github.com/aws/aws-sdk-go-v2/service/location v1.52.1 h1:hXk27fqFGrjvlX0MaCzf1SOmpufFro0xRFnMZDqOe0c=
+github.com/aws/aws-sdk-go-v2/service/location v1.52.1/go.mod h1:v/d1IGFeuze4lsKEU1juoMgzuIXBrFXh0nIjJK9Mls8=
 github.com/aws/aws-sdk-go-v2/service/m2 v1.26.16 h1:i8B10mRygZ706QPnu8wLK0sqpjXA+pBiaVBDNPQ9bvo=
 github.com/aws/aws-sdk-go-v2/service/m2 v1.26.16/go.mod h1:b6JagtYF0M3jkPWFBOjtkDDsLH6vvRetHTmqwIbNVLk=
 github.com/aws/aws-sdk-go-v2/service/macie2 v1.51.2 h1:JPIqNyD7JAaQddkmXRFVI7My2vtJ40uqTpEYIlnTEVw=

--- a/go.sum
+++ b/go.sum
@@ -363,8 +363,8 @@ github.com/aws/aws-sdk-go-v2/service/mediapackage v1.39.24 h1:fyFyHZcBKpyUsppI5n
 github.com/aws/aws-sdk-go-v2/service/mediapackage v1.39.24/go.mod h1:/QFYcNuiSprNSxlGHsb9nZwzYgCnIhi9j4BlEQvZtZU=
 github.com/aws/aws-sdk-go-v2/service/mediapackagev2 v1.39.1 h1:2vjqeQHRqh/ILzIff5oT67sLJ7nRrqU7h0QZXPziGZY=
 github.com/aws/aws-sdk-go-v2/service/mediapackagev2 v1.39.1/go.mod h1:uzIN1W4NqMdy0yFFyRBihyGYAGzvtyPzrEfodrDqCLs=
-github.com/aws/aws-sdk-go-v2/service/mediapackagevod v1.39.23 h1:3D0AdP2dlAuyS8+bI32nwWeVElqpum5x57qd7gnv0/g=
-github.com/aws/aws-sdk-go-v2/service/mediapackagevod v1.39.23/go.mod h1:3nv4OO4gMdloy2CVFb+veQzwndmDhxXatvZ/D0dEN1Y=
+github.com/aws/aws-sdk-go-v2/service/mediapackagevod v1.39.24 h1:frq+4ymwr6AvyAvm3FXH0hxg9Oj7o+ISkqX+/ZRiO4k=
+github.com/aws/aws-sdk-go-v2/service/mediapackagevod v1.39.24/go.mod h1:8onlaKcsWCncSk0syNzxl2FWeurmeqDOciE387GEjQw=
 github.com/aws/aws-sdk-go-v2/service/mediastore v1.29.23 h1:yxt0mlXvIz6tBqE6tE+8nT4HInWgEjzwnHDI6TxKm7E=
 github.com/aws/aws-sdk-go-v2/service/mediastore v1.29.23/go.mod h1:8nxl+cuTs2USuUurU51GknJf37qAFtSRsrpSomYqqsA=
 github.com/aws/aws-sdk-go-v2/service/memorydb v1.33.16 h1:sFFA8VBMMksHbFaV689agmYNnKeP162vtYg+4U/Orks=

--- a/go.sum
+++ b/go.sum
@@ -459,8 +459,8 @@ github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.32.1 h1:3VYXjxI
 github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.32.1/go.mod h1:FPN5JcyM3LRy070DtXbb+8eT53HR/cSP/yt/fmvdL4U=
 github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.23.1 h1:Qrebotu1g1iw4P+huw7lYnIN/qcZtIO3giD+f2dlwM4=
 github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.23.1/go.mod h1:BNimlkjkBkiYd1OzVjX74gX5rt/H3kBfElrth3FpE4o=
-github.com/aws/aws-sdk-go-v2/service/route53 v1.62.7 h1:twRRMmtSITnt/rrp+D7UDLzE5pKMZe759aalkUdN+OY=
-github.com/aws/aws-sdk-go-v2/service/route53 v1.62.7/go.mod h1:ztM1lr+sRoCAI8336ZUvlRPbToue0d3gE/wd6jomSJ8=
+github.com/aws/aws-sdk-go-v2/service/route53 v1.62.8 h1:1QC1xoZg5XSes1CXQ20Y0qTaaeDj12e7bB0/Yw9sQwI=
+github.com/aws/aws-sdk-go-v2/service/route53 v1.62.8/go.mod h1:+GpgmfX7rnzQ8WMbMCMnI+VOjPZCf9yaUlBmRTvQgFE=
 github.com/aws/aws-sdk-go-v2/service/route53domains v1.35.0 h1:9WcucZLCnH5OLj6PO+smG3ityqw7OrHa/SkCUmnk7Kw=
 github.com/aws/aws-sdk-go-v2/service/route53domains v1.35.0/go.mod h1:oitnZaE7dxuIbSC08U6C7PgSSXjvs1LF4D0oMFFJiIU=
 github.com/aws/aws-sdk-go-v2/service/route53profiles v1.9.25 h1:YJM60kSq17CZWAni+v2LSOI++oO+UfjL8ShOZvCHwck=

--- a/go.sum
+++ b/go.sum
@@ -143,8 +143,8 @@ github.com/aws/aws-sdk-go-v2/service/codebuild v1.68.17 h1:nuZd0+/dAPNruSr1QPP0W
 github.com/aws/aws-sdk-go-v2/service/codebuild v1.68.17/go.mod h1:bqp9F33QsLJl//rIXwqZeqRrGoZX4VkS20gfCA8o3VM=
 github.com/aws/aws-sdk-go-v2/service/codecatalyst v1.21.15 h1:c4gKdl1Ea0yepVffQ3cTVWEeqvtVipyXKcXderDQbl8=
 github.com/aws/aws-sdk-go-v2/service/codecatalyst v1.21.15/go.mod h1:ohktYOwIHO3/CE0lZ5gd181R0CF1m63fWBkOn0hXvuU=
-github.com/aws/aws-sdk-go-v2/service/codecommit v1.33.14 h1:3N664oayz66ttIkc8B9/OLntMWhoGhKqPudRRfsZQ20=
-github.com/aws/aws-sdk-go-v2/service/codecommit v1.33.14/go.mod h1:M+6j5lOmtDMjLlFMO8lfTs0gI3qBsSjM8L7F1cQF5Ng=
+github.com/aws/aws-sdk-go-v2/service/codecommit v1.33.15 h1:jG7/DRMMhbNG4S7mDRdZLKMmyojud6QhHcJ9TPxxjpA=
+github.com/aws/aws-sdk-go-v2/service/codecommit v1.33.15/go.mod h1:TWZz5ml6Jv36EO4eUGxp82JucQuG/ZH4InxEcLetXZg=
 github.com/aws/aws-sdk-go-v2/service/codeconnections v1.11.0 h1:OqIM7wA2amkOIJTSOJjx2KL/LKr1inVzh3lqPIC97m0=
 github.com/aws/aws-sdk-go-v2/service/codeconnections v1.11.0/go.mod h1:TcTHKeyZCc14t8RI8PM8nbwid4Xr4CzxEZfHKcGlCiA=
 github.com/aws/aws-sdk-go-v2/service/codedeploy v1.35.15 h1:iFcroRD6TUmNLCoAMdPJGV28h1K4yULxNludMiA/LwA=

--- a/go.sum
+++ b/go.sum
@@ -417,8 +417,8 @@ github.com/aws/aws-sdk-go-v2/service/pcaconnectorad v1.16.1 h1:DdbnVx5+9A5M92fkG
 github.com/aws/aws-sdk-go-v2/service/pcaconnectorad v1.16.1/go.mod h1:jzVcQK4cv6oDsUYYlMrrydw6weuGzmtE4JRIcIup3iM=
 github.com/aws/aws-sdk-go-v2/service/pcs v1.19.0 h1:ojV3rqbQU8gXcmJ+grR1axc+mT5mXA+vC4XNr/33DkA=
 github.com/aws/aws-sdk-go-v2/service/pcs v1.19.0/go.mod h1:M+qbwaZuyooD1vA2rrRkoaokZ4V21Kitfu4+qN58Fsw=
-github.com/aws/aws-sdk-go-v2/service/pinpoint v1.39.23 h1:YEwsIfiIhbD4eVaM8GmvFAb5w3MBtNka6lWNBQAEEuc=
-github.com/aws/aws-sdk-go-v2/service/pinpoint v1.39.23/go.mod h1:5cQboSsKjW/hMBKeTzbjK93jmgsiCakuK7m4iNxfiFY=
+github.com/aws/aws-sdk-go-v2/service/pinpoint v1.39.24 h1:67Y2jqLLj6en/ZCG8ISz0LQbJCkLbcKStkncVLn8r0k=
+github.com/aws/aws-sdk-go-v2/service/pinpoint v1.39.24/go.mod h1:k9ZdOPKJWrh5bFUnC0K4A0omUyGp0zFAcnPUX2/1v2o=
 github.com/aws/aws-sdk-go-v2/service/pinpointsmsvoicev2 v1.28.2 h1:CCUupPmQvjZRsQlyF6/qmrWgOwLhejP+prj273iCuyY=
 github.com/aws/aws-sdk-go-v2/service/pinpointsmsvoicev2 v1.28.2/go.mod h1:8+8lD4dvbnctRIsbL4mHv8FEhm5a5RLdwVElfA9rxoM=
 github.com/aws/aws-sdk-go-v2/service/pipes v1.24.0 h1:NlxDsdecMTXaqjwym1Bvfq5SkIvcowO5BfDouo3nLIE=

--- a/go.sum
+++ b/go.sum
@@ -493,8 +493,8 @@ github.com/aws/aws-sdk-go-v2/service/scheduler v1.18.1 h1:Bnd6NBK0dffch1jzoLW5kY
 github.com/aws/aws-sdk-go-v2/service/scheduler v1.18.1/go.mod h1:WxEyYX1IGwN35IsEOicEvOwTG32yu33kYcc+gHanyYQ=
 github.com/aws/aws-sdk-go-v2/service/schemas v1.35.1 h1:WVrl+FWZ3d7uOzZ/Vz7IzVWd0kc+7yi//DNFO1rEpVg=
 github.com/aws/aws-sdk-go-v2/service/schemas v1.35.1/go.mod h1:Q5TGR5yNtrh/lEtpz4YeyYyXh3Aahx3BT/fPPEtUcfM=
-github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.7 h1:JUGKqUnJHbXpS8uyuICP/zpQ+vXUIXW2zTEqjMLCqrY=
-github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.7/go.mod h1:l/cqI7ujYqBuTR6Ll13d9/gG/uUdlVzJ1UDltEEBTOo=
+github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.8 h1:1+cxbGx12HXmXlJnU7FYHw/lmgm5Fz5F/zuaOWSpOzc=
+github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.8/go.mod h1:OoxL3xzUUjYMDWPxth/zM+wlgmYOKAU5qY4BKit3u8U=
 github.com/aws/aws-sdk-go-v2/service/securityhub v1.71.0 h1:cWBwwMRfARTheeY+g3ykiyoQdR48Hb8S6qVCysB87/I=
 github.com/aws/aws-sdk-go-v2/service/securityhub v1.71.0/go.mod h1:zaWfTggHBDZYQS7YIk6Atd2SsxXehBvSQjyN65+KCtk=
 github.com/aws/aws-sdk-go-v2/service/securitylake v1.25.15 h1:s92UU/ju1C28XiBmf4nmCRYnWLOpbxuLJ/iCDPC0RLg=

--- a/go.sum
+++ b/go.sum
@@ -257,8 +257,8 @@ github.com/aws/aws-sdk-go-v2/service/evidently v1.30.0 h1:XzLucuWDJKFGR2+krY+ZOf
 github.com/aws/aws-sdk-go-v2/service/evidently v1.30.0/go.mod h1:C2rE4PiwysyiqCWqQbc0kmO1Jnr4UlpXWEZG18yruSA=
 github.com/aws/aws-sdk-go-v2/service/evs v1.10.1 h1:Yhpuxq270m6fkSTcv4+XqshcPrcC5oDHIW+luaYIDZY=
 github.com/aws/aws-sdk-go-v2/service/evs v1.10.1/go.mod h1:QAoOVq2InsEnSsl3MR+RstiyukTltYJqHVbT/ImJv2w=
-github.com/aws/aws-sdk-go-v2/service/finspace v1.33.23 h1:82NyfnpmHfHzhedQ3hMRti2BUlWFR6Tpf5h5gtGjC8I=
-github.com/aws/aws-sdk-go-v2/service/finspace v1.33.23/go.mod h1:4BIGPIjoKsxB3CGsaJ3+uLn6zn2j6Uu3xQEcXMGz+C8=
+github.com/aws/aws-sdk-go-v2/service/finspace v1.34.1 h1:sQa8VyMLc2BhEy8kLuve3ufn3bh6W8BQv+xmpa52/Fw=
+github.com/aws/aws-sdk-go-v2/service/finspace v1.34.1/go.mod h1:kpT6GkbkbP3ZJUvz+9iaeXvcv79VmfN5X9xzQJidB3E=
 github.com/aws/aws-sdk-go-v2/service/firehose v1.42.16 h1:nSg1UAENCjuryTr9JMPMOPXkYOkcpVwQjrrp5rkHUus=
 github.com/aws/aws-sdk-go-v2/service/firehose v1.42.16/go.mod h1:8atLs+8lOWcDaxiD+suvyvt63IuwLbT8zlU6Ti9qZiY=
 github.com/aws/aws-sdk-go-v2/service/fis v1.37.22 h1:2LO81Hj8dYOxioN/ztt5iiSzrYgIgMe3wowSEcW5VsY=

--- a/go.sum
+++ b/go.sum
@@ -151,8 +151,8 @@ github.com/aws/aws-sdk-go-v2/service/codedeploy v1.35.16 h1:SWw60uVRCfmuw11uZVKz
 github.com/aws/aws-sdk-go-v2/service/codedeploy v1.35.16/go.mod h1:BQ4gZJB6Cu71Aft0Dp5nal9mwlLGJIrYy3X36Zu1giY=
 github.com/aws/aws-sdk-go-v2/service/codeguruprofiler v1.30.1 h1:zoQt0M9PoeUxEDSVgN//BuRoRKh/9UFjgC5Atg1wrZ0=
 github.com/aws/aws-sdk-go-v2/service/codeguruprofiler v1.30.1/go.mod h1:UpiP4zJee3P/NTiH6mUFBuaEJpGZS39OjEZ1nYBE/sE=
-github.com/aws/aws-sdk-go-v2/service/codegurureviewer v1.34.22 h1:3SujyqCjZ0WFkwhReUv6bWvVzoqQeS//pQT7ByeqXiE=
-github.com/aws/aws-sdk-go-v2/service/codegurureviewer v1.34.22/go.mod h1:Wt9LWJboCaH1z4Jq6TJr/DahjcenYatyFDdGXCQ++ro=
+github.com/aws/aws-sdk-go-v2/service/codegurureviewer v1.35.0 h1:KsQiex+Ui0vkLC21ucGvO3XGJKpVnBY1xeBj02KE3fk=
+github.com/aws/aws-sdk-go-v2/service/codegurureviewer v1.35.0/go.mod h1:XeKclJyntSdXdpadNx+AdetSR6lLnt+EcjwjbnBQX+k=
 github.com/aws/aws-sdk-go-v2/service/codepipeline v1.46.23 h1:T1CJQxFSFH/74qHb6h02V7oJBCcNlWoBZj+ZM1C/+0I=
 github.com/aws/aws-sdk-go-v2/service/codepipeline v1.46.23/go.mod h1:YRBQdlmNr8T+a+cvU7p0s7kYNT9UrZ4RPfLSHthtMOc=
 github.com/aws/aws-sdk-go-v2/service/codestarconnections v1.35.15 h1:W6e6rV6k2oUthzPZTPgon2IcOg5DiGTimnwK76UyUuk=

--- a/go.sum
+++ b/go.sum
@@ -171,8 +171,8 @@ github.com/aws/aws-sdk-go-v2/service/configservice v1.62.4 h1:Vzzl4mk9hu0sE0lKhY
 github.com/aws/aws-sdk-go-v2/service/configservice v1.62.4/go.mod h1:HGcpycwfNZW3ADZFgUl/GxbIAQ9qkcY9YERr7QPvlaE=
 github.com/aws/aws-sdk-go-v2/service/connect v1.175.1 h1:2cacszmtdexvFZIo+3wex3BDX2+euDdyI42YOKOwXCU=
 github.com/aws/aws-sdk-go-v2/service/connect v1.175.1/go.mod h1:U7i2UrYMvRevhvH0+fzqcgFEDjA+aZw05usgvyWp/v8=
-github.com/aws/aws-sdk-go-v2/service/connectcases v1.41.0 h1:3cyJsw7HOjnAl/UU7seVUXAXE1gB/aGuCVIfpEon0JQ=
-github.com/aws/aws-sdk-go-v2/service/connectcases v1.41.0/go.mod h1:Po801bVNjB1+ZF8gmqjeQUb8ay5XcpQFVi6Bhm/85Iw=
+github.com/aws/aws-sdk-go-v2/service/connectcases v1.42.1 h1:GU/QQUClfsIpr8AiTzW7oDB0MDB4gP8cuG2v8OfjD+U=
+github.com/aws/aws-sdk-go-v2/service/connectcases v1.42.1/go.mod h1:Jd2ciDlob6BwGJIU/VpmdQoOPtrFmpJ9gCePVnjH7jE=
 github.com/aws/aws-sdk-go-v2/service/controltower v1.29.0 h1:5kicsTVcky+MfpGh6KATnmBx3Sx4lzo1JF5vKPVdyG4=
 github.com/aws/aws-sdk-go-v2/service/controltower v1.29.0/go.mod h1:OFxC/BGLWxWAGdqX7BgT/reALU6Pp9NPkvUDM5KJeEg=
 github.com/aws/aws-sdk-go-v2/service/costandusagereportservice v1.34.15 h1:iI5WGYZl5mU9OWa0EBj6TOY0NQ4JLvevo0txMpdq20g=

--- a/go.sum
+++ b/go.sum
@@ -95,8 +95,8 @@ github.com/aws/aws-sdk-go-v2/service/backup v1.57.1 h1:/6tJSdy0K4A1lsoMcY5DqFkQM
 github.com/aws/aws-sdk-go-v2/service/backup v1.57.1/go.mod h1:T961j1gPTNYG/vN/6cQJK06gdtyAWP9MjHNnPIAapX0=
 github.com/aws/aws-sdk-go-v2/service/batch v1.65.1 h1:1tGBoOvPGsbeb3a8RO6sNLjP9LxoVrBTRdQVg85hpCk=
 github.com/aws/aws-sdk-go-v2/service/batch v1.65.1/go.mod h1:YtletEcjRsIfctckbFMfsXEiuvm5FjitU2MNmoOHsYA=
-github.com/aws/aws-sdk-go-v2/service/bcmdataexports v1.16.0 h1:XEUbEn17sz6yPl3kP+DUs0cYi5qX2MPjag+A7P3I0Zo=
-github.com/aws/aws-sdk-go-v2/service/bcmdataexports v1.16.0/go.mod h1:zoV7Gv5idtxuUXqF1uRxS83Jb7zeHCa16s27f7dQs9A=
+github.com/aws/aws-sdk-go-v2/service/bcmdataexports v1.16.1 h1:k3W+G/GuG+hjaNESDiYhRddvXd5lMpleMd3QPXCvYak=
+github.com/aws/aws-sdk-go-v2/service/bcmdataexports v1.16.1/go.mod h1:PVM2CvJlYTfvVn6siQgUUQnet+tiW2Bv0sL7Pa2JakM=
 github.com/aws/aws-sdk-go-v2/service/bedrock v1.61.0 h1:KnLJsk989Y8FvZmEAzjNoQRyx6DK4/WeDDZsGb1X2Yc=
 github.com/aws/aws-sdk-go-v2/service/bedrock v1.61.0/go.mod h1:v/+a2bHvfo04yQC/p2HOK1iJF6V59OwCfCSf4iYgob4=
 github.com/aws/aws-sdk-go-v2/service/bedrockagent v1.54.0 h1:OnHTo0dbX2kWlAYHQZceppeMDfp07I+Kjtuk3T+1N70=

--- a/go.sum
+++ b/go.sum
@@ -263,8 +263,8 @@ github.com/aws/aws-sdk-go-v2/service/firehose v1.42.17 h1:OyU46F3vfHyX8XIf6jAyXt
 github.com/aws/aws-sdk-go-v2/service/firehose v1.42.17/go.mod h1:B0QS9gXSFnQlvnw8hGDigT6KBkEh/om5C+WvdfoWYXw=
 github.com/aws/aws-sdk-go-v2/service/fis v1.38.1 h1:HqYQa990x6wWfCynr4uXS+Gmu0FAjxkGT65Xk7wWQV8=
 github.com/aws/aws-sdk-go-v2/service/fis v1.38.1/go.mod h1:i2OcUIs4mCx4zH/tesSFfLBaoI1qVz6QTwexgtcoqTI=
-github.com/aws/aws-sdk-go-v2/service/fms v1.45.0 h1:OZj0sNgMfshwwIi59oXDj8EWaEES0faYNUZ/iO9fV9E=
-github.com/aws/aws-sdk-go-v2/service/fms v1.45.0/go.mod h1:cIz6sTAJzcJceQM5chsHkKq5agNHWtLCm5r20teGur8=
+github.com/aws/aws-sdk-go-v2/service/fms v1.45.1 h1:BXUO368cAQX3BTvRg3BnSyIT53v/qygNteYwuCJ+YaE=
+github.com/aws/aws-sdk-go-v2/service/fms v1.45.1/go.mod h1:zPxf7KJDIlavIfbrET7zYSIjqxmkMT7ziFCa+DPVrTc=
 github.com/aws/aws-sdk-go-v2/service/fsx v1.66.0 h1:ecF4zwUh0+0v9jMAv1cJ2VyTk8Hx+pjkxC446pkv2gw=
 github.com/aws/aws-sdk-go-v2/service/fsx v1.66.0/go.mod h1:ZhrGF6EmakQJR9N5lGxh7LdkVG+v+Iaa1+PKU9eehWQ=
 github.com/aws/aws-sdk-go-v2/service/gamelift v1.54.0 h1:TnDHcCjQbeyxNgWV67Gz8DigkCDcz6t4y+UWBItR1zc=

--- a/go.sum
+++ b/go.sum
@@ -83,8 +83,8 @@ github.com/aws/aws-sdk-go-v2/service/arcregionswitch v1.8.0 h1:clvHruzXl4C4/fDAC
 github.com/aws/aws-sdk-go-v2/service/arcregionswitch v1.8.0/go.mod h1:hnvcKnh9kG1cJrZ/3fxXPEC9Bd/ck3mwXl9je2Kwo1Y=
 github.com/aws/aws-sdk-go-v2/service/arczonalshift v1.22.26 h1:nv0oX1ZZ+6ny92QDpjPP9lfYTlZh4EUFyeJmng++Ous=
 github.com/aws/aws-sdk-go-v2/service/arczonalshift v1.22.26/go.mod h1:+REsC19JcG05zJBgsR87rXVWwfBgdKXmmibQOrEmtok=
-github.com/aws/aws-sdk-go-v2/service/athena v1.57.6 h1:QPDxHlfHmozXUj9rmUyxQiOLVEJL3qX4x56CrwAtytM=
-github.com/aws/aws-sdk-go-v2/service/athena v1.57.6/go.mod h1:3QLTFWWkK+tGp4LD0ClX5Ib75MWE5H66vBat1N9f8Os=
+github.com/aws/aws-sdk-go-v2/service/athena v1.57.7 h1:LqflSmquSJVH5UYG0oW+YPWMOo/zWTv84fFyZmiMkuc=
+github.com/aws/aws-sdk-go-v2/service/athena v1.57.7/go.mod h1:EI9CjMXiFy6pqdEWf4zhEcu06Xpr1Mxt+Lf+XAznpIE=
 github.com/aws/aws-sdk-go-v2/service/auditmanager v1.46.14 h1:JUaGgEfBSS1ok2Fmd6tUkNJviWk3NzgnS+zEbo2mMKo=
 github.com/aws/aws-sdk-go-v2/service/auditmanager v1.46.14/go.mod h1:KXqDl2so93n0kVWxXJm+oesedc5WfxVS6coPV7orpiA=
 github.com/aws/aws-sdk-go-v2/service/autoscaling v1.66.2 h1:pPd+/Ujqf2+DmPOdB47EN7ox1iC21lu2zlOccUlfHeo=

--- a/go.sum
+++ b/go.sum
@@ -567,8 +567,8 @@ github.com/aws/aws-sdk-go-v2/service/verifiedpermissions v1.34.0 h1:LqkQfCt37IEb
 github.com/aws/aws-sdk-go-v2/service/verifiedpermissions v1.34.0/go.mod h1:ujqEP1vFTIBsr/Fn2iZiaM3fHvlrfFfXkikWaZaU5aQ=
 github.com/aws/aws-sdk-go-v2/service/vpclattice v1.21.1 h1:XNrEJtc7gbo+UK9Otbyy/0Uobvx3lq60usTf01qxWgY=
 github.com/aws/aws-sdk-go-v2/service/vpclattice v1.21.1/go.mod h1:+6bxeMVFiKF9DbsnlPWSZZc09qvkEJAPaC9dZQvABYU=
-github.com/aws/aws-sdk-go-v2/service/waf v1.30.22 h1:EI78jKQQi/G+HRZeopJFSPSyG1/GzjCTeGd/1HPLHw8=
-github.com/aws/aws-sdk-go-v2/service/waf v1.30.22/go.mod h1:0KD+OoOdCNYDPZuFx2Ul5hHamV/vuC/Xs/f+Ke2x6y8=
+github.com/aws/aws-sdk-go-v2/service/waf v1.30.23 h1:haJSEMjnZSN06jrA3EtdHtYrzKZOmeaUtZ/jM3iIk18=
+github.com/aws/aws-sdk-go-v2/service/waf v1.30.23/go.mod h1:UU4sTEqsR0ymj69LvuxKBtneEvqnxkAnoRT58mJAF4U=
 github.com/aws/aws-sdk-go-v2/service/wafregional v1.30.23 h1:nSMoPH2GSzNREwCcUNgUuTT5fbN/NRlLXmF4ozCWXmw=
 github.com/aws/aws-sdk-go-v2/service/wafregional v1.30.23/go.mod h1:4z6g4XTbZ0xEwM6sJYBDn4YTkC7IItBYBBXMtcQzLAo=
 github.com/aws/aws-sdk-go-v2/service/wafv2 v1.71.5 h1:IMqwkBHrf3RjjNl+Xw0hkWz4WjB0ypcyNnRqOGiT7J0=

--- a/go.sum
+++ b/go.sum
@@ -249,8 +249,8 @@ github.com/aws/aws-sdk-go-v2/service/emr v1.59.3 h1:4h8LV+59JgGjcZaAhNvVatYG8CLI
 github.com/aws/aws-sdk-go-v2/service/emr v1.59.3/go.mod h1:RVZ0qkKp+7zm3wTQVEVf6yxTFUjVjbpThQkySXwtsfc=
 github.com/aws/aws-sdk-go-v2/service/emrcontainers v1.41.1 h1:zYb59S5qlJPP0UKwfN5b5ZeBzRl05pC2PYbzuVrM9Hc=
 github.com/aws/aws-sdk-go-v2/service/emrcontainers v1.41.1/go.mod h1:D2r6LGoC8ROaN5xH6MFNdmLX70Xskt6zEarzRiqgX+Q=
-github.com/aws/aws-sdk-go-v2/service/emrserverless v1.41.0 h1:/avPf4MwaJqp6hr/bJhLilQtOO2uQN/t/8B8DOVnrRE=
-github.com/aws/aws-sdk-go-v2/service/emrserverless v1.41.0/go.mod h1:xfX7dZWdVvSyv9wDHlfpYp1iIA9Y+D/oYwAGYFDPgjQ=
+github.com/aws/aws-sdk-go-v2/service/emrserverless v1.41.1 h1:uSr4AROQTSlhF+NLQwiY48S47K4BrkscrKy0Mge0yo8=
+github.com/aws/aws-sdk-go-v2/service/emrserverless v1.41.1/go.mod h1:0hsO5tjvol21vzxO2fvw6XmrTAzEVVnKqG9O/dqNoMc=
 github.com/aws/aws-sdk-go-v2/service/eventbridge v1.45.25 h1:9PZbyFSCN/E0TnqXqnvYJRhu7yQJv31vHG/vyuirbCY=
 github.com/aws/aws-sdk-go-v2/service/eventbridge v1.45.25/go.mod h1:ZJ1LBykgykfLqmsP2pBUesSd24sL6SebSEeXzzJ2hhE=
 github.com/aws/aws-sdk-go-v2/service/evidently v1.30.0 h1:XzLucuWDJKFGR2+krY+ZOfs5fjC9BpeDaHYEf+VIBiA=

--- a/go.sum
+++ b/go.sum
@@ -273,8 +273,8 @@ github.com/aws/aws-sdk-go-v2/service/glacier v1.32.9 h1:YmKhaCkxIDABhKu4UXPNgSTN
 github.com/aws/aws-sdk-go-v2/service/glacier v1.32.9/go.mod h1:vlEeKKUe2y0PXooxWUyDP8WgOhUH5gHGGrR9dn3bdyg=
 github.com/aws/aws-sdk-go-v2/service/globalaccelerator v1.36.1 h1:1YvLkahfJgY0IfJnA1ikids8/CC/s5LHrmbhWpz9U+w=
 github.com/aws/aws-sdk-go-v2/service/globalaccelerator v1.36.1/go.mod h1:gRlTv00BpckxaCzUTJ+qmVzgQp8YFtGpQz/MRXnRv/M=
-github.com/aws/aws-sdk-go-v2/service/glue v1.142.0 h1:ztxbPEsd9yyuf2A41ZwtCXtI61t7ocnQ7vUdziFiFUc=
-github.com/aws/aws-sdk-go-v2/service/glue v1.142.0/go.mod h1:FZCvt95CcJWRkZNRcmMW1uQkpDHmyUSkZfz3awyZgqg=
+github.com/aws/aws-sdk-go-v2/service/glue v1.142.1 h1:Xq3xf10SK8eQx2C0QmHhveoShZxr1WKLaVsZPBWcfkE=
+github.com/aws/aws-sdk-go-v2/service/glue v1.142.1/go.mod h1:NaK8CYNUIE/ctvfqGl2F9uD9PqTzGQwRENp1MFNgyCs=
 github.com/aws/aws-sdk-go-v2/service/grafana v1.35.0 h1:o9fN0lOXbKu+IL4yY6Z8/Ay8qCjYmtO0wNdg3rfZY5Q=
 github.com/aws/aws-sdk-go-v2/service/grafana v1.35.0/go.mod h1:2O+Qnaf3MT2sWatyqn4FezjE0dHUFJX/m7fiuRdW7SY=
 github.com/aws/aws-sdk-go-v2/service/greengrass v1.32.23 h1:VTghmVEn2zf3DVkqNE9d8gdg+Tc2Lj0CggsTXtU0zGo=

--- a/go.sum
+++ b/go.sum
@@ -187,8 +187,8 @@ github.com/aws/aws-sdk-go-v2/service/databasemigrationservice v1.63.1 h1:A3ZPi0A
 github.com/aws/aws-sdk-go-v2/service/databasemigrationservice v1.63.1/go.mod h1:+5VgeIKl82hc3J8/Z6rZpGLaNMrRYkHdR7n4pWhaNOo=
 github.com/aws/aws-sdk-go-v2/service/databrew v1.40.1 h1:CrqRhUBWuTcdNbCAWVoWpAE898qU2kiGuayCv4Ffe5Q=
 github.com/aws/aws-sdk-go-v2/service/databrew v1.40.1/go.mod h1:Za6vZBh9dK4VLieS+BBOLuz+3Vz+9PYUKI1+vrJ6DDo=
-github.com/aws/aws-sdk-go-v2/service/dataexchange v1.41.2 h1:kO0lpy2o5+OFc7RA2u0xHQvf7gFmVxuljgbe9xt5d/M=
-github.com/aws/aws-sdk-go-v2/service/dataexchange v1.41.2/go.mod h1:nozeyNDLibm9cyf4nf7yIdzMeQt+8w2mvuSQj6qKAE0=
+github.com/aws/aws-sdk-go-v2/service/dataexchange v1.42.1 h1:NV6JSW33vKaD675ZpaduwOsBlD8hOhlzGoGYAYFEDn4=
+github.com/aws/aws-sdk-go-v2/service/dataexchange v1.42.1/go.mod h1:LnluRcm5NhbRSq7mIzN/l3+63a89KUNLBrth2lF9QCw=
 github.com/aws/aws-sdk-go-v2/service/datapipeline v1.30.22 h1:th7UIseI06gZDd/7ntsyUJmVVbbowq4ypEUh8gf5+OU=
 github.com/aws/aws-sdk-go-v2/service/datapipeline v1.30.22/go.mod h1:vNpeL80rYCglcJXUOeCbC8/qQ9vMclvff5kFMNf7iI0=
 github.com/aws/aws-sdk-go-v2/service/datasync v1.59.0 h1:ZVx+zJCX9kwDoFv5tJxSW3ESEIimK/u8D/tP4ouyIFY=

--- a/go.sum
+++ b/go.sum
@@ -389,8 +389,8 @@ github.com/aws/aws-sdk-go-v2/service/networkflowmonitor v1.11.12 h1:wjAGQwXknovX
 github.com/aws/aws-sdk-go-v2/service/networkflowmonitor v1.11.12/go.mod h1:LXVPCQiyrT5jBtZwCrzCxTomfsy+W/ZYzy2VmDlorn0=
 github.com/aws/aws-sdk-go-v2/service/networkmanager v1.42.1 h1:9o2GTfTTFQtorK/GUQt7Oj53+WuUJmfXcyTsQqQux34=
 github.com/aws/aws-sdk-go-v2/service/networkmanager v1.42.1/go.mod h1:jWEPRVbipvd1/BZHOIgQjBN0RjPX+VE+vi7EbO52gkI=
-github.com/aws/aws-sdk-go-v2/service/networkmonitor v1.13.15 h1:Ji9P/9srs4/zg76hJP1117SuDZXDQ/ooeETlNPmhXcM=
-github.com/aws/aws-sdk-go-v2/service/networkmonitor v1.13.15/go.mod h1:qISrDtSm2hQNPt9O1kwCvk5IwD01lE9WAhB9hnddNvg=
+github.com/aws/aws-sdk-go-v2/service/networkmonitor v1.14.0 h1:kRw49kdziIuc5pz2+dPb9sYNf+1WCd10/pYl437M0bA=
+github.com/aws/aws-sdk-go-v2/service/networkmonitor v1.14.0/go.mod h1:G7P74BfTAeAp1qmfBe4NOlcz28e0L1a6xkjm/cdLGb4=
 github.com/aws/aws-sdk-go-v2/service/notifications v1.8.0 h1:TjLraX0tvsqAN1CgkQkQbl3ga91FhAXRPsPvQf+dp6I=
 github.com/aws/aws-sdk-go-v2/service/notifications v1.8.0/go.mod h1:2ShOanXPWp9GRHTHQP4gV2+YCrfiXL5gpchgRJzfdf4=
 github.com/aws/aws-sdk-go-v2/service/notificationscontacts v1.6.0 h1:3Roxg1ro+M11PFgPTmAuc4WnaD6B57s+Uur5l9Od/ck=

--- a/go.sum
+++ b/go.sum
@@ -471,8 +471,8 @@ github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.26.24 h1:Fz0Fkq
 github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.26.24/go.mod h1:MPhW9xnKREEBarsR9trTTga2QPWIpNVh0DdSYqIXRxM=
 github.com/aws/aws-sdk-go-v2/service/route53resolver v1.44.1 h1:/WLmwOCXZhgV1hMIqFioY6OW4pH/9IOuyKEBs/ULOX4=
 github.com/aws/aws-sdk-go-v2/service/route53resolver v1.44.1/go.mod h1:Zu3OBgl+NDcA1fe/+h2j7A4feaC0BkFG4qfrQA7IUg8=
-github.com/aws/aws-sdk-go-v2/service/rum v1.30.12 h1:WO4GCFUbqUPMZ7ICqGtqqT60aVIosYeVKl3cdeiil/s=
-github.com/aws/aws-sdk-go-v2/service/rum v1.30.12/go.mod h1:i8qJS9c/JjEF1vAfIz3HbIFx5+K5uC5pditPl2hy8Og=
+github.com/aws/aws-sdk-go-v2/service/rum v1.31.1 h1:4uWoRB+WRGc5z6Anztw3qwdGLCpC0643Kh0f1WlTEnM=
+github.com/aws/aws-sdk-go-v2/service/rum v1.31.1/go.mod h1:AsDtKeq5z+QO+OE5mnxaHqy+KCrjZDyc1F4QUkCUx3w=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.102.1 h1:vttIo8BQwfnhimKRBZBBF3Y38SAIxif72B/M91m9hDk=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.102.1/go.mod h1:2qjInACJr84m/Tm4XXCcVNpejmbKy9kz7TEa6viQHSk=
 github.com/aws/aws-sdk-go-v2/service/s3control v1.70.1 h1:jbMg6zIdFawDnLhbzaLGUxaMN2H42wP4hKsjG0OuLmA=

--- a/go.sum
+++ b/go.sum
@@ -133,8 +133,8 @@ github.com/aws/aws-sdk-go-v2/service/cloudsearch v1.32.15 h1:ETNqwiPFuwQQbqoVhcw
 github.com/aws/aws-sdk-go-v2/service/cloudsearch v1.32.15/go.mod h1:7ThInmcOZindokcAKJxcStdW2I6jl0heM7OMe5ukQZI=
 github.com/aws/aws-sdk-go-v2/service/cloudtrail v1.55.12 h1:vEtY+NJKYmCBjFrMQob5ex4mDKQgCW2v4NWfufAg9YA=
 github.com/aws/aws-sdk-go-v2/service/cloudtrail v1.55.12/go.mod h1:3M8MhO9Z7Ev065eLAkInHs4vZABsa/SBMNg0m7NoVyI=
-github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.57.0 h1:dlkFtYOrwOuM7IIBD6FPLtt0Xvnph+8hqmmbzyowkCk=
-github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.57.0/go.mod h1:7900IH3EvTrwNGLNx3QDKnQwPF/Cw+pD9cuvBDQ4org=
+github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.57.1 h1:i4i1wpCbEiFsge84hmvuLHpBCdhgfoAJTfDpPMr+sZA=
+github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.57.1/go.mod h1:751oDslfSNqbjCBSZYZKOvXl8Pbx9soAk2nISFo9sN0=
 github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.74.0 h1:6TqDeYdvJJEIJGg5ICy7nzC7/UuHk2Eg3wrpb5bWKPM=
 github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.74.0/go.mod h1:MLJu3PUd8fp5Qvj4CiLvyY5H8y7kxHKlTp060Wsd+Vc=
 github.com/aws/aws-sdk-go-v2/service/codeartifact v1.39.0 h1:Fn9GARyT8xa81y8sYE5pvIjIRpYdUlbFyEuMadrkgoE=

--- a/go.sum
+++ b/go.sum
@@ -489,8 +489,8 @@ github.com/aws/aws-sdk-go-v2/service/sagemaker v1.250.1 h1:KoMKWfzAftZzto69IkrRn
 github.com/aws/aws-sdk-go-v2/service/sagemaker v1.250.1/go.mod h1:5Rogcr8mhSUah+AoYFZvB10D3qPtqa3GbbxSx+pW3yI=
 github.com/aws/aws-sdk-go-v2/service/savingsplans v1.33.1 h1:g4IDAQgDNOn6XAGdQgv9zpDTtPlAZmWM9NgBgEvoiG0=
 github.com/aws/aws-sdk-go-v2/service/savingsplans v1.33.1/go.mod h1:M+v5amm+fIixMXUd9D6XLsNeNOHhnj7R7y8sVKuPku4=
-github.com/aws/aws-sdk-go-v2/service/scheduler v1.18.0 h1:Qq2vBd/eezmHlfkaINHdzS3+r6B+1d+NJXYj4iVZ3rE=
-github.com/aws/aws-sdk-go-v2/service/scheduler v1.18.0/go.mod h1:0/mvOL++cUfpS4KgHigHDo+x8KLYG/grOTyIOw3KCPM=
+github.com/aws/aws-sdk-go-v2/service/scheduler v1.18.1 h1:Bnd6NBK0dffch1jzoLW5kY1IseJgKhK7bKWK9CDIwls=
+github.com/aws/aws-sdk-go-v2/service/scheduler v1.18.1/go.mod h1:WxEyYX1IGwN35IsEOicEvOwTG32yu33kYcc+gHanyYQ=
 github.com/aws/aws-sdk-go-v2/service/schemas v1.35.0 h1:SWK85nZP86S/uwIqQ54G81PYLuATBaPxKEmRFDoP35o=
 github.com/aws/aws-sdk-go-v2/service/schemas v1.35.0/go.mod h1:/EC2ZUKZo8m/Pws9YuzgBSL8GZE7alyCYaYJyyZDah4=
 github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.7 h1:JUGKqUnJHbXpS8uyuICP/zpQ+vXUIXW2zTEqjMLCqrY=

--- a/go.sum
+++ b/go.sum
@@ -411,8 +411,8 @@ github.com/aws/aws-sdk-go-v2/service/osis v1.22.1 h1:pQiTQtB/V1rnUIy11EcmYf5FEzk
 github.com/aws/aws-sdk-go-v2/service/osis v1.22.1/go.mod h1:L8Tvf0GshqlZ1nUIK+TdPmxXz379eRT3R+EtCyPLqgU=
 github.com/aws/aws-sdk-go-v2/service/outposts v1.60.1 h1:8UCOqAoJ68CU5YqSZ0inZuYkLnkk1nyjQa1tLf9C+68=
 github.com/aws/aws-sdk-go-v2/service/outposts v1.60.1/go.mod h1:Yfs4XytNgJNBYeO9VK37ln5SUViyyDQosIZU+JykOnc=
-github.com/aws/aws-sdk-go-v2/service/paymentcryptography v1.29.0 h1:lRe1Q5Rz1xFQlov+KkOm10XK/t1Mfe65lOA68hfZoBo=
-github.com/aws/aws-sdk-go-v2/service/paymentcryptography v1.29.0/go.mod h1:kZX+7Aq8eBUcO5qf8BNrFw9nsP3VZoXWK39sC79bwoc=
+github.com/aws/aws-sdk-go-v2/service/paymentcryptography v1.30.1 h1:/qmXfvYpUCvjIQvxaap4Qh+B6k0LS5vQl4hbiqL+7D4=
+github.com/aws/aws-sdk-go-v2/service/paymentcryptography v1.30.1/go.mod h1:VG1mn7qHIypEmLludHRsXov7u+oW9Pk/Q74fPwIGpKY=
 github.com/aws/aws-sdk-go-v2/service/pcaconnectorad v1.15.23 h1:CtTEAf/iYhq8G9KLBJH0T3GOZQ6/Ejjt0+J66jdSfKk=
 github.com/aws/aws-sdk-go-v2/service/pcaconnectorad v1.15.23/go.mod h1:rHRclwfqAZZNIE/8KCVZomUOeLyuUd8jdU9a5Z4NQX4=
 github.com/aws/aws-sdk-go-v2/service/pcs v1.18.0 h1:mQiOx3IVBZ2by9VcOETEgsfNTJrxqbYjoE1UpJ1A5E0=

--- a/go.sum
+++ b/go.sum
@@ -231,8 +231,8 @@ github.com/aws/aws-sdk-go-v2/service/ecs v1.81.1 h1:LyyVqeXzra+cPw0BGloOuowJCTvl
 github.com/aws/aws-sdk-go-v2/service/ecs v1.81.1/go.mod h1:0Lg4lqs9OzRR/Ne8x/rQnRi7qe4LLPnLch/VhqmFPRc=
 github.com/aws/aws-sdk-go-v2/service/efs v1.41.17 h1:0RViZJ5P2Tpm8OSTGFMVRJHDP6dhY0LKcYB/G99Reb4=
 github.com/aws/aws-sdk-go-v2/service/efs v1.41.17/go.mod h1:epIbYreyUL7HvPdLyEGpao66ZKaeafXHAXuWdB3Oass=
-github.com/aws/aws-sdk-go-v2/service/eks v1.84.0 h1:U9HMTDPdZtkCOTE8ACbHQJmXGBKP7/mBds7M1JbUZH0=
-github.com/aws/aws-sdk-go-v2/service/eks v1.84.0/go.mod h1:JQcyECIV9iZHm+GMrWn1pTPTJYRavOVsqPvlCbjt+Fg=
+github.com/aws/aws-sdk-go-v2/service/eks v1.84.1 h1:v3IeM72tqpk3LGx+PCPEP2IP8SsBwdIimDRpk+RcAvc=
+github.com/aws/aws-sdk-go-v2/service/eks v1.84.1/go.mod h1:4KiCxT4w134foeUz8N5tKJBNaKMBw62nYTsr9ewDVP4=
 github.com/aws/aws-sdk-go-v2/service/elasticache v1.52.2 h1:5wbCUfyxXcjIqesyVfJBBJs0bDMyejthtHyy48mfZCI=
 github.com/aws/aws-sdk-go-v2/service/elasticache v1.52.2/go.mod h1:o4vQxDt6oteknUjkXIEskp0ccy+93NRTPKXw3HlVMFE=
 github.com/aws/aws-sdk-go-v2/service/elasticbeanstalk v1.34.4 h1:0lWGw/CCacFJ97IBwi25huydqDogkF+aX0cnluiTsNA=

--- a/go.sum
+++ b/go.sum
@@ -211,8 +211,8 @@ github.com/aws/aws-sdk-go-v2/service/directoryservice v1.38.19 h1:7uzyDjdMN99ALP
 github.com/aws/aws-sdk-go-v2/service/directoryservice v1.38.19/go.mod h1:QmDYiedOfdgvQk6gtAHwa8yAgYSZXqiB6dHUxJ1CVBM=
 github.com/aws/aws-sdk-go-v2/service/dlm v1.37.1 h1:m0/eWYy9aNesQr7fjtWzLWhiHZTuhcE7rn0wryW0PGE=
 github.com/aws/aws-sdk-go-v2/service/dlm v1.37.1/go.mod h1:lxtBECY+gv9fB14kFslHOFV28Pj6RJEem6kPZdCrVZw=
-github.com/aws/aws-sdk-go-v2/service/docdb v1.48.15 h1:jvP746CYJno9fSBqvPMShLPVu+P9wetNsSb+xYk52ag=
-github.com/aws/aws-sdk-go-v2/service/docdb v1.48.15/go.mod h1:wMMgRe7xZVJu58h7CI06EV6n/QUOILSk53/3EYzkorg=
+github.com/aws/aws-sdk-go-v2/service/docdb v1.48.16 h1:JVfVNI1W7geUmJuyTPVKDdym3cpOXfxWKfGdRhm5O6k=
+github.com/aws/aws-sdk-go-v2/service/docdb v1.48.16/go.mod h1:qzkOzKUNO8ZzfMCC8gTh2uxD/7UmpS9scLHfAZ696i4=
 github.com/aws/aws-sdk-go-v2/service/docdbelastic v1.20.15 h1:7yp69z1AGCHUznyl4At8SUYZHd5tDu+IMfqMqzGOBqM=
 github.com/aws/aws-sdk-go-v2/service/docdbelastic v1.20.15/go.mod h1:kzaI5ZnKnaKp6p8rK2jPBR16sonsZ7UysOUywcjCz+A=
 github.com/aws/aws-sdk-go-v2/service/drs v1.38.2 h1:lGGi8jgwirRgq3AicTFBr5u1nqkE/y3bJuhjQQI3e1o=

--- a/go.sum
+++ b/go.sum
@@ -341,8 +341,8 @@ github.com/aws/aws-sdk-go-v2/service/launchwizard v1.15.1 h1:7xZRe3mqApyzsWqjtNn
 github.com/aws/aws-sdk-go-v2/service/launchwizard v1.15.1/go.mod h1:5kDHQj+69vTbiXJTkjw92qjEPROvbzJIZAeOad73814=
 github.com/aws/aws-sdk-go-v2/service/lexmodelbuildingservice v1.35.1 h1:NZX1pOWZuw85O34v5prNeAgSmbjZzzVAG7y4j2+EZX8=
 github.com/aws/aws-sdk-go-v2/service/lexmodelbuildingservice v1.35.1/go.mod h1:rzQ2SsbFij+4zX+SUNYMDL632DqZHY6t+pEeBzmD7e4=
-github.com/aws/aws-sdk-go-v2/service/lexmodelsv2 v1.61.0 h1:6rjKCcc8dGyhGzbgRe5M1Zfp73OubQe2x8AzF31UpLE=
-github.com/aws/aws-sdk-go-v2/service/lexmodelsv2 v1.61.0/go.mod h1:lTTUoKQCz5RgFIWMUcO/MaDuJG4MNxKRQSc2ZOaFz/c=
+github.com/aws/aws-sdk-go-v2/service/lexmodelsv2 v1.61.1 h1:rKfX8s06E/LQ2GTsqP+RazndMRfeLRJCA7gISHn1I9s=
+github.com/aws/aws-sdk-go-v2/service/lexmodelsv2 v1.61.1/go.mod h1:NFAqjgrK+zDT/FBpxy8hhv6TeihDTevN/Sesh8qr8Bw=
 github.com/aws/aws-sdk-go-v2/service/licensemanager v1.37.12 h1:CRnlzGMTYDTHpmFSGUe+CjEHzNQzL+fRZS5weQLvRfc=
 github.com/aws/aws-sdk-go-v2/service/licensemanager v1.37.12/go.mod h1:1Y6IDySTexX5E3Jl95awEToOP1pW/rwEfcUwNElaF5A=
 github.com/aws/aws-sdk-go-v2/service/lightsail v1.54.0 h1:07DKnL5eKSel3XEM2UxlD/z9zUZZ6XMHLGDXkAdY4u8=

--- a/go.sum
+++ b/go.sum
@@ -97,8 +97,8 @@ github.com/aws/aws-sdk-go-v2/service/batch v1.65.1 h1:1tGBoOvPGsbeb3a8RO6sNLjP9L
 github.com/aws/aws-sdk-go-v2/service/batch v1.65.1/go.mod h1:YtletEcjRsIfctckbFMfsXEiuvm5FjitU2MNmoOHsYA=
 github.com/aws/aws-sdk-go-v2/service/bcmdataexports v1.16.1 h1:k3W+G/GuG+hjaNESDiYhRddvXd5lMpleMd3QPXCvYak=
 github.com/aws/aws-sdk-go-v2/service/bcmdataexports v1.16.1/go.mod h1:PVM2CvJlYTfvVn6siQgUUQnet+tiW2Bv0sL7Pa2JakM=
-github.com/aws/aws-sdk-go-v2/service/bedrock v1.61.0 h1:KnLJsk989Y8FvZmEAzjNoQRyx6DK4/WeDDZsGb1X2Yc=
-github.com/aws/aws-sdk-go-v2/service/bedrock v1.61.0/go.mod h1:v/+a2bHvfo04yQC/p2HOK1iJF6V59OwCfCSf4iYgob4=
+github.com/aws/aws-sdk-go-v2/service/bedrock v1.62.0 h1:W+9SC9IbSJfB8uIVvYrE4+AR5Id47q6uma7zKcpoHMc=
+github.com/aws/aws-sdk-go-v2/service/bedrock v1.62.0/go.mod h1:s8wtBVt3pTWX6N4QvrYzOehkoUsVzkiGRdZuA4utdVQ=
 github.com/aws/aws-sdk-go-v2/service/bedrockagent v1.54.0 h1:OnHTo0dbX2kWlAYHQZceppeMDfp07I+Kjtuk3T+1N70=
 github.com/aws/aws-sdk-go-v2/service/bedrockagent v1.54.0/go.mod h1:zue4MN4ji6nlKYQYwVLmaPXJ66wB9JnIePX1e1yg5MU=
 github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol v1.40.0 h1:4QLszbAJFRdTRVU3b0FVnSavqarnrTBdjmrfdCfETyQ=

--- a/go.sum
+++ b/go.sum
@@ -335,8 +335,8 @@ github.com/aws/aws-sdk-go-v2/service/kms v1.52.1 h1:qBc+5ZvMjb+Y+Ho+0wwyBYBITH1W
 github.com/aws/aws-sdk-go-v2/service/kms v1.52.1/go.mod h1:bWSG4E0FxeeDdfXseEnPfkFv4MqTY/6fDFGUHu/Wkb0=
 github.com/aws/aws-sdk-go-v2/service/lakeformation v1.47.9 h1:pLP0jbhZSUY3T8LPHWJ9BWbJPKE2i6TAW5l2emgZM9o=
 github.com/aws/aws-sdk-go-v2/service/lakeformation v1.47.9/go.mod h1:ZHQuEeYF365Q5ASJDbYzg/4ZxaTTyWmfBGyXaKxZw9A=
-github.com/aws/aws-sdk-go-v2/service/lambda v1.90.1 h1:odCeJgHXfQoXEWQUIzPkKvsJTWcLMsaOWowNpovPFFw=
-github.com/aws/aws-sdk-go-v2/service/lambda v1.90.1/go.mod h1:NbtJVztitG7JkuoI4GSrDUlsB32zeXqKBvXj6bUxcMo=
+github.com/aws/aws-sdk-go-v2/service/lambda v1.90.2 h1:dBiVUhd21cs5C3RUiAKTMc4Cw+5kvTBhM/GGlYTXrpo=
+github.com/aws/aws-sdk-go-v2/service/lambda v1.90.2/go.mod h1:gFmCYh+m/TwFPR3o30V83jaNVIzN5ozPrf7eC29mBJU=
 github.com/aws/aws-sdk-go-v2/service/launchwizard v1.14.6 h1:csDiL1/b79JOn9c02M5l3COsSPsUVFM4Q0TT9BEbkYk=
 github.com/aws/aws-sdk-go-v2/service/launchwizard v1.14.6/go.mod h1:Ivm9tKepKZYnZF5EUdRXaKx/6onFvtuLAvbReL/13OQ=
 github.com/aws/aws-sdk-go-v2/service/lexmodelbuildingservice v1.35.0 h1:LJ+UCPYUUAPlKNBj/r+mNZA8msdgFFa4tQNr/fUE2bE=

--- a/go.sum
+++ b/go.sum
@@ -553,8 +553,8 @@ github.com/aws/aws-sdk-go-v2/service/taxsettings v1.16.24 h1:jLJ3xMWjeHbmilHerEy
 github.com/aws/aws-sdk-go-v2/service/taxsettings v1.16.24/go.mod h1:Ufi/y8T3Yuj3w05IDIvevtz+wxQjrXeBIroAGjCKJtQ=
 github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.20.0 h1:4zRcgn5fbavj1H4EaQzsK5cqe7HJhdh+2zsS6Qpnscc=
 github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.20.0/go.mod h1:HuKojo4zKYq6UOvPeorfcmR6BlOxIjZx9/6mXVV5C5M=
-github.com/aws/aws-sdk-go-v2/service/timestreamquery v1.36.17 h1:PAw0bg4Vw9G19+ozW3uJQXxxNYqk8J3jztJxZBCU71g=
-github.com/aws/aws-sdk-go-v2/service/timestreamquery v1.36.17/go.mod h1:/LTHgqxCcbaCh1QLp/uclq79iOFiauvra1lUNb4Co40=
+github.com/aws/aws-sdk-go-v2/service/timestreamquery v1.36.18 h1:cYAZklvpeCttnJeiG6b0ouYxy1fdzG52svDhllRF9c0=
+github.com/aws/aws-sdk-go-v2/service/timestreamquery v1.36.18/go.mod h1:D9Xer57g8BV+0T+to7RZ5U1aOd4cdTFVVK6OUH1pvHw=
 github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.35.23 h1:ibF4VUUnR8kveX/3pURldl1bTaEEAin8mjnmtzQGuzw=
 github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.35.23/go.mod h1:A9LLxRTZsFAoe66dPqfgMIB8bZeoo7Jzg5ZGzKRxFkc=
 github.com/aws/aws-sdk-go-v2/service/transcribe v1.55.0 h1:RKV4MScftqxaWNft0S5MqGgz78zyFU6IK/pxNlH6MJs=

--- a/go.sum
+++ b/go.sum
@@ -469,8 +469,8 @@ github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.33.0 h1:PN2
 github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.33.0/go.mod h1:B2YQF5Mu9cs5J5TTYvSMcdATZLaOkoYVZ8lc3sfDsIU=
 github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.26.24 h1:Fz0FkqtkuAaY9y1t3BkJiLkFQ18rIZp/aezHn7SCf8U=
 github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.26.24/go.mod h1:MPhW9xnKREEBarsR9trTTga2QPWIpNVh0DdSYqIXRxM=
-github.com/aws/aws-sdk-go-v2/service/route53resolver v1.44.0 h1:9VLmITeTm+jTiL48ZSll0A4KW3AD/IcRENQG2s3jxMc=
-github.com/aws/aws-sdk-go-v2/service/route53resolver v1.44.0/go.mod h1:OAvZZokn38D2+MY88EllrzDyl6MyEHTRAx0u5WvqBAI=
+github.com/aws/aws-sdk-go-v2/service/route53resolver v1.44.1 h1:/WLmwOCXZhgV1hMIqFioY6OW4pH/9IOuyKEBs/ULOX4=
+github.com/aws/aws-sdk-go-v2/service/route53resolver v1.44.1/go.mod h1:Zu3OBgl+NDcA1fe/+h2j7A4feaC0BkFG4qfrQA7IUg8=
 github.com/aws/aws-sdk-go-v2/service/rum v1.30.12 h1:WO4GCFUbqUPMZ7ICqGtqqT60aVIosYeVKl3cdeiil/s=
 github.com/aws/aws-sdk-go-v2/service/rum v1.30.12/go.mod h1:i8qJS9c/JjEF1vAfIz3HbIFx5+K5uC5pditPl2hy8Og=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.102.1 h1:vttIo8BQwfnhimKRBZBBF3Y38SAIxif72B/M91m9hDk=

--- a/go.sum
+++ b/go.sum
@@ -261,8 +261,8 @@ github.com/aws/aws-sdk-go-v2/service/finspace v1.34.1 h1:sQa8VyMLc2BhEy8kLuve3uf
 github.com/aws/aws-sdk-go-v2/service/finspace v1.34.1/go.mod h1:kpT6GkbkbP3ZJUvz+9iaeXvcv79VmfN5X9xzQJidB3E=
 github.com/aws/aws-sdk-go-v2/service/firehose v1.42.17 h1:OyU46F3vfHyX8XIf6jAyXtGu7wA1zE/XzmIbLVt+orQ=
 github.com/aws/aws-sdk-go-v2/service/firehose v1.42.17/go.mod h1:B0QS9gXSFnQlvnw8hGDigT6KBkEh/om5C+WvdfoWYXw=
-github.com/aws/aws-sdk-go-v2/service/fis v1.37.22 h1:2LO81Hj8dYOxioN/ztt5iiSzrYgIgMe3wowSEcW5VsY=
-github.com/aws/aws-sdk-go-v2/service/fis v1.37.22/go.mod h1:NW+8sdgF3jxYlnmmmzSnPnfGdgoJP1rUlbn+9m8O1+8=
+github.com/aws/aws-sdk-go-v2/service/fis v1.38.1 h1:HqYQa990x6wWfCynr4uXS+Gmu0FAjxkGT65Xk7wWQV8=
+github.com/aws/aws-sdk-go-v2/service/fis v1.38.1/go.mod h1:i2OcUIs4mCx4zH/tesSFfLBaoI1qVz6QTwexgtcoqTI=
 github.com/aws/aws-sdk-go-v2/service/fms v1.45.0 h1:OZj0sNgMfshwwIi59oXDj8EWaEES0faYNUZ/iO9fV9E=
 github.com/aws/aws-sdk-go-v2/service/fms v1.45.0/go.mod h1:cIz6sTAJzcJceQM5chsHkKq5agNHWtLCm5r20teGur8=
 github.com/aws/aws-sdk-go-v2/service/fsx v1.66.0 h1:ecF4zwUh0+0v9jMAv1cJ2VyTk8Hx+pjkxC446pkv2gw=

--- a/go.sum
+++ b/go.sum
@@ -101,8 +101,8 @@ github.com/aws/aws-sdk-go-v2/service/bedrock v1.62.0 h1:W+9SC9IbSJfB8uIVvYrE4+AR
 github.com/aws/aws-sdk-go-v2/service/bedrock v1.62.0/go.mod h1:s8wtBVt3pTWX6N4QvrYzOehkoUsVzkiGRdZuA4utdVQ=
 github.com/aws/aws-sdk-go-v2/service/bedrockagent v1.54.1 h1:jc+0xbKgIthQDrAb8KVr5uJdItkany+WIEb3dnkJiHQ=
 github.com/aws/aws-sdk-go-v2/service/bedrockagent v1.54.1/go.mod h1:mHMqUmNCieOVD/XOD6Xmlqof1ptZnF/TsRMTy/Jr8CY=
-github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol v1.40.0 h1:4QLszbAJFRdTRVU3b0FVnSavqarnrTBdjmrfdCfETyQ=
-github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol v1.40.0/go.mod h1:WXGqnCrWtpgiig7ymwkNHdGvWF7FJtGvx8ldK/yy5BQ=
+github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol v1.41.0 h1:s+9aRVnNcNpct2raxZ+2sE1QUFRwx74HJrVD8CWcxQU=
+github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol v1.41.0/go.mod h1:MJLW1rK+TZO6mExsuFg7O+vFELkILGAu6+L943Q+Akk=
 github.com/aws/aws-sdk-go-v2/service/billing v1.11.0 h1:BttT9s7XhvQ0B3fR3EZ2jglkd8nIj75yXTkQinlJd8E=
 github.com/aws/aws-sdk-go-v2/service/billing v1.11.0/go.mod h1:3/4KagnaoaVLj9jIOKGWCZc+YFETolSQV+AjOPB+WUY=
 github.com/aws/aws-sdk-go-v2/service/budgets v1.43.7 h1:5da51kHGIcUydFIQnPTQxwxlraBc6Z2M/Mg430mJGcw=

--- a/go.sum
+++ b/go.sum
@@ -307,8 +307,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.24 h1:yPLVC8Lbsw92e
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.24/go.mod h1:H2h39H1AivHYkozUIUYoVJGMUOvdJ4Lv9DLyUSMAjW8=
 github.com/aws/aws-sdk-go-v2/service/internetmonitor v1.27.1 h1:5FWxiFSsPmdUC3XkkoWFwA1JIGP3nFCrHylCNByoYhc=
 github.com/aws/aws-sdk-go-v2/service/internetmonitor v1.27.1/go.mod h1:1qUwGVZnLhCkPkQ3SM6RqunW4kyuEmZJsoNjmUx5Q9c=
-github.com/aws/aws-sdk-go-v2/service/invoicing v1.11.0 h1:s/WRy52LDxbT4a4PIMX0zFrpLKsm4uvN6oeW/L+RnNg=
-github.com/aws/aws-sdk-go-v2/service/invoicing v1.11.0/go.mod h1:jm9V3Cs38eUnjUzhEg3Acdz9CFAwd/E0uX1LH99PK80=
+github.com/aws/aws-sdk-go-v2/service/invoicing v1.11.1 h1:kTiy0bkxsbkzBwZkwYDo8W+vhdqZFqYvEkrRiO9oF/A=
+github.com/aws/aws-sdk-go-v2/service/invoicing v1.11.1/go.mod h1:iCJX4vAw5TUZz+IbcrxugeF03bK/2VrAKUV7wguQIUo=
 github.com/aws/aws-sdk-go-v2/service/iot v1.73.0 h1:7ZI147ei1koJE5dnfus8cfMOp2CRxsMgORp6hmewV9I=
 github.com/aws/aws-sdk-go-v2/service/iot v1.73.0/go.mod h1:9OGjPSOz2OZbObVfBcn110WPW/XZ1k6rSCpky8EvfHQ=
 github.com/aws/aws-sdk-go-v2/service/ivs v1.50.1 h1:H/tTA4a7nmiFacIKeQjK/S8m7Ah/OXzSSLwPXEtD3l8=

--- a/go.sum
+++ b/go.sum
@@ -573,8 +573,8 @@ github.com/aws/aws-sdk-go-v2/service/wafregional v1.30.24 h1:rYfUYezU29dhNnX0ufD
 github.com/aws/aws-sdk-go-v2/service/wafregional v1.30.24/go.mod h1:X7/MWb1tXmdavn712tp+wPf4gC/zl6H4MHGOD8sZD7s=
 github.com/aws/aws-sdk-go-v2/service/wafv2 v1.71.6 h1:SKPs3pBnHGs4hAKW1I3CoH8GffR2EZqKbqIYiQcpVJ8=
 github.com/aws/aws-sdk-go-v2/service/wafv2 v1.71.6/go.mod h1:L30J3rRiVI9inT2rOU6xD5ysqmbwwmj+ng1rReS0Xt0=
-github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.39.23 h1:5xJQfmla2mUX3vaYBMBTzF31Db4UWqKIjtcjZ3+rOnc=
-github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.39.23/go.mod h1:PwOqXK/zLygfNnxe76HRT+SUenchdxHRfGX2kCVQZ+c=
+github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.40.1 h1:1P2yEK/4l3aMcpfnwHGVYs5BlbsF9LtnYWaypkdgxLg=
+github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.40.1/go.mod h1:qlP/IKEhKywBy4iHYWPgGnhVZ43ns08vpl3GpPC+D2Y=
 github.com/aws/aws-sdk-go-v2/service/workmail v1.37.0 h1:JLmbQeUOmgc1k14QJyxO+goWW0fePbGaT/g0haIiSNk=
 github.com/aws/aws-sdk-go-v2/service/workmail v1.37.0/go.mod h1:1dIDHNIcmjGLavibuIO54qfx1GreVSr0msbVVvtxAoA=
 github.com/aws/aws-sdk-go-v2/service/workspaces v1.68.1 h1:Jf5Hb+1UABUn01BGk6vwPFtnyX51wgvqo97bNogM1kI=

--- a/go.sum
+++ b/go.sum
@@ -105,8 +105,8 @@ github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol v1.41.0 h1:s+9aRVnN
 github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol v1.41.0/go.mod h1:MJLW1rK+TZO6mExsuFg7O+vFELkILGAu6+L943Q+Akk=
 github.com/aws/aws-sdk-go-v2/service/billing v1.11.1 h1:20TUeXiZAAngesBpuyvxz+d0ZGzH8z3fzA/3c3bBOk0=
 github.com/aws/aws-sdk-go-v2/service/billing v1.11.1/go.mod h1:R2U4hP2CSLK5UseLbHUFKFNFF4U/7HMfcrJ3zyxV4I0=
-github.com/aws/aws-sdk-go-v2/service/budgets v1.43.7 h1:5da51kHGIcUydFIQnPTQxwxlraBc6Z2M/Mg430mJGcw=
-github.com/aws/aws-sdk-go-v2/service/budgets v1.43.7/go.mod h1:W/ACxHO2V65T11t9KLLG+pQytcYk206Ff5b5lbGeMF8=
+github.com/aws/aws-sdk-go-v2/service/budgets v1.43.8 h1:R4H5x5/neeXximWnr2RyM4BYLl47reWVMxbGW0qQSmA=
+github.com/aws/aws-sdk-go-v2/service/budgets v1.43.8/go.mod h1:WrxNwTTCRAEHvIU8Y5/EUpfcrHy7nlm8+DN9edSeqI4=
 github.com/aws/aws-sdk-go-v2/service/chatbot v1.14.23 h1:eVFe0spV/qN307E9M7EWomXBx20d6iSCRU9uhZnbbEM=
 github.com/aws/aws-sdk-go-v2/service/chatbot v1.14.23/go.mod h1:gDe8Q0Jr8+z3yoGmU38eVPCWGA3iBR9hJF8osx2Th5A=
 github.com/aws/aws-sdk-go-v2/service/chime v1.41.14 h1:1dS2RRGAELUPmXaNFZYgkxnOmYbMj5Uu4JETv8OwgxA=

--- a/go.sum
+++ b/go.sum
@@ -179,8 +179,8 @@ github.com/aws/aws-sdk-go-v2/service/costandusagereportservice v1.34.16 h1:w20+c
 github.com/aws/aws-sdk-go-v2/service/costandusagereportservice v1.34.16/go.mod h1:9FEyLTz1kOG0l/DWCCbvpAuJUlawnKJPaSA+xO0jpfg=
 github.com/aws/aws-sdk-go-v2/service/costexplorer v1.63.9 h1:cVSd0kgTG+dvJlglPapLihiYNM69k+ZJxb2OqGY73BQ=
 github.com/aws/aws-sdk-go-v2/service/costexplorer v1.63.9/go.mod h1:bm12cXeoasdLU/Ra6PdxnbE8YZsbXDYHfLU4Z9yGBDc=
-github.com/aws/aws-sdk-go-v2/service/costoptimizationhub v1.22.10 h1:ZbXEmYQ2SuF9LXqdHAgcx5ThxphG2OxiiVsnQ7TrHAQ=
-github.com/aws/aws-sdk-go-v2/service/costoptimizationhub v1.22.10/go.mod h1:deL+2XD+z69IsKSRyxo+9/4xlRVdg9uL+B4RJW+t4RY=
+github.com/aws/aws-sdk-go-v2/service/costoptimizationhub v1.23.0 h1:H5zZyEmWfUUAlgIpkCl9UlCoTYsl9KdsoMBRPGTei9I=
+github.com/aws/aws-sdk-go-v2/service/costoptimizationhub v1.23.0/go.mod h1:+/F97SyLRVhK+fM3dQge1DWIrhhr/bNEzMCvixl0VRs=
 github.com/aws/aws-sdk-go-v2/service/customerprofiles v1.61.0 h1:rfU1DhRBbNg9f8uh9L4dJNZYSYRjrgqTxSI4aPkkzvE=
 github.com/aws/aws-sdk-go-v2/service/customerprofiles v1.61.0/go.mod h1:P8xXL2qstcrbxBXjHnL3VVBIWqGrHIn6YA+XSd4S8rA=
 github.com/aws/aws-sdk-go-v2/service/databasemigrationservice v1.63.0 h1:n80jw/JxEyeeZo9Df9fHUFVIrPmY5WRZSo9u6WkbWKk=

--- a/go.sum
+++ b/go.sum
@@ -353,8 +353,8 @@ github.com/aws/aws-sdk-go-v2/service/m2 v1.27.1 h1:1vzECynzUz+/8ablxRU4iPqLbuiaf
 github.com/aws/aws-sdk-go-v2/service/m2 v1.27.1/go.mod h1:Ydcsj053d85MCqN+G/sg/RAUgA4DRqakxKnEw5Yhf8g=
 github.com/aws/aws-sdk-go-v2/service/macie2 v1.51.3 h1:MjhvPAy7WONLMkYlKXySflQMk7GqFLLssUO60BNkJMA=
 github.com/aws/aws-sdk-go-v2/service/macie2 v1.51.3/go.mod h1:rUVkJJSpImXmBlMc1ZWrx/PF2Kz+jch45cIdm4OVnb4=
-github.com/aws/aws-sdk-go-v2/service/mediaconnect v1.49.0 h1:soyDbvfrfgCA6NffTlHCOPLxvasNN0I9gVKpDXgIOxs=
-github.com/aws/aws-sdk-go-v2/service/mediaconnect v1.49.0/go.mod h1:LcKdUwEuIHXayPjypC3VXZoPp8kNkxHAil8OdLJF0jk=
+github.com/aws/aws-sdk-go-v2/service/mediaconnect v1.49.1 h1:pKLK86zyE6qkeBtAdY/JXQCcfP6wPY24ZFWZ1tpU5c0=
+github.com/aws/aws-sdk-go-v2/service/mediaconnect v1.49.1/go.mod h1:a08ydPBd3DmBpYl0ELaaWY0PbG0T+XZ6DjrVC154IDY=
 github.com/aws/aws-sdk-go-v2/service/mediaconvert v1.91.2 h1:h466gQU4HNXHgTdz7a45mGudKsB+NeyPVYr6hf9F4gM=
 github.com/aws/aws-sdk-go-v2/service/mediaconvert v1.91.2/go.mod h1:r/qoOppQk/ZTUHNBdj9S8R8k0JCV2iApiKfyxDyU42s=
 github.com/aws/aws-sdk-go-v2/service/medialive v1.96.0 h1:2A2YYpr3IDLZ9y2WRg/oXSmlrmDQA+KNvgcFGOWr+PY=

--- a/go.sum
+++ b/go.sum
@@ -571,8 +571,8 @@ github.com/aws/aws-sdk-go-v2/service/waf v1.30.23 h1:haJSEMjnZSN06jrA3EtdHtYrzKZ
 github.com/aws/aws-sdk-go-v2/service/waf v1.30.23/go.mod h1:UU4sTEqsR0ymj69LvuxKBtneEvqnxkAnoRT58mJAF4U=
 github.com/aws/aws-sdk-go-v2/service/wafregional v1.30.24 h1:rYfUYezU29dhNnX0ufDAiqLkuAqCigquygJogheO3iU=
 github.com/aws/aws-sdk-go-v2/service/wafregional v1.30.24/go.mod h1:X7/MWb1tXmdavn712tp+wPf4gC/zl6H4MHGOD8sZD7s=
-github.com/aws/aws-sdk-go-v2/service/wafv2 v1.71.5 h1:IMqwkBHrf3RjjNl+Xw0hkWz4WjB0ypcyNnRqOGiT7J0=
-github.com/aws/aws-sdk-go-v2/service/wafv2 v1.71.5/go.mod h1:4PHOazTWE3wBq/xYohRMnO7vv3H0WgBYAvR8hyeZCfI=
+github.com/aws/aws-sdk-go-v2/service/wafv2 v1.71.6 h1:SKPs3pBnHGs4hAKW1I3CoH8GffR2EZqKbqIYiQcpVJ8=
+github.com/aws/aws-sdk-go-v2/service/wafv2 v1.71.6/go.mod h1:L30J3rRiVI9inT2rOU6xD5ysqmbwwmj+ng1rReS0Xt0=
 github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.39.23 h1:5xJQfmla2mUX3vaYBMBTzF31Db4UWqKIjtcjZ3+rOnc=
 github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.39.23/go.mod h1:PwOqXK/zLygfNnxe76HRT+SUenchdxHRfGX2kCVQZ+c=
 github.com/aws/aws-sdk-go-v2/service/workmail v1.37.0 h1:JLmbQeUOmgc1k14QJyxO+goWW0fePbGaT/g0haIiSNk=

--- a/go.sum
+++ b/go.sum
@@ -245,8 +245,8 @@ github.com/aws/aws-sdk-go-v2/service/elasticsearchservice v1.41.1 h1:JRRK81bkltT
 github.com/aws/aws-sdk-go-v2/service/elasticsearchservice v1.41.1/go.mod h1:OuZGLKWumnY/JRK/brwybxha4yAonCWeS5XeUyr0XuE=
 github.com/aws/aws-sdk-go-v2/service/elastictranscoder v1.33.0 h1:ZD8Iw3WQlZYoCJtK3VBAUVO0DZFLSfHCKbze1xfYRdc=
 github.com/aws/aws-sdk-go-v2/service/elastictranscoder v1.33.0/go.mod h1:1TkRQZaHJfi2GSj/kQNuxQVUyKLAErm+QXF6Dvz7iOs=
-github.com/aws/aws-sdk-go-v2/service/emr v1.59.2 h1:BR7dPfnYULtw1QMLTb4p67A5O7cOhwsRh6arvYQFIQg=
-github.com/aws/aws-sdk-go-v2/service/emr v1.59.2/go.mod h1:cWxbjdU0/WUkpKZ+k03XbZiC5b8OVjCRzQ4wJlnO0Q4=
+github.com/aws/aws-sdk-go-v2/service/emr v1.59.3 h1:4h8LV+59JgGjcZaAhNvVatYG8CLIY767Y4naJ7Yliho=
+github.com/aws/aws-sdk-go-v2/service/emr v1.59.3/go.mod h1:RVZ0qkKp+7zm3wTQVEVf6yxTFUjVjbpThQkySXwtsfc=
 github.com/aws/aws-sdk-go-v2/service/emrcontainers v1.41.0 h1:9p3/KIL9zZu9NtzX9g3CAQ6ZBw+xcUHSngn+9MhrLPc=
 github.com/aws/aws-sdk-go-v2/service/emrcontainers v1.41.0/go.mod h1:OxVncWlX7EmiBJwHi8aEsDJyTUTmS96j46XbSG/19XE=
 github.com/aws/aws-sdk-go-v2/service/emrserverless v1.41.0 h1:/avPf4MwaJqp6hr/bJhLilQtOO2uQN/t/8B8DOVnrRE=

--- a/go.sum
+++ b/go.sum
@@ -129,8 +129,8 @@ github.com/aws/aws-sdk-go-v2/service/cloudfrontkeyvaluestore v1.13.0 h1:hsxsHl8H
 github.com/aws/aws-sdk-go-v2/service/cloudfrontkeyvaluestore v1.13.0/go.mod h1:l6Cy+yFNEducMfkStt4kQjgnqXKslfbqjVH7orDS8og=
 github.com/aws/aws-sdk-go-v2/service/cloudhsmv2 v1.34.26 h1:lyAQbQ0pkqvAg4reG1JjKQ22Ctsc1GLBD1NfE8bTXdo=
 github.com/aws/aws-sdk-go-v2/service/cloudhsmv2 v1.34.26/go.mod h1:sDedonK8Lz6fMf4q1vEjzyyO3jskCECWosEhNS40sro=
-github.com/aws/aws-sdk-go-v2/service/cloudsearch v1.32.14 h1:dOFz4EN9UgHW91gLgplACvAMElqFXKyHzetpphgjOEo=
-github.com/aws/aws-sdk-go-v2/service/cloudsearch v1.32.14/go.mod h1:tAXEWXgcwNtdCXC9GqNAUpsNs53hDmyRnZsm3yyXvV4=
+github.com/aws/aws-sdk-go-v2/service/cloudsearch v1.32.15 h1:ETNqwiPFuwQQbqoVhcwb+L9lmkjZmGHxmEOUo9SkYLw=
+github.com/aws/aws-sdk-go-v2/service/cloudsearch v1.32.15/go.mod h1:7ThInmcOZindokcAKJxcStdW2I6jl0heM7OMe5ukQZI=
 github.com/aws/aws-sdk-go-v2/service/cloudtrail v1.55.11 h1:3IDx7ybn7pyrLgVShEfGmEXec1xsqgoD1ADI1SxqKT0=
 github.com/aws/aws-sdk-go-v2/service/cloudtrail v1.55.11/go.mod h1:iSArc5uhvz1S3EICNNvRzPksb6HPAUhltzMvoCrGyfM=
 github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.57.0 h1:dlkFtYOrwOuM7IIBD6FPLtt0Xvnph+8hqmmbzyowkCk=

--- a/go.sum
+++ b/go.sum
@@ -325,8 +325,8 @@ github.com/aws/aws-sdk-go-v2/service/keyspaces v1.26.0 h1:XzWibdCvfAdFtmEfoYe+gG
 github.com/aws/aws-sdk-go-v2/service/keyspaces v1.26.0/go.mod h1:GANMXCrbHQ3PXkymiJZLCwICRitWb7AVOnrwb8N2d/A=
 github.com/aws/aws-sdk-go-v2/service/kinesis v1.43.8 h1:MJ1r18td42gvrFGZcu0bHWcqyPBgcJ/A3gEi5k84gEA=
 github.com/aws/aws-sdk-go-v2/service/kinesis v1.43.8/go.mod h1:f7HKjso4tq0v/kVZB4QNHrZZ0sMZqk/2Wpr7JgL7Y1Y=
-github.com/aws/aws-sdk-go-v2/service/kinesisanalytics v1.30.25 h1:OBjINDp8xhZjliKWnidzagqyHpNIRPDm4jeP/173WkI=
-github.com/aws/aws-sdk-go-v2/service/kinesisanalytics v1.30.25/go.mod h1:PdNJ4V245nwJUkLf5VmeHCEE+dYg60vg0y5f+UpOZUw=
+github.com/aws/aws-sdk-go-v2/service/kinesisanalytics v1.30.26 h1:bWGA6teid64RQubUlLy++x3mqcDu2A0EParvmFZ4uyk=
+github.com/aws/aws-sdk-go-v2/service/kinesisanalytics v1.30.26/go.mod h1:F1D1LL8hXSfe0VKDA89e0TvAFFp3slFHMv3C5FaRU50=
 github.com/aws/aws-sdk-go-v2/service/kinesisanalyticsv2 v1.37.2 h1:rln/edRVCCmMlxaFc0UaroIOWEuQr9ih2/1jIUWNNNg=
 github.com/aws/aws-sdk-go-v2/service/kinesisanalyticsv2 v1.37.2/go.mod h1:h9uvfBlO37RRw0CZQIXanA1kqpDEvnsUeVSf9pNej3I=
 github.com/aws/aws-sdk-go-v2/service/kinesisvideo v1.33.10 h1:Z3xoYyzvZa3YmIzTdUctjgEEvuE6NMcJqEKHAZkJxns=

--- a/go.sum
+++ b/go.sum
@@ -217,8 +217,8 @@ github.com/aws/aws-sdk-go-v2/service/docdbelastic v1.21.1 h1:h/8yW1Qh78RTRmT1WOh
 github.com/aws/aws-sdk-go-v2/service/docdbelastic v1.21.1/go.mod h1:BoVuSamInxADdfbPKk92a5ozopz1pjGnm+iv82rxj44=
 github.com/aws/aws-sdk-go-v2/service/drs v1.38.3 h1:HwQ821+/yd6GSmIWHU2cSUUEcTp2NWN4PjoCFGw6VMM=
 github.com/aws/aws-sdk-go-v2/service/drs v1.38.3/go.mod h1:iq+Z1AOHKY/yRRUtgxQjCKjAEuHNiQcYsULuGHZKJLA=
-github.com/aws/aws-sdk-go-v2/service/dsql v1.14.0 h1:g/vNRzoxAtEEImkLqL9Nfi/meauKiOvj9XJjTjRA2XQ=
-github.com/aws/aws-sdk-go-v2/service/dsql v1.14.0/go.mod h1:Urak1kEuxp8VUQySLI4kL/hnRfYUOpvgSTyKTx7+Fh4=
+github.com/aws/aws-sdk-go-v2/service/dsql v1.14.1 h1:RmsuXZWU4Ij5fN7ODA7DIJxX36z43LgovrghT/MfvgQ=
+github.com/aws/aws-sdk-go-v2/service/dsql v1.14.1/go.mod h1:gyjbYTqyg94CBANbsuY+rBFxHCt1On5N6NdTQkUiIAk=
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.4 h1:0E3bfw1Va3vfCrmtATvKRnGojY4oIlLl0u0xRDDUgfY=
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.4/go.mod h1:dFPU89qDDGgQbXyzQ5ZY6zcjjKPVW+1M63axOw887JE=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.304.0 h1:wZthLlYdKxBo7NpWLbl0A/8DB/QNDB+8RJa9WboK9Q0=

--- a/go.sum
+++ b/go.sum
@@ -141,8 +141,8 @@ github.com/aws/aws-sdk-go-v2/service/codeartifact v1.39.1 h1:f11z1s2b5Yn/vdvS6PW
 github.com/aws/aws-sdk-go-v2/service/codeartifact v1.39.1/go.mod h1:PZ43Dwh72tKIZv/nL1+4tre21tuMEkKnH7ktxnNu8Ss=
 github.com/aws/aws-sdk-go-v2/service/codebuild v1.68.17 h1:nuZd0+/dAPNruSr1QPP0Wc6zedGnFMi/OfaSCgnmP50=
 github.com/aws/aws-sdk-go-v2/service/codebuild v1.68.17/go.mod h1:bqp9F33QsLJl//rIXwqZeqRrGoZX4VkS20gfCA8o3VM=
-github.com/aws/aws-sdk-go-v2/service/codecatalyst v1.21.14 h1:djJmgkjv6JU9c7cNrK7GLJgkEi4ZEae2mm8ZqPaeiZU=
-github.com/aws/aws-sdk-go-v2/service/codecatalyst v1.21.14/go.mod h1:qU9Wr223MMoQiblOqRVbOB9Pa1uC8Ih2XIQIK5QAjcA=
+github.com/aws/aws-sdk-go-v2/service/codecatalyst v1.21.15 h1:c4gKdl1Ea0yepVffQ3cTVWEeqvtVipyXKcXderDQbl8=
+github.com/aws/aws-sdk-go-v2/service/codecatalyst v1.21.15/go.mod h1:ohktYOwIHO3/CE0lZ5gd181R0CF1m63fWBkOn0hXvuU=
 github.com/aws/aws-sdk-go-v2/service/codecommit v1.33.14 h1:3N664oayz66ttIkc8B9/OLntMWhoGhKqPudRRfsZQ20=
 github.com/aws/aws-sdk-go-v2/service/codecommit v1.33.14/go.mod h1:M+6j5lOmtDMjLlFMO8lfTs0gI3qBsSjM8L7F1cQF5Ng=
 github.com/aws/aws-sdk-go-v2/service/codeconnections v1.11.0 h1:OqIM7wA2amkOIJTSOJjx2KL/LKr1inVzh3lqPIC97m0=

--- a/go.sum
+++ b/go.sum
@@ -271,8 +271,8 @@ github.com/aws/aws-sdk-go-v2/service/gamelift v1.54.1 h1:7Appei3huNvhHlVaX4l87fy
 github.com/aws/aws-sdk-go-v2/service/gamelift v1.54.1/go.mod h1:VnK+7iDsbhPDJ0BPuwDM80sPCGatD5dh4SJs5vacvbE=
 github.com/aws/aws-sdk-go-v2/service/glacier v1.32.9 h1:YmKhaCkxIDABhKu4UXPNgSTN1ITmRynmalkS1atyqOI=
 github.com/aws/aws-sdk-go-v2/service/glacier v1.32.9/go.mod h1:vlEeKKUe2y0PXooxWUyDP8WgOhUH5gHGGrR9dn3bdyg=
-github.com/aws/aws-sdk-go-v2/service/globalaccelerator v1.36.0 h1:9xK/+z/QIEu7DocAeM8w4I7JU+MqcN8gPrlEo0VpkH0=
-github.com/aws/aws-sdk-go-v2/service/globalaccelerator v1.36.0/go.mod h1:e2pOrIpl2zSGFiNvd0FvAP01z9XOKR9Y1aJ7dYiE2YM=
+github.com/aws/aws-sdk-go-v2/service/globalaccelerator v1.36.1 h1:1YvLkahfJgY0IfJnA1ikids8/CC/s5LHrmbhWpz9U+w=
+github.com/aws/aws-sdk-go-v2/service/globalaccelerator v1.36.1/go.mod h1:gRlTv00BpckxaCzUTJ+qmVzgQp8YFtGpQz/MRXnRv/M=
 github.com/aws/aws-sdk-go-v2/service/glue v1.142.0 h1:ztxbPEsd9yyuf2A41ZwtCXtI61t7ocnQ7vUdziFiFUc=
 github.com/aws/aws-sdk-go-v2/service/glue v1.142.0/go.mod h1:FZCvt95CcJWRkZNRcmMW1uQkpDHmyUSkZfz3awyZgqg=
 github.com/aws/aws-sdk-go-v2/service/grafana v1.35.0 h1:o9fN0lOXbKu+IL4yY6Z8/Ay8qCjYmtO0wNdg3rfZY5Q=

--- a/go.sum
+++ b/go.sum
@@ -161,8 +161,8 @@ github.com/aws/aws-sdk-go-v2/service/codestarnotifications v1.32.1 h1:MkB0/DJ8XC
 github.com/aws/aws-sdk-go-v2/service/codestarnotifications v1.32.1/go.mod h1:def5w+aEKHpEosI+xJ9FGKJElmu/RRL2xjd+adgaZCg=
 github.com/aws/aws-sdk-go-v2/service/cognitoidentity v1.33.25 h1:XXa5oulvKVj4jTLV6rgCmo6gptqyeJ0yzAjhaAiIXjc=
 github.com/aws/aws-sdk-go-v2/service/cognitoidentity v1.33.25/go.mod h1:jgO0hOeOmaYby7RvK4EXrSAwchb4KgSiM/+V5WchNgE=
-github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.60.2 h1:pZxE29WAHgnk0jGj1P4UOOJnNPHXfltkfnK4F1Tg8jU=
-github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.60.2/go.mod h1:nbe4Nf/HOY+e54Dl+yjv04scYTGTC+4ZthbfOuPTXQs=
+github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.60.3 h1:X3qB+VaAA66Na9aieVR3ziXJ83tVcLiHdEq3FldjmT4=
+github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.60.3/go.mod h1:8IfDUcBSJboFS3Az4MX8Oh1ik/P/X7jyFf5Q2UZLtrk=
 github.com/aws/aws-sdk-go-v2/service/comprehend v1.41.0 h1:eAzz571JckxP387G0vRwoDS4xARluclKYt5pGUaR6+I=
 github.com/aws/aws-sdk-go-v2/service/comprehend v1.41.0/go.mod h1:XdcHFOF8Kvzv6Ng37wgQgw59AMMxLT/sHrdZc2lLEK0=
 github.com/aws/aws-sdk-go-v2/service/computeoptimizer v1.50.1 h1:FyZGfF3X2uzNSZjIxXgiW/5va1HcJKueMIXEbEhVa78=

--- a/go.sum
+++ b/go.sum
@@ -281,8 +281,8 @@ github.com/aws/aws-sdk-go-v2/service/greengrass v1.32.24 h1:2IcMPOpDsVIfaj9YFKuH
 github.com/aws/aws-sdk-go-v2/service/greengrass v1.32.24/go.mod h1:3c1oObcY5EL5WcU6TIwyhWQ4yySFUdtJzskkINO0Ryw=
 github.com/aws/aws-sdk-go-v2/service/groundstation v1.42.0 h1:lFg4tM2tx+FQNy36hxl9oFNgntLzFxYlS+4fd6pjGnU=
 github.com/aws/aws-sdk-go-v2/service/groundstation v1.42.0/go.mod h1:q65bYfAuFmMS7zdSgFFs7FRygyzMfKtAnbqMF1H23YY=
-github.com/aws/aws-sdk-go-v2/service/guardduty v1.78.0 h1:G+ZbdL3onjVLfReu4piSAdE/Q9GOH89oNEXekFM+LUk=
-github.com/aws/aws-sdk-go-v2/service/guardduty v1.78.0/go.mod h1:kCpMuo4vLtzUaugNCZGCkVtdehl2YvoSd73Jmiuh1M0=
+github.com/aws/aws-sdk-go-v2/service/guardduty v1.78.1 h1:t1B3HJA+ehBVWsbyN06FcamKXZc0lQrsBP2yNspOfLU=
+github.com/aws/aws-sdk-go-v2/service/guardduty v1.78.1/go.mod h1:mxLYMURDsGZnM8Syt/a0npPMYX28grL3R1xUpiMD0h0=
 github.com/aws/aws-sdk-go-v2/service/healthlake v1.37.0 h1:/y3MPNKd8QvlnCAltxWg9rflfbWgF8XH6ehX8xD4OFE=
 github.com/aws/aws-sdk-go-v2/service/healthlake v1.37.0/go.mod h1:xW2c/WbdF4VnPp2dw/uUjcf8+SnAPilvlSYsfWcHo3Y=
 github.com/aws/aws-sdk-go-v2/service/iam v1.53.10 h1:kcN3I3llO7VwIY5w3Pc5FmEonpsr23Ou7Cwk4qf7dik=

--- a/go.sum
+++ b/go.sum
@@ -495,8 +495,8 @@ github.com/aws/aws-sdk-go-v2/service/schemas v1.35.1 h1:WVrl+FWZ3d7uOzZ/Vz7IzVWd
 github.com/aws/aws-sdk-go-v2/service/schemas v1.35.1/go.mod h1:Q5TGR5yNtrh/lEtpz4YeyYyXh3Aahx3BT/fPPEtUcfM=
 github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.8 h1:1+cxbGx12HXmXlJnU7FYHw/lmgm5Fz5F/zuaOWSpOzc=
 github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.8/go.mod h1:OoxL3xzUUjYMDWPxth/zM+wlgmYOKAU5qY4BKit3u8U=
-github.com/aws/aws-sdk-go-v2/service/securityhub v1.71.0 h1:cWBwwMRfARTheeY+g3ykiyoQdR48Hb8S6qVCysB87/I=
-github.com/aws/aws-sdk-go-v2/service/securityhub v1.71.0/go.mod h1:zaWfTggHBDZYQS7YIk6Atd2SsxXehBvSQjyN65+KCtk=
+github.com/aws/aws-sdk-go-v2/service/securityhub v1.71.1 h1:hbs1hLreR86SPC4wRp3GglTvNlqrhEZUFvEbuhYzUGs=
+github.com/aws/aws-sdk-go-v2/service/securityhub v1.71.1/go.mod h1:agWYh3l/L9DfbvSKZBRlOYWhhl0ItrwmNzAbJLHvpPs=
 github.com/aws/aws-sdk-go-v2/service/securitylake v1.25.15 h1:s92UU/ju1C28XiBmf4nmCRYnWLOpbxuLJ/iCDPC0RLg=
 github.com/aws/aws-sdk-go-v2/service/securitylake v1.25.15/go.mod h1:JgTWGploCcj5G0rPdcYDR3Ao3T4J4kPMEB5hPv6IGBk=
 github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.31.0 h1:3qMdhh0sw7j73U82bj5PXXm4QVo23ANHsWF0JnmW5ls=

--- a/go.sum
+++ b/go.sum
@@ -169,8 +169,8 @@ github.com/aws/aws-sdk-go-v2/service/computeoptimizer v1.51.1 h1:Cy3+tJvG/0K2Tlz
 github.com/aws/aws-sdk-go-v2/service/computeoptimizer v1.51.1/go.mod h1:y5HaCvXXAcgvjkHvPCrq1FFeHQ7VQnvS8wg8idHVX5k=
 github.com/aws/aws-sdk-go-v2/service/configservice v1.62.4 h1:Vzzl4mk9hu0sE0lKhYiH3uD15nL9nyQ8PUlVKHXsqnA=
 github.com/aws/aws-sdk-go-v2/service/configservice v1.62.4/go.mod h1:HGcpycwfNZW3ADZFgUl/GxbIAQ9qkcY9YERr7QPvlaE=
-github.com/aws/aws-sdk-go-v2/service/connect v1.175.0 h1:ryfwFSnLovIyJd6xX4M9CToQbaa3YZjOkt+wyRuPiPs=
-github.com/aws/aws-sdk-go-v2/service/connect v1.175.0/go.mod h1:Du5pBjluSAHkGpEiz8aCfk9NdndzEeGpCqARDWAlGGQ=
+github.com/aws/aws-sdk-go-v2/service/connect v1.175.1 h1:2cacszmtdexvFZIo+3wex3BDX2+euDdyI42YOKOwXCU=
+github.com/aws/aws-sdk-go-v2/service/connect v1.175.1/go.mod h1:U7i2UrYMvRevhvH0+fzqcgFEDjA+aZw05usgvyWp/v8=
 github.com/aws/aws-sdk-go-v2/service/connectcases v1.41.0 h1:3cyJsw7HOjnAl/UU7seVUXAXE1gB/aGuCVIfpEon0JQ=
 github.com/aws/aws-sdk-go-v2/service/connectcases v1.41.0/go.mod h1:Po801bVNjB1+ZF8gmqjeQUb8ay5XcpQFVi6Bhm/85Iw=
 github.com/aws/aws-sdk-go-v2/service/controltower v1.29.0 h1:5kicsTVcky+MfpGh6KATnmBx3Sx4lzo1JF5vKPVdyG4=

--- a/go.sum
+++ b/go.sum
@@ -145,8 +145,8 @@ github.com/aws/aws-sdk-go-v2/service/codecatalyst v1.21.15 h1:c4gKdl1Ea0yepVffQ3
 github.com/aws/aws-sdk-go-v2/service/codecatalyst v1.21.15/go.mod h1:ohktYOwIHO3/CE0lZ5gd181R0CF1m63fWBkOn0hXvuU=
 github.com/aws/aws-sdk-go-v2/service/codecommit v1.33.15 h1:jG7/DRMMhbNG4S7mDRdZLKMmyojud6QhHcJ9TPxxjpA=
 github.com/aws/aws-sdk-go-v2/service/codecommit v1.33.15/go.mod h1:TWZz5ml6Jv36EO4eUGxp82JucQuG/ZH4InxEcLetXZg=
-github.com/aws/aws-sdk-go-v2/service/codeconnections v1.11.0 h1:OqIM7wA2amkOIJTSOJjx2KL/LKr1inVzh3lqPIC97m0=
-github.com/aws/aws-sdk-go-v2/service/codeconnections v1.11.0/go.mod h1:TcTHKeyZCc14t8RI8PM8nbwid4Xr4CzxEZfHKcGlCiA=
+github.com/aws/aws-sdk-go-v2/service/codeconnections v1.11.1 h1:IkztdxEx9jg3mtcn/0PQ5sb/y5yCJ1tbNHaQahdfweA=
+github.com/aws/aws-sdk-go-v2/service/codeconnections v1.11.1/go.mod h1:4Txe845x0NmXze3vzvVAw9Iy/Cb4dyVnxvk+qTceMJI=
 github.com/aws/aws-sdk-go-v2/service/codedeploy v1.35.15 h1:iFcroRD6TUmNLCoAMdPJGV28h1K4yULxNludMiA/LwA=
 github.com/aws/aws-sdk-go-v2/service/codedeploy v1.35.15/go.mod h1:r8xU4gaQ0oQNlfptj6Lzyv2Ityc2o0Sp3Gl3bX8KVE0=
 github.com/aws/aws-sdk-go-v2/service/codeguruprofiler v1.30.0 h1:h9gG2F8LkS6IICbMUKVNquYeNYKTzNOZBkLx6NSlFN8=

--- a/go.sum
+++ b/go.sum
@@ -71,8 +71,8 @@ github.com/aws/aws-sdk-go-v2/service/applicationinsights v1.34.23 h1:s/zG75mlE08
 github.com/aws/aws-sdk-go-v2/service/applicationinsights v1.34.23/go.mod h1:ioZ050CgtUShNUI4TQ5bnYMCBhS8k/nDZn9+Hj6aF3I=
 github.com/aws/aws-sdk-go-v2/service/applicationsignals v1.22.1 h1:midboezGCtGsrFF3D2wbEzNb1vvYrRprXMysYFGfgFI=
 github.com/aws/aws-sdk-go-v2/service/applicationsignals v1.22.1/go.mod h1:VtkMZ2Ugj03+OEOap4oID3BhbDMiKcExitr43/F/umY=
-github.com/aws/aws-sdk-go-v2/service/appmesh v1.35.14 h1:31mnzduRd3FyuGCwgdMfPAu6MG1XnQf4zJrPjpZvnbM=
-github.com/aws/aws-sdk-go-v2/service/appmesh v1.35.14/go.mod h1:u/RTn1872BcpTxDnsQXi0AO8nxMch/46nlr3/loCpu8=
+github.com/aws/aws-sdk-go-v2/service/appmesh v1.35.15 h1:vmTlolVTemGK//2CRSsX9esIvh9DQqRCKc15Gkwj6Oo=
+github.com/aws/aws-sdk-go-v2/service/appmesh v1.35.15/go.mod h1:IohdJ/2Kiag9GMPP2Uxq8V9qhmrIS7vsGG/+gduSJYE=
 github.com/aws/aws-sdk-go-v2/service/apprunner v1.40.0 h1:zJKGRaZd15XaRLa3eTO9B47lrOvmxSNc9nOciUuDR8Y=
 github.com/aws/aws-sdk-go-v2/service/apprunner v1.40.0/go.mod h1:QA5CUOg5mkS73RhLYCDPeFuCFxoeW2TPA6XRo4JL2Ek=
 github.com/aws/aws-sdk-go-v2/service/appstream v1.59.0 h1:9EuZwqW8tDPZQwt2nGnXDBrcHY4CND/Fk7L50P6wV20=

--- a/go.sum
+++ b/go.sum
@@ -349,8 +349,8 @@ github.com/aws/aws-sdk-go-v2/service/lightsail v1.54.1 h1:TA/8uCWJQzeNy8fTf8ojFx
 github.com/aws/aws-sdk-go-v2/service/lightsail v1.54.1/go.mod h1:F0RbBQMzN+pD4BswikBhagVqSQWqjMnmx14plgRsxKA=
 github.com/aws/aws-sdk-go-v2/service/location v1.52.1 h1:hXk27fqFGrjvlX0MaCzf1SOmpufFro0xRFnMZDqOe0c=
 github.com/aws/aws-sdk-go-v2/service/location v1.52.1/go.mod h1:v/d1IGFeuze4lsKEU1juoMgzuIXBrFXh0nIjJK9Mls8=
-github.com/aws/aws-sdk-go-v2/service/m2 v1.26.16 h1:i8B10mRygZ706QPnu8wLK0sqpjXA+pBiaVBDNPQ9bvo=
-github.com/aws/aws-sdk-go-v2/service/m2 v1.26.16/go.mod h1:b6JagtYF0M3jkPWFBOjtkDDsLH6vvRetHTmqwIbNVLk=
+github.com/aws/aws-sdk-go-v2/service/m2 v1.27.1 h1:1vzECynzUz+/8ablxRU4iPqLbuiafwGfr8pSDTnbZsI=
+github.com/aws/aws-sdk-go-v2/service/m2 v1.27.1/go.mod h1:Ydcsj053d85MCqN+G/sg/RAUgA4DRqakxKnEw5Yhf8g=
 github.com/aws/aws-sdk-go-v2/service/macie2 v1.51.2 h1:JPIqNyD7JAaQddkmXRFVI7My2vtJ40uqTpEYIlnTEVw=
 github.com/aws/aws-sdk-go-v2/service/macie2 v1.51.2/go.mod h1:Y1uuzDg6j6jVdm/xMgIgEaCJ2fMLPAgoKzKYuMBhJUQ=
 github.com/aws/aws-sdk-go-v2/service/mediaconnect v1.49.0 h1:soyDbvfrfgCA6NffTlHCOPLxvasNN0I9gVKpDXgIOxs=

--- a/go.sum
+++ b/go.sum
@@ -357,8 +357,8 @@ github.com/aws/aws-sdk-go-v2/service/mediaconnect v1.49.1 h1:pKLK86zyE6qkeBtAdY/
 github.com/aws/aws-sdk-go-v2/service/mediaconnect v1.49.1/go.mod h1:a08ydPBd3DmBpYl0ELaaWY0PbG0T+XZ6DjrVC154IDY=
 github.com/aws/aws-sdk-go-v2/service/mediaconvert v1.91.3 h1:8/TuAc1vhYA4Woy7TfqQ3eRYkLGsV1D7qWH6Tik2zpk=
 github.com/aws/aws-sdk-go-v2/service/mediaconvert v1.91.3/go.mod h1:K7xRA32242aLotLpG35AptbkKgBuSWfCQvSuflTRURI=
-github.com/aws/aws-sdk-go-v2/service/medialive v1.96.0 h1:2A2YYpr3IDLZ9y2WRg/oXSmlrmDQA+KNvgcFGOWr+PY=
-github.com/aws/aws-sdk-go-v2/service/medialive v1.96.0/go.mod h1:YtEXuL0GNGkAeeFSs2wT/KTnaqykXJ52d+4MefPwJKg=
+github.com/aws/aws-sdk-go-v2/service/medialive v1.97.1 h1:CaaGyFVpZGGydt4vkFFx2rUNw8wg2zlwYlNcweLBLpM=
+github.com/aws/aws-sdk-go-v2/service/medialive v1.97.1/go.mod h1:7imY/+11Qy5wkFLlDbgclEzsCRM3kkJaxx2E7oPFtwI=
 github.com/aws/aws-sdk-go-v2/service/mediapackage v1.39.23 h1:ztbUtcql2vd65yqnEz/k+bTX8PBP1J4to32/ck5hLAA=
 github.com/aws/aws-sdk-go-v2/service/mediapackage v1.39.23/go.mod h1:3+LhO1Y/ZUTvLmnBsWJyMs4qBBUQJ9dAe8/DqutP+48=
 github.com/aws/aws-sdk-go-v2/service/mediapackagev2 v1.39.0 h1:+rIQceAbYT97OKasPK7f8E/wwh/3wAdABV0fSs+CUhU=

--- a/go.sum
+++ b/go.sum
@@ -557,8 +557,8 @@ github.com/aws/aws-sdk-go-v2/service/timestreamquery v1.36.18 h1:cYAZklvpeCttnJe
 github.com/aws/aws-sdk-go-v2/service/timestreamquery v1.36.18/go.mod h1:D9Xer57g8BV+0T+to7RZ5U1aOd4cdTFVVK6OUH1pvHw=
 github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.35.24 h1:9qHHrg3FTH+APkpY0DeKvpvO/XLmkYtWZJw2ENc9lts=
 github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.35.24/go.mod h1:E0ZDPhSKPaocAmHmVX6lr4QsTOn/FFi39uTb2Y2sSrg=
-github.com/aws/aws-sdk-go-v2/service/transcribe v1.55.0 h1:RKV4MScftqxaWNft0S5MqGgz78zyFU6IK/pxNlH6MJs=
-github.com/aws/aws-sdk-go-v2/service/transcribe v1.55.0/go.mod h1:z29t64Pva4oeaYboSZrJhhYJDZu80VCV/AnMnqhNvwE=
+github.com/aws/aws-sdk-go-v2/service/transcribe v1.55.1 h1:bEAU9OOwAyEOJF8cq94ysE/D9jQeWJRapb9Vo5RIE58=
+github.com/aws/aws-sdk-go-v2/service/transcribe v1.55.1/go.mod h1:l8fV0et8V7he/M+q43fNHvzN2jwxUqwBQjP4lJsnf8k=
 github.com/aws/aws-sdk-go-v2/service/transfer v1.72.0 h1:RbzzKZwU/fPSDpO731YSRDQqbp/h6IycNV5pgVCbJVk=
 github.com/aws/aws-sdk-go-v2/service/transfer v1.72.0/go.mod h1:NuALErcQ4g5s7KJef/5aoMwFmWn6deuczObKXYnuVRg=
 github.com/aws/aws-sdk-go-v2/service/uxc v1.0.3 h1:IITkqJoAxK9qNzDXCAOisBMcUVhHM5AgUkAXHKu1JwY=

--- a/go.sum
+++ b/go.sum
@@ -525,8 +525,8 @@ github.com/aws/aws-sdk-go-v2/service/sns v1.39.18 h1:z5zzs1HGWZX1PVs7DcnjSuuuoKx
 github.com/aws/aws-sdk-go-v2/service/sns v1.39.18/go.mod h1:OtbHWFTJ/cJHF/3t+H7ZJpMY43NbngwFrt0xq5u/28c=
 github.com/aws/aws-sdk-go-v2/service/sqs v1.42.28 h1:CsLiNChqRvXWtIjyjUaqg9vq+0md9R1vC+hGZ18zmTI=
 github.com/aws/aws-sdk-go-v2/service/sqs v1.42.28/go.mod h1:ZhBg8NNBEs+UuIILtpcUaX8iV4yU/sF7vBiS+U9P83A=
-github.com/aws/aws-sdk-go-v2/service/ssm v1.68.6 h1:0LPJjbSNEDHidGOXa0LfvSVbdn9/GdlJUQTgE0kFpso=
-github.com/aws/aws-sdk-go-v2/service/ssm v1.68.6/go.mod h1:SrZAopBP5/lyQ6NBVXKlRp8wPIXhzBCZU98sEozmv8Y=
+github.com/aws/aws-sdk-go-v2/service/ssm v1.68.7 h1:mKVjTrV40syRvcLfenT75nY8MTr6Nz3UyXSNxUaANRA=
+github.com/aws/aws-sdk-go-v2/service/ssm v1.68.7/go.mod h1:67nfKysKquQ5VKZOPfxI8+0FCa18Vj8Ojy2nKjPHkR4=
 github.com/aws/aws-sdk-go-v2/service/ssmcontacts v1.31.16 h1:8cOU6CwAoKHYdcKNvkQklc+QAFAMCOdKItfLkvKmmNc=
 github.com/aws/aws-sdk-go-v2/service/ssmcontacts v1.31.16/go.mod h1:F2vkPqylPCcAAM3xi+OClxWIHeOPPdnzfb60WVHFq8A=
 github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.39.22 h1:xAMqo7ys/lr5jCxK922v755qklNno+aZHFxOXkYCcU8=

--- a/go.sum
+++ b/go.sum
@@ -159,8 +159,8 @@ github.com/aws/aws-sdk-go-v2/service/codestarconnections v1.36.0 h1:/dOf5ugZheZR
 github.com/aws/aws-sdk-go-v2/service/codestarconnections v1.36.0/go.mod h1:IuvHlOzVFdseyeqMUZ5GSXg33+H8YdZjJI0wJ1McDyg=
 github.com/aws/aws-sdk-go-v2/service/codestarnotifications v1.32.1 h1:MkB0/DJ8XCCQR5PZvUiWt5HgOa+75Q4K+QxOT6UnHko=
 github.com/aws/aws-sdk-go-v2/service/codestarnotifications v1.32.1/go.mod h1:def5w+aEKHpEosI+xJ9FGKJElmu/RRL2xjd+adgaZCg=
-github.com/aws/aws-sdk-go-v2/service/cognitoidentity v1.33.24 h1:DLQWli3xz20zXXwMahVJ7xVgAZTmYLfMx7bB2Blwx18=
-github.com/aws/aws-sdk-go-v2/service/cognitoidentity v1.33.24/go.mod h1:D9DtGGYo4Fp2t1UwtaoTKuemugfwy5VG5aQLCqan5yk=
+github.com/aws/aws-sdk-go-v2/service/cognitoidentity v1.33.25 h1:XXa5oulvKVj4jTLV6rgCmo6gptqyeJ0yzAjhaAiIXjc=
+github.com/aws/aws-sdk-go-v2/service/cognitoidentity v1.33.25/go.mod h1:jgO0hOeOmaYby7RvK4EXrSAwchb4KgSiM/+V5WchNgE=
 github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.60.2 h1:pZxE29WAHgnk0jGj1P4UOOJnNPHXfltkfnK4F1Tg8jU=
 github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.60.2/go.mod h1:nbe4Nf/HOY+e54Dl+yjv04scYTGTC+4ZthbfOuPTXQs=
 github.com/aws/aws-sdk-go-v2/service/comprehend v1.41.0 h1:eAzz571JckxP387G0vRwoDS4xARluclKYt5pGUaR6+I=

--- a/go.sum
+++ b/go.sum
@@ -267,8 +267,8 @@ github.com/aws/aws-sdk-go-v2/service/fms v1.45.1 h1:BXUO368cAQX3BTvRg3BnSyIT53v/
 github.com/aws/aws-sdk-go-v2/service/fms v1.45.1/go.mod h1:zPxf7KJDIlavIfbrET7zYSIjqxmkMT7ziFCa+DPVrTc=
 github.com/aws/aws-sdk-go-v2/service/fsx v1.66.1 h1:YX1l7nNVKvHe3pEu498sW76WuHUAapZwQU2SpqRVMi8=
 github.com/aws/aws-sdk-go-v2/service/fsx v1.66.1/go.mod h1:DL5UJomGBiqjRf84eSykFbyQoLretYc1JPysrsKZSDc=
-github.com/aws/aws-sdk-go-v2/service/gamelift v1.54.0 h1:TnDHcCjQbeyxNgWV67Gz8DigkCDcz6t4y+UWBItR1zc=
-github.com/aws/aws-sdk-go-v2/service/gamelift v1.54.0/go.mod h1:krO76k8XMEa+hBF4M+zuyU2XXct6JQIdH5LKOrltHew=
+github.com/aws/aws-sdk-go-v2/service/gamelift v1.54.1 h1:7Appei3huNvhHlVaX4l87fyQMTiutTKDTR/q33RoR7I=
+github.com/aws/aws-sdk-go-v2/service/gamelift v1.54.1/go.mod h1:VnK+7iDsbhPDJ0BPuwDM80sPCGatD5dh4SJs5vacvbE=
 github.com/aws/aws-sdk-go-v2/service/glacier v1.32.8 h1:OGRgf5Jd5Vfxksc/HU4oCuYVes+/N0qWbMys90WMLsw=
 github.com/aws/aws-sdk-go-v2/service/glacier v1.32.8/go.mod h1:GnOJNdxnD5QSBqILVzFAjURLpXrQrUH83amUZam2I1o=
 github.com/aws/aws-sdk-go-v2/service/globalaccelerator v1.36.0 h1:9xK/+z/QIEu7DocAeM8w4I7JU+MqcN8gPrlEo0VpkH0=

--- a/go.sum
+++ b/go.sum
@@ -337,8 +337,8 @@ github.com/aws/aws-sdk-go-v2/service/lakeformation v1.47.9 h1:pLP0jbhZSUY3T8LPHW
 github.com/aws/aws-sdk-go-v2/service/lakeformation v1.47.9/go.mod h1:ZHQuEeYF365Q5ASJDbYzg/4ZxaTTyWmfBGyXaKxZw9A=
 github.com/aws/aws-sdk-go-v2/service/lambda v1.90.2 h1:dBiVUhd21cs5C3RUiAKTMc4Cw+5kvTBhM/GGlYTXrpo=
 github.com/aws/aws-sdk-go-v2/service/lambda v1.90.2/go.mod h1:gFmCYh+m/TwFPR3o30V83jaNVIzN5ozPrf7eC29mBJU=
-github.com/aws/aws-sdk-go-v2/service/launchwizard v1.14.6 h1:csDiL1/b79JOn9c02M5l3COsSPsUVFM4Q0TT9BEbkYk=
-github.com/aws/aws-sdk-go-v2/service/launchwizard v1.14.6/go.mod h1:Ivm9tKepKZYnZF5EUdRXaKx/6onFvtuLAvbReL/13OQ=
+github.com/aws/aws-sdk-go-v2/service/launchwizard v1.15.1 h1:7xZRe3mqApyzsWqjtNn+J73jc9DfMhEiRBt1scdxNF4=
+github.com/aws/aws-sdk-go-v2/service/launchwizard v1.15.1/go.mod h1:5kDHQj+69vTbiXJTkjw92qjEPROvbzJIZAeOad73814=
 github.com/aws/aws-sdk-go-v2/service/lexmodelbuildingservice v1.35.0 h1:LJ+UCPYUUAPlKNBj/r+mNZA8msdgFFa4tQNr/fUE2bE=
 github.com/aws/aws-sdk-go-v2/service/lexmodelbuildingservice v1.35.0/go.mod h1:zlyhvqBbKJLCktons66dFSfNMKKZ7XRNk5kGqaQUccE=
 github.com/aws/aws-sdk-go-v2/service/lexmodelsv2 v1.61.0 h1:6rjKCcc8dGyhGzbgRe5M1Zfp73OubQe2x8AzF31UpLE=

--- a/go.sum
+++ b/go.sum
@@ -201,8 +201,8 @@ github.com/aws/aws-sdk-go-v2/service/detective v1.39.0 h1:YfhUgn/USIV3sTmMeHdpQn
 github.com/aws/aws-sdk-go-v2/service/detective v1.39.0/go.mod h1:2PAHITEaW85PWDdqe3TuSny3o+BD4uoystdaH/EYJdE=
 github.com/aws/aws-sdk-go-v2/service/devicefarm v1.38.11 h1:71pCfxH8KVqP34bsmmDw35FR54dVbdcnbVFYqovpyAY=
 github.com/aws/aws-sdk-go-v2/service/devicefarm v1.38.11/go.mod h1:I/md2ejJNL/3hWXi+iAkbiNPrhQq0cqMWPd7c0NOiVg=
-github.com/aws/aws-sdk-go-v2/service/devopsagent v1.4.0 h1:XaP6w9oxccwZ5ycXQD7WNsKI+rPGrh9u4jzugPR+1mE=
-github.com/aws/aws-sdk-go-v2/service/devopsagent v1.4.0/go.mod h1:QmrrmO/P7VfCf68eQbY+kXL+ZuyUjbAUs82sKOHw14c=
+github.com/aws/aws-sdk-go-v2/service/devopsagent v1.5.1 h1:c6K2TLSv75lt2R3+jKyDRDzZo1rINjidrngfuHXGoN4=
+github.com/aws/aws-sdk-go-v2/service/devopsagent v1.5.1/go.mod h1:geVmKDQ6LzByWVYJYlwKg249rG1mWlZ8gmKlPARovWk=
 github.com/aws/aws-sdk-go-v2/service/devopsguru v1.41.0 h1:oivWpWrQ2iwG9uQIcwJfEwi+FgDD8weBrTG5/CnS8qY=
 github.com/aws/aws-sdk-go-v2/service/devopsguru v1.41.0/go.mod h1:7M6Y0kEPcla1JcdHe5IO+kq1XcmblIPgLAOerkiPXf8=
 github.com/aws/aws-sdk-go-v2/service/directconnect v1.38.17 h1:fkeDjhbAy9ddanOVlxP2vnY2dbTxA8HL+DdV9HezVSs=

--- a/go.sum
+++ b/go.sum
@@ -155,8 +155,8 @@ github.com/aws/aws-sdk-go-v2/service/codegurureviewer v1.35.0 h1:KsQiex+Ui0vkLC2
 github.com/aws/aws-sdk-go-v2/service/codegurureviewer v1.35.0/go.mod h1:XeKclJyntSdXdpadNx+AdetSR6lLnt+EcjwjbnBQX+k=
 github.com/aws/aws-sdk-go-v2/service/codepipeline v1.46.24 h1:DZR12e2R+OdulGzxcG8LWawnNJ4MPbbtIUK2sjBN0ho=
 github.com/aws/aws-sdk-go-v2/service/codepipeline v1.46.24/go.mod h1:K4x180hh43u6yepGq4lMqpU/KVtN9TwM8Rlfqo1XiWQ=
-github.com/aws/aws-sdk-go-v2/service/codestarconnections v1.35.15 h1:W6e6rV6k2oUthzPZTPgon2IcOg5DiGTimnwK76UyUuk=
-github.com/aws/aws-sdk-go-v2/service/codestarconnections v1.35.15/go.mod h1:40aemoBtijD+fwyMWhUYsQ0pB/2PH2VYarYEWJDu5c4=
+github.com/aws/aws-sdk-go-v2/service/codestarconnections v1.36.0 h1:/dOf5ugZheZRQpKVetyzEbjmfiEexAADSrSf/RgiSx8=
+github.com/aws/aws-sdk-go-v2/service/codestarconnections v1.36.0/go.mod h1:IuvHlOzVFdseyeqMUZ5GSXg33+H8YdZjJI0wJ1McDyg=
 github.com/aws/aws-sdk-go-v2/service/codestarnotifications v1.32.0 h1:ZhPhn5tFRF/7XeoH24D/JGsXHuOPRjp9Ri5+BNkB7GQ=
 github.com/aws/aws-sdk-go-v2/service/codestarnotifications v1.32.0/go.mod h1:e/u0po2zsCdMWrenoCgTJ1vyctChUnm8m+zNN3WeBk8=
 github.com/aws/aws-sdk-go-v2/service/cognitoidentity v1.33.24 h1:DLQWli3xz20zXXwMahVJ7xVgAZTmYLfMx7bB2Blwx18=

--- a/go.sum
+++ b/go.sum
@@ -455,8 +455,8 @@ github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.24.1 h1:UW8Cxq/yCtXahO
 github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.24.1/go.mod h1:Wr9N1XAxETSULikeGK1CSoxKqGe5CStOLtR4cQfP9KM=
 github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.33.27 h1:PBuU5HO0JhThHHOZ9WG0xyvK7lsx6XIGRW9ACvvCtHA=
 github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.33.27/go.mod h1:rqCOOEEd3ofM5Lltmv7IehmpnyXCDzxlydqXc6Sx35k=
-github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.32.0 h1:99o6w7ROYcs6aATT6af2LPtUfCCDSKAFDMDorUHgNHw=
-github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.32.0/go.mod h1:n8ixkV2383DfuJhsCMVdfeSfYWqJhO2uadau9wrta9U=
+github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.32.1 h1:3VYXjxI8ZDW5h3yDaSXNpGW86quViQatLNNclkypnfM=
+github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.32.1/go.mod h1:FPN5JcyM3LRy070DtXbb+8eT53HR/cSP/yt/fmvdL4U=
 github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.23.0 h1:BD6q8KEiom1qJpDC7kmBrKwMXCRkuSy7JXWPhQThFkI=
 github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.23.0/go.mod h1:kJgqmGmlOPqTe9cntPrSgMdIQ3cAama8TAW+NKaDCzE=
 github.com/aws/aws-sdk-go-v2/service/route53 v1.62.7 h1:twRRMmtSITnt/rrp+D7UDLzE5pKMZe759aalkUdN+OY=

--- a/go.sum
+++ b/go.sum
@@ -277,8 +277,8 @@ github.com/aws/aws-sdk-go-v2/service/glue v1.142.1 h1:Xq3xf10SK8eQx2C0QmHhveoShZ
 github.com/aws/aws-sdk-go-v2/service/glue v1.142.1/go.mod h1:NaK8CYNUIE/ctvfqGl2F9uD9PqTzGQwRENp1MFNgyCs=
 github.com/aws/aws-sdk-go-v2/service/grafana v1.35.1 h1:FmwZf8Zab+T2eOzl8zUxrnZiAVTMc2lUHiqCUJSR6jc=
 github.com/aws/aws-sdk-go-v2/service/grafana v1.35.1/go.mod h1:ZaE4XEcA7/Gi4Jf9vDpiiIE2zbuy3+bx1tpw0RdWJ/c=
-github.com/aws/aws-sdk-go-v2/service/greengrass v1.32.23 h1:VTghmVEn2zf3DVkqNE9d8gdg+Tc2Lj0CggsTXtU0zGo=
-github.com/aws/aws-sdk-go-v2/service/greengrass v1.32.23/go.mod h1:+tdzf4AVqOA+hkiiLnOIDJDywxXUnbB7IccwOdPrXVQ=
+github.com/aws/aws-sdk-go-v2/service/greengrass v1.32.24 h1:2IcMPOpDsVIfaj9YFKuH1USw0hWvf1n6ZSL2V+y49Do=
+github.com/aws/aws-sdk-go-v2/service/greengrass v1.32.24/go.mod h1:3c1oObcY5EL5WcU6TIwyhWQ4yySFUdtJzskkINO0Ryw=
 github.com/aws/aws-sdk-go-v2/service/groundstation v1.41.1 h1:IQAuKMncZtYlrMX4N61s08EVJvllV2mBdNZJF1FAT6g=
 github.com/aws/aws-sdk-go-v2/service/groundstation v1.41.1/go.mod h1:qPVSrGBE5s3TSsN81w3aMrnFVN5hZkg4T/oW92/2m1I=
 github.com/aws/aws-sdk-go-v2/service/guardduty v1.78.0 h1:G+ZbdL3onjVLfReu4piSAdE/Q9GOH89oNEXekFM+LUk=

--- a/go.sum
+++ b/go.sum
@@ -317,8 +317,8 @@ github.com/aws/aws-sdk-go-v2/service/ivschat v1.22.1 h1:VDLXIapXxzqeVeN1y2F1Ac/H
 github.com/aws/aws-sdk-go-v2/service/ivschat v1.22.1/go.mod h1:WohHsJOzPsHz8PmhizkZdExh0UbxG1P7zaIyV02Y4xQ=
 github.com/aws/aws-sdk-go-v2/service/kafka v1.52.1 h1:0Urw2AE2z/Ggs03KStjJT0rGqYScYfIlK6sRt0XlciQ=
 github.com/aws/aws-sdk-go-v2/service/kafka v1.52.1/go.mod h1:oB2qlsK9KHfAmHYQVxro0OwHf+9f1f4i/D9XJ5ibF+k=
-github.com/aws/aws-sdk-go-v2/service/kafkaconnect v1.31.0 h1:M0d76RXXSr320mhbr91xGraQX5qZHyjqaa0TR+FQkzg=
-github.com/aws/aws-sdk-go-v2/service/kafkaconnect v1.31.0/go.mod h1:/hZaVDUfPexuU2tdKL2YU/A+PMvr/PKuMtNuJ/LaiMw=
+github.com/aws/aws-sdk-go-v2/service/kafkaconnect v1.31.1 h1:ArCnvm+dkW5eThfz1P98P6vMM68wbe+tXAwedcMSbFo=
+github.com/aws/aws-sdk-go-v2/service/kafkaconnect v1.31.1/go.mod h1:71UZVNa0zpSvliXmaOVhFTa7YDQePW6AxyWV1F29PDo=
 github.com/aws/aws-sdk-go-v2/service/kendra v1.60.23 h1:1AZgLYCMh//yiVdPwwltHFFqVxpRboFUtozB3ItiSAQ=
 github.com/aws/aws-sdk-go-v2/service/kendra v1.60.23/go.mod h1:cznbYGyQ57ijyUhYzyCSDaKVSIh8ryhCu5te3l1aaL4=
 github.com/aws/aws-sdk-go-v2/service/keyspaces v1.25.7 h1:uQF+sXd/0Y1bIci9KCyxdDhbgI8O5JWea2VUukicctg=

--- a/go.sum
+++ b/go.sum
@@ -87,8 +87,8 @@ github.com/aws/aws-sdk-go-v2/service/athena v1.57.7 h1:LqflSmquSJVH5UYG0oW+YPWMO
 github.com/aws/aws-sdk-go-v2/service/athena v1.57.7/go.mod h1:EI9CjMXiFy6pqdEWf4zhEcu06Xpr1Mxt+Lf+XAznpIE=
 github.com/aws/aws-sdk-go-v2/service/auditmanager v1.46.15 h1:dTNrl3E7ODY2PwCBnkamxnPUpDtSOq9wSuUGN+9FUmE=
 github.com/aws/aws-sdk-go-v2/service/auditmanager v1.46.15/go.mod h1:MCSrmKum8NXNs+tl3yS7obnDNdZX/TAqG8ooqmc6j3U=
-github.com/aws/aws-sdk-go-v2/service/autoscaling v1.66.2 h1:pPd+/Ujqf2+DmPOdB47EN7ox1iC21lu2zlOccUlfHeo=
-github.com/aws/aws-sdk-go-v2/service/autoscaling v1.66.2/go.mod h1:b3XHAIEe5I9cmeZ9MLvUqj5DRWcBuh1/hpKDPb7T6KE=
+github.com/aws/aws-sdk-go-v2/service/autoscaling v1.66.3 h1:3ZLIDyYYWWxnxdt4EjbgHL6PQlnkiwKAJV4eSQv03ZY=
+github.com/aws/aws-sdk-go-v2/service/autoscaling v1.66.3/go.mod h1:H5gqqRutsdQYgHMlFiqf6t3cmm98xRJwB0zzHc6vqzQ=
 github.com/aws/aws-sdk-go-v2/service/autoscalingplans v1.30.16 h1:NHXI8e2fGE30FviOO2x5M0sKc94E0uWLe+S4tG1ulBs=
 github.com/aws/aws-sdk-go-v2/service/autoscalingplans v1.30.16/go.mod h1:OxmESzY5G8tAzVcQZE10oKW3LS6JXf3HXjzWF/zUEE0=
 github.com/aws/aws-sdk-go-v2/service/backup v1.57.0 h1:MK5y/qUq8I4OD7JEF1LDjkmLTfAonyiE+6N6i4asdwk=

--- a/go.sum
+++ b/go.sum
@@ -319,8 +319,8 @@ github.com/aws/aws-sdk-go-v2/service/kafka v1.52.1 h1:0Urw2AE2z/Ggs03KStjJT0rGqY
 github.com/aws/aws-sdk-go-v2/service/kafka v1.52.1/go.mod h1:oB2qlsK9KHfAmHYQVxro0OwHf+9f1f4i/D9XJ5ibF+k=
 github.com/aws/aws-sdk-go-v2/service/kafkaconnect v1.31.1 h1:ArCnvm+dkW5eThfz1P98P6vMM68wbe+tXAwedcMSbFo=
 github.com/aws/aws-sdk-go-v2/service/kafkaconnect v1.31.1/go.mod h1:71UZVNa0zpSvliXmaOVhFTa7YDQePW6AxyWV1F29PDo=
-github.com/aws/aws-sdk-go-v2/service/kendra v1.60.23 h1:1AZgLYCMh//yiVdPwwltHFFqVxpRboFUtozB3ItiSAQ=
-github.com/aws/aws-sdk-go-v2/service/kendra v1.60.23/go.mod h1:cznbYGyQ57ijyUhYzyCSDaKVSIh8ryhCu5te3l1aaL4=
+github.com/aws/aws-sdk-go-v2/service/kendra v1.60.24 h1:rEo4jyDWChQCAHo55ryGSIrQYNbr/ZglWZQ1UIXHcks=
+github.com/aws/aws-sdk-go-v2/service/kendra v1.60.24/go.mod h1:zu/m6Ap5qItkBSIDoQlRFo6BNwZ145tpGmr0N2HwRqs=
 github.com/aws/aws-sdk-go-v2/service/keyspaces v1.25.7 h1:uQF+sXd/0Y1bIci9KCyxdDhbgI8O5JWea2VUukicctg=
 github.com/aws/aws-sdk-go-v2/service/keyspaces v1.25.7/go.mod h1:+666D+0+cFuzSwavezjOcMMxDuASZpb0f6kXSNxQ4A0=
 github.com/aws/aws-sdk-go-v2/service/kinesis v1.43.7 h1:9FvrpWzkSPbm995UGQ4jOdRDuhQLmwgh/5t8UoosTdY=

--- a/go.sum
+++ b/go.sum
@@ -395,8 +395,8 @@ github.com/aws/aws-sdk-go-v2/service/notifications v1.8.1 h1:p3fifBWnYwYZDl4dWnY
 github.com/aws/aws-sdk-go-v2/service/notifications v1.8.1/go.mod h1:BFR5AGKy6wApHVrQzMGzAIIhu9XHLsC9Vr4Dhrr8MhU=
 github.com/aws/aws-sdk-go-v2/service/notificationscontacts v1.6.1 h1:/+83sWWF9wzvNZrS2JuVTk2rz9x1eH2jM7JcFcfiCYA=
 github.com/aws/aws-sdk-go-v2/service/notificationscontacts v1.6.1/go.mod h1:CgMKkMvi8mRoRFbjbhGj/tuYvhIp5wmiHkC4aYwCQAo=
-github.com/aws/aws-sdk-go-v2/service/oam v1.24.0 h1:O0sFLaMTd2qQHtU8HFH9hgnTcJCzEoGNmxdE7P1yuSo=
-github.com/aws/aws-sdk-go-v2/service/oam v1.24.0/go.mod h1:RxA073SQ1NzTBNrAs1N2iQ1WACFWdUxIL+pmvw9Ih9U=
+github.com/aws/aws-sdk-go-v2/service/oam v1.24.1 h1:QrXBn2Al2hSKd7iuncZwBh3Sm/M4w/AJqJwbUB/bcKo=
+github.com/aws/aws-sdk-go-v2/service/oam v1.24.1/go.mod h1:eQpqFnDbhCA78FU2Z5ZHyQ/x8mxPJMfWms/BnyB3POc=
 github.com/aws/aws-sdk-go-v2/service/observabilityadmin v1.16.0 h1:Ys/ZOm9bowwjJRkkv8iVjz6tRTnx1yAWknsdydNKnJU=
 github.com/aws/aws-sdk-go-v2/service/observabilityadmin v1.16.0/go.mod h1:BXfyXkrz+WDrJkHfWlj/+/WtVS2mKDUsWc2UcgcvVLY=
 github.com/aws/aws-sdk-go-v2/service/odb v1.11.0 h1:ugOElkAyu12xSVwgBZc4kK/bydeJpo7HVeWOqHFLSJ8=

--- a/go.sum
+++ b/go.sum
@@ -523,8 +523,8 @@ github.com/aws/aws-sdk-go-v2/service/signin v1.1.0 h1:yQo3eZ5qFaL1sJWqs1nL6j3yPH
 github.com/aws/aws-sdk-go-v2/service/signin v1.1.0/go.mod h1:3Zzou41Qt/ueXfIzHvTEjDNuR5IjCUBVF01SNhrt1e8=
 github.com/aws/aws-sdk-go-v2/service/sns v1.39.18 h1:z5zzs1HGWZX1PVs7DcnjSuuuoKx0tkM9RfU+5hLoKAE=
 github.com/aws/aws-sdk-go-v2/service/sns v1.39.18/go.mod h1:OtbHWFTJ/cJHF/3t+H7ZJpMY43NbngwFrt0xq5u/28c=
-github.com/aws/aws-sdk-go-v2/service/sqs v1.42.27 h1:QgaWXVmNDxv/U/3UIHfGb7ohvtFgerf/bYcYylj4i8E=
-github.com/aws/aws-sdk-go-v2/service/sqs v1.42.27/go.mod h1:8S6ExnLprS0oIeA8ZlHkJUJ0BMpKqnRPws/S0jegTqQ=
+github.com/aws/aws-sdk-go-v2/service/sqs v1.42.28 h1:CsLiNChqRvXWtIjyjUaqg9vq+0md9R1vC+hGZ18zmTI=
+github.com/aws/aws-sdk-go-v2/service/sqs v1.42.28/go.mod h1:ZhBg8NNBEs+UuIILtpcUaX8iV4yU/sF7vBiS+U9P83A=
 github.com/aws/aws-sdk-go-v2/service/ssm v1.68.6 h1:0LPJjbSNEDHidGOXa0LfvSVbdn9/GdlJUQTgE0kFpso=
 github.com/aws/aws-sdk-go-v2/service/ssm v1.68.6/go.mod h1:SrZAopBP5/lyQ6NBVXKlRp8wPIXhzBCZU98sEozmv8Y=
 github.com/aws/aws-sdk-go-v2/service/ssmcontacts v1.31.16 h1:8cOU6CwAoKHYdcKNvkQklc+QAFAMCOdKItfLkvKmmNc=

--- a/go.sum
+++ b/go.sum
@@ -61,8 +61,8 @@ github.com/aws/aws-sdk-go-v2/service/appconfig v1.44.1 h1:niGlkXPUtDuQyYn2+jgeMD
 github.com/aws/aws-sdk-go-v2/service/appconfig v1.44.1/go.mod h1:9bwVUBzUZR3spy1RgP9iKxiMa6qcSUIMg+IX2lg/aA0=
 github.com/aws/aws-sdk-go-v2/service/appfabric v1.16.24 h1:or50VRIC8Teh4DNVXcLfesnmdN9Wbq4sGLvCnuVXGX0=
 github.com/aws/aws-sdk-go-v2/service/appfabric v1.16.24/go.mod h1:Vuux/tWc3oyiGn9BSSErHjU5lXQElBbkb/VZFOGeVJM=
-github.com/aws/aws-sdk-go-v2/service/appflow v1.51.14 h1:+Ty4C5yqKzL+AbI20nUKkkElHf2Cn8IGdAou6mwd9UI=
-github.com/aws/aws-sdk-go-v2/service/appflow v1.51.14/go.mod h1:JbM1SD1BwFKHndHw6iIHhQzF3RTTC36xLYWPUj3jHds=
+github.com/aws/aws-sdk-go-v2/service/appflow v1.51.15 h1:iz+/nmbL/lLn6Jdqb3xXNE92k15LH7E84VdSNg1lDgI=
+github.com/aws/aws-sdk-go-v2/service/appflow v1.51.15/go.mod h1:f3rmeXbgWBepM1ftO73MEVbi2OkAo2dbhJiW30+xK1w=
 github.com/aws/aws-sdk-go-v2/service/appintegrations v1.37.9 h1:e51YjJHGLC86GPxLox3PNwnlbgMbLPJ7Ph4vcTeM4GY=
 github.com/aws/aws-sdk-go-v2/service/appintegrations v1.37.9/go.mod h1:EhPRMWYqp8CDlJ/EEYNegsBOTTJRN6HbNaUCQ9J7JGw=
 github.com/aws/aws-sdk-go-v2/service/applicationautoscaling v1.41.16 h1:9ePxWacyZEGJQIBfYxumxYjDZvvpCcUAnFQUQy4GI2U=

--- a/go.sum
+++ b/go.sum
@@ -387,8 +387,8 @@ github.com/aws/aws-sdk-go-v2/service/networkfirewall v1.61.1 h1:ewqow8gclzOTZRvg
 github.com/aws/aws-sdk-go-v2/service/networkfirewall v1.61.1/go.mod h1:7bRBjeRP7pMQOX2qP8d7kEO1FV1WekbuMq5ZJXQpxCo=
 github.com/aws/aws-sdk-go-v2/service/networkflowmonitor v1.11.12 h1:wjAGQwXknovXHWsomCz7sOCdSMVlRc9mD/J7ut2GCEI=
 github.com/aws/aws-sdk-go-v2/service/networkflowmonitor v1.11.12/go.mod h1:LXVPCQiyrT5jBtZwCrzCxTomfsy+W/ZYzy2VmDlorn0=
-github.com/aws/aws-sdk-go-v2/service/networkmanager v1.42.0 h1:xWEOUBxKqNCR3qkUsmYOPUyW7ZlyWzKX6s0f81PW60A=
-github.com/aws/aws-sdk-go-v2/service/networkmanager v1.42.0/go.mod h1:x0O7AHep2gwquyfW6gmNql2OM4LEloyJGFflJfEJV+U=
+github.com/aws/aws-sdk-go-v2/service/networkmanager v1.42.1 h1:9o2GTfTTFQtorK/GUQt7Oj53+WuUJmfXcyTsQqQux34=
+github.com/aws/aws-sdk-go-v2/service/networkmanager v1.42.1/go.mod h1:jWEPRVbipvd1/BZHOIgQjBN0RjPX+VE+vi7EbO52gkI=
 github.com/aws/aws-sdk-go-v2/service/networkmonitor v1.13.15 h1:Ji9P/9srs4/zg76hJP1117SuDZXDQ/ooeETlNPmhXcM=
 github.com/aws/aws-sdk-go-v2/service/networkmonitor v1.13.15/go.mod h1:qISrDtSm2hQNPt9O1kwCvk5IwD01lE9WAhB9hnddNvg=
 github.com/aws/aws-sdk-go-v2/service/notifications v1.8.0 h1:TjLraX0tvsqAN1CgkQkQbl3ga91FhAXRPsPvQf+dp6I=

--- a/go.sum
+++ b/go.sum
@@ -477,8 +477,8 @@ github.com/aws/aws-sdk-go-v2/service/s3 v1.102.1 h1:vttIo8BQwfnhimKRBZBBF3Y38SAI
 github.com/aws/aws-sdk-go-v2/service/s3 v1.102.1/go.mod h1:2qjInACJr84m/Tm4XXCcVNpejmbKy9kz7TEa6viQHSk=
 github.com/aws/aws-sdk-go-v2/service/s3control v1.71.0 h1:WLG6J5K6u5wY6rRt/H/9bdx0mPFd0yDiooVLktIGodg=
 github.com/aws/aws-sdk-go-v2/service/s3control v1.71.0/go.mod h1:XDxWqWcbRTSEjyGQ11yXnlrSvyacvuA/r00Xw7XqxTo=
-github.com/aws/aws-sdk-go-v2/service/s3files v1.0.2 h1:DQle06mhK+kiLv2fMzDW3gS0D0hAXSRM5CdWnHjM1BI=
-github.com/aws/aws-sdk-go-v2/service/s3files v1.0.2/go.mod h1:V9cqxfwLPBIb1bnB5bSCp/O7Nzqmd965WXByJa8GXcI=
+github.com/aws/aws-sdk-go-v2/service/s3files v1.0.3 h1:S3+dpkrgIdGvw8kt4bESzv+uUo49Cqnn/rnx1Sjh9j8=
+github.com/aws/aws-sdk-go-v2/service/s3files v1.0.3/go.mod h1:peu+U0l09wQS8QIDhZU9dHM35RkvmtBjaVPWNioftX8=
 github.com/aws/aws-sdk-go-v2/service/s3outposts v1.34.14 h1:+Kd3/zK8ivdwLKtMeqXcPPU+v2X7juW73BgRDKqMD8o=
 github.com/aws/aws-sdk-go-v2/service/s3outposts v1.34.14/go.mod h1:mWkKCdYcl0Oem0dQ1PVdn3sjPSe9wi9UtGOsu2d/ncA=
 github.com/aws/aws-sdk-go-v2/service/s3tables v1.16.0 h1:/oAhojlGOkpTz9qnblIpoq7tYvjU6smR2cTHGauvjQA=

--- a/go.sum
+++ b/go.sum
@@ -59,8 +59,8 @@ github.com/aws/aws-sdk-go-v2/service/apigatewayv2 v1.35.1 h1:eRIunIWPX26Rlm9RC3S
 github.com/aws/aws-sdk-go-v2/service/apigatewayv2 v1.35.1/go.mod h1:nHWH6McU6utUoLb6vm0QVaPSk9e41bdNQ1mvpEGT7ew=
 github.com/aws/aws-sdk-go-v2/service/appconfig v1.44.1 h1:niGlkXPUtDuQyYn2+jgeMDutZ9POGCqgtj98xL1XsxI=
 github.com/aws/aws-sdk-go-v2/service/appconfig v1.44.1/go.mod h1:9bwVUBzUZR3spy1RgP9iKxiMa6qcSUIMg+IX2lg/aA0=
-github.com/aws/aws-sdk-go-v2/service/appfabric v1.16.23 h1:y5Hr7EcQ70FQthOFj4tRm0uRaU4ImfGxmO6nvmUy06k=
-github.com/aws/aws-sdk-go-v2/service/appfabric v1.16.23/go.mod h1:C8NRhUWVxUpI/rvhU4xaL/4QxH+kxy8pVCf8DrXLiwM=
+github.com/aws/aws-sdk-go-v2/service/appfabric v1.16.24 h1:or50VRIC8Teh4DNVXcLfesnmdN9Wbq4sGLvCnuVXGX0=
+github.com/aws/aws-sdk-go-v2/service/appfabric v1.16.24/go.mod h1:Vuux/tWc3oyiGn9BSSErHjU5lXQElBbkb/VZFOGeVJM=
 github.com/aws/aws-sdk-go-v2/service/appflow v1.51.14 h1:+Ty4C5yqKzL+AbI20nUKkkElHf2Cn8IGdAou6mwd9UI=
 github.com/aws/aws-sdk-go-v2/service/appflow v1.51.14/go.mod h1:JbM1SD1BwFKHndHw6iIHhQzF3RTTC36xLYWPUj3jHds=
 github.com/aws/aws-sdk-go-v2/service/appintegrations v1.37.9 h1:e51YjJHGLC86GPxLox3PNwnlbgMbLPJ7Ph4vcTeM4GY=

--- a/go.sum
+++ b/go.sum
@@ -485,8 +485,8 @@ github.com/aws/aws-sdk-go-v2/service/s3tables v1.16.1 h1:5+iKON1AS7XVpgNQxn9Tidz
 github.com/aws/aws-sdk-go-v2/service/s3tables v1.16.1/go.mod h1:uqGcjeWoKrvYefPNpHdQ2Ne/8HUtzshAuG4VzH7XhIg=
 github.com/aws/aws-sdk-go-v2/service/s3vectors v1.7.1 h1:kS5jiMR5DgHoBHKyTZerpQjzUWvcTbeHVFbi5cL+H3s=
 github.com/aws/aws-sdk-go-v2/service/s3vectors v1.7.1/go.mod h1:EbboPnapUuRZyMud+453TcE1BKQ9QJYP77RmGmT2CUM=
-github.com/aws/aws-sdk-go-v2/service/sagemaker v1.249.0 h1:n8V311ky0gvDeiO6d+srI/6Ai/vmGVIdWWax+rp9dXA=
-github.com/aws/aws-sdk-go-v2/service/sagemaker v1.249.0/go.mod h1:CWbiQe1BkvmBlSfdI8DOoNaqoehc2+JWnylOfmR7aKU=
+github.com/aws/aws-sdk-go-v2/service/sagemaker v1.250.1 h1:KoMKWfzAftZzto69IkrRnilMJtmso3B+szOBp0gM2M4=
+github.com/aws/aws-sdk-go-v2/service/sagemaker v1.250.1/go.mod h1:5Rogcr8mhSUah+AoYFZvB10D3qPtqa3GbbxSx+pW3yI=
 github.com/aws/aws-sdk-go-v2/service/savingsplans v1.32.4 h1:BWmdjmP8sWqe0eICMM+2X2jic2S41bJ7xDhz3Wfd8/0=
 github.com/aws/aws-sdk-go-v2/service/savingsplans v1.32.4/go.mod h1:r/jBjd7QFGv9fsk0EFMjHKMPV6El60e4pa+BU4oyjBI=
 github.com/aws/aws-sdk-go-v2/service/scheduler v1.18.0 h1:Qq2vBd/eezmHlfkaINHdzS3+r6B+1d+NJXYj4iVZ3rE=

--- a/go.sum
+++ b/go.sum
@@ -505,8 +505,8 @@ github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.39.16 h1:mbqBPEMz8JjdTM1M
 github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.39.16/go.mod h1:P0nEJjEHZpZ+BLv4iUjkIfNjvvpCXcJoyvjlN02AwZ4=
 github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry v1.36.1 h1:wuMAk0DcF1Us0+vZzgIePw7fVdfy4Xj0gg7TlmtC/0g=
 github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry v1.36.1/go.mod h1:cL0D+MJfloyTVGgf3zmcavs4giz3W1x/z/wMo9O4V+M=
-github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.40.0 h1:8eUbfsuVdhqlek1EJny/jE2OSbhjSpnsRsyOTFowDlo=
-github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.40.0/go.mod h1:1lUDU6qw3e5FKsegwe+hZZJJXUjg8/L/szYUgVih8yM=
+github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.40.1 h1:vyjZg2SefsacQFgU9WfbTve/3Aj6hE2NSJuChImmyVg=
+github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.40.1/go.mod h1:9BpYYXW/GFuScrtiSbfKHLP3LJSYUYKyWLbvXZkB9os=
 github.com/aws/aws-sdk-go-v2/service/servicequotas v1.35.0 h1:qaB32zX2iiSWa2ml5DO0F71AOU+VuyuttbFd+kxxzf0=
 github.com/aws/aws-sdk-go-v2/service/servicequotas v1.35.0/go.mod h1:52QJsp2N27Em8o5H/cgkBwjTY4I/TYpTBHMlqhuCHMQ=
 github.com/aws/aws-sdk-go-v2/service/ses v1.34.24 h1:ZPCoU087iv2IWJKNQyN+MYOqZAM9lEVevS9MHWGG4wI=

--- a/go.sum
+++ b/go.sum
@@ -91,8 +91,8 @@ github.com/aws/aws-sdk-go-v2/service/autoscaling v1.66.3 h1:3ZLIDyYYWWxnxdt4Ejbg
 github.com/aws/aws-sdk-go-v2/service/autoscaling v1.66.3/go.mod h1:H5gqqRutsdQYgHMlFiqf6t3cmm98xRJwB0zzHc6vqzQ=
 github.com/aws/aws-sdk-go-v2/service/autoscalingplans v1.30.17 h1:fB+sNF4xqcysho/KeJHOF1YnizXYrOxN4FvTbdx9vEU=
 github.com/aws/aws-sdk-go-v2/service/autoscalingplans v1.30.17/go.mod h1:D13yDn18/1mh7ptciNt6Nxt8DEmcGeubZSe5LyZoZtE=
-github.com/aws/aws-sdk-go-v2/service/backup v1.57.0 h1:MK5y/qUq8I4OD7JEF1LDjkmLTfAonyiE+6N6i4asdwk=
-github.com/aws/aws-sdk-go-v2/service/backup v1.57.0/go.mod h1:uMh3ZDoLKhXldYL1qcBYy1HsNQfKgL/w8iF2onOyoKY=
+github.com/aws/aws-sdk-go-v2/service/backup v1.57.1 h1:/6tJSdy0K4A1lsoMcY5DqFkQMHMMF4w8EOmA81hNw08=
+github.com/aws/aws-sdk-go-v2/service/backup v1.57.1/go.mod h1:T961j1gPTNYG/vN/6cQJK06gdtyAWP9MjHNnPIAapX0=
 github.com/aws/aws-sdk-go-v2/service/batch v1.65.0 h1:F2G4oJT5uJyJ/brhUl/NcMDlB9krWdAfqTUhSM41S/k=
 github.com/aws/aws-sdk-go-v2/service/batch v1.65.0/go.mod h1:EHhfaNTxntvYHmSdHGLLSxuerqkMIlXY9lWjl+CJJxg=
 github.com/aws/aws-sdk-go-v2/service/bcmdataexports v1.16.0 h1:XEUbEn17sz6yPl3kP+DUs0cYi5qX2MPjag+A7P3I0Zo=

--- a/go.sum
+++ b/go.sum
@@ -439,8 +439,8 @@ github.com/aws/aws-sdk-go-v2/service/rbin v1.28.1 h1:vrR/SGBj/uCiJVUHPIxcqK+wt4Z
 github.com/aws/aws-sdk-go-v2/service/rbin v1.28.1/go.mod h1:OET1iQb9KlgKiRcT4rqsG5EbcGIAZu6+sptNIOO7mUg=
 github.com/aws/aws-sdk-go-v2/service/rds v1.118.3 h1:Q6o5SuzC3+T1WjA6y/+vxPkFRFXPiGilPCdhdQZ4qp8=
 github.com/aws/aws-sdk-go-v2/service/rds v1.118.3/go.mod h1:Fjbrf3IlJCagXHMf1GRBLmpcBXK60g3y9laWG2lgUmg=
-github.com/aws/aws-sdk-go-v2/service/rdsdata v1.32.23 h1:CrpsWnO5yFYIBEqqOO70hbwJWHtipXd8bWHpfPxz0sk=
-github.com/aws/aws-sdk-go-v2/service/rdsdata v1.32.23/go.mod h1:USBiT9IyJ5Qi32+1al0yNYuAcwTjGMi0s/4ksO9MjdE=
+github.com/aws/aws-sdk-go-v2/service/rdsdata v1.32.24 h1:i62rjzGXWqDWVhpO/KVBw3ez5ANAu9Gh4RzJRnJSE+A=
+github.com/aws/aws-sdk-go-v2/service/rdsdata v1.32.24/go.mod h1:N5iVwQXS/jDd0ljhmLfd8W3295wp4gwKvNAXhPjyCKQ=
 github.com/aws/aws-sdk-go-v2/service/redshift v1.62.8 h1:5Wg38ZauCqmomDAGTCDbA/t4vR5fUqIBTEwAOAswdng=
 github.com/aws/aws-sdk-go-v2/service/redshift v1.62.8/go.mod h1:uLWlNO4q8278lSx2iKIJZ09zSXNJ6uQTFM1jvZIZRf4=
 github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.39.2 h1:5MMxyip6xYVD6LgkaXM2wJVnUabv5rUf3nWBdNQRXRo=

--- a/go.sum
+++ b/go.sum
@@ -195,8 +195,8 @@ github.com/aws/aws-sdk-go-v2/service/datasync v1.59.1 h1:0rV9cHprMcB05StCAiqt1Za
 github.com/aws/aws-sdk-go-v2/service/datasync v1.59.1/go.mod h1:sQV6i+7URqrZCc8IsjVS75RVYdSB9+P31uY6dt7sUqY=
 github.com/aws/aws-sdk-go-v2/service/datazone v1.62.1 h1:RAGYoo2eV8cCmeFpDpAJzG0wHiPRFrx8EN3XtyxdTkc=
 github.com/aws/aws-sdk-go-v2/service/datazone v1.62.1/go.mod h1:ywdC/CddVikMtG/IoiGw9t2ZEdWQcFJ4PdeOie3M5KY=
-github.com/aws/aws-sdk-go-v2/service/dax v1.29.18 h1:sZwTAlW7WiDiLBjDk6OvmbOBjXQPooArNkUbTzCupOU=
-github.com/aws/aws-sdk-go-v2/service/dax v1.29.18/go.mod h1:zAdYaGSQXmr+LwBX8pp5vHvcToXC5SEOKPlDUhZMMRc=
+github.com/aws/aws-sdk-go-v2/service/dax v1.29.19 h1:s+l4YYZcDuYI8EvhxV+66xj7mKwq4mthpuwTEeCuRDA=
+github.com/aws/aws-sdk-go-v2/service/dax v1.29.19/go.mod h1:hIn61FGs/Ju7NY+Hf8OwNAxMo1v83/eBkH+AuqCk8dc=
 github.com/aws/aws-sdk-go-v2/service/detective v1.38.15 h1:H5v+Sro9ZL5OQGOoxuZz8RTzvO23VkOJ1LjKqXbank8=
 github.com/aws/aws-sdk-go-v2/service/detective v1.38.15/go.mod h1:/DN1zJ/OloIC8JwOVgOjbSDpl0S56cnu5Qnf9D/sXc8=
 github.com/aws/aws-sdk-go-v2/service/devicefarm v1.38.10 h1:57LpTN6FaBV417EbwvNC0/rdFRhZm/nrf01XEXPy+nI=

--- a/go.sum
+++ b/go.sum
@@ -355,8 +355,8 @@ github.com/aws/aws-sdk-go-v2/service/macie2 v1.51.3 h1:MjhvPAy7WONLMkYlKXySflQMk
 github.com/aws/aws-sdk-go-v2/service/macie2 v1.51.3/go.mod h1:rUVkJJSpImXmBlMc1ZWrx/PF2Kz+jch45cIdm4OVnb4=
 github.com/aws/aws-sdk-go-v2/service/mediaconnect v1.49.1 h1:pKLK86zyE6qkeBtAdY/JXQCcfP6wPY24ZFWZ1tpU5c0=
 github.com/aws/aws-sdk-go-v2/service/mediaconnect v1.49.1/go.mod h1:a08ydPBd3DmBpYl0ELaaWY0PbG0T+XZ6DjrVC154IDY=
-github.com/aws/aws-sdk-go-v2/service/mediaconvert v1.91.2 h1:h466gQU4HNXHgTdz7a45mGudKsB+NeyPVYr6hf9F4gM=
-github.com/aws/aws-sdk-go-v2/service/mediaconvert v1.91.2/go.mod h1:r/qoOppQk/ZTUHNBdj9S8R8k0JCV2iApiKfyxDyU42s=
+github.com/aws/aws-sdk-go-v2/service/mediaconvert v1.91.3 h1:8/TuAc1vhYA4Woy7TfqQ3eRYkLGsV1D7qWH6Tik2zpk=
+github.com/aws/aws-sdk-go-v2/service/mediaconvert v1.91.3/go.mod h1:K7xRA32242aLotLpG35AptbkKgBuSWfCQvSuflTRURI=
 github.com/aws/aws-sdk-go-v2/service/medialive v1.96.0 h1:2A2YYpr3IDLZ9y2WRg/oXSmlrmDQA+KNvgcFGOWr+PY=
 github.com/aws/aws-sdk-go-v2/service/medialive v1.96.0/go.mod h1:YtEXuL0GNGkAeeFSs2wT/KTnaqykXJ52d+4MefPwJKg=
 github.com/aws/aws-sdk-go-v2/service/mediapackage v1.39.23 h1:ztbUtcql2vd65yqnEz/k+bTX8PBP1J4to32/ck5hLAA=

--- a/go.sum
+++ b/go.sum
@@ -99,8 +99,8 @@ github.com/aws/aws-sdk-go-v2/service/bcmdataexports v1.16.1 h1:k3W+G/GuG+hjaNESD
 github.com/aws/aws-sdk-go-v2/service/bcmdataexports v1.16.1/go.mod h1:PVM2CvJlYTfvVn6siQgUUQnet+tiW2Bv0sL7Pa2JakM=
 github.com/aws/aws-sdk-go-v2/service/bedrock v1.62.0 h1:W+9SC9IbSJfB8uIVvYrE4+AR5Id47q6uma7zKcpoHMc=
 github.com/aws/aws-sdk-go-v2/service/bedrock v1.62.0/go.mod h1:s8wtBVt3pTWX6N4QvrYzOehkoUsVzkiGRdZuA4utdVQ=
-github.com/aws/aws-sdk-go-v2/service/bedrockagent v1.54.0 h1:OnHTo0dbX2kWlAYHQZceppeMDfp07I+Kjtuk3T+1N70=
-github.com/aws/aws-sdk-go-v2/service/bedrockagent v1.54.0/go.mod h1:zue4MN4ji6nlKYQYwVLmaPXJ66wB9JnIePX1e1yg5MU=
+github.com/aws/aws-sdk-go-v2/service/bedrockagent v1.54.1 h1:jc+0xbKgIthQDrAb8KVr5uJdItkany+WIEb3dnkJiHQ=
+github.com/aws/aws-sdk-go-v2/service/bedrockagent v1.54.1/go.mod h1:mHMqUmNCieOVD/XOD6Xmlqof1ptZnF/TsRMTy/Jr8CY=
 github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol v1.40.0 h1:4QLszbAJFRdTRVU3b0FVnSavqarnrTBdjmrfdCfETyQ=
 github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol v1.40.0/go.mod h1:WXGqnCrWtpgiig7ymwkNHdGvWF7FJtGvx8ldK/yy5BQ=
 github.com/aws/aws-sdk-go-v2/service/billing v1.11.0 h1:BttT9s7XhvQ0B3fR3EZ2jglkd8nIj75yXTkQinlJd8E=

--- a/go.sum
+++ b/go.sum
@@ -343,8 +343,8 @@ github.com/aws/aws-sdk-go-v2/service/lexmodelbuildingservice v1.35.1 h1:NZX1pOWZ
 github.com/aws/aws-sdk-go-v2/service/lexmodelbuildingservice v1.35.1/go.mod h1:rzQ2SsbFij+4zX+SUNYMDL632DqZHY6t+pEeBzmD7e4=
 github.com/aws/aws-sdk-go-v2/service/lexmodelsv2 v1.61.1 h1:rKfX8s06E/LQ2GTsqP+RazndMRfeLRJCA7gISHn1I9s=
 github.com/aws/aws-sdk-go-v2/service/lexmodelsv2 v1.61.1/go.mod h1:NFAqjgrK+zDT/FBpxy8hhv6TeihDTevN/Sesh8qr8Bw=
-github.com/aws/aws-sdk-go-v2/service/licensemanager v1.37.12 h1:CRnlzGMTYDTHpmFSGUe+CjEHzNQzL+fRZS5weQLvRfc=
-github.com/aws/aws-sdk-go-v2/service/licensemanager v1.37.12/go.mod h1:1Y6IDySTexX5E3Jl95awEToOP1pW/rwEfcUwNElaF5A=
+github.com/aws/aws-sdk-go-v2/service/licensemanager v1.37.13 h1:111XpjGyREF2grOTU5eqLeQqa7NH9uZqHhOJMQ44gPg=
+github.com/aws/aws-sdk-go-v2/service/licensemanager v1.37.13/go.mod h1:8GKUM7OrtYiizLA72d3799YulE9YYd1LBjitI9gni6U=
 github.com/aws/aws-sdk-go-v2/service/lightsail v1.54.0 h1:07DKnL5eKSel3XEM2UxlD/z9zUZZ6XMHLGDXkAdY4u8=
 github.com/aws/aws-sdk-go-v2/service/lightsail v1.54.0/go.mod h1:Etcg8xorq1b0g0V2KMNgFjubYITZseJv08qtX/3szko=
 github.com/aws/aws-sdk-go-v2/service/location v1.51.1 h1:V2YRh41kS0i5lzJqEJlpnv5ljKUKBPQl0WJ8p8MEYU8=

--- a/go.sum
+++ b/go.sum
@@ -153,8 +153,8 @@ github.com/aws/aws-sdk-go-v2/service/codeguruprofiler v1.30.1 h1:zoQt0M9PoeUxEDS
 github.com/aws/aws-sdk-go-v2/service/codeguruprofiler v1.30.1/go.mod h1:UpiP4zJee3P/NTiH6mUFBuaEJpGZS39OjEZ1nYBE/sE=
 github.com/aws/aws-sdk-go-v2/service/codegurureviewer v1.35.0 h1:KsQiex+Ui0vkLC21ucGvO3XGJKpVnBY1xeBj02KE3fk=
 github.com/aws/aws-sdk-go-v2/service/codegurureviewer v1.35.0/go.mod h1:XeKclJyntSdXdpadNx+AdetSR6lLnt+EcjwjbnBQX+k=
-github.com/aws/aws-sdk-go-v2/service/codepipeline v1.46.23 h1:T1CJQxFSFH/74qHb6h02V7oJBCcNlWoBZj+ZM1C/+0I=
-github.com/aws/aws-sdk-go-v2/service/codepipeline v1.46.23/go.mod h1:YRBQdlmNr8T+a+cvU7p0s7kYNT9UrZ4RPfLSHthtMOc=
+github.com/aws/aws-sdk-go-v2/service/codepipeline v1.46.24 h1:DZR12e2R+OdulGzxcG8LWawnNJ4MPbbtIUK2sjBN0ho=
+github.com/aws/aws-sdk-go-v2/service/codepipeline v1.46.24/go.mod h1:K4x180hh43u6yepGq4lMqpU/KVtN9TwM8Rlfqo1XiWQ=
 github.com/aws/aws-sdk-go-v2/service/codestarconnections v1.35.15 h1:W6e6rV6k2oUthzPZTPgon2IcOg5DiGTimnwK76UyUuk=
 github.com/aws/aws-sdk-go-v2/service/codestarconnections v1.35.15/go.mod h1:40aemoBtijD+fwyMWhUYsQ0pB/2PH2VYarYEWJDu5c4=
 github.com/aws/aws-sdk-go-v2/service/codestarnotifications v1.32.0 h1:ZhPhn5tFRF/7XeoH24D/JGsXHuOPRjp9Ri5+BNkB7GQ=

--- a/go.sum
+++ b/go.sum
@@ -57,8 +57,8 @@ github.com/aws/aws-sdk-go-v2/service/apigateway v1.40.1 h1:t2zoClYnI9AHqxyV/lmEC
 github.com/aws/aws-sdk-go-v2/service/apigateway v1.40.1/go.mod h1:nzQqqeubg1kjVdwEW+7aSs/Nvp6AC2lAX9UQFHt4U6c=
 github.com/aws/aws-sdk-go-v2/service/apigatewayv2 v1.35.1 h1:eRIunIWPX26Rlm9RC3S7xP1DEv5Z/ob6m8Wi+mWKPaM=
 github.com/aws/aws-sdk-go-v2/service/apigatewayv2 v1.35.1/go.mod h1:nHWH6McU6utUoLb6vm0QVaPSk9e41bdNQ1mvpEGT7ew=
-github.com/aws/aws-sdk-go-v2/service/appconfig v1.44.0 h1:YqhwsY0LG3JDJaCWKzTRO/KzkUsv2WJSIRqAJ/mK03E=
-github.com/aws/aws-sdk-go-v2/service/appconfig v1.44.0/go.mod h1:rvo3cSBQ0Qgt6mF6ITZTZ0ssHQJ0kBcaUpIWCaldJVQ=
+github.com/aws/aws-sdk-go-v2/service/appconfig v1.44.1 h1:niGlkXPUtDuQyYn2+jgeMDutZ9POGCqgtj98xL1XsxI=
+github.com/aws/aws-sdk-go-v2/service/appconfig v1.44.1/go.mod h1:9bwVUBzUZR3spy1RgP9iKxiMa6qcSUIMg+IX2lg/aA0=
 github.com/aws/aws-sdk-go-v2/service/appfabric v1.16.23 h1:y5Hr7EcQ70FQthOFj4tRm0uRaU4ImfGxmO6nvmUy06k=
 github.com/aws/aws-sdk-go-v2/service/appfabric v1.16.23/go.mod h1:C8NRhUWVxUpI/rvhU4xaL/4QxH+kxy8pVCf8DrXLiwM=
 github.com/aws/aws-sdk-go-v2/service/appflow v1.51.14 h1:+Ty4C5yqKzL+AbI20nUKkkElHf2Cn8IGdAou6mwd9UI=

--- a/go.sum
+++ b/go.sum
@@ -453,8 +453,8 @@ github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.36.1 h1:vPc2Z406d6QIX6lMTA
 github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.36.1/go.mod h1:NxGhbjNENgzBTTz0YZeTXiBUB76h8X9Bj0/oX1wfTao=
 github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.24.1 h1:UW8Cxq/yCtXahOLPJ7yYCDSN71pum/fZYic1PZuslZ4=
 github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.24.1/go.mod h1:Wr9N1XAxETSULikeGK1CSoxKqGe5CStOLtR4cQfP9KM=
-github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.33.26 h1:HmcCtAaTeZTskXrcrdoioe6oDsQCbdGekBkLOCUE8F8=
-github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.33.26/go.mod h1:nYctzUkOuHA0n6thF68Td93Mm8NJzAhWuhKOIqk5vW8=
+github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.33.27 h1:PBuU5HO0JhThHHOZ9WG0xyvK7lsx6XIGRW9ACvvCtHA=
+github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.33.27/go.mod h1:rqCOOEEd3ofM5Lltmv7IehmpnyXCDzxlydqXc6Sx35k=
 github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.32.0 h1:99o6w7ROYcs6aATT6af2LPtUfCCDSKAFDMDorUHgNHw=
 github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.32.0/go.mod h1:n8ixkV2383DfuJhsCMVdfeSfYWqJhO2uadau9wrta9U=
 github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.23.0 h1:BD6q8KEiom1qJpDC7kmBrKwMXCRkuSy7JXWPhQThFkI=

--- a/go.sum
+++ b/go.sum
@@ -73,8 +73,8 @@ github.com/aws/aws-sdk-go-v2/service/applicationsignals v1.22.1 h1:midboezGCtGsr
 github.com/aws/aws-sdk-go-v2/service/applicationsignals v1.22.1/go.mod h1:VtkMZ2Ugj03+OEOap4oID3BhbDMiKcExitr43/F/umY=
 github.com/aws/aws-sdk-go-v2/service/appmesh v1.35.15 h1:vmTlolVTemGK//2CRSsX9esIvh9DQqRCKc15Gkwj6Oo=
 github.com/aws/aws-sdk-go-v2/service/appmesh v1.35.15/go.mod h1:IohdJ/2Kiag9GMPP2Uxq8V9qhmrIS7vsGG/+gduSJYE=
-github.com/aws/aws-sdk-go-v2/service/apprunner v1.40.0 h1:zJKGRaZd15XaRLa3eTO9B47lrOvmxSNc9nOciUuDR8Y=
-github.com/aws/aws-sdk-go-v2/service/apprunner v1.40.0/go.mod h1:QA5CUOg5mkS73RhLYCDPeFuCFxoeW2TPA6XRo4JL2Ek=
+github.com/aws/aws-sdk-go-v2/service/apprunner v1.40.1 h1:o/4DSr4gIe+PBGbAIG0SSZrix7MKh7B2m3P3t0dkjCM=
+github.com/aws/aws-sdk-go-v2/service/apprunner v1.40.1/go.mod h1:24gjDeb/xEFpfIfkxh5T1JTDd/f9Gtbada7V52Q401I=
 github.com/aws/aws-sdk-go-v2/service/appstream v1.59.0 h1:9EuZwqW8tDPZQwt2nGnXDBrcHY4CND/Fk7L50P6wV20=
 github.com/aws/aws-sdk-go-v2/service/appstream v1.59.0/go.mod h1:E5vrX7/8w/HM5rhk2LQyuzF+PKECUmE44tp6xvuNYTc=
 github.com/aws/aws-sdk-go-v2/service/appsync v1.53.7 h1:SjkXYNc15FoovS9k6ML7dO7pkXE3ns66RXwL+rfQVl8=

--- a/go.sum
+++ b/go.sum
@@ -275,8 +275,8 @@ github.com/aws/aws-sdk-go-v2/service/globalaccelerator v1.36.1 h1:1YvLkahfJgY0If
 github.com/aws/aws-sdk-go-v2/service/globalaccelerator v1.36.1/go.mod h1:gRlTv00BpckxaCzUTJ+qmVzgQp8YFtGpQz/MRXnRv/M=
 github.com/aws/aws-sdk-go-v2/service/glue v1.142.1 h1:Xq3xf10SK8eQx2C0QmHhveoShZxr1WKLaVsZPBWcfkE=
 github.com/aws/aws-sdk-go-v2/service/glue v1.142.1/go.mod h1:NaK8CYNUIE/ctvfqGl2F9uD9PqTzGQwRENp1MFNgyCs=
-github.com/aws/aws-sdk-go-v2/service/grafana v1.35.0 h1:o9fN0lOXbKu+IL4yY6Z8/Ay8qCjYmtO0wNdg3rfZY5Q=
-github.com/aws/aws-sdk-go-v2/service/grafana v1.35.0/go.mod h1:2O+Qnaf3MT2sWatyqn4FezjE0dHUFJX/m7fiuRdW7SY=
+github.com/aws/aws-sdk-go-v2/service/grafana v1.35.1 h1:FmwZf8Zab+T2eOzl8zUxrnZiAVTMc2lUHiqCUJSR6jc=
+github.com/aws/aws-sdk-go-v2/service/grafana v1.35.1/go.mod h1:ZaE4XEcA7/Gi4Jf9vDpiiIE2zbuy3+bx1tpw0RdWJ/c=
 github.com/aws/aws-sdk-go-v2/service/greengrass v1.32.23 h1:VTghmVEn2zf3DVkqNE9d8gdg+Tc2Lj0CggsTXtU0zGo=
 github.com/aws/aws-sdk-go-v2/service/greengrass v1.32.23/go.mod h1:+tdzf4AVqOA+hkiiLnOIDJDywxXUnbB7IccwOdPrXVQ=
 github.com/aws/aws-sdk-go-v2/service/groundstation v1.41.1 h1:IQAuKMncZtYlrMX4N61s08EVJvllV2mBdNZJF1FAT6g=

--- a/go.sum
+++ b/go.sum
@@ -561,8 +561,8 @@ github.com/aws/aws-sdk-go-v2/service/transcribe v1.55.1 h1:bEAU9OOwAyEOJF8cq94ys
 github.com/aws/aws-sdk-go-v2/service/transcribe v1.55.1/go.mod h1:l8fV0et8V7he/M+q43fNHvzN2jwxUqwBQjP4lJsnf8k=
 github.com/aws/aws-sdk-go-v2/service/transfer v1.72.1 h1:Pj3ornr6k2QZco8JXnwzqBQ4xjnsCE7zuG18Wd3b7pw=
 github.com/aws/aws-sdk-go-v2/service/transfer v1.72.1/go.mod h1:XzQPYzVLZiYqzySF5BqMEDZG8888AzZXVMzq4qdIZm0=
-github.com/aws/aws-sdk-go-v2/service/uxc v1.0.3 h1:IITkqJoAxK9qNzDXCAOisBMcUVhHM5AgUkAXHKu1JwY=
-github.com/aws/aws-sdk-go-v2/service/uxc v1.0.3/go.mod h1:sD2byZmMTGnne1H+za5t3bdPCicEknO9MIqMy0wlR8o=
+github.com/aws/aws-sdk-go-v2/service/uxc v1.0.4 h1:f3FKLPhloiQRS0ImgXLmwjhBTplqBxBiUEUDQEVLjbk=
+github.com/aws/aws-sdk-go-v2/service/uxc v1.0.4/go.mod h1:/rKEAGJenQXrxXXPvxlYBBD5hS4qbQIzoTMKfgeo9do=
 github.com/aws/aws-sdk-go-v2/service/verifiedpermissions v1.33.0 h1:iqCdhY/fp+khS49n07W3t5A4BnA1De5J7539g99IdMk=
 github.com/aws/aws-sdk-go-v2/service/verifiedpermissions v1.33.0/go.mod h1:lQ9Sg9AKiZ7OE/MdjWWN6V6PQS1Sv4Yzf1gj8Usuakc=
 github.com/aws/aws-sdk-go-v2/service/vpclattice v1.21.0 h1:5ZVG7gGUYgKTeHYr56h1tyc/9zQNGQaDqCvz4cUTM3c=

--- a/go.sum
+++ b/go.sum
@@ -173,8 +173,8 @@ github.com/aws/aws-sdk-go-v2/service/connect v1.175.1 h1:2cacszmtdexvFZIo+3wex3B
 github.com/aws/aws-sdk-go-v2/service/connect v1.175.1/go.mod h1:U7i2UrYMvRevhvH0+fzqcgFEDjA+aZw05usgvyWp/v8=
 github.com/aws/aws-sdk-go-v2/service/connectcases v1.42.1 h1:GU/QQUClfsIpr8AiTzW7oDB0MDB4gP8cuG2v8OfjD+U=
 github.com/aws/aws-sdk-go-v2/service/connectcases v1.42.1/go.mod h1:Jd2ciDlob6BwGJIU/VpmdQoOPtrFmpJ9gCePVnjH7jE=
-github.com/aws/aws-sdk-go-v2/service/controltower v1.29.0 h1:5kicsTVcky+MfpGh6KATnmBx3Sx4lzo1JF5vKPVdyG4=
-github.com/aws/aws-sdk-go-v2/service/controltower v1.29.0/go.mod h1:OFxC/BGLWxWAGdqX7BgT/reALU6Pp9NPkvUDM5KJeEg=
+github.com/aws/aws-sdk-go-v2/service/controltower v1.29.1 h1:FG7qE3bUC6XqHY2lQ/BV65q3F8dJea/dW2uLUZYFQyY=
+github.com/aws/aws-sdk-go-v2/service/controltower v1.29.1/go.mod h1:2pnXa7KVMMvd+KdNWGiVuS7Fs4FNtWu+j9Oe9XyQs3U=
 github.com/aws/aws-sdk-go-v2/service/costandusagereportservice v1.34.15 h1:iI5WGYZl5mU9OWa0EBj6TOY0NQ4JLvevo0txMpdq20g=
 github.com/aws/aws-sdk-go-v2/service/costandusagereportservice v1.34.15/go.mod h1:3oLucoNB1dcG76JxzFFsSSnmpwl0BfX7CT1r0BgWavc=
 github.com/aws/aws-sdk-go-v2/service/costexplorer v1.63.8 h1:rUg81vwoGgCmnQxsVl+B65QF8Qh+zYCluhyAcxsk79o=

--- a/go.sum
+++ b/go.sum
@@ -315,8 +315,8 @@ github.com/aws/aws-sdk-go-v2/service/ivs v1.51.0 h1:j9mf27acqCoQYGgOyMnXdofsai5Z
 github.com/aws/aws-sdk-go-v2/service/ivs v1.51.0/go.mod h1:jQ4K6GQ00jAI+UzNdil6lG9bBD6+loFAd2S4GoZAzD4=
 github.com/aws/aws-sdk-go-v2/service/ivschat v1.22.1 h1:VDLXIapXxzqeVeN1y2F1Ac/HjErc7ZPTz+dD0EfiKSg=
 github.com/aws/aws-sdk-go-v2/service/ivschat v1.22.1/go.mod h1:WohHsJOzPsHz8PmhizkZdExh0UbxG1P7zaIyV02Y4xQ=
-github.com/aws/aws-sdk-go-v2/service/kafka v1.52.0 h1:jalIJqKvZMvJRvs6ABLX+FhHz8E9pjU03Pyml4D9r3k=
-github.com/aws/aws-sdk-go-v2/service/kafka v1.52.0/go.mod h1:pW4pYNuVeScl13yqwsjLY0F/7g2YD8E0AvR6SOQsJZE=
+github.com/aws/aws-sdk-go-v2/service/kafka v1.52.1 h1:0Urw2AE2z/Ggs03KStjJT0rGqYScYfIlK6sRt0XlciQ=
+github.com/aws/aws-sdk-go-v2/service/kafka v1.52.1/go.mod h1:oB2qlsK9KHfAmHYQVxro0OwHf+9f1f4i/D9XJ5ibF+k=
 github.com/aws/aws-sdk-go-v2/service/kafkaconnect v1.31.0 h1:M0d76RXXSr320mhbr91xGraQX5qZHyjqaa0TR+FQkzg=
 github.com/aws/aws-sdk-go-v2/service/kafkaconnect v1.31.0/go.mod h1:/hZaVDUfPexuU2tdKL2YU/A+PMvr/PKuMtNuJ/LaiMw=
 github.com/aws/aws-sdk-go-v2/service/kendra v1.60.23 h1:1AZgLYCMh//yiVdPwwltHFFqVxpRboFUtozB3ItiSAQ=

--- a/go.sum
+++ b/go.sum
@@ -415,8 +415,8 @@ github.com/aws/aws-sdk-go-v2/service/paymentcryptography v1.30.1 h1:/qmXfvYpUCvj
 github.com/aws/aws-sdk-go-v2/service/paymentcryptography v1.30.1/go.mod h1:VG1mn7qHIypEmLludHRsXov7u+oW9Pk/Q74fPwIGpKY=
 github.com/aws/aws-sdk-go-v2/service/pcaconnectorad v1.16.1 h1:DdbnVx5+9A5M92fkGprj26BORbkyPG+UbUAJuTpRYIY=
 github.com/aws/aws-sdk-go-v2/service/pcaconnectorad v1.16.1/go.mod h1:jzVcQK4cv6oDsUYYlMrrydw6weuGzmtE4JRIcIup3iM=
-github.com/aws/aws-sdk-go-v2/service/pcs v1.18.0 h1:mQiOx3IVBZ2by9VcOETEgsfNTJrxqbYjoE1UpJ1A5E0=
-github.com/aws/aws-sdk-go-v2/service/pcs v1.18.0/go.mod h1:2OGJaB8B0hHY3ZsIYzEevlMjLpWJCbHcBQJbNi5NGWw=
+github.com/aws/aws-sdk-go-v2/service/pcs v1.19.0 h1:ojV3rqbQU8gXcmJ+grR1axc+mT5mXA+vC4XNr/33DkA=
+github.com/aws/aws-sdk-go-v2/service/pcs v1.19.0/go.mod h1:M+qbwaZuyooD1vA2rrRkoaokZ4V21Kitfu4+qN58Fsw=
 github.com/aws/aws-sdk-go-v2/service/pinpoint v1.39.23 h1:YEwsIfiIhbD4eVaM8GmvFAb5w3MBtNka6lWNBQAEEuc=
 github.com/aws/aws-sdk-go-v2/service/pinpoint v1.39.23/go.mod h1:5cQboSsKjW/hMBKeTzbjK93jmgsiCakuK7m4iNxfiFY=
 github.com/aws/aws-sdk-go-v2/service/pinpointsmsvoicev2 v1.28.2 h1:CCUupPmQvjZRsQlyF6/qmrWgOwLhejP+prj273iCuyY=

--- a/go.sum
+++ b/go.sum
@@ -117,8 +117,8 @@ github.com/aws/aws-sdk-go-v2/service/chimesdkvoice v1.28.16 h1:j6t6St4yP9kQHNyAt
 github.com/aws/aws-sdk-go-v2/service/chimesdkvoice v1.28.16/go.mod h1:7nxpEWr4b40lkq70qNLl7hAEsBOuoTRigacXsgRrTE0=
 github.com/aws/aws-sdk-go-v2/service/cleanrooms v1.45.1 h1:NJCoe6Vj3l8MqvWDcgJr82aVzUlfTJQ0KWcElMAcIvA=
 github.com/aws/aws-sdk-go-v2/service/cleanrooms v1.45.1/go.mod h1:2d8vMUOBBXQ7b5iUZKMAduQZOgDYp75ICcXRXm/NnKc=
-github.com/aws/aws-sdk-go-v2/service/cloud9 v1.34.0 h1:2+hgocCkYVinuAFFV1ujvzdc5W4kbJQBkE0T4zMHYLo=
-github.com/aws/aws-sdk-go-v2/service/cloud9 v1.34.0/go.mod h1:2NzxPvL0r5xpfRQJgQLsc5m7drkG0cvFeowbibC2Qcg=
+github.com/aws/aws-sdk-go-v2/service/cloud9 v1.34.1 h1:Ggr0UznpMf8Bs5VP6k7CqxohKYIcHkXwAbq428cJ79A=
+github.com/aws/aws-sdk-go-v2/service/cloud9 v1.34.1/go.mod h1:GVumurfBCSPfjp0Nq5zyQsFkwxm0u5JpG/1ltIeGyEI=
 github.com/aws/aws-sdk-go-v2/service/cloudcontrol v1.30.0 h1:2Ov1YcFJZktFa5ah08gyktZjEjkbLA0g0sbG6ZxV/G4=
 github.com/aws/aws-sdk-go-v2/service/cloudcontrol v1.30.0/go.mod h1:qdsQO5+urrlkcsolFWgiNQ0lpFB0UCQbTKK9j79b1Wg=
 github.com/aws/aws-sdk-go-v2/service/cloudformation v1.71.11 h1:gIRdzLv98ugE0nvMkub5yp4uziPFHF66ERrQ9JN+D54=

--- a/go.sum
+++ b/go.sum
@@ -425,8 +425,8 @@ github.com/aws/aws-sdk-go-v2/service/pipes v1.24.1 h1:0s9bqePCk0ViKJ4xlLRAG5gm/m
 github.com/aws/aws-sdk-go-v2/service/pipes v1.24.1/go.mod h1:4wuEBSaANzxEjG58fcQeVmB2zV8m+iXQTV1phQdX/sE=
 github.com/aws/aws-sdk-go-v2/service/polly v1.57.6 h1:TqNFnSXqL6eKmMiUCyX+EEQfa3omsM8NUjNaSBSH1Zo=
 github.com/aws/aws-sdk-go-v2/service/polly v1.57.6/go.mod h1:TdxNyiJawW7TwVxHULA7Rg3MStnSgBIBF6S+XiF0o4A=
-github.com/aws/aws-sdk-go-v2/service/pricing v1.42.0 h1:SsLM4EzFcuoHCTOnoldpRLUnJQJ/6/UfxwW33atxrwA=
-github.com/aws/aws-sdk-go-v2/service/pricing v1.42.0/go.mod h1:zXv2YjVkSugNoBHG8WrHHNqCyTFplsE8B8hCAV9riRA=
+github.com/aws/aws-sdk-go-v2/service/pricing v1.42.1 h1:jjVDmqf3S3+KmHR24xJUR5ih2JPH3Hh/mG1r1Sejl28=
+github.com/aws/aws-sdk-go-v2/service/pricing v1.42.1/go.mod h1:lNpZkF5CiauLI0irg40hCRrPRP2Y9Cu9yGTxnSNZh/o=
 github.com/aws/aws-sdk-go-v2/service/qbusiness v1.34.8 h1:fMFheeWMyC7aGeTIz+GJAaKanfOtOzOg78q/v0jKA4E=
 github.com/aws/aws-sdk-go-v2/service/qbusiness v1.34.8/go.mod h1:S8/FKYPSm2WEEGMs5gmbrOrULz0zvJ1CYkf2UEnYzYw=
 github.com/aws/aws-sdk-go-v2/service/qldb v1.32.2 h1:tSctQisNHgXnDmyoOdLXkSQmHYo5yPQuvYK+4c4QiNI=

--- a/go.sum
+++ b/go.sum
@@ -327,8 +327,8 @@ github.com/aws/aws-sdk-go-v2/service/kinesis v1.43.8 h1:MJ1r18td42gvrFGZcu0bHWcq
 github.com/aws/aws-sdk-go-v2/service/kinesis v1.43.8/go.mod h1:f7HKjso4tq0v/kVZB4QNHrZZ0sMZqk/2Wpr7JgL7Y1Y=
 github.com/aws/aws-sdk-go-v2/service/kinesisanalytics v1.30.26 h1:bWGA6teid64RQubUlLy++x3mqcDu2A0EParvmFZ4uyk=
 github.com/aws/aws-sdk-go-v2/service/kinesisanalytics v1.30.26/go.mod h1:F1D1LL8hXSfe0VKDA89e0TvAFFp3slFHMv3C5FaRU50=
-github.com/aws/aws-sdk-go-v2/service/kinesisanalyticsv2 v1.37.2 h1:rln/edRVCCmMlxaFc0UaroIOWEuQr9ih2/1jIUWNNNg=
-github.com/aws/aws-sdk-go-v2/service/kinesisanalyticsv2 v1.37.2/go.mod h1:h9uvfBlO37RRw0CZQIXanA1kqpDEvnsUeVSf9pNej3I=
+github.com/aws/aws-sdk-go-v2/service/kinesisanalyticsv2 v1.38.0 h1:lTH3x76PDEV1aMnPjfCnSFh9FJmrRUFE1ipPBhjq9Lg=
+github.com/aws/aws-sdk-go-v2/service/kinesisanalyticsv2 v1.38.0/go.mod h1:8OH7Tvb6KDFKpID8pkeCo668eGLAe7VsipQtcF7ktLI=
 github.com/aws/aws-sdk-go-v2/service/kinesisvideo v1.33.10 h1:Z3xoYyzvZa3YmIzTdUctjgEEvuE6NMcJqEKHAZkJxns=
 github.com/aws/aws-sdk-go-v2/service/kinesisvideo v1.33.10/go.mod h1:EgB0GBJpnq1xEuoeXnpRixPx2kwaWWMkl5JKMXx43f0=
 github.com/aws/aws-sdk-go-v2/service/kms v1.52.0 h1:QNtg+Mtj1zmepk568+UKBD5DFfqh+ESTUUqQT27JkQc=

--- a/go.sum
+++ b/go.sum
@@ -367,8 +367,8 @@ github.com/aws/aws-sdk-go-v2/service/mediapackagevod v1.39.24 h1:frq+4ymwr6AvyAv
 github.com/aws/aws-sdk-go-v2/service/mediapackagevod v1.39.24/go.mod h1:8onlaKcsWCncSk0syNzxl2FWeurmeqDOciE387GEjQw=
 github.com/aws/aws-sdk-go-v2/service/mediastore v1.29.24 h1:m2irBJGMbk8sMSwzib4pAFNrNqlTtVLgKZIVVQt3lRk=
 github.com/aws/aws-sdk-go-v2/service/mediastore v1.29.24/go.mod h1:LYq03oKrNcnkcLLtcg0EXBUWZ5JXx1a+f3eZiwh77DQ=
-github.com/aws/aws-sdk-go-v2/service/memorydb v1.33.16 h1:sFFA8VBMMksHbFaV689agmYNnKeP162vtYg+4U/Orks=
-github.com/aws/aws-sdk-go-v2/service/memorydb v1.33.16/go.mod h1:Iv+M4ZOQuUzzM7MeyFi/qBZRejA9vi689eZ//Zdxbac=
+github.com/aws/aws-sdk-go-v2/service/memorydb v1.34.1 h1:RhXEEuM4OcMbRSMIqxNjFYwys+T3QYRf0PqzplaqtfY=
+github.com/aws/aws-sdk-go-v2/service/memorydb v1.34.1/go.mod h1:p2VcxOL4NmPRJW3Nl20lghEqJFVhWjZpT5uP46mhM44=
 github.com/aws/aws-sdk-go-v2/service/mgn v1.43.0 h1:/kOYSCEHwgu4rk9mvd/7Dc2G0jfv3sHMcFkOLHphOjs=
 github.com/aws/aws-sdk-go-v2/service/mgn v1.43.0/go.mod h1:fv/GNkmJYpQaKqCiuOcekqutnbRkr5LIPpp5U3u3veQ=
 github.com/aws/aws-sdk-go-v2/service/mpa v1.7.4 h1:ZaNccmns5TnxUasTmyma6Z8nwy70A54OyNwxvFXFLhI=

--- a/go.sum
+++ b/go.sum
@@ -513,8 +513,8 @@ github.com/aws/aws-sdk-go-v2/service/ses v1.34.25 h1:DTpjLExwQKSSWO0Q0zmFRWJTL2z
 github.com/aws/aws-sdk-go-v2/service/ses v1.34.25/go.mod h1:AGkPDUK1aHopltzewQ2M125cJ5LfNGq3UNAvSRqyFUE=
 github.com/aws/aws-sdk-go-v2/service/sesv2 v1.61.1 h1:hwZmof1yhUHQkNDx8RrhX0CMNMFP6HNYCIMgc+R5O3I=
 github.com/aws/aws-sdk-go-v2/service/sesv2 v1.61.1/go.mod h1:5NtZCuE27gANW013bfdrXxD58KB4fr7Lgxub8TS4c6I=
-github.com/aws/aws-sdk-go-v2/service/sfn v1.41.0 h1:DjtJU3mUbj3Q6ggWmiCZuBfOf1k89O55knWuLABRUYs=
-github.com/aws/aws-sdk-go-v2/service/sfn v1.41.0/go.mod h1:4FYhQ/fQeVDlW53MUOevhxGhJ9RYOYV8HSwyVmFCer0=
+github.com/aws/aws-sdk-go-v2/service/sfn v1.41.1 h1:4zfm2N+Ip8J3MMTZhGH1O48Ys41DtHuRzbxA6Qzf/J0=
+github.com/aws/aws-sdk-go-v2/service/sfn v1.41.1/go.mod h1:hjpLasQKdoWfJvDu9X4m4rsH+XUKaRaGa3Uu3zmkKc4=
 github.com/aws/aws-sdk-go-v2/service/shield v1.34.23 h1:J/F0GdRt3gHtS7U5IGq37+dBQR3OCXzDFgAkCRJw//k=
 github.com/aws/aws-sdk-go-v2/service/shield v1.34.23/go.mod h1:G/PDEt2cCa1XH1hHT+g0Px4MzsknI460+3gxVP69V7g=
 github.com/aws/aws-sdk-go-v2/service/signer v1.33.0 h1:TDg2kuUTXjjY98Vmf3TagGSiV6PgnSI79sqPK4rGN4E=

--- a/go.sum
+++ b/go.sum
@@ -125,8 +125,8 @@ github.com/aws/aws-sdk-go-v2/service/cloudformation v1.71.12 h1:XS2aRt1R1+ioudqh
 github.com/aws/aws-sdk-go-v2/service/cloudformation v1.71.12/go.mod h1:QnZX1r0jQrYXnTlpne1T04aGFjbeFtmvY38o+fsVlvU=
 github.com/aws/aws-sdk-go-v2/service/cloudfront v1.64.1 h1:ZTPq5RiymFaH+UoFz0fRV2/mszi8QMXPU/OWr3uxigo=
 github.com/aws/aws-sdk-go-v2/service/cloudfront v1.64.1/go.mod h1:gaGjhyTtT7wcnc7SIPC1+hACSRMQV7VRN8ACY6khGOc=
-github.com/aws/aws-sdk-go-v2/service/cloudfrontkeyvaluestore v1.12.26 h1:nHUJWEa2oFFRWJpTVjxZp2QiaQl89Z8O7rmHW/yeu+0=
-github.com/aws/aws-sdk-go-v2/service/cloudfrontkeyvaluestore v1.12.26/go.mod h1:1HLozcnJWth+NZw49XJlluaQKcOQvkB+MKNiUx35qQI=
+github.com/aws/aws-sdk-go-v2/service/cloudfrontkeyvaluestore v1.13.0 h1:hsxsHl8HC0sGpReyfruPJZCyOt05mYf+tleAOcIr+V0=
+github.com/aws/aws-sdk-go-v2/service/cloudfrontkeyvaluestore v1.13.0/go.mod h1:l6Cy+yFNEducMfkStt4kQjgnqXKslfbqjVH7orDS8og=
 github.com/aws/aws-sdk-go-v2/service/cloudhsmv2 v1.34.25 h1:OOrm22PtgqY0/NaHxytd42a6i6lepRE8PPPPKDRt3eA=
 github.com/aws/aws-sdk-go-v2/service/cloudhsmv2 v1.34.25/go.mod h1:KBEemKWZnAP3hVnxCdSO29XcAaH8D42CJeRy/fjDqgg=
 github.com/aws/aws-sdk-go-v2/service/cloudsearch v1.32.14 h1:dOFz4EN9UgHW91gLgplACvAMElqFXKyHzetpphgjOEo=

--- a/go.sum
+++ b/go.sum
@@ -431,8 +431,8 @@ github.com/aws/aws-sdk-go-v2/service/qbusiness v1.34.9 h1:rmjAYwOYrhNeK5RTBMcr84
 github.com/aws/aws-sdk-go-v2/service/qbusiness v1.34.9/go.mod h1:DTnIR42C7d8ubYOZWmTiBLKP2xxvCQCRYNBkTdhE/7I=
 github.com/aws/aws-sdk-go-v2/service/qldb v1.32.2 h1:tSctQisNHgXnDmyoOdLXkSQmHYo5yPQuvYK+4c4QiNI=
 github.com/aws/aws-sdk-go-v2/service/qldb v1.32.2/go.mod h1:m6bmXbLs5XiGnTLcgKn9eNk5+GCO5e/wHQsIuN7d1Tw=
-github.com/aws/aws-sdk-go-v2/service/quicksight v1.111.0 h1:9lnHJnuRb9o7UXtPNwdOUHjnSuBKuw5RNXG98EiZQdw=
-github.com/aws/aws-sdk-go-v2/service/quicksight v1.111.0/go.mod h1:wlXJJU4SX+4l8Mhu+t1+eOatdX+wT62wHbczlbdHwH8=
+github.com/aws/aws-sdk-go-v2/service/quicksight v1.111.1 h1:/HUZnYW1sHZBAtdTGwuWtVnNjRCixSrvQGxpHHlRrhw=
+github.com/aws/aws-sdk-go-v2/service/quicksight v1.111.1/go.mod h1:pEHxeKThX/zJkHjgLu0WvrODRLYMws3C/K+7pQLkQfo=
 github.com/aws/aws-sdk-go-v2/service/ram v1.36.5 h1:/fBlF6QctcMLhErPd/TzSV41wihdQKVhbrC2zxFtOn4=
 github.com/aws/aws-sdk-go-v2/service/ram v1.36.5/go.mod h1:YRX/UBxAWvjuN/UKBcIgaVcV4L343rUxOifybaw0eFM=
 github.com/aws/aws-sdk-go-v2/service/rbin v1.28.0 h1:Mg/mflO6s0/a2zgtuqR2KGatzJyE+kSwURNfrzCfEBQ=

--- a/go.sum
+++ b/go.sum
@@ -377,8 +377,8 @@ github.com/aws/aws-sdk-go-v2/service/mq v1.34.23 h1:W65gsIOHWb1jwqkILta3uVormtrg
 github.com/aws/aws-sdk-go-v2/service/mq v1.34.23/go.mod h1:8neGcEvd8ny7TLfOT9be0HUx+jA7w46g2QM6JHl4Ptk=
 github.com/aws/aws-sdk-go-v2/service/mwaa v1.40.2 h1:HjEVYf5acZzGMV2vrRsPSsXotF62rjw32IvDs5idLVQ=
 github.com/aws/aws-sdk-go-v2/service/mwaa v1.40.2/go.mod h1:QWhxT8PFUeriuIyNPNoPtKMCpsaxPraSu8V+B50cCcs=
-github.com/aws/aws-sdk-go-v2/service/mwaaserverless v1.0.11 h1:F6jhTASJH6ekrt1mbD/KKxVcA4cZYOLEWLHuPedAw88=
-github.com/aws/aws-sdk-go-v2/service/mwaaserverless v1.0.11/go.mod h1:gnvpQdIADizJ9VLRCzZQLgL0lNz8ZSH73hQWUgR9N70=
+github.com/aws/aws-sdk-go-v2/service/mwaaserverless v1.0.12 h1:WdKoYiwzDxdeaynP/Qo1WnjeSD8JaTaPHxcM5XKFuMc=
+github.com/aws/aws-sdk-go-v2/service/mwaaserverless v1.0.12/go.mod h1:z3yp7mzFwRvWFayqFKJq8hsLxbTD1YiMVeowTwlg2YQ=
 github.com/aws/aws-sdk-go-v2/service/neptune v1.44.5 h1:v+XVk5OQnhm6EasbClY036A1gTtVdtdNdG8/Q3rLYU4=
 github.com/aws/aws-sdk-go-v2/service/neptune v1.44.5/go.mod h1:Y/yH7q6R/qaO4g6YTBbAMSu5T4NjVo+7+P1UNZ2NlzA=
 github.com/aws/aws-sdk-go-v2/service/neptunegraph v1.21.23 h1:0QhwVtPhDWDUN98mArFWF5GyFyeDLntZYGR0fG9l6/w=

--- a/go.sum
+++ b/go.sum
@@ -191,8 +191,8 @@ github.com/aws/aws-sdk-go-v2/service/dataexchange v1.42.1 h1:NV6JSW33vKaD675Zpad
 github.com/aws/aws-sdk-go-v2/service/dataexchange v1.42.1/go.mod h1:LnluRcm5NhbRSq7mIzN/l3+63a89KUNLBrth2lF9QCw=
 github.com/aws/aws-sdk-go-v2/service/datapipeline v1.30.23 h1:6YmSGnneMPxn3l3mHCZp/V22WOSeWFgpVhnOtwq5NOU=
 github.com/aws/aws-sdk-go-v2/service/datapipeline v1.30.23/go.mod h1:98PrkTTHhKEp4uYhBYynJxNeuui1KXR6WvtT1mQGH3U=
-github.com/aws/aws-sdk-go-v2/service/datasync v1.59.0 h1:ZVx+zJCX9kwDoFv5tJxSW3ESEIimK/u8D/tP4ouyIFY=
-github.com/aws/aws-sdk-go-v2/service/datasync v1.59.0/go.mod h1:5H2TlnEkHntq2f9qVEZ9Fc0uO0vf+30KtECvmnms2m8=
+github.com/aws/aws-sdk-go-v2/service/datasync v1.59.1 h1:0rV9cHprMcB05StCAiqt1ZarbSDMst1wzMIDX6fxX5I=
+github.com/aws/aws-sdk-go-v2/service/datasync v1.59.1/go.mod h1:sQV6i+7URqrZCc8IsjVS75RVYdSB9+P31uY6dt7sUqY=
 github.com/aws/aws-sdk-go-v2/service/datazone v1.62.0 h1:ThT7AGMBPcBhDgXVOwiZyJ3x63X4NfruC63Ij4hnFjI=
 github.com/aws/aws-sdk-go-v2/service/datazone v1.62.0/go.mod h1:XdP77XvH2J7MVHRA+i7JSxpEqDC0TeXEfbXPHMQLEFw=
 github.com/aws/aws-sdk-go-v2/service/dax v1.29.18 h1:sZwTAlW7WiDiLBjDk6OvmbOBjXQPooArNkUbTzCupOU=

--- a/go.sum
+++ b/go.sum
@@ -509,8 +509,8 @@ github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.40.1 h1:vyjZg2SefsacQFg
 github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.40.1/go.mod h1:9BpYYXW/GFuScrtiSbfKHLP3LJSYUYKyWLbvXZkB9os=
 github.com/aws/aws-sdk-go-v2/service/servicequotas v1.35.1 h1:ixj7b/LEZAuNWwORvR2xGawnasYHAbzGNVly/fEfq6o=
 github.com/aws/aws-sdk-go-v2/service/servicequotas v1.35.1/go.mod h1:OLExSerzvmddN8vnbNcW1AgvpMHE3LtU/hh4CYLsZXY=
-github.com/aws/aws-sdk-go-v2/service/ses v1.34.24 h1:ZPCoU087iv2IWJKNQyN+MYOqZAM9lEVevS9MHWGG4wI=
-github.com/aws/aws-sdk-go-v2/service/ses v1.34.24/go.mod h1:4T8OWyQ9nkdUrcqHHJkyibP5TfcWDTe4kWL40tiCOcs=
+github.com/aws/aws-sdk-go-v2/service/ses v1.34.25 h1:DTpjLExwQKSSWO0Q0zmFRWJTL2zG4QW/7jtxcKribwc=
+github.com/aws/aws-sdk-go-v2/service/ses v1.34.25/go.mod h1:AGkPDUK1aHopltzewQ2M125cJ5LfNGq3UNAvSRqyFUE=
 github.com/aws/aws-sdk-go-v2/service/sesv2 v1.61.0 h1:d5valptgkxExUHAnyFp4iswYAoTqDD5g32tmTwj18j8=
 github.com/aws/aws-sdk-go-v2/service/sesv2 v1.61.0/go.mod h1:l5cTwZSX9kzxDHz9IpgZC0XIJ/cc43JL6hZzCd0iTwI=
 github.com/aws/aws-sdk-go-v2/service/sfn v1.41.0 h1:DjtJU3mUbj3Q6ggWmiCZuBfOf1k89O55knWuLABRUYs=

--- a/go.sum
+++ b/go.sum
@@ -285,8 +285,8 @@ github.com/aws/aws-sdk-go-v2/service/guardduty v1.78.1 h1:t1B3HJA+ehBVWsbyN06Fca
 github.com/aws/aws-sdk-go-v2/service/guardduty v1.78.1/go.mod h1:mxLYMURDsGZnM8Syt/a0npPMYX28grL3R1xUpiMD0h0=
 github.com/aws/aws-sdk-go-v2/service/healthlake v1.37.1 h1:40UHAoml+Isk+Tp2+kaoK6Vkr7uR7FcIUw+r97HmLvA=
 github.com/aws/aws-sdk-go-v2/service/healthlake v1.37.1/go.mod h1:q3E7DgMX7FNV9Q1Fqv/E6aLa7fcDqOK50zVinEKeRyU=
-github.com/aws/aws-sdk-go-v2/service/iam v1.53.10 h1:kcN3I3llO7VwIY5w3Pc5FmEonpsr23Ou7Cwk4qf7dik=
-github.com/aws/aws-sdk-go-v2/service/iam v1.53.10/go.mod h1:1vkJzjCYC3byO0kIrBqLPzvZpuvYhPXkuyARs6E7tM4=
+github.com/aws/aws-sdk-go-v2/service/iam v1.53.11 h1:xt4JHLHBQonQXApaYfS0FvdIeALRuaN/aUWxM+4RNSo=
+github.com/aws/aws-sdk-go-v2/service/iam v1.53.11/go.mod h1:VkuYu8oSpQAx+hKNFvJqqei6/PACzkpqVdM6ylo0scg=
 github.com/aws/aws-sdk-go-v2/service/identitystore v1.37.0 h1:iVXnOYef3NmG72qZt525K8H2gdYJ03MTw/QaeTiKl0E=
 github.com/aws/aws-sdk-go-v2/service/identitystore v1.37.0/go.mod h1:9xdQ3N06kOdsL2JVtw8HhtpFA+bnTCoKhfBY4oKi8kM=
 github.com/aws/aws-sdk-go-v2/service/imagebuilder v1.54.0 h1:MlFy3L3RStulK0LNyq9LzrRf45nsCYsIK6fw3M4St8s=

--- a/go.sum
+++ b/go.sum
@@ -259,8 +259,8 @@ github.com/aws/aws-sdk-go-v2/service/evs v1.10.1 h1:Yhpuxq270m6fkSTcv4+XqshcPrcC
 github.com/aws/aws-sdk-go-v2/service/evs v1.10.1/go.mod h1:QAoOVq2InsEnSsl3MR+RstiyukTltYJqHVbT/ImJv2w=
 github.com/aws/aws-sdk-go-v2/service/finspace v1.34.1 h1:sQa8VyMLc2BhEy8kLuve3ufn3bh6W8BQv+xmpa52/Fw=
 github.com/aws/aws-sdk-go-v2/service/finspace v1.34.1/go.mod h1:kpT6GkbkbP3ZJUvz+9iaeXvcv79VmfN5X9xzQJidB3E=
-github.com/aws/aws-sdk-go-v2/service/firehose v1.42.16 h1:nSg1UAENCjuryTr9JMPMOPXkYOkcpVwQjrrp5rkHUus=
-github.com/aws/aws-sdk-go-v2/service/firehose v1.42.16/go.mod h1:8atLs+8lOWcDaxiD+suvyvt63IuwLbT8zlU6Ti9qZiY=
+github.com/aws/aws-sdk-go-v2/service/firehose v1.42.17 h1:OyU46F3vfHyX8XIf6jAyXtGu7wA1zE/XzmIbLVt+orQ=
+github.com/aws/aws-sdk-go-v2/service/firehose v1.42.17/go.mod h1:B0QS9gXSFnQlvnw8hGDigT6KBkEh/om5C+WvdfoWYXw=
 github.com/aws/aws-sdk-go-v2/service/fis v1.37.22 h1:2LO81Hj8dYOxioN/ztt5iiSzrYgIgMe3wowSEcW5VsY=
 github.com/aws/aws-sdk-go-v2/service/fis v1.37.22/go.mod h1:NW+8sdgF3jxYlnmmmzSnPnfGdgoJP1rUlbn+9m8O1+8=
 github.com/aws/aws-sdk-go-v2/service/fms v1.45.0 h1:OZj0sNgMfshwwIi59oXDj8EWaEES0faYNUZ/iO9fV9E=

--- a/go.sum
+++ b/go.sum
@@ -441,8 +441,8 @@ github.com/aws/aws-sdk-go-v2/service/rds v1.118.3 h1:Q6o5SuzC3+T1WjA6y/+vxPkFRFX
 github.com/aws/aws-sdk-go-v2/service/rds v1.118.3/go.mod h1:Fjbrf3IlJCagXHMf1GRBLmpcBXK60g3y9laWG2lgUmg=
 github.com/aws/aws-sdk-go-v2/service/rdsdata v1.32.24 h1:i62rjzGXWqDWVhpO/KVBw3ez5ANAu9Gh4RzJRnJSE+A=
 github.com/aws/aws-sdk-go-v2/service/rdsdata v1.32.24/go.mod h1:N5iVwQXS/jDd0ljhmLfd8W3295wp4gwKvNAXhPjyCKQ=
-github.com/aws/aws-sdk-go-v2/service/redshift v1.62.8 h1:5Wg38ZauCqmomDAGTCDbA/t4vR5fUqIBTEwAOAswdng=
-github.com/aws/aws-sdk-go-v2/service/redshift v1.62.8/go.mod h1:uLWlNO4q8278lSx2iKIJZ09zSXNJ6uQTFM1jvZIZRf4=
+github.com/aws/aws-sdk-go-v2/service/redshift v1.62.9 h1:YHFGMgQa2zDRUTzvD8GtrOJoO96aU1BduliXEl65NtU=
+github.com/aws/aws-sdk-go-v2/service/redshift v1.62.9/go.mod h1://ALEpBVXJfV8saFPor8HMJ74xERWhrOYaPd+pNWUdk=
 github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.39.2 h1:5MMxyip6xYVD6LgkaXM2wJVnUabv5rUf3nWBdNQRXRo=
 github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.39.2/go.mod h1:jLwMScfDY+ED2F2pglheE5OV6TCC/B8rnxVgX4qaAO8=
 github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.35.0 h1:4bhy+oTqgUdtw8IvWcc1pPL4DCH5ZT4rkV9a1eggQGY=

--- a/go.sum
+++ b/go.sum
@@ -291,8 +291,8 @@ github.com/aws/aws-sdk-go-v2/service/identitystore v1.37.1 h1:hNsPPU6m/Hi0p2QXm4
 github.com/aws/aws-sdk-go-v2/service/identitystore v1.37.1/go.mod h1:STQWDynKsiZADmYxFBQ+hUx9VBMxGu5ZhdN6PPIrBXU=
 github.com/aws/aws-sdk-go-v2/service/imagebuilder v1.55.1 h1:BatfYeFcs220jnKlxrPE+mMtBOiiszLousw5jSVGClw=
 github.com/aws/aws-sdk-go-v2/service/imagebuilder v1.55.1/go.mod h1:IjRdS2Ybudj2D7Vpt5OPcJax5JEFOrhmviv9aesTuds=
-github.com/aws/aws-sdk-go-v2/service/inspector v1.30.22 h1:phWl4pu6OSvB8xRF14eTKWrvk7hQspQqz1YqyV++fmA=
-github.com/aws/aws-sdk-go-v2/service/inspector v1.30.22/go.mod h1:BRKeLwlPqToFLwqO3GcIETzktr5QvnWprfI/iICeyJ0=
+github.com/aws/aws-sdk-go-v2/service/inspector v1.30.23 h1:xZpQfU8tqiHpQ3bW3XvZAaKh2nGWCOnQ33AN9rToWYo=
+github.com/aws/aws-sdk-go-v2/service/inspector v1.30.23/go.mod h1:1QT2AJ4rehmxv/05zIB2PUqDF5I9J1g0scaNE78H2QA=
 github.com/aws/aws-sdk-go-v2/service/inspector2 v1.47.7 h1:vHOhsldnj34FLcf4Vhruf4rXjuS/h2+rVq7g/Ff2Z1E=
 github.com/aws/aws-sdk-go-v2/service/inspector2 v1.47.7/go.mod h1:LuywkZEbCgj1aB3Ij62TrWfPThhx6GHJqZSO1ZDj2cM=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.9 h1:FLudkZLt5ci0ozzgkVo8BJGwvqNaZbTWb3UcucAateA=

--- a/go.sum
+++ b/go.sum
@@ -115,8 +115,8 @@ github.com/aws/aws-sdk-go-v2/service/chimesdkmediapipelines v1.27.1 h1:JP5Jz9OCn
 github.com/aws/aws-sdk-go-v2/service/chimesdkmediapipelines v1.27.1/go.mod h1:/4racxzJ7S4x0j6EkPl7YpBqncHL2v85hchmoY+JnB8=
 github.com/aws/aws-sdk-go-v2/service/chimesdkvoice v1.28.16 h1:j6t6St4yP9kQHNyAtQe6YSsT6HUlsneVzmvGahwPKGo=
 github.com/aws/aws-sdk-go-v2/service/chimesdkvoice v1.28.16/go.mod h1:7nxpEWr4b40lkq70qNLl7hAEsBOuoTRigacXsgRrTE0=
-github.com/aws/aws-sdk-go-v2/service/cleanrooms v1.45.0 h1:kBzMXsg/R1N25ylMalFU29HdrQotblZgDcenVwvgWZo=
-github.com/aws/aws-sdk-go-v2/service/cleanrooms v1.45.0/go.mod h1:HCv37Z4wolPLADD63F9X3nIfKcxA1WwH9NJjWChRzMU=
+github.com/aws/aws-sdk-go-v2/service/cleanrooms v1.45.1 h1:NJCoe6Vj3l8MqvWDcgJr82aVzUlfTJQ0KWcElMAcIvA=
+github.com/aws/aws-sdk-go-v2/service/cleanrooms v1.45.1/go.mod h1:2d8vMUOBBXQ7b5iUZKMAduQZOgDYp75ICcXRXm/NnKc=
 github.com/aws/aws-sdk-go-v2/service/cloud9 v1.34.0 h1:2+hgocCkYVinuAFFV1ujvzdc5W4kbJQBkE0T4zMHYLo=
 github.com/aws/aws-sdk-go-v2/service/cloud9 v1.34.0/go.mod h1:2NzxPvL0r5xpfRQJgQLsc5m7drkG0cvFeowbibC2Qcg=
 github.com/aws/aws-sdk-go-v2/service/cloudcontrol v1.30.0 h1:2Ov1YcFJZktFa5ah08gyktZjEjkbLA0g0sbG6ZxV/G4=

--- a/go.sum
+++ b/go.sum
@@ -565,8 +565,8 @@ github.com/aws/aws-sdk-go-v2/service/uxc v1.0.4 h1:f3FKLPhloiQRS0ImgXLmwjhBTplqB
 github.com/aws/aws-sdk-go-v2/service/uxc v1.0.4/go.mod h1:/rKEAGJenQXrxXXPvxlYBBD5hS4qbQIzoTMKfgeo9do=
 github.com/aws/aws-sdk-go-v2/service/verifiedpermissions v1.34.0 h1:LqkQfCt37IEbUtvi8hJpJOBSOwZSDOMYNr2jH6/Vk2o=
 github.com/aws/aws-sdk-go-v2/service/verifiedpermissions v1.34.0/go.mod h1:ujqEP1vFTIBsr/Fn2iZiaM3fHvlrfFfXkikWaZaU5aQ=
-github.com/aws/aws-sdk-go-v2/service/vpclattice v1.21.0 h1:5ZVG7gGUYgKTeHYr56h1tyc/9zQNGQaDqCvz4cUTM3c=
-github.com/aws/aws-sdk-go-v2/service/vpclattice v1.21.0/go.mod h1:GMCAnmnB2tlV0CrzwpowxpLb2H+MCp0mvW5A1DvwIKI=
+github.com/aws/aws-sdk-go-v2/service/vpclattice v1.21.1 h1:XNrEJtc7gbo+UK9Otbyy/0Uobvx3lq60usTf01qxWgY=
+github.com/aws/aws-sdk-go-v2/service/vpclattice v1.21.1/go.mod h1:+6bxeMVFiKF9DbsnlPWSZZc09qvkEJAPaC9dZQvABYU=
 github.com/aws/aws-sdk-go-v2/service/waf v1.30.22 h1:EI78jKQQi/G+HRZeopJFSPSyG1/GzjCTeGd/1HPLHw8=
 github.com/aws/aws-sdk-go-v2/service/waf v1.30.22/go.mod h1:0KD+OoOdCNYDPZuFx2Ul5hHamV/vuC/Xs/f+Ke2x6y8=
 github.com/aws/aws-sdk-go-v2/service/wafregional v1.30.23 h1:nSMoPH2GSzNREwCcUNgUuTT5fbN/NRlLXmF4ozCWXmw=

--- a/go.sum
+++ b/go.sum
@@ -479,8 +479,8 @@ github.com/aws/aws-sdk-go-v2/service/s3control v1.71.0 h1:WLG6J5K6u5wY6rRt/H/9bd
 github.com/aws/aws-sdk-go-v2/service/s3control v1.71.0/go.mod h1:XDxWqWcbRTSEjyGQ11yXnlrSvyacvuA/r00Xw7XqxTo=
 github.com/aws/aws-sdk-go-v2/service/s3files v1.0.3 h1:S3+dpkrgIdGvw8kt4bESzv+uUo49Cqnn/rnx1Sjh9j8=
 github.com/aws/aws-sdk-go-v2/service/s3files v1.0.3/go.mod h1:peu+U0l09wQS8QIDhZU9dHM35RkvmtBjaVPWNioftX8=
-github.com/aws/aws-sdk-go-v2/service/s3outposts v1.34.14 h1:+Kd3/zK8ivdwLKtMeqXcPPU+v2X7juW73BgRDKqMD8o=
-github.com/aws/aws-sdk-go-v2/service/s3outposts v1.34.14/go.mod h1:mWkKCdYcl0Oem0dQ1PVdn3sjPSe9wi9UtGOsu2d/ncA=
+github.com/aws/aws-sdk-go-v2/service/s3outposts v1.34.15 h1:dpMlv/sdP2z367O3/YniZHbuYXBlATqaSYX4ukOd07A=
+github.com/aws/aws-sdk-go-v2/service/s3outposts v1.34.15/go.mod h1:YXQPuBVEAA+8BRLzs3FMwvcfUdTvXVBRCIrPMghTmDM=
 github.com/aws/aws-sdk-go-v2/service/s3tables v1.16.0 h1:/oAhojlGOkpTz9qnblIpoq7tYvjU6smR2cTHGauvjQA=
 github.com/aws/aws-sdk-go-v2/service/s3tables v1.16.0/go.mod h1:eppybYlnphhnRlQ92dS4ENotpFE2OmwyJsVIICCOjW8=
 github.com/aws/aws-sdk-go-v2/service/s3vectors v1.7.0 h1:CABF4mzlIlRhO0F+HxxIVHMnlCE776sZ+nqkwrdxTc4=

--- a/go.sum
+++ b/go.sum
@@ -147,8 +147,8 @@ github.com/aws/aws-sdk-go-v2/service/codecommit v1.33.15 h1:jG7/DRMMhbNG4S7mDRdZ
 github.com/aws/aws-sdk-go-v2/service/codecommit v1.33.15/go.mod h1:TWZz5ml6Jv36EO4eUGxp82JucQuG/ZH4InxEcLetXZg=
 github.com/aws/aws-sdk-go-v2/service/codeconnections v1.11.1 h1:IkztdxEx9jg3mtcn/0PQ5sb/y5yCJ1tbNHaQahdfweA=
 github.com/aws/aws-sdk-go-v2/service/codeconnections v1.11.1/go.mod h1:4Txe845x0NmXze3vzvVAw9Iy/Cb4dyVnxvk+qTceMJI=
-github.com/aws/aws-sdk-go-v2/service/codedeploy v1.35.15 h1:iFcroRD6TUmNLCoAMdPJGV28h1K4yULxNludMiA/LwA=
-github.com/aws/aws-sdk-go-v2/service/codedeploy v1.35.15/go.mod h1:r8xU4gaQ0oQNlfptj6Lzyv2Ityc2o0Sp3Gl3bX8KVE0=
+github.com/aws/aws-sdk-go-v2/service/codedeploy v1.35.16 h1:SWw60uVRCfmuw11uZVKz8gXaNSONa4KcgtK7jUy8yXY=
+github.com/aws/aws-sdk-go-v2/service/codedeploy v1.35.16/go.mod h1:BQ4gZJB6Cu71Aft0Dp5nal9mwlLGJIrYy3X36Zu1giY=
 github.com/aws/aws-sdk-go-v2/service/codeguruprofiler v1.30.0 h1:h9gG2F8LkS6IICbMUKVNquYeNYKTzNOZBkLx6NSlFN8=
 github.com/aws/aws-sdk-go-v2/service/codeguruprofiler v1.30.0/go.mod h1:fheDmr63trGw/27X+o9ZpPBN4GCOBCghaZBLoCO0NIo=
 github.com/aws/aws-sdk-go-v2/service/codegurureviewer v1.34.22 h1:3SujyqCjZ0WFkwhReUv6bWvVzoqQeS//pQT7ByeqXiE=

--- a/go.sum
+++ b/go.sum
@@ -447,8 +447,8 @@ github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.40.0 h1:jbRyKYbNrEnRd+nphrU
 github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.40.0/go.mod h1:WPZLtD9otyFLcz+ZxS3QUuCd67f+7kAJaPjJ31ahO3M=
 github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.35.1 h1:q4W7YdDkLlrIjhk9zKEuGSIinADL6G/qZMNQBD6LNcg=
 github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.35.1/go.mod h1:qmN3dNnbhFHpwkQbpqbjjDH4co6/ETmKavalziNWLLs=
-github.com/aws/aws-sdk-go-v2/service/rekognition v1.51.24 h1:TjTpw5c4Z5DFHRHMZqL+rR/Jk9zlsGW4/gQxCqgWiHY=
-github.com/aws/aws-sdk-go-v2/service/rekognition v1.51.24/go.mod h1:1j7mu8NwhHLrAB43agCDAv4BsncoE0Ld+JWpDgUKH6w=
+github.com/aws/aws-sdk-go-v2/service/rekognition v1.51.25 h1:sHLu2nnBgPPimcMM5ux3jvaX2EA8DGrYqNQ5q6B3YPI=
+github.com/aws/aws-sdk-go-v2/service/rekognition v1.51.25/go.mod h1:FgKCcRxb+AKh5sEpCa2hFSUa5LX85mNMxba7DJXxgtw=
 github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.36.0 h1:1Nsy4eFGYxZqGfDA6+X23ngP1QiXmqjititE5quiVX0=
 github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.36.0/go.mod h1:SgbYsV9bP7Ol85rNEwH3PY1cgw/UWZCNkoUhMfb236U=
 github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.23.6 h1:v4Gii9Pxx4bvvNmV5Se1pmx0ag5+Eb3/wZkT03iyCCI=

--- a/go.sum
+++ b/go.sum
@@ -399,8 +399,8 @@ github.com/aws/aws-sdk-go-v2/service/oam v1.24.1 h1:QrXBn2Al2hSKd7iuncZwBh3Sm/M4
 github.com/aws/aws-sdk-go-v2/service/oam v1.24.1/go.mod h1:eQpqFnDbhCA78FU2Z5ZHyQ/x8mxPJMfWms/BnyB3POc=
 github.com/aws/aws-sdk-go-v2/service/observabilityadmin v1.16.1 h1:UuKlVsiBejuh5sXgRRPPP0NcuDf5CArVCw4IBBEwwpM=
 github.com/aws/aws-sdk-go-v2/service/observabilityadmin v1.16.1/go.mod h1:krmgFpcpTaoPQlNgbliWg/O+UxC/jXn26a0NKKldCnY=
-github.com/aws/aws-sdk-go-v2/service/odb v1.11.0 h1:ugOElkAyu12xSVwgBZc4kK/bydeJpo7HVeWOqHFLSJ8=
-github.com/aws/aws-sdk-go-v2/service/odb v1.11.0/go.mod h1:2e7052lsNNzRF38Ogopkj2dlzFlSOQi3yX+uO8056pQ=
+github.com/aws/aws-sdk-go-v2/service/odb v1.11.1 h1:PMrQsLY8KqDizjsK3Mn+GhXIplc6xLPSyww17jzFJV0=
+github.com/aws/aws-sdk-go-v2/service/odb v1.11.1/go.mod h1:hyWPzIu5qQyr7VBqZa/Y3gyrnsEsYbjvdd5d3IKKWvc=
 github.com/aws/aws-sdk-go-v2/service/opensearch v1.69.0 h1:ogIqeUpD0k00Jr7DwaaO6VIR0o6aqnLiLetBVLgYt/4=
 github.com/aws/aws-sdk-go-v2/service/opensearch v1.69.0/go.mod h1:m6jcW6ksKQtM4f/AsUbYdfbyM9xv4jjrBnRWWh1q0VQ=
 github.com/aws/aws-sdk-go-v2/service/opensearchserverless v1.30.3 h1:47FPswEE4RKBY0sUivfFCqBS5PVAfg2iiNaSl9rHOX4=

--- a/go.sum
+++ b/go.sum
@@ -239,8 +239,8 @@ github.com/aws/aws-sdk-go-v2/service/elasticbeanstalk v1.34.5 h1:lngZe4LXmP9FlF9
 github.com/aws/aws-sdk-go-v2/service/elasticbeanstalk v1.34.5/go.mod h1:lxzT/1L6i9X/yAAE1zArAoFjWao/tjlfwo38zFp+RI0=
 github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing v1.33.26 h1:4dwPvA64UPjLWC7m3yrdWeRVdvPDKPbqyBrH5n9NJKM=
 github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing v1.33.26/go.mod h1:Xct3NIOlINw4osqGbz1ryjxo5+Hro1YpY2xyZ426JYc=
-github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.54.12 h1:TJXv7kZjdXA2maPDaJFFEQPBrPmvPtMybN3qYDOpJ4Y=
-github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.54.12/go.mod h1:lwjtb9DHOAmNt7EUW68Zd1Qd+cPyFxacXHN5c9JZ2VY=
+github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.54.13 h1:buH8t6gaixz7eOUZT80GGgG/DZaUlsE/C/Tm8geXI18=
+github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.54.13/go.mod h1:m5G75JYjHbUd9ojxhN36A2Z4hoYRQZ4aOApHJZfGsMA=
 github.com/aws/aws-sdk-go-v2/service/elasticsearchservice v1.41.0 h1:+2UoP7IQFeATSuXiv4REnMSNIIQVEhG3yNIypruQoa8=
 github.com/aws/aws-sdk-go-v2/service/elasticsearchservice v1.41.0/go.mod h1:KQ3FbmRw8nNDoSn6ykLZKyj6hlAHcu/oeLBjnofRjS0=
 github.com/aws/aws-sdk-go-v2/service/elastictranscoder v1.33.0 h1:ZD8Iw3WQlZYoCJtK3VBAUVO0DZFLSfHCKbze1xfYRdc=

--- a/go.sum
+++ b/go.sum
@@ -241,8 +241,8 @@ github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing v1.33.26 h1:4dwPvA64UP
 github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing v1.33.26/go.mod h1:Xct3NIOlINw4osqGbz1ryjxo5+Hro1YpY2xyZ426JYc=
 github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.54.13 h1:buH8t6gaixz7eOUZT80GGgG/DZaUlsE/C/Tm8geXI18=
 github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.54.13/go.mod h1:m5G75JYjHbUd9ojxhN36A2Z4hoYRQZ4aOApHJZfGsMA=
-github.com/aws/aws-sdk-go-v2/service/elasticsearchservice v1.41.0 h1:+2UoP7IQFeATSuXiv4REnMSNIIQVEhG3yNIypruQoa8=
-github.com/aws/aws-sdk-go-v2/service/elasticsearchservice v1.41.0/go.mod h1:KQ3FbmRw8nNDoSn6ykLZKyj6hlAHcu/oeLBjnofRjS0=
+github.com/aws/aws-sdk-go-v2/service/elasticsearchservice v1.41.1 h1:JRRK81bkltTYmSMKM7enQUqwEFZaX4vgRKzVwKyux0M=
+github.com/aws/aws-sdk-go-v2/service/elasticsearchservice v1.41.1/go.mod h1:OuZGLKWumnY/JRK/brwybxha4yAonCWeS5XeUyr0XuE=
 github.com/aws/aws-sdk-go-v2/service/elastictranscoder v1.33.0 h1:ZD8Iw3WQlZYoCJtK3VBAUVO0DZFLSfHCKbze1xfYRdc=
 github.com/aws/aws-sdk-go-v2/service/elastictranscoder v1.33.0/go.mod h1:1TkRQZaHJfi2GSj/kQNuxQVUyKLAErm+QXF6Dvz7iOs=
 github.com/aws/aws-sdk-go-v2/service/emr v1.59.2 h1:BR7dPfnYULtw1QMLTb4p67A5O7cOhwsRh6arvYQFIQg=

--- a/go.sum
+++ b/go.sum
@@ -63,8 +63,8 @@ github.com/aws/aws-sdk-go-v2/service/appfabric v1.16.24 h1:or50VRIC8Teh4DNVXcLfe
 github.com/aws/aws-sdk-go-v2/service/appfabric v1.16.24/go.mod h1:Vuux/tWc3oyiGn9BSSErHjU5lXQElBbkb/VZFOGeVJM=
 github.com/aws/aws-sdk-go-v2/service/appflow v1.51.15 h1:iz+/nmbL/lLn6Jdqb3xXNE92k15LH7E84VdSNg1lDgI=
 github.com/aws/aws-sdk-go-v2/service/appflow v1.51.15/go.mod h1:f3rmeXbgWBepM1ftO73MEVbi2OkAo2dbhJiW30+xK1w=
-github.com/aws/aws-sdk-go-v2/service/appintegrations v1.37.9 h1:e51YjJHGLC86GPxLox3PNwnlbgMbLPJ7Ph4vcTeM4GY=
-github.com/aws/aws-sdk-go-v2/service/appintegrations v1.37.9/go.mod h1:EhPRMWYqp8CDlJ/EEYNegsBOTTJRN6HbNaUCQ9J7JGw=
+github.com/aws/aws-sdk-go-v2/service/appintegrations v1.37.10 h1:1KCD21KPp0HrEKXB7zlQcS5cxD0bKhDPKZcybJzp7iA=
+github.com/aws/aws-sdk-go-v2/service/appintegrations v1.37.10/go.mod h1:aRi8xw3Xl/McDp/yDbgzZsr10xVgG/iYYOath9LvooQ=
 github.com/aws/aws-sdk-go-v2/service/applicationautoscaling v1.41.16 h1:9ePxWacyZEGJQIBfYxumxYjDZvvpCcUAnFQUQy4GI2U=
 github.com/aws/aws-sdk-go-v2/service/applicationautoscaling v1.41.16/go.mod h1:gR1tnThD1DBemyG1rmZ9U5+WbfGoiLUaZDvsQ6wbAjM=
 github.com/aws/aws-sdk-go-v2/service/applicationinsights v1.34.22 h1:Efp05vChZXL5og/ix/bjwIB8Yea0Kge//pGnbQk22Mc=

--- a/go.sum
+++ b/go.sum
@@ -199,8 +199,8 @@ github.com/aws/aws-sdk-go-v2/service/dax v1.29.19 h1:s+l4YYZcDuYI8EvhxV+66xj7mKw
 github.com/aws/aws-sdk-go-v2/service/dax v1.29.19/go.mod h1:hIn61FGs/Ju7NY+Hf8OwNAxMo1v83/eBkH+AuqCk8dc=
 github.com/aws/aws-sdk-go-v2/service/detective v1.39.0 h1:YfhUgn/USIV3sTmMeHdpQn4VTCLSYMtNzbX6gX3zkdY=
 github.com/aws/aws-sdk-go-v2/service/detective v1.39.0/go.mod h1:2PAHITEaW85PWDdqe3TuSny3o+BD4uoystdaH/EYJdE=
-github.com/aws/aws-sdk-go-v2/service/devicefarm v1.38.10 h1:57LpTN6FaBV417EbwvNC0/rdFRhZm/nrf01XEXPy+nI=
-github.com/aws/aws-sdk-go-v2/service/devicefarm v1.38.10/go.mod h1:PrGKZECbjGdAFagZ+UlbXV2Gw9B287/VJ/Y48YmmAQQ=
+github.com/aws/aws-sdk-go-v2/service/devicefarm v1.38.11 h1:71pCfxH8KVqP34bsmmDw35FR54dVbdcnbVFYqovpyAY=
+github.com/aws/aws-sdk-go-v2/service/devicefarm v1.38.11/go.mod h1:I/md2ejJNL/3hWXi+iAkbiNPrhQq0cqMWPd7c0NOiVg=
 github.com/aws/aws-sdk-go-v2/service/devopsagent v1.4.0 h1:XaP6w9oxccwZ5ycXQD7WNsKI+rPGrh9u4jzugPR+1mE=
 github.com/aws/aws-sdk-go-v2/service/devopsagent v1.4.0/go.mod h1:QmrrmO/P7VfCf68eQbY+kXL+ZuyUjbAUs82sKOHw14c=
 github.com/aws/aws-sdk-go-v2/service/devopsguru v1.41.0 h1:oivWpWrQ2iwG9uQIcwJfEwi+FgDD8weBrTG5/CnS8qY=

--- a/go.sum
+++ b/go.sum
@@ -219,8 +219,8 @@ github.com/aws/aws-sdk-go-v2/service/drs v1.38.3 h1:HwQ821+/yd6GSmIWHU2cSUUEcTp2
 github.com/aws/aws-sdk-go-v2/service/drs v1.38.3/go.mod h1:iq+Z1AOHKY/yRRUtgxQjCKjAEuHNiQcYsULuGHZKJLA=
 github.com/aws/aws-sdk-go-v2/service/dsql v1.14.1 h1:RmsuXZWU4Ij5fN7ODA7DIJxX36z43LgovrghT/MfvgQ=
 github.com/aws/aws-sdk-go-v2/service/dsql v1.14.1/go.mod h1:gyjbYTqyg94CBANbsuY+rBFxHCt1On5N6NdTQkUiIAk=
-github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.4 h1:0E3bfw1Va3vfCrmtATvKRnGojY4oIlLl0u0xRDDUgfY=
-github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.4/go.mod h1:dFPU89qDDGgQbXyzQ5ZY6zcjjKPVW+1M63axOw887JE=
+github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.5 h1:8dBj9DoTg1rNP/n5FC13c7zc97hx6Urc+jT+iSC7PVA=
+github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.5/go.mod h1:cFa8ItF/dcfex+Op4D0oWbZePIq1ljmrAOAGlEQyGHo=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.304.0 h1:wZthLlYdKxBo7NpWLbl0A/8DB/QNDB+8RJa9WboK9Q0=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.304.0/go.mod h1:Y95W0Hm6FYLPa6o0hbnJ+sWgmdc4ifcLFjGkdobWVhY=
 github.com/aws/aws-sdk-go-v2/service/ecr v1.57.2 h1:rHEW02JFJUV2/ttjzyPIvbD0YraqpyU2w6m6DfQUmdg=
@@ -299,8 +299,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.9 h1:FLudkZL
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.9/go.mod h1:w7wZ/s9qK7c8g4al+UyoF1Sp/Z45UwMGcqIzLWVQHWk=
 github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.17 h1:Zma31M1f9bbD/bsl6haTxupA0+z72L3l2ujKAH37zuI=
 github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.17/go.mod h1:ZNHrGwBST3tZxBCTKbindx0BEdPN0Jnh7yJ7EVnktUM=
-github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.12.0 h1:iNQlIMVathbcvo6USGjFFO8SgANIBg5hsoIv/QAiYK4=
-github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.12.0/go.mod h1:3oh+5xGSd1iuxonVb3Qbm+WJYlbhczT9kbzr6doJLzY=
+github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.12.1 h1:7InFIafuKLWUQ3hieU3b23JmEKlFAWIzq9GHmYn4rWA=
+github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.12.1/go.mod h1:lfCeSIEwe7jvMcEBKcQ/vVoYK0RNJh1X8pja5GqDQtM=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.24 h1:CQW2FTrflfoslYWLf3fv7vG28Q219+v8YJS5QTQb2+Y=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.24/go.mod h1:Xfx13T+u3nH6EEzgl9fBSO6nDRmze1FvnZNYkctQ2zw=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.24 h1:yPLVC8Lbsw92eepgdIZCChHRNQek5eAvAz5wS+UIpJE=

--- a/go.sum
+++ b/go.sum
@@ -503,8 +503,8 @@ github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.31.1 h1:
 github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.31.1/go.mod h1:J2Tcq2gsS7odqtAtMBWjcqnvh0Iz2l1SCowpzMBO0xE=
 github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.39.16 h1:mbqBPEMz8JjdTM1MhyimEBErhVwlK0L4dZjpo1kXDck=
 github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.39.16/go.mod h1:P0nEJjEHZpZ+BLv4iUjkIfNjvvpCXcJoyvjlN02AwZ4=
-github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry v1.36.0 h1:kXEL4NsZt/JUCMOzQFi5qSD2CcfkzuZba4bvPdNsgtY=
-github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry v1.36.0/go.mod h1:G6KLt0Sx2E6KKOJscRGWeuQ1V4IEYitzbmmgzXYc5hA=
+github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry v1.36.1 h1:wuMAk0DcF1Us0+vZzgIePw7fVdfy4Xj0gg7TlmtC/0g=
+github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry v1.36.1/go.mod h1:cL0D+MJfloyTVGgf3zmcavs4giz3W1x/z/wMo9O4V+M=
 github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.40.0 h1:8eUbfsuVdhqlek1EJny/jE2OSbhjSpnsRsyOTFowDlo=
 github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.40.0/go.mod h1:1lUDU6qw3e5FKsegwe+hZZJJXUjg8/L/szYUgVih8yM=
 github.com/aws/aws-sdk-go-v2/service/servicequotas v1.35.0 h1:qaB32zX2iiSWa2ml5DO0F71AOU+VuyuttbFd+kxxzf0=

--- a/go.sum
+++ b/go.sum
@@ -501,8 +501,8 @@ github.com/aws/aws-sdk-go-v2/service/securitylake v1.25.16 h1:fw1BIyWJrpjLhkdyiC
 github.com/aws/aws-sdk-go-v2/service/securitylake v1.25.16/go.mod h1:l/xI6VzP6fKQLvJi9rAbYym6ba/BI6Xl4GWM9IsyWdE=
 github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.31.1 h1:dViX67zSP0rzdE8o4JW+Ttnm12+P+dwlgKnR48acSQI=
 github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.31.1/go.mod h1:J2Tcq2gsS7odqtAtMBWjcqnvh0Iz2l1SCowpzMBO0xE=
-github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.39.15 h1:ZCxvNcAKhyoOtNcBOTWMK9SzgMWf9TUlsx/pX5SqcTc=
-github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.39.15/go.mod h1:Ava9lSQtC5dJqB/H+usuyndF17h2o4YWEVF1MYxGss0=
+github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.39.16 h1:mbqBPEMz8JjdTM1MhyimEBErhVwlK0L4dZjpo1kXDck=
+github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.39.16/go.mod h1:P0nEJjEHZpZ+BLv4iUjkIfNjvvpCXcJoyvjlN02AwZ4=
 github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry v1.36.0 h1:kXEL4NsZt/JUCMOzQFi5qSD2CcfkzuZba4bvPdNsgtY=
 github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry v1.36.0/go.mod h1:G6KLt0Sx2E6KKOJscRGWeuQ1V4IEYitzbmmgzXYc5hA=
 github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.40.0 h1:8eUbfsuVdhqlek1EJny/jE2OSbhjSpnsRsyOTFowDlo=

--- a/go.sum
+++ b/go.sum
@@ -269,8 +269,8 @@ github.com/aws/aws-sdk-go-v2/service/fsx v1.66.1 h1:YX1l7nNVKvHe3pEu498sW76WuHUA
 github.com/aws/aws-sdk-go-v2/service/fsx v1.66.1/go.mod h1:DL5UJomGBiqjRf84eSykFbyQoLretYc1JPysrsKZSDc=
 github.com/aws/aws-sdk-go-v2/service/gamelift v1.54.1 h1:7Appei3huNvhHlVaX4l87fyQMTiutTKDTR/q33RoR7I=
 github.com/aws/aws-sdk-go-v2/service/gamelift v1.54.1/go.mod h1:VnK+7iDsbhPDJ0BPuwDM80sPCGatD5dh4SJs5vacvbE=
-github.com/aws/aws-sdk-go-v2/service/glacier v1.32.8 h1:OGRgf5Jd5Vfxksc/HU4oCuYVes+/N0qWbMys90WMLsw=
-github.com/aws/aws-sdk-go-v2/service/glacier v1.32.8/go.mod h1:GnOJNdxnD5QSBqILVzFAjURLpXrQrUH83amUZam2I1o=
+github.com/aws/aws-sdk-go-v2/service/glacier v1.32.9 h1:YmKhaCkxIDABhKu4UXPNgSTN1ITmRynmalkS1atyqOI=
+github.com/aws/aws-sdk-go-v2/service/glacier v1.32.9/go.mod h1:vlEeKKUe2y0PXooxWUyDP8WgOhUH5gHGGrR9dn3bdyg=
 github.com/aws/aws-sdk-go-v2/service/globalaccelerator v1.36.0 h1:9xK/+z/QIEu7DocAeM8w4I7JU+MqcN8gPrlEo0VpkH0=
 github.com/aws/aws-sdk-go-v2/service/globalaccelerator v1.36.0/go.mod h1:e2pOrIpl2zSGFiNvd0FvAP01z9XOKR9Y1aJ7dYiE2YM=
 github.com/aws/aws-sdk-go-v2/service/glue v1.142.0 h1:ztxbPEsd9yyuf2A41ZwtCXtI61t7ocnQ7vUdziFiFUc=

--- a/go.sum
+++ b/go.sum
@@ -443,8 +443,8 @@ github.com/aws/aws-sdk-go-v2/service/rdsdata v1.32.24 h1:i62rjzGXWqDWVhpO/KVBw3e
 github.com/aws/aws-sdk-go-v2/service/rdsdata v1.32.24/go.mod h1:N5iVwQXS/jDd0ljhmLfd8W3295wp4gwKvNAXhPjyCKQ=
 github.com/aws/aws-sdk-go-v2/service/redshift v1.62.9 h1:YHFGMgQa2zDRUTzvD8GtrOJoO96aU1BduliXEl65NtU=
 github.com/aws/aws-sdk-go-v2/service/redshift v1.62.9/go.mod h1://ALEpBVXJfV8saFPor8HMJ74xERWhrOYaPd+pNWUdk=
-github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.39.2 h1:5MMxyip6xYVD6LgkaXM2wJVnUabv5rUf3nWBdNQRXRo=
-github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.39.2/go.mod h1:jLwMScfDY+ED2F2pglheE5OV6TCC/B8rnxVgX4qaAO8=
+github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.40.0 h1:jbRyKYbNrEnRd+nphrUIH345qpOGDqOfxjNpz3oZEJk=
+github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.40.0/go.mod h1:WPZLtD9otyFLcz+ZxS3QUuCd67f+7kAJaPjJ31ahO3M=
 github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.35.0 h1:4bhy+oTqgUdtw8IvWcc1pPL4DCH5ZT4rkV9a1eggQGY=
 github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.35.0/go.mod h1:24tWvrWAt7wxYpXYPSmDyfyRWKGdz2glsgnLV9MSRq4=
 github.com/aws/aws-sdk-go-v2/service/rekognition v1.51.24 h1:TjTpw5c4Z5DFHRHMZqL+rR/Jk9zlsGW4/gQxCqgWiHY=

--- a/go.sum
+++ b/go.sum
@@ -69,8 +69,8 @@ github.com/aws/aws-sdk-go-v2/service/applicationautoscaling v1.41.17 h1:W47YuCgU
 github.com/aws/aws-sdk-go-v2/service/applicationautoscaling v1.41.17/go.mod h1:76qbqOwmn5GX0Oo/7Qz/RyZX+vMwkQqpW46d+MGpwHY=
 github.com/aws/aws-sdk-go-v2/service/applicationinsights v1.34.23 h1:s/zG75mlE08UEIDv85gH8gOKQXwNENLgOhLmwxEYEOA=
 github.com/aws/aws-sdk-go-v2/service/applicationinsights v1.34.23/go.mod h1:ioZ050CgtUShNUI4TQ5bnYMCBhS8k/nDZn9+Hj6aF3I=
-github.com/aws/aws-sdk-go-v2/service/applicationsignals v1.22.0 h1:o9KsVNy6vQcytangT1DMYgz2AXJ/NRGB+TswhVJc3yw=
-github.com/aws/aws-sdk-go-v2/service/applicationsignals v1.22.0/go.mod h1:pK5zExLS4u5kh2swzrGKTQHbexXeIzKW/Cz2hjgl9q4=
+github.com/aws/aws-sdk-go-v2/service/applicationsignals v1.22.1 h1:midboezGCtGsrFF3D2wbEzNb1vvYrRprXMysYFGfgFI=
+github.com/aws/aws-sdk-go-v2/service/applicationsignals v1.22.1/go.mod h1:VtkMZ2Ugj03+OEOap4oID3BhbDMiKcExitr43/F/umY=
 github.com/aws/aws-sdk-go-v2/service/appmesh v1.35.14 h1:31mnzduRd3FyuGCwgdMfPAu6MG1XnQf4zJrPjpZvnbM=
 github.com/aws/aws-sdk-go-v2/service/appmesh v1.35.14/go.mod h1:u/RTn1872BcpTxDnsQXi0AO8nxMch/46nlr3/loCpu8=
 github.com/aws/aws-sdk-go-v2/service/apprunner v1.40.0 h1:zJKGRaZd15XaRLa3eTO9B47lrOvmxSNc9nOciUuDR8Y=

--- a/go.sum
+++ b/go.sum
@@ -225,8 +225,8 @@ github.com/aws/aws-sdk-go-v2/service/ec2 v1.304.1 h1:ViHXq1M38VYp2KuxM9Gcwohp9fw
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.304.1/go.mod h1:+AkYu92PhPD3Utfj3ruK5hGpQF0OHm8ffj10X2T+ufE=
 github.com/aws/aws-sdk-go-v2/service/ecr v1.57.3 h1:A96oesTgxeuq40H9PKkPXQDvqeLy8fzSXaMxjTVWdsc=
 github.com/aws/aws-sdk-go-v2/service/ecr v1.57.3/go.mod h1:wig6P1dEk+MIgducD7hX+RcnnRBSvk9S/4J398XJ+sE=
-github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.38.15 h1:nW/zPIjkAgHV1xv8NHdLQtGMoHVj2toMj8/H6SMqjVw=
-github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.38.15/go.mod h1:FXDXpYy2PKdkQQr4ERMoRzVKcga0O/hmtRbMaQSpe8U=
+github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.39.1 h1:AgyAEGH3FMq76rF/0oZNbvKWE0TJDwA3lK+Zwq6fujQ=
+github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.39.1/go.mod h1:x2sEaNEFTaoEOC7G+tLOh2MWCdjzvNrJO76YyA+inLo=
 github.com/aws/aws-sdk-go-v2/service/ecs v1.80.0 h1:orZYOYtvYU7A45XTWC/UchWSkkdWjOyXi8MYksnmQf0=
 github.com/aws/aws-sdk-go-v2/service/ecs v1.80.0/go.mod h1:TIKZ9zIFS6W2k9FeW+r5sGVnlxp+aUt9oQ/St3Suj1o=
 github.com/aws/aws-sdk-go-v2/service/efs v1.41.16 h1:qHmh61/S6g+scI9M4U3XYivCiEp1tUadKgyrczuLJpM=

--- a/go.sum
+++ b/go.sum
@@ -507,8 +507,8 @@ github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry v1.36.1 h1:wuMAk0
 github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry v1.36.1/go.mod h1:cL0D+MJfloyTVGgf3zmcavs4giz3W1x/z/wMo9O4V+M=
 github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.40.1 h1:vyjZg2SefsacQFgU9WfbTve/3Aj6hE2NSJuChImmyVg=
 github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.40.1/go.mod h1:9BpYYXW/GFuScrtiSbfKHLP3LJSYUYKyWLbvXZkB9os=
-github.com/aws/aws-sdk-go-v2/service/servicequotas v1.35.0 h1:qaB32zX2iiSWa2ml5DO0F71AOU+VuyuttbFd+kxxzf0=
-github.com/aws/aws-sdk-go-v2/service/servicequotas v1.35.0/go.mod h1:52QJsp2N27Em8o5H/cgkBwjTY4I/TYpTBHMlqhuCHMQ=
+github.com/aws/aws-sdk-go-v2/service/servicequotas v1.35.1 h1:ixj7b/LEZAuNWwORvR2xGawnasYHAbzGNVly/fEfq6o=
+github.com/aws/aws-sdk-go-v2/service/servicequotas v1.35.1/go.mod h1:OLExSerzvmddN8vnbNcW1AgvpMHE3LtU/hh4CYLsZXY=
 github.com/aws/aws-sdk-go-v2/service/ses v1.34.24 h1:ZPCoU087iv2IWJKNQyN+MYOqZAM9lEVevS9MHWGG4wI=
 github.com/aws/aws-sdk-go-v2/service/ses v1.34.24/go.mod h1:4T8OWyQ9nkdUrcqHHJkyibP5TfcWDTe4kWL40tiCOcs=
 github.com/aws/aws-sdk-go-v2/service/sesv2 v1.61.0 h1:d5valptgkxExUHAnyFp4iswYAoTqDD5g32tmTwj18j8=

--- a/go.sum
+++ b/go.sum
@@ -351,8 +351,8 @@ github.com/aws/aws-sdk-go-v2/service/location v1.52.1 h1:hXk27fqFGrjvlX0MaCzf1SO
 github.com/aws/aws-sdk-go-v2/service/location v1.52.1/go.mod h1:v/d1IGFeuze4lsKEU1juoMgzuIXBrFXh0nIjJK9Mls8=
 github.com/aws/aws-sdk-go-v2/service/m2 v1.27.1 h1:1vzECynzUz+/8ablxRU4iPqLbuiafwGfr8pSDTnbZsI=
 github.com/aws/aws-sdk-go-v2/service/m2 v1.27.1/go.mod h1:Ydcsj053d85MCqN+G/sg/RAUgA4DRqakxKnEw5Yhf8g=
-github.com/aws/aws-sdk-go-v2/service/macie2 v1.51.2 h1:JPIqNyD7JAaQddkmXRFVI7My2vtJ40uqTpEYIlnTEVw=
-github.com/aws/aws-sdk-go-v2/service/macie2 v1.51.2/go.mod h1:Y1uuzDg6j6jVdm/xMgIgEaCJ2fMLPAgoKzKYuMBhJUQ=
+github.com/aws/aws-sdk-go-v2/service/macie2 v1.51.3 h1:MjhvPAy7WONLMkYlKXySflQMk7GqFLLssUO60BNkJMA=
+github.com/aws/aws-sdk-go-v2/service/macie2 v1.51.3/go.mod h1:rUVkJJSpImXmBlMc1ZWrx/PF2Kz+jch45cIdm4OVnb4=
 github.com/aws/aws-sdk-go-v2/service/mediaconnect v1.49.0 h1:soyDbvfrfgCA6NffTlHCOPLxvasNN0I9gVKpDXgIOxs=
 github.com/aws/aws-sdk-go-v2/service/mediaconnect v1.49.0/go.mod h1:LcKdUwEuIHXayPjypC3VXZoPp8kNkxHAil8OdLJF0jk=
 github.com/aws/aws-sdk-go-v2/service/mediaconvert v1.91.2 h1:h466gQU4HNXHgTdz7a45mGudKsB+NeyPVYr6hf9F4gM=

--- a/go.sum
+++ b/go.sum
@@ -103,8 +103,8 @@ github.com/aws/aws-sdk-go-v2/service/bedrockagent v1.54.1 h1:jc+0xbKgIthQDrAb8KV
 github.com/aws/aws-sdk-go-v2/service/bedrockagent v1.54.1/go.mod h1:mHMqUmNCieOVD/XOD6Xmlqof1ptZnF/TsRMTy/Jr8CY=
 github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol v1.41.0 h1:s+9aRVnNcNpct2raxZ+2sE1QUFRwx74HJrVD8CWcxQU=
 github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol v1.41.0/go.mod h1:MJLW1rK+TZO6mExsuFg7O+vFELkILGAu6+L943Q+Akk=
-github.com/aws/aws-sdk-go-v2/service/billing v1.11.0 h1:BttT9s7XhvQ0B3fR3EZ2jglkd8nIj75yXTkQinlJd8E=
-github.com/aws/aws-sdk-go-v2/service/billing v1.11.0/go.mod h1:3/4KagnaoaVLj9jIOKGWCZc+YFETolSQV+AjOPB+WUY=
+github.com/aws/aws-sdk-go-v2/service/billing v1.11.1 h1:20TUeXiZAAngesBpuyvxz+d0ZGzH8z3fzA/3c3bBOk0=
+github.com/aws/aws-sdk-go-v2/service/billing v1.11.1/go.mod h1:R2U4hP2CSLK5UseLbHUFKFNFF4U/7HMfcrJ3zyxV4I0=
 github.com/aws/aws-sdk-go-v2/service/budgets v1.43.7 h1:5da51kHGIcUydFIQnPTQxwxlraBc6Z2M/Mg430mJGcw=
 github.com/aws/aws-sdk-go-v2/service/budgets v1.43.7/go.mod h1:W/ACxHO2V65T11t9KLLG+pQytcYk206Ff5b5lbGeMF8=
 github.com/aws/aws-sdk-go-v2/service/chatbot v1.14.23 h1:eVFe0spV/qN307E9M7EWomXBx20d6iSCRU9uhZnbbEM=

--- a/go.sum
+++ b/go.sum
@@ -65,8 +65,8 @@ github.com/aws/aws-sdk-go-v2/service/appflow v1.51.15 h1:iz+/nmbL/lLn6Jdqb3xXNE9
 github.com/aws/aws-sdk-go-v2/service/appflow v1.51.15/go.mod h1:f3rmeXbgWBepM1ftO73MEVbi2OkAo2dbhJiW30+xK1w=
 github.com/aws/aws-sdk-go-v2/service/appintegrations v1.37.10 h1:1KCD21KPp0HrEKXB7zlQcS5cxD0bKhDPKZcybJzp7iA=
 github.com/aws/aws-sdk-go-v2/service/appintegrations v1.37.10/go.mod h1:aRi8xw3Xl/McDp/yDbgzZsr10xVgG/iYYOath9LvooQ=
-github.com/aws/aws-sdk-go-v2/service/applicationautoscaling v1.41.16 h1:9ePxWacyZEGJQIBfYxumxYjDZvvpCcUAnFQUQy4GI2U=
-github.com/aws/aws-sdk-go-v2/service/applicationautoscaling v1.41.16/go.mod h1:gR1tnThD1DBemyG1rmZ9U5+WbfGoiLUaZDvsQ6wbAjM=
+github.com/aws/aws-sdk-go-v2/service/applicationautoscaling v1.41.17 h1:W47YuCgU/hJJIr3q32qDmFfPgzRFAqa4rRMZzBI9o/4=
+github.com/aws/aws-sdk-go-v2/service/applicationautoscaling v1.41.17/go.mod h1:76qbqOwmn5GX0Oo/7Qz/RyZX+vMwkQqpW46d+MGpwHY=
 github.com/aws/aws-sdk-go-v2/service/applicationinsights v1.34.22 h1:Efp05vChZXL5og/ix/bjwIB8Yea0Kge//pGnbQk22Mc=
 github.com/aws/aws-sdk-go-v2/service/applicationinsights v1.34.22/go.mod h1:pm+LG2M+wklS+qMReaKBWmEwR8vkUwWbUIVEjIkZnuw=
 github.com/aws/aws-sdk-go-v2/service/applicationsignals v1.22.0 h1:o9KsVNy6vQcytangT1DMYgz2AXJ/NRGB+TswhVJc3yw=

--- a/go.sum
+++ b/go.sum
@@ -229,8 +229,8 @@ github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.39.1 h1:AgyAEGH3FMq76rF/0oZNbv
 github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.39.1/go.mod h1:x2sEaNEFTaoEOC7G+tLOh2MWCdjzvNrJO76YyA+inLo=
 github.com/aws/aws-sdk-go-v2/service/ecs v1.81.1 h1:LyyVqeXzra+cPw0BGloOuowJCTvl6joUAxOgs3+lxNQ=
 github.com/aws/aws-sdk-go-v2/service/ecs v1.81.1/go.mod h1:0Lg4lqs9OzRR/Ne8x/rQnRi7qe4LLPnLch/VhqmFPRc=
-github.com/aws/aws-sdk-go-v2/service/efs v1.41.16 h1:qHmh61/S6g+scI9M4U3XYivCiEp1tUadKgyrczuLJpM=
-github.com/aws/aws-sdk-go-v2/service/efs v1.41.16/go.mod h1:Q7WcY1H6krqZEnFyxyuzfLAnEad1Q69U4CrBbY4P2Fg=
+github.com/aws/aws-sdk-go-v2/service/efs v1.41.17 h1:0RViZJ5P2Tpm8OSTGFMVRJHDP6dhY0LKcYB/G99Reb4=
+github.com/aws/aws-sdk-go-v2/service/efs v1.41.17/go.mod h1:epIbYreyUL7HvPdLyEGpao66ZKaeafXHAXuWdB3Oass=
 github.com/aws/aws-sdk-go-v2/service/eks v1.84.0 h1:U9HMTDPdZtkCOTE8ACbHQJmXGBKP7/mBds7M1JbUZH0=
 github.com/aws/aws-sdk-go-v2/service/eks v1.84.0/go.mod h1:JQcyECIV9iZHm+GMrWn1pTPTJYRavOVsqPvlCbjt+Fg=
 github.com/aws/aws-sdk-go-v2/service/elasticache v1.52.2 h1:5wbCUfyxXcjIqesyVfJBBJs0bDMyejthtHyy48mfZCI=

--- a/go.sum
+++ b/go.sum
@@ -339,8 +339,8 @@ github.com/aws/aws-sdk-go-v2/service/lambda v1.90.2 h1:dBiVUhd21cs5C3RUiAKTMc4Cw
 github.com/aws/aws-sdk-go-v2/service/lambda v1.90.2/go.mod h1:gFmCYh+m/TwFPR3o30V83jaNVIzN5ozPrf7eC29mBJU=
 github.com/aws/aws-sdk-go-v2/service/launchwizard v1.15.1 h1:7xZRe3mqApyzsWqjtNn+J73jc9DfMhEiRBt1scdxNF4=
 github.com/aws/aws-sdk-go-v2/service/launchwizard v1.15.1/go.mod h1:5kDHQj+69vTbiXJTkjw92qjEPROvbzJIZAeOad73814=
-github.com/aws/aws-sdk-go-v2/service/lexmodelbuildingservice v1.35.0 h1:LJ+UCPYUUAPlKNBj/r+mNZA8msdgFFa4tQNr/fUE2bE=
-github.com/aws/aws-sdk-go-v2/service/lexmodelbuildingservice v1.35.0/go.mod h1:zlyhvqBbKJLCktons66dFSfNMKKZ7XRNk5kGqaQUccE=
+github.com/aws/aws-sdk-go-v2/service/lexmodelbuildingservice v1.35.1 h1:NZX1pOWZuw85O34v5prNeAgSmbjZzzVAG7y4j2+EZX8=
+github.com/aws/aws-sdk-go-v2/service/lexmodelbuildingservice v1.35.1/go.mod h1:rzQ2SsbFij+4zX+SUNYMDL632DqZHY6t+pEeBzmD7e4=
 github.com/aws/aws-sdk-go-v2/service/lexmodelsv2 v1.61.0 h1:6rjKCcc8dGyhGzbgRe5M1Zfp73OubQe2x8AzF31UpLE=
 github.com/aws/aws-sdk-go-v2/service/lexmodelsv2 v1.61.0/go.mod h1:lTTUoKQCz5RgFIWMUcO/MaDuJG4MNxKRQSc2ZOaFz/c=
 github.com/aws/aws-sdk-go-v2/service/licensemanager v1.37.12 h1:CRnlzGMTYDTHpmFSGUe+CjEHzNQzL+fRZS5weQLvRfc=

--- a/go.sum
+++ b/go.sum
@@ -123,8 +123,8 @@ github.com/aws/aws-sdk-go-v2/service/cloudcontrol v1.30.1 h1:AGb453LNQkxO5AJaQhI
 github.com/aws/aws-sdk-go-v2/service/cloudcontrol v1.30.1/go.mod h1:0yYjIDvv3b9RHChdAEotH9RQNjQAJxyvFRpvTZMJJ0M=
 github.com/aws/aws-sdk-go-v2/service/cloudformation v1.71.12 h1:XS2aRt1R1+ioudqhFIWLHhi8LoXobIIIx9zfoUrRLYE=
 github.com/aws/aws-sdk-go-v2/service/cloudformation v1.71.12/go.mod h1:QnZX1r0jQrYXnTlpne1T04aGFjbeFtmvY38o+fsVlvU=
-github.com/aws/aws-sdk-go-v2/service/cloudfront v1.64.0 h1:a6XmNe8cAvfrXVKwjXzWl9HHtuyE/n4kBroNm2mSOyo=
-github.com/aws/aws-sdk-go-v2/service/cloudfront v1.64.0/go.mod h1:brhMG/gR2xEB5lezxL2Cx+hqsEzGUn4LhNUtu7+ePFE=
+github.com/aws/aws-sdk-go-v2/service/cloudfront v1.64.1 h1:ZTPq5RiymFaH+UoFz0fRV2/mszi8QMXPU/OWr3uxigo=
+github.com/aws/aws-sdk-go-v2/service/cloudfront v1.64.1/go.mod h1:gaGjhyTtT7wcnc7SIPC1+hACSRMQV7VRN8ACY6khGOc=
 github.com/aws/aws-sdk-go-v2/service/cloudfrontkeyvaluestore v1.12.26 h1:nHUJWEa2oFFRWJpTVjxZp2QiaQl89Z8O7rmHW/yeu+0=
 github.com/aws/aws-sdk-go-v2/service/cloudfrontkeyvaluestore v1.12.26/go.mod h1:1HLozcnJWth+NZw49XJlluaQKcOQvkB+MKNiUx35qQI=
 github.com/aws/aws-sdk-go-v2/service/cloudhsmv2 v1.34.25 h1:OOrm22PtgqY0/NaHxytd42a6i6lepRE8PPPPKDRt3eA=

--- a/go.sum
+++ b/go.sum
@@ -167,8 +167,8 @@ github.com/aws/aws-sdk-go-v2/service/comprehend v1.41.1 h1:qh4h+vi4SQ1EoFYQ1M+hB
 github.com/aws/aws-sdk-go-v2/service/comprehend v1.41.1/go.mod h1:ZGajmgEyhNgAzoGgVuBUn4CRkCZ+bi4tACWf8HHmgLo=
 github.com/aws/aws-sdk-go-v2/service/computeoptimizer v1.51.1 h1:Cy3+tJvG/0K2TlzO+H0MYrIUdwTfkKvOH/9n1yp11Jg=
 github.com/aws/aws-sdk-go-v2/service/computeoptimizer v1.51.1/go.mod h1:y5HaCvXXAcgvjkHvPCrq1FFeHQ7VQnvS8wg8idHVX5k=
-github.com/aws/aws-sdk-go-v2/service/configservice v1.62.3 h1:8rcAUMhCUuQe7kVBTBLPqMsJWFSVDPSFdpFexVQEEdU=
-github.com/aws/aws-sdk-go-v2/service/configservice v1.62.3/go.mod h1:PvCpYWzh0/jwa8v3jYJOaDobKiKQzFm1hI7+4Ms3J90=
+github.com/aws/aws-sdk-go-v2/service/configservice v1.62.4 h1:Vzzl4mk9hu0sE0lKhYiH3uD15nL9nyQ8PUlVKHXsqnA=
+github.com/aws/aws-sdk-go-v2/service/configservice v1.62.4/go.mod h1:HGcpycwfNZW3ADZFgUl/GxbIAQ9qkcY9YERr7QPvlaE=
 github.com/aws/aws-sdk-go-v2/service/connect v1.175.0 h1:ryfwFSnLovIyJd6xX4M9CToQbaa3YZjOkt+wyRuPiPs=
 github.com/aws/aws-sdk-go-v2/service/connect v1.175.0/go.mod h1:Du5pBjluSAHkGpEiz8aCfk9NdndzEeGpCqARDWAlGGQ=
 github.com/aws/aws-sdk-go-v2/service/connectcases v1.41.0 h1:3cyJsw7HOjnAl/UU7seVUXAXE1gB/aGuCVIfpEon0JQ=

--- a/go.sum
+++ b/go.sum
@@ -113,8 +113,8 @@ github.com/aws/aws-sdk-go-v2/service/chime v1.41.15 h1:NjDzXghqrmE5KFPedLuioRk08
 github.com/aws/aws-sdk-go-v2/service/chime v1.41.15/go.mod h1:T11rZ8NkCnMjuSu72hcd6sIS5drVGfAv8xJx8n2Hg3I=
 github.com/aws/aws-sdk-go-v2/service/chimesdkmediapipelines v1.27.1 h1:JP5Jz9OCnqownQNBKTPxH89eAx5wZcMzWiKWw1gRiCg=
 github.com/aws/aws-sdk-go-v2/service/chimesdkmediapipelines v1.27.1/go.mod h1:/4racxzJ7S4x0j6EkPl7YpBqncHL2v85hchmoY+JnB8=
-github.com/aws/aws-sdk-go-v2/service/chimesdkvoice v1.28.15 h1:21vkPfPLTrzWnp3c+d5NJu9om1sLHg2tS1p72bxU+3A=
-github.com/aws/aws-sdk-go-v2/service/chimesdkvoice v1.28.15/go.mod h1:C6UVSmolomJa9uw9VAgIBVKx92I5jZ+vW24yeVvyXqs=
+github.com/aws/aws-sdk-go-v2/service/chimesdkvoice v1.28.16 h1:j6t6St4yP9kQHNyAtQe6YSsT6HUlsneVzmvGahwPKGo=
+github.com/aws/aws-sdk-go-v2/service/chimesdkvoice v1.28.16/go.mod h1:7nxpEWr4b40lkq70qNLl7hAEsBOuoTRigacXsgRrTE0=
 github.com/aws/aws-sdk-go-v2/service/cleanrooms v1.45.0 h1:kBzMXsg/R1N25ylMalFU29HdrQotblZgDcenVwvgWZo=
 github.com/aws/aws-sdk-go-v2/service/cleanrooms v1.45.0/go.mod h1:HCv37Z4wolPLADD63F9X3nIfKcxA1WwH9NJjWChRzMU=
 github.com/aws/aws-sdk-go-v2/service/cloud9 v1.34.0 h1:2+hgocCkYVinuAFFV1ujvzdc5W4kbJQBkE0T4zMHYLo=

--- a/go.sum
+++ b/go.sum
@@ -185,8 +185,8 @@ github.com/aws/aws-sdk-go-v2/service/customerprofiles v1.62.0 h1:+5UR/UaODIBy0e1
 github.com/aws/aws-sdk-go-v2/service/customerprofiles v1.62.0/go.mod h1:wssUdi0eG5acDhEjKWq11oP1X49rSMJ7ztO0hHFLIOk=
 github.com/aws/aws-sdk-go-v2/service/databasemigrationservice v1.63.1 h1:A3ZPi0AHJvhq4OiBFqjGkCW/OV0n0bYJnubWyUKwyhs=
 github.com/aws/aws-sdk-go-v2/service/databasemigrationservice v1.63.1/go.mod h1:+5VgeIKl82hc3J8/Z6rZpGLaNMrRYkHdR7n4pWhaNOo=
-github.com/aws/aws-sdk-go-v2/service/databrew v1.40.0 h1:wuMzTtsMNVfR954WDxxuTSxE84uBjbUZpkHzl8FGEzY=
-github.com/aws/aws-sdk-go-v2/service/databrew v1.40.0/go.mod h1:JR6djN/YtdK6R03KYsrMoh/GzmFsIDAdtzjl1RjqqSQ=
+github.com/aws/aws-sdk-go-v2/service/databrew v1.40.1 h1:CrqRhUBWuTcdNbCAWVoWpAE898qU2kiGuayCv4Ffe5Q=
+github.com/aws/aws-sdk-go-v2/service/databrew v1.40.1/go.mod h1:Za6vZBh9dK4VLieS+BBOLuz+3Vz+9PYUKI1+vrJ6DDo=
 github.com/aws/aws-sdk-go-v2/service/dataexchange v1.41.2 h1:kO0lpy2o5+OFc7RA2u0xHQvf7gFmVxuljgbe9xt5d/M=
 github.com/aws/aws-sdk-go-v2/service/dataexchange v1.41.2/go.mod h1:nozeyNDLibm9cyf4nf7yIdzMeQt+8w2mvuSQj6qKAE0=
 github.com/aws/aws-sdk-go-v2/service/datapipeline v1.30.22 h1:th7UIseI06gZDd/7ntsyUJmVVbbowq4ypEUh8gf5+OU=

--- a/go.sum
+++ b/go.sum
@@ -361,8 +361,8 @@ github.com/aws/aws-sdk-go-v2/service/medialive v1.97.1 h1:CaaGyFVpZGGydt4vkFFx2r
 github.com/aws/aws-sdk-go-v2/service/medialive v1.97.1/go.mod h1:7imY/+11Qy5wkFLlDbgclEzsCRM3kkJaxx2E7oPFtwI=
 github.com/aws/aws-sdk-go-v2/service/mediapackage v1.39.24 h1:fyFyHZcBKpyUsppI5nxHf/uHZobtBjn39l1EFRQfHJA=
 github.com/aws/aws-sdk-go-v2/service/mediapackage v1.39.24/go.mod h1:/QFYcNuiSprNSxlGHsb9nZwzYgCnIhi9j4BlEQvZtZU=
-github.com/aws/aws-sdk-go-v2/service/mediapackagev2 v1.39.0 h1:+rIQceAbYT97OKasPK7f8E/wwh/3wAdABV0fSs+CUhU=
-github.com/aws/aws-sdk-go-v2/service/mediapackagev2 v1.39.0/go.mod h1:lmYE+EShgxxI35+UwVCbE8Z3OsutViSOMNNx3Y3/Y3c=
+github.com/aws/aws-sdk-go-v2/service/mediapackagev2 v1.39.1 h1:2vjqeQHRqh/ILzIff5oT67sLJ7nRrqU7h0QZXPziGZY=
+github.com/aws/aws-sdk-go-v2/service/mediapackagev2 v1.39.1/go.mod h1:uzIN1W4NqMdy0yFFyRBihyGYAGzvtyPzrEfodrDqCLs=
 github.com/aws/aws-sdk-go-v2/service/mediapackagevod v1.39.23 h1:3D0AdP2dlAuyS8+bI32nwWeVElqpum5x57qd7gnv0/g=
 github.com/aws/aws-sdk-go-v2/service/mediapackagevod v1.39.23/go.mod h1:3nv4OO4gMdloy2CVFb+veQzwndmDhxXatvZ/D0dEN1Y=
 github.com/aws/aws-sdk-go-v2/service/mediastore v1.29.23 h1:yxt0mlXvIz6tBqE6tE+8nT4HInWgEjzwnHDI6TxKm7E=

--- a/go.sum
+++ b/go.sum
@@ -345,8 +345,8 @@ github.com/aws/aws-sdk-go-v2/service/lexmodelsv2 v1.61.1 h1:rKfX8s06E/LQ2GTsqP+R
 github.com/aws/aws-sdk-go-v2/service/lexmodelsv2 v1.61.1/go.mod h1:NFAqjgrK+zDT/FBpxy8hhv6TeihDTevN/Sesh8qr8Bw=
 github.com/aws/aws-sdk-go-v2/service/licensemanager v1.37.13 h1:111XpjGyREF2grOTU5eqLeQqa7NH9uZqHhOJMQ44gPg=
 github.com/aws/aws-sdk-go-v2/service/licensemanager v1.37.13/go.mod h1:8GKUM7OrtYiizLA72d3799YulE9YYd1LBjitI9gni6U=
-github.com/aws/aws-sdk-go-v2/service/lightsail v1.54.0 h1:07DKnL5eKSel3XEM2UxlD/z9zUZZ6XMHLGDXkAdY4u8=
-github.com/aws/aws-sdk-go-v2/service/lightsail v1.54.0/go.mod h1:Etcg8xorq1b0g0V2KMNgFjubYITZseJv08qtX/3szko=
+github.com/aws/aws-sdk-go-v2/service/lightsail v1.54.1 h1:TA/8uCWJQzeNy8fTf8ojFxZuvWA+R20CMu0b7IxYcp0=
+github.com/aws/aws-sdk-go-v2/service/lightsail v1.54.1/go.mod h1:F0RbBQMzN+pD4BswikBhagVqSQWqjMnmx14plgRsxKA=
 github.com/aws/aws-sdk-go-v2/service/location v1.51.1 h1:V2YRh41kS0i5lzJqEJlpnv5ljKUKBPQl0WJ8p8MEYU8=
 github.com/aws/aws-sdk-go-v2/service/location v1.51.1/go.mod h1:vItA3+XI99kmKXC2ILRMsBVOLB6lNUg5E5Jn01JGE78=
 github.com/aws/aws-sdk-go-v2/service/m2 v1.26.16 h1:i8B10mRygZ706QPnu8wLK0sqpjXA+pBiaVBDNPQ9bvo=

--- a/go.sum
+++ b/go.sum
@@ -381,8 +381,8 @@ github.com/aws/aws-sdk-go-v2/service/mwaaserverless v1.0.12 h1:WdKoYiwzDxdeaynP/
 github.com/aws/aws-sdk-go-v2/service/mwaaserverless v1.0.12/go.mod h1:z3yp7mzFwRvWFayqFKJq8hsLxbTD1YiMVeowTwlg2YQ=
 github.com/aws/aws-sdk-go-v2/service/neptune v1.44.6 h1:fEiBIUr6UVYs6LxASES6m8a6Nyfe2MkLMY6h1/7G/f4=
 github.com/aws/aws-sdk-go-v2/service/neptune v1.44.6/go.mod h1:+UvGeb9YQ093vXXr5/GM8AcOcLeXsO/zejCbna5zZQo=
-github.com/aws/aws-sdk-go-v2/service/neptunegraph v1.21.23 h1:0QhwVtPhDWDUN98mArFWF5GyFyeDLntZYGR0fG9l6/w=
-github.com/aws/aws-sdk-go-v2/service/neptunegraph v1.21.23/go.mod h1:QYHHT9HDGfjS40Xcj1JgY6g7Q0zAqPtJT/s0hvZzvcc=
+github.com/aws/aws-sdk-go-v2/service/neptunegraph v1.22.0 h1:iTnqzV7TNmSlH+wpUszaDtNPK6xANHW8wQIbuGPO1kI=
+github.com/aws/aws-sdk-go-v2/service/neptunegraph v1.22.0/go.mod h1:PMRZaSonQvYX8d0u6JciqToJh3JHIcNDU8JwpLeFiT0=
 github.com/aws/aws-sdk-go-v2/service/networkfirewall v1.61.0 h1:/cxzydSADiL23o7Z8ZYdNTDGSx2RuJZr3mJa67MtBOc=
 github.com/aws/aws-sdk-go-v2/service/networkfirewall v1.61.0/go.mod h1:oWCet/AjsuKhMkvcXOGEeS2QmssLJX1UmX2SiKCEsFM=
 github.com/aws/aws-sdk-go-v2/service/networkflowmonitor v1.11.11 h1:/FfmXTc20Nc4NWFdAd0o5tekmtQ+M1Tr2xOqCdRp9GQ=

--- a/go.sum
+++ b/go.sum
@@ -139,8 +139,8 @@ github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.74.1 h1:8jNx+q40WGu+oYvW9
 github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.74.1/go.mod h1:fzoRhw/rzt5X9EPA8fjbhZ/Ph0tChldiC/kPIFAGI7A=
 github.com/aws/aws-sdk-go-v2/service/codeartifact v1.39.1 h1:f11z1s2b5Yn/vdvS6PWHI8FnEHZnq/iBhk24NVGlE4Q=
 github.com/aws/aws-sdk-go-v2/service/codeartifact v1.39.1/go.mod h1:PZ43Dwh72tKIZv/nL1+4tre21tuMEkKnH7ktxnNu8Ss=
-github.com/aws/aws-sdk-go-v2/service/codebuild v1.68.16 h1:ocvG4uGirVVBVsDQZGNlFPcKghtC/rxLW4y0jcwBp1I=
-github.com/aws/aws-sdk-go-v2/service/codebuild v1.68.16/go.mod h1:9WntqQzPVMdtY8e9rM22XT1ykcrmxdr/l/A2w17+l+8=
+github.com/aws/aws-sdk-go-v2/service/codebuild v1.68.17 h1:nuZd0+/dAPNruSr1QPP0Wc6zedGnFMi/OfaSCgnmP50=
+github.com/aws/aws-sdk-go-v2/service/codebuild v1.68.17/go.mod h1:bqp9F33QsLJl//rIXwqZeqRrGoZX4VkS20gfCA8o3VM=
 github.com/aws/aws-sdk-go-v2/service/codecatalyst v1.21.14 h1:djJmgkjv6JU9c7cNrK7GLJgkEi4ZEae2mm8ZqPaeiZU=
 github.com/aws/aws-sdk-go-v2/service/codecatalyst v1.21.14/go.mod h1:qU9Wr223MMoQiblOqRVbOB9Pa1uC8Ih2XIQIK5QAjcA=
 github.com/aws/aws-sdk-go-v2/service/codecommit v1.33.14 h1:3N664oayz66ttIkc8B9/OLntMWhoGhKqPudRRfsZQ20=

--- a/go.sum
+++ b/go.sum
@@ -323,8 +323,8 @@ github.com/aws/aws-sdk-go-v2/service/kendra v1.60.24 h1:rEo4jyDWChQCAHo55ryGSIrQ
 github.com/aws/aws-sdk-go-v2/service/kendra v1.60.24/go.mod h1:zu/m6Ap5qItkBSIDoQlRFo6BNwZ145tpGmr0N2HwRqs=
 github.com/aws/aws-sdk-go-v2/service/keyspaces v1.26.0 h1:XzWibdCvfAdFtmEfoYe+gGS5qmZFsCSf/OuzmqOmtjI=
 github.com/aws/aws-sdk-go-v2/service/keyspaces v1.26.0/go.mod h1:GANMXCrbHQ3PXkymiJZLCwICRitWb7AVOnrwb8N2d/A=
-github.com/aws/aws-sdk-go-v2/service/kinesis v1.43.7 h1:9FvrpWzkSPbm995UGQ4jOdRDuhQLmwgh/5t8UoosTdY=
-github.com/aws/aws-sdk-go-v2/service/kinesis v1.43.7/go.mod h1:A7b/tv2nIcdfLY6EfH9fklY+L/wpVo6PtDJ6KA43PKg=
+github.com/aws/aws-sdk-go-v2/service/kinesis v1.43.8 h1:MJ1r18td42gvrFGZcu0bHWcqyPBgcJ/A3gEi5k84gEA=
+github.com/aws/aws-sdk-go-v2/service/kinesis v1.43.8/go.mod h1:f7HKjso4tq0v/kVZB4QNHrZZ0sMZqk/2Wpr7JgL7Y1Y=
 github.com/aws/aws-sdk-go-v2/service/kinesisanalytics v1.30.25 h1:OBjINDp8xhZjliKWnidzagqyHpNIRPDm4jeP/173WkI=
 github.com/aws/aws-sdk-go-v2/service/kinesisanalytics v1.30.25/go.mod h1:PdNJ4V245nwJUkLf5VmeHCEE+dYg60vg0y5f+UpOZUw=
 github.com/aws/aws-sdk-go-v2/service/kinesisanalyticsv2 v1.37.2 h1:rln/edRVCCmMlxaFc0UaroIOWEuQr9ih2/1jIUWNNNg=

--- a/go.sum
+++ b/go.sum
@@ -305,8 +305,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.24 h1:CQW2FTrf
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.24/go.mod h1:Xfx13T+u3nH6EEzgl9fBSO6nDRmze1FvnZNYkctQ2zw=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.24 h1:yPLVC8Lbsw92eepgdIZCChHRNQek5eAvAz5wS+UIpJE=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.24/go.mod h1:H2h39H1AivHYkozUIUYoVJGMUOvdJ4Lv9DLyUSMAjW8=
-github.com/aws/aws-sdk-go-v2/service/internetmonitor v1.27.0 h1:+XikKwVDm44set9GFXXkiQWEX8waSdTL6jSnEPoDzX8=
-github.com/aws/aws-sdk-go-v2/service/internetmonitor v1.27.0/go.mod h1:ULNZ7u37CWurqKFBIlvgiuBpftawq8LFpNRV3+TIwIM=
+github.com/aws/aws-sdk-go-v2/service/internetmonitor v1.27.1 h1:5FWxiFSsPmdUC3XkkoWFwA1JIGP3nFCrHylCNByoYhc=
+github.com/aws/aws-sdk-go-v2/service/internetmonitor v1.27.1/go.mod h1:1qUwGVZnLhCkPkQ3SM6RqunW4kyuEmZJsoNjmUx5Q9c=
 github.com/aws/aws-sdk-go-v2/service/invoicing v1.11.0 h1:s/WRy52LDxbT4a4PIMX0zFrpLKsm4uvN6oeW/L+RnNg=
 github.com/aws/aws-sdk-go-v2/service/invoicing v1.11.0/go.mod h1:jm9V3Cs38eUnjUzhEg3Acdz9CFAwd/E0uX1LH99PK80=
 github.com/aws/aws-sdk-go-v2/service/iot v1.73.0 h1:7ZI147ei1koJE5dnfus8cfMOp2CRxsMgORp6hmewV9I=

--- a/go.sum
+++ b/go.sum
@@ -451,8 +451,8 @@ github.com/aws/aws-sdk-go-v2/service/rekognition v1.51.25 h1:sHLu2nnBgPPimcMM5ux
 github.com/aws/aws-sdk-go-v2/service/rekognition v1.51.25/go.mod h1:FgKCcRxb+AKh5sEpCa2hFSUa5LX85mNMxba7DJXxgtw=
 github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.36.1 h1:vPc2Z406d6QIX6lMTAJkwlqteR2BQau90jXiF2F/9gY=
 github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.36.1/go.mod h1:NxGhbjNENgzBTTz0YZeTXiBUB76h8X9Bj0/oX1wfTao=
-github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.23.6 h1:v4Gii9Pxx4bvvNmV5Se1pmx0ag5+Eb3/wZkT03iyCCI=
-github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.23.6/go.mod h1:W/WhNWo1nbW+wVQTw8681WzAj6yTOvGLl8GLWNEWC2I=
+github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.24.1 h1:UW8Cxq/yCtXahOLPJ7yYCDSN71pum/fZYic1PZuslZ4=
+github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.24.1/go.mod h1:Wr9N1XAxETSULikeGK1CSoxKqGe5CStOLtR4cQfP9KM=
 github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.33.26 h1:HmcCtAaTeZTskXrcrdoioe6oDsQCbdGekBkLOCUE8F8=
 github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.33.26/go.mod h1:nYctzUkOuHA0n6thF68Td93Mm8NJzAhWuhKOIqk5vW8=
 github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.32.0 h1:99o6w7ROYcs6aATT6af2LPtUfCCDSKAFDMDorUHgNHw=

--- a/go.sum
+++ b/go.sum
@@ -255,8 +255,8 @@ github.com/aws/aws-sdk-go-v2/service/eventbridge v1.46.1 h1:L+gdqhYUoNwwmJQyrvD1
 github.com/aws/aws-sdk-go-v2/service/eventbridge v1.46.1/go.mod h1:seQW28L9RT5hICfCQG7s/N+Tlfe5Q7lb4gyombZqo+U=
 github.com/aws/aws-sdk-go-v2/service/evidently v1.30.0 h1:XzLucuWDJKFGR2+krY+ZOfs5fjC9BpeDaHYEf+VIBiA=
 github.com/aws/aws-sdk-go-v2/service/evidently v1.30.0/go.mod h1:C2rE4PiwysyiqCWqQbc0kmO1Jnr4UlpXWEZG18yruSA=
-github.com/aws/aws-sdk-go-v2/service/evs v1.10.0 h1:n2SZEQalw3m6TR8sAuEKm8f10Jb+0gqxhpEEpEaTuIs=
-github.com/aws/aws-sdk-go-v2/service/evs v1.10.0/go.mod h1:CfV+SikA+gkA31MfLmMIo+1dN3+qNkKBjtQ/XSjipiY=
+github.com/aws/aws-sdk-go-v2/service/evs v1.10.1 h1:Yhpuxq270m6fkSTcv4+XqshcPrcC5oDHIW+luaYIDZY=
+github.com/aws/aws-sdk-go-v2/service/evs v1.10.1/go.mod h1:QAoOVq2InsEnSsl3MR+RstiyukTltYJqHVbT/ImJv2w=
 github.com/aws/aws-sdk-go-v2/service/finspace v1.33.23 h1:82NyfnpmHfHzhedQ3hMRti2BUlWFR6Tpf5h5gtGjC8I=
 github.com/aws/aws-sdk-go-v2/service/finspace v1.33.23/go.mod h1:4BIGPIjoKsxB3CGsaJ3+uLn6zn2j6Uu3xQEcXMGz+C8=
 github.com/aws/aws-sdk-go-v2/service/firehose v1.42.16 h1:nSg1UAENCjuryTr9JMPMOPXkYOkcpVwQjrrp5rkHUus=

--- a/go.sum
+++ b/go.sum
@@ -371,8 +371,8 @@ github.com/aws/aws-sdk-go-v2/service/memorydb v1.34.1 h1:RhXEEuM4OcMbRSMIqxNjFYw
 github.com/aws/aws-sdk-go-v2/service/memorydb v1.34.1/go.mod h1:p2VcxOL4NmPRJW3Nl20lghEqJFVhWjZpT5uP46mhM44=
 github.com/aws/aws-sdk-go-v2/service/mgn v1.44.1 h1:5Etw8C5flLuINUJNlE9HanIDd6Z6+3FCAEO1Z827dOI=
 github.com/aws/aws-sdk-go-v2/service/mgn v1.44.1/go.mod h1:KR2PuoyY3PpsnMaQ7F+6EnvsUUSVbSwNwrQxBjUy7eU=
-github.com/aws/aws-sdk-go-v2/service/mpa v1.7.4 h1:ZaNccmns5TnxUasTmyma6Z8nwy70A54OyNwxvFXFLhI=
-github.com/aws/aws-sdk-go-v2/service/mpa v1.7.4/go.mod h1:Ap++P+Jq969tV8X0Vf9jkLuCZ3ssdLBHovSsmL0+CHU=
+github.com/aws/aws-sdk-go-v2/service/mpa v1.8.1 h1:w72sLJK6Oqa4kKmBCtrYxvcUqoGACcQ51ePjrAtMi2s=
+github.com/aws/aws-sdk-go-v2/service/mpa v1.8.1/go.mod h1:hKfTw6IUWyrVbmuHu9fouTshz1KJdPFLE3SDpXgtF4o=
 github.com/aws/aws-sdk-go-v2/service/mq v1.34.22 h1:l7nzDTuFH15cvRIFo5cFokN5g+9sA/ZYUsiffFBTObk=
 github.com/aws/aws-sdk-go-v2/service/mq v1.34.22/go.mod h1:aWvcRNyk/LFb3R6xIJE1o4MDwJcLjXhpdlg8X4kW57k=
 github.com/aws/aws-sdk-go-v2/service/mwaa v1.40.1 h1:fVJ6uZsjHWiMbT4tPsNPmA5VElniNCKj1pE4nb1J9gg=

--- a/go.sum
+++ b/go.sum
@@ -419,8 +419,8 @@ github.com/aws/aws-sdk-go-v2/service/pcs v1.19.0 h1:ojV3rqbQU8gXcmJ+grR1axc+mT5m
 github.com/aws/aws-sdk-go-v2/service/pcs v1.19.0/go.mod h1:M+qbwaZuyooD1vA2rrRkoaokZ4V21Kitfu4+qN58Fsw=
 github.com/aws/aws-sdk-go-v2/service/pinpoint v1.39.24 h1:67Y2jqLLj6en/ZCG8ISz0LQbJCkLbcKStkncVLn8r0k=
 github.com/aws/aws-sdk-go-v2/service/pinpoint v1.39.24/go.mod h1:k9ZdOPKJWrh5bFUnC0K4A0omUyGp0zFAcnPUX2/1v2o=
-github.com/aws/aws-sdk-go-v2/service/pinpointsmsvoicev2 v1.28.2 h1:CCUupPmQvjZRsQlyF6/qmrWgOwLhejP+prj273iCuyY=
-github.com/aws/aws-sdk-go-v2/service/pinpointsmsvoicev2 v1.28.2/go.mod h1:8+8lD4dvbnctRIsbL4mHv8FEhm5a5RLdwVElfA9rxoM=
+github.com/aws/aws-sdk-go-v2/service/pinpointsmsvoicev2 v1.29.0 h1:QZcwdS7MHOTFy3kcEO/88Ql3sOmjRhCIAzIVdeZUum8=
+github.com/aws/aws-sdk-go-v2/service/pinpointsmsvoicev2 v1.29.0/go.mod h1:3JW0jAoKkJsjUJuSbCDFyra1qIR0PRJfmPQWwe3lT04=
 github.com/aws/aws-sdk-go-v2/service/pipes v1.24.0 h1:NlxDsdecMTXaqjwym1Bvfq5SkIvcowO5BfDouo3nLIE=
 github.com/aws/aws-sdk-go-v2/service/pipes v1.24.0/go.mod h1:zpfI78kzmseqeSDG1tA4++Y8TKMDDTBQcFiwNoPgjgU=
 github.com/aws/aws-sdk-go-v2/service/polly v1.57.5 h1:6pvU6R++AiWb3+NNgpoMjYnPNu2hsEEXJLK5V8BQ1G4=

--- a/go.sum
+++ b/go.sum
@@ -515,8 +515,8 @@ github.com/aws/aws-sdk-go-v2/service/sesv2 v1.61.1 h1:hwZmof1yhUHQkNDx8RrhX0CMNM
 github.com/aws/aws-sdk-go-v2/service/sesv2 v1.61.1/go.mod h1:5NtZCuE27gANW013bfdrXxD58KB4fr7Lgxub8TS4c6I=
 github.com/aws/aws-sdk-go-v2/service/sfn v1.41.1 h1:4zfm2N+Ip8J3MMTZhGH1O48Ys41DtHuRzbxA6Qzf/J0=
 github.com/aws/aws-sdk-go-v2/service/sfn v1.41.1/go.mod h1:hjpLasQKdoWfJvDu9X4m4rsH+XUKaRaGa3Uu3zmkKc4=
-github.com/aws/aws-sdk-go-v2/service/shield v1.34.23 h1:J/F0GdRt3gHtS7U5IGq37+dBQR3OCXzDFgAkCRJw//k=
-github.com/aws/aws-sdk-go-v2/service/shield v1.34.23/go.mod h1:G/PDEt2cCa1XH1hHT+g0Px4MzsknI460+3gxVP69V7g=
+github.com/aws/aws-sdk-go-v2/service/shield v1.34.24 h1:VHoKrfI8KCSP/kRD4tWv5gn4pf6hW4QNgEH8vPwPaFY=
+github.com/aws/aws-sdk-go-v2/service/shield v1.34.24/go.mod h1:25MGNwFePM9m38MHD9qGSJEcpH1oJLBAB2OdxrJS65U=
 github.com/aws/aws-sdk-go-v2/service/signer v1.33.0 h1:TDg2kuUTXjjY98Vmf3TagGSiV6PgnSI79sqPK4rGN4E=
 github.com/aws/aws-sdk-go-v2/service/signer v1.33.0/go.mod h1:GltxkRtgafy6gdpgP0BICa1H5/pBaQDINsyLbGr59Lw=
 github.com/aws/aws-sdk-go-v2/service/signin v1.1.0 h1:yQo3eZ5qFaL1sJWqs1nL6j3yPHA2/R7c6tQ4T+0IO10=

--- a/go.sum
+++ b/go.sum
@@ -283,8 +283,8 @@ github.com/aws/aws-sdk-go-v2/service/groundstation v1.42.0 h1:lFg4tM2tx+FQNy36hx
 github.com/aws/aws-sdk-go-v2/service/groundstation v1.42.0/go.mod h1:q65bYfAuFmMS7zdSgFFs7FRygyzMfKtAnbqMF1H23YY=
 github.com/aws/aws-sdk-go-v2/service/guardduty v1.78.1 h1:t1B3HJA+ehBVWsbyN06FcamKXZc0lQrsBP2yNspOfLU=
 github.com/aws/aws-sdk-go-v2/service/guardduty v1.78.1/go.mod h1:mxLYMURDsGZnM8Syt/a0npPMYX28grL3R1xUpiMD0h0=
-github.com/aws/aws-sdk-go-v2/service/healthlake v1.37.0 h1:/y3MPNKd8QvlnCAltxWg9rflfbWgF8XH6ehX8xD4OFE=
-github.com/aws/aws-sdk-go-v2/service/healthlake v1.37.0/go.mod h1:xW2c/WbdF4VnPp2dw/uUjcf8+SnAPilvlSYsfWcHo3Y=
+github.com/aws/aws-sdk-go-v2/service/healthlake v1.37.1 h1:40UHAoml+Isk+Tp2+kaoK6Vkr7uR7FcIUw+r97HmLvA=
+github.com/aws/aws-sdk-go-v2/service/healthlake v1.37.1/go.mod h1:q3E7DgMX7FNV9Q1Fqv/E6aLa7fcDqOK50zVinEKeRyU=
 github.com/aws/aws-sdk-go-v2/service/iam v1.53.10 h1:kcN3I3llO7VwIY5w3Pc5FmEonpsr23Ou7Cwk4qf7dik=
 github.com/aws/aws-sdk-go-v2/service/iam v1.53.10/go.mod h1:1vkJzjCYC3byO0kIrBqLPzvZpuvYhPXkuyARs6E7tM4=
 github.com/aws/aws-sdk-go-v2/service/identitystore v1.37.0 h1:iVXnOYef3NmG72qZt525K8H2gdYJ03MTw/QaeTiKl0E=

--- a/go.sum
+++ b/go.sum
@@ -127,8 +127,8 @@ github.com/aws/aws-sdk-go-v2/service/cloudfront v1.64.1 h1:ZTPq5RiymFaH+UoFz0fRV
 github.com/aws/aws-sdk-go-v2/service/cloudfront v1.64.1/go.mod h1:gaGjhyTtT7wcnc7SIPC1+hACSRMQV7VRN8ACY6khGOc=
 github.com/aws/aws-sdk-go-v2/service/cloudfrontkeyvaluestore v1.13.0 h1:hsxsHl8HC0sGpReyfruPJZCyOt05mYf+tleAOcIr+V0=
 github.com/aws/aws-sdk-go-v2/service/cloudfrontkeyvaluestore v1.13.0/go.mod h1:l6Cy+yFNEducMfkStt4kQjgnqXKslfbqjVH7orDS8og=
-github.com/aws/aws-sdk-go-v2/service/cloudhsmv2 v1.34.25 h1:OOrm22PtgqY0/NaHxytd42a6i6lepRE8PPPPKDRt3eA=
-github.com/aws/aws-sdk-go-v2/service/cloudhsmv2 v1.34.25/go.mod h1:KBEemKWZnAP3hVnxCdSO29XcAaH8D42CJeRy/fjDqgg=
+github.com/aws/aws-sdk-go-v2/service/cloudhsmv2 v1.34.26 h1:lyAQbQ0pkqvAg4reG1JjKQ22Ctsc1GLBD1NfE8bTXdo=
+github.com/aws/aws-sdk-go-v2/service/cloudhsmv2 v1.34.26/go.mod h1:sDedonK8Lz6fMf4q1vEjzyyO3jskCECWosEhNS40sro=
 github.com/aws/aws-sdk-go-v2/service/cloudsearch v1.32.14 h1:dOFz4EN9UgHW91gLgplACvAMElqFXKyHzetpphgjOEo=
 github.com/aws/aws-sdk-go-v2/service/cloudsearch v1.32.14/go.mod h1:tAXEWXgcwNtdCXC9GqNAUpsNs53hDmyRnZsm3yyXvV4=
 github.com/aws/aws-sdk-go-v2/service/cloudtrail v1.55.11 h1:3IDx7ybn7pyrLgVShEfGmEXec1xsqgoD1ADI1SxqKT0=

--- a/go.sum
+++ b/go.sum
@@ -235,8 +235,8 @@ github.com/aws/aws-sdk-go-v2/service/eks v1.84.1 h1:v3IeM72tqpk3LGx+PCPEP2IP8SsB
 github.com/aws/aws-sdk-go-v2/service/eks v1.84.1/go.mod h1:4KiCxT4w134foeUz8N5tKJBNaKMBw62nYTsr9ewDVP4=
 github.com/aws/aws-sdk-go-v2/service/elasticache v1.52.3 h1:l6i/86M1/beEHPdxcj/85RuUH0egKZ2m8F8eMA+ejPE=
 github.com/aws/aws-sdk-go-v2/service/elasticache v1.52.3/go.mod h1:hpwaNXHNAM4EP+m38yzQI4hOgVwnjlNfK7Iq9GXYl04=
-github.com/aws/aws-sdk-go-v2/service/elasticbeanstalk v1.34.4 h1:0lWGw/CCacFJ97IBwi25huydqDogkF+aX0cnluiTsNA=
-github.com/aws/aws-sdk-go-v2/service/elasticbeanstalk v1.34.4/go.mod h1:DVDotsaHVCjF12bvBnytGoD5VU+eRYpAuaKdB9US49Q=
+github.com/aws/aws-sdk-go-v2/service/elasticbeanstalk v1.34.5 h1:lngZe4LXmP9FlF9LQ0YhNdRpLJi65oN/Mc41VQoxSJM=
+github.com/aws/aws-sdk-go-v2/service/elasticbeanstalk v1.34.5/go.mod h1:lxzT/1L6i9X/yAAE1zArAoFjWao/tjlfwo38zFp+RI0=
 github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing v1.33.25 h1:VzmoYPRbNSUqk3pA04ZyGZUg52yfX259XXRqwr1lns4=
 github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing v1.33.25/go.mod h1:r7chQGimOmFs4oqawhO+i+o3ez2l69rzAco5KTb7bjY=
 github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.54.12 h1:TJXv7kZjdXA2maPDaJFFEQPBrPmvPtMybN3qYDOpJ4Y=

--- a/go.sum
+++ b/go.sum
@@ -481,8 +481,8 @@ github.com/aws/aws-sdk-go-v2/service/s3files v1.0.3 h1:S3+dpkrgIdGvw8kt4bESzv+uU
 github.com/aws/aws-sdk-go-v2/service/s3files v1.0.3/go.mod h1:peu+U0l09wQS8QIDhZU9dHM35RkvmtBjaVPWNioftX8=
 github.com/aws/aws-sdk-go-v2/service/s3outposts v1.34.15 h1:dpMlv/sdP2z367O3/YniZHbuYXBlATqaSYX4ukOd07A=
 github.com/aws/aws-sdk-go-v2/service/s3outposts v1.34.15/go.mod h1:YXQPuBVEAA+8BRLzs3FMwvcfUdTvXVBRCIrPMghTmDM=
-github.com/aws/aws-sdk-go-v2/service/s3tables v1.16.0 h1:/oAhojlGOkpTz9qnblIpoq7tYvjU6smR2cTHGauvjQA=
-github.com/aws/aws-sdk-go-v2/service/s3tables v1.16.0/go.mod h1:eppybYlnphhnRlQ92dS4ENotpFE2OmwyJsVIICCOjW8=
+github.com/aws/aws-sdk-go-v2/service/s3tables v1.16.1 h1:5+iKON1AS7XVpgNQxn9TidzGSWhBG+9CD6B+tPlx/PY=
+github.com/aws/aws-sdk-go-v2/service/s3tables v1.16.1/go.mod h1:uqGcjeWoKrvYefPNpHdQ2Ne/8HUtzshAuG4VzH7XhIg=
 github.com/aws/aws-sdk-go-v2/service/s3vectors v1.7.0 h1:CABF4mzlIlRhO0F+HxxIVHMnlCE776sZ+nqkwrdxTc4=
 github.com/aws/aws-sdk-go-v2/service/s3vectors v1.7.0/go.mod h1:loahjH/vYffb8QjGNCG7lNTvjot1Hy0eikvRuyMAymg=
 github.com/aws/aws-sdk-go-v2/service/sagemaker v1.249.0 h1:n8V311ky0gvDeiO6d+srI/6Ai/vmGVIdWWax+rp9dXA=

--- a/go.sum
+++ b/go.sum
@@ -517,8 +517,8 @@ github.com/aws/aws-sdk-go-v2/service/sfn v1.41.1 h1:4zfm2N+Ip8J3MMTZhGH1O48Ys41D
 github.com/aws/aws-sdk-go-v2/service/sfn v1.41.1/go.mod h1:hjpLasQKdoWfJvDu9X4m4rsH+XUKaRaGa3Uu3zmkKc4=
 github.com/aws/aws-sdk-go-v2/service/shield v1.34.24 h1:VHoKrfI8KCSP/kRD4tWv5gn4pf6hW4QNgEH8vPwPaFY=
 github.com/aws/aws-sdk-go-v2/service/shield v1.34.24/go.mod h1:25MGNwFePM9m38MHD9qGSJEcpH1oJLBAB2OdxrJS65U=
-github.com/aws/aws-sdk-go-v2/service/signer v1.33.0 h1:TDg2kuUTXjjY98Vmf3TagGSiV6PgnSI79sqPK4rGN4E=
-github.com/aws/aws-sdk-go-v2/service/signer v1.33.0/go.mod h1:GltxkRtgafy6gdpgP0BICa1H5/pBaQDINsyLbGr59Lw=
+github.com/aws/aws-sdk-go-v2/service/signer v1.33.1 h1:DNU6RZIbz7rEP0H1YErn1ElWNor/+hqmDalu5PJLOhY=
+github.com/aws/aws-sdk-go-v2/service/signer v1.33.1/go.mod h1:31a60A8v7+SYksLgSpOPcSbgexJw5dS9gGiXbbS1CMY=
 github.com/aws/aws-sdk-go-v2/service/signin v1.1.0 h1:yQo3eZ5qFaL1sJWqs1nL6j3yPHA2/R7c6tQ4T+0IO10=
 github.com/aws/aws-sdk-go-v2/service/signin v1.1.0/go.mod h1:3Zzou41Qt/ueXfIzHvTEjDNuR5IjCUBVF01SNhrt1e8=
 github.com/aws/aws-sdk-go-v2/service/sns v1.39.17 h1:synXIPC/L4Cc489P0XDcrVJzHSLj7krKRpFLalbGM2k=

--- a/go.sum
+++ b/go.sum
@@ -93,8 +93,8 @@ github.com/aws/aws-sdk-go-v2/service/autoscalingplans v1.30.17 h1:fB+sNF4xqcysho
 github.com/aws/aws-sdk-go-v2/service/autoscalingplans v1.30.17/go.mod h1:D13yDn18/1mh7ptciNt6Nxt8DEmcGeubZSe5LyZoZtE=
 github.com/aws/aws-sdk-go-v2/service/backup v1.57.1 h1:/6tJSdy0K4A1lsoMcY5DqFkQMHMMF4w8EOmA81hNw08=
 github.com/aws/aws-sdk-go-v2/service/backup v1.57.1/go.mod h1:T961j1gPTNYG/vN/6cQJK06gdtyAWP9MjHNnPIAapX0=
-github.com/aws/aws-sdk-go-v2/service/batch v1.65.0 h1:F2G4oJT5uJyJ/brhUl/NcMDlB9krWdAfqTUhSM41S/k=
-github.com/aws/aws-sdk-go-v2/service/batch v1.65.0/go.mod h1:EHhfaNTxntvYHmSdHGLLSxuerqkMIlXY9lWjl+CJJxg=
+github.com/aws/aws-sdk-go-v2/service/batch v1.65.1 h1:1tGBoOvPGsbeb3a8RO6sNLjP9LxoVrBTRdQVg85hpCk=
+github.com/aws/aws-sdk-go-v2/service/batch v1.65.1/go.mod h1:YtletEcjRsIfctckbFMfsXEiuvm5FjitU2MNmoOHsYA=
 github.com/aws/aws-sdk-go-v2/service/bcmdataexports v1.16.0 h1:XEUbEn17sz6yPl3kP+DUs0cYi5qX2MPjag+A7P3I0Zo=
 github.com/aws/aws-sdk-go-v2/service/bcmdataexports v1.16.0/go.mod h1:zoV7Gv5idtxuUXqF1uRxS83Jb7zeHCa16s27f7dQs9A=
 github.com/aws/aws-sdk-go-v2/service/bedrock v1.61.0 h1:KnLJsk989Y8FvZmEAzjNoQRyx6DK4/WeDDZsGb1X2Yc=

--- a/go.sum
+++ b/go.sum
@@ -189,8 +189,8 @@ github.com/aws/aws-sdk-go-v2/service/databrew v1.40.1 h1:CrqRhUBWuTcdNbCAWVoWpAE
 github.com/aws/aws-sdk-go-v2/service/databrew v1.40.1/go.mod h1:Za6vZBh9dK4VLieS+BBOLuz+3Vz+9PYUKI1+vrJ6DDo=
 github.com/aws/aws-sdk-go-v2/service/dataexchange v1.42.1 h1:NV6JSW33vKaD675ZpaduwOsBlD8hOhlzGoGYAYFEDn4=
 github.com/aws/aws-sdk-go-v2/service/dataexchange v1.42.1/go.mod h1:LnluRcm5NhbRSq7mIzN/l3+63a89KUNLBrth2lF9QCw=
-github.com/aws/aws-sdk-go-v2/service/datapipeline v1.30.22 h1:th7UIseI06gZDd/7ntsyUJmVVbbowq4ypEUh8gf5+OU=
-github.com/aws/aws-sdk-go-v2/service/datapipeline v1.30.22/go.mod h1:vNpeL80rYCglcJXUOeCbC8/qQ9vMclvff5kFMNf7iI0=
+github.com/aws/aws-sdk-go-v2/service/datapipeline v1.30.23 h1:6YmSGnneMPxn3l3mHCZp/V22WOSeWFgpVhnOtwq5NOU=
+github.com/aws/aws-sdk-go-v2/service/datapipeline v1.30.23/go.mod h1:98PrkTTHhKEp4uYhBYynJxNeuui1KXR6WvtT1mQGH3U=
 github.com/aws/aws-sdk-go-v2/service/datasync v1.59.0 h1:ZVx+zJCX9kwDoFv5tJxSW3ESEIimK/u8D/tP4ouyIFY=
 github.com/aws/aws-sdk-go-v2/service/datasync v1.59.0/go.mod h1:5H2TlnEkHntq2f9qVEZ9Fc0uO0vf+30KtECvmnms2m8=
 github.com/aws/aws-sdk-go-v2/service/datazone v1.62.0 h1:ThT7AGMBPcBhDgXVOwiZyJ3x63X4NfruC63Ij4hnFjI=

--- a/go.sum
+++ b/go.sum
@@ -413,8 +413,8 @@ github.com/aws/aws-sdk-go-v2/service/outposts v1.60.1 h1:8UCOqAoJ68CU5YqSZ0inZuY
 github.com/aws/aws-sdk-go-v2/service/outposts v1.60.1/go.mod h1:Yfs4XytNgJNBYeO9VK37ln5SUViyyDQosIZU+JykOnc=
 github.com/aws/aws-sdk-go-v2/service/paymentcryptography v1.30.1 h1:/qmXfvYpUCvjIQvxaap4Qh+B6k0LS5vQl4hbiqL+7D4=
 github.com/aws/aws-sdk-go-v2/service/paymentcryptography v1.30.1/go.mod h1:VG1mn7qHIypEmLludHRsXov7u+oW9Pk/Q74fPwIGpKY=
-github.com/aws/aws-sdk-go-v2/service/pcaconnectorad v1.15.23 h1:CtTEAf/iYhq8G9KLBJH0T3GOZQ6/Ejjt0+J66jdSfKk=
-github.com/aws/aws-sdk-go-v2/service/pcaconnectorad v1.15.23/go.mod h1:rHRclwfqAZZNIE/8KCVZomUOeLyuUd8jdU9a5Z4NQX4=
+github.com/aws/aws-sdk-go-v2/service/pcaconnectorad v1.16.1 h1:DdbnVx5+9A5M92fkGprj26BORbkyPG+UbUAJuTpRYIY=
+github.com/aws/aws-sdk-go-v2/service/pcaconnectorad v1.16.1/go.mod h1:jzVcQK4cv6oDsUYYlMrrydw6weuGzmtE4JRIcIup3iM=
 github.com/aws/aws-sdk-go-v2/service/pcs v1.18.0 h1:mQiOx3IVBZ2by9VcOETEgsfNTJrxqbYjoE1UpJ1A5E0=
 github.com/aws/aws-sdk-go-v2/service/pcs v1.18.0/go.mod h1:2OGJaB8B0hHY3ZsIYzEevlMjLpWJCbHcBQJbNi5NGWw=
 github.com/aws/aws-sdk-go-v2/service/pinpoint v1.39.23 h1:YEwsIfiIhbD4eVaM8GmvFAb5w3MBtNka6lWNBQAEEuc=

--- a/go.sum
+++ b/go.sum
@@ -137,8 +137,8 @@ github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.57.1 h1:i4i1wpCbEiFsge84hmvuL
 github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.57.1/go.mod h1:751oDslfSNqbjCBSZYZKOvXl8Pbx9soAk2nISFo9sN0=
 github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.74.1 h1:8jNx+q40WGu+oYvW9bAo4wA/5P4RwKcMgInblHVRFhM=
 github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.74.1/go.mod h1:fzoRhw/rzt5X9EPA8fjbhZ/Ph0tChldiC/kPIFAGI7A=
-github.com/aws/aws-sdk-go-v2/service/codeartifact v1.39.0 h1:Fn9GARyT8xa81y8sYE5pvIjIRpYdUlbFyEuMadrkgoE=
-github.com/aws/aws-sdk-go-v2/service/codeartifact v1.39.0/go.mod h1:eyySIoSU4Mj4Ya1HD5Mf1EuzWvXAGaAS4mjSuGiBF4A=
+github.com/aws/aws-sdk-go-v2/service/codeartifact v1.39.1 h1:f11z1s2b5Yn/vdvS6PWHI8FnEHZnq/iBhk24NVGlE4Q=
+github.com/aws/aws-sdk-go-v2/service/codeartifact v1.39.1/go.mod h1:PZ43Dwh72tKIZv/nL1+4tre21tuMEkKnH7ktxnNu8Ss=
 github.com/aws/aws-sdk-go-v2/service/codebuild v1.68.16 h1:ocvG4uGirVVBVsDQZGNlFPcKghtC/rxLW4y0jcwBp1I=
 github.com/aws/aws-sdk-go-v2/service/codebuild v1.68.16/go.mod h1:9WntqQzPVMdtY8e9rM22XT1ykcrmxdr/l/A2w17+l+8=
 github.com/aws/aws-sdk-go-v2/service/codecatalyst v1.21.14 h1:djJmgkjv6JU9c7cNrK7GLJgkEi4ZEae2mm8ZqPaeiZU=

--- a/go.sum
+++ b/go.sum
@@ -227,8 +227,8 @@ github.com/aws/aws-sdk-go-v2/service/ecr v1.57.3 h1:A96oesTgxeuq40H9PKkPXQDvqeLy
 github.com/aws/aws-sdk-go-v2/service/ecr v1.57.3/go.mod h1:wig6P1dEk+MIgducD7hX+RcnnRBSvk9S/4J398XJ+sE=
 github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.39.1 h1:AgyAEGH3FMq76rF/0oZNbvKWE0TJDwA3lK+Zwq6fujQ=
 github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.39.1/go.mod h1:x2sEaNEFTaoEOC7G+tLOh2MWCdjzvNrJO76YyA+inLo=
-github.com/aws/aws-sdk-go-v2/service/ecs v1.80.0 h1:orZYOYtvYU7A45XTWC/UchWSkkdWjOyXi8MYksnmQf0=
-github.com/aws/aws-sdk-go-v2/service/ecs v1.80.0/go.mod h1:TIKZ9zIFS6W2k9FeW+r5sGVnlxp+aUt9oQ/St3Suj1o=
+github.com/aws/aws-sdk-go-v2/service/ecs v1.81.1 h1:LyyVqeXzra+cPw0BGloOuowJCTvl6joUAxOgs3+lxNQ=
+github.com/aws/aws-sdk-go-v2/service/ecs v1.81.1/go.mod h1:0Lg4lqs9OzRR/Ne8x/rQnRi7qe4LLPnLch/VhqmFPRc=
 github.com/aws/aws-sdk-go-v2/service/efs v1.41.16 h1:qHmh61/S6g+scI9M4U3XYivCiEp1tUadKgyrczuLJpM=
 github.com/aws/aws-sdk-go-v2/service/efs v1.41.16/go.mod h1:Q7WcY1H6krqZEnFyxyuzfLAnEad1Q69U4CrBbY4P2Fg=
 github.com/aws/aws-sdk-go-v2/service/eks v1.84.0 h1:U9HMTDPdZtkCOTE8ACbHQJmXGBKP7/mBds7M1JbUZH0=

--- a/go.sum
+++ b/go.sum
@@ -375,8 +375,8 @@ github.com/aws/aws-sdk-go-v2/service/mpa v1.8.1 h1:w72sLJK6Oqa4kKmBCtrYxvcUqoGAC
 github.com/aws/aws-sdk-go-v2/service/mpa v1.8.1/go.mod h1:hKfTw6IUWyrVbmuHu9fouTshz1KJdPFLE3SDpXgtF4o=
 github.com/aws/aws-sdk-go-v2/service/mq v1.34.23 h1:W65gsIOHWb1jwqkILta3uVormtrgYKVdef0U9BHTJ54=
 github.com/aws/aws-sdk-go-v2/service/mq v1.34.23/go.mod h1:8neGcEvd8ny7TLfOT9be0HUx+jA7w46g2QM6JHl4Ptk=
-github.com/aws/aws-sdk-go-v2/service/mwaa v1.40.1 h1:fVJ6uZsjHWiMbT4tPsNPmA5VElniNCKj1pE4nb1J9gg=
-github.com/aws/aws-sdk-go-v2/service/mwaa v1.40.1/go.mod h1:O2kdYrYDkdHdUpvYcrWQoYaJgPJCGHdaLF06ep3HzKI=
+github.com/aws/aws-sdk-go-v2/service/mwaa v1.40.2 h1:HjEVYf5acZzGMV2vrRsPSsXotF62rjw32IvDs5idLVQ=
+github.com/aws/aws-sdk-go-v2/service/mwaa v1.40.2/go.mod h1:QWhxT8PFUeriuIyNPNoPtKMCpsaxPraSu8V+B50cCcs=
 github.com/aws/aws-sdk-go-v2/service/mwaaserverless v1.0.11 h1:F6jhTASJH6ekrt1mbD/KKxVcA4cZYOLEWLHuPedAw88=
 github.com/aws/aws-sdk-go-v2/service/mwaaserverless v1.0.11/go.mod h1:gnvpQdIADizJ9VLRCzZQLgL0lNz8ZSH73hQWUgR9N70=
 github.com/aws/aws-sdk-go-v2/service/neptune v1.44.5 h1:v+XVk5OQnhm6EasbClY036A1gTtVdtdNdG8/Q3rLYU4=

--- a/go.sum
+++ b/go.sum
@@ -483,8 +483,8 @@ github.com/aws/aws-sdk-go-v2/service/s3outposts v1.34.15 h1:dpMlv/sdP2z367O3/Yni
 github.com/aws/aws-sdk-go-v2/service/s3outposts v1.34.15/go.mod h1:YXQPuBVEAA+8BRLzs3FMwvcfUdTvXVBRCIrPMghTmDM=
 github.com/aws/aws-sdk-go-v2/service/s3tables v1.16.1 h1:5+iKON1AS7XVpgNQxn9TidzGSWhBG+9CD6B+tPlx/PY=
 github.com/aws/aws-sdk-go-v2/service/s3tables v1.16.1/go.mod h1:uqGcjeWoKrvYefPNpHdQ2Ne/8HUtzshAuG4VzH7XhIg=
-github.com/aws/aws-sdk-go-v2/service/s3vectors v1.7.0 h1:CABF4mzlIlRhO0F+HxxIVHMnlCE776sZ+nqkwrdxTc4=
-github.com/aws/aws-sdk-go-v2/service/s3vectors v1.7.0/go.mod h1:loahjH/vYffb8QjGNCG7lNTvjot1Hy0eikvRuyMAymg=
+github.com/aws/aws-sdk-go-v2/service/s3vectors v1.7.1 h1:kS5jiMR5DgHoBHKyTZerpQjzUWvcTbeHVFbi5cL+H3s=
+github.com/aws/aws-sdk-go-v2/service/s3vectors v1.7.1/go.mod h1:EbboPnapUuRZyMud+453TcE1BKQ9QJYP77RmGmT2CUM=
 github.com/aws/aws-sdk-go-v2/service/sagemaker v1.249.0 h1:n8V311ky0gvDeiO6d+srI/6Ai/vmGVIdWWax+rp9dXA=
 github.com/aws/aws-sdk-go-v2/service/sagemaker v1.249.0/go.mod h1:CWbiQe1BkvmBlSfdI8DOoNaqoehc2+JWnylOfmR7aKU=
 github.com/aws/aws-sdk-go-v2/service/savingsplans v1.32.4 h1:BWmdjmP8sWqe0eICMM+2X2jic2S41bJ7xDhz3Wfd8/0=

--- a/go.sum
+++ b/go.sum
@@ -549,8 +549,8 @@ github.com/aws/aws-sdk-go-v2/service/swf v1.33.19 h1:H/an3wyJhN77u6RLkzG4cief0Ep
 github.com/aws/aws-sdk-go-v2/service/swf v1.33.19/go.mod h1:4eZKh8JaPvMXUmTf4wHl7S30oumGXWpFCF1pfLR9ico=
 github.com/aws/aws-sdk-go-v2/service/synthetics v1.42.17 h1:laIoRwwPASaSQl/U+8mratWJ5IK2mzl/7nhyFA9+4jg=
 github.com/aws/aws-sdk-go-v2/service/synthetics v1.42.17/go.mod h1:OnocIS6UzQdU0bC/tP7vNkB/6Lb3jwgEqO1bhQhbpco=
-github.com/aws/aws-sdk-go-v2/service/taxsettings v1.16.23 h1:39DCdgj7earBK4aIN7iON1PjoyduoTIxwkW3O+LyAfk=
-github.com/aws/aws-sdk-go-v2/service/taxsettings v1.16.23/go.mod h1:/U0lhg35wBZFmjijdF3imRoXuoDwM2KjCkSE2GlWnzU=
+github.com/aws/aws-sdk-go-v2/service/taxsettings v1.16.24 h1:jLJ3xMWjeHbmilHerEyVMILfQ/imOFAslNgHswpPXdo=
+github.com/aws/aws-sdk-go-v2/service/taxsettings v1.16.24/go.mod h1:Ufi/y8T3Yuj3w05IDIvevtz+wxQjrXeBIroAGjCKJtQ=
 github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.19.2 h1:D9z71BkiK5Xa6ibHU/3bkIAyGRwfqnn3jH8EWGhuzxs=
 github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.19.2/go.mod h1:hMTWUZs9ne9yqIiqHuMc0UcdNA6gYiA4VPyJ0jK7YJs=
 github.com/aws/aws-sdk-go-v2/service/timestreamquery v1.36.17 h1:PAw0bg4Vw9G19+ozW3uJQXxxNYqk8J3jztJxZBCU71g=

--- a/go.sum
+++ b/go.sum
@@ -265,8 +265,8 @@ github.com/aws/aws-sdk-go-v2/service/fis v1.38.1 h1:HqYQa990x6wWfCynr4uXS+Gmu0FA
 github.com/aws/aws-sdk-go-v2/service/fis v1.38.1/go.mod h1:i2OcUIs4mCx4zH/tesSFfLBaoI1qVz6QTwexgtcoqTI=
 github.com/aws/aws-sdk-go-v2/service/fms v1.45.1 h1:BXUO368cAQX3BTvRg3BnSyIT53v/qygNteYwuCJ+YaE=
 github.com/aws/aws-sdk-go-v2/service/fms v1.45.1/go.mod h1:zPxf7KJDIlavIfbrET7zYSIjqxmkMT7ziFCa+DPVrTc=
-github.com/aws/aws-sdk-go-v2/service/fsx v1.66.0 h1:ecF4zwUh0+0v9jMAv1cJ2VyTk8Hx+pjkxC446pkv2gw=
-github.com/aws/aws-sdk-go-v2/service/fsx v1.66.0/go.mod h1:ZhrGF6EmakQJR9N5lGxh7LdkVG+v+Iaa1+PKU9eehWQ=
+github.com/aws/aws-sdk-go-v2/service/fsx v1.66.1 h1:YX1l7nNVKvHe3pEu498sW76WuHUAapZwQU2SpqRVMi8=
+github.com/aws/aws-sdk-go-v2/service/fsx v1.66.1/go.mod h1:DL5UJomGBiqjRf84eSykFbyQoLretYc1JPysrsKZSDc=
 github.com/aws/aws-sdk-go-v2/service/gamelift v1.54.0 h1:TnDHcCjQbeyxNgWV67Gz8DigkCDcz6t4y+UWBItR1zc=
 github.com/aws/aws-sdk-go-v2/service/gamelift v1.54.0/go.mod h1:krO76k8XMEa+hBF4M+zuyU2XXct6JQIdH5LKOrltHew=
 github.com/aws/aws-sdk-go-v2/service/glacier v1.32.8 h1:OGRgf5Jd5Vfxksc/HU4oCuYVes+/N0qWbMys90WMLsw=

--- a/go.sum
+++ b/go.sum
@@ -449,8 +449,8 @@ github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.35.1 h1:q4W7YdDkLlrIj
 github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.35.1/go.mod h1:qmN3dNnbhFHpwkQbpqbjjDH4co6/ETmKavalziNWLLs=
 github.com/aws/aws-sdk-go-v2/service/rekognition v1.51.25 h1:sHLu2nnBgPPimcMM5ux3jvaX2EA8DGrYqNQ5q6B3YPI=
 github.com/aws/aws-sdk-go-v2/service/rekognition v1.51.25/go.mod h1:FgKCcRxb+AKh5sEpCa2hFSUa5LX85mNMxba7DJXxgtw=
-github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.36.0 h1:1Nsy4eFGYxZqGfDA6+X23ngP1QiXmqjititE5quiVX0=
-github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.36.0/go.mod h1:SgbYsV9bP7Ol85rNEwH3PY1cgw/UWZCNkoUhMfb236U=
+github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.36.1 h1:vPc2Z406d6QIX6lMTAJkwlqteR2BQau90jXiF2F/9gY=
+github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.36.1/go.mod h1:NxGhbjNENgzBTTz0YZeTXiBUB76h8X9Bj0/oX1wfTao=
 github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.23.6 h1:v4Gii9Pxx4bvvNmV5Se1pmx0ag5+Eb3/wZkT03iyCCI=
 github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.23.6/go.mod h1:W/WhNWo1nbW+wVQTw8681WzAj6yTOvGLl8GLWNEWC2I=
 github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.33.26 h1:HmcCtAaTeZTskXrcrdoioe6oDsQCbdGekBkLOCUE8F8=

--- a/go.sum
+++ b/go.sum
@@ -379,8 +379,8 @@ github.com/aws/aws-sdk-go-v2/service/mwaa v1.40.2 h1:HjEVYf5acZzGMV2vrRsPSsXotF6
 github.com/aws/aws-sdk-go-v2/service/mwaa v1.40.2/go.mod h1:QWhxT8PFUeriuIyNPNoPtKMCpsaxPraSu8V+B50cCcs=
 github.com/aws/aws-sdk-go-v2/service/mwaaserverless v1.0.12 h1:WdKoYiwzDxdeaynP/Qo1WnjeSD8JaTaPHxcM5XKFuMc=
 github.com/aws/aws-sdk-go-v2/service/mwaaserverless v1.0.12/go.mod h1:z3yp7mzFwRvWFayqFKJq8hsLxbTD1YiMVeowTwlg2YQ=
-github.com/aws/aws-sdk-go-v2/service/neptune v1.44.5 h1:v+XVk5OQnhm6EasbClY036A1gTtVdtdNdG8/Q3rLYU4=
-github.com/aws/aws-sdk-go-v2/service/neptune v1.44.5/go.mod h1:Y/yH7q6R/qaO4g6YTBbAMSu5T4NjVo+7+P1UNZ2NlzA=
+github.com/aws/aws-sdk-go-v2/service/neptune v1.44.6 h1:fEiBIUr6UVYs6LxASES6m8a6Nyfe2MkLMY6h1/7G/f4=
+github.com/aws/aws-sdk-go-v2/service/neptune v1.44.6/go.mod h1:+UvGeb9YQ093vXXr5/GM8AcOcLeXsO/zejCbna5zZQo=
 github.com/aws/aws-sdk-go-v2/service/neptunegraph v1.21.23 h1:0QhwVtPhDWDUN98mArFWF5GyFyeDLntZYGR0fG9l6/w=
 github.com/aws/aws-sdk-go-v2/service/neptunegraph v1.21.23/go.mod h1:QYHHT9HDGfjS40Xcj1JgY6g7Q0zAqPtJT/s0hvZzvcc=
 github.com/aws/aws-sdk-go-v2/service/networkfirewall v1.61.0 h1:/cxzydSADiL23o7Z8ZYdNTDGSx2RuJZr3mJa67MtBOc=

--- a/go.sum
+++ b/go.sum
@@ -579,8 +579,8 @@ github.com/aws/aws-sdk-go-v2/service/workmail v1.37.1 h1:kkW+177cM7iuWX5VYUR4BOy
 github.com/aws/aws-sdk-go-v2/service/workmail v1.37.1/go.mod h1:UcDqAbgkZdXt7qiHgrC5qSUIGPaV35b0L2/2Nt/EcY0=
 github.com/aws/aws-sdk-go-v2/service/workspaces v1.68.2 h1:tDCxiS3qmTHTnLj88M4UjFRHdp3x+CCfpwBiOPiBZTk=
 github.com/aws/aws-sdk-go-v2/service/workspaces v1.68.2/go.mod h1:zkyqZ/TcuMeIkKVmI0DdC3k7VMj649AQScJSq9yvbb0=
-github.com/aws/aws-sdk-go-v2/service/workspacesweb v1.39.0 h1:oieTfrV3d0D/00Q7T8zc7vxnnz89M6Ux02Ocaw2qu50=
-github.com/aws/aws-sdk-go-v2/service/workspacesweb v1.39.0/go.mod h1:5d3WGmJnZy7o8uLL4hAGEcj1aDM1UkP1+rVPOhSe6cw=
+github.com/aws/aws-sdk-go-v2/service/workspacesweb v1.40.1 h1:AqfLNl9FpoH6stsFchZPaUuinb+CpbjF+jQdrCrOxO0=
+github.com/aws/aws-sdk-go-v2/service/workspacesweb v1.40.1/go.mod h1:LkpCj8zttwGuTuSM/Lkq7DGsrFx3asPdj9rKyAJekiw=
 github.com/aws/aws-sdk-go-v2/service/xray v1.36.23 h1:23UXC4h6nNZqOmk+xaXcfyTH/IIvqWycQk154GaSiE8=
 github.com/aws/aws-sdk-go-v2/service/xray v1.36.23/go.mod h1:XEYnz2YYwBDEDHrfBWjv31kK8vCTrvCcnS7K7vyrDA0=
 github.com/aws/smithy-go v1.26.0 h1:9ouqbi+NyKP7fV3Te7UElCwdAb6Y8uk7LGwPE5tVe/s=

--- a/go.sum
+++ b/go.sum
@@ -77,8 +77,8 @@ github.com/aws/aws-sdk-go-v2/service/apprunner v1.40.1 h1:o/4DSr4gIe+PBGbAIG0SSZ
 github.com/aws/aws-sdk-go-v2/service/apprunner v1.40.1/go.mod h1:24gjDeb/xEFpfIfkxh5T1JTDd/f9Gtbada7V52Q401I=
 github.com/aws/aws-sdk-go-v2/service/appstream v1.60.0 h1:JuwEfGyAHpofgXhxNy5jIGaiUulBlH1/5KPb6mTnjtc=
 github.com/aws/aws-sdk-go-v2/service/appstream v1.60.0/go.mod h1:NgdOdv2hoXmENwpqqLtyFC8MTcjqRpR9khOl2s1uWyU=
-github.com/aws/aws-sdk-go-v2/service/appsync v1.53.7 h1:SjkXYNc15FoovS9k6ML7dO7pkXE3ns66RXwL+rfQVl8=
-github.com/aws/aws-sdk-go-v2/service/appsync v1.53.7/go.mod h1:RcoBov7Pw38ViMxlthKRr1GLgHPPseA+kY2bupWVm10=
+github.com/aws/aws-sdk-go-v2/service/appsync v1.53.8 h1:CwHQQiBhvXbsEiDS3GERuVE4dRoH8S02jiMIf+Vcihw=
+github.com/aws/aws-sdk-go-v2/service/appsync v1.53.8/go.mod h1:gXYrh3UXmGd/XYsWikBgcjSLs1BAbxqzutFe8JZSuzU=
 github.com/aws/aws-sdk-go-v2/service/arcregionswitch v1.7.0 h1:z4HLC7u07UaaxClNTRsSt4Gy+AAOynoJZMMLijRHoAk=
 github.com/aws/aws-sdk-go-v2/service/arcregionswitch v1.7.0/go.mod h1:5RPh0JZSLageN5/FN0TUGaU+BjEyuXayyOtOo2DMvnU=
 github.com/aws/aws-sdk-go-v2/service/arczonalshift v1.22.25 h1:K3E2d85dSlIfC+cZox0Bg1fjUeYtoOglDDYNqECA30w=

--- a/go.sum
+++ b/go.sum
@@ -247,8 +247,8 @@ github.com/aws/aws-sdk-go-v2/service/elastictranscoder v1.33.0 h1:ZD8Iw3WQlZYoCJ
 github.com/aws/aws-sdk-go-v2/service/elastictranscoder v1.33.0/go.mod h1:1TkRQZaHJfi2GSj/kQNuxQVUyKLAErm+QXF6Dvz7iOs=
 github.com/aws/aws-sdk-go-v2/service/emr v1.59.3 h1:4h8LV+59JgGjcZaAhNvVatYG8CLIY767Y4naJ7Yliho=
 github.com/aws/aws-sdk-go-v2/service/emr v1.59.3/go.mod h1:RVZ0qkKp+7zm3wTQVEVf6yxTFUjVjbpThQkySXwtsfc=
-github.com/aws/aws-sdk-go-v2/service/emrcontainers v1.41.0 h1:9p3/KIL9zZu9NtzX9g3CAQ6ZBw+xcUHSngn+9MhrLPc=
-github.com/aws/aws-sdk-go-v2/service/emrcontainers v1.41.0/go.mod h1:OxVncWlX7EmiBJwHi8aEsDJyTUTmS96j46XbSG/19XE=
+github.com/aws/aws-sdk-go-v2/service/emrcontainers v1.41.1 h1:zYb59S5qlJPP0UKwfN5b5ZeBzRl05pC2PYbzuVrM9Hc=
+github.com/aws/aws-sdk-go-v2/service/emrcontainers v1.41.1/go.mod h1:D2r6LGoC8ROaN5xH6MFNdmLX70Xskt6zEarzRiqgX+Q=
 github.com/aws/aws-sdk-go-v2/service/emrserverless v1.41.0 h1:/avPf4MwaJqp6hr/bJhLilQtOO2uQN/t/8B8DOVnrRE=
 github.com/aws/aws-sdk-go-v2/service/emrserverless v1.41.0/go.mod h1:xfX7dZWdVvSyv9wDHlfpYp1iIA9Y+D/oYwAGYFDPgjQ=
 github.com/aws/aws-sdk-go-v2/service/eventbridge v1.45.25 h1:9PZbyFSCN/E0TnqXqnvYJRhu7yQJv31vHG/vyuirbCY=


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Manual update of `github.com/aws/aws-sdk-go-v2/aws` dependencies to [Release 2026-05-28](https://github.com/aws/aws-sdk-go-v2/commit/74c501189a40c9b937432a1b2a4cacffc851ea76) due to dependabot failures.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/47708.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/47528.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/47129.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/46946.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/46754.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/46635.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/45944.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/45038.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/44939.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/44909.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/44716.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/44484.
Relates https://github.com/hashicorp/terraform-provider-aws/issues/39287.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/43585.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/43619.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/43709.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/43829.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/43980.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/44036.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/44112.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/44203.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make sane
make: Sane Smoke Tests (x tests of Top y resources)
make: Like 'sanity' except full output and stops soon after 1st error
make: NOTE: NOT an exhaustive set of tests! Finds big problems only.
2026/05/29 09:40:20 Creating Terraform AWS Provider (SDKv2-style)...
2026/05/29 09:40:20 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccIAMInstanceProfile_tags
=== PAUSE TestAccIAMInstanceProfile_tags
=== RUN   TestAccIAMInstanceProfile_basic
=== PAUSE TestAccIAMInstanceProfile_basic
=== RUN   TestAccIAMPolicyDocumentDataSource_basic
=== PAUSE TestAccIAMPolicyDocumentDataSource_basic
=== RUN   TestAccIAMPolicyDocumentDataSource_sourceConflicting
=== PAUSE TestAccIAMPolicyDocumentDataSource_sourceConflicting
=== RUN   TestAccIAMPolicy_tags
=== PAUSE TestAccIAMPolicy_tags
=== RUN   TestAccIAMPolicy_basic
=== PAUSE TestAccIAMPolicy_basic
=== RUN   TestAccIAMPolicy_policy
=== PAUSE TestAccIAMPolicy_policy
=== RUN   TestAccIAMRolePolicyAttachment_basic
=== PAUSE TestAccIAMRolePolicyAttachment_basic
=== RUN   TestAccIAMRolePolicyAttachment_disappears
=== PAUSE TestAccIAMRolePolicyAttachment_disappears
=== RUN   TestAccIAMRolePolicyAttachment_Disappears_role
=== PAUSE TestAccIAMRolePolicyAttachment_Disappears_role
=== RUN   TestAccIAMRolePolicy_basic
=== PAUSE TestAccIAMRolePolicy_basic
=== RUN   TestAccIAMRolePolicy_unknownsInPolicy
=== PAUSE TestAccIAMRolePolicy_unknownsInPolicy
=== RUN   TestAccIAMRole_basic
=== PAUSE TestAccIAMRole_basic
=== RUN   TestAccIAMRole_namePrefix
=== PAUSE TestAccIAMRole_namePrefix
=== RUN   TestAccIAMRole_disappears
=== PAUSE TestAccIAMRole_disappears
=== RUN   TestAccIAMRole_InlinePolicy_basic
=== PAUSE TestAccIAMRole_InlinePolicy_basic
=== CONT  TestAccIAMInstanceProfile_tags
=== CONT  TestAccIAMRole_InlinePolicy_basic
=== CONT  TestAccIAMPolicy_policy
=== CONT  TestAccIAMPolicy_basic
=== CONT  TestAccIAMPolicyDocumentDataSource_basic
=== CONT  TestAccIAMPolicyDocumentDataSource_sourceConflicting
=== CONT  TestAccIAMRolePolicy_unknownsInPolicy
=== CONT  TestAccIAMRolePolicy_basic
=== CONT  TestAccIAMRole_basic
=== CONT  TestAccIAMRolePolicyAttachment_Disappears_role
=== CONT  TestAccIAMRole_disappears
=== CONT  TestAccIAMRole_namePrefix
=== CONT  TestAccIAMPolicy_tags
=== CONT  TestAccIAMRolePolicyAttachment_basic
=== CONT  TestAccIAMInstanceProfile_basic
=== CONT  TestAccIAMRolePolicyAttachment_disappears
--- PASS: TestAccIAMPolicyDocumentDataSource_sourceConflicting (23.42s)
--- PASS: TestAccIAMPolicyDocumentDataSource_basic (23.54s)
--- PASS: TestAccIAMRole_disappears (31.03s)
--- PASS: TestAccIAMRolePolicyAttachment_Disappears_role (31.56s)
--- PASS: TestAccIAMRolePolicyAttachment_disappears (31.67s)
--- PASS: TestAccIAMRolePolicy_unknownsInPolicy (32.13s)
--- PASS: TestAccIAMRole_basic (32.76s)
--- PASS: TestAccIAMPolicy_basic (33.12s)
--- PASS: TestAccIAMRole_namePrefix (33.12s)
--- PASS: TestAccIAMRolePolicy_basic (33.19s)
--- PASS: TestAccIAMInstanceProfile_basic (35.75s)
--- PASS: TestAccIAMRolePolicyAttachment_basic (43.57s)
--- PASS: TestAccIAMPolicy_policy (44.08s)
--- PASS: TestAccIAMRole_InlinePolicy_basic (53.30s)
--- PASS: TestAccIAMPolicy_tags (79.08s)
--- PASS: TestAccIAMInstanceProfile_tags (97.29s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/iam        103.204s
2026/05/29 09:42:35 Creating Terraform AWS Provider (SDKv2-style)...
2026/05/29 09:42:35 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccLogsLogGroup_basic
=== PAUSE TestAccLogsLogGroup_basic
=== RUN   TestAccLogsLogGroup_multiple
=== PAUSE TestAccLogsLogGroup_multiple
=== CONT  TestAccLogsLogGroup_basic
=== CONT  TestAccLogsLogGroup_multiple
--- PASS: TestAccLogsLogGroup_multiple (16.96s)
--- PASS: TestAccLogsLogGroup_basic (20.08s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/logs       26.335s
2026/05/29 09:42:43 Creating Terraform AWS Provider (SDKv2-style)...
2026/05/29 09:42:43 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccVPCDataSource_basic
=== PAUSE TestAccVPCDataSource_basic
=== RUN   TestAccVPCRouteTableAssociation_Subnet_basic
=== PAUSE TestAccVPCRouteTableAssociation_Subnet_basic
=== RUN   TestAccVPCRouteTable_basic
=== PAUSE TestAccVPCRouteTable_basic
=== RUN   TestAccVPCSecurityGroupRule_race
=== PAUSE TestAccVPCSecurityGroupRule_race
=== RUN   TestAccVPCSecurityGroupRule_protocolChange
=== PAUSE TestAccVPCSecurityGroupRule_protocolChange
=== RUN   TestAccVPCSecurityGroup_basic
=== PAUSE TestAccVPCSecurityGroup_basic
=== RUN   TestAccVPCSecurityGroup_egressMode
=== PAUSE TestAccVPCSecurityGroup_egressMode
=== RUN   TestAccVPCSecurityGroup_vpcAllEgress
=== PAUSE TestAccVPCSecurityGroup_vpcAllEgress
=== RUN   TestAccVPCSubnet_basic
=== PAUSE TestAccVPCSubnet_basic
=== RUN   TestAccVPC_tenancy
=== PAUSE TestAccVPC_tenancy
=== CONT  TestAccVPCDataSource_basic
=== CONT  TestAccVPCSecurityGroup_vpcAllEgress
=== CONT  TestAccVPCSecurityGroupRule_race
=== CONT  TestAccVPCSecurityGroupRule_protocolChange
=== CONT  TestAccVPCSecurityGroup_egressMode
=== CONT  TestAccVPCRouteTableAssociation_Subnet_basic
=== CONT  TestAccVPCSecurityGroup_basic
=== CONT  TestAccVPCRouteTable_basic
=== CONT  TestAccVPCSubnet_basic
=== CONT  TestAccVPC_tenancy
--- PASS: TestAccVPCSubnet_basic (32.41s)
--- PASS: TestAccVPCRouteTable_basic (32.97s)
--- PASS: TestAccVPCSecurityGroup_basic (34.15s)
--- PASS: TestAccVPCSecurityGroup_vpcAllEgress (34.38s)
--- PASS: TestAccVPCRouteTableAssociation_Subnet_basic (35.08s)
--- PASS: TestAccVPCDataSource_basic (37.17s)
--- PASS: TestAccVPCSecurityGroup_egressMode (58.70s)
--- PASS: TestAccVPCSecurityGroupRule_protocolChange (64.32s)
--- PASS: TestAccVPC_tenancy (65.80s)
--- PASS: TestAccVPCSecurityGroupRule_race (167.56s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        174.094s
2026/05/29 09:42:47 Creating Terraform AWS Provider (SDKv2-style)...
2026/05/29 09:42:47 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccECSService_basic
=== PAUSE TestAccECSService_basic
=== RUN   TestAccECSTaskDefinition_basic
=== PAUSE TestAccECSTaskDefinition_basic
=== CONT  TestAccECSService_basic
=== CONT  TestAccECSTaskDefinition_basic
--- PASS: TestAccECSTaskDefinition_basic (32.74s)
--- PASS: TestAccECSService_basic (82.54s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ecs        93.364s
?       github.com/hashicorp/terraform-provider-aws/internal/service/ecs/test-fixtures  [no test files]
2026/05/29 09:42:56 Creating Terraform AWS Provider (SDKv2-style)...
2026/05/29 09:42:56 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccELBV2TargetGroup_basic
=== PAUSE TestAccELBV2TargetGroup_basic
=== CONT  TestAccELBV2TargetGroup_basic
--- PASS: TestAccELBV2TargetGroup_basic (25.57s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elbv2      45.547s
2026/05/29 09:42:52 Creating Terraform AWS Provider (SDKv2-style)...
2026/05/29 09:42:52 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccEventsPutEventsAction_basic
=== PAUSE TestAccEventsPutEventsAction_basic
=== CONT  TestAccEventsPutEventsAction_basic
--- PASS: TestAccEventsPutEventsAction_basic (224.57s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/events     239.872s
2026/05/29 09:43:01 Creating Terraform AWS Provider (SDKv2-style)...
2026/05/29 09:43:01 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccKMSKey_basic
=== PAUSE TestAccKMSKey_basic
=== CONT  TestAccKMSKey_basic
--- PASS: TestAccKMSKey_basic (34.30s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/kms        59.004s
2026/05/29 09:47:07 Creating Terraform AWS Provider (SDKv2-style)...
2026/05/29 09:47:07 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccLambdaFunction_basic
=== PAUSE TestAccLambdaFunction_basic
=== RUN   TestAccLambdaPermission_basic
=== PAUSE TestAccLambdaPermission_basic
=== CONT  TestAccLambdaFunction_basic
=== CONT  TestAccLambdaPermission_basic
--- PASS: TestAccLambdaPermission_basic (42.63s)
--- PASS: TestAccLambdaFunction_basic (49.86s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lambda     60.518s
2026/05/29 09:47:03 Creating Terraform AWS Provider (SDKv2-style)...
2026/05/29 09:47:03 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccMetaPartitionDataSource_basic
=== PAUSE TestAccMetaPartitionDataSource_basic
=== RUN   TestAccMetaRegionDataSource_basic
=== PAUSE TestAccMetaRegionDataSource_basic
=== RUN   TestAccMetaRegionDataSource_endpoint
=== PAUSE TestAccMetaRegionDataSource_endpoint
=== CONT  TestAccMetaPartitionDataSource_basic
=== CONT  TestAccMetaRegionDataSource_endpoint
=== CONT  TestAccMetaRegionDataSource_basic
--- PASS: TestAccMetaRegionDataSource_endpoint (14.51s)
--- PASS: TestAccMetaPartitionDataSource_basic (14.52s)
--- PASS: TestAccMetaRegionDataSource_basic (15.36s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/meta       21.593s
2026/05/29 09:47:12 Creating Terraform AWS Provider (SDKv2-style)...
2026/05/29 09:47:12 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccRoute53Record_basic
=== PAUSE TestAccRoute53Record_basic
=== RUN   TestAccRoute53Record_Latency_basic
=== PAUSE TestAccRoute53Record_Latency_basic
=== RUN   TestAccRoute53ZoneDataSource_name
=== PAUSE TestAccRoute53ZoneDataSource_name
=== CONT  TestAccRoute53Record_basic
=== CONT  TestAccRoute53Record_Latency_basic
=== CONT  TestAccRoute53ZoneDataSource_name
--- PASS: TestAccRoute53ZoneDataSource_name (75.21s)
--- PASS: TestAccRoute53Record_basic (139.74s)
--- PASS: TestAccRoute53Record_Latency_basic (139.80s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/route53    154.708s
2026/05/29 09:47:34 Creating Terraform AWS Provider (SDKv2-style)...
2026/05/29 09:47:34 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccS3BucketACL_updateACL
=== PAUSE TestAccS3BucketACL_updateACL
=== RUN   TestAccS3BucketPolicy_basic
=== PAUSE TestAccS3BucketPolicy_basic
=== RUN   TestAccS3BucketPublicAccessBlock_basic
=== PAUSE TestAccS3BucketPublicAccessBlock_basic
=== RUN   TestAccS3Bucket_Basic_basic
=== PAUSE TestAccS3Bucket_Basic_basic
=== RUN   TestAccS3Bucket_Security_corsUpdate
=== PAUSE TestAccS3Bucket_Security_corsUpdate
=== RUN   TestAccS3Object_basic
=== PAUSE TestAccS3Object_basic
=== CONT  TestAccS3BucketACL_updateACL
=== CONT  TestAccS3Bucket_Basic_basic
=== CONT  TestAccS3BucketPublicAccessBlock_basic
=== CONT  TestAccS3BucketPolicy_basic
=== CONT  TestAccS3Bucket_Security_corsUpdate
=== CONT  TestAccS3Object_basic
--- PASS: TestAccS3BucketPublicAccessBlock_basic (25.09s)
--- PASS: TestAccS3Bucket_Basic_basic (25.11s)
--- PASS: TestAccS3BucketPolicy_basic (25.12s)
--- PASS: TestAccS3Object_basic (28.11s)
--- PASS: TestAccS3BucketACL_updateACL (38.97s)
--- PASS: TestAccS3Bucket_Security_corsUpdate (41.83s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/s3 76.322s
2026/05/29 09:47:21 Creating Terraform AWS Provider (SDKv2-style)...
2026/05/29 09:47:21 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccSSMParameterEphemeral_basic
=== PAUSE TestAccSSMParameterEphemeral_basic
=== CONT  TestAccSSMParameterEphemeral_basic
--- PASS: TestAccSSMParameterEphemeral_basic (17.48s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ssm        38.386s
2026/05/29 09:47:25 Creating Terraform AWS Provider (SDKv2-style)...
2026/05/29 09:47:25 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccSecretsManagerSecret_basic
=== PAUSE TestAccSecretsManagerSecret_basic
=== CONT  TestAccSecretsManagerSecret_basic
--- PASS: TestAccSecretsManagerSecret_basic (20.34s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/secretsmanager     45.493s
2026/05/29 09:47:16 Creating Terraform AWS Provider (SDKv2-style)...
2026/05/29 09:47:16 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccSTSCallerIdentityDataSource_basic
=== PAUSE TestAccSTSCallerIdentityDataSource_basic
=== CONT  TestAccSTSCallerIdentityDataSource_basic
--- PASS: TestAccSTSCallerIdentityDataSource_basic (14.20s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/sts        30.506s
2026/05/29 09:47:29 Creating Terraform AWS Provider (SDKv2-style)...
2026/05/29 09:47:29 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestARNParseFunction_known
=== PAUSE TestARNParseFunction_known
=== CONT  TestARNParseFunction_known
--- PASS: TestARNParseFunction_known (10.09s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/function   39.630s
```
