### PR TITLE
[Enhancement] aws_bedrockagentcore_gateway: Add `protocol_configuration.mcp.session_configuration` and `protocol_configuration.mcp.streaming_configuration` blocks

### DIFF
--- a/.changelog/48179.txt
+++ b/.changelog/48179.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_bedrockagentcore_gateway: Add `protocol_configuration.mcp.session_configuration` block
+```
+
+```release-note:enhancement
+resource/aws_bedrockagentcore_gateway: Add `protocol_configuration.mcp.streaming_configuration` block
+```

--- a/internal/service/bedrockagentcore/gateway.go
+++ b/internal/service/bedrockagentcore/gateway.go
@@ -18,6 +18,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol/types"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -200,6 +201,37 @@ func (r *gatewayResource) Schema(ctx context.Context, request resource.SchemaReq
 									"supported_versions": schema.SetAttribute{
 										CustomType: fwtypes.SetOfStringType,
 										Optional:   true,
+									},
+								},
+								Blocks: map[string]schema.Block{
+									"session_configuration": schema.ListNestedBlock{
+										CustomType: fwtypes.NewListNestedObjectTypeOf[sessionConfigurationModel](ctx),
+										Validators: []validator.List{
+											listvalidator.SizeAtMost(1),
+										},
+										NestedObject: schema.NestedBlockObject{
+											Attributes: map[string]schema.Attribute{
+												"session_timeout_in_seconds": schema.Int64Attribute{
+													Optional: true,
+													Validators: []validator.Int64{
+														int64validator.Between(900, 28800),
+													},
+												},
+											},
+										},
+									},
+									"streaming_configuration": schema.ListNestedBlock{
+										CustomType: fwtypes.NewListNestedObjectTypeOf[streamingConfigurationModel](ctx),
+										Validators: []validator.List{
+											listvalidator.SizeAtMost(1),
+										},
+										NestedObject: schema.NestedBlockObject{
+											Attributes: map[string]schema.Attribute{
+												"enable_response_streaming": schema.BoolAttribute{
+													Optional: true,
+												},
+											},
+										},
 									},
 								},
 							},
@@ -576,9 +608,19 @@ func (m gatewayProtocolConfigurationModel) Expand(ctx context.Context) (any, dia
 }
 
 type mcpGatewayConfigurationModel struct {
-	Instructions      types.String                            `tfsdk:"instructions"`
-	SearchType        fwtypes.StringEnum[awstypes.SearchType] `tfsdk:"search_type"`
-	SupportedVersions fwtypes.SetOfString                     `tfsdk:"supported_versions"`
+	Instructions           types.String                                                 `tfsdk:"instructions"`
+	SearchType             fwtypes.StringEnum[awstypes.SearchType]                      `tfsdk:"search_type"`
+	SessionConfiguration   fwtypes.ListNestedObjectValueOf[sessionConfigurationModel]   `tfsdk:"session_configuration"`
+	StreamingConfiguration fwtypes.ListNestedObjectValueOf[streamingConfigurationModel] `tfsdk:"streaming_configuration"`
+	SupportedVersions      fwtypes.SetOfString                                          `tfsdk:"supported_versions"`
+}
+
+type sessionConfigurationModel struct {
+	SessionTimeoutInSeconds types.Int64 `tfsdk:"session_timeout_in_seconds"`
+}
+
+type streamingConfigurationModel struct {
+	EnableResponseStreaming types.Bool `tfsdk:"enable_response_streaming"`
 }
 
 type gatewayInterceptorConfigurationModel struct {

--- a/internal/service/bedrockagentcore/gateway_test.go
+++ b/internal/service/bedrockagentcore/gateway_test.go
@@ -462,6 +462,83 @@ func TestAccBedrockAgentCoreGateway_protocolConfiguration(t *testing.T) {
 	})
 }
 
+func TestAccBedrockAgentCoreGateway_protocolConfigurationWithSessionAndStreamingConfiguration(t *testing.T) {
+	ctx := acctest.Context(t)
+	var gateway bedrockagentcorecontrol.GetGatewayOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_bedrockagentcore_gateway.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID)
+			testAccPreCheckGateways(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockAgentCoreServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckGatewayDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGatewayConfig_protocolConfigurationWithSessionAndStreamingConfiguration(rName, "First set of instructions", 1200, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckGatewayExists(ctx, t, resourceName, &gateway),
+					resource.TestCheckResourceAttr(resourceName, "protocol_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "protocol_configuration.0.mcp.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "protocol_configuration.0.mcp.0.session_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "protocol_configuration.0.mcp.0.session_configuration.0.session_timeout_in_seconds", "1200"),
+					resource.TestCheckResourceAttr(resourceName, "protocol_configuration.0.mcp.0.streaming_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "protocol_configuration.0.mcp.0.streaming_configuration.0.enable_response_streaming", acctest.CtTrue),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, "gateway_id"),
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "gateway_id",
+			},
+			{
+				Config: testAccGatewayConfig_protocolConfigurationWithSessionAndStreamingConfiguration(rName, "Second set of instructions", 1800, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckGatewayExists(ctx, t, resourceName, &gateway),
+					resource.TestCheckResourceAttr(resourceName, "protocol_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "protocol_configuration.0.mcp.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "protocol_configuration.0.mcp.0.session_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "protocol_configuration.0.mcp.0.session_configuration.0.session_timeout_in_seconds", "1800"),
+					resource.TestCheckResourceAttr(resourceName, "protocol_configuration.0.mcp.0.streaming_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "protocol_configuration.0.mcp.0.streaming_configuration.0.enable_response_streaming", acctest.CtFalse),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				// Remove session_configuration and streaming_configuration blocks
+				Config: testAccGatewayConfig_protocolConfiguration(rName, "Third set of instructions"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckGatewayExists(ctx, t, resourceName, &gateway),
+					resource.TestCheckResourceAttr(resourceName, "protocol_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "protocol_configuration.0.mcp.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "protocol_configuration.0.mcp.0.session_configuration.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "protocol_configuration.0.mcp.0.streaming_configuration.#", "0"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+		},
+	})
+}
+
 func TestAccBedrockAgentCoreGateway_noProtocolType(t *testing.T) {
 	ctx := acctest.Context(t)
 	var gateway bedrockagentcorecontrol.GetGatewayOutput
@@ -1003,6 +1080,41 @@ resource "aws_bedrockagentcore_gateway" "test" {
   protocol_type = "MCP"
 }
 `, rName, instructions))
