### PR TITLE
Enable Resource Identity test generation for all services

### DIFF
--- a/internal/service/accessanalyzer/generate.go
+++ b/internal/service/accessanalyzer/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ListTags -ServiceTagsMap -UpdateTags -KVTValues
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 //go:generate go run ../../generate/tagstests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 

--- a/internal/service/account/generate.go
+++ b/internal/service/account/generate.go
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 //go:generate go run ../../generate/tagstests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 

--- a/internal/service/amplify/generate.go
+++ b/internal/service/amplify/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ListTags -ServiceTagsMap -UpdateTags -KVTValues
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 //go:generate go run ../../generate/tagstests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 

--- a/internal/service/appconfig/generate.go
+++ b/internal/service/appconfig/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ListTags -ServiceTagsMap -UpdateTags -KVTValues
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 //go:generate go run ../../generate/tagstests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 

--- a/internal/service/appintegrations/generate.go
+++ b/internal/service/appintegrations/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ServiceTagsMap -UpdateTags -KVTValues -ListTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 //go:generate go run ../../generate/tagstests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 

--- a/internal/service/applicationinsights/generate.go
+++ b/internal/service/applicationinsights/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ListTags -ListTagsInIDElem=ResourceARN -ServiceTagsSlice -TagInIDElem=ResourceARN -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 //go:generate go run ../../generate/tagstests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 

--- a/internal/service/applicationsignals/generate.go
+++ b/internal/service/applicationsignals/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ListTags -ServiceTagsSlice -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package applicationsignals

--- a/internal/service/appmesh/generate.go
+++ b/internal/service/appmesh/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ListTags -ListTagsOpPaginated -ServiceTagsSlice -TagType=TagRef -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 //go:generate go run ../../generate/tagstests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 

--- a/internal/service/appstream/generate.go
+++ b/internal/service/appstream/generate.go
@@ -4,6 +4,7 @@
 //go:generate go run ../../generate/listpages/main.go -ListOps=DescribeDirectoryConfigs,DescribeFleets,DescribeImageBuilders,DescribeStacks,DescribeUsers,DescribeUserStackAssociations,ListAssociatedStacks
 //go:generate go run ../../generate/tags/main.go -ListTags -ServiceTagsMap -UpdateTags -KVTValues
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package appstream

--- a/internal/service/athena/generate.go
+++ b/internal/service/athena/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ListTags -ListTagsOpPaginated -ListTagsInIDElem=ResourceARN -ServiceTagsSlice -TagInIDElem=ResourceARN -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package athena

--- a/internal/service/autoscalingplans/generate.go
+++ b/internal/service/autoscalingplans/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/listpages/main.go -ListOps=DescribeScalingPlans
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package autoscalingplans

--- a/internal/service/bedrockagent/generate.go
+++ b/internal/service/bedrockagent/generate.go
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 //go:generate go run ../../generate/tags/main.go -ServiceTagsMap -KVTValues -ListTags -UpdateTags
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 

--- a/internal/service/billing/generate.go
+++ b/internal/service/billing/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ServiceTagsSlice -TagType=ResourceTag -ListTags -UpdateTags -ListTagsOutTagsElem=ResourceTags -UntagInTagsElem=ResourceTagKeys -TagInTagsElem=ResourceTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package billing

--- a/internal/service/budgets/generate.go
+++ b/internal/service/budgets/generate.go
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 //go:generate go run ../../generate/tags/main.go -ListTags -ServiceTagsSlice -TagType=ResourceTag -TagInIDElem=ResourceARN -UntagInTagsElem=ResourceTagKeys -UpdateTags -ListTagsInIDElem=ResourceARN -ListTagsOutTagsElem=ResourceTags -TagInTagsElem=ResourceTags
 //go:generate go run ../../generate/tagstests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.

--- a/internal/service/chatbot/generate.go
+++ b/internal/service/chatbot/generate.go
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 //go:generate go run ../../generate/tags/main.go -ListTags -ListTagsInIDElem=ResourceARN -ServiceTagsSlice -KVTValues -TagOp=TagResource -TagInIDElem=ResourceARN -UntagOp=UntagResource -UpdateTags -TagTypeKeyElem=TagKey -TagTypeValElem=TagValue
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 

--- a/internal/service/chime/generate.go
+++ b/internal/service/chime/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ListTags -ListTagsInIDElem=ResourceARN -ServiceTagsSlice -TagInIDElem=ResourceARN -UpdateTags -AWSSDKServicePackage=chimesdkvoice
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package chime

--- a/internal/service/chimesdkvoice/generate.go
+++ b/internal/service/chimesdkvoice/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ListTags -ListTagsInIDElem=ResourceARN -ServiceTagsSlice -TagInIDElem=ResourceARN -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package chimesdkvoice

--- a/internal/service/cloud9/generate.go
+++ b/internal/service/cloud9/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ListTags -ListTagsInIDElem=ResourceARN -ServiceTagsSlice -TagInIDElem=ResourceARN -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package cloud9

