### PR TITLE
Use `SchemaFunc` instead of `Schema` for `d` services

### DIFF
--- a/.ci/semgrep/pluginsdk/schema.yml
+++ b/.ci/semgrep/pluginsdk/schema.yml
@@ -28,19 +28,6 @@ rules:
     severity: WARNING
     paths:
       exclude:
-        - /internal/service/dataexchange
-        - /internal/service/datapipeline
-        - /internal/service/datasync
-        - /internal/service/dax
-        - /internal/service/deploy
-        - /internal/service/detective
-        - /internal/service/devicefarm
-        - /internal/service/directconnect
-        - /internal/service/dlm
-        - /internal/service/dms
-        - /internal/service/docdb
-        - /internal/service/ds
-        - /internal/service/dynamodb
         - /internal/service/ec2
         - /internal/service/ecr
         - /internal/service/ecrpublic

--- a/internal/service/dataexchange/data_set.go
+++ b/internal/service/dataexchange/data_set.go
@@ -39,28 +39,30 @@ func resourceDataSet() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"asset_type": {
-				Type:             schema.TypeString,
-				Required:         true,
-				ForceNew:         true,
-				ValidateDiagFunc: enum.Validate[awstypes.AssetType](),
-			},
-			names.AttrDescription: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringLenBetween(1, 16348),
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"asset_type": {
+					Type:             schema.TypeString,
+					Required:         true,
+					ForceNew:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.AssetType](),
+				},
+				names.AttrDescription: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringLenBetween(1, 16348),
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			}
 		},
 	}
 }

--- a/internal/service/dataexchange/revision.go
+++ b/internal/service/dataexchange/revision.go
@@ -39,27 +39,29 @@ func resourceRevision() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrComment: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringLenBetween(0, 16_348),
-			},
-			"data_set_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"revision_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrComment: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringLenBetween(0, 16_348),
+				},
+				"data_set_id": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"revision_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			}
 		},
 	}
 }

--- a/internal/service/datapipeline/pipeline.go
+++ b/internal/service/datapipeline/pipeline.go
@@ -38,21 +38,23 @@ func resourcePipeline() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
 
-			names.AttrDescription: {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
+				names.AttrDescription: {
+					Type:     schema.TypeString,
+					Optional: true,
+					ForceNew: true,
+				},
 
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			}
 		},
 	}
 }

--- a/internal/service/datapipeline/pipeline_data_source.go
+++ b/internal/service/datapipeline/pipeline_data_source.go
@@ -23,20 +23,22 @@ func dataSourcePipeline() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourcePipelineRead,
 
-		Schema: map[string]*schema.Schema{
-			"pipeline_id": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrDescription: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrTags: tftags.TagsSchemaComputed(),
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"pipeline_id": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrDescription: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrTags: tftags.TagsSchemaComputed(),
+			}
 		},
 	}
 }

--- a/internal/service/datapipeline/pipeline_definition.go
+++ b/internal/service/datapipeline/pipeline_definition.go
@@ -35,103 +35,105 @@ func ResourcePipelineDefinition() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Schema: map[string]*schema.Schema{
-			"parameter_object": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"attribute": {
-							Type:     schema.TypeSet,
-							Optional: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									names.AttrKey: {
-										Type:         schema.TypeString,
-										Required:     true,
-										ValidateFunc: validation.StringLenBetween(1, 256),
-									},
-									"string_value": {
-										Type:         schema.TypeString,
-										Required:     true,
-										ValidateFunc: validation.StringLenBetween(0, 10240),
-									},
-								},
-							},
-						},
-						names.AttrID: {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validation.StringLenBetween(1, 256),
-						},
-					},
-				},
-			},
-			"parameter_value": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrID: {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validation.StringLenBetween(1, 256),
-						},
-						"string_value": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validation.StringLenBetween(0, 10240),
-						},
-					},
-				},
-			},
-			"pipeline_id": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(1, 1024),
-			},
-			"pipeline_object": {
-				Type:     schema.TypeSet,
-				Required: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrField: {
-							Type:     schema.TypeSet,
-							Optional: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									names.AttrKey: {
-										Type:         schema.TypeString,
-										Required:     true,
-										ValidateFunc: validation.StringLenBetween(1, 256),
-									},
-									"ref_value": {
-										Type:         schema.TypeString,
-										Optional:     true,
-										ValidateFunc: validation.StringLenBetween(1, 256),
-									},
-									"string_value": {
-										Type:         schema.TypeString,
-										Optional:     true,
-										ValidateFunc: validation.StringLenBetween(0, 10240),
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"parameter_object": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"attribute": {
+								Type:     schema.TypeSet,
+								Optional: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										names.AttrKey: {
+											Type:         schema.TypeString,
+											Required:     true,
+											ValidateFunc: validation.StringLenBetween(1, 256),
+										},
+										"string_value": {
+											Type:         schema.TypeString,
+											Required:     true,
+											ValidateFunc: validation.StringLenBetween(0, 10240),
+										},
 									},
 								},
 							},
-						},
-						names.AttrID: {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validation.StringLenBetween(1, 1024),
-						},
-						names.AttrName: {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validation.StringLenBetween(1, 1024),
+							names.AttrID: {
+								Type:         schema.TypeString,
+								Required:     true,
+								ValidateFunc: validation.StringLenBetween(1, 256),
+							},
 						},
 					},
 				},
-			},
+				"parameter_value": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrID: {
+								Type:         schema.TypeString,
+								Required:     true,
+								ValidateFunc: validation.StringLenBetween(1, 256),
+							},
+							"string_value": {
+								Type:         schema.TypeString,
+								Required:     true,
+								ValidateFunc: validation.StringLenBetween(0, 10240),
+							},
+						},
+					},
+				},
+				"pipeline_id": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringLenBetween(1, 1024),
+				},
+				"pipeline_object": {
+					Type:     schema.TypeSet,
+					Required: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrField: {
+								Type:     schema.TypeSet,
+								Optional: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										names.AttrKey: {
+											Type:         schema.TypeString,
+											Required:     true,
+											ValidateFunc: validation.StringLenBetween(1, 256),
+										},
+										"ref_value": {
+											Type:         schema.TypeString,
+											Optional:     true,
+											ValidateFunc: validation.StringLenBetween(1, 256),
+										},
+										"string_value": {
+											Type:         schema.TypeString,
+											Optional:     true,
+											ValidateFunc: validation.StringLenBetween(0, 10240),
+										},
+									},
+								},
+							},
+							names.AttrID: {
+								Type:         schema.TypeString,
+								Required:     true,
+								ValidateFunc: validation.StringLenBetween(1, 1024),
+							},
+							names.AttrName: {
+								Type:         schema.TypeString,
+								Required:     true,
+								ValidateFunc: validation.StringLenBetween(1, 1024),
+							},
+						},
+					},
+				},
+			}
 		},
 	}
 }

--- a/internal/service/datapipeline/pipeline_definition_data_source.go
+++ b/internal/service/datapipeline/pipeline_definition_data_source.go
@@ -23,94 +23,96 @@ func DataSourcePipelineDefinition() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourcePipelineDefinitionRead,
 
-		Schema: map[string]*schema.Schema{
-			"parameter_object": {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"attribute": {
-							Type:     schema.TypeSet,
-							Computed: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									names.AttrKey: {
-										Type:     schema.TypeString,
-										Computed: true,
-									},
-									"string_value": {
-										Type:     schema.TypeString,
-										Computed: true,
-									},
-								},
-							},
-						},
-						names.AttrID: {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-					},
-				},
-			},
-			"parameter_value": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				ForceNew: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrID: {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"string_value": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-					},
-				},
-			},
-			"pipeline_id": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringLenBetween(1, 1024),
-			},
-			"pipeline_object": {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrField: {
-							Type:     schema.TypeSet,
-							Optional: true,
-							ForceNew: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									names.AttrKey: {
-										Type:     schema.TypeString,
-										Computed: true,
-									},
-									"ref_value": {
-										Type:     schema.TypeString,
-										Computed: true,
-									},
-									"string_value": {
-										Type:     schema.TypeString,
-										Computed: true,
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"parameter_object": {
+					Type:     schema.TypeSet,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"attribute": {
+								Type:     schema.TypeSet,
+								Computed: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										names.AttrKey: {
+											Type:     schema.TypeString,
+											Computed: true,
+										},
+										"string_value": {
+											Type:     schema.TypeString,
+											Computed: true,
+										},
 									},
 								},
 							},
-						},
-						names.AttrID: {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						names.AttrName: {
-							Type:     schema.TypeString,
-							Computed: true,
+							names.AttrID: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
 						},
 					},
 				},
-			},
+				"parameter_value": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					ForceNew: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrID: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"string_value": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+						},
+					},
+				},
+				"pipeline_id": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringLenBetween(1, 1024),
+				},
+				"pipeline_object": {
+					Type:     schema.TypeSet,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrField: {
+								Type:     schema.TypeSet,
+								Optional: true,
+								ForceNew: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										names.AttrKey: {
+											Type:     schema.TypeString,
+											Computed: true,
+										},
+										"ref_value": {
+											Type:     schema.TypeString,
+											Computed: true,
+										},
+										"string_value": {
+											Type:     schema.TypeString,
+											Computed: true,
+										},
+									},
+								},
+							},
+							names.AttrID: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							names.AttrName: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+						},
+					},
+				},
+			}
 		},
 	}
 }

--- a/internal/service/datasync/agent.go
+++ b/internal/service/datasync/agent.go
@@ -48,55 +48,57 @@ func resourceAgent() *schema.Resource {
 			Create: schema.DefaultTimeout(10 * time.Minute),
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"activation_key": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				ForceNew:      true,
-				ConflictsWith: []string{"private_link_endpoint", names.AttrIPAddress},
-			},
-			names.AttrIPAddress: {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				ForceNew:      true,
-				ConflictsWith: []string{"activation_key"},
-			},
-			"private_link_endpoint": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				ForceNew:      true,
-				ConflictsWith: []string{"activation_key"},
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"security_group_arns": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				ForceNew: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			"subnet_arns": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				ForceNew: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			names.AttrVPCEndpointID: {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"activation_key": {
+					Type:          schema.TypeString,
+					Optional:      true,
+					Computed:      true,
+					ForceNew:      true,
+					ConflictsWith: []string{"private_link_endpoint", names.AttrIPAddress},
+				},
+				names.AttrIPAddress: {
+					Type:          schema.TypeString,
+					Optional:      true,
+					Computed:      true,
+					ForceNew:      true,
+					ConflictsWith: []string{"activation_key"},
+				},
+				"private_link_endpoint": {
+					Type:          schema.TypeString,
+					Optional:      true,
+					Computed:      true,
+					ForceNew:      true,
+					ConflictsWith: []string{"activation_key"},
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"security_group_arns": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					ForceNew: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"subnet_arns": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					ForceNew: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				names.AttrVPCEndpointID: {
+					Type:     schema.TypeString,
+					Optional: true,
+					ForceNew: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/datasync/location_azure_blob.go
+++ b/internal/service/datasync/location_azure_blob.go
@@ -43,75 +43,77 @@ func resourceLocationAzureBlob() *schema.Resource {
 		UpdateWithoutTimeout: resourceLocationAzureBlobUpdate,
 		DeleteWithoutTimeout: resourceLocationAzureBlobDelete,
 
-		Schema: map[string]*schema.Schema{
-			"access_tier": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Default:          awstypes.AzureAccessTierHot,
-				ValidateDiagFunc: enum.Validate[awstypes.AzureAccessTier](),
-			},
-			"agent_arns": {
-				Type:     schema.TypeSet,
-				Required: true,
-				Elem: &schema.Schema{
-					Type:         schema.TypeString,
-					ValidateFunc: verify.ValidARN,
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"access_tier": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					Default:          awstypes.AzureAccessTierHot,
+					ValidateDiagFunc: enum.Validate[awstypes.AzureAccessTier](),
 				},
-			},
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"authentication_type": {
-				Type:             schema.TypeString,
-				Required:         true,
-				ValidateDiagFunc: enum.Validate[awstypes.AzureBlobAuthenticationType](),
-			},
-			"blob_type": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Default:          awstypes.AzureBlobTypeBlock,
-				ValidateDiagFunc: enum.Validate[awstypes.AzureBlobType](),
-			},
-			"container_url": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"sas_configuration": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"token": {
-							Type:     schema.TypeString,
-							Required: true,
+				"agent_arns": {
+					Type:     schema.TypeSet,
+					Required: true,
+					Elem: &schema.Schema{
+						Type:         schema.TypeString,
+						ValidateFunc: verify.ValidARN,
+					},
+				},
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"authentication_type": {
+					Type:             schema.TypeString,
+					Required:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.AzureBlobAuthenticationType](),
+				},
+				"blob_type": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					Default:          awstypes.AzureBlobTypeBlock,
+					ValidateDiagFunc: enum.Validate[awstypes.AzureBlobType](),
+				},
+				"container_url": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"sas_configuration": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"token": {
+								Type:     schema.TypeString,
+								Required: true,
+							},
 						},
 					},
 				},
-			},
-			"subdirectory": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				// Ignore missing trailing slash
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					if new == "/" {
+				"subdirectory": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+					// Ignore missing trailing slash
+					DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+						if new == "/" {
+							return false
+						}
+						if strings.TrimSuffix(old, "/") == strings.TrimSuffix(new, "/") {
+							return true
+						}
 						return false
-					}
-					if strings.TrimSuffix(old, "/") == strings.TrimSuffix(new, "/") {
-						return true
-					}
-					return false
+					},
 				},
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			names.AttrURI: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				names.AttrURI: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/datasync/location_efs.go
+++ b/internal/service/datasync/location_efs.go
@@ -42,82 +42,84 @@ func resourceLocationEFS() *schema.Resource {
 		UpdateWithoutTimeout: resourceLocationEFSUpdate,
 		DeleteWithoutTimeout: resourceLocationEFSDelete,
 
-		Schema: map[string]*schema.Schema{
-			"access_point_arn": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"ec2_config": {
-				Type:     schema.TypeList,
-				Required: true,
-				ForceNew: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"security_group_arns": {
-							Type:     schema.TypeSet,
-							Required: true,
-							ForceNew: true,
-							Elem: &schema.Schema{
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"access_point_arn": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ForceNew:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"ec2_config": {
+					Type:     schema.TypeList,
+					Required: true,
+					ForceNew: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"security_group_arns": {
+								Type:     schema.TypeSet,
+								Required: true,
+								ForceNew: true,
+								Elem: &schema.Schema{
+									Type:         schema.TypeString,
+									ValidateFunc: verify.ValidARN,
+								},
+							},
+							"subnet_arn": {
 								Type:         schema.TypeString,
+								Required:     true,
+								ForceNew:     true,
 								ValidateFunc: verify.ValidARN,
 							},
 						},
-						"subnet_arn": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ForceNew:     true,
-							ValidateFunc: verify.ValidARN,
-						},
 					},
 				},
-			},
-			"efs_file_system_arn": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			"file_system_access_role_arn": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			"in_transit_encryption": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				ForceNew:         true,
-				ValidateDiagFunc: enum.Validate[awstypes.EfsInTransitEncryption](),
-			},
-			"subdirectory": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Default:  "/",
-				// Ignore missing trailing slash
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					if new == "/" {
-						return false
-					}
-					if strings.TrimSuffix(old, "/") == strings.TrimSuffix(new, "/") {
-						return true
-					}
-					return false
+				"efs_file_system_arn": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: verify.ValidARN,
 				},
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			names.AttrURI: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+				"file_system_access_role_arn": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ForceNew:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				"in_transit_encryption": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					ForceNew:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.EfsInTransitEncryption](),
+				},
+				"subdirectory": {
+					Type:     schema.TypeString,
+					Optional: true,
+					ForceNew: true,
+					Default:  "/",
+					// Ignore missing trailing slash
+					DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+						if new == "/" {
+							return false
+						}
+						if strings.TrimSuffix(old, "/") == strings.TrimSuffix(new, "/") {
+							return true
+						}
+						return false
+					},
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				names.AttrURI: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/datasync/location_fsx_lustre_file_system.go
+++ b/internal/service/datasync/location_fsx_lustre_file_system.go
@@ -62,45 +62,47 @@ func resourceLocationFSxLustreFileSystem() *schema.Resource {
 			},
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrCreationTime: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"fsx_filesystem_arn": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			"security_group_arns": {
-				Type:     schema.TypeSet,
-				Required: true,
-				ForceNew: true,
-				MinItems: 1,
-				MaxItems: 5,
-				Elem: &schema.Schema{
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrCreationTime: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"fsx_filesystem_arn": {
 					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
 					ValidateFunc: verify.ValidARN,
 				},
-			},
-			"subdirectory": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(1, 4096),
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			names.AttrURI: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+				"security_group_arns": {
+					Type:     schema.TypeSet,
+					Required: true,
+					ForceNew: true,
+					MinItems: 1,
+					MaxItems: 5,
+					Elem: &schema.Schema{
+						Type:         schema.TypeString,
+						ValidateFunc: verify.ValidARN,
+					},
+				},
+				"subdirectory": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Computed:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringLenBetween(1, 4096),
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				names.AttrURI: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/datasync/location_fsx_ontap_file_system.go
+++ b/internal/service/datasync/location_fsx_ontap_file_system.go
@@ -63,139 +63,141 @@ func resourceLocationFSxONTAPFileSystem() *schema.Resource {
 			},
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrCreationTime: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"fsx_filesystem_arn": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrProtocol: {
-				Type:     schema.TypeList,
-				Required: true,
-				ForceNew: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"nfs": {
-							Type:         schema.TypeList,
-							Optional:     true,
-							ForceNew:     true,
-							MaxItems:     1,
-							ExactlyOneOf: []string{"protocol.0.nfs", "protocol.0.smb"},
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"mount_options": {
-										Type:     schema.TypeList,
-										Required: true,
-										ForceNew: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												names.AttrVersion: {
-													Type:         schema.TypeString,
-													Default:      awstypes.NfsVersionNfs3,
-													Optional:     true,
-													ForceNew:     true,
-													ValidateFunc: validation.StringInSlice(enum.Slice(awstypes.NfsVersionNfs3), false),
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrCreationTime: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"fsx_filesystem_arn": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrProtocol: {
+					Type:     schema.TypeList,
+					Required: true,
+					ForceNew: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"nfs": {
+								Type:         schema.TypeList,
+								Optional:     true,
+								ForceNew:     true,
+								MaxItems:     1,
+								ExactlyOneOf: []string{"protocol.0.nfs", "protocol.0.smb"},
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"mount_options": {
+											Type:     schema.TypeList,
+											Required: true,
+											ForceNew: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													names.AttrVersion: {
+														Type:         schema.TypeString,
+														Default:      awstypes.NfsVersionNfs3,
+														Optional:     true,
+														ForceNew:     true,
+														ValidateFunc: validation.StringInSlice(enum.Slice(awstypes.NfsVersionNfs3), false),
+													},
 												},
 											},
 										},
 									},
 								},
 							},
-						},
-						"smb": {
-							Type:         schema.TypeList,
-							Optional:     true,
-							ForceNew:     true,
-							MaxItems:     1,
-							ExactlyOneOf: []string{"protocol.0.nfs", "protocol.0.smb"},
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									names.AttrDomain: {
-										Type:         schema.TypeString,
-										Optional:     true,
-										ForceNew:     true,
-										ValidateFunc: validation.StringLenBetween(1, 253),
-									},
-									"mount_options": {
-										Type:     schema.TypeList,
-										Required: true,
-										ForceNew: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												names.AttrVersion: {
-													Type:     schema.TypeString,
-													Default:  awstypes.SmbVersionAutomatic,
-													Optional: true,
-													ForceNew: true,
-													ValidateFunc: validation.StringInSlice(enum.Slice(
-														awstypes.SmbVersionAutomatic,
-														awstypes.SmbVersionSmb2,
-														awstypes.SmbVersionSmb3,
-														awstypes.SmbVersionSmb20,
-													), false),
+							"smb": {
+								Type:         schema.TypeList,
+								Optional:     true,
+								ForceNew:     true,
+								MaxItems:     1,
+								ExactlyOneOf: []string{"protocol.0.nfs", "protocol.0.smb"},
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										names.AttrDomain: {
+											Type:         schema.TypeString,
+											Optional:     true,
+											ForceNew:     true,
+											ValidateFunc: validation.StringLenBetween(1, 253),
+										},
+										"mount_options": {
+											Type:     schema.TypeList,
+											Required: true,
+											ForceNew: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													names.AttrVersion: {
+														Type:     schema.TypeString,
+														Default:  awstypes.SmbVersionAutomatic,
+														Optional: true,
+														ForceNew: true,
+														ValidateFunc: validation.StringInSlice(enum.Slice(
+															awstypes.SmbVersionAutomatic,
+															awstypes.SmbVersionSmb2,
+															awstypes.SmbVersionSmb3,
+															awstypes.SmbVersionSmb20,
+														), false),
+													},
 												},
 											},
 										},
-									},
-									names.AttrPassword: {
-										Type:         schema.TypeString,
-										Required:     true,
-										ForceNew:     true,
-										Sensitive:    true,
-										ValidateFunc: validation.StringLenBetween(1, 104),
-									},
-									"user": {
-										Type:         schema.TypeString,
-										Required:     true,
-										ForceNew:     true,
-										ValidateFunc: validation.StringLenBetween(1, 104),
+										names.AttrPassword: {
+											Type:         schema.TypeString,
+											Required:     true,
+											ForceNew:     true,
+											Sensitive:    true,
+											ValidateFunc: validation.StringLenBetween(1, 104),
+										},
+										"user": {
+											Type:         schema.TypeString,
+											Required:     true,
+											ForceNew:     true,
+											ValidateFunc: validation.StringLenBetween(1, 104),
+										},
 									},
 								},
 							},
 						},
 					},
 				},
-			},
-			"security_group_arns": {
-				Type:     schema.TypeSet,
-				Required: true,
-				ForceNew: true,
-				MinItems: 1,
-				MaxItems: 5,
-				Elem: &schema.Schema{
+				"security_group_arns": {
+					Type:     schema.TypeSet,
+					Required: true,
+					ForceNew: true,
+					MinItems: 1,
+					MaxItems: 5,
+					Elem: &schema.Schema{
+						Type:         schema.TypeString,
+						ValidateFunc: verify.ValidARN,
+					},
+				},
+				"storage_virtual_machine_arn": {
 					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
 					ValidateFunc: verify.ValidARN,
 				},
-			},
-			"storage_virtual_machine_arn": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			"subdirectory": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(1, 4096),
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			names.AttrURI: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+				"subdirectory": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Computed:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringLenBetween(1, 4096),
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				names.AttrURI: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/datasync/location_fsx_openzfs_file_system.go
+++ b/internal/service/datasync/location_fsx_openzfs_file_system.go
@@ -63,48 +63,50 @@ func resourceLocationFSxOpenZFSFileSystem() *schema.Resource {
 			},
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrCreationTime: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"fsx_filesystem_arn": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			names.AttrProtocol: {
-				Type:     schema.TypeList,
-				Required: true,
-				ForceNew: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"nfs": {
-							Type:     schema.TypeList,
-							Required: true,
-							ForceNew: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"mount_options": {
-										Type:     schema.TypeList,
-										Required: true,
-										ForceNew: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												names.AttrVersion: {
-													Type:             schema.TypeString,
-													Default:          awstypes.NfsVersionAutomatic,
-													Optional:         true,
-													ForceNew:         true,
-													ValidateDiagFunc: enum.Validate[awstypes.NfsVersion](),
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrCreationTime: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"fsx_filesystem_arn": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				names.AttrProtocol: {
+					Type:     schema.TypeList,
+					Required: true,
+					ForceNew: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"nfs": {
+								Type:     schema.TypeList,
+								Required: true,
+								ForceNew: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"mount_options": {
+											Type:     schema.TypeList,
+											Required: true,
+											ForceNew: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													names.AttrVersion: {
+														Type:             schema.TypeString,
+														Default:          awstypes.NfsVersionAutomatic,
+														Optional:         true,
+														ForceNew:         true,
+														ValidateDiagFunc: enum.Validate[awstypes.NfsVersion](),
+													},
 												},
 											},
 										},
@@ -114,31 +116,31 @@ func resourceLocationFSxOpenZFSFileSystem() *schema.Resource {
 						},
 					},
 				},
-			},
-			"security_group_arns": {
-				Type:     schema.TypeSet,
-				Required: true,
-				ForceNew: true,
-				MinItems: 1,
-				MaxItems: 5,
-				Elem: &schema.Schema{
-					Type:         schema.TypeString,
-					ValidateFunc: verify.ValidARN,
+				"security_group_arns": {
+					Type:     schema.TypeSet,
+					Required: true,
+					ForceNew: true,
+					MinItems: 1,
+					MaxItems: 5,
+					Elem: &schema.Schema{
+						Type:         schema.TypeString,
+						ValidateFunc: verify.ValidARN,
+					},
 				},
-			},
-			"subdirectory": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(1, 4096),
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			names.AttrURI: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+				"subdirectory": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Computed:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringLenBetween(1, 4096),
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				names.AttrURI: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/datasync/location_fsx_windows_file_system.go
+++ b/internal/service/datasync/location_fsx_windows_file_system.go
@@ -64,64 +64,66 @@ func resourceLocationFSxWindowsFileSystem() *schema.Resource {
 			},
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrCreationTime: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrDomain: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(1, 253),
-			},
-			"fsx_filesystem_arn": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			names.AttrPassword: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				Sensitive:    true,
-				ValidateFunc: validation.StringLenBetween(1, 104),
-			},
-			"security_group_arns": {
-				Type:     schema.TypeSet,
-				Required: true,
-				ForceNew: true,
-				MinItems: 1,
-				MaxItems: 5,
-				Elem: &schema.Schema{
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrCreationTime: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrDomain: {
 					Type:         schema.TypeString,
+					Optional:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringLenBetween(1, 253),
+				},
+				"fsx_filesystem_arn": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
 					ValidateFunc: verify.ValidARN,
 				},
-			},
-			"subdirectory": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(1, 4096),
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			names.AttrURI: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"user": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(1, 104),
-			},
+				names.AttrPassword: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					Sensitive:    true,
+					ValidateFunc: validation.StringLenBetween(1, 104),
+				},
+				"security_group_arns": {
+					Type:     schema.TypeSet,
+					Required: true,
+					ForceNew: true,
+					MinItems: 1,
+					MaxItems: 5,
+					Elem: &schema.Schema{
+						Type:         schema.TypeString,
+						ValidateFunc: verify.ValidARN,
+					},
+				},
+				"subdirectory": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Computed:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringLenBetween(1, 4096),
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				names.AttrURI: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"user": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringLenBetween(1, 104),
+				},
+			}
 		},
 	}
 }

--- a/internal/service/datasync/location_hdfs.go
+++ b/internal/service/datasync/location_hdfs.go
@@ -42,138 +42,140 @@ func resourceLocationHDFS() *schema.Resource {
 		UpdateWithoutTimeout: resourceLocationHDFSUpdate,
 		DeleteWithoutTimeout: resourceLocationHDFSDelete,
 
-		Schema: map[string]*schema.Schema{
-			"agent_arns": {
-				Type:     schema.TypeSet,
-				Required: true,
-				Elem: &schema.Schema{
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"agent_arns": {
+					Type:     schema.TypeSet,
+					Required: true,
+					Elem: &schema.Schema{
+						Type:         schema.TypeString,
+						ValidateFunc: verify.ValidARN,
+					},
+				},
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"authentication_type": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.HdfsAuthenticationType](),
+				},
+				"block_size": {
+					Type:     schema.TypeInt,
+					Optional: true,
+					Default:  128 * 1024 * 1024, // 128 MiB
+					ValidateFunc: validation.All(
+						validation.IntDivisibleBy(512),
+						validation.IntBetween(1048576, 1073741824),
+					),
+				},
+				"kerberos_keytab": {
+					Type:          schema.TypeString,
+					Optional:      true,
+					ConflictsWith: []string{"kerberos_keytab_base64"},
+				},
+				"kerberos_keytab_base64": {
+					Type:          schema.TypeString,
+					Optional:      true,
+					ConflictsWith: []string{"kerberos_keytab"},
+					ValidateFunc:  verify.ValidBase64String,
+				},
+				"kerberos_krb5_conf": {
+					Type:          schema.TypeString,
+					Optional:      true,
+					ConflictsWith: []string{"kerberos_krb5_conf_base64"},
+				},
+				"kerberos_krb5_conf_base64": {
+					Type:          schema.TypeString,
+					Optional:      true,
+					ConflictsWith: []string{"kerberos_krb5_conf"},
+					ValidateFunc:  verify.ValidBase64String,
+				},
+				"kerberos_principal": {
 					Type:         schema.TypeString,
-					ValidateFunc: verify.ValidARN,
+					Optional:     true,
+					ValidateFunc: validation.StringLenBetween(1, 255),
 				},
-			},
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"authentication_type": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				ValidateDiagFunc: enum.Validate[awstypes.HdfsAuthenticationType](),
-			},
-			"block_size": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Default:  128 * 1024 * 1024, // 128 MiB
-				ValidateFunc: validation.All(
-					validation.IntDivisibleBy(512),
-					validation.IntBetween(1048576, 1073741824),
-				),
-			},
-			"kerberos_keytab": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				ConflictsWith: []string{"kerberos_keytab_base64"},
-			},
-			"kerberos_keytab_base64": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				ConflictsWith: []string{"kerberos_keytab"},
-				ValidateFunc:  verify.ValidBase64String,
-			},
-			"kerberos_krb5_conf": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				ConflictsWith: []string{"kerberos_krb5_conf_base64"},
-			},
-			"kerberos_krb5_conf_base64": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				ConflictsWith: []string{"kerberos_krb5_conf"},
-				ValidateFunc:  verify.ValidBase64String,
-			},
-			"kerberos_principal": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringLenBetween(1, 255),
-			},
-			"kms_key_provider_uri": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringLenBetween(1, 255),
-			},
-			"name_node": {
-				Type:     schema.TypeSet,
-				Required: true,
-				MinItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"hostname": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validation.StringLenBetween(1, 255),
-						},
-						names.AttrPort: {
-							Type:         schema.TypeInt,
-							Required:     true,
-							ValidateFunc: validation.IsPortNumber,
+				"kms_key_provider_uri": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringLenBetween(1, 255),
+				},
+				"name_node": {
+					Type:     schema.TypeSet,
+					Required: true,
+					MinItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"hostname": {
+								Type:         schema.TypeString,
+								Required:     true,
+								ValidateFunc: validation.StringLenBetween(1, 255),
+							},
+							names.AttrPort: {
+								Type:         schema.TypeInt,
+								Required:     true,
+								ValidateFunc: validation.IsPortNumber,
+							},
 						},
 					},
 				},
-			},
-			"qop_configuration": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Computed: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"data_transfer_protection": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Computed:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.HdfsDataTransferProtection](),
-						},
-						"rpc_protection": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Computed:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.HdfsRpcProtection](),
+				"qop_configuration": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Computed: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"data_transfer_protection": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								Computed:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.HdfsDataTransferProtection](),
+							},
+							"rpc_protection": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								Computed:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.HdfsRpcProtection](),
+							},
 						},
 					},
 				},
-			},
-			"replication_factor": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				Default:      3,
-				ValidateFunc: validation.IntBetween(1, 512),
-			},
-			"simple_user": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringLenBetween(1, 255),
-			},
-			"subdirectory": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Default:      "/",
-				ValidateFunc: validation.StringLenBetween(1, 4096),
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					if new == "/" {
+				"replication_factor": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					Default:      3,
+					ValidateFunc: validation.IntBetween(1, 512),
+				},
+				"simple_user": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringLenBetween(1, 255),
+				},
+				"subdirectory": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Default:      "/",
+					ValidateFunc: validation.StringLenBetween(1, 4096),
+					DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+						if new == "/" {
+							return false
+						}
+						if strings.TrimSuffix(old, "/") == strings.TrimSuffix(new, "/") {
+							return true
+						}
 						return false
-					}
-					if strings.TrimSuffix(old, "/") == strings.TrimSuffix(new, "/") {
-						return true
-					}
-					return false
+					},
 				},
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			names.AttrURI: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				names.AttrURI: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/datasync/location_nfs.go
+++ b/internal/service/datasync/location_nfs.go
@@ -41,73 +41,75 @@ func resourceLocationNFS() *schema.Resource {
 		UpdateWithoutTimeout: resourceLocationNFSUpdate,
 		DeleteWithoutTimeout: resourceLocationNFSDelete,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"mount_options": {
-				Type:             schema.TypeList,
-				Optional:         true,
-				MaxItems:         1,
-				DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrVersion: {
-							Type:             schema.TypeString,
-							Default:          awstypes.NfsVersionAutomatic,
-							Optional:         true,
-							ForceNew:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.NfsVersion](),
-						},
-					},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
 				},
-			},
-			"on_prem_config": {
-				Type:     schema.TypeList,
-				Required: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"agent_arns": {
-							Type:     schema.TypeSet,
-							Required: true,
-							ForceNew: true,
-							Elem: &schema.Schema{
-								Type:         schema.TypeString,
-								ValidateFunc: verify.ValidARN,
+				"mount_options": {
+					Type:             schema.TypeList,
+					Optional:         true,
+					MaxItems:         1,
+					DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrVersion: {
+								Type:             schema.TypeString,
+								Default:          awstypes.NfsVersionAutomatic,
+								Optional:         true,
+								ForceNew:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.NfsVersion](),
 							},
 						},
 					},
 				},
