### PR TITLE
s3_bucket_versioning: Fixes regression bug around mfa_delete

### DIFF
--- a/.changelog/48161.txt
+++ b/.changelog/48161.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_s3_bucket_versioning: Fix perpetual drift on `versioning_configuration.mfa_delete` when `status` is `Disabled`
+```

--- a/internal/service/s3/bucket_versioning.go
+++ b/internal/service/s3/bucket_versioning.go
@@ -326,7 +326,7 @@ func flattenVersioning(config *s3.GetBucketVersioningOutput) []any {
 		return []any{}
 	}
 
-	m := map[string]any{}
+	m := make(map[string]any)
 	if config.MFADelete != "" {
 		m["mfa_delete"] = config.MFADelete
 	} else {
@@ -412,7 +412,7 @@ func waitForBucketVersioningStatus(ctx context.Context, conn *s3.Client, bucket,
 
 const (
 	bucketVersioningStatusDisabled    = "Disabled"
-	bucketVersioningMfaDeleteDisabled = "Disabled"
+	bucketVersioningMFADeleteDisabled = "Disabled"
 )
 
 func bucketVersioningStatus_Values() []string {

--- a/internal/service/s3/bucket_versioning.go
+++ b/internal/service/s3/bucket_versioning.go
@@ -330,7 +330,7 @@ func flattenVersioning(config *s3.GetBucketVersioningOutput) []any {
 	if config.MFADelete != "" {
 		m["mfa_delete"] = config.MFADelete
 	} else {
-		m["mfa_delete"] = bucketVersioningMfaDeleteDisabled
+		m["mfa_delete"] = bucketVersioningMFADeleteDisabled
 	}
 
 	if config.Status != "" {

--- a/internal/service/s3/bucket_versioning.go
+++ b/internal/service/s3/bucket_versioning.go
@@ -326,8 +326,11 @@ func flattenVersioning(config *s3.GetBucketVersioningOutput) []any {
 		return []any{}
 	}
 
-	m := map[string]any{
-		"mfa_delete": config.MFADelete,
+	m := map[string]any{}
+	if config.MFADelete != "" {
+		m["mfa_delete"] = config.MFADelete
+	} else {
+		m["mfa_delete"] = bucketVersioningMfaDeleteDisabled
 	}
 
 	if config.Status != "" {
@@ -408,7 +411,8 @@ func waitForBucketVersioningStatus(ctx context.Context, conn *s3.Client, bucket,
 }
 
 const (
-	bucketVersioningStatusDisabled = "Disabled"
+	bucketVersioningStatusDisabled    = "Disabled"
+	bucketVersioningMfaDeleteDisabled = "Disabled"
 )
 
 func bucketVersioningStatus_Values() []string {

--- a/internal/service/s3/bucket_versioning_test.go
+++ b/internal/service/s3/bucket_versioning_test.go
@@ -189,6 +189,43 @@ func TestAccS3BucketVersioning_MFADelete(t *testing.T) {
 	})
 }
 
+func TestAccS3BucketVersioning_MFADelete_statusDisabled(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket_versioning.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckBucketVersioningDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketVersioningConfig_statusAndMFADelete(rName, tfs3.BucketVersioningStatusDisabled, string(types.MFADeleteDisabled)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketVersioningExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "versioning_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "versioning_configuration.0.mfa_delete", string(types.MFADeleteDisabled)),
+					resource.TestCheckResourceAttr(resourceName, "versioning_configuration.0.status", tfs3.BucketVersioningStatusDisabled),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccS3BucketVersioning_migrate_versioningDisabledNoChange(t *testing.T) {
 	ctx := acctest.Context(t)
 	bucketName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
@@ -882,6 +919,22 @@ resource "aws_s3_bucket_versioning" "test" {
 
 data "aws_caller_identity" "current" {}
 `, rName)
