### PR TITLE
Fix VPC Lattice attachment destroy

### DIFF
--- a/.changelog/40581.txt
+++ b/.changelog/40581.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_vpclattice_target_group_attachment: Fix destroy failures for unavailable targets
+```

--- a/internal/service/vpclattice/target_group_attachment.go
+++ b/internal/service/vpclattice/target_group_attachment.go
@@ -262,7 +262,7 @@ func waitTargetGroupAttachmentCreated(ctx context.Context, conn *vpclattice.Clie
 
 func waitTargetGroupAttachmentDeleted(ctx context.Context, conn *vpclattice.Client, targetGroupID, targetID string, targetPort int32, timeout time.Duration) (*types.TargetSummary, error) {
 	stateConf := &retry.StateChangeConf{
-		Pending: enum.Slice(types.TargetStatusDraining, types.TargetStatusInitial),
+		Pending: enum.Slice(types.TargetStatusDraining, types.TargetStatusInitial, types.TargetStatusUnavailable),
 		Target:  []string{},
 		Refresh: statusTarget(conn, targetGroupID, targetID, targetPort),
 		Timeout: timeout,


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
### Description

ALB target groups report UNAVAILABLE with HealthCheckNotSupported because VPC Lattice does not support health checks for them. The delete waiter should continue polling in that state so destroy can observe the deregistered target disappear instead of failing the first attempt.

### Testing

No new acceptance test was added because the existing `TestAccVPCLatticeTargetGroupAttachment_alb` test already creates the affected resource shape: a VPC Lattice target group attachment with an ALB target. The bug is not triggered by a different Terraform configuration but by the AWS state observed during destroy.

In real environments, ALB targets commonly report `UNAVAILABLE` with reason `HealthCheckNotSupported` because VPC Lattice does not support health checks for ALB target groups. During destroy, the provider calls `DeregisterTargets` and then polls `ListTargets` until the target disappears. If AWS returns the still-present ALB target in the `UNAVAILABLE` state during that polling window, the old waiter treated it as an unexpected state and failed even though deletion was progressing.

An acceptance test can create the ALB attachment, but it cannot force AWS to return `UNAVAILABLE` at the exact delete polling moment. If AWS removes the target before the waiter observes that state, the test passes even without this fix. Covering the exact sequence deterministically would require a unit test around an injected/fake waiter refresh function rather than another acceptance test configuration.

> Note: I've used Codex to suggest the change, verify test coverage, point me to which acceptance tests to run, and phrasing of the commit message and parts of this PR description.

### Relations

Closes #40581

### References

### Output from Acceptance Testing

```console
% make testacc TESTS='^TestAccVPCLatticeTargetGroupAttachment_alb$' PKG=vpclattice
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2	5.428s
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider/framework	5.291s
make: Running acceptance tests on branch: 🌿 fix-vpclattice-alb-target-attachment-delete 🌿...
TF_ACC=1 go1.26.3 test ./internal/service/vpclattice/... -v -count 1 -parallel 20 -run='^TestAccVPCLatticeTargetGroupAttachment_alb'  -timeout 360m -vet=off -buildvcs=false
2026/06/03 10:31:08 Creating Terraform AWS Provider (SDKv2-style)...
2026/06/03 10:31:08 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccVPCLatticeTargetGroupAttachment_alb
=== PAUSE TestAccVPCLatticeTargetGroupAttachment_alb
=== CONT  TestAccVPCLatticeTargetGroupAttachment_alb
--- PASS: TestAccVPCLatticeTargetGroupAttachment_alb (251.22s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/vpclattice	256.451s
make testacc TESTS='^TestAccVPCLatticeTargetGroupAttachment_alb$'   70.56s user 38.61s system 33% cpu 5:24.14 total
```
