### PR TITLE
aws_vpc_ipam_pool_cidr: Throw failure reason instead of timing out

### DIFF
--- a/internal/service/ec2/status.go
+++ b/internal/service/ec2/status.go
@@ -1168,6 +1168,17 @@ func statusIPAMPoolCIDR(conn *ec2.Client, cidrBlock, poolID, poolCIDRID string) 
 			return nil, "", err
 		}
 
+		// If a FailureReason is present, report the state as failed even if the API
+		// still shows a pending state. This surfaces quota-related errors immediately
+		// rather than waiting for the timeout.
+		if output.FailureReason != nil && output.FailureReason.Code != "" {
+			state := output.State
+			if state == awstypes.IpamPoolCidrStatePendingProvision {
+				state = awstypes.IpamPoolCidrStateFailedProvision
+			}
+			return output, string(state), nil
+		}
+
 		return output, string(output.State), nil
 	}
 }

--- a/internal/service/ec2/wait.go
+++ b/internal/service/ec2/wait.go
@@ -990,7 +990,7 @@ func waitIPAMPoolCIDRCreated(ctx context.Context, conn *ec2.Client, poolCIDRID, 
 	outputRaw, err := stateConf.WaitForStateContext(ctx)
 
 	if output, ok := outputRaw.(*awstypes.IpamPoolCidr); ok {
-		if state, failureReason := output.State, output.FailureReason; state == awstypes.IpamPoolCidrStateFailedProvision && failureReason != nil {
+		if failureReason := output.FailureReason; failureReason != nil && failureReason.Code != "" {
 			retry.SetLastError(err, fmt.Errorf("%s: %s", string(failureReason.Code), aws.ToString(failureReason.Message)))
 		}
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

### Description

When provisioning an IPAM Pool CIDR fails due to quota limits, the provider previously waited the full timeout (10 minutes) before reporting a generic timeout error. This change detects the failure reason from the AWS API immediately and surfaces it to the user, e.g.: "account X cannot provision a ipv4 contiguous block of size /27 in locale us-east-1."

🤖🤖🤖 AI-assisted change.

### References

- AWS populates `FailureReason` on `IpamPoolCidr` while the state may still show `pending-provision`

### Output from Acceptance Testing

Not applicable — this change only affects error reporting behavior when provisioning fails due to quota. Existing acceptance tests do not cover quota-exceeded scenarios as they require specific account limits.