--- a/internal/service/cloudcontrol/generate.go
+++ b/internal/service/cloudcontrol/generate.go
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package cloudcontrol

--- a/internal/service/cloudformation/generate.go
+++ b/internal/service/cloudformation/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ServiceTagsSlice
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package cloudformation

--- a/internal/service/cloudhsmv2/generate.go
+++ b/internal/service/cloudhsmv2/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ListTags -ListTagsOp=ListTags -ListTagsOpPaginated -ListTagsInIDElem=ResourceId -ListTagsOutTagsElem=TagList -ServiceTagsSlice -TagInIDElem=ResourceId -TagInTagsElem=TagList -UntagInTagsElem=TagKeyList -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package cloudhsmv2

--- a/internal/service/cloudsearch/generate.go
+++ b/internal/service/cloudsearch/generate.go
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package cloudsearch

--- a/internal/service/codecatalyst/generate.go
+++ b/internal/service/codecatalyst/generate.go
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package codecatalyst

--- a/internal/service/codecommit/generate.go
+++ b/internal/service/codecommit/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ListTags -ServiceTagsMap -UpdateTags -KVTValues
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package codecommit

--- a/internal/service/codeguruprofiler/generate.go
+++ b/internal/service/codeguruprofiler/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -KVTValues -ServiceTagsMap -ListTags -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package codeguruprofiler

--- a/internal/service/cognitoidentity/generate.go
+++ b/internal/service/cognitoidentity/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ListTags -ServiceTagsMap -UpdateTags -KVTValues
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package cognitoidentity

--- a/internal/service/computeoptimizer/generate.go
+++ b/internal/service/computeoptimizer/generate.go
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package computeoptimizer

--- a/internal/service/connectcases/generate.go
+++ b/internal/service/connectcases/generate.go
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package connectcases

--- a/internal/service/controltower/generate.go
+++ b/internal/service/controltower/generate.go
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 //go:generate go run ../../generate/tags/main.go -ServiceTagsMap -KVTValues -ListTags -UpdateTags
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 

--- a/internal/service/costoptimizationhub/generate.go
+++ b/internal/service/costoptimizationhub/generate.go
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package costoptimizationhub

--- a/internal/service/cur/generate.go
+++ b/internal/service/cur/generate.go
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 //go:generate go run ../../generate/tags/main.go -ServiceTagsSlice -ListTags -ListTagsInIDElem=ReportName -UpdateTags -TagInIDElem=ReportName -KVTValues
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 

--- a/internal/service/customerprofiles/generate.go
+++ b/internal/service/customerprofiles/generate.go
@@ -4,6 +4,7 @@
 //go:generate go run ../../generate/tags/main.go -ServiceTagsMap -KVTValues -ListTags -UpdateTags
 //go:generate go run ../../generate/listpages/main.go -ListOps=ListDomains,SearchProfiles
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package customerprofiles

--- a/internal/service/databrew/generate.go
+++ b/internal/service/databrew/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -KVTValues -ListTags -ServiceTagsMap -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package databrew

--- a/internal/service/dataexchange/generate.go
+++ b/internal/service/dataexchange/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -KVTValues -ListTags -ServiceTagsMap -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 //go:generate go run ../../generate/tagstests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 

--- a/internal/service/datapipeline/generate.go
+++ b/internal/service/datapipeline/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ListTagsInIDElem=PipelineId -ServiceTagsSlice -TagOp=AddTags -TagInIDElem=PipelineId -UntagOp=RemoveTags -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 //go:generate go run ../../generate/tagstests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 

--- a/internal/service/dax/generate.go
+++ b/internal/service/dax/generate.go
@@ -4,6 +4,7 @@
 //go:generate go run ../../generate/tags/main.go -ListTags -ListTagsOp=ListTags -ListTagsInIDElem=ResourceName -ServiceTagsSlice -TagInIDElem=ResourceName -UpdateTags
 //go:generate go run ../../generate/listpages/main.go -ListOps=DescribeClusters
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package dax

--- a/internal/service/deploy/generate.go
+++ b/internal/service/deploy/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ListTags -ServiceTagsSlice -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package deploy

--- a/internal/service/detective/generate.go
+++ b/internal/service/detective/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -KVTValues -ListTags -ServiceTagsMap -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package detective

--- a/internal/service/dlm/generate.go
+++ b/internal/service/dlm/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -KVTValues -ListTags -ServiceTagsMap -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package dlm

--- a/internal/service/docdb/generate.go
+++ b/internal/service/docdb/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ListTags -ListTagsInIDElem=ResourceName -ListTagsOutTagsElem=TagList -ServiceTagsSlice -TagOp=AddTagsToResource -TagInIDElem=ResourceName -UntagOp=RemoveTagsFromResource -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package docdb

--- a/internal/service/drs/generate.go
+++ b/internal/service/drs/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ListTags -ListTagsInIDElem=ResourceArn -ServiceTagsMap -KVTValues -TagOp=TagResource -TagInIDElem=ResourceArn -UntagOp=UntagResource -ListTags -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 //go:generate go run ../../generate/tagstests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 

