### PR TITLE
r/datazone: fix import testing

### DIFF
--- a/.changelog/48271.txt
+++ b/.changelog/48271.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_datazone_project: Fix import separator to match the expected format.
+```

--- a/internal/service/datazone/glossary.go
+++ b/internal/service/datazone/glossary.go
@@ -148,7 +148,7 @@ func (r *glossaryResource) Read(ctx context.Context, req resource.ReadRequest, r
 	}
 	if err != nil {
 		resp.Diagnostics.AddError(
-			create.ProblemStandardMessage(names.DataZone, create.ErrActionSetting, ResNameProject, state.Id.String(), err),
+			create.ProblemStandardMessage(names.DataZone, create.ErrActionReading, ResNameGlossary, state.Id.String(), err),
 			err.Error(),
 		)
 		return

--- a/internal/service/datazone/glossary_term_test.go
+++ b/internal/service/datazone/glossary_term_test.go
@@ -230,7 +230,7 @@ func testAccAuthorizerGlossaryTermImportStateIdFunc(resourceName string) resourc
 			return "", fmt.Errorf("Not found: %s", resourceName)
 		}
 
-		return strings.Join([]string{rs.Primary.Attributes["domain_identifier"], rs.Primary.ID, rs.Primary.Attributes["glossary_identifier"]}, ","), nil
+		return strings.Join([]string{rs.Primary.Attributes["domain_identifier"], rs.Primary.ID}, ","), nil
 	}
 }
 

--- a/internal/service/datazone/glossary_test.go
+++ b/internal/service/datazone/glossary_test.go
@@ -229,7 +229,7 @@ func testAccAuthorizerGlossaryImportStateIdFunc(resourceName string) resource.Im
 			return "", fmt.Errorf("Not found: %s", resourceName)
 		}
 
-		return strings.Join([]string{rs.Primary.Attributes["domain_identifier"], rs.Primary.ID, rs.Primary.Attributes["owning_project_identifier"]}, ","), nil
+		return strings.Join([]string{rs.Primary.Attributes["domain_identifier"], rs.Primary.ID}, ","), nil
 	}
 }
 

--- a/internal/service/datazone/project.go
+++ b/internal/service/datazone/project.go
@@ -47,6 +47,7 @@ import (
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/datazone;datazone.GetProjectOutput")
 // @Testing(importIgnore="skip_deletion_check;project_status")
 // @Testing(importStateIdAttributes="domain_identifier;id", importStateIdAttributesSep="flex.ResourceIdSeparator")
+// @Testing(importStateIdFunc="testAccProjectImportStateIdFunc")
 // @Testing(preIdentityVersion="v6.47.0")
 func newProjectResource(_ context.Context) (resource.ResourceWithConfigure, error) {
 	r := &projectResource{}

--- a/internal/service/datazone/project.go
+++ b/internal/service/datazone/project.go
@@ -30,7 +30,6 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
-	intflex "github.com/hashicorp/terraform-provider-aws/internal/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
 	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
@@ -413,9 +412,9 @@ var (
 type projectImportID struct{}
 
 func (projectImportID) Parse(id string) (string, map[string]any, error) {
-	domainID, projectID, found := strings.Cut(id, intflex.ResourceIdSeparator)
+	domainID, projectID, found := strings.Cut(id, ":")
 	if !found {
-		return "", nil, fmt.Errorf("id %q should be in the format <domain-identifier>%s<id>", id, intflex.ResourceIdSeparator)
+		return "", nil, fmt.Errorf("id %q should be in the format <domain-identifier>%s<id>", id, ":")
 	}
 
 	result := map[string]any{

--- a/internal/service/datazone/project_identity_gen_test.go
+++ b/internal/service/datazone/project_identity_gen_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	tfknownvalue "github.com/hashicorp/terraform-provider-aws/internal/acctest/knownvalue"
 	tfstatecheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/statecheck"
-	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -68,7 +67,7 @@ func TestAccDataZoneProject_Identity_basic(t *testing.T) {
 					acctest.CtRName: config.StringVariable(rName),
 				},
 				ImportStateKind:                      resource.ImportCommandWithID,
-				ImportStateIdFunc:                    acctest.AttrsImportStateIdFunc(resourceName, flex.ResourceIdSeparator, "domain_identifier", names.AttrID),
+				ImportStateIdFunc:                    testAccProjectImportStateIdFunc(resourceName),
 				ResourceName:                         resourceName,
 				ImportState:                          true,
 				ImportStateVerify:                    true,
@@ -87,7 +86,7 @@ func TestAccDataZoneProject_Identity_basic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateKind:   resource.ImportBlockWithID,
-				ImportStateIdFunc: acctest.AttrsImportStateIdFunc(resourceName, flex.ResourceIdSeparator, "domain_identifier", names.AttrID),
+				ImportStateIdFunc: testAccProjectImportStateIdFunc(resourceName),
 				ImportPlanChecks: resource.ImportPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
@@ -165,7 +164,7 @@ func TestAccDataZoneProject_Identity_regionOverride(t *testing.T) {
 					"region":        config.StringVariable(acctest.AlternateRegion()),
 				},
 				ImportStateKind:                      resource.ImportCommandWithID,
-				ImportStateIdFunc:                    acctest.CrossRegionAttrsImportStateIdFunc(resourceName, flex.ResourceIdSeparator, "domain_identifier", names.AttrID),
+				ImportStateIdFunc:                    acctest.CrossRegionImportStateIdFuncAdapter(resourceName, testAccProjectImportStateIdFunc),
 				ResourceName:                         resourceName,
 				ImportState:                          true,
 				ImportStateVerify:                    true,
@@ -185,7 +184,7 @@ func TestAccDataZoneProject_Identity_regionOverride(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateKind:   resource.ImportBlockWithID,
-				ImportStateIdFunc: acctest.CrossRegionAttrsImportStateIdFunc(resourceName, flex.ResourceIdSeparator, "domain_identifier", names.AttrID),
+				ImportStateIdFunc: acctest.CrossRegionImportStateIdFuncAdapter(resourceName, testAccProjectImportStateIdFunc),
 				ImportPlanChecks: resource.ImportPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),

--- a/internal/service/datazone/project_test.go
+++ b/internal/service/datazone/project_test.go
@@ -62,7 +62,7 @@ func TestAccDataZoneProject_basic(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateIdFunc:       testAccAuthorizerImportStateIdFunc(resourceName),
+				ImportStateIdFunc:       testAccProjectImportStateIdFunc(resourceName),
 				ImportStateVerifyIgnore: []string{"project_status", "skip_deletion_check"},
 			},
 		},
@@ -142,7 +142,7 @@ func TestAccDataZoneProject_description(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateIdFunc:       testAccAuthorizerImportStateIdFunc(resourceName),
+				ImportStateIdFunc:       testAccProjectImportStateIdFunc(resourceName),
 				ImportStateVerifyIgnore: []string{"project_status", "skip_deletion_check"},
 			},
 			{
@@ -164,7 +164,7 @@ func TestAccDataZoneProject_description(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateIdFunc:       testAccAuthorizerImportStateIdFunc(resourceName),
+				ImportStateIdFunc:       testAccProjectImportStateIdFunc(resourceName),
 				ImportStateVerifyIgnore: []string{"project_status", "skip_deletion_check"},
 			},
 		},
@@ -250,7 +250,7 @@ func testAccCheckProjectNotRecreated(before, after *datazone.GetProjectOutput) r
 	}
 }
 
-func testAccAuthorizerImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
+func testAccProjectImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
 	return func(s *terraform.State) (string, error) {
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Fix test failures.

Fix `aws_datazone_project` separator for import. Update tests

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->


### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=datazone TESTARGS='-run=TestAccDataZoneGlossaryTerm_'                 
    
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework (cached)
make: Running acceptance tests on branch: 🌿 b-datazone_import_testing 🌿...
TF_ACC=1 go1.26.3 test ./internal/service/datazone/... -v -count 1 -parallel 20  -run=TestAccDataZoneGlossaryTerm_ -timeout 360m -vet=off -buildvcs=false
2026/06/09 11:32:46 Creating Terraform AWS Provider (SDKv2-style)...                                       2026/06/09 11:32:46 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccDataZoneGlossaryTerm_Identity_basic
=== PAUSE TestAccDataZoneGlossaryTerm_Identity_basic                                                       === RUN   TestAccDataZoneGlossaryTerm_Identity_regionOverride                                              === PAUSE TestAccDataZoneGlossaryTerm_Identity_regionOverride
=== RUN   TestAccDataZoneGlossaryTerm_Identity_ExistingResource_basic
=== PAUSE TestAccDataZoneGlossaryTerm_Identity_ExistingResource_basic
=== RUN   TestAccDataZoneGlossaryTerm_Identity_ExistingResource_noRefreshNoChange
=== PAUSE TestAccDataZoneGlossaryTerm_Identity_ExistingResource_noRefreshNoChange                          === RUN   TestAccDataZoneGlossaryTerm_basic
=== PAUSE TestAccDataZoneGlossaryTerm_basic
=== RUN   TestAccDataZoneGlossaryTerm_update
=== PAUSE TestAccDataZoneGlossaryTerm_update                                                               === RUN   TestAccDataZoneGlossaryTerm_disappears
=== PAUSE TestAccDataZoneGlossaryTerm_disappears
=== CONT  TestAccDataZoneGlossaryTerm_Identity_basic
=== CONT  TestAccDataZoneGlossaryTerm_basic
=== CONT  TestAccDataZoneGlossaryTerm_Identity_ExistingResource_basic
=== CONT  TestAccDataZoneGlossaryTerm_Identity_regionOverride
=== CONT  TestAccDataZoneGlossaryTerm_disappears
=== CONT  TestAccDataZoneGlossaryTerm_update
=== CONT  TestAccDataZoneGlossaryTerm_Identity_ExistingResource_noRefreshNoChange
--- PASS: TestAccDataZoneGlossaryTerm_disappears (47.17s)
--- PASS: TestAccDataZoneGlossaryTerm_basic (49.50s)
--- PASS: TestAccDataZoneGlossaryTerm_Identity_regionOverride (56.64s)
--- PASS: TestAccDataZoneGlossaryTerm_Identity_basic (62.36s)
--- PASS: TestAccDataZoneGlossaryTerm_update (69.93s)                                                      --- PASS: TestAccDataZoneGlossaryTerm_Identity_ExistingResource_noRefreshNoChange (76.27s)
--- PASS: TestAccDataZoneGlossaryTerm_Identity_ExistingResource_basic (79.34s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/datazone   87.840s
```

