### PR TITLE
feat(billing): Add cost_categories filter to aws_billing_view

### DIFF
--- a/.changelog/48219.txt
+++ b/.changelog/48219.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_billing_view: Add `cost_categories` configuration block to `data_filter_expression`
+```

--- a/internal/service/billing/view.go
+++ b/internal/service/billing/view.go
@@ -123,6 +123,24 @@ func (r *resourceView) Schema(ctx context.Context, req resource.SchemaRequest, r
 				},
 				NestedObject: schema.NestedBlockObject{
 					Blocks: map[string]schema.Block{
+						"cost_categories": schema.ListNestedBlock{
+							CustomType: fwtypes.NewListNestedObjectTypeOf[costCategoryValuesModel](ctx),
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									names.AttrKey: schema.StringAttribute{
+										Required: true,
+									},
+									names.AttrValues: schema.ListAttribute{
+										CustomType:  fwtypes.ListOfStringType,
+										ElementType: types.StringType,
+										Required:    true,
+										Validators: []validator.List{
+											listvalidator.SizeAtLeast(1),
+										},
+									},
+								},
+							},
+						},
 						"dimensions": schema.ListNestedBlock{
 							CustomType: fwtypes.NewListNestedObjectTypeOf[dimensionsModel](ctx),
 							Validators: []validator.List{
@@ -489,9 +507,15 @@ type resourceViewModel struct {
 }
 
 type dataFilterExpressionModel struct {
-	Dimensions fwtypes.ListNestedObjectValueOf[dimensionsModel] `tfsdk:"dimensions"`
-	Tags       fwtypes.ListNestedObjectValueOf[tagValuesModel]  `tfsdk:"tags"`
-	TimeRange  fwtypes.ListNestedObjectValueOf[timeRangeModel]  `tfsdk:"time_range"`
+	CostCategories fwtypes.ListNestedObjectValueOf[costCategoryValuesModel] `tfsdk:"cost_categories"`
+	Dimensions     fwtypes.ListNestedObjectValueOf[dimensionsModel]         `tfsdk:"dimensions"`
+	Tags           fwtypes.ListNestedObjectValueOf[tagValuesModel]          `tfsdk:"tags"`
+	TimeRange      fwtypes.ListNestedObjectValueOf[timeRangeModel]          `tfsdk:"time_range"`
+}
+
+type costCategoryValuesModel struct {
+	Key    types.String         `tfsdk:"key"`
+	Values fwtypes.ListOfString `tfsdk:"values"`
 }
 
 type dimensionsModel struct {

--- a/internal/service/billing/view_test.go
+++ b/internal/service/billing/view_test.go
@@ -323,6 +323,62 @@ func TestAccBillingView_dataFilterExpressionDimensions(t *testing.T) {
 	})
 }
 
+func TestAccBillingView_dataFilterExpressionCostCategories(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var view1, view2 awstypes.BillingViewElement
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_billing_view.test"
+	costCategoryResourceName := "aws_ce_cost_category.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BillingServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckViewDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccViewConfig_dataFilterExpressionCostCategories(rName, []string{"production"}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckViewExists(ctx, t, resourceName, &view1),
+					resource.TestCheckResourceAttr(resourceName, "data_filter_expression.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "data_filter_expression.0.cost_categories.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "data_filter_expression.0.cost_categories.0.key", costCategoryResourceName, names.AttrName),
+					resource.TestCheckResourceAttr(resourceName, "data_filter_expression.0.cost_categories.0.values.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "data_filter_expression.0.cost_categories.0.values.0", "production"),
+				),
+			},
+			{
+				Config: testAccViewConfig_dataFilterExpressionCostCategories(rName, []string{"production", "staging"}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckViewExists(ctx, t, resourceName, &view2),
+					resource.TestCheckResourceAttr(resourceName, "data_filter_expression.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "data_filter_expression.0.cost_categories.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "data_filter_expression.0.cost_categories.0.key", costCategoryResourceName, names.AttrName),
+					resource.TestCheckResourceAttr(resourceName, "data_filter_expression.0.cost_categories.0.values.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "data_filter_expression.0.cost_categories.0.values.0", "production"),
+					resource.TestCheckResourceAttr(resourceName, "data_filter_expression.0.cost_categories.0.values.1", "staging"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, names.AttrARN),
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: names.AttrARN,
+			},
+		},
+	})
+}
+
 func testAccCheckViewDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.ProviderMeta(ctx, t).BillingClient(ctx)
@@ -469,6 +525,56 @@ resource "aws_billing_view" "test" {
   }
 }
 `, rName, tagKey, tagValuesStr.String()))
