### PR TITLE
resource/aws_dx_lag: support MACsec

### DIFF
--- a/.changelog/48172.txt
+++ b/.changelog/48172.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_dx_lag: Add `request_macsec`, `encryption_mode` arguments and `macsec_capable` attribute for MAC Security (MACsec) support
+```

--- a/internal/service/directconnect/lag.go
+++ b/internal/service/directconnect/lag.go
@@ -17,6 +17,7 @@ import (
 	awstypes "github.com/aws/aws-sdk-go-v2/service/directconnect/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
@@ -58,6 +59,12 @@ func resourceLag() *schema.Resource {
 					ForceNew:     true,
 					ValidateFunc: validConnectionBandWidth(),
 				},
+				"encryption_mode": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Computed:     true,
+					ValidateFunc: validation.StringInSlice([]string{"no_encrypt", "should_encrypt", "must_encrypt"}, false),
+				},
 				names.AttrForceDestroy: {
 					Type:     schema.TypeBool,
 					Optional: true,
@@ -76,6 +83,10 @@ func resourceLag() *schema.Resource {
 					Required: true,
 					ForceNew: true,
 				},
+				"macsec_capable": {
+					Type:     schema.TypeBool,
+					Computed: true,
+				},
 				names.AttrName: {
 					Type:     schema.TypeString,
 					Required: true,
@@ -88,6 +99,12 @@ func resourceLag() *schema.Resource {
 					Type:     schema.TypeString,
 					Optional: true,
 					Computed: true,
+					ForceNew: true,
+				},
+				"request_macsec": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  false,
 					ForceNew: true,
 				},
 				names.AttrTags:    tftags.TagsSchema(),
@@ -106,6 +123,7 @@ func resourceLagCreate(ctx context.Context, d *schema.ResourceData, meta any) di
 		ConnectionsBandwidth: aws.String(d.Get("connections_bandwidth").(string)),
 		LagName:              aws.String(name),
 		Location:             aws.String(d.Get(names.AttrLocation).(string)),
+		RequestMACSec:        aws.Bool(d.Get("request_macsec").(bool)),
 		Tags:                 getTagsIn(ctx),
 	}
 
@@ -165,9 +183,11 @@ func resourceLagRead(ctx context.Context, d *schema.ResourceData, meta any) diag
 	}.String()
 	d.Set(names.AttrARN, arn)
 	d.Set("connections_bandwidth", lag.ConnectionsBandwidth)
+	d.Set("encryption_mode", lag.EncryptionMode)
 	d.Set("has_logical_redundancy", lag.HasLogicalRedundancy)
 	d.Set("jumbo_frame_capable", lag.JumboFrameCapable)
 	d.Set(names.AttrLocation, lag.Location)
+	d.Set("macsec_capable", lag.MacSecCapable)
 	d.Set(names.AttrName, lag.LagName)
 	d.Set(names.AttrOwnerAccountID, lag.OwnerAccount)
 	d.Set(names.AttrProviderName, lag.ProviderName)
@@ -189,6 +209,19 @@ func resourceLagUpdate(ctx context.Context, d *schema.ResourceData, meta any) di
 
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating Direct Connect LAG (%s): %s", d.Id(), err)
+		}
+	}
+
+	if d.HasChange("encryption_mode") {
+		input := &directconnect.UpdateLagInput{
+			EncryptionMode: aws.String(d.Get("encryption_mode").(string)),
+			LagId:          aws.String(d.Id()),
+		}
+
+		_, err := conn.UpdateLag(ctx, input)
+
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "updating Direct Connect LAG (%s) encryption mode: %s", d.Id(), err)
 		}
 	}
 

--- a/internal/service/directconnect/lag.go
+++ b/internal/service/directconnect/lag.go
@@ -17,6 +17,7 @@ import (
 	awstypes "github.com/aws/aws-sdk-go-v2/service/directconnect/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
@@ -58,6 +59,12 @@ func resourceLag() *schema.Resource {
 					ForceNew:     true,
 					ValidateFunc: validConnectionBandWidth(),
 				},
+				"encryption_mode": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Computed:     true,
+					ValidateFunc: validation.StringInSlice([]string{"no_encrypt", "should_encrypt", "must_encrypt"}, false),
+				},
 				names.AttrForceDestroy: {
 					Type:     schema.TypeBool,
 					Optional: true,
@@ -76,6 +83,10 @@ func resourceLag() *schema.Resource {
 					Required: true,
 					ForceNew: true,
 				},
+				"macsec_capable": {
+					Type:     schema.TypeBool,
+					Computed: true,
+				},
 				names.AttrName: {
 					Type:     schema.TypeString,
 					Required: true,
@@ -91,8 +102,14 @@ func resourceLag() *schema.Resource {
 					ForceNew: true,
 				},
 				"rate_limiter_status": rateLimiterStatusSchema(),
-				names.AttrTags:        tftags.TagsSchema(),
-				names.AttrTagsAll:     tftags.TagsSchemaComputed(),
+				"request_macsec": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  false,
+					ForceNew: true,
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			}
 		},
 	}
@@ -107,6 +124,7 @@ func resourceLagCreate(ctx context.Context, d *schema.ResourceData, meta any) di
 		ConnectionsBandwidth: aws.String(d.Get("connections_bandwidth").(string)),
 		LagName:              aws.String(name),
 		Location:             aws.String(d.Get(names.AttrLocation).(string)),
+		RequestMACSec:        aws.Bool(d.Get("request_macsec").(bool)),
 		Tags:                 getTagsIn(ctx),
 	}
 
@@ -138,6 +156,12 @@ func resourceLagCreate(ctx context.Context, d *schema.ResourceData, meta any) di
 		}
 	}
 
+	if v, ok := d.GetOk("encryption_mode"); ok {
+		if err := updateLagEncryptionMode(ctx, conn, d.Id(), v.(string)); err != nil {
+			return sdkdiag.AppendErrorf(diags, "updating Direct Connect LAG (%s) encryption mode after create: %s", d.Id(), err)
+		}
+	}
+
 	return append(diags, resourceLagRead(ctx, d, meta)...)
 }
 
@@ -166,9 +190,11 @@ func resourceLagRead(ctx context.Context, d *schema.ResourceData, meta any) diag
 	}.String()
 	d.Set(names.AttrARN, arn)
 	d.Set("connections_bandwidth", lag.ConnectionsBandwidth)
+	d.Set("encryption_mode", lag.EncryptionMode)
 	d.Set("has_logical_redundancy", lag.HasLogicalRedundancy)
 	d.Set("jumbo_frame_capable", lag.JumboFrameCapable)
 	d.Set(names.AttrLocation, lag.Location)
+	d.Set("macsec_capable", lag.MacSecCapable)
 	d.Set(names.AttrName, lag.LagName)
 	d.Set(names.AttrOwnerAccountID, lag.OwnerAccount)
 	d.Set(names.AttrProviderName, lag.ProviderName)
@@ -194,7 +220,24 @@ func resourceLagUpdate(ctx context.Context, d *schema.ResourceData, meta any) di
 		}
 	}
 
+	if d.HasChange("encryption_mode") {
+		if err := updateLagEncryptionMode(ctx, conn, d.Id(), d.Get("encryption_mode").(string)); err != nil {
+			return sdkdiag.AppendErrorf(diags, "updating Direct Connect LAG (%s) encryption mode: %s", d.Id(), err)
+		}
+	}
+
 	return append(diags, resourceLagRead(ctx, d, meta)...)
+}
+
+func updateLagEncryptionMode(ctx context.Context, conn *directconnect.Client, id, encryptionMode string) error {
+	input := &directconnect.UpdateLagInput{
+		EncryptionMode: aws.String(encryptionMode),
+		LagId:          aws.String(id),
+	}
+
+	_, err := conn.UpdateLag(ctx, input)
+
+	return err
 }
 
 func resourceLagDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/internal/service/directconnect/lag_test.go
+++ b/internal/service/directconnect/lag_test.go
@@ -6,9 +6,13 @@ package directconnect_test
 import (
 	"context"
 	"fmt"
+	"slices"
 	"testing"
 
 	"github.com/YakDriver/regexache"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/directconnect"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/directconnect/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -70,7 +74,7 @@ func TestAccDirectConnectLag_basic(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{names.AttrForceDestroy},
+				ImportStateVerifyIgnore: []string{names.AttrForceDestroy, "request_macsec"},
 			},
 		},
 	})
@@ -142,7 +146,7 @@ func TestAccDirectConnectLag_connectionID(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{names.AttrConnectionID, names.AttrForceDestroy},
+				ImportStateVerifyIgnore: []string{names.AttrConnectionID, names.AttrForceDestroy, "request_macsec"},
 			},
 		},
 	})
@@ -181,7 +185,50 @@ func TestAccDirectConnectLag_providerName(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{names.AttrForceDestroy},
+				ImportStateVerifyIgnore: []string{names.AttrForceDestroy, "request_macsec"},
+			},
+		},
+	})
+}
+
+func TestAccDirectConnectLag_requestMACSec(t *testing.T) {
+	ctx := acctest.Context(t)
+	var lag awstypes.Lag
+	resourceName := "aws_dx_lag.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	locationCode, providerName := testAccFindMacSecCapableLocation(ctx, t, "10G")
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.DirectConnectServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckLagDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLagConfig_requestMACSec(rName, locationCode, providerName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLagExists(ctx, t, resourceName, &lag),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "directconnect", regexache.MustCompile(`dxlag/.+`)),
+					resource.TestCheckNoResourceAttr(resourceName, names.AttrConnectionID),
+					resource.TestCheckResourceAttr(resourceName, "connections_bandwidth", "10Gbps"),
+					resource.TestCheckResourceAttrSet(resourceName, "encryption_mode"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrForceDestroy, acctest.CtFalse),
+					resource.TestCheckResourceAttrSet(resourceName, "has_logical_redundancy"),
+					resource.TestCheckResourceAttrSet(resourceName, "jumbo_frame_capable"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrLocation, locationCode),
+					resource.TestCheckResourceAttr(resourceName, "macsec_capable", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					acctest.CheckResourceAttrAccountID(ctx, resourceName, names.AttrOwnerAccountID),
+					resource.TestCheckResourceAttr(resourceName, names.AttrProviderName, providerName),
+					resource.TestCheckResourceAttr(resourceName, "request_macsec", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "0"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{names.AttrForceDestroy, "request_macsec"},
 			},
 		},
 	})
@@ -212,7 +259,7 @@ func TestAccDirectConnectLag_tags(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{names.AttrForceDestroy},
+				ImportStateVerifyIgnore: []string{names.AttrForceDestroy, "request_macsec"},
 			},
 			{
 				Config: testAccLagConfig_tags2(rName, acctest.CtKey1, acctest.CtValue1Updated, acctest.CtKey2, acctest.CtValue2),
@@ -331,6 +378,58 @@ resource "aws_dx_lag" "test" {
   provider_name = data.aws_dx_location.test.available_providers[0]
 }
 `, rName)