-			},
-			"server_hostname": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(1, 255),
-			},
-			"subdirectory": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringLenBetween(1, 4096),
-				// Ignore missing trailing slash
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					if new == "/" {
-						return false
-					}
-					if strings.TrimSuffix(old, "/") == strings.TrimSuffix(new, "/") {
-						return true
-					}
-					return false
+				"on_prem_config": {
+					Type:     schema.TypeList,
+					Required: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"agent_arns": {
+								Type:     schema.TypeSet,
+								Required: true,
+								ForceNew: true,
+								Elem: &schema.Schema{
+									Type:         schema.TypeString,
+									ValidateFunc: verify.ValidARN,
+								},
+							},
+						},
+					},
 				},
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			names.AttrURI: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+				"server_hostname": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringLenBetween(1, 255),
+				},
+				"subdirectory": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringLenBetween(1, 4096),
+					// Ignore missing trailing slash
+					DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+						if new == "/" {
+							return false
+						}
+						if strings.TrimSuffix(old, "/") == strings.TrimSuffix(new, "/") {
+							return true
+						}
+						return false
+					},
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				names.AttrURI: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/datasync/location_object_storage.go
+++ b/internal/service/datasync/location_object_storage.go
@@ -44,70 +44,72 @@ func resourceLocationObjectStorage() *schema.Resource {
 		UpdateWithoutTimeout: resourceLocationObjectStorageUpdate,
 		DeleteWithoutTimeout: resourceLocationObjectStorageDelete,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrAccessKey: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringLenBetween(8, 200),
-			},
-			"agent_arns": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem: &schema.Schema{
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrAccessKey: {
 					Type:         schema.TypeString,
-					ValidateFunc: verify.ValidARN,
+					Optional:     true,
+					ValidateFunc: validation.StringLenBetween(8, 200),
 				},
-			},
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrBucketName: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(3, 63),
-			},
-			names.AttrSecretKey: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Sensitive:    true,
-				ValidateFunc: validation.StringLenBetween(8, 200),
-			},
-			"server_certificate": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"server_hostname": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(0, 255),
-			},
-			"server_port": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				Default:      443,
-				ValidateFunc: validation.IsPortNumber,
-			},
-			"server_protocol": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Default:          awstypes.ObjectStorageServerProtocolHttps,
-				ValidateDiagFunc: enum.Validate[awstypes.ObjectStorageServerProtocol](),
-			},
-			"subdirectory": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: validation.StringLenBetween(1, 4096),
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			names.AttrURI: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+				"agent_arns": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem: &schema.Schema{
+						Type:         schema.TypeString,
+						ValidateFunc: verify.ValidARN,
+					},
+				},
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrBucketName: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringLenBetween(3, 63),
+				},
+				names.AttrSecretKey: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Sensitive:    true,
+					ValidateFunc: validation.StringLenBetween(8, 200),
+				},
+				"server_certificate": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"server_hostname": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringLenBetween(0, 255),
+				},
+				"server_port": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					Default:      443,
+					ValidateFunc: validation.IsPortNumber,
+				},
+				"server_protocol": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					Default:          awstypes.ObjectStorageServerProtocolHttps,
+					ValidateDiagFunc: enum.Validate[awstypes.ObjectStorageServerProtocol](),
+				},
+				"subdirectory": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Computed:     true,
+					ValidateFunc: validation.StringLenBetween(1, 4096),
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				names.AttrURI: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			}
 		},
 
 		CustomizeDiff: customdiff.ForceNewIfChange("agent_arns", func(_ context.Context, old, new, meta any) bool {

--- a/internal/service/datasync/location_s3.go
+++ b/internal/service/datasync/location_s3.go
@@ -41,70 +41,72 @@ func resourceLocationS3() *schema.Resource {
 		UpdateWithoutTimeout: resourceLocationS3Update,
 		DeleteWithoutTimeout: resourceLocationS3Delete,
 
-		Schema: map[string]*schema.Schema{
-			"agent_arns": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				ForceNew: true,
-				Elem: &schema.Schema{
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"agent_arns": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					ForceNew: true,
+					Elem: &schema.Schema{
+						Type:         schema.TypeString,
+						ValidateFunc: verify.ValidARN,
+					},
+				},
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"s3_bucket_arn": {
 					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
 					ValidateFunc: verify.ValidARN,
 				},
-			},
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"s3_bucket_arn": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			"s3_config": {
-				Type:     schema.TypeList,
-				Required: true,
-				ForceNew: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"bucket_access_role_arn": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ForceNew:     true,
-							ValidateFunc: verify.ValidARN,
+				"s3_config": {
+					Type:     schema.TypeList,
+					Required: true,
+					ForceNew: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"bucket_access_role_arn": {
+								Type:         schema.TypeString,
+								Required:     true,
+								ForceNew:     true,
+								ValidateFunc: verify.ValidARN,
+							},
 						},
 					},
 				},
-			},
-			"s3_storage_class": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Computed:         true,
-				ForceNew:         true,
-				ValidateDiagFunc: enum.Validate[awstypes.S3StorageClass](),
-			},
-			"subdirectory": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-				// Ignore missing trailing slash
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					if new == "/" {
-						return false
-					}
-					if strings.TrimSuffix(old, "/") == strings.TrimSuffix(new, "/") {
-						return true
-					}
-					return false
+				"s3_storage_class": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					Computed:         true,
+					ForceNew:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.S3StorageClass](),
 				},
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			names.AttrURI: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+				"subdirectory": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+					// Ignore missing trailing slash
+					DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+						if new == "/" {
+							return false
+						}
+						if strings.TrimSuffix(old, "/") == strings.TrimSuffix(new, "/") {
+							return true
+						}
+						return false
+					},
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				names.AttrURI: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/datasync/location_smb.go
+++ b/internal/service/datasync/location_smb.go
@@ -41,80 +41,82 @@ func resourceLocationSMB() *schema.Resource {
 		UpdateWithoutTimeout: resourceLocationSMBUpdate,
 		DeleteWithoutTimeout: resourceLocationSMBDelete,
 
-		Schema: map[string]*schema.Schema{
-			"agent_arns": {
-				Type:     schema.TypeSet,
-				Required: true,
-				Elem: &schema.Schema{
-					Type:         schema.TypeString,
-					ValidateFunc: verify.ValidARN,
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"agent_arns": {
+					Type:     schema.TypeSet,
+					Required: true,
+					Elem: &schema.Schema{
+						Type:         schema.TypeString,
+						ValidateFunc: verify.ValidARN,
+					},
 				},
-			},
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrDomain: {
-				Type:         schema.TypeString,
-				Computed:     true,
-				Optional:     true,
-				ValidateFunc: validation.StringLenBetween(1, 253),
-			},
-			"mount_options": {
-				Type:             schema.TypeList,
-				Optional:         true,
-				MaxItems:         1,
-				DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrVersion: {
-							Type:             schema.TypeString,
-							Default:          awstypes.SmbVersionAutomatic,
-							Optional:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.SmbVersion](),
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrDomain: {
+					Type:         schema.TypeString,
+					Computed:     true,
+					Optional:     true,
+					ValidateFunc: validation.StringLenBetween(1, 253),
+				},
+				"mount_options": {
+					Type:             schema.TypeList,
+					Optional:         true,
+					MaxItems:         1,
+					DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrVersion: {
+								Type:             schema.TypeString,
+								Default:          awstypes.SmbVersionAutomatic,
+								Optional:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.SmbVersion](),
+							},
 						},
 					},
 				},
-			},
-			names.AttrPassword: {
-				Type:         schema.TypeString,
-				Required:     true,
-				Sensitive:    true,
-				ValidateFunc: validation.StringLenBetween(1, 104),
-			},
-			"server_hostname": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(1, 255),
-			},
-			"subdirectory": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringLenBetween(1, 4096),
-				/*// Ignore missing trailing slash
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					if new == "/" {
-						return false
-					}
-					if strings.TrimSuffix(old, "/") == strings.TrimSuffix(new, "/") {
-						return true
-					}
-					return false
+				names.AttrPassword: {
+					Type:         schema.TypeString,
+					Required:     true,
+					Sensitive:    true,
+					ValidateFunc: validation.StringLenBetween(1, 104),
 				},
-				*/
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			names.AttrURI: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"user": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringLenBetween(1, 104),
-			},
+				"server_hostname": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringLenBetween(1, 255),
+				},
+				"subdirectory": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringLenBetween(1, 4096),
+					/*// Ignore missing trailing slash
+					DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+						if new == "/" {
+							return false
+						}
+						if strings.TrimSuffix(old, "/") == strings.TrimSuffix(new, "/") {
+							return true
+						}
+						return false
+					},
+					*/
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				names.AttrURI: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"user": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringLenBetween(1, 104),
+				},
+			}
 		},
 	}
 }

--- a/internal/service/datasync/task.go
+++ b/internal/service/datasync/task.go
@@ -46,277 +46,279 @@ func resourceTask() *schema.Resource {
 			Create: schema.DefaultTimeout(5 * time.Minute),
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrCloudWatchLogGroupARN: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			"destination_location_arn": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			"excludes": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"filter_type": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.FilterType](),
-						},
-						names.AttrValue: {
-							Type:     schema.TypeString,
-							Optional: true,
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrCloudWatchLogGroupARN: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				"destination_location_arn": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				"excludes": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"filter_type": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.FilterType](),
+							},
+							names.AttrValue: {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
 						},
 					},
 				},
-			},
-			"includes": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"filter_type": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.FilterType](),
-						},
-						names.AttrValue: {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-					},
-				},
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"options": {
-				Type:             schema.TypeList,
-				Optional:         true,
-				MaxItems:         1,
-				DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"atime": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Default:          awstypes.AtimeBestEffort,
-							ValidateDiagFunc: enum.Validate[awstypes.Atime](),
-						},
-						"bytes_per_second": {
-							Type:         schema.TypeInt,
-							Optional:     true,
-							Default:      -1,
-							ValidateFunc: validation.IntAtLeast(-1),
-						},
-						"gid": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Default:          awstypes.GidIntValue,
-							ValidateDiagFunc: enum.Validate[awstypes.Gid](),
-						},
-						"log_level": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Default:          awstypes.LogLevelOff,
-							ValidateDiagFunc: enum.Validate[awstypes.LogLevel](),
-						},
-						"mtime": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Default:          awstypes.MtimePreserve,
-							ValidateDiagFunc: enum.Validate[awstypes.Mtime](),
-						},
-						"object_tags": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Default:          awstypes.ObjectTagsPreserve,
-							ValidateDiagFunc: enum.Validate[awstypes.ObjectTags](),
-						},
-						"overwrite_mode": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Default:          awstypes.OverwriteModeAlways,
-							ValidateDiagFunc: enum.Validate[awstypes.OverwriteMode](),
-						},
-						"posix_permissions": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Default:          awstypes.PosixPermissionsPreserve,
-							ValidateDiagFunc: enum.Validate[awstypes.PosixPermissions](),
-						},
-						"preserve_deleted_files": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Default:          awstypes.PreserveDeletedFilesPreserve,
-							ValidateDiagFunc: enum.Validate[awstypes.PreserveDeletedFiles](),
-						},
-						"preserve_devices": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Default:          awstypes.PreserveDevicesNone,
-							ValidateDiagFunc: enum.Validate[awstypes.PreserveDevices](),
-						},
-						"security_descriptor_copy_flags": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Computed:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.SmbSecurityDescriptorCopyFlags](),
-						},
-						"task_queueing": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Default:          awstypes.TaskQueueingEnabled,
-							ValidateDiagFunc: enum.Validate[awstypes.TaskQueueing](),
-						},
-						"transfer_mode": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Default:          awstypes.TransferModeChanged,
-							ValidateDiagFunc: enum.Validate[awstypes.TransferMode](),
-						},
-						"uid": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Default:          awstypes.UidIntValue,
-							ValidateDiagFunc: enum.Validate[awstypes.Uid](),
-						},
-						"verify_mode": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Default:          awstypes.VerifyModePointInTimeConsistent,
-							ValidateDiagFunc: enum.Validate[awstypes.VerifyMode](),
+				"includes": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"filter_type": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.FilterType](),
+							},
+							names.AttrValue: {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
 						},
 					},
 				},
-			},
-			names.AttrSchedule: {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrScheduleExpression: {
-							Type:     schema.TypeString,
-							Required: true,
-							ValidateFunc: validation.All(
-								validation.StringLenBetween(1, 256),
-								validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z_\s #()*+,/?^|-]*$`),
-									"Schedule expressions must have the following syntax: rate(<number>\\\\s?(minutes?|hours?|days?)), cron(<cron_expression>) or at(yyyy-MM-dd'T'HH:mm:ss)."),
-							),
-						},
-						names.AttrStatus: {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Computed:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.ScheduleStatus](),
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"options": {
+					Type:             schema.TypeList,
+					Optional:         true,
+					MaxItems:         1,
+					DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"atime": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								Default:          awstypes.AtimeBestEffort,
+								ValidateDiagFunc: enum.Validate[awstypes.Atime](),
+							},
+							"bytes_per_second": {
+								Type:         schema.TypeInt,
+								Optional:     true,
+								Default:      -1,
+								ValidateFunc: validation.IntAtLeast(-1),
+							},
+							"gid": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								Default:          awstypes.GidIntValue,
+								ValidateDiagFunc: enum.Validate[awstypes.Gid](),
+							},
+							"log_level": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								Default:          awstypes.LogLevelOff,
+								ValidateDiagFunc: enum.Validate[awstypes.LogLevel](),
+							},
+							"mtime": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								Default:          awstypes.MtimePreserve,
+								ValidateDiagFunc: enum.Validate[awstypes.Mtime](),
+							},
+							"object_tags": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								Default:          awstypes.ObjectTagsPreserve,
+								ValidateDiagFunc: enum.Validate[awstypes.ObjectTags](),
+							},
+							"overwrite_mode": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								Default:          awstypes.OverwriteModeAlways,
+								ValidateDiagFunc: enum.Validate[awstypes.OverwriteMode](),
+							},
+							"posix_permissions": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								Default:          awstypes.PosixPermissionsPreserve,
+								ValidateDiagFunc: enum.Validate[awstypes.PosixPermissions](),
+							},
+							"preserve_deleted_files": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								Default:          awstypes.PreserveDeletedFilesPreserve,
+								ValidateDiagFunc: enum.Validate[awstypes.PreserveDeletedFiles](),
+							},
+							"preserve_devices": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								Default:          awstypes.PreserveDevicesNone,
+								ValidateDiagFunc: enum.Validate[awstypes.PreserveDevices](),
+							},
+							"security_descriptor_copy_flags": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								Computed:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.SmbSecurityDescriptorCopyFlags](),
+							},
+							"task_queueing": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								Default:          awstypes.TaskQueueingEnabled,
+								ValidateDiagFunc: enum.Validate[awstypes.TaskQueueing](),
+							},
+							"transfer_mode": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								Default:          awstypes.TransferModeChanged,
+								ValidateDiagFunc: enum.Validate[awstypes.TransferMode](),
+							},
+							"uid": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								Default:          awstypes.UidIntValue,
+								ValidateDiagFunc: enum.Validate[awstypes.Uid](),
+							},
+							"verify_mode": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								Default:          awstypes.VerifyModePointInTimeConsistent,
+								ValidateDiagFunc: enum.Validate[awstypes.VerifyMode](),
+							},
 						},
 					},
 				},
-			},
-			"source_location_arn": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			"task_mode": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Computed:         true,
-				ForceNew:         true,
-				ValidateDiagFunc: enum.Validate[awstypes.TaskMode](),
-			},
-			"task_report_config": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"s3_destination": {
-							Type:     schema.TypeList,
-							Required: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"bucket_access_role_arn": {
-										Type:         schema.TypeString,
-										Required:     true,
-										ValidateFunc: verify.ValidARN,
-									},
-									"s3_bucket_arn": {
-										Type:         schema.TypeString,
-										Required:     true,
-										ValidateFunc: verify.ValidARN,
-									},
-									"subdirectory": {
-										Type:     schema.TypeString,
-										Optional: true,
+				names.AttrSchedule: {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrScheduleExpression: {
+								Type:     schema.TypeString,
+								Required: true,
+								ValidateFunc: validation.All(
+									validation.StringLenBetween(1, 256),
+									validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z_\s #()*+,/?^|-]*$`),
+										"Schedule expressions must have the following syntax: rate(<number>\\\\s?(minutes?|hours?|days?)), cron(<cron_expression>) or at(yyyy-MM-dd'T'HH:mm:ss)."),
+								),
+							},
+							names.AttrStatus: {
+								Type:             schema.TypeString,
+								Optional:         true,
+								Computed:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.ScheduleStatus](),
+							},
+						},
+					},
+				},
+				"source_location_arn": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				"task_mode": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					Computed:         true,
+					ForceNew:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.TaskMode](),
+				},
+				"task_report_config": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"s3_destination": {
+								Type:     schema.TypeList,
+								Required: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"bucket_access_role_arn": {
+											Type:         schema.TypeString,
+											Required:     true,
+											ValidateFunc: verify.ValidARN,
+										},
+										"s3_bucket_arn": {
+											Type:         schema.TypeString,
+											Required:     true,
+											ValidateFunc: verify.ValidARN,
+										},
+										"subdirectory": {
+											Type:     schema.TypeString,
+											Optional: true,
+										},
 									},
 								},
 							},
-						},
-						"s3_object_versioning": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.ObjectVersionIds](),
-						},
-						"output_type": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.ReportOutputType](),
-						},
-						"report_overrides": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"deleted_override": {
-										Type:             schema.TypeString,
-										Optional:         true,
-										ValidateDiagFunc: enum.Validate[awstypes.ReportLevel](),
-									},
-									"skipped_override": {
-										Type:             schema.TypeString,
-										Optional:         true,
-										ValidateDiagFunc: enum.Validate[awstypes.ReportLevel](),
-									},
-									"transferred_override": {
-										Type:             schema.TypeString,
-										Optional:         true,
-										ValidateDiagFunc: enum.Validate[awstypes.ReportLevel](),
-									},
-									"verified_override": {
-										Type:             schema.TypeString,
-										Optional:         true,
-										ValidateDiagFunc: enum.Validate[awstypes.ReportLevel](),
+							"s3_object_versioning": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.ObjectVersionIds](),
+							},
+							"output_type": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.ReportOutputType](),
+							},
+							"report_overrides": {
+								Type:     schema.TypeList,
+								Optional: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"deleted_override": {
+											Type:             schema.TypeString,
+											Optional:         true,
+											ValidateDiagFunc: enum.Validate[awstypes.ReportLevel](),
+										},
+										"skipped_override": {
+											Type:             schema.TypeString,
+											Optional:         true,
+											ValidateDiagFunc: enum.Validate[awstypes.ReportLevel](),
+										},
+										"transferred_override": {
+											Type:             schema.TypeString,
+											Optional:         true,
+											ValidateDiagFunc: enum.Validate[awstypes.ReportLevel](),
+										},
+										"verified_override": {
+											Type:             schema.TypeString,
+											Optional:         true,
+											ValidateDiagFunc: enum.Validate[awstypes.ReportLevel](),
+										},
 									},
 								},
 							},
-						},
-						"report_level": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.ReportLevel](),
+							"report_level": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.ReportLevel](),
+							},
 						},
 					},
 				},
-			},
+			}
 		},
 	}
 }

--- a/internal/service/dax/cluster.go
+++ b/internal/service/dax/cluster.go
@@ -52,156 +52,158 @@ func ResourceCluster() *schema.Resource {
 			Update: schema.DefaultTimeout(90 * time.Minute),
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"cluster_endpoint_encryption_type": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				ForceNew:         true,
-				ValidateDiagFunc: enum.Validate[awstypes.ClusterEndpointEncryptionType](),
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					// API returns "NONE" by default.
-					if old == string(awstypes.ClusterEndpointEncryptionTypeNone) && new == "" {
-						return true
-					}
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"cluster_endpoint_encryption_type": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					ForceNew:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.ClusterEndpointEncryptionType](),
+					DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+						// API returns "NONE" by default.
+						if old == string(awstypes.ClusterEndpointEncryptionTypeNone) && new == "" {
+							return true
+						}
 
-					return old == new
+						return old == new
+					},
 				},
-			},
-			names.AttrClusterName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-				StateFunc: func(val any) string {
-					return strings.ToLower(val.(string))
+				names.AttrClusterName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+					StateFunc: func(val any) string {
+						return strings.ToLower(val.(string))
+					},
+					ValidateFunc: validation.All(
+						validation.StringLenBetween(1, 20),
+						validation.StringMatch(regexache.MustCompile(`^[0-9a-z-]+$`), "must contain only lowercase alphanumeric characters and hyphens"),
+						validation.StringMatch(regexache.MustCompile(`^[a-z]`), "must begin with a lowercase letter"),
+						validation.StringDoesNotMatch(regexache.MustCompile(`--`), "cannot contain two consecutive hyphens"),
+						validation.StringDoesNotMatch(regexache.MustCompile(`-$`), "cannot end with a hyphen"),
+					),
 				},
-				ValidateFunc: validation.All(
-					validation.StringLenBetween(1, 20),
-					validation.StringMatch(regexache.MustCompile(`^[0-9a-z-]+$`), "must contain only lowercase alphanumeric characters and hyphens"),
-					validation.StringMatch(regexache.MustCompile(`^[a-z]`), "must begin with a lowercase letter"),
-					validation.StringDoesNotMatch(regexache.MustCompile(`--`), "cannot contain two consecutive hyphens"),
-					validation.StringDoesNotMatch(regexache.MustCompile(`-$`), "cannot end with a hyphen"),
-				),
-			},
-			names.AttrIAMRoleARN: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			"node_type": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"replication_factor": {
-				Type:     schema.TypeInt,
-				Required: true,
-			},
-			names.AttrAvailabilityZones: {
-				Type:     schema.TypeSet,
-				Optional: true,
-				ForceNew: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Set:      schema.HashString,
-			},
-			names.AttrDescription: {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"notification_topic_arn": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			names.AttrParameterGroupName: {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-			"maintenance_window": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				StateFunc: func(val any) string {
-					return strings.ToLower(val.(string))
+				names.AttrIAMRoleARN: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: verify.ValidARN,
 				},
-				ValidateFunc: verify.ValidOnceAWeekWindowFormat,
-			},
-			names.AttrSecurityGroupIDs: {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Set:      schema.HashString,
-			},
-			"server_side_encryption": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					if old == "1" && new == "0" {
-						return true
-					}
-					return false
+				"node_type": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
 				},
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrEnabled: {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  false,
-							ForceNew: true,
+				"replication_factor": {
+					Type:     schema.TypeInt,
+					Required: true,
+				},
+				names.AttrAvailabilityZones: {
+					Type:     schema.TypeSet,
+					Optional: true,
+					ForceNew: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+					Set:      schema.HashString,
+				},
+				names.AttrDescription: {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"notification_topic_arn": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				names.AttrParameterGroupName: {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+				},
+				"maintenance_window": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+					StateFunc: func(val any) string {
+						return strings.ToLower(val.(string))
+					},
+					ValidateFunc: verify.ValidOnceAWeekWindowFormat,
+				},
+				names.AttrSecurityGroupIDs: {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+					Set:      schema.HashString,
+				},
+				"server_side_encryption": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+						if old == "1" && new == "0" {
+							return true
+						}
+						return false
+					},
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrEnabled: {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Default:  false,
+								ForceNew: true,
+							},
 						},
 					},
 				},
-			},
-			"subnet_group_name": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			names.AttrPort: {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-			"configuration_endpoint": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"cluster_address": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"nodes": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrID: {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						names.AttrAddress: {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						names.AttrPort: {
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
-						names.AttrAvailabilityZone: {
-							Type:     schema.TypeString,
-							Computed: true,
+				"subnet_group_name": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				names.AttrPort: {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
+				"configuration_endpoint": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"cluster_address": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"nodes": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrID: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							names.AttrAddress: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							names.AttrPort: {
+								Type:     schema.TypeInt,
+								Computed: true,
+							},
+							names.AttrAvailabilityZone: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
 						},
 					},
 				},
-			},
+			}
 		},
 	}
 }

--- a/internal/service/dax/parameter_group.go
+++ b/internal/service/dax/parameter_group.go
@@ -32,34 +32,36 @@ func ResourceParameterGroup() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			names.AttrDescription: {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
-			names.AttrParameters: {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrName: {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						names.AttrValue: {
-							Type:     schema.TypeString,
-							Required: true,
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				names.AttrDescription: {
+					Type:     schema.TypeString,
+					Optional: true,
+					ForceNew: true,
+				},
+				names.AttrParameters: {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrName: {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+							names.AttrValue: {
+								Type:     schema.TypeString,
+								Required: true,
+							},
 						},
 					},
 				},
-			},
+			}
 		},
 	}
 }

--- a/internal/service/dax/subnet_group.go
+++ b/internal/service/dax/subnet_group.go
@@ -33,26 +33,28 @@ func ResourceSubnetGroup() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			names.AttrDescription: {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			names.AttrSubnetIDs: {
-				Type:     schema.TypeSet,
-				Required: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Set:      schema.HashString,
-			},
-			names.AttrVPCID: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				names.AttrDescription: {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				names.AttrSubnetIDs: {
+					Type:     schema.TypeSet,
+					Required: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+					Set:      schema.HashString,
+				},
+				names.AttrVPCID: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/deploy/app.go
+++ b/internal/service/deploy/app.go
@@ -61,37 +61,39 @@ func resourceApp() *schema.Resource {
 			},
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrApplicationID: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"compute_platform": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				ForceNew:         true,
-				ValidateDiagFunc: enum.Validate[types.ComputePlatform](),
-				Default:          types.ComputePlatformServer,
-			},
-			"github_account_name": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"linked_to_github": {
-				Type:     schema.TypeBool,
-				Computed: true,
-			},
-			names.AttrName: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringLenBetween(1, 100),
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrApplicationID: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"compute_platform": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					ForceNew:         true,
+					ValidateDiagFunc: enum.Validate[types.ComputePlatform](),
+					Default:          types.ComputePlatformServer,
+				},
+				"github_account_name": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"linked_to_github": {
+					Type:     schema.TypeBool,
+					Computed: true,
+				},
+				names.AttrName: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringLenBetween(1, 100),
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			}
 		},
 	}
 }

--- a/internal/service/deploy/deployment_config.go
+++ b/internal/service/deploy/deployment_config.go
@@ -35,148 +35,150 @@ func resourceDeploymentConfig() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"compute_platform": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				ForceNew:         true,
-				Default:          types.ComputePlatformServer,
-				ValidateDiagFunc: enum.Validate[types.ComputePlatform](),
-			},
-			"deployment_config_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"deployment_config_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"minimum_healthy_hosts": {
-				Type:     schema.TypeList,
-				Optional: true,
-				ForceNew: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrType: {
-							Type:             schema.TypeString,
-							Optional:         true,
-							ForceNew:         true,
-							ValidateDiagFunc: enum.Validate[types.MinimumHealthyHostsType](),
-						},
-						names.AttrValue: {
-							Type:     schema.TypeInt,
-							Optional: true,
-							ForceNew: true,
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"compute_platform": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					ForceNew:         true,
+					Default:          types.ComputePlatformServer,
+					ValidateDiagFunc: enum.Validate[types.ComputePlatform](),
+				},
+				"deployment_config_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"deployment_config_name": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"minimum_healthy_hosts": {
+					Type:     schema.TypeList,
+					Optional: true,
+					ForceNew: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrType: {
+								Type:             schema.TypeString,
+								Optional:         true,
+								ForceNew:         true,
+								ValidateDiagFunc: enum.Validate[types.MinimumHealthyHostsType](),
+							},
+							names.AttrValue: {
+								Type:     schema.TypeInt,
+								Optional: true,
+								ForceNew: true,
+							},
 						},
 					},
 				},
-			},
-			"traffic_routing_config": {
-				Type:     schema.TypeList,
-				Optional: true,
-				ForceNew: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"time_based_canary": {
-							Type:          schema.TypeList,
-							Optional:      true,
-							ForceNew:      true,
-							MaxItems:      1,
-							ConflictsWith: []string{"traffic_routing_config.0.time_based_linear"},
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									names.AttrInterval: {
-										Type:     schema.TypeInt,
-										Optional: true,
-										ForceNew: true,
-									},
-									"percentage": {
-										Type:     schema.TypeInt,
-										Optional: true,
-										ForceNew: true,
-									},
-								},
-							},
-						},
-						"time_based_linear": {
-							Type:          schema.TypeList,
-							Optional:      true,
-							ForceNew:      true,
-							MaxItems:      1,
-							ConflictsWith: []string{"traffic_routing_config.0.time_based_canary"},
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									names.AttrInterval: {
-										Type:     schema.TypeInt,
-										Optional: true,
-										ForceNew: true,
-									},
-									"percentage": {
-										Type:     schema.TypeInt,
-										Optional: true,
-										ForceNew: true,
+				"traffic_routing_config": {
+					Type:     schema.TypeList,
+					Optional: true,
+					ForceNew: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"time_based_canary": {
+								Type:          schema.TypeList,
+								Optional:      true,
+								ForceNew:      true,
+								MaxItems:      1,
+								ConflictsWith: []string{"traffic_routing_config.0.time_based_linear"},
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										names.AttrInterval: {
+											Type:     schema.TypeInt,
+											Optional: true,
+											ForceNew: true,
+										},
+										"percentage": {
+											Type:     schema.TypeInt,
+											Optional: true,
+											ForceNew: true,
+										},
 									},
 								},
 							},
-						},
-						names.AttrType: {
-							Type:             schema.TypeString,
-							Optional:         true,
-							ForceNew:         true,
-							Default:          types.TrafficRoutingTypeAllAtOnce,
-							ValidateDiagFunc: enum.Validate[types.TrafficRoutingType](),
+							"time_based_linear": {
+								Type:          schema.TypeList,
+								Optional:      true,
+								ForceNew:      true,
+								MaxItems:      1,
+								ConflictsWith: []string{"traffic_routing_config.0.time_based_canary"},
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										names.AttrInterval: {
+											Type:     schema.TypeInt,
+											Optional: true,
+											ForceNew: true,
+										},
+										"percentage": {
+											Type:     schema.TypeInt,
+											Optional: true,
+											ForceNew: true,
+										},
+									},
+								},
+							},
+							names.AttrType: {
+								Type:             schema.TypeString,
+								Optional:         true,
+								ForceNew:         true,
+								Default:          types.TrafficRoutingTypeAllAtOnce,
+								ValidateDiagFunc: enum.Validate[types.TrafficRoutingType](),
+							},
 						},
 					},
 				},
-			},
-			"zonal_config": {
-				Type:     schema.TypeList,
-				Optional: true,
-				ForceNew: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"first_zone_monitor_duration_in_seconds": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							ForceNew: true,
-						},
-						"minimum_healthy_hosts_per_zone": {
-							Type:     schema.TypeList,
-							Optional: true,
-							ForceNew: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									names.AttrType: {
-										Type:             schema.TypeString,
-										Optional:         true,
-										ForceNew:         true,
-										ValidateDiagFunc: enum.Validate[types.MinimumHealthyHostsPerZoneType](),
-									},
-									names.AttrValue: {
-										Type:     schema.TypeInt,
-										Optional: true,
-										ForceNew: true,
+				"zonal_config": {
+					Type:     schema.TypeList,
+					Optional: true,
+					ForceNew: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"first_zone_monitor_duration_in_seconds": {
+								Type:     schema.TypeInt,
+								Optional: true,
+								ForceNew: true,
+							},
+							"minimum_healthy_hosts_per_zone": {
+								Type:     schema.TypeList,
+								Optional: true,
+								ForceNew: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										names.AttrType: {
+											Type:             schema.TypeString,
+											Optional:         true,
+											ForceNew:         true,
+											ValidateDiagFunc: enum.Validate[types.MinimumHealthyHostsPerZoneType](),
+										},
+										names.AttrValue: {
+											Type:     schema.TypeInt,
+											Optional: true,
+											ForceNew: true,
+										},
 									},
 								},
 							},
-						},
-						"monitor_duration_in_seconds": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							ForceNew: true,
+							"monitor_duration_in_seconds": {
+								Type:     schema.TypeInt,
+								Optional: true,
+								ForceNew: true,
+							},
 						},
 					},
 				},
-			},
+			}
 		},
 	}
 }

--- a/internal/service/deploy/deployment_group.go
+++ b/internal/service/deploy/deployment_group.go
@@ -67,318 +67,118 @@ func resourceDeploymentGroup() *schema.Resource {
 			},
 		},
 
-		Schema: map[string]*schema.Schema{
-			"alarm_configuration": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"alarms": {
-							Type:     schema.TypeSet,
-							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-						names.AttrEnabled: {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
-						"ignore_poll_alarm_failure": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  false,
-						},
-					},
-				},
-			},
-			"app_name": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringLenBetween(0, 100),
-			},
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"auto_rollback_configuration": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrEnabled: {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
-						"events": {
-							Type:     schema.TypeSet,
-							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-					},
-				},
-			},
-			"autoscaling_groups": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			"blue_green_deployment_config": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Computed: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"deployment_ready_option": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"action_on_timeout": {
-										Type:             schema.TypeString,
-										Optional:         true,
-										ValidateDiagFunc: enum.Validate[types.DeploymentReadyAction](),
-									},
-									"wait_time_in_minutes": {
-										Type:     schema.TypeInt,
-										Optional: true,
-									},
-								},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"alarm_configuration": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"alarms": {
+								Type:     schema.TypeSet,
+								Optional: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
 							},
-						},
-						"green_fleet_provisioning_option": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Computed: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									names.AttrAction: {
-										Type:             schema.TypeString,
-										Optional:         true,
-										ValidateDiagFunc: enum.Validate[types.GreenFleetProvisioningAction](),
-									},
-								},
+							names.AttrEnabled: {
+								Type:     schema.TypeBool,
+								Optional: true,
 							},
-						},
-						"terminate_blue_instances_on_deployment_success": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									names.AttrAction: {
-										Type:             schema.TypeString,
-										Optional:         true,
-										ValidateDiagFunc: enum.Validate[types.InstanceAction](),
-									},
-									"termination_wait_time_in_minutes": {
-										Type:         schema.TypeInt,
-										Optional:     true,
-										ValidateFunc: validation.IntAtMost(2880),
-									},
-								},
+							"ignore_poll_alarm_failure": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Default:  false,
 							},
 						},
 					},
 				},
-			},
-			"compute_platform": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"deployment_config_name": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Default:      "CodeDeployDefault.OneAtATime",
-				ValidateFunc: validation.StringLenBetween(0, 100),
-			},
-			"deployment_group_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"deployment_group_name": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringLenBetween(0, 100),
-			},
-			"deployment_style": {
-				Type:             schema.TypeList,
-				Optional:         true,
-				DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
-				MaxItems:         1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"deployment_option": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Default:          types.DeploymentOptionWithoutTrafficControl,
-							ValidateDiagFunc: enum.Validate[types.DeploymentOption](),
-						},
-						"deployment_type": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Default:          types.DeploymentTypeInPlace,
-							ValidateDiagFunc: enum.Validate[types.DeploymentType](),
-						},
-					},
+				"app_name": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringLenBetween(0, 100),
 				},
-			},
-			"ec2_tag_filter": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrKey: {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						names.AttrType: {
-							Type:             schema.TypeString,
-							Optional:         true,
-							ValidateDiagFunc: enum.Validate[types.EC2TagFilterType](),
-						},
-						names.AttrValue: {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-					},
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
 				},
-			},
-			"ec2_tag_set": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"ec2_tag_filter": {
-							Type:     schema.TypeSet,
-							Optional: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									names.AttrKey: {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
-									names.AttrType: {
-										Type:             schema.TypeString,
-										Optional:         true,
-										ValidateDiagFunc: enum.Validate[types.EC2TagFilterType](),
-									},
-									names.AttrValue: {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
-								},
+				"auto_rollback_configuration": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrEnabled: {
+								Type:     schema.TypeBool,
+								Optional: true,
+							},
+							"events": {
+								Type:     schema.TypeSet,
+								Optional: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
 							},
 						},
 					},
 				},
-			},
-			"ecs_service": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrClusterName: {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validation.NoZeroValues,
-						},
-						names.AttrServiceName: {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validation.NoZeroValues,
-						},
-					},
+				"autoscaling_groups": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
 				},
-			},
-			"load_balancer_info": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"elb_info": {
-							Type:     schema.TypeSet,
-							Optional: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									names.AttrName: {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
-								},
-							},
-						},
-						"target_group_info": {
-							Type:     schema.TypeSet,
-							Optional: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									names.AttrName: {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
-								},
-							},
-						},
-						"target_group_pair_info": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"prod_traffic_route": {
-										Type:     schema.TypeList,
-										Required: true,
-										MinItems: 1,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"listener_arns": {
-													Type:     schema.TypeSet,
-													Required: true,
-													Elem: &schema.Schema{
-														Type:         schema.TypeString,
-														ValidateFunc: verify.ValidARN,
-													},
-												},
-											},
+				"blue_green_deployment_config": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Computed: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"deployment_ready_option": {
+								Type:     schema.TypeList,
+								Optional: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"action_on_timeout": {
+											Type:             schema.TypeString,
+											Optional:         true,
+											ValidateDiagFunc: enum.Validate[types.DeploymentReadyAction](),
+										},
+										"wait_time_in_minutes": {
+											Type:     schema.TypeInt,
+											Optional: true,
 										},
 									},
-									"target_group": {
-										Type:     schema.TypeList,
-										Required: true,
-										MinItems: 1,
-										MaxItems: 2,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												names.AttrName: {
-													Type:         schema.TypeString,
-													Required:     true,
-													ValidateFunc: validation.NoZeroValues,
-												},
-											},
+								},
+							},
+							"green_fleet_provisioning_option": {
+								Type:     schema.TypeList,
+								Optional: true,
+								Computed: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										names.AttrAction: {
+											Type:             schema.TypeString,
+											Optional:         true,
+											ValidateDiagFunc: enum.Validate[types.GreenFleetProvisioningAction](),
 										},
 									},
