### PR TITLE
aws_redshift_idc_application cannot create application_type = "Lakehouse" because only one service_integration is serialized

### DIFF
--- a/.changelog/48181.txt
+++ b/.changelog/48181.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_redshift_idc_application: Fix `InvalidParameterValue` error when creating a `Lakehouse` application by sending all populated `service_integration` sub-blocks (`lake_formation`, `redshift`, `s3_access_grants`) as separate entries in the API's `ServiceIntegrations` array instead of only one
+```
+
+```release-note:enhancement
+resource/aws_redshift_idc_application: Add plan-time validation requiring both `service_integration.lake_formation.lake_formation_query` and `service_integration.redshift.connect` when `application_type` is `Lakehouse`
+```

--- a/internal/service/redshift/idc_application.go
+++ b/internal/service/redshift/idc_application.go
@@ -209,6 +209,12 @@ func (r *idcApplicationResource) Schema(ctx context.Context, req resource.Schema
 	}
 }
 
+func (r *idcApplicationResource) ConfigValidators(_ context.Context) []resource.ConfigValidator {
+	return []resource.ConfigValidator{
+		lakehouseServiceIntegrationsValidator{},
+	}
+}
+
 func (r *idcApplicationResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	conn := r.Meta().RedshiftClient(ctx)
 
@@ -226,6 +232,13 @@ func (r *idcApplicationResource) Create(ctx context.Context, req resource.Create
 		return
 	}
 
+	si, d := expandServiceIntegrations(ctx, plan.ServiceIntegrations)
+	smerr.AddEnrich(ctx, &resp.Diagnostics, d)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	input.ServiceIntegrations = si
+
 	out, err := conn.CreateRedshiftIdcApplication(ctx, &input)
 	if err != nil {
 		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, plan.RedshiftIDCApplicationName.String())
@@ -240,6 +253,14 @@ func (r *idcApplicationResource) Create(ctx context.Context, req resource.Create
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	flatSI, d := flattenServiceIntegrations(ctx, out.RedshiftIdcApplication.ServiceIntegrations)
+	smerr.AddEnrich(ctx, &resp.Diagnostics, d)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	plan.ServiceIntegrations = flatSI
+
 	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, plan))
 }
 
@@ -270,6 +291,13 @@ func (r *idcApplicationResource) Read(ctx context.Context, req resource.ReadRequ
 		return
 	}
 
+	flatSI, d := flattenServiceIntegrations(ctx, out.ServiceIntegrations)
+	smerr.AddEnrich(ctx, &resp.Diagnostics, d)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	state.ServiceIntegrations = flatSI
+
 	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, &state))
 }
 
@@ -289,12 +317,22 @@ func (r *idcApplicationResource) Update(ctx context.Context, req resource.Update
 		return
 	}
 
-	if diff.HasChanges() {
+	// service_integration is handled outside autoflex (autoflex:"-"), so detect changes manually.
+	siChanged := !plan.ServiceIntegrations.Equal(state.ServiceIntegrations)
+
+	if diff.HasChanges() || siChanged {
 		var input redshift.ModifyRedshiftIdcApplicationInput
 		smerr.AddEnrich(ctx, &resp.Diagnostics, fwflex.Expand(ctx, plan, &input))
 		if resp.Diagnostics.HasError() {
 			return
 		}
+
+		si, d := expandServiceIntegrations(ctx, plan.ServiceIntegrations)
+		smerr.AddEnrich(ctx, &resp.Diagnostics, d)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		input.ServiceIntegrations = si
 
 		out, err := conn.ModifyRedshiftIdcApplication(ctx, &input)
 		if err != nil {
@@ -310,6 +348,13 @@ func (r *idcApplicationResource) Update(ctx context.Context, req resource.Update
 		if resp.Diagnostics.HasError() {
 			return
 		}
+
+		flatSI, d := flattenServiceIntegrations(ctx, out.RedshiftIdcApplication.ServiceIntegrations)
+		smerr.AddEnrich(ctx, &resp.Diagnostics, d)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		plan.ServiceIntegrations = flatSI
 	}
 
 	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, &plan))
@@ -354,9 +399,10 @@ type idcApplicationResourceModel struct {
 	IdentityNamespace          types.String                                                `tfsdk:"identity_namespace"`
 	RedshiftIDCApplicationARN  types.String                                                `tfsdk:"redshift_idc_application_arn"`
 	RedshiftIDCApplicationName types.String                                                `tfsdk:"redshift_idc_application_name"`
-	ServiceIntegrations        fwtypes.ListNestedObjectValueOf[serviceIntegrationsModel]   `tfsdk:"service_integration"`
-	Tags                       tftags.Map                                                  `tfsdk:"tags"`
-	TagsAll                    tftags.Map                                                  `tfsdk:"tags_all"`
+	// Handled manually so a single block can fan out into multiple ServiceIntegrationsUnion entries.
+	ServiceIntegrations fwtypes.ListNestedObjectValueOf[serviceIntegrationsModel] `tfsdk:"service_integration" autoflex:"-"`
+	Tags                tftags.Map                                                `tfsdk:"tags"`
+	TagsAll             tftags.Map                                                `tfsdk:"tags_all"`
 }
 
 type authorizedTokenIssuerModel struct {
@@ -368,164 +414,6 @@ type serviceIntegrationsModel struct {
 	LakeFormation  fwtypes.ListNestedObjectValueOf[lakeFormationModel]  `tfsdk:"lake_formation"`
 	Redshift       fwtypes.ListNestedObjectValueOf[redshiftModel]       `tfsdk:"redshift"`
 	S3AccessGrants fwtypes.ListNestedObjectValueOf[s3AccessGrantsModel] `tfsdk:"s3_access_grants"`
-}
-
-var (
-	_ fwflex.Expander  = serviceIntegrationsModel{}
-	_ fwflex.Flattener = &serviceIntegrationsModel{}
-)
-
-func (m serviceIntegrationsModel) Expand(ctx context.Context) (result any, diags diag.Diagnostics) {
-	switch {
-	case !m.LakeFormation.IsNull():
-		lakeFormationData, d := m.LakeFormation.ToPtr(ctx)
-		diags.Append(d...)
-		if diags.HasError() {
-			return nil, diags
-		}
-
-		lfQuery, d := lakeFormationData.LakeFormationQuery.ToPtr(ctx)
-		diags.Append(d...)
-		if diags.HasError() {
-			return nil, diags
-		}
-
-		var r awstypes.ServiceIntegrationsUnionMemberLakeFormation
-		if lfQuery != nil {
-			var query awstypes.LakeFormationScopeUnionMemberLakeFormationQuery
-			diags.Append(fwflex.Expand(ctx, lfQuery, &query.Value)...)
-			if diags.HasError() {
-				return nil, diags
-			}
-			r.Value = []awstypes.LakeFormationScopeUnion{&query}
-		}
-
-		return &r, diags
-
-	case !m.Redshift.IsNull():
-		redshiftData, d := m.Redshift.ToPtr(ctx)
-		diags.Append(d...)
-		if diags.HasError() {
-			return nil, diags
-		}
-
-		connect, d := redshiftData.Connect.ToPtr(ctx)
-		diags.Append(d...)
-		if diags.HasError() {
-			return nil, diags
-		}
-
-		var r awstypes.ServiceIntegrationsUnionMemberRedshift
-		if connect != nil {
-			var connectScope awstypes.RedshiftScopeUnionMemberConnect
-			diags.Append(fwflex.Expand(ctx, connect, &connectScope.Value)...)
-			if diags.HasError() {
-				return nil, diags
-			}
-			r.Value = []awstypes.RedshiftScopeUnion{&connectScope}
-		}
-
-		return &r, diags
-
-	case !m.S3AccessGrants.IsNull():
-		s3AccessGrants, d := m.S3AccessGrants.ToPtr(ctx)
-		diags.Append(d...)
-		if diags.HasError() {
-			return nil, diags
-		}
-
-		readWriteAccess, d := s3AccessGrants.ReadWriteAccess.ToPtr(ctx)
-		diags.Append(d...)
-		if diags.HasError() {
-			return nil, diags
-		}
-
-		var r awstypes.ServiceIntegrationsUnionMemberS3AccessGrants
-		if readWriteAccess != nil {
-			var rwaGrantsScope awstypes.S3AccessGrantsScopeUnionMemberReadWriteAccess
-			diags.Append(fwflex.Expand(ctx, readWriteAccess, &rwaGrantsScope.Value)...)
-			if diags.HasError() {
-				return nil, diags
-			}
-			r.Value = []awstypes.S3AccessGrantsScopeUnion{&rwaGrantsScope}
-		}
-
-		return &r, diags
-	}
-
-	return nil, diags
-}
-
-func (m *serviceIntegrationsModel) Flatten(ctx context.Context, v any) diag.Diagnostics {
-	var diags diag.Diagnostics
-
-	switch t := v.(type) {
-	case awstypes.ServiceIntegrationsUnionMemberLakeFormation:
-		var data lakeFormationModel
-		if len(t.Value) > 0 {
-			var lfQueryData lakeFormationQueryModel
-
-			// Type switch on the LakeFormationScopeUnion to get LakeFormationQuery
-			switch scopeUnion := t.Value[0].(type) {
-			case *awstypes.LakeFormationScopeUnionMemberLakeFormationQuery:
-				// Flatten the LakeFormationQuery value into the model
-				diags.Append(fwflex.Flatten(ctx, scopeUnion.Value, &lfQueryData)...)
-				if diags.HasError() {
-					return diags
-				}
-
-				// Set the LakeFormationQuery in the parent model
-				data.LakeFormationQuery = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &lfQueryData)
-			}
-		}
-		m.LakeFormation = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &data)
-
-	case awstypes.ServiceIntegrationsUnionMemberRedshift:
-		var data redshiftModel
-
-		// Handle the nested RedshiftScope union
-		if len(t.Value) > 0 {
-			var connectData connectModel
-
-			// Type switch on the RedshiftScopeUnion to get Connect
-			switch scopeUnion := t.Value[0].(type) {
-			case *awstypes.RedshiftScopeUnionMemberConnect:
-				// Flatten the Connect value into the model
-				diags.Append(fwflex.Flatten(ctx, scopeUnion.Value, &connectData)...)
-				if diags.HasError() {
-					return diags
-				}
-
-				// Set the Connect in the parent model
-				data.Connect = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &connectData)
-			}
-		}
-		m.Redshift = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &data)
-
-	case awstypes.ServiceIntegrationsUnionMemberS3AccessGrants:
-		var data s3AccessGrantsModel
-
-		// Handle the nested S3AccessGrantsScope union
-		if len(t.Value) > 0 {
-			var readWriteAccessData readWriteAccessModel
-
-			// Type switch on the S3AccessGrantsScopeUnion to get ReadWriteAccess
-			switch scopeUnion := t.Value[0].(type) {
-			case *awstypes.S3AccessGrantsScopeUnionMemberReadWriteAccess:
-				// Flatten the ReadWriteAccess value into the model
-				diags.Append(fwflex.Flatten(ctx, scopeUnion.Value, &readWriteAccessData)...)
-				if diags.HasError() {
-					return diags
-				}
-
-				// Set the ReadWriteAccess in the parent model
-				data.ReadWriteAccess = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &readWriteAccessData)
-			}
-		}
-		m.S3AccessGrants = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &data)
-	}
-
-	return diags
 }
 
 type lakeFormationModel struct {
@@ -550,4 +438,220 @@ type s3AccessGrantsModel struct {
 
 type readWriteAccessModel struct {
 	Authorization fwtypes.StringEnum[awstypes.ServiceAuthorization] `tfsdk:"authorization"`
+}
+
+// expandServiceIntegrations turns the single HCL service_integration block into
+// the array of ServiceIntegrationsUnion entries the Redshift API expects.
+// This is required for application_type = "Lakehouse", which requires both
+// LakeFormation:LakeFormationQuery and Redshift:Connect to be present.
+func expandServiceIntegrations(ctx context.Context, l fwtypes.ListNestedObjectValueOf[serviceIntegrationsModel]) ([]awstypes.ServiceIntegrationsUnion, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if l.IsNull() || l.IsUnknown() {
+		return nil, diags
+	}
+
+	m, d := l.ToPtr(ctx)
+	diags.Append(d...)
+	if diags.HasError() || m == nil {
+		return nil, diags
+	}
+
+	var out []awstypes.ServiceIntegrationsUnion
+
+	if !m.LakeFormation.IsNull() && !m.LakeFormation.IsUnknown() {
+		lf, d := m.LakeFormation.ToPtr(ctx)
+		diags.Append(d...)
+		if diags.HasError() {
+			return nil, diags
+		}
+		if lf != nil {
+			q, d := lf.LakeFormationQuery.ToPtr(ctx)
+			diags.Append(d...)
+			if diags.HasError() {
+				return nil, diags
+			}
+			if q != nil {
+				var scope awstypes.LakeFormationScopeUnionMemberLakeFormationQuery
+				diags.Append(fwflex.Expand(ctx, q, &scope.Value)...)
+				if diags.HasError() {
+					return nil, diags
+				}
+				out = append(out, &awstypes.ServiceIntegrationsUnionMemberLakeFormation{
+					Value: []awstypes.LakeFormationScopeUnion{&scope},
+				})
+			}
+		}
+	}
+
+	if !m.Redshift.IsNull() && !m.Redshift.IsUnknown() {
+		rs, d := m.Redshift.ToPtr(ctx)
+		diags.Append(d...)
+		if diags.HasError() {
+			return nil, diags
+		}
+		if rs != nil {
+			c, d := rs.Connect.ToPtr(ctx)
+			diags.Append(d...)
+			if diags.HasError() {
+				return nil, diags
+			}
+			if c != nil {
+				var scope awstypes.RedshiftScopeUnionMemberConnect
+				diags.Append(fwflex.Expand(ctx, c, &scope.Value)...)
+				if diags.HasError() {
+					return nil, diags
+				}
+				out = append(out, &awstypes.ServiceIntegrationsUnionMemberRedshift{
+					Value: []awstypes.RedshiftScopeUnion{&scope},
+				})
+			}
+		}
+	}
+
+	if !m.S3AccessGrants.IsNull() && !m.S3AccessGrants.IsUnknown() {
+		sg, d := m.S3AccessGrants.ToPtr(ctx)
+		diags.Append(d...)
+		if diags.HasError() {
+			return nil, diags
+		}
+		if sg != nil {
+			rwa, d := sg.ReadWriteAccess.ToPtr(ctx)
+			diags.Append(d...)
+			if diags.HasError() {
+				return nil, diags
+			}
+			if rwa != nil {
+				var scope awstypes.S3AccessGrantsScopeUnionMemberReadWriteAccess
+				diags.Append(fwflex.Expand(ctx, rwa, &scope.Value)...)
+				if diags.HasError() {
+					return nil, diags
+				}
+				out = append(out, &awstypes.ServiceIntegrationsUnionMemberS3AccessGrants{
+					Value: []awstypes.S3AccessGrantsScopeUnion{&scope},
+				})
+			}
+		}
+	}
+
+	return out, diags
+}
+
+// flattenServiceIntegrations folds an API []ServiceIntegrationsUnion back into
+// a single service_integration block with multiple sub-blocks set.
+func flattenServiceIntegrations(ctx context.Context, unions []awstypes.ServiceIntegrationsUnion) (fwtypes.ListNestedObjectValueOf[serviceIntegrationsModel], diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if len(unions) == 0 {
+		return fwtypes.NewListNestedObjectValueOfNull[serviceIntegrationsModel](ctx), diags
+	}
+
+	model := serviceIntegrationsModel{
+		LakeFormation:  fwtypes.NewListNestedObjectValueOfNull[lakeFormationModel](ctx),
+		Redshift:       fwtypes.NewListNestedObjectValueOfNull[redshiftModel](ctx),
+		S3AccessGrants: fwtypes.NewListNestedObjectValueOfNull[s3AccessGrantsModel](ctx),
+	}
+
+	for _, u := range unions {
+		switch t := u.(type) {
+		case *awstypes.ServiceIntegrationsUnionMemberLakeFormation:
+			data := lakeFormationModel{
+				LakeFormationQuery: fwtypes.NewListNestedObjectValueOfNull[lakeFormationQueryModel](ctx),
+			}
+			if len(t.Value) > 0 {
+				if s, ok := t.Value[0].(*awstypes.LakeFormationScopeUnionMemberLakeFormationQuery); ok {
+					var q lakeFormationQueryModel
+					diags.Append(fwflex.Flatten(ctx, s.Value, &q)...)
+					if diags.HasError() {
+						return fwtypes.NewListNestedObjectValueOfNull[serviceIntegrationsModel](ctx), diags
+					}
+					data.LakeFormationQuery = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &q)
+				}
+			}
+			model.LakeFormation = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &data)
+
+		case *awstypes.ServiceIntegrationsUnionMemberRedshift:
+			data := redshiftModel{
+				Connect: fwtypes.NewListNestedObjectValueOfNull[connectModel](ctx),
+			}
+			if len(t.Value) > 0 {
+				if s, ok := t.Value[0].(*awstypes.RedshiftScopeUnionMemberConnect); ok {
+					var c connectModel
+					diags.Append(fwflex.Flatten(ctx, s.Value, &c)...)
+					if diags.HasError() {
+						return fwtypes.NewListNestedObjectValueOfNull[serviceIntegrationsModel](ctx), diags
+					}
+					data.Connect = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &c)
+				}
+			}
+			model.Redshift = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &data)
+
+		case *awstypes.ServiceIntegrationsUnionMemberS3AccessGrants:
+			data := s3AccessGrantsModel{
+				ReadWriteAccess: fwtypes.NewListNestedObjectValueOfNull[readWriteAccessModel](ctx),
+			}
+			if len(t.Value) > 0 {
+				if s, ok := t.Value[0].(*awstypes.S3AccessGrantsScopeUnionMemberReadWriteAccess); ok {
+					var r readWriteAccessModel
+					diags.Append(fwflex.Flatten(ctx, s.Value, &r)...)
+					if diags.HasError() {
+						return fwtypes.NewListNestedObjectValueOfNull[serviceIntegrationsModel](ctx), diags
+					}
+					data.ReadWriteAccess = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &r)
+				}
+			}
+			model.S3AccessGrants = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &data)
+		}
+	}
+
+	return fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &model), diags
+}
+
+// lakehouseServiceIntegrationsValidator surfaces the AWS Lakehouse precondition
+// (must enable both LakeFormation:LakeFormationQuery and Redshift:Connect) at
+// plan time instead of waiting for the API to return InvalidParameterValue.
+type lakehouseServiceIntegrationsValidator struct{}
+
+func (lakehouseServiceIntegrationsValidator) Description(_ context.Context) string {
+	return `When application_type = "Lakehouse", service_integration must enable both lake_formation.lake_formation_query and redshift.connect.`
+}
+
+func (v lakehouseServiceIntegrationsValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (lakehouseServiceIntegrationsValidator) ValidateResource(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var cfg idcApplicationResourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &cfg)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if cfg.ApplicationType.IsNull() || cfg.ApplicationType.IsUnknown() {
+		return
+	}
+	if cfg.ApplicationType.ValueString() != string(awstypes.ApplicationTypeLakehouse) {
+		return
+	}
+	if cfg.ServiceIntegrations.IsNull() || cfg.ServiceIntegrations.IsUnknown() {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("service_integration"),
+			"Invalid Lakehouse service_integration",
+			`application_type = "Lakehouse" requires both lake_formation.lake_formation_query.authorization = "Enabled" and redshift.connect.authorization = "Enabled".`,
+		)
+		return
+	}
+
+	si, diags := cfg.ServiceIntegrations.ToPtr(ctx)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() || si == nil {
+		return
+	}
+
+	if si.LakeFormation.IsNull() || si.LakeFormation.IsUnknown() ||
+		si.Redshift.IsNull() || si.Redshift.IsUnknown() {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("service_integration"),
+			"Invalid Lakehouse service_integration",
+			`application_type = "Lakehouse" requires both lake_formation.lake_formation_query.authorization = "Enabled" and redshift.connect.authorization = "Enabled".`,
+		)
+	}
 }

--- a/internal/service/redshift/idc_application_test.go
+++ b/internal/service/redshift/idc_application_test.go
@@ -118,7 +118,7 @@ func TestAccRedshiftIDCApplication_authorizedTokenIssuerList(t *testing.T) {
 	})
 }
 
-func TestAccRedshiftIDCApplication_serviceIntegrationsLakehouse(t *testing.T) {
+func TestAccRedshiftIDCApplication_serviceIntegrationsLakeFormationOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_redshift_idc_application.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
@@ -130,7 +130,7 @@ func TestAccRedshiftIDCApplication_serviceIntegrationsLakehouse(t *testing.T) {
 		CheckDestroy:             testAccCheckIDCApplicationDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIdcApplicationConfig_serviceIntegrationsLakehouse(rName),
+				Config: testAccIdcApplicationConfig_serviceIntegrationsLakeFormationOnly(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIDCApplicationExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "redshift_idc_application_name", rName),
@@ -201,6 +201,44 @@ func TestAccRedshiftIDCApplication_serviceIntegrationsS3AccessGrants(t *testing.
 					resource.TestCheckResourceAttr(resourceName, "service_integration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "service_integration.0.s3_access_grants.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "service_integration.0.s3_access_grants.0.read_write_access.0.authorization", "Enabled"),
+				),
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, "redshift_idc_application_arn"),
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "redshift_idc_application_arn",
+			},
+		},
+	})
+}
+
+// TestAccRedshiftIDCApplication_serviceIntegrationsLakehouse exercises the
+// regression covered by GitHub issue: Lakehouse applications require BOTH
+// LakeFormation:LakeFormationQuery and Redshift:Connect to be enabled in a
+// single API call.
+func TestAccRedshiftIDCApplication_serviceIntegrationsLakehouse(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_redshift_idc_application.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckSSOAdminInstances(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.RedshiftServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckIDCApplicationDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIdcApplicationConfig_serviceIntegrationsLakehouseBoth(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIDCApplicationExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "application_type", "Lakehouse"),
+					resource.TestCheckResourceAttr(resourceName, "service_integration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "service_integration.0.lake_formation.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "service_integration.0.lake_formation.0.lake_formation_query.0.authorization", "Enabled"),
+					resource.TestCheckResourceAttr(resourceName, "service_integration.0.redshift.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "service_integration.0.redshift.0.connect.0.authorization", "Enabled"),
 				),
 			},
 			{
@@ -400,7 +438,7 @@ resource "aws_redshift_idc_application" "test" {
 `, rName))
 }
 