--- a/internal/service/ds/generate.go
+++ b/internal/service/ds/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ListTags -ListTagsOpPaginated -ListTagsInIDElem=ResourceId -ServiceTagsSlice -TagOp=AddTagsToResource -TagInIDElem=ResourceId -UntagOp=RemoveTagsFromResource -UpdateTags -CreateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package ds

--- a/internal/service/dsql/generate.go
+++ b/internal/service/dsql/generate.go
@@ -4,6 +4,7 @@
 //go:generate go run ../../generate/tags/main.go -KVTValues -ListTags -ServiceTagsMap -UpdateTags
 //go:generate go run ../../generate/tagstests/main.go
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package dsql

--- a/internal/service/ecrpublic/generate.go
+++ b/internal/service/ecrpublic/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ListTags -ServiceTagsSlice -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package ecrpublic

--- a/internal/service/efs/generate.go
+++ b/internal/service/efs/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ListTags -ListTagsOp=DescribeTags -ListTagsOpPaginated -ListTagsInIDElem=FileSystemId -ServiceTagsSlice -TagInIDElem=ResourceId -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package efs

--- a/internal/service/elasticache/generate.go
+++ b/internal/service/elasticache/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -CreateTags -ListTags -ListTagsInIDElem=ResourceName -ListTagsOutTagsElem=TagList -ServiceTagsSlice -TagOp=AddTagsToResource -TagInIDElem=ResourceName -UntagOp=RemoveTagsFromResource -UpdateTags -RetryTagOps -RetryTagsListTagsType=ListTagsForResourceOutput -RetryErrorCode=awstypes.InvalidReplicationGroupStateFault "-RetryErrorMessage=not in available state" -RetryTimeout=15m
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package elasticache

--- a/internal/service/elasticbeanstalk/generate.go
+++ b/internal/service/elasticbeanstalk/generate.go
@@ -4,6 +4,7 @@
 //go:generate go run ../../generate/tags/main.go -KVTValues -ListTags -ListTagsOutTagsElem=ResourceTags -ServiceTagsSlice -TagOp=UpdateTagsForResource -TagInTagsElem=TagsToAdd -UntagOp=UpdateTagsForResource -UntagInTagsElem=TagsToRemove -UpdateTags
 //go:generate go run ../../generate/listpages/main.go -ListOps=DescribeApplicationVersions,DescribeEnvironments
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package elasticbeanstalk

--- a/internal/service/elasticsearch/generate.go
+++ b/internal/service/elasticsearch/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ListTags -ListTagsOp=ListTags -ListTagsInIDElem=ARN -ListTagsOutTagsElem=TagList -ServiceTagsSlice -TagOp=AddTags -TagInIDElem=ARN -TagInTagsElem=TagList -UntagOp=RemoveTags -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package elasticsearch

--- a/internal/service/elastictranscoder/generate.go
+++ b/internal/service/elastictranscoder/generate.go
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package elastictranscoder

--- a/internal/service/emr/generate.go
+++ b/internal/service/emr/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ServiceTagsSlice -TagInIDElem=ResourceId -TagOp=AddTags -UntagOp=RemoveTags -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package emr

--- a/internal/service/emrcontainers/generate.go
+++ b/internal/service/emrcontainers/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -KVTValues -ListTags -ServiceTagsMap -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package emrcontainers

--- a/internal/service/emrserverless/generate.go
+++ b/internal/service/emrserverless/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ListTags -ServiceTagsMap -UpdateTags -KVTValues
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package emrserverless

--- a/internal/service/evidently/generate.go
+++ b/internal/service/evidently/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ServiceTagsMap -KVTValues -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package evidently

--- a/internal/service/evs/generate.go
+++ b/internal/service/evs/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ServiceTagsMap -KVTValues -ListTags -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package evs

--- a/internal/service/finspace/generate.go
+++ b/internal/service/finspace/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ServiceTagsMap -KVTValues -ListTags -CreateTags -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package finspace

--- a/internal/service/fis/generate.go
+++ b/internal/service/fis/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ListTags -ServiceTagsMap -UpdateTags -KVTValues
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package fis

--- a/internal/service/fms/generate.go
+++ b/internal/service/fms/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ListTags -ListTagsOp=ListTagsForResource -ListTagsInIDElem=ResourceArn -ListTagsOutTagsElem=TagList -ServiceTagsSlice -TagOp=TagResource -TagInTagsElem=TagList -TagInIDElem=ResourceArn -UpdateTags -TagType=Tag
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 //go:generate go run ../../generate/tagstests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 

--- a/internal/service/fsx/generate.go
+++ b/internal/service/fsx/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ListTags -ListTagsOpPaginated -ListTagsInIDElem=ResourceARN -ServiceTagsSlice -TagInIDElem=ResourceARN -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package fsx

--- a/internal/service/gamelift/generate.go
+++ b/internal/service/gamelift/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ListTags -ListTagsInIDElem=ResourceARN -ServiceTagsSlice -TagInIDElem=ResourceARN -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package gamelift