+}
+
+func testAccBucketVersioningConfig_statusAndMFADelete(rName, status, mfaDelete string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+}
+
+resource "aws_s3_bucket_versioning" "test" {
+  bucket = aws_s3_bucket.test.bucket
+  versioning_configuration {
+    mfa_delete = %[3]q
+    status     = %[2]q
+  }
+}
+`, rName, status, mfaDelete)
 }
 
 func testAccBucketVersioningConfig_directoryBucket(rName, status string) string {


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

When creating `aws_s3_bucket_versioning` with status = "Disabled", the Create handler intentionally skips the `PutBucketVersioning` API call, so AWS never records an MfaDelete value and omits it from subsequent GetBucketVersioning responses. 
In v6, a v5→v6 SDK migration changed MFADelete from a nil-checkable string pointer to a string-based enum, and the nil-guard that prevented writing absent values to state was dropped. As a result, the flattener unconditionally wrote mfa_delete = "" to state.
On every subsequent plan, state ("") diverged from config ("Disabled"), producing perpetual drift that when applied sent MfaDelete=Disabled to AWS without the required MFA header, causing a MalformedXML rejection.

Added a test which reproduces the bug, and passes after the fix is applied.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #47566

### Output from Acceptance Testing

```console
% make t T=TestAccS3BucketVersioning_ K=s3 
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-s3_bucket_versioning_mfa_delete_bug 🌿...
TF_ACC=1 go1.26.3 test ./internal/service/s3/... -v -count 1 -parallel 20 -run='TestAccS3BucketVersioning_'  -timeout 360m -vet=off
2026/06/02 15:41:53 Creating Terraform AWS Provider (SDKv2-style)...
2026/06/02 15:41:53 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccS3BucketVersioning_Identity_basic
=== PAUSE TestAccS3BucketVersioning_Identity_basic
=== RUN   TestAccS3BucketVersioning_Identity_regionOverride
=== PAUSE TestAccS3BucketVersioning_Identity_regionOverride
=== RUN   TestAccS3BucketVersioning_Identity_ExistingResource_basic
=== PAUSE TestAccS3BucketVersioning_Identity_ExistingResource_basic
=== RUN   TestAccS3BucketVersioning_Identity_ExistingResource_noRefreshNoChange
=== PAUSE TestAccS3BucketVersioning_Identity_ExistingResource_noRefreshNoChange
=== RUN   TestAccS3BucketVersioning_Identity_upgrade
=== PAUSE TestAccS3BucketVersioning_Identity_upgrade
=== RUN   TestAccS3BucketVersioning_Identity_Upgrade_noRefresh
=== PAUSE TestAccS3BucketVersioning_Identity_Upgrade_noRefresh
=== RUN   TestAccS3BucketVersioning_List_basic
=== PAUSE TestAccS3BucketVersioning_List_basic
=== RUN   TestAccS3BucketVersioning_List_includeResource
=== PAUSE TestAccS3BucketVersioning_List_includeResource
=== RUN   TestAccS3BucketVersioning_List_regionOverride
=== PAUSE TestAccS3BucketVersioning_List_regionOverride
=== RUN   TestAccS3BucketVersioning_basic
=== PAUSE TestAccS3BucketVersioning_basic
=== RUN   TestAccS3BucketVersioning_disappears
=== PAUSE TestAccS3BucketVersioning_disappears
=== RUN   TestAccS3BucketVersioning_disappears_bucket
=== PAUSE TestAccS3BucketVersioning_disappears_bucket
=== RUN   TestAccS3BucketVersioning_update
=== PAUSE TestAccS3BucketVersioning_update
=== RUN   TestAccS3BucketVersioning_MFADelete
=== PAUSE TestAccS3BucketVersioning_MFADelete
=== RUN   TestAccS3BucketVersioning_MFADelete_statusDisabled
=== PAUSE TestAccS3BucketVersioning_MFADelete_statusDisabled
=== RUN   TestAccS3BucketVersioning_migrate_versioningDisabledNoChange
=== PAUSE TestAccS3BucketVersioning_migrate_versioningDisabledNoChange
=== RUN   TestAccS3BucketVersioning_migrate_versioningDisabledWithChange
=== PAUSE TestAccS3BucketVersioning_migrate_versioningDisabledWithChange
=== RUN   TestAccS3BucketVersioning_migrate_versioningEnabledNoChange
=== PAUSE TestAccS3BucketVersioning_migrate_versioningEnabledNoChange
=== RUN   TestAccS3BucketVersioning_migrate_versioningEnabledWithChange
=== PAUSE TestAccS3BucketVersioning_migrate_versioningEnabledWithChange
=== RUN   TestAccS3BucketVersioning_migrate_mfaDeleteNoChange
=== PAUSE TestAccS3BucketVersioning_migrate_mfaDeleteNoChange
=== RUN   TestAccS3BucketVersioning_Status_disabled
=== PAUSE TestAccS3BucketVersioning_Status_disabled
=== RUN   TestAccS3BucketVersioning_Status_disabledToEnabled
=== PAUSE TestAccS3BucketVersioning_Status_disabledToEnabled
=== RUN   TestAccS3BucketVersioning_Status_disabledToSuspended
=== PAUSE TestAccS3BucketVersioning_Status_disabledToSuspended
=== RUN   TestAccS3BucketVersioning_Status_enabledToDisabled
=== PAUSE TestAccS3BucketVersioning_Status_enabledToDisabled
=== RUN   TestAccS3BucketVersioning_Status_suspendedToDisabled
=== PAUSE TestAccS3BucketVersioning_Status_suspendedToDisabled
=== RUN   TestAccS3BucketVersioning_expectedBucketOwner
=== PAUSE TestAccS3BucketVersioning_expectedBucketOwner
=== RUN   TestAccS3BucketVersioning_Identity_expectedBucketOwner
=== PAUSE TestAccS3BucketVersioning_Identity_expectedBucketOwner
=== RUN   TestAccS3BucketVersioning_Identity_ExistingResource_expectedBucketOwner
=== PAUSE TestAccS3BucketVersioning_Identity_ExistingResource_expectedBucketOwner
=== RUN   TestAccS3BucketVersioning_Identity_Upgrade_expectedBucketOwner
=== PAUSE TestAccS3BucketVersioning_Identity_Upgrade_expectedBucketOwner
=== RUN   TestAccS3BucketVersioning_directoryBucket
=== PAUSE TestAccS3BucketVersioning_directoryBucket
=== CONT  TestAccS3BucketVersioning_Identity_basic
=== CONT  TestAccS3BucketVersioning_migrate_versioningDisabledNoChange
=== CONT  TestAccS3BucketVersioning_List_regionOverride
=== CONT  TestAccS3BucketVersioning_Identity_upgrade
=== CONT  TestAccS3BucketVersioning_Identity_Upgrade_noRefresh
=== CONT  TestAccS3BucketVersioning_Identity_regionOverride
=== CONT  TestAccS3BucketVersioning_List_basic
=== CONT  TestAccS3BucketVersioning_update
=== CONT  TestAccS3BucketVersioning_List_includeResource
=== CONT  TestAccS3BucketVersioning_Identity_ExistingResource_basic
=== CONT  TestAccS3BucketVersioning_Identity_ExistingResource_noRefreshNoChange
=== CONT  TestAccS3BucketVersioning_MFADelete_statusDisabled
=== CONT  TestAccS3BucketVersioning_MFADelete
=== CONT  TestAccS3BucketVersioning_disappears
=== CONT  TestAccS3BucketVersioning_disappears_bucket
=== CONT  TestAccS3BucketVersioning_basic
=== CONT  TestAccS3BucketVersioning_Status_enabledToDisabled
=== CONT  TestAccS3BucketVersioning_directoryBucket
=== CONT  TestAccS3BucketVersioning_Identity_Upgrade_expectedBucketOwner
=== CONT  TestAccS3BucketVersioning_Identity_ExistingResource_expectedBucketOwner
--- PASS: TestAccS3BucketVersioning_directoryBucket (21.30s)
=== CONT  TestAccS3BucketVersioning_Identity_expectedBucketOwner
=== NAME  TestAccS3BucketVersioning_disappears
    bucket_versioning_test.go:63: Step 1/1 error: Post-apply refresh plan check(s) failed:
        'aws_s3_bucket_versioning.test' - expected Create, got action(s): [update]