+}
+
+func testAccGatewayConfig_protocolConfigurationWithSessionAndStreamingConfiguration(rName, instructions string, sessionTimeoutInSeconds int, enableResponseStreaming bool) string {
+	return acctest.ConfigCompose(testAccGatewayConfig_iamRole(rName), fmt.Sprintf(`
+resource "aws_bedrockagentcore_gateway" "test" {
+  name     = %[1]q
+  role_arn = aws_iam_role.test.arn
+
+  authorizer_type = "CUSTOM_JWT"
+  authorizer_configuration {
+    custom_jwt_authorizer {
+      discovery_url    = "https://accounts.google.com/.well-known/openid-configuration"
+      allowed_audience = ["test1", "test2"]
+    }
+  }
+
+  protocol_configuration {
+    mcp {
+      instructions       = %[2]q
+      search_type        = "SEMANTIC"
+      supported_versions = ["2025-03-26"]
+
+      session_configuration {
+        session_timeout_in_seconds = %[3]d
+      }
+
+      streaming_configuration {
+        enable_response_streaming = %[4]t
+      }
+    }
+  }
+
+  protocol_type = "MCP"
+}
+`, rName, instructions, sessionTimeoutInSeconds, enableResponseStreaming))
 }
 
 func testAccGatewayConfig_description(rName, description string) string {

--- a/website/docs/r/bedrockagentcore_gateway.html.markdown
+++ b/website/docs/r/bedrockagentcore_gateway.html.markdown
@@ -206,8 +206,8 @@ The `mcp` block supports the following:
 
 * `instructions` - (Optional) Instructions for the MCP protocol configuration.
 * `search_type` - (Optional) Search type for MCP. Valid values: `SEMANTIC`.
-* `session_configutraion` - (Optional) Configuration block for session configuration for the MCP gateway. See [`session_configuration`](#session_configuration) below.
-* `streaming_configuration` - (Optional) Configuration block for streaming configuration for the MCP gateway. See [`streaming_configuration`](#streaming_configuration) below.
+* `session_configuration` - (Optional) Configuration block for session settings of the MCP gateway. See [`session_configuration`](#session_configuration) below.
+* `streaming_configuration` - (Optional) Configuration block for streaming settings of the MCP gateway. See [`streaming_configuration`](#streaming_configuration) below.
 * `supported_versions` - (Optional) Set of supported MCP protocol versions.
 
 ### `session_configuration`

--- a/website/docs/r/bedrockagentcore_gateway.html.markdown
+++ b/website/docs/r/bedrockagentcore_gateway.html.markdown
@@ -206,7 +206,21 @@ The `mcp` block supports the following:
 
 * `instructions` - (Optional) Instructions for the MCP protocol configuration.
 * `search_type` - (Optional) Search type for MCP. Valid values: `SEMANTIC`.
+* `session_configutraion` - (Optional) Configuration block for session configuration for the MCP gateway. See [`session_configuration`](#session_configuration) below.
+* `streaming_configuration` - (Optional) Configuration block for streaming configuration for the MCP gateway. See [`streaming_configuration`](#streaming_configuration) below.
 * `supported_versions` - (Optional) Set of supported MCP protocol versions.
+
+### `session_configuration`
+
+The `session_configuration` block supports the following:
+
+* `session_timeout_in_seconds` - (Optional) Integer value for session timeout in seconds. Must be between 900 and 28800.
+
+### `streaming_configuration`
+
+The `streaming_configuration` block supports the following:
+
+* `enable_response_streaming` - (Optional) Boolean indicating whether response streaming is enabled for the gateway.
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
This PR adds `protocol_configuration.mcp.session_configuration` and `protocol_configuration.mcp.streaming_configuration` blocks to `aws_bedrockagentcore_gateway` resource.

### Relations
Closes #48176

### References
https://docs.aws.amazon.com/bedrock-agentcore-control/latest/APIReference/API_CreateGateway.html#bedrockagentcorecontrol-CreateGateway-request-protocolConfiguration

### Output from Acceptance Testing

Although two tests are failing, they do not appear to be related to the changes in this PR.

```console
$ make testacc TESTS='TestAccBedrockAgentCoreGateway_' PKG=bedrockagentcore 
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework (cached)
make: Running acceptance tests on branch: 🌿 f-aws_bedrockagentcore_gateway-add_session_and_streaming_configuration 🌿...
TF_ACC=1 go1.26.3 test ./internal/service/bedrockagentcore/... -v -count 1 -parallel 20 -run='TestAccBedrockAgentCoreGateway_'  -timeout 360m -vet=off -buildvcs=false
2026/06/03 22:50:23 Creating Terraform AWS Provider (SDKv2-style)...
2026/06/03 22:50:23 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccBedrockAgentCoreGateway_basic
=== PAUSE TestAccBedrockAgentCoreGateway_basic
=== RUN   TestAccBedrockAgentCoreGateway_xrayDelivery
=== PAUSE TestAccBedrockAgentCoreGateway_xrayDelivery
=== RUN   TestAccBedrockAgentCoreGateway_disappears
=== PAUSE TestAccBedrockAgentCoreGateway_disappears
=== RUN   TestAccBedrockAgentCoreGateway_tags
=== PAUSE TestAccBedrockAgentCoreGateway_tags
=== RUN   TestAccBedrockAgentCoreGateway_interceptorConfigurations
=== PAUSE TestAccBedrockAgentCoreGateway_interceptorConfigurations
=== RUN   TestAccBedrockAgentCoreGateway_description
=== PAUSE TestAccBedrockAgentCoreGateway_description
=== RUN   TestAccBedrockAgentCoreGateway_IAMAuthorizer
=== PAUSE TestAccBedrockAgentCoreGateway_IAMAuthorizer
=== RUN   TestAccBedrockAgentCoreGateway_kmsKey
    gateway_test.go:367: KMS key returns HTTP 500
--- SKIP: TestAccBedrockAgentCoreGateway_kmsKey (0.00s)
=== RUN   TestAccBedrockAgentCoreGateway_protocolConfiguration
=== PAUSE TestAccBedrockAgentCoreGateway_protocolConfiguration
=== RUN   TestAccBedrockAgentCoreGateway_protocolConfigurationWithSessionAndStreamingConfiguration
=== PAUSE TestAccBedrockAgentCoreGateway_protocolConfigurationWithSessionAndStreamingConfiguration
=== RUN   TestAccBedrockAgentCoreGateway_noProtocolType
=== PAUSE TestAccBedrockAgentCoreGateway_noProtocolType
=== RUN   TestAccBedrockAgentCoreGateway_customJWTAuthorizer
=== PAUSE TestAccBedrockAgentCoreGateway_customJWTAuthorizer
=== RUN   TestAccBedrockAgentCoreGateway_customJWTAuthorizerCustomClaim
=== PAUSE TestAccBedrockAgentCoreGateway_customJWTAuthorizerCustomClaim
=== CONT  TestAccBedrockAgentCoreGateway_basic
=== CONT  TestAccBedrockAgentCoreGateway_IAMAuthorizer
=== CONT  TestAccBedrockAgentCoreGateway_protocolConfiguration
=== CONT  TestAccBedrockAgentCoreGateway_noProtocolType
=== CONT  TestAccBedrockAgentCoreGateway_customJWTAuthorizerCustomClaim
=== CONT  TestAccBedrockAgentCoreGateway_customJWTAuthorizer
=== CONT  TestAccBedrockAgentCoreGateway_protocolConfigurationWithSessionAndStreamingConfiguration
=== CONT  TestAccBedrockAgentCoreGateway_tags
=== CONT  TestAccBedrockAgentCoreGateway_description
=== CONT  TestAccBedrockAgentCoreGateway_interceptorConfigurations
=== CONT  TestAccBedrockAgentCoreGateway_disappears
=== CONT  TestAccBedrockAgentCoreGateway_xrayDelivery
    gateway_test.go:80: Step 1/1 error: Error running apply: exit status 1
        
        Error: creating CloudWatch Logs Delivery
        
          with aws_cloudwatch_log_delivery.test,
          on terraform_plugin_test.tf line 54, in resource "aws_cloudwatch_log_delivery" "test":
          54: resource "aws_cloudwatch_log_delivery" "test" {
        
        operation error CloudWatch Logs: CreateDelivery, https response error
        StatusCode: 400, RequestID: d3479d9b-4261-40a1-8684-ed4ec69f1eb0,
        ValidationException: X-Ray Delivery Destination is supported with CloudWatch
        Logs as a Trace Segment Destination. Please enable the CloudWatch Logs
        destination for your traces using the UpdateTraceSegmentDestination API
        (https://docs.aws.amazon.com/xray/latest/api/API_UpdateTraceSegmentDestination.html)
--- FAIL: TestAccBedrockAgentCoreGateway_xrayDelivery (68.70s)
=== NAME  TestAccBedrockAgentCoreGateway_disappears
    gateway_test.go:114: Error running post-test destroy, there may be dangling resources: exit status 1
        
        Error: deleting Bedrock AgentCore Gateway
        
        ID: tf-acc-test-7515177152901415994-7oix9t085m
        Cause: listing Bedrock AgentCore Gateway Targets: operation error Bedrock
        AgentCore Control: ListGatewayTargets, , api error ResourceNotFoundException:
        Failed to retrieve gateway because it doesn't exist. Retry the request with a
        different resource identifier."
        
--- FAIL: TestAccBedrockAgentCoreGateway_disappears (105.53s)
--- PASS: TestAccBedrockAgentCoreGateway_noProtocolType (133.60s)
--- PASS: TestAccBedrockAgentCoreGateway_basic (133.75s)
--- PASS: TestAccBedrockAgentCoreGateway_interceptorConfigurations (139.38s)
--- PASS: TestAccBedrockAgentCoreGateway_protocolConfiguration (169.98s)
--- PASS: TestAccBedrockAgentCoreGateway_description (183.02s)
--- PASS: TestAccBedrockAgentCoreGateway_customJWTAuthorizer (183.37s)
--- PASS: TestAccBedrockAgentCoreGateway_IAMAuthorizer (183.94s)
--- PASS: TestAccBedrockAgentCoreGateway_protocolConfigurationWithSessionAndStreamingConfiguration (206.13s)
--- PASS: TestAccBedrockAgentCoreGateway_tags (213.12s)
--- PASS: TestAccBedrockAgentCoreGateway_customJWTAuthorizerCustomClaim (222.71s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/bedrockagentcore   234.280s
FAIL
make: *** [testacc] Error 1

```