--- a/internal/service/glacier/generate.go
+++ b/internal/service/glacier/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ListTags -ListTagsOp=ListTagsForVault -ListTagsInIDElem=VaultName -ServiceTagsMap -KVTValues -TagOp=AddTagsToVault -TagInIDElem=VaultName -UntagOp=RemoveTagsFromVault -UpdateTags -CreateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package glacier

--- a/internal/service/grafana/generate.go
+++ b/internal/service/grafana/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ListTags -ServiceTagsMap -UpdateTags -KVTValues
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package grafana

--- a/internal/service/greengrass/generate.go
+++ b/internal/service/greengrass/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ListTags -ServiceTagsMap -UpdateTags -KVTValues
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package greengrass

--- a/internal/service/groundstation/generate.go
+++ b/internal/service/groundstation/generate.go
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package groundstation

--- a/internal/service/guardduty/generate.go
+++ b/internal/service/guardduty/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ServiceTagsMap -KVTValues -ListTags -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 //go:generate go run ../../generate/tagstests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 

--- a/internal/service/healthlake/generate.go
+++ b/internal/service/healthlake/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -KVTValues=true -TagInIDElem=ResourceARN -ListTagsInIDElem=ResourceARN -ListTags -ServiceTagsSlice -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package healthlake

--- a/internal/service/identitystore/generate.go
+++ b/internal/service/identitystore/generate.go
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package identitystore

--- a/internal/service/internetmonitor/generate.go
+++ b/internal/service/internetmonitor/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ListTags -ListTagsInIDElem=ResourceArn -ServiceTagsMap -KVTValues -TagInIDElem=ResourceArn -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package internetmonitor

--- a/internal/service/kafkaconnect/generate.go
+++ b/internal/service/kafkaconnect/generate.go
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 //go:generate go run ../../generate/tags/main.go -ServiceTagsMap -ListTags -UpdateTags -KVTValues
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 

--- a/internal/service/kendra/generate.go
+++ b/internal/service/kendra/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -TagInIDElem=ResourceARN -ListTags -ListTagsInIDElem=ResourceARN -ServiceTagsSlice -UpdateTags -UntagInTagsElem=TagKeys
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package kendra

--- a/internal/service/keyspaces/generate.go
+++ b/internal/service/keyspaces/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ListTags -ListTagsOpPaginated -ServiceTagsSlice -UpdateTags -UntagInTagsElem=Tags -UntagInNeedTagType
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package keyspaces

--- a/internal/service/kinesisanalytics/generate.go
+++ b/internal/service/kinesisanalytics/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ListTags -ListTagsInIDElem=ResourceARN -ServiceTagsSlice -TagInIDElem=ResourceARN -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package kinesisanalytics

--- a/internal/service/kinesisanalyticsv2/generate.go
+++ b/internal/service/kinesisanalyticsv2/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ListTags -ListTagsInIDElem=ResourceARN -ServiceTagsSlice -TagInIDElem=ResourceARN -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package kinesisanalyticsv2

--- a/internal/service/kinesisvideo/generate.go
+++ b/internal/service/kinesisvideo/generate.go
@@ -4,6 +4,7 @@
 //go:generate go run ../../generate/listpages/main.go -ListOps=ListTagsForStream
 //go:generate go run ../../generate/tags/main.go -KVTValues -ListTags -ListTagsOpPaginated -ListTagsOpPaginatorCustom -ListTagsOp=ListTagsForStream -ListTagsInIDElem=StreamARN -ServiceTagsMap -TagOp=TagStream -TagInIDElem=StreamARN -UntagOp=UntagStream -UntagInTagsElem=TagKeyList -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package kinesisvideo

--- a/internal/service/launchwizard/generate.go
+++ b/internal/service/launchwizard/generate.go
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package launchwizard

--- a/internal/service/lexmodels/generate.go
+++ b/internal/service/lexmodels/generate.go
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package lexmodels

--- a/internal/service/lexv2models/generate.go
+++ b/internal/service/lexv2models/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ServiceTagsMap -KVTValues -TagInIDElem=ResourceARN -ListTagsInIDElem=ResourceARN -ListTags -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package lexv2models

--- a/internal/service/licensemanager/generate.go
+++ b/internal/service/licensemanager/generate.go
@@ -4,6 +4,7 @@
 //go:generate go run ../../generate/tags/main.go -ServiceTagsSlice -UpdateTags
 //go:generate go run ../../generate/listpages/main.go -ListOps=ListLicenseConfigurations,ListLicenseSpecificationsForResource,ListReceivedLicenses,ListDistributedGrants,ListReceivedGrants
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package licensemanager

--- a/internal/service/lightsail/generate.go
+++ b/internal/service/lightsail/generate.go
@@ -4,6 +4,7 @@
 //go:generate go run ../../generate/listpages/main.go -ListOps=GetRelationalDatabases,GetLoadBalancers,GetDisks,GetDistributions,GetDomains -InputPaginator=PageToken -OutputPaginator=NextPageToken
 //go:generate go run ../../generate/tags/main.go -ServiceTagsSlice -TagInIDElem=ResourceName -CreateTags -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package lightsail

