### PR TITLE
`skaff`: Use `acctest.ParallelTest` for data source and ephemeral resource tests

### DIFF
--- a/skaff/datasource/datasourcetest.gtpl
+++ b/skaff/datasource/datasourcetest.gtpl
@@ -165,7 +165,7 @@ func TestAcc{{ .Service }}{{ .DataSource }}DataSource_basic(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	dataSourceName := "data.aws_{{ .ServicePackage }}_{{ .DataSourceSnake }}.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, names.{{ .Service }}EndpointID)

--- a/skaff/ephemeral/ephemeraltest.gtpl
+++ b/skaff/ephemeral/ephemeraltest.gtpl
@@ -170,7 +170,7 @@ func TestAcc{{ .Service }}{{ .EphemeralResource }}DataSource_basic(t *testing.T)
     dataPath := tfjsonpath.New("data")
     secretString := "super-secret"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, names.{{ .Service }}EndpointID)


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

`skaff`: Use `acctest.ParallelTest` for data source and ephemeral resource tests