```console
% make testacc PKG=datazone TESTARGS='-run=TestAccDataZoneGlossary_'

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework (cached)
make: Running acceptance tests on branch: 🌿 b-datazone_import_testing 🌿...
TF_ACC=1 go1.26.3 test ./internal/service/datazone/... -v -count 1 -parallel 20  -run=TestAccDataZoneGlossary_ -timeout 360m -vet=off -buildvcs=false
2026/06/09 11:35:54 Creating Terraform AWS Provider (SDKv2-style)...
2026/06/09 11:35:54 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccDataZoneGlossary_Identity_basic
=== PAUSE TestAccDataZoneGlossary_Identity_basic
=== RUN   TestAccDataZoneGlossary_Identity_regionOverride
=== PAUSE TestAccDataZoneGlossary_Identity_regionOverride
=== RUN   TestAccDataZoneGlossary_Identity_ExistingResource_basic
=== PAUSE TestAccDataZoneGlossary_Identity_ExistingResource_basic
=== RUN   TestAccDataZoneGlossary_Identity_ExistingResource_noRefreshNoChange
=== PAUSE TestAccDataZoneGlossary_Identity_ExistingResource_noRefreshNoChange
=== RUN   TestAccDataZoneGlossary_basic
=== PAUSE TestAccDataZoneGlossary_basic
=== RUN   TestAccDataZoneGlossary_update
=== PAUSE TestAccDataZoneGlossary_update
=== RUN   TestAccDataZoneGlossary_disappears
=== PAUSE TestAccDataZoneGlossary_disappears
=== CONT  TestAccDataZoneGlossary_Identity_basic
=== CONT  TestAccDataZoneGlossary_basic
=== CONT  TestAccDataZoneGlossary_disappears
=== CONT  TestAccDataZoneGlossary_update
=== CONT  TestAccDataZoneGlossary_Identity_ExistingResource_basic
=== CONT  TestAccDataZoneGlossary_Identity_ExistingResource_noRefreshNoChange
=== CONT  TestAccDataZoneGlossary_Identity_regionOverride
--- PASS: TestAccDataZoneGlossary_disappears (44.10s)
--- PASS: TestAccDataZoneGlossary_basic (47.84s)
--- PASS: TestAccDataZoneGlossary_Identity_regionOverride (56.59s)
--- PASS: TestAccDataZoneGlossary_Identity_basic (62.14s)
--- PASS: TestAccDataZoneGlossary_update (66.13s)
--- PASS: TestAccDataZoneGlossary_Identity_ExistingResource_noRefreshNoChange (75.69s)
--- PASS: TestAccDataZoneGlossary_Identity_ExistingResource_basic (80.06s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/datazone   88.691s
```

