### PR TITLE
[Enhancement] aws_sesv2_account_suppression_attributes: Add `validation_attributes` configuration block

### DIFF
--- a/.changelog/48238.txt
+++ b/.changelog/48238.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_sesv2_account_suppression_attributes: Add `validation_attributes` configuration block
+```

--- a/internal/service/sesv2/account_suppression_attributes.go
+++ b/internal/service/sesv2/account_suppression_attributes.go
@@ -11,8 +11,10 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/sesv2"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/sesv2/types"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
@@ -44,6 +46,48 @@ func (r *accountSuppressionAttributesResource) Schema(ctx context.Context, reque
 				CustomType:  fwtypes.SetOfStringEnumType[awstypes.SuppressionListReason](),
 				Required:    true,
 				ElementType: fwtypes.StringEnumType[awstypes.SuppressionListReason](),
+			},
+		},
+		Blocks: map[string]schema.Block{
+			"validation_attributes": schema.ListNestedBlock{
+				CustomType: fwtypes.NewListNestedObjectTypeOf[suppressionValidationAttributesModel](ctx),
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Blocks: map[string]schema.Block{
+						"condition_threshold": schema.ListNestedBlock{
+							CustomType: fwtypes.NewListNestedObjectTypeOf[suppressionConditionThresholdModel](ctx),
+							Validators: []validator.List{
+								listvalidator.SizeAtMost(1),
+							},
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									"condition_threshold_enabled": schema.StringAttribute{
+										CustomType: fwtypes.StringEnumType[awstypes.FeatureStatus](),
+										Required:   true,
+									},
+								},
+								Blocks: map[string]schema.Block{
+									"overall_confidence_threshold": schema.ListNestedBlock{
+										CustomType: fwtypes.NewListNestedObjectTypeOf[suppressionConfidenceThresholdModel](ctx),
+										Validators: []validator.List{
+											listvalidator.SizeAtMost(1),
+										},
+										NestedObject: schema.NestedBlockObject{
+											Attributes: map[string]schema.Attribute{
+												"confidence_verdict_threshold": schema.StringAttribute{
+													CustomType: fwtypes.StringEnumType[awstypes.SuppressionConfidenceVerdictThreshold](),
+													Required:   true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
 			},
 		},
 	}
@@ -153,6 +197,20 @@ func findAccountSuppressionAttributes(ctx context.Context, conn *sesv2.Client) (
 
 type accountSuppressionAttributesResourceModel struct {
 	framework.WithRegionModel
-	ID                types.String                                            `tfsdk:"id"`
-	SuppressedReasons fwtypes.SetOfStringEnum[awstypes.SuppressionListReason] `tfsdk:"suppressed_reasons"`
+	ID                   types.String                                                          `tfsdk:"id"`
+	SuppressedReasons    fwtypes.SetOfStringEnum[awstypes.SuppressionListReason]               `tfsdk:"suppressed_reasons"`
+	ValidationAttributes fwtypes.ListNestedObjectValueOf[suppressionValidationAttributesModel] `tfsdk:"validation_attributes"`
+}
+
+type suppressionValidationAttributesModel struct {
+	ConditionThreshold fwtypes.ListNestedObjectValueOf[suppressionConditionThresholdModel] `tfsdk:"condition_threshold"`
+}
+
+type suppressionConditionThresholdModel struct {
+	ConditionThresholdEnabled  fwtypes.StringEnum[awstypes.FeatureStatus]                           `tfsdk:"condition_threshold_enabled"`
+	OverallConfidenceThreshold fwtypes.ListNestedObjectValueOf[suppressionConfidenceThresholdModel] `tfsdk:"overall_confidence_threshold"`
+}
+
+type suppressionConfidenceThresholdModel struct {
+	ConfidenceVerdictThreshold fwtypes.StringEnum[awstypes.SuppressionConfidenceVerdictThreshold] `tfsdk:"confidence_verdict_threshold"`
 }

--- a/internal/service/sesv2/account_suppression_attributes.go
+++ b/internal/service/sesv2/account_suppression_attributes.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sesv2"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/sesv2/types"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -57,7 +58,7 @@ func (r *accountSuppressionAttributesResource) Schema(ctx context.Context, reque
 				NestedObject: schema.NestedBlockObject{
 					Blocks: map[string]schema.Block{
 						"condition_threshold": schema.ListNestedBlock{
-							CustomType: fwtypes.NewListNestedObjectTypeOf[suppressionConditionThresholdModel](ctx),
+							CustomType: fwtypes.NewListNestedObjectTypeOf[suppressionConditionThresholdModel](ctx, fwtypes.WithSemanticEqualityFunc(suppressionConditionThresholdSemanticEquals)),
 							Validators: []validator.List{
 								listvalidator.SizeAtMost(1),
 							},
@@ -147,7 +148,14 @@ func (r *accountSuppressionAttributesResource) Read(ctx context.Context, request
 		return
 	}
 
+	priorState := data
+
 	response.Diagnostics.Append(fwflex.Flatten(ctx, suppressionAttributes, &data)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	normalizeAccountSuppressionAttributesState(ctx, &data, &priorState, &response.Diagnostics)
 	if response.Diagnostics.HasError() {
 		return
 	}
@@ -213,4 +221,84 @@ type suppressionConditionThresholdModel struct {
 
 type suppressionConfidenceThresholdModel struct {
 	ConfidenceVerdictThreshold fwtypes.StringEnum[awstypes.SuppressionConfidenceVerdictThreshold] `tfsdk:"confidence_verdict_threshold"`
+}
+
+// When condition_threshold_enabled is disabled, the overall_confidence_threshold block is set to an empty list to prevent drift.
+func normalizeAccountSuppressionAttributesState(ctx context.Context, data, priorState *accountSuppressionAttributesResourceModel, diags *diag.Diagnostics) {
+	validationAttributes, d := data.ValidationAttributes.ToPtr(ctx)
+	diags.Append(d...)
+	if diags.HasError() || validationAttributes == nil {
+		return
+	}
+
+	conditionThreshold, d := validationAttributes.ConditionThreshold.ToPtr(ctx)
+	diags.Append(d...)
+	if diags.HasError() || conditionThreshold == nil {
+		return
+	}
+
+	if conditionThreshold.ConditionThresholdEnabled.IsNull() || conditionThreshold.ConditionThresholdEnabled.IsUnknown() {
+		return
+	}
+
+	if conditionThreshold.ConditionThresholdEnabled.ValueEnum() == awstypes.FeatureStatusDisabled {
+		priorOverallConfidenceThreshold, d := priorStateOverallConfidenceThreshold(ctx, priorState)
+		diags.Append(d...)
+		if diags.HasError() || priorOverallConfidenceThreshold != nil {
+			return
+		}
+
+		conditionThreshold.OverallConfidenceThreshold = fwtypes.NewListNestedObjectValueOfSliceMust(ctx, []*suppressionConfidenceThresholdModel{})
+		validationAttributes.ConditionThreshold = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, conditionThreshold, fwtypes.WithSemanticEqualityFunc(suppressionConditionThresholdSemanticEquals))
+		data.ValidationAttributes = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, validationAttributes)
+	}
+}
+
+// Extracts the overall confidence threshold from the prior state, if it exists.
+// This is used to determine whether to set the overall confidence threshold to an empty list when condition_threshold_enabled is disabled.
+func priorStateOverallConfidenceThreshold(ctx context.Context, priorState *accountSuppressionAttributesResourceModel) (*suppressionConfidenceThresholdModel, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	validationAttributes, d := priorState.ValidationAttributes.ToPtr(ctx)
+	diags.Append(d...)
+	if diags.HasError() || validationAttributes == nil {
+		return nil, diags
+	}
+
+	conditionThreshold, d := validationAttributes.ConditionThreshold.ToPtr(ctx)
+	diags.Append(d...)
+	if diags.HasError() || conditionThreshold == nil {
+		return nil, diags
+	}
+
+	overallConfidenceThreshold, d := conditionThreshold.OverallConfidenceThreshold.ToPtr(ctx)
+	diags.Append(d...)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return overallConfidenceThreshold, diags
+}
+
+func suppressionConditionThresholdSemanticEquals(ctx context.Context, current, new fwtypes.NestedCollectionValue[suppressionConditionThresholdModel]) (bool, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	currentValue, d := current.ToPtr(ctx)
+	diags.Append(d...)
+	newValue, d := new.ToPtr(ctx)
+	diags.Append(d...)
+	if diags.HasError() || currentValue == nil || newValue == nil {
+		return false, diags
+	}
+
+	if currentValue.ConditionThresholdEnabled.IsNull() || currentValue.ConditionThresholdEnabled.IsUnknown() ||
+		newValue.ConditionThresholdEnabled.IsNull() || newValue.ConditionThresholdEnabled.IsUnknown() {
+		return false, diags
+	}
+
+	if currentValue.ConditionThresholdEnabled.ValueEnum() != newValue.ConditionThresholdEnabled.ValueEnum() {
+		return false, diags
+	}
+
+	return newValue.ConditionThresholdEnabled.ValueEnum() == awstypes.FeatureStatusDisabled, diags
 }

--- a/internal/service/sesv2/account_suppression_attributes.go
+++ b/internal/service/sesv2/account_suppression_attributes.go
@@ -35,7 +35,6 @@ func newAccountSuppressionAttributesResource(context.Context) (resource.Resource
 
 type accountSuppressionAttributesResource struct {
 	framework.ResourceWithModel[accountSuppressionAttributesResourceModel]
-	framework.WithNoOpDelete
 	framework.WithImportByID
 }
 
@@ -187,6 +186,36 @@ func (r *accountSuppressionAttributesResource) Update(ctx context.Context, reque
 	}
 
 	response.Diagnostics.Append(response.State.Set(ctx, &new)...)
+}
+
+func (r *accountSuppressionAttributesResource) Delete(ctx context.Context, request resource.DeleteRequest, response *resource.DeleteResponse) {
+	var data accountSuppressionAttributesResourceModel
+	response.Diagnostics.Append(request.State.Get(ctx, &data)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	conn := r.Meta().SESV2Client(ctx)
+
+	// Reset singleton settings to the service defaults on Delete.
+	input := &sesv2.PutAccountSuppressionAttributesInput{
+		SuppressedReasons: []awstypes.SuppressionListReason{
+			awstypes.SuppressionListReasonBounce,
+			awstypes.SuppressionListReasonComplaint,
+		},
+		ValidationAttributes: &awstypes.SuppressionValidationAttributes{
+			ConditionThreshold: &awstypes.SuppressionConditionThreshold{
+				ConditionThresholdEnabled: awstypes.FeatureStatusDisabled,
+			},
+		},
+	}
+
+	_, err := conn.PutAccountSuppressionAttributes(ctx, input)
+	if err != nil {
+		response.Diagnostics.AddError(fmt.Sprintf("resetting SESv2 Account Suppression Attributes (%s)", data.ID.ValueString()), err.Error())
+
+		return
+	}
 }
 
 func findAccountSuppressionAttributes(ctx context.Context, conn *sesv2.Client) (*awstypes.SuppressionAttributes, error) {

--- a/internal/service/sesv2/account_suppression_attributes.go
+++ b/internal/service/sesv2/account_suppression_attributes.go
@@ -223,7 +223,8 @@ type suppressionConfidenceThresholdModel struct {
 	ConfidenceVerdictThreshold fwtypes.StringEnum[awstypes.SuppressionConfidenceVerdictThreshold] `tfsdk:"confidence_verdict_threshold"`
 }
 
-// When condition_threshold_enabled is disabled, the overall_confidence_threshold block is set to an empty list to prevent drift.
+// When condition_threshold_enabled is set to "DISABLED", and overall_confidence_threshold block is not set in the prior state
+// the overall_confidence_threshold block in the state is set to an empty list to prevent drift.
 func normalizeAccountSuppressionAttributesState(ctx context.Context, data, priorState *accountSuppressionAttributesResourceModel, diags *diag.Diagnostics) {
 	validationAttributes, d := data.ValidationAttributes.ToPtr(ctx)
 	diags.Append(d...)
@@ -254,8 +255,8 @@ func normalizeAccountSuppressionAttributesState(ctx context.Context, data, prior
 	}
 }
 
-// Extracts the overall confidence threshold from the prior state, if it exists.
-// This is used to determine whether to set the overall confidence threshold to an empty list when condition_threshold_enabled is disabled.
+// Extracts overall_confidence_threshold from the prior state, if it exists.
+// This is used to determine whether to set the overall_confidence_threshold to an empty list when condition_threshold_enabled is set to "DISABLED".
 func priorStateOverallConfidenceThreshold(ctx context.Context, priorState *accountSuppressionAttributesResourceModel) (*suppressionConfidenceThresholdModel, diag.Diagnostics) {
 	var diags diag.Diagnostics
 

--- a/internal/service/sesv2/account_suppression_attributes_test.go
+++ b/internal/service/sesv2/account_suppression_attributes_test.go
@@ -23,8 +23,9 @@ func TestAccSESV2AccountSuppressionAttributes_serial(t *testing.T) {
 	t.Parallel()
 
 	testCases := map[string]func(t *testing.T){
-		acctest.CtBasic: testAccAccountSuppressionAttributes_basic,
-		"update":        testAccAccountSuppressionAttributes_update,
+		acctest.CtBasic:        testAccAccountSuppressionAttributes_basic,
+		"update":               testAccAccountSuppressionAttributes_update,
+		"validationAttributes": testAccAccountSuppressionAttributes_validationAttributes,
 	}
 
 	acctest.RunSerialTests1Level(t, testCases, 0)
@@ -100,6 +101,97 @@ func testAccAccountSuppressionAttributes_update(t *testing.T) {
 	})
 }
 
+func testAccAccountSuppressionAttributes_validationAttributes(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_sesv2_account_suppression_attributes.test"
+
+	acctest.Test(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SESV2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             acctest.CheckDestroyNoop,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAccountSuppressionAttributesConfig_validationAttributes(string(types.FeatureStatusEnabled), string(types.SuppressionConfidenceVerdictThresholdHigh)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAccountSuppressionAttributesExists(ctx, t, resourceName),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("validation_attributes"), knownvalue.ListSizeExact(1)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("validation_attributes").AtSliceIndex(0).AtMapKey("condition_threshold"),
+						knownvalue.ListSizeExact(1),
+					),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("validation_attributes").AtSliceIndex(0).AtMapKey("condition_threshold").AtSliceIndex(0).AtMapKey("condition_threshold_enabled"),
+						knownvalue.StringExact(string(types.FeatureStatusEnabled)),
+					),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("validation_attributes").AtSliceIndex(0).AtMapKey("condition_threshold").AtSliceIndex(0).AtMapKey("overall_confidence_threshold"),
+						knownvalue.ListSizeExact(1),
+					),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("validation_attributes").AtSliceIndex(0).AtMapKey("condition_threshold").AtSliceIndex(0).AtMapKey("overall_confidence_threshold").AtSliceIndex(0).AtMapKey("confidence_verdict_threshold"),
+						knownvalue.StringExact(string(types.SuppressionConfidenceVerdictThresholdHigh)),
+					),
+				},
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAccountSuppressionAttributesConfig_validationAttributes(string(types.FeatureStatusEnabled), string(types.SuppressionConfidenceVerdictThresholdManaged)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAccountSuppressionAttributesExists(ctx, t, resourceName),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("validation_attributes"), knownvalue.ListSizeExact(1)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("validation_attributes").AtSliceIndex(0).AtMapKey("condition_threshold"),
+						knownvalue.ListSizeExact(1),
+					),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("validation_attributes").AtSliceIndex(0).AtMapKey("condition_threshold").AtSliceIndex(0).AtMapKey("condition_threshold_enabled"),
+						knownvalue.StringExact(string(types.FeatureStatusEnabled)),
+					),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("validation_attributes").AtSliceIndex(0).AtMapKey("condition_threshold").AtSliceIndex(0).AtMapKey("overall_confidence_threshold"),
+						knownvalue.ListSizeExact(1),
+					),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("validation_attributes").AtSliceIndex(0).AtMapKey("condition_threshold").AtSliceIndex(0).AtMapKey("overall_confidence_threshold").AtSliceIndex(0).AtMapKey("confidence_verdict_threshold"),
+						knownvalue.StringExact(string(types.SuppressionConfidenceVerdictThresholdManaged)),
+					),
+				},
+			},
+			{
+				Config: testAccAccountSuppressionAttributesConfig_validationAttributes(string(types.FeatureStatusDisabled), string(types.SuppressionConfidenceVerdictThresholdManaged)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAccountSuppressionAttributesExists(ctx, t, resourceName),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("validation_attributes"), knownvalue.ListSizeExact(1)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("validation_attributes").AtSliceIndex(0).AtMapKey("condition_threshold"),
+						knownvalue.ListSizeExact(1),
+					),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("validation_attributes").AtSliceIndex(0).AtMapKey("condition_threshold").AtSliceIndex(0).AtMapKey("condition_threshold_enabled"),
+						knownvalue.StringExact(string(types.FeatureStatusDisabled)),
+					),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("validation_attributes").AtSliceIndex(0).AtMapKey("condition_threshold").AtSliceIndex(0).AtMapKey("overall_confidence_threshold"),
+						knownvalue.ListSizeExact(1),
+					),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("validation_attributes").AtSliceIndex(0).AtMapKey("condition_threshold").AtSliceIndex(0).AtMapKey("overall_confidence_threshold").AtSliceIndex(0).AtMapKey("confidence_verdict_threshold"),
+						knownvalue.StringExact(string(types.SuppressionConfidenceVerdictThresholdManaged)),
+					),
+				},
+			},
+			{
+				Config: testAccAccountSuppressionAttributesConfig_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAccountSuppressionAttributesExists(ctx, t, resourceName),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("validation_attributes"), knownvalue.ListSizeExact(0)),
+				},
+			},
+		},
+	})
+}
+
 func testAccCheckAccountSuppressionAttributesExists(ctx context.Context, t *testing.T, n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		_, ok := s.RootModule().Resources[n]
@@ -126,3 +218,19 @@ resource "aws_sesv2_account_suppression_attributes" "test" {
   suppressed_reasons = []
 }
 `