+}
+
+func testAccLagConfig_requestMACSec(rName, locationCode, providerName string) string {
+	return fmt.Sprintf(`
+resource "aws_dx_lag" "test" {
+  name                  = %[1]q
+  connections_bandwidth = "10Gbps"
+  location              = %[2]q
+  request_macsec        = true
+
+  provider_name = %[3]q
+}
+`, rName, locationCode, providerName)
+}
+
+// testAccFindMacSecCapableLocation queries Direct Connect for a location that
+// supports MACsec at the given port speed (e.g. "10G", "100G"). It uses the
+// AWS SDK directly (rather than the test framework's provider client) so that
+// the location can be resolved before the TestCase struct is constructed and
+// embedded as a literal in the HCL config string.
+//
+// The test is skipped if no MACsec-capable location with at least one provider
+// is available in the active region, or if Direct Connect itself is not
+// available in the partition.
+func testAccFindMacSecCapableLocation(ctx context.Context, t *testing.T, portSpeed string) (locationCode, providerName string) {
+	t.Helper()
+
+	cfg, err := awsconfig.LoadDefaultConfig(ctx)
+	if err != nil {
+		t.Skipf("loading AWS config: %s", err)
+		return "", ""
+	}
+
+	conn := directconnect.NewFromConfig(cfg)
+	input := directconnect.DescribeLocationsInput{}
+	output, err := conn.DescribeLocations(ctx, &input)
+	if err != nil {
+		t.Skipf("describing Direct Connect locations: %s", err)
+		return "", ""
+	}
+
+	for _, loc := range output.Locations {
+		if len(loc.AvailableProviders) == 0 {
+			continue
+		}
+		if slices.Contains(loc.AvailableMacSecPortSpeeds, portSpeed) {
+			return aws.ToString(loc.LocationCode), loc.AvailableProviders[0]
+		}
+	}
+
+	t.Skipf("no Direct Connect location supporting %s MACsec available in this region; skipping", portSpeed)
+	return "", ""
 }
 
 func testAccLagConfig_tags1(rName, tagKey1, tagValue1 string) string {

--- a/internal/service/directconnect/lag_test.go
+++ b/internal/service/directconnect/lag_test.go
@@ -6,9 +6,13 @@ package directconnect_test
 import (
 	"context"
 	"fmt"
+	"slices"
 	"testing"
 
 	"github.com/YakDriver/regexache"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/directconnect"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/directconnect/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -71,7 +75,7 @@ func TestAccDirectConnectLag_basic(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{names.AttrForceDestroy},
+				ImportStateVerifyIgnore: []string{names.AttrForceDestroy, "request_macsec"},
 			},
 		},
 	})