-									"test_traffic_route": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"listener_arns": {
-													Type:     schema.TypeSet,
-													Required: true,
-													Elem: &schema.Schema{
-														Type:         schema.TypeString,
-														ValidateFunc: verify.ValidARN,
-													},
-												},
-											},
+								},
+							},
+							"terminate_blue_instances_on_deployment_success": {
+								Type:     schema.TypeList,
+								Optional: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										names.AttrAction: {
+											Type:             schema.TypeString,
+											Optional:         true,
+											ValidateDiagFunc: enum.Validate[types.InstanceAction](),
+										},
+										"termination_wait_time_in_minutes": {
+											Type:         schema.TypeInt,
+											Optional:     true,
+											ValidateFunc: validation.IntAtMost(2880),
 										},
 									},
 								},
@@ -386,71 +186,273 @@ func resourceDeploymentGroup() *schema.Resource {
 						},
 					},
 				},
-			},
-			"on_premises_instance_tag_filter": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrKey: {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						names.AttrType: {
-							Type:             schema.TypeString,
-							Optional:         true,
-							ValidateDiagFunc: enum.Validate[types.TagFilterType](),
-						},
-						names.AttrValue: {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-					},
+				"compute_platform": {
+					Type:     schema.TypeString,
+					Computed: true,
 				},
-			},
-			"outdated_instances_strategy": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Default:          types.OutdatedInstancesStrategyUpdate,
-				ValidateDiagFunc: enum.Validate[types.OutdatedInstancesStrategy](),
-			},
-			names.AttrServiceRoleARN: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			"termination_hook_enabled": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-			"trigger_configuration": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"trigger_events": {
-							Type:     schema.TypeSet,
-							Required: true,
-							Elem: &schema.Schema{
+				"deployment_config_name": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Default:      "CodeDeployDefault.OneAtATime",
+					ValidateFunc: validation.StringLenBetween(0, 100),
+				},
+				"deployment_group_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"deployment_group_name": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringLenBetween(0, 100),
+				},
+				"deployment_style": {
+					Type:             schema.TypeList,
+					Optional:         true,
+					DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
+					MaxItems:         1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"deployment_option": {
 								Type:             schema.TypeString,
-								ValidateDiagFunc: enum.Validate[types.TriggerEventType](),
+								Optional:         true,
+								Default:          types.DeploymentOptionWithoutTrafficControl,
+								ValidateDiagFunc: enum.Validate[types.DeploymentOption](),
 							},
-						},
-						"trigger_name": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"trigger_target_arn": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: verify.ValidARN,
+							"deployment_type": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								Default:          types.DeploymentTypeInPlace,
+								ValidateDiagFunc: enum.Validate[types.DeploymentType](),
+							},
 						},
 					},
 				},
-			},
+				"ec2_tag_filter": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrKey: {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+							names.AttrType: {
+								Type:             schema.TypeString,
+								Optional:         true,
+								ValidateDiagFunc: enum.Validate[types.EC2TagFilterType](),
+							},
+							names.AttrValue: {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+						},
+					},
+				},
+				"ec2_tag_set": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"ec2_tag_filter": {
+								Type:     schema.TypeSet,
+								Optional: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										names.AttrKey: {
+											Type:     schema.TypeString,
+											Optional: true,
+										},
+										names.AttrType: {
+											Type:             schema.TypeString,
+											Optional:         true,
+											ValidateDiagFunc: enum.Validate[types.EC2TagFilterType](),
+										},
+										names.AttrValue: {
+											Type:     schema.TypeString,
+											Optional: true,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				"ecs_service": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrClusterName: {
+								Type:         schema.TypeString,
+								Required:     true,
+								ValidateFunc: validation.NoZeroValues,
+							},
+							names.AttrServiceName: {
+								Type:         schema.TypeString,
+								Required:     true,
+								ValidateFunc: validation.NoZeroValues,
+							},
+						},
+					},
+				},
+				"load_balancer_info": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"elb_info": {
+								Type:     schema.TypeSet,
+								Optional: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										names.AttrName: {
+											Type:     schema.TypeString,
+											Optional: true,
+										},
+									},
+								},
+							},
+							"target_group_info": {
+								Type:     schema.TypeSet,
+								Optional: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										names.AttrName: {
+											Type:     schema.TypeString,
+											Optional: true,
+										},
+									},
+								},
+							},
+							"target_group_pair_info": {
+								Type:     schema.TypeList,
+								Optional: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"prod_traffic_route": {
+											Type:     schema.TypeList,
+											Required: true,
+											MinItems: 1,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"listener_arns": {
+														Type:     schema.TypeSet,
+														Required: true,
+														Elem: &schema.Schema{
+															Type:         schema.TypeString,
+															ValidateFunc: verify.ValidARN,
+														},
+													},
+												},
+											},
+										},
+										"target_group": {
+											Type:     schema.TypeList,
+											Required: true,
+											MinItems: 1,
+											MaxItems: 2,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													names.AttrName: {
+														Type:         schema.TypeString,
+														Required:     true,
+														ValidateFunc: validation.NoZeroValues,
+													},
+												},
+											},
+										},
+										"test_traffic_route": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"listener_arns": {
+														Type:     schema.TypeSet,
+														Required: true,
+														Elem: &schema.Schema{
+															Type:         schema.TypeString,
+															ValidateFunc: verify.ValidARN,
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				"on_premises_instance_tag_filter": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrKey: {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+							names.AttrType: {
+								Type:             schema.TypeString,
+								Optional:         true,
+								ValidateDiagFunc: enum.Validate[types.TagFilterType](),
+							},
+							names.AttrValue: {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+						},
+					},
+				},
+				"outdated_instances_strategy": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					Default:          types.OutdatedInstancesStrategyUpdate,
+					ValidateDiagFunc: enum.Validate[types.OutdatedInstancesStrategy](),
+				},
+				names.AttrServiceRoleARN: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				"termination_hook_enabled": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
+				"trigger_configuration": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"trigger_events": {
+								Type:     schema.TypeSet,
+								Required: true,
+								Elem: &schema.Schema{
+									Type:             schema.TypeString,
+									ValidateDiagFunc: enum.Validate[types.TriggerEventType](),
+								},
+							},
+							"trigger_name": {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+							"trigger_target_arn": {
+								Type:         schema.TypeString,
+								Required:     true,
+								ValidateFunc: verify.ValidARN,
+							},
+						},
+					},
+				},
+			}
 		},
 	}
 }

--- a/internal/service/detective/graph.go
+++ b/internal/service/detective/graph.go
@@ -38,17 +38,19 @@ func ResourceGraph() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrCreatedTime: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"graph_arn": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrCreatedTime: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"graph_arn": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			}
 		},
 	}
 }

--- a/internal/service/detective/invitation_accepter.go
+++ b/internal/service/detective/invitation_accepter.go
@@ -34,13 +34,15 @@ func ResourceInvitationAccepter() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"graph_arn": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidARN,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"graph_arn": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/detective/member.go
+++ b/internal/service/detective/member.go
@@ -39,58 +39,60 @@ func ResourceMember() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrAccountID: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidAccountID,
-			},
-			"administrator_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"disable_email_notification": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				ForceNew: true,
-			},
-			"disabled_reason": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"email_address": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"graph_arn": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			"invited_time": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrMessage: {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
-			names.AttrStatus: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"updated_time": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"volume_usage_in_bytes": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrAccountID: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: verify.ValidAccountID,
+				},
+				"administrator_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"disable_email_notification": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					ForceNew: true,
+				},
+				"disabled_reason": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"email_address": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"graph_arn": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				"invited_time": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrMessage: {
+					Type:     schema.TypeString,
+					Optional: true,
+					ForceNew: true,
+				},
+				names.AttrStatus: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"updated_time": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"volume_usage_in_bytes": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/detective/organization_admin_account.go
+++ b/internal/service/detective/organization_admin_account.go
@@ -36,13 +36,15 @@ func ResourceOrganizationAdminAccount() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrAccountID: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidAccountID,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrAccountID: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: verify.ValidAccountID,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/detective/organization_configuration.go
+++ b/internal/service/detective/organization_configuration.go
@@ -29,17 +29,19 @@ func ResourceOrganizationConfiguration() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"auto_enable": {
-				Type:     schema.TypeBool,
-				Required: true,
-			},
-			"graph_arn": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidARN,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"auto_enable": {
+					Type:     schema.TypeBool,
+					Required: true,
+				},
+				"graph_arn": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/devicefarm/device_pool.go
+++ b/internal/service/devicefarm/device_pool.go
@@ -43,58 +43,60 @@ func resourceDevicePool() *schema.Resource {
 		UpdateWithoutTimeout: resourceDevicePoolUpdate,
 		DeleteWithoutTimeout: resourceDevicePoolDelete,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrName: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringLenBetween(0, 256),
-			},
-			names.AttrDescription: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringLenBetween(0, 16384),
-			},
-			"max_devices": {
-				Type:     schema.TypeInt,
-				Optional: true,
-			},
-			"project_arn": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			names.AttrRule: {
-				Type:     schema.TypeSet,
-				Required: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"attribute": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.DeviceAttribute](),
-						},
-						"operator": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.RuleOperator](),
-						},
-						names.AttrValue: {
-							Type:     schema.TypeString,
-							Optional: true,
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrName: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringLenBetween(0, 256),
+				},
+				names.AttrDescription: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringLenBetween(0, 16384),
+				},
+				"max_devices": {
+					Type:     schema.TypeInt,
+					Optional: true,
+				},
+				"project_arn": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				names.AttrRule: {
+					Type:     schema.TypeSet,
+					Required: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"attribute": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.DeviceAttribute](),
+							},
+							"operator": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.RuleOperator](),
+							},
+							names.AttrValue: {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
 						},
 					},
 				},
-			},
-			names.AttrType: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				names.AttrType: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			}
 		},
 	}
 }

--- a/internal/service/devicefarm/instance_profile.go
+++ b/internal/service/devicefarm/instance_profile.go
@@ -39,37 +39,39 @@ func resourceInstanceProfile() *schema.Resource {
 		UpdateWithoutTimeout: resourceInstanceProfileUpdate,
 		DeleteWithoutTimeout: resourceInstanceProfileDelete,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrDescription: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringLenBetween(0, 16384),
-			},
-			"exclude_app_packages_from_cleanup": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			names.AttrName: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringLenBetween(0, 256),
-			},
-			"package_cleanup": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
-			"reboot_after_use": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrDescription: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringLenBetween(0, 16384),
+				},
+				"exclude_app_packages_from_cleanup": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				names.AttrName: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringLenBetween(0, 256),
+				},
+				"package_cleanup": {
+					Type:     schema.TypeBool,
+					Optional: true,
+				},
+				"reboot_after_use": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  true,
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			}
 		},
 	}
 }

--- a/internal/service/devicefarm/network_profile.go
+++ b/internal/service/devicefarm/network_profile.go
@@ -40,76 +40,78 @@ func resourceNetworkProfile() *schema.Resource {
 		UpdateWithoutTimeout: resourceNetworkProfileUpdate,
 		DeleteWithoutTimeout: resourceNetworkProfileDelete,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrDescription: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringLenBetween(0, 16384),
-			},
-			"downlink_bandwidth_bits": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				Default:      104857600,
-				ValidateFunc: validation.IntBetween(0, 104857600),
-			},
-			"downlink_delay_ms": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				ValidateFunc: validation.IntBetween(0, 2000),
-			},
-			"downlink_jitter_ms": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				ValidateFunc: validation.IntBetween(0, 2000),
-			},
-			"downlink_loss_percent": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				ValidateFunc: validation.IntBetween(0, 100),
-			},
-			names.AttrName: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringLenBetween(0, 256),
-			},
-			"project_arn": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			"uplink_bandwidth_bits": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				Default:      104857600,
-				ValidateFunc: validation.IntBetween(0, 104857600),
-			},
-			"uplink_delay_ms": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				ValidateFunc: validation.IntBetween(0, 2000),
-			},
-			"uplink_jitter_ms": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				ValidateFunc: validation.IntBetween(0, 2000),
-			},
-			"uplink_loss_percent": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				ValidateFunc: validation.IntBetween(0, 100),
-			},
-			names.AttrType: {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Default:          awstypes.NetworkProfileTypePrivate,
-				ValidateDiagFunc: enum.Validate[awstypes.NetworkProfileType](),
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrDescription: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringLenBetween(0, 16384),
+				},
+				"downlink_bandwidth_bits": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					Default:      104857600,
+					ValidateFunc: validation.IntBetween(0, 104857600),
+				},
+				"downlink_delay_ms": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					ValidateFunc: validation.IntBetween(0, 2000),
+				},
+				"downlink_jitter_ms": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					ValidateFunc: validation.IntBetween(0, 2000),
+				},
+				"downlink_loss_percent": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					ValidateFunc: validation.IntBetween(0, 100),
+				},
+				names.AttrName: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringLenBetween(0, 256),
+				},
+				"project_arn": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				"uplink_bandwidth_bits": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					Default:      104857600,
+					ValidateFunc: validation.IntBetween(0, 104857600),
+				},
+				"uplink_delay_ms": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					ValidateFunc: validation.IntBetween(0, 2000),
+				},
+				"uplink_jitter_ms": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					ValidateFunc: validation.IntBetween(0, 2000),
+				},
+				"uplink_loss_percent": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					ValidateFunc: validation.IntBetween(0, 100),
+				},
+				names.AttrType: {
+					Type:             schema.TypeString,
+					Optional:         true,
+					Default:          awstypes.NetworkProfileTypePrivate,
+					ValidateDiagFunc: enum.Validate[awstypes.NetworkProfileType](),
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			}
 		},
 	}
 }

--- a/internal/service/devicefarm/project.go
+++ b/internal/service/devicefarm/project.go
@@ -38,22 +38,24 @@ func resourceProject() *schema.Resource {
 		UpdateWithoutTimeout: resourceProjectUpdate,
 		DeleteWithoutTimeout: resourceProjectDelete,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"default_job_timeout_minutes": {
-				Type:     schema.TypeInt,
-				Optional: true,
-			},
-			names.AttrName: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringLenBetween(0, 256),
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"default_job_timeout_minutes": {
+					Type:     schema.TypeInt,
+					Optional: true,
+				},
+				names.AttrName: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringLenBetween(0, 256),
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			}
 		},
 	}
 }

--- a/internal/service/devicefarm/test_grid_project.go
+++ b/internal/service/devicefarm/test_grid_project.go
@@ -39,48 +39,50 @@ func resourceTestGridProject() *schema.Resource {
 		UpdateWithoutTimeout: resourceTestGridProjectUpdate,
 		DeleteWithoutTimeout: resourceTestGridProjectDelete,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
 
-			names.AttrName: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringLenBetween(0, 256),
-			},
-			names.AttrDescription: {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			names.AttrVPCConfig: {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrSecurityGroupIDs: {
-							Type:     schema.TypeSet,
-							MinItems: 1,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-							Required: true,
-						},
-						names.AttrSubnetIDs: {
-							Type:     schema.TypeSet,
-							MinItems: 1,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-							Required: true,
-						},
-						names.AttrVPCID: {
-							Type:     schema.TypeString,
-							Required: true,
+				names.AttrName: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringLenBetween(0, 256),
+				},
+				names.AttrDescription: {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				names.AttrVPCConfig: {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrSecurityGroupIDs: {
+								Type:     schema.TypeSet,
+								MinItems: 1,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+								Required: true,
+							},
+							names.AttrSubnetIDs: {
+								Type:     schema.TypeSet,
+								MinItems: 1,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+								Required: true,
+							},
+							names.AttrVPCID: {
+								Type:     schema.TypeString,
+								Required: true,
+							},
 						},
 					},
 				},
-			},
+			}
 		},
 	}
 }

--- a/internal/service/devicefarm/upload.go
+++ b/internal/service/devicefarm/upload.go
@@ -39,45 +39,47 @@ func resourceUpload() *schema.Resource {
 		UpdateWithoutTimeout: resourceUploadUpdate,
 		DeleteWithoutTimeout: resourceUploadDelete,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"category": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrContentType: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringLenBetween(0, 64),
-			},
-			"metadata": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrName: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringLenBetween(1, 256),
-			},
-			"project_arn": {
-				Type:         schema.TypeString,
-				ForceNew:     true,
-				Required:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			names.AttrType: {
-				Type:             schema.TypeString,
-				Required:         true,
-				ForceNew:         true,
-				ValidateDiagFunc: enum.Validate[awstypes.UploadType](),
-			},
-			names.AttrURL: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"category": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrContentType: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringLenBetween(0, 64),
+				},
+				"metadata": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrName: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringLenBetween(1, 256),
+				},
+				"project_arn": {
+					Type:         schema.TypeString,
+					ForceNew:     true,
+					Required:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				names.AttrType: {
+					Type:             schema.TypeString,
+					Required:         true,
+					ForceNew:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.UploadType](),
+				},
+				names.AttrURL: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/directconnect/bgp_peer.go
+++ b/internal/service/directconnect/bgp_peer.go
@@ -32,53 +32,55 @@ func resourceBGPPeer() *schema.Resource {
 		ReadWithoutTimeout:   resourceBGPPeerRead,
 		DeleteWithoutTimeout: resourceBGPPeerDelete,
 
-		Schema: map[string]*schema.Schema{
-			"address_family": {
-				Type:             schema.TypeString,
-				Required:         true,
-				ForceNew:         true,
-				ValidateDiagFunc: enum.Validate[awstypes.AddressFamily](),
-			},
-			"amazon_address": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
-			"aws_device": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"bgp_asn": {
-				Type:     schema.TypeInt,
-				Required: true,
-				ForceNew: true,
-			},
-			"bgp_auth_key": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
-			"bgp_peer_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"bgp_status": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"customer_address": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
-			"virtual_interface_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"address_family": {
+					Type:             schema.TypeString,
+					Required:         true,
+					ForceNew:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.AddressFamily](),
+				},
+				"amazon_address": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+				},
+				"aws_device": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"bgp_asn": {
+					Type:     schema.TypeInt,
+					Required: true,
+					ForceNew: true,
+				},
+				"bgp_auth_key": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+				},
+				"bgp_peer_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"bgp_status": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"customer_address": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+				},
+				"virtual_interface_id": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+			}
 		},
 
 		Timeouts: &schema.ResourceTimeout{

--- a/internal/service/directconnect/connection.go
+++ b/internal/service/directconnect/connection.go
@@ -35,82 +35,84 @@ import (
 func resourceConnection() *schema.Resource {
 	// Resource with v0 schema (provider v5.0.1).
 	resourceV0 := &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"aws_device": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"bandwidth": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"encryption_mode": {
-				Type:     schema.TypeString,
-				Computed: true,
-				Optional: true,
-			},
-			"has_logical_redundancy": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"jumbo_frame_capable": {
-				Type:     schema.TypeBool,
-				Computed: true,
-			},
-			names.AttrLocation: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"macsec_capable": {
-				Type:     schema.TypeBool,
-				Computed: true,
-			},
-			"request_macsec": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-				ForceNew: true,
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			names.AttrOwnerAccountID: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"partner_name": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"port_encryption_status": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrProviderName: {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
-			names.AttrSkipDestroy: {
-				Type:     schema.TypeBool,
-				Default:  false,
-				Optional: true,
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			"vlan_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"aws_device": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"bandwidth": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"encryption_mode": {
+					Type:     schema.TypeString,
+					Computed: true,
+					Optional: true,
+				},
+				"has_logical_redundancy": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"jumbo_frame_capable": {
+					Type:     schema.TypeBool,
+					Computed: true,
+				},
+				names.AttrLocation: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"macsec_capable": {
+					Type:     schema.TypeBool,
+					Computed: true,
+				},
+				"request_macsec": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  false,
+					ForceNew: true,
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				names.AttrOwnerAccountID: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"partner_name": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"port_encryption_status": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrProviderName: {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+				},
+				names.AttrSkipDestroy: {
+					Type:     schema.TypeBool,
+					Default:  false,
+					Optional: true,
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				"vlan_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			}
 		},
 	}
 
@@ -150,87 +152,89 @@ func resourceConnection() *schema.Resource {
 			},
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"aws_device": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"bandwidth": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validConnectionBandWidth(),
-			},
-			// The MAC Security (MACsec) connection encryption mode.
-			"encryption_mode": {
-				Type:         schema.TypeString,
-				Computed:     true,
-				Optional:     true,
-				ValidateFunc: validation.StringInSlice([]string{"no_encrypt", "should_encrypt", "must_encrypt"}, false),
-			},
-			"has_logical_redundancy": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"jumbo_frame_capable": {
-				Type:     schema.TypeBool,
-				Computed: true,
-			},
-			names.AttrLocation: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			// Indicates whether the connection supports MAC Security (MACsec).
-			"macsec_capable": {
-				Type:     schema.TypeBool,
-				Computed: true,
-			},
-			// Enable or disable MAC Security (MACsec) on this connection.
-			"request_macsec": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-				ForceNew: true,
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			names.AttrOwnerAccountID: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"partner_name": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"port_encryption_status": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrProviderName: {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
-			names.AttrSkipDestroy: {
-				Type:     schema.TypeBool,
-				Default:  false,
-				Optional: true,
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			"vlan_id": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"aws_device": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"bandwidth": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validConnectionBandWidth(),
+				},
+				// The MAC Security (MACsec) connection encryption mode.
+				"encryption_mode": {
+					Type:         schema.TypeString,
+					Computed:     true,
+					Optional:     true,
+					ValidateFunc: validation.StringInSlice([]string{"no_encrypt", "should_encrypt", "must_encrypt"}, false),
+				},
+				"has_logical_redundancy": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"jumbo_frame_capable": {
+					Type:     schema.TypeBool,
+					Computed: true,
+				},
+				names.AttrLocation: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				// Indicates whether the connection supports MAC Security (MACsec).
+				"macsec_capable": {
+					Type:     schema.TypeBool,
+					Computed: true,
+				},
+				// Enable or disable MAC Security (MACsec) on this connection.
+				"request_macsec": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  false,
+					ForceNew: true,
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				names.AttrOwnerAccountID: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"partner_name": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"port_encryption_status": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrProviderName: {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+				},
+				names.AttrSkipDestroy: {
+					Type:     schema.TypeBool,
+					Default:  false,
+					Optional: true,
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				"vlan_id": {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/directconnect/connection_association.go
+++ b/internal/service/directconnect/connection_association.go
@@ -31,17 +31,19 @@ func resourceConnectionAssociation() *schema.Resource {
 		ReadWithoutTimeout:   resourceConnectionAssociationRead,
 		DeleteWithoutTimeout: resourceConnectionAssociationDelete,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrConnectionID: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"lag_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrConnectionID: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"lag_id": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/directconnect/connection_confirmation.go
+++ b/internal/service/directconnect/connection_confirmation.go
@@ -29,12 +29,14 @@ func resourceConnectionConfirmation() *schema.Resource {
 		ReadWithoutTimeout:   resourceConnectionConfirmationRead,
 		DeleteWithoutTimeout: schema.NoopContext,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrConnectionID: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrConnectionID: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/directconnect/connection_data_source.go
+++ b/internal/service/directconnect/connection_data_source.go
@@ -27,48 +27,50 @@ func dataSourceConnection() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceConnectionRead,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"aws_device": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"bandwidth": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrLocation: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			names.AttrState: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrOwnerAccountID: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"partner_name": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrProviderName: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrTags: tftags.TagsSchemaComputed(),
-			"vlan_id": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"aws_device": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"bandwidth": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrLocation: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				names.AttrState: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrOwnerAccountID: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"partner_name": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrProviderName: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrTags: tftags.TagsSchemaComputed(),
+				"vlan_id": {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/directconnect/gateway.go
+++ b/internal/service/directconnect/gateway.go
@@ -43,27 +43,29 @@ func resourceGateway() *schema.Resource {
 		UpdateWithoutTimeout: resourceGatewayUpdate,
 		DeleteWithoutTimeout: resourceGatewayDelete,
 
-		Schema: map[string]*schema.Schema{
-			"amazon_side_asn": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidAmazonSideASN,
-			},
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			names.AttrOwnerAccountID: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"amazon_side_asn": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: verify.ValidAmazonSideASN,
+				},
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				names.AttrOwnerAccountID: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			}
 		},
 
 		Timeouts: &schema.ResourceTimeout{

--- a/internal/service/directconnect/gateway_association.go
+++ b/internal/service/directconnect/gateway_association.go
@@ -57,58 +57,60 @@ func resourceGatewayAssociation() *schema.Resource {
 			},
 		},
 
-		Schema: map[string]*schema.Schema{
-			"allowed_prefixes": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			"associated_gateway_id": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				ForceNew:      true,
-				ConflictsWith: []string{"associated_gateway_owner_account_id", "proposal_id"},
-				AtLeastOneOf:  []string{"associated_gateway_id", "associated_gateway_owner_account_id", "proposal_id"},
-			},
-			"associated_gateway_owner_account_id": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				ForceNew:      true,
-				ValidateFunc:  verify.ValidAccountID,
-				ConflictsWith: []string{"associated_gateway_id"},
-				RequiredWith:  []string{"proposal_id"},
-				AtLeastOneOf:  []string{"associated_gateway_id", "associated_gateway_owner_account_id", "proposal_id"},
-			},
-			"associated_gateway_type": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"dx_gateway_association_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"dx_gateway_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"dx_gateway_owner_account_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"proposal_id": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				ConflictsWith: []string{"associated_gateway_id"},
-				AtLeastOneOf:  []string{"associated_gateway_id", "associated_gateway_owner_account_id", "proposal_id"},
-			},
-			names.AttrTransitGatewayAttachmentID: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"allowed_prefixes": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"associated_gateway_id": {
+					Type:          schema.TypeString,
+					Optional:      true,
+					Computed:      true,
+					ForceNew:      true,
+					ConflictsWith: []string{"associated_gateway_owner_account_id", "proposal_id"},
+					AtLeastOneOf:  []string{"associated_gateway_id", "associated_gateway_owner_account_id", "proposal_id"},
+				},
+				"associated_gateway_owner_account_id": {
+					Type:          schema.TypeString,
+					Optional:      true,
+					Computed:      true,
+					ForceNew:      true,
+					ValidateFunc:  verify.ValidAccountID,
+					ConflictsWith: []string{"associated_gateway_id"},
+					RequiredWith:  []string{"proposal_id"},
+					AtLeastOneOf:  []string{"associated_gateway_id", "associated_gateway_owner_account_id", "proposal_id"},
+				},
+				"associated_gateway_type": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"dx_gateway_association_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"dx_gateway_id": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"dx_gateway_owner_account_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"proposal_id": {
+					Type:          schema.TypeString,
+					Optional:      true,
+					ConflictsWith: []string{"associated_gateway_id"},
+					AtLeastOneOf:  []string{"associated_gateway_id", "associated_gateway_owner_account_id", "proposal_id"},
+				},
+				names.AttrTransitGatewayAttachmentID: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			}
 		},
 
 		Timeouts: &schema.ResourceTimeout{

--- a/internal/service/directconnect/gateway_association_migrate.go
+++ b/internal/service/directconnect/gateway_association_migrate.go
@@ -18,84 +18,88 @@ import (
 
 func resourceGatewayAssociationResourceV0() *schema.Resource {
 	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"allowed_prefixes": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			"associated_gateway_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"associated_gateway_owner_account_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"associated_gateway_type": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"dx_gateway_association_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"dx_gateway_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"dx_gateway_owner_account_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"proposal_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"vpn_gateway_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"allowed_prefixes": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"associated_gateway_id": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"associated_gateway_owner_account_id": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"associated_gateway_type": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"dx_gateway_association_id": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"dx_gateway_id": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"dx_gateway_owner_account_id": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"proposal_id": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"vpn_gateway_id": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+			}
 		},
 	}
 }
 
 func resourceGatewayAssociationResourceV1() *schema.Resource {
 	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"allowed_prefixes": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			"associated_gateway_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"associated_gateway_owner_account_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"associated_gateway_type": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"dx_gateway_association_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"dx_gateway_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"dx_gateway_owner_account_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"proposal_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"allowed_prefixes": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"associated_gateway_id": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"associated_gateway_owner_account_id": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"associated_gateway_type": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"dx_gateway_association_id": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"dx_gateway_id": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"dx_gateway_owner_account_id": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"proposal_id": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/directconnect/gateway_association_proposal.go
+++ b/internal/service/directconnect/gateway_association_proposal.go
@@ -61,37 +61,39 @@ func resourceGatewayAssociationProposal() *schema.Resource {
 			}),
 		),
 
-		Schema: map[string]*schema.Schema{
-			"allowed_prefixes": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			"associated_gateway_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"associated_gateway_owner_account_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"associated_gateway_type": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"dx_gateway_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"dx_gateway_owner_account_id": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidAccountID,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"allowed_prefixes": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"associated_gateway_id": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"associated_gateway_owner_account_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"associated_gateway_type": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"dx_gateway_id": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"dx_gateway_owner_account_id": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: verify.ValidAccountID,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/directconnect/gateway_data_source.go
+++ b/internal/service/directconnect/gateway_data_source.go
@@ -28,24 +28,26 @@ func dataSourceGateway() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceGatewayRead,
 
-		Schema: map[string]*schema.Schema{
-			"amazon_side_asn": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			names.AttrOwnerAccountID: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrTags: tftags.TagsSchemaComputed(),
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"amazon_side_asn": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				names.AttrOwnerAccountID: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrTags: tftags.TagsSchemaComputed(),
+			}
 		},
 	}
 }

--- a/internal/service/directconnect/hosted_connection.go
+++ b/internal/service/directconnect/hosted_connection.go
@@ -35,80 +35,82 @@ func resourceHostedConnection() *schema.Resource {
 		ReadWithoutTimeout:   resourceHostedConnectionRead,
 		DeleteWithoutTimeout: resourceHostedConnectionDelete,
 
-		Schema: map[string]*schema.Schema{
-			"aws_device": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"bandwidth": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validConnectionBandWidth(),
-			},
-			names.AttrConnectionID: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"connection_region": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"has_logical_redundancy": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"jumbo_frame_capable": {
-				Type:     schema.TypeBool,
-				Computed: true,
-			},
-			"lag_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"loa_issue_time": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrLocation: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			names.AttrOwnerAccountID: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidAccountID,
-			},
-			"partner_name": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrProviderName: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrRegion: {
-				Type:       schema.TypeString,
-				Computed:   true,
-				Deprecated: "region is deprecated. Use connection_region instead.",
-			},
-			names.AttrState: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"vlan": {
-				Type:         schema.TypeInt,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.IntBetween(1, 4094),
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"aws_device": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"bandwidth": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validConnectionBandWidth(),
+				},
+				names.AttrConnectionID: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"connection_region": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"has_logical_redundancy": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"jumbo_frame_capable": {
+					Type:     schema.TypeBool,
+					Computed: true,
+				},
+				"lag_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"loa_issue_time": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrLocation: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				names.AttrOwnerAccountID: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: verify.ValidAccountID,
+				},
+				"partner_name": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrProviderName: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrRegion: {
+					Type:       schema.TypeString,
+					Computed:   true,
+					Deprecated: "region is deprecated. Use connection_region instead.",
+				},
+				names.AttrState: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"vlan": {
+					Type:         schema.TypeInt,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.IntBetween(1, 4094),
+				},
+			}
 		},
 	}
 }

