### PR TITLE
r/aws_bedrockagentcore_memory: Add indexed_keys and stream_delivery_resources arguments

### DIFF
--- a/.changelog/48240.txt
+++ b/.changelog/48240.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_bedrockagentcore_memory: Add `indexed_keys` and `stream_delivery_resources` arguments
+```

--- a/.changelog/48240.txt
+++ b/.changelog/48240.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_bedrockagentcore_memory: Add `indexed_keys` and `stream_delivery_resources` arguments
+resource/aws_bedrockagentcore_memory: Add `indexed_key` and `stream_delivery_resources` arguments
 ```

--- a/internal/service/bedrockagentcore/memory.go
+++ b/internal/service/bedrockagentcore/memory.go
@@ -8,6 +8,7 @@ package bedrockagentcore
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/YakDriver/regexache"
@@ -18,9 +19,12 @@ import (
 	"github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int32validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -99,6 +103,85 @@ func (r *memoryResource) Schema(ctx context.Context, request resource.SchemaRequ
 			names.AttrTagsAll: tftags.TagsAttributeComputedOnly(),
 		},
 		Blocks: map[string]schema.Block{
+			"indexed_keys": schema.ListNestedBlock{
+				CustomType: fwtypes.NewListNestedObjectTypeOf[indexedKeyModel](ctx),
+				Validators: []validator.List{
+					listvalidator.SizeBetween(1, 10),
+				},
+				PlanModifiers: []planmodifier.List{
+					listplanmodifier.RequiresReplace(),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						names.AttrKey: schema.StringAttribute{
+							Required: true,
+							Validators: []validator.String{
+								stringvalidator.LengthBetween(1, 128),
+								stringvalidator.RegexMatches(regexache.MustCompile(`^[a-zA-Z0-9\s._:/=+@-]*$`), ""),
+							},
+						},
+						names.AttrType: schema.StringAttribute{
+							CustomType: fwtypes.StringEnumType[awstypes.MetadataValueType](),
+							Required:   true,
+						},
+					},
+				},
+			},
+			"stream_delivery_resources": schema.ListNestedBlock{
+				CustomType: fwtypes.NewListNestedObjectTypeOf[streamDeliveryResourcesModel](ctx),
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Blocks: map[string]schema.Block{
+						names.AttrResources: schema.ListNestedBlock{
+							CustomType: fwtypes.NewListNestedObjectTypeOf[streamDeliveryResourceModel](ctx),
+							Validators: []validator.List{
+								listvalidator.SizeAtMost(1),
+							},
+							NestedObject: schema.NestedBlockObject{
+								Blocks: map[string]schema.Block{
+									"kinesis": schema.ListNestedBlock{
+										CustomType: fwtypes.NewListNestedObjectTypeOf[kinesisResourceModel](ctx),
+										Validators: []validator.List{
+											listvalidator.SizeAtMost(1),
+										},
+										NestedObject: schema.NestedBlockObject{
+											Attributes: map[string]schema.Attribute{
+												"data_stream_arn": schema.StringAttribute{
+													CustomType: fwtypes.ARNType,
+													Required:   true,
+												},
+											},
+											Blocks: map[string]schema.Block{
+												"content_configurations": schema.ListNestedBlock{
+													CustomType: fwtypes.NewListNestedObjectTypeOf[contentConfigurationModel](ctx),
+													Validators: []validator.List{
+														listvalidator.SizeBetween(1, 1),
+													},
+													NestedObject: schema.NestedBlockObject{
+														Attributes: map[string]schema.Attribute{
+															names.AttrType: schema.StringAttribute{
+																CustomType: fwtypes.StringEnumType[awstypes.ContentType](),
+																Required:   true,
+															},
+															"level": schema.StringAttribute{
+																CustomType: fwtypes.StringEnumType[awstypes.ContentLevel](),
+																Optional:   true,
+																Computed:   true,
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 			names.AttrTimeouts: timeouts.Block(ctx, timeouts.Opts{
 				Create: true,
 				Delete: true,
@@ -138,6 +221,12 @@ func (r *memoryResource) Create(ctx context.Context, request resource.CreateRequ
 			return tfresource.RetryableError(err)
 		}
 		if tfawserr.ErrMessageContains(err, errCodeValidationException, "valid trust policy") {
+			return tfresource.RetryableError(err)
+		}
+		// IAM propagation - retry while the execution role's permissions to a
+		// referenced resource (e.g. a Kinesis stream in stream_delivery_resources)
+		// have not yet propagated.
+		if tfawserr.ErrMessageContains(err, errCodeValidationException, "does not have access to provided") {
 			return tfresource.RetryableError(err)
 		}
 
@@ -342,14 +431,84 @@ func findMemory(ctx context.Context, conn *bedrockagentcorecontrol.Client, input
 
 type memoryResourceModel struct {
 	framework.WithRegionModel
-	ARN                    types.String   `tfsdk:"arn"`
-	Description            types.String   `tfsdk:"description"`
-	EncryptionKeyARN       fwtypes.ARN    `tfsdk:"encryption_key_arn"`
-	EventExpiryDuration    types.Int32    `tfsdk:"event_expiry_duration"`
-	ID                     types.String   `tfsdk:"id"`
-	MemoryExecutionRoleARN fwtypes.ARN    `tfsdk:"memory_execution_role_arn"`
-	Name                   types.String   `tfsdk:"name"`
-	Tags                   tftags.Map     `tfsdk:"tags"`
-	TagsAll                tftags.Map     `tfsdk:"tags_all"`
-	Timeouts               timeouts.Value `tfsdk:"timeouts"`
+	ARN                     types.String                                                  `tfsdk:"arn"`
+	Description             types.String                                                  `tfsdk:"description"`
+	EncryptionKeyARN        fwtypes.ARN                                                   `tfsdk:"encryption_key_arn"`
+	EventExpiryDuration     types.Int32                                                   `tfsdk:"event_expiry_duration"`
+	ID                      types.String                                                  `tfsdk:"id"`
+	IndexedKeys             fwtypes.ListNestedObjectValueOf[indexedKeyModel]              `tfsdk:"indexed_keys"`
+	MemoryExecutionRoleARN  fwtypes.ARN                                                   `tfsdk:"memory_execution_role_arn"`
+	Name                    types.String                                                  `tfsdk:"name"`
+	StreamDeliveryResources fwtypes.ListNestedObjectValueOf[streamDeliveryResourcesModel] `tfsdk:"stream_delivery_resources"`
+	Tags                    tftags.Map                                                    `tfsdk:"tags"`
+	TagsAll                 tftags.Map                                                    `tfsdk:"tags_all"`
+	Timeouts                timeouts.Value                                                `tfsdk:"timeouts"`
+}
+
+type indexedKeyModel struct {
+	Key  types.String                                   `tfsdk:"key"`
+	Type fwtypes.StringEnum[awstypes.MetadataValueType] `tfsdk:"type"`
+}
+
+type streamDeliveryResourcesModel struct {
+	Resources fwtypes.ListNestedObjectValueOf[streamDeliveryResourceModel] `tfsdk:"resources"`
+}
+
+// streamDeliveryResourceModel maps to the awstypes.StreamDeliveryResource union.
+type streamDeliveryResourceModel struct {
+	Kinesis fwtypes.ListNestedObjectValueOf[kinesisResourceModel] `tfsdk:"kinesis"`
+}
+
+var (
+	_ fwflex.Expander  = streamDeliveryResourceModel{}
+	_ fwflex.Flattener = &streamDeliveryResourceModel{}
+)
+
+func (m *streamDeliveryResourceModel) Flatten(ctx context.Context, v any) diag.Diagnostics {
+	var diags diag.Diagnostics
+	switch t := v.(type) {
+	case awstypes.StreamDeliveryResourceMemberKinesis:
+		var data kinesisResourceModel
+		smerr.AddEnrich(ctx, &diags, fwflex.Flatten(ctx, t.Value, &data))
+		if diags.HasError() {
+			return diags
+		}
+		m.Kinesis = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &data)
+
+	default:
+		diags.AddError(
+			"Unsupported Type",
+			fmt.Sprintf("stream delivery resource flatten: %T", v),
+		)
+	}
+	return diags
+}
+
+func (m streamDeliveryResourceModel) Expand(ctx context.Context) (any, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	switch {
+	case !m.Kinesis.IsNull():
+		data, d := m.Kinesis.ToPtr(ctx)
+		smerr.AddEnrich(ctx, &diags, d)
+		if diags.HasError() {
+			return nil, diags
+		}
+		var r awstypes.StreamDeliveryResourceMemberKinesis
+		smerr.AddEnrich(ctx, &diags, fwflex.Expand(ctx, data, &r.Value))
+		if diags.HasError() {
+			return nil, diags
+		}
+		return &r, diags
+	}
+	return nil, diags
+}
+
+type kinesisResourceModel struct {
+	ContentConfigurations fwtypes.ListNestedObjectValueOf[contentConfigurationModel] `tfsdk:"content_configurations"`
+	DataStreamARN         fwtypes.ARN                                                `tfsdk:"data_stream_arn"`
+}
+
+type contentConfigurationModel struct {
+	Level fwtypes.StringEnum[awstypes.ContentLevel] `tfsdk:"level"`
+	Type  fwtypes.StringEnum[awstypes.ContentType]  `tfsdk:"type"`
 }

--- a/internal/service/bedrockagentcore/memory.go
+++ b/internal/service/bedrockagentcore/memory.go
@@ -103,7 +103,7 @@ func (r *memoryResource) Schema(ctx context.Context, request resource.SchemaRequ
 			names.AttrTagsAll: tftags.TagsAttributeComputedOnly(),
 		},
 		Blocks: map[string]schema.Block{
-			"indexed_keys": schema.ListNestedBlock{
+			"indexed_key": schema.ListNestedBlock{
 				CustomType: fwtypes.NewListNestedObjectTypeOf[indexedKeyModel](ctx),
 				Validators: []validator.List{
 					listvalidator.SizeBetween(1, 10),
@@ -436,7 +436,7 @@ type memoryResourceModel struct {
 	EncryptionKeyARN        fwtypes.ARN                                                   `tfsdk:"encryption_key_arn"`
 	EventExpiryDuration     types.Int32                                                   `tfsdk:"event_expiry_duration"`
 	ID                      types.String                                                  `tfsdk:"id"`
-	IndexedKeys             fwtypes.ListNestedObjectValueOf[indexedKeyModel]              `tfsdk:"indexed_keys"`
+	IndexedKeys             fwtypes.ListNestedObjectValueOf[indexedKeyModel]              `tfsdk:"indexed_key"`
 	MemoryExecutionRoleARN  fwtypes.ARN                                                   `tfsdk:"memory_execution_role_arn"`
 	Name                    types.String                                                  `tfsdk:"name"`
 	StreamDeliveryResources fwtypes.ListNestedObjectValueOf[streamDeliveryResourcesModel] `tfsdk:"stream_delivery_resources"`

--- a/internal/service/bedrockagentcore/memory.go
+++ b/internal/service/bedrockagentcore/memory.go
@@ -134,7 +134,7 @@ func (r *memoryResource) Schema(ctx context.Context, request resource.SchemaRequ
 				},
 				NestedObject: schema.NestedBlockObject{
 					Blocks: map[string]schema.Block{
-						names.AttrResources: schema.ListNestedBlock{
+						"resource": schema.ListNestedBlock{
 							CustomType: fwtypes.NewListNestedObjectTypeOf[streamDeliveryResourceModel](ctx),
 							Validators: []validator.List{
 								listvalidator.SizeAtMost(1),
@@ -154,7 +154,7 @@ func (r *memoryResource) Schema(ctx context.Context, request resource.SchemaRequ
 												},
 											},
 											Blocks: map[string]schema.Block{
-												"content_configurations": schema.ListNestedBlock{
+												"content_configuration": schema.ListNestedBlock{
 													CustomType: fwtypes.NewListNestedObjectTypeOf[contentConfigurationModel](ctx),
 													Validators: []validator.List{
 														listvalidator.SizeBetween(1, 1),
@@ -451,7 +451,7 @@ type indexedKeyModel struct {
 }
 
 type streamDeliveryResourcesModel struct {
-	Resources fwtypes.ListNestedObjectValueOf[streamDeliveryResourceModel] `tfsdk:"resources"`
+	Resources fwtypes.ListNestedObjectValueOf[streamDeliveryResourceModel] `tfsdk:"resource"`
 }
 
 // streamDeliveryResourceModel maps to the awstypes.StreamDeliveryResource union.
@@ -504,7 +504,7 @@ func (m streamDeliveryResourceModel) Expand(ctx context.Context) (any, diag.Diag
 }
 
 type kinesisResourceModel struct {
-	ContentConfigurations fwtypes.ListNestedObjectValueOf[contentConfigurationModel] `tfsdk:"content_configurations"`
+	ContentConfigurations fwtypes.ListNestedObjectValueOf[contentConfigurationModel] `tfsdk:"content_configuration"`
 	DataStreamARN         fwtypes.ARN                                                `tfsdk:"data_stream_arn"`
 }
 

--- a/internal/service/bedrockagentcore/memory_test.go
+++ b/internal/service/bedrockagentcore/memory_test.go
@@ -221,11 +221,11 @@ func TestAccBedrockAgentCoreMemory_indexedKeys(t *testing.T) {
 					},
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("indexed_keys"), knownvalue.ListSizeExact(2)),
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("indexed_keys").AtSliceIndex(0).AtMapKey(names.AttrKey), knownvalue.StringExact("customer_id")),
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("indexed_keys").AtSliceIndex(0).AtMapKey(names.AttrType), knownvalue.StringExact("STRING")),
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("indexed_keys").AtSliceIndex(1).AtMapKey(names.AttrKey), knownvalue.StringExact("score")),
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("indexed_keys").AtSliceIndex(1).AtMapKey(names.AttrType), knownvalue.StringExact("NUMBER")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("indexed_key"), knownvalue.ListSizeExact(2)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("indexed_key").AtSliceIndex(0).AtMapKey(names.AttrKey), knownvalue.StringExact("customer_id")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("indexed_key").AtSliceIndex(0).AtMapKey(names.AttrType), knownvalue.StringExact("STRING")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("indexed_key").AtSliceIndex(1).AtMapKey(names.AttrKey), knownvalue.StringExact("score")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("indexed_key").AtSliceIndex(1).AtMapKey(names.AttrType), knownvalue.StringExact("NUMBER")),
 				},
 			},
 			{
@@ -405,12 +405,12 @@ resource "aws_bedrockagentcore_memory" "test" {
   name                  = %[1]q
   event_expiry_duration = 7
 
-  indexed_keys {
+  indexed_key {
     key  = "customer_id"
     type = "STRING"
   }
 
-  indexed_keys {
+  indexed_key {
     key  = "score"
     type = "NUMBER"
   }

--- a/internal/service/bedrockagentcore/memory_test.go
+++ b/internal/service/bedrockagentcore/memory_test.go
@@ -264,8 +264,8 @@ func TestAccBedrockAgentCoreMemory_streamDeliveryResources(t *testing.T) {
 					},
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("stream_delivery_resources").AtSliceIndex(0).AtMapKey(names.AttrResources).AtSliceIndex(0).AtMapKey("kinesis").AtSliceIndex(0).AtMapKey("data_stream_arn"), knownvalue.NotNull()),
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("stream_delivery_resources").AtSliceIndex(0).AtMapKey(names.AttrResources).AtSliceIndex(0).AtMapKey("kinesis").AtSliceIndex(0).AtMapKey("content_configurations").AtSliceIndex(0).AtMapKey(names.AttrType), knownvalue.StringExact("MEMORY_RECORDS")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("stream_delivery_resources").AtSliceIndex(0).AtMapKey("resource").AtSliceIndex(0).AtMapKey("kinesis").AtSliceIndex(0).AtMapKey("data_stream_arn"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("stream_delivery_resources").AtSliceIndex(0).AtMapKey("resource").AtSliceIndex(0).AtMapKey("kinesis").AtSliceIndex(0).AtMapKey("content_configuration").AtSliceIndex(0).AtMapKey(names.AttrType), knownvalue.StringExact("MEMORY_RECORDS")),
 				},
 			},
 			{
@@ -452,11 +452,11 @@ resource "aws_bedrockagentcore_memory" "test" {
   depends_on = [aws_iam_role_policy.test_kinesis]
 
   stream_delivery_resources {
-    resources {
+    resource {
       kinesis {
         data_stream_arn = aws_kinesis_stream.test.arn
 
-        content_configurations {
+        content_configuration {
           type  = "MEMORY_RECORDS"
           level = "METADATA_ONLY"
         }

--- a/internal/service/bedrockagentcore/memory_test.go
+++ b/internal/service/bedrockagentcore/memory_test.go
@@ -194,6 +194,89 @@ func TestAccBedrockAgentCoreMemory_memoryExecutionRole(t *testing.T) {
 	})
 }
 
+func TestAccBedrockAgentCoreMemory_indexedKeys(t *testing.T) {
+	ctx := acctest.Context(t)
+	var m awstypes.Memory
+	rName := randomMemoryName(t)
+	resourceName := "aws_bedrockagentcore_memory.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID)
+			testAccPreCheckMemories(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockAgentCoreServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckMemoryDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMemoryConfig_indexedKeys(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckMemoryExists(ctx, t, resourceName, &m),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("indexed_keys"), knownvalue.ListSizeExact(2)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("indexed_keys").AtSliceIndex(0).AtMapKey(names.AttrKey), knownvalue.StringExact("customer_id")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("indexed_keys").AtSliceIndex(0).AtMapKey(names.AttrType), knownvalue.StringExact("STRING")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("indexed_keys").AtSliceIndex(1).AtMapKey(names.AttrKey), knownvalue.StringExact("score")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("indexed_keys").AtSliceIndex(1).AtMapKey(names.AttrType), knownvalue.StringExact("NUMBER")),
+				},
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccBedrockAgentCoreMemory_streamDeliveryResources(t *testing.T) {
+	ctx := acctest.Context(t)
+	var m awstypes.Memory
+	rName := randomMemoryName(t)
+	resourceName := "aws_bedrockagentcore_memory.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID)
+			testAccPreCheckMemories(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockAgentCoreServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckMemoryDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMemoryConfig_streamDeliveryResources(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckMemoryExists(ctx, t, resourceName, &m),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("stream_delivery_resources").AtSliceIndex(0).AtMapKey(names.AttrResources).AtSliceIndex(0).AtMapKey("kinesis").AtSliceIndex(0).AtMapKey("data_stream_arn"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("stream_delivery_resources").AtSliceIndex(0).AtMapKey(names.AttrResources).AtSliceIndex(0).AtMapKey("kinesis").AtSliceIndex(0).AtMapKey("content_configurations").AtSliceIndex(0).AtMapKey(names.AttrType), knownvalue.StringExact("MEMORY_RECORDS")),
+				},
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckMemoryDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.ProviderMeta(ctx, t).BedrockAgentCoreClient(ctx)
@@ -312,6 +395,74 @@ resource "aws_bedrockagentcore_memory" "test" {
   name                      = %[1]q
   event_expiry_duration     = 7
   memory_execution_role_arn = aws_iam_role.test.arn
+}
+`, rName))
+}
+
+func testAccMemoryConfig_indexedKeys(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_bedrockagentcore_memory" "test" {
+  name                  = %[1]q
+  event_expiry_duration = 7
+
+  indexed_keys {
+    key  = "customer_id"
+    type = "STRING"
+  }
+
+  indexed_keys {
+    key  = "score"
+    type = "NUMBER"
+  }
+}
+`, rName)
+}
+
+func testAccMemoryConfig_streamDeliveryResources(rName string) string {
+	return acctest.ConfigCompose(testAccMemoryConfig_baseIAMRole(rName), fmt.Sprintf(`
+resource "aws_kinesis_stream" "test" {
+  name        = %[1]q
+  shard_count = 1
+}
+
+resource "aws_iam_role_policy" "test_kinesis" {
+  role = aws_iam_role.test.name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "kinesis:PutRecord",
+        "kinesis:PutRecords",
+        "kinesis:DescribeStream",
+        "kinesis:DescribeStreamSummary",
+        "kinesis:ListShards",
+      ]
+      Resource = aws_kinesis_stream.test.arn
+    }]
+  })
+}
+
+resource "aws_bedrockagentcore_memory" "test" {
+  name                      = %[1]q
+  event_expiry_duration     = 7
+  memory_execution_role_arn = aws_iam_role.test.arn
+
+  depends_on = [aws_iam_role_policy.test_kinesis]
+
+  stream_delivery_resources {
+    resources {
+      kinesis {
+        data_stream_arn = aws_kinesis_stream.test.arn
+
+        content_configurations {
+          type  = "MEMORY_RECORDS"
+          level = "METADATA_ONLY"
+        }
+      }
+    }
+  }
 }
 `, rName))
 }

--- a/website/docs/r/bedrockagentcore_memory.html.markdown
+++ b/website/docs/r/bedrockagentcore_memory.html.markdown
@@ -83,18 +83,18 @@ The following arguments are optional:
 
 ### stream_delivery_resources
 
-* `resources` - (Required) List of stream delivery resource configurations. See [`resources`](#resources) below.
+* `resource` - (Required) List of stream delivery resource configurations. See [`resource`](#resource) below.
 
-### resources
+### resource
 
 * `kinesis` - (Optional) Kinesis Data Stream configuration. See [`kinesis`](#kinesis) below.
 
 ### kinesis
 
 * `data_stream_arn` - (Required) ARN of the Kinesis Data Stream.
-* `content_configurations` - (Required) Content configurations for stream delivery. See [`content_configurations`](#content_configurations) below.
+* `content_configuration` - (Required) Content configurations for stream delivery. See [`content_configuration`](#content_configuration) below.
 
-### content_configurations
+### content_configuration
 
 * `type` - (Required) Type of content to stream. Valid value is `MEMORY_RECORDS`.
 * `level` - (Optional) Level of detail for streamed content. Valid values are `METADATA_ONLY` and `FULL_CONTENT`. Defaults to `METADATA_ONLY`.

--- a/website/docs/r/bedrockagentcore_memory.html.markdown
+++ b/website/docs/r/bedrockagentcore_memory.html.markdown
@@ -71,8 +71,33 @@ The following arguments are optional:
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `description` - (Optional) Description of the memory.
 * `encryption_key_arn` - (Optional) ARN of the KMS key used to encrypt the memory. If not provided, AWS managed encryption is used.
+* `indexed_keys` - (Optional) Metadata keys to index for filtering. Up to 10 entries. Changing this forces a new resource to be created. See [`indexed_keys`](#indexed_keys) below.
 * `memory_execution_role_arn` - (Optional) ARN of the IAM role that the memory service assumes to perform operations. Required when using custom memory strategies with model processing.
+* `stream_delivery_resources` - (Optional) Configuration for streaming memory record data to external resources. See [`stream_delivery_resources`](#stream_delivery_resources) below.
 * `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+### indexed_keys
+
+* `key` - (Required) Metadata key name to index.
+* `type` - (Required) Data type of the indexed key. Valid values are `STRING`, `STRINGLIST`, and `NUMBER`.
+
+### stream_delivery_resources
+
+* `resources` - (Required) List of stream delivery resource configurations. See [`resources`](#resources) below.
+
+### resources
+
+* `kinesis` - (Optional) Kinesis Data Stream configuration. See [`kinesis`](#kinesis) below.
+
+### kinesis
+
+* `data_stream_arn` - (Required) ARN of the Kinesis Data Stream.
+* `content_configurations` - (Required) Content configurations for stream delivery. See [`content_configurations`](#content_configurations) below.
+
+### content_configurations
+
+* `type` - (Required) Type of content to stream. Valid value is `MEMORY_RECORDS`.
+* `level` - (Optional) Level of detail for streamed content. Valid values are `METADATA_ONLY` and `FULL_CONTENT`. Defaults to `METADATA_ONLY`.
 
 ## Attribute Reference
 

--- a/website/docs/r/bedrockagentcore_memory.html.markdown
+++ b/website/docs/r/bedrockagentcore_memory.html.markdown
@@ -71,12 +71,12 @@ The following arguments are optional:
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `description` - (Optional) Description of the memory.
 * `encryption_key_arn` - (Optional) ARN of the KMS key used to encrypt the memory. If not provided, AWS managed encryption is used.
-* `indexed_keys` - (Optional) Metadata keys to index for filtering. Up to 10 entries. Changing this forces a new resource to be created. See [`indexed_keys`](#indexed_keys) below.
+* `indexed_key` - (Optional) Metadata keys to index for filtering. Up to 10 entries. Changing this forces a new resource to be created. See [`indexed_key`](#indexed_key) below.
 * `memory_execution_role_arn` - (Optional) ARN of the IAM role that the memory service assumes to perform operations. Required when using custom memory strategies with model processing.
 * `stream_delivery_resources` - (Optional) Configuration for streaming memory record data to external resources. See [`stream_delivery_resources`](#stream_delivery_resources) below.
 * `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
-### indexed_keys
+### indexed_key
 
 * `key` - (Required) Metadata key name to index.
 * `type` - (Required) Data type of the indexed key. Valid values are `STRING`, `STRINGLIST`, and `NUMBER`.


### PR DESCRIPTION
## Description

Adds two `CreateMemoryInput` arguments to the `aws_bedrockagentcore_memory` resource that were present in the SDK but missing from the Terraform schema:

- `indexed_keys` — list (1–10) of `{ key, type }` metadata keys to index for filtering. Because the update API uses add/remove semantics (`addIndexedKeys`) rather than a replace, this attribute is marked `RequiresReplace`.
- `stream_delivery_resources` — configuration for streaming memory record data to external resources. Models the `resources` → `kinesis` (`StreamDeliveryResource`) union with `data_stream_arn` and `content_configurations` (`type`, `level`).

Validators are translated directly from the Smithy model (length/pattern on `indexed_keys.key`, `SizeAtMost(1)` on the single-variant union lists, enum custom types for `type`/`level`).

Also adds an IAM-propagation retry for the `CreateMemory` call: when `stream_delivery_resources` references a Kinesis stream, the execution role's permissions can lag, and the service returns `ValidationException: ... does not have access to provided Kinesis stream`. This is retried consistently with the existing role-validation/trust-policy retries.

## Source

- Go SDK: `aws/aws-sdk-go-v2` @ `7146c2b4007293f0acc9b2e8b92ffa7a30841df0` (`service/bedrockagentcorecontrol`, `CreateMemoryInput`)
- Generated/assisted by the internal agentcore-terraform skill.

## Testing

Run in `us-west-2` against a real account:

```
TF_ACC=1 go test -v -timeout 60m ./internal/service/bedrockagentcore/ \
  -run 'TestAccBedrockAgentCoreMemory_(basic|indexedKeys|streamDeliveryResources)'
```

```
--- PASS: TestAccBedrockAgentCoreMemory_indexedKeys (206.93s)
--- PASS: TestAccBedrockAgentCoreMemory_basic (215.52s)
--- PASS: TestAccBedrockAgentCoreMemory_streamDeliveryResources (246.45s)
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/bedrockagentcore	254.971s
```

(`_basic` and `_indexedKeys` ran together in one invocation; `_streamDeliveryResources` passed on the follow-up invocation after the IAM retry was added.)

## Honest caveats

- **`memory_strategies` is intentionally out of scope** for this PR — it is a 5-variant union (`semantic`/`summary`/`userPreference`/`custom`/`episodic`) being handled separately.
- `stream_delivery_resources` is modeled as a single-variant union (`kinesis`) per the current SDK; additional variants would need new nested blocks + Expander/Flattener cases.
- `stream_delivery_resources` is updatable in-place per `UpdateMemoryInput`, but only create-path acceptance coverage is included here.
- The SDK Smithy model lists `event_expiry_duration`'s range as `[3, 365]`, while the existing schema validator uses `[7, 365]`. This PR leaves the existing validator unchanged.
