### PR TITLE
resource/aws_uxc_account_customizations: Fix inconsistent result errors

### DIFF
--- a/.changelog/48250.txt
+++ b/.changelog/48250.txt
@@ -1,0 +1,2 @@
+```release-note:bug
+resource/aws_uxc_account_customizations: Fixes inconsistent result errors

--- a/internal/framework/types/listof.go
+++ b/internal/framework/types/listof.go
@@ -215,3 +215,7 @@ func validateStringEnumSlice[T enum.Valueser[T]](ctx context.Context, path path.
 	}
 	return diags
 }
+
+func NewListValueOfEmpty[T attr.Value](ctx context.Context) ListValueOf[T] {
+	return NewListValueOfMust[T](ctx, []attr.Value{})
+}

--- a/internal/framework/types/setof.go
+++ b/internal/framework/types/setof.go
@@ -180,3 +180,7 @@ func NewSetValueOf[T attr.Value](ctx context.Context, elements []attr.Value) (Se
 func NewSetValueOfMust[T attr.Value](ctx context.Context, elements []attr.Value) SetValueOf[T] {
 	return fwdiag.Must(NewSetValueOf[T](ctx, elements))
 }
+
+func NewSetValueOfEmpty[T attr.Value](ctx context.Context) SetValueOf[T] {
+	return NewSetValueOfMust[T](ctx, []attr.Value{})
+}

--- a/internal/service/uxc/account_customizations.go
+++ b/internal/service/uxc/account_customizations.go
@@ -62,6 +62,8 @@ func (r *accountCustomizationsResource) Schema(ctx context.Context, _ resource.S
 				CustomType:  fwtypes.SetOfStringType,
 				ElementType: types.StringType,
 				Optional:    true,
+				Computed:    true,
+				Default:     setdefault.StaticValue(fwtypes.NewSetValueOfEmpty[types.String](ctx).SetValue),
 			},
 		},
 	}
@@ -76,16 +78,10 @@ func (r *accountCustomizationsResource) Create(ctx context.Context, req resource
 
 	conn := r.Meta().UXCClient(ctx)
 
-	prior := plan
-
 	input := uxc.UpdateAccountCustomizationsInput{}
 	smerr.AddEnrich(ctx, &resp.Diagnostics, fwflex.Expand(ctx, plan, &input))
 	if resp.Diagnostics.HasError() {
 		return
-	}
-	// nil means "no change" in the API; use empty slice to explicitly clear any pre-existing restrictions.
-	if input.VisibleServices == nil {
-		input.VisibleServices = []string{}
 	}
 
 	output, err := conn.UpdateAccountCustomizations(ctx, &input)
@@ -95,7 +91,6 @@ func (r *accountCustomizationsResource) Create(ctx context.Context, req resource
 	}
 
 	smerr.AddEnrich(ctx, &resp.Diagnostics, fwflex.Flatten(ctx, output, &plan))
-	normalizeAccountCustomizationsModel(ctx, &plan, &prior)
 
 	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, &plan))
 }
@@ -106,8 +101,6 @@ func (r *accountCustomizationsResource) Read(ctx context.Context, req resource.R
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	prior := state
 
 	conn := r.Meta().UXCClient(ctx)
 
@@ -123,7 +116,7 @@ func (r *accountCustomizationsResource) Read(ctx context.Context, req resource.R
 	}
 
 	smerr.AddEnrich(ctx, &resp.Diagnostics, fwflex.Flatten(ctx, output, &state))
-	normalizeAccountCustomizationsModel(ctx, &state, &prior)
+
 	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, &state))
 }
 
@@ -134,20 +127,12 @@ func (r *accountCustomizationsResource) Update(ctx context.Context, req resource
 		return
 	}
 
-	prior := plan
-
 	conn := r.Meta().UXCClient(ctx)
 
 	input := uxc.UpdateAccountCustomizationsInput{}
 	smerr.AddEnrich(ctx, &resp.Diagnostics, fwflex.Expand(ctx, plan, &input))
 	if resp.Diagnostics.HasError() {
 		return
-	}
-	if input.VisibleRegions == nil {
-		input.VisibleRegions = []string{}
-	}
-	if input.VisibleServices == nil {
-		input.VisibleServices = []string{}
 	}
 
 	output, err := conn.UpdateAccountCustomizations(ctx, &input)
@@ -157,7 +142,6 @@ func (r *accountCustomizationsResource) Update(ctx context.Context, req resource
 	}
 
 	smerr.AddEnrich(ctx, &resp.Diagnostics, fwflex.Flatten(ctx, output, &plan))
-	normalizeAccountCustomizationsModel(ctx, &plan, &prior)
 
 	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, &plan))
 }
@@ -197,23 +181,7 @@ func (r *accountCustomizationsResource) ImportState(ctx context.Context, req res
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	normalizeAccountCustomizationsModel(ctx, &state, nil)
 	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, &state))
-}
-
-// normalizeAccountCustomizationsModel maps empty API sets to null so that unconfigured
-// optional attributes don't drift against a config that omits them.
-// prior holds the values from the plan (Create/Update) or prior state (Read); a nil prior
-// means no prior context is available (ImportState), in which case all empty sets are normalized.
-// When the prior value for an attribute is an explicit empty set, the empty set is preserved
-// so that a user-configured `visible_regions = []` or `visible_services = []` does not cause
-// a permanent plan diff.
-func normalizeAccountCustomizationsModel(ctx context.Context, m *accountCustomizationsResourceModel, prior *accountCustomizationsResourceModel) {
-	if prior == nil || prior.VisibleServices.IsNull() {
-		if !m.VisibleServices.IsNull() && len(m.VisibleServices.Elements()) == 0 {
-			m.VisibleServices = fwtypes.NewSetValueOfNull[types.String](ctx)
-		}
-	}
 }
 
 func findAccountCustomizations(ctx context.Context, conn *uxc.Client) (*uxc.GetAccountCustomizationsOutput, error) {
@@ -234,5 +202,5 @@ type accountCustomizationsResourceModel struct {
 	// TODO: `legacy` mode is used here for the behavior. It is not a legacy resource.
 	// Needs a new mode that flattens to an empty collection instead of null.
 	VisibleRegions  fwtypes.SetOfString `tfsdk:"visible_regions" autoflex:",legacy"`
-	VisibleServices fwtypes.SetOfString `tfsdk:"visible_services"`
+	VisibleServices fwtypes.SetOfString `tfsdk:"visible_services" autoflex:",legacy"`
 }

--- a/internal/service/uxc/account_customizations.go
+++ b/internal/service/uxc/account_customizations.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
@@ -36,7 +37,7 @@ type accountCustomizationsResource struct {
 	framework.WithImportByIdentity
 }
 
-func (r *accountCustomizationsResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+func (r *accountCustomizationsResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	accountColorType := fwtypes.StringEnumType[awstypes.AccountColor]()
 
 	resp.Schema = schema.Schema{
@@ -54,6 +55,8 @@ func (r *accountCustomizationsResource) Schema(_ context.Context, _ resource.Sch
 				CustomType:  fwtypes.SetOfStringType,
 				ElementType: types.StringType,
 				Optional:    true,
+				Computed:    true,
+				Default:     setdefault.StaticValue(fwtypes.NewSetValueOfEmpty[types.String](ctx).SetValue),
 			},
 			"visible_services": schema.SetAttribute{
 				CustomType:  fwtypes.SetOfStringType,
@@ -81,9 +84,6 @@ func (r *accountCustomizationsResource) Create(ctx context.Context, req resource
 		return
 	}
 	// nil means "no change" in the API; use empty slice to explicitly clear any pre-existing restrictions.
-	if input.VisibleRegions == nil {
-		input.VisibleRegions = []string{}
-	}
 	if input.VisibleServices == nil {
 		input.VisibleServices = []string{}
 	}
@@ -209,11 +209,6 @@ func (r *accountCustomizationsResource) ImportState(ctx context.Context, req res
 // so that a user-configured `visible_regions = []` or `visible_services = []` does not cause
 // a permanent plan diff.
 func normalizeAccountCustomizationsModel(ctx context.Context, m *accountCustomizationsResourceModel, prior *accountCustomizationsResourceModel) {
-	if prior == nil || prior.VisibleRegions.IsNull() {
-		if !m.VisibleRegions.IsNull() && len(m.VisibleRegions.Elements()) == 0 {
-			m.VisibleRegions = fwtypes.NewSetValueOfNull[types.String](ctx)
-		}
-	}
 	if prior == nil || prior.VisibleServices.IsNull() {
 		if !m.VisibleServices.IsNull() && len(m.VisibleServices.Elements()) == 0 {
 			m.VisibleServices = fwtypes.NewSetValueOfNull[types.String](ctx)
@@ -235,7 +230,9 @@ func findAccountCustomizations(ctx context.Context, conn *uxc.Client) (*uxc.GetA
 }
 
 type accountCustomizationsResourceModel struct {
-	AccountColor    fwtypes.StringEnum[awstypes.AccountColor] `tfsdk:"account_color"`
-	VisibleRegions  fwtypes.SetOfString                       `tfsdk:"visible_regions"`
-	VisibleServices fwtypes.SetOfString                       `tfsdk:"visible_services"`
+	AccountColor fwtypes.StringEnum[awstypes.AccountColor] `tfsdk:"account_color"`
+	// TODO: `legacy` mode is used here for the behavior. It is not a legacy resource.
+	// Needs a new mode that flattens to an empty collection instead of null.
+	VisibleRegions  fwtypes.SetOfString `tfsdk:"visible_regions" autoflex:",legacy"`
+	VisibleServices fwtypes.SetOfString `tfsdk:"visible_services"`
 }

--- a/internal/service/uxc/account_customizations_test.go
+++ b/internal/service/uxc/account_customizations_test.go
@@ -268,7 +268,7 @@ func testAccAccountCustomizations_disappears(t *testing.T) {
 						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
 					},
 					PostApplyPostRefresh: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
 					},
 				},
 			},

--- a/internal/service/uxc/account_customizations_test.go
+++ b/internal/service/uxc/account_customizations_test.go
@@ -12,9 +12,13 @@ import (
 
 	awstypes "github.com/aws/aws-sdk-go-v2/service/uxc/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	tfknownvalue "github.com/hashicorp/terraform-provider-aws/internal/acctest/knownvalue"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfuxc "github.com/hashicorp/terraform-provider-aws/internal/service/uxc"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -32,6 +36,7 @@ func TestAccUXC_serial(t *testing.T) {
 			"visibleServices":      testAccAccountCustomizations_visibleServices,
 			"visibleServicesEmpty": testAccAccountCustomizations_visibleServicesEmpty,
 			"disappears":           testAccAccountCustomizations_disappears,
+			"migrate":              testAccAccountCustomizations_Migrate_basic,
 		},
 		"ServicesDataSource": {
 			"basic": testAccServicesDataSource_basic,
@@ -58,8 +63,13 @@ func testAccAccountCustomizations_basic(t *testing.T) {
 				Config: testAccAccountCustomizationsConfig_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAccountCustomizationsExists(ctx, t, resourceName),
-					resource.TestCheckResourceAttr(resourceName, "account_color", string(awstypes.AccountColorNone)),
 				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("account_color"), tfknownvalue.StringExact(awstypes.AccountColorNone)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("visible_regions"), knownvalue.ListSizeExact(0)),
+					// statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("visible_services"), knownvalue.ListSizeExact(0)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("visible_services"), knownvalue.Null()),
+				},
 			},
 			{
 				ResourceName:                         resourceName,
@@ -307,6 +317,60 @@ func testAccAccountCustomizations_disappears(t *testing.T) {
 					},
 					PostApplyPostRefresh: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccAccountCustomizations_Migrate_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_uxc_account_customizations.test"
+
+	acctest.Test(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:   acctest.ErrorCheck(t, names.UXCServiceID),
+		CheckDestroy: testAccCheckAccountCustomizationsDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"aws": {
+						Source:            "hashicorp/aws",
+						VersionConstraint: "6.49.0",
+					},
+				},
+				Config: testAccAccountCustomizationsConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAccountCustomizationsExists(ctx, t, resourceName),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("account_color"), tfknownvalue.StringExact(awstypes.AccountColorNone)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("visible_regions"), knownvalue.Null()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("visible_services"), knownvalue.Null()),
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				Config:                   testAccAccountCustomizationsConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAccountCustomizationsExists(ctx, t, resourceName),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("account_color"), tfknownvalue.StringExact(awstypes.AccountColorNone)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("visible_regions"), knownvalue.ListSizeExact(0)),
+					// statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("visible_services"), knownvalue.ListSizeExact(0)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("visible_services"), knownvalue.Null()),
+				},
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
 					},
 				},
 			},

--- a/internal/service/uxc/account_customizations_test.go
+++ b/internal/service/uxc/account_customizations_test.go
@@ -525,7 +525,7 @@ func testAccAccountCustomizations_disappears(t *testing.T) {
 				Config: testAccAccountCustomizationsConfig_accountColor("pink"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAccountCustomizationsExists(ctx, t, resourceName),
-					acctest.CheckFrameworkResourceDisappears(ctx, t, tfuxc.ResourceAccountCustomizations, resourceName),
+					acctest.CheckFrameworkResourceDisappears(ctx, t, tfuxc.ResourceAccountCustomizations, resourceName), // nosemgrep:disappears-expect-resource-action
 				),
 				ExpectNonEmptyPlan: true,
 				ConfigPlanChecks: resource.ConfigPlanChecks{

--- a/internal/service/uxc/account_customizations_test.go
+++ b/internal/service/uxc/account_customizations_test.go
@@ -29,7 +29,7 @@ func TestAccUXC_serial(t *testing.T) {
 
 	testCases := map[string]map[string]func(t *testing.T){
 		"AccountCustomizations": {
-			"basic":                testAccAccountCustomizations_basic,
+			acctest.CtBasic:        testAccAccountCustomizations_basic,
 			"accountColor":         testAccAccountCustomizations_accountColor,
 			"visibleRegions":       testAccAccountCustomizations_visibleRegions,
 			"visibleRegionsEmpty":  testAccAccountCustomizations_visibleRegionsEmpty,
@@ -37,11 +37,11 @@ func TestAccUXC_serial(t *testing.T) {
 			"visibleServices":      testAccAccountCustomizations_visibleServices,
 			"visibleServicesEmpty": testAccAccountCustomizations_visibleServicesEmpty,
 			"visibleServicesNil":   testAccAccountCustomizations_visibleServicesNil,
-			"disappears":           testAccAccountCustomizations_disappears,
+			acctest.CtDisappears:   testAccAccountCustomizations_disappears,
 			"migrate":              testAccAccountCustomizations_Migrate_basic,
 		},
 		"ServicesDataSource": {
-			"basic": testAccServicesDataSource_basic,
+			acctest.CtBasic: testAccServicesDataSource_basic,
 		},
 	}
 

--- a/internal/service/uxc/account_customizations_test.go
+++ b/internal/service/uxc/account_customizations_test.go
@@ -19,21 +19,24 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// All UXC tests run serially — the service is account-scoped and tests would interfere if run in parallel.
 func TestAccUXC_serial(t *testing.T) {
 	t.Parallel()
 
-	testCases := map[string]func(t *testing.T){
-		"accountCustomizationsBasic":                testAccAccountCustomizations_basic,
-		"accountCustomizationsVisibleRegions":       testAccAccountCustomizations_visibleRegions,
-		"accountCustomizationsVisibleRegionsEmpty":  testAccAccountCustomizations_visibleRegionsEmpty,
-		"accountCustomizationsVisibleServices":      testAccAccountCustomizations_visibleServices,
-		"accountCustomizationsVisibleServicesEmpty": testAccAccountCustomizations_visibleServicesEmpty,
-		"accountCustomizationsDisappears":           testAccAccountCustomizations_disappears,
-		"servicesDataSourceBasic":                   testAccServicesDataSource_basic,
+	testCases := map[string]map[string]func(t *testing.T){
+		"AccountCustomizations": {
+			"basic":                testAccAccountCustomizations_basic,
+			"visibleRegions":       testAccAccountCustomizations_visibleRegions,
+			"visibleRegionsEmpty":  testAccAccountCustomizations_visibleRegionsEmpty,
+			"visibleServices":      testAccAccountCustomizations_visibleServices,
+			"visibleServicesEmpty": testAccAccountCustomizations_visibleServicesEmpty,
+			"disappears":           testAccAccountCustomizations_disappears,
+		},
+		"ServicesDataSource": {
+			"basic": testAccServicesDataSource_basic,
+		},
 	}
 
-	acctest.RunSerialTests1Level(t, testCases, 0)
+	acctest.RunSerialTests2Levels(t, testCases, 0)
 }
 
 func testAccAccountCustomizations_basic(t *testing.T) {

--- a/internal/service/uxc/account_customizations_test.go
+++ b/internal/service/uxc/account_customizations_test.go
@@ -36,6 +36,7 @@ func TestAccUXC_serial(t *testing.T) {
 			"visibleRegionsNil":    testAccAccountCustomizations_visibleRegionsNil,
 			"visibleServices":      testAccAccountCustomizations_visibleServices,
 			"visibleServicesEmpty": testAccAccountCustomizations_visibleServicesEmpty,
+			"visibleServicesNil":   testAccAccountCustomizations_visibleServicesNil,
 			"disappears":           testAccAccountCustomizations_disappears,
 			"migrate":              testAccAccountCustomizations_Migrate_basic,
 		},
@@ -67,9 +68,8 @@ func testAccAccountCustomizations_basic(t *testing.T) {
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("account_color"), tfknownvalue.StringExact(awstypes.AccountColorNone)),
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("visible_regions"), knownvalue.ListSizeExact(0)),
-					// statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("visible_services"), knownvalue.ListSizeExact(0)),
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("visible_services"), knownvalue.Null()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("visible_regions"), knownvalue.SetSizeExact(0)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("visible_services"), knownvalue.SetSizeExact(0)),
 				},
 			},
 			{
@@ -198,7 +198,7 @@ func testAccAccountCustomizations_visibleRegionsEmpty_onCreate(t *testing.T) {
 					testAccCheckAccountCustomizationsExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("visible_regions"), knownvalue.ListSizeExact(0)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("visible_regions"), knownvalue.SetSizeExact(0)),
 				},
 			},
 			{
@@ -230,7 +230,7 @@ func testAccAccountCustomizations_visibleRegionsEmpty_onUpdate(t *testing.T) {
 					testAccCheckAccountCustomizationsExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("visible_regions"), knownvalue.ListExact([]knownvalue.Check{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("visible_regions"), knownvalue.SetExact([]knownvalue.Check{
 						knownvalue.StringExact("us-east-1"), //lintignore:AWSAT003
 					})),
 				},
@@ -242,7 +242,7 @@ func testAccAccountCustomizations_visibleRegionsEmpty_onUpdate(t *testing.T) {
 					testAccCheckAccountCustomizationsExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("visible_regions"), knownvalue.ListSizeExact(0)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("visible_regions"), knownvalue.SetSizeExact(0)),
 				},
 			},
 			{
@@ -285,7 +285,7 @@ func testAccAccountCustomizations_visibleRegionsNil_onUpdate(t *testing.T) {
 					testAccCheckAccountCustomizationsExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("visible_regions"), knownvalue.ListExact([]knownvalue.Check{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("visible_regions"), knownvalue.SetExact([]knownvalue.Check{
 						knownvalue.StringExact("us-east-1"), //lintignore:AWSAT003
 					})),
 				},
@@ -297,7 +297,7 @@ func testAccAccountCustomizations_visibleRegionsNil_onUpdate(t *testing.T) {
 					testAccCheckAccountCustomizationsExists(ctx, t, resourceName),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("visible_regions"), knownvalue.ListSizeExact(0)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("visible_regions"), knownvalue.SetSizeExact(0)),
 				},
 			},
 			{
@@ -334,6 +334,12 @@ func testAccAccountCustomizations_visibleServices(t *testing.T) {
 					resource.TestCheckTypeSetElemAttr(resourceName, "visible_services.*", "s3"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "visible_services.*", "ec2"),
 				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("visible_services"), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.StringExact("s3"),
+						knownvalue.StringExact("ec2"),
+					})),
+				},
 			},
 			{
 				ResourceName:                         resourceName,
@@ -345,15 +351,59 @@ func testAccAccountCustomizations_visibleServices(t *testing.T) {
 				Config: testAccAccountCustomizationsConfig_visibleServices([]string{"s3"}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAccountCustomizationsExists(ctx, t, resourceName),
-					resource.TestCheckResourceAttr(resourceName, "visible_services.#", "1"),
-					resource.TestCheckTypeSetElemAttr(resourceName, "visible_services.*", "s3"),
 				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("visible_services"), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.StringExact("s3"),
+					})),
+				},
 			},
 		},
 	})
 }
 
 func testAccAccountCustomizations_visibleServicesEmpty(t *testing.T) {
+	testCases := map[string]func(t *testing.T){
+		"onCreate": testAccAccountCustomizations_visibleServicesEmpty_onCreate,
+		"onUpdate": testAccAccountCustomizations_visibleServicesEmpty_onUpdate,
+	}
+
+	acctest.RunSerialTests1Level(t, testCases, 0)
+}
+
+func testAccAccountCustomizations_visibleServicesEmpty_onCreate(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_uxc_account_customizations.test"
+
+	acctest.Test(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.UXCServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckAccountCustomizationsDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAccountCustomizationsConfig_visibleServicesEmpty(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAccountCustomizationsExists(ctx, t, resourceName),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("visible_services"), knownvalue.SetSizeExact(0)),
+				},
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "account_color",
+			},
+		},
+	})
+}
+
+func testAccAccountCustomizations_visibleServicesEmpty_onUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_uxc_account_customizations.test"
 
@@ -370,20 +420,81 @@ func testAccAccountCustomizations_visibleServicesEmpty(t *testing.T) {
 				Config: testAccAccountCustomizationsConfig_visibleServices([]string{"s3"}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAccountCustomizationsExists(ctx, t, resourceName),
-					resource.TestCheckResourceAttr(resourceName, "visible_services.#", "1"),
 				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("visible_services"), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.StringExact("s3"),
+					})),
+				},
 			},
 			{
 				// Explicitly set an empty set — must not cause a permanent diff.
 				Config: testAccAccountCustomizationsConfig_visibleServicesEmpty(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAccountCustomizationsExists(ctx, t, resourceName),
-					resource.TestCheckResourceAttr(resourceName, "visible_services.#", "0"),
 				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("visible_services"), knownvalue.SetSizeExact(0)),
+				},
 			},
 			{
 				// Confirm no diff on subsequent plan.
 				Config: testAccAccountCustomizationsConfig_visibleServicesEmpty(),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccAccountCustomizations_visibleServicesNil(t *testing.T) {
+	testCases := map[string]func(t *testing.T){
+		"onUpdate": testAccAccountCustomizations_visibleServicesNil_onUpdate,
+	}
+
+	acctest.RunSerialTests1Level(t, testCases, 0)
+}
+
+func testAccAccountCustomizations_visibleServicesNil_onUpdate(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_uxc_account_customizations.test"
+
+	acctest.Test(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.UXCServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckAccountCustomizationsDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAccountCustomizationsConfig_visibleServices([]string{"s3"}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAccountCustomizationsExists(ctx, t, resourceName),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("visible_services"), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.StringExact("s3"),
+					})),
+				},
+			},
+			{
+				// Explicitly set nil — must not cause a permanent diff.
+				Config: testAccAccountCustomizationsConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAccountCustomizationsExists(ctx, t, resourceName),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("visible_services"), knownvalue.SetSizeExact(0)),
+				},
+			},
+			{
+				// Confirm no diff on subsequent plan.
+				Config: testAccAccountCustomizationsConfig_basic(),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectEmptyPlan(),
@@ -464,9 +575,8 @@ func testAccAccountCustomizations_Migrate_basic(t *testing.T) {
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("account_color"), tfknownvalue.StringExact(awstypes.AccountColorNone)),
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("visible_regions"), knownvalue.ListSizeExact(0)),
-					// statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("visible_services"), knownvalue.ListSizeExact(0)),
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("visible_services"), knownvalue.Null()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("visible_regions"), knownvalue.SetSizeExact(0)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("visible_services"), knownvalue.SetSizeExact(0)),
 				},
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -579,14 +689,6 @@ resource "aws_uxc_account_customizations" "test" {
 `
 }
 
