### PR TITLE
🤖🤖🤖 r/aws_cleanrooms_collaboration: bring schema up to date with current API

### DIFF
--- a/.changelog/48138.txt
+++ b/.changelog/48138.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_cleanrooms_collaboration: Add `allowed_result_regions`, `auto_approved_change_request_types`, `creator_ml_member_abilities`, `creator_payment_configuration`, `is_metrics_enabled`, `job_log_status`, `membership_arn`, and `membership_id` arguments and attributes
+```
+
+```release-note:enhancement
+resource/aws_cleanrooms_collaboration: Add `ml_member_abilities` and `payment_configuration` to the `member` block
+```

--- a/internal/service/cleanrooms/collaboration.go
+++ b/internal/service/cleanrooms/collaboration.go
@@ -8,7 +8,6 @@ package cleanrooms
 import (
 	"context"
 	"errors"
-	"fmt"
 	"log"
 	"time"
 
@@ -21,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -48,14 +48,35 @@ func resourceCollaboration() *schema.Resource {
 
 		SchemaFunc: func() map[string]*schema.Schema {
 			return map[string]*schema.Schema{
+				"allowed_result_regions": {
+					Type:     schema.TypeList,
+					Optional: true,
+					ForceNew: true,
+					Elem: &schema.Schema{
+						Type:             schema.TypeString,
+						ValidateDiagFunc: enum.Validate[types.SupportedS3Region](),
+					},
+				},
 				"analytics_engine": {
 					Type:             schema.TypeString,
 					Optional:         true,
+					Computed:         true,
+					ForceNew:         true,
 					ValidateDiagFunc: enum.Validate[types.AnalyticsEngine](),
+					Deprecated:       "AWS Clean Rooms now uses Spark exclusively for new collaborations. CLEAN_ROOMS_SQL is no longer accepted at create time and AWS will return a ValidationException. See https://docs.aws.amazon.com/clean-rooms/latest/userguide/doc-history.html.",
 				},
 				names.AttrARN: {
 					Type:     schema.TypeString,
 					Computed: true,
+				},
+				"auto_approved_change_request_types": {
+					Type:     schema.TypeList,
+					Optional: true,
+					ForceNew: true,
+					Elem: &schema.Schema{
+						Type:             schema.TypeString,
+						ValidateDiagFunc: enum.Validate[types.AutoApprovedChangeType](),
+					},
 				},
 				names.AttrCreateTime: {
 					Type:     schema.TypeString,
@@ -70,8 +91,13 @@ func resourceCollaboration() *schema.Resource {
 					Type:     schema.TypeList,
 					Required: true,
 					ForceNew: true,
-					Elem:     &schema.Schema{Type: schema.TypeString},
+					Elem: &schema.Schema{
+						Type:             schema.TypeString,
+						ValidateDiagFunc: enum.Validate[types.MemberAbility](),
+					},
 				},
+				"creator_ml_member_abilities":   mlMemberAbilitiesSchema(),
+				"creator_payment_configuration": paymentConfigurationSchema(),
 				names.AttrDescription: {
 					Type:     schema.TypeString,
 					Required: true,
@@ -110,10 +136,27 @@ func resourceCollaboration() *schema.Resource {
 					Type:     schema.TypeString,
 					Computed: true,
 				},
+				"is_metrics_enabled": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+				},
+				"job_log_status": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					Computed:         true,
+					ForceNew:         true,
+					ValidateDiagFunc: enum.Validate[types.CollaborationJobLogStatus](),
+				},
 				"member": {
 					Type:     schema.TypeSet,
 					Optional: true,
 					ForceNew: true,
+					Set: func(v any) int {
+						m := v.(map[string]any)
+						return create.StringHashcode(m[names.AttrAccountID].(string))
+					},
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{
 							names.AttrAccountID: {
@@ -126,27 +169,41 @@ func resourceCollaboration() *schema.Resource {
 								Required: true,
 								ForceNew: true,
 							},
-							names.AttrStatus: {
-								Type:     schema.TypeString,
-								Computed: true,
-							},
 							"member_abilities": {
 								Type:     schema.TypeList,
 								Required: true,
 								ForceNew: true,
-								Elem:     &schema.Schema{Type: schema.TypeString},
+								Elem: &schema.Schema{
+									Type:             schema.TypeString,
+									ValidateDiagFunc: enum.Validate[types.MemberAbility](),
+								},
+							},
+							"ml_member_abilities":   mlMemberAbilitiesSchema(),
+							"payment_configuration": paymentConfigurationSchema(),
+							names.AttrStatus: {
+								Type:     schema.TypeString,
+								Computed: true,
 							},
 						},
 					},
+				},
+				"membership_arn": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"membership_id": {
+					Type:     schema.TypeString,
+					Computed: true,
 				},
 				names.AttrName: {
 					Type:     schema.TypeString,
 					Required: true,
 				},
 				"query_log_status": {
-					Type:     schema.TypeString,
-					ForceNew: true,
-					Required: true,
+					Type:             schema.TypeString,
+					Required:         true,
+					ForceNew:         true,
+					ValidateDiagFunc: enum.Validate[types.CollaborationQueryLogStatus](),
 				},
 				names.AttrTags:    tftags.TagsSchema(),
 				names.AttrTagsAll: tftags.TagsSchemaComputed(),
@@ -155,6 +212,94 @@ func resourceCollaboration() *schema.Resource {
 					Computed: true,
 				},
 			}
+		},
+	}
+}
+
+func mlMemberAbilitiesSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		Computed: true,
+		ForceNew: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"custom_ml_member_abilities": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+					Elem: &schema.Schema{
+						Type:             schema.TypeString,
+						ValidateDiagFunc: enum.Validate[types.CustomMLMemberAbility](),
+					},
+				},
+			},
+		},
+	}
+}
+
+func paymentConfigurationSchema() *schema.Schema {
+	isResponsibleBlock := func() *schema.Schema {
+		return &schema.Schema{
+			Type:     schema.TypeList,
+			Optional: true,
+			Computed: true,
+			ForceNew: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"is_responsible": {
+						Type:     schema.TypeBool,
+						Required: true,
+						ForceNew: true,
+					},
+				},
+			},
+		}
+	}
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		Computed: true,
+		ForceNew: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"job_compute": isResponsibleBlock(),
+				"machine_learning": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"model_inference":           isResponsibleBlock(),
+							"model_training":            isResponsibleBlock(),
+							"synthetic_data_generation": isResponsibleBlock(),
+						},
+					},
+				},
+				// query_compute is required by the AWS API on every PaymentConfiguration.
+				// See https://docs.aws.amazon.com/clean-rooms/latest/apireference/API_PaymentConfiguration.html.
+				"query_compute": {
+					Type:     schema.TypeList,
+					Required: true,
+					ForceNew: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"is_responsible": {
+								Type:     schema.TypeBool,
+								Required: true,
+								ForceNew: true,
+							},
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -168,25 +313,35 @@ func resourceCollaborationCreate(ctx context.Context, d *schema.ResourceData, me
 
 	conn := meta.(*conns.AWSClient).CleanRoomsClient(ctx)
 
-	creatorAbilities := d.Get("creator_member_abilities").([]any)
-
 	input := cleanrooms.CreateCollaborationInput{
 		Name:                   aws.String(d.Get(names.AttrName).(string)),
 		CreatorDisplayName:     aws.String(d.Get("creator_display_name").(string)),
-		CreatorMemberAbilities: expandMemberAbilities(creatorAbilities),
+		CreatorMemberAbilities: flex.ExpandStringyValueList[types.MemberAbility](d.Get("creator_member_abilities").([]any)),
 		Members:                *expandMembers(d.Get("member").(*schema.Set).List()),
 		Tags:                   getTagsIn(ctx),
+	}
+
+	if v, ok := d.GetOk("allowed_result_regions"); ok {
+		input.AllowedResultRegions = flex.ExpandStringyValueList[types.SupportedS3Region](v.([]any))
 	}
 
 	if v, ok := d.GetOk("analytics_engine"); ok {
 		input.AnalyticsEngine = types.AnalyticsEngine(v.(string))
 	}
 
-	queryLogStatus, err := expandQueryLogStatus(d.Get("query_log_status").(string))
-	if err != nil {
-		return create.AppendDiagError(diags, names.CleanRooms, create.ErrActionCreating, ResNameCollaboration, d.Get(names.AttrName).(string), err)
+	if v, ok := d.GetOk("auto_approved_change_request_types"); ok {
+		input.AutoApprovedChangeRequestTypes = flex.ExpandStringyValueList[types.AutoApprovedChangeType](v.([]any))
 	}
-	input.QueryLogStatus = queryLogStatus
+
+	if v, ok := d.GetOk("creator_ml_member_abilities"); ok {
+		input.CreatorMLMemberAbilities = expandMLMemberAbilities(v.([]any))
+	}
+
+	if v, ok := d.GetOk("creator_payment_configuration"); ok {
+		input.CreatorPaymentConfiguration = expandPaymentConfiguration(v.([]any))
+	}
+
+	input.QueryLogStatus = types.CollaborationQueryLogStatus(d.Get("query_log_status").(string))
 
 	if v, ok := d.GetOk("data_encryption_metadata"); ok {
 		input.DataEncryptionMetadata = expandDataEncryptionMetadata(v.([]any))
@@ -194,6 +349,17 @@ func resourceCollaborationCreate(ctx context.Context, d *schema.ResourceData, me
 
 	if v, ok := d.GetOk(names.AttrDescription); ok {
 		input.Description = aws.String(v.(string))
+	}
+
+	// is_metrics_enabled is Optional+Computed+TypeBool. Use GetRawConfig so an
+	// explicit `false` is reliably distinguished from absence; d.GetOk and
+	// d.GetOkExists are unreliable here per terraform-plugin-sdk guidance.
+	if v := d.GetRawConfig().GetAttr("is_metrics_enabled"); v.IsKnown() && !v.IsNull() {
+		input.IsMetricsEnabled = aws.Bool(v.True())
+	}
+
+	if v, ok := d.GetOk("job_log_status"); ok {
+		input.JobLogStatus = types.CollaborationJobLogStatus(v.(string))
 	}
 
 	out, err := conn.CreateCollaboration(ctx, &input)
@@ -244,10 +410,6 @@ func resourceCollaborationUpdate(ctx context.Context, d *schema.ResourceData, me
 
 		if d.HasChanges(names.AttrName) {
 			input.Name = aws.String(d.Get(names.AttrName).(string))
-		}
-
-		if d.HasChanges("analytics_engine") {
-			input.AnalyticsEngine = types.AnalyticsEngine(d.Get("analytics_engine").(string))
 		}
 
 		_, err := conn.UpdateCollaboration(ctx, &input)
@@ -328,30 +490,6 @@ func findMembersByCollaborationId(ctx context.Context, conn *cleanrooms.Client, 
 	return out, nil
 }
 
-func expandMemberAbilities(data []any) []types.MemberAbility {
-	mappedAbilities := make([]types.MemberAbility, 0)
-	for _, v := range data {
-		switch v.(string) {
-		case "CAN_QUERY":
-			mappedAbilities = append(mappedAbilities, types.MemberAbilityCanQuery)
-		case "CAN_RECEIVE_RESULTS":
-			mappedAbilities = append(mappedAbilities, types.MemberAbilityCanReceiveResults)
-		}
-	}
-	return mappedAbilities
-}
-
-func expandQueryLogStatus(status string) (types.CollaborationQueryLogStatus, error) {
-	switch status {
-	case "ENABLED":
-		return types.CollaborationQueryLogStatusEnabled, nil
-	case "DISABLED":
-		return types.CollaborationQueryLogStatusDisabled, nil
-	default:
-		return types.CollaborationQueryLogStatusDisabled, fmt.Errorf("Invalid query log status type: %s", status)
-	}
-}
-
 func expandDataEncryptionMetadata(data []any) *types.DataEncryptionMetadata {
 	dataEncryptionMetadata := types.DataEncryptionMetadata{}
 	if len(data) > 0 {
@@ -370,12 +508,75 @@ func expandMembers(data []any) *[]types.MemberSpecification {
 		memberMap := member.(map[string]any)
 		m := types.MemberSpecification{
 			AccountId:       aws.String(memberMap[names.AttrAccountID].(string)),
-			MemberAbilities: expandMemberAbilities(memberMap["member_abilities"].([]any)),
+			MemberAbilities: flex.ExpandStringyValueList[types.MemberAbility](memberMap["member_abilities"].([]any)),
 			DisplayName:     aws.String(memberMap[names.AttrDisplayName].(string)),
+		}
+		if v, ok := memberMap["ml_member_abilities"].([]any); ok && len(v) > 0 {
+			m.MlMemberAbilities = expandMLMemberAbilities(v)
+		}
+		if v, ok := memberMap["payment_configuration"].([]any); ok && len(v) > 0 {
+			m.PaymentConfiguration = expandPaymentConfiguration(v)
 		}
 		members = append(members, m)
 	}
 	return &members
+}
+
+func expandMLMemberAbilities(data []any) *types.MLMemberAbilities {
+	if len(data) == 0 {
+		return nil
+	}
+	m := data[0].(map[string]any)
+	return &types.MLMemberAbilities{
+		CustomMLMemberAbilities: flex.ExpandStringyValueList[types.CustomMLMemberAbility](m["custom_ml_member_abilities"].([]any)),
+	}
+}
+
+// expandIsResponsible reads the `is_responsible` bool from a single-element
+// list block (the shape used by every leaf payment-config block) and returns
+// nil when the block is absent.
+func expandIsResponsible(v any) *bool {
+	data, ok := v.([]any)
+	if !ok || len(data) == 0 {
+		return nil
+	}
+	return aws.Bool(data[0].(map[string]any)["is_responsible"].(bool))
+}
+
+func expandPaymentConfiguration(data []any) *types.PaymentConfiguration {
+	if len(data) == 0 {
+		return nil
+	}
+	m := data[0].(map[string]any)
+	out := &types.PaymentConfiguration{}
+	if r := expandIsResponsible(m["query_compute"]); r != nil {
+		out.QueryCompute = &types.QueryComputePaymentConfig{IsResponsible: r}
+	}
+	if r := expandIsResponsible(m["job_compute"]); r != nil {
+		out.JobCompute = &types.JobComputePaymentConfig{IsResponsible: r}
+	}
+	if v, ok := m["machine_learning"].([]any); ok && len(v) > 0 {
+		out.MachineLearning = expandMLPaymentConfig(v)
+	}
+	return out
+}
+
+func expandMLPaymentConfig(data []any) *types.MLPaymentConfig {
+	if len(data) == 0 {
+		return nil
+	}
+	m := data[0].(map[string]any)
+	out := &types.MLPaymentConfig{}
+	if r := expandIsResponsible(m["model_inference"]); r != nil {
+		out.ModelInference = &types.ModelInferencePaymentConfig{IsResponsible: r}
+	}
+	if r := expandIsResponsible(m["model_training"]); r != nil {
+		out.ModelTraining = &types.ModelTrainingPaymentConfig{IsResponsible: r}
+	}
+	if r := expandIsResponsible(m["synthetic_data_generation"]); r != nil {
+		out.SyntheticDataGeneration = &types.SyntheticDataGenerationPaymentConfig{IsResponsible: r}
+	}
+	return out
 }
 
 func flattenDataEncryptionMetadata(dataEncryptionMetadata *types.DataEncryptionMetadata) []any {
@@ -393,34 +594,85 @@ func flattenDataEncryptionMetadata(dataEncryptionMetadata *types.DataEncryptionM
 func flattenMembers(members []types.MemberSummary, ownerAccount *string) []any {
 	flattenedMembers := make([]any, 0)
 	for _, member := range members {
-		if aws.ToString(member.AccountId) != aws.ToString(ownerAccount) {
-			memberMap := map[string]any{}
-			memberMap[names.AttrStatus] = member.Status
-			memberMap[names.AttrAccountID] = member.AccountId
-			memberMap[names.AttrDisplayName] = member.DisplayName
-			memberMap["member_abilities"] = flattenMemberAbilities(member.Abilities)
-			flattenedMembers = append(flattenedMembers, memberMap)
+		if aws.ToString(member.AccountId) == aws.ToString(ownerAccount) {
+			continue
 		}
+		flattenedMembers = append(flattenedMembers, map[string]any{
+			names.AttrStatus:        member.Status,
+			names.AttrAccountID:     member.AccountId,
+			names.AttrDisplayName:   member.DisplayName,
+			"member_abilities":      flex.FlattenStringyValueList(member.Abilities),
+			"ml_member_abilities":   flattenMLMemberAbilities(member.MlAbilities),
+			"payment_configuration": flattenPaymentConfiguration(member.PaymentConfiguration),
+		})
 	}
 	return flattenedMembers
 }
 
-func flattenCreatorAbilities(members []types.MemberSummary, ownerAccount *string) []string {
-	flattenedAbilities := make([]string, 0)
-	for _, member := range members {
+// findCreatorMember returns the MemberSummary entry matching the creator
+// account, or nil if it is not present in the list.
+func findCreatorMember(members []types.MemberSummary, ownerAccount *string) *types.MemberSummary {
+	for i, member := range members {
 		if aws.ToString(member.AccountId) == aws.ToString(ownerAccount) {
-			return flattenMemberAbilities(member.Abilities)
+			return &members[i]
 		}
 	}
-	return flattenedAbilities
+	return nil
 }
 
-func flattenMemberAbilities(abilities []types.MemberAbility) []string {
-	flattenedAbilities := make([]string, 0)
-	for _, ability := range abilities {
-		flattenedAbilities = append(flattenedAbilities, string(ability))
+func flattenMLMemberAbilities(in *types.MLMemberAbilities) []any {
+	if in == nil {
+		return nil
 	}
-	return flattenedAbilities
+	return []any{map[string]any{
+		"custom_ml_member_abilities": flex.FlattenStringyValueList(in.CustomMLMemberAbilities),
+	}}
+}
+
+// flattenIsResponsible builds the single-element list block that wraps
+// `is_responsible` for every leaf payment-config block. Returns nil when the
+// input pointer is nil so the wrapping caller can skip the key.
+func flattenIsResponsible(b *bool) []any {
+	if b == nil {
+		return nil
+	}
+	return []any{map[string]any{
+		"is_responsible": aws.ToBool(b),
+	}}
+}
+
+func flattenPaymentConfiguration(in *types.PaymentConfiguration) []any {
+	if in == nil {
+		return nil
+	}
+	m := map[string]any{}
+	if in.QueryCompute != nil {
+		m["query_compute"] = flattenIsResponsible(in.QueryCompute.IsResponsible)
+	}
+	if in.JobCompute != nil {
+		m["job_compute"] = flattenIsResponsible(in.JobCompute.IsResponsible)
+	}
+	if in.MachineLearning != nil {
+		m["machine_learning"] = flattenMLPaymentConfig(in.MachineLearning)
+	}
+	return []any{m}
+}
+
+func flattenMLPaymentConfig(in *types.MLPaymentConfig) []any {
+	if in == nil {
+		return nil
+	}
+	m := map[string]any{}
+	if in.ModelInference != nil {
+		m["model_inference"] = flattenIsResponsible(in.ModelInference.IsResponsible)
+	}
+	if in.ModelTraining != nil {
+		m["model_training"] = flattenIsResponsible(in.ModelTraining.IsResponsible)
+	}
+	if in.SyntheticDataGeneration != nil {
+		m["synthetic_data_generation"] = flattenIsResponsible(in.SyntheticDataGeneration.IsResponsible)
+	}
+	return []any{m}
 }
 
 func resourceCollaborationFlatten(ctx context.Context, conn *cleanrooms.Client, d *schema.ResourceData, out *cleanrooms.GetCollaborationOutput) diag.Diagnostics {
@@ -430,9 +682,15 @@ func resourceCollaborationFlatten(ctx context.Context, conn *cleanrooms.Client, 
 	d.Set(names.AttrARN, collaboration.Arn)
 	d.Set(names.AttrName, collaboration.Name)
 	d.Set(names.AttrDescription, collaboration.Description)
+	d.Set("allowed_result_regions", flex.FlattenStringyValueList(collaboration.AllowedResultRegions))
 	d.Set("analytics_engine", collaboration.AnalyticsEngine)
+	d.Set("auto_approved_change_request_types", flex.FlattenStringyValueList(collaboration.AutoApprovedChangeTypes))
 	d.Set("creator_display_name", collaboration.CreatorDisplayName)
 	d.Set(names.AttrCreateTime, collaboration.CreateTime.String())
+	d.Set("is_metrics_enabled", aws.ToBool(collaboration.IsMetricsEnabled))
+	d.Set("job_log_status", collaboration.JobLogStatus)
+	d.Set("membership_arn", collaboration.MembershipArn)
+	d.Set("membership_id", collaboration.MembershipId)
 	d.Set("update_time", collaboration.UpdateTime.String())
 	d.Set("query_log_status", collaboration.QueryLogStatus)
 	d.Set("data_encryption_metadata", flattenDataEncryptionMetadata(collaboration.DataEncryptionMetadata))
@@ -443,7 +701,12 @@ func resourceCollaborationFlatten(ctx context.Context, conn *cleanrooms.Client, 
 	}
 
 	d.Set("member", flattenMembers(membersOut.MemberSummaries, collaboration.CreatorAccountId))
-	d.Set("creator_member_abilities", flattenCreatorAbilities(membersOut.MemberSummaries, collaboration.CreatorAccountId))
+
+	if creator := findCreatorMember(membersOut.MemberSummaries, collaboration.CreatorAccountId); creator != nil {
+		d.Set("creator_member_abilities", flex.FlattenStringyValueList(creator.Abilities))
+		d.Set("creator_ml_member_abilities", flattenMLMemberAbilities(creator.MlAbilities))
+		d.Set("creator_payment_configuration", flattenPaymentConfiguration(creator.PaymentConfiguration))
+	}
 
 	return diags
 }

--- a/internal/service/cleanrooms/collaboration_test.go
+++ b/internal/service/cleanrooms/collaboration_test.go
@@ -590,3 +590,153 @@ resource "aws_cleanrooms_collaboration" "test" {
 }
 `, rName, engine)
 }
