### PR TITLE
New Data Source: `aws_elasticache_service_updates`

### DIFF
--- a/.changelog/44608.txt
+++ b/.changelog/44608.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_elasticache_service_updates
+```

--- a/internal/service/elasticache/service_package_gen.go
+++ b/internal/service/elasticache/service_package_gen.go
@@ -34,6 +34,12 @@ func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*inttypes.S
 			Name:     "Serverless Cache",
 			Region:   inttypes.ResourceRegionDefault(),
 		},
+		{
+			Factory:  newServiceUpdatesDataSource,
+			TypeName: "aws_elasticache_service_updates",
+			Name:     "Service Updates",
+			Region:   inttypes.ResourceRegionDefault(),
+		},
 	}
 }
 

--- a/internal/service/elasticache/service_updates_data_source.go
+++ b/internal/service/elasticache/service_updates_data_source.go
@@ -110,7 +110,6 @@ func findServiceUpdates(ctx context.Context, conn *elasticache.Client, input *el
 		}
 
 		output = append(output, page.ServiceUpdates...)
-
 	}
 
 	return output, nil

--- a/internal/service/elasticache/service_updates_data_source.go
+++ b/internal/service/elasticache/service_updates_data_source.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
 	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/smerr"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 // @FrameworkDataSource("aws_elasticache_service_updates", name="Service Updates")
@@ -36,6 +37,11 @@ type serviceUpdatesDataSource struct {
 func (d *serviceUpdatesDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
+			names.AttrStatus: schema.SetAttribute{
+				Optional:    true,
+				CustomType:  fwtypes.SetOfStringEnumType[awstypes.ServiceUpdateStatus](),
+				ElementType: fwtypes.StringEnumType[awstypes.ServiceUpdateStatus](),
+			},
 			"service_updates": framework.DataSourceComputedListOfObjectAttribute[serviceUpdateModel](ctx),
 		},
 	}
@@ -51,6 +57,11 @@ func (d *serviceUpdatesDataSource) Read(ctx context.Context, req datasource.Read
 	}
 
 	var input elasticache.DescribeServiceUpdatesInput
+	resp.Diagnostics.Append(flex.Expand(ctx, data, &input)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	serviceUpdates, err := findServiceUpdates(ctx, conn, &input)
 	if err != nil {
 		smerr.AddError(ctx, &resp.Diagnostics, err)
@@ -67,7 +78,8 @@ func (d *serviceUpdatesDataSource) Read(ctx context.Context, req datasource.Read
 
 type serviceUpdatesDataSourceModel struct {
 	framework.WithRegionModel
-	ServiceUpdates fwtypes.ListNestedObjectValueOf[serviceUpdateModel] `tfsdk:"service_updates"`
+	ServiceUpdates      fwtypes.ListNestedObjectValueOf[serviceUpdateModel]   `tfsdk:"service_updates"`
+	ServiceUpdateStatus fwtypes.SetOfStringEnum[awstypes.ServiceUpdateStatus] `tfsdk:"status"`
 }
 
 type serviceUpdateModel struct {
@@ -86,7 +98,8 @@ type serviceUpdateModel struct {
 }
 
 func findServiceUpdates(ctx context.Context, conn *elasticache.Client, input *elasticache.DescribeServiceUpdatesInput) ([]awstypes.ServiceUpdate, error) {
-	var output []awstypes.ServiceUpdate
+	// Ensure that if no results are returned, an empty slice is returned instead of nil
+	output := make([]awstypes.ServiceUpdate, 0)
 
 	pages := elasticache.NewDescribeServiceUpdatesPaginator(conn, input)
 

--- a/internal/service/elasticache/service_updates_data_source.go
+++ b/internal/service/elasticache/service_updates_data_source.go
@@ -1,0 +1,104 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+// DONOTCOPY: Copying old resources spreads bad habits. Use skaff instead.
+
+package elasticache
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/elasticache"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/smerr"
+)
+
+// @FrameworkDataSource("aws_elasticache_service_updates", name="Service Updates")
+func newServiceUpdatesDataSource(context.Context) (datasource.DataSourceWithConfigure, error) {
+	return &serviceUpdatesDataSource{}, nil
+}
+
+const (
+	DSNameServiceUpdates = "Service Updates Data Source"
+)
+
+type serviceUpdatesDataSource struct {
+	framework.DataSourceWithModel[serviceUpdatesDataSourceModel]
+}
+
+func (d *serviceUpdatesDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"service_updates": framework.DataSourceComputedListOfObjectAttribute[serviceUpdateModel](ctx),
+		},
+	}
+}
+
+func (d *serviceUpdatesDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	conn := d.Meta().ElastiCacheClient(ctx)
+
+	var data serviceUpdatesDataSourceModel
+	smerr.AddEnrich(ctx, &resp.Diagnostics, req.Config.Get(ctx, &data))
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var input elasticache.DescribeServiceUpdatesInput
+	serviceUpdates, err := findServiceUpdates(ctx, conn, &input)
+	if err != nil {
+		smerr.AddError(ctx, &resp.Diagnostics, err)
+		return
+	}
+
+	smerr.AddEnrich(ctx, &resp.Diagnostics, flex.Flatten(ctx, serviceUpdates, &data.ServiceUpdates))
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, &data))
+}
+
+type serviceUpdatesDataSourceModel struct {
+	framework.WithRegionModel
+	ServiceUpdates fwtypes.ListNestedObjectValueOf[serviceUpdateModel] `tfsdk:"service_updates"`
+}
+
+type serviceUpdateModel struct {
+	AutoUpdateAfterRecommendedApplyByDate types.Bool        `tfsdk:"auto_update_after_recommended_apply_by_date"`
+	Engine                                types.String      `tfsdk:"engine"`
+	EngineVersion                         types.String      `tfsdk:"engine_version"`
+	EstimatedUpdateTime                   types.String      `tfsdk:"estimated_update_time"`
+	ServiceUpdateDescription              types.String      `tfsdk:"description"`
+	ServiceUpdateEndDate                  timetypes.RFC3339 `tfsdk:"end_date"`
+	ServiceUpdateName                     types.String      `tfsdk:"name"`
+	ServiceUpdateRecommendedApplyByDate   timetypes.RFC3339 `tfsdk:"recommended_apply_by_date"`
+	ServiceUpdateReleaseDate              timetypes.RFC3339 `tfsdk:"release_date"`
+	ServiceUpdateSeverity                 types.String      `tfsdk:"severity"`
+	ServiceUpdateStatus                   types.String      `tfsdk:"status"`
+	ServiceUpdateType                     types.String      `tfsdk:"type"`
+}
+
+func findServiceUpdates(ctx context.Context, conn *elasticache.Client, input *elasticache.DescribeServiceUpdatesInput) ([]awstypes.ServiceUpdate, error) {
+	var output []awstypes.ServiceUpdate
+
+	pages := elasticache.NewDescribeServiceUpdatesPaginator(conn, input)
+
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		output = append(output, page.ServiceUpdates...)
+
+	}
+
+	return output, nil
+}

--- a/internal/service/elasticache/service_updates_data_source_test.go
+++ b/internal/service/elasticache/service_updates_data_source_test.go
@@ -6,11 +6,13 @@ package elasticache_test
 import (
 	"testing"
 
+	awstypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	tfknownvalue "github.com/hashicorp/terraform-provider-aws/internal/acctest/knownvalue"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -19,7 +21,7 @@ func TestAccElastiCacheServiceUpdatesDataSource_basic(t *testing.T) {
 
 	dataSourceName := "data.aws_elasticache_service_updates.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, names.ElastiCacheEndpointID)
@@ -33,6 +35,51 @@ func TestAccElastiCacheServiceUpdatesDataSource_basic(t *testing.T) {
 				Config: testAccServiceUpdatesDataSourceConfig_basic(),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("service_updates"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("service_updates"), knownvalue.SetPartial([]knownvalue.Check{
+						knownvalue.ObjectPartial(map[string]knownvalue.Check{
+							names.AttrStatus: tfknownvalue.StringExact(awstypes.ServiceUpdateStatusAvailable),
+						}),
+						// There are currently no cancelled service updates
+						// knownvalue.ObjectPartial(map[string]knownvalue.Check{
+						// 	names.AttrStatus: tfknownvalue.StringExact(awstypes.ServiceUpdateStatusCancelled),
+						// }),
+						knownvalue.ObjectPartial(map[string]knownvalue.Check{
+							names.AttrStatus: tfknownvalue.StringExact(awstypes.ServiceUpdateStatusExpired),
+						}),
+					})),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrStatus), knownvalue.Null()),
+				},
+			},
+		},
+	})
+}
+
+func TestAccElastiCacheServiceUpdatesDataSource_bySingleStatus(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	dataSourceName := "data.aws_elasticache_service_updates.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.ElastiCacheEndpointID)
+			testAccPreCheck(t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             acctest.CheckDestroyNoop,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceUpdatesDataSourceConfig_bySingleStatus(),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("service_updates"), knownvalue.SetPartial([]knownvalue.Check{
+						knownvalue.ObjectPartial(map[string]knownvalue.Check{
+							names.AttrStatus: tfknownvalue.StringExact(awstypes.ServiceUpdateStatusAvailable),
+						}),
+					})),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrStatus), knownvalue.SetExact([]knownvalue.Check{
+						tfknownvalue.StringExact(awstypes.ServiceUpdateStatusAvailable),
+					})),
 				},
 			},
 		},
@@ -42,5 +89,13 @@ func TestAccElastiCacheServiceUpdatesDataSource_basic(t *testing.T) {
 func testAccServiceUpdatesDataSourceConfig_basic() string {
 	return `
 data "aws_elasticache_service_updates" "test" {}