--- a/internal/service/directconnect/hosted_private_virtual_interface.go
+++ b/internal/service/directconnect/hosted_private_virtual_interface.go
@@ -38,81 +38,83 @@ func resourceHostedPrivateVirtualInterface() *schema.Resource {
 			StateContext: resourceHostedPrivateVirtualInterfaceImport,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"address_family": {
-				Type:             schema.TypeString,
-				Required:         true,
-				ForceNew:         true,
-				ValidateDiagFunc: enum.Validate[awstypes.AddressFamily](),
-			},
-			"amazon_address": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"amazon_side_asn": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"aws_device": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"bgp_asn": {
-				Type:     schema.TypeInt,
-				Required: true,
-				ForceNew: true,
-			},
-			"bgp_auth_key": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
-			names.AttrConnectionID: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"customer_address": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
-			"jumbo_frame_capable": {
-				Type:     schema.TypeBool,
-				Computed: true,
-			},
-			"mtu": {
-				Type:         schema.TypeInt,
-				Default:      1500,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.IntInSlice([]int{1500, 9001}),
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			names.AttrOwnerAccountID: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidAccountID,
-			},
-			"vlan": {
-				Type:         schema.TypeInt,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.IntBetween(1, 4094),
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"address_family": {
+					Type:             schema.TypeString,
+					Required:         true,
+					ForceNew:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.AddressFamily](),
+				},
+				"amazon_address": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+				},
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"amazon_side_asn": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"aws_device": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"bgp_asn": {
+					Type:     schema.TypeInt,
+					Required: true,
+					ForceNew: true,
+				},
+				"bgp_auth_key": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+				},
+				names.AttrConnectionID: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"customer_address": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+				},
+				"jumbo_frame_capable": {
+					Type:     schema.TypeBool,
+					Computed: true,
+				},
+				"mtu": {
+					Type:         schema.TypeInt,
+					Default:      1500,
+					Optional:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.IntInSlice([]int{1500, 9001}),
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				names.AttrOwnerAccountID: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: verify.ValidAccountID,
+				},
+				"vlan": {
+					Type:         schema.TypeInt,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.IntBetween(1, 4094),
+				},
+			}
 		},
 
 		Timeouts: &schema.ResourceTimeout{

--- a/internal/service/directconnect/hosted_private_virtual_interface_accepter.go
+++ b/internal/service/directconnect/hosted_private_virtual_interface_accepter.go
@@ -38,30 +38,32 @@ func resourceHostedPrivateVirtualInterfaceAccepter() *schema.Resource {
 			StateContext: resourceHostedPrivateVirtualInterfaceAccepterImport,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"dx_gateway_id": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ExactlyOneOf: []string{"dx_gateway_id", "vpn_gateway_id"},
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			"virtual_interface_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"vpn_gateway_id": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ExactlyOneOf: []string{"dx_gateway_id", "vpn_gateway_id"},
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"dx_gateway_id": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ForceNew:     true,
+					ExactlyOneOf: []string{"dx_gateway_id", "vpn_gateway_id"},
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				"virtual_interface_id": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"vpn_gateway_id": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ForceNew:     true,
+					ExactlyOneOf: []string{"dx_gateway_id", "vpn_gateway_id"},
+				},
+			}
 		},
 
 		Timeouts: &schema.ResourceTimeout{

--- a/internal/service/directconnect/hosted_public_virtual_interface.go
+++ b/internal/service/directconnect/hosted_public_virtual_interface.go
@@ -40,77 +40,79 @@ func resourceHostedPublicVirtualInterface() *schema.Resource {
 
 		CustomizeDiff: resourceHostedPublicVirtualInterfaceCustomizeDiff,
 
-		Schema: map[string]*schema.Schema{
-			"address_family": {
-				Type:             schema.TypeString,
-				Required:         true,
-				ForceNew:         true,
-				ValidateDiagFunc: enum.Validate[awstypes.AddressFamily](),
-			},
-			"amazon_address": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
-			"amazon_side_asn": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"aws_device": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"bgp_asn": {
-				Type:     schema.TypeInt,
-				Required: true,
-				ForceNew: true,
-			},
-			"bgp_auth_key": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
-			names.AttrConnectionID: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"customer_address": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			names.AttrOwnerAccountID: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidAccountID,
-			},
-			"route_filter_prefixes": {
-				Type:     schema.TypeSet,
-				Required: true,
-				ForceNew: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				MinItems: 1,
-			},
-			"vlan": {
-				Type:         schema.TypeInt,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.IntBetween(1, 4094),
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"address_family": {
+					Type:             schema.TypeString,
+					Required:         true,
+					ForceNew:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.AddressFamily](),
+				},
+				"amazon_address": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+				},
+				"amazon_side_asn": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"aws_device": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"bgp_asn": {
+					Type:     schema.TypeInt,
+					Required: true,
+					ForceNew: true,
+				},
+				"bgp_auth_key": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+				},
+				names.AttrConnectionID: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"customer_address": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				names.AttrOwnerAccountID: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: verify.ValidAccountID,
+				},
+				"route_filter_prefixes": {
+					Type:     schema.TypeSet,
+					Required: true,
+					ForceNew: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+					MinItems: 1,
+				},
+				"vlan": {
+					Type:         schema.TypeInt,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.IntBetween(1, 4094),
+				},
+			}
 		},
 
 		Timeouts: &schema.ResourceTimeout{

--- a/internal/service/directconnect/hosted_public_virtual_interface_accepter.go
+++ b/internal/service/directconnect/hosted_public_virtual_interface_accepter.go
@@ -38,18 +38,20 @@ func resourceHostedPublicVirtualInterfaceAccepter() *schema.Resource {
 			StateContext: resourceHostedPublicVirtualInterfaceAccepterImport,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			"virtual_interface_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				"virtual_interface_id": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+			}
 		},
 
 		Timeouts: &schema.ResourceTimeout{

--- a/internal/service/directconnect/hosted_transit_virtual_interface.go
+++ b/internal/service/directconnect/hosted_transit_virtual_interface.go
@@ -38,81 +38,83 @@ func resourceHostedTransitVirtualInterface() *schema.Resource {
 			StateContext: resourceHostedTransitVirtualInterfaceImport,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"address_family": {
-				Type:             schema.TypeString,
-				Required:         true,
-				ForceNew:         true,
-				ValidateDiagFunc: enum.Validate[awstypes.AddressFamily](),
-			},
-			"amazon_address": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
-			"amazon_side_asn": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"aws_device": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"bgp_asn": {
-				Type:     schema.TypeInt,
-				Required: true,
-				ForceNew: true,
-			},
-			"bgp_auth_key": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
-			names.AttrConnectionID: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"customer_address": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
-			"jumbo_frame_capable": {
-				Type:     schema.TypeBool,
-				Computed: true,
-			},
-			"mtu": {
-				Type:         schema.TypeInt,
-				Default:      1500,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.IntInSlice([]int{1500, 8500}),
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			names.AttrOwnerAccountID: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidAccountID,
-			},
-			"vlan": {
-				Type:         schema.TypeInt,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.IntBetween(1, 4094),
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"address_family": {
+					Type:             schema.TypeString,
+					Required:         true,
+					ForceNew:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.AddressFamily](),
+				},
+				"amazon_address": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+				},
+				"amazon_side_asn": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"aws_device": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"bgp_asn": {
+					Type:     schema.TypeInt,
+					Required: true,
+					ForceNew: true,
+				},
+				"bgp_auth_key": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+				},
+				names.AttrConnectionID: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"customer_address": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+				},
+				"jumbo_frame_capable": {
+					Type:     schema.TypeBool,
+					Computed: true,
+				},
+				"mtu": {
+					Type:         schema.TypeInt,
+					Default:      1500,
+					Optional:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.IntInSlice([]int{1500, 8500}),
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				names.AttrOwnerAccountID: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: verify.ValidAccountID,
+				},
+				"vlan": {
+					Type:         schema.TypeInt,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.IntBetween(1, 4094),
+				},
+			}
 		},
 
 		Timeouts: &schema.ResourceTimeout{

--- a/internal/service/directconnect/hosted_transit_virtual_interface_accepter.go
+++ b/internal/service/directconnect/hosted_transit_virtual_interface_accepter.go
@@ -38,23 +38,25 @@ func resourceHostedTransitVirtualInterfaceAccepter() *schema.Resource {
 			StateContext: resourceHostedTransitVirtualInterfaceAccepterImport,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"dx_gateway_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			"virtual_interface_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"dx_gateway_id": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				"virtual_interface_id": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+			}
 		},
 
 		Timeouts: &schema.ResourceTimeout{

--- a/internal/service/directconnect/lag.go
+++ b/internal/service/directconnect/lag.go
@@ -41,56 +41,58 @@ func resourceLag() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrConnectionID: {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
-			"connections_bandwidth": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validConnectionBandWidth(),
-			},
-			names.AttrForceDestroy: {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-			"has_logical_redundancy": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"jumbo_frame_capable": {
-				Type:     schema.TypeBool,
-				Computed: true,
-			},
-			names.AttrLocation: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			names.AttrOwnerAccountID: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrProviderName: {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrConnectionID: {
+					Type:     schema.TypeString,
+					Optional: true,
+					ForceNew: true,
+				},
+				"connections_bandwidth": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validConnectionBandWidth(),
+				},
+				names.AttrForceDestroy: {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
+				"has_logical_redundancy": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"jumbo_frame_capable": {
+					Type:     schema.TypeBool,
+					Computed: true,
+				},
+				names.AttrLocation: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				names.AttrOwnerAccountID: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrProviderName: {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			}
 		},
 	}
 }

--- a/internal/service/directconnect/location_data_source.go
+++ b/internal/service/directconnect/location_data_source.go
@@ -24,30 +24,32 @@ func dataSourceLocation() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceLocationRead,
 
-		Schema: map[string]*schema.Schema{
-			"available_macsec_port_speeds": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			"available_port_speeds": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			"available_providers": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			"location_code": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"location_name": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"available_macsec_port_speeds": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"available_port_speeds": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"available_providers": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"location_code": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"location_name": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/directconnect/locations_data_source.go
+++ b/internal/service/directconnect/locations_data_source.go
@@ -23,12 +23,14 @@ func dataSourceLocations() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceLocationsRead,
 
-		Schema: map[string]*schema.Schema{
-			"location_codes": {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"location_codes": {
+					Type:     schema.TypeSet,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+			}
 		},
 	}
 }

--- a/internal/service/directconnect/macsec_key_association.go
+++ b/internal/service/directconnect/macsec_key_association.go
@@ -38,43 +38,45 @@ func resourceMacSecKeyAssociation() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"cak": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				RequiredWith: []string{"ckn"},
-				ValidateFunc: validation.StringMatch(regexache.MustCompile(`[0-9A-Fa-f]{64}$`), "Must be 64-character hex code string"),
-			},
-			"ckn": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				Computed:     true,
-				AtLeastOneOf: []string{"ckn", "secret_arn"},
-				ValidateFunc: validation.StringMatch(regexache.MustCompile(`[0-9A-Fa-f]{64}$`), "Must be 64-character hex code string"),
-			},
-			names.AttrConnectionID: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"secret_arn": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ForceNew:     true,
-				AtLeastOneOf: []string{"ckn", "secret_arn"},
-				ValidateFunc: verify.ValidARN,
-			},
-			"start_on": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrState: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"cak": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ForceNew:     true,
+					RequiredWith: []string{"ckn"},
+					ValidateFunc: validation.StringMatch(regexache.MustCompile(`[0-9A-Fa-f]{64}$`), "Must be 64-character hex code string"),
+				},
+				"ckn": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ForceNew:     true,
+					Computed:     true,
+					AtLeastOneOf: []string{"ckn", "secret_arn"},
+					ValidateFunc: validation.StringMatch(regexache.MustCompile(`[0-9A-Fa-f]{64}$`), "Must be 64-character hex code string"),
+				},
+				names.AttrConnectionID: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"secret_arn": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Computed:     true,
+					ForceNew:     true,
+					AtLeastOneOf: []string{"ckn", "secret_arn"},
+					ValidateFunc: verify.ValidARN,
+				},
+				"start_on": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrState: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/directconnect/private_virtual_interface.go
+++ b/internal/service/directconnect/private_virtual_interface.go
@@ -40,92 +40,94 @@ func resourcePrivateVirtualInterface() *schema.Resource {
 			StateContext: resourcePrivateVirtualInterfaceImport,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"address_family": {
-				Type:             schema.TypeString,
-				Required:         true,
-				ForceNew:         true,
-				ValidateDiagFunc: enum.Validate[awstypes.AddressFamily](),
-			},
-			"amazon_address": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
-			"amazon_side_asn": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"aws_device": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"bgp_asn": {
-				Type:     schema.TypeInt,
-				Required: true,
-				ForceNew: true,
-			},
-			"bgp_auth_key": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
-			names.AttrConnectionID: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"customer_address": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
-			"dx_gateway_id": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ExactlyOneOf: []string{"dx_gateway_id", "vpn_gateway_id"},
-			},
-			"jumbo_frame_capable": {
-				Type:     schema.TypeBool,
-				Computed: true,
-			},
-			"mtu": {
-				Type:         schema.TypeInt,
-				Default:      1500,
-				Optional:     true,
-				ValidateFunc: validation.IntInSlice([]int{1500, 9001}),
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"sitelink_enabled": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			"vlan": {
-				Type:         schema.TypeInt,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.IntBetween(1, 4094),
-			},
-			"vpn_gateway_id": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ExactlyOneOf: []string{"dx_gateway_id", "vpn_gateway_id"},
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"address_family": {
+					Type:             schema.TypeString,
+					Required:         true,
+					ForceNew:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.AddressFamily](),
+				},
+				"amazon_address": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+				},
+				"amazon_side_asn": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"aws_device": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"bgp_asn": {
+					Type:     schema.TypeInt,
+					Required: true,
+					ForceNew: true,
+				},
+				"bgp_auth_key": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+				},
+				names.AttrConnectionID: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"customer_address": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+				},
+				"dx_gateway_id": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ForceNew:     true,
+					ExactlyOneOf: []string{"dx_gateway_id", "vpn_gateway_id"},
+				},
+				"jumbo_frame_capable": {
+					Type:     schema.TypeBool,
+					Computed: true,
+				},
+				"mtu": {
+					Type:         schema.TypeInt,
+					Default:      1500,
+					Optional:     true,
+					ValidateFunc: validation.IntInSlice([]int{1500, 9001}),
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"sitelink_enabled": {
+					Type:     schema.TypeBool,
+					Optional: true,
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				"vlan": {
+					Type:         schema.TypeInt,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.IntBetween(1, 4094),
+				},
+				"vpn_gateway_id": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ForceNew:     true,
+					ExactlyOneOf: []string{"dx_gateway_id", "vpn_gateway_id"},
+				},
+			}
 		},
 
 		Timeouts: &schema.ResourceTimeout{

--- a/internal/service/directconnect/public_virtual_interface.go
+++ b/internal/service/directconnect/public_virtual_interface.go
@@ -42,73 +42,75 @@ func resourcePublicVirtualInterface() *schema.Resource {
 
 		CustomizeDiff: resourcePublicVirtualInterfaceCustomizeDiff,
 
-		Schema: map[string]*schema.Schema{
-			"address_family": {
-				Type:             schema.TypeString,
-				Required:         true,
-				ForceNew:         true,
-				ValidateDiagFunc: enum.Validate[awstypes.AddressFamily](),
-			},
-			"amazon_address": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
-			"amazon_side_asn": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"aws_device": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"bgp_asn": {
-				Type:     schema.TypeInt,
-				Required: true,
-				ForceNew: true,
-			},
-			"bgp_auth_key": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
-			names.AttrConnectionID: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"customer_address": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"route_filter_prefixes": {
-				Type:     schema.TypeSet,
-				Required: true,
-				ForceNew: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				MinItems: 1,
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			"vlan": {
-				Type:         schema.TypeInt,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.IntBetween(1, 4094),
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"address_family": {
+					Type:             schema.TypeString,
+					Required:         true,
+					ForceNew:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.AddressFamily](),
+				},
+				"amazon_address": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+				},
+				"amazon_side_asn": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"aws_device": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"bgp_asn": {
+					Type:     schema.TypeInt,
+					Required: true,
+					ForceNew: true,
+				},
+				"bgp_auth_key": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+				},
+				names.AttrConnectionID: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"customer_address": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"route_filter_prefixes": {
+					Type:     schema.TypeSet,
+					Required: true,
+					ForceNew: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+					MinItems: 1,
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				"vlan": {
+					Type:         schema.TypeInt,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.IntBetween(1, 4094),
+				},
+			}
 		},
 
 		Timeouts: &schema.ResourceTimeout{

--- a/internal/service/directconnect/router_configuration_data_source.go
+++ b/internal/service/directconnect/router_configuration_data_source.go
@@ -24,56 +24,58 @@ func dataSourceRouterConfiguration() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceRouterConfigurationRead,
 
-		Schema: map[string]*schema.Schema{
-			"customer_router_config": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"router": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"platform": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"router_type_identifier": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"software": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"vendor": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"xslt_template_name": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"xslt_template_name_for_mac_sec": {
-							Type:     schema.TypeString,
-							Computed: true,
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"customer_router_config": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"router": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"platform": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"router_type_identifier": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"software": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"vendor": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"xslt_template_name": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"xslt_template_name_for_mac_sec": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
 						},
 					},
 				},
-			},
-			"router_type_identifier": {
-				Type: schema.TypeString,
-				// even though the API Reference shows this as optional, the API call will fail without this argument
-				Required: true,
-			},
-			"virtual_interface_id": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"virtual_interface_name": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+				"router_type_identifier": {
+					Type: schema.TypeString,
+					// even though the API Reference shows this as optional, the API call will fail without this argument
+					Required: true,
+				},
+				"virtual_interface_id": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"virtual_interface_name": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/directconnect/transit_virtual_interface.go
+++ b/internal/service/directconnect/transit_virtual_interface.go
@@ -40,85 +40,87 @@ func resourceTransitVirtualInterface() *schema.Resource {
 			StateContext: resourceTransitVirtualInterfaceImport,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"address_family": {
-				Type:             schema.TypeString,
-				Required:         true,
-				ForceNew:         true,
-				ValidateDiagFunc: enum.Validate[awstypes.AddressFamily](),
-			},
-			"amazon_address": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
-			"amazon_side_asn": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"aws_device": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"bgp_asn": {
-				Type:     schema.TypeInt,
-				Required: true,
-				ForceNew: true,
-			},
-			"bgp_auth_key": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
-			names.AttrConnectionID: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"customer_address": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
-			"dx_gateway_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"jumbo_frame_capable": {
-				Type:     schema.TypeBool,
-				Computed: true,
-			},
-			"mtu": {
-				Type:         schema.TypeInt,
-				Default:      1500,
-				Optional:     true,
-				ValidateFunc: validation.IntInSlice([]int{1500, 8500}),
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"sitelink_enabled": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			"vlan": {
-				Type:         schema.TypeInt,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.IntBetween(1, 4094),
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"address_family": {
+					Type:             schema.TypeString,
+					Required:         true,
+					ForceNew:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.AddressFamily](),
+				},
+				"amazon_address": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+				},
+				"amazon_side_asn": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"aws_device": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"bgp_asn": {
+					Type:     schema.TypeInt,
+					Required: true,
+					ForceNew: true,
+				},
+				"bgp_auth_key": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+				},
+				names.AttrConnectionID: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"customer_address": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+				},
+				"dx_gateway_id": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"jumbo_frame_capable": {
+					Type:     schema.TypeBool,
+					Computed: true,
+				},
+				"mtu": {
+					Type:         schema.TypeInt,
+					Default:      1500,
+					Optional:     true,
+					ValidateFunc: validation.IntInSlice([]int{1500, 8500}),
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"sitelink_enabled": {
+					Type:     schema.TypeBool,
+					Optional: true,
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				"vlan": {
+					Type:         schema.TypeInt,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.IntBetween(1, 4094),
+				},
+			}
 		},
 
 		Timeouts: &schema.ResourceTimeout{

--- a/internal/service/dlm/lifecycle_policy.go
+++ b/internal/service/dlm/lifecycle_policy.go
@@ -41,313 +41,315 @@ func resourceLifecyclePolicy() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrDescription: {
-				Type:     schema.TypeString,
-				Required: true,
-				ValidateFunc: validation.All(
-					validation.StringMatch(regexache.MustCompile("^[0-9A-Za-z _-]+$"), "see https://docs.aws.amazon.com/cli/latest/reference/dlm/create-lifecycle-policy.html"),
-					validation.StringLenBetween(1, 500),
-				),
-			},
-			"default_policy": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				ValidateDiagFunc: enum.Validate[awstypes.DefaultPolicyTypeValues](),
-			},
-			names.AttrExecutionRoleARN: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			"policy_details": {
-				Type:     schema.TypeList,
-				Required: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrAction: {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"cross_region_copy": {
-										Type:     schema.TypeSet,
-										Required: true,
-										MaxItems: 3,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												names.AttrEncryptionConfiguration: {
-													Type:     schema.TypeList,
-													Required: true,
-													MaxItems: 1,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															"cmk_arn": {
-																Type:         schema.TypeString,
-																Optional:     true,
-																ValidateFunc: verify.ValidARN,
-															},
-															names.AttrEncrypted: {
-																Type:     schema.TypeBool,
-																Optional: true,
-																Default:  false,
-															},
-														},
-													},
-												},
-												"retain_rule": {
-													Type:     schema.TypeList,
-													Optional: true,
-													MaxItems: 1,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															names.AttrInterval: {
-																Type:         schema.TypeInt,
-																Required:     true,
-																ValidateFunc: validation.IntAtLeast(1),
-															},
-															"interval_unit": {
-																Type:             schema.TypeString,
-																Required:         true,
-																ValidateDiagFunc: enum.Validate[awstypes.RetentionIntervalUnitValues](),
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrDescription: {
+					Type:     schema.TypeString,
+					Required: true,
+					ValidateFunc: validation.All(
+						validation.StringMatch(regexache.MustCompile("^[0-9A-Za-z _-]+$"), "see https://docs.aws.amazon.com/cli/latest/reference/dlm/create-lifecycle-policy.html"),
+						validation.StringLenBetween(1, 500),
+					),
+				},
+				"default_policy": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.DefaultPolicyTypeValues](),
+				},
+				names.AttrExecutionRoleARN: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				"policy_details": {
+					Type:     schema.TypeList,
+					Required: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrAction: {
+								Type:     schema.TypeList,
+								Optional: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"cross_region_copy": {
+											Type:     schema.TypeSet,
+											Required: true,
+											MaxItems: 3,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													names.AttrEncryptionConfiguration: {
+														Type:     schema.TypeList,
+														Required: true,
+														MaxItems: 1,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																"cmk_arn": {
+																	Type:         schema.TypeString,
+																	Optional:     true,
+																	ValidateFunc: verify.ValidARN,
+																},
+																names.AttrEncrypted: {
+																	Type:     schema.TypeBool,
+																	Optional: true,
+																	Default:  false,
+																},
 															},
 														},
 													},
-												},
-												names.AttrTarget: {
-													Type:         schema.TypeString,
-													Required:     true,
-													ValidateFunc: validation.StringMatch(regexache.MustCompile(`^[\w:\-\/\*]+$`), ""),
-												},
-											},
-										},
-									},
-									names.AttrName: {
-										Type:     schema.TypeString,
-										Required: true,
-										ValidateFunc: validation.All(
-											validation.StringLenBetween(0, 120),
-											validation.StringMatch(regexache.MustCompile("^[0-9A-Za-z _-]+$"), "see https://docs.aws.amazon.com/dlm/latest/APIReference/API_Action.html"),
-										),
-									},
-								},
-							},
-						},
-						"copy_tags": {
-							Type:          schema.TypeBool,
-							Optional:      true,
-							Default:       false,
-							ConflictsWith: []string{"policy_details.0.schedule"},
-							RequiredWith:  []string{"default_policy"},
-						},
-						"create_interval": {
-							Type:          schema.TypeInt,
-							Optional:      true,
-							Default:       1,
-							ValidateFunc:  validation.IntBetween(1, 7),
-							ConflictsWith: []string{"policy_details.0.schedule"},
-							RequiredWith:  []string{"default_policy"},
-							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-								if d.Get("default_policy").(string) == "" {
-									if old == "0" && new == "1" {
-										return true
-									}
-								}
-								return false
-							},
-						},
-						"exclusions": {
-							Type:          schema.TypeList,
-							Optional:      true,
-							MaxItems:      1,
-							RequiredWith:  []string{"default_policy"},
-							ConflictsWith: []string{"policy_details.0.resource_types", "policy_details.0.schedule"},
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"exclude_boot_volumes": {
-										Type:     schema.TypeBool,
-										Optional: true,
-									},
-									"exclude_tags": {
-										Type:     schema.TypeMap,
-										Optional: true,
-										Elem:     &schema.Schema{Type: schema.TypeString},
-									},
-									"exclude_volume_types": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MinItems: 0,
-										MaxItems: 6,
-										Elem:     &schema.Schema{Type: schema.TypeString},
-									},
-								},
-							},
-						},
-						"extend_deletion": {
-							Type:          schema.TypeBool,
-							Optional:      true,
-							Default:       false,
-							ConflictsWith: []string{"policy_details.0.schedule"},
-							RequiredWith:  []string{"default_policy"},
-						},
-						"event_source": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									names.AttrParameters: {
-										Type:     schema.TypeList,
-										Required: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"description_regex": {
-													Type:         schema.TypeString,
-													Required:     true,
-													ValidateFunc: validation.StringLenBetween(0, 1000),
-												},
-												"event_type": {
-													Type:             schema.TypeString,
-													Required:         true,
-													ValidateDiagFunc: enum.Validate[awstypes.EventTypeValues](),
-												},
-												"snapshot_owner": {
-													Type:     schema.TypeSet,
-													Required: true,
-													MaxItems: 50,
-													Elem: &schema.Schema{
+													"retain_rule": {
+														Type:     schema.TypeList,
+														Optional: true,
+														MaxItems: 1,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																names.AttrInterval: {
+																	Type:         schema.TypeInt,
+																	Required:     true,
+																	ValidateFunc: validation.IntAtLeast(1),
+																},
+																"interval_unit": {
+																	Type:             schema.TypeString,
+																	Required:         true,
+																	ValidateDiagFunc: enum.Validate[awstypes.RetentionIntervalUnitValues](),
+																},
+															},
+														},
+													},
+													names.AttrTarget: {
 														Type:         schema.TypeString,
-														ValidateFunc: verify.ValidAccountID,
+														Required:     true,
+														ValidateFunc: validation.StringMatch(regexache.MustCompile(`^[\w:\-\/\*]+$`), ""),
 													},
 												},
 											},
 										},
-									},
-									names.AttrType: {
-										Type:             schema.TypeString,
-										Required:         true,
-										ValidateDiagFunc: enum.Validate[awstypes.EventSourceValues](),
-									},
-								},
-							},
-						},
-						names.AttrParameters: {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"exclude_boot_volume": {
-										Type:     schema.TypeBool,
-										Optional: true,
-									},
-									"no_reboot": {
-										Type:     schema.TypeBool,
-										Optional: true,
+										names.AttrName: {
+											Type:     schema.TypeString,
+											Required: true,
+											ValidateFunc: validation.All(
+												validation.StringLenBetween(0, 120),
+												validation.StringMatch(regexache.MustCompile("^[0-9A-Za-z _-]+$"), "see https://docs.aws.amazon.com/dlm/latest/APIReference/API_Action.html"),
+											),
+										},
 									},
 								},
 							},
-						},
-						"policy_language": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Computed:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.PolicyLanguageValues](),
-						},
-						"policy_type": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Default:          awstypes.PolicyTypeValuesEbsSnapshotManagement,
-							ValidateDiagFunc: enum.Validate[awstypes.PolicyTypeValues](),
-						},
-						"resource_locations": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Computed: true,
-							MaxItems: 1,
-							Elem: &schema.Schema{
-								Type:             schema.TypeString,
-								ValidateDiagFunc: enum.Validate[awstypes.ResourceLocationValues](),
+							"copy_tags": {
+								Type:          schema.TypeBool,
+								Optional:      true,
+								Default:       false,
+								ConflictsWith: []string{"policy_details.0.schedule"},
+								RequiredWith:  []string{"default_policy"},
 							},
-						},
-						names.AttrResourceType: {
-							Type:             schema.TypeString,
-							Optional:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.ResourceTypeValues](),
-							ConflictsWith:    []string{"policy_details.0.resource_types", "policy_details.0.schedule"},
-							RequiredWith:     []string{"default_policy"},
-						},
-						"resource_types": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem: &schema.Schema{
-								Type:             schema.TypeString,
-								ValidateDiagFunc: enum.Validate[awstypes.ResourceTypeValues](),
-							},
-							ConflictsWith: []string{"policy_details.0.resource_type", "default_policy"},
-						},
-						"retain_interval": {
-							Type:          schema.TypeInt,
-							Optional:      true,
-							Default:       7,
-							ValidateFunc:  validation.IntBetween(2, 14),
-							ConflictsWith: []string{"policy_details.0.schedule"},
-							RequiredWith:  []string{"default_policy"},
-							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-								if d.Get("default_policy").(string) == "" {
-									if old == "0" && new == "7" {
-										return true
+							"create_interval": {
+								Type:          schema.TypeInt,
+								Optional:      true,
+								Default:       1,
+								ValidateFunc:  validation.IntBetween(1, 7),
+								ConflictsWith: []string{"policy_details.0.schedule"},
+								RequiredWith:  []string{"default_policy"},
+								DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+									if d.Get("default_policy").(string) == "" {
+										if old == "0" && new == "1" {
+											return true
+										}
 									}
-								}
-								return false
+									return false
+								},
 							},
-						},
-						names.AttrSchedule: {
-							Type:     schema.TypeList,
-							Optional: true,
-							MinItems: 1,
-							MaxItems: 4,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"archive_rule": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"archive_retain_rule": {
-													Type:     schema.TypeList,
-													Required: true,
-													MaxItems: 1,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															"retention_archive_tier": {
-																Type:     schema.TypeList,
-																Required: true,
-																MaxItems: 1,
-																Elem: &schema.Resource{
-																	Schema: map[string]*schema.Schema{
-																		"count": {
-																			Type:         schema.TypeInt,
-																			Optional:     true,
-																			ValidateFunc: validation.IntBetween(1, 1000),
-																		},
-																		names.AttrInterval: {
-																			Type:         schema.TypeInt,
-																			Optional:     true,
-																			ValidateFunc: validation.IntAtLeast(1),
-																		},
-																		"interval_unit": {
-																			Type:             schema.TypeString,
-																			Optional:         true,
-																			ValidateDiagFunc: enum.Validate[awstypes.RetentionIntervalUnitValues](),
+							"exclusions": {
+								Type:          schema.TypeList,
+								Optional:      true,
+								MaxItems:      1,
+								RequiredWith:  []string{"default_policy"},
+								ConflictsWith: []string{"policy_details.0.resource_types", "policy_details.0.schedule"},
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"exclude_boot_volumes": {
+											Type:     schema.TypeBool,
+											Optional: true,
+										},
+										"exclude_tags": {
+											Type:     schema.TypeMap,
+											Optional: true,
+											Elem:     &schema.Schema{Type: schema.TypeString},
+										},
+										"exclude_volume_types": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MinItems: 0,
+											MaxItems: 6,
+											Elem:     &schema.Schema{Type: schema.TypeString},
+										},
+									},
+								},
+							},
+							"extend_deletion": {
+								Type:          schema.TypeBool,
+								Optional:      true,
+								Default:       false,
+								ConflictsWith: []string{"policy_details.0.schedule"},
+								RequiredWith:  []string{"default_policy"},
+							},
+							"event_source": {
+								Type:     schema.TypeList,
+								Optional: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										names.AttrParameters: {
+											Type:     schema.TypeList,
+											Required: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"description_regex": {
+														Type:         schema.TypeString,
+														Required:     true,
+														ValidateFunc: validation.StringLenBetween(0, 1000),
+													},
+													"event_type": {
+														Type:             schema.TypeString,
+														Required:         true,
+														ValidateDiagFunc: enum.Validate[awstypes.EventTypeValues](),
+													},
+													"snapshot_owner": {
+														Type:     schema.TypeSet,
+														Required: true,
+														MaxItems: 50,
+														Elem: &schema.Schema{
+															Type:         schema.TypeString,
+															ValidateFunc: verify.ValidAccountID,
+														},
+													},
+												},
+											},
+										},
+										names.AttrType: {
+											Type:             schema.TypeString,
+											Required:         true,
+											ValidateDiagFunc: enum.Validate[awstypes.EventSourceValues](),
+										},
+									},
+								},
+							},
+							names.AttrParameters: {
+								Type:     schema.TypeList,
+								Optional: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"exclude_boot_volume": {
+											Type:     schema.TypeBool,
+											Optional: true,
+										},
+										"no_reboot": {
+											Type:     schema.TypeBool,
+											Optional: true,
+										},
+									},
+								},
+							},
+							"policy_language": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								Computed:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.PolicyLanguageValues](),
+							},
+							"policy_type": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								Default:          awstypes.PolicyTypeValuesEbsSnapshotManagement,
+								ValidateDiagFunc: enum.Validate[awstypes.PolicyTypeValues](),
+							},
+							"resource_locations": {
+								Type:     schema.TypeList,
+								Optional: true,
+								Computed: true,
+								MaxItems: 1,
+								Elem: &schema.Schema{
+									Type:             schema.TypeString,
+									ValidateDiagFunc: enum.Validate[awstypes.ResourceLocationValues](),
+								},
+							},
+							names.AttrResourceType: {
+								Type:             schema.TypeString,
+								Optional:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.ResourceTypeValues](),
+								ConflictsWith:    []string{"policy_details.0.resource_types", "policy_details.0.schedule"},
+								RequiredWith:     []string{"default_policy"},
+							},
+							"resource_types": {
+								Type:     schema.TypeList,
+								Optional: true,
+								Elem: &schema.Schema{
+									Type:             schema.TypeString,
+									ValidateDiagFunc: enum.Validate[awstypes.ResourceTypeValues](),
+								},
+								ConflictsWith: []string{"policy_details.0.resource_type", "default_policy"},
+							},
+							"retain_interval": {
+								Type:          schema.TypeInt,
+								Optional:      true,
+								Default:       7,
+								ValidateFunc:  validation.IntBetween(2, 14),
+								ConflictsWith: []string{"policy_details.0.schedule"},
+								RequiredWith:  []string{"default_policy"},
+								DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+									if d.Get("default_policy").(string) == "" {
+										if old == "0" && new == "7" {
+											return true
+										}
+									}
+									return false
+								},
+							},
+							names.AttrSchedule: {
+								Type:     schema.TypeList,
+								Optional: true,
+								MinItems: 1,
+								MaxItems: 4,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"archive_rule": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"archive_retain_rule": {
+														Type:     schema.TypeList,
+														Required: true,
+														MaxItems: 1,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																"retention_archive_tier": {
+																	Type:     schema.TypeList,
+																	Required: true,
+																	MaxItems: 1,
+																	Elem: &schema.Resource{
+																		Schema: map[string]*schema.Schema{
+																			"count": {
+																				Type:         schema.TypeInt,
+																				Optional:     true,
+																				ValidateFunc: validation.IntBetween(1, 1000),
+																			},
+																			names.AttrInterval: {
+																				Type:         schema.TypeInt,
+																				Optional:     true,
+																				ValidateFunc: validation.IntAtLeast(1),
+																			},
+																			"interval_unit": {
+																				Type:             schema.TypeString,
+																				Optional:         true,
+																				ValidateDiagFunc: enum.Validate[awstypes.RetentionIntervalUnitValues](),
+																			},
 																		},
 																	},
 																},
@@ -357,316 +359,316 @@ func resourceLifecyclePolicy() *schema.Resource {
 												},
 											},
 										},
