### PR TITLE
bug: aws_route53domains_delegation_signer_record key on digest and migrate prior state

### DIFF
--- a/.changelog/48165.txt
+++ b/.changelog/48165.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_route53domains_delegation_signer_record: Stop removing the resource from state and forcing replacement on refresh by keying the DS record on its digest, skipping refresh of write-only `signing_attributes`, and migrating prior state via a schema upgrader
+```

--- a/internal/service/route53domains/delegation_signer_record.go
+++ b/internal/service/route53domains/delegation_signer_record.go
@@ -54,6 +54,7 @@ type delegationSignerRecordResource struct {
 
 func (r *delegationSignerRecordResource) Schema(ctx context.Context, request resource.SchemaRequest, response *resource.SchemaResponse) {
 	response.Schema = schema.Schema{
+		Version: 1,
 		Attributes: map[string]schema.Attribute{
 			"dnssec_key_id": framework.IDAttribute(),
 			names.AttrDomainName: schema.StringAttribute{
@@ -105,6 +106,17 @@ func (r *delegationSignerRecordResource) Schema(ctx context.Context, request res
 	}
 }
 
+func (r *delegationSignerRecordResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
+	schemaV0 := delegationSignerRecordSchemaV0(ctx)
+
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema:   &schemaV0,
+			StateUpgrader: upgradeDelegationSignerRecordStateFromV0,
+		},
+	}
+}
+
 func (r *delegationSignerRecordResource) Create(ctx context.Context, request resource.CreateRequest, response *resource.CreateResponse) {
 	var data delegationSignerRecordResourceModel
 	response.Diagnostics.Append(request.Plan.Get(ctx, &data)...)
@@ -148,8 +160,12 @@ func (r *delegationSignerRecordResource) Create(ctx context.Context, request res
 		return
 	}
 
-	// Set values for unknowns.
-	data.DNSSECKeyID = fwflex.StringToFramework(ctx, dnssecKey.Id)
+	// Set values for unknowns. Key on the DnssecKey's Digest, which is the stable
+	// value returned by GetDomainDetail. The DnssecKey.Id returned by
+	// AssociateDelegationSignerToDomain is not reliably echoed back by the
+	// registry on subsequent reads, so storing it here would cause refresh to
+	// drop the resource from state. See #47928.
+	data.DNSSECKeyID = fwflex.StringToFramework(ctx, dnssecKey.Digest)
 	id, err := data.setID()
 	if err != nil {
 		response.Diagnostics.AddError(fmt.Sprintf("flattening resource ID Route 53 Domains Domain (%s) DNSSEC key", data.DomainName.ValueString()), err.Error())
@@ -175,29 +191,22 @@ func (r *delegationSignerRecordResource) Read(ctx context.Context, request resou
 
 	conn := r.Meta().Route53DomainsClient(ctx)
 
-	dnssecKey, err := findDNSSECKeyByTwoPartKey(ctx, conn, data.DomainName.ValueString(), data.DNSSECKeyID.ValueString())
-
-	if retry.NotFound(err) {
+	// Only existence matters here. GetDomainDetail does not populate the
+	// DnssecKey's Algorithm, Flags, or PublicKey fields, so flattening the
+	// response onto signing_attributes would overwrite configured values with
+	// zeros and produce a permanent RequiresReplace diff. signing_attributes
+	// is RequiresReplace and write-only from the registry's perspective, so we
+	// leave the configured values untouched. See #47928.
+	if _, err := findDNSSECKeyByTwoPartKey(ctx, conn, data.DomainName.ValueString(), data.DNSSECKeyID.ValueString()); retry.NotFound(err) {
 		response.Diagnostics.Append(fwdiag.NewResourceNotFoundWarningDiagnostic(err))
 		response.State.RemoveResource(ctx)
 
 		return
-	}
-
-	if err != nil {
+	} else if err != nil {
 		response.Diagnostics.AddError(fmt.Sprintf("reading Route 53 Domains Domain (%s) DNSSEC key", data.DomainName.ValueString()), err.Error())
 
 		return
 	}
-
-	// Set attributes for import.
-	var signingAttributes delegationSignerRecordSigningAttributesModel
-	response.Diagnostics.Append(fwflex.Flatten(ctx, dnssecKey, &signingAttributes)...)
-	if response.Diagnostics.HasError() {
-		return
-	}
-
-	data.SigningAttributes = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &signingAttributes)
 
 	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
 }
@@ -211,9 +220,24 @@ func (r *delegationSignerRecordResource) Delete(ctx context.Context, request res
 
 	conn := r.Meta().Route53DomainsClient(ctx)
 
+	// dnssec_key_id stores the registry-stable Digest, but
+	// DisassociateDelegationSignerFromDomain requires the internal DnssecKey.Id.
+	// Resolve the internal Id by looking the key up by digest.
+	dnssecKey, err := findDNSSECKeyByTwoPartKey(ctx, conn, data.DomainName.ValueString(), data.DNSSECKeyID.ValueString())
+
+	if retry.NotFound(err) {
+		return
+	}
+
+	if err != nil {
+		response.Diagnostics.AddError(fmt.Sprintf("reading Route 53 Domains Delegation Signer Record (%s)", data.ID.ValueString()), err.Error())
+
+		return
+	}
+
 	output, err := conn.DisassociateDelegationSignerFromDomain(ctx, &route53domains.DisassociateDelegationSignerFromDomainInput{
 		DomainName: data.DomainName.ValueStringPointer(),
-		Id:         data.DNSSECKeyID.ValueStringPointer(),
+		Id:         dnssecKey.Id,
 	})
 
 	if err != nil {
@@ -280,7 +304,7 @@ func findDNSSECKeyByTwoPartKey(ctx context.Context, conn *route53domains.Client,
 	}
 
 	return tfresource.AssertSingleValueResult(tfslices.Filter(output.DnssecKeys, func(v awstypes.DnssecKey) bool {
-		return aws.ToString(v.Id) == keyID
+		return aws.ToString(v.Digest) == keyID
 	}))
 }
 

--- a/internal/service/route53domains/delegation_signer_record_migrate.go
+++ b/internal/service/route53domains/delegation_signer_record_migrate.go
@@ -1,0 +1,142 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package route53domains
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// delegationSignerRecordSchemaV0 mirrors the schema as it existed before the
+// digest-keying fix (#47928). The attribute set is identical to v1; the
+// version bump exists solely to give us a hook to rewrite the value stored in
+// dnssec_key_id (and the composite id) from the prior
+// "DS:keytag-algorithm-digesttype-digest" form down to the bare digest that
+// GetDomainDetail actually returns.
+func delegationSignerRecordSchemaV0(ctx context.Context) schema.Schema {
+	return schema.Schema{
+		Version: 0,
+		Attributes: map[string]schema.Attribute{
+			"dnssec_key_id": framework.IDAttribute(),
+			names.AttrDomainName: schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			names.AttrID: framework.IDAttribute(),
+		},
+		Blocks: map[string]schema.Block{
+			"signing_attributes": schema.ListNestedBlock{
+				CustomType: fwtypes.NewListNestedObjectTypeOf[delegationSignerRecordSigningAttributesModel](ctx),
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"algorithm": schema.Int64Attribute{
+							Required: true,
+							PlanModifiers: []planmodifier.Int64{
+								int64planmodifier.RequiresReplace(),
+							},
+						},
+						"flags": schema.Int64Attribute{
+							Required: true,
+							PlanModifiers: []planmodifier.Int64{
+								int64planmodifier.RequiresReplace(),
+							},
+						},
+						names.AttrPublicKey: schema.StringAttribute{
+							Required: true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.RequiresReplace(),
+							},
+						},
+					},
+				},
+				PlanModifiers: []planmodifier.List{
+					listplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.List{
+					listvalidator.SizeAtLeast(1),
+					listvalidator.SizeAtMost(1),
+				},
+			},
+			names.AttrTimeouts: timeouts.Block(ctx, timeouts.Opts{
+				Create: true,
+				Delete: true,
+			}),
+		},
+	}
+}
+
+// delegationSignerRecordResourceModelV0 has the same shape as the current
+// model. The migration only mutates string values.
+type delegationSignerRecordResourceModelV0 struct {
+	DNSSECKeyID       types.String                                                                  `tfsdk:"dnssec_key_id"`
+	DomainName        types.String                                                                  `tfsdk:"domain_name"`
+	ID                types.String                                                                  `tfsdk:"id"`
+	SigningAttributes fwtypes.ListNestedObjectValueOf[delegationSignerRecordSigningAttributesModel] `tfsdk:"signing_attributes"`
+	Timeouts          timeouts.Value                                                                `tfsdk:"timeouts"`
+}
+
+// digestFromLegacyDNSSECKeyID extracts the bare digest from a prior-form
+// dnssec_key_id value. The Route 53 Domains API documents the DS record id as
+// "DS:keytag-algorithm-digesttype-digest". We split on "-" and take the
+// trailing segment after stripping the "DS:" prefix.
+//
+// If the input is empty or does not have the "DS:" prefix it is returned
+// unchanged so that the upgrader is idempotent and safe to run against state
+// that was already imported with the digest form.
+func digestFromLegacyDNSSECKeyID(v string) string {
+	if !strings.HasPrefix(v, "DS:") {
+		return v
+	}
+	trimmed := strings.TrimPrefix(v, "DS:")
+	parts := strings.Split(trimmed, "-")
+	if len(parts) < 4 {
+		// Unexpected shape - leave the original alone rather than corrupt
+		// state. A subsequent Read will surface the mismatch loudly.
+		return v
+	}
+	return parts[len(parts)-1]
+}
+
+func upgradeDelegationSignerRecordStateFromV0(ctx context.Context, request resource.UpgradeStateRequest, response *resource.UpgradeStateResponse) {
+	var dataV0 delegationSignerRecordResourceModelV0
+	response.Diagnostics.Append(request.State.Get(ctx, &dataV0)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	upgraded := delegationSignerRecordResourceModel{
+		DNSSECKeyID:       types.StringValue(digestFromLegacyDNSSECKeyID(dataV0.DNSSECKeyID.ValueString())),
+		DomainName:        dataV0.DomainName,
+		SigningAttributes: dataV0.SigningAttributes,
+		Timeouts:          dataV0.Timeouts,
+	}
+
+	// Rebuild the composite id from the (possibly rewritten) DomainName and
+	// DNSSECKeyID so that the id stored in state matches what setID() would
+	// have produced for a fresh Create.
+	id, err := upgraded.setID()
+	if err != nil {
+		response.Diagnostics.AddError("upgrading Route 53 Domains Delegation Signer Record state", err.Error())
+		return
+	}
+	upgraded.ID = types.StringValue(id)
+
+	response.Diagnostics.Append(response.State.Set(ctx, upgraded)...)
+}

--- a/internal/service/route53domains/delegation_signer_record_migrate_test.go
+++ b/internal/service/route53domains/delegation_signer_record_migrate_test.go
@@ -1,0 +1,46 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package route53domains
+
+import "testing"
+
+func TestDigestFromLegacyDNSSECKeyID(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		in   string
+		want string
+	}{
+		"legacy DS form is reduced to digest": {
+			in:   "DS:12345-13-2-abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+			want: "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+		},
+		"already-digest is unchanged (idempotent)": {
+			in:   "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+			want: "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+		},
+		"empty is unchanged": {
+			in:   "",
+			want: "",
+		},
+		"malformed DS prefix with too few segments is left alone": {
+			in:   "DS:12345-13",
+			want: "DS:12345-13",
+		},
+		"digest containing hyphen-like chars from a longer split keeps trailing segment": {
+			in:   "DS:1-2-3-DEADBEEF",
+			want: "DEADBEEF",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got := digestFromLegacyDNSSECKeyID(tc.in)
+			if got != tc.want {
+				t.Fatalf("digestFromLegacyDNSSECKeyID(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/service/route53domains/delegation_signer_record_test.go
+++ b/internal/service/route53domains/delegation_signer_record_test.go
@@ -37,6 +37,17 @@ func testAccDelegationSignerRecord_basic(t *testing.T) {
 				),
 			},
 			{
+				// Regression guard for #47928: after Create the very next
+				// refresh + plan must be empty. Prior to the digest-keying
+				// fix, Read would fail to match the stored dnssec_key_id
+				// against any DnssecKey returned by GetDomainDetail and would
+				// remove the resource from state, producing a non-empty plan
+				// (a fresh Create).
+				Config:             testAccDelegationSignerAssociationConfig_basic(domainName, publicKey),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,


### PR DESCRIPTION
## Description

Fixes `aws_route53domains_delegation_signer_record` so that the resource survives `terraform plan/apply -refresh-only` cycles. The bug was reported in #47928: after a successful `Create`, the very next refresh would remove the resource from state and the following plan would unconditionally re-create it.

Three independent issues had to be fixed together to make the resource stable, and prior state (which contains the broken value) has to be migrated for existing users:

1. **Create stored the wrong identifier.** `AssociateDelegationSignerToDomain` returns `DnssecKey.Id`, but `GetDomainDetail` does not echo that `Id` back in any reliable form. The stable value across both APIs is `DnssecKey.Digest`. Create now stores `Digest` in `dnssec_key_id`.
2. **Read overwrote write-only attributes with zeros.** `GetDomainDetail` does not populate `Algorithm`, `Flags`, or `PublicKey` on `DnssecKey`. The previous code flattened the response into `signing_attributes`, replacing the configured values with zero values and producing a permanent `RequiresReplace` diff. `signing_attributes` is `RequiresReplace` and effectively write-only from the registry's perspective, so Read no longer touches it.
3. **Delete needed the internal Id.** `DisassociateDelegationSignerFromDomain` requires the internal `DnssecKey.Id`, not the digest. Delete now resolves the internal Id by looking the key up by digest, and treats already-absent keys as a no-op.

### State upgrader (v0 → v1)

Because existing user state contains `dnssec_key_id` values shaped like `DS:keytag-algorithm-digesttype-digest`, the schema version is bumped to 1 with a state upgrader that:

- Detects the `DS:` prefix and rewrites `dnssec_key_id` to the bare digest segment (last `-`-separated component after stripping the prefix).
- Rebuilds the composite resource `id` via `setID()` so the stored `id` matches what a fresh Create would produce.
- Is **idempotent**: state already in the new digest form (no `DS:` prefix) passes through unchanged. Malformed `DS:` values with too few segments are left alone rather than corrupted, so the next Read surfaces the mismatch loudly instead of silently dropping the resource.

### Relationship to prior PRs

This PR supersedes and credits two earlier partial fixes:

- #47932 — fixed Create/Read/findByTwoPartKey to key on digest. Did not address Delete or signing_attributes flatten, and did not include a state upgrader.
- #48163 — additionally fixed Delete (resolve Id from digest) and dropped the signing_attributes flatten. Still no state upgrader, no acceptance assertion that would have caught the regression, and no unit coverage of the prior-state shape.

This PR adds the missing pieces:

- v0 → v1 state upgrader (the differentiator — without it, existing users still lose their resource on first refresh after upgrading the provider).
- `PlanOnly: true` step in the basic acceptance test that asserts an empty plan immediately after Create. That is exactly the failure mode of #47928, so this step is a permanent regression guard.
- Plain-Go unit test for the digest parser used by the upgrader.

If the original authors prefer to fold these additions into their PRs I'm happy to defer — see the cross-reference comments on #47932 and #48163.

## Relations

Closes #47928
Supersedes #47932
Supersedes #48163

## References

- AWS Route 53 Domains [`AssociateDelegationSignerToDomain`](https://docs.aws.amazon.com/Route53/latest/APIReference/API_domains_AssociateDelegationSignerToDomain.html) / [`DisassociateDelegationSignerFromDomain`](https://docs.aws.amazon.com/Route53/latest/APIReference/API_domains_DisassociateDelegationSignerFromDomain.html) / [`GetDomainDetail`](https://docs.aws.amazon.com/Route53/latest/APIReference/API_domains_GetDomainDetail.html)
- `DnssecKey` type — only `Digest` is reliably populated across the lifecycle.

## Output from Acceptance Testing

Live acceptance tests require a registered domain (`ROUTE53DOMAINS_DOMAIN_NAME`) which I do not have. A maintainer who does should run:

```
make testacc TESTS=TestAccRoute53DomainsDelegationSignerRecord PKG=route53domains
```

The PR adds a new test step that **would have caught the original bug** — after `Create`, a `PlanOnly: true` step asserts an empty plan. Prior to this fix, Read would drop the resource and the plan would propose a fresh Create.

State upgrader unit test (does **not** require AWS credentials) passes locally:

```
$ go test ./internal/service/route53domains/ -run TestDigestFromLegacyDNSSECKeyID -v
=== RUN   TestDigestFromLegacyDNSSECKeyID
=== PAUSE TestDigestFromLegacyDNSSECKeyID
=== CONT  TestDigestFromLegacyDNSSECKeyID
=== RUN   TestDigestFromLegacyDNSSECKeyID/legacy_DS_form_is_reduced_to_digest
=== RUN   TestDigestFromLegacyDNSSECKeyID/already-digest_is_unchanged_(idempotent)
=== RUN   TestDigestFromLegacyDNSSECKeyID/empty_is_unchanged
=== RUN   TestDigestFromLegacyDNSSECKeyID/malformed_DS_prefix_with_too_few_segments_is_left_alone
=== RUN   TestDigestFromLegacyDNSSECKeyID/digest_containing_hyphen-like_chars_from_a_longer_split_keeps_trailing_segment
--- PASS: TestDigestFromLegacyDNSSECKeyID (0.00s)
    --- PASS: TestDigestFromLegacyDNSSECKeyID/legacy_DS_form_is_reduced_to_digest (0.00s)
    --- PASS: TestDigestFromLegacyDNSSECKeyID/already-digest_is_unchanged_(idempotent) (0.00s)
    --- PASS: TestDigestFromLegacyDNSSECKeyID/empty_is_unchanged (0.00s)
    --- PASS: TestDigestFromLegacyDNSSECKeyID/malformed_DS_prefix_with_too_few_segments_is_left_alone (0.00s)
    --- PASS: TestDigestFromLegacyDNSSECKeyID/digest_containing_hyphen-like_chars_from_a_longer_split_keeps_trailing_segment (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/route53domains	4.542s
```

`go build` and `go vet` are clean on the package:

```
$ go build ./internal/service/route53domains/...
$ go vet ./internal/service/route53domains/...
$ echo $?
0
```
