### PR TITLE
🤖🤖🤖 r/aws_cleanrooms_configured_table: bring schema up to date with current API

### DIFF
--- a/.changelog/48143.txt
+++ b/.changelog/48143.txt
@@ -1,0 +1,15 @@
+```release-note:enhancement
+resource/aws_cleanrooms_configured_table: Add `selected_analysis_methods` argument
+```
+
+```release-note:enhancement
+resource/aws_cleanrooms_configured_table: Add `athena` and `snowflake` sub-blocks to `table_reference`
+```
+
+```release-note:bug
+resource/aws_cleanrooms_configured_table: Fix `allowed_columns` and `analysis_method` incorrectly marked as `ForceNew`; both are mutable via `UpdateConfiguredTable`
+```
+
+```release-note:bug
+resource/aws_cleanrooms_configured_table: Fix `analysis_method` validation rejecting valid values `DIRECT_JOB` and `MULTIPLE`
+```

--- a/internal/service/cleanrooms/configured_table.go
+++ b/internal/service/cleanrooms/configured_table.go
@@ -79,7 +79,6 @@ func resourceConfiguredTable() *schema.Resource {
 				"selected_analysis_methods": {
 					Type:     schema.TypeSet,
 					Optional: true,
-					Computed: true,
 					Elem: &schema.Schema{
 						Type:             schema.TypeString,
 						ValidateDiagFunc: enum.Validate[awstypes.SelectedAnalysisMethod](),
@@ -96,12 +95,15 @@ func resourceConfiguredTable() *schema.Resource {
 								Type:          schema.TypeString,
 								Optional:      true,
 								ForceNew:      true,
+								RequiredWith:  []string{"table_reference.0.table_name"},
+								AtLeastOneOf:  []string{"table_reference.0.database_name", "table_reference.0.athena", "table_reference.0.snowflake"},
 								ConflictsWith: []string{"table_reference.0.athena", "table_reference.0.snowflake"},
 							},
 							names.AttrTableName: {
 								Type:          schema.TypeString,
 								Optional:      true,
 								ForceNew:      true,
+								RequiredWith:  []string{"table_reference.0.database_name"},
 								ConflictsWith: []string{"table_reference.0.athena", "table_reference.0.snowflake"},
 							},
 							"athena": {
@@ -308,8 +310,10 @@ func resourceConfiguredTableUpdate(ctx context.Context, d *schema.ResourceData, 
 
 		if d.HasChanges("analysis_method", "selected_analysis_methods") {
 			input.AnalysisMethod = awstypes.AnalysisMethod(d.Get("analysis_method").(string))
-			if v, ok := d.GetOk("selected_analysis_methods"); ok {
-				input.SelectedAnalysisMethods = flex.ExpandStringyValueSet[awstypes.SelectedAnalysisMethod](v.(*schema.Set))
+			if input.AnalysisMethod == awstypes.AnalysisMethodMultiple {
+				if v, ok := d.GetOk("selected_analysis_methods"); ok {
+					input.SelectedAnalysisMethods = flex.ExpandStringyValueSet[awstypes.SelectedAnalysisMethod](v.(*schema.Set))
+				}
 			}
 		}
 
@@ -444,8 +448,8 @@ func flattenTableReference(tableReference awstypes.TableReference) []any {
 	switch v := tableReference.(type) {
 	case *awstypes.TableReferenceMemberGlue:
 		return []any{map[string]any{
-			names.AttrDatabaseName: v.Value.DatabaseName,
-			names.AttrTableName:    v.Value.TableName,
+			names.AttrDatabaseName: aws.ToString(v.Value.DatabaseName),
+			names.AttrTableName:    aws.ToString(v.Value.TableName),
 		}}
 	case *awstypes.TableReferenceMemberAthena:
 		inner := map[string]any{

--- a/internal/service/cleanrooms/configured_table.go
+++ b/internal/service/cleanrooms/configured_table.go
@@ -8,7 +8,6 @@ package cleanrooms
 import (
 	"context"
 	"errors"
-	"fmt"
 	"log"
 	"time"
 
@@ -19,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
@@ -51,14 +51,14 @@ func resourceConfiguredTable() *schema.Resource {
 				"allowed_columns": {
 					Type:     schema.TypeSet,
 					Required: true,
-					ForceNew: true,
 					Elem:     &schema.Schema{Type: schema.TypeString},
 					MinItems: 1,
 					MaxItems: 225,
 				},
 				"analysis_method": {
-					Type:     schema.TypeString,
-					Required: true,
+					Type:             schema.TypeString,
+					Required:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.AnalysisMethod](),
 				},
 				names.AttrARN: {
 					Type:     schema.TypeString,
@@ -76,6 +76,15 @@ func resourceConfiguredTable() *schema.Resource {
 					Type:     schema.TypeString,
 					Required: true,
 				},
+				"selected_analysis_methods": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Computed: true,
+					Elem: &schema.Schema{
+						Type:             schema.TypeString,
+						ValidateDiagFunc: enum.Validate[awstypes.SelectedAnalysisMethod](),
+					},
+				},
 				"table_reference": {
 					Type:     schema.TypeList,
 					Required: true,
@@ -84,14 +93,131 @@ func resourceConfiguredTable() *schema.Resource {
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{
 							names.AttrDatabaseName: {
-								Type:     schema.TypeString,
-								Required: true,
-								ForceNew: true,
+								Type:          schema.TypeString,
+								Optional:      true,
+								ForceNew:      true,
+								ConflictsWith: []string{"table_reference.0.athena", "table_reference.0.snowflake"},
 							},
 							names.AttrTableName: {
-								Type:     schema.TypeString,
-								Required: true,
+								Type:          schema.TypeString,
+								Optional:      true,
+								ForceNew:      true,
+								ConflictsWith: []string{"table_reference.0.athena", "table_reference.0.snowflake"},
+							},
+							"athena": {
+								Type:     schema.TypeList,
+								Optional: true,
 								ForceNew: true,
+								MaxItems: 1,
+								ConflictsWith: []string{
+									"table_reference.0.database_name",
+									"table_reference.0.table_name",
+									"table_reference.0.snowflake",
+								},
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										names.AttrDatabaseName: {
+											Type:     schema.TypeString,
+											Required: true,
+											ForceNew: true,
+										},
+										names.AttrTableName: {
+											Type:     schema.TypeString,
+											Required: true,
+											ForceNew: true,
+										},
+										"workgroup": {
+											Type:     schema.TypeString,
+											Required: true,
+											ForceNew: true,
+										},
+										"catalog_name": {
+											Type:     schema.TypeString,
+											Optional: true,
+											ForceNew: true,
+										},
+										"output_location": {
+											Type:     schema.TypeString,
+											Optional: true,
+											ForceNew: true,
+										},
+										names.AttrRegion: {
+											Type:             schema.TypeString,
+											Optional:         true,
+											ForceNew:         true,
+											ValidateDiagFunc: enum.Validate[awstypes.CommercialRegion](),
+										},
+									},
+								},
+							},
+							"snowflake": {
+								Type:     schema.TypeList,
+								Optional: true,
+								ForceNew: true,
+								MaxItems: 1,
+								ConflictsWith: []string{
+									"table_reference.0.database_name",
+									"table_reference.0.table_name",
+									"table_reference.0.athena",
+								},
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"account_identifier": {
+											Type:     schema.TypeString,
+											Required: true,
+											ForceNew: true,
+										},
+										names.AttrDatabaseName: {
+											Type:     schema.TypeString,
+											Required: true,
+											ForceNew: true,
+										},
+										"schema_name": {
+											Type:     schema.TypeString,
+											Required: true,
+											ForceNew: true,
+										},
+										"secret_arn": {
+											Type:     schema.TypeString,
+											Required: true,
+											ForceNew: true,
+										},
+										names.AttrTableName: {
+											Type:     schema.TypeString,
+											Required: true,
+											ForceNew: true,
+										},
+										"table_schema": {
+											Type:     schema.TypeList,
+											Required: true,
+											ForceNew: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"v1": {
+														Type:     schema.TypeList,
+														Required: true,
+														ForceNew: true,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																"column_name": {
+																	Type:     schema.TypeString,
+																	Required: true,
+																	ForceNew: true,
+																},
+																"column_type": {
+																	Type:     schema.TypeString,
+																	Required: true,
+																	ForceNew: true,
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
 							},
 						},
 					},
@@ -119,18 +245,17 @@ func resourceConfiguredTableCreate(ctx context.Context, d *schema.ResourceData, 
 	input := cleanrooms.CreateConfiguredTableInput{
 		Name:           aws.String(d.Get(names.AttrName).(string)),
 		AllowedColumns: flex.ExpandStringValueSet(d.Get("allowed_columns").(*schema.Set)),
+		AnalysisMethod: awstypes.AnalysisMethod(d.Get("analysis_method").(string)),
 		TableReference: expandTableReference(d.Get("table_reference").([]any)),
 		Tags:           getTagsIn(ctx),
 	}
 
-	analysisMethod, err := expandAnalysisMethod(d.Get("analysis_method").(string))
-	if err != nil {
-		return create.AppendDiagError(diags, names.CleanRooms, create.ErrActionCreating, ResNameConfiguredTable, d.Get(names.AttrName).(string), err)
-	}
-	input.AnalysisMethod = analysisMethod
-
 	if v, ok := d.GetOk(names.AttrDescription); ok {
 		input.Description = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("selected_analysis_methods"); ok {
+		input.SelectedAnalysisMethods = flex.ExpandStringyValueSet[awstypes.SelectedAnalysisMethod](v.(*schema.Set))
 	}
 
 	out, err := conn.CreateConfiguredTable(ctx, &input)
@@ -175,6 +300,17 @@ func resourceConfiguredTableUpdate(ctx context.Context, d *schema.ResourceData, 
 	if d.HasChangesExcept(names.AttrTags, names.AttrTagsAll) {
 		input := cleanrooms.UpdateConfiguredTableInput{
 			ConfiguredTableIdentifier: aws.String(d.Id()),
+		}
+
+		if d.HasChanges("allowed_columns") {
+			input.AllowedColumns = flex.ExpandStringValueSet(d.Get("allowed_columns").(*schema.Set))
+		}
+
+		if d.HasChanges("analysis_method", "selected_analysis_methods") {
+			input.AnalysisMethod = awstypes.AnalysisMethod(d.Get("analysis_method").(string))
+			if v, ok := d.GetOk("selected_analysis_methods"); ok {
+				input.SelectedAnalysisMethods = flex.ExpandStringyValueSet[awstypes.SelectedAnalysisMethod](v.(*schema.Set))
+			}
 		}
 
 		if d.HasChanges(names.AttrDescription) {
@@ -241,17 +377,17 @@ func findConfiguredTableByID(ctx context.Context, conn *cleanrooms.Client, id st
 	return out, nil
 }
 
-func expandAnalysisMethod(analysisMethod string) (awstypes.AnalysisMethod, error) {
-	switch analysisMethod {
-	case "DIRECT_QUERY":
-		return awstypes.AnalysisMethodDirectQuery, nil
-	default:
-		return "", fmt.Errorf("Invalid analysis method type: %s. Currently the only valid value is `DIRECT_QUERY`", analysisMethod)
-	}
-}
-
 func expandTableReference(data []any) awstypes.TableReference {
 	tableReference := data[0].(map[string]any)
+
+	if v, ok := tableReference["athena"].([]any); ok && len(v) > 0 {
+		return expandAthenaTableReference(v[0].(map[string]any))
+	}
+
+	if v, ok := tableReference["snowflake"].([]any); ok && len(v) > 0 {
+		return expandSnowflakeTableReference(v[0].(map[string]any))
+	}
+
 	return &awstypes.TableReferenceMemberGlue{
 		Value: awstypes.GlueTableReference{
 			DatabaseName: aws.String(tableReference[names.AttrDatabaseName].(string)),
@@ -260,14 +396,93 @@ func expandTableReference(data []any) awstypes.TableReference {
 	}
 }
 
+func expandAthenaTableReference(m map[string]any) awstypes.TableReference {
+	ref := awstypes.AthenaTableReference{
+		DatabaseName: aws.String(m[names.AttrDatabaseName].(string)),
+		TableName:    aws.String(m[names.AttrTableName].(string)),
+		WorkGroup:    aws.String(m["workgroup"].(string)),
+	}
+	if v, ok := m["catalog_name"].(string); ok && v != "" {
+		ref.CatalogName = aws.String(v)
+	}
+	if v, ok := m["output_location"].(string); ok && v != "" {
+		ref.OutputLocation = aws.String(v)
+	}
+	if v, ok := m[names.AttrRegion].(string); ok && v != "" {
+		ref.Region = awstypes.CommercialRegion(v)
+	}
+	return &awstypes.TableReferenceMemberAthena{Value: ref}
+}
+
+func expandSnowflakeTableReference(m map[string]any) awstypes.TableReference {
+	ref := awstypes.SnowflakeTableReference{
+		AccountIdentifier: aws.String(m["account_identifier"].(string)),
+		DatabaseName:      aws.String(m[names.AttrDatabaseName].(string)),
+		SchemaName:        aws.String(m["schema_name"].(string)),
+		SecretArn:         aws.String(m["secret_arn"].(string)),
+		TableName:         aws.String(m[names.AttrTableName].(string)),
+		TableSchema:       expandSnowflakeTableSchema(m["table_schema"].([]any)),
+	}
+	return &awstypes.TableReferenceMemberSnowflake{Value: ref}
+}
+
+func expandSnowflakeTableSchema(data []any) awstypes.SnowflakeTableSchema {
+	schemaMap := data[0].(map[string]any)
+	v1Raw := schemaMap["v1"].([]any)
+	cols := make([]awstypes.SnowflakeTableSchemaV1, len(v1Raw))
+	for i, col := range v1Raw {
+		c := col.(map[string]any)
+		cols[i] = awstypes.SnowflakeTableSchemaV1{
+			ColumnName: aws.String(c["column_name"].(string)),
+			ColumnType: aws.String(c["column_type"].(string)),
+		}
+	}
+	return &awstypes.SnowflakeTableSchemaMemberV1{Value: cols}
+}
+
 func flattenTableReference(tableReference awstypes.TableReference) []any {
 	switch v := tableReference.(type) {
 	case *awstypes.TableReferenceMemberGlue:
-		m := map[string]any{
+		return []any{map[string]any{
 			names.AttrDatabaseName: v.Value.DatabaseName,
 			names.AttrTableName:    v.Value.TableName,
+		}}
+	case *awstypes.TableReferenceMemberAthena:
+		inner := map[string]any{
+			names.AttrDatabaseName: aws.ToString(v.Value.DatabaseName),
+			names.AttrTableName:    aws.ToString(v.Value.TableName),
+			"workgroup":            aws.ToString(v.Value.WorkGroup),
+			"catalog_name":         aws.ToString(v.Value.CatalogName),
+			"output_location":      aws.ToString(v.Value.OutputLocation),
+			names.AttrRegion:       string(v.Value.Region),
 		}
-		return []any{m}
+		return []any{map[string]any{"athena": []any{inner}}}
+	case *awstypes.TableReferenceMemberSnowflake:
+		inner := map[string]any{
+			"account_identifier":   aws.ToString(v.Value.AccountIdentifier),
+			names.AttrDatabaseName: aws.ToString(v.Value.DatabaseName),
+			"schema_name":          aws.ToString(v.Value.SchemaName),
+			"secret_arn":           aws.ToString(v.Value.SecretArn),
+			names.AttrTableName:    aws.ToString(v.Value.TableName),
+			"table_schema":         flattenSnowflakeTableSchema(v.Value.TableSchema),
+		}
+		return []any{map[string]any{"snowflake": []any{inner}}}
+	default:
+		return nil
+	}
+}
+
+func flattenSnowflakeTableSchema(schema awstypes.SnowflakeTableSchema) []any {
+	switch v := schema.(type) {
+	case *awstypes.SnowflakeTableSchemaMemberV1:
+		cols := make([]any, len(v.Value))
+		for i, col := range v.Value {
+			cols[i] = map[string]any{
+				"column_name": aws.ToString(col.ColumnName),
+				"column_type": aws.ToString(col.ColumnType),
+			}
+		}
+		return []any{map[string]any{"v1": cols}}
 	default:
 		return nil
 	}
@@ -280,6 +495,7 @@ func resourceConfiguredTableFlatten(_ context.Context, d *schema.ResourceData, o
 	d.Set(names.AttrDescription, configuredTable.Description)
 	d.Set("allowed_columns", configuredTable.AllowedColumns)
 	d.Set("analysis_method", configuredTable.AnalysisMethod)
+	d.Set("selected_analysis_methods", configuredTable.SelectedAnalysisMethods)
 	d.Set(names.AttrCreateTime, configuredTable.CreateTime.String())
 	d.Set("update_time", configuredTable.UpdateTime.String())
 	d.Set("table_reference", flattenTableReference(configuredTable.TableReference))

--- a/internal/service/cleanrooms/configured_table.go
+++ b/internal/service/cleanrooms/configured_table.go
@@ -79,6 +79,8 @@ func resourceConfiguredTable() *schema.Resource {
 				"selected_analysis_methods": {
 					Type:     schema.TypeSet,
 					Optional: true,
+					MinItems: 2,
+					MaxItems: 2,
 					Elem: &schema.Schema{
 						Type:             schema.TypeString,
 						ValidateDiagFunc: enum.Validate[awstypes.SelectedAnalysisMethod](),
@@ -105,6 +107,13 @@ func resourceConfiguredTable() *schema.Resource {
 								ForceNew:      true,
 								RequiredWith:  []string{"table_reference.0.database_name"},
 								ConflictsWith: []string{"table_reference.0.athena", "table_reference.0.snowflake"},
+							},
+							names.AttrRegion: {
+								Type:             schema.TypeString,
+								Optional:         true,
+								ForceNew:         true,
+								ConflictsWith:    []string{"table_reference.0.athena", "table_reference.0.snowflake"},
+								ValidateDiagFunc: enum.Validate[awstypes.CommercialRegion](),
 							},
 							"athena": {
 								Type:     schema.TypeList,
@@ -392,12 +401,14 @@ func expandTableReference(data []any) awstypes.TableReference {
 		return expandSnowflakeTableReference(v[0].(map[string]any))
 	}
 
-	return &awstypes.TableReferenceMemberGlue{
-		Value: awstypes.GlueTableReference{
-			DatabaseName: aws.String(tableReference[names.AttrDatabaseName].(string)),
-			TableName:    aws.String(tableReference[names.AttrTableName].(string)),
-		},
+	ref := awstypes.GlueTableReference{
+		DatabaseName: aws.String(tableReference[names.AttrDatabaseName].(string)),
+		TableName:    aws.String(tableReference[names.AttrTableName].(string)),
 	}
+	if v, ok := tableReference[names.AttrRegion].(string); ok && v != "" {
+		ref.Region = awstypes.CommercialRegion(v)
+	}
+	return &awstypes.TableReferenceMemberGlue{Value: ref}
 }
 
 func expandAthenaTableReference(m map[string]any) awstypes.TableReference {
@@ -450,6 +461,7 @@ func flattenTableReference(tableReference awstypes.TableReference) []any {
 		return []any{map[string]any{
 			names.AttrDatabaseName: aws.ToString(v.Value.DatabaseName),
 			names.AttrTableName:    aws.ToString(v.Value.TableName),
+			names.AttrRegion:       string(v.Value.Region),
 		}}
 	case *awstypes.TableReferenceMemberAthena:
 		inner := map[string]any{

--- a/internal/service/cleanrooms/configured_table_test.go
+++ b/internal/service/cleanrooms/configured_table_test.go
@@ -137,16 +137,74 @@ func TestAccCleanRoomsConfiguredTable_updateAllowedColumns(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConfiguredTableExists(ctx, t, resourceName, &configuredTable),
 					resource.TestCheckResourceAttr(resourceName, "allowed_columns.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "allowed_columns.0", "my_column_1"),
-					resource.TestCheckResourceAttr(resourceName, "allowed_columns.1", "my_column_2"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "allowed_columns.*", "my_column_1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "allowed_columns.*", "my_column_2"),
 				),
 			},
 			{
 				Config: testAccConfiguredTableConfig_allowedColumns("[\"my_column_1\"]", rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckConfiguredTableRecreated(resourceName, &configuredTable),
+					testAccCheckConfiguredTableIsTheSame(resourceName, &configuredTable),
 					resource.TestCheckResourceAttr(resourceName, "allowed_columns.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "allowed_columns.0", "my_column_1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "allowed_columns.*", "my_column_1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCleanRoomsConfiguredTable_updateAnalysisMethod(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var configuredTable cleanrooms.GetConfiguredTableOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_cleanrooms_configured_table.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CleanRoomsServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckConfiguredTableDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfiguredTableConfig_analysisMethod("DIRECT_QUERY", rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfiguredTableExists(ctx, t, resourceName, &configuredTable),
+					resource.TestCheckResourceAttr(resourceName, "analysis_method", "DIRECT_QUERY"),
+				),
+			},
+			{
+				Config: testAccConfiguredTableConfig_analysisMethod("DIRECT_JOB", rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfiguredTableIsTheSame(resourceName, &configuredTable),
+					resource.TestCheckResourceAttr(resourceName, "analysis_method", "DIRECT_JOB"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCleanRoomsConfiguredTable_selectedAnalysisMethods(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var configuredTable cleanrooms.GetConfiguredTableOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_cleanrooms_configured_table.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CleanRoomsServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckConfiguredTableDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfiguredTableConfig_selectedAnalysisMethods(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfiguredTableExists(ctx, t, resourceName, &configuredTable),
+					resource.TestCheckResourceAttr(resourceName, "analysis_method", "MULTIPLE"),
+					resource.TestCheckResourceAttr(resourceName, "selected_analysis_methods.#", "2"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "selected_analysis_methods.*", "DIRECT_QUERY"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "selected_analysis_methods.*", "DIRECT_JOB"),
 				),
 			},
 		},
@@ -369,6 +427,62 @@ func testAccConfiguredTableConfig_basic(name string, description string, tagValu
 func testAccConfiguredTableConfig_allowedColumns(allowedColumns string, rName string) string {
 	return testAccConfiguredTableConfig(rName, TEST_NAME, TEST_DESCRIPTION, TEST_TAG, allowedColumns,
 		TEST_ANALYSIS_METHOD, rName, rName)
+}
+
+func testAccConfiguredTableConfig_analysisMethod(analysisMethod string, rName string) string {
+	return testAccConfiguredTableConfig(rName, TEST_NAME, TEST_DESCRIPTION, TEST_TAG, TEST_ALLOWED_COLUMNS,
+		analysisMethod, rName, rName)
+}
+
+func testAccConfiguredTableConfig_selectedAnalysisMethods(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+}
+
+resource "aws_glue_catalog_database" "test" {
+  name = %[1]q
+}
+
+resource "aws_glue_catalog_table" "test" {
+  name          = %[1]q
+  database_name = %[1]q
+
+  storage_descriptor {
+    location = "s3://${aws_s3_bucket.test.bucket}"
+
+    columns {
+      name = "my_column_1"
+      type = "string"
+    }
+
+    columns {
+      name = "my_column_2"
+      type = "string"
+    }
+  }
+}
+
+resource "aws_cleanrooms_configured_table" "test" {
+  name            = %[2]q
+  description     = %[3]q
+  analysis_method = "MULTIPLE"
+  allowed_columns = %[4]s
+
+  selected_analysis_methods = ["DIRECT_QUERY", "DIRECT_JOB"]
+
+  table_reference {
+    database_name = %[1]q
+    table_name    = %[1]q
+  }
+
+  tags = {
+    Project = %[5]q
+  }
+
+  depends_on = [aws_glue_catalog_table.test]
+}
+	`, rName, TEST_NAME, TEST_DESCRIPTION, TEST_ALLOWED_COLUMNS, TEST_TAG)
 }
 
 const TEST_FIRST_ADDITIONAL_TABLE_NAME = "table_1"


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No.

### Description

Brings `aws_cleanrooms_configured_table` up to date with the current AWS Clean Rooms API.

**`analysis_method`**

- The hand-rolled expand function accepted only `DIRECT_QUERY`. The API also supports `DIRECT_JOB` and `MULTIPLE`. Replaced with `enum.Validate[awstypes.AnalysisMethod]()`.
- `ForceNew` was incorrectly set. `UpdateConfiguredTable` accepts `analysisMethod` in place.

**`allowed_columns`**

- `ForceNew` was incorrectly set. `UpdateConfiguredTable` accepts `allowedColumns` in place.

**`selected_analysis_methods` (new)**

- `SelectedAnalysisMethods` is present in `CreateConfiguredTableInput`, `UpdateConfiguredTableInput`, and the `ConfiguredTable` response type but was not modeled. Added as `Optional` with `MinItems: 2, MaxItems: 2`. Required when `analysis_method = MULTIPLE`.

**`table_reference` — Athena and Snowflake variants (new)**

- `TableReference` is a union with three members: `Glue`, `Athena`, `Snowflake`. Only `Glue` was modeled. The existing flat `database_name`/`table_name` fields are kept for backward compatibility; `athena {}` and `snowflake {}` are added as optional siblings with `ConflictsWith` guards.

**`table_reference` Glue `region` (new)**

- `GlueTableReference.Region` was not modeled. Added as optional, consistent with `AthenaTableReference.Region`.

### Relations

Relates #48135

### References

### Output from Acceptance Testing

```console
% make testacc TESTS=TestAccCleanRoomsConfiguredTable PKG=cleanrooms

--- PASS: TestAccCleanRoomsConfiguredTable_basic (46.94s)
--- PASS: TestAccCleanRoomsConfiguredTable_disappears (48.85s)
--- PASS: TestAccCleanRoomsConfiguredTable_Identity_basic (80.78s)
--- PASS: TestAccCleanRoomsConfiguredTable_Identity_ExistingResource_basic (106.87s)
--- PASS: TestAccCleanRoomsConfiguredTable_Identity_ExistingResource_noRefreshNoChange (99.81s)
--- PASS: TestAccCleanRoomsConfiguredTable_Identity_regionOverride (68.23s)
--- PASS: TestAccCleanRoomsConfiguredTable_List_basic (54.42s)
--- PASS: TestAccCleanRoomsConfiguredTable_List_includeResource (56.60s)
--- PASS: TestAccCleanRoomsConfiguredTable_List_regionOverride (37.12s)
--- PASS: TestAccCleanRoomsConfiguredTable_mutableProperties (60.04s)
--- PASS: TestAccCleanRoomsConfiguredTable_selectedAnalysisMethods (48.70s)
--- PASS: TestAccCleanRoomsConfiguredTable_updateAllowedColumns (78.34s)
--- PASS: TestAccCleanRoomsConfiguredTable_updateAnalysisMethod (77.99s)
--- PASS: TestAccCleanRoomsConfiguredTable_updateTableReference (57.15s)
--- PASS: TestAccCleanRoomsConfiguredTable_updateTableReference_onlyDatabase (59.17s)
--- PASS: TestAccCleanRoomsConfiguredTable_updateTableReference_onlyTable (59.20s)
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cleanrooms
```