-									},
-									"copy_tags": {
-										Type:     schema.TypeBool,
-										Optional: true,
-										Computed: true,
-										ForceNew: true,
-									},
-									"create_rule": {
-										Type:     schema.TypeList,
-										Required: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"cron_expression": {
-													Type:         schema.TypeString,
-													Optional:     true,
-													ValidateFunc: validation.StringMatch(regexache.MustCompile("^cron\\([^\n]{11,100}\\)$"), "see https://docs.aws.amazon.com/dlm/latest/APIReference/API_CreateRule.html"),
-												},
-												names.AttrInterval: {
-													Type:         schema.TypeInt,
-													Optional:     true,
-													ValidateFunc: validation.IntInSlice([]int{1, 2, 3, 4, 6, 8, 12, 24}),
-												},
-												"interval_unit": {
-													Type:             schema.TypeString,
-													Optional:         true,
-													Computed:         true,
-													ValidateDiagFunc: enum.Validate[awstypes.IntervalUnitValues](),
-												},
-												names.AttrLocation: {
-													Type:             schema.TypeString,
-													Optional:         true,
-													Computed:         true,
-													ValidateDiagFunc: enum.Validate[awstypes.LocationValues](),
-												},
-												"scripts": {
-													Type:     schema.TypeList,
-													Optional: true,
-													MaxItems: 1,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															"execute_operation_on_script_failure": {
-																Type:     schema.TypeBool,
-																Computed: true,
-																Optional: true,
-															},
-															"execution_handler": {
-																Type:     schema.TypeString,
-																Required: true,
-																ValidateFunc: validation.All(
-																	validation.StringLenBetween(0, 200),
-																	validation.StringMatch(regexache.MustCompile("^([a-zA-Z0-9_\\-.]{3,128}|[a-zA-Z0-9_\\-.:/]{3,200}|[A-Z0-9_]+)$"), "see https://docs.aws.amazon.com/dlm/latest/APIReference/API_Action.html"),
-																),
-															},
-															"execution_handler_service": {
-																Type:             schema.TypeString,
-																Computed:         true,
-																Optional:         true,
-																ValidateDiagFunc: enum.Validate[awstypes.ExecutionHandlerServiceValues](),
-															},
-															"execution_timeout": {
-																Type:         schema.TypeInt,
-																Computed:     true,
-																Optional:     true,
-																ValidateFunc: validation.IntBetween(1, 120),
-															},
-															"maximum_retry_count": {
-																Type:         schema.TypeInt,
-																Computed:     true,
-																Optional:     true,
-																ValidateFunc: validation.IntBetween(1, 3),
-															},
-															"stages": {
-																Type:     schema.TypeList,
-																Optional: true,
-																MinItems: 1,
-																MaxItems: 2,
-																Elem: &schema.Schema{
+										"copy_tags": {
+											Type:     schema.TypeBool,
+											Optional: true,
+											Computed: true,
+											ForceNew: true,
+										},
+										"create_rule": {
+											Type:     schema.TypeList,
+											Required: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"cron_expression": {
+														Type:         schema.TypeString,
+														Optional:     true,
+														ValidateFunc: validation.StringMatch(regexache.MustCompile("^cron\\([^\n]{11,100}\\)$"), "see https://docs.aws.amazon.com/dlm/latest/APIReference/API_CreateRule.html"),
+													},
+													names.AttrInterval: {
+														Type:         schema.TypeInt,
+														Optional:     true,
+														ValidateFunc: validation.IntInSlice([]int{1, 2, 3, 4, 6, 8, 12, 24}),
+													},
+													"interval_unit": {
+														Type:             schema.TypeString,
+														Optional:         true,
+														Computed:         true,
+														ValidateDiagFunc: enum.Validate[awstypes.IntervalUnitValues](),
+													},
+													names.AttrLocation: {
+														Type:             schema.TypeString,
+														Optional:         true,
+														Computed:         true,
+														ValidateDiagFunc: enum.Validate[awstypes.LocationValues](),
+													},
+													"scripts": {
+														Type:     schema.TypeList,
+														Optional: true,
+														MaxItems: 1,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																"execute_operation_on_script_failure": {
+																	Type:     schema.TypeBool,
+																	Computed: true,
+																	Optional: true,
+																},
+																"execution_handler": {
+																	Type:     schema.TypeString,
+																	Required: true,
+																	ValidateFunc: validation.All(
+																		validation.StringLenBetween(0, 200),
+																		validation.StringMatch(regexache.MustCompile("^([a-zA-Z0-9_\\-.]{3,128}|[a-zA-Z0-9_\\-.:/]{3,200}|[A-Z0-9_]+)$"), "see https://docs.aws.amazon.com/dlm/latest/APIReference/API_Action.html"),
+																	),
+																},
+																"execution_handler_service": {
 																	Type:             schema.TypeString,
-																	ValidateDiagFunc: enum.Validate[awstypes.StageValues](),
+																	Computed:         true,
+																	Optional:         true,
+																	ValidateDiagFunc: enum.Validate[awstypes.ExecutionHandlerServiceValues](),
+																},
+																"execution_timeout": {
+																	Type:         schema.TypeInt,
+																	Computed:     true,
+																	Optional:     true,
+																	ValidateFunc: validation.IntBetween(1, 120),
+																},
+																"maximum_retry_count": {
+																	Type:         schema.TypeInt,
+																	Computed:     true,
+																	Optional:     true,
+																	ValidateFunc: validation.IntBetween(1, 3),
+																},
+																"stages": {
+																	Type:     schema.TypeList,
+																	Optional: true,
+																	MinItems: 1,
+																	MaxItems: 2,
+																	Elem: &schema.Schema{
+																		Type:             schema.TypeString,
+																		ValidateDiagFunc: enum.Validate[awstypes.StageValues](),
+																	},
 																},
 															},
 														},
 													},
-												},
-												"times": {
-													Type:     schema.TypeList,
-													Optional: true,
-													Computed: true,
-													MaxItems: 1,
-													Elem: &schema.Schema{
-														Type:         schema.TypeString,
-														ValidateFunc: validation.StringMatch(regexache.MustCompile("^(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]$"), "see https://docs.aws.amazon.com/dlm/latest/APIReference/API_CreateRule.html#dlm-Type-CreateRule-Times"),
-													},
-												},
-											},
-										},
-									},
-									"cross_region_copy_rule": {
-										Type:     schema.TypeSet,
-										Optional: true,
-										MaxItems: 3,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"cmk_arn": {
-													Type:         schema.TypeString,
-													Optional:     true,
-													ValidateFunc: verify.ValidARN,
-												},
-												"copy_tags": {
-													Type:     schema.TypeBool,
-													Optional: true,
-													Computed: true,
-												},
-												"deprecate_rule": {
-													Type:     schema.TypeList,
-													Optional: true,
-													MaxItems: 1,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															names.AttrInterval: {
-																Type:         schema.TypeInt,
-																Required:     true,
-																ValidateFunc: validation.IntAtLeast(1),
-															},
-															"interval_unit": {
-																Type:             schema.TypeString,
-																Required:         true,
-																ValidateDiagFunc: enum.Validate[awstypes.RetentionIntervalUnitValues](),
-															},
+													"times": {
+														Type:     schema.TypeList,
+														Optional: true,
+														Computed: true,
+														MaxItems: 1,
+														Elem: &schema.Schema{
+															Type:         schema.TypeString,
+															ValidateFunc: validation.StringMatch(regexache.MustCompile("^(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]$"), "see https://docs.aws.amazon.com/dlm/latest/APIReference/API_CreateRule.html#dlm-Type-CreateRule-Times"),
 														},
 													},
 												},
-												names.AttrEncrypted: {
-													Type:     schema.TypeBool,
-													Required: true,
-												},
-												"retain_rule": {
-													Type:     schema.TypeList,
-													Optional: true,
-													MaxItems: 1,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															names.AttrInterval: {
-																Type:         schema.TypeInt,
-																Required:     true,
-																ValidateFunc: validation.IntAtLeast(1),
-															},
-															"interval_unit": {
-																Type:             schema.TypeString,
-																Required:         true,
-																ValidateDiagFunc: enum.Validate[awstypes.RetentionIntervalUnitValues](),
+											},
+										},
+										"cross_region_copy_rule": {
+											Type:     schema.TypeSet,
+											Optional: true,
+											MaxItems: 3,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"cmk_arn": {
+														Type:         schema.TypeString,
+														Optional:     true,
+														ValidateFunc: verify.ValidARN,
+													},
+													"copy_tags": {
+														Type:     schema.TypeBool,
+														Optional: true,
+														Computed: true,
+													},
+													"deprecate_rule": {
+														Type:     schema.TypeList,
+														Optional: true,
+														MaxItems: 1,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																names.AttrInterval: {
+																	Type:         schema.TypeInt,
+																	Required:     true,
+																	ValidateFunc: validation.IntAtLeast(1),
+																},
+																"interval_unit": {
+																	Type:             schema.TypeString,
+																	Required:         true,
+																	ValidateDiagFunc: enum.Validate[awstypes.RetentionIntervalUnitValues](),
+																},
 															},
 														},
 													},
-												},
-												names.AttrTarget: {
-													Type:         schema.TypeString,
-													Optional:     true,
-													ValidateFunc: validation.StringMatch(regexache.MustCompile(`^[\w:\-\/\*]+$`), ""),
-												},
-												"target_region": {
-													Type:         schema.TypeString,
-													Optional:     true,
-													ValidateFunc: verify.ValidRegionName,
-												},
-											},
-										},
-									},
-									"deprecate_rule": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"count": {
-													Type:         schema.TypeInt,
-													Optional:     true,
-													ValidateFunc: validation.IntBetween(1, 1000),
-												},
-												names.AttrInterval: {
-													Type:         schema.TypeInt,
-													Optional:     true,
-													ValidateFunc: validation.IntAtLeast(1),
-												},
-												"interval_unit": {
-													Type:             schema.TypeString,
-													Optional:         true,
-													ValidateDiagFunc: enum.Validate[awstypes.RetentionIntervalUnitValues](),
-												},
-											},
-										},
-									},
-									"fast_restore_rule": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												names.AttrAvailabilityZones: {
-													Type:     schema.TypeSet,
-													Required: true,
-													MinItems: 1,
-													MaxItems: 10,
-													Elem:     &schema.Schema{Type: schema.TypeString},
-												},
-												"count": {
-													Type:         schema.TypeInt,
-													Optional:     true,
-													ValidateFunc: validation.IntBetween(1, 1000),
-												},
-												names.AttrInterval: {
-													Type:         schema.TypeInt,
-													Optional:     true,
-													ValidateFunc: validation.IntAtLeast(1),
-												},
-												"interval_unit": {
-													Type:             schema.TypeString,
-													Optional:         true,
-													ValidateDiagFunc: enum.Validate[awstypes.RetentionIntervalUnitValues](),
-												},
-											},
-										},
-									},
-									names.AttrName: {
-										Type:         schema.TypeString,
-										Required:     true,
-										ValidateFunc: validation.StringLenBetween(0, 120),
-									},
-									"retain_rule": {
-										Type:     schema.TypeList,
-										Required: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"count": {
-													Type:         schema.TypeInt,
-													Optional:     true,
-													ValidateFunc: validation.IntBetween(1, 1000),
-												},
-												names.AttrInterval: {
-													Type:         schema.TypeInt,
-													Optional:     true,
-													ValidateFunc: validation.IntAtLeast(1),
-												},
-												"interval_unit": {
-													Type:             schema.TypeString,
-													Optional:         true,
-													ValidateDiagFunc: enum.Validate[awstypes.RetentionIntervalUnitValues](),
-												},
-											},
-										},
-									},
-									"share_rule": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"target_accounts": {
-													Type:     schema.TypeSet,
-													Required: true,
-													MinItems: 1,
-													Elem: &schema.Schema{
+													names.AttrEncrypted: {
+														Type:     schema.TypeBool,
+														Required: true,
+													},
+													"retain_rule": {
+														Type:     schema.TypeList,
+														Optional: true,
+														MaxItems: 1,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																names.AttrInterval: {
+																	Type:         schema.TypeInt,
+																	Required:     true,
+																	ValidateFunc: validation.IntAtLeast(1),
+																},
+																"interval_unit": {
+																	Type:             schema.TypeString,
+																	Required:         true,
+																	ValidateDiagFunc: enum.Validate[awstypes.RetentionIntervalUnitValues](),
+																},
+															},
+														},
+													},
+													names.AttrTarget: {
 														Type:         schema.TypeString,
-														ValidateFunc: verify.ValidAccountID,
+														Optional:     true,
+														ValidateFunc: validation.StringMatch(regexache.MustCompile(`^[\w:\-\/\*]+$`), ""),
+													},
+													"target_region": {
+														Type:         schema.TypeString,
+														Optional:     true,
+														ValidateFunc: verify.ValidRegionName,
 													},
 												},
-												"unshare_interval": {
-													Type:         schema.TypeInt,
-													Optional:     true,
-													ValidateFunc: validation.IntAtLeast(1),
-												},
-												"unshare_interval_unit": {
-													Type:             schema.TypeString,
-													Optional:         true,
-													ValidateDiagFunc: enum.Validate[awstypes.RetentionIntervalUnitValues](),
+											},
+										},
+										"deprecate_rule": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"count": {
+														Type:         schema.TypeInt,
+														Optional:     true,
+														ValidateFunc: validation.IntBetween(1, 1000),
+													},
+													names.AttrInterval: {
+														Type:         schema.TypeInt,
+														Optional:     true,
+														ValidateFunc: validation.IntAtLeast(1),
+													},
+													"interval_unit": {
+														Type:             schema.TypeString,
+														Optional:         true,
+														ValidateDiagFunc: enum.Validate[awstypes.RetentionIntervalUnitValues](),
+													},
 												},
 											},
 										},
-									},
-									"tags_to_add": {
-										Type:     schema.TypeMap,
-										Optional: true,
-										Elem:     &schema.Schema{Type: schema.TypeString},
-									},
-									"variable_tags": {
-										Type:     schema.TypeMap,
-										Optional: true,
-										Elem:     &schema.Schema{Type: schema.TypeString},
+										"fast_restore_rule": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													names.AttrAvailabilityZones: {
+														Type:     schema.TypeSet,
+														Required: true,
+														MinItems: 1,
+														MaxItems: 10,
+														Elem:     &schema.Schema{Type: schema.TypeString},
+													},
+													"count": {
+														Type:         schema.TypeInt,
+														Optional:     true,
+														ValidateFunc: validation.IntBetween(1, 1000),
+													},
+													names.AttrInterval: {
+														Type:         schema.TypeInt,
+														Optional:     true,
+														ValidateFunc: validation.IntAtLeast(1),
+													},
+													"interval_unit": {
+														Type:             schema.TypeString,
+														Optional:         true,
+														ValidateDiagFunc: enum.Validate[awstypes.RetentionIntervalUnitValues](),
+													},
+												},
+											},
+										},
+										names.AttrName: {
+											Type:         schema.TypeString,
+											Required:     true,
+											ValidateFunc: validation.StringLenBetween(0, 120),
+										},
+										"retain_rule": {
+											Type:     schema.TypeList,
+											Required: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"count": {
+														Type:         schema.TypeInt,
+														Optional:     true,
+														ValidateFunc: validation.IntBetween(1, 1000),
+													},
+													names.AttrInterval: {
+														Type:         schema.TypeInt,
+														Optional:     true,
+														ValidateFunc: validation.IntAtLeast(1),
+													},
+													"interval_unit": {
+														Type:             schema.TypeString,
+														Optional:         true,
+														ValidateDiagFunc: enum.Validate[awstypes.RetentionIntervalUnitValues](),
+													},
+												},
+											},
+										},
+										"share_rule": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"target_accounts": {
+														Type:     schema.TypeSet,
+														Required: true,
+														MinItems: 1,
+														Elem: &schema.Schema{
+															Type:         schema.TypeString,
+															ValidateFunc: verify.ValidAccountID,
+														},
+													},
+													"unshare_interval": {
+														Type:         schema.TypeInt,
+														Optional:     true,
+														ValidateFunc: validation.IntAtLeast(1),
+													},
+													"unshare_interval_unit": {
+														Type:             schema.TypeString,
+														Optional:         true,
+														ValidateDiagFunc: enum.Validate[awstypes.RetentionIntervalUnitValues](),
+													},
+												},
+											},
+										},
+										"tags_to_add": {
+											Type:     schema.TypeMap,
+											Optional: true,
+											Elem:     &schema.Schema{Type: schema.TypeString},
+										},
+										"variable_tags": {
+											Type:     schema.TypeMap,
+											Optional: true,
+											Elem:     &schema.Schema{Type: schema.TypeString},
+										},
 									},
 								},
 							},
-						},
-						"target_tags": {
-							Type:     schema.TypeMap,
-							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
+							"target_tags": {
+								Type:     schema.TypeMap,
+								Optional: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+							},
 						},
 					},
 				},
-			},
-			names.AttrState: {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Default:          awstypes.SettablePolicyStateValuesEnabled,
-				ValidateDiagFunc: enum.Validate[awstypes.SettablePolicyStateValues](),
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				names.AttrState: {
+					Type:             schema.TypeString,
+					Optional:         true,
+					Default:          awstypes.SettablePolicyStateValuesEnabled,
+					ValidateDiagFunc: enum.Validate[awstypes.SettablePolicyStateValues](),
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			}
 		},
 	}
 }

--- a/internal/service/dms/certificate.go
+++ b/internal/service/dms/certificate.go
@@ -39,38 +39,40 @@ func resourceCertificate() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrCertificateARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"certificate_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-				ValidateFunc: validation.All(
-					validation.StringLenBetween(1, 255),
-					validation.StringMatch(regexache.MustCompile("^[A-Za-z][0-9A-Za-z-]+$"), "must start with a letter, only contain alphanumeric characters and hyphens"),
-					validation.StringDoesNotMatch(regexache.MustCompile(`--`), "cannot contain two consecutive hyphens"),
-					validation.StringDoesNotMatch(regexache.MustCompile(`-$`), "cannot end in a hyphen"),
-				),
-			},
-			"certificate_pem": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				Sensitive:    true,
-				ExactlyOneOf: []string{"certificate_pem", "certificate_wallet"},
-			},
-			"certificate_wallet": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				Sensitive:    true,
-				ExactlyOneOf: []string{"certificate_pem", "certificate_wallet"},
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrCertificateARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"certificate_id": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+					ValidateFunc: validation.All(
+						validation.StringLenBetween(1, 255),
+						validation.StringMatch(regexache.MustCompile("^[A-Za-z][0-9A-Za-z-]+$"), "must start with a letter, only contain alphanumeric characters and hyphens"),
+						validation.StringDoesNotMatch(regexache.MustCompile(`--`), "cannot contain two consecutive hyphens"),
+						validation.StringDoesNotMatch(regexache.MustCompile(`-$`), "cannot end in a hyphen"),
+					),
+				},
+				"certificate_pem": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ForceNew:     true,
+					Sensitive:    true,
+					ExactlyOneOf: []string{"certificate_pem", "certificate_wallet"},
+				},
+				"certificate_wallet": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ForceNew:     true,
+					Sensitive:    true,
+					ExactlyOneOf: []string{"certificate_pem", "certificate_wallet"},
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			}
 		},
 	}
 }

--- a/internal/service/dms/certificate_data_source.go
+++ b/internal/service/dms/certificate_data_source.go
@@ -26,56 +26,58 @@ func dataSourceCertificate() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceCertificateRead,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrCertificateARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"certificate_creation_date": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"certificate_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ValidateFunc: validation.All(
-					validation.StringLenBetween(1, 255),
-					validation.StringMatch(regexache.MustCompile("^[A-Za-z][0-9A-Za-z-]+$"), "must start with a letter, only contain alphanumeric characters and hyphens"),
-					validation.StringDoesNotMatch(regexache.MustCompile(`--`), "cannot contain two consecutive hyphens"),
-					validation.StringDoesNotMatch(regexache.MustCompile(`-$`), "cannot end in a hyphen"),
-				),
-			},
-			"certificate_owner": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"certificate_pem": {
-				Type:      schema.TypeString,
-				Computed:  true,
-				Sensitive: true,
-			},
-			"certificate_wallet": {
-				Type:      schema.TypeString,
-				Computed:  true,
-				Sensitive: true,
-			},
-			"key_length": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-			"signing_algorithm": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrTags: tftags.TagsSchemaComputed(),
-			"valid_from_date": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"valid_to_date": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrCertificateARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"certificate_creation_date": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"certificate_id": {
+					Type:     schema.TypeString,
+					Required: true,
+					ValidateFunc: validation.All(
+						validation.StringLenBetween(1, 255),
+						validation.StringMatch(regexache.MustCompile("^[A-Za-z][0-9A-Za-z-]+$"), "must start with a letter, only contain alphanumeric characters and hyphens"),
+						validation.StringDoesNotMatch(regexache.MustCompile(`--`), "cannot contain two consecutive hyphens"),
+						validation.StringDoesNotMatch(regexache.MustCompile(`-$`), "cannot end in a hyphen"),
+					),
+				},
+				"certificate_owner": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"certificate_pem": {
+					Type:      schema.TypeString,
+					Computed:  true,
+					Sensitive: true,
+				},
+				"certificate_wallet": {
+					Type:      schema.TypeString,
+					Computed:  true,
+					Sensitive: true,
+				},
+				"key_length": {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
+				"signing_algorithm": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrTags: tftags.TagsSchemaComputed(),
+				"valid_from_date": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"valid_to_date": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/dms/endpoint.go
+++ b/internal/service/dms/endpoint.go
@@ -54,790 +54,792 @@ func resourceEndpoint() *schema.Resource {
 			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrCertificateARN: {
-				Type:         schema.TypeString,
-				Computed:     true,
-				Optional:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			names.AttrDatabaseName: {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"elasticsearch_settings": {
-				Type:             schema.TypeList,
-				Optional:         true,
-				MaxItems:         1,
-				DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"endpoint_uri": {
-							Type:     schema.TypeString,
-							Required: true,
-							ForceNew: true,
-						},
-						"error_retry_duration": {
-							Type:         schema.TypeInt,
-							Optional:     true,
-							ForceNew:     true,
-							Default:      300,
-							ValidateFunc: validation.IntAtLeast(0),
-						},
-						"full_load_error_percentage": {
-							Type:         schema.TypeInt,
-							Optional:     true,
-							ForceNew:     true,
-							Default:      10,
-							ValidateFunc: validation.IntBetween(0, 100),
-						},
-						"service_access_role_arn": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ForceNew:     true,
-							ValidateFunc: verify.ValidARN,
-						},
-						"use_new_mapping_type": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							ForceNew: true,
-							Default:  false,
-						},
-					},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrCertificateARN: {
+					Type:         schema.TypeString,
+					Computed:     true,
+					Optional:     true,
+					ValidateFunc: verify.ValidARN,
 				},
-			},
-			"endpoint_arn": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"endpoint_id": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validEndpointID,
-			},
-			names.AttrEndpointType: {
-				Type:             schema.TypeString,
-				Required:         true,
-				ValidateDiagFunc: enum.Validate[awstypes.ReplicationEndpointTypeValue](),
-			},
-			"engine_name": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringInSlice(engineName_Values(), false),
-			},
-			"extra_connection_attributes": {
-				Type:             schema.TypeString,
-				Computed:         true,
-				Optional:         true,
-				DiffSuppressFunc: suppressExtraConnectionAttributesDiffs,
-			},
-			"kafka_settings": {
-				Type:             schema.TypeList,
-				Optional:         true,
-				MaxItems:         1,
-				DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"broker": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validation.NoZeroValues,
-						},
-						"include_control_details": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  false,
-						},
-						"include_null_and_empty": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  false,
-						},
-						"include_partition_value": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  false,
-						},
-						"include_table_alter_operations": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  false,
-						},
-						"include_transaction_details": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  false,
-						},
-						"message_format": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Default:          awstypes.MessageFormatValueJson,
-							ValidateDiagFunc: enum.Validate[awstypes.MessageFormatValue](),
-						},
-						"message_max_bytes": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							Default:  1000000,
-						},
-						"no_hex_prefix": {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
-						"partition_include_schema_table": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  false,
-						},
-						"sasl_mechanism": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.KafkaSaslMechanism](),
-						},
-						"sasl_password": {
-							Type:      schema.TypeString,
-							Optional:  true,
-							Sensitive: true,
-						},
-						"sasl_username": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"security_protocol": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.KafkaSecurityProtocol](),
-						},
-						"ssl_ca_certificate_arn": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							ValidateFunc: verify.ValidARN,
-						},
-						"ssl_client_certificate_arn": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							ValidateFunc: verify.ValidARN,
-						},
-						"ssl_client_key_arn": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							ValidateFunc: verify.ValidARN,
-						},
-						"ssl_client_key_password": {
-							Type:      schema.TypeString,
-							Optional:  true,
-							Sensitive: true,
-						},
-						"topic": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Default:  kafkaDefaultTopic,
-						},
-					},
+				names.AttrDatabaseName: {
+					Type:     schema.TypeString,
+					Optional: true,
 				},
-			},
-			"kinesis_settings": {
-				Type:             schema.TypeList,
-				Optional:         true,
-				MaxItems:         1,
-				DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"include_control_details": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  false,
-						},
-						"include_null_and_empty": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  false,
-						},
-						"include_partition_value": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  false,
-						},
-						"include_table_alter_operations": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  false,
-						},
-						"include_transaction_details": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  false,
-						},
-						"message_format": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							ForceNew:         true,
-							Default:          awstypes.MessageFormatValueJson,
-							ValidateDiagFunc: enum.Validate[awstypes.MessageFormatValue](),
-						},
-						"partition_include_schema_table": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  false,
-						},
-						"service_access_role_arn": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							ValidateFunc: verify.ValidARN,
-						},
-						names.AttrStreamARN: {
-							Type:         schema.TypeString,
-							Optional:     true,
-							ValidateFunc: verify.ValidARN,
-						},
-						"use_large_integer_value": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  false,
-						},
-					},
-				},
-			},
-			names.AttrKMSKeyARN: {
-				Type:         schema.TypeString,
-				Computed:     true,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			"mongodb_settings": {
-				Type:             schema.TypeList,
-				Optional:         true,
-				MaxItems:         1,
-				DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"auth_mechanism": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							Default:      mongoDBAuthMechanismValueDefault,
-							ValidateFunc: validation.StringInSlice(mongoDBAuthMechanismValue_Values(), false),
-						},
-						"auth_source": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Default:  mongoDBAuthSourceAdmin,
-						},
-						"auth_type": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Default:          awstypes.AuthTypeValuePassword,
-							ValidateDiagFunc: enum.Validate[awstypes.AuthTypeValue](),
-						},
-						"docs_to_investigate": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Default:  "1000",
-						},
-						"extract_doc_id": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Default:  "false",
-						},
-						"nesting_level": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Default:          awstypes.NestingLevelValueNone,
-							ValidateDiagFunc: enum.Validate[awstypes.NestingLevelValue](),
-						},
-						"use_update_lookup": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  false,
-						},
-					},
-				},
-			},
-			"mysql_settings": {
-				Type:             schema.TypeList,
-				Optional:         true,
-				MaxItems:         1,
-				DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"after_connect_script": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Computed: true,
-						},
-						"authentication_method": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Computed:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.MySQLAuthenticationMethod](),
-						},
-						"clean_source_metadata_on_mismatch": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Computed: true,
-						},
-						"events_poll_interval": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							Computed: true,
-						},
-						"execute_timeout": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							Computed: true,
-						},
-						"max_file_size": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							Computed: true,
-						},
-						"parallel_load_threads": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							Computed: true,
-						},
-						"server_timezone": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Computed: true,
-						},
-						"service_access_role_arn": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							Computed:     true,
-							ValidateFunc: verify.ValidARN,
-						},
-						"target_db_type": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Computed:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.TargetDbType](),
-						},
-					},
-				},
-			},
-			"oracle_settings": {
-				Type:             schema.TypeList,
-				Optional:         true,
-				MaxItems:         1,
-				DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"access_alternate_directly": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Computed: true,
-						},
-						"add_supplemental_logging": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Computed: true,
-						},
-						"additional_archived_log_dest_id": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							Computed: true,
-						},
-						"allow_selected_nested_tables": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Computed: true,
-						},
-						"archived_log_dest_id": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							Computed: true,
-						},
-						"archived_logs_only": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Computed: true,
-						},
-						"asm_password": {
-							Type:      schema.TypeString,
-							Optional:  true,
-							Computed:  true,
-							Sensitive: true,
-						},
-						"asm_server": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Computed: true,
-						},
-						"asm_user": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Computed: true,
-						},
-						"authentication_method": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Computed:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.OracleAuthenticationMethod](),
-							ConflictsWith:    []string{"secrets_manager_access_role_arn", "secrets_manager_arn"},
-						},
-						"char_length_semantics": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Computed:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.CharLengthSemantics](),
-						},
-						"convert_timestamp_with_zone_to_utc": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Computed: true,
-						},
-						"direct_path_no_log": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Computed: true,
-						},
-						"direct_path_parallel_load": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Computed: true,
-						},
-						"enable_homogenous_tablespace": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Computed: true,
-						},
-						"extra_archived_log_dest_ids": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Computed: true,
-							Elem: &schema.Schema{
-								Type: schema.TypeInt,
+				"elasticsearch_settings": {
+					Type:             schema.TypeList,
+					Optional:         true,
+					MaxItems:         1,
+					DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"endpoint_uri": {
+								Type:     schema.TypeString,
+								Required: true,
+								ForceNew: true,
+							},
+							"error_retry_duration": {
+								Type:         schema.TypeInt,
+								Optional:     true,
+								ForceNew:     true,
+								Default:      300,
+								ValidateFunc: validation.IntAtLeast(0),
+							},
+							"full_load_error_percentage": {
+								Type:         schema.TypeInt,
+								Optional:     true,
+								ForceNew:     true,
+								Default:      10,
+								ValidateFunc: validation.IntBetween(0, 100),
+							},
+							"service_access_role_arn": {
+								Type:         schema.TypeString,
+								Required:     true,
+								ForceNew:     true,
+								ValidateFunc: verify.ValidARN,
+							},
+							"use_new_mapping_type": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								ForceNew: true,
+								Default:  false,
 							},
 						},
-						"fail_task_on_lob_truncation": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Computed: true,
-						},
-						"number_datatype_scale": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							Computed: true,
-						},
-						"open_transaction_window": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							Computed: true,
-						},
-						"oracle_path_prefix": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Computed: true,
-						},
-						"parallel_asm_read_threads": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							Computed: true,
-						},
-						"read_ahead_blocks": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							Computed: true,
-						},
-						"read_table_space_name": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Computed: true,
-						},
-						"replace_path_prefix": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Computed: true,
-						},
-						"retry_interval": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							Computed: true,
-						},
-						"secrets_manager_oracle_asm_access_role_arn": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							Computed:     true,
-							ValidateFunc: verify.ValidARN,
-						},
-						"secrets_manager_oracle_asm_secret_id": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Computed: true,
-						},
-						"security_db_encryption": {
-							Type:      schema.TypeString,
-							Optional:  true,
-							Computed:  true,
-							Sensitive: true,
-						},
-						"security_db_encryption_name": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Computed: true,
-						},
-						"spatial_data_option_to_geo_json_function_name": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Computed: true,
-						},
-						"standby_delay_time": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							Computed: true,
-						},
-						"trim_space_in_char": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Computed: true,
-						},
-						"use_alternate_folder_for_online": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Computed: true,
-						},
-						"use_bfile": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Computed: true,
-						},
-						"use_direct_path_full_load": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Computed: true,
-						},
-						"use_logminer_reader": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Computed: true,
-						},
-						"use_path_prefix": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Computed: true,
+					},
+				},
+				"endpoint_arn": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"endpoint_id": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validEndpointID,
+				},
+				names.AttrEndpointType: {
+					Type:             schema.TypeString,
+					Required:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.ReplicationEndpointTypeValue](),
+				},
+				"engine_name": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringInSlice(engineName_Values(), false),
+				},
+				"extra_connection_attributes": {
+					Type:             schema.TypeString,
+					Computed:         true,
+					Optional:         true,
+					DiffSuppressFunc: suppressExtraConnectionAttributesDiffs,
+				},
+				"kafka_settings": {
+					Type:             schema.TypeList,
+					Optional:         true,
+					MaxItems:         1,
+					DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"broker": {
+								Type:         schema.TypeString,
+								Required:     true,
+								ValidateFunc: validation.NoZeroValues,
+							},
+							"include_control_details": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Default:  false,
+							},
+							"include_null_and_empty": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Default:  false,
+							},
+							"include_partition_value": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Default:  false,
+							},
+							"include_table_alter_operations": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Default:  false,
+							},
+							"include_transaction_details": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Default:  false,
+							},
+							"message_format": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								Default:          awstypes.MessageFormatValueJson,
+								ValidateDiagFunc: enum.Validate[awstypes.MessageFormatValue](),
+							},
+							"message_max_bytes": {
+								Type:     schema.TypeInt,
+								Optional: true,
+								Default:  1000000,
+							},
+							"no_hex_prefix": {
+								Type:     schema.TypeBool,
+								Optional: true,
+							},
+							"partition_include_schema_table": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Default:  false,
+							},
+							"sasl_mechanism": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.KafkaSaslMechanism](),
+							},
+							"sasl_password": {
+								Type:      schema.TypeString,
+								Optional:  true,
+								Sensitive: true,
+							},
+							"sasl_username": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+							"security_protocol": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.KafkaSecurityProtocol](),
+							},
+							"ssl_ca_certificate_arn": {
+								Type:         schema.TypeString,
+								Optional:     true,
+								ValidateFunc: verify.ValidARN,
+							},
+							"ssl_client_certificate_arn": {
+								Type:         schema.TypeString,
+								Optional:     true,
+								ValidateFunc: verify.ValidARN,
+							},
+							"ssl_client_key_arn": {
+								Type:         schema.TypeString,
+								Optional:     true,
+								ValidateFunc: verify.ValidARN,
+							},
+							"ssl_client_key_password": {
+								Type:      schema.TypeString,
+								Optional:  true,
+								Sensitive: true,
+							},
+							"topic": {
+								Type:     schema.TypeString,
+								Optional: true,
+								Default:  kafkaDefaultTopic,
+							},
 						},
 					},
 				},
-			},
-			names.AttrPassword: {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Sensitive:     true,
-				ConflictsWith: []string{"secrets_manager_access_role_arn", "secrets_manager_arn"},
-			},
-			"pause_replication_tasks": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
-			names.AttrPort: {
-				Type:          schema.TypeInt,
-				Optional:      true,
-				ConflictsWith: []string{"secrets_manager_access_role_arn", "secrets_manager_arn"},
-			},
-			"postgres_settings": {
-				Type:             schema.TypeList,
-				Optional:         true,
-				MaxItems:         1,
-				DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"after_connect_script": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"authentication_method": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Computed:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.PostgreSQLAuthenticationMethod](),
-						},
-						"babelfish_database_name": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"capture_ddls": {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
-						"database_mode": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.DatabaseMode](),
-						},
-						"ddl_artifacts_schema": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"execute_timeout": {
-							Type:     schema.TypeInt,
-							Optional: true,
-						},
-						"fail_tasks_on_lob_truncation": {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
-						"heartbeat_enable": {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
-						"heartbeat_frequency": {
-							Type:     schema.TypeInt,
-							Optional: true,
-						},
-						"heartbeat_schema": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"map_boolean_as_boolean": {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
-						"map_jsonb_as_clob": {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
-						"map_long_varchar_as": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.LongVarcharMappingType](),
-						},
-						"max_file_size": {
-							Type:     schema.TypeInt,
-							Optional: true,
-						},
-						"plugin_name": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.PluginNameValue](),
-						},
-						"service_access_role_arn": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							ValidateFunc: verify.ValidARN,
-						},
-						"slot_name": {
-							Type:     schema.TypeString,
-							Optional: true,
+				"kinesis_settings": {
+					Type:             schema.TypeList,
+					Optional:         true,
+					MaxItems:         1,
+					DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"include_control_details": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Default:  false,
+							},
+							"include_null_and_empty": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Default:  false,
+							},
+							"include_partition_value": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Default:  false,
+							},
+							"include_table_alter_operations": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Default:  false,
+							},
+							"include_transaction_details": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Default:  false,
+							},
+							"message_format": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								ForceNew:         true,
+								Default:          awstypes.MessageFormatValueJson,
+								ValidateDiagFunc: enum.Validate[awstypes.MessageFormatValue](),
+							},
+							"partition_include_schema_table": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Default:  false,
+							},
+							"service_access_role_arn": {
+								Type:         schema.TypeString,
+								Optional:     true,
+								ValidateFunc: verify.ValidARN,
+							},
+							names.AttrStreamARN: {
+								Type:         schema.TypeString,
+								Optional:     true,
+								ValidateFunc: verify.ValidARN,
+							},
+							"use_large_integer_value": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Default:  false,
+							},
 						},
 					},
 				},
-			},
-			"redis_settings": {
-				Type:             schema.TypeList,
-				Optional:         true,
-				MaxItems:         1,
-				DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"auth_password": {
-							Type:      schema.TypeString,
-							Optional:  true,
-							Sensitive: true,
-						},
-						"auth_type": {
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.RedisAuthTypeValue](),
-						},
-						"auth_user_name": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						names.AttrPort: {
-							Type:         schema.TypeInt,
-							Required:     true,
-							ValidateFunc: validation.IntAtLeast(0),
-						},
-						"server_name": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"ssl_ca_certificate_arn": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"ssl_security_protocol": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Default:          awstypes.SslSecurityProtocolValueSslEncryption,
-							ValidateDiagFunc: enum.Validate[awstypes.SslSecurityProtocolValue](),
+				names.AttrKMSKeyARN: {
+					Type:         schema.TypeString,
+					Computed:     true,
+					Optional:     true,
+					ForceNew:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				"mongodb_settings": {
+					Type:             schema.TypeList,
+					Optional:         true,
+					MaxItems:         1,
+					DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"auth_mechanism": {
+								Type:         schema.TypeString,
+								Optional:     true,
+								Default:      mongoDBAuthMechanismValueDefault,
+								ValidateFunc: validation.StringInSlice(mongoDBAuthMechanismValue_Values(), false),
+							},
+							"auth_source": {
+								Type:     schema.TypeString,
+								Optional: true,
+								Default:  mongoDBAuthSourceAdmin,
+							},
+							"auth_type": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								Default:          awstypes.AuthTypeValuePassword,
+								ValidateDiagFunc: enum.Validate[awstypes.AuthTypeValue](),
+							},
+							"docs_to_investigate": {
+								Type:     schema.TypeString,
+								Optional: true,
+								Default:  "1000",
+							},
+							"extract_doc_id": {
+								Type:     schema.TypeString,
+								Optional: true,
+								Default:  "false",
+							},
+							"nesting_level": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								Default:          awstypes.NestingLevelValueNone,
+								ValidateDiagFunc: enum.Validate[awstypes.NestingLevelValue](),
+							},
+							"use_update_lookup": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Default:  false,
+							},
 						},
 					},
 				},
