### PR TITLE
fix(logs): Prevent ConflictException with aws_cloudwatch_log_delivery

### DIFF
--- a/.changelog/48158.txt
+++ b/.changelog/48158.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cloudwatch_log_delivery: Add mutex lock around create, update, and delete operations to prevent `ConflictException` errors
+```

--- a/internal/service/logs/delivery.go
+++ b/internal/service/logs/delivery.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
@@ -101,6 +102,22 @@ func (r *deliveryResource) Schema(ctx context.Context, request resource.SchemaRe
 
 var s3DeliveryConfigurationListOptions = []fwtypes.NestedObjectOfOption[s3DeliveryConfigurationModel]{}
 
+// deliveryMutexLock acquires locks on both delivery source and destination to prevent concurrent modification conflicts.
+// Locks are acquired in a consistent order (source first, then destination) to prevent deadlocks.
+// Returns a deferrable function that unlocks both in reverse order (destination first, then source).
+func deliveryMutexLock(model *deliveryResourceModel) func() {
+	sourceKey := fmt.Sprintf("logs-delivery-source:%s", model.DeliverySourceName.ValueString())
+	destKey := fmt.Sprintf("logs-delivery-destination:%s", model.DeliveryDestinationARN.ValueString())
+
+	conns.GlobalMutexKV.Lock(sourceKey)
+	conns.GlobalMutexKV.Lock(destKey)
+
+	return func() {
+		conns.GlobalMutexKV.Unlock(destKey)
+		conns.GlobalMutexKV.Unlock(sourceKey)
+	}
+}
+
 // normalizeS3SuffixPath strips AWS-added prefixes from the API-returned suffix path.
 // AWS automatically prepends "AWSLogs/{account-id}/CloudFront/" for CloudFront sources.
 // This normalization ensures the state matches the user's configuration value.
@@ -128,6 +145,8 @@ func (r *deliveryResource) Create(ctx context.Context, request resource.CreateRe
 
 	// Additional fields.
 	input.Tags = getTagsIn(ctx)
+
+	defer deliveryMutexLock(&data)()
 
 	output, err := conn.CreateDelivery(ctx, &input)
 
@@ -289,6 +308,8 @@ func (r *deliveryResource) Update(ctx context.Context, request resource.UpdateRe
 			return
 		}
 
+		defer deliveryMutexLock(&new)()
+
 		_, err := conn.UpdateDeliveryConfiguration(ctx, &input)
 
 		if err != nil {
@@ -309,6 +330,8 @@ func (r *deliveryResource) Delete(ctx context.Context, request resource.DeleteRe
 	}
 
 	conn := r.Meta().LogsClient(ctx)
+
+	defer deliveryMutexLock(&data)()
 
 	_, err := conn.DeleteDelivery(ctx, &cloudwatchlogs.DeleteDeliveryInput{
 		Id: fwflex.StringFromFramework(ctx, data.ID),


### PR DESCRIPTION
Serialize CloudWatch logs delivery CRUD operations when source or destination are the same resource. This helps prevent ConflictException responses due to concurrent operations.

<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

**No**

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This fix helps resolve failed applies caused by concurrent resource changes raising ConflictException API responses. The fix uses an existing mutex pattern to serialize operations involving the same underlying resource. For the delivery resource type, concurrency errors can occur when the either the source or the destination resource are the same and a pair of locks are acquired. 

AI assistance under human direction was used to generate the code change.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #42194

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
No new acceptance test. Practical demonstration provided instead

```console
$ terraform init

