### PR TITLE
🤖🤖🤖 r/aws_lakeformation_data_cells_filter: Preserve empty excluded columns

### DIFF
--- a/.changelog/48209.txt
+++ b/.changelog/48209.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_lakeformation_data_cells_filter: Fix inconsistent result when `column_wildcard.excluded_column_names` is configured as an empty set
+```

--- a/internal/service/lakeformation/data_cells_filter.go
+++ b/internal/service/lakeformation/data_cells_filter.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/resourcevalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -231,6 +232,11 @@ func (r *dataCellsFilterResource) Create(ctx context.Context, req resource.Creat
 		return
 	}
 
+	resp.Diagnostics.Append(td.preserveEmptyColumnWildcardExcludedColumnNames(ctx, *planTD)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	state.TableData = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &td)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
@@ -241,6 +247,12 @@ func (r *dataCellsFilterResource) Read(ctx context.Context, req resource.ReadReq
 
 	var state dataCellsFilterResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	stateTD, diags := state.TableData.ToPtr(ctx)
+	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -264,6 +276,13 @@ func (r *dataCellsFilterResource) Read(ctx context.Context, req resource.ReadReq
 
 	if resp.Diagnostics.HasError() {
 		return
+	}
+
+	if stateTD != nil {
+		resp.Diagnostics.Append(td.preserveEmptyColumnWildcardExcludedColumnNames(ctx, *stateTD)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	state.TableData = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &td)
@@ -312,6 +331,16 @@ func (r *dataCellsFilterResource) Update(ctx context.Context, req resource.Updat
 			return
 		}
 
+		planTD, diags := plan.TableData.ToPtr(ctx)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		resp.Diagnostics.Append(td.preserveEmptyColumnWildcardExcludedColumnNames(ctx, *planTD)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 		plan.TableData = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &td)
 	}
 
@@ -431,6 +460,36 @@ type tableData struct {
 
 type columnWildcard struct {
 	ExcludedColumnNames fwtypes.SetOfString `tfsdk:"excluded_column_names"`
+}
+
+func (td *tableData) preserveEmptyColumnWildcardExcludedColumnNames(ctx context.Context, prior tableData) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	if td.ColumnWildcard.IsNull() || td.ColumnWildcard.IsUnknown() || prior.ColumnWildcard.IsNull() || prior.ColumnWildcard.IsUnknown() {
+		return diags
+	}
+
+	columnWildcard, d := td.ColumnWildcard.ToPtr(ctx)
+	diags.Append(d...)
+	if diags.HasError() || columnWildcard == nil {
+		return diags
+	}
+
+	priorColumnWildcard, d := prior.ColumnWildcard.ToPtr(ctx)
+	diags.Append(d...)
+	if diags.HasError() || priorColumnWildcard == nil {
+		return diags
+	}
+
+	if columnWildcard.ExcludedColumnNames.IsNull() &&
+		!priorColumnWildcard.ExcludedColumnNames.IsNull() &&
+		!priorColumnWildcard.ExcludedColumnNames.IsUnknown() &&
+		len(priorColumnWildcard.ExcludedColumnNames.Elements()) == 0 {
+		columnWildcard.ExcludedColumnNames = priorColumnWildcard.ExcludedColumnNames
+		td.ColumnWildcard = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, columnWildcard)
+	}
+
+	return diags
 }
 
 type rowFilter struct {

--- a/internal/service/lakeformation/data_cells_filter_internal_test.go
+++ b/internal/service/lakeformation/data_cells_filter_internal_test.go
@@ -1,0 +1,103 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package lakeformation
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+)
+
+func TestDataCellsFilterPreserveEmptyColumnWildcardExcludedColumnNames(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	emptySet := fwtypes.NewSetValueOfMust[types.String](ctx, []attr.Value{})
+	nonEmptySet := fwtypes.NewSetValueOfMust[types.String](ctx, []attr.Value{
+		types.StringValue("column_name"),
+	})
+
+	t.Run("preserves empty prior set", func(t *testing.T) {
+		current := tableData{
+			ColumnWildcard: fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &columnWildcard{
+				ExcludedColumnNames: fwtypes.NewSetValueOfNull[types.String](ctx),
+			}),
+		}
+		prior := tableData{
+			ColumnWildcard: fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &columnWildcard{
+				ExcludedColumnNames: emptySet,
+			}),
+		}
+
+		diags := current.preserveEmptyColumnWildcardExcludedColumnNames(ctx, prior)
+		if diags.HasError() {
+			t.Fatalf("unexpected diagnostics: %s", diags.Errors())
+		}
+
+		currentColumnWildcard, diags := current.ColumnWildcard.ToPtr(ctx)
+		if diags.HasError() {
+			t.Fatalf("unexpected diagnostics: %s", diags.Errors())
+		}
+
+		if !currentColumnWildcard.ExcludedColumnNames.Equal(emptySet) {
+			t.Fatalf("expected empty excluded column names to be preserved, got %s", currentColumnWildcard.ExcludedColumnNames.String())
+		}
+	})
+
+	t.Run("ignores non-empty prior set", func(t *testing.T) {
+		current := tableData{
+			ColumnWildcard: fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &columnWildcard{
+				ExcludedColumnNames: fwtypes.NewSetValueOfNull[types.String](ctx),
+			}),
+		}
+		prior := tableData{
+			ColumnWildcard: fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &columnWildcard{
+				ExcludedColumnNames: nonEmptySet,
+			}),
+		}
+
+		diags := current.preserveEmptyColumnWildcardExcludedColumnNames(ctx, prior)
+		if diags.HasError() {
+			t.Fatalf("unexpected diagnostics: %s", diags.Errors())
+		}
+
+		currentColumnWildcard, diags := current.ColumnWildcard.ToPtr(ctx)
+		if diags.HasError() {
+			t.Fatalf("unexpected diagnostics: %s", diags.Errors())
+		}
+
+		if !currentColumnWildcard.ExcludedColumnNames.IsNull() {
+			t.Fatalf("expected non-empty prior excluded column names not to be copied, got %s", currentColumnWildcard.ExcludedColumnNames.String())
+		}
+	})
+
+	t.Run("keeps current set", func(t *testing.T) {
+		current := tableData{
+			ColumnWildcard: fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &columnWildcard{
+				ExcludedColumnNames: nonEmptySet,
+			}),
+		}
+		prior := tableData{
+			ColumnWildcard: fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &columnWildcard{
+				ExcludedColumnNames: emptySet,
+			}),
+		}
+
+		diags := current.preserveEmptyColumnWildcardExcludedColumnNames(ctx, prior)
+		if diags.HasError() {
+			t.Fatalf("unexpected diagnostics: %s", diags.Errors())
+		}
+
+		currentColumnWildcard, diags := current.ColumnWildcard.ToPtr(ctx)
+		if diags.HasError() {
+			t.Fatalf("unexpected diagnostics: %s", diags.Errors())
+		}
+
+		if !currentColumnWildcard.ExcludedColumnNames.Equal(nonEmptySet) {
+			t.Fatalf("expected current excluded column names to be preserved, got %s", currentColumnWildcard.ExcludedColumnNames.String())
+		}
+	})
+}


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

### Description

Preserves a configured empty `table_data.column_wildcard.excluded_column_names` set when the Lake Formation API returns the column wildcard without excluded column names.

After AWS readback is flattened, the provider currently converts the nil/empty API value to Terraform null. When configuration explicitly sets `excluded_column_names = []`, that produces an inconsistent result after apply. This change carries forward only the prior/plan empty set for this specific field and only when the freshly flattened value is null.

AI usage: An LLM coding agent assisted with investigating the state preservation path, implementing the helper/test, and drafting this PR. I reviewed the diff and local validation output before submitting.

### Relations

Closes #48208

### References


### Output from Acceptance Testing

Acceptance tests were not run because they require AWS resources.

A local package test was attempted for the new unit coverage, but the local Go compiler process was terminated by the environment while compiling the provider dependency graph before a test result was produced.