-			},
-			"redshift_settings": {
-				Type:             schema.TypeList,
-				Optional:         true,
-				Computed:         true,
-				MaxItems:         1,
-				DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"bucket_folder": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						names.AttrBucketName: {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"encryption_mode": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							Default:      encryptionModeSseS3,
-							ValidateFunc: validation.StringInSlice(encryptionMode_Values(), false),
-						},
-						"server_side_encryption_kms_key_id": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							DiffSuppressFunc: tfkms.DiffSuppressKey,
-							ValidateFunc:     tfkms.ValidateKey,
-						},
-						"service_access_role_arn": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							ValidateFunc: verify.ValidARN,
+				"mysql_settings": {
+					Type:             schema.TypeList,
+					Optional:         true,
+					MaxItems:         1,
+					DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"after_connect_script": {
+								Type:     schema.TypeString,
+								Optional: true,
+								Computed: true,
+							},
+							"authentication_method": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								Computed:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.MySQLAuthenticationMethod](),
+							},
+							"clean_source_metadata_on_mismatch": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Computed: true,
+							},
+							"events_poll_interval": {
+								Type:     schema.TypeInt,
+								Optional: true,
+								Computed: true,
+							},
+							"execute_timeout": {
+								Type:     schema.TypeInt,
+								Optional: true,
+								Computed: true,
+							},
+							"max_file_size": {
+								Type:     schema.TypeInt,
+								Optional: true,
+								Computed: true,
+							},
+							"parallel_load_threads": {
+								Type:     schema.TypeInt,
+								Optional: true,
+								Computed: true,
+							},
+							"server_timezone": {
+								Type:     schema.TypeString,
+								Optional: true,
+								Computed: true,
+							},
+							"service_access_role_arn": {
+								Type:         schema.TypeString,
+								Optional:     true,
+								Computed:     true,
+								ValidateFunc: verify.ValidARN,
+							},
+							"target_db_type": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								Computed:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.TargetDbType](),
+							},
 						},
 					},
 				},
-			},
-			"secrets_manager_access_role_arn": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				ValidateFunc:  verify.ValidARN,
-				RequiredWith:  []string{"secrets_manager_arn"},
-				ConflictsWith: []string{names.AttrUsername, names.AttrPassword, "server_name", names.AttrPort},
-			},
-			"secrets_manager_arn": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				ValidateFunc:  verify.ValidARN,
-				RequiredWith:  []string{"secrets_manager_access_role_arn"},
-				ConflictsWith: []string{names.AttrUsername, names.AttrPassword, "server_name", names.AttrPort},
-			},
-			"server_name": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				ConflictsWith: []string{"secrets_manager_access_role_arn", "secrets_manager_arn"},
-			},
-			"service_access_role": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"ssl_mode": {
-				Type:             schema.TypeString,
-				Computed:         true,
-				Optional:         true,
-				ValidateDiagFunc: enum.Validate[awstypes.DmsSslModeValue](),
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			names.AttrUsername: {
-				Type:          schema.TypeString,
-				Optional:      true,
-				ConflictsWith: []string{"secrets_manager_access_role_arn", "secrets_manager_arn"},
-			},
+				"oracle_settings": {
+					Type:             schema.TypeList,
+					Optional:         true,
+					MaxItems:         1,
+					DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"access_alternate_directly": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Computed: true,
+							},
+							"add_supplemental_logging": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Computed: true,
+							},
+							"additional_archived_log_dest_id": {
+								Type:     schema.TypeInt,
+								Optional: true,
+								Computed: true,
+							},
+							"allow_selected_nested_tables": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Computed: true,
+							},
+							"archived_log_dest_id": {
+								Type:     schema.TypeInt,
+								Optional: true,
+								Computed: true,
+							},
+							"archived_logs_only": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Computed: true,
+							},
+							"asm_password": {
+								Type:      schema.TypeString,
+								Optional:  true,
+								Computed:  true,
+								Sensitive: true,
+							},
+							"asm_server": {
+								Type:     schema.TypeString,
+								Optional: true,
+								Computed: true,
+							},
+							"asm_user": {
+								Type:     schema.TypeString,
+								Optional: true,
+								Computed: true,
+							},
+							"authentication_method": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								Computed:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.OracleAuthenticationMethod](),
+								ConflictsWith:    []string{"secrets_manager_access_role_arn", "secrets_manager_arn"},
+							},
+							"char_length_semantics": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								Computed:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.CharLengthSemantics](),
+							},
+							"convert_timestamp_with_zone_to_utc": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Computed: true,
+							},
+							"direct_path_no_log": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Computed: true,
+							},
+							"direct_path_parallel_load": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Computed: true,
+							},
+							"enable_homogenous_tablespace": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Computed: true,
+							},
+							"extra_archived_log_dest_ids": {
+								Type:     schema.TypeList,
+								Optional: true,
+								Computed: true,
+								Elem: &schema.Schema{
+									Type: schema.TypeInt,
+								},
+							},
+							"fail_task_on_lob_truncation": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Computed: true,
+							},
+							"number_datatype_scale": {
+								Type:     schema.TypeInt,
+								Optional: true,
+								Computed: true,
+							},
+							"open_transaction_window": {
+								Type:     schema.TypeInt,
+								Optional: true,
+								Computed: true,
+							},
+							"oracle_path_prefix": {
+								Type:     schema.TypeString,
+								Optional: true,
+								Computed: true,
+							},
+							"parallel_asm_read_threads": {
+								Type:     schema.TypeInt,
+								Optional: true,
+								Computed: true,
+							},
+							"read_ahead_blocks": {
+								Type:     schema.TypeInt,
+								Optional: true,
+								Computed: true,
+							},
+							"read_table_space_name": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Computed: true,
+							},
+							"replace_path_prefix": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Computed: true,
+							},
+							"retry_interval": {
+								Type:     schema.TypeInt,
+								Optional: true,
+								Computed: true,
+							},
+							"secrets_manager_oracle_asm_access_role_arn": {
+								Type:         schema.TypeString,
+								Optional:     true,
+								Computed:     true,
+								ValidateFunc: verify.ValidARN,
+							},
+							"secrets_manager_oracle_asm_secret_id": {
+								Type:     schema.TypeString,
+								Optional: true,
+								Computed: true,
+							},
+							"security_db_encryption": {
+								Type:      schema.TypeString,
+								Optional:  true,
+								Computed:  true,
+								Sensitive: true,
+							},
+							"security_db_encryption_name": {
+								Type:     schema.TypeString,
+								Optional: true,
+								Computed: true,
+							},
+							"spatial_data_option_to_geo_json_function_name": {
+								Type:     schema.TypeString,
+								Optional: true,
+								Computed: true,
+							},
+							"standby_delay_time": {
+								Type:     schema.TypeInt,
+								Optional: true,
+								Computed: true,
+							},
+							"trim_space_in_char": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Computed: true,
+							},
+							"use_alternate_folder_for_online": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Computed: true,
+							},
+							"use_bfile": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Computed: true,
+							},
+							"use_direct_path_full_load": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Computed: true,
+							},
+							"use_logminer_reader": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Computed: true,
+							},
+							"use_path_prefix": {
+								Type:     schema.TypeString,
+								Optional: true,
+								Computed: true,
+							},
+						},
+					},
+				},
+				names.AttrPassword: {
+					Type:          schema.TypeString,
+					Optional:      true,
+					Sensitive:     true,
+					ConflictsWith: []string{"secrets_manager_access_role_arn", "secrets_manager_arn"},
+				},
+				"pause_replication_tasks": {
+					Type:     schema.TypeBool,
+					Optional: true,
+				},
+				names.AttrPort: {
+					Type:          schema.TypeInt,
+					Optional:      true,
+					ConflictsWith: []string{"secrets_manager_access_role_arn", "secrets_manager_arn"},
+				},
+				"postgres_settings": {
+					Type:             schema.TypeList,
+					Optional:         true,
+					MaxItems:         1,
+					DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"after_connect_script": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+							"authentication_method": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								Computed:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.PostgreSQLAuthenticationMethod](),
+							},
+							"babelfish_database_name": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+							"capture_ddls": {
+								Type:     schema.TypeBool,
+								Optional: true,
+							},
+							"database_mode": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.DatabaseMode](),
+							},
+							"ddl_artifacts_schema": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+							"execute_timeout": {
+								Type:     schema.TypeInt,
+								Optional: true,
+							},
+							"fail_tasks_on_lob_truncation": {
+								Type:     schema.TypeBool,
+								Optional: true,
+							},
+							"heartbeat_enable": {
+								Type:     schema.TypeBool,
+								Optional: true,
+							},
+							"heartbeat_frequency": {
+								Type:     schema.TypeInt,
+								Optional: true,
+							},
+							"heartbeat_schema": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+							"map_boolean_as_boolean": {
+								Type:     schema.TypeBool,
+								Optional: true,
+							},
+							"map_jsonb_as_clob": {
+								Type:     schema.TypeBool,
+								Optional: true,
+							},
+							"map_long_varchar_as": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.LongVarcharMappingType](),
+							},
+							"max_file_size": {
+								Type:     schema.TypeInt,
+								Optional: true,
+							},
+							"plugin_name": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.PluginNameValue](),
+							},
+							"service_access_role_arn": {
+								Type:         schema.TypeString,
+								Optional:     true,
+								ValidateFunc: verify.ValidARN,
+							},
+							"slot_name": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+						},
+					},
+				},
+				"redis_settings": {
+					Type:             schema.TypeList,
+					Optional:         true,
+					MaxItems:         1,
+					DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"auth_password": {
+								Type:      schema.TypeString,
+								Optional:  true,
+								Sensitive: true,
+							},
+							"auth_type": {
+								Type:             schema.TypeString,
+								Required:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.RedisAuthTypeValue](),
+							},
+							"auth_user_name": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+							names.AttrPort: {
+								Type:         schema.TypeInt,
+								Required:     true,
+								ValidateFunc: validation.IntAtLeast(0),
+							},
+							"server_name": {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+							"ssl_ca_certificate_arn": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+							"ssl_security_protocol": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								Default:          awstypes.SslSecurityProtocolValueSslEncryption,
+								ValidateDiagFunc: enum.Validate[awstypes.SslSecurityProtocolValue](),
+							},
+						},
+					},
+				},
+				"redshift_settings": {
+					Type:             schema.TypeList,
+					Optional:         true,
+					Computed:         true,
+					MaxItems:         1,
+					DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"bucket_folder": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+							names.AttrBucketName: {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+							"encryption_mode": {
+								Type:         schema.TypeString,
+								Optional:     true,
+								Default:      encryptionModeSseS3,
+								ValidateFunc: validation.StringInSlice(encryptionMode_Values(), false),
+							},
+							"server_side_encryption_kms_key_id": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								DiffSuppressFunc: tfkms.DiffSuppressKey,
+								ValidateFunc:     tfkms.ValidateKey,
+							},
+							"service_access_role_arn": {
+								Type:         schema.TypeString,
+								Optional:     true,
+								ValidateFunc: verify.ValidARN,
+							},
+						},
+					},
+				},
+				"secrets_manager_access_role_arn": {
+					Type:          schema.TypeString,
+					Optional:      true,
+					ValidateFunc:  verify.ValidARN,
+					RequiredWith:  []string{"secrets_manager_arn"},
+					ConflictsWith: []string{names.AttrUsername, names.AttrPassword, "server_name", names.AttrPort},
+				},
+				"secrets_manager_arn": {
+					Type:          schema.TypeString,
+					Optional:      true,
+					ValidateFunc:  verify.ValidARN,
+					RequiredWith:  []string{"secrets_manager_access_role_arn"},
+					ConflictsWith: []string{names.AttrUsername, names.AttrPassword, "server_name", names.AttrPort},
+				},
+				"server_name": {
+					Type:          schema.TypeString,
+					Optional:      true,
+					ConflictsWith: []string{"secrets_manager_access_role_arn", "secrets_manager_arn"},
+				},
+				"service_access_role": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"ssl_mode": {
+					Type:             schema.TypeString,
+					Computed:         true,
+					Optional:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.DmsSslModeValue](),
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				names.AttrUsername: {
+					Type:          schema.TypeString,
+					Optional:      true,
+					ConflictsWith: []string{"secrets_manager_access_role_arn", "secrets_manager_arn"},
+				},
+			}
 		},
 
 		CustomizeDiff: customdiff.All(

--- a/internal/service/dms/endpoint_data_source.go
+++ b/internal/service/dms/endpoint_data_source.go
@@ -26,620 +26,622 @@ func dataSourceEndpoint() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceEndpointRead,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrCertificateARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrDatabaseName: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"elasticsearch_settings": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"endpoint_uri": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"error_retry_duration": {
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
-						"full_load_error_percentage": {
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
-						"service_access_role_arn": {
-							Type:     schema.TypeString,
-							Computed: true,
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrCertificateARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrDatabaseName: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"elasticsearch_settings": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"endpoint_uri": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"error_retry_duration": {
+								Type:     schema.TypeInt,
+								Computed: true,
+							},
+							"full_load_error_percentage": {
+								Type:     schema.TypeInt,
+								Computed: true,
+							},
+							"service_access_role_arn": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
 						},
 					},
 				},
-			},
-			"endpoint_arn": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"endpoint_id": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			names.AttrEndpointType: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"engine_name": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"extra_connection_attributes": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"kafka_settings": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"broker": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"include_control_details": {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
-						"include_null_and_empty": {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
-						"include_partition_value": {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
-						"include_table_alter_operations": {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
-						"include_transaction_details": {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
-						"message_format": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"message_max_bytes": {
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
-						"no_hex_prefix": {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
-						"partition_include_schema_table": {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
-						"sasl_mechanism": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"sasl_password": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"sasl_username": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"security_protocol": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"ssl_ca_certificate_arn": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"ssl_client_certificate_arn": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"ssl_client_key_arn": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"ssl_client_key_password": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"topic": {
-							Type:     schema.TypeString,
-							Computed: true,
+				"endpoint_arn": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"endpoint_id": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				names.AttrEndpointType: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"engine_name": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"extra_connection_attributes": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"kafka_settings": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"broker": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"include_control_details": {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
+							"include_null_and_empty": {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
+							"include_partition_value": {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
+							"include_table_alter_operations": {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
+							"include_transaction_details": {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
+							"message_format": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"message_max_bytes": {
+								Type:     schema.TypeInt,
+								Computed: true,
+							},
+							"no_hex_prefix": {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
+							"partition_include_schema_table": {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
+							"sasl_mechanism": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"sasl_password": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"sasl_username": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"security_protocol": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"ssl_ca_certificate_arn": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"ssl_client_certificate_arn": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"ssl_client_key_arn": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"ssl_client_key_password": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"topic": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
 						},
 					},
 				},
-			},
-			"kinesis_settings": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"include_control_details": {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
-						"include_null_and_empty": {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
-						"include_partition_value": {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
-						"include_table_alter_operations": {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
-						"include_transaction_details": {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
-						"message_format": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"partition_include_schema_table": {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
-						"service_access_role_arn": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						names.AttrStreamARN: {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"use_large_integer_value": {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
-					},
-				},
-			},
-			names.AttrKMSKeyARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"mongodb_settings": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"auth_mechanism": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"auth_source": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"auth_type": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"docs_to_investigate": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"extract_doc_id": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"nesting_level": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"use_update_lookup": {
-							Type:     schema.TypeBool,
-							Computed: true,
+				"kinesis_settings": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"include_control_details": {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
+							"include_null_and_empty": {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
+							"include_partition_value": {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
+							"include_table_alter_operations": {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
+							"include_transaction_details": {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
+							"message_format": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"partition_include_schema_table": {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
+							"service_access_role_arn": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							names.AttrStreamARN: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"use_large_integer_value": {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
 						},
 					},
 				},
-			},
-			"mysql_settings": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"after_connect_script": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"authentication_method": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"clean_source_metadata_on_mismatch": {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
-						"events_poll_interval": {
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
-						"execute_timeout": {
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
-						"max_file_size": {
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
-						"parallel_load_threads": {
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
-						"server_timezone": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"service_access_role_arn": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"target_db_type": {
-							Type:     schema.TypeString,
-							Computed: true,
+				names.AttrKMSKeyARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"mongodb_settings": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"auth_mechanism": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"auth_source": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"auth_type": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"docs_to_investigate": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"extract_doc_id": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"nesting_level": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"use_update_lookup": {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
 						},
 					},
 				},
-			},
-			names.AttrPassword: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrPort: {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-			"postgres_settings": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"after_connect_script": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"authentication_method": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"babelfish_database_name": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"capture_ddls": {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
-						"database_mode": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"ddl_artifacts_schema": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"execute_timeout": {
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
-						"fail_tasks_on_lob_truncation": {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
-						"heartbeat_enable": {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
-						"heartbeat_frequency": {
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
-						"heartbeat_schema": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"map_boolean_as_boolean": {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
-						"map_jsonb_as_clob": {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
-						"map_long_varchar_as": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"max_file_size": {
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
-						"plugin_name": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"service_access_role_arn": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"slot_name": {
-							Type:     schema.TypeString,
-							Computed: true,
+				"mysql_settings": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"after_connect_script": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"authentication_method": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"clean_source_metadata_on_mismatch": {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
+							"events_poll_interval": {
+								Type:     schema.TypeInt,
+								Computed: true,
+							},
+							"execute_timeout": {
+								Type:     schema.TypeInt,
+								Computed: true,
+							},
+							"max_file_size": {
+								Type:     schema.TypeInt,
+								Computed: true,
+							},
+							"parallel_load_threads": {
+								Type:     schema.TypeInt,
+								Computed: true,
+							},
+							"server_timezone": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"service_access_role_arn": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"target_db_type": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
 						},
 					},
 				},
-			},
-			"redis_settings": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"auth_password": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"auth_type": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"auth_user_name": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						names.AttrPort: {
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
-						"server_name": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"ssl_ca_certificate_arn": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"ssl_security_protocol": {
-							Type:     schema.TypeString,
-							Computed: true,
+				names.AttrPassword: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrPort: {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
+				"postgres_settings": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"after_connect_script": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"authentication_method": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"babelfish_database_name": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"capture_ddls": {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
+							"database_mode": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"ddl_artifacts_schema": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"execute_timeout": {
+								Type:     schema.TypeInt,
+								Computed: true,
+							},
+							"fail_tasks_on_lob_truncation": {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
+							"heartbeat_enable": {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
+							"heartbeat_frequency": {
+								Type:     schema.TypeInt,
+								Computed: true,
+							},
+							"heartbeat_schema": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"map_boolean_as_boolean": {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
+							"map_jsonb_as_clob": {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
+							"map_long_varchar_as": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"max_file_size": {
+								Type:     schema.TypeInt,
+								Computed: true,
+							},
+							"plugin_name": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"service_access_role_arn": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"slot_name": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
 						},
 					},
 				},
-			},
-			"redshift_settings": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"bucket_folder": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						names.AttrBucketName: {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"encryption_mode": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"server_side_encryption_kms_key_id": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"service_access_role_arn": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-					},
-				},
-			},
-			"s3_settings": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"add_column_name": {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
-						"bucket_folder": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						names.AttrBucketName: {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"canned_acl_for_objects": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"cdc_inserts_and_updates": {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
-						"cdc_inserts_only": {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
-						"cdc_max_batch_interval": {
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
-						"cdc_min_file_size": {
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
-						"cdc_path": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"compression_type": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"csv_delimiter": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"csv_no_sup_value": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"csv_null_value": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"csv_row_delimiter": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"data_format": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"data_page_size": {
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
-						"date_partition_delimiter": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"date_partition_enabled": {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
-						"date_partition_sequence": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"dict_page_size_limit": {
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
-						"enable_statistics": {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
-						"encoding_type": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"encryption_mode": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"external_table_definition": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"glue_catalog_generation": {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
-						"ignore_headers_row": {
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
-						"ignore_header_rows": {
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
-						"include_op_for_full_load": {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
-						"max_file_size": {
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
-						"parquet_timestamp_in_millisecond": {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
-						"parquet_version": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"preserve_transactions": {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
-						"rfc_4180": {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
-						"row_group_length": {
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
-						"server_side_encryption_kms_key_id": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"service_access_role_arn": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"timestamp_column_name": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"use_csv_no_sup_value": {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
-						"use_task_start_time_for_full_load_timestamp": {
-							Type:     schema.TypeBool,
-							Computed: true,
+				"redis_settings": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"auth_password": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"auth_type": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"auth_user_name": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							names.AttrPort: {
+								Type:     schema.TypeInt,
+								Computed: true,
+							},
+							"server_name": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"ssl_ca_certificate_arn": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"ssl_security_protocol": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
 						},
 					},
 				},
-			},
-			"secrets_manager_access_role_arn": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"secrets_manager_arn": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"server_name": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"service_access_role": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"ssl_mode": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrUsername: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrTags: tftags.TagsSchemaComputed(),
+				"redshift_settings": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"bucket_folder": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							names.AttrBucketName: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"encryption_mode": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"server_side_encryption_kms_key_id": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"service_access_role_arn": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+						},
+					},
+				},
+				"s3_settings": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"add_column_name": {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
+							"bucket_folder": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							names.AttrBucketName: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"canned_acl_for_objects": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"cdc_inserts_and_updates": {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
+							"cdc_inserts_only": {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
+							"cdc_max_batch_interval": {
+								Type:     schema.TypeInt,
+								Computed: true,
+							},
+							"cdc_min_file_size": {
+								Type:     schema.TypeInt,
+								Computed: true,
+							},
+							"cdc_path": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"compression_type": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"csv_delimiter": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"csv_no_sup_value": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"csv_null_value": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"csv_row_delimiter": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"data_format": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"data_page_size": {
+								Type:     schema.TypeInt,
+								Computed: true,
+							},
+							"date_partition_delimiter": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"date_partition_enabled": {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
+							"date_partition_sequence": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"dict_page_size_limit": {
+								Type:     schema.TypeInt,
+								Computed: true,
+							},
+							"enable_statistics": {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
+							"encoding_type": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"encryption_mode": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"external_table_definition": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"glue_catalog_generation": {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
+							"ignore_headers_row": {
+								Type:     schema.TypeInt,
+								Computed: true,
+							},
+							"ignore_header_rows": {
+								Type:     schema.TypeInt,
+								Computed: true,
+							},
+							"include_op_for_full_load": {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
+							"max_file_size": {
+								Type:     schema.TypeInt,
+								Computed: true,
+							},
+							"parquet_timestamp_in_millisecond": {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
+							"parquet_version": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"preserve_transactions": {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
+							"rfc_4180": {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
+							"row_group_length": {
+								Type:     schema.TypeInt,
+								Computed: true,
+							},
+							"server_side_encryption_kms_key_id": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"service_access_role_arn": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"timestamp_column_name": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"use_csv_no_sup_value": {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
+							"use_task_start_time_for_full_load_timestamp": {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
+						},
+					},
+				},
+				"secrets_manager_access_role_arn": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"secrets_manager_arn": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"server_name": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"service_access_role": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"ssl_mode": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrUsername: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrTags: tftags.TagsSchemaComputed(),
+			}
 		},
 	}
 }

--- a/internal/service/dms/event_subscription.go
+++ b/internal/service/dms/event_subscription.go
@@ -49,49 +49,51 @@ func resourceEventSubscription() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrEnabled: {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
-			},
-			"event_categories": {
-				Type:     schema.TypeSet,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Required: true,
-			},
-			names.AttrName: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(1, 255),
-			},
-			names.AttrSNSTopicARN: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			"source_ids": {
-				Type:     schema.TypeSet,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Optional: true,
-				ForceNew: true,
-			},
-			names.AttrSourceType: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					"replication-instance",
-					"replication-task",
-				}, false),
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrEnabled: {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  true,
+				},
+				"event_categories": {
+					Type:     schema.TypeSet,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+					Required: true,
+				},
+				names.AttrName: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringLenBetween(1, 255),
+				},
+				names.AttrSNSTopicARN: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				"source_ids": {
+					Type:     schema.TypeSet,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+					Optional: true,
+					ForceNew: true,
+				},
+				names.AttrSourceType: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+					ValidateFunc: validation.StringInSlice([]string{
+						"replication-instance",
+						"replication-task",
+					}, false),
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			}
 		},
 	}
 }

--- a/internal/service/dms/replication_config.go
+++ b/internal/service/dms/replication_config.go
@@ -50,126 +50,128 @@ func resourceReplicationConfig() *schema.Resource {
 			Delete: schema.DefaultTimeout(60 * time.Minute),
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"compute_config": {
-				Type:     schema.TypeList,
-				Required: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrAvailabilityZone: {
-							Type:     schema.TypeString,
-							Optional: true,
-							Computed: true,
-							ForceNew: true,
-						},
-						"dns_name_servers": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						names.AttrKMSKeyID: {
-							Type:         schema.TypeString,
-							Optional:     true,
-							Computed:     true,
-							ForceNew:     true,
-							ValidateFunc: verify.ValidARN,
-						},
-						"max_capacity_units": {
-							Type:     schema.TypeInt,
-							Optional: true,
-						},
-						"min_capacity_units": {
-							Type:     schema.TypeInt,
-							Optional: true,
-						},
-						"multi_az": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Computed: true,
-						},
-						names.AttrPreferredMaintenanceWindow: {
-							Type:         schema.TypeString,
-							Optional:     true,
-							Computed:     true,
-							ValidateFunc: verify.ValidOnceAWeekWindowFormat,
-						},
-						"replication_subnet_group_id": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ForceNew:     true,
-							ValidateFunc: validReplicationSubnetGroupID,
-						},
-						names.AttrVPCSecurityGroupIDs: {
-							Type:     schema.TypeSet,
-							Optional: true,
-							Computed: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"compute_config": {
+					Type:     schema.TypeList,
+					Required: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrAvailabilityZone: {
+								Type:     schema.TypeString,
+								Optional: true,
+								Computed: true,
+								ForceNew: true,
+							},
+							"dns_name_servers": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+							names.AttrKMSKeyID: {
+								Type:         schema.TypeString,
+								Optional:     true,
+								Computed:     true,
+								ForceNew:     true,
+								ValidateFunc: verify.ValidARN,
+							},
+							"max_capacity_units": {
+								Type:     schema.TypeInt,
+								Optional: true,
+							},
+							"min_capacity_units": {
+								Type:     schema.TypeInt,
+								Optional: true,
+							},
+							"multi_az": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Computed: true,
+							},
+							names.AttrPreferredMaintenanceWindow: {
+								Type:         schema.TypeString,
+								Optional:     true,
+								Computed:     true,
+								ValidateFunc: verify.ValidOnceAWeekWindowFormat,
+							},
+							"replication_subnet_group_id": {
+								Type:         schema.TypeString,
+								Required:     true,
+								ForceNew:     true,
+								ValidateFunc: validReplicationSubnetGroupID,
+							},
+							names.AttrVPCSecurityGroupIDs: {
+								Type:     schema.TypeSet,
+								Optional: true,
+								Computed: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+							},
 						},
 					},
 				},
-			},
-			"replication_config_identifier": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			// "replication_settings" is equivalent to "replication_task_settings" on "aws_dms_replication_task"
-			// All changes to this field and supporting tests should be mirrored in "aws_dms_replication_task"
-			"replication_settings": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ValidateDiagFunc: validation.AllDiag(
-					validation.ToDiagFunc(validation.StringIsJSON),
-					validateReplicationSettings,
-				),
-				DiffSuppressFunc:      suppressEquivalentTaskSettings,
-				DiffSuppressOnRefresh: true,
-			},
-			"replication_type": {
-				Type:             schema.TypeString,
-				Required:         true,
-				ValidateDiagFunc: enum.Validate[awstypes.MigrationTypeValue](),
-			},
-			"resource_identifier": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
-			"source_endpoint_arn": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			"start_replication": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-			"supplemental_settings": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				ValidateFunc:     validation.StringIsJSON,
-				DiffSuppressFunc: verify.SuppressEquivalentJSONDiffs,
-			},
-			"table_mappings": {
-				Type:             schema.TypeString,
-				Required:         true,
-				ValidateFunc:     validation.StringIsJSON,
-				DiffSuppressFunc: verify.SuppressEquivalentJSONDiffs,
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			"target_endpoint_arn": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: verify.ValidARN,
-			},
+				"replication_config_identifier": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				// "replication_settings" is equivalent to "replication_task_settings" on "aws_dms_replication_task"
+				// All changes to this field and supporting tests should be mirrored in "aws_dms_replication_task"
+				"replication_settings": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+					ValidateDiagFunc: validation.AllDiag(
+						validation.ToDiagFunc(validation.StringIsJSON),
+						validateReplicationSettings,
+					),
+					DiffSuppressFunc:      suppressEquivalentTaskSettings,
+					DiffSuppressOnRefresh: true,
+				},
+				"replication_type": {
+					Type:             schema.TypeString,
+					Required:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.MigrationTypeValue](),
+				},
+				"resource_identifier": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+				},
+				"source_endpoint_arn": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				"start_replication": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
+				"supplemental_settings": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					ValidateFunc:     validation.StringIsJSON,
+					DiffSuppressFunc: verify.SuppressEquivalentJSONDiffs,
+				},
+				"table_mappings": {
+					Type:             schema.TypeString,
+					Required:         true,
+					ValidateFunc:     validation.StringIsJSON,
+					DiffSuppressFunc: verify.SuppressEquivalentJSONDiffs,
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				"target_endpoint_arn": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/dms/replication_instance.go
+++ b/internal/service/dms/replication_instance.go
@@ -48,134 +48,136 @@ func resourceReplicationInstance() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrAllocatedStorage: {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: validation.IntBetween(5, 6144),
-			},
-			names.AttrAllowMajorVersionUpgrade: {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
-			names.AttrApplyImmediately: {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
-			names.AttrAutoMinorVersionUpgrade: {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Computed: true,
-			},
-			names.AttrAvailabilityZone: {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
-			"dns_name_servers": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
-			names.AttrEngineVersion: {
-				Type:     schema.TypeString,
-				Computed: true,
-				Optional: true,
-			},
-			"kerberos_authentication_settings": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"key_cache_secret_iam_arn": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: verify.ValidARN,
-						},
-						"key_cache_secret_id": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"krb5_file_contents": {
-							Type:     schema.TypeString,
-							Required: true,
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrAllocatedStorage: {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					Computed:     true,
+					ValidateFunc: validation.IntBetween(5, 6144),
+				},
+				names.AttrAllowMajorVersionUpgrade: {
+					Type:     schema.TypeBool,
+					Optional: true,
+				},
+				names.AttrApplyImmediately: {
+					Type:     schema.TypeBool,
+					Optional: true,
+				},
+				names.AttrAutoMinorVersionUpgrade: {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Computed: true,
+				},
+				names.AttrAvailabilityZone: {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+				},
+				"dns_name_servers": {
+					Type:     schema.TypeString,
+					Optional: true,
+					ForceNew: true,
+				},
+				names.AttrEngineVersion: {
+					Type:     schema.TypeString,
+					Computed: true,
+					Optional: true,
+				},
+				"kerberos_authentication_settings": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"key_cache_secret_iam_arn": {
+								Type:         schema.TypeString,
+								Required:     true,
+								ValidateFunc: verify.ValidARN,
+							},
+							"key_cache_secret_id": {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+							"krb5_file_contents": {
+								Type:     schema.TypeString,
+								Required: true,
+							},
 						},
 					},
 				},
-			},
-			names.AttrKMSKeyARN: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			"multi_az": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Computed: true,
-			},
-			"network_type": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: validation.StringInSlice(networkType_Values(), false),
-			},
-			names.AttrPreferredMaintenanceWindow: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: verify.ValidOnceAWeekWindowFormat,
-			},
-			names.AttrPubliclyAccessible: {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
-			"replication_instance_arn": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"replication_instance_class": {
-				Type:     schema.TypeString,
-				Required: true,
-				// Valid Values: dms.t2.micro | dms.t2.small | dms.t2.medium | dms.t2.large | dms.c4.large |
-				// dms.c4.xlarge | dms.c4.2xlarge | dms.c4.4xlarge
-			},
-			"replication_instance_id": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validReplicationInstanceID,
-			},
-			"replication_instance_private_ips": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			"replication_instance_public_ips": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			"replication_subnet_group_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			names.AttrVPCSecurityGroupIDs: {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
+				names.AttrKMSKeyARN: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Computed:     true,
+					ForceNew:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				"multi_az": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Computed: true,
+				},
+				"network_type": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Computed:     true,
+					ValidateFunc: validation.StringInSlice(networkType_Values(), false),
+				},
+				names.AttrPreferredMaintenanceWindow: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Computed:     true,
+					ValidateFunc: verify.ValidOnceAWeekWindowFormat,
+				},
+				names.AttrPubliclyAccessible: {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+				},
+				"replication_instance_arn": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"replication_instance_class": {
+					Type:     schema.TypeString,
+					Required: true,
+					// Valid Values: dms.t2.micro | dms.t2.small | dms.t2.medium | dms.t2.large | dms.c4.large |
+					// dms.c4.xlarge | dms.c4.2xlarge | dms.c4.4xlarge
+				},
+				"replication_instance_id": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validReplicationInstanceID,
+				},
+				"replication_instance_private_ips": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"replication_instance_public_ips": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"replication_subnet_group_id": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				names.AttrVPCSecurityGroupIDs: {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+			}
 		},
 	}
 }

--- a/internal/service/dms/replication_instance_data_source.go
+++ b/internal/service/dms/replication_instance_data_source.go
@@ -25,76 +25,78 @@ func dataSourceReplicationInstance() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceReplicationInstanceRead,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrAllocatedStorage: {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-			names.AttrAutoMinorVersionUpgrade: {
-				Type:     schema.TypeBool,
-				Computed: true,
-			},
-			names.AttrAvailabilityZone: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrEngineVersion: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrKMSKeyARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"multi_az": {
-				Type:     schema.TypeBool,
-				Computed: true,
-			},
-			"network_type": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrPreferredMaintenanceWindow: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrPubliclyAccessible: {
-				Type:     schema.TypeBool,
-				Computed: true,
-			},
-			"replication_instance_arn": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"replication_instance_class": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"replication_instance_id": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"replication_instance_private_ips": {
-				Type:     schema.TypeList,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Computed: true,
-			},
-			"replication_instance_public_ips": {
-				Type:     schema.TypeList,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Computed: true,
-			},
-			"replication_subnet_group_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrTags: tftags.TagsSchemaComputed(),
-			names.AttrVPCSecurityGroupIDs: {
-				Type:     schema.TypeSet,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Set:      schema.HashString,
-				Computed: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrAllocatedStorage: {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
+				names.AttrAutoMinorVersionUpgrade: {
+					Type:     schema.TypeBool,
+					Computed: true,
+				},
+				names.AttrAvailabilityZone: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrEngineVersion: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrKMSKeyARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"multi_az": {
+					Type:     schema.TypeBool,
+					Computed: true,
+				},
+				"network_type": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrPreferredMaintenanceWindow: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrPubliclyAccessible: {
+					Type:     schema.TypeBool,
+					Computed: true,
+				},
+				"replication_instance_arn": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"replication_instance_class": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"replication_instance_id": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"replication_instance_private_ips": {
+					Type:     schema.TypeList,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+					Computed: true,
+				},
+				"replication_instance_public_ips": {
+					Type:     schema.TypeList,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+					Computed: true,
+				},
+				"replication_subnet_group_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrTags: tftags.TagsSchemaComputed(),
+				names.AttrVPCSecurityGroupIDs: {
+					Type:     schema.TypeSet,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+					Set:      schema.HashString,
+					Computed: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/dms/replication_subnet_group.go
+++ b/internal/service/dms/replication_subnet_group.go
@@ -40,33 +40,35 @@ func resourceReplicationSubnetGroup() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"replication_subnet_group_arn": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"replication_subnet_group_description": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"replication_subnet_group_id": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validReplicationSubnetGroupID,
-			},
-			names.AttrSubnetIDs: {
-				Type:     schema.TypeSet,
-				MinItems: 2,
-				Required: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			names.AttrVPCID: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"replication_subnet_group_arn": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"replication_subnet_group_description": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"replication_subnet_group_id": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validReplicationSubnetGroupID,
+				},
+				names.AttrSubnetIDs: {
+					Type:     schema.TypeSet,
+					MinItems: 2,
+					Required: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				names.AttrVPCID: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/dms/replication_subnet_group_data_source.go
+++ b/internal/service/dms/replication_subnet_group_data_source.go
@@ -27,33 +27,35 @@ func dataSourceReplicationSubnetGroup() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceReplicationSubnetGroupRead,
 
-		Schema: map[string]*schema.Schema{
-			"replication_subnet_group_arn": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"replication_subnet_group_description": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"replication_subnet_group_id": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"subnet_group_status": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrSubnetIDs: {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			names.AttrTags: tftags.TagsSchemaComputed(),
-			names.AttrVPCID: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"replication_subnet_group_arn": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"replication_subnet_group_description": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"replication_subnet_group_id": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"subnet_group_status": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrSubnetIDs: {
+					Type:     schema.TypeSet,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				names.AttrTags: tftags.TagsSchemaComputed(),
+				names.AttrVPCID: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/dms/replication_task.go
+++ b/internal/service/dms/replication_task.go
@@ -46,92 +46,94 @@ func resourceReplicationTask() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"cdc_start_position": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				ConflictsWith: []string{"cdc_start_time"},
-			},
-			"cdc_start_time": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				ValidateFunc:  verify.ValidStringDateOrPositiveInt,
-				ConflictsWith: []string{"cdc_start_position"},
-			},
-			"migration_type": {
-				Type:             schema.TypeString,
-				Required:         true,
-				ValidateDiagFunc: enum.Validate[awstypes.MigrationTypeValue](),
-			},
-			"replication_instance_arn": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			"replication_task_arn": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"replication_task_id": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validReplicationTaskID,
-			},
-			// "replication_task_settings" is equivalent to "replication_settings" on "aws_dms_replication_config"
-			// All changes to this field and supporting tests should be mirrored in "aws_dms_replication_config"
-			"replication_task_settings": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ValidateDiagFunc: validation.AllDiag(
-					validation.ToDiagFunc(validation.StringIsJSON),
-					validateReplicationSettings,
-				),
-				DiffSuppressFunc:      suppressEquivalentTaskSettings,
-				DiffSuppressOnRefresh: true,
-			},
-			"resource_identifier": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				ValidateFunc: validation.All(
-					validation.StringLenBetween(1, 31),
-					validation.StringMatch(regexache.MustCompile("^[A-Za-z][0-9A-Za-z-]+$"), "must start with a letter, only contain alphanumeric characters and hyphens"),
-					validation.StringDoesNotMatch(regexache.MustCompile(`--`), "cannot contain two consecutive hyphens"),
-					validation.StringDoesNotMatch(regexache.MustCompile(`-$`), "cannot end in a hyphen"),
-				),
-			},
-			"source_endpoint_arn": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			"start_replication_task": {
-				Type:     schema.TypeBool,
-				Default:  false,
-				Optional: true,
-			},
-			names.AttrStatus: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"table_mappings": {
-				Type:             schema.TypeString,
-				Required:         true,
-				ValidateFunc:     validation.StringIsJSON,
-				DiffSuppressFunc: verify.SuppressEquivalentJSONDiffs,
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			"target_endpoint_arn": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidARN,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"cdc_start_position": {
+					Type:          schema.TypeString,
+					Optional:      true,
+					Computed:      true,
+					ConflictsWith: []string{"cdc_start_time"},
+				},
+				"cdc_start_time": {
+					Type:          schema.TypeString,
+					Optional:      true,
+					ValidateFunc:  verify.ValidStringDateOrPositiveInt,
+					ConflictsWith: []string{"cdc_start_position"},
+				},
+				"migration_type": {
+					Type:             schema.TypeString,
+					Required:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.MigrationTypeValue](),
+				},
+				"replication_instance_arn": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				"replication_task_arn": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"replication_task_id": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validReplicationTaskID,
+				},
+				// "replication_task_settings" is equivalent to "replication_settings" on "aws_dms_replication_config"
+				// All changes to this field and supporting tests should be mirrored in "aws_dms_replication_config"
+				"replication_task_settings": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+					ValidateDiagFunc: validation.AllDiag(
+						validation.ToDiagFunc(validation.StringIsJSON),
+						validateReplicationSettings,
+					),
+					DiffSuppressFunc:      suppressEquivalentTaskSettings,
+					DiffSuppressOnRefresh: true,
+				},
+				"resource_identifier": {
+					Type:     schema.TypeString,
+					Optional: true,
+					ForceNew: true,
+					ValidateFunc: validation.All(
+						validation.StringLenBetween(1, 31),
+						validation.StringMatch(regexache.MustCompile("^[A-Za-z][0-9A-Za-z-]+$"), "must start with a letter, only contain alphanumeric characters and hyphens"),
+						validation.StringDoesNotMatch(regexache.MustCompile(`--`), "cannot contain two consecutive hyphens"),
+						validation.StringDoesNotMatch(regexache.MustCompile(`-$`), "cannot end in a hyphen"),
+					),
+				},
+				"source_endpoint_arn": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				"start_replication_task": {
+					Type:     schema.TypeBool,
+					Default:  false,
+					Optional: true,
+				},
+				names.AttrStatus: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"table_mappings": {
+					Type:             schema.TypeString,
+					Required:         true,
+					ValidateFunc:     validation.StringIsJSON,
+					DiffSuppressFunc: verify.SuppressEquivalentJSONDiffs,
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				"target_endpoint_arn": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/dms/replication_task_data_source.go
+++ b/internal/service/dms/replication_task_data_source.go
@@ -23,56 +23,58 @@ func dataSourceReplicationTask() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceReplicationTaskRead,
 
-		Schema: map[string]*schema.Schema{
-			"cdc_start_position": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"cdc_start_time": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"migration_type": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"replication_instance_arn": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"replication_task_arn": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"replication_task_id": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"replication_task_settings": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"source_endpoint_arn": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"start_replication_task": {
-				Type:     schema.TypeBool,
-				Computed: true,
-			},
-			names.AttrStatus: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"table_mappings": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrTags: tftags.TagsSchemaComputed(),
-			"target_endpoint_arn": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"cdc_start_position": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"cdc_start_time": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"migration_type": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"replication_instance_arn": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"replication_task_arn": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"replication_task_id": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"replication_task_settings": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"source_endpoint_arn": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"start_replication_task": {
+					Type:     schema.TypeBool,
+					Computed: true,
+				},
+				names.AttrStatus: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"table_mappings": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrTags: tftags.TagsSchemaComputed(),
+				"target_endpoint_arn": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/dms/s3_endpoint.go
+++ b/internal/service/dms/s3_endpoint.go
@@ -48,276 +48,278 @@ func resourceS3Endpoint() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrCertificateARN: {
-				Type:         schema.TypeString,
-				Computed:     true,
-				Optional:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			"endpoint_arn": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"endpoint_id": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validEndpointID,
-			},
-			names.AttrEndpointType: {
-				Type:             schema.TypeString,
-				Required:         true,
-				ValidateDiagFunc: enum.Validate[awstypes.ReplicationEndpointTypeValue](),
-			},
-			"engine_display_name": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrExternalID: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrKMSKeyARN: {
-				Type:         schema.TypeString,
-				Computed:     true,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			"ssl_mode": {
-				Type:             schema.TypeString,
-				Computed:         true,
-				Optional:         true,
-				ValidateDiagFunc: enum.Validate[awstypes.DmsSslModeValue](),
-			},
-			names.AttrStatus: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrCertificateARN: {
+					Type:         schema.TypeString,
+					Computed:     true,
+					Optional:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				"endpoint_arn": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"endpoint_id": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validEndpointID,
+				},
+				names.AttrEndpointType: {
+					Type:             schema.TypeString,
+					Required:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.ReplicationEndpointTypeValue](),
+				},
+				"engine_display_name": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrExternalID: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrKMSKeyARN: {
+					Type:         schema.TypeString,
+					Computed:     true,
+					Optional:     true,
+					ForceNew:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				"ssl_mode": {
+					Type:             schema.TypeString,
+					Computed:         true,
+					Optional:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.DmsSslModeValue](),
+				},
+				names.AttrStatus: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
 
-			/////// S3-Specific Settings
-			"add_column_name": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-			"add_trailing_padding_character": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
-			"bucket_folder": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			names.AttrBucketName: {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"canned_acl_for_objects": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				ValidateDiagFunc: enum.ValidateIgnoreCase[awstypes.CannedAclForObjectsValue](),
-				StateFunc: func(v any) string {
-					return strings.ToLower(v.(string))
+				/////// S3-Specific Settings
+				"add_column_name": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  false,
 				},
-			},
-			"cdc_inserts_and_updates": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-			"cdc_inserts_only": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-			"cdc_max_batch_interval": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				ValidateFunc: validation.IntAtLeast(0),
-			},
-			"cdc_min_file_size": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				ValidateFunc: validation.IntAtLeast(0),
-			},
-			"cdc_path": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"compression_type": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				ValidateDiagFunc: enum.ValidateIgnoreCase[awstypes.CompressionTypeValue](),
-				Default:          strings.ToUpper(string(awstypes.CompressionTypeValueNone)),
-				StateFunc: func(v any) string {
-					return strings.ToUpper(v.(string))
+				"add_trailing_padding_character": {
+					Type:     schema.TypeBool,
+					Optional: true,
 				},
-			},
-			"csv_delimiter": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  ",",
-			},
-			"csv_no_sup_value": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"csv_null_value": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"csv_row_delimiter": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  "\\n",
-			},
-			"data_format": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				ValidateDiagFunc: enum.Validate[awstypes.DataFormatValue](),
-			},
-			"data_page_size": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				ValidateFunc: validation.IntAtLeast(0),
-			},
-			"date_partition_delimiter": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				ValidateDiagFunc: enum.ValidateIgnoreCase[awstypes.DatePartitionDelimiterValue](),
-				StateFunc: func(v any) string {
-					return strings.ToUpper(v.(string))
+				"bucket_folder": {
+					Type:     schema.TypeString,
+					Optional: true,
 				},
-			},
-			"date_partition_enabled": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-			"date_partition_sequence": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				ValidateDiagFunc: enum.ValidateIgnoreCase[awstypes.DatePartitionSequenceValue](),
-				StateFunc: func(v any) string {
-					return strings.ToLower(v.(string))
+				names.AttrBucketName: {
+					Type:     schema.TypeString,
+					Required: true,
 				},
-			},
-			"date_partition_timezone": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"detach_target_on_lob_lookup_failure_parquet": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
-			"dict_page_size_limit": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				ValidateFunc: validation.IntAtLeast(0),
-			},
-			"enable_statistics": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
-			},
-			"encoding_type": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				ValidateDiagFunc: enum.Validate[awstypes.EncodingTypeValue](),
-			},
-			"encryption_mode": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringInSlice(encryptionMode_Values(), false),
-			},
-			names.AttrExpectedBucketOwner: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: verify.ValidAccountID,
-			},
-			"external_table_definition": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringIsJSON,
-				StateFunc: func(v any) string {
-					json, _ := structure.NormalizeJsonString(v)
-					return json
+				"canned_acl_for_objects": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					ValidateDiagFunc: enum.ValidateIgnoreCase[awstypes.CannedAclForObjectsValue](),
+					StateFunc: func(v any) string {
+						return strings.ToLower(v.(string))
+					},
 				},
-			},
-			"glue_catalog_generation": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-			"ignore_header_rows": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.IntInSlice([]int{0, 1}),
-			},
-			"include_op_for_full_load": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-			"max_file_size": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				ValidateFunc: validation.IntBetween(1, 1048576),
-			},
-			"parquet_timestamp_in_millisecond": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-			"parquet_version": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				ValidateDiagFunc: enum.Validate[awstypes.ParquetVersionValue](),
-			},
-			"preserve_transactions": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-			"rfc_4180": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
-			},
-			"row_group_length": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				ValidateFunc: validation.IntAtLeast(0),
-			},
-			"server_side_encryption_kms_key_id": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			"service_access_role_arn": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			"timestamp_column_name": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"use_csv_no_sup_value": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-			"use_task_start_time_for_full_load_timestamp": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
+				"cdc_inserts_and_updates": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
+				"cdc_inserts_only": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
+				"cdc_max_batch_interval": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					ValidateFunc: validation.IntAtLeast(0),
+				},
+				"cdc_min_file_size": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					ValidateFunc: validation.IntAtLeast(0),
+				},
+				"cdc_path": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"compression_type": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					ValidateDiagFunc: enum.ValidateIgnoreCase[awstypes.CompressionTypeValue](),
+					Default:          strings.ToUpper(string(awstypes.CompressionTypeValueNone)),
+					StateFunc: func(v any) string {
+						return strings.ToUpper(v.(string))
+					},
+				},
+				"csv_delimiter": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Default:  ",",
+				},
+				"csv_no_sup_value": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"csv_null_value": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"csv_row_delimiter": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Default:  "\\n",
+				},
+				"data_format": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.DataFormatValue](),
+				},
+				"data_page_size": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					ValidateFunc: validation.IntAtLeast(0),
+				},
+				"date_partition_delimiter": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					ValidateDiagFunc: enum.ValidateIgnoreCase[awstypes.DatePartitionDelimiterValue](),
+					StateFunc: func(v any) string {
+						return strings.ToUpper(v.(string))
+					},
+				},
+				"date_partition_enabled": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
+				"date_partition_sequence": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					ValidateDiagFunc: enum.ValidateIgnoreCase[awstypes.DatePartitionSequenceValue](),
+					StateFunc: func(v any) string {
+						return strings.ToLower(v.(string))
+					},
+				},
+				"date_partition_timezone": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"detach_target_on_lob_lookup_failure_parquet": {
+					Type:     schema.TypeBool,
+					Optional: true,
+				},
+				"dict_page_size_limit": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					ValidateFunc: validation.IntAtLeast(0),
+				},
+				"enable_statistics": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  true,
+				},
+				"encoding_type": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.EncodingTypeValue](),
+				},
+				"encryption_mode": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringInSlice(encryptionMode_Values(), false),
+				},
+				names.AttrExpectedBucketOwner: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: verify.ValidAccountID,
+				},
+				"external_table_definition": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringIsJSON,
+					StateFunc: func(v any) string {
+						json, _ := structure.NormalizeJsonString(v)
+						return json
+					},
+				},
+				"glue_catalog_generation": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
+				"ignore_header_rows": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.IntInSlice([]int{0, 1}),
+				},
+				"include_op_for_full_load": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
+				"max_file_size": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					ValidateFunc: validation.IntBetween(1, 1048576),
+				},
+				"parquet_timestamp_in_millisecond": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
+				"parquet_version": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.ParquetVersionValue](),
+				},
+				"preserve_transactions": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
+				"rfc_4180": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  true,
+				},
+				"row_group_length": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					ValidateFunc: validation.IntAtLeast(0),
+				},
+				"server_side_encryption_kms_key_id": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				"service_access_role_arn": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				"timestamp_column_name": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"use_csv_no_sup_value": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
+				"use_task_start_time_for_full_load_timestamp": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/docdb/cluster.go
+++ b/internal/service/docdb/cluster.go
@@ -61,324 +61,326 @@ func resourceCluster() *schema.Resource {
 			Delete: schema.DefaultTimeout(120 * time.Minute),
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrAllowMajorVersionUpgrade: {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
-			names.AttrApplyImmediately: {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrAvailabilityZones: {
-				Type:     schema.TypeSet,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
-			"backup_retention_period": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				Default:      1,
-				ValidateFunc: validation.IntAtMost(35),
-			},
-			names.AttrClusterIdentifier: {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				ForceNew:      true,
-				ConflictsWith: []string{"cluster_identifier_prefix"},
-				ValidateFunc:  validIdentifier,
-			},
-			"cluster_identifier_prefix": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				ForceNew:      true,
-				ConflictsWith: []string{names.AttrClusterIdentifier},
-				ValidateFunc:  validIdentifierPrefix,
-			},
-			"cluster_members": {
-				Type:     schema.TypeSet,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Optional: true,
-				Computed: true,
-			},
-			"cluster_resource_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"db_cluster_parameter_group_name": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-			"db_subnet_group_name": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
-			names.AttrDeletionProtection: {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
-			"enabled_cloudwatch_logs_exports": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-					ValidateFunc: validation.StringInSlice([]string{
-						"audit",
-						"profiler",
-					}, false),
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrAllowMajorVersionUpgrade: {
+					Type:     schema.TypeBool,
+					Optional: true,
 				},
-			},
-			names.AttrEndpoint: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrEngine: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				Default:      engineDocDB,
-				ValidateFunc: validation.StringInSlice(engine_Values(), false),
-			},
-			names.AttrEngineVersion: {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-			names.AttrFinalSnapshotIdentifier: {
-				Type:     schema.TypeString,
-				Optional: true,
-				ValidateFunc: func(v any, k string) (ws []string, es []error) {
-					value := v.(string)
-					if !regexache.MustCompile(`^[0-9A-Za-z-]+$`).MatchString(value) {
-						es = append(es, fmt.Errorf(
-							"only alphanumeric characters and hyphens allowed in %q", k))
-					}
-					if regexache.MustCompile(`--`).MatchString(value) {
-						es = append(es, fmt.Errorf("%q cannot contain two consecutive hyphens", k))
-					}
-					if regexache.MustCompile(`-$`).MatchString(value) {
-						es = append(es, fmt.Errorf("%q cannot end in a hyphen", k))
-					}
-					return
+				names.AttrApplyImmediately: {
+					Type:     schema.TypeBool,
+					Optional: true,
 				},
-			},
-			"global_cluster_identifier": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validGlobalCusterIdentifier,
-			},
-			names.AttrHostedZoneID: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrKMSKeyID: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			"manage_master_user_password": {
-				Type:          schema.TypeBool,
-				Optional:      true,
-				ConflictsWith: []string{"master_password", "master_password_wo"},
-			},
-			"master_password": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Sensitive:     true,
-				ConflictsWith: []string{"manage_master_user_password", "master_password_wo"},
-			},
-			"master_password_wo": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				WriteOnly:     true,
-				ConflictsWith: []string{"manage_master_user_password", "master_password"},
-				RequiredWith:  []string{"master_password_wo_version"},
-			},
-			"master_password_wo_version": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				RequiredWith: []string{"master_password_wo"},
-			},
-			"master_user_secret": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrKMSKeyID: {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"secret_arn": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"secret_status": {
-							Type:     schema.TypeString,
-							Computed: true,
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrAvailabilityZones: {
+					Type:     schema.TypeSet,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+				},
+				"backup_retention_period": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					Default:      1,
+					ValidateFunc: validation.IntAtMost(35),
+				},
+				names.AttrClusterIdentifier: {
+					Type:          schema.TypeString,
+					Optional:      true,
+					Computed:      true,
+					ForceNew:      true,
+					ConflictsWith: []string{"cluster_identifier_prefix"},
+					ValidateFunc:  validIdentifier,
+				},
+				"cluster_identifier_prefix": {
+					Type:          schema.TypeString,
+					Optional:      true,
+					Computed:      true,
+					ForceNew:      true,
+					ConflictsWith: []string{names.AttrClusterIdentifier},
+					ValidateFunc:  validIdentifierPrefix,
+				},
+				"cluster_members": {
+					Type:     schema.TypeSet,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+					Optional: true,
+					Computed: true,
+				},
+				"cluster_resource_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"db_cluster_parameter_group_name": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+				},
+				"db_subnet_group_name": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+				},
+				names.AttrDeletionProtection: {
+					Type:     schema.TypeBool,
+					Optional: true,
+				},
+				"enabled_cloudwatch_logs_exports": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Elem: &schema.Schema{
+						Type: schema.TypeString,
+						ValidateFunc: validation.StringInSlice([]string{
+							"audit",
+							"profiler",
+						}, false),
+					},
+				},
+				names.AttrEndpoint: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrEngine: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ForceNew:     true,
+					Default:      engineDocDB,
+					ValidateFunc: validation.StringInSlice(engine_Values(), false),
+				},
+				names.AttrEngineVersion: {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+				},
+				names.AttrFinalSnapshotIdentifier: {
+					Type:     schema.TypeString,
+					Optional: true,
+					ValidateFunc: func(v any, k string) (ws []string, es []error) {
+						value := v.(string)
+						if !regexache.MustCompile(`^[0-9A-Za-z-]+$`).MatchString(value) {
+							es = append(es, fmt.Errorf(
+								"only alphanumeric characters and hyphens allowed in %q", k))
+						}
+						if regexache.MustCompile(`--`).MatchString(value) {
+							es = append(es, fmt.Errorf("%q cannot contain two consecutive hyphens", k))
+						}
+						if regexache.MustCompile(`-$`).MatchString(value) {
+							es = append(es, fmt.Errorf("%q cannot end in a hyphen", k))
+						}
+						return
+					},
+				},
+				"global_cluster_identifier": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validGlobalCusterIdentifier,
+				},
+				names.AttrHostedZoneID: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrKMSKeyID: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Computed:     true,
+					ForceNew:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				"manage_master_user_password": {
+					Type:          schema.TypeBool,
+					Optional:      true,
+					ConflictsWith: []string{"master_password", "master_password_wo"},
+				},
+				"master_password": {
+					Type:          schema.TypeString,
+					Optional:      true,
+					Sensitive:     true,
+					ConflictsWith: []string{"manage_master_user_password", "master_password_wo"},
+				},
+				"master_password_wo": {
+					Type:          schema.TypeString,
+					Optional:      true,
+					WriteOnly:     true,
+					ConflictsWith: []string{"manage_master_user_password", "master_password"},
+					RequiredWith:  []string{"master_password_wo_version"},
+				},
+				"master_password_wo_version": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					RequiredWith: []string{"master_password_wo"},
+				},
+				"master_user_secret": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrKMSKeyID: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"secret_arn": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"secret_status": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
 						},
 					},
 				},