+
+func TestAccCleanRoomsCollaboration_topLevelAttributes(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var collaboration cleanrooms.GetCollaborationOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_cleanrooms_collaboration.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CleanRoomsServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckCollaborationDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCollaborationConfig_topLevelAttributes(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCollaborationExists(ctx, t, resourceName, &collaboration),
+					resource.TestCheckResourceAttr(resourceName, "allowed_result_regions.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_result_regions.0", "us-east-1"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_result_regions.1", "us-west-2"),
+					resource.TestCheckResourceAttr(resourceName, "auto_approved_change_request_types.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "auto_approved_change_request_types.0", "ADD_MEMBER"),
+					resource.TestCheckResourceAttr(resourceName, "is_metrics_enabled", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "job_log_status", "DISABLED"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccCleanRoomsCollaboration_paymentAndMLConfig(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var collaboration cleanrooms.GetCollaborationOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_cleanrooms_collaboration.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CleanRoomsServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckCollaborationDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCollaborationConfig_paymentAndMLConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCollaborationExists(ctx, t, resourceName, &collaboration),
+					resource.TestCheckResourceAttr(resourceName, "creator_ml_member_abilities.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "creator_ml_member_abilities.0.custom_ml_member_abilities.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "creator_payment_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "creator_payment_configuration.0.query_compute.0.is_responsible", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "creator_payment_configuration.0.job_compute.0.is_responsible", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "creator_payment_configuration.0.machine_learning.0.model_inference.0.is_responsible", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "creator_payment_configuration.0.machine_learning.0.model_training.0.is_responsible", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "creator_payment_configuration.0.machine_learning.0.synthetic_data_generation.0.is_responsible", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "member.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "member.0.ml_member_abilities.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "member.0.ml_member_abilities.0.custom_ml_member_abilities.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "member.0.payment_configuration.0.query_compute.0.is_responsible", acctest.CtFalse),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCollaborationConfig_topLevelAttributes(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_cleanrooms_collaboration" "test" {
+  name                               = %[1]q
+  creator_display_name               = "creator"
+  creator_member_abilities           = ["CAN_QUERY", "CAN_RECEIVE_RESULTS", "CAN_RUN_JOB"]
+  description                        = "top-level attributes"
+  query_log_status                   = "DISABLED"
+  allowed_result_regions             = ["us-east-1", "us-west-2"]
+  auto_approved_change_request_types = ["ADD_MEMBER"]
+  is_metrics_enabled                 = true
+  job_log_status                     = "DISABLED"
+
+  member {
+    account_id       = 123456789012
+    display_name     = "OtherMember"
+    member_abilities = ["CAN_RECEIVE_RESULTS"]
+  }
+}
+`, rName)
+}
+
+func testAccCollaborationConfig_paymentAndMLConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_cleanrooms_collaboration" "test" {
+  name                     = %[1]q
+  creator_display_name     = "creator"
+  creator_member_abilities = ["CAN_QUERY", "CAN_RECEIVE_RESULTS", "CAN_RUN_JOB"]
+  description              = "payment and ML config"
+  query_log_status         = "DISABLED"
+  job_log_status           = "DISABLED"
+
+  creator_ml_member_abilities {
+    custom_ml_member_abilities = ["CAN_RECEIVE_MODEL_OUTPUT", "CAN_RECEIVE_INFERENCE_OUTPUT"]
+  }
+
+  creator_payment_configuration {
+    query_compute {
+      is_responsible = true
+    }
+    job_compute {
+      is_responsible = true
+    }
+    machine_learning {
+      model_inference {
+        is_responsible = true
+      }
+      model_training {
+        is_responsible = true
+      }
+      synthetic_data_generation {
+        is_responsible = true
+      }
+    }
+  }
+
+  member {
+    account_id       = 123456789012
+    display_name     = "OtherMember"
+    member_abilities = []
+
+    ml_member_abilities {
+      custom_ml_member_abilities = ["CAN_RECEIVE_MODEL_OUTPUT"]
+    }
+
+    payment_configuration {
+      query_compute {
+        is_responsible = false
+      }
+    }
+  }
+}
+`, rName)
+}

--- a/website/docs/r/cleanrooms_collaboration.html.markdown
+++ b/website/docs/r/cleanrooms_collaboration.html.markdown
@@ -20,7 +20,6 @@ resource "aws_cleanrooms_collaboration" "test_collaboration" {
   creator_display_name     = "Creator "
   description              = "I made this collaboration with terraform!"
   query_log_status         = "DISABLED"
-  analytics_engine         = "SPARK"
 
   data_encryption_metadata {
     allow_clear_text                            = true
@@ -53,8 +52,14 @@ The following arguments are required:
 
 The following arguments are optional:
 
-* `analytics_engine` - (Optional) Analytics engine used by the collaboration. Valid values are `CLEAN_ROOMS_SQL` (deprecated) and `SPARK`.
+* `allowed_result_regions` - (Optional - Forces new resource) AWS Regions where collaboration query results can be stored. Valid values [may be found here](https://docs.aws.amazon.com/clean-rooms/latest/apireference/API_SupportedS3Region.html).
+* `analytics_engine` - (Optional - Forces new resource, **deprecated**) Analytics engine for the collaboration. Spark is now the only engine accepted by AWS for new collaborations; supplying `CLEAN_ROOMS_SQL` results in a `ValidationException` at apply time. Omitting this argument lets AWS apply its default. See the [AWS Clean Rooms document history](https://docs.aws.amazon.com/clean-rooms/latest/userguide/doc-history.html).
+* `auto_approved_change_request_types` - (Optional - Forces new resource) Types of change requests that are automatically approved for this collaboration. Valid values [may be found here](https://docs.aws.amazon.com/clean-rooms/latest/apireference/API_AutoApprovedChangeType.html).
+* `creator_ml_member_abilities` - (Optional - Forces new resource) ML abilities granted to the collaboration creator. [See below](#ml_member_abilities-configuration-block).
+* `creator_payment_configuration` - (Optional - Forces new resource) Collaboration creator's payment responsibilities for query, job, and ML compute costs. [See below](#payment_configuration-configuration-block).
 * `data_encryption_metadata` - (Optional - Forces new resource) Collection of settings which determine how the [c3r client](https://docs.aws.amazon.com/clean-rooms/latest/userguide/crypto-computing.html) will encrypt data for use within this collaboration. [See below](#data_encryption_metadata-configuration-block).
+* `is_metrics_enabled` - (Optional - Forces new resource) Whether collaboration members can opt in to Amazon CloudWatch metrics for their membership queries.
+* `job_log_status` - (Optional - Forces new resource) Whether job logs are enabled for this collaboration. Valid values are `ENABLED` and `DISABLED`.
 * `member` - (Optional - Forces new resource) Additional members of the collaboration which will be invited to join the collaboration. [See below](#member-configuration-block).
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `tags` - (Optional) Key value pairs which tag the collaboration.
@@ -71,6 +76,30 @@ The following arguments are optional:
 * `account_id` - (Required - Forces new resource) Account ID for the invited member.
 * `display_name` - (Required - Forces new resource) Display name for the invited member.
 * `member_abilities` - (Required - Forces new resource) List of abilities for the invited member. Valid values [may be found here](https://docs.aws.amazon.com/clean-rooms/latest/apireference/API_CreateCollaboration.html#API-CreateCollaboration-request-creatorMemberAbilities).
+* `ml_member_abilities` - (Optional - Forces new resource) ML abilities granted to the invited member. [See below](#ml_member_abilities-configuration-block).
+* `payment_configuration` - (Optional - Forces new resource) Invited member's payment responsibilities for query, job, and ML compute costs. [See below](#payment_configuration-configuration-block).
+
+### `ml_member_abilities` Configuration Block
+
+* `custom_ml_member_abilities` - (Required - Forces new resource) Custom ML abilities granted to the member. Valid values are `CAN_RECEIVE_MODEL_OUTPUT` and `CAN_RECEIVE_INFERENCE_OUTPUT`.
+
+### `payment_configuration` Configuration Block
+
+* `query_compute` - (Required - Forces new resource) Payment responsibilities for query compute costs. [See below](#is_responsible-configuration-block).
+* `job_compute` - (Optional - Forces new resource) Payment responsibilities for job compute costs. [See below](#is_responsible-configuration-block).
+* `machine_learning` - (Optional - Forces new resource) Payment responsibilities for ML compute costs. [See below](#machine_learning-configuration-block).
+
+#### `machine_learning` Configuration Block
+
+* `model_inference` - (Optional - Forces new resource) Payment responsibilities for model inference. [See below](#is_responsible-configuration-block).
+* `model_training` - (Optional - Forces new resource) Payment responsibilities for model training. [See below](#is_responsible-configuration-block).
+* `synthetic_data_generation` - (Optional - Forces new resource) Payment responsibilities for synthetic data generation. [See below](#is_responsible-configuration-block).
+
+#### `is_responsible` Configuration Block
+
+The `query_compute`, `job_compute`, `model_inference`, `model_training`, and `synthetic_data_generation` blocks all share this shape:
+
+* `is_responsible` - (Required - Forces new resource) Whether the member is responsible for the corresponding compute costs.
 
 ## Attribute Reference
 
@@ -80,6 +109,8 @@ This resource exports the following attributes in addition to the arguments abov
 * `create_time` - Date and time the collaboration was created.
 * `id` - ID of the collaboration.
 * `member.status` - For each member included in the collaboration an additional computed attribute of status is added. These values [may be found here](https://docs.aws.amazon.com/clean-rooms/latest/apireference/API_MemberSummary.html#API-Type-MemberSummary-status).
+* `membership_arn` - The unique ARN for the calling account's membership within the collaboration, if present. May be empty when no associated membership has been created with `aws_cleanrooms_membership`. See [`API_Collaboration#membershipArn`](https://docs.aws.amazon.com/clean-rooms/latest/apireference/API_Collaboration.html).
+* `membership_id` - The unique ID for the calling account's membership within the collaboration, if present. May be empty when no associated membership has been created with `aws_cleanrooms_membership`. See [`API_Collaboration#membershipId`](https://docs.aws.amazon.com/clean-rooms/latest/apireference/API_Collaboration.html).
 * `update_time` - Date and time the collaboration was last updated.
 
 ## Timeouts


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls. The existing IAM- and tag-based access patterns are unchanged.

### Description

Brings `aws_cleanrooms_collaboration` up to date with the current AWS Clean Rooms API.

**Schema additions** — fields exposed by the Collaboration object that the resource was not modeling:
- `allowed_result_regions`
- `auto_approved_change_request_types`
- `creator_ml_member_abilities`
- `creator_payment_configuration`
- `is_metrics_enabled`
- `job_log_status`
- `membership_arn` (computed)
- `membership_id` (computed)
- Inside the `member` block: `ml_member_abilities` and `payment_configuration`

The `member` block now uses a custom `Set:` hash keyed only on `account_id` so per-member fields that AWS auto-populates (notably `paymentConfiguration`) round-trip cleanly without spurious set-element churn.

**`analytics_engine` deprecation** — AWS Clean Rooms now uses Spark exclusively for collaborations:
- 2025-07-17: customers can no longer create new collaborations with the legacy Clean Rooms SQL analytics engine.
- 2025-12-17: support for the Clean Rooms SQL analytics engine ended; Spark SQL is the only option.

The attribute is now `Optional + Computed + ForceNew` with a `Deprecated` message. The user's value is forwarded to `CreateCollaboration` unchanged, so AWS gets to be the source of truth on what is valid: any user whose HCL sets `analytics_engine = "CLEAN_ROOMS_SQL"` gets an apply-time `ValidationException` directly from AWS ("Your account is not approved to use Clean Rooms SQL for new collaborations. Create a collaboration using the Spark SQL analytics engine"). The Update branch is removed because AWS does not honor analytics_engine on Update. `Computed: true` ensures users who omit the attribute no longer see a perpetual `analytics_engine: "SPARK" -> null` diff after Read populates state with the API value.

**Other supporting fixes**:
- `expandMemberAbilities` no longer enumerates valid values via a hand-written switch; the switch silently dropped unknown abilities, including `CAN_RUN_JOB`, which made `job_log_status` unusable. Replaced with a direct SDK enum cast plus an `enum.Validate[types.MemberAbility]()` schema validator for plan-time validation.
- `expandQueryLogStatus` (a similar hand-rolled switch) is removed in favor of an SDK enum cast plus a schema-level enum validator.
- `flattenDataEncryptionMetadata` switched from `aws.Bool(*x)` (which nil-derefs if the SDK ever returns a partial struct) to `aws.ToBool(x)`.
- `query_compute` inside `paymentConfigurationSchema` is `Required` so an empty `payment_configuration {}` block is caught at plan time rather than at apply time with an opaque AWS `ValidationException`.
- String-list expand/flatten loops replaced with the project-wide `flex.ExpandStringyValueList[E]` / `flex.FlattenStringyValueList[E]` helpers.
- Repeated `is_responsible` extract+wrap blocks consolidated into `expandIsResponsible` / `flattenIsResponsible` helpers.
- Three separate creator-walks of `MemberSummaries` replaced by one `findCreatorMember` helper.
- `is_metrics_enabled` reads its config value via `d.GetRawConfig()` instead of the deprecated `d.GetOkExists`, so an explicit `false` is reliably distinguished from absence.

End-user documentation in `website/docs/r/cleanrooms_collaboration.html.markdown` is updated to describe every new attribute and the new nested blocks.

### Relations

Relates #48135

### References

- [AWS Clean Rooms document history](https://docs.aws.amazon.com/clean-rooms/latest/userguide/doc-history.html)
- [`API_Collaboration`](https://docs.aws.amazon.com/clean-rooms/latest/apireference/API_Collaboration.html)
- [`API_CreateCollaboration`](https://docs.aws.amazon.com/clean-rooms/latest/apireference/API_CreateCollaboration.html)
- [`API_PaymentConfiguration`](https://docs.aws.amazon.com/clean-rooms/latest/apireference/API_PaymentConfiguration.html)
- [`API_MLMemberAbilities`](https://docs.aws.amazon.com/clean-rooms/latest/apireference/API_MLMemberAbilities.html)

### Output from Acceptance Testing

Two new acceptance tests were added (`TestAccCleanRoomsCollaboration_topLevelAttributes` and `TestAccCleanRoomsCollaboration_paymentAndMLConfig`). All `TestAccCleanRoomsCollaboration_*` tests pass:

```console
% TF_ACC=1 AWS_DEFAULT_REGION=us-west-2 go test -v -run '^TestAccCleanRoomsCollaboration_' -count=1 -timeout 30m ./internal/service/cleanrooms/

--- PASS: TestAccCleanRoomsCollaboration_basic (23.17s)
--- PASS: TestAccCleanRoomsCollaboration_disappears (...)
--- PASS: TestAccCleanRoomsCollaboration_dataEncryptionSettings (...)
--- PASS: TestAccCleanRoomsCollaboration_updateMemberAbilities (...)
--- PASS: TestAccCleanRoomsCollaboration_updateCreatorDisplayName (...)
--- PASS: TestAccCleanRoomsCollaboration_updateQueryLogStatus (...)
--- PASS: TestAccCleanRoomsCollaboration_mutableProperties (...)
--- PASS: TestAccCleanRoomsCollaboration_analyticsEngine (23.14s)
--- PASS: TestAccCleanRoomsCollaboration_topLevelAttributes (23.57s)
--- PASS: TestAccCleanRoomsCollaboration_paymentAndMLConfig (24.90s)
--- PASS: TestAccCleanRoomsCollaboration_Identity_basic (...)
--- PASS: TestAccCleanRoomsCollaboration_Identity_ExistingResource_basic (...)
--- PASS: TestAccCleanRoomsCollaboration_Identity_ExistingResource_noRefreshNoChange (...)
--- PASS: TestAccCleanRoomsCollaboration_Identity_regionOverride (...)
PASS
```

### AI Usage

This PR was developed using an AI coding assistant (Claude). The assistant was used to draft schema changes, refactorings, acceptance test scaffolding, and documentation updates. Every line of the resulting code was reviewed and tested by the human author against the AWS API and the verification matrix described above.
