### PR TITLE
`aws_cloudfront_distribution_tenant`: fields are not XML Wrappers

### DIFF
--- a/internal/service/cloudfront/distribution_tenant.go
+++ b/internal/service/cloudfront/distribution_tenant.go
@@ -214,13 +214,13 @@ type distributionTenantResourceModel struct {
 	ConnectionGroupID         types.String                                                    `tfsdk:"connection_group_id"`
 	Customizations            fwtypes.ListNestedObjectValueOf[customizationsModel]            `tfsdk:"customizations"`
 	DistributionID            types.String                                                    `tfsdk:"distribution_id"`
-	Domains                   fwtypes.SetNestedObjectValueOf[domainResultModel]               `tfsdk:"domain" autoflex:",xmlwrapper=Items"`
+	Domains                   fwtypes.SetNestedObjectValueOf[domainResultModel]               `tfsdk:"domain"`
 	Enabled                   types.Bool                                                      `tfsdk:"enabled"`
 	ETag                      types.String                                                    `tfsdk:"etag"`
 	ID                        types.String                                                    `tfsdk:"id"`
 	ManagedCertificateRequest fwtypes.ListNestedObjectValueOf[managedCertificateRequestModel] `tfsdk:"managed_certificate_request"`
 	Name                      types.String                                                    `tfsdk:"name"`
-	Parameters                fwtypes.SetNestedObjectValueOf[parameterModel]                  `tfsdk:"parameter" autoflex:",xmlwrapper=Items"`
+	Parameters                fwtypes.SetNestedObjectValueOf[parameterModel]                  `tfsdk:"parameter"`
 	Status                    types.String                                                    `tfsdk:"status"`
 	Tags                      tftags.Map                                                      `tfsdk:"tags"`
 	TagsAll                   tftags.Map                                                      `tfsdk:"tags_all"`

--- a/internal/service/cloudfront/distribution_tenant_data_source.go
+++ b/internal/service/cloudfront/distribution_tenant_data_source.go
@@ -166,13 +166,13 @@ type distributionTenantDataSourceModel struct {
 	Customizations            fwtypes.ListNestedObjectValueOf[customizationsModel]            `tfsdk:"customizations"`
 	DistributionID            types.String                                                    `tfsdk:"distribution_id"`
 	Domain                    types.String                                                    `tfsdk:"domain"`
-	Domains                   fwtypes.ListNestedObjectValueOf[domainResultModel]              `tfsdk:"domains" autoflex:",xmlwrapper=Items"`
+	Domains                   fwtypes.ListNestedObjectValueOf[domainResultModel]              `tfsdk:"domains"`
 	Enabled                   types.Bool                                                      `tfsdk:"enabled"`
 	ETag                      types.String                                                    `tfsdk:"etag"`
 	ID                        types.String                                                    `tfsdk:"id"`
 	ManagedCertificateRequest fwtypes.ListNestedObjectValueOf[managedCertificateRequestModel] `tfsdk:"managed_certificate_request"`
 	Name                      types.String                                                    `tfsdk:"name"`
-	Parameters                fwtypes.ListNestedObjectValueOf[parameterModel]                 `tfsdk:"parameters" autoflex:",xmlwrapper=Items"`
+	Parameters                fwtypes.ListNestedObjectValueOf[parameterModel]                 `tfsdk:"parameters"`
 	Status                    types.String                                                    `tfsdk:"status"`
 	Tags                      tftags.Map                                                      `tfsdk:"tags"`
 }


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Removes the `xmlwrapper` struct tag from `Domains` and `Parameters`, as the AWS structs do not match the XML Wrapper pattern

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=cloudfront TESTS='TestAccCloudFrontDistributionTenant_|TestAccCloudFrontDistributionTenantDataSource_'

--- PASS: TestAccCloudFrontDistributionTenant_customCertificate (593.31s)
--- PASS: TestAccCloudFrontDistributionTenant_customCertificateWithWebACL (593.41s)
--- PASS: TestAccCloudFrontDistributionTenantDataSource_basic (619.67s)
--- PASS: TestAccCloudFrontDistributionTenant_basic (635.21s)
--- PASS: TestAccCloudFrontDistributionTenantDataSource_byName (637.75s)
--- PASS: TestAccCloudFrontDistributionTenant_disappears (638.54s)
--- PASS: TestAccCloudFrontDistributionTenantDataSource_byARN (638.57s)
--- PASS: TestAccCloudFrontDistributionTenantDataSource_byDomain (639.52s)
--- PASS: TestAccCloudFrontDistributionTenant_tags (684.48s)
```
