### PR TITLE
d/aws_ec2_capacity_reservation: New data source

### DIFF
--- a/.changelog/48184.txt
+++ b/.changelog/48184.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_ec2_capacity_reservation
+```

--- a/internal/service/ec2/ec2_capacity_reservation_data_source.go
+++ b/internal/service/ec2/ec2_capacity_reservation_data_source.go
@@ -1,0 +1,193 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package ec2
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkDataSource("aws_ec2_capacity_reservation", name="Capacity Reservation")
+func newCapacityReservationDataSource(context.Context) (datasource.DataSourceWithConfigure, error) {
+	return &capacityReservationDataSource{}, nil
+}
+
+type capacityReservationDataSource struct {
+	framework.DataSourceWithModel[capacityReservationDataSourceModel]
+}
+
+func (d *capacityReservationDataSource) Schema(ctx context.Context, _ datasource.SchemaRequest, response *datasource.SchemaResponse) {
+	response.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			names.AttrARN: schema.StringAttribute{
+				Computed: true,
+			},
+			names.AttrAvailabilityZone: schema.StringAttribute{
+				Computed: true,
+			},
+			"availability_zone_id": schema.StringAttribute{
+				Computed: true,
+			},
+			"available_instance_count": schema.Int64Attribute{
+				Computed: true,
+			},
+			"commitment_info": schema.ObjectAttribute{
+				CustomType: fwtypes.NewObjectTypeOf[commitmentInfoModel](ctx),
+				Computed:   true,
+			},
+			names.AttrCreatedDate: schema.StringAttribute{
+				CustomType: timetypes.RFC3339Type{},
+				Computed:   true,
+			},
+			"ebs_optimized": schema.BoolAttribute{
+				Computed: true,
+			},
+			"end_date": schema.StringAttribute{
+				CustomType: timetypes.RFC3339Type{},
+				Computed:   true,
+			},
+			"end_date_type": schema.StringAttribute{
+				CustomType: fwtypes.StringEnumType[awstypes.EndDateType](),
+				Computed:   true,
+			},
+			"ephemeral_storage": schema.BoolAttribute{
+				Computed: true,
+			},
+			names.AttrID: schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+			},
+			names.AttrInstanceCount: schema.Int64Attribute{
+				Computed: true,
+			},
+			"instance_match_criteria": schema.StringAttribute{
+				CustomType: fwtypes.StringEnumType[awstypes.InstanceMatchCriteria](),
+				Computed:   true,
+			},
+			"instance_platform": schema.StringAttribute{
+				CustomType: fwtypes.StringEnumType[awstypes.CapacityReservationInstancePlatform](),
+				Computed:   true,
+			},
+			names.AttrInstanceType: schema.StringAttribute{
+				Computed: true,
+			},
+			"interruptible_capacity_allocation": schema.ObjectAttribute{
+				CustomType: fwtypes.NewObjectTypeOf[interruptibleCapacityAllocationModel](ctx),
+				Computed:   true,
+			},
+			"interruption_info": schema.ObjectAttribute{
+				CustomType: fwtypes.NewObjectTypeOf[interruptionInfoModel](ctx),
+				Computed:   true,
+			},
+			names.AttrOutpostARN: schema.StringAttribute{
+				Computed: true,
+			},
+			names.AttrOwnerID: schema.StringAttribute{
+				Computed: true,
+			},
+			"placement_group_arn": schema.StringAttribute{
+				Computed: true,
+			},
+			"reservation_type": schema.StringAttribute{
+				CustomType: fwtypes.StringEnumType[awstypes.CapacityReservationType](),
+				Computed:   true,
+			},
+			"start_date": schema.StringAttribute{
+				CustomType: timetypes.RFC3339Type{},
+				Computed:   true,
+			},
+			names.AttrState: schema.StringAttribute{
+				CustomType: fwtypes.StringEnumType[awstypes.CapacityReservationState](),
+				Computed:   true,
+			},
+			names.AttrTags: tftags.TagsAttributeComputedOnly(),
+			"tenancy": schema.StringAttribute{
+				CustomType: fwtypes.StringEnumType[awstypes.CapacityReservationTenancy](),
+				Computed:   true,
+			},
+		},
+		Blocks: map[string]schema.Block{
+			names.AttrFilter: customFiltersBlock(ctx),
+		},
+	}
+}
+
+func (d *capacityReservationDataSource) Read(ctx context.Context, request datasource.ReadRequest, response *datasource.ReadResponse) {
+	var data capacityReservationDataSourceModel
+	response.Diagnostics.Append(request.Config.Get(ctx, &data)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	conn := d.Meta().EC2Client(ctx)
+	ignoreTagsConfig := d.Meta().IgnoreTagsConfig(ctx)
+
+	input := ec2.DescribeCapacityReservationsInput{
+		Filters: newCustomFilterListFramework(ctx, data.Filters),
+	}
+
+	if !data.ID.IsNull() {
+		input.CapacityReservationIds = []string{fwflex.StringValueFromFramework(ctx, data.ID)}
+	}
+
+	output, err := findCapacityReservation(ctx, conn, &input)
+	if err != nil {
+		response.Diagnostics.AddError(
+			"reading EC2 Capacity Reservation",
+			tfresource.SingularDataSourceFindError("EC2 Capacity Reservation", err).Error(),
+		)
+		return
+	}
+
+	response.Diagnostics.Append(fwflex.Flatten(ctx, output, &data, fwflex.WithFieldNamePrefix("CapacityReservation"))...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	data.Tags = tftags.FlattenStringValueMap(ctx, keyValueTags(ctx, output.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map())
+
+	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
+}
+
+type capacityReservationDataSourceModel struct {
+	framework.WithRegionModel
+	ARN                             types.String                                                     `tfsdk:"arn"`
+	AvailabilityZone                types.String                                                     `tfsdk:"availability_zone"`
+	AvailabilityZoneID              types.String                                                     `tfsdk:"availability_zone_id"`
+	AvailableInstanceCount          types.Int64                                                      `tfsdk:"available_instance_count"`
+	CommitmentInfo                  fwtypes.ObjectValueOf[commitmentInfoModel]                       `tfsdk:"commitment_info"`
+	CreateDate                      timetypes.RFC3339                                                `tfsdk:"created_date"`
+	EbsOptimized                    types.Bool                                                       `tfsdk:"ebs_optimized"`
+	EndDate                         timetypes.RFC3339                                                `tfsdk:"end_date"`
+	EndDateType                     fwtypes.StringEnum[awstypes.EndDateType]                         `tfsdk:"end_date_type"`
+	EphemeralStorage                types.Bool                                                       `tfsdk:"ephemeral_storage"`
+	Filters                         customFilters                                                    `tfsdk:"filter" autoflex:"-"`
+	ID                              types.String                                                     `tfsdk:"id"`
+	InstanceMatchCriteria           fwtypes.StringEnum[awstypes.InstanceMatchCriteria]               `tfsdk:"instance_match_criteria"`
+	InstancePlatform                fwtypes.StringEnum[awstypes.CapacityReservationInstancePlatform] `tfsdk:"instance_platform"`
+	InstanceType                    types.String                                                     `tfsdk:"instance_type"`
+	InterruptibleCapacityAllocation fwtypes.ObjectValueOf[interruptibleCapacityAllocationModel]      `tfsdk:"interruptible_capacity_allocation"`
+	InterruptionInfo                fwtypes.ObjectValueOf[interruptionInfoModel]                     `tfsdk:"interruption_info"`
+	OutpostARN                      types.String                                                     `tfsdk:"outpost_arn"`
+	OwnerID                         types.String                                                     `tfsdk:"owner_id"`
+	PlacementGroupARN               types.String                                                     `tfsdk:"placement_group_arn"`
+	ReservationType                 fwtypes.StringEnum[awstypes.CapacityReservationType]             `tfsdk:"reservation_type"`
+	StartDate                       timetypes.RFC3339                                                `tfsdk:"start_date"`
+	State                           fwtypes.StringEnum[awstypes.CapacityReservationState]            `tfsdk:"state"`
+	Tags                            tftags.Map                                                       `tfsdk:"tags"`
+	Tenancy                         fwtypes.StringEnum[awstypes.CapacityReservationTenancy]          `tfsdk:"tenancy"`
+	TotalInstanceCount              types.Int64                                                      `tfsdk:"instance_count"`
+}

--- a/internal/service/ec2/ec2_capacity_reservation_data_source_test.go
+++ b/internal/service/ec2/ec2_capacity_reservation_data_source_test.go
@@ -1,0 +1,128 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package ec2_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccEC2CapacityReservationDataSource_id(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_ec2_capacity_reservation.test"
+	resourceName := "aws_ec2_capacity_reservation.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckCapacityReservation(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCapacityReservationDataSourceConfig_id,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrARN, resourceName, names.AttrARN),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrAvailabilityZone, resourceName, names.AttrAvailabilityZone),
+					resource.TestCheckResourceAttrPair(dataSourceName, "ebs_optimized", resourceName, "ebs_optimized"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "end_date_type", resourceName, "end_date_type"),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrID, resourceName, names.AttrID),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrInstanceCount, resourceName, names.AttrInstanceCount),
+					resource.TestCheckResourceAttrPair(dataSourceName, "instance_match_criteria", resourceName, "instance_match_criteria"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "instance_platform", resourceName, "instance_platform"),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrInstanceType, resourceName, names.AttrInstanceType),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrOwnerID, resourceName, names.AttrOwnerID),
+					resource.TestCheckResourceAttr(dataSourceName, names.AttrState, "active"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "tenancy", resourceName, "tenancy"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccEC2CapacityReservationDataSource_filter(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_ec2_capacity_reservation.test"
+	resourceName := "aws_ec2_capacity_reservation.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckCapacityReservation(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCapacityReservationDataSourceConfig_filter,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrID, resourceName, names.AttrID),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrInstanceType, resourceName, names.AttrInstanceType),
+				),
+			},
+		},
+	})
+}
+
+const testAccCapacityReservationDataSourceConfig_id = `
+data "aws_availability_zones" "available" {
+  state = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
+resource "aws_ec2_capacity_reservation" "test" {
+  availability_zone = data.aws_availability_zones.available.names[0]
+  instance_count    = 1
+  instance_platform = "Linux/UNIX"
+  instance_type     = "t3.micro"
+}
+
+data "aws_ec2_capacity_reservation" "test" {
+  id = aws_ec2_capacity_reservation.test.id
+}
+`
+
+const testAccCapacityReservationDataSourceConfig_filter = `
+data "aws_availability_zones" "available" {
+  state = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
+data "aws_caller_identity" "current" {}
+
+resource "aws_ec2_capacity_reservation" "test" {
+  availability_zone = data.aws_availability_zones.available.names[0]
+  instance_count    = 1
+  instance_platform = "Linux/UNIX"
+  instance_type     = "m5.xlarge"
+}
+
+data "aws_ec2_capacity_reservation" "test" {
+  filter {
+    name   = "instance-type"
+    values = [aws_ec2_capacity_reservation.test.instance_type]
+  }
+
+  filter {
+    name   = "state"
+    values = ["active"]
+  }
+
+  filter {
+    name   = "availability-zone"
+    values = [aws_ec2_capacity_reservation.test.availability_zone]
+  }
+
+  filter {
+    name   = "owner-id"
+    values = [data.aws_caller_identity.current.account_id]
+  }
+}
+`

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -49,6 +49,12 @@ func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*inttypes.S
 			Region:   inttypes.ResourceRegionDefault(),
 		},
 		{
+			Factory:  newCapacityReservationDataSource,
+			TypeName: "aws_ec2_capacity_reservation",
+			Name:     "Capacity Reservation",
+			Region:   inttypes.ResourceRegionDefault(),
+		},
+		{
 			Factory:  newHostsDataSource,
 			TypeName: "aws_ec2_hosts",
 			Name:     "Hosts",

--- a/website/docs/d/ec2_capacity_reservation.html.markdown
+++ b/website/docs/d/ec2_capacity_reservation.html.markdown
@@ -1,0 +1,119 @@
+---
+subcategory: "EC2 (Elastic Compute Cloud)"
+layout: "aws"
+page_title: "AWS: aws_ec2_capacity_reservation"
+description: |-
+  Information about an existing EC2 On-Demand Capacity Reservation (ODCR).
+---
+
+# Data Source: aws_ec2_capacity_reservation
+
+Information about an existing EC2 On-Demand Capacity Reservation (ODCR).
+
+This data source returns only Capacity Reservations whose `reservation_type` is `default`. Use the [`aws_ec2_capacity_block_reservation`](./ec2_capacity_block_reservation.html.markdown) data source to look up Capacity Block reservations.
+
+At least one of `id` or `filter` must be specified. Filter combinations that match multiple Capacity Reservations will return an error.
+
+## Example Usage
+
+### Lookup by ID
+
+```terraform
+data "aws_ec2_capacity_reservation" "example" {
+  id = "cr-0123456789abcdef0"
+}
+```
+
+### Lookup by filter
+
+```terraform
+data "aws_ec2_capacity_reservation" "example" {
+  filter {
+    name   = "instance-type"
+    values = ["m5.large"]
+  }
+
+  filter {
+    name   = "availability-zone"
+    values = ["us-west-2a"]
+  }
+
+  filter {
+    name   = "state"
+    values = ["active"]
+  }
+}
+```
+
+### Lookup by tag
+
+```terraform
+data "aws_ec2_capacity_reservation" "example" {
+  filter {
+    name   = "tag:Name"
+    values = ["prod-reservation"]
+  }
+}
+```
+
+## Argument Reference
+
+This data source supports the following arguments:
+
+* `filter` - (Optional) Configuration block(s) for filtering. Detailed below.
+* `id` - (Optional) ID of the Capacity Reservation to retrieve.
+* `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
+
+### `filter` Block
+
+The `filter` configuration block supports the following arguments:
+
+* `name` - (Required) Name of the filter field. See the [DescribeCapacityReservations API Reference](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeCapacityReservations.html) for valid values. Common filters include `instance-type`, `availability-zone`, `state`, `instance-platform`, `tenancy`, `outpost-arn`, `placement-group-arn`, `instance-match-criteria`, and `tag:<KEY>`.
+* `values` - (Required) Set of values that are accepted for the given filter field. A Capacity Reservation will be selected if any one of the given values matches.
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `arn` - ARN of the Capacity Reservation.
+* `availability_zone` - Availability Zone in which the capacity is reserved.
+* `availability_zone_id` - ID of the Availability Zone in which the capacity is reserved.
+* `available_instance_count` - Remaining capacity, indicating the number of instances that can still be launched into the Capacity Reservation.
+* `commitment_info` - Information about your commitment for the Capacity Reservation, when applicable. See [`commitment_info` Attribute Reference](#commitment_info-attribute-reference) below.
+* `created_date` - Date and time the Capacity Reservation was created in [RFC3339 format](https://tools.ietf.org/html/rfc3339#section-5.8).
+* `ebs_optimized` - Whether the Capacity Reservation supports EBS-optimized instances.
+* `end_date` - Date and time the Capacity Reservation expires in [RFC3339 format](https://tools.ietf.org/html/rfc3339#section-5.8). Empty when `end_date_type` is `unlimited`.
+* `end_date_type` - End type of the Capacity Reservation. Either `limited` or `unlimited`.
+* `ephemeral_storage` - Whether the Capacity Reservation supports instance store volumes.
+* `instance_count` - Total number of instances for which the Capacity Reservation reserves capacity.
+* `instance_match_criteria` - Type of instance launches that the Capacity Reservation accepts. Either `open` or `targeted`.
+* `instance_platform` - Operating system platform for which the Capacity Reservation reserves capacity.
+* `instance_type` - Instance type for which the Capacity Reservation reserves capacity.
+* `interruptible_capacity_allocation` - Information about the interruptible capacity allocation, when applicable. See [`interruptible_capacity_allocation` Attribute Reference](#interruptible_capacity_allocation-attribute-reference) below.
+* `interruption_info` - Information about an interrupted Capacity Reservation, when applicable. See [`interruption_info` Attribute Reference](#interruption_info-attribute-reference) below.
+* `outpost_arn` - ARN of the Outpost on which the Capacity Reservation was created, if applicable.
+* `owner_id` - ID of the AWS account that owns the Capacity Reservation.
+* `placement_group_arn` - ARN of the cluster placement group in which the Capacity Reservation was created, if applicable.
+* `reservation_type` - Type of Capacity Reservation. Always `default` for this data source.
+* `start_date` - Date and time the Capacity Reservation was started in [RFC3339 format](https://tools.ietf.org/html/rfc3339#section-5.8).
+* `state` - Current state of the Capacity Reservation. One of `active`, `expired`, `cancelled`, `pending`, `failed`, `scheduled`, `payment-pending`, `payment-failed`, or `assessing`.
+* `tags` - Map of tags assigned to the Capacity Reservation.
+* `tenancy` - Tenancy of the Capacity Reservation. Either `default` or `dedicated`.
+
+### `commitment_info` Attribute Reference
+
+* `commitment_end_date` - Date and time the commitment duration ends in [RFC3339 format](https://tools.ietf.org/html/rfc3339#section-5.8).
+* `committed_instance_count` - Number of instances committed to the Capacity Reservation.
+
+### `interruptible_capacity_allocation` Attribute Reference
+
+* `instance_count` - Number of instances allocated as interruptible capacity within the Capacity Reservation.
+* `interruptible_capacity_reservation_id` - ID of the interruptible Capacity Reservation associated with this allocation.
+* `interruption_type` - Type of interruption that may occur. Either `spot-interruption` or `capacity-block-interruption`.
+* `status` - Status of the interruptible capacity allocation. One of `pending`, `confirmed`, or `cancelled`.
+* `target_instance_count` - Target number of interruptible instances for the allocation.
+
+### `interruption_info` Attribute Reference
+
+* `interruption_type` - Type of interruption that occurred. Either `spot-interruption` or `capacity-block-interruption`.
+* `source_capacity_reservation_id` - ID of the source Capacity Reservation that originally held the capacity, if the reservation was created as a result of an interruption.


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

### Description

Add a new `aws_ec2_capacity_reservation` data source for looking up On-Demand Capacity Reservations (ODCRs).

Accepts `id` or a `filter` block (any filter supported by `DescribeCapacityReservations`). Returns all API fields including nested computed attributes: `commitment_info`, `interruptible_capacity_allocation`, and `interruption_info`.

Implemented with Plugin Framework. Reuses the existing `findCapacityReservation` paginator and the `customFiltersBlock` / `newCustomFilterListFramework` pattern (same as `aws_ec2_host`, `aws_vpc_security_group_rule`).

### Relations

Closes #47485 (partially — ODCR half)

Companion PR for Capacity Blocks: #48185 

### References

- AWS API: [`DescribeCapacityReservations`](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeCapacityReservations.html)
- [Valid server-side filters](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeCapacityReservations.html#API_DescribeCapacityReservations_RequestParameters) (`instance-type`, `owner-id`, `instance-platform`, `availability-zone`, `tenancy`, `outpost-arn`, `state`, `end-date-type`, `instance-match-criteria`, `placement-group-arn`)
- Filter pattern modeled after: [`aws_ec2_host`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ec2_host)

### Output from Acceptance Testing

```console
% make testacc TESTS=TestAccEC2CapacityReservationDataSource PKG=ec2 GO_VER=go
=== RUN   TestAccEC2CapacityReservationDataSource_id
=== PAUSE TestAccEC2CapacityReservationDataSource_id
=== RUN   TestAccEC2CapacityReservationDataSource_filter
=== PAUSE TestAccEC2CapacityReservationDataSource_filter
=== CONT  TestAccEC2CapacityReservationDataSource_id
=== CONT  TestAccEC2CapacityReservationDataSource_filter
--- PASS: TestAccEC2CapacityReservationDataSource_id (24.32s)
--- PASS: TestAccEC2CapacityReservationDataSource_filter (24.59s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        24.780s
```