### PR TITLE
r/aws_ecs_capacity_provider , r/aws_ecs_cluster_capacity_providers: fail early when delete fails + suggest a workaround in docs

### DIFF
--- a/.changelog/14393.txt
+++ b/.changelog/14393.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ecs_capacity_provider: Fix destroy timing out for 20 minutes when capacity provider is still associated with a cluster by immediately returning the error from the API
+```

--- a/.changelog/14393.txt
+++ b/.changelog/14393.txt
@@ -1,3 +1,0 @@
-```release-note:bug
-resource/aws_ecs_capacity_provider: Fix destroy timing out for 20 minutes when capacity provider is still associated with a cluster by immediately returning the error from the API
-```

--- a/.changelog/48156.txt
+++ b/.changelog/48156.txt
@@ -1,3 +1,7 @@
 ```release-note:bug
 resource/aws_ecs_capacity_provider: Return the underlying error immediately instead of timing out after 20 minutes when deleting a capacity provider that is still associated with a cluster
 ```
+
+```release-note:note
+resource/aws_ecs_capacity_provider: When a change forces replacement of a capacity provider that is associated with a cluster via `aws_ecs_cluster_capacity_providers`, add a `replace_triggered_by` lifecycle rule to the association so the old capacity provider is detached before it is deleted
+```

--- a/.changelog/48156.txt
+++ b/.changelog/48156.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_ecs_capacity_provider: Fix destroy timing out for 20 minutes when capacity provider is still associated with a cluster by immediately returning the error from the API
+resource/aws_ecs_capacity_provider: Return the underlying error immediately instead of timing out after 20 minutes when deleting a capacity provider that is still associated with a cluster
 ```