@@ -143,7 +147,7 @@ func TestAccDirectConnectLag_connectionID(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{names.AttrConnectionID, names.AttrForceDestroy},
+				ImportStateVerifyIgnore: []string{names.AttrConnectionID, names.AttrForceDestroy, "request_macsec"},
 			},
 		},
 	})
@@ -182,7 +186,50 @@ func TestAccDirectConnectLag_providerName(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{names.AttrForceDestroy},
+				ImportStateVerifyIgnore: []string{names.AttrForceDestroy, "request_macsec"},
+			},
+		},
+	})
+}
+
+func TestAccDirectConnectLag_requestMACSec(t *testing.T) {
+	ctx := acctest.Context(t)
+	var lag awstypes.Lag
+	resourceName := "aws_dx_lag.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	locationCode, providerName := testAccFindMacSecCapableLocation(ctx, t, "10G")
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.DirectConnectServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckLagDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLagConfig_requestMACSec(rName, locationCode, providerName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLagExists(ctx, t, resourceName, &lag),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "directconnect", regexache.MustCompile(`dxlag/.+`)),
+					resource.TestCheckNoResourceAttr(resourceName, names.AttrConnectionID),
+					resource.TestCheckResourceAttr(resourceName, "connections_bandwidth", "10Gbps"),
+					resource.TestCheckResourceAttr(resourceName, "encryption_mode", "no_encrypt"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrForceDestroy, acctest.CtFalse),
+					resource.TestCheckResourceAttrSet(resourceName, "has_logical_redundancy"),
+					resource.TestCheckResourceAttrSet(resourceName, "jumbo_frame_capable"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrLocation, locationCode),
+					resource.TestCheckResourceAttr(resourceName, "macsec_capable", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					acctest.CheckResourceAttrAccountID(ctx, resourceName, names.AttrOwnerAccountID),
+					resource.TestCheckResourceAttr(resourceName, names.AttrProviderName, providerName),
+					resource.TestCheckResourceAttr(resourceName, "request_macsec", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "0"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{names.AttrForceDestroy, "request_macsec"},
 			},
 		},
 	})