--- a/internal/service/location/generate.go
+++ b/internal/service/location/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ServiceTagsMap -UpdateTags -ListTags -KVTValues
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package location

--- a/internal/service/m2/generate.go
+++ b/internal/service/m2/generate.go
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 //go:generate go run ../../generate/tags/main.go -ListTags -ServiceTagsMap -UpdateTags -KVTValues
 //go:generate go run ../../generate/tagstests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file

--- a/internal/service/mediaconnect/generate.go
+++ b/internal/service/mediaconnect/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -KVTValues -ListTags -ServiceTagsMap -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package mediaconnect

--- a/internal/service/mediaconvert/generate.go
+++ b/internal/service/mediaconvert/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ListTags -ListTagsInIDElem=Arn -ListTagsOutTagsElem=ResourceTags.Tags -ServiceTagsMap -TagInIDElem=Arn -UpdateTags -KVTValues
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package mediaconvert

--- a/internal/service/medialive/generate.go
+++ b/internal/service/medialive/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -KVTValues=true -ListTags -ServiceTagsMap -TagOp=CreateTags -UntagOp=DeleteTags -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 //go:generate go run ../../generate/tagstests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 

--- a/internal/service/mediapackage/generate.go
+++ b/internal/service/mediapackage/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -KVTValues -ListTags -ServiceTagsMap -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package mediapackage

--- a/internal/service/mediapackagev2/generate.go
+++ b/internal/service/mediapackagev2/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -KVTValues -ListTags -ServiceTagsMap -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 //go:generate go run ../../generate/tagstests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 

--- a/internal/service/mediapackagevod/generate.go
+++ b/internal/service/mediapackagevod/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -KVTValues -ListTags -ServiceTagsMap -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package mediapackagevod

--- a/internal/service/mediastore/generate.go
+++ b/internal/service/mediastore/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ListTags -ListTagsInIDElem=Resource -ServiceTagsSlice -TagInIDElem=Resource -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package mediastore

--- a/internal/service/memorydb/generate.go
+++ b/internal/service/memorydb/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ListTags -ListTagsOp=ListTags -ListTagsOutTagsElem=TagList -ServiceTagsSlice -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package memorydb

--- a/internal/service/meta/generate.go
+++ b/internal/service/meta/generate.go
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package meta

--- a/internal/service/mgn/generate.go
+++ b/internal/service/mgn/generate.go
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package mgn

--- a/internal/service/mpa/generate.go
+++ b/internal/service/mpa/generate.go
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package mpa

--- a/internal/service/mq/generate.go
+++ b/internal/service/mq/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ListTags -ListTagsOp=ListTags -ServiceTagsMap -TagOp=CreateTags -UntagOp=DeleteTags -UpdateTags -KVTValues
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package mq

--- a/internal/service/mwaa/generate.go
+++ b/internal/service/mwaa/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -KVTValues -ListTagsOp=ListTags -ServiceTagsMap -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package mwaa

--- a/internal/service/mwaaserverless/generate.go
+++ b/internal/service/mwaaserverless/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -KVTValues -ListTagsOp=ListTags -ServiceTagsMap -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package mwaaserverless

--- a/internal/service/neptune/generate.go
+++ b/internal/service/neptune/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ListTags -ListTagsInIDElem=ResourceName -ListTagsOutTagsElem=TagList -ServiceTagsSlice -TagOp=AddTagsToResource -TagInIDElem=ResourceName -UntagOp=RemoveTagsFromResource -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package neptune

--- a/internal/service/neptunegraph/generate.go
+++ b/internal/service/neptunegraph/generate.go
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 //go:generate go run ../../generate/tags/main.go -KVTValues -ListTags -ServiceTagsMap -UpdateTags
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 

--- a/internal/service/networkflowmonitor/generate.go
+++ b/internal/service/networkflowmonitor/generate.go
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 //go:generate go run ../../generate/tags/main.go -KVTValues -ServiceTagsMap -ListTags -UpdateTags
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 

--- a/internal/service/networkmonitor/generate.go
+++ b/internal/service/networkmonitor/generate.go
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 //go:generate go run ../../generate/tags/main.go -KVTValues -ServiceTagsMap -ListTags -UpdateTags
 //go:generate go run ../../generate/tagstests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.

--- a/internal/service/notifications/generate.go
+++ b/internal/service/notifications/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ServiceTagsMap -KVTValues -UpdateTags -ListTags -ListTagsInIDElem=Arn -TagInIDElem=Arn
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package notifications

--- a/internal/service/notificationscontacts/generate.go
+++ b/internal/service/notificationscontacts/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ServiceTagsMap -KVTValues -UpdateTags -ListTags -ListTagsInIDElem=Arn -TagInIDElem=Arn
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package notificationscontacts

--- a/internal/service/oam/generate.go
+++ b/internal/service/oam/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -KVTValues=true -ListTags -ServiceTagsMap -TagOp=TagResource -UntagOp=UntagResource -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package oam