--- a/.changelog/48156.txt
+++ b/.changelog/48156.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ecs_capacity_provider: Fix destroy timing out for 20 minutes when capacity provider is still associated with a cluster by immediately returning the error from the API
+```

--- a/internal/service/ecs/capacity_provider.go
+++ b/internal/service/ecs/capacity_provider.go
@@ -8,6 +8,7 @@ package ecs
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log"
 	"time"
 
@@ -758,6 +759,10 @@ func statusCapacityProvider(conn *ecs.Client, arn string) retry.StateRefreshFunc
 
 		if err != nil {
 			return nil, "", err
+		}
+
+		if output.UpdateStatus == awstypes.CapacityProviderUpdateStatusDeleteFailed {
+			return output, string(output.Status), fmt.Errorf("capacity provider delete failed: %s", aws.ToString(output.UpdateStatusReason))
 		}
 
 		return output, string(output.Status), nil

--- a/internal/service/ecs/capacity_provider.go
+++ b/internal/service/ecs/capacity_provider.go
@@ -748,7 +748,7 @@ func findCapacityProviderByARN(ctx context.Context, conn *ecs.Client, arn string
 	return output, nil
 }
 
-func statusCapacityProvider(conn *ecs.Client, arn string) retry.StateRefreshFunc {
+func statusCapacityProviderDelete(conn *ecs.Client, arn string) retry.StateRefreshFunc {
 	return func(ctx context.Context) (any, string, error) {
 		output, err := findCapacityProviderByARN(ctx, conn, arn)
 
@@ -809,7 +809,7 @@ func waitCapacityProviderDeleted(ctx context.Context, conn *ecs.Client, arn stri
 	stateConf := &retry.StateChangeConf{
 		Pending: enum.Slice(awstypes.CapacityProviderStatusActive, awstypes.CapacityProviderStatusDeprovisioning),
 		Target:  []string{},
-		Refresh: statusCapacityProvider(conn, arn),
+		Refresh: statusCapacityProviderDelete(conn, arn),
 		Timeout: timeout,
 	}
 

--- a/internal/service/ecs/capacity_provider.go
+++ b/internal/service/ecs/capacity_provider.go
@@ -8,7 +8,6 @@ package ecs
 import (
 	"context"
 	"errors"
-	"fmt"
 	"log"
 	"time"
 
@@ -762,7 +761,7 @@ func statusCapacityProvider(conn *ecs.Client, arn string) retry.StateRefreshFunc
 		}
 
 		if output.UpdateStatus == awstypes.CapacityProviderUpdateStatusDeleteFailed {
-			return output, string(output.Status), fmt.Errorf("capacity provider delete failed: %s", aws.ToString(output.UpdateStatusReason))
+			return output, string(output.Status), errors.New(aws.ToString(output.UpdateStatusReason))
 		}
 
 		return output, string(output.Status), nil

--- a/internal/service/ecs/capacity_provider.go
+++ b/internal/service/ecs/capacity_provider.go
@@ -780,6 +780,10 @@ func statusCapacityProviderUpdate(conn *ecs.Client, arn string) retry.StateRefre
 			return nil, "", err
 		}
 
+		if output.UpdateStatus == awstypes.CapacityProviderUpdateStatusUpdateFailed {
+			return output, string(output.UpdateStatus), errors.New(aws.ToString(output.UpdateStatusReason))
+		}
+
 		return output, string(output.UpdateStatus), nil
 	}
 }
@@ -795,8 +799,6 @@ func waitCapacityProviderUpdated(ctx context.Context, conn *ecs.Client, arn stri
 	outputRaw, err := stateConf.WaitForStateContext(ctx)
 
 	if output, ok := outputRaw.(*awstypes.CapacityProvider); ok {
-		retry.SetLastError(err, errors.New(aws.ToString(output.UpdateStatusReason)))
-
 		return output, err
 	}
 

--- a/internal/service/ecs/capacity_provider_test.go
+++ b/internal/service/ecs/capacity_provider_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/YakDriver/regexache"
-	ecsapi "github.com/aws/aws-sdk-go-v2/service/ecs"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -56,37 +55,6 @@ func TestAccECSCapacityProvider_basic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAccECSCapacityProvider_deleteFailsWhenAssociated(t *testing.T) {
-	ctx := acctest.Context(t)
-	var provider awstypes.CapacityProvider
-	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	resourceName := "aws_ecs_capacity_provider.test"
-
-	acctest.ParallelTest(ctx, t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, names.ECSServiceID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckCapacityProviderDestroy(ctx, t),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCapacityProviderConfig_withClusterNoAssociation(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCapacityProviderExists(ctx, t, resourceName, &provider),
-					testAccAssociateCapacityProviderWithCluster(ctx, t, rName, rName),
-				),
-			},
-			{
-				Config:      testAccCapacityProviderConfig_withClusterNoAssociationRemoved(rName),
-				ExpectError: regexache.MustCompile(`capacity provider cannot be deleted because it is associated with cluster`),
-			},
-			{
-				// Disassociate and destroy cleanly.
-				Config: testAccCapacityProviderConfig_withClusterAssociation(rName),
 			},
 		},
 	})
@@ -1177,63 +1145,4 @@ resource "aws_ecs_capacity_provider" "test" {
   }
 }
 `, rName, monitoring))
-}
-
-func testAccAssociateCapacityProviderWithCluster(ctx context.Context, t *testing.T, clusterName, cpName string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		conn := acctest.ProviderMeta(ctx, t).ECSClient(ctx)
-
-		_, err := conn.PutClusterCapacityProviders(ctx, &ecsapi.PutClusterCapacityProvidersInput{
-			Cluster:                         &clusterName,
-			CapacityProviders:               []string{cpName},
-			DefaultCapacityProviderStrategy: []awstypes.CapacityProviderStrategyItem{},
-		})
-
-		return err
-	}
-}
-
-func testAccCapacityProviderConfig_withClusterNoAssociation(rName string) string {
-	return acctest.ConfigCompose(testAccCapacityProviderConfig_base(rName), fmt.Sprintf(`
-resource "aws_ecs_cluster" "test" {
-  name = %[1]q
-}
-
-resource "aws_ecs_capacity_provider" "test" {
-  name = %[1]q
-
-  auto_scaling_group_provider {
-    auto_scaling_group_arn = aws_autoscaling_group.test.arn
-  }
-}
-`, rName))
-}
-
-func testAccCapacityProviderConfig_withClusterNoAssociationRemoved(rName string) string {
-	return acctest.ConfigCompose(testAccCapacityProviderConfig_base(rName), fmt.Sprintf(`
-resource "aws_ecs_cluster" "test" {
-  name = %[1]q
-}
-`, rName))
-}
-
-func testAccCapacityProviderConfig_withClusterAssociation(rName string) string {
-	return acctest.ConfigCompose(testAccCapacityProviderConfig_base(rName), fmt.Sprintf(`
-resource "aws_ecs_cluster" "test" {
-  name = %[1]q
-}
-
-resource "aws_ecs_capacity_provider" "test" {
-  name = %[1]q
-
-  auto_scaling_group_provider {
-    auto_scaling_group_arn = aws_autoscaling_group.test.arn
-  }
-}
-
-resource "aws_ecs_cluster_capacity_providers" "test" {
-  cluster_name       = aws_ecs_cluster.test.name
-  capacity_providers = [aws_ecs_capacity_provider.test.name]
-}
-`, rName))
 }