+
+func testAccAccountSuppressionAttributesConfig_validationAttributes(conditionThresholdEnabled, confidenceVerdictThreshold string) string {
+	return fmt.Sprintf(`
+resource "aws_sesv2_account_suppression_attributes" "test" {
+  suppressed_reasons = ["COMPLAINT"]
+  validation_attributes {
+    condition_threshold {
+      condition_threshold_enabled = %[1]q
+      overall_confidence_threshold {
+        confidence_verdict_threshold = %[2]q
+      }
+    }
+  }
+}
+`, conditionThresholdEnabled, confidenceVerdictThreshold)
+}

--- a/internal/service/sesv2/account_suppression_attributes_test.go
+++ b/internal/service/sesv2/account_suppression_attributes_test.go
@@ -6,15 +6,18 @@ package sesv2_test
 import (
 	"context"
 	"fmt"
+	"slices"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/sesv2/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfsesv2 "github.com/hashicorp/terraform-provider-aws/internal/service/sesv2"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -24,6 +27,7 @@ func TestAccSESV2AccountSuppressionAttributes_serial(t *testing.T) {
 
 	testCases := map[string]func(t *testing.T){
 		acctest.CtBasic:        testAccAccountSuppressionAttributes_basic,
+		acctest.CtDisappears:   testAccAccountSuppressionAttributes_disappears,
 		"update":               testAccAccountSuppressionAttributes_update,
 		"validationAttributes": testAccAccountSuppressionAttributes_validationAttributes,
 	}
@@ -39,7 +43,7 @@ func testAccAccountSuppressionAttributes_basic(t *testing.T) {
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SESV2ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             acctest.CheckDestroyNoop,
+		CheckDestroy:             testAccCheckAccountSuppressionAttributesDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAccountSuppressionAttributesConfig_basic,
@@ -64,6 +68,35 @@ func testAccAccountSuppressionAttributes_basic(t *testing.T) {
 	})
 }
 
+func testAccAccountSuppressionAttributes_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_sesv2_account_suppression_attributes.test"
+
+	acctest.Test(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SESV2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckAccountSuppressionAttributesDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAccountSuppressionAttributesConfig_basic,
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckFrameworkResourceDisappears(ctx, t, tfsesv2.ResourceAccountSuppressionAttributes, resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+		},
+	})
+}
+
 func testAccAccountSuppressionAttributes_update(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_account_suppression_attributes.test"
@@ -72,7 +105,7 @@ func testAccAccountSuppressionAttributes_update(t *testing.T) {
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SESV2ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             acctest.CheckDestroyNoop,
+		CheckDestroy:             testAccCheckAccountSuppressionAttributesDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAccountSuppressionAttributesConfig_basic,
@@ -109,7 +142,7 @@ func testAccAccountSuppressionAttributes_validationAttributes(t *testing.T) {
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SESV2ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             acctest.CheckDestroyNoop,
+		CheckDestroy:             testAccCheckAccountSuppressionAttributesDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAccountSuppressionAttributesConfig_validationAttributes(string(types.FeatureStatusEnabled), string(types.SuppressionConfidenceVerdictThresholdHigh)),
@@ -239,6 +272,45 @@ func testAccCheckAccountSuppressionAttributesExists(ctx context.Context, t *test
 		_, err := tfsesv2.FindAccountSuppressionAttributes(ctx, conn)
 
 		return err
+	}
+}
+
+func testAccCheckAccountSuppressionAttributesDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.ProviderMeta(ctx, t).SESV2Client(ctx)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_sesv2_account_suppression_attributes" {
+				continue
+			}
+
+			output, err := tfsesv2.FindAccountSuppressionAttributes(ctx, conn)
+			if retry.NotFound(err) {
+				continue
+			}
+
+			if err != nil {
+				return err
+			}
+
+			if len(output.SuppressedReasons) != 2 ||
+				!slices.Contains(output.SuppressedReasons, types.SuppressionListReasonBounce) ||
+				!slices.Contains(output.SuppressedReasons, types.SuppressionListReasonComplaint) {
+				return fmt.Errorf("SESv2 Account Suppression Attributes %s was not reset to default suppressed reasons", rs.Primary.ID)
+			}
+
+			if output.ValidationAttributes == nil || output.ValidationAttributes.ConditionThreshold == nil {
+				continue
+			}
+
+			if output.ValidationAttributes.ConditionThreshold.ConditionThresholdEnabled == types.FeatureStatusDisabled {
+				continue
+			}
+
+			return fmt.Errorf("SESv2 Account Suppression Attributes %s was not reset to disabled condition threshold", rs.Primary.ID)
+		}
+
+		return nil
 	}
 }
 

