### PR TITLE
feat: add model_lifecycle to aws_bedrock_foundation_model and aws_bedrock_foundation_models

### DIFF
--- a/.changelog/48140.txt
+++ b/.changelog/48140.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+data-source/aws_bedrock_foundation_model: Add `model_lifecycle` attribute
+```
+
+```release-note:enhancement
+data-source/aws_bedrock_foundation_models: Add `model_lifecycle` attribute to `model_summaries`
+```

--- a/internal/service/bedrock/foundation_model_data_source.go
+++ b/internal/service/bedrock/foundation_model_data_source.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/service/bedrock"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/bedrock/types"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -65,6 +66,18 @@ func (d *foundationModelDataSource) Schema(ctx context.Context, request datasour
 			names.AttrProviderName: schema.StringAttribute{
 				Computed: true,
 			},
+			"model_lifecycle": schema.ListNestedAttribute{
+				CustomType: fwtypes.NewListNestedObjectTypeOf[foundationModelLifecycleModel](ctx),
+				Computed:   true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"status": schema.StringAttribute{
+							CustomType: fwtypes.StringEnumType[awstypes.FoundationModelLifecycleStatus](),
+							Computed:   true,
+						},
+					},
+				},
+			},
 			"response_streaming_supported": schema.BoolAttribute{
 				Computed: true,
 			},
@@ -105,14 +118,19 @@ func (d *foundationModelDataSource) Read(ctx context.Context, request datasource
 
 type foundationModelDataSourceModel struct {
 	framework.WithRegionModel
-	CustomizationsSupported    fwtypes.SetOfString `tfsdk:"customizations_supported"`
-	ID                         types.String        `tfsdk:"id"`
-	InferenceTypesSupported    fwtypes.SetOfString `tfsdk:"inference_types_supported"`
-	InputModalities            fwtypes.SetOfString `tfsdk:"input_modalities"`
-	ModelARN                   fwtypes.ARN         `tfsdk:"model_arn"`
-	ModelID                    types.String        `tfsdk:"model_id"`
-	ModelName                  types.String        `tfsdk:"model_name"`
-	OutputModalities           fwtypes.SetOfString `tfsdk:"output_modalities"`
-	ProviderName               types.String        `tfsdk:"provider_name"`
-	ResponseStreamingSupported types.Bool          `tfsdk:"response_streaming_supported"`
+	CustomizationsSupported    fwtypes.SetOfString                                            `tfsdk:"customizations_supported"`
+	ID                         types.String                                                   `tfsdk:"id"`
+	InferenceTypesSupported    fwtypes.SetOfString                                            `tfsdk:"inference_types_supported"`
+	InputModalities            fwtypes.SetOfString                                            `tfsdk:"input_modalities"`
+	ModelARN                   fwtypes.ARN                                                    `tfsdk:"model_arn"`
+	ModelID                    types.String                                                   `tfsdk:"model_id"`
+	ModelLifecycle             fwtypes.ListNestedObjectValueOf[foundationModelLifecycleModel] `tfsdk:"model_lifecycle"`
+	ModelName                  types.String                                                   `tfsdk:"model_name"`
+	OutputModalities           fwtypes.SetOfString                                            `tfsdk:"output_modalities"`
+	ProviderName               types.String                                                   `tfsdk:"provider_name"`
+	ResponseStreamingSupported types.Bool                                                     `tfsdk:"response_streaming_supported"`
+}
+
+type foundationModelLifecycleModel struct {
+	Status fwtypes.StringEnum[awstypes.FoundationModelLifecycleStatus] `tfsdk:"status"`
 }

--- a/internal/service/bedrock/foundation_model_data_source.go
+++ b/internal/service/bedrock/foundation_model_data_source.go
@@ -66,18 +66,7 @@ func (d *foundationModelDataSource) Schema(ctx context.Context, request datasour
 			names.AttrProviderName: schema.StringAttribute{
 				Computed: true,
 			},
-			"model_lifecycle": schema.ListNestedAttribute{
-				CustomType: fwtypes.NewListNestedObjectTypeOf[foundationModelLifecycleModel](ctx),
-				Computed:   true,
-				NestedObject: schema.NestedAttributeObject{
-					Attributes: map[string]schema.Attribute{
-						"status": schema.StringAttribute{
-							CustomType: fwtypes.StringEnumType[awstypes.FoundationModelLifecycleStatus](),
-							Computed:   true,
-						},
-					},
-				},
-			},
+			"model_lifecycle": framework.DataSourceComputedListOfObjectAttribute[foundationModelLifecycleModel](ctx),
 			"response_streaming_supported": schema.BoolAttribute{
 				Computed: true,
 			},

--- a/internal/service/bedrock/foundation_model_data_source_test.go
+++ b/internal/service/bedrock/foundation_model_data_source_test.go
@@ -28,6 +28,8 @@ func TestAccBedrockFoundationModelDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(datasourceName, "inference_types_supported.#"),
 					resource.TestCheckResourceAttrSet(datasourceName, "input_modalities.#"),
 					resource.TestCheckResourceAttrSet(datasourceName, "model_arn"),
+					resource.TestCheckResourceAttr(datasourceName, "model_lifecycle.#", "1"),
+					resource.TestCheckResourceAttrSet(datasourceName, "model_lifecycle.0.status"),
 					resource.TestCheckResourceAttrSet(datasourceName, "model_name"),
 					resource.TestCheckResourceAttrSet(datasourceName, "output_modalities.#"),
 					resource.TestCheckResourceAttrSet(datasourceName, names.AttrProviderName),

--- a/internal/service/bedrock/foundation_models_data_source.go
+++ b/internal/service/bedrock/foundation_models_data_source.go
@@ -102,13 +102,14 @@ type foundationModelsDataSourceModel struct {
 }
 
 type foundationModelSummaryModel struct {
-	CustomizationsSupported    fwtypes.SetOfString `tfsdk:"customizations_supported"`
-	InferenceTypesSupported    fwtypes.SetOfString `tfsdk:"inference_types_supported"`
-	InputModalities            fwtypes.SetOfString `tfsdk:"input_modalities"`
-	ModelARN                   fwtypes.ARN         `tfsdk:"model_arn"`
-	ModelID                    types.String        `tfsdk:"model_id"`
-	ModelName                  types.String        `tfsdk:"model_name"`
-	OutputModalities           fwtypes.SetOfString `tfsdk:"output_modalities"`
-	ProviderName               types.String        `tfsdk:"provider_name"`
-	ResponseStreamingSupported types.Bool          `tfsdk:"response_streaming_supported"`
+	CustomizationsSupported    fwtypes.SetOfString                                            `tfsdk:"customizations_supported"`
+	InferenceTypesSupported    fwtypes.SetOfString                                            `tfsdk:"inference_types_supported"`
+	InputModalities            fwtypes.SetOfString                                            `tfsdk:"input_modalities"`
+	ModelARN                   fwtypes.ARN                                                    `tfsdk:"model_arn"`
+	ModelID                    types.String                                                   `tfsdk:"model_id"`
+	ModelLifecycle             fwtypes.ListNestedObjectValueOf[foundationModelLifecycleModel] `tfsdk:"model_lifecycle"`
+	ModelName                  types.String                                                   `tfsdk:"model_name"`
+	OutputModalities           fwtypes.SetOfString                                            `tfsdk:"output_modalities"`
+	ProviderName               types.String                                                   `tfsdk:"provider_name"`
+	ResponseStreamingSupported types.Bool                                                     `tfsdk:"response_streaming_supported"`
 }

--- a/internal/service/bedrock/foundation_models_data_source_test.go
+++ b/internal/service/bedrock/foundation_models_data_source_test.go
@@ -27,6 +27,8 @@ func TestAccBedrockFoundationModelsDataSource_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(datasourceName, names.AttrID),
 					acctest.CheckResourceAttrGreaterThanValue(datasourceName, "model_summaries.#", 0),
+					resource.TestCheckResourceAttr(datasourceName, "model_summaries.0.model_lifecycle.#", "1"),
+					resource.TestCheckResourceAttrSet(datasourceName, "model_summaries.0.model_lifecycle.0.status"),
 				),
 			},
 		},

--- a/website/docs/d/bedrock_foundation_model.html.markdown
+++ b/website/docs/d/bedrock_foundation_model.html.markdown
@@ -37,7 +37,12 @@ This data source exports the following attributes in addition to the arguments a
 * `inference_types_supported` - Inference types that the model supports.
 * `input_modalities` - Input modalities that the model supports.
 * `model_arn` - Model ARN.
+* `model_lifecycle` - Model lifecycle details. See [`model_lifecycle`](#model_lifecycle).
 * `model_name` - Model name.
 * `output_modalities` - Output modalities that the model supports.
 * `provider_name` - Model provider name.
 * `response_streaming_supported` - Indicates whether the model supports streaming.
+
+### `model_lifecycle`
+
+* `status` - Lifecycle status of the model. Valid values are `ACTIVE` and `LEGACY`.

--- a/website/docs/d/bedrock_foundation_models.html.markdown
+++ b/website/docs/d/bedrock_foundation_models.html.markdown
@@ -50,7 +50,12 @@ This data source exports the following attributes in addition to the arguments a
 * `input_modalities` - Input modalities that the model supports.
 * `model_arn` - Model ARN.
 * `model_id` - Model identifier.
+* `model_lifecycle` - Model lifecycle details. See [`model_lifecycle`](#model_lifecycle).
 * `model_name` - Model name.
 * `output_modalities` - Output modalities that the model supports.
 * `provider_name` - Model provider name.
 * `response_streaming_supported` - Indicates whether the model supports streaming.
+
+### `model_lifecycle`
+
+* `status` - Lifecycle status of the model. Valid values are `ACTIVE` and `LEGACY`.


### PR DESCRIPTION
## Summary

Closes #47779

Exposes the `modelLifecycle` attribute returned by the AWS Bedrock API for both the `aws_bedrock_foundation_model` and `aws_bedrock_foundation_models` data sources.

- **`data.aws_bedrock_foundation_model`** — adds a computed `model_lifecycle` block with a `status` attribute (`ACTIVE` or `LEGACY`)
- **`data.aws_bedrock_foundation_models.model_summaries`** — same `model_lifecycle` block on each summary entry

Both data sources use auto-flex (`fwflex.Flatten`) which maps `FoundationModelLifecycle.Status` automatically. No manual flatten/expand needed.

## Usage

```hcl
data "aws_bedrock_foundation_models" "all" {}

locals {
  active_models = [
    for model in data.aws_bedrock_foundation_models.all.model_summaries :
    model.model_id
    if model.model_lifecycle[0].status == "ACTIVE"
  ]
}
```

## Test plan

- [ ] `TestAccBedrockFoundationModelDataSource_basic` — checks `model_lifecycle.#` = 1 and `model_lifecycle.0.status` is set
- [ ] `TestAccBedrockFoundationModelsDataSource_basic` — checks `model_summaries.0.model_lifecycle.#` = 1 and status is set

```
make testacc TESTS=TestAccBedrockFoundationModel PKG=bedrock
```