--- PASS: TestAccS3BucketVersioning_disappears_bucket (42.36s)
=== CONT  TestAccS3BucketVersioning_expectedBucketOwner
=== NAME  TestAccS3BucketVersioning_Identity_ExistingResource_expectedBucketOwner
    bucket_versioning_test.go:654: Step 1/2 error: Post-apply refresh state check(s) failed:
        aws_s3_bucket_versioning.test - Identity found in state, and was not expected.
--- FAIL: TestAccS3BucketVersioning_disappears (47.03s)
=== CONT  TestAccS3BucketVersioning_Status_suspendedToDisabled
--- PASS: TestAccS3BucketVersioning_List_regionOverride (47.85s)
=== CONT  TestAccS3BucketVersioning_migrate_mfaDeleteNoChange
--- PASS: TestAccS3BucketVersioning_basic (49.05s)
=== CONT  TestAccS3BucketVersioning_Status_disabledToSuspended
=== NAME  TestAccS3BucketVersioning_Identity_ExistingResource_basic
    bucket_versioning_identity_gen_test.go:202: Step 1/2 error: Post-apply refresh state check(s) failed:
        aws_s3_bucket_versioning.test - Identity found in state, and was not expected.
--- PASS: TestAccS3BucketVersioning_List_basic (50.32s)
=== CONT  TestAccS3BucketVersioning_Status_disabledToEnabled
--- PASS: TestAccS3BucketVersioning_MFADelete_statusDisabled (52.46s)
=== CONT  TestAccS3BucketVersioning_Status_disabled
--- PASS: TestAccS3BucketVersioning_MFADelete (52.47s)
=== CONT  TestAccS3BucketVersioning_migrate_versioningEnabledNoChange
--- FAIL: TestAccS3BucketVersioning_Identity_ExistingResource_expectedBucketOwner (52.92s)
=== CONT  TestAccS3BucketVersioning_migrate_versioningEnabledWithChange
--- PASS: TestAccS3BucketVersioning_Status_enabledToDisabled (56.05s)
=== CONT  TestAccS3BucketVersioning_migrate_versioningDisabledWithChange
--- FAIL: TestAccS3BucketVersioning_Identity_ExistingResource_basic (57.23s)
=== NAME  TestAccS3BucketVersioning_Identity_ExistingResource_noRefreshNoChange
    bucket_versioning_identity_gen_test.go:259: Step 1/2 error: Post-apply refresh state check(s) failed:
        aws_s3_bucket_versioning.test - Identity found in state, and was not expected.