-			},
-			"master_username": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
-			"network_type": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: validation.StringInSlice(networkType_Values(), false),
-			},
-			names.AttrPort: {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				ForceNew:     true,
-				Default:      27017,
-				ValidateFunc: validation.IntBetween(1150, 65535),
-			},
-			"preferred_backup_window": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: verify.ValidOnceADayWindowFormat,
-			},
-			names.AttrPreferredMaintenanceWindow: {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				StateFunc: func(val any) string {
-					if val == nil {
-						return ""
-					}
-					return strings.ToLower(val.(string))
+				"master_username": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
 				},
-				ValidateFunc: verify.ValidOnceAWeekWindowFormat,
-			},
-			"reader_endpoint": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"restore_to_point_in_time": {
-				Type:     schema.TypeList,
-				Optional: true,
-				ForceNew: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"restore_to_time": {
-							Type:          schema.TypeString,
-							Optional:      true,
-							ForceNew:      true,
-							ValidateFunc:  verify.ValidUTCTimestamp,
-							ConflictsWith: []string{"restore_to_point_in_time.0.use_latest_restorable_time"},
+				"network_type": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Computed:     true,
+					ValidateFunc: validation.StringInSlice(networkType_Values(), false),
+				},
+				names.AttrPort: {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					ForceNew:     true,
+					Default:      27017,
+					ValidateFunc: validation.IntBetween(1150, 65535),
+				},
+				"preferred_backup_window": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Computed:     true,
+					ValidateFunc: verify.ValidOnceADayWindowFormat,
+				},
+				names.AttrPreferredMaintenanceWindow: {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+					StateFunc: func(val any) string {
+						if val == nil {
+							return ""
+						}
+						return strings.ToLower(val.(string))
+					},
+					ValidateFunc: verify.ValidOnceAWeekWindowFormat,
+				},
+				"reader_endpoint": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"restore_to_point_in_time": {
+					Type:     schema.TypeList,
+					Optional: true,
+					ForceNew: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"restore_to_time": {
+								Type:          schema.TypeString,
+								Optional:      true,
+								ForceNew:      true,
+								ValidateFunc:  verify.ValidUTCTimestamp,
+								ConflictsWith: []string{"restore_to_point_in_time.0.use_latest_restorable_time"},
+							},
+							"restore_type": {
+								Type:         schema.TypeString,
+								Optional:     true,
+								ForceNew:     true,
+								ValidateFunc: validation.StringInSlice(restoreType_Values(), false),
+							},
+							"source_cluster_identifier": {
+								Type:     schema.TypeString,
+								Required: true,
+								ForceNew: true,
+							},
+							"use_latest_restorable_time": {
+								Type:          schema.TypeBool,
+								Optional:      true,
+								ForceNew:      true,
+								ConflictsWith: []string{"restore_to_point_in_time.0.restore_to_time"},
+							},
 						},
-						"restore_type": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							ForceNew:     true,
-							ValidateFunc: validation.StringInSlice(restoreType_Values(), false),
-						},
-						"source_cluster_identifier": {
-							Type:     schema.TypeString,
-							Required: true,
-							ForceNew: true,
-						},
-						"use_latest_restorable_time": {
-							Type:          schema.TypeBool,
-							Optional:      true,
-							ForceNew:      true,
-							ConflictsWith: []string{"restore_to_point_in_time.0.restore_to_time"},
+					},
+					ConflictsWith: []string{
+						"snapshot_identifier",
+					},
+				},
+				"serverless_v2_scaling_configuration": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrMaxCapacity: {
+								Type:     schema.TypeFloat,
+								Required: true,
+								ValidateFunc: validation.All(
+									validation.FloatBetween(1.0, 256.0),
+									validateServerlessCapacity,
+								),
+							},
+							"min_capacity": {
+								Type:     schema.TypeFloat,
+								Required: true,
+								ValidateFunc: validation.All(
+									validation.FloatBetween(0.5, 256.0),
+									validateServerlessCapacity,
+								),
+							},
 						},
 					},
 				},
-				ConflictsWith: []string{
-					"snapshot_identifier",
+				"skip_final_snapshot": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  false,
 				},
-			},
-			"serverless_v2_scaling_configuration": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrMaxCapacity: {
-							Type:     schema.TypeFloat,
-							Required: true,
-							ValidateFunc: validation.All(
-								validation.FloatBetween(1.0, 256.0),
-								validateServerlessCapacity,
-							),
-						},
-						"min_capacity": {
-							Type:     schema.TypeFloat,
-							Required: true,
-							ValidateFunc: validation.All(
-								validation.FloatBetween(0.5, 256.0),
-								validateServerlessCapacity,
-							),
-						},
+				"snapshot_identifier": {
+					Type:     schema.TypeString,
+					Optional: true,
+					ForceNew: true,
+					DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+						// allow snapshot_idenfitier to be removed without forcing re-creation
+						return new == ""
+					},
+					ConflictsWith: []string{
+						"restore_to_point_in_time",
 					},
 				},
-			},
-			"skip_final_snapshot": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-			"snapshot_identifier": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					// allow snapshot_idenfitier to be removed without forcing re-creation
-					return new == ""
+				names.AttrStorageEncrypted: {
+					Type:     schema.TypeBool,
+					Optional: true,
+					ForceNew: true,
 				},
-				ConflictsWith: []string{
-					"restore_to_point_in_time",
+				names.AttrStorageType: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringInSlice(storageType_Values(), false),
+					DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+						// When you create a DocumentDB DB cluster with the storage type set to "iopt1",
+						// the storage type is returned in the response.
+						// The storage type isn't returned when you set it to "standard".
+						if old == "" && new == storageTypeStandard {
+							return true
+						}
+						return old == new
+					},
 				},
-			},
-			names.AttrStorageEncrypted: {
-				Type:     schema.TypeBool,
-				Optional: true,
-				ForceNew: true,
-			},
-			names.AttrStorageType: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringInSlice(storageType_Values(), false),
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					// When you create a DocumentDB DB cluster with the storage type set to "iopt1",
-					// the storage type is returned in the response.
-					// The storage type isn't returned when you set it to "standard".
-					if old == "" && new == storageTypeStandard {
-						return true
-					}
-					return old == new
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				names.AttrVPCSecurityGroupIDs: {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
 				},
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			names.AttrVPCSecurityGroupIDs: {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
+			}
 		},
 		CustomizeDiff: customdiff.All(
 			// ForceNew only when removing serverless_v2_scaling_configuration; adding or modifying is supported in-place.

--- a/internal/service/docdb/cluster_instance.go
+++ b/internal/service/docdb/cluster_instance.go
@@ -49,141 +49,143 @@ func resourceClusterInstance() *schema.Resource {
 			Delete: schema.DefaultTimeout(90 * time.Minute),
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrApplyImmediately: {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrAutoMinorVersionUpgrade: {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
-			},
-			names.AttrAvailabilityZone: {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
-			"ca_cert_identifier": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-			"certificate_rotation_restart": {
-				Type:         nullable.TypeNullableBool,
-				Optional:     true,
-				ValidateFunc: nullable.ValidateTypeStringNullableBool,
-			},
-			names.AttrClusterIdentifier: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"copy_tags_to_snapshot": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
-			"db_subnet_group_name": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"dbi_resource_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"enable_performance_insights": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
-			names.AttrEndpoint: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrEngine: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				Default:      engineDocDB,
-				ValidateFunc: validation.StringInSlice(engine_Values(), false),
-			},
-			names.AttrEngineVersion: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrIdentifier: {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				ForceNew:      true,
-				ConflictsWith: []string{"identifier_prefix"},
-				ValidateFunc:  validIdentifier,
-			},
-			"identifier_prefix": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ForceNew:     true,
-				ValidateFunc: validIdentifierPrefix,
-			},
-			"instance_class": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			names.AttrKMSKeyID: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"performance_insights_kms_key_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-			names.AttrPort: {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-			"preferred_backup_window": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrPreferredMaintenanceWindow: {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				StateFunc: func(v any) string {
-					if v != nil {
-						value := v.(string)
-						return strings.ToLower(value)
-					}
-					return ""
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrApplyImmediately: {
+					Type:     schema.TypeBool,
+					Optional: true,
 				},
-				ValidateFunc: verify.ValidOnceAWeekWindowFormat,
-			},
-			"promotion_tier": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				Default:      0,
-				ValidateFunc: validation.IntBetween(0, 15),
-			},
-			names.AttrPubliclyAccessible: {
-				Type:     schema.TypeBool,
-				Computed: true,
-			},
-			names.AttrStorageEncrypted: {
-				Type:     schema.TypeBool,
-				Computed: true,
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			"writer": {
-				Type:     schema.TypeBool,
-				Computed: true,
-			},
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrAutoMinorVersionUpgrade: {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  true,
+				},
+				names.AttrAvailabilityZone: {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+				},
+				"ca_cert_identifier": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+				},
+				"certificate_rotation_restart": {
+					Type:         nullable.TypeNullableBool,
+					Optional:     true,
+					ValidateFunc: nullable.ValidateTypeStringNullableBool,
+				},
+				names.AttrClusterIdentifier: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"copy_tags_to_snapshot": {
+					Type:     schema.TypeBool,
+					Optional: true,
+				},
+				"db_subnet_group_name": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"dbi_resource_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"enable_performance_insights": {
+					Type:     schema.TypeBool,
+					Optional: true,
+				},
+				names.AttrEndpoint: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrEngine: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ForceNew:     true,
+					Default:      engineDocDB,
+					ValidateFunc: validation.StringInSlice(engine_Values(), false),
+				},
+				names.AttrEngineVersion: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrIdentifier: {
+					Type:          schema.TypeString,
+					Optional:      true,
+					Computed:      true,
+					ForceNew:      true,
+					ConflictsWith: []string{"identifier_prefix"},
+					ValidateFunc:  validIdentifier,
+				},
+				"identifier_prefix": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Computed:     true,
+					ForceNew:     true,
+					ValidateFunc: validIdentifierPrefix,
+				},
+				"instance_class": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				names.AttrKMSKeyID: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"performance_insights_kms_key_id": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+				},
+				names.AttrPort: {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
+				"preferred_backup_window": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrPreferredMaintenanceWindow: {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+					StateFunc: func(v any) string {
+						if v != nil {
+							value := v.(string)
+							return strings.ToLower(value)
+						}
+						return ""
+					},
+					ValidateFunc: verify.ValidOnceAWeekWindowFormat,
+				},
+				"promotion_tier": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					Default:      0,
+					ValidateFunc: validation.IntBetween(0, 15),
+				},
+				names.AttrPubliclyAccessible: {
+					Type:     schema.TypeBool,
+					Computed: true,
+				},
+				names.AttrStorageEncrypted: {
+					Type:     schema.TypeBool,
+					Computed: true,
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				"writer": {
+					Type:     schema.TypeBool,
+					Computed: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/docdb/cluster_parameter_group.go
+++ b/internal/service/docdb/cluster_parameter_group.go
@@ -42,62 +42,64 @@ func resourceClusterParameterGroup() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrDescription: {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Default:  "Managed by Terraform",
-			},
-			names.AttrFamily: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			names.AttrName: {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				ForceNew:      true,
-				ConflictsWith: []string{names.AttrNamePrefix},
-				ValidateFunc:  validParamGroupName,
-			},
-			names.AttrNamePrefix: {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				ForceNew:      true,
-				ConflictsWith: []string{names.AttrName},
-				ValidateFunc:  validParamGroupNamePrefix,
-			},
-			names.AttrParameter: {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"apply_method": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Default:          awstypes.ApplyMethodPendingReboot,
-							ValidateDiagFunc: enum.Validate[awstypes.ApplyMethod](),
-						},
-						names.AttrName: {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						names.AttrValue: {
-							Type:     schema.TypeString,
-							Required: true,
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrDescription: {
+					Type:     schema.TypeString,
+					Optional: true,
+					ForceNew: true,
+					Default:  "Managed by Terraform",
+				},
+				names.AttrFamily: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				names.AttrName: {
+					Type:          schema.TypeString,
+					Optional:      true,
+					Computed:      true,
+					ForceNew:      true,
+					ConflictsWith: []string{names.AttrNamePrefix},
+					ValidateFunc:  validParamGroupName,
+				},
+				names.AttrNamePrefix: {
+					Type:          schema.TypeString,
+					Optional:      true,
+					Computed:      true,
+					ForceNew:      true,
+					ConflictsWith: []string{names.AttrName},
+					ValidateFunc:  validParamGroupNamePrefix,
+				},
+				names.AttrParameter: {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"apply_method": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								Default:          awstypes.ApplyMethodPendingReboot,
+								ValidateDiagFunc: enum.Validate[awstypes.ApplyMethod](),
+							},
+							names.AttrName: {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+							names.AttrValue: {
+								Type:     schema.TypeString,
+								Required: true,
+							},
 						},
 					},
 				},
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			}
 		},
 	}
 }

