### PR TITLE
aws_cloudfront_distribution_tenant: Checks all values in `_basic` tests

### DIFF
--- a/internal/service/cloudfront/distribution_tenant_data_source_test.go
+++ b/internal/service/cloudfront/distribution_tenant_data_source_test.go
@@ -7,7 +7,11 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-testing/compare"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -43,6 +47,19 @@ func TestAccCloudFrontDistributionTenantDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName, "parameters.#", resourceName, "parameter.#"),
 					resource.TestCheckResourceAttrSet(dataSourceName, names.AttrStatus),
 				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrDomain), knownvalue.Null()),
+					statecheck.CompareValuePairs(
+						dataSourceName, tfjsonpath.New(names.AttrID),
+						resourceName, tfjsonpath.New(names.AttrID),
+						compare.ValuesSame(),
+					),
+					statecheck.CompareValuePairs(
+						dataSourceName, tfjsonpath.New(names.AttrTags),
+						resourceName, tfjsonpath.New(names.AttrTagsAll),
+						compare.ValuesSame(),
+					),
+				},
 			},
 		},
 	})

--- a/internal/service/cloudfront/distribution_tenant_test.go
+++ b/internal/service/cloudfront/distribution_tenant_test.go
@@ -157,6 +157,22 @@ func TestAccCloudFrontDistributionTenant_customCertificate(t *testing.T) {
 						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
 					},
 				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("customizations"), knownvalue.ListExact([]knownvalue.Check{
+						knownvalue.ObjectPartial(map[string]knownvalue.Check{
+							names.AttrCertificate: knownvalue.ListExact([]knownvalue.Check{
+								knownvalue.ObjectExact(map[string]knownvalue.Check{
+									names.AttrARN: knownvalue.NotNull(),
+								}),
+							}),
+						}),
+					})),
+					statecheck.CompareValuePairs(
+						resourceName, tfjsonpath.New("customizations").AtSliceIndex(0).AtMapKey(names.AttrCertificate).AtSliceIndex(0).AtMapKey(names.AttrARN),
+						"data.aws_acm_certificate.test", tfjsonpath.New(names.AttrARN),
+						compare.ValuesSame(),
+					),
+				},
 			},
 			{
 				ResourceName:      resourceName,
@@ -198,6 +214,23 @@ func TestAccCloudFrontDistributionTenant_customCertificateWithWebACL(t *testing.
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
 					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("customizations"), knownvalue.ListExact([]knownvalue.Check{
+						knownvalue.ObjectPartial(map[string]knownvalue.Check{
+							"web_acl": knownvalue.ListExact([]knownvalue.Check{
+								knownvalue.ObjectExact(map[string]knownvalue.Check{
+									names.AttrAction: tfknownvalue.StringExact(awstypes.CustomizationActionTypeOverride),
+									names.AttrARN:    knownvalue.NotNull(),
+								}),
+							}),
+						}),
+					})),
+					statecheck.CompareValuePairs(
+						resourceName, tfjsonpath.New("customizations").AtSliceIndex(0).AtMapKey("web_acl").AtSliceIndex(0).AtMapKey(names.AttrARN),
+						"aws_wafv2_web_acl.test", tfjsonpath.New(names.AttrARN),
+						compare.ValuesSame(),
+					),
 				},
 			},
 			{

--- a/internal/service/cloudfront/distribution_tenant_test.go
+++ b/internal/service/cloudfront/distribution_tenant_test.go
@@ -62,7 +62,7 @@ func TestAccCloudFrontDistributionTenant_basic(t *testing.T) {
 							names.AttrStatus: tfknownvalue.StringExact(awstypes.DomainStatusActive),
 						}),
 					})),
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrEnabled), knownvalue.Bool(false)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrEnabled), knownvalue.Bool(true)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("etag"), knownvalue.NotNull()),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrID), knownvalue.NotNull()),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("managed_certificate_request"), knownvalue.ListExact([]knownvalue.Check{})),
@@ -468,8 +468,7 @@ resource "aws_cloudfront_distribution_tenant" "test" {
   domain {
     domain = %[2]q
   }
-  name    = %[1]q
-  enabled = false
+  name = %[1]q
 
   parameter {
     name  = "origin_domain"

--- a/internal/service/cloudfront/distribution_tenant_test.go
+++ b/internal/service/cloudfront/distribution_tenant_test.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/YakDriver/regexache"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/cloudfront/types"
+	"github.com/hashicorp/terraform-plugin-testing/compare"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	tfknownvalue "github.com/hashicorp/terraform-provider-aws/internal/acctest/knownvalue"
+	tfstatecheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/statecheck"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfcloudfront "github.com/hashicorp/terraform-provider-aws/internal/service/cloudfront"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -51,10 +52,31 @@ func TestAccCloudFrontDistributionTenant_basic(t *testing.T) {
 					},
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrARN), tfknownvalue.GlobalARNRegexp("cloudfront", regexache.MustCompile(`distribution-tenant/dt_[0-9A-Za-z]+`))),
+					tfstatecheck.ExpectGlobalARNFormat(resourceName, tfjsonpath.New(names.AttrARN), "cloudfront", "distribution-tenant/{id}"),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("connection_group_id"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("customizations"), knownvalue.ListExact([]knownvalue.Check{})),
+					statecheck.CompareValuePairs(resourceName, tfjsonpath.New("distribution_id"), "aws_cloudfront_multitenant_distribution.test", tfjsonpath.New(names.AttrID), compare.ValuesSame()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrDomain), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							names.AttrDomain: knownvalue.StringExact(domain),
+							names.AttrStatus: tfknownvalue.StringExact(awstypes.DomainStatusActive),
+						}),
+					})),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrEnabled), knownvalue.Bool(false)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("etag"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrID), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("managed_certificate_request"), knownvalue.ListExact([]knownvalue.Check{})),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrName), knownvalue.StringExact(rName)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrParameter), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							names.AttrName:  knownvalue.StringExact("origin_domain"),
+							names.AttrValue: knownvalue.StringExact("www.example.com"),
+						}),
+					})),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrStatus), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTagsAll), knownvalue.MapSizeExact(0)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("wait_for_deployment"), knownvalue.Bool(true)),
 				},
 			},
 			{


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Checks values for all attributes in `_basic` tests for `aws_cloudfront_distribution_tenant` resource and data source.

Uses default value `true` for `enabled`, so there is now a test for enabled tenants.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=cloudfront TESTS='TestAccCloudFrontDistributionTenant_|TestAccCloudFrontDistributionTenantDataSource_'

--- PASS: TestAccCloudFrontDistributionTenant_customCertificateWithWebACL (535.43s)
--- PASS: TestAccCloudFrontDistributionTenant_customCertificate (535.71s)
--- PASS: TestAccCloudFrontDistributionTenantDataSource_basic (609.40s)
--- PASS: TestAccCloudFrontDistributionTenantDataSource_byDomain (612.39s)
--- PASS: TestAccCloudFrontDistributionTenantDataSource_byARN (629.64s)
--- PASS: TestAccCloudFrontDistributionTenantDataSource_byName (633.00s)
--- PASS: TestAccCloudFrontDistributionTenant_disappears (633.44s)
--- PASS: TestAccCloudFrontDistributionTenant_basic (634.73s)
--- PASS: TestAccCloudFrontDistributionTenant_tags (705.04s)
```
