### PR TITLE
[Enhancement] aws_opensearch_domain: Add `advanced_security_options.jwt_options.jwks_url`

### DIFF
--- a/.changelog/48146.txt
+++ b/.changelog/48146.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_opensearch_domain: Add `advanced_security_options.jwt_options.jwks_url` argument
+```
+
+```release-note:enhancement
+data-source/aws_opensearch_domain: Add `advanced_security_options.jwt_options.jwks_url` attribute
+```

--- a/internal/service/opensearch/domain.go
+++ b/internal/service/opensearch/domain.go
@@ -162,7 +162,7 @@ func resourceDomain() *schema.Resource {
 									"jwks_url": {
 										Type:     schema.TypeString,
 										Optional: true,
-										ExactlyOneOf: []string{
+										AtLeastOneOf: []string{
 											"advanced_security_options.0.jwt_options.0.jwks_url",
 											"advanced_security_options.0.jwt_options.0.public_key",
 										},
@@ -175,7 +175,7 @@ func resourceDomain() *schema.Resource {
 										Optional:         true,
 										Computed:         true,
 										DiffSuppressFunc: suppressPublicKeyDiff,
-										ExactlyOneOf: []string{
+										AtLeastOneOf: []string{
 											"advanced_security_options.0.jwt_options.0.jwks_url",
 											"advanced_security_options.0.jwt_options.0.public_key",
 										},

--- a/internal/service/opensearch/domain.go
+++ b/internal/service/opensearch/domain.go
@@ -162,6 +162,10 @@ func resourceDomain() *schema.Resource {
 									"jwks_url": {
 										Type:     schema.TypeString,
 										Optional: true,
+										ExactlyOneOf: []string{
+											"advanced_security_options.0.jwt_options.0.jwks_url",
+											"advanced_security_options.0.jwt_options.0.public_key",
+										},
 										ValidateFunc: validation.All(
 											validation.StringLenBetween(1, 2048),
 										),
@@ -171,6 +175,10 @@ func resourceDomain() *schema.Resource {
 										Optional:         true,
 										Computed:         true,
 										DiffSuppressFunc: suppressPublicKeyDiff,
+										ExactlyOneOf: []string{
+											"advanced_security_options.0.jwt_options.0.jwks_url",
+											"advanced_security_options.0.jwt_options.0.public_key",
+										},
 									},
 									"roles_key": {
 										Type:         schema.TypeString,

--- a/internal/service/opensearch/domain.go
+++ b/internal/service/opensearch/domain.go
@@ -159,6 +159,13 @@ func resourceDomain() *schema.Resource {
 										Optional: true,
 										Computed: true,
 									},
+									"jwks_url": {
+										Type:     schema.TypeString,
+										Optional: true,
+										ValidateFunc: validation.All(
+											validation.StringLenBetween(1, 2048),
+										),
+									},
 									names.AttrPublicKey: {
 										Type:             schema.TypeString,
 										Optional:         true,

--- a/internal/service/opensearch/domain_data_source.go
+++ b/internal/service/opensearch/domain_data_source.go
@@ -61,6 +61,10 @@ func dataSourceDomain() *schema.Resource {
 										Type:     schema.TypeBool,
 										Computed: true,
 									},
+									"jwks_url": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
 									names.AttrPublicKey: {
 										Type:     schema.TypeString,
 										Computed: true,

--- a/internal/service/opensearch/domain_data_source_test.go
+++ b/internal/service/opensearch/domain_data_source_test.go
@@ -118,6 +118,35 @@ func TestAccOpenSearchDomainDataSource_advancedSecurityOptionsJWTOptions(t *test
 	})
 }
 
+func TestAccOpenSearchDomainDataSource_advancedSecurityOptionsJWTOptionsWithJwksURL(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	ctx := acctest.Context(t)
+	rName := testAccRandomDomainName(t)
+	datasourceName := "data.aws_opensearch_domain.test"
+	resourceName := "aws_opensearch_domain.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckIAMServiceLinkedRole(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.OpenSearchServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDomainDataSourceConfig_advancedSecurityOptionsJWTOptionsWithJwksURL(rName, "OpenSearch", "3.5", "sub", "roles", "https://example.com/.well-known/jwks.json"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(datasourceName, "advanced_security_options.0.jwt_options.#", resourceName, "advanced_security_options.0.jwt_options.#"),
+					resource.TestCheckResourceAttrPair(datasourceName, "advanced_security_options.0.jwt_options.0.enabled", resourceName, "advanced_security_options.0.jwt_options.0.enabled"),
+					resource.TestCheckResourceAttrPair(datasourceName, "advanced_security_options.0.jwt_options.0.jwks_url", resourceName, "advanced_security_options.0.jwt_options.0.jwks_url"),
+					resource.TestCheckResourceAttrPair(datasourceName, "advanced_security_options.0.jwt_options.0.subject_key", resourceName, "advanced_security_options.0.jwt_options.0.subject_key"),
+					resource.TestCheckResourceAttrPair(datasourceName, "advanced_security_options.0.jwt_options.0.roles_key", resourceName, "advanced_security_options.0.jwt_options.0.roles_key"),
+				),
+			},
+		},
+	})
+}
+
 func testAccDomainDataSourceConfig_basic(rName string) string {
 	return acctest.ConfigCompose(testAccDomainConfig_basic(rName), `
 data "aws_opensearch_domain" "test" {
@@ -136,6 +165,14 @@ data "aws_opensearch_domain" "test" {
 
 func testAccDomainDataSourceConfig_advancedSecurityOptionsJWTOptions(rName, engineType, version, subjectKey, rolesKey string) string {
 	return acctest.ConfigCompose(testAccDomainConfig_advancedSecurityOptionsJWTOptions(rName, engineType, version, subjectKey, rolesKey), `
+data "aws_opensearch_domain" "test" {
+  domain_name = aws_opensearch_domain.test.domain_name
+}
+`)
+}
+
+func testAccDomainDataSourceConfig_advancedSecurityOptionsJWTOptionsWithJwksURL(rName, engineType, version, subjectKey, rolesKey, jwksURL string) string {
+	return acctest.ConfigCompose(testAccDomainConfig_advancedSecurityOptionsJWTOptionsWithJwksURL(rName, engineType, version, subjectKey, rolesKey, jwksURL), `
 data "aws_opensearch_domain" "test" {
   domain_name = aws_opensearch_domain.test.domain_name
 }

--- a/internal/service/opensearch/domain_structure.go
+++ b/internal/service/opensearch/domain_structure.go
@@ -70,6 +70,10 @@ func expandJWTOptionsInput(tfMap map[string]any) *awstypes.JWTOptionsInput {
 		apiObject.Enabled = aws.Bool(v)
 	}
 
+	if v, ok := tfMap["jwks_url"].(string); ok && v != "" {
+		apiObject.JwksUrl = aws.String(v)
+	}
+
 	if v, ok := tfMap[names.AttrPublicKey].(string); ok && v != "" {
 		// AWS expects the public key without newlines
 		publicKey := strings.ReplaceAll(v, "\n", "")
@@ -358,6 +362,10 @@ func flattenJWTOptionsOutput(apiObject *awstypes.JWTOptionsOutput) []map[string]
 
 	if apiObject.Enabled != nil {
 		m[names.AttrEnabled] = aws.ToBool(apiObject.Enabled)
+	}
+
+	if apiObject.JwksUrl != nil {
+		m["jwks_url"] = aws.ToString(apiObject.JwksUrl)
 	}
 
 	if apiObject.PublicKey != nil {

--- a/internal/service/opensearch/domain_test.go
+++ b/internal/service/opensearch/domain_test.go
@@ -269,7 +269,7 @@ func TestAccOpenSearchDomain_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "aiml_options.#", "1"),
 					resource.TestMatchResourceAttr(resourceName, "dashboard_endpoint", regexache.MustCompile(`.*(opensearch|es)\..*/_dashboards`)),
 					resource.TestCheckResourceAttr(resourceName, "deployment_strategy_options.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "deployment_strategy_options.0.deployment_strategy", string(awstypes.DeploymentStrategyDefault)),
+					resource.TestCheckResourceAttr(resourceName, "deployment_strategy_options.0.deployment_strategy", string(awstypes.DeploymentStrategyCapacityOptimized)),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrEngineVersion),
 					resource.TestCheckResourceAttr(resourceName, "identity_center_options.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "off_peak_window_options.#", "1"),

--- a/internal/service/opensearch/domain_test.go
+++ b/internal/service/opensearch/domain_test.go
@@ -1238,6 +1238,60 @@ func TestAccOpenSearchDomain_AdvancedSecurityOptions_jwtOptions(t *testing.T) {
 	})
 }
 
+func TestAccOpenSearchDomain_AdvancedSecurityOptions_jwtOptionsWithJwksURL(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var domain awstypes.DomainStatus
+	rName := testAccRandomDomainName(t)
+	resourceName := "aws_opensearch_domain.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckIAMServiceLinkedRole(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.OpenSearchServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDomainDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDomainConfig_advancedSecurityOptionsJWTOptionsWithJwksURL(rName, "OpenSearch", "3.5", names.AttrEmail, "groups", "https://example.com/.well-known/jwks.json"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDomainExists(ctx, t, resourceName, &domain),
+					testAccCheckAdvancedSecurityOptions(true, true, false, &domain),
+					resource.TestCheckResourceAttr(resourceName, "advanced_security_options.0.jwt_options.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_security_options.0.jwt_options.0.enabled", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "advanced_security_options.0.jwt_options.0.jwks_url", "https://example.com/.well-known/jwks.json"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_security_options.0.jwt_options.0.subject_key", names.AttrEmail),
+					resource.TestCheckResourceAttr(resourceName, "advanced_security_options.0.jwt_options.0.roles_key", "groups"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateId:     rName,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"advanced_security_options.0.internal_user_database_enabled",
+					"advanced_security_options.0.master_user_options",
+				},
+			},
+			{
+				Config: testAccDomainConfig_advancedSecurityOptionsJWTOptionsWithJwksURL(rName, "OpenSearch", "3.5", names.AttrEmail, "groups", "https://example2.com/.well-known/jwks.json"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDomainExists(ctx, t, resourceName, &domain),
+					testAccCheckAdvancedSecurityOptions(true, true, false, &domain),
+					resource.TestCheckResourceAttr(resourceName, "advanced_security_options.0.jwt_options.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_security_options.0.jwt_options.0.enabled", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "advanced_security_options.0.jwt_options.0.jwks_url", "https://example2.com/.well-known/jwks.json"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_security_options.0.jwt_options.0.subject_key", names.AttrEmail),
+					resource.TestCheckResourceAttr(resourceName, "advanced_security_options.0.jwt_options.0.roles_key", "groups"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccOpenSearchDomain_AdvancedSecurityOptions_jwtOptions_versionValidation(t *testing.T) {
 	t.Parallel()
 
@@ -4510,6 +4564,52 @@ resource "aws_opensearch_domain" "test" {
   }
 }
 `, rName, engineType, version, subjectKey, rolesKey)
+}
+
+func testAccDomainConfig_advancedSecurityOptionsJWTOptionsWithJwksURL(rName, engineType, version, subjectKey, rolesKey, jwksURL string) string {
+	return fmt.Sprintf(`
+resource "aws_opensearch_domain" "test" {
+  domain_name    = %[1]q
+  engine_version = "%[2]s_%[3]s"
+
+  cluster_config {
+    instance_type = "r5.large.search"
+  }
+
+  advanced_security_options {
+    enabled                        = true
+    internal_user_database_enabled = true
+    master_user_options {
+      master_user_name     = "testmasteruser"
+      master_user_password = "Barbarbarbar1!"
+    }
+    jwt_options {
+      enabled     = true
+      jwks_url    = %[6]q
+      subject_key = %[4]q
+      roles_key   = %[5]q
+    }
+  }
+
+  encrypt_at_rest {
+    enabled = true
+  }
+
+  domain_endpoint_options {
+    enforce_https       = true
+    tls_security_policy = "Policy-Min-TLS-1-2-2019-07"
+  }
+
+  node_to_node_encryption {
+    enabled = true
+  }
+
+  ebs_options {
+    ebs_enabled = true
+    volume_size = 10
+  }
+}
+`, rName, engineType, version, subjectKey, rolesKey, jwksURL)
 }
 
 func testAccDomainConfig_advancedSecurityOptionsDisabled(rName string) string {

--- a/website/docs/d/opensearch_domain.html.markdown
+++ b/website/docs/d/opensearch_domain.html.markdown
@@ -37,6 +37,7 @@ This data source exports the following attributes in addition to the arguments a
     * `internal_user_database_enabled` - Whether the internal user database is enabled.
     * `jwt_options` - Block for JWT authentication.
         * `enabled` - Whether JWT authentication is enabled.
+        * `jwks_url` - URL endpoint that hosts the JSON Web Key Set (JWKS) containing public keys used to verify JWT signatures.
         * `public_key` - PEM-encoded public key used to verify JWT signatures.
         * `role_key` - Element of the JWT assertion to use for roles.
         * `subject_key` - Element of the JWT assertion to use for the user name.

--- a/website/docs/r/opensearch_domain.html.markdown
+++ b/website/docs/r/opensearch_domain.html.markdown
@@ -356,8 +356,8 @@ The following arguments are optional:
 #### jwt_options
 
 * `enabled` - (Optional) Whether JWT authentication is enabled.
-* `jwks_url` - (Optional) URL endpoint that hosts the JSON Web Key Set (JWKS) containing public keys used to verify JWT signatures. This argument can be specified only with OpenSearch versions 3.3 and later.
-* `public_key` - (Optional) PEM-encoded public key used to verify JWT signatures.
+* `jwks_url` - (Optional) URL endpoint that hosts the JSON Web Key Set (JWKS) containing public keys used to verify JWT signatures. This argument can be specified only with OpenSearch versions 3.3 and later. Exactly one of `jwks_url` or `public_key` must be specified when `enabled` is set to `true`.
+* `public_key` - (Optional) PEM-encoded public key used to verify JWT signatures. Exactly one of `jwks_url` or `public_key` must be specified when `enabled` is set to `true`.
 * `roles_key` - (Optional) Element of the JWT assertion to use for roles. Default is `roles`.
 * `subject_key` - (Optional) Element of the JWT assertion to use for the user name. Default is `sub`.
 

--- a/website/docs/r/opensearch_domain.html.markdown
+++ b/website/docs/r/opensearch_domain.html.markdown
@@ -356,6 +356,7 @@ The following arguments are optional:
 #### jwt_options
 
 * `enabled` - (Optional) Whether JWT authentication is enabled.
+* `jwks_url` - (Optional) URL endpoint that hosts the JSON Web Key Set (JWKS) containing public keys used to verify JWT signatures. This argument can be specified only with OpenSearch versions 3.3 and later.
 * `public_key` - (Optional) PEM-encoded public key used to verify JWT signatures.
 * `roles_key` - (Optional) Element of the JWT assertion to use for roles. Default is `roles`.
 * `subject_key` - (Optional) Element of the JWT assertion to use for the user name. Default is `sub`.

--- a/website/docs/r/opensearch_domain.html.markdown
+++ b/website/docs/r/opensearch_domain.html.markdown
@@ -356,8 +356,8 @@ The following arguments are optional:
 #### jwt_options
 
 * `enabled` - (Optional) Whether JWT authentication is enabled.
-* `jwks_url` - (Optional) URL endpoint that hosts the JSON Web Key Set (JWKS) containing public keys used to verify JWT signatures. This argument can be specified only with OpenSearch versions 3.3 and later. Exactly one of `jwks_url` or `public_key` must be specified when `enabled` is set to `true`.
-* `public_key` - (Optional) PEM-encoded public key used to verify JWT signatures. Exactly one of `jwks_url` or `public_key` must be specified when `enabled` is set to `true`.
+* `jwks_url` - (Optional) URL endpoint that hosts the JSON Web Key Set (JWKS) containing public keys used to verify JWT signatures. This argument can be specified only with OpenSearch versions 3.3 and later. At least one of `jwks_url` or `public_key` must be specified when `enabled` is set to `true`.
+* `public_key` - (Optional) PEM-encoded public key used to verify JWT signatures. At least one of `jwks_url` or `public_key` must be specified when `enabled` is set to `true`. If both `jwks_url` and `public_key` are specified, `public_key` is ignored.
 * `roles_key` - (Optional) Element of the JWT assertion to use for roles. Default is `roles`.
 * `subject_key` - (Optional) Element of the JWT assertion to use for the user name. Default is `sub`.
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

This PR adds the `advanced_security_options.jwt_options.jwks_url` argument/attribute to the `aws_opensearch_domain` resource and data source.

* `jwks_url` is supported only with OpenSearch version 3.3 and later. This limitation has been documented.
* At least one of `jwks_url` or `public_key` must be specified.

  * If neither `jwks_url` nor `public_key` is specified, the AWS API returns an error. `AtLeastOneOf` has been added to enforce this constraint in the Terraform provider.
  * The AWS API does not return an error when both `jwks_url` and `public_key` are specified.  Therefore, `ExactlyOneOf` is too strict to follow the API behavior. Note that, according to [the AWS documentation](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/JSON-Web-tokens.html#test), `public_key` is ignored when `jwks_url` is provided. 

* In the basic Acceptance test, the expected value of `deployment_strategy_options.0.deployment_strategy` is fixed to pass the test. The AWS API behavior may have changed.

### Relations

Closes #48144

### References

https://docs.aws.amazon.com/opensearch-service/latest/APIReference/API_JWTOptionsInput.html
https://docs.aws.amazon.com/opensearch-service/latest/developerguide/JSON-Web-tokens.html#test

### Output from Acceptance Testing

```console
$ make testacc TESTS='TestAccOpenSearchDomain(|DataSource)_(basic|AdvancedSecurityOptions_jwtOptions|advancedSecurityOptionsJWTOptions)' PKG=opensearch
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     8.955s
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework 8.958s
make: Running acceptance tests on branch: 🌿 f-aws_opensearch_domain-add_jwt_options_jwks_url 🌿...
TF_ACC=1 go1.26.3 test ./internal/service/opensearch/... -v -count 1 -parallel 20 -run='TestAccOpenSearchDomain(|DataSource)_(basic|AdvancedSecurityOptions_jwtOptions|advancedSecurityOptionsJWTOptions)'  -timeout 360m -vet=off -buildvcs=false
2026/06/01 23:31:15 Creating Terraform AWS Provider (SDKv2-style)...
2026/06/01 23:31:15 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccOpenSearchDomainDataSource_basic
=== PAUSE TestAccOpenSearchDomainDataSource_basic
=== RUN   TestAccOpenSearchDomainDataSource_advancedSecurityOptionsJWTOptions
=== PAUSE TestAccOpenSearchDomainDataSource_advancedSecurityOptionsJWTOptions
=== RUN   TestAccOpenSearchDomainDataSource_advancedSecurityOptionsJWTOptionsWithJwksURL
=== PAUSE TestAccOpenSearchDomainDataSource_advancedSecurityOptionsJWTOptionsWithJwksURL
=== RUN   TestAccOpenSearchDomain_basic
=== PAUSE TestAccOpenSearchDomain_basic
=== RUN   TestAccOpenSearchDomain_AdvancedSecurityOptions_jwtOptions
=== PAUSE TestAccOpenSearchDomain_AdvancedSecurityOptions_jwtOptions
=== RUN   TestAccOpenSearchDomain_AdvancedSecurityOptions_jwtOptionsWithJwksURL
=== PAUSE TestAccOpenSearchDomain_AdvancedSecurityOptions_jwtOptionsWithJwksURL
=== RUN   TestAccOpenSearchDomain_AdvancedSecurityOptions_jwtOptions_versionValidation
=== PAUSE TestAccOpenSearchDomain_AdvancedSecurityOptions_jwtOptions_versionValidation
=== CONT  TestAccOpenSearchDomainDataSource_basic
=== CONT  TestAccOpenSearchDomain_AdvancedSecurityOptions_jwtOptions
=== CONT  TestAccOpenSearchDomain_basic
=== CONT  TestAccOpenSearchDomainDataSource_advancedSecurityOptionsJWTOptionsWithJwksURL
=== CONT  TestAccOpenSearchDomainDataSource_advancedSecurityOptionsJWTOptions
=== CONT  TestAccOpenSearchDomain_AdvancedSecurityOptions_jwtOptionsWithJwksURL
=== CONT  TestAccOpenSearchDomain_AdvancedSecurityOptions_jwtOptions_versionValidation
=== RUN   TestAccOpenSearchDomain_AdvancedSecurityOptions_jwtOptions_versionValidation/opensearch_2.9
=== PAUSE TestAccOpenSearchDomain_AdvancedSecurityOptions_jwtOptions_versionValidation/opensearch_2.9
=== RUN   TestAccOpenSearchDomain_AdvancedSecurityOptions_jwtOptions_versionValidation/opensearch_2.10
=== PAUSE TestAccOpenSearchDomain_AdvancedSecurityOptions_jwtOptions_versionValidation/opensearch_2.10
=== RUN   TestAccOpenSearchDomain_AdvancedSecurityOptions_jwtOptions_versionValidation/elasticsearch_7.10
=== PAUSE TestAccOpenSearchDomain_AdvancedSecurityOptions_jwtOptions_versionValidation/elasticsearch_7.10
=== RUN   TestAccOpenSearchDomain_AdvancedSecurityOptions_jwtOptions_versionValidation/opensearch_2.11
=== PAUSE TestAccOpenSearchDomain_AdvancedSecurityOptions_jwtOptions_versionValidation/opensearch_2.11
=== RUN   TestAccOpenSearchDomain_AdvancedSecurityOptions_jwtOptions_versionValidation/opensearch_2.13
=== PAUSE TestAccOpenSearchDomain_AdvancedSecurityOptions_jwtOptions_versionValidation/opensearch_2.13
=== CONT  TestAccOpenSearchDomain_AdvancedSecurityOptions_jwtOptions_versionValidation/opensearch_2.9
=== CONT  TestAccOpenSearchDomain_AdvancedSecurityOptions_jwtOptions_versionValidation/opensearch_2.11
=== CONT  TestAccOpenSearchDomain_AdvancedSecurityOptions_jwtOptions_versionValidation/opensearch_2.13
=== CONT  TestAccOpenSearchDomain_AdvancedSecurityOptions_jwtOptions_versionValidation/elasticsearch_7.10
=== CONT  TestAccOpenSearchDomain_AdvancedSecurityOptions_jwtOptions_versionValidation/opensearch_2.10
--- PASS: TestAccOpenSearchDomain_AdvancedSecurityOptions_jwtOptions_versionValidation (0.00s)
    --- PASS: TestAccOpenSearchDomain_AdvancedSecurityOptions_jwtOptions_versionValidation/opensearch_2.10 (13.38s)
    --- PASS: TestAccOpenSearchDomain_AdvancedSecurityOptions_jwtOptions_versionValidation/opensearch_2.9 (13.44s)
    --- PASS: TestAccOpenSearchDomain_AdvancedSecurityOptions_jwtOptions_versionValidation/elasticsearch_7.10 (13.50s)
    --- PASS: TestAccOpenSearchDomain_AdvancedSecurityOptions_jwtOptions_versionValidation/opensearch_2.11 (30.16s)
    --- PASS: TestAccOpenSearchDomain_AdvancedSecurityOptions_jwtOptions_versionValidation/opensearch_2.13 (30.35s)
--- PASS: TestAccOpenSearchDomainDataSource_advancedSecurityOptionsJWTOptions (1498.03s)
--- PASS: TestAccOpenSearchDomain_basic (1599.33s)
--- PASS: TestAccOpenSearchDomainDataSource_advancedSecurityOptionsJWTOptionsWithJwksURL (1625.74s)
--- PASS: TestAccOpenSearchDomainDataSource_basic (1647.57s)
--- PASS: TestAccOpenSearchDomain_AdvancedSecurityOptions_jwtOptions (1660.67s)
--- PASS: TestAccOpenSearchDomain_AdvancedSecurityOptions_jwtOptionsWithJwksURL (1740.89s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/opensearch 1749.928s

```