```console
% make testacc PKG=datazone TESTARGS='-run=TestAccDataZoneProject_'

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     8.448s
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework 8.410s
make: Running acceptance tests on branch: 🌿 b-datazone_import_testing 🌿...
TF_ACC=1 go1.26.3 test ./internal/service/datazone/... -v -count 1 -parallel 20  -run=TestAccDataZoneProject_ -timeout 360m -vet=off -buildvcs=false
2026/06/09 11:46:38 Creating Terraform AWS Provider (SDKv2-style)...
2026/06/09 11:46:38 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccDataZoneProject_Identity_basic
=== PAUSE TestAccDataZoneProject_Identity_basic
=== RUN   TestAccDataZoneProject_Identity_regionOverride
=== PAUSE TestAccDataZoneProject_Identity_regionOverride
=== RUN   TestAccDataZoneProject_Identity_ExistingResource_basic
=== PAUSE TestAccDataZoneProject_Identity_ExistingResource_basic
=== RUN   TestAccDataZoneProject_Identity_ExistingResource_noRefreshNoChange
=== PAUSE TestAccDataZoneProject_Identity_ExistingResource_noRefreshNoChange
=== RUN   TestAccDataZoneProject_basic
=== PAUSE TestAccDataZoneProject_basic
=== RUN   TestAccDataZoneProject_disappears
=== PAUSE TestAccDataZoneProject_disappears
=== RUN   TestAccDataZoneProject_description
=== PAUSE TestAccDataZoneProject_description
=== CONT  TestAccDataZoneProject_Identity_basic
=== CONT  TestAccDataZoneProject_basic
=== CONT  TestAccDataZoneProject_description
=== CONT  TestAccDataZoneProject_Identity_ExistingResource_basic
=== CONT  TestAccDataZoneProject_Identity_ExistingResource_noRefreshNoChange
=== CONT  TestAccDataZoneProject_Identity_regionOverride
=== CONT  TestAccDataZoneProject_disappears
--- PASS: TestAccDataZoneProject_disappears (43.03s)
--- PASS: TestAccDataZoneProject_basic (43.54s)
--- PASS: TestAccDataZoneProject_Identity_regionOverride (54.20s)
--- PASS: TestAccDataZoneProject_description (62.81s)
--- PASS: TestAccDataZoneProject_Identity_basic (66.95s)
--- PASS: TestAccDataZoneProject_Identity_ExistingResource_noRefreshNoChange (73.21s)
--- PASS: TestAccDataZoneProject_Identity_ExistingResource_basic (76.27s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/datazone   84.639s
```