-func testAccAccountCustomizationsConfig_visibleServicesEmpty() string {
-	return `
-resource "aws_uxc_account_customizations" "test" {
-  visible_services = []
-}
-`
-}
-
 func testAccAccountCustomizationsConfig_visibleServices(services []string) string {
 	quoted := make([]string, len(services))
 	for i, s := range services {
@@ -597,4 +699,12 @@ resource "aws_uxc_account_customizations" "test" {
   visible_services = [%s]
 }
 `, strings.Join(quoted, ", "))
+}
+
+func testAccAccountCustomizationsConfig_visibleServicesEmpty() string {
+	return `
+resource "aws_uxc_account_customizations" "test" {
+  visible_services = []
+}
+`
 }

--- a/internal/service/uxc/account_customizations_test.go
+++ b/internal/service/uxc/account_customizations_test.go
@@ -33,6 +33,7 @@ func TestAccUXC_serial(t *testing.T) {
 			"accountColor":         testAccAccountCustomizations_accountColor,
 			"visibleRegions":       testAccAccountCustomizations_visibleRegions,
 			"visibleRegionsEmpty":  testAccAccountCustomizations_visibleRegionsEmpty,
+			"visibleRegionsNil":    testAccAccountCustomizations_visibleRegionsNil,
 			"visibleServices":      testAccAccountCustomizations_visibleServices,
 			"visibleServicesEmpty": testAccAccountCustomizations_visibleServicesEmpty,
 			"disappears":           testAccAccountCustomizations_disappears,
@@ -170,6 +171,47 @@ func testAccAccountCustomizations_visibleRegions(t *testing.T) {
 }
 
 func testAccAccountCustomizations_visibleRegionsEmpty(t *testing.T) {
+	testCases := map[string]func(t *testing.T){
+		"onCreate": testAccAccountCustomizations_visibleRegionsEmpty_onCreate,
+		"onUpdate": testAccAccountCustomizations_visibleRegionsEmpty_onUpdate,
+	}
+
+	acctest.RunSerialTests1Level(t, testCases, 0)
+}
+
+func testAccAccountCustomizations_visibleRegionsEmpty_onCreate(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_uxc_account_customizations.test"
+
+	acctest.Test(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.UXCServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckAccountCustomizationsDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAccountCustomizationsConfig_visibleRegionsEmpty(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAccountCustomizationsExists(ctx, t, resourceName),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("visible_regions"), knownvalue.ListSizeExact(0)),
+				},
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "account_color",
+			},
+		},
+	})
+}
+
+func testAccAccountCustomizations_visibleRegionsEmpty_onUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_uxc_account_customizations.test"
 
@@ -186,20 +228,81 @@ func testAccAccountCustomizations_visibleRegionsEmpty(t *testing.T) {
 				Config: testAccAccountCustomizationsConfig_visibleRegions([]string{"us-east-1"}), //lintignore:AWSAT003
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAccountCustomizationsExists(ctx, t, resourceName),
-					resource.TestCheckResourceAttr(resourceName, "visible_regions.#", "1"),
 				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("visible_regions"), knownvalue.ListExact([]knownvalue.Check{
+						knownvalue.StringExact("us-east-1"), //lintignore:AWSAT003
+					})),
+				},
 			},
 			{
 				// Explicitly set an empty set — must not cause a permanent diff.
 				Config: testAccAccountCustomizationsConfig_visibleRegionsEmpty(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAccountCustomizationsExists(ctx, t, resourceName),
-					resource.TestCheckResourceAttr(resourceName, "visible_regions.#", "0"),
 				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("visible_regions"), knownvalue.ListSizeExact(0)),
+				},
 			},
 			{
 				// Confirm no diff on subsequent plan.
 				Config: testAccAccountCustomizationsConfig_visibleRegionsEmpty(),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccAccountCustomizations_visibleRegionsNil(t *testing.T) {
+	testCases := map[string]func(t *testing.T){
+		"onUpdate": testAccAccountCustomizations_visibleRegionsNil_onUpdate,
+	}
+
+	acctest.RunSerialTests1Level(t, testCases, 0)
+}
+
+func testAccAccountCustomizations_visibleRegionsNil_onUpdate(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_uxc_account_customizations.test"
+
+	acctest.Test(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.UXCServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckAccountCustomizationsDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAccountCustomizationsConfig_visibleRegions([]string{"us-east-1"}), //lintignore:AWSAT003
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAccountCustomizationsExists(ctx, t, resourceName),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("visible_regions"), knownvalue.ListExact([]knownvalue.Check{
+						knownvalue.StringExact("us-east-1"), //lintignore:AWSAT003
+					})),
+				},
+			},
+			{
+				// Explicitly set to nil — must not cause a permanent diff.
+				Config: testAccAccountCustomizationsConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAccountCustomizationsExists(ctx, t, resourceName),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("visible_regions"), knownvalue.ListSizeExact(0)),
+				},
+			},
+			{
+				// Confirm no diff on subsequent plan.
+				Config: testAccAccountCustomizationsConfig_basic(),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectEmptyPlan(),

--- a/internal/service/uxc/account_customizations_test.go
+++ b/internal/service/uxc/account_customizations_test.go
@@ -145,10 +145,13 @@ func testAccAccountCustomizations_visibleRegions(t *testing.T) {
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAccountCustomizationsExists(ctx, t, resourceName),
-					resource.TestCheckResourceAttr(resourceName, "visible_regions.#", "2"),
-					resource.TestCheckTypeSetElemAttr(resourceName, "visible_regions.*", "us-east-1"), //lintignore:AWSAT003
-					resource.TestCheckTypeSetElemAttr(resourceName, "visible_regions.*", "us-west-2"), //lintignore:AWSAT003
 				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("visible_regions"), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.StringExact("us-east-1"), //lintignore:AWSAT003
+						knownvalue.StringExact("us-west-2"), //lintignore:AWSAT003
+					})),
+				},
 			},
 			{
 				ResourceName:                         resourceName,
@@ -162,9 +165,12 @@ func testAccAccountCustomizations_visibleRegions(t *testing.T) {
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAccountCustomizationsExists(ctx, t, resourceName),
-					resource.TestCheckResourceAttr(resourceName, "visible_regions.#", "1"),
-					resource.TestCheckTypeSetElemAttr(resourceName, "visible_regions.*", "eu-west-1"), //lintignore:AWSAT003
 				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("visible_regions"), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.StringExact("eu-west-1"), //lintignore:AWSAT003
+					})),
+				},
 			},
 		},
 	})
@@ -330,9 +336,6 @@ func testAccAccountCustomizations_visibleServices(t *testing.T) {
 				Config: testAccAccountCustomizationsConfig_visibleServices([]string{"s3", "ec2"}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAccountCustomizationsExists(ctx, t, resourceName),
-					resource.TestCheckResourceAttr(resourceName, "visible_services.#", "2"),
-					resource.TestCheckTypeSetElemAttr(resourceName, "visible_services.*", "s3"),
-					resource.TestCheckTypeSetElemAttr(resourceName, "visible_services.*", "ec2"),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("visible_services"), knownvalue.SetExact([]knownvalue.Check{

--- a/internal/service/uxc/account_customizations_test.go
+++ b/internal/service/uxc/account_customizations_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	awstypes "github.com/aws/aws-sdk-go-v2/service/uxc/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -25,6 +26,7 @@ func TestAccUXC_serial(t *testing.T) {
 	testCases := map[string]map[string]func(t *testing.T){
 		"AccountCustomizations": {
 			"basic":                testAccAccountCustomizations_basic,
+			"accountColor":         testAccAccountCustomizations_accountColor,
 			"visibleRegions":       testAccAccountCustomizations_visibleRegions,
 			"visibleRegionsEmpty":  testAccAccountCustomizations_visibleRegionsEmpty,
 			"visibleServices":      testAccAccountCustomizations_visibleServices,
@@ -53,7 +55,37 @@ func testAccAccountCustomizations_basic(t *testing.T) {
 		CheckDestroy:             testAccCheckAccountCustomizationsDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAccountCustomizationsConfig_basic("pink"),
+				Config: testAccAccountCustomizationsConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAccountCustomizationsExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "account_color", string(awstypes.AccountColorNone)),
+				),
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "account_color",
+			},
+		},
+	})
+}
+
+func testAccAccountCustomizations_accountColor(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_uxc_account_customizations.test"
+
+	acctest.Test(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.UXCServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckAccountCustomizationsDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAccountCustomizationsConfig_accountColor("pink"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAccountCustomizationsExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "account_color", "pink"),
@@ -66,11 +98,17 @@ func testAccAccountCustomizations_basic(t *testing.T) {
 				ImportStateVerifyIdentifierAttribute: "account_color",
 			},
 			{
-				Config: testAccAccountCustomizationsConfig_basic("purple"),
+				Config: testAccAccountCustomizationsConfig_accountColor("purple"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAccountCustomizationsExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "account_color", "purple"),
 				),
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "account_color",
 			},
 		},
 	})
@@ -257,7 +295,7 @@ func testAccAccountCustomizations_disappears(t *testing.T) {
 		CheckDestroy:             testAccCheckAccountCustomizationsDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAccountCustomizationsConfig_basic("pink"),
+				Config: testAccAccountCustomizationsConfig_accountColor("pink"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAccountCustomizationsExists(ctx, t, resourceName),
 					acctest.CheckFrameworkResourceDisappears(ctx, t, tfuxc.ResourceAccountCustomizations, resourceName),
@@ -340,7 +378,13 @@ func testAccPreCheck(ctx context.Context, t *testing.T) {
 	}
 }
 
-func testAccAccountCustomizationsConfig_basic(color string) string {
+func testAccAccountCustomizationsConfig_basic() string {
+	return `
+resource "aws_uxc_account_customizations" "test" {}
+`
+}
+
+func testAccAccountCustomizationsConfig_accountColor(color string) string {
 	return fmt.Sprintf(`
 resource "aws_uxc_account_customizations" "test" {
   account_color = %[1]q


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Fixes inconsistent result errors for `aws_uxc_account_customizations`

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=uxc TESTS=TestAccUXC_serial

--- PASS: TestAccUXC_serial (891.37s)
    --- PASS: TestAccUXC_serial/AccountCustomizations (863.56s)
        --- PASS: TestAccUXC_serial/AccountCustomizations/visibleServices (79.47s)
        --- PASS: TestAccUXC_serial/AccountCustomizations/basic (46.52s)
        --- PASS: TestAccUXC_serial/AccountCustomizations/visibleRegionsEmpty (135.77s)
            --- PASS: TestAccUXC_serial/AccountCustomizations/visibleRegionsEmpty/onCreate (44.25s)
            --- PASS: TestAccUXC_serial/AccountCustomizations/visibleRegionsEmpty/onUpdate (91.52s)
        --- PASS: TestAccUXC_serial/AccountCustomizations/visibleRegionsNil (94.80s)
            --- PASS: TestAccUXC_serial/AccountCustomizations/visibleRegionsNil/onUpdate (94.80s)
        --- PASS: TestAccUXC_serial/AccountCustomizations/visibleServicesEmpty (142.03s)
            --- PASS: TestAccUXC_serial/AccountCustomizations/visibleServicesEmpty/onCreate (39.83s)
            --- PASS: TestAccUXC_serial/AccountCustomizations/visibleServicesEmpty/onUpdate (102.20s)
        --- PASS: TestAccUXC_serial/AccountCustomizations/visibleServicesNil (87.83s)
            --- PASS: TestAccUXC_serial/AccountCustomizations/visibleServicesNil/onUpdate (87.83s)
        --- PASS: TestAccUXC_serial/AccountCustomizations/disappears (46.40s)
        --- PASS: TestAccUXC_serial/AccountCustomizations/migrate (103.52s)
        --- PASS: TestAccUXC_serial/AccountCustomizations/accountColor (68.34s)
        --- PASS: TestAccUXC_serial/AccountCustomizations/visibleRegions (58.83s)
    --- PASS: TestAccUXC_serial/ServicesDataSource (27.82s)
        --- PASS: TestAccUXC_serial/ServicesDataSource/basic (27.82s)
```
