### PR TITLE
Build the AWS Provider on S390x

### DIFF
--- a/.changelog/48272.txt
+++ b/.changelog/48272.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+Add Linux s390x support
+```

--- a/.changelog/48272.txt
+++ b/.changelog/48272.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-Add Linux s390x support
+provider: Add Linux s390x support
 ```

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,7 +124,7 @@ jobs:
       fail-fast: true
       matrix:
         goos: [freebsd, windows, linux, darwin, openbsd]
-        goarch: ["386", "amd64", "arm", "arm64"]
+        goarch: ["386", "amd64", "arm", "arm64", "s390x"]
         exclude:
           - goos: freebsd
             goarch: arm64
@@ -138,6 +138,14 @@ jobs:
             goarch: arm
           - goos: openbsd
             goarch: arm64
+          - goos: openbsd
+            goarch: s390x
+          - goos: darwin
+            goarch: s390x
+          - goos: freebsd
+            goarch: s390x
+          - goos: windows
+            goarch: s390x
 
     name: Go ${{ needs.get-go-version.outputs.go-version }} ${{ matrix.goos }} ${{ matrix.goarch }} build
     steps:

--- a/.release/terraform-provider-aws-artifacts.hcl
+++ b/.release/terraform-provider-aws-artifacts.hcl
@@ -13,6 +13,7 @@ artifacts {
     "terraform-provider-aws_${version}_linux_amd64.zip",
     "terraform-provider-aws_${version}_linux_arm.zip",
     "terraform-provider-aws_${version}_linux_arm64.zip",
+    "terraform-provider-aws_${version}_linux_s390x.zip",
     "terraform-provider-aws_${version}_openbsd_386.zip",
     "terraform-provider-aws_${version}_openbsd_amd64.zip",
     "terraform-provider-aws_${version}_openbsd_arm.zip",


### PR DESCRIPTION
### Description

This PR adds a build for s390x linux for the AWS Provider.  My team uses the AWS Provider to provision resources in CI, and we'd like to use it on our s390x runners as well.  For now I just compile it locally, but would prefer to switch to the official artifact 