Initializing the backend...
Initializing provider plugins...
- Finding hashicorp/aws versions matching ">= 6.0.0"...
- Finding latest version of hashicorp/random...
- Installing hashicorp/aws v6.47.0...
- Installed hashicorp/aws v6.47.0 (signed by HashiCorp)
- Installing hashicorp/random v3.9.0...
- Installed hashicorp/random v3.9.0 (signed by HashiCorp)
Terraform has created a lock file terraform.lock.hcl to record the provider
selections it made above. Include this file in your version control repository
so that Terraform can guarantee to make the same selections by default when
you run "terraform init" in the future.

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.[0m

$ terraform version 

Terraform v1.11.4
on windows_amd64
+ provider registry.terraform.io/hashicorp/aws v6.47.0
+ provider registry.terraform.io/hashicorp/random v3.9.0

Your version of Terraform is out of date! The latest version
is 1.15.5. You can update by downloading from https://developer.hashicorp.com/terraform/install
data.aws_region.current: Reading...
data.aws_caller_identity.current: Reading...
data.aws_region.current: Read complete after 0s [id=us-east-1]
data.aws_caller_identity.current: Read complete after 0s [id=009911276521]

(v6.47.0)
$  terraform apply -var rule_set_id=rs-htlnc3nlgyr32xefquu6slio -var rule_set_id_2=rs-6km5liqgwdn6kw5w6ufw7b37 -var enable_loggroup_delivery=true -auto-approve -no-color 2>&1 | tee -a testcase.log

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_cloudwatch_log_delivery.to_loggroup[0] will be created
  + resource "aws_cloudwatch_log_delivery" "to_loggroup" {
      + arn                       = (known after apply)
      + delivery_destination_arn  = (known after apply)
      + delivery_source_name      = "ses-mail-manager-source"
      + field_delimiter           = (known after apply)
      + id                        = (known after apply)
      + record_fields             = (known after apply)
      + region                    = "us-east-1"
      + s3_delivery_configuration = (known after apply)
      + tags_all                  = {}
    }

  # aws_cloudwatch_log_delivery.to_loggroup_source2[0] will be created
  + resource "aws_cloudwatch_log_delivery" "to_loggroup_source2" {
      + arn                       = (known after apply)
      + delivery_destination_arn  = (known after apply)
      + delivery_source_name      = "ses-mail-manager-source-2"
      + field_delimiter           = (known after apply)
      + id                        = (known after apply)
      + record_fields             = (known after apply)
      + region                    = "us-east-1"
      + s3_delivery_configuration = (known after apply)
      + tags_all                  = {}
    }

  # aws_cloudwatch_log_delivery.to_s3 will be created
  + resource "aws_cloudwatch_log_delivery" "to_s3" {
      + arn                       = (known after apply)
      + delivery_destination_arn  = (known after apply)
      + delivery_source_name      = "ses-mail-manager-source"
      + field_delimiter           = (known after apply)
      + id                        = (known after apply)
      + record_fields             = (known after apply)
      + region                    = "us-east-1"
      + s3_delivery_configuration = (known after apply)
      + tags_all                  = {}
    }

  # aws_cloudwatch_log_delivery.to_s3_source2[0] will be created
  + resource "aws_cloudwatch_log_delivery" "to_s3_source2" {
      + arn                       = (known after apply)
      + delivery_destination_arn  = (known after apply)
      + delivery_source_name      = "ses-mail-manager-source-2"
      + field_delimiter           = (known after apply)
      + id                        = (known after apply)
      + record_fields             = (known after apply)
      + region                    = "us-east-1"
      + s3_delivery_configuration = (known after apply)
      + tags_all                  = {}
    }

  # aws_cloudwatch_log_delivery_destination.loggroup_dest will be created
  + resource "aws_cloudwatch_log_delivery_destination" "loggroup_dest" {
      + arn                       = (known after apply)
      + delivery_destination_type = (known after apply)
      + name                      = "ses-cwlg-destination"
      + region                    = "us-east-1"
      + tags_all                  = {}

      + delivery_destination_configuration {
          + destination_resource_arn = (known after apply)
        }
    }

  # aws_cloudwatch_log_delivery_destination.s3_dest will be created
  + resource "aws_cloudwatch_log_delivery_destination" "s3_dest" {
      + arn                       = (known after apply)
      + delivery_destination_type = (known after apply)
      + name                      = "ses-s3-destination"
      + region                    = "us-east-1"
      + tags_all                  = {}

      + delivery_destination_configuration {
          + destination_resource_arn = (known after apply)
        }
    }

  # aws_cloudwatch_log_delivery_source.ses_source will be created
  + resource "aws_cloudwatch_log_delivery_source" "ses_source" {
      + arn          = (known after apply)
      + log_type     = "APPLICATION_LOGS"
      + name         = "ses-mail-manager-source"
      + region       = "us-east-1"
      + resource_arn = "arn:aws:ses:us-east-1:009911276521:mailmanager-rule-set/rs-htlnc3nlgyr32xefquu6slio"
      + service      = (known after apply)
      + tags_all     = {}
    }

  # aws_cloudwatch_log_delivery_source.ses_source_2[0] will be created
  + resource "aws_cloudwatch_log_delivery_source" "ses_source_2" {
      + arn          = (known after apply)
      + log_type     = "APPLICATION_LOGS"
      + name         = "ses-mail-manager-source-2"
      + region       = "us-east-1"
      + resource_arn = "arn:aws:ses:us-east-1:009911276521:mailmanager-rule-set/rs-6km5liqgwdn6kw5w6ufw7b37"
      + service      = (known after apply)
      + tags_all     = {}
    }

  # aws_cloudwatch_log_group.ses_logs will be created
  + resource "aws_cloudwatch_log_group" "ses_logs" {
      + arn                         = (known after apply)
      + deletion_protection_enabled = (known after apply)
      + id                          = (known after apply)
      + log_group_class             = (known after apply)
      + name                        = "/aws/ses/mail-manager"
      + name_prefix                 = (known after apply)
      + region                      = "us-east-1"
      + retention_in_days           = 14
      + skip_destroy                = false
      + tags_all                    = (known after apply)
    }

  # aws_s3_bucket.logs will be created
  + resource "aws_s3_bucket" "logs" {
      + acceleration_status         = (known after apply)
      + acl                         = (known after apply)
      + arn                         = (known after apply)
      + bucket                      = (known after apply)
      + bucket_domain_name          = (known after apply)
      + bucket_namespace            = (known after apply)
      + bucket_prefix               = (known after apply)
      + bucket_region               = (known after apply)
      + bucket_regional_domain_name = (known after apply)
      + force_destroy               = true
      + hosted_zone_id              = (known after apply)
      + id                          = (known after apply)
      + object_lock_enabled         = (known after apply)
      + policy                      = (known after apply)
      + region                      = "us-east-1"
      + request_payer               = (known after apply)
      + tags_all                    = (known after apply)
      + website_domain              = (known after apply)
      + website_endpoint            = (known after apply)

      + cors_rule (known after apply)

      + grant (known after apply)

      + lifecycle_rule (known after apply)

      + logging (known after apply)

      + object_lock_configuration (known after apply)

      + replication_configuration (known after apply)

      + server_side_encryption_configuration (known after apply)

      + versioning (known after apply)

      + website (known after apply)
    }

  # aws_s3_bucket_policy.logs_policy will be created
  + resource "aws_s3_bucket_policy" "logs_policy" {
      + bucket = (known after apply)
      + id     = (known after apply)
      + policy = (known after apply)
      + region = "us-east-1"
    }

  # aws_ses_receipt_rule_set.main will be created
  + resource "aws_ses_receipt_rule_set" "main" {
      + arn           = (known after apply)
      + id            = (known after apply)
      + region        = "us-east-1"
      + rule_set_name = "primary-rules"
    }

  # random_id.suffix will be created
  + resource "random_id" "suffix" {
      + b64_std     = (known after apply)
      + b64_url     = (known after apply)
      + byte_length = 4
      + dec         = (known after apply)
      + hex         = (known after apply)
      + id          = (known after apply)
    }

Plan: 13 to add, 0 to change, 0 to destroy.
random_id.suffix: Creating...
random_id.suffix: Creation complete after 0s [id=d72mxw]
aws_ses_receipt_rule_set.main: Creating...
aws_cloudwatch_log_group.ses_logs: Creating...
aws_s3_bucket.logs: Creating...
aws_cloudwatch_log_delivery_source.ses_source_2[0]: Creating...
aws_cloudwatch_log_delivery_source.ses_source: Creating...
aws_ses_receipt_rule_set.main: Creation complete after 1s [id=primary-rules]
aws_cloudwatch_log_delivery_source.ses_source: Creation complete after 1s [name=ses-mail-manager-source]
aws_cloudwatch_log_delivery_source.ses_source_2[0]: Creation complete after 1s [name=ses-mail-manager-source-2]
aws_cloudwatch_log_group.ses_logs: Creation complete after 1s [id=/aws/ses/mail-manager]
aws_cloudwatch_log_delivery_destination.loggroup_dest: Creating...
aws_cloudwatch_log_delivery_destination.loggroup_dest: Creation complete after 0s [name=ses-cwlg-destination]
aws_s3_bucket.logs: Creation complete after 2s [id=ses-mail-logs-77bda6c7]
aws_s3_bucket_policy.logs_policy: Creating...
aws_cloudwatch_log_delivery_destination.s3_dest: Creating...
aws_cloudwatch_log_delivery_destination.s3_dest: Creation complete after 0s [name=ses-s3-destination]
aws_cloudwatch_log_delivery.to_loggroup[0]: Creating...
aws_cloudwatch_log_delivery.to_s3_source2[0]: Creating...
aws_cloudwatch_log_delivery.to_s3: Creating...
aws_cloudwatch_log_delivery.to_loggroup_source2[0]: Creating...
aws_s3_bucket_policy.logs_policy: Creation complete after 0s [id=ses-mail-logs-77bda6c7]
aws_cloudwatch_log_delivery.to_loggroup[0]: Creation complete after 1s [id=qbU0not6qz5elRVt]
aws_cloudwatch_log_delivery.to_s3_source2[0]: Creation complete after 1s [id=4aYeQiRADsz6eCKB]

Error: creating CloudWatch Logs Delivery

  with aws_cloudwatch_log_delivery.to_s3,
  on main.tf line 109, in resource "aws_cloudwatch_log_delivery" "to_s3":
 109: resource "aws_cloudwatch_log_delivery" "to_s3" {

operation error CloudWatch Logs: CreateDelivery, https response error
StatusCode: 400, RequestID: 9bd168d2-1640-4166-8ba4-bc0a2a64980e,
ConflictException: Requested resource is currently being updated. Please try
again later.

Error: creating CloudWatch Logs Delivery

  with aws_cloudwatch_log_delivery.to_loggroup_source2[0],
  on main.tf line 139, in resource "aws_cloudwatch_log_delivery" "to_loggroup_source2":
 139: resource "aws_cloudwatch_log_delivery" "to_loggroup_source2" {

operation error CloudWatch Logs: CreateDelivery, https response error
StatusCode: 400, RequestID: aa9d5115-2905-40ca-a616-48e99a716b42,
ConflictException: Requested resource is currently being updated. Please try
again later.
random_id.suffix: Refreshing state... [id=d72mxw]
aws_ses_receipt_rule_set.main: Refreshing state... [id=primary-rules]
data.aws_caller_identity.current: Reading...
data.aws_region.current: Reading...
aws_cloudwatch_log_group.ses_logs: Refreshing state... [id=/aws/ses/mail-manager]
data.aws_region.current: Read complete after 0s [id=us-east-1]
aws_s3_bucket.logs: Refreshing state... [id=ses-mail-logs-77bda6c7]
data.aws_caller_identity.current: Read complete after 0s [id=009911276521]
aws_cloudwatch_log_delivery_source.ses_source: Refreshing state... [name=ses-mail-manager-source]
aws_cloudwatch_log_delivery_source.ses_source_2[0]: Refreshing state... [name=ses-mail-manager-source-2]
aws_cloudwatch_log_delivery_destination.loggroup_dest: Refreshing state... [name=ses-cwlg-destination]
aws_s3_bucket_policy.logs_policy: Refreshing state... [id=ses-mail-logs-77bda6c7]
aws_cloudwatch_log_delivery_destination.s3_dest: Refreshing state... [name=ses-s3-destination]
aws_cloudwatch_log_delivery.to_s3_source2[0]: Refreshing state... [id=4aYeQiRADsz6eCKB]
aws_cloudwatch_log_delivery.to_loggroup[0]: Refreshing state... [id=qbU0not6qz5elRVt]


(fix)
$ terraform apply -var rule_set_id=rs-htlnc3nlgyr32xefquu6slio -var rule_set_id_2=rs-6km5liqgwdn6kw5w6ufw7b37 -var enable_loggroup_delivery=true -auto-approve -no-color 2>&1 | tee -a testcase.log

Warning: Provider development overrides are in effect

The following provider development overrides are set in the CLI
configuration:
 - hashicorp/aws in C:\Users\cshar\wip\myfork-terraform-aws-provider\terraform-plugin-dir\registry.terraform.io\hashicorp\aws\99.99.99\windows_amd64

The behavior may therefore not match any released version of the provider and
applying changes may cause the state to become incompatible with published
releases.
data.aws_caller_identity.current: Reading...
data.aws_region.current: Reading...
data.aws_region.current: Read complete after 0s [id=us-east-1]
data.aws_caller_identity.current: Read complete after 0s [id=009911276521]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_cloudwatch_log_delivery.to_loggroup[0] will be created
  + resource "aws_cloudwatch_log_delivery" "to_loggroup" {
      + arn                       = (known after apply)
      + delivery_destination_arn  = (known after apply)
      + delivery_source_name      = "ses-mail-manager-source"
      + field_delimiter           = (known after apply)
      + id                        = (known after apply)
      + record_fields             = (known after apply)
      + region                    = "us-east-1"
      + s3_delivery_configuration = (known after apply)
      + tags_all                  = {}
    }

  # aws_cloudwatch_log_delivery.to_loggroup_source2[0] will be created
  + resource "aws_cloudwatch_log_delivery" "to_loggroup_source2" {
      + arn                       = (known after apply)
      + delivery_destination_arn  = (known after apply)
      + delivery_source_name      = "ses-mail-manager-source-2"
      + field_delimiter           = (known after apply)
      + id                        = (known after apply)
      + record_fields             = (known after apply)
      + region                    = "us-east-1"
      + s3_delivery_configuration = (known after apply)
      + tags_all                  = {}
    }

  # aws_cloudwatch_log_delivery.to_s3 will be created
  + resource "aws_cloudwatch_log_delivery" "to_s3" {
      + arn                       = (known after apply)
      + delivery_destination_arn  = (known after apply)
      + delivery_source_name      = "ses-mail-manager-source"
      + field_delimiter           = (known after apply)
      + id                        = (known after apply)
      + record_fields             = (known after apply)
      + region                    = "us-east-1"
      + s3_delivery_configuration = (known after apply)
      + tags_all                  = {}
    }

  # aws_cloudwatch_log_delivery.to_s3_source2[0] will be created
  + resource "aws_cloudwatch_log_delivery" "to_s3_source2" {
      + arn                       = (known after apply)
      + delivery_destination_arn  = (known after apply)
      + delivery_source_name      = "ses-mail-manager-source-2"
      + field_delimiter           = (known after apply)
      + id                        = (known after apply)
      + record_fields             = (known after apply)
      + region                    = "us-east-1"
      + s3_delivery_configuration = (known after apply)
      + tags_all                  = {}
    }

  # aws_cloudwatch_log_delivery_destination.loggroup_dest will be created
  + resource "aws_cloudwatch_log_delivery_destination" "loggroup_dest" {
      + arn                       = (known after apply)
      + delivery_destination_type = (known after apply)
      + name                      = "ses-cwlg-destination"
      + region                    = "us-east-1"
      + tags_all                  = {}

      + delivery_destination_configuration {
          + destination_resource_arn = (known after apply)
        }
    }

  # aws_cloudwatch_log_delivery_destination.s3_dest will be created
  + resource "aws_cloudwatch_log_delivery_destination" "s3_dest" {
      + arn                       = (known after apply)
      + delivery_destination_type = (known after apply)
      + name                      = "ses-s3-destination"
      + region                    = "us-east-1"
      + tags_all                  = {}

      + delivery_destination_configuration {
          + destination_resource_arn = (known after apply)
        }
    }

  # aws_cloudwatch_log_delivery_source.ses_source will be created
  + resource "aws_cloudwatch_log_delivery_source" "ses_source" {
      + arn          = (known after apply)
      + log_type     = "APPLICATION_LOGS"
      + name         = "ses-mail-manager-source"
      + region       = "us-east-1"
      + resource_arn = "arn:aws:ses:us-east-1:009911276521:mailmanager-rule-set/rs-htlnc3nlgyr32xefquu6slio"
      + service      = (known after apply)
      + tags_all     = {}
    }

  # aws_cloudwatch_log_delivery_source.ses_source_2[0] will be created
  + resource "aws_cloudwatch_log_delivery_source" "ses_source_2" {
      + arn          = (known after apply)
      + log_type     = "APPLICATION_LOGS"
      + name         = "ses-mail-manager-source-2"
      + region       = "us-east-1"
      + resource_arn = "arn:aws:ses:us-east-1:009911276521:mailmanager-rule-set/rs-6km5liqgwdn6kw5w6ufw7b37"
      + service      = (known after apply)
      + tags_all     = {}
    }

  # aws_cloudwatch_log_group.ses_logs will be created
  + resource "aws_cloudwatch_log_group" "ses_logs" {
      + arn                         = (known after apply)
      + deletion_protection_enabled = (known after apply)
      + id                          = (known after apply)
      + log_group_class             = (known after apply)
      + name                        = "/aws/ses/mail-manager"
      + name_prefix                 = (known after apply)
      + region                      = "us-east-1"
      + retention_in_days           = 14
      + skip_destroy                = false
      + tags_all                    = (known after apply)
    }

  # aws_s3_bucket.logs will be created
  + resource "aws_s3_bucket" "logs" {
      + acceleration_status         = (known after apply)
      + acl                         = (known after apply)
      + arn                         = (known after apply)
      + bucket                      = (known after apply)
      + bucket_domain_name          = (known after apply)
      + bucket_namespace            = (known after apply)
      + bucket_prefix               = (known after apply)
      + bucket_region               = (known after apply)
      + bucket_regional_domain_name = (known after apply)
      + force_destroy               = true
      + hosted_zone_id              = (known after apply)
      + id                          = (known after apply)
      + object_lock_enabled         = (known after apply)
      + policy                      = (known after apply)
      + region                      = "us-east-1"
      + request_payer               = (known after apply)
      + tags_all                    = (known after apply)
      + website_domain              = (known after apply)
      + website_endpoint            = (known after apply)

      + cors_rule (known after apply)

      + grant (known after apply)

      + lifecycle_rule (known after apply)

      + logging (known after apply)

      + object_lock_configuration (known after apply)

      + replication_configuration (known after apply)

      + server_side_encryption_configuration (known after apply)

      + versioning (known after apply)

      + website (known after apply)
    }

  # aws_s3_bucket_policy.logs_policy will be created
  + resource "aws_s3_bucket_policy" "logs_policy" {
      + bucket = (known after apply)
      + id     = (known after apply)
      + policy = (known after apply)
      + region = "us-east-1"
    }

  # aws_ses_receipt_rule_set.main will be created
  + resource "aws_ses_receipt_rule_set" "main" {
      + arn           = (known after apply)
      + id            = (known after apply)
      + region        = "us-east-1"
      + rule_set_name = "primary-rules"
    }

  # random_id.suffix will be created
  + resource "random_id" "suffix" {
      + b64_std     = (known after apply)
      + b64_url     = (known after apply)
      + byte_length = 4
      + dec         = (known after apply)
      + hex         = (known after apply)
      + id          = (known after apply)
    }

Plan: 13 to add, 0 to change, 0 to destroy.
random_id.suffix: Creating...
random_id.suffix: Creation complete after 0s [id=auqgiA]
aws_ses_receipt_rule_set.main: Creating...
aws_cloudwatch_log_group.ses_logs: Creating...
aws_s3_bucket.logs: Creating...
aws_cloudwatch_log_delivery_source.ses_source_2[0]: Creating...
aws_cloudwatch_log_delivery_source.ses_source: Creating...
aws_ses_receipt_rule_set.main: Creation complete after 0s [id=primary-rules]
aws_cloudwatch_log_delivery_source.ses_source: Creation complete after 0s [name=ses-mail-manager-source]
aws_cloudwatch_log_delivery_source.ses_source_2[0]: Creation complete after 0s [name=ses-mail-manager-source-2]
aws_cloudwatch_log_group.ses_logs: Creation complete after 0s [id=/aws/ses/mail-manager]
aws_cloudwatch_log_delivery_destination.loggroup_dest: Creating...
aws_cloudwatch_log_delivery_destination.loggroup_dest: Creation complete after 0s [name=ses-cwlg-destination]
aws_s3_bucket.logs: Creation complete after 1s [id=ses-mail-logs-6aeaa088]
aws_s3_bucket_policy.logs_policy: Creating...
aws_cloudwatch_log_delivery_destination.s3_dest: Creating...
aws_cloudwatch_log_delivery_destination.s3_dest: Creation complete after 0s [name=ses-s3-destination]
aws_cloudwatch_log_delivery.to_loggroup_source2[0]: Creating...
aws_cloudwatch_log_delivery.to_s3: Creating...
aws_cloudwatch_log_delivery.to_s3_source2[0]: Creating...
aws_cloudwatch_log_delivery.to_loggroup[0]: Creating...
aws_s3_bucket_policy.logs_policy: Creation complete after 1s [id=ses-mail-logs-6aeaa088]
aws_cloudwatch_log_delivery.to_s3: Creation complete after 1s [id=DLmC3tpsKmCZ1Ewd]
aws_cloudwatch_log_delivery.to_loggroup_source2[0]: Creation complete after 1s [id=DEf6TBwPdfmwTh1j]
aws_cloudwatch_log_delivery.to_loggroup[0]: Creation complete after 1s [id=xhxwzJzcEEcKUrgm]
aws_cloudwatch_log_delivery.to_s3_source2[0]: Creation complete after 1s [id=QhbhS5dEpCjzEU1e]

Apply complete! Resources: 13 added, 0 changed, 0 destroyed.

```