--- a/internal/service/ecs/capacity_provider_test.go
+++ b/internal/service/ecs/capacity_provider_test.go
@@ -191,6 +191,43 @@ func TestAccECSCapacityProvider_managedScalingPartial(t *testing.T) {
 	})
 }
 
+func TestAccECSCapacityProvider_replaceWhenAssociated(t *testing.T) {
+	ctx := acctest.Context(t)
+	var provider awstypes.CapacityProvider
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	cpName1 := fmt.Sprintf("%s-1", rName)
+	cpName2 := fmt.Sprintf("%s-2", rName)
+	resourceName := "aws_ecs_capacity_provider.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ECSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckCapacityProviderDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCapacityProviderConfig_replaceWhenAssociated(rName, cpName1),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckCapacityProviderExists(ctx, t, resourceName, &provider),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, cpName1),
+				),
+			},
+			{
+				Config: testAccCapacityProviderConfig_replaceWhenAssociated(rName, cpName2),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckCapacityProviderExists(ctx, t, resourceName, &provider),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, cpName2),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionReplace),
+					},
+				},
+			},
+		},
+	})
+}
+
 func TestAccECSCapacityProvider_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var provider awstypes.CapacityProvider
@@ -691,6 +728,31 @@ resource "aws_ecs_capacity_provider" "test" {
   }
 }
 `, rName))
+}
+
+func testAccCapacityProviderConfig_replaceWhenAssociated(rName, cpName string) string {
+	return acctest.ConfigCompose(testAccCapacityProviderConfig_base(rName), fmt.Sprintf(`
+resource "aws_ecs_capacity_provider" "test" {
+  name = %[2]q
+
+  auto_scaling_group_provider {
+    auto_scaling_group_arn = aws_autoscaling_group.test.arn
+  }
+}
+
+resource "aws_ecs_cluster" "test" {
+  name = %[1]q
+}
+
+resource "aws_ecs_cluster_capacity_providers" "test" {
+  cluster_name       = aws_ecs_cluster.test.name
+  capacity_providers = [aws_ecs_capacity_provider.test.name]
+
+  lifecycle {
+    replace_triggered_by = [aws_ecs_capacity_provider.test]
+  }
+}
+`, rName, cpName))
 }
 
 func testAccCapacityProviderConfig_tags1(rName, tag1Key, tag1Value string) string {

--- a/internal/service/ecs/capacity_provider_test.go
+++ b/internal/service/ecs/capacity_provider_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/YakDriver/regexache"
+	"github.com/aws/aws-sdk-go-v2/service/ecs"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -223,6 +224,36 @@ func TestAccECSCapacityProvider_replaceWhenAssociated(t *testing.T) {
 						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionReplace),
 					},
 				},
+			},
+		},
+	})
+}
+
+func TestAccECSCapacityProvider_deleteFailsWhenAssociated(t *testing.T) {
+	ctx := acctest.Context(t)
+	var provider awstypes.CapacityProvider
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_ecs_capacity_provider.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ECSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckCapacityProviderDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCapacityProviderConfig_withClusterNoAssociation(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCapacityProviderExists(ctx, t, resourceName, &provider),
+					testAccAssociateCapacityProviderWithCluster(ctx, t, rName, rName),
+				),
+			},
+			{
+				Config:      testAccCapacityProviderConfig_withClusterNoAssociationRemoved(rName),
+				ExpectError: regexache.MustCompile(`capacity provider cannot be deleted because it is associated with cluster`),
+			},
+			{
+				Config: testAccCapacityProviderConfig_withClusterAssociation(rName),
 			},
 		},
 	})
@@ -1207,4 +1238,63 @@ resource "aws_ecs_capacity_provider" "test" {
   }
 }
 `, rName, monitoring))