--- a/internal/service/odb/generate.go
+++ b/internal/service/odb/generate.go
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 //go:generate go run ../../generate/tags/main.go -ServiceTagsMap -KVTValues -ListTags -UpdateTags
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 

--- a/internal/service/opensearch/generate.go
+++ b/internal/service/opensearch/generate.go
@@ -4,6 +4,7 @@
 //go:generate go run ../../generate/tags/main.go -ListTags -ListTagsOp=ListTags -ListTagsInIDElem=ARN -ListTagsOutTagsElem=TagList -ServiceTagsSlice -TagOp=AddTags -TagInIDElem=ARN -TagInTagsElem=TagList -UntagOp=RemoveTags -UpdateTags
 //go:generate go run ../../generate/listpages/main.go -ListOps=ListVpcEndpointAccess
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package opensearch

--- a/internal/service/pcaconnectorad/generate.go
+++ b/internal/service/pcaconnectorad/generate.go
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package pcaconnectorad

--- a/internal/service/pcs/generate.go
+++ b/internal/service/pcs/generate.go
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package pcs

--- a/internal/service/pinpoint/generate.go
+++ b/internal/service/pinpoint/generate.go
@@ -4,6 +4,7 @@
 //go:generate go run ../../generate/tags/main.go -ListTags -ListTagsOutTagsElem=TagsModel.Tags -ServiceTagsMap "-TagInCustomVal=&awstypes.TagsModel{Tags: svcTags(updatedTags.IgnoreAWS())}" -TagInTagsElem=TagsModel -UpdateTags -KVTValues
 //go:generate go run ../../generate/listpages/main.go -ListOps=GetApps -OutputPaginator=ApplicationsResponse.NextToken -InputPaginator=Token
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package pinpoint

--- a/internal/service/pipes/generate.go
+++ b/internal/service/pipes/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ListTags -UpdateTags -ServiceTagsMap  -KVTValues
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package pipes

--- a/internal/service/polly/generate.go
+++ b/internal/service/polly/generate.go
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package polly

--- a/internal/service/pricing/generate.go
+++ b/internal/service/pricing/generate.go
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package pricing

--- a/internal/service/qbusiness/generate.go
+++ b/internal/service/qbusiness/generate.go
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 //go:generate go run ../../generate/tags/main.go -ListTags -ServiceTagsSlice -UpdateTags -ListTagsInIDElem=ResourceARN -TagInIDElem=ResourceARN
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 

--- a/internal/service/qldb/generate.go
+++ b/internal/service/qldb/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ListTags -ServiceTagsMap -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package qldb

--- a/internal/service/quicksight/generate.go
+++ b/internal/service/quicksight/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ListTags -ServiceTagsSlice -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 //go:generate go run ../../generate/tagstests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 

--- a/internal/service/rbin/generate.go
+++ b/internal/service/rbin/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ListTags -ListTagsOp=ListTagsForResource -ListTagsInIDElem=ResourceArn  -ServiceTagsSlice -TagOp=TagResource -TagInIDElem=ResourceArn  -UntagOp=UntagResource -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package rbin

--- a/internal/service/rdsdata/generate.go
+++ b/internal/service/rdsdata/generate.go
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package rdsdata

--- a/internal/service/redshiftdata/generate.go
+++ b/internal/service/redshiftdata/generate.go
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package redshiftdata

--- a/internal/service/redshiftserverless/generate.go
+++ b/internal/service/redshiftserverless/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ListTags -ServiceTagsSlice -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package redshiftserverless

--- a/internal/service/rekognition/generate.go
+++ b/internal/service/rekognition/generate.go
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 //go:generate go run ../../generate/tags/main.go -ServiceTagsMap -KVTValues -ListTags -UpdateTags
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 

--- a/internal/service/resiliencehub/generate.go
+++ b/internal/service/resiliencehub/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ServiceTagsMap -KVTValues -ListTags -ListTagsInIDElem=ResourceArn -ListTagsOutTagsElem=Tags  -TagOp=TagResource -TagInIDElem=ResourceArn -UntagOp=UntagResource -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 //go:generate go run ../../generate/tagstests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 

--- a/internal/service/resourcegroups/generate.go
+++ b/internal/service/resourcegroups/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ListTags -ListTagsOp=GetTags -ListTagsInIDElem=Arn -ServiceTagsMap -TagOp=Tag -TagInIDElem=Arn -UntagOp=Untag -UntagInTagsElem=Keys -UpdateTags -KVTValues
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package resourcegroups

--- a/internal/service/resourcegroupstaggingapi/generate.go
+++ b/internal/service/resourcegroupstaggingapi/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ServiceTagsSlice
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package resourcegroupstaggingapi

--- a/internal/service/rolesanywhere/generate.go
+++ b/internal/service/rolesanywhere/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ListTags -ServiceTagsSlice -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package rolesanywhere