-func testAccIdcApplicationConfig_serviceIntegrationsLakehouse(rName string) string {
+func testAccIdcApplicationConfig_serviceIntegrationsLakeFormationOnly(rName string) string {
 	return acctest.ConfigCompose(testAccIdcApplicationConfig_baseIAMRole(rName), fmt.Sprintf(`
 data "aws_ssoadmin_instances" "test" {}
 
@@ -452,6 +490,34 @@ resource "aws_redshift_idc_application" "test" {
   service_integration {
     s3_access_grants {
       read_write_access {
+        authorization = "Enabled"
+      }
+    }
+  }
+}
+`, rName))
+}
+
+func testAccIdcApplicationConfig_serviceIntegrationsLakehouseBoth(rName string) string {
+	return acctest.ConfigCompose(testAccIdcApplicationConfig_baseIAMRole(rName), fmt.Sprintf(`
+data "aws_ssoadmin_instances" "test" {}
+
+resource "aws_redshift_idc_application" "test" {
+  application_type              = "Lakehouse"
+  iam_role_arn                  = aws_iam_role.test.arn
+  idc_display_name              = %[1]q
+  idc_instance_arn              = tolist(data.aws_ssoadmin_instances.test.arns)[0]
+  identity_namespace            = %[1]q
+  redshift_idc_application_name = %[1]q
+
+  service_integration {
+    lake_formation {
+      lake_formation_query {
+        authorization = "Enabled"
+      }
+    }
+    redshift {
+      connect {
         authorization = "Enabled"
       }
     }


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

There are no changes to security controls (access controls, encryption, logging) in this pull request. The change is limited to how the `aws_redshift_idc_application` resource serializes the `service_integration` block to the Redshift `CreateRedshiftIdcApplication` / `ModifyRedshiftIdcApplication` APIs. IAM roles, ARNs, audiences and trusted token issuers continue to be passed through unchanged.

### Description

Fixes a bug in `aws_redshift_idc_application` that prevents creating an IDC application with `application_type = "Lakehouse"`.

The Redshift `CreateRedshiftIdcApplication` API accepts `ServiceIntegrations` as an **array** of `ServiceIntegrationsUnion` entries. For Lakehouse applications, AWS requires **both** entries to be present in the same call:

- `LakeFormation:LakeFormationQuery` with `authorization = Enabled`
- `Redshift:Connect` with `authorization = Enabled`

This matches the AWS console behavior for *"Configure Amazon Redshift federated permissions using AWS IAM Identity Center (Recommended)"*.

The previous implementation of `serviceIntegrationsModel.Expand()` was a `switch` statement that returned **at most one** union member, so even when users specified both `lake_formation` and `redshift` sub-blocks under the single `service_integration` block, only one of them was sent to the API. The result was that `terraform plan` succeeded but `terraform apply` failed with:

```
InvalidParameterValue: The lakehouse application requires authorization
enabled for both "LakeFormation:LakeFormationQuery" and "Redshift:Connect".
```

#### What this PR changes

1. **Bypass autoflex for `service_integration`.** The field is annotated with `autoflex:"-"` so that autoflex no longer drives expand/flatten through the (single-member) `Expander`/`Flattener` interface.
2. **New `expandServiceIntegrations` helper** builds `[]awstypes.ServiceIntegrationsUnion` from a single HCL block, emitting one union entry per populated sub-block (`lake_formation`, `redshift`, `s3_access_grants`). This makes Lakehouse work without any HCL change for users.
3. **New `flattenServiceIntegrations` helper** folds the API response array back into the single-block schema, so `Read` / `Import` round-trip correctly when multiple entries are returned.
4. **`Create` / `Read` / `Update`** now call the helpers in addition to autoflex. `Update` also detects `service_integration` changes manually since it's no longer covered by `fwflex.Diff`.
5. **`ConfigValidators`** adds a plan-time validator that fails fast with a clear message when `application_type = "Lakehouse"` is set without both `lake_formation` and `redshift` sub-blocks. This addresses the issue's concern about silently planning a configuration that the API will reject.
6. **Acceptance tests:**
   - Added `TestAccRedshiftIDCApplication_serviceIntegrationsLakehouse` covering the regression (`application_type = "Lakehouse"` with both sub-blocks set).
   - Renamed the previous `_serviceIntegrationsLakehouse` test (which didn't actually configure a Lakehouse application) to `_serviceIntegrationsLakeFormationOnly` to better reflect what it covers.

#### Backwards compatibility

The schema is unchanged. Existing configurations using a single `service_integration` block with one of `lake_formation`, `redshift`, or `s3_access_grants` continue to work and produce identical API calls. Users who were previously specifying both `lake_formation` and `redshift` (and hitting the `InvalidParameterValue` error) will now succeed without modifying their HCL.

### Relations

Closes #47866

### References

- AWS API: [`CreateRedshiftIdcApplication`](https://docs.aws.amazon.com/redshift/latest/APIReference/API_CreateRedshiftIdcApplication.html) — `ServiceIntegrations` is an array of `ServiceIntegrationsUnion`.
- AWS Console flow: *"Configure Amazon Redshift federated permissions using AWS IAM Identity Center (Recommended)"* enables both LakeFormation and Redshift integrations simultaneously.

### Output from Acceptance Testing

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

I do not have an AWS account suitable for running the Redshift IDC + IAM Identity Center acceptance tests locally, so I have not run `make testacc` against this change. The affected tests are:

```console
% make testacc TESTS='TestAccRedshiftIDCApplication_' PKG=redshift
```

Specifically:

- `TestAccRedshiftIDCApplication_basic`
- `TestAccRedshiftIDCApplication_disappears`
- `TestAccRedshiftIDCApplication_authorizedTokenIssuerList`
- `TestAccRedshiftIDCApplication_serviceIntegrationsLakeFormationOnly` *(renamed from `_serviceIntegrationsLakehouse`)*
- `TestAccRedshiftIDCApplication_serviceIntegrationsRshift`
- `TestAccRedshiftIDCApplication_serviceIntegrationsS3AccessGrants`
- `TestAccRedshiftIDCApplication_serviceIntegrationsLakehouse` *(new — exercises the regression from #47866)*
- `TestAccRedshiftIDCApplication_tags`

Could a maintainer please run the suite in the project's CI environment? Happy to iterate on any failures.