### PR TITLE
provider: Add `TF_AWS_DEFAULT_TAGS` environment variable

### DIFF
--- a/.changelog/48247.txt
+++ b/.changelog/48247.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+provider: Add support for specifying default tags as comma-separated `key=value` pairs in the `TF_AWS_DEFAULT_TAGS` environment variable.
+```

--- a/internal/provider/framework/provider.go
+++ b/internal/provider/framework/provider.go
@@ -299,7 +299,8 @@ func (*frameworkProvider) Schema(ctx context.Context, request provider.SchemaReq
 							ElementType: types.StringType,
 							Optional:    true,
 							Description: "Resource tags to default across all resources. " +
-								"Can also be configured with environment variables like `" + tftags.DefaultTagsEnvVarPrefix + "<tag_name>`.",
+								"Can also be configured with environment variables like `" + tftags.DefaultTagsEnvVarPrefix + "<tag_name>`, " +
+								"or with the `" + tftags.DefaultTagsEnvVar + "` environment variable containing comma-separated `key=value` pairs.",
 						},
 					},
 				},

--- a/internal/provider/sdkv2/provider.go
+++ b/internal/provider/sdkv2/provider.go
@@ -90,7 +90,8 @@ func NewProvider(ctx context.Context) (*schema.Provider, error) {
 								Optional: true,
 								Elem:     &schema.Schema{Type: schema.TypeString},
 								Description: "Resource tags to default across all resources. " +
-									"Can also be configured with environment variables like `" + tftags.DefaultTagsEnvVarPrefix + "<tag_name>`.",
+									"Can also be configured with environment variables like `" + tftags.DefaultTagsEnvVarPrefix + "<tag_name>`, " +
+									"or with the `" + tftags.DefaultTagsEnvVar + "` environment variable containing comma-separated `key=value` pairs.",
 							},
 						},
 					},
@@ -435,11 +436,18 @@ func (p *sdkProvider) configure(ctx context.Context, d *schema.ResourceData) (an
 		})
 	}
 
+	var defaultTagsConfig *tftags.DefaultConfig
+	var dtDiags diag.Diagnostics
 	if v, ok := d.GetOk("default_tags"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
-		config.DefaultTagsConfig = expandDefaultTags(ctx, v.([]any)[0].(map[string]any))
+		defaultTagsConfig, dtDiags = expandDefaultTags(ctx, v.([]any)[0].(map[string]any))
 	} else {
-		config.DefaultTagsConfig = expandDefaultTags(ctx, nil)
+		defaultTagsConfig, dtDiags = expandDefaultTags(ctx, nil)
 	}
+	diags = append(diags, dtDiags...)
+	if dtDiags.HasError() {
+		return nil, diags
+	}
+	config.DefaultTagsConfig = defaultTagsConfig
 
 	v := d.Get("endpoints")
 	endpoints, dx := expandEndpoints(ctx, v.(*schema.Set).List())
@@ -1027,8 +1035,28 @@ func expandAssumeRoleWithWebIdentity(_ context.Context, tfMap map[string]any) *a
 	return &assumeRole
 }
 
-func expandDefaultTags(ctx context.Context, tfMap map[string]any) *tftags.DefaultConfig {
+func expandDefaultTags(ctx context.Context, tfMap map[string]any) (*tftags.DefaultConfig, diag.Diagnostics) {
+	var diags diag.Diagnostics
 	tags := make(map[string]any)
+
+	if v := os.Getenv(tftags.DefaultTagsEnvVar); v != "" {
+		for pair := range strings.SplitSeq(v, ",") {
+			pair = strings.TrimSpace(pair)
+			if pair == "" {
+				continue
+			}
+			tk, tv, ok := strings.Cut(pair, "=")
+			if !ok || tk == "" {
+				diags = append(diags, errs.NewErrorDiagnostic(
+					summaryInvalidEnvironmentVariableValue,
+					fmt.Sprintf("%s must be a comma-separated list of \"key=value\" pairs: invalid entry %q", tftags.DefaultTagsEnvVar, pair),
+				))
+				continue
+			}
+			tags[tk] = tv
+		}
+	}
+
 	for _, ev := range os.Environ() {
 		k, v, _ := strings.Cut(ev, "=")
 		if before, tk, ok := strings.Cut(k, tftags.DefaultTagsEnvVarPrefix); ok && before == "" {
@@ -1043,10 +1071,10 @@ func expandDefaultTags(ctx context.Context, tfMap map[string]any) *tftags.Defaul
 	if len(tags) > 0 {
 		return &tftags.DefaultConfig{
 			Tags: tftags.New(ctx, tags),
-		}
+		}, diags
 	}
 
-	return nil
+	return nil, diags
 }
 
 func expandIgnoreTags(ctx context.Context, tfMap map[string]any) *tftags.IgnoreConfig {

--- a/internal/provider/sdkv2/provider_acc_test.go
+++ b/internal/provider/sdkv2/provider_acc_test.go
@@ -137,6 +137,33 @@ func TestAccProvider_DefaultTagsTags_envVars(t *testing.T) {
 	})
 }
 
+func TestAccProvider_DefaultTagsTags_envVarCommaSeparated(t *testing.T) {
+	ctx := acctest.Context(t)
+	var p *schema.Provider
+
+	t.Setenv(tftags.DefaultTagsEnvVar, "test1=commaValue1,test2=commaValue2,test3=commaValue3")
+	t.Setenv(tftags.DefaultTagsEnvVarPrefix+"test2", "envValue2")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t),
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactoriesInternal(ctx, t, &p),
+		CheckDestroy:             nil,
+		Steps: []resource.TestStep{
+			{ // nosemgrep:ci.test-config-funcs-correct-form
+				Config: acctest.ConfigDefaultTags_Tags1("test1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckProviderDefaultTags_Tags(ctx, t, &p, map[string]string{
+						"test1": "value1",
+						"test2": "envValue2",
+						"test3": "commaValue3",
+					}),
+				),
+			},
+		},
+	})
+}
+
 func TestAccProvider_DefaultAndIgnoreTags_emptyBlocks(t *testing.T) {
 	ctx := acctest.Context(t)
 	var provider *schema.Provider

--- a/internal/provider/sdkv2/provider_test.go
+++ b/internal/provider/sdkv2/provider_test.go
@@ -251,6 +251,7 @@ func TestExpandDefaultTags(t *testing.T) { //nolint:paralleltest
 		tags                  map[string]any
 		envvars               map[string]string
 		expectedDefaultConfig *tftags.DefaultConfig
+		expectError           bool
 	}{
 		"nil": {
 			tags:                  nil,
@@ -294,6 +295,116 @@ func TestExpandDefaultTags(t *testing.T) { //nolint:paralleltest
 				}),
 			},
 		},
+		"comma-separated envvar": {
+			tags: nil,
+			envvars: map[string]string{
+				tftags.DefaultTagsEnvVar: "Owner=my-team,Access-Project=foobar",
+			},
+			expectedDefaultConfig: &tftags.DefaultConfig{
+				Tags: tftags.New(ctx, map[string]string{
+					"Owner":          "my-team",
+					"Access-Project": "foobar",
+				}),
+			},
+		},
+		"comma-separated envvar with whitespace and trailing comma": {
+			tags: nil,
+			envvars: map[string]string{
+				tftags.DefaultTagsEnvVar: " Owner=my-team , Access-Project=foobar ,",
+			},
+			expectedDefaultConfig: &tftags.DefaultConfig{
+				Tags: tftags.New(ctx, map[string]string{
+					"Owner":          "my-team",
+					"Access-Project": "foobar",
+				}),
+			},
+		},
+		"comma-separated envvar with empty value": {
+			tags: nil,
+			envvars: map[string]string{
+				tftags.DefaultTagsEnvVar: "Owner=",
+			},
+			expectedDefaultConfig: &tftags.DefaultConfig{
+				Tags: tftags.New(ctx, map[string]string{
+					"Owner": "",
+				}),
+			},
+		},
+		"comma-separated envvar with value containing equals sign": {
+			tags: nil,
+			envvars: map[string]string{
+				tftags.DefaultTagsEnvVar: "Formula=a=b",
+			},
+			expectedDefaultConfig: &tftags.DefaultConfig{
+				Tags: tftags.New(ctx, map[string]string{
+					"Formula": "a=b",
+				}),
+			},
+		},
+		"comma-separated envvar and prefixed envvar": {
+			tags: nil,
+			envvars: map[string]string{
+				tftags.DefaultTagsEnvVar:                       "Application=my-app,Owner=other-team",
+				tftags.DefaultTagsEnvVarPrefix + "Application": "prefixed-app",
+			},
+			expectedDefaultConfig: &tftags.DefaultConfig{
+				Tags: tftags.New(ctx, map[string]string{
+					"Application": "prefixed-app",
+					"Owner":       "other-team",
+				}),
+			},
+		},
+		"comma-separated envvar and config": {
+			tags: map[string]any{
+				"Application": "foobar",
+			},
+			envvars: map[string]string{
+				tftags.DefaultTagsEnvVar: "Application=my-app,Owner=my-team",
+			},
+			expectedDefaultConfig: &tftags.DefaultConfig{
+				Tags: tftags.New(ctx, map[string]string{
+					"Application": "foobar",
+					"Owner":       "my-team",
+				}),
+			},
+		},
+		"comma-separated envvar, prefixed envvar, and config": {
+			tags: map[string]any{
+				"Application": "foobar",
+			},
+			envvars: map[string]string{
+				tftags.DefaultTagsEnvVar:                       "Application=my-app,Owner=other-team,CostCenter=1234",
+				tftags.DefaultTagsEnvVarPrefix + "Application": "prefixed-app",
+				tftags.DefaultTagsEnvVarPrefix + "Owner":       "my-team",
+			},
+			expectedDefaultConfig: &tftags.DefaultConfig{
+				Tags: tftags.New(ctx, map[string]string{
+					"Application": "foobar",
+					"Owner":       "my-team",
+					"CostCenter":  "1234",
+				}),
+			},
+		},
+		"comma-separated envvar with entry missing equals sign": {
+			tags: nil,
+			envvars: map[string]string{
+				tftags.DefaultTagsEnvVar: "Owner=my-team,oops",
+			},
+			expectedDefaultConfig: &tftags.DefaultConfig{
+				Tags: tftags.New(ctx, map[string]string{
+					"Owner": "my-team",
+				}),
+			},
+			expectError: true,
+		},
+		"comma-separated envvar with entry missing key": {
+			tags: nil,
+			envvars: map[string]string{
+				tftags.DefaultTagsEnvVar: "=value",
+			},
+			expectedDefaultConfig: nil,
+			expectError:           true,
+		},
 	}
 
 	for name, testcase := range testcases { //nolint:paralleltest
@@ -305,9 +416,13 @@ func TestExpandDefaultTags(t *testing.T) { //nolint:paralleltest
 				os.Setenv(k, v) //nolint:usetesting // stashEnv & popEnv require os.Setenv
 			}
 
-			results := expandDefaultTags(ctx, map[string]any{
+			results, diags := expandDefaultTags(ctx, map[string]any{
 				"tags": testcase.tags,
 			})
+
+			if diags.HasError() != testcase.expectError {
+				t.Errorf("Expected HasError %t, got %t: %v", testcase.expectError, diags.HasError(), diags)
+			}
 
 			if results == nil {
 				if testcase.expectedDefaultConfig == nil {

--- a/internal/provider/sdkv2/tags_interceptor_test.go
+++ b/internal/provider/sdkv2/tags_interceptor_test.go
@@ -78,9 +78,10 @@ func TestTagsResourceInterceptor(t *testing.T) {
 	conn.SetServicePackages(ctx, map[string]conns.ServicePackage{
 		"Test": &mockService{},
 	})
-	conns.SetDefaultTagsConfig(conn, expandDefaultTags(ctx, map[string]any{
+	defaultTagsConfig, _ := expandDefaultTags(ctx, map[string]any{
 		"tag": "",
-	}))
+	})
+	conns.SetDefaultTagsConfig(conn, defaultTagsConfig)
 	conns.SetIgnoreTagsConfig(conn, expandIgnoreTags(ctx, map[string]any{
 		"tag2": "tag",
 	}))

--- a/internal/tags/key_value_tags.go
+++ b/internal/tags/key_value_tags.go
@@ -27,10 +27,20 @@ const (
 	NameTagKey                                  = `Name`
 	ServerlessApplicationRepositoryTagKeyPrefix = `serverlessrepo:`
 
+	// Environment variable specifying `default_tags` as comma-separated "key=value" pairs,
+	// e.g. "key1=value1,key2=value2". Empty values are permitted. Useful where tag keys
+	// contain characters not allowed in environment variable names.
+	//
+	// Tags read from this environment variable have lower precedence than tags specified
+	// via DefaultTagsEnvVarPrefix environment variables.
+	DefaultTagsEnvVar = "TF_AWS_DEFAULT_TAGS"
+
 	// Environment variables with this prefix will be treated as a `default_tags` key value pair
 	//
 	// The environment variable name after this suffix will be treated as the tag key. The
 	// value of the variable will be treated as the tag value. Empty values are permitted.
+	// Tags read from these environment variables have lower precedence than tags specified
+	// in the provider configuration.
 	DefaultTagsEnvVarPrefix = "TF_AWS_DEFAULT_TAGS_"
 
 	// Environment variable specifying a list of tag keys to be ignored

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -766,11 +766,30 @@ vpc_all_tags = tomap({
 })
 ```
 