--- a/internal/service/route53domains/generate.go
+++ b/internal/service/route53domains/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ListTags -ListTagsOp=ListTagsForDomain -ListTagsInIDElem=DomainName -ListTagsOutTagsElem=TagList -ServiceTagsSlice -UpdateTags -UntagOp=DeleteTagsForDomain -UntagInTagsElem=TagsToDelete -TagOp=UpdateTagsForDomain -TagInTagsElem=TagsToUpdate -TagInIDElem=DomainName -CreateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package route53domains

--- a/internal/service/route53profiles/generate.go
+++ b/internal/service/route53profiles/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ListTags -ListTagsInIDElem=ResourceArn -KVTValues -UpdateTags -TagInIDElem=ResourceArn -ServiceTagsMap
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package route53profiles

--- a/internal/service/route53recoverycontrolconfig/generate.go
+++ b/internal/service/route53recoverycontrolconfig/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ServiceTagsMap -CreateTags -ListTags -UpdateTags -KVTValues
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package route53recoverycontrolconfig

--- a/internal/service/route53recoveryreadiness/generate.go
+++ b/internal/service/route53recoveryreadiness/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ListTags -ListTagsOp=ListTagsForResources -UpdateTags -CreateTags -ServiceTagsMap -KVTValues
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package route53recoveryreadiness

--- a/internal/service/rum/generate.go
+++ b/internal/service/rum/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -KVTValues -ServiceTagsMap -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package rum

--- a/internal/service/s3outposts/generate.go
+++ b/internal/service/s3outposts/generate.go
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package s3outposts

--- a/internal/service/savingsplans/generate.go
+++ b/internal/service/savingsplans/generate.go
@@ -4,6 +4,7 @@
 //go:generate go run ../../generate/listpages/main.go -ListOps=DescribeSavingsPlans,DescribeSavingsPlansOfferings
 //go:generate go run ../../generate/tags/main.go -KVTValues -ServiceTagsMap -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY://go:generate go run ../../generate/tagstests/main.go
 
 package savingsplans

--- a/internal/service/scheduler/generate.go
+++ b/internal/service/scheduler/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ListTags -UpdateTags -ServiceTagsSlice
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package scheduler

--- a/internal/service/schemas/generate.go
+++ b/internal/service/schemas/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ListTags -ServiceTagsMap -UpdateTags -KVTValues
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package schemas

--- a/internal/service/serverlessrepo/generate.go
+++ b/internal/service/serverlessrepo/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ServiceTagsSlice
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package serverlessrepo

--- a/internal/service/servicecatalog/generate.go
+++ b/internal/service/servicecatalog/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ServiceTagsSlice
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 //go:generate go run ../../generate/tagstests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 

--- a/internal/service/servicecatalogappregistry/generate.go
+++ b/internal/service/servicecatalogappregistry/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ListTags -ServiceTagsMap -UpdateTags -KVTValues
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 //go:generate go run ../../generate/tagstests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 

--- a/internal/service/servicediscovery/generate.go
+++ b/internal/service/servicediscovery/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ListTags -ListTagsInIDElem=ResourceARN -ServiceTagsSlice -TagInIDElem=ResourceARN -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package servicediscovery

--- a/internal/service/ses/generate.go
+++ b/internal/service/ses/generate.go
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package ses

--- a/internal/service/sesv2/generate.go
+++ b/internal/service/sesv2/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ServiceTagsSlice -ListTags -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 //go:generate go run ../../generate/tagstests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 

--- a/internal/service/signer/generate.go
+++ b/internal/service/signer/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -KVTValues -ListTags -ServiceTagsMap -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package signer

--- a/internal/service/ssmincidents/generate.go
+++ b/internal/service/ssmincidents/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go  -TagInIDElem=ResourceArn -ListTags -ListTagsInIDElem=ResourceArn -ServiceTagsMap -UpdateTags -KVTValues
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package ssmincidents

--- a/internal/service/ssmquicksetup/generate.go
+++ b/internal/service/ssmquicksetup/generate.go
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 //go:generate go run ../../generate/tags/main.go -ServiceTagsMap -UpdateTags -KVTValues
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 

--- a/internal/service/ssmsap/generate.go
+++ b/internal/service/ssmsap/generate.go
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package ssmsap

--- a/internal/service/sso/generate.go
+++ b/internal/service/sso/generate.go
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package sso

--- a/internal/service/storagegateway/generate.go
+++ b/internal/service/storagegateway/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ListTags -ListTagsOpPaginated -ListTagsInIDElem=ResourceARN -ServiceTagsSlice -TagOp=AddTagsToResource -TagInIDElem=ResourceARN -UntagOp=RemoveTagsFromResource -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package storagegateway

--- a/internal/service/sts/generate.go
+++ b/internal/service/sts/generate.go
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package sts

--- a/internal/service/swf/generate.go
+++ b/internal/service/swf/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ListTags -ServiceTagsSlice -TagType=ResourceTag -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package swf

--- a/internal/service/synthetics/generate.go
+++ b/internal/service/synthetics/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ServiceTagsMap -KVTValues -ListTags -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package synthetics

--- a/internal/service/taxsettings/generate.go
+++ b/internal/service/taxsettings/generate.go
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package taxsettings