--- a/internal/service/docdb/cluster_snapshot.go
+++ b/internal/service/docdb/cluster_snapshot.go
@@ -39,64 +39,66 @@ func resourceClusterSnapshot() *schema.Resource {
 			Create: schema.DefaultTimeout(20 * time.Minute),
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrAvailabilityZones: {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			"db_cluster_identifier": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validClusterIdentifier,
-			},
-			"db_cluster_snapshot_arn": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"db_cluster_snapshot_identifier": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validClusterSnapshotIdentifier,
-			},
-			names.AttrEngine: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrEngineVersion: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrKMSKeyID: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrPort: {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-			"snapshot_type": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"source_db_cluster_snapshot_arn": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrStatus: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrStorageEncrypted: {
-				Type:     schema.TypeBool,
-				Computed: true,
-			},
-			names.AttrVPCID: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrAvailabilityZones: {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"db_cluster_identifier": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validClusterIdentifier,
+				},
+				"db_cluster_snapshot_arn": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"db_cluster_snapshot_identifier": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validClusterSnapshotIdentifier,
+				},
+				names.AttrEngine: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrEngineVersion: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrKMSKeyID: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrPort: {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
+				"snapshot_type": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"source_db_cluster_snapshot_arn": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrStatus: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrStorageEncrypted: {
+					Type:     schema.TypeBool,
+					Computed: true,
+				},
+				names.AttrVPCID: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/docdb/engine_version_data_source.go
+++ b/internal/service/docdb/engine_version_data_source.go
@@ -25,51 +25,53 @@ import (
 func dataSourceEngineVersion() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceEngineVersionRead,
-		Schema: map[string]*schema.Schema{
-			names.AttrEngine: {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  engineDocDB,
-			},
-			"engine_description": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"exportable_log_types": {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			"parameter_group_family": {
-				Type:     schema.TypeString,
-				Computed: true,
-				Optional: true,
-			},
-			"preferred_versions": {
-				Type:          schema.TypeList,
-				Optional:      true,
-				Elem:          &schema.Schema{Type: schema.TypeString},
-				ConflictsWith: []string{names.AttrVersion},
-			},
-			"supports_log_exports_to_cloudwatch": {
-				Type:     schema.TypeBool,
-				Computed: true,
-			},
-			"valid_upgrade_targets": {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			names.AttrVersion: {
-				Type:          schema.TypeString,
-				Computed:      true,
-				Optional:      true,
-				ConflictsWith: []string{"preferred_versions"},
-			},
-			"version_description": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrEngine: {
+					Type:     schema.TypeString,
+					Optional: true,
+					Default:  engineDocDB,
+				},
+				"engine_description": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"exportable_log_types": {
+					Type:     schema.TypeSet,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"parameter_group_family": {
+					Type:     schema.TypeString,
+					Computed: true,
+					Optional: true,
+				},
+				"preferred_versions": {
+					Type:          schema.TypeList,
+					Optional:      true,
+					Elem:          &schema.Schema{Type: schema.TypeString},
+					ConflictsWith: []string{names.AttrVersion},
+				},
+				"supports_log_exports_to_cloudwatch": {
+					Type:     schema.TypeBool,
+					Computed: true,
+				},
+				"valid_upgrade_targets": {
+					Type:     schema.TypeSet,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				names.AttrVersion: {
+					Type:          schema.TypeString,
+					Computed:      true,
+					Optional:      true,
+					ConflictsWith: []string{"preferred_versions"},
+				},
+				"version_description": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/docdb/event_subscription.go
+++ b/internal/service/docdb/event_subscription.go
@@ -47,57 +47,59 @@ func resourceEventSubscription() *schema.Resource {
 			Update: schema.DefaultTimeout(40 * time.Minute),
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"customer_aws_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrEnabled: {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
-			},
-			"event_categories": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			names.AttrName: {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				ForceNew:      true,
-				ConflictsWith: []string{names.AttrNamePrefix},
-				ValidateFunc:  validEventSubscriptionName,
-			},
-			names.AttrNamePrefix: {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				ForceNew:      true,
-				ConflictsWith: []string{names.AttrName},
-				ValidateFunc:  validEventSubscriptionNamePrefix,
-			},
-			names.AttrSNSTopicARN: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			"source_ids": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			names.AttrSourceType: {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"customer_aws_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrEnabled: {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  true,
+				},
+				"event_categories": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				names.AttrName: {
+					Type:          schema.TypeString,
+					Optional:      true,
+					Computed:      true,
+					ForceNew:      true,
+					ConflictsWith: []string{names.AttrNamePrefix},
+					ValidateFunc:  validEventSubscriptionName,
+				},
+				names.AttrNamePrefix: {
+					Type:          schema.TypeString,
+					Optional:      true,
+					Computed:      true,
+					ForceNew:      true,
+					ConflictsWith: []string{names.AttrName},
+					ValidateFunc:  validEventSubscriptionNamePrefix,
+				},
+				names.AttrSNSTopicARN: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				"source_ids": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				names.AttrSourceType: {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			}
 		},
 	}
 }

--- a/internal/service/docdb/global_cluster.go
+++ b/internal/service/docdb/global_cluster.go
@@ -45,79 +45,81 @@ func resourceGlobalCluster() *schema.Resource {
 			Delete: schema.DefaultTimeout(5 * time.Minute),
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrDatabaseName: {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
-			names.AttrDeletionProtection: {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-			names.AttrEngine: {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				ForceNew:      true,
-				ValidateFunc:  validation.StringInSlice(engine_Values(), false),
-				AtLeastOneOf:  []string{names.AttrEngine, "source_db_cluster_identifier"},
-				ConflictsWith: []string{"source_db_cluster_identifier"},
-			},
-			names.AttrEngineVersion: {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-			"global_cluster_identifier": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validGlobalCusterIdentifier,
-			},
-			"global_cluster_members": {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"db_cluster_arn": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"is_writer": {
-							Type:     schema.TypeBool,
-							Computed: true,
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrDatabaseName: {
+					Type:     schema.TypeString,
+					Optional: true,
+					ForceNew: true,
+				},
+				names.AttrDeletionProtection: {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
+				names.AttrEngine: {
+					Type:          schema.TypeString,
+					Optional:      true,
+					Computed:      true,
+					ForceNew:      true,
+					ValidateFunc:  validation.StringInSlice(engine_Values(), false),
+					AtLeastOneOf:  []string{names.AttrEngine, "source_db_cluster_identifier"},
+					ConflictsWith: []string{"source_db_cluster_identifier"},
+				},
+				names.AttrEngineVersion: {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+				},
+				"global_cluster_identifier": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validGlobalCusterIdentifier,
+				},
+				"global_cluster_members": {
+					Type:     schema.TypeSet,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"db_cluster_arn": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"is_writer": {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
 						},
 					},
 				},
-			},
-			"global_cluster_resource_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"source_db_cluster_identifier": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				ForceNew:      true,
-				AtLeastOneOf:  []string{names.AttrEngine, "source_db_cluster_identifier"},
-				ConflictsWith: []string{names.AttrEngine},
-			},
-			names.AttrStatus: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrStorageEncrypted: {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
+				"global_cluster_resource_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"source_db_cluster_identifier": {
+					Type:          schema.TypeString,
+					Optional:      true,
+					Computed:      true,
+					ForceNew:      true,
+					AtLeastOneOf:  []string{names.AttrEngine, "source_db_cluster_identifier"},
+					ConflictsWith: []string{names.AttrEngine},
+				},
+				names.AttrStatus: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrStorageEncrypted: {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/docdb/orderable_db_instance_data_source.go
+++ b/internal/service/docdb/orderable_db_instance_data_source.go
@@ -26,44 +26,46 @@ import (
 func dataSourceOrderableDBInstance() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceOrderableDBInstanceRead,
-		Schema: map[string]*schema.Schema{
-			names.AttrAvailabilityZones: {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			names.AttrEngine: {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  engineDocDB,
-			},
-			names.AttrEngineVersion: {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-			"instance_class": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				ConflictsWith: []string{"preferred_instance_classes"},
-			},
-			"license_model": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  "na",
-			},
-			"preferred_instance_classes": {
-				Type:          schema.TypeList,
-				Optional:      true,
-				Elem:          &schema.Schema{Type: schema.TypeString},
-				ConflictsWith: []string{"instance_class"},
-			},
-			"vpc": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Computed: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrAvailabilityZones: {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				names.AttrEngine: {
+					Type:     schema.TypeString,
+					Optional: true,
+					Default:  engineDocDB,
+				},
+				names.AttrEngineVersion: {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+				},
+				"instance_class": {
+					Type:          schema.TypeString,
+					Optional:      true,
+					Computed:      true,
+					ConflictsWith: []string{"preferred_instance_classes"},
+				},
+				"license_model": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Default:  "na",
+				},
+				"preferred_instance_classes": {
+					Type:          schema.TypeList,
+					Optional:      true,
+					Elem:          &schema.Schema{Type: schema.TypeString},
+					ConflictsWith: []string{"instance_class"},
+				},
+				"vpc": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Computed: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/docdb/subnet_group.go
+++ b/internal/service/docdb/subnet_group.go
@@ -39,45 +39,47 @@ func resourceSubnetGroup() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrDescription: {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  "Managed by Terraform",
-			},
-			names.AttrName: {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				ForceNew:      true,
-				ConflictsWith: []string{names.AttrNamePrefix},
-				ValidateFunc:  validSubnetGroupName,
-			},
-			names.AttrNamePrefix: {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				ForceNew:      true,
-				ConflictsWith: []string{names.AttrName},
-				ValidateFunc:  validSubnetGroupNamePrefix,
-			},
-			names.AttrSubnetIDs: {
-				Type:     schema.TypeSet,
-				Required: true,
-				MinItems: 1,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			"supported_network_types": {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrDescription: {
+					Type:     schema.TypeString,
+					Optional: true,
+					Default:  "Managed by Terraform",
+				},
+				names.AttrName: {
+					Type:          schema.TypeString,
+					Optional:      true,
+					Computed:      true,
+					ForceNew:      true,
+					ConflictsWith: []string{names.AttrNamePrefix},
+					ValidateFunc:  validSubnetGroupName,
+				},
+				names.AttrNamePrefix: {
+					Type:          schema.TypeString,
+					Optional:      true,
+					Computed:      true,
+					ForceNew:      true,
+					ConflictsWith: []string{names.AttrName},
+					ValidateFunc:  validSubnetGroupNamePrefix,
+				},
+				names.AttrSubnetIDs: {
+					Type:     schema.TypeSet,
+					Required: true,
+					MinItems: 1,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"supported_network_types": {
+					Type:     schema.TypeSet,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			}
 		},
 	}
 }

--- a/internal/service/ds/conditional_forwarder.go
+++ b/internal/service/ds/conditional_forwarder.go
@@ -37,27 +37,29 @@ func resourceConditionalForwarder() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"directory_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"dns_ips": {
-				Type:     schema.TypeList,
-				Required: true,
-				MinItems: 1,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"directory_id": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
 				},
-			},
-			"remote_domain_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-				// Documentation is incorrect, the API call fails if a trailing period is included
-				ValidateFunc: domainValidator,
-			},
+				"dns_ips": {
+					Type:     schema.TypeList,
+					Required: true,
+					MinItems: 1,
+					Elem: &schema.Schema{
+						Type: schema.TypeString,
+					},
+				},
+				"remote_domain_name": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+					// Documentation is incorrect, the API call fails if a trailing period is included
+					ValidateFunc: domainValidator,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/ds/directory.go
+++ b/internal/service/ds/directory.go
@@ -53,159 +53,161 @@ func resourceDirectory() *schema.Resource {
 			Delete: schema.DefaultTimeout(60 * time.Minute),
 		},
 
-		Schema: map[string]*schema.Schema{
-			"access_url": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrAlias: {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
-			"connect_settings": {
-				Type:     schema.TypeList,
-				MaxItems: 1,
-				Optional: true,
-				ForceNew: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrAvailabilityZones: {
-							Type:     schema.TypeSet,
-							Computed: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-						"connect_ips": {
-							Type:     schema.TypeSet,
-							Computed: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-						"customer_dns_ips": {
-							Type:     schema.TypeSet,
-							Required: true,
-							ForceNew: true,
-							Elem: &schema.Schema{
-								Type:         schema.TypeString,
-								ValidateFunc: validation.IsIPAddress,
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"access_url": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrAlias: {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+				},
+				"connect_settings": {
+					Type:     schema.TypeList,
+					MaxItems: 1,
+					Optional: true,
+					ForceNew: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrAvailabilityZones: {
+								Type:     schema.TypeSet,
+								Computed: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+							},
+							"connect_ips": {
+								Type:     schema.TypeSet,
+								Computed: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+							},
+							"customer_dns_ips": {
+								Type:     schema.TypeSet,
+								Required: true,
+								ForceNew: true,
+								Elem: &schema.Schema{
+									Type:         schema.TypeString,
+									ValidateFunc: validation.IsIPAddress,
+								},
+							},
+							"customer_username": {
+								Type:     schema.TypeString,
+								Required: true,
+								ForceNew: true,
+							},
+							names.AttrSubnetIDs: {
+								Type:     schema.TypeSet,
+								Required: true,
+								ForceNew: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+							},
+							names.AttrVPCID: {
+								Type:     schema.TypeString,
+								Required: true,
+								ForceNew: true,
 							},
 						},
-						"customer_username": {
-							Type:     schema.TypeString,
-							Required: true,
-							ForceNew: true,
-						},
-						names.AttrSubnetIDs: {
-							Type:     schema.TypeSet,
-							Required: true,
-							ForceNew: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-						names.AttrVPCID: {
-							Type:     schema.TypeString,
-							Required: true,
-							ForceNew: true,
+					},
+				},
+				names.AttrDescription: {
+					Type:     schema.TypeString,
+					Optional: true,
+					ForceNew: true,
+				},
+				"desired_number_of_domain_controllers": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					Computed:     true,
+					ValidateFunc: validation.IntAtLeast(2),
+				},
+				"dns_ip_addresses": {
+					Type:     schema.TypeSet,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+					Computed: true,
+				},
+				"edition": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					Computed:         true,
+					ForceNew:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.DirectoryEdition](),
+				},
+				"enable_sso": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
+				names.AttrName: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: domainValidator,
+				},
+				names.AttrPassword: {
+					Type:      schema.TypeString,
+					Required:  true,
+					ForceNew:  true,
+					Sensitive: true,
+				},
+				"security_group_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"short_name": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+				},
+				names.AttrSize: {
+					Type:             schema.TypeString,
+					Optional:         true,
+					Computed:         true,
+					ForceNew:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.DirectorySize](),
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				names.AttrType: {
+					Type:             schema.TypeString,
+					Optional:         true,
+					Default:          awstypes.DirectoryTypeSimpleAd,
+					ForceNew:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.DirectoryType](),
+				},
+				"vpc_settings": {
+					Type:     schema.TypeList,
+					MaxItems: 1,
+					Optional: true,
+					ForceNew: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrAvailabilityZones: {
+								Type:     schema.TypeSet,
+								Computed: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+							},
+							names.AttrSubnetIDs: {
+								Type:     schema.TypeSet,
+								Required: true,
+								ForceNew: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+							},
+							names.AttrVPCID: {
+								Type:     schema.TypeString,
+								Required: true,
+								ForceNew: true,
+							},
 						},
 					},
 				},
-			},
-			names.AttrDescription: {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
-			"desired_number_of_domain_controllers": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: validation.IntAtLeast(2),
-			},
-			"dns_ip_addresses": {
-				Type:     schema.TypeSet,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Computed: true,
-			},
-			"edition": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Computed:         true,
-				ForceNew:         true,
-				ValidateDiagFunc: enum.Validate[awstypes.DirectoryEdition](),
-			},
-			"enable_sso": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-			names.AttrName: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: domainValidator,
-			},
-			names.AttrPassword: {
-				Type:      schema.TypeString,
-				Required:  true,
-				ForceNew:  true,
-				Sensitive: true,
-			},
-			"security_group_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"short_name": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
-			names.AttrSize: {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Computed:         true,
-				ForceNew:         true,
-				ValidateDiagFunc: enum.Validate[awstypes.DirectorySize](),
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			names.AttrType: {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Default:          awstypes.DirectoryTypeSimpleAd,
-				ForceNew:         true,
-				ValidateDiagFunc: enum.Validate[awstypes.DirectoryType](),
-			},
-			"vpc_settings": {
-				Type:     schema.TypeList,
-				MaxItems: 1,
-				Optional: true,
-				ForceNew: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrAvailabilityZones: {
-							Type:     schema.TypeSet,
-							Computed: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-						names.AttrSubnetIDs: {
-							Type:     schema.TypeSet,
-							Required: true,
-							ForceNew: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-						names.AttrVPCID: {
-							Type:     schema.TypeString,
-							Required: true,
-							ForceNew: true,
-						},
-					},
+				"enable_directory_data_access": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  false,
 				},
-			},
-			"enable_directory_data_access": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
+			}
 		},
 	}
 }

--- a/internal/service/ds/directory_data_source.go
+++ b/internal/service/ds/directory_data_source.go
@@ -24,152 +24,154 @@ func dataSourceDirectory() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceDirectoryRead,
 
-		Schema: map[string]*schema.Schema{
-			"access_url": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrAlias: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"connect_settings": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrAvailabilityZones: {
-							Type:     schema.TypeSet,
-							Computed: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-						"connect_ips": {
-							Type:     schema.TypeSet,
-							Computed: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-						"customer_dns_ips": {
-							Type:     schema.TypeSet,
-							Computed: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-						"customer_username": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						names.AttrSubnetIDs: {
-							Type:     schema.TypeSet,
-							Computed: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-						names.AttrVPCID: {
-							Type:     schema.TypeString,
-							Computed: true,
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"access_url": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrAlias: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"connect_settings": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrAvailabilityZones: {
+								Type:     schema.TypeSet,
+								Computed: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+							},
+							"connect_ips": {
+								Type:     schema.TypeSet,
+								Computed: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+							},
+							"customer_dns_ips": {
+								Type:     schema.TypeSet,
+								Computed: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+							},
+							"customer_username": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							names.AttrSubnetIDs: {
+								Type:     schema.TypeSet,
+								Computed: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+							},
+							names.AttrVPCID: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
 						},
 					},
 				},
-			},
-			names.AttrDescription: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"directory_id": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"dns_ip_addresses": {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			"edition": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"enable_sso": {
-				Type:     schema.TypeBool,
-				Computed: true,
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"radius_settings": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"authentication_protocol": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"display_label": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"radius_port": {
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
-						"radius_retries": {
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
-						"radius_servers": {
-							Type:     schema.TypeSet,
-							Computed: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-						"radius_timeout": {
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
-						"use_same_username": {
-							Type:     schema.TypeBool,
-							Computed: true,
+				names.AttrDescription: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"directory_id": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"dns_ip_addresses": {
+					Type:     schema.TypeSet,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"edition": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"enable_sso": {
+					Type:     schema.TypeBool,
+					Computed: true,
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"radius_settings": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"authentication_protocol": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"display_label": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"radius_port": {
+								Type:     schema.TypeInt,
+								Computed: true,
+							},
+							"radius_retries": {
+								Type:     schema.TypeInt,
+								Computed: true,
+							},
+							"radius_servers": {
+								Type:     schema.TypeSet,
+								Computed: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+							},
+							"radius_timeout": {
+								Type:     schema.TypeInt,
+								Computed: true,
+							},
+							"use_same_username": {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
 						},
 					},
 				},
-			},
-			"security_group_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"short_name": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrSize: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrTags: tftags.TagsSchemaComputed(),
-			names.AttrType: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"vpc_settings": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrAvailabilityZones: {
-							Type:     schema.TypeSet,
-							Computed: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-						names.AttrSubnetIDs: {
-							Type:     schema.TypeSet,
-							Computed: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-						names.AttrVPCID: {
-							Type:     schema.TypeString,
-							Computed: true,
+				"security_group_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"short_name": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrSize: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrTags: tftags.TagsSchemaComputed(),
+				names.AttrType: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"vpc_settings": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrAvailabilityZones: {
+								Type:     schema.TypeSet,
+								Computed: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+							},
+							names.AttrSubnetIDs: {
+								Type:     schema.TypeSet,
+								Computed: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+							},
+							names.AttrVPCID: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
 						},
 					},
 				},
-			},
+			}
 		},
 	}
 }

--- a/internal/service/ds/log_subscription.go
+++ b/internal/service/ds/log_subscription.go
@@ -33,17 +33,19 @@ func resourceLogSubscription() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"directory_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			names.AttrLogGroupName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"directory_id": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				names.AttrLogGroupName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/ds/radius_settings.go
+++ b/internal/service/ds/radius_settings.go
@@ -42,55 +42,57 @@ func resourceRadiusSettings() *schema.Resource {
 			Update: schema.DefaultTimeout(30 * time.Minute),
 		},
 
-		Schema: map[string]*schema.Schema{
-			"authentication_protocol": {
-				Type:             schema.TypeString,
-				Required:         true,
-				ValidateDiagFunc: enum.Validate[awstypes.RadiusAuthenticationProtocol](),
-			},
-			"directory_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"display_label": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringLenBetween(1, 64),
-			},
-			"radius_port": {
-				Type:         schema.TypeInt,
-				Required:     true,
-				ValidateFunc: validation.IsPortNumber,
-			},
-			"radius_retries": {
-				Type:         schema.TypeInt,
-				Required:     true,
-				ValidateFunc: validation.IntBetween(0, 10),
-			},
-			"radius_servers": {
-				Type:     schema.TypeSet,
-				Required: true,
-				Elem: &schema.Schema{
-					Type:         schema.TypeString,
-					ValidateFunc: validation.StringLenBetween(1, 256),
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"authentication_protocol": {
+					Type:             schema.TypeString,
+					Required:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.RadiusAuthenticationProtocol](),
 				},
-			},
-			"radius_timeout": {
-				Type:         schema.TypeInt,
-				Required:     true,
-				ValidateFunc: validation.IntBetween(1, 50),
-			},
-			"shared_secret": {
-				Type:         schema.TypeString,
-				Required:     true,
-				Sensitive:    true,
-				ValidateFunc: validation.StringLenBetween(8, 512),
-			},
-			"use_same_username": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
+				"directory_id": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"display_label": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringLenBetween(1, 64),
+				},
+				"radius_port": {
+					Type:         schema.TypeInt,
+					Required:     true,
+					ValidateFunc: validation.IsPortNumber,
+				},
+				"radius_retries": {
+					Type:         schema.TypeInt,
+					Required:     true,
+					ValidateFunc: validation.IntBetween(0, 10),
+				},
+				"radius_servers": {
+					Type:     schema.TypeSet,
+					Required: true,
+					Elem: &schema.Schema{
+						Type:         schema.TypeString,
+						ValidateFunc: validation.StringLenBetween(1, 256),
+					},
+				},
+				"radius_timeout": {
+					Type:         schema.TypeInt,
+					Required:     true,
+					ValidateFunc: validation.IntBetween(1, 50),
+				},
+				"shared_secret": {
+					Type:         schema.TypeString,
+					Required:     true,
+					Sensitive:    true,
+					ValidateFunc: validation.StringLenBetween(8, 512),
+				},
+				"use_same_username": {
+					Type:     schema.TypeBool,
+					Optional: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/ds/region.go
+++ b/internal/service/ds/region.go
@@ -48,47 +48,49 @@ func resourceRegion() *schema.Resource {
 			Delete: schema.DefaultTimeout(90 * time.Minute),
 		},
 
-		Schema: map[string]*schema.Schema{
-			"desired_number_of_domain_controllers": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: validation.IntAtLeast(2),
-			},
-			"directory_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"region_name": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidRegionName,
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			"vpc_settings": {
-				Type:     schema.TypeList,
-				MaxItems: 1,
-				Required: true,
-				ForceNew: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrSubnetIDs: {
-							Type:     schema.TypeSet,
-							Required: true,
-							ForceNew: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-						names.AttrVPCID: {
-							Type:     schema.TypeString,
-							Required: true,
-							ForceNew: true,
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"desired_number_of_domain_controllers": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					Computed:     true,
+					ValidateFunc: validation.IntAtLeast(2),
+				},
+				"directory_id": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"region_name": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: verify.ValidRegionName,
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				"vpc_settings": {
+					Type:     schema.TypeList,
+					MaxItems: 1,
+					Required: true,
+					ForceNew: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrSubnetIDs: {
+								Type:     schema.TypeSet,
+								Required: true,
+								ForceNew: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+							},
+							names.AttrVPCID: {
+								Type:     schema.TypeString,
+								Required: true,
+								ForceNew: true,
+							},
 						},
 					},
 				},
-			},
+			}
 		},
 	}
 }

--- a/internal/service/ds/shared_directory.go
+++ b/internal/service/ds/shared_directory.go
@@ -41,50 +41,52 @@ func resourceSharedDirectory() *schema.Resource {
 			Delete: schema.DefaultTimeout(60 * time.Minute),
 		},
 
-		Schema: map[string]*schema.Schema{
-			"directory_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"method": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				ForceNew:         true,
-				Default:          awstypes.ShareMethodHandshake,
-				ValidateDiagFunc: enum.Validate[awstypes.ShareMethod](),
-			},
-			"notes": {
-				Type:      schema.TypeString,
-				Optional:  true,
-				ForceNew:  true,
-				Sensitive: true,
-			},
-			"shared_directory_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrTarget: {
-				Type:     schema.TypeList,
-				MaxItems: 1,
-				Required: true,
-				ForceNew: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrID: {
-							Type:     schema.TypeString,
-							Required: true,
-							ForceNew: true,
-						},
-						names.AttrType: {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Default:          awstypes.TargetTypeAccount,
-							ValidateDiagFunc: enum.Validate[awstypes.TargetType](),
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"directory_id": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"method": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					ForceNew:         true,
+					Default:          awstypes.ShareMethodHandshake,
+					ValidateDiagFunc: enum.Validate[awstypes.ShareMethod](),
+				},
+				"notes": {
+					Type:      schema.TypeString,
+					Optional:  true,
+					ForceNew:  true,
+					Sensitive: true,
+				},
+				"shared_directory_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrTarget: {
+					Type:     schema.TypeList,
+					MaxItems: 1,
+					Required: true,
+					ForceNew: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrID: {
+								Type:     schema.TypeString,
+								Required: true,
+								ForceNew: true,
+							},
+							names.AttrType: {
+								Type:             schema.TypeString,
+								Optional:         true,
+								Default:          awstypes.TargetTypeAccount,
+								ValidateDiagFunc: enum.Validate[awstypes.TargetType](),
+							},
 						},
 					},
 				},
-			},
+			}
 		},
 	}
 }

--- a/internal/service/ds/shared_directory_accepter.go
+++ b/internal/service/ds/shared_directory_accepter.go
@@ -40,28 +40,30 @@ func resourceSharedDirectoryAccepter() *schema.Resource {
 			Delete: schema.DefaultTimeout(60 * time.Minute),
 		},
 
-		Schema: map[string]*schema.Schema{
-			"method": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"notes": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrOwnerAccountID: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"owner_directory_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"shared_directory_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"method": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"notes": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrOwnerAccountID: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"owner_directory_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"shared_directory_id": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/dynamodb/contributor_insights.go
+++ b/internal/service/dynamodb/contributor_insights.go
@@ -42,23 +42,25 @@ func resourceContributorInsights() *schema.Resource {
 			Delete: schema.DefaultTimeout(5 * time.Minute),
 		},
 
-		Schema: map[string]*schema.Schema{
-			"index_name": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
-			names.AttrMode: {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Computed:         true,
-				ValidateDiagFunc: enum.Validate[awstypes.ContributorInsightsMode](),
-			},
-			names.AttrTableName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"index_name": {
+					Type:     schema.TypeString,
+					Optional: true,
+					ForceNew: true,
+				},
+				names.AttrMode: {
+					Type:             schema.TypeString,
+					Optional:         true,
+					Computed:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.ContributorInsightsMode](),
+				},
+				names.AttrTableName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/dynamodb/global_table.go
+++ b/internal/service/dynamodb/global_table.go
@@ -42,29 +42,31 @@ func resourceGlobalTable() *schema.Resource {
 			Delete: schema.DefaultTimeout(1 * time.Minute),
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrName: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validGlobalTableName,
-			},
-			"replica": {
-				Type:     schema.TypeSet,
-				Required: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"region_name": {
-							Type:     schema.TypeString,
-							Required: true,
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrName: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validGlobalTableName,
+				},
+				"replica": {
+					Type:     schema.TypeSet,
+					Required: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"region_name": {
+								Type:     schema.TypeString,
+								Required: true,
+							},
 						},
 					},
 				},
-			},
+			}
 		},
 	}
 }

--- a/internal/service/dynamodb/kinesis_streaming_destination.go
+++ b/internal/service/dynamodb/kinesis_streaming_destination.go
@@ -43,25 +43,27 @@ func resourceKinesisStreamingDestination() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"approximate_creation_date_time_precision": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Computed:         true,
-				ForceNew:         true,
-				ValidateDiagFunc: enum.Validate[awstypes.ApproximateCreationDateTimePrecision](),
-			},
-			names.AttrStreamARN: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			names.AttrTableName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"approximate_creation_date_time_precision": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					Computed:         true,
+					ForceNew:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.ApproximateCreationDateTimePrecision](),
+				},
+				names.AttrStreamARN: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				names.AttrTableName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/dynamodb/table_export.go
+++ b/internal/service/dynamodb/table_export.go
@@ -42,125 +42,127 @@ func resourceTableExport() *schema.Resource {
 			Delete: schema.DefaultTimeout(60 * time.Minute),
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"billed_size_in_bytes": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-			"end_time": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"export_format": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				ForceNew:         true,
-				Default:          awstypes.ExportFormatDynamodbJson,
-				ValidateDiagFunc: enum.Validate[awstypes.ExportFormat](),
-			},
-			"export_status": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"export_time": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidUTCTimestamp,
-			},
-			"export_type": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Computed:         true,
-				ForceNew:         true,
-				ValidateDiagFunc: enum.Validate[awstypes.ExportType](),
-			},
-			"incremental_export_specification": {
-				Type:     schema.TypeList,
-				Optional: true,
-				ForceNew: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"export_from_time": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							Computed:     true,
-							ForceNew:     true,
-							ValidateFunc: verify.ValidUTCTimestamp,
-						},
-						"export_to_time": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							Computed:     true,
-							ForceNew:     true,
-							ValidateFunc: verify.ValidUTCTimestamp,
-						},
-						"export_view_type": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Computed:         true,
-							ForceNew:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.ExportViewType](),
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"billed_size_in_bytes": {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
+				"end_time": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"export_format": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					ForceNew:         true,
+					Default:          awstypes.ExportFormatDynamodbJson,
+					ValidateDiagFunc: enum.Validate[awstypes.ExportFormat](),
+				},
+				"export_status": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"export_time": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Computed:     true,
+					ForceNew:     true,
+					ValidateFunc: verify.ValidUTCTimestamp,
+				},
+				"export_type": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					Computed:         true,
+					ForceNew:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.ExportType](),
+				},
+				"incremental_export_specification": {
+					Type:     schema.TypeList,
+					Optional: true,
+					ForceNew: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"export_from_time": {
+								Type:         schema.TypeString,
+								Optional:     true,
+								Computed:     true,
+								ForceNew:     true,
+								ValidateFunc: verify.ValidUTCTimestamp,
+							},
+							"export_to_time": {
+								Type:         schema.TypeString,
+								Optional:     true,
+								Computed:     true,
+								ForceNew:     true,
+								ValidateFunc: verify.ValidUTCTimestamp,
+							},
+							"export_view_type": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								Computed:         true,
+								ForceNew:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.ExportViewType](),
+							},
 						},
 					},
 				},
-			},
-			"item_count": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-			"manifest_files_s3_key": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrS3Bucket: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"s3_bucket_owner": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidAccountID,
-			},
-			"s3_prefix": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(0, 1024),
-			},
-			"s3_sse_algorithm": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Computed:         true,
-				ForceNew:         true,
-				ValidateDiagFunc: enum.Validate[awstypes.S3SseAlgorithm](),
-			},
-			"s3_sse_kms_key_id": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(0, 2048),
-			},
-			names.AttrStartTime: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"table_arn": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidARN,
-			},
+				"item_count": {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
+				"manifest_files_s3_key": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrS3Bucket: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"s3_bucket_owner": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Computed:     true,
+					ForceNew:     true,
+					ValidateFunc: verify.ValidAccountID,
+				},
+				"s3_prefix": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Computed:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringLenBetween(0, 1024),
+				},
+				"s3_sse_algorithm": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					Computed:         true,
+					ForceNew:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.S3SseAlgorithm](),
+				},
+				"s3_sse_kms_key_id": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringLenBetween(0, 2048),
+				},
+				names.AttrStartTime: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"table_arn": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/dynamodb/table_item.go
+++ b/internal/service/dynamodb/table_item.go
@@ -35,29 +35,31 @@ func resourceTableItem() *schema.Resource {
 		UpdateWithoutTimeout: resourceTableItemUpdate,
 		DeleteWithoutTimeout: resourceTableItemDelete,
 
-		Schema: map[string]*schema.Schema{
-			"hash_key": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"item": {
-				Type:                  schema.TypeString,
-				Required:              true,
-				ValidateFunc:          validateTableItem,
-				DiffSuppressFunc:      verify.SuppressEquivalentJSONDiffs,
-				DiffSuppressOnRefresh: true,
-			},
-			"range_key": {
-				Type:     schema.TypeString,
-				ForceNew: true,
-				Optional: true,
-			},
-			names.AttrTableName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"hash_key": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"item": {
+					Type:                  schema.TypeString,
+					Required:              true,
+					ValidateFunc:          validateTableItem,
+					DiffSuppressFunc:      verify.SuppressEquivalentJSONDiffs,
+					DiffSuppressOnRefresh: true,
+				},
+				"range_key": {
+					Type:     schema.TypeString,
+					ForceNew: true,
+					Optional: true,
+				},
+				names.AttrTableName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/dynamodb/table_item_data_source.go
+++ b/internal/service/dynamodb/table_item_data_source.go
@@ -26,29 +26,31 @@ func dataSourceTableItem() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceTableItemRead,
 
-		Schema: map[string]*schema.Schema{
-			"expression_attribute_names": {
-				Type:     schema.TypeMap,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			"item": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrKey: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validateTableItem,
-			},
-			"projection_expression": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			names.AttrTableName: {
-				Type:     schema.TypeString,
-				Required: true,
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"expression_attribute_names": {
+					Type:     schema.TypeMap,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"item": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrKey: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validateTableItem,
+				},
+				"projection_expression": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				names.AttrTableName: {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/dynamodb/table_replica.go
+++ b/internal/service/dynamodb/table_replica.go
@@ -58,44 +58,46 @@ func resourceTableReplica() *schema.Resource {
 			Update: schema.DefaultTimeout(20 * time.Minute),
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: { // direct to replica
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"deletion_protection_enabled": { // direct to replica
-				Type:     schema.TypeBool,
-				Optional: true,
-				Computed: true,
-			},
-			// global_secondary_index read capacity override can be set but not return by aws atm either through main/replica nor directly
-			"global_table_arn": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			names.AttrKMSKeyARN: { // through main table
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			"point_in_time_recovery": { // direct to replica
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-			// read_capacity_override can be set but requires table write_capacity to be autoscaled which is not yet supported in the provider
-			"table_class_override": { // through main table
-				Type:             schema.TypeString,
-				Optional:         true,
-				ForceNew:         true,
-				ValidateDiagFunc: enum.Validate[awstypes.TableClass](),
-			},
-			names.AttrTags:    tftags.TagsSchema(),         // direct to replica
-			names.AttrTagsAll: tftags.TagsSchemaComputed(), // direct to replica
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: { // direct to replica
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"deletion_protection_enabled": { // direct to replica
+					Type:     schema.TypeBool,
+					Optional: true,
+					Computed: true,
+				},
+				// global_secondary_index read capacity override can be set but not return by aws atm either through main/replica nor directly
+				"global_table_arn": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				names.AttrKMSKeyARN: { // through main table
+					Type:         schema.TypeString,
+					Optional:     true,
+					Computed:     true,
+					ForceNew:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				"point_in_time_recovery": { // direct to replica
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
+				// read_capacity_override can be set but requires table write_capacity to be autoscaled which is not yet supported in the provider
+				"table_class_override": { // through main table
+					Type:             schema.TypeString,
+					Optional:         true,
+					ForceNew:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.TableClass](),
+				},
+				names.AttrTags:    tftags.TagsSchema(),         // direct to replica
+				names.AttrTagsAll: tftags.TagsSchemaComputed(), // direct to replica
+			}
 		},
 	}
 }


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Use `SchemaFunc` instead of `Schema` for `d` services

Schema is unchanged according to the script in #47758