+}
+
+func testAccViewConfig_dataFilterExpressionCostCategories(rName string, ccValues []string) string {
+	var ccValuesStr strings.Builder
+	for i, v := range ccValues {
+		if i > 0 {
+			ccValuesStr.WriteString(", ")
+		}
+		fmt.Fprintf(&ccValuesStr, "%q", v)
+	}
+	return acctest.ConfigCompose(testAccViewConfig_base(), fmt.Sprintf(`
+resource "aws_ce_cost_category" "test" {
+  name         = %[1]q
+  rule_version = "CostCategoryExpression.v1"
+  rule {
+    value = "production"
+    rule {
+      dimension {
+        key           = "LINKED_ACCOUNT_NAME"
+        values        = ["-prod"]
+        match_options = ["ENDS_WITH"]
+      }
+    }
+    type = "REGULAR"
+  }
+  rule {
+    value = "staging"
+    rule {
+      dimension {
+        key           = "LINKED_ACCOUNT_NAME"
+        values        = ["-stg"]
+        match_options = ["ENDS_WITH"]
+      }
+    }
+    type = "REGULAR"
+  }
+}
+
+resource "aws_billing_view" "test" {
+  name         = %[1]q
+  description  = "Test with data_filter_expression cost_categories"
+  source_views = ["arn:${data.aws_partition.current.partition}:billing::${data.aws_caller_identity.current.account_id}:billingview/primary"]
+  data_filter_expression {
+    cost_categories {
+      key    = aws_ce_cost_category.test.name
+      values = [%[2]s]
+    }
+  }
+}
+`, rName, ccValuesStr.String()))
 }
 
 func testAccViewConfig_dataFilterExpressionDimensions(rName, dimensionKey string, dimensionValues []string) string {

--- a/website/docs/r/billing_view.html.markdown
+++ b/website/docs/r/billing_view.html.markdown
@@ -39,9 +39,17 @@ The following arguments are optional:
 
 A `data-filter-expression` block supports the following:
 
+* `cost_categories` - (Optional) Cost Category values to use for `expression`. Refer to [#cost-categories](#cost-categories) for more details.
 * `dimensions` - (Optional) Dimension to use for `expression`. Refer to [#dimensions](#dimensions) for more details.
 * `tags` - (Optional) Tags to use for `expression`. Refer to [#tags](#tags) for more details.
 * `time_range` - (Optional) Time range to use for `expression`. Refer to [#time-range](#time-range) for more details.
+
+#### cost-categories
+
+A `cost_categories` block supports the following:
+
+* `key` - (Required) Unique name of the Cost Category.
+* `values` - (Required) List of Cost Category values.
 
 #### dimensions
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

None

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Updates the `aws_billing_view` resource to add a `cost_categories` block to `data_filter_expression`.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #48219

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

[AWS API - Billing Expression](https://docs.aws.amazon.com/aws-cost-management/latest/APIReference/API_billing_Expression.html)

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccBillingView_dataFilterExpression PKG=billing
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     8.246s
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework 8.114s
make: Running acceptance tests on branch: 🌿 48219-billing-view-cost-categories 🌿...
TF_ACC=1 go1.26.3 test ./internal/service/billing/... -v -count 1 -parallel 20 -run='TestAccBillingView_dataFilterExpression'  -timeout 360m -vet=off -buildvcs=false
2026/06/04 15:40:31 Creating Terraform AWS Provider (SDKv2-style)...
2026/06/04 15:40:31 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccBillingView_dataFilterExpressionTags
=== PAUSE TestAccBillingView_dataFilterExpressionTags
=== RUN   TestAccBillingView_dataFilterExpressionDimensions
=== PAUSE TestAccBillingView_dataFilterExpressionDimensions
=== RUN   TestAccBillingView_dataFilterExpressionCostCategories
=== PAUSE TestAccBillingView_dataFilterExpressionCostCategories
=== CONT  TestAccBillingView_dataFilterExpressionTags
=== CONT  TestAccBillingView_dataFilterExpressionCostCategories
=== CONT  TestAccBillingView_dataFilterExpressionDimensions
--- PASS: TestAccBillingView_dataFilterExpressionTags (36.85s)
--- PASS: TestAccBillingView_dataFilterExpressionCostCategories (38.53s)
--- PASS: TestAccBillingView_dataFilterExpressionDimensions (47.54s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/billing    52.900s
...
```