### PR TITLE
r/aws_s3_bucket_versioning: expect update since it is not a standalone resource for `_disappears` test case

### DIFF
--- a/internal/service/s3/bucket_versioning_test.go
+++ b/internal/service/s3/bucket_versioning_test.go
@@ -70,6 +70,7 @@ func TestAccS3BucketVersioning_disappears(t *testing.T) {
 				Config: testAccBucketVersioningConfig_basic(rName, string(types.BucketVersioningStatusEnabled)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBucketVersioningExists(ctx, t, resourceName),
+					// nosemgrep:ci.semgrep.acctest.disappears-expect-resource-action -- Versioning is a sub-resource of the bucket; "disappearing" it suspends versioning, so the plan is an update, not a create.
 					acctest.CheckSDKResourceDisappears(ctx, t, tfs3.ResourceBucketVersioning(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,

--- a/internal/service/s3/bucket_versioning_test.go
+++ b/internal/service/s3/bucket_versioning_test.go
@@ -78,7 +78,7 @@ func TestAccS3BucketVersioning_disappears(t *testing.T) {
 						plancheck.ExpectResourceAction("aws_s3_bucket_versioning.test", plancheck.ResourceActionCreate),
 					},
 					PostApplyPostRefresh: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction("aws_s3_bucket_versioning.test", plancheck.ResourceActionCreate),
+						plancheck.ExpectResourceAction("aws_s3_bucket_versioning.test", plancheck.ResourceActionUpdate),
 					},
 				},
 			},


### PR DESCRIPTION


<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->


### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Fixes a test failure found that the `s3_bucket_versioning` disappears case

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #48204



### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->


#### Before
```console
make t T=TestAccS3BucketVersioning_disappears K=s3
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 t-s3_bucket_versioning-dissapears-fix 🌿...
TF_ACC=1 go1.26.3 test ./internal/service/s3/... -v -count 1 -parallel 20 -run='TestAccS3BucketVersioning_disappears'  -timeout 360m -vet=off
2026/06/08 13:40:54 Creating Terraform AWS Provider (SDKv2-style)...
2026/06/08 13:40:54 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccS3BucketVersioning_disappears
=== PAUSE TestAccS3BucketVersioning_disappears
=== RUN   TestAccS3BucketVersioning_disappears_bucket
=== PAUSE TestAccS3BucketVersioning_disappears_bucket
=== CONT  TestAccS3BucketVersioning_disappears
=== CONT  TestAccS3BucketVersioning_disappears_bucket
=== NAME  TestAccS3BucketVersioning_disappears
    bucket_versioning_test.go:63: Step 1/1 error: Post-apply refresh plan check(s) failed:
        'aws_s3_bucket_versioning.test' - expected Create, got action(s): [update]
--- PASS: TestAccS3BucketVersioning_disappears_bucket (38.00s)
--- FAIL: TestAccS3BucketVersioning_disappears (39.94s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/s3 48.154s
FAIL
```

#### After

```console
make t T=TestAccS3BucketVersioning_disappears K=s3
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 t-s3_bucket_versioning-dissapears-fix 🌿...
TF_ACC=1 go1.26.3 test ./internal/service/s3/... -v -count 1 -parallel 20 -run='TestAccS3BucketVersioning_disappears'  -timeout 360m -vet=off
2026/06/08 13:48:38 Creating Terraform AWS Provider (SDKv2-style)...
2026/06/08 13:48:38 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccS3BucketVersioning_disappears
=== PAUSE TestAccS3BucketVersioning_disappears
=== RUN   TestAccS3BucketVersioning_disappears_bucket
=== PAUSE TestAccS3BucketVersioning_disappears_bucket
=== CONT  TestAccS3BucketVersioning_disappears
=== CONT  TestAccS3BucketVersioning_disappears_bucket
--- PASS: TestAccS3BucketVersioning_disappears_bucket (36.40s)
--- PASS: TestAccS3BucketVersioning_disappears (39.11s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/s3 47.319s
```
