### PR TITLE
fix(fms): resource_tag_logical_operator silently changes from OR to AND

### DIFF
--- a/.changelog/48207.txt
+++ b/.changelog/48207.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_fms_policy: Fix `resource_tag_logical_operator` silently changing from OR to AND when not set in config
+```

--- a/internal/service/fms/policy.go
+++ b/internal/service/fms/policy.go
@@ -501,7 +501,9 @@ func expandPolicy(d *schema.ResourceData) *awstypes.Policy {
 				Key:   aws.String(k),
 				Value: aws.String(v),
 			})
-			apiObject.ResourceTagLogicalOperator = awstypes.ResourceTagLogicalOperator(d.Get("resource_tag_logical_operator").(string))
+		}
+		if v, ok := d.GetOk("resource_tag_logical_operator"); ok {
+			apiObject.ResourceTagLogicalOperator = awstypes.ResourceTagLogicalOperator(v.(string))
 		}
 	}
 


### PR DESCRIPTION
The `resource_tag_logical_operator` attribute in `aws_fms_policy` was being set inside the resource tags loop using `d.Get()`, which returns an empty string when the attribute is not explicitly set. This silently changed the API value from OR to AND without showing a diff in the plan.

Switched to `d.GetOk()` so the attribute is only set when explicitly provided, preserving the existing API behavior when it's not configured.