+`
+}
+
+func testAccServiceUpdatesDataSourceConfig_bySingleStatus() string {
+	return `
+data "aws_elasticache_service_updates" "test" {
+  status = ["available"]
+}
 `
 }

--- a/internal/service/elasticache/service_updates_data_source_test.go
+++ b/internal/service/elasticache/service_updates_data_source_test.go
@@ -1,0 +1,46 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package elasticache_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccElastiCacheServiceUpdatesDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	dataSourceName := "data.aws_elasticache_service_updates.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.ElastiCacheEndpointID)
+			testAccPreCheck(t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             acctest.CheckDestroyNoop,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceUpdatesDataSourceConfig_basic(),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("service_updates"), knownvalue.NotNull()),
+				},
+			},
+		},
+	})
+}
+
+func testAccServiceUpdatesDataSourceConfig_basic() string {
+	return `
+data "aws_elasticache_service_updates" "test" {}
+`
+}

--- a/website/docs/d/elasticache_service_updates.html.markdown
+++ b/website/docs/d/elasticache_service_updates.html.markdown
@@ -1,0 +1,46 @@
+---
+subcategory: "ElastiCache"
+layout: "aws"
+page_title: "AWS: aws_elasticache_service_updates"
+description: |-
+  Provides details about AWS ElastiCache Service Updates.
+---
+
+# Data Source: aws_elasticache_service_updates
+
+Provides details about AWS ElastiCache Service Updates.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_elasticache_service_updates" "example" {
+  status = ["available"]
+}
+```
+
+## Argument Reference
+
+This data source supports the following arguments:
+
+* `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
+* `status` - (Optional) Set of one or more Service Update statuses. Elements must be one of `available`, `cancelled`, or `expired`.
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `service_updates` - Set of Service Updates. Each element has the following attributes:
+    * `auto_update_after_recommended_apply_by_date` - Whether the update will be applied after `recommended_apply_by_date`.
+    * `engine` - Engine this update applies to.
+    * `engine_version` - Engine version this update applies to.
+    * `estimated_update_time` - Estimated duration of update.
+    * `description` - Description of the update.
+    * `end_date` - Date the update will no longer be available.
+    * `name` - Name of the update.
+    * `recommended_apply_by_date` - Date the update should be applied by.
+    * `release_date` - Date the update was released.
+    * `severity` - Severity of the update. One of `critical`, `important`, `medium`, or `low`.
+    * `status` - Availability of the update. One of `available`, `cancelled`, or `expired`.
+    * `type` - Type of the update.


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

New Data Source: `aws_elasticache_service_updates`

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #20112

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=elasticache TESTS=TestAccElastiCacheServiceUpdatesDataSource_

--- PASS: TestAccElastiCacheServiceUpdatesDataSource_bySingleStatus (14.03s)
--- PASS: TestAccElastiCacheServiceUpdatesDataSource_basic (14.06s)
```