+Default tags can also be provided as comma-separated `<tag_key>=<tag_value>` pairs in the `TF_AWS_DEFAULT_TAGS` environment variable.
+This is useful for tag keys containing characters that are not allowed in environment variable names, such as `-`:
+
+```console
+$ export TF_AWS_DEFAULT_TAGS=Environment=Test,Access-Project=example
+$ terraform apply
+...
+Outputs:
+
+vpc_all_tags = tomap({
+  "Environment" = "Test"
+  "Name" = "Provider Tag"
+  "Access-Project" = "example"
+})
+```
+
 The `default_tags` configuration block supports the following argument:
 
 * `tags` - (Optional) Key-value map of tags to apply to all resources.
-Default tags can also be provided via environment variables matching the pattern `TF_AWS_DEFAULT_TAGS_<tag_key>=<tag_value>`.
-If a tag is present in both an environment variable and this argument, the value in the provider configuration takes precedence.
+Default tags can also be provided via environment variables matching the pattern `TF_AWS_DEFAULT_TAGS_<tag_key>=<tag_value>`,
+or via the `TF_AWS_DEFAULT_TAGS` environment variable containing comma-separated `<tag_key>=<tag_value>` pairs (e.g., `TF_AWS_DEFAULT_TAGS=key1=value1,key2=value2`).
+If a tag is defined in more than one place, the provider configuration takes precedence over `TF_AWS_DEFAULT_TAGS_<tag_key>` environment variables,
+which in turn take precedence over `TF_AWS_DEFAULT_TAGS`.
+Tag values containing commas cannot be specified in `TF_AWS_DEFAULT_TAGS`; use a `TF_AWS_DEFAULT_TAGS_<tag_key>` environment variable instead.
 
 ### ignore_tags Configuration Block
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Adds an environment variable `TF_AWS_DEFAULT_TAGS` that the provider will parse to extract comma-separated `key=value` pairs, which will be treated as default tags by the provider.

