### PR TITLE
Adds semgrep rule to require identity test generator for service packages

### DIFF
--- a/.ci/semgrep/service-package/generate.yml
+++ b/.ci/semgrep/service-package/generate.yml
@@ -1,0 +1,15 @@
+rules:
+  - id: missing-identitytests-generator
+    message: >-
+      Missing the identitytests generator directive. Add:
+      //go:generate go run ../../generate/identitytests/main.go
+    severity: WARNING
+    languages: [generic]
+    paths:
+      include:
+        - /internal/service/*/generate.go
+      exclude:
+        - /internal/service/uxc/generate.go
+    patterns:
+      - pattern-regex: "(?s).*servicepackage.*package \\w+"
+      - pattern-not-regex: "(?s).*identitytests.*"


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Adds semgrep rule to require identity test generator for service packages. Excludes `uxc`.