--- a/internal/service/sesv2/account_suppression_attributes_test.go
+++ b/internal/service/sesv2/account_suppression_attributes_test.go
@@ -81,7 +81,7 @@ func testAccAccountSuppressionAttributes_disappears(t *testing.T) {
 			{
 				Config: testAccAccountSuppressionAttributesConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
-					acctest.CheckFrameworkResourceDisappears(ctx, t, tfsesv2.ResourceAccountSuppressionAttributes, resourceName),
+					acctest.CheckFrameworkResourceDisappears(ctx, t, tfsesv2.ResourceAccountSuppressionAttributes, resourceName), // nosemgrep:disappears-expect-resource-action
 				),
 				ExpectNonEmptyPlan: true,
 				ConfigPlanChecks: resource.ConfigPlanChecks{

--- a/internal/service/sesv2/account_suppression_attributes_test.go
+++ b/internal/service/sesv2/account_suppression_attributes_test.go
@@ -138,6 +138,7 @@ func testAccAccountSuppressionAttributes_validationAttributes(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
+				// Update confidence_verdict_threshold
 				Config: testAccAccountSuppressionAttributesConfig_validationAttributes(string(types.FeatureStatusEnabled), string(types.SuppressionConfidenceVerdictThresholdManaged)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAccountSuppressionAttributesExists(ctx, t, resourceName),
@@ -159,6 +160,7 @@ func testAccAccountSuppressionAttributes_validationAttributes(t *testing.T) {
 				},
 			},
 			{
+				// Disable condition_threshold_enabled
 				Config: testAccAccountSuppressionAttributesConfig_validationAttributes(string(types.FeatureStatusDisabled), string(types.SuppressionConfidenceVerdictThresholdManaged)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAccountSuppressionAttributesExists(ctx, t, resourceName),
@@ -171,6 +173,22 @@ func testAccAccountSuppressionAttributes_validationAttributes(t *testing.T) {
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("validation_attributes").AtSliceIndex(0).AtMapKey("condition_threshold").AtSliceIndex(0).AtMapKey("condition_threshold_enabled"),
 						knownvalue.StringExact(string(types.FeatureStatusDisabled)),
 					),
+				},
+			},
+			{
+				// Enable condition_threshold_enabled again
+				Config: testAccAccountSuppressionAttributesConfig_validationAttributes(string(types.FeatureStatusEnabled), string(types.SuppressionConfidenceVerdictThresholdManaged)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAccountSuppressionAttributesExists(ctx, t, resourceName),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("validation_attributes"), knownvalue.ListSizeExact(1)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("validation_attributes").AtSliceIndex(0).AtMapKey("condition_threshold"),
+						knownvalue.ListSizeExact(1),
+					),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("validation_attributes").AtSliceIndex(0).AtMapKey("condition_threshold").AtSliceIndex(0).AtMapKey("condition_threshold_enabled"),
+						knownvalue.StringExact(string(types.FeatureStatusEnabled)),
+					),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("validation_attributes").AtSliceIndex(0).AtMapKey("condition_threshold").AtSliceIndex(0).AtMapKey("overall_confidence_threshold"),
 						knownvalue.ListSizeExact(1),
 					),
@@ -180,6 +198,23 @@ func testAccAccountSuppressionAttributes_validationAttributes(t *testing.T) {
 				},
 			},
 			{
+				// Disable condition_threshold_enabled without providing overall_confidence_threshold block
+				Config: testAccAccountSuppressionAttributesConfig_validationAttributesConditionThresholdDisabled(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAccountSuppressionAttributesExists(ctx, t, resourceName),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("validation_attributes"), knownvalue.ListSizeExact(1)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("validation_attributes").AtSliceIndex(0).AtMapKey("condition_threshold"),
+						knownvalue.ListSizeExact(1),
+					),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("validation_attributes").AtSliceIndex(0).AtMapKey("condition_threshold").AtSliceIndex(0).AtMapKey("condition_threshold_enabled"),
+						knownvalue.StringExact(string(types.FeatureStatusDisabled)),
+					),
+				},
+			},
+			{
+				// Remove validation_attributes block
 				Config: testAccAccountSuppressionAttributesConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAccountSuppressionAttributesExists(ctx, t, resourceName),
@@ -233,4 +268,17 @@ resource "aws_sesv2_account_suppression_attributes" "test" {
   }
 }
 `, conditionThresholdEnabled, confidenceVerdictThreshold)
+}
+
+func testAccAccountSuppressionAttributesConfig_validationAttributesConditionThresholdDisabled() string {
+	return `
+resource "aws_sesv2_account_suppression_attributes" "test" {
+  suppressed_reasons = ["COMPLAINT"]
+  validation_attributes {
+    condition_threshold {
+      condition_threshold_enabled = "DISABLED"
+    }
+  }
+}
+`
 }

--- a/internal/service/sesv2/exports_test.go
+++ b/internal/service/sesv2/exports_test.go
@@ -5,6 +5,7 @@ package sesv2
 
 // Exports for use in tests only.
 var (
+	ResourceAccountSuppressionAttributes     = newAccountSuppressionAttributesResource
 	ResourceAccountVDMAttributes             = resourceAccountVDMAttributes
 	ResourceConfigurationSet                 = resourceConfigurationSet
 	ResourceConfigurationSetEventDestination = resourceConfigurationSetEventDestination

--- a/website/docs/r/sesv2_account_suppression_attributes.html.markdown
+++ b/website/docs/r/sesv2_account_suppression_attributes.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Manages AWS SESv2 (Simple Email V2) account-level suppression attributes.
 
+~> **Note:** Destroying this resource resets `suppressed_reasons` to `["BOUNCE", "COMPLAINT"]`. According to the [Amazon SES documentation](https://docs.aws.amazon.com/ses/latest/dg/sending-email-suppression-list.html), this has been the default account-level suppression behavior for SES accounts that started using SES after November 25, 2019.
+
 ## Example Usage
 
 ```terraform