@@ -213,7 +260,7 @@ func TestAccDirectConnectLag_tags(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{names.AttrForceDestroy},
+				ImportStateVerifyIgnore: []string{names.AttrForceDestroy, "request_macsec"},
 			},
 			{
 				Config: testAccLagConfig_tags2(rName, acctest.CtKey1, acctest.CtValue1Updated, acctest.CtKey2, acctest.CtValue2),
@@ -332,6 +379,59 @@ resource "aws_dx_lag" "test" {
   provider_name = data.aws_dx_location.test.available_providers[0]
 }
 `, rName)
+}
+
+func testAccLagConfig_requestMACSec(rName, locationCode, providerName string) string {
+	return fmt.Sprintf(`
+resource "aws_dx_lag" "test" {
+  name                  = %[1]q
+  connections_bandwidth = "10Gbps"
+  location              = %[2]q
+  request_macsec        = true
+  encryption_mode       = "no_encrypt"
+
+  provider_name = %[3]q
+}
+`, rName, locationCode, providerName)
+}
+
+// testAccFindMacSecCapableLocation queries Direct Connect for a location that
+// supports MACsec at the given port speed (e.g. "10G", "100G"). It uses the
+// AWS SDK directly (rather than the test framework's provider client) so that
+// the location can be resolved before the TestCase struct is constructed and
+// embedded as a literal in the HCL config string.
+//
+// The test is skipped if no MACsec-capable location with at least one provider
+// is available in the active region, or if Direct Connect itself is not
+// available in the partition.
+func testAccFindMacSecCapableLocation(ctx context.Context, t *testing.T, portSpeed string) (locationCode, providerName string) {
+	t.Helper()
+
+	cfg, err := awsconfig.LoadDefaultConfig(ctx)
+	if err != nil {
+		t.Skipf("loading AWS config: %s", err)
+		return "", ""
+	}
+
+	conn := directconnect.NewFromConfig(cfg)
+	input := directconnect.DescribeLocationsInput{}
+	output, err := conn.DescribeLocations(ctx, &input)
+	if err != nil {
+		t.Skipf("describing Direct Connect locations: %s", err)
+		return "", ""
+	}
+
+	for _, loc := range output.Locations {
+		if len(loc.AvailableProviders) == 0 {
+			continue
+		}
+		if slices.Contains(loc.AvailableMacSecPortSpeeds, portSpeed) {
+			return aws.ToString(loc.LocationCode), loc.AvailableProviders[0]
+		}
+	}
+
+	t.Skipf("no Direct Connect location supporting %s MACsec available in this region; skipping", portSpeed)
+	return "", ""
 }
 
 func testAccLagConfig_tags1(rName, tagKey1, tagValue1 string) string {

--- a/website/docs/r/dx_lag.html.markdown
+++ b/website/docs/r/dx_lag.html.markdown
@@ -14,6 +14,8 @@ Provides a Direct Connect LAG. Connections can be added to the LAG via the [`aws
 
 ## Example Usage
 
+### Create a LAG
+
 ```terraform
 resource "aws_dx_lag" "hoge" {
   name                  = "tf-dx-lag"
@@ -22,6 +24,31 @@ resource "aws_dx_lag" "hoge" {
   force_destroy         = true
 }
 ```
+
+### Request a MACsec-capable LAG
+
+```terraform
+resource "aws_dx_lag" "example" {
+  name                  = "tf-dx-lag-macsec"
+  connections_bandwidth = "100Gbps"
+  location              = "CSVA1"
+  request_macsec        = true
+}
+
+resource "aws_dx_connection" "example" {
+  name           = "tf-dx-connection-macsec"
+  bandwidth      = "100Gbps"
+  location       = "CSVA1"
+  request_macsec = true
+}
+
+resource "aws_dx_connection_association" "example" {
+  connection_id = aws_dx_connection.example.id
+  lag_id        = aws_dx_lag.example.id
+}
+```
+
+~> *NOTE:* When associating a MACsec-capable [`aws_dx_connection`](/docs/providers/aws/r/dx_connection.html) to a LAG, both resources must have `request_macsec = true` set at creation. MACsec cannot be enabled on an existing LAG.
 
 ## Argument Reference
 
@@ -32,8 +59,10 @@ This resource supports the following arguments:
 * `connections_bandwidth` - (Required) The bandwidth of the individual dedicated connections bundled by the LAG. Valid values: 1Gbps, 10Gbps, 100Gbps, and 400Gbps. Case sensitive. Refer to the AWS Direct Connection supported bandwidths for [Dedicated Connections](https://docs.aws.amazon.com/directconnect/latest/UserGuide/dedicated_connection.html).
 * `location` - (Required) The AWS Direct Connect location in which the LAG should be allocated. See [DescribeLocations](https://docs.aws.amazon.com/directconnect/latest/APIReference/API_DescribeLocations.html) for the list of AWS Direct Connect locations. Use `locationCode`.
 * `connection_id` - (Optional) The ID of an existing dedicated connection to migrate to the LAG.
+* `encryption_mode` - (Optional) The MAC Security (MACsec) connection encryption mode. Valid values: `no_encrypt`, `should_encrypt`, `must_encrypt`. Only applicable to LAGs created with `request_macsec = true`.
 * `force_destroy` - (Optional, Default:false) A boolean that indicates all connections associated with the LAG should be deleted so that the LAG can be destroyed without error. These objects are *not* recoverable.
 * `provider_name` - (Optional) The name of the service provider associated with the LAG.
+* `request_macsec` - (Optional, Forces new resource) Indicates whether the LAG supports MAC Security (MACsec). Default value is `false`. Refer to the AWS Direct Connect documentation for [supported locations and bandwidths](https://docs.aws.amazon.com/directconnect/latest/UserGuide/direct-connect-mac-sec-getting-started.html).
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## Attribute Reference
@@ -44,6 +73,7 @@ This resource exports the following attributes in addition to the arguments abov
 * `has_logical_redundancy` - Indicates whether the LAG supports a secondary BGP peer in the same address family (IPv4/IPv6).
 * `id` - The ID of the LAG.
 * `jumbo_frame_capable` -Indicates whether jumbo frames (9001 MTU) are supported.
+* `macsec_capable` - Indicates whether the LAG supports MAC Security (MACsec).
 * `owner_account_id` - The ID of the AWS account that owns the LAG.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 

--- a/website/docs/r/dx_lag.html.markdown
+++ b/website/docs/r/dx_lag.html.markdown
@@ -14,6 +14,8 @@ Provides a Direct Connect LAG. Connections can be added to the LAG via the [`aws
 
 ## Example Usage
 
+### Create a LAG
+
 ```terraform
 resource "aws_dx_lag" "hoge" {
   name                  = "tf-dx-lag"
@@ -22,6 +24,31 @@ resource "aws_dx_lag" "hoge" {
   force_destroy         = true
 }
 ```
+
+### Request a MACsec-capable LAG
+
+```terraform
+resource "aws_dx_lag" "example" {
+  name                  = "tf-dx-lag-macsec"
+  connections_bandwidth = "100Gbps"
+  location              = "CSVA1"
+  request_macsec        = true
+}
+
+resource "aws_dx_connection" "example" {
+  name           = "tf-dx-connection-macsec"
+  bandwidth      = "100Gbps"
+  location       = "CSVA1"
+  request_macsec = true
+}
+
+resource "aws_dx_connection_association" "example" {
+  connection_id = aws_dx_connection.example.id
+  lag_id        = aws_dx_lag.example.id
+}
+```
+
+~> *NOTE:* When associating a MACsec-capable [`aws_dx_connection`](/docs/providers/aws/r/dx_connection.html) to a LAG, both resources must have `request_macsec = true` set at creation. MACsec cannot be enabled on an existing LAG.
 
 ## Argument Reference
 
@@ -32,8 +59,10 @@ This resource supports the following arguments:
 * `connections_bandwidth` - (Required) The bandwidth of the individual dedicated connections bundled by the LAG. Valid values: 1Gbps, 10Gbps, 100Gbps, and 400Gbps. Case sensitive. Refer to the AWS Direct Connection supported bandwidths for [Dedicated Connections](https://docs.aws.amazon.com/directconnect/latest/UserGuide/dedicated_connection.html).
 * `location` - (Required) The AWS Direct Connect location in which the LAG should be allocated. See [DescribeLocations](https://docs.aws.amazon.com/directconnect/latest/APIReference/API_DescribeLocations.html) for the list of AWS Direct Connect locations. Use `locationCode`.
 * `connection_id` - (Optional) The ID of an existing dedicated connection to migrate to the LAG.
+* `encryption_mode` - (Optional) The MAC Security (MACsec) connection encryption mode. Valid values: `no_encrypt`, `should_encrypt`, `must_encrypt`. Only applicable to LAGs created with `request_macsec = true`.
 * `force_destroy` - (Optional, Default:false) A boolean that indicates all connections associated with the LAG should be deleted so that the LAG can be destroyed without error. These objects are *not* recoverable.
 * `provider_name` - (Optional) The name of the service provider associated with the LAG.
+* `request_macsec` - (Optional, Forces new resource) Indicates whether the LAG supports MAC Security (MACsec). Default value is `false`. Refer to the AWS Direct Connect documentation for [supported locations and bandwidths](https://docs.aws.amazon.com/directconnect/latest/UserGuide/direct-connect-mac-sec-getting-started.html).
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## Attribute Reference
@@ -44,6 +73,7 @@ This resource exports the following attributes in addition to the arguments abov
 * `has_logical_redundancy` - Indicates whether the LAG supports a secondary BGP peer in the same address family (IPv4/IPv6).
 * `id` - The ID of the LAG.
 * `jumbo_frame_capable` - Indicates whether jumbo frames (9001 MTU) are supported.
+* `macsec_capable` - Indicates whether the LAG supports MAC Security (MACsec).
 * `owner_account_id` - The ID of the AWS account that owns the LAG.
 * `rate_limiter_status` - Rate limiter status for the LAG. See [`rate_limiter_status` Block](#rate_limiter_status-block) below.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

This change exposes existing AWS Direct Connect MACsec controls through the `aws_dx_lag` resource. It does not introduce new security mechanisms, change the behavior of existing controls, or alter the default security posture: `request_macsec` defaults to `false` (matching `aws_dx_connection`), and `encryption_mode` defaults to whatever AWS returns for the LAG. Users explicitly opt in by setting `request_macsec = true` at create time.

### Description
Adds MACsec support to the `aws_dx_lag` resource by exposing three new schema fields, mirroring the existing support on `aws_dx_connection`:

- `request_macsec` — (Optional, ForceNew, default `false`) Indicates whether the LAG should be created with MACsec requested. Wired into `CreateLag` as `RequestMACSec`. Marked `ForceNew` because AWS only accepts this on `CreateLag`, not `UpdateLag`.
- `encryption_mode` — (Optional, Computed) The MACsec connection encryption mode. Validated against `no_encrypt` / `should_encrypt` / `must_encrypt`. Updates after creation are dispatched via `UpdateLag` with `EncryptionMode`.
- `macsec_capable` — (Computed) Surfaces the LAG's MACsec capability flag from `DescribeLags`.

Without `request_macsec` on the LAG, attempting to associate a MACsec-enabled `aws_dx_connection` to a LAG fails with:

> `DirectConnectClientException: Connection <id> and lag <id> should be requested MacSec at the same time`

because AWS requires MACsec to be requested on both the connection and the LAG at creation time. After this change, the failing configuration in the issue works as expected.

Tests:

- New `TestAccDirectConnectLag_requestMACSec` exercises the create + read + import path with `request_macsec = true`.
- Test config resolves a MACsec-capable Direct Connect location for the active region using the AWS SDK directly (`testAccFindMacSecCapableLocation`). This is reliable across regions: if the active region has no MACsec-capable location, the test skips rather than failing with `MacSec feature not available at this location`.
- All five existing `_basic`/`_connectionID`/`_providerName`/`_tags` import-state-verify steps add `"request_macsec"` to `ImportStateVerifyIgnore`. `DescribeLags` does not return `RequestMACSec`, so import would otherwise drift from the schema's default. This matches the pattern already used by `aws_dx_connection`'s import tests.


### Relations

Closes #47663

### References
AWS API: [`CreateLag.RequestMACSec`](https://docs.aws.amazon.com/directconnect/latest/APIReference/API_CreateLag.html), [`UpdateLag.EncryptionMode`](https://docs.aws.amazon.com/directconnect/latest/APIReference/API_UpdateLag.html), [`Lag.MacSecCapable`/`Lag.EncryptionMode`](https://docs.aws.amazon.com/directconnect/latest/APIReference/API_Lag.html)
AWS docs: [Getting started with MACsec on Direct Connect](https://docs.aws.amazon.com/directconnect/latest/UserGuide/direct-connect-mac-sec-getting-started.html)


### Output from Acceptance Testing
Tested in `us-east-1`. The SDK helper resolved Direct Connect location `165HS` for the MACsec test.

```console
% make testacc TESTS='TestAccDirectConnectLag_basic|TestAccDirectConnectLag_requestMACSec' PKG=directconnect

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/directconnect/... -v -count 1 -parallel 20 -run='TestAccDirectConnectLag_basic|TestAccDirectConnectLag_requestMACSec' -timeout 360m

=== RUN   TestAccDirectConnectLag_basic
=== PAUSE TestAccDirectConnectLag_basic
=== RUN   TestAccDirectConnectLag_requestMACSec
=== PAUSE TestAccDirectConnectLag_requestMACSec
=== CONT  TestAccDirectConnectLag_basic
=== CONT  TestAccDirectConnectLag_requestMACSec
--- PASS: TestAccDirectConnectLag_requestMACSec (24.06s)
--- PASS: TestAccDirectConnectLag_basic (37.52s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/directconnect	38.292s