--- PASS: TestAccS3BucketVersioning_List_includeResource (65.82s)
--- PASS: TestAccS3BucketVersioning_migrate_versioningDisabledNoChange (65.82s)
--- FAIL: TestAccS3BucketVersioning_Identity_ExistingResource_noRefreshNoChange (66.48s)
--- PASS: TestAccS3BucketVersioning_Identity_basic (77.20s)
--- PASS: TestAccS3BucketVersioning_Identity_regionOverride (77.50s)
--- PASS: TestAccS3BucketVersioning_Identity_Upgrade_noRefresh (86.51s)
--- PASS: TestAccS3BucketVersioning_expectedBucketOwner (44.54s)
--- PASS: TestAccS3BucketVersioning_Status_suspendedToDisabled (43.37s)
--- PASS: TestAccS3BucketVersioning_Identity_expectedBucketOwner (70.46s)
--- PASS: TestAccS3BucketVersioning_Status_disabled (39.68s)
--- PASS: TestAccS3BucketVersioning_Identity_Upgrade_expectedBucketOwner (98.79s)
--- PASS: TestAccS3BucketVersioning_Identity_upgrade (100.55s)
--- PASS: TestAccS3BucketVersioning_migrate_mfaDeleteNoChange (56.11s)
--- PASS: TestAccS3BucketVersioning_update (106.39s)
--- PASS: TestAccS3BucketVersioning_migrate_versioningEnabledNoChange (56.67s)
--- PASS: TestAccS3BucketVersioning_migrate_versioningEnabledWithChange (57.25s)
--- PASS: TestAccS3BucketVersioning_migrate_versioningDisabledWithChange (55.64s)
--- PASS: TestAccS3BucketVersioning_Status_disabledToSuspended (66.29s)
--- PASS: TestAccS3BucketVersioning_Status_disabledToEnabled (65.97s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/s3 121.496s

...
```

The disappears test has the same issue on main, hence unrelated to this change.
```console
% make t T=TestAccS3BucketVersioning_disappears K=s3
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 main 🌿...
TF_ACC=1 go1.26.3 test ./internal/service/s3/... -v -count 1 -parallel 20 -run='TestAccS3BucketVersioning_disappears'  -timeout 360m -vet=off
2026/06/02 15:21:50 Creating Terraform AWS Provider (SDKv2-style)...
2026/06/02 15:21:50 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccS3BucketVersioning_disappears
=== PAUSE TestAccS3BucketVersioning_disappears
=== RUN   TestAccS3BucketVersioning_disappears_bucket
=== PAUSE TestAccS3BucketVersioning_disappears_bucket
=== CONT  TestAccS3BucketVersioning_disappears
=== CONT  TestAccS3BucketVersioning_disappears_bucket
=== NAME  TestAccS3BucketVersioning_disappears
    bucket_versioning_test.go:63: Step 1/1 error: Post-apply refresh plan check(s) failed:
        'aws_s3_bucket_versioning.test' - expected Create, got action(s): [update]
--- PASS: TestAccS3BucketVersioning_disappears_bucket (32.31s)
--- FAIL: TestAccS3BucketVersioning_disappears (34.85s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/s3 40.250s
```