--- a/website/docs/r/sesv2_account_suppression_attributes.html.markdown
+++ b/website/docs/r/sesv2_account_suppression_attributes.html.markdown
@@ -24,6 +24,20 @@ This resource supports the following arguments:
 
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `suppressed_reasons` - (Required) A list that contains the reasons that email addresses will be automatically added to the suppression list for your account. Valid values: `COMPLAINT`, `BOUNCE`.
+* `validation_attributes` - (Optional) Configuration block for additional account-level suppression settings. See [`validation_attributes` Block](#validation_attributes-block) for details.
+
+### `validation_attributes` Block
+
+* `condition_threshold` - (Required) Configuration block for account-level suppression threshold settings. See [`condition_threshold` Block](#condition_threshold-block) for details.
+
+### `condition_threshold` Block
+
+* `condition_threshold_enabled` - (Required) Indicates whether Auto Validation is enabled for suppression. Valid values: `ENABLED`, `DISABLED`.
+* `overall_confidence_threshold` - (Optional) Configuration block for overall confidence threshold used to determine suppression decisions. See [`overall_confidence_threshold` Block](#overall_confidence_threshold-block) for details.
+
+### `overall_confidence_threshold` Block
+
+* `confidence_verdict_threshold` - (Required) Confidence level threshold for suppression decisions. Valid values: `MEDIUM`, `HIGH`, `MANAGED`.
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
This PR adds `validation_attributes` configuration block to `aws_sesv2_account_suppression_attributes` resource.

#### Suppression Diffs when `condition_threshold_enabled` is `DISABLED`

If `condition_threshold_enabled` is set to `DISABLED`, the `overall_confidence_threshold` block is irrelevant. However, the AWS API returns values for `overall_confidence_threshold` even when `condition_threshold_enabled` is `DISABLED`.

Moreover, if `condition_threshold_enabled` is set to `DISABLED` and the `overall_confidence_threshold` block is removed, the AWS API continues to return the previous value of `overall_confidence_threshold`, resulting in perpetual diffs.

To suppress these diffs, some functions which suppress the diff have been implemented.

#### Implementation of `Delete` Operation

* The `Delete` operation has not been implemented so far.
* To reset the account-level configuration, implementing the `Delete` operation is necessary.

  * Similar implementation:  `internal/service/sesv2/account_vdm_attributes_test.go`

* During deletion, `suppressed_reasons` is reset to `["BOUNCE", "COMPLAINT"]`, which is the default account-level suppression behavior for SES accounts that started using Amazon SES after November 25, 2019, according to the Amazon SES documentation.
* This behavior is documented in a note in the resource documentation.

### Relations

Relates #48043 (can be closed by this PR together with #48236)
Relates #48236 

### References
https://docs.aws.amazon.com/ja_jp/ses/latest/APIReference-V2/API_PutAccountSuppressionAttributes.html

### Output from Acceptance Testing

```console
$ make testacc TESTS='TestAccSESV2AccountSuppressionAttributes_serial' PKG=sesv2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     9.542s
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework 10.990s
make: Running acceptance tests on branch: 🌿 f-aws_sesv2_account_suppression_attributes-add_validation_attributes 🌿...
TF_ACC=1 go1.26.3 test ./internal/service/sesv2/... -v -count 1 -parallel 20 -run='TestAccSESV2AccountSuppressionAttributes_serial'  -timeout 360m -vet=off -buildvcs=false
2026/06/08 07:37:30 Creating Terraform AWS Provider (SDKv2-style)...
2026/06/08 07:37:30 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccSESV2AccountSuppressionAttributes_serial
=== PAUSE TestAccSESV2AccountSuppressionAttributes_serial
=== CONT  TestAccSESV2AccountSuppressionAttributes_serial
=== RUN   TestAccSESV2AccountSuppressionAttributes_serial/update
=== RUN   TestAccSESV2AccountSuppressionAttributes_serial/validationAttributes
=== RUN   TestAccSESV2AccountSuppressionAttributes_serial/basic
=== RUN   TestAccSESV2AccountSuppressionAttributes_serial/disappears
--- PASS: TestAccSESV2AccountSuppressionAttributes_serial (254.46s)
    --- PASS: TestAccSESV2AccountSuppressionAttributes_serial/update (56.20s)
    --- PASS: TestAccSESV2AccountSuppressionAttributes_serial/validationAttributes (141.98s)
    --- PASS: TestAccSESV2AccountSuppressionAttributes_serial/basic (30.07s)
    --- PASS: TestAccSESV2AccountSuppressionAttributes_serial/disappears (26.20s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/sesv2      264.999s
```
