### PR TITLE
docs(sns): add note about using pem files for apns

### DIFF
--- a/website/docs/r/sns_platform_application.html.markdown
+++ b/website/docs/r/sns_platform_application.html.markdown
@@ -14,12 +14,14 @@ Provides an SNS platform application resource
 
 ### Apple Push Notification Service (APNS) using certificate-based authentication
 
+~> **NOTE:** Terraform expects string values to be UTF-8 encoded. If you are provided with an Apple `.p12` binary file, you must convert it to `.pem` format to use it for the `platform_credential` and `platform_principal` arguments.
+
 ```terraform
 resource "aws_sns_platform_application" "apns_application" {
   name                = "apns_application"
   platform            = "APNS"
-  platform_credential = "<APNS PRIVATE KEY>"
-  platform_principal  = "<APNS CERTIFICATE>"
+  platform_credential = file("apns-private-key.pem")
+  platform_principal  = file("apns-certificate.pem")
 }
 ```
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```

## Description
This PR updates the `aws_sns_platform_application` documentation to clarify that Apple `.p12` binary files must be converted to `.pem` format to be used as `platform_credential` and `platform_principal`.

## References
Resolves #40803