+}
+
+func testAccAssociateCapacityProviderWithCluster(ctx context.Context, t *testing.T, clusterName, cpName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.ProviderMeta(ctx, t).ECSClient(ctx)
+
+		_, err := conn.PutClusterCapacityProviders(ctx, &ecs.PutClusterCapacityProvidersInput{
+			Cluster:                         &clusterName,
+			CapacityProviders:               []string{cpName},
+			DefaultCapacityProviderStrategy: []awstypes.CapacityProviderStrategyItem{},
+		})
+
+		return err
+	}
+}
+
+func testAccCapacityProviderConfig_withClusterNoAssociation(rName string) string {
+	return acctest.ConfigCompose(testAccCapacityProviderConfig_base(rName), fmt.Sprintf(`
+resource "aws_ecs_cluster" "test" {
+  name = %[1]q
+}
+
+resource "aws_ecs_capacity_provider" "test" {
+  name = %[1]q
+
+  auto_scaling_group_provider {
+    auto_scaling_group_arn = aws_autoscaling_group.test.arn
+  }
+}
+`, rName))
+}
+
+func testAccCapacityProviderConfig_withClusterNoAssociationRemoved(rName string) string {
+	return acctest.ConfigCompose(testAccCapacityProviderConfig_base(rName), fmt.Sprintf(`
+resource "aws_ecs_cluster" "test" {
+  name = %[1]q
+}
+`, rName))
+}
+
+func testAccCapacityProviderConfig_withClusterAssociation(rName string) string {
+	return acctest.ConfigCompose(testAccCapacityProviderConfig_base(rName), fmt.Sprintf(`
+resource "aws_ecs_cluster" "test" {
+  name = %[1]q
+}
+
+resource "aws_ecs_capacity_provider" "test" {
+  name = %[1]q
+
+  auto_scaling_group_provider {
+    auto_scaling_group_arn = aws_autoscaling_group.test.arn
+  }
+}
+
+resource "aws_ecs_cluster_capacity_providers" "test" {
+  cluster_name       = aws_ecs_cluster.test.name
+  capacity_providers = [aws_ecs_capacity_provider.test.name]
+}
+`, rName))
 }

--- a/internal/service/ecs/capacity_provider_test.go
+++ b/internal/service/ecs/capacity_provider_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/YakDriver/regexache"
+	ecsapi "github.com/aws/aws-sdk-go-v2/service/ecs"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -55,6 +56,37 @@ func TestAccECSCapacityProvider_basic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccECSCapacityProvider_deleteFailsWhenAssociated(t *testing.T) {
+	ctx := acctest.Context(t)
+	var provider awstypes.CapacityProvider
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_ecs_capacity_provider.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ECSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckCapacityProviderDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCapacityProviderConfig_withClusterNoAssociation(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCapacityProviderExists(ctx, t, resourceName, &provider),
+					testAccAssociateCapacityProviderWithCluster(ctx, t, rName, rName),
+				),
+			},
+			{
+				Config:      testAccCapacityProviderConfig_withClusterNoAssociationRemoved(rName),
+				ExpectError: regexache.MustCompile(`capacity provider cannot be deleted because it is associated with cluster`),
+			},
+			{
+				// Disassociate and destroy cleanly.
+				Config: testAccCapacityProviderConfig_withClusterAssociation(rName),
 			},
 		},
 	})