Default tags can already be set by individual env vars matching `TF_AWS_DEFAULT_TAGS_<tag_key>`, but some shells and HCP Terraform restrict the characters allowed in env var names, making tag keys such as `Access-Project` impossible to express.

Default tag source precedence, from highest to lowest becomes:

- Provider config in the `*.tf` files
- `TF_AWS_DEFAULT_TAGS_<tag_key>`
- `TF_AWS_DEFAULT_TAGS`

I considered adding some kind of character escaping so you could have commas in tag values e.g. `key=a\,b`, but that seemed too complicated for a first pass. Having commas in the value will raise an error diagnostic during provider configuration.

AI disclaimer: I used Claude Code to write this. It drafted the implementation, tests, and docs. I reviewed and verified all of it.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Would have closed the already closed #38889. The workaround described in that issue isn't available in HCP Terraform.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG_NAME=internal/provider/sdkv2 TESTS='TestAccProvider_DefaultTags|TestAccProvider_DefaultAndIgnoreTags'
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework (cached)
make: Running acceptance tests on branch: 🌿 f-default-tags-env-var 🌿...
TF_ACC=1 go1.26.3 test ./internal/provider/sdkv2/... -v -count 1 -parallel 20 -run='TestAccProvider_DefaultTags|TestAccProvider_DefaultAndIgnoreTags'  -timeout 360m -vet=off -buildvcs=false
2026/06/05 14:49:00 Creating Terraform AWS Provider (SDKv2-style)...
2026/06/05 14:49:00 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccProvider_DefaultTags_emptyBlock
=== PAUSE TestAccProvider_DefaultTags_emptyBlock
=== RUN   TestAccProvider_DefaultTagsTags_none
=== PAUSE TestAccProvider_DefaultTagsTags_none
=== RUN   TestAccProvider_DefaultTagsTags_one
=== PAUSE TestAccProvider_DefaultTagsTags_one
=== RUN   TestAccProvider_DefaultTagsTags_multiple
=== PAUSE TestAccProvider_DefaultTagsTags_multiple
=== RUN   TestAccProvider_DefaultTagsTags_envVars
--- PASS: TestAccProvider_DefaultTagsTags_envVars (17.12s)
=== RUN   TestAccProvider_DefaultTagsTags_envVarCommaSeparated
--- PASS: TestAccProvider_DefaultTagsTags_envVarCommaSeparated (16.60s)
=== RUN   TestAccProvider_DefaultAndIgnoreTags_emptyBlocks
=== PAUSE TestAccProvider_DefaultAndIgnoreTags_emptyBlocks
=== CONT  TestAccProvider_DefaultTags_emptyBlock
=== CONT  TestAccProvider_DefaultTagsTags_multiple
=== CONT  TestAccProvider_DefaultTagsTags_one
=== CONT  TestAccProvider_DefaultAndIgnoreTags_emptyBlocks
=== CONT  TestAccProvider_DefaultTagsTags_none
--- PASS: TestAccProvider_DefaultTagsTags_multiple (20.71s)
--- PASS: TestAccProvider_DefaultTags_emptyBlock (21.22s)
--- PASS: TestAccProvider_DefaultAndIgnoreTags_emptyBlocks (21.98s)
--- PASS: TestAccProvider_DefaultTagsTags_none (23.59s)
--- PASS: TestAccProvider_DefaultTagsTags_one (24.93s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     58.822s
?       github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2/identity    [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2/importer    0.051s [no tests to run]
```