--- a/internal/service/timestreamquery/generate.go
+++ b/internal/service/timestreamquery/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ListTags -ListTagsOpPaginated -ListTagsInIDElem=ResourceARN -ServiceTagsSlice -TagInIDElem=ResourceARN -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package timestreamquery

--- a/internal/service/timestreamwrite/generate.go
+++ b/internal/service/timestreamwrite/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ListTags -ListTagsInIDElem=ResourceARN -ServiceTagsSlice -TagInIDElem=ResourceARN -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package timestreamwrite

--- a/internal/service/transcribe/generate.go
+++ b/internal/service/transcribe/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -TagInIDElem=ResourceArn -ListTags -ListTagsInIDElem=ResourceArn -ServiceTagsSlice -UpdateTags -UntagInTagsElem=TagKeys
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package transcribe

--- a/internal/service/transfer/generate.go
+++ b/internal/service/transfer/generate.go
@@ -5,6 +5,7 @@
 //go:generate go run ../../generate/tags/main.go -GetTag -ListTags -ListTagsOpPaginated -ListTagsInIDElem=Arn -ServiceTagsSlice -TagInIDElem=Arn -UpdateTags
 //go:generate go run ../../generate/tags/main.go -TagInIDElem=Arn -UpdateTags -UpdateTagsFunc=updateTagsNoIgnoreSystem -UpdateTagsNoIgnoreSystem -- update_tags_no_system_ignore_gen.go
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package transfer

--- a/internal/service/verifiedpermissions/generate.go
+++ b/internal/service/verifiedpermissions/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ListTags -KVTValues=true -ServiceTagsMap -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package verifiedpermissions

--- a/internal/service/vpclattice/generate.go
+++ b/internal/service/vpclattice/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ServiceTagsMap -KVTValues -ListTags -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 //go:generate go run ../../generate/tagstests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 

--- a/internal/service/waf/generate.go
+++ b/internal/service/waf/generate.go
@@ -4,6 +4,7 @@
 //go:generate go run ../../generate/listpages/main.go -ListOps=ListActivatedRulesInRuleGroup,ListByteMatchSets,ListGeoMatchSets,ListIPSets,ListRateBasedRules,ListRegexMatchSets,ListRegexPatternSets,ListRules,ListRuleGroups,ListSizeConstraintSets,ListSqlInjectionMatchSets,ListSubscribedRuleGroups,ListWebACLs,ListXssMatchSets -Paginator=NextMarker
 //go:generate go run ../../generate/tags/main.go -ListTags -ListTagsInIDElem=ResourceARN -ListTagsOutTagsElem=TagInfoForResource.TagList -ServiceTagsSlice -TagInIDElem=ResourceARN -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package waf

--- a/internal/service/wafregional/generate.go
+++ b/internal/service/wafregional/generate.go
@@ -4,6 +4,7 @@
 //go:generate go run ../../generate/listpages/main.go -ListOps=ListActivatedRulesInRuleGroup,ListByteMatchSets,ListGeoMatchSets,ListIPSets,ListRateBasedRules,ListRegexMatchSets,ListRegexPatternSets,ListRules,ListRuleGroups,ListSizeConstraintSets,ListSqlInjectionMatchSets,ListSubscribedRuleGroups,ListWebACLs,ListXssMatchSets -Paginator=NextMarker
 //go:generate go run ../../generate/tags/main.go -ListTags -ListTagsInIDElem=ResourceARN -ListTagsOutTagsElem=TagInfoForResource.TagList -ServiceTagsSlice -TagInIDElem=ResourceARN -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package wafregional

--- a/internal/service/wellarchitected/generate.go
+++ b/internal/service/wellarchitected/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ListTags -ListTagsInIDElem=WorkloadArn -UpdateTags -TagInIDElem=WorkloadArn -ServiceTagsMap -KVTValues
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package wellarchitected

--- a/internal/service/workspaces/generate.go
+++ b/internal/service/workspaces/generate.go
@@ -4,6 +4,7 @@
 //go:generate go run ../../generate/listpages/main.go -ListOps=DescribeConnectionAliases,DescribeIpGroups,DescribeWorkspaceImages
 //go:generate go run ../../generate/tags/main.go -ListTags -ListTagsOp=DescribeTags -ListTagsInIDElem=ResourceId -ListTagsOutTagsElem=TagList -ServiceTagsSlice -TagOp=CreateTags -TagInIDElem=ResourceId -UntagOp=DeleteTags -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package workspaces

--- a/internal/service/workspacesweb/generate.go
+++ b/internal/service/workspacesweb/generate.go
@@ -3,6 +3,7 @@
 
 //go:generate go run ../../generate/tags/main.go -ListTags -ServiceTagsSlice -KVTValues -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
+//go:generate go run ../../generate/identitytests/main.go
 //go:generate go run ../../generate/tagstests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Enables Resource Identity test generation for all services except `networkmanager` (#48217) and `uxc` (has failing tests).

No tests were added, just the generator command