@@ -1145,4 +1177,63 @@ resource "aws_ecs_capacity_provider" "test" {
   }
 }
 `, rName, monitoring))
+}
+
+func testAccAssociateCapacityProviderWithCluster(ctx context.Context, t *testing.T, clusterName, cpName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.ProviderMeta(ctx, t).ECSClient(ctx)
+
+		_, err := conn.PutClusterCapacityProviders(ctx, &ecsapi.PutClusterCapacityProvidersInput{
+			Cluster:                         &clusterName,
+			CapacityProviders:               []string{cpName},
+			DefaultCapacityProviderStrategy: []awstypes.CapacityProviderStrategyItem{},
+		})
+
+		return err
+	}
+}
+
+func testAccCapacityProviderConfig_withClusterNoAssociation(rName string) string {
+	return acctest.ConfigCompose(testAccCapacityProviderConfig_base(rName), fmt.Sprintf(`
+resource "aws_ecs_cluster" "test" {
+  name = %[1]q
+}
+
+resource "aws_ecs_capacity_provider" "test" {
+  name = %[1]q
+
+  auto_scaling_group_provider {
+    auto_scaling_group_arn = aws_autoscaling_group.test.arn
+  }
+}
+`, rName))
+}
+
+func testAccCapacityProviderConfig_withClusterNoAssociationRemoved(rName string) string {
+	return acctest.ConfigCompose(testAccCapacityProviderConfig_base(rName), fmt.Sprintf(`
+resource "aws_ecs_cluster" "test" {
+  name = %[1]q
+}
+`, rName))
+}
+
+func testAccCapacityProviderConfig_withClusterAssociation(rName string) string {
+	return acctest.ConfigCompose(testAccCapacityProviderConfig_base(rName), fmt.Sprintf(`
+resource "aws_ecs_cluster" "test" {
+  name = %[1]q
+}
+
+resource "aws_ecs_capacity_provider" "test" {
+  name = %[1]q
+
+  auto_scaling_group_provider {
+    auto_scaling_group_arn = aws_autoscaling_group.test.arn
+  }
+}
+
+resource "aws_ecs_cluster_capacity_providers" "test" {
+  cluster_name       = aws_ecs_cluster.test.name
+  capacity_providers = [aws_ecs_capacity_provider.test.name]
+}
+`, rName))
 }

--- a/website/docs/r/ecs_capacity_provider.html.markdown
+++ b/website/docs/r/ecs_capacity_provider.html.markdown
@@ -14,6 +14,8 @@ Provides an ECS cluster capacity provider. More information can be found on the 
 
 ~> **NOTE:** You must specify exactly one of `auto_scaling_group_provider` or `managed_instances_provider`. When using `managed_instances_provider`, the `cluster` parameter is required. When using `auto_scaling_group_provider`, the `cluster` parameter must not be set.
 
+~> **NOTE:** AWS cannot delete a capacity provider that is still associated with a cluster through [`aws_ecs_cluster_capacity_providers`](ecs_cluster_capacity_providers.html). When a change forces replacement, add a [`replace_triggered_by`](https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle#replace_triggered_by) lifecycle rule to the `aws_ecs_cluster_capacity_providers` resource so the association is recreated before the old capacity provider is deleted.
+
 ## Example Usage
 
 ### Auto Scaling Group Provider

--- a/website/docs/r/ecs_cluster_capacity_providers.html.markdown
+++ b/website/docs/r/ecs_cluster_capacity_providers.html.markdown
@@ -12,6 +12,8 @@ Manages the capacity providers of an ECS Cluster.
 
 More information about capacity providers can be found in the [ECS User Guide](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/cluster-capacity-providers.html).
 
+~> **NOTE:** When an associated [`aws_ecs_capacity_provider`](ecs_capacity_provider.html) must be replaced, add a [`replace_triggered_by`](https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle#replace_triggered_by) lifecycle rule referencing the capacity provider. This recreates the association so the old capacity provider is detached from the cluster before it is deleted, which AWS otherwise disallows.
+
 ## Example Usage
 
 ```terraform


### PR DESCRIPTION
## Summary

Relates to #14393.

When a capacity provider is associated with a cluster, the `DeleteCapacityProvider` API sets `UpdateStatus` to `DELETE_FAILED` (with a clear reason message) but leaves `Status` as `ACTIVE`. Previously the delete waiter only checked `Status`, so it polled for 20 minutes before timing out with a generic error.

Now the waiter checks `UpdateStatus` — if it sees `DELETE_FAILED`, it returns immediately with the API's error message: "The capacity provider cannot be deleted because it is associated with cluster: X. Remove the capacity provider from the cluster and try again."

This turns a 20-minute mystery timeout into an instant, actionable error. Users should use `aws_ecs_cluster_capacity_providers` to manage cluster associations so Terraform handles disassociation ordering automatically.

### AI disclosure

This PR was authored with the assistance of an LLM agent.

## Test plan

- [x] New acceptance test `TestAccECSCapacityProvider_deleteFailsWhenAssociated` — associates a CP with a cluster out-of-band, verifies the delete fails immediately with the expected error message
- [x] Existing tests pass (`TestAccECSCapacityProvider_basic`, `TestAccECSCapacityProvider_disappears`)