### PR TITLE
Use `SchemaFunc` instead of `Schema` for `t`, `v`, `w`, and `x` services

### DIFF
--- a/.ci/semgrep/pluginsdk/schema.yml
+++ b/.ci/semgrep/pluginsdk/schema.yml
@@ -31,7 +31,6 @@ rules:
     severity: WARNING
     paths:
       exclude:
-        - /internal/service/wafregional
         - /internal/service/workspaces
         - /internal/service/xray
 

--- a/.ci/semgrep/pluginsdk/schema.yml
+++ b/.ci/semgrep/pluginsdk/schema.yml
@@ -31,7 +31,6 @@ rules:
     severity: WARNING
     paths:
       exclude:
-        - /internal/service/transfer
         - /internal/service/vpclattice
         - /internal/service/waf
         - /internal/service/wafregional

--- a/.ci/semgrep/pluginsdk/schema.yml
+++ b/.ci/semgrep/pluginsdk/schema.yml
@@ -29,9 +29,6 @@ rules:
       	return $SCHEMA
       }
     severity: WARNING
-    paths:
-      exclude:
-        - /internal/service/xray
 
   - id: use-schema-map
     languages: [go]

--- a/.ci/semgrep/pluginsdk/schema.yml
+++ b/.ci/semgrep/pluginsdk/schema.yml
@@ -31,7 +31,6 @@ rules:
     severity: WARNING
     paths:
       exclude:
-        - /internal/service/timestreamwrite
         - /internal/service/transcribe
         - /internal/service/transfer
         - /internal/service/vpclattice

--- a/.ci/semgrep/pluginsdk/schema.yml
+++ b/.ci/semgrep/pluginsdk/schema.yml
@@ -31,7 +31,6 @@ rules:
     severity: WARNING
     paths:
       exclude:
-        - /internal/service/vpclattice
         - /internal/service/waf
         - /internal/service/wafregional
         - /internal/service/workspaces

--- a/.ci/semgrep/pluginsdk/schema.yml
+++ b/.ci/semgrep/pluginsdk/schema.yml
@@ -31,7 +31,6 @@ rules:
     severity: WARNING
     paths:
       exclude:
-        - /internal/service/workspaces
         - /internal/service/xray
 
   - id: use-schema-map

--- a/.ci/semgrep/pluginsdk/schema.yml
+++ b/.ci/semgrep/pluginsdk/schema.yml
@@ -31,7 +31,6 @@ rules:
     severity: WARNING
     paths:
       exclude:
-        - /internal/service/waf
         - /internal/service/wafregional
         - /internal/service/workspaces
         - /internal/service/xray

--- a/.ci/semgrep/pluginsdk/schema.yml
+++ b/.ci/semgrep/pluginsdk/schema.yml
@@ -31,7 +31,6 @@ rules:
     severity: WARNING
     paths:
       exclude:
-        - /internal/service/transcribe
         - /internal/service/transfer
         - /internal/service/vpclattice
         - /internal/service/waf

--- a/internal/service/timestreamwrite/database.go
+++ b/internal/service/timestreamwrite/database.go
@@ -39,36 +39,38 @@ func resourceDatabase() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrDatabaseName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-				ValidateFunc: validation.All(
-					validation.StringLenBetween(3, 64),
-					validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z_.-]+$`), "must only include alphanumeric, underscore, period, or hyphen characters"),
-				),
-			},
-			names.AttrKMSKeyID: {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				// The Timestream API accepts the KmsKeyId as an ID, ARN, alias, or alias ARN but always returns the ARN of the key.
-				// The ARN is of the format 'arn:aws:kms:REGION:ACCOUNT_ID:key/KMS_KEY_ID'. Appropriate diff suppression
-				// would require an extra API call to the kms service's DescribeKey method to decipher aliases.
-				// To avoid importing an extra service in this resource, input here is restricted to only ARNs.
-				ValidateFunc: verify.ValidARN,
-			},
-			"table_count": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrDatabaseName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+					ValidateFunc: validation.All(
+						validation.StringLenBetween(3, 64),
+						validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z_.-]+$`), "must only include alphanumeric, underscore, period, or hyphen characters"),
+					),
+				},
+				names.AttrKMSKeyID: {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+					// The Timestream API accepts the KmsKeyId as an ID, ARN, alias, or alias ARN but always returns the ARN of the key.
+					// The ARN is of the format 'arn:aws:kms:REGION:ACCOUNT_ID:key/KMS_KEY_ID'. Appropriate diff suppression
+					// would require an extra API call to the kms service's DescribeKey method to decipher aliases.
+					// To avoid importing an extra service in this resource, input here is restricted to only ARNs.
+					ValidateFunc: verify.ValidARN,
+				},
+				"table_count": {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			}
 		},
 	}
 }

--- a/internal/service/timestreamwrite/table.go
+++ b/internal/service/timestreamwrite/table.go
@@ -42,61 +42,63 @@ func resourceTable() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrDatabaseName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-				ValidateFunc: validation.All(
-					validation.StringLenBetween(3, 64),
-					validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z_.-]+$`), "must only include alphanumeric, underscore, period, or hyphen characters"),
-				),
-			},
-			"magnetic_store_write_properties": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Computed: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"enable_magnetic_store_writes": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  false,
-						},
-						"magnetic_store_rejected_data_location": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"s3_configuration": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												names.AttrBucketName: {
-													Type:     schema.TypeString,
-													Optional: true,
-												},
-												"encryption_option": {
-													Type:             schema.TypeString,
-													Optional:         true,
-													ValidateDiagFunc: enum.Validate[types.S3EncryptionOption](),
-												},
-												names.AttrKMSKeyID: {
-													Type:         schema.TypeString,
-													Optional:     true,
-													ValidateFunc: verify.ValidARN,
-												},
-												"object_key_prefix": {
-													Type:     schema.TypeString,
-													Optional: true,
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrDatabaseName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+					ValidateFunc: validation.All(
+						validation.StringLenBetween(3, 64),
+						validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z_.-]+$`), "must only include alphanumeric, underscore, period, or hyphen characters"),
+					),
+				},
+				"magnetic_store_write_properties": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Computed: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"enable_magnetic_store_writes": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Default:  false,
+							},
+							"magnetic_store_rejected_data_location": {
+								Type:     schema.TypeList,
+								Optional: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"s3_configuration": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													names.AttrBucketName: {
+														Type:     schema.TypeString,
+														Optional: true,
+													},
+													"encryption_option": {
+														Type:             schema.TypeString,
+														Optional:         true,
+														ValidateDiagFunc: enum.Validate[types.S3EncryptionOption](),
+													},
+													names.AttrKMSKeyID: {
+														Type:         schema.TypeString,
+														Optional:     true,
+														ValidateFunc: verify.ValidARN,
+													},
+													"object_key_prefix": {
+														Type:     schema.TypeString,
+														Optional: true,
+													},
 												},
 											},
 										},
@@ -106,76 +108,76 @@ func resourceTable() *schema.Resource {
 						},
 					},
 				},
-			},
-			"retention_properties": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Computed: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"magnetic_store_retention_period_in_days": {
-							Type:         schema.TypeInt,
-							Required:     true,
-							ValidateFunc: validation.IntBetween(1, 73000),
-						},
-						"memory_store_retention_period_in_hours": {
-							Type:         schema.TypeInt,
-							Required:     true,
-							ValidateFunc: validation.IntBetween(1, 8766),
+				"retention_properties": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Computed: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"magnetic_store_retention_period_in_days": {
+								Type:         schema.TypeInt,
+								Required:     true,
+								ValidateFunc: validation.IntBetween(1, 73000),
+							},
+							"memory_store_retention_period_in_hours": {
+								Type:         schema.TypeInt,
+								Required:     true,
+								ValidateFunc: validation.IntBetween(1, 8766),
+							},
 						},
 					},
 				},
-			},
-			names.AttrSchema: {
-				Type:     schema.TypeList,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"composite_partition_key": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Computed: true,
-							ForceNew: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"enforcement_in_record": {
-										Type:             schema.TypeString,
-										Optional:         true,
-										ValidateDiagFunc: enum.Validate[types.PartitionKeyEnforcementLevel](),
-									},
-									names.AttrName: {
-										Type:     schema.TypeString,
-										Optional: true,
-										ForceNew: true,
-									},
-									names.AttrType: {
-										Type:             schema.TypeString,
-										Required:         true,
-										ForceNew:         true,
-										ValidateDiagFunc: enum.Validate[types.PartitionKeyType](),
+				names.AttrSchema: {
+					Type:     schema.TypeList,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"composite_partition_key": {
+								Type:     schema.TypeList,
+								Optional: true,
+								Computed: true,
+								ForceNew: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"enforcement_in_record": {
+											Type:             schema.TypeString,
+											Optional:         true,
+											ValidateDiagFunc: enum.Validate[types.PartitionKeyEnforcementLevel](),
+										},
+										names.AttrName: {
+											Type:     schema.TypeString,
+											Optional: true,
+											ForceNew: true,
+										},
+										names.AttrType: {
+											Type:             schema.TypeString,
+											Required:         true,
+											ForceNew:         true,
+											ValidateDiagFunc: enum.Validate[types.PartitionKeyType](),
+										},
 									},
 								},
 							},
 						},
 					},
 				},
-			},
-			names.AttrTableName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-				ValidateFunc: validation.All(
-					validation.StringLenBetween(3, 64),
-					validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z_.-]+$`), "must only include alphanumeric, underscore, period, or hyphen characters"),
-				),
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				names.AttrTableName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+					ValidateFunc: validation.All(
+						validation.StringLenBetween(3, 64),
+						validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z_.-]+$`), "must only include alphanumeric, underscore, period, or hyphen characters"),
+					),
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			}
 		},
 	}
 }

--- a/internal/service/transcribe/language_model.go
+++ b/internal/service/transcribe/language_model.go
@@ -47,57 +47,59 @@ func ResourceLanguageModel() *schema.Resource {
 			Create: schema.DefaultTimeout(600 * time.Minute),
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"base_model_name": {
-				Type:             schema.TypeString,
-				Required:         true,
-				ForceNew:         true,
-				ValidateDiagFunc: enum.Validate[types.BaseModelName](),
-			},
-			"input_data_config": {
-				Type:     schema.TypeList,
-				Required: true,
-				ForceNew: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"data_access_role_arn": {
-							Type:             schema.TypeString,
-							Required:         true,
-							ForceNew:         true,
-							ValidateDiagFunc: validation.ToDiagFunc(verify.ValidARN),
-						},
-						"s3_uri": {
-							Type:     schema.TypeString,
-							Required: true,
-							ForceNew: true,
-						},
-						"tuning_data_s3_uri": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ForceNew: true,
-							Computed: true,
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"base_model_name": {
+					Type:             schema.TypeString,
+					Required:         true,
+					ForceNew:         true,
+					ValidateDiagFunc: enum.Validate[types.BaseModelName](),
+				},
+				"input_data_config": {
+					Type:     schema.TypeList,
+					Required: true,
+					ForceNew: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"data_access_role_arn": {
+								Type:             schema.TypeString,
+								Required:         true,
+								ForceNew:         true,
+								ValidateDiagFunc: validation.ToDiagFunc(verify.ValidARN),
+							},
+							"s3_uri": {
+								Type:     schema.TypeString,
+								Required: true,
+								ForceNew: true,
+							},
+							"tuning_data_s3_uri": {
+								Type:     schema.TypeString,
+								Optional: true,
+								ForceNew: true,
+								Computed: true,
+							},
 						},
 					},
 				},
-			},
-			names.AttrLanguageCode: {
-				Type:             schema.TypeString,
-				Required:         true,
-				ForceNew:         true,
-				ValidateDiagFunc: enum.Validate[types.LanguageCode](),
-			},
-			"model_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				names.AttrLanguageCode: {
+					Type:             schema.TypeString,
+					Required:         true,
+					ForceNew:         true,
+					ValidateDiagFunc: enum.Validate[types.LanguageCode](),
+				},
+				"model_name": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			}
 		},
 	}
 }

--- a/internal/service/transcribe/medical_vocabulary.go
+++ b/internal/service/transcribe/medical_vocabulary.go
@@ -46,34 +46,36 @@ func ResourceMedicalVocabulary() *schema.Resource {
 			Delete: schema.DefaultTimeout(30 * time.Minute),
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"download_uri": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrLanguageCode: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringInSlice([]string{"en-US"}, false), // en-US is the only supported language for this service
-			},
-			"vocabulary_file_uri": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringLenBetween(1, 2000),
-			},
-			"vocabulary_name": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(1, 200),
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"download_uri": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrLanguageCode: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringInSlice([]string{"en-US"}, false), // en-US is the only supported language for this service
+				},
+				"vocabulary_file_uri": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringLenBetween(1, 2000),
+				},
+				"vocabulary_name": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringLenBetween(1, 200),
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			}
 		},
 	}
 }

--- a/internal/service/transcribe/vocabulary.go
+++ b/internal/service/transcribe/vocabulary.go
@@ -46,43 +46,45 @@ func ResourceVocabulary() *schema.Resource {
 			Delete: schema.DefaultTimeout(30 * time.Minute),
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"download_uri": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrLanguageCode: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringInSlice(validateLanguageCodes(types.LanguageCode("").Values()), false),
-			},
-			"phrases": {
-				Type:         schema.TypeList,
-				Optional:     true,
-				MaxItems:     256,
-				ExactlyOneOf: []string{"phrases", "vocabulary_file_uri"},
-				Elem:         &schema.Schema{Type: schema.TypeString},
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			"vocabulary_file_uri": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ExactlyOneOf: []string{"phrases", "vocabulary_file_uri"},
-				ValidateFunc: validation.StringLenBetween(1, 2000),
-			},
-			"vocabulary_name": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(1, 200),
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"download_uri": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrLanguageCode: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringInSlice(validateLanguageCodes(types.LanguageCode("").Values()), false),
+				},
+				"phrases": {
+					Type:         schema.TypeList,
+					Optional:     true,
+					MaxItems:     256,
+					ExactlyOneOf: []string{"phrases", "vocabulary_file_uri"},
+					Elem:         &schema.Schema{Type: schema.TypeString},
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				"vocabulary_file_uri": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Computed:     true,
+					ExactlyOneOf: []string{"phrases", "vocabulary_file_uri"},
+					ValidateFunc: validation.StringLenBetween(1, 2000),
+				},
+				"vocabulary_name": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringLenBetween(1, 200),
+				},
+			}
 		},
 	}
 }

--- a/internal/service/transcribe/vocabulary_filter.go
+++ b/internal/service/transcribe/vocabulary_filter.go
@@ -41,42 +41,44 @@ func ResourceVocabularyFilter() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"download_uri": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrLanguageCode: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringInSlice(validateLanguageCodes(types.LanguageCode("").Values()), false),
-			},
-			"words": {
-				Type:         schema.TypeList,
-				Optional:     true,
-				MaxItems:     256,
-				ExactlyOneOf: []string{"words", "vocabulary_filter_file_uri"},
-				Elem:         &schema.Schema{Type: schema.TypeString},
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			"vocabulary_filter_file_uri": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ExactlyOneOf: []string{"words", "vocabulary_filter_file_uri"},
-				ValidateFunc: validation.StringLenBetween(1, 2000),
-			},
-			"vocabulary_filter_name": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(1, 200),
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"download_uri": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrLanguageCode: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringInSlice(validateLanguageCodes(types.LanguageCode("").Values()), false),
+				},
+				"words": {
+					Type:         schema.TypeList,
+					Optional:     true,
+					MaxItems:     256,
+					ExactlyOneOf: []string{"words", "vocabulary_filter_file_uri"},
+					Elem:         &schema.Schema{Type: schema.TypeString},
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				"vocabulary_filter_file_uri": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ExactlyOneOf: []string{"words", "vocabulary_filter_file_uri"},
+					ValidateFunc: validation.StringLenBetween(1, 2000),
+				},
+				"vocabulary_filter_name": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringLenBetween(1, 200),
+				},
+			}
 		},
 
 		CustomizeDiff: customdiff.Sequence(

--- a/internal/service/transfer/access.go
+++ b/internal/service/transfer/access.go
@@ -40,88 +40,90 @@ func resourceAccess() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrExternalID: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringLenBetween(1, 256),
-			},
-			"home_directory": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringLenBetween(0, 1024),
-			},
-			"home_directory_mappings": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 50,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"entry": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validation.StringLenBetween(0, 1024),
-						},
-						names.AttrTarget: {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validation.StringLenBetween(0, 1024),
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrExternalID: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringLenBetween(1, 256),
+				},
+				"home_directory": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringLenBetween(0, 1024),
+				},
+				"home_directory_mappings": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 50,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"entry": {
+								Type:         schema.TypeString,
+								Required:     true,
+								ValidateFunc: validation.StringLenBetween(0, 1024),
+							},
+							names.AttrTarget: {
+								Type:         schema.TypeString,
+								Required:     true,
+								ValidateFunc: validation.StringLenBetween(0, 1024),
+							},
 						},
 					},
 				},
-			},
-			"home_directory_type": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Default:          awstypes.HomeDirectoryTypePath,
-				ValidateDiagFunc: enum.Validate[awstypes.HomeDirectoryType](),
-			},
-			names.AttrPolicy: {
-				Type:                  schema.TypeString,
-				Optional:              true,
-				ValidateFunc:          verify.ValidIAMPolicyJSON,
-				DiffSuppressFunc:      verify.SuppressEquivalentPolicyDiffs,
-				DiffSuppressOnRefresh: true,
-				StateFunc: func(v any) string {
-					json, _ := structure.NormalizeJsonString(v)
-					return json
+				"home_directory_type": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					Default:          awstypes.HomeDirectoryTypePath,
+					ValidateDiagFunc: enum.Validate[awstypes.HomeDirectoryType](),
 				},
-			},
-			"posix_profile": {
-				Type:     schema.TypeList,
-				MaxItems: 1,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"gid": {
-							Type:     schema.TypeInt,
-							Required: true,
-						},
-						"secondary_gids": {
-							Type:     schema.TypeSet,
-							Elem:     &schema.Schema{Type: schema.TypeInt},
-							Optional: true,
-						},
-						"uid": {
-							Type:     schema.TypeInt,
-							Required: true,
+				names.AttrPolicy: {
+					Type:                  schema.TypeString,
+					Optional:              true,
+					ValidateFunc:          verify.ValidIAMPolicyJSON,
+					DiffSuppressFunc:      verify.SuppressEquivalentPolicyDiffs,
+					DiffSuppressOnRefresh: true,
+					StateFunc: func(v any) string {
+						json, _ := structure.NormalizeJsonString(v)
+						return json
+					},
+				},
+				"posix_profile": {
+					Type:     schema.TypeList,
+					MaxItems: 1,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"gid": {
+								Type:     schema.TypeInt,
+								Required: true,
+							},
+							"secondary_gids": {
+								Type:     schema.TypeSet,
+								Elem:     &schema.Schema{Type: schema.TypeInt},
+								Optional: true,
+							},
+							"uid": {
+								Type:     schema.TypeInt,
+								Required: true,
+							},
 						},
 					},
 				},
-			},
-			names.AttrRole: {
-				Type: schema.TypeString,
-				// Although Role is required in the API it is not currently returned on Read.
-				// Required:     true,
-				Optional:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			"server_id": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validServerID,
-			},
+				names.AttrRole: {
+					Type: schema.TypeString,
+					// Although Role is required in the API it is not currently returned on Read.
+					// Required:     true,
+					Optional:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				"server_id": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validServerID,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/transfer/agreement.go
+++ b/internal/service/transfer/agreement.go
@@ -39,46 +39,48 @@ func resourceAgreement() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"access_role": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			"agreement_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"base_directory": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			names.AttrDescription: {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"local_profile_id": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"partner_profile_id": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"server_id": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			names.AttrStatus: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"access_role": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				"agreement_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"base_directory": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				names.AttrDescription: {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"local_profile_id": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"partner_profile_id": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"server_id": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				names.AttrStatus: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			}
 		},
 	}
 }

--- a/internal/service/transfer/certificate.go
+++ b/internal/service/transfer/certificate.go
@@ -39,58 +39,60 @@ func resourceCertificate() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"active_date": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrCertificate: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				Sensitive:    true,
-				ValidateFunc: validation.StringLenBetween(0, 16384),
-			},
-			names.AttrCertificateChain: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				Sensitive:    true,
-				ValidateFunc: validation.StringLenBetween(0, 2097152),
-			},
-			"certificate_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrDescription: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringLenBetween(0, 200),
-			},
-			"inactive_date": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrPrivateKey: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				Sensitive:    true,
-				ValidateFunc: validation.StringLenBetween(0, 16384),
-				//ExactlyOneOf: []string{"certificate_chain", "private_key"},
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			"usage": {
-				Type:             schema.TypeString,
-				Required:         true,
-				ForceNew:         true,
-				ValidateDiagFunc: enum.Validate[awstypes.CertificateUsageType](),
-			},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"active_date": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrCertificate: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					Sensitive:    true,
+					ValidateFunc: validation.StringLenBetween(0, 16384),
+				},
+				names.AttrCertificateChain: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ForceNew:     true,
+					Sensitive:    true,
+					ValidateFunc: validation.StringLenBetween(0, 2097152),
+				},
+				"certificate_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrDescription: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringLenBetween(0, 200),
+				},
+				"inactive_date": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrPrivateKey: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ForceNew:     true,
+					Sensitive:    true,
+					ValidateFunc: validation.StringLenBetween(0, 16384),
+					//ExactlyOneOf: []string{"certificate_chain", "private_key"},
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				"usage": {
+					Type:             schema.TypeString,
+					Required:         true,
+					ForceNew:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.CertificateUsageType](),
+				},
+			}
 		},
 	}
 }

--- a/internal/service/transfer/connector.go
+++ b/internal/service/transfer/connector.go
@@ -49,136 +49,138 @@ func resourceConnector() *schema.Resource {
 			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
 
-		Schema: map[string]*schema.Schema{
-			"access_role": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"as2_config": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"compression": {
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.CompressionEnum](),
-						},
-						"encryption_algorithm": {
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.EncryptionAlg](),
-						},
-						"local_profile_id": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"mdn_response": {
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.MdnResponse](),
-						},
-						"mdn_signing_algorithm": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.MdnSigningAlg](),
-						},
-						"message_subject": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"partner_profile_id": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"signing_algorithm": {
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.SigningAlg](),
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"access_role": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"as2_config": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"compression": {
+								Type:             schema.TypeString,
+								Required:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.CompressionEnum](),
+							},
+							"encryption_algorithm": {
+								Type:             schema.TypeString,
+								Required:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.EncryptionAlg](),
+							},
+							"local_profile_id": {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+							"mdn_response": {
+								Type:             schema.TypeString,
+								Required:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.MdnResponse](),
+							},
+							"mdn_signing_algorithm": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.MdnSigningAlg](),
+							},
+							"message_subject": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+							"partner_profile_id": {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+							"signing_algorithm": {
+								Type:             schema.TypeString,
+								Required:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.SigningAlg](),
+							},
 						},
 					},
 				},
-			},
-			"connector_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"egress_config": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"vpc_lattice": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"port_number": {
-										Type:         schema.TypeInt,
-										Optional:     true,
-										ValidateFunc: validation.IntBetween(1, 65535),
-									},
-									"resource_configuration_arn": {
-										Type:         schema.TypeString,
-										Required:     true,
-										ValidateFunc: verify.ValidARN,
+				"connector_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"egress_config": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"vpc_lattice": {
+								Type:     schema.TypeList,
+								Optional: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"port_number": {
+											Type:         schema.TypeInt,
+											Optional:     true,
+											ValidateFunc: validation.IntBetween(1, 65535),
+										},
+										"resource_configuration_arn": {
+											Type:         schema.TypeString,
+											Required:     true,
+											ValidateFunc: verify.ValidARN,
+										},
 									},
 								},
 							},
 						},
 					},
 				},
-			},
-			"logging_role": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"security_policy_name": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ValidateFunc: validation.All(
-					validation.StringLenBetween(0, 100),
-					validation.StringMatch(regexache.MustCompile(`^TransferSFTPConnectorSecurityPolicy-[A-Za-z0-9-]+$`), "must be in the format matching TransferSFTPConnectorSecurityPolicy-[A-Za-z0-9-]+"),
-				),
-			},
-			"sftp_config": {
-				Type:     schema.TypeList,
-				MaxItems: 1,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"trusted_host_keys": {
-							Type:     schema.TypeSet,
-							Optional: true,
-							MinItems: 1,
-							MaxItems: 10,
-							Elem: &schema.Schema{
+				"logging_role": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"security_policy_name": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+					ValidateFunc: validation.All(
+						validation.StringLenBetween(0, 100),
+						validation.StringMatch(regexache.MustCompile(`^TransferSFTPConnectorSecurityPolicy-[A-Za-z0-9-]+$`), "must be in the format matching TransferSFTPConnectorSecurityPolicy-[A-Za-z0-9-]+"),
+					),
+				},
+				"sftp_config": {
+					Type:     schema.TypeList,
+					MaxItems: 1,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"trusted_host_keys": {
+								Type:     schema.TypeSet,
+								Optional: true,
+								MinItems: 1,
+								MaxItems: 10,
+								Elem: &schema.Schema{
+									Type:         schema.TypeString,
+									ValidateFunc: validation.StringLenBetween(1, 2028),
+								},
+							},
+							"user_secret_id": {
 								Type:         schema.TypeString,
+								Optional:     true,
 								ValidateFunc: validation.StringLenBetween(1, 2028),
 							},
 						},
-						"user_secret_id": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							ValidateFunc: validation.StringLenBetween(1, 2028),
-						},
 					},
 				},
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			names.AttrURL: {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				names.AttrURL: {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/transfer/profile.go
+++ b/internal/service/transfer/profile.go
@@ -38,33 +38,35 @@ func resourceProfile() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"as2_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"certificate_ids": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			"profile_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"profile_type": {
-				Type:             schema.TypeString,
-				Required:         true,
-				ForceNew:         true,
-				ValidateDiagFunc: enum.Validate[awstypes.ProfileType](),
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"as2_id": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"certificate_ids": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"profile_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"profile_type": {
+					Type:             schema.TypeString,
+					Required:         true,
+					ForceNew:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.ProfileType](),
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			}
 		},
 	}
 }

--- a/internal/service/transfer/server.go
+++ b/internal/service/transfer/server.go
@@ -66,270 +66,272 @@ func resourceServer() *schema.Resource {
 			},
 		),
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrCertificate: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			"directory_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			names.AttrDomain: {
-				Type:             schema.TypeString,
-				Optional:         true,
-				ForceNew:         true,
-				Default:          awstypes.DomainS3,
-				ValidateDiagFunc: enum.Validate[awstypes.Domain](),
-			},
-			names.AttrEndpoint: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"endpoint_details": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"address_allocation_ids": {
-							Type:          schema.TypeSet,
-							Optional:      true,
-							Elem:          &schema.Schema{Type: schema.TypeString},
-							ConflictsWith: []string{"endpoint_details.0.vpc_endpoint_id"},
-						},
-						names.AttrSecurityGroupIDs: {
-							Type:          schema.TypeSet,
-							Optional:      true,
-							Computed:      true,
-							Elem:          &schema.Schema{Type: schema.TypeString},
-							ConflictsWith: []string{"endpoint_details.0.vpc_endpoint_id"},
-						},
-						names.AttrSubnetIDs: {
-							Type:          schema.TypeSet,
-							Optional:      true,
-							Elem:          &schema.Schema{Type: schema.TypeString},
-							ConflictsWith: []string{"endpoint_details.0.vpc_endpoint_id"},
-						},
-						names.AttrVPCEndpointID: {
-							Type:          schema.TypeString,
-							Optional:      true,
-							Computed:      true,
-							ConflictsWith: []string{"endpoint_details.0.address_allocation_ids", "endpoint_details.0.security_group_ids", "endpoint_details.0.subnet_ids", "endpoint_details.0.vpc_id"},
-						},
-						names.AttrVPCID: {
-							Type:          schema.TypeString,
-							Optional:      true,
-							ValidateFunc:  validation.NoZeroValues,
-							ConflictsWith: []string{"endpoint_details.0.vpc_endpoint_id"},
-						},
-					},
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
 				},
-			},
-			names.AttrEndpointType: {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Default:          awstypes.EndpointTypePublic,
-				ValidateDiagFunc: enum.Validate[awstypes.EndpointType](),
-			},
-			names.AttrForceDestroy: {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-			"function": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			"host_key": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Sensitive:    true,
-				ValidateFunc: validation.StringLenBetween(0, 4096),
-			},
-			"host_key_fingerprint": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"identity_provider_type": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				ForceNew:         true,
-				Default:          awstypes.IdentityProviderTypeServiceManaged,
-				ValidateDiagFunc: enum.Validate[awstypes.IdentityProviderType](),
-			},
-			"invocation_role": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			names.AttrIPAddressType: {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Computed:         true,
-				ValidateDiagFunc: enum.Validate[awstypes.IpAddressType](),
-			},
-			"logging_role": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			"post_authentication_login_banner": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Sensitive:    true,
-				ValidateFunc: validation.StringLenBetween(0, 4096),
-			},
-			"pre_authentication_login_banner": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Sensitive:    true,
-				ValidateFunc: validation.StringLenBetween(0, 4096),
-			},
-			"protocol_details": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Computed: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"as2_transports": {
-							Type:     schema.TypeSet,
-							Optional: true,
-							Computed: true,
-							Elem: &schema.Schema{
-								Type:             schema.TypeString,
-								ValidateDiagFunc: enum.Validate[awstypes.As2Transport](),
-							},
-						},
-						"passive_ip": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							Computed:     true,
-							ValidateFunc: validation.StringLenBetween(0, 15),
-						},
-						"set_stat_option": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Computed:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.SetStatOption](),
-						},
-						"tls_session_resumption_mode": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Computed:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.TlsSessionResumptionMode](),
-						},
-					},
-				},
-			},
-			"protocols": {
-				Type:     schema.TypeSet,
-				MinItems: 1,
-				MaxItems: 3,
-				Optional: true,
-				Computed: true,
-				Elem: &schema.Schema{
-					Type:             schema.TypeString,
-					ValidateDiagFunc: enum.Validate[awstypes.Protocol](),
-				},
-			},
-			"s3_storage_options": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Computed: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"directory_listing_optimization": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Computed:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.DirectoryListingOptimization](),
-						},
-					},
-				},
-			},
-			"security_policy_name": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Default:          securityPolicyName2018_11,
-				ValidateDiagFunc: enum.Validate[securityPolicyName](),
-			},
-			"sftp_authentication_methods": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Computed:         true,
-				ValidateDiagFunc: enum.Validate[awstypes.SftpAuthenticationMethods](),
-			},
-			"structured_log_destinations": {
-				Type: schema.TypeSet,
-				Elem: &schema.Schema{
+				names.AttrCertificate: {
 					Type:         schema.TypeString,
+					Optional:     true,
 					ValidateFunc: verify.ValidARN,
 				},
-				Description: "This is a set of arns of destinations that will receive structured logs from the transfer server",
-				Optional:    true,
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			names.AttrURL: {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"workflow_details": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"on_partial_upload": {
-							Type:         schema.TypeList,
-							Optional:     true,
-							MaxItems:     1,
-							AtLeastOneOf: []string{"workflow_details.0.on_upload", "workflow_details.0.on_partial_upload"},
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"execution_role": {
-										Type:         schema.TypeString,
-										Required:     true,
-										ValidateFunc: verify.ValidARN,
-									},
-									"workflow_id": {
-										Type:     schema.TypeString,
-										Required: true,
+				"directory_id": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				names.AttrDomain: {
+					Type:             schema.TypeString,
+					Optional:         true,
+					ForceNew:         true,
+					Default:          awstypes.DomainS3,
+					ValidateDiagFunc: enum.Validate[awstypes.Domain](),
+				},
+				names.AttrEndpoint: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"endpoint_details": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"address_allocation_ids": {
+								Type:          schema.TypeSet,
+								Optional:      true,
+								Elem:          &schema.Schema{Type: schema.TypeString},
+								ConflictsWith: []string{"endpoint_details.0.vpc_endpoint_id"},
+							},
+							names.AttrSecurityGroupIDs: {
+								Type:          schema.TypeSet,
+								Optional:      true,
+								Computed:      true,
+								Elem:          &schema.Schema{Type: schema.TypeString},
+								ConflictsWith: []string{"endpoint_details.0.vpc_endpoint_id"},
+							},
+							names.AttrSubnetIDs: {
+								Type:          schema.TypeSet,
+								Optional:      true,
+								Elem:          &schema.Schema{Type: schema.TypeString},
+								ConflictsWith: []string{"endpoint_details.0.vpc_endpoint_id"},
+							},
+							names.AttrVPCEndpointID: {
+								Type:          schema.TypeString,
+								Optional:      true,
+								Computed:      true,
+								ConflictsWith: []string{"endpoint_details.0.address_allocation_ids", "endpoint_details.0.security_group_ids", "endpoint_details.0.subnet_ids", "endpoint_details.0.vpc_id"},
+							},
+							names.AttrVPCID: {
+								Type:          schema.TypeString,
+								Optional:      true,
+								ValidateFunc:  validation.NoZeroValues,
+								ConflictsWith: []string{"endpoint_details.0.vpc_endpoint_id"},
+							},
+						},
+					},
+				},
+				names.AttrEndpointType: {
+					Type:             schema.TypeString,
+					Optional:         true,
+					Default:          awstypes.EndpointTypePublic,
+					ValidateDiagFunc: enum.Validate[awstypes.EndpointType](),
+				},
+				names.AttrForceDestroy: {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
+				"function": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				"host_key": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Sensitive:    true,
+					ValidateFunc: validation.StringLenBetween(0, 4096),
+				},
+				"host_key_fingerprint": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"identity_provider_type": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					ForceNew:         true,
+					Default:          awstypes.IdentityProviderTypeServiceManaged,
+					ValidateDiagFunc: enum.Validate[awstypes.IdentityProviderType](),
+				},
+				"invocation_role": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				names.AttrIPAddressType: {
+					Type:             schema.TypeString,
+					Optional:         true,
+					Computed:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.IpAddressType](),
+				},
+				"logging_role": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				"post_authentication_login_banner": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Sensitive:    true,
+					ValidateFunc: validation.StringLenBetween(0, 4096),
+				},
+				"pre_authentication_login_banner": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Sensitive:    true,
+					ValidateFunc: validation.StringLenBetween(0, 4096),
+				},
+				"protocol_details": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Computed: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"as2_transports": {
+								Type:     schema.TypeSet,
+								Optional: true,
+								Computed: true,
+								Elem: &schema.Schema{
+									Type:             schema.TypeString,
+									ValidateDiagFunc: enum.Validate[awstypes.As2Transport](),
+								},
+							},
+							"passive_ip": {
+								Type:         schema.TypeString,
+								Optional:     true,
+								Computed:     true,
+								ValidateFunc: validation.StringLenBetween(0, 15),
+							},
+							"set_stat_option": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								Computed:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.SetStatOption](),
+							},
+							"tls_session_resumption_mode": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								Computed:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.TlsSessionResumptionMode](),
+							},
+						},
+					},
+				},
+				"protocols": {
+					Type:     schema.TypeSet,
+					MinItems: 1,
+					MaxItems: 3,
+					Optional: true,
+					Computed: true,
+					Elem: &schema.Schema{
+						Type:             schema.TypeString,
+						ValidateDiagFunc: enum.Validate[awstypes.Protocol](),
+					},
+				},
+				"s3_storage_options": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Computed: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"directory_listing_optimization": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								Computed:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.DirectoryListingOptimization](),
+							},
+						},
+					},
+				},
+				"security_policy_name": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					Default:          securityPolicyName2018_11,
+					ValidateDiagFunc: enum.Validate[securityPolicyName](),
+				},
+				"sftp_authentication_methods": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					Computed:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.SftpAuthenticationMethods](),
+				},
+				"structured_log_destinations": {
+					Type: schema.TypeSet,
+					Elem: &schema.Schema{
+						Type:         schema.TypeString,
+						ValidateFunc: verify.ValidARN,
+					},
+					Description: "This is a set of arns of destinations that will receive structured logs from the transfer server",
+					Optional:    true,
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				names.AttrURL: {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"workflow_details": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"on_partial_upload": {
+								Type:         schema.TypeList,
+								Optional:     true,
+								MaxItems:     1,
+								AtLeastOneOf: []string{"workflow_details.0.on_upload", "workflow_details.0.on_partial_upload"},
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"execution_role": {
+											Type:         schema.TypeString,
+											Required:     true,
+											ValidateFunc: verify.ValidARN,
+										},
+										"workflow_id": {
+											Type:     schema.TypeString,
+											Required: true,
+										},
 									},
 								},
 							},
-						},
-						"on_upload": {
-							Type:         schema.TypeList,
-							Optional:     true,
-							MaxItems:     1,
-							AtLeastOneOf: []string{"workflow_details.0.on_upload", "workflow_details.0.on_partial_upload"},
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"execution_role": {
-										Type:         schema.TypeString,
-										Required:     true,
-										ValidateFunc: verify.ValidARN,
-									},
-									"workflow_id": {
-										Type:     schema.TypeString,
-										Required: true,
+							"on_upload": {
+								Type:         schema.TypeList,
+								Optional:     true,
+								MaxItems:     1,
+								AtLeastOneOf: []string{"workflow_details.0.on_upload", "workflow_details.0.on_partial_upload"},
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"execution_role": {
+											Type:         schema.TypeString,
+											Required:     true,
+											ValidateFunc: verify.ValidARN,
+										},
+										"workflow_id": {
+											Type:     schema.TypeString,
+											Required: true,
+										},
 									},
 								},
 							},
 						},
 					},
 				},
-			},
+			}
 		},
 	}
 }

--- a/internal/service/transfer/server_data_source.go
+++ b/internal/service/transfer/server_data_source.go
@@ -24,70 +24,72 @@ func dataSourceServer() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceServerRead,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrCertificate: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrDomain: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrEndpoint: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrEndpointType: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"identity_provider_type": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"invocation_role": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrIPAddressType: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"logging_role": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"protocols": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
 				},
-			},
-			"security_policy_name": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"server_id": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"structured_log_destinations": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
+				names.AttrCertificate: {
+					Type:     schema.TypeString,
+					Computed: true,
 				},
-			},
-			names.AttrURL: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrTags: tftags.TagsSchemaComputed(),
+				names.AttrDomain: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrEndpoint: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrEndpointType: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"identity_provider_type": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"invocation_role": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrIPAddressType: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"logging_role": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"protocols": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Schema{
+						Type: schema.TypeString,
+					},
+				},
+				"security_policy_name": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"server_id": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"structured_log_destinations": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Schema{
+						Type: schema.TypeString,
+					},
+				},
+				names.AttrURL: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrTags: tftags.TagsSchemaComputed(),
+			}
 		},
 	}
 }

--- a/internal/service/transfer/ssh_key.go
+++ b/internal/service/transfer/ssh_key.go
@@ -36,33 +36,35 @@ func resourceSSHKey() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"body": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					old = cleanSSHKey(old)
-					new = cleanSSHKey(new)
-					return strings.Trim(old, "\n") == strings.Trim(new, "\n")
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"body": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+					DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+						old = cleanSSHKey(old)
+						new = cleanSSHKey(new)
+						return strings.Trim(old, "\n") == strings.Trim(new, "\n")
+					},
 				},
-			},
-			"server_id": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validServerID,
-			},
-			"ssh_key_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrUserName: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validUserName,
-			},
+				"server_id": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validServerID,
+				},
+				"ssh_key_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrUserName: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validUserName,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/transfer/user.go
+++ b/internal/service/transfer/user.go
@@ -49,82 +49,84 @@ func resourceUser() *schema.Resource {
 			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"home_directory": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringLenBetween(0, 1024),
-			},
-			"home_directory_mappings": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"entry": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validation.StringLenBetween(0, 1024),
-						},
-						names.AttrTarget: {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validation.StringLenBetween(0, 1024),
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"home_directory": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringLenBetween(0, 1024),
+				},
+				"home_directory_mappings": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"entry": {
+								Type:         schema.TypeString,
+								Required:     true,
+								ValidateFunc: validation.StringLenBetween(0, 1024),
+							},
+							names.AttrTarget: {
+								Type:         schema.TypeString,
+								Required:     true,
+								ValidateFunc: validation.StringLenBetween(0, 1024),
+							},
 						},
 					},
 				},
-			},
-			"home_directory_type": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Default:          awstypes.HomeDirectoryTypePath,
-				ValidateDiagFunc: enum.Validate[awstypes.HomeDirectoryType](),
-			},
-			names.AttrPolicy: sdkv2.IAMPolicyDocumentSchemaOptional(),
-			"posix_profile": {
-				Type:     schema.TypeList,
-				MaxItems: 1,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"gid": {
-							Type:     schema.TypeInt,
-							Required: true,
-						},
-						"secondary_gids": {
-							Type:     schema.TypeSet,
-							Elem:     &schema.Schema{Type: schema.TypeInt},
-							Optional: true,
-						},
-						"uid": {
-							Type:     schema.TypeInt,
-							Required: true,
+				"home_directory_type": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					Default:          awstypes.HomeDirectoryTypePath,
+					ValidateDiagFunc: enum.Validate[awstypes.HomeDirectoryType](),
+				},
+				names.AttrPolicy: sdkv2.IAMPolicyDocumentSchemaOptional(),
+				"posix_profile": {
+					Type:     schema.TypeList,
+					MaxItems: 1,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"gid": {
+								Type:     schema.TypeInt,
+								Required: true,
+							},
+							"secondary_gids": {
+								Type:     schema.TypeSet,
+								Elem:     &schema.Schema{Type: schema.TypeInt},
+								Optional: true,
+							},
+							"uid": {
+								Type:     schema.TypeInt,
+								Required: true,
+							},
 						},
 					},
 				},
-			},
-			names.AttrRole: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			"server_id": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validServerID,
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			names.AttrUserName: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validUserName,
-			},
+				names.AttrRole: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				"server_id": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validServerID,
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				names.AttrUserName: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validUserName,
+				},
+			}
 		},
 	}
 }

--- a/internal/service/transfer/workflow.go
+++ b/internal/service/transfer/workflow.go
@@ -40,645 +40,647 @@ func resourceWorkflow() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrDescription: {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
-			"on_exception_steps": {
-				Type:     schema.TypeList,
-				Optional: true,
-				ForceNew: true,
-				MaxItems: 8,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"copy_step_details": {
-							Type:     schema.TypeList,
-							Optional: true,
-							ForceNew: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"destination_file_location": {
-										Type:     schema.TypeList,
-										Optional: true,
-										ForceNew: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"efs_file_location": {
-													Type:     schema.TypeList,
-													Optional: true,
-													ForceNew: true,
-													MaxItems: 1,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															names.AttrFileSystemID: {
-																Type:     schema.TypeString,
-																Optional: true,
-																ForceNew: true,
-															},
-															names.AttrPath: {
-																Type:         schema.TypeString,
-																Optional:     true,
-																ForceNew:     true,
-																ValidateFunc: validation.StringLenBetween(1, 65536),
-															},
-														},
-													},
-												},
-												"s3_file_location": {
-													Type:     schema.TypeList,
-													Optional: true,
-													ForceNew: true,
-													MaxItems: 1,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															names.AttrBucket: {
-																Type:     schema.TypeString,
-																Optional: true,
-																ForceNew: true,
-															},
-															names.AttrKey: {
-																Type:         schema.TypeString,
-																Optional:     true,
-																ForceNew:     true,
-																ValidateFunc: validation.StringLenBetween(0, 1024),
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrDescription: {
+					Type:     schema.TypeString,
+					Optional: true,
+					ForceNew: true,
+				},
+				"on_exception_steps": {
+					Type:     schema.TypeList,
+					Optional: true,
+					ForceNew: true,
+					MaxItems: 8,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"copy_step_details": {
+								Type:     schema.TypeList,
+								Optional: true,
+								ForceNew: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"destination_file_location": {
+											Type:     schema.TypeList,
+											Optional: true,
+											ForceNew: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"efs_file_location": {
+														Type:     schema.TypeList,
+														Optional: true,
+														ForceNew: true,
+														MaxItems: 1,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																names.AttrFileSystemID: {
+																	Type:     schema.TypeString,
+																	Optional: true,
+																	ForceNew: true,
+																},
+																names.AttrPath: {
+																	Type:         schema.TypeString,
+																	Optional:     true,
+																	ForceNew:     true,
+																	ValidateFunc: validation.StringLenBetween(1, 65536),
+																},
 															},
 														},
 													},
-												},
-											},
-										},
-									},
-									names.AttrName: {
-										Type:     schema.TypeString,
-										Optional: true,
-										ForceNew: true,
-										ValidateFunc: validation.All(
-											validation.StringLenBetween(0, 30),
-											validation.StringMatch(regexache.MustCompile(`^[\w-]*$`), "Must be of the pattern ^[\\w-]*$"),
-										),
-									},
-									"overwrite_existing": {
-										Type:             schema.TypeString,
-										Optional:         true,
-										ForceNew:         true,
-										Default:          awstypes.OverwriteExistingFalse,
-										ValidateDiagFunc: enum.Validate[awstypes.OverwriteExisting](),
-									},
-									"source_file_location": {
-										Type:     schema.TypeString,
-										Optional: true,
-										ForceNew: true,
-										ValidateFunc: validation.All(
-											validation.StringLenBetween(0, 256),
-											validation.StringMatch(regexache.MustCompile(`^\$\{(\w+.)+\w+\}$`), "Must be of the pattern ^\\$\\{(\\w+.)+\\w+\\}$"),
-										),
-									},
-								},
-							},
-						},
-						"custom_step_details": {
-							Type:     schema.TypeList,
-							Optional: true,
-							ForceNew: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									names.AttrName: {
-										Type:     schema.TypeString,
-										Optional: true,
-										ForceNew: true,
-										ValidateFunc: validation.All(
-											validation.StringLenBetween(0, 30),
-											validation.StringMatch(regexache.MustCompile(`^[\w-]*$`), "Must be of the pattern ^[\\w-]*$"),
-										),
-									},
-									"source_file_location": {
-										Type:     schema.TypeString,
-										Optional: true,
-										ForceNew: true,
-										ValidateFunc: validation.All(
-											validation.StringLenBetween(0, 256),
-											validation.StringMatch(regexache.MustCompile(`^\$\{(\w+.)+\w+\}$`), "Must be of the pattern ^\\$\\{(\\w+.)+\\w+\\}$"),
-										),
-									},
-									names.AttrTarget: {
-										Type:         schema.TypeString,
-										Optional:     true,
-										ForceNew:     true,
-										ValidateFunc: verify.ValidARN,
-									},
-									"timeout_seconds": {
-										Type:         schema.TypeInt,
-										Optional:     true,
-										ForceNew:     true,
-										ValidateFunc: validation.IntBetween(1, 1800),
-									},
-								},
-							},
-						},
-						"decrypt_step_details": {
-							Type:     schema.TypeList,
-							Optional: true,
-							ForceNew: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"destination_file_location": {
-										Type:     schema.TypeList,
-										Optional: true,
-										ForceNew: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"efs_file_location": {
-													Type:     schema.TypeList,
-													Optional: true,
-													ForceNew: true,
-													MaxItems: 1,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															names.AttrFileSystemID: {
-																Type:     schema.TypeString,
-																Optional: true,
-																ForceNew: true,
-															},
-															names.AttrPath: {
-																Type:         schema.TypeString,
-																Optional:     true,
-																ForceNew:     true,
-																ValidateFunc: validation.StringLenBetween(1, 65536),
-															},
-														},
-													},
-												},
-												"s3_file_location": {
-													Type:     schema.TypeList,
-													Optional: true,
-													MaxItems: 1,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															names.AttrBucket: {
-																Type:     schema.TypeString,
-																Optional: true,
-																ForceNew: true,
-															},
-															names.AttrKey: {
-																Type:         schema.TypeString,
-																Optional:     true,
-																ForceNew:     true,
-																ValidateFunc: validation.StringLenBetween(0, 1024),
+													"s3_file_location": {
+														Type:     schema.TypeList,
+														Optional: true,
+														ForceNew: true,
+														MaxItems: 1,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																names.AttrBucket: {
+																	Type:     schema.TypeString,
+																	Optional: true,
+																	ForceNew: true,
+																},
+																names.AttrKey: {
+																	Type:         schema.TypeString,
+																	Optional:     true,
+																	ForceNew:     true,
+																	ValidateFunc: validation.StringLenBetween(0, 1024),
+																},
 															},
 														},
 													},
 												},
 											},
 										},
-									},
-									names.AttrName: {
-										Type:     schema.TypeString,
-										Optional: true,
-										ForceNew: true,
-										ValidateFunc: validation.All(
-											validation.StringLenBetween(0, 30),
-											validation.StringMatch(regexache.MustCompile(`^[\w-]*$`), "Must be of the pattern ^[\\w-]*$"),
-										),
-									},
-									"overwrite_existing": {
-										Type:             schema.TypeString,
-										Optional:         true,
-										ForceNew:         true,
-										Default:          awstypes.OverwriteExistingFalse,
-										ValidateDiagFunc: enum.Validate[awstypes.OverwriteExisting](),
-									},
-									"source_file_location": {
-										Type:     schema.TypeString,
-										Optional: true,
-										ForceNew: true,
-										ValidateFunc: validation.All(
-											validation.StringLenBetween(0, 256),
-											validation.StringMatch(regexache.MustCompile(`^\$\{(\w+.)+\w+\}$`), "Must be of the pattern ^\\$\\{(\\w+.)+\\w+\\}$"),
-										),
-									},
-									names.AttrType: {
-										Type:             schema.TypeString,
-										Required:         true,
-										ForceNew:         true,
-										ValidateDiagFunc: enum.Validate[awstypes.EncryptionType](),
+										names.AttrName: {
+											Type:     schema.TypeString,
+											Optional: true,
+											ForceNew: true,
+											ValidateFunc: validation.All(
+												validation.StringLenBetween(0, 30),
+												validation.StringMatch(regexache.MustCompile(`^[\w-]*$`), "Must be of the pattern ^[\\w-]*$"),
+											),
+										},
+										"overwrite_existing": {
+											Type:             schema.TypeString,
+											Optional:         true,
+											ForceNew:         true,
+											Default:          awstypes.OverwriteExistingFalse,
+											ValidateDiagFunc: enum.Validate[awstypes.OverwriteExisting](),
+										},
+										"source_file_location": {
+											Type:     schema.TypeString,
+											Optional: true,
+											ForceNew: true,
+											ValidateFunc: validation.All(
+												validation.StringLenBetween(0, 256),
+												validation.StringMatch(regexache.MustCompile(`^\$\{(\w+.)+\w+\}$`), "Must be of the pattern ^\\$\\{(\\w+.)+\\w+\\}$"),
+											),
+										},
 									},
 								},
 							},
-						},
-						"delete_step_details": {
-							Type:     schema.TypeList,
-							Optional: true,
-							ForceNew: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									names.AttrName: {
-										Type:     schema.TypeString,
-										Optional: true,
-										ForceNew: true,
-										ValidateFunc: validation.All(
-											validation.StringLenBetween(0, 30),
-											validation.StringMatch(regexache.MustCompile(`^[\w-]*$`), "Must be of the pattern ^[\\w-]*$"),
-										),
-									},
-									"source_file_location": {
-										Type:     schema.TypeString,
-										Optional: true,
-										ForceNew: true,
-										ValidateFunc: validation.All(
-											validation.StringLenBetween(0, 256),
-											validation.StringMatch(regexache.MustCompile(`^\$\{(\w+.)+\w+\}$`), "Must be of the pattern ^\\$\\{(\\w+.)+\\w+\\}$"),
-										),
+							"custom_step_details": {
+								Type:     schema.TypeList,
+								Optional: true,
+								ForceNew: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										names.AttrName: {
+											Type:     schema.TypeString,
+											Optional: true,
+											ForceNew: true,
+											ValidateFunc: validation.All(
+												validation.StringLenBetween(0, 30),
+												validation.StringMatch(regexache.MustCompile(`^[\w-]*$`), "Must be of the pattern ^[\\w-]*$"),
+											),
+										},
+										"source_file_location": {
+											Type:     schema.TypeString,
+											Optional: true,
+											ForceNew: true,
+											ValidateFunc: validation.All(
+												validation.StringLenBetween(0, 256),
+												validation.StringMatch(regexache.MustCompile(`^\$\{(\w+.)+\w+\}$`), "Must be of the pattern ^\\$\\{(\\w+.)+\\w+\\}$"),
+											),
+										},
+										names.AttrTarget: {
+											Type:         schema.TypeString,
+											Optional:     true,
+											ForceNew:     true,
+											ValidateFunc: verify.ValidARN,
+										},
+										"timeout_seconds": {
+											Type:         schema.TypeInt,
+											Optional:     true,
+											ForceNew:     true,
+											ValidateFunc: validation.IntBetween(1, 1800),
+										},
 									},
 								},
 							},
-						},
-						"tag_step_details": {
-							Type:     schema.TypeList,
-							Optional: true,
-							ForceNew: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									names.AttrName: {
-										Type:     schema.TypeString,
-										Optional: true,
-										ForceNew: true,
-										ValidateFunc: validation.All(
-											validation.StringLenBetween(0, 30),
-											validation.StringMatch(regexache.MustCompile(`^[\w-]*$`), "Must be of the pattern ^[\\w-]*$"),
-										),
-									},
-									"source_file_location": {
-										Type:     schema.TypeString,
-										Optional: true,
-										ForceNew: true,
-										ValidateFunc: validation.All(
-											validation.StringLenBetween(0, 256),
-											validation.StringMatch(regexache.MustCompile(`^\$\{(\w+.)+\w+\}$`), "Must be of the pattern ^\\$\\{(\\w+.)+\\w+\\}$"),
-										),
-									},
-									names.AttrTags: {
-										Type:     schema.TypeList,
-										Optional: true,
-										ForceNew: true,
-										MaxItems: 10,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												names.AttrKey: {
-													Type:         schema.TypeString,
-													Required:     true,
-													ForceNew:     true,
-													ValidateFunc: validation.StringLenBetween(0, 128),
+							"decrypt_step_details": {
+								Type:     schema.TypeList,
+								Optional: true,
+								ForceNew: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"destination_file_location": {
+											Type:     schema.TypeList,
+											Optional: true,
+											ForceNew: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"efs_file_location": {
+														Type:     schema.TypeList,
+														Optional: true,
+														ForceNew: true,
+														MaxItems: 1,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																names.AttrFileSystemID: {
+																	Type:     schema.TypeString,
+																	Optional: true,
+																	ForceNew: true,
+																},
+																names.AttrPath: {
+																	Type:         schema.TypeString,
+																	Optional:     true,
+																	ForceNew:     true,
+																	ValidateFunc: validation.StringLenBetween(1, 65536),
+																},
+															},
+														},
+													},
+													"s3_file_location": {
+														Type:     schema.TypeList,
+														Optional: true,
+														MaxItems: 1,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																names.AttrBucket: {
+																	Type:     schema.TypeString,
+																	Optional: true,
+																	ForceNew: true,
+																},
+																names.AttrKey: {
+																	Type:         schema.TypeString,
+																	Optional:     true,
+																	ForceNew:     true,
+																	ValidateFunc: validation.StringLenBetween(0, 1024),
+																},
+															},
+														},
+													},
 												},
-												names.AttrValue: {
-													Type:         schema.TypeString,
-													Required:     true,
-													ForceNew:     true,
-													ValidateFunc: validation.StringLenBetween(0, 256),
+											},
+										},
+										names.AttrName: {
+											Type:     schema.TypeString,
+											Optional: true,
+											ForceNew: true,
+											ValidateFunc: validation.All(
+												validation.StringLenBetween(0, 30),
+												validation.StringMatch(regexache.MustCompile(`^[\w-]*$`), "Must be of the pattern ^[\\w-]*$"),
+											),
+										},
+										"overwrite_existing": {
+											Type:             schema.TypeString,
+											Optional:         true,
+											ForceNew:         true,
+											Default:          awstypes.OverwriteExistingFalse,
+											ValidateDiagFunc: enum.Validate[awstypes.OverwriteExisting](),
+										},
+										"source_file_location": {
+											Type:     schema.TypeString,
+											Optional: true,
+											ForceNew: true,
+											ValidateFunc: validation.All(
+												validation.StringLenBetween(0, 256),
+												validation.StringMatch(regexache.MustCompile(`^\$\{(\w+.)+\w+\}$`), "Must be of the pattern ^\\$\\{(\\w+.)+\\w+\\}$"),
+											),
+										},
+										names.AttrType: {
+											Type:             schema.TypeString,
+											Required:         true,
+											ForceNew:         true,
+											ValidateDiagFunc: enum.Validate[awstypes.EncryptionType](),
+										},
+									},
+								},
+							},
+							"delete_step_details": {
+								Type:     schema.TypeList,
+								Optional: true,
+								ForceNew: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										names.AttrName: {
+											Type:     schema.TypeString,
+											Optional: true,
+											ForceNew: true,
+											ValidateFunc: validation.All(
+												validation.StringLenBetween(0, 30),
+												validation.StringMatch(regexache.MustCompile(`^[\w-]*$`), "Must be of the pattern ^[\\w-]*$"),
+											),
+										},
+										"source_file_location": {
+											Type:     schema.TypeString,
+											Optional: true,
+											ForceNew: true,
+											ValidateFunc: validation.All(
+												validation.StringLenBetween(0, 256),
+												validation.StringMatch(regexache.MustCompile(`^\$\{(\w+.)+\w+\}$`), "Must be of the pattern ^\\$\\{(\\w+.)+\\w+\\}$"),
+											),
+										},
+									},
+								},
+							},
+							"tag_step_details": {
+								Type:     schema.TypeList,
+								Optional: true,
+								ForceNew: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										names.AttrName: {
+											Type:     schema.TypeString,
+											Optional: true,
+											ForceNew: true,
+											ValidateFunc: validation.All(
+												validation.StringLenBetween(0, 30),
+												validation.StringMatch(regexache.MustCompile(`^[\w-]*$`), "Must be of the pattern ^[\\w-]*$"),
+											),
+										},
+										"source_file_location": {
+											Type:     schema.TypeString,
+											Optional: true,
+											ForceNew: true,
+											ValidateFunc: validation.All(
+												validation.StringLenBetween(0, 256),
+												validation.StringMatch(regexache.MustCompile(`^\$\{(\w+.)+\w+\}$`), "Must be of the pattern ^\\$\\{(\\w+.)+\\w+\\}$"),
+											),
+										},
+										names.AttrTags: {
+											Type:     schema.TypeList,
+											Optional: true,
+											ForceNew: true,
+											MaxItems: 10,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													names.AttrKey: {
+														Type:         schema.TypeString,
+														Required:     true,
+														ForceNew:     true,
+														ValidateFunc: validation.StringLenBetween(0, 128),
+													},
+													names.AttrValue: {
+														Type:         schema.TypeString,
+														Required:     true,
+														ForceNew:     true,
+														ValidateFunc: validation.StringLenBetween(0, 256),
+													},
 												},
 											},
 										},
 									},
 								},
 							},
-						},
-						names.AttrType: {
-							Type:             schema.TypeString,
-							Required:         true,
-							ForceNew:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.WorkflowStepType](),
+							names.AttrType: {
+								Type:             schema.TypeString,
+								Required:         true,
+								ForceNew:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.WorkflowStepType](),
+							},
 						},
 					},
 				},
-			},
-			"steps": {
-				Type:     schema.TypeList,
-				Required: true,
-				ForceNew: true,
-				MaxItems: 8,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"copy_step_details": {
-							Type:     schema.TypeList,
-							Optional: true,
-							ForceNew: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"destination_file_location": {
-										Type:     schema.TypeList,
-										Optional: true,
-										ForceNew: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"efs_file_location": {
-													Type:     schema.TypeList,
-													Optional: true,
-													ForceNew: true,
-													MaxItems: 1,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															names.AttrFileSystemID: {
-																Type:     schema.TypeString,
-																Optional: true,
-																ForceNew: true,
-															},
-															names.AttrPath: {
-																Type:         schema.TypeString,
-																Optional:     true,
-																ForceNew:     true,
-																ValidateFunc: validation.StringLenBetween(1, 65536),
-															},
-														},
-													},
-												},
-												"s3_file_location": {
-													Type:     schema.TypeList,
-													Optional: true,
-													ForceNew: true,
-													MaxItems: 1,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															names.AttrBucket: {
-																Type:     schema.TypeString,
-																Optional: true,
-																ForceNew: true,
-															},
-															names.AttrKey: {
-																Type:         schema.TypeString,
-																Optional:     true,
-																ForceNew:     true,
-																ValidateFunc: validation.StringLenBetween(0, 1024),
+				"steps": {
+					Type:     schema.TypeList,
+					Required: true,
+					ForceNew: true,
+					MaxItems: 8,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"copy_step_details": {
+								Type:     schema.TypeList,
+								Optional: true,
+								ForceNew: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"destination_file_location": {
+											Type:     schema.TypeList,
+											Optional: true,
+											ForceNew: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"efs_file_location": {
+														Type:     schema.TypeList,
+														Optional: true,
+														ForceNew: true,
+														MaxItems: 1,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																names.AttrFileSystemID: {
+																	Type:     schema.TypeString,
+																	Optional: true,
+																	ForceNew: true,
+																},
+																names.AttrPath: {
+																	Type:         schema.TypeString,
+																	Optional:     true,
+																	ForceNew:     true,
+																	ValidateFunc: validation.StringLenBetween(1, 65536),
+																},
 															},
 														},
 													},
-												},
-											},
-										},
-									},
-									names.AttrName: {
-										Type:     schema.TypeString,
-										Optional: true,
-										ForceNew: true,
-										ValidateFunc: validation.All(
-											validation.StringLenBetween(0, 30),
-											validation.StringMatch(regexache.MustCompile(`^[\w-]*$`), "Must be of the pattern ^[\\w-]*$"),
-										),
-									},
-									"overwrite_existing": {
-										Type:             schema.TypeString,
-										Optional:         true,
-										ForceNew:         true,
-										Default:          awstypes.OverwriteExistingFalse,
-										ValidateDiagFunc: enum.Validate[awstypes.OverwriteExisting](),
-									},
-									"source_file_location": {
-										Type:     schema.TypeString,
-										Optional: true,
-										ForceNew: true,
-										ValidateFunc: validation.All(
-											validation.StringLenBetween(0, 256),
-											validation.StringMatch(regexache.MustCompile(`^\$\{(\w+.)+\w+\}$`), "Must be of the pattern ^\\$\\{(\\w+.)+\\w+\\}$"),
-										),
-									},
-								},
-							},
-						},
-						"custom_step_details": {
-							Type:     schema.TypeList,
-							Optional: true,
-							ForceNew: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									names.AttrName: {
-										Type:     schema.TypeString,
-										Optional: true,
-										ForceNew: true,
-										ValidateFunc: validation.All(
-											validation.StringLenBetween(0, 30),
-											validation.StringMatch(regexache.MustCompile(`^[\w-]*$`), "Must be of the pattern ^[\\w-]*$"),
-										),
-									},
-									"source_file_location": {
-										Type:     schema.TypeString,
-										Optional: true,
-										ForceNew: true,
-										ValidateFunc: validation.All(
-											validation.StringLenBetween(0, 256),
-											validation.StringMatch(regexache.MustCompile(`^\$\{(\w+.)+\w+\}$`), "Must be of the pattern ^\\$\\{(\\w+.)+\\w+\\}$"),
-										),
-									},
-									names.AttrTarget: {
-										Type:         schema.TypeString,
-										Optional:     true,
-										ForceNew:     true,
-										ValidateFunc: verify.ValidARN,
-									},
-									"timeout_seconds": {
-										Type:         schema.TypeInt,
-										Optional:     true,
-										ForceNew:     true,
-										ValidateFunc: validation.IntBetween(1, 1800),
-									},
-								},
-							},
-						},
-						"decrypt_step_details": {
-							Type:     schema.TypeList,
-							Optional: true,
-							ForceNew: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"destination_file_location": {
-										Type:     schema.TypeList,
-										Optional: true,
-										ForceNew: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"efs_file_location": {
-													Type:     schema.TypeList,
-													Optional: true,
-													ForceNew: true,
-													MaxItems: 1,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															names.AttrFileSystemID: {
-																Type:     schema.TypeString,
-																Optional: true,
-																ForceNew: true,
-															},
-															names.AttrPath: {
-																Type:         schema.TypeString,
-																Optional:     true,
-																ForceNew:     true,
-																ValidateFunc: validation.StringLenBetween(1, 65536),
-															},
-														},
-													},
-												},
-												"s3_file_location": {
-													Type:     schema.TypeList,
-													Optional: true,
-													ForceNew: true,
-													MaxItems: 1,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															names.AttrBucket: {
-																Type:     schema.TypeString,
-																Optional: true,
-																ForceNew: true,
-															},
-															names.AttrKey: {
-																Type:         schema.TypeString,
-																Optional:     true,
-																ForceNew:     true,
-																ValidateFunc: validation.StringLenBetween(0, 1024),
+													"s3_file_location": {
+														Type:     schema.TypeList,
+														Optional: true,
+														ForceNew: true,
+														MaxItems: 1,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																names.AttrBucket: {
+																	Type:     schema.TypeString,
+																	Optional: true,
+																	ForceNew: true,
+																},
+																names.AttrKey: {
+																	Type:         schema.TypeString,
+																	Optional:     true,
+																	ForceNew:     true,
+																	ValidateFunc: validation.StringLenBetween(0, 1024),
+																},
 															},
 														},
 													},
 												},
 											},
 										},
-									},
-									names.AttrName: {
-										Type:     schema.TypeString,
-										Optional: true,
-										ForceNew: true,
-										ValidateFunc: validation.All(
-											validation.StringLenBetween(0, 30),
-											validation.StringMatch(regexache.MustCompile(`^[\w-]*$`), "Must be of the pattern ^[\\w-]*$"),
-										),
-									},
-									"overwrite_existing": {
-										Type:             schema.TypeString,
-										Optional:         true,
-										ForceNew:         true,
-										Default:          awstypes.OverwriteExistingFalse,
-										ValidateDiagFunc: enum.Validate[awstypes.OverwriteExisting](),
-									},
-									"source_file_location": {
-										Type:     schema.TypeString,
-										Optional: true,
-										ForceNew: true,
-										ValidateFunc: validation.All(
-											validation.StringLenBetween(0, 256),
-											validation.StringMatch(regexache.MustCompile(`^\$\{(\w+.)+\w+\}$`), "Must be of the pattern ^\\$\\{(\\w+.)+\\w+\\}$"),
-										),
-									},
-									names.AttrType: {
-										Type:             schema.TypeString,
-										Required:         true,
-										ForceNew:         true,
-										ValidateDiagFunc: enum.Validate[awstypes.EncryptionType](),
+										names.AttrName: {
+											Type:     schema.TypeString,
+											Optional: true,
+											ForceNew: true,
+											ValidateFunc: validation.All(
+												validation.StringLenBetween(0, 30),
+												validation.StringMatch(regexache.MustCompile(`^[\w-]*$`), "Must be of the pattern ^[\\w-]*$"),
+											),
+										},
+										"overwrite_existing": {
+											Type:             schema.TypeString,
+											Optional:         true,
+											ForceNew:         true,
+											Default:          awstypes.OverwriteExistingFalse,
+											ValidateDiagFunc: enum.Validate[awstypes.OverwriteExisting](),
+										},
+										"source_file_location": {
+											Type:     schema.TypeString,
+											Optional: true,
+											ForceNew: true,
+											ValidateFunc: validation.All(
+												validation.StringLenBetween(0, 256),
+												validation.StringMatch(regexache.MustCompile(`^\$\{(\w+.)+\w+\}$`), "Must be of the pattern ^\\$\\{(\\w+.)+\\w+\\}$"),
+											),
+										},
 									},
 								},
 							},
-						},
-						"delete_step_details": {
-							Type:     schema.TypeList,
-							Optional: true,
-							ForceNew: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									names.AttrName: {
-										Type:     schema.TypeString,
-										Optional: true,
-										ForceNew: true,
-										ValidateFunc: validation.All(
-											validation.StringLenBetween(0, 30),
-											validation.StringMatch(regexache.MustCompile(`^[\w-]*$`), "Must be of the pattern ^[\\w-]*$"),
-										),
-									},
-									"source_file_location": {
-										Type:     schema.TypeString,
-										Optional: true,
-										ForceNew: true,
-										ValidateFunc: validation.All(
-											validation.StringLenBetween(0, 256),
-											validation.StringMatch(regexache.MustCompile(`^\$\{(\w+.)+\w+\}$`), "Must be of the pattern ^\\$\\{(\\w+.)+\\w+\\}$"),
-										),
+							"custom_step_details": {
+								Type:     schema.TypeList,
+								Optional: true,
+								ForceNew: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										names.AttrName: {
+											Type:     schema.TypeString,
+											Optional: true,
+											ForceNew: true,
+											ValidateFunc: validation.All(
+												validation.StringLenBetween(0, 30),
+												validation.StringMatch(regexache.MustCompile(`^[\w-]*$`), "Must be of the pattern ^[\\w-]*$"),
+											),
+										},
+										"source_file_location": {
+											Type:     schema.TypeString,
+											Optional: true,
+											ForceNew: true,
+											ValidateFunc: validation.All(
+												validation.StringLenBetween(0, 256),
+												validation.StringMatch(regexache.MustCompile(`^\$\{(\w+.)+\w+\}$`), "Must be of the pattern ^\\$\\{(\\w+.)+\\w+\\}$"),
+											),
+										},
+										names.AttrTarget: {
+											Type:         schema.TypeString,
+											Optional:     true,
+											ForceNew:     true,
+											ValidateFunc: verify.ValidARN,
+										},
+										"timeout_seconds": {
+											Type:         schema.TypeInt,
+											Optional:     true,
+											ForceNew:     true,
+											ValidateFunc: validation.IntBetween(1, 1800),
+										},
 									},
 								},
 							},
-						},
-						"tag_step_details": {
-							Type:     schema.TypeList,
-							Optional: true,
-							ForceNew: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									names.AttrName: {
-										Type:     schema.TypeString,
-										Optional: true,
-										ForceNew: true,
-										ValidateFunc: validation.All(
-											validation.StringLenBetween(0, 30),
-											validation.StringMatch(regexache.MustCompile(`^[\w-]*$`), "Must be of the pattern ^[\\w-]*$"),
-										),
-									},
-									"source_file_location": {
-										Type:     schema.TypeString,
-										Optional: true,
-										ForceNew: true,
-										ValidateFunc: validation.All(
-											validation.StringLenBetween(0, 256),
-											validation.StringMatch(regexache.MustCompile(`^\$\{(\w+.)+\w+\}$`), "Must be of the pattern ^\\$\\{(\\w+.)+\\w+\\}$"),
-										),
-									},
-									names.AttrTags: {
-										Type:     schema.TypeList,
-										Optional: true,
-										ForceNew: true,
-										MaxItems: 10,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												names.AttrKey: {
-													Type:         schema.TypeString,
-													Required:     true,
-													ForceNew:     true,
-													ValidateFunc: validation.StringLenBetween(0, 128),
+							"decrypt_step_details": {
+								Type:     schema.TypeList,
+								Optional: true,
+								ForceNew: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"destination_file_location": {
+											Type:     schema.TypeList,
+											Optional: true,
+											ForceNew: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"efs_file_location": {
+														Type:     schema.TypeList,
+														Optional: true,
+														ForceNew: true,
+														MaxItems: 1,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																names.AttrFileSystemID: {
+																	Type:     schema.TypeString,
+																	Optional: true,
+																	ForceNew: true,
+																},
+																names.AttrPath: {
+																	Type:         schema.TypeString,
+																	Optional:     true,
+																	ForceNew:     true,
+																	ValidateFunc: validation.StringLenBetween(1, 65536),
+																},
+															},
+														},
+													},
+													"s3_file_location": {
+														Type:     schema.TypeList,
+														Optional: true,
+														ForceNew: true,
+														MaxItems: 1,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																names.AttrBucket: {
+																	Type:     schema.TypeString,
+																	Optional: true,
+																	ForceNew: true,
+																},
+																names.AttrKey: {
+																	Type:         schema.TypeString,
+																	Optional:     true,
+																	ForceNew:     true,
+																	ValidateFunc: validation.StringLenBetween(0, 1024),
+																},
+															},
+														},
+													},
 												},
-												names.AttrValue: {
-													Type:         schema.TypeString,
-													Required:     true,
-													ForceNew:     true,
-													ValidateFunc: validation.StringLenBetween(0, 256),
+											},
+										},
+										names.AttrName: {
+											Type:     schema.TypeString,
+											Optional: true,
+											ForceNew: true,
+											ValidateFunc: validation.All(
+												validation.StringLenBetween(0, 30),
+												validation.StringMatch(regexache.MustCompile(`^[\w-]*$`), "Must be of the pattern ^[\\w-]*$"),
+											),
+										},
+										"overwrite_existing": {
+											Type:             schema.TypeString,
+											Optional:         true,
+											ForceNew:         true,
+											Default:          awstypes.OverwriteExistingFalse,
+											ValidateDiagFunc: enum.Validate[awstypes.OverwriteExisting](),
+										},
+										"source_file_location": {
+											Type:     schema.TypeString,
+											Optional: true,
+											ForceNew: true,
+											ValidateFunc: validation.All(
+												validation.StringLenBetween(0, 256),
+												validation.StringMatch(regexache.MustCompile(`^\$\{(\w+.)+\w+\}$`), "Must be of the pattern ^\\$\\{(\\w+.)+\\w+\\}$"),
+											),
+										},
+										names.AttrType: {
+											Type:             schema.TypeString,
+											Required:         true,
+											ForceNew:         true,
+											ValidateDiagFunc: enum.Validate[awstypes.EncryptionType](),
+										},
+									},
+								},
+							},
+							"delete_step_details": {
+								Type:     schema.TypeList,
+								Optional: true,
+								ForceNew: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										names.AttrName: {
+											Type:     schema.TypeString,
+											Optional: true,
+											ForceNew: true,
+											ValidateFunc: validation.All(
+												validation.StringLenBetween(0, 30),
+												validation.StringMatch(regexache.MustCompile(`^[\w-]*$`), "Must be of the pattern ^[\\w-]*$"),
+											),
+										},
+										"source_file_location": {
+											Type:     schema.TypeString,
+											Optional: true,
+											ForceNew: true,
+											ValidateFunc: validation.All(
+												validation.StringLenBetween(0, 256),
+												validation.StringMatch(regexache.MustCompile(`^\$\{(\w+.)+\w+\}$`), "Must be of the pattern ^\\$\\{(\\w+.)+\\w+\\}$"),
+											),
+										},
+									},
+								},
+							},
+							"tag_step_details": {
+								Type:     schema.TypeList,
+								Optional: true,
+								ForceNew: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										names.AttrName: {
+											Type:     schema.TypeString,
+											Optional: true,
+											ForceNew: true,
+											ValidateFunc: validation.All(
+												validation.StringLenBetween(0, 30),
+												validation.StringMatch(regexache.MustCompile(`^[\w-]*$`), "Must be of the pattern ^[\\w-]*$"),
+											),
+										},
+										"source_file_location": {
+											Type:     schema.TypeString,
+											Optional: true,
+											ForceNew: true,
+											ValidateFunc: validation.All(
+												validation.StringLenBetween(0, 256),
+												validation.StringMatch(regexache.MustCompile(`^\$\{(\w+.)+\w+\}$`), "Must be of the pattern ^\\$\\{(\\w+.)+\\w+\\}$"),
+											),
+										},
+										names.AttrTags: {
+											Type:     schema.TypeList,
+											Optional: true,
+											ForceNew: true,
+											MaxItems: 10,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													names.AttrKey: {
+														Type:         schema.TypeString,
+														Required:     true,
+														ForceNew:     true,
+														ValidateFunc: validation.StringLenBetween(0, 128),
+													},
+													names.AttrValue: {
+														Type:         schema.TypeString,
+														Required:     true,
+														ForceNew:     true,
+														ValidateFunc: validation.StringLenBetween(0, 256),
+													},
 												},
 											},
 										},
 									},
 								},
 							},
-						},
-						names.AttrType: {
-							Type:             schema.TypeString,
-							Required:         true,
-							ForceNew:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.WorkflowStepType](),
+							names.AttrType: {
+								Type:             schema.TypeString,
+								Required:         true,
+								ForceNew:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.WorkflowStepType](),
+							},
 						},
 					},
 				},
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			}
 		},
 	}
 }

--- a/internal/service/vpclattice/access_log_subscription.go
+++ b/internal/service/vpclattice/access_log_subscription.go
@@ -41,38 +41,40 @@ func resourceAccessLogSubscription() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrDestinationARN: {
-				Type:             schema.TypeString,
-				Required:         true,
-				ForceNew:         true,
-				ValidateFunc:     verify.ValidARN,
-				DiffSuppressFunc: sdkv2.SuppressEquivalentCloudWatchLogsLogGroupARN,
-			},
-			names.AttrResourceARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"resource_identifier": {
-				Type:             schema.TypeString,
-				Required:         true,
-				ForceNew:         true,
-				DiffSuppressFunc: suppressEquivalentIDOrARN,
-			},
-			"service_network_log_type": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Computed:         true,
-				ForceNew:         true,
-				ValidateDiagFunc: enum.Validate[awstypes.ServiceNetworkLogType](),
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-		},
+		SchemaFunc: func() map[string]*schema.Schema {
+  	return map[string]*schema.Schema{
+  			names.AttrARN: {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			names.AttrDestinationARN: {
+  				Type:             schema.TypeString,
+  				Required:         true,
+  				ForceNew:         true,
+  				ValidateFunc:     verify.ValidARN,
+  				DiffSuppressFunc: sdkv2.SuppressEquivalentCloudWatchLogsLogGroupARN,
+  			},
+  			names.AttrResourceARN: {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			"resource_identifier": {
+  				Type:             schema.TypeString,
+  				Required:         true,
+  				ForceNew:         true,
+  				DiffSuppressFunc: suppressEquivalentIDOrARN,
+  			},
+  			"service_network_log_type": {
+  				Type:             schema.TypeString,
+  				Optional:         true,
+  				Computed:         true,
+  				ForceNew:         true,
+  				ValidateDiagFunc: enum.Validate[awstypes.ServiceNetworkLogType](),
+  			},
+  			names.AttrTags:    tftags.TagsSchema(),
+  			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+  		}
+  },
 	}
 }
 

--- a/internal/service/vpclattice/access_log_subscription.go
+++ b/internal/service/vpclattice/access_log_subscription.go
@@ -42,39 +42,39 @@ func resourceAccessLogSubscription() *schema.Resource {
 		},
 
 		SchemaFunc: func() map[string]*schema.Schema {
-  	return map[string]*schema.Schema{
-  			names.AttrARN: {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			names.AttrDestinationARN: {
-  				Type:             schema.TypeString,
-  				Required:         true,
-  				ForceNew:         true,
-  				ValidateFunc:     verify.ValidARN,
-  				DiffSuppressFunc: sdkv2.SuppressEquivalentCloudWatchLogsLogGroupARN,
-  			},
-  			names.AttrResourceARN: {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			"resource_identifier": {
-  				Type:             schema.TypeString,
-  				Required:         true,
-  				ForceNew:         true,
-  				DiffSuppressFunc: suppressEquivalentIDOrARN,
-  			},
-  			"service_network_log_type": {
-  				Type:             schema.TypeString,
-  				Optional:         true,
-  				Computed:         true,
-  				ForceNew:         true,
-  				ValidateDiagFunc: enum.Validate[awstypes.ServiceNetworkLogType](),
-  			},
-  			names.AttrTags:    tftags.TagsSchema(),
-  			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-  		}
-  },
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrDestinationARN: {
+					Type:             schema.TypeString,
+					Required:         true,
+					ForceNew:         true,
+					ValidateFunc:     verify.ValidARN,
+					DiffSuppressFunc: sdkv2.SuppressEquivalentCloudWatchLogsLogGroupARN,
+				},
+				names.AttrResourceARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"resource_identifier": {
+					Type:             schema.TypeString,
+					Required:         true,
+					ForceNew:         true,
+					DiffSuppressFunc: suppressEquivalentIDOrARN,
+				},
+				"service_network_log_type": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					Computed:         true,
+					ForceNew:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.ServiceNetworkLogType](),
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			}
+		},
 	}
 }
 

--- a/internal/service/vpclattice/auth_policy.go
+++ b/internal/service/vpclattice/auth_policy.go
@@ -44,18 +44,20 @@ func resourceAuthPolicy() *schema.Resource {
 			Delete: schema.DefaultTimeout(30 * time.Minute),
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrPolicy: sdkv2.IAMPolicyDocumentSchemaRequired(),
-			"resource_identifier": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			names.AttrState: {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-		},
+		SchemaFunc: func() map[string]*schema.Schema {
+  	return map[string]*schema.Schema{
+  			names.AttrPolicy: sdkv2.IAMPolicyDocumentSchemaRequired(),
+  			"resource_identifier": {
+  				Type:         schema.TypeString,
+  				Required:     true,
+  				ValidateFunc: verify.ValidARN,
+  			},
+  			names.AttrState: {
+  				Type:     schema.TypeString,
+  				Optional: true,
+  			},
+  		}
+  },
 	}
 }
 

--- a/internal/service/vpclattice/auth_policy.go
+++ b/internal/service/vpclattice/auth_policy.go
@@ -45,19 +45,19 @@ func resourceAuthPolicy() *schema.Resource {
 		},
 
 		SchemaFunc: func() map[string]*schema.Schema {
-  	return map[string]*schema.Schema{
-  			names.AttrPolicy: sdkv2.IAMPolicyDocumentSchemaRequired(),
-  			"resource_identifier": {
-  				Type:         schema.TypeString,
-  				Required:     true,
-  				ValidateFunc: verify.ValidARN,
-  			},
-  			names.AttrState: {
-  				Type:     schema.TypeString,
-  				Optional: true,
-  			},
-  		}
-  },
+			return map[string]*schema.Schema{
+				names.AttrPolicy: sdkv2.IAMPolicyDocumentSchemaRequired(),
+				"resource_identifier": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				names.AttrState: {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+			}
+		},
 	}
 }
 

--- a/internal/service/vpclattice/auth_policy_data_source.go
+++ b/internal/service/vpclattice/auth_policy_data_source.go
@@ -22,21 +22,23 @@ func dataSourceAuthPolicy() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceAuthPolicyRead,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrPolicy: {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"resource_identifier": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			names.AttrState: {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-		},
+		SchemaFunc: func() map[string]*schema.Schema {
+  	return map[string]*schema.Schema{
+  			names.AttrPolicy: {
+  				Type:     schema.TypeString,
+  				Optional: true,
+  			},
+  			"resource_identifier": {
+  				Type:         schema.TypeString,
+  				Required:     true,
+  				ValidateFunc: verify.ValidARN,
+  			},
+  			names.AttrState: {
+  				Type:     schema.TypeString,
+  				Optional: true,
+  			},
+  		}
+  },
 	}
 }
 

--- a/internal/service/vpclattice/auth_policy_data_source.go
+++ b/internal/service/vpclattice/auth_policy_data_source.go
@@ -23,22 +23,22 @@ func dataSourceAuthPolicy() *schema.Resource {
 		ReadWithoutTimeout: dataSourceAuthPolicyRead,
 
 		SchemaFunc: func() map[string]*schema.Schema {
-  	return map[string]*schema.Schema{
-  			names.AttrPolicy: {
-  				Type:     schema.TypeString,
-  				Optional: true,
-  			},
-  			"resource_identifier": {
-  				Type:         schema.TypeString,
-  				Required:     true,
-  				ValidateFunc: verify.ValidARN,
-  			},
-  			names.AttrState: {
-  				Type:     schema.TypeString,
-  				Optional: true,
-  			},
-  		}
-  },
+			return map[string]*schema.Schema{
+				names.AttrPolicy: {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"resource_identifier": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				names.AttrState: {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+			}
+		},
 	}
 }
 

--- a/internal/service/vpclattice/listener.go
+++ b/internal/service/vpclattice/listener.go
@@ -50,107 +50,107 @@ func resourceListener() *schema.Resource {
 		},
 
 		SchemaFunc: func() map[string]*schema.Schema {
-  	return map[string]*schema.Schema{
-  			names.AttrARN: {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			names.AttrCreatedAt: {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			names.AttrDefaultAction: {
-  				Type:     schema.TypeList,
-  				MaxItems: 1,
-  				MinItems: 1,
-  				Required: true,
-  				Elem: &schema.Resource{
-  					Schema: map[string]*schema.Schema{
-  						"fixed_response": {
-  							Type:     schema.TypeList,
-  							Optional: true,
-  							MaxItems: 1,
-  							Elem: &schema.Resource{
-  								Schema: map[string]*schema.Schema{
-  									names.AttrStatusCode: {
-  										Type:     schema.TypeInt,
-  										Required: true,
-  									},
-  								},
-  							},
-  						},
-  						"forward": {
-  							Type:     schema.TypeList,
-  							Optional: true,
-  							MinItems: 1,
-  							Elem: &schema.Resource{
-  								Schema: map[string]*schema.Schema{
-  									"target_groups": {
-  										Type:     schema.TypeList,
-  										Optional: true,
-  										MinItems: 1,
-  										Elem: &schema.Resource{
-  											Schema: map[string]*schema.Schema{
-  												"target_group_identifier": {
-  													Type:     schema.TypeString,
-  													Optional: true,
-  												},
-  												names.AttrWeight: {
-  													Type:     schema.TypeInt,
-  													Default:  100,
-  													Optional: true,
-  												},
-  											},
-  										},
-  									},
-  								},
-  							},
-  						},
-  					},
-  				},
-  			},
-  			"last_updated_at": {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			"listener_id": {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			names.AttrName: {
-  				Type:     schema.TypeString,
-  				ForceNew: true,
-  				Required: true,
-  			},
-  			names.AttrPort: {
-  				Type:         schema.TypeInt,
-  				Computed:     true,
-  				Optional:     true,
-  				ForceNew:     true,
-  				ValidateFunc: validation.IsPortNumber,
-  			},
-  			names.AttrProtocol: {
-  				Type:             schema.TypeString,
-  				Required:         true,
-  				ForceNew:         true,
-  				ValidateDiagFunc: enum.Validate[types.ListenerProtocol](),
-  			},
-  			"service_arn": {
-  				Type:         schema.TypeString,
-  				Computed:     true,
-  				Optional:     true,
-  				AtLeastOneOf: []string{"service_arn", "service_identifier"},
-  			},
-  			"service_identifier": {
-  				Type:         schema.TypeString,
-  				Computed:     true,
-  				Optional:     true,
-  				AtLeastOneOf: []string{"service_arn", "service_identifier"},
-  			},
-  			names.AttrTags:    tftags.TagsSchema(),
-  			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-  		}
-  },
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrCreatedAt: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrDefaultAction: {
+					Type:     schema.TypeList,
+					MaxItems: 1,
+					MinItems: 1,
+					Required: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"fixed_response": {
+								Type:     schema.TypeList,
+								Optional: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										names.AttrStatusCode: {
+											Type:     schema.TypeInt,
+											Required: true,
+										},
+									},
+								},
+							},
+							"forward": {
+								Type:     schema.TypeList,
+								Optional: true,
+								MinItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"target_groups": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MinItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"target_group_identifier": {
+														Type:     schema.TypeString,
+														Optional: true,
+													},
+													names.AttrWeight: {
+														Type:     schema.TypeInt,
+														Default:  100,
+														Optional: true,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				"last_updated_at": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"listener_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					ForceNew: true,
+					Required: true,
+				},
+				names.AttrPort: {
+					Type:         schema.TypeInt,
+					Computed:     true,
+					Optional:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.IsPortNumber,
+				},
+				names.AttrProtocol: {
+					Type:             schema.TypeString,
+					Required:         true,
+					ForceNew:         true,
+					ValidateDiagFunc: enum.Validate[types.ListenerProtocol](),
+				},
+				"service_arn": {
+					Type:         schema.TypeString,
+					Computed:     true,
+					Optional:     true,
+					AtLeastOneOf: []string{"service_arn", "service_identifier"},
+				},
+				"service_identifier": {
+					Type:         schema.TypeString,
+					Computed:     true,
+					Optional:     true,
+					AtLeastOneOf: []string{"service_arn", "service_identifier"},
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			}
+		},
 	}
 }
 

--- a/internal/service/vpclattice/listener.go
+++ b/internal/service/vpclattice/listener.go
@@ -49,106 +49,108 @@ func resourceListener() *schema.Resource {
 			Delete: schema.DefaultTimeout(30 * time.Minute),
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrCreatedAt: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrDefaultAction: {
-				Type:     schema.TypeList,
-				MaxItems: 1,
-				MinItems: 1,
-				Required: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"fixed_response": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									names.AttrStatusCode: {
-										Type:     schema.TypeInt,
-										Required: true,
-									},
-								},
-							},
-						},
-						"forward": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MinItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"target_groups": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MinItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"target_group_identifier": {
-													Type:     schema.TypeString,
-													Optional: true,
-												},
-												names.AttrWeight: {
-													Type:     schema.TypeInt,
-													Default:  100,
-													Optional: true,
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			"last_updated_at": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"listener_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				ForceNew: true,
-				Required: true,
-			},
-			names.AttrPort: {
-				Type:         schema.TypeInt,
-				Computed:     true,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.IsPortNumber,
-			},
-			names.AttrProtocol: {
-				Type:             schema.TypeString,
-				Required:         true,
-				ForceNew:         true,
-				ValidateDiagFunc: enum.Validate[types.ListenerProtocol](),
-			},
-			"service_arn": {
-				Type:         schema.TypeString,
-				Computed:     true,
-				Optional:     true,
-				AtLeastOneOf: []string{"service_arn", "service_identifier"},
-			},
-			"service_identifier": {
-				Type:         schema.TypeString,
-				Computed:     true,
-				Optional:     true,
-				AtLeastOneOf: []string{"service_arn", "service_identifier"},
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-		},
+		SchemaFunc: func() map[string]*schema.Schema {
+  	return map[string]*schema.Schema{
+  			names.AttrARN: {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			names.AttrCreatedAt: {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			names.AttrDefaultAction: {
+  				Type:     schema.TypeList,
+  				MaxItems: 1,
+  				MinItems: 1,
+  				Required: true,
+  				Elem: &schema.Resource{
+  					Schema: map[string]*schema.Schema{
+  						"fixed_response": {
+  							Type:     schema.TypeList,
+  							Optional: true,
+  							MaxItems: 1,
+  							Elem: &schema.Resource{
+  								Schema: map[string]*schema.Schema{
+  									names.AttrStatusCode: {
+  										Type:     schema.TypeInt,
+  										Required: true,
+  									},
+  								},
+  							},
+  						},
+  						"forward": {
+  							Type:     schema.TypeList,
+  							Optional: true,
+  							MinItems: 1,
+  							Elem: &schema.Resource{
+  								Schema: map[string]*schema.Schema{
+  									"target_groups": {
+  										Type:     schema.TypeList,
+  										Optional: true,
+  										MinItems: 1,
+  										Elem: &schema.Resource{
+  											Schema: map[string]*schema.Schema{
+  												"target_group_identifier": {
+  													Type:     schema.TypeString,
+  													Optional: true,
+  												},
+  												names.AttrWeight: {
+  													Type:     schema.TypeInt,
+  													Default:  100,
+  													Optional: true,
+  												},
+  											},
+  										},
+  									},
+  								},
+  							},
+  						},
+  					},
+  				},
+  			},
+  			"last_updated_at": {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			"listener_id": {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			names.AttrName: {
+  				Type:     schema.TypeString,
+  				ForceNew: true,
+  				Required: true,
+  			},
+  			names.AttrPort: {
+  				Type:         schema.TypeInt,
+  				Computed:     true,
+  				Optional:     true,
+  				ForceNew:     true,
+  				ValidateFunc: validation.IsPortNumber,
+  			},
+  			names.AttrProtocol: {
+  				Type:             schema.TypeString,
+  				Required:         true,
+  				ForceNew:         true,
+  				ValidateDiagFunc: enum.Validate[types.ListenerProtocol](),
+  			},
+  			"service_arn": {
+  				Type:         schema.TypeString,
+  				Computed:     true,
+  				Optional:     true,
+  				AtLeastOneOf: []string{"service_arn", "service_identifier"},
+  			},
+  			"service_identifier": {
+  				Type:         schema.TypeString,
+  				Computed:     true,
+  				Optional:     true,
+  				AtLeastOneOf: []string{"service_arn", "service_identifier"},
+  			},
+  			names.AttrTags:    tftags.TagsSchema(),
+  			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+  		}
+  },
 	}
 }
 

--- a/internal/service/vpclattice/listener_data_source.go
+++ b/internal/service/vpclattice/listener_data_source.go
@@ -24,97 +24,99 @@ func dataSourceListener() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceListenerRead,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrCreatedAt: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrDefaultAction: {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"fixed_response": {
-							Type:     schema.TypeList,
-							Computed: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									names.AttrStatusCode: {
-										Type:     schema.TypeInt,
-										Computed: true,
-									},
-								},
-							},
-						},
-						"forward": {
-							Type:     schema.TypeList,
-							Computed: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"target_groups": {
-										Type:     schema.TypeList,
-										Computed: true,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"target_group_identifier": {
-													Type:     schema.TypeString,
-													Computed: true,
-												},
-												names.AttrWeight: {
-													Type:     schema.TypeInt,
-													Computed: true,
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			"last_updated_at": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"listener_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"listener_identifier": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrPort: {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-			names.AttrProtocol: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"service_arn": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"service_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"service_identifier": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			names.AttrTags: tftags.TagsSchemaComputed(),
-		},
+		SchemaFunc: func() map[string]*schema.Schema {
+  	return map[string]*schema.Schema{
+  			names.AttrARN: {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			names.AttrCreatedAt: {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			names.AttrDefaultAction: {
+  				Type:     schema.TypeList,
+  				Computed: true,
+  				Elem: &schema.Resource{
+  					Schema: map[string]*schema.Schema{
+  						"fixed_response": {
+  							Type:     schema.TypeList,
+  							Computed: true,
+  							Elem: &schema.Resource{
+  								Schema: map[string]*schema.Schema{
+  									names.AttrStatusCode: {
+  										Type:     schema.TypeInt,
+  										Computed: true,
+  									},
+  								},
+  							},
+  						},
+  						"forward": {
+  							Type:     schema.TypeList,
+  							Computed: true,
+  							Elem: &schema.Resource{
+  								Schema: map[string]*schema.Schema{
+  									"target_groups": {
+  										Type:     schema.TypeList,
+  										Computed: true,
+  										Elem: &schema.Resource{
+  											Schema: map[string]*schema.Schema{
+  												"target_group_identifier": {
+  													Type:     schema.TypeString,
+  													Computed: true,
+  												},
+  												names.AttrWeight: {
+  													Type:     schema.TypeInt,
+  													Computed: true,
+  												},
+  											},
+  										},
+  									},
+  								},
+  							},
+  						},
+  					},
+  				},
+  			},
+  			"last_updated_at": {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			"listener_id": {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			"listener_identifier": {
+  				Type:     schema.TypeString,
+  				Required: true,
+  			},
+  			names.AttrName: {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			names.AttrPort: {
+  				Type:     schema.TypeInt,
+  				Computed: true,
+  			},
+  			names.AttrProtocol: {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			"service_arn": {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			"service_id": {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			"service_identifier": {
+  				Type:     schema.TypeString,
+  				Required: true,
+  			},
+  			names.AttrTags: tftags.TagsSchemaComputed(),
+  		}
+  },
 	}
 }
 

--- a/internal/service/vpclattice/listener_data_source.go
+++ b/internal/service/vpclattice/listener_data_source.go
@@ -25,98 +25,98 @@ func dataSourceListener() *schema.Resource {
 		ReadWithoutTimeout: dataSourceListenerRead,
 
 		SchemaFunc: func() map[string]*schema.Schema {
-  	return map[string]*schema.Schema{
-  			names.AttrARN: {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			names.AttrCreatedAt: {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			names.AttrDefaultAction: {
-  				Type:     schema.TypeList,
-  				Computed: true,
-  				Elem: &schema.Resource{
-  					Schema: map[string]*schema.Schema{
-  						"fixed_response": {
-  							Type:     schema.TypeList,
-  							Computed: true,
-  							Elem: &schema.Resource{
-  								Schema: map[string]*schema.Schema{
-  									names.AttrStatusCode: {
-  										Type:     schema.TypeInt,
-  										Computed: true,
-  									},
-  								},
-  							},
-  						},
-  						"forward": {
-  							Type:     schema.TypeList,
-  							Computed: true,
-  							Elem: &schema.Resource{
-  								Schema: map[string]*schema.Schema{
-  									"target_groups": {
-  										Type:     schema.TypeList,
-  										Computed: true,
-  										Elem: &schema.Resource{
-  											Schema: map[string]*schema.Schema{
-  												"target_group_identifier": {
-  													Type:     schema.TypeString,
-  													Computed: true,
-  												},
-  												names.AttrWeight: {
-  													Type:     schema.TypeInt,
-  													Computed: true,
-  												},
-  											},
-  										},
-  									},
-  								},
-  							},
-  						},
-  					},
-  				},
-  			},
-  			"last_updated_at": {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			"listener_id": {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			"listener_identifier": {
-  				Type:     schema.TypeString,
-  				Required: true,
-  			},
-  			names.AttrName: {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			names.AttrPort: {
-  				Type:     schema.TypeInt,
-  				Computed: true,
-  			},
-  			names.AttrProtocol: {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			"service_arn": {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			"service_id": {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			"service_identifier": {
-  				Type:     schema.TypeString,
-  				Required: true,
-  			},
-  			names.AttrTags: tftags.TagsSchemaComputed(),
-  		}
-  },
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrCreatedAt: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrDefaultAction: {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"fixed_response": {
+								Type:     schema.TypeList,
+								Computed: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										names.AttrStatusCode: {
+											Type:     schema.TypeInt,
+											Computed: true,
+										},
+									},
+								},
+							},
+							"forward": {
+								Type:     schema.TypeList,
+								Computed: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"target_groups": {
+											Type:     schema.TypeList,
+											Computed: true,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"target_group_identifier": {
+														Type:     schema.TypeString,
+														Computed: true,
+													},
+													names.AttrWeight: {
+														Type:     schema.TypeInt,
+														Computed: true,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				"last_updated_at": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"listener_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"listener_identifier": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrPort: {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
+				names.AttrProtocol: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"service_arn": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"service_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"service_identifier": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				names.AttrTags: tftags.TagsSchemaComputed(),
+			}
+		},
 	}
 }
 

--- a/internal/service/vpclattice/listener_rule.go
+++ b/internal/service/vpclattice/listener_rule.go
@@ -62,194 +62,196 @@ func resourceListenerRule() *schema.Resource {
 			Delete: schema.DefaultTimeout(30 * time.Minute),
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrAction: {
-				Type:     schema.TypeList,
-				MaxItems: 1,
-				Required: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"fixed_response": {
-							Type:     schema.TypeList,
-							MaxItems: 1,
-							Optional: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									names.AttrStatusCode: {
-										Type:     schema.TypeInt,
-										Required: true,
-									},
-								},
-							},
-							ExactlyOneOf: []string{
-								"action.0.fixed_response",
-								"action.0.forward",
-							},
-						},
-						"forward": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"target_groups": {
-										Type:     schema.TypeList,
-										Required: true,
-										MinItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"target_group_identifier": {
-													Type:     schema.TypeString,
-													Required: true,
-												},
-												names.AttrWeight: {
-													Type:         schema.TypeInt,
-													ValidateFunc: validation.IntBetween(0, 999),
-													Default:      100,
-													Optional:     true,
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"listener_identifier": {
-				Type:             schema.TypeString,
-				Required:         true,
-				ForceNew:         true,
-				DiffSuppressFunc: suppressEquivalentIDOrARN,
-			},
-			"match": {
-				Type:             schema.TypeList,
-				Required:         true,
-				MaxItems:         1,
-				DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"http_match": {
-							Type:     schema.TypeList,
-							Required: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"header_matches": {
-										Type:             schema.TypeList,
-										Optional:         true,
-										DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
-										MinItems:         1,
-										MaxItems:         5,
-										AtLeastOneOf: []string{
-											"match.0.http_match.0.header_matches",
-											"match.0.http_match.0.method",
-											"match.0.http_match.0.path_match",
-										},
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"case_sensitive": {
-													Type:     schema.TypeBool,
-													Optional: true,
-												},
-												"match": {
-													Type:             schema.TypeList,
-													Required:         true,
-													MaxItems:         1,
-													DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															"contains": {
-																Type:     schema.TypeString,
-																Optional: true,
-															},
-															"exact": {
-																Type:     schema.TypeString,
-																Optional: true,
-															},
-															names.AttrPrefix: {
-																Type:     schema.TypeString,
-																Optional: true,
-															},
-														},
-													},
-												},
-												names.AttrName: {
-													Type:     schema.TypeString,
-													Required: true,
-												},
-											},
-										},
-									},
-									"method": {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
-									"path_match": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"case_sensitive": {
-													Type:     schema.TypeBool,
-													Optional: true,
-												},
-												"match": {
-													Type:     schema.TypeList,
-													Required: true,
-													MaxItems: 1,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															"exact": {
-																Type:     schema.TypeString,
-																Optional: true,
-															},
-															names.AttrPrefix: {
-																Type:     schema.TypeString,
-																Optional: true,
-															},
-														},
-													},
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			names.AttrName: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(3, 63),
-			},
-			names.AttrPriority: {
-				Type:         schema.TypeInt,
-				Required:     true,
-				ValidateFunc: validation.IntBetween(1, 100),
-			},
-			"rule_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"service_identifier": {
-				Type:             schema.TypeString,
-				Required:         true,
-				ForceNew:         true,
-				DiffSuppressFunc: suppressEquivalentIDOrARN,
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-		},
+		SchemaFunc: func() map[string]*schema.Schema {
+  	return map[string]*schema.Schema{
+  			names.AttrAction: {
+  				Type:     schema.TypeList,
+  				MaxItems: 1,
+  				Required: true,
+  				Elem: &schema.Resource{
+  					Schema: map[string]*schema.Schema{
+  						"fixed_response": {
+  							Type:     schema.TypeList,
+  							MaxItems: 1,
+  							Optional: true,
+  							Elem: &schema.Resource{
+  								Schema: map[string]*schema.Schema{
+  									names.AttrStatusCode: {
+  										Type:     schema.TypeInt,
+  										Required: true,
+  									},
+  								},
+  							},
+  							ExactlyOneOf: []string{
+  								"action.0.fixed_response",
+  								"action.0.forward",
+  							},
+  						},
+  						"forward": {
+  							Type:     schema.TypeList,
+  							Optional: true,
+  							MaxItems: 1,
+  							Elem: &schema.Resource{
+  								Schema: map[string]*schema.Schema{
+  									"target_groups": {
+  										Type:     schema.TypeList,
+  										Required: true,
+  										MinItems: 1,
+  										Elem: &schema.Resource{
+  											Schema: map[string]*schema.Schema{
+  												"target_group_identifier": {
+  													Type:     schema.TypeString,
+  													Required: true,
+  												},
+  												names.AttrWeight: {
+  													Type:         schema.TypeInt,
+  													ValidateFunc: validation.IntBetween(0, 999),
+  													Default:      100,
+  													Optional:     true,
+  												},
+  											},
+  										},
+  									},
+  								},
+  							},
+  						},
+  					},
+  				},
+  			},
+  			names.AttrARN: {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			"listener_identifier": {
+  				Type:             schema.TypeString,
+  				Required:         true,
+  				ForceNew:         true,
+  				DiffSuppressFunc: suppressEquivalentIDOrARN,
+  			},
+  			"match": {
+  				Type:             schema.TypeList,
+  				Required:         true,
+  				MaxItems:         1,
+  				DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
+  				Elem: &schema.Resource{
+  					Schema: map[string]*schema.Schema{
+  						"http_match": {
+  							Type:     schema.TypeList,
+  							Required: true,
+  							MaxItems: 1,
+  							Elem: &schema.Resource{
+  								Schema: map[string]*schema.Schema{
+  									"header_matches": {
+  										Type:             schema.TypeList,
+  										Optional:         true,
+  										DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
+  										MinItems:         1,
+  										MaxItems:         5,
+  										AtLeastOneOf: []string{
+  											"match.0.http_match.0.header_matches",
+  											"match.0.http_match.0.method",
+  											"match.0.http_match.0.path_match",
+  										},
+  										Elem: &schema.Resource{
+  											Schema: map[string]*schema.Schema{
+  												"case_sensitive": {
+  													Type:     schema.TypeBool,
+  													Optional: true,
+  												},
+  												"match": {
+  													Type:             schema.TypeList,
+  													Required:         true,
+  													MaxItems:         1,
+  													DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
+  													Elem: &schema.Resource{
+  														Schema: map[string]*schema.Schema{
+  															"contains": {
+  																Type:     schema.TypeString,
+  																Optional: true,
+  															},
+  															"exact": {
+  																Type:     schema.TypeString,
+  																Optional: true,
+  															},
+  															names.AttrPrefix: {
+  																Type:     schema.TypeString,
+  																Optional: true,
+  															},
+  														},
+  													},
+  												},
+  												names.AttrName: {
+  													Type:     schema.TypeString,
+  													Required: true,
+  												},
+  											},
+  										},
+  									},
+  									"method": {
+  										Type:     schema.TypeString,
+  										Optional: true,
+  									},
+  									"path_match": {
+  										Type:     schema.TypeList,
+  										Optional: true,
+  										MaxItems: 1,
+  										Elem: &schema.Resource{
+  											Schema: map[string]*schema.Schema{
+  												"case_sensitive": {
+  													Type:     schema.TypeBool,
+  													Optional: true,
+  												},
+  												"match": {
+  													Type:     schema.TypeList,
+  													Required: true,
+  													MaxItems: 1,
+  													Elem: &schema.Resource{
+  														Schema: map[string]*schema.Schema{
+  															"exact": {
+  																Type:     schema.TypeString,
+  																Optional: true,
+  															},
+  															names.AttrPrefix: {
+  																Type:     schema.TypeString,
+  																Optional: true,
+  															},
+  														},
+  													},
+  												},
+  											},
+  										},
+  									},
+  								},
+  							},
+  						},
+  					},
+  				},
+  			},
+  			names.AttrName: {
+  				Type:         schema.TypeString,
+  				Required:     true,
+  				ForceNew:     true,
+  				ValidateFunc: validation.StringLenBetween(3, 63),
+  			},
+  			names.AttrPriority: {
+  				Type:         schema.TypeInt,
+  				Required:     true,
+  				ValidateFunc: validation.IntBetween(1, 100),
+  			},
+  			"rule_id": {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			"service_identifier": {
+  				Type:             schema.TypeString,
+  				Required:         true,
+  				ForceNew:         true,
+  				DiffSuppressFunc: suppressEquivalentIDOrARN,
+  			},
+  			names.AttrTags:    tftags.TagsSchema(),
+  			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+  		}
+  },
 	}
 }
 

--- a/internal/service/vpclattice/listener_rule.go
+++ b/internal/service/vpclattice/listener_rule.go
@@ -63,195 +63,195 @@ func resourceListenerRule() *schema.Resource {
 		},
 
 		SchemaFunc: func() map[string]*schema.Schema {
-  	return map[string]*schema.Schema{
-  			names.AttrAction: {
-  				Type:     schema.TypeList,
-  				MaxItems: 1,
-  				Required: true,
-  				Elem: &schema.Resource{
-  					Schema: map[string]*schema.Schema{
-  						"fixed_response": {
-  							Type:     schema.TypeList,
-  							MaxItems: 1,
-  							Optional: true,
-  							Elem: &schema.Resource{
-  								Schema: map[string]*schema.Schema{
-  									names.AttrStatusCode: {
-  										Type:     schema.TypeInt,
-  										Required: true,
-  									},
-  								},
-  							},
-  							ExactlyOneOf: []string{
-  								"action.0.fixed_response",
-  								"action.0.forward",
-  							},
-  						},
-  						"forward": {
-  							Type:     schema.TypeList,
-  							Optional: true,
-  							MaxItems: 1,
-  							Elem: &schema.Resource{
-  								Schema: map[string]*schema.Schema{
-  									"target_groups": {
-  										Type:     schema.TypeList,
-  										Required: true,
-  										MinItems: 1,
-  										Elem: &schema.Resource{
-  											Schema: map[string]*schema.Schema{
-  												"target_group_identifier": {
-  													Type:     schema.TypeString,
-  													Required: true,
-  												},
-  												names.AttrWeight: {
-  													Type:         schema.TypeInt,
-  													ValidateFunc: validation.IntBetween(0, 999),
-  													Default:      100,
-  													Optional:     true,
-  												},
-  											},
-  										},
-  									},
-  								},
-  							},
-  						},
-  					},
-  				},
-  			},
-  			names.AttrARN: {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			"listener_identifier": {
-  				Type:             schema.TypeString,
-  				Required:         true,
-  				ForceNew:         true,
-  				DiffSuppressFunc: suppressEquivalentIDOrARN,
-  			},
-  			"match": {
-  				Type:             schema.TypeList,
-  				Required:         true,
-  				MaxItems:         1,
-  				DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
-  				Elem: &schema.Resource{
-  					Schema: map[string]*schema.Schema{
-  						"http_match": {
-  							Type:     schema.TypeList,
-  							Required: true,
-  							MaxItems: 1,
-  							Elem: &schema.Resource{
-  								Schema: map[string]*schema.Schema{
-  									"header_matches": {
-  										Type:             schema.TypeList,
-  										Optional:         true,
-  										DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
-  										MinItems:         1,
-  										MaxItems:         5,
-  										AtLeastOneOf: []string{
-  											"match.0.http_match.0.header_matches",
-  											"match.0.http_match.0.method",
-  											"match.0.http_match.0.path_match",
-  										},
-  										Elem: &schema.Resource{
-  											Schema: map[string]*schema.Schema{
-  												"case_sensitive": {
-  													Type:     schema.TypeBool,
-  													Optional: true,
-  												},
-  												"match": {
-  													Type:             schema.TypeList,
-  													Required:         true,
-  													MaxItems:         1,
-  													DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
-  													Elem: &schema.Resource{
-  														Schema: map[string]*schema.Schema{
-  															"contains": {
-  																Type:     schema.TypeString,
-  																Optional: true,
-  															},
-  															"exact": {
-  																Type:     schema.TypeString,
-  																Optional: true,
-  															},
-  															names.AttrPrefix: {
-  																Type:     schema.TypeString,
-  																Optional: true,
-  															},
-  														},
-  													},
-  												},
-  												names.AttrName: {
-  													Type:     schema.TypeString,
-  													Required: true,
-  												},
-  											},
-  										},
-  									},
-  									"method": {
-  										Type:     schema.TypeString,
-  										Optional: true,
-  									},
-  									"path_match": {
-  										Type:     schema.TypeList,
-  										Optional: true,
-  										MaxItems: 1,
-  										Elem: &schema.Resource{
-  											Schema: map[string]*schema.Schema{
-  												"case_sensitive": {
-  													Type:     schema.TypeBool,
-  													Optional: true,
-  												},
-  												"match": {
-  													Type:     schema.TypeList,
-  													Required: true,
-  													MaxItems: 1,
-  													Elem: &schema.Resource{
-  														Schema: map[string]*schema.Schema{
-  															"exact": {
-  																Type:     schema.TypeString,
-  																Optional: true,
-  															},
-  															names.AttrPrefix: {
-  																Type:     schema.TypeString,
-  																Optional: true,
-  															},
-  														},
-  													},
-  												},
-  											},
-  										},
-  									},
-  								},
-  							},
-  						},
-  					},
-  				},
-  			},
-  			names.AttrName: {
-  				Type:         schema.TypeString,
-  				Required:     true,
-  				ForceNew:     true,
-  				ValidateFunc: validation.StringLenBetween(3, 63),
-  			},
-  			names.AttrPriority: {
-  				Type:         schema.TypeInt,
-  				Required:     true,
-  				ValidateFunc: validation.IntBetween(1, 100),
-  			},
-  			"rule_id": {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			"service_identifier": {
-  				Type:             schema.TypeString,
-  				Required:         true,
-  				ForceNew:         true,
-  				DiffSuppressFunc: suppressEquivalentIDOrARN,
-  			},
-  			names.AttrTags:    tftags.TagsSchema(),
-  			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-  		}
-  },
+			return map[string]*schema.Schema{
+				names.AttrAction: {
+					Type:     schema.TypeList,
+					MaxItems: 1,
+					Required: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"fixed_response": {
+								Type:     schema.TypeList,
+								MaxItems: 1,
+								Optional: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										names.AttrStatusCode: {
+											Type:     schema.TypeInt,
+											Required: true,
+										},
+									},
+								},
+								ExactlyOneOf: []string{
+									"action.0.fixed_response",
+									"action.0.forward",
+								},
+							},
+							"forward": {
+								Type:     schema.TypeList,
+								Optional: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"target_groups": {
+											Type:     schema.TypeList,
+											Required: true,
+											MinItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"target_group_identifier": {
+														Type:     schema.TypeString,
+														Required: true,
+													},
+													names.AttrWeight: {
+														Type:         schema.TypeInt,
+														ValidateFunc: validation.IntBetween(0, 999),
+														Default:      100,
+														Optional:     true,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"listener_identifier": {
+					Type:             schema.TypeString,
+					Required:         true,
+					ForceNew:         true,
+					DiffSuppressFunc: suppressEquivalentIDOrARN,
+				},
+				"match": {
+					Type:             schema.TypeList,
+					Required:         true,
+					MaxItems:         1,
+					DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"http_match": {
+								Type:     schema.TypeList,
+								Required: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"header_matches": {
+											Type:             schema.TypeList,
+											Optional:         true,
+											DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
+											MinItems:         1,
+											MaxItems:         5,
+											AtLeastOneOf: []string{
+												"match.0.http_match.0.header_matches",
+												"match.0.http_match.0.method",
+												"match.0.http_match.0.path_match",
+											},
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"case_sensitive": {
+														Type:     schema.TypeBool,
+														Optional: true,
+													},
+													"match": {
+														Type:             schema.TypeList,
+														Required:         true,
+														MaxItems:         1,
+														DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																"contains": {
+																	Type:     schema.TypeString,
+																	Optional: true,
+																},
+																"exact": {
+																	Type:     schema.TypeString,
+																	Optional: true,
+																},
+																names.AttrPrefix: {
+																	Type:     schema.TypeString,
+																	Optional: true,
+																},
+															},
+														},
+													},
+													names.AttrName: {
+														Type:     schema.TypeString,
+														Required: true,
+													},
+												},
+											},
+										},
+										"method": {
+											Type:     schema.TypeString,
+											Optional: true,
+										},
+										"path_match": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"case_sensitive": {
+														Type:     schema.TypeBool,
+														Optional: true,
+													},
+													"match": {
+														Type:     schema.TypeList,
+														Required: true,
+														MaxItems: 1,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																"exact": {
+																	Type:     schema.TypeString,
+																	Optional: true,
+																},
+																names.AttrPrefix: {
+																	Type:     schema.TypeString,
+																	Optional: true,
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				names.AttrName: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringLenBetween(3, 63),
+				},
+				names.AttrPriority: {
+					Type:         schema.TypeInt,
+					Required:     true,
+					ValidateFunc: validation.IntBetween(1, 100),
+				},
+				"rule_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"service_identifier": {
+					Type:             schema.TypeString,
+					Required:         true,
+					ForceNew:         true,
+					DiffSuppressFunc: suppressEquivalentIDOrARN,
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			}
+		},
 	}
 }
 

--- a/internal/service/vpclattice/resource_policy.go
+++ b/internal/service/vpclattice/resource_policy.go
@@ -39,16 +39,16 @@ func resourceResourcePolicy() *schema.Resource {
 		},
 
 		SchemaFunc: func() map[string]*schema.Schema {
-  	return map[string]*schema.Schema{
-  			names.AttrPolicy: sdkv2.IAMPolicyDocumentSchemaRequired(),
-  			names.AttrResourceARN: {
-  				Type:         schema.TypeString,
-  				Required:     true,
-  				ForceNew:     true,
-  				ValidateFunc: verify.ValidARN,
-  			},
-  		}
-  },
+			return map[string]*schema.Schema{
+				names.AttrPolicy: sdkv2.IAMPolicyDocumentSchemaRequired(),
+				names.AttrResourceARN: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+			}
+		},
 	}
 }
 

--- a/internal/service/vpclattice/resource_policy.go
+++ b/internal/service/vpclattice/resource_policy.go
@@ -38,15 +38,17 @@ func resourceResourcePolicy() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrPolicy: sdkv2.IAMPolicyDocumentSchemaRequired(),
-			names.AttrResourceARN: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-		},
+		SchemaFunc: func() map[string]*schema.Schema {
+  	return map[string]*schema.Schema{
+  			names.AttrPolicy: sdkv2.IAMPolicyDocumentSchemaRequired(),
+  			names.AttrResourceARN: {
+  				Type:         schema.TypeString,
+  				Required:     true,
+  				ForceNew:     true,
+  				ValidateFunc: verify.ValidARN,
+  			},
+  		}
+  },
 	}
 }
 

--- a/internal/service/vpclattice/resource_policy_data_source.go
+++ b/internal/service/vpclattice/resource_policy_data_source.go
@@ -21,17 +21,19 @@ func dataSourceResourcePolicy() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceResourcePolicyRead,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrPolicy: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrResourceARN: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-		},
+		SchemaFunc: func() map[string]*schema.Schema {
+  	return map[string]*schema.Schema{
+  			names.AttrPolicy: {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			names.AttrResourceARN: {
+  				Type:         schema.TypeString,
+  				Required:     true,
+  				ValidateFunc: verify.ValidARN,
+  			},
+  		}
+  },
 	}
 }
 

--- a/internal/service/vpclattice/resource_policy_data_source.go
+++ b/internal/service/vpclattice/resource_policy_data_source.go
@@ -22,18 +22,18 @@ func dataSourceResourcePolicy() *schema.Resource {
 		ReadWithoutTimeout: dataSourceResourcePolicyRead,
 
 		SchemaFunc: func() map[string]*schema.Schema {
-  	return map[string]*schema.Schema{
-  			names.AttrPolicy: {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			names.AttrResourceARN: {
-  				Type:         schema.TypeString,
-  				Required:     true,
-  				ValidateFunc: verify.ValidARN,
-  			},
-  		}
-  },
+			return map[string]*schema.Schema{
+				names.AttrPolicy: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrResourceARN: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+			}
+		},
 	}
 }
 

--- a/internal/service/vpclattice/service.go
+++ b/internal/service/vpclattice/service.go
@@ -50,58 +50,58 @@ func resourceService() *schema.Resource {
 		},
 
 		SchemaFunc: func() map[string]*schema.Schema {
-  	return map[string]*schema.Schema{
-  			names.AttrARN: {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			"auth_type": {
-  				Type:             schema.TypeString,
-  				Optional:         true,
-  				Computed:         true,
-  				ValidateDiagFunc: enum.Validate[types.AuthType](),
-  			},
-  			names.AttrCertificateARN: {
-  				Type:         schema.TypeString,
-  				Optional:     true,
-  				ValidateFunc: verify.ValidARN,
-  			},
-  			"custom_domain_name": {
-  				Type:         schema.TypeString,
-  				Optional:     true,
-  				ForceNew:     true,
-  				ValidateFunc: validation.StringLenBetween(3, 255),
-  			},
-  			"dns_entry": {
-  				Type:     schema.TypeList,
-  				Computed: true,
-  				Elem: &schema.Resource{
-  					Schema: map[string]*schema.Schema{
-  						names.AttrDomainName: {
-  							Type:     schema.TypeString,
-  							Computed: true,
-  						},
-  						names.AttrHostedZoneID: {
-  							Type:     schema.TypeString,
-  							Computed: true,
-  						},
-  					},
-  				},
-  			},
-  			names.AttrName: {
-  				Type:         schema.TypeString,
-  				Required:     true,
-  				ForceNew:     true,
-  				ValidateFunc: validation.StringLenBetween(3, 40),
-  			},
-  			names.AttrStatus: {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			names.AttrTags:    tftags.TagsSchema(),
-  			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-  		}
-  },
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"auth_type": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					Computed:         true,
+					ValidateDiagFunc: enum.Validate[types.AuthType](),
+				},
+				names.AttrCertificateARN: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				"custom_domain_name": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringLenBetween(3, 255),
+				},
+				"dns_entry": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrDomainName: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							names.AttrHostedZoneID: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+						},
+					},
+				},
+				names.AttrName: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringLenBetween(3, 40),
+				},
+				names.AttrStatus: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			}
+		},
 	}
 }
 

--- a/internal/service/vpclattice/service.go
+++ b/internal/service/vpclattice/service.go
@@ -49,57 +49,59 @@ func resourceService() *schema.Resource {
 			Delete: schema.DefaultTimeout(5 * time.Minute),
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"auth_type": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Computed:         true,
-				ValidateDiagFunc: enum.Validate[types.AuthType](),
-			},
-			names.AttrCertificateARN: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			"custom_domain_name": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(3, 255),
-			},
-			"dns_entry": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrDomainName: {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						names.AttrHostedZoneID: {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-					},
-				},
-			},
-			names.AttrName: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(3, 40),
-			},
-			names.AttrStatus: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-		},
+		SchemaFunc: func() map[string]*schema.Schema {
+  	return map[string]*schema.Schema{
+  			names.AttrARN: {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			"auth_type": {
+  				Type:             schema.TypeString,
+  				Optional:         true,
+  				Computed:         true,
+  				ValidateDiagFunc: enum.Validate[types.AuthType](),
+  			},
+  			names.AttrCertificateARN: {
+  				Type:         schema.TypeString,
+  				Optional:     true,
+  				ValidateFunc: verify.ValidARN,
+  			},
+  			"custom_domain_name": {
+  				Type:         schema.TypeString,
+  				Optional:     true,
+  				ForceNew:     true,
+  				ValidateFunc: validation.StringLenBetween(3, 255),
+  			},
+  			"dns_entry": {
+  				Type:     schema.TypeList,
+  				Computed: true,
+  				Elem: &schema.Resource{
+  					Schema: map[string]*schema.Schema{
+  						names.AttrDomainName: {
+  							Type:     schema.TypeString,
+  							Computed: true,
+  						},
+  						names.AttrHostedZoneID: {
+  							Type:     schema.TypeString,
+  							Computed: true,
+  						},
+  					},
+  				},
+  			},
+  			names.AttrName: {
+  				Type:         schema.TypeString,
+  				Required:     true,
+  				ForceNew:     true,
+  				ValidateFunc: validation.StringLenBetween(3, 40),
+  			},
+  			names.AttrStatus: {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			names.AttrTags:    tftags.TagsSchema(),
+  			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+  		}
+  },
 	}
 }
 

--- a/internal/service/vpclattice/service_data_source.go
+++ b/internal/service/vpclattice/service_data_source.go
@@ -30,58 +30,58 @@ func dataSourceService() *schema.Resource {
 		ReadWithoutTimeout: dataSourceServiceRead,
 
 		SchemaFunc: func() map[string]*schema.Schema {
-  	return map[string]*schema.Schema{
-  			names.AttrARN: {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			"auth_type": {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			names.AttrCertificateARN: {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			"custom_domain_name": {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			"dns_entry": {
-  				Type:     schema.TypeList,
-  				Computed: true,
-  				Elem: &schema.Resource{
-  					Schema: map[string]*schema.Schema{
-  						names.AttrDomainName: {
-  							Type:     schema.TypeString,
-  							Computed: true,
-  						},
-  						names.AttrHostedZoneID: {
-  							Type:     schema.TypeString,
-  							Computed: true,
-  						},
-  					},
-  				},
-  			},
-  			names.AttrName: {
-  				Type:         schema.TypeString,
-  				Optional:     true,
-  				Computed:     true,
-  				ExactlyOneOf: []string{names.AttrName, "service_identifier"},
-  			},
-  			"service_identifier": {
-  				Type:         schema.TypeString,
-  				Optional:     true,
-  				Computed:     true,
-  				ExactlyOneOf: []string{names.AttrName, "service_identifier"},
-  			},
-  			names.AttrStatus: {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			names.AttrTags: tftags.TagsSchemaComputed(),
-  		}
-  },
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"auth_type": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrCertificateARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"custom_domain_name": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"dns_entry": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrDomainName: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							names.AttrHostedZoneID: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+						},
+					},
+				},
+				names.AttrName: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Computed:     true,
+					ExactlyOneOf: []string{names.AttrName, "service_identifier"},
+				},
+				"service_identifier": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Computed:     true,
+					ExactlyOneOf: []string{names.AttrName, "service_identifier"},
+				},
+				names.AttrStatus: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrTags: tftags.TagsSchemaComputed(),
+			}
+		},
 	}
 }
 

--- a/internal/service/vpclattice/service_data_source.go
+++ b/internal/service/vpclattice/service_data_source.go
@@ -29,57 +29,59 @@ func dataSourceService() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceServiceRead,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"auth_type": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrCertificateARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"custom_domain_name": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"dns_entry": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrDomainName: {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						names.AttrHostedZoneID: {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-					},
-				},
-			},
-			names.AttrName: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ExactlyOneOf: []string{names.AttrName, "service_identifier"},
-			},
-			"service_identifier": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ExactlyOneOf: []string{names.AttrName, "service_identifier"},
-			},
-			names.AttrStatus: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrTags: tftags.TagsSchemaComputed(),
-		},
+		SchemaFunc: func() map[string]*schema.Schema {
+  	return map[string]*schema.Schema{
+  			names.AttrARN: {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			"auth_type": {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			names.AttrCertificateARN: {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			"custom_domain_name": {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			"dns_entry": {
+  				Type:     schema.TypeList,
+  				Computed: true,
+  				Elem: &schema.Resource{
+  					Schema: map[string]*schema.Schema{
+  						names.AttrDomainName: {
+  							Type:     schema.TypeString,
+  							Computed: true,
+  						},
+  						names.AttrHostedZoneID: {
+  							Type:     schema.TypeString,
+  							Computed: true,
+  						},
+  					},
+  				},
+  			},
+  			names.AttrName: {
+  				Type:         schema.TypeString,
+  				Optional:     true,
+  				Computed:     true,
+  				ExactlyOneOf: []string{names.AttrName, "service_identifier"},
+  			},
+  			"service_identifier": {
+  				Type:         schema.TypeString,
+  				Optional:     true,
+  				Computed:     true,
+  				ExactlyOneOf: []string{names.AttrName, "service_identifier"},
+  			},
+  			names.AttrStatus: {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			names.AttrTags: tftags.TagsSchemaComputed(),
+  		}
+  },
 	}
 }
 

--- a/internal/service/vpclattice/service_network.go
+++ b/internal/service/vpclattice/service_network.go
@@ -42,27 +42,27 @@ func resourceServiceNetwork() *schema.Resource {
 		},
 
 		SchemaFunc: func() map[string]*schema.Schema {
-  	return map[string]*schema.Schema{
-  			names.AttrARN: {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			"auth_type": {
-  				Type:             schema.TypeString,
-  				Optional:         true,
-  				Computed:         true,
-  				ValidateDiagFunc: enum.Validate[types.AuthType](),
-  			},
-  			names.AttrName: {
-  				Type:         schema.TypeString,
-  				Required:     true,
-  				ForceNew:     true,
-  				ValidateFunc: validation.StringLenBetween(3, 63),
-  			},
-  			names.AttrTags:    tftags.TagsSchema(),
-  			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-  		}
-  },
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"auth_type": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					Computed:         true,
+					ValidateDiagFunc: enum.Validate[types.AuthType](),
+				},
+				names.AttrName: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringLenBetween(3, 63),
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			}
+		},
 	}
 }
 

--- a/internal/service/vpclattice/service_network.go
+++ b/internal/service/vpclattice/service_network.go
@@ -41,26 +41,28 @@ func resourceServiceNetwork() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"auth_type": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Computed:         true,
-				ValidateDiagFunc: enum.Validate[types.AuthType](),
-			},
-			names.AttrName: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(3, 63),
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-		},
+		SchemaFunc: func() map[string]*schema.Schema {
+  	return map[string]*schema.Schema{
+  			names.AttrARN: {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			"auth_type": {
+  				Type:             schema.TypeString,
+  				Optional:         true,
+  				Computed:         true,
+  				ValidateDiagFunc: enum.Validate[types.AuthType](),
+  			},
+  			names.AttrName: {
+  				Type:         schema.TypeString,
+  				Required:     true,
+  				ForceNew:     true,
+  				ValidateFunc: validation.StringLenBetween(3, 63),
+  			},
+  			names.AttrTags:    tftags.TagsSchema(),
+  			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+  		}
+  },
 	}
 }
 

--- a/internal/service/vpclattice/service_network_data_source.go
+++ b/internal/service/vpclattice/service_network_data_source.go
@@ -35,42 +35,42 @@ func dataSourceServiceNetwork() *schema.Resource {
 		ReadWithoutTimeout: dataSourceServiceNetworkRead,
 
 		SchemaFunc: func() map[string]*schema.Schema {
-  	return map[string]*schema.Schema{
-  			names.AttrARN: {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			"auth_type": {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			names.AttrCreatedAt: {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			"last_updated_at": {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			names.AttrName: {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			"number_of_associated_services": {
-  				Type:     schema.TypeInt,
-  				Computed: true,
-  			},
-  			"number_of_associated_vpcs": {
-  				Type:     schema.TypeInt,
-  				Computed: true,
-  			},
-  			"service_network_identifier": {
-  				Type:     schema.TypeString,
-  				Required: true,
-  			},
-  			names.AttrTags: tftags.TagsSchemaComputed(),
-  		}
-  },
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"auth_type": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrCreatedAt: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"last_updated_at": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"number_of_associated_services": {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
+				"number_of_associated_vpcs": {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
+				"service_network_identifier": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				names.AttrTags: tftags.TagsSchemaComputed(),
+			}
+		},
 	}
 }
 

--- a/internal/service/vpclattice/service_network_data_source.go
+++ b/internal/service/vpclattice/service_network_data_source.go
@@ -34,41 +34,43 @@ func dataSourceServiceNetwork() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceServiceNetworkRead,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"auth_type": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrCreatedAt: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"last_updated_at": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"number_of_associated_services": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-			"number_of_associated_vpcs": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-			"service_network_identifier": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			names.AttrTags: tftags.TagsSchemaComputed(),
-		},
+		SchemaFunc: func() map[string]*schema.Schema {
+  	return map[string]*schema.Schema{
+  			names.AttrARN: {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			"auth_type": {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			names.AttrCreatedAt: {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			"last_updated_at": {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			names.AttrName: {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			"number_of_associated_services": {
+  				Type:     schema.TypeInt,
+  				Computed: true,
+  			},
+  			"number_of_associated_vpcs": {
+  				Type:     schema.TypeInt,
+  				Computed: true,
+  			},
+  			"service_network_identifier": {
+  				Type:     schema.TypeString,
+  				Required: true,
+  			},
+  			names.AttrTags: tftags.TagsSchemaComputed(),
+  		}
+  },
 	}
 }
 

--- a/internal/service/vpclattice/service_network_service_association.go
+++ b/internal/service/vpclattice/service_network_service_association.go
@@ -47,54 +47,56 @@ func resourceServiceNetworkServiceAssociation() *schema.Resource {
 			Delete: schema.DefaultTimeout(5 * time.Minute),
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"created_by": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"custom_domain_name": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"dns_entry": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrDomainName: {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						names.AttrHostedZoneID: {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-					},
-				},
-			},
-			"service_identifier": {
-				Type:             schema.TypeString,
-				Required:         true,
-				ForceNew:         true,
-				DiffSuppressFunc: suppressEquivalentIDOrARN,
-			},
-			"service_network_identifier": {
-				Type:             schema.TypeString,
-				Required:         true,
-				ForceNew:         true,
-				DiffSuppressFunc: suppressEquivalentIDOrARN,
-			},
-			names.AttrStatus: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-		},
+		SchemaFunc: func() map[string]*schema.Schema {
+  	return map[string]*schema.Schema{
+  			names.AttrARN: {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			"created_by": {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			"custom_domain_name": {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			"dns_entry": {
+  				Type:     schema.TypeList,
+  				Computed: true,
+  				Elem: &schema.Resource{
+  					Schema: map[string]*schema.Schema{
+  						names.AttrDomainName: {
+  							Type:     schema.TypeString,
+  							Computed: true,
+  						},
+  						names.AttrHostedZoneID: {
+  							Type:     schema.TypeString,
+  							Computed: true,
+  						},
+  					},
+  				},
+  			},
+  			"service_identifier": {
+  				Type:             schema.TypeString,
+  				Required:         true,
+  				ForceNew:         true,
+  				DiffSuppressFunc: suppressEquivalentIDOrARN,
+  			},
+  			"service_network_identifier": {
+  				Type:             schema.TypeString,
+  				Required:         true,
+  				ForceNew:         true,
+  				DiffSuppressFunc: suppressEquivalentIDOrARN,
+  			},
+  			names.AttrStatus: {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			names.AttrTags:    tftags.TagsSchema(),
+  			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+  		}
+  },
 	}
 }
 

--- a/internal/service/vpclattice/service_network_service_association.go
+++ b/internal/service/vpclattice/service_network_service_association.go
@@ -48,55 +48,55 @@ func resourceServiceNetworkServiceAssociation() *schema.Resource {
 		},
 
 		SchemaFunc: func() map[string]*schema.Schema {
-  	return map[string]*schema.Schema{
-  			names.AttrARN: {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			"created_by": {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			"custom_domain_name": {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			"dns_entry": {
-  				Type:     schema.TypeList,
-  				Computed: true,
-  				Elem: &schema.Resource{
-  					Schema: map[string]*schema.Schema{
-  						names.AttrDomainName: {
-  							Type:     schema.TypeString,
-  							Computed: true,
-  						},
-  						names.AttrHostedZoneID: {
-  							Type:     schema.TypeString,
-  							Computed: true,
-  						},
-  					},
-  				},
-  			},
-  			"service_identifier": {
-  				Type:             schema.TypeString,
-  				Required:         true,
-  				ForceNew:         true,
-  				DiffSuppressFunc: suppressEquivalentIDOrARN,
-  			},
-  			"service_network_identifier": {
-  				Type:             schema.TypeString,
-  				Required:         true,
-  				ForceNew:         true,
-  				DiffSuppressFunc: suppressEquivalentIDOrARN,
-  			},
-  			names.AttrStatus: {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			names.AttrTags:    tftags.TagsSchema(),
-  			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-  		}
-  },
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"created_by": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"custom_domain_name": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"dns_entry": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrDomainName: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							names.AttrHostedZoneID: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+						},
+					},
+				},
+				"service_identifier": {
+					Type:             schema.TypeString,
+					Required:         true,
+					ForceNew:         true,
+					DiffSuppressFunc: suppressEquivalentIDOrARN,
+				},
+				"service_network_identifier": {
+					Type:             schema.TypeString,
+					Required:         true,
+					ForceNew:         true,
+					DiffSuppressFunc: suppressEquivalentIDOrARN,
+				},
+				names.AttrStatus: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			}
+		},
 	}
 }
 

--- a/internal/service/vpclattice/service_network_vpc_association.go
+++ b/internal/service/vpclattice/service_network_vpc_association.go
@@ -50,73 +50,73 @@ func resourceServiceNetworkVPCAssociation() *schema.Resource {
 		},
 
 		SchemaFunc: func() map[string]*schema.Schema {
-  	return map[string]*schema.Schema{
-  			names.AttrARN: {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			"created_by": {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			"dns_options": {
-  				Type:     schema.TypeList,
-  				Optional: true,
-  				MaxItems: 1,
-  				ForceNew: true,
-  				Elem: &schema.Resource{
-  					Schema: map[string]*schema.Schema{
-  						"private_dns_preference": {
-  							Type:             schema.TypeString,
-  							Optional:         true,
-  							ForceNew:         true,
-  							ValidateDiagFunc: enum.Validate[types.PrivateDnsPreference](),
-  						},
-  						"private_dns_specified_domains": {
-  							Type:     schema.TypeSet,
-  							MaxItems: 10,
-  							Optional: true,
-  							Computed: true,
-  							ForceNew: true,
-  							Elem: &schema.Schema{
-  								Type:         schema.TypeString,
-  								ValidateFunc: validation.StringLenBetween(1, 255),
-  							},
-  						},
-  					},
-  				},
-  			},
-  			"private_dns_enabled": {
-  				Type:     schema.TypeBool,
-  				Optional: true,
-  				Computed: true,
-  				ForceNew: true,
-  			},
-  			names.AttrSecurityGroupIDs: {
-  				Type:     schema.TypeList,
-  				MaxItems: 5,
-  				Optional: true,
-  				Elem:     &schema.Schema{Type: schema.TypeString},
-  			},
-  			"service_network_identifier": {
-  				Type:             schema.TypeString,
-  				Required:         true,
-  				ForceNew:         true,
-  				DiffSuppressFunc: suppressEquivalentIDOrARN,
-  			},
-  			names.AttrStatus: {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			names.AttrTags:    tftags.TagsSchema(),
-  			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-  			"vpc_identifier": {
-  				Type:     schema.TypeString,
-  				Required: true,
-  				ForceNew: true,
-  			},
-  		}
-  },
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"created_by": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"dns_options": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					ForceNew: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"private_dns_preference": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								ForceNew:         true,
+								ValidateDiagFunc: enum.Validate[types.PrivateDnsPreference](),
+							},
+							"private_dns_specified_domains": {
+								Type:     schema.TypeSet,
+								MaxItems: 10,
+								Optional: true,
+								Computed: true,
+								ForceNew: true,
+								Elem: &schema.Schema{
+									Type:         schema.TypeString,
+									ValidateFunc: validation.StringLenBetween(1, 255),
+								},
+							},
+						},
+					},
+				},
+				"private_dns_enabled": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+				},
+				names.AttrSecurityGroupIDs: {
+					Type:     schema.TypeList,
+					MaxItems: 5,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"service_network_identifier": {
+					Type:             schema.TypeString,
+					Required:         true,
+					ForceNew:         true,
+					DiffSuppressFunc: suppressEquivalentIDOrARN,
+				},
+				names.AttrStatus: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				"vpc_identifier": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+			}
+		},
 	}
 }
 

--- a/internal/service/vpclattice/service_network_vpc_association.go
+++ b/internal/service/vpclattice/service_network_vpc_association.go
@@ -49,72 +49,74 @@ func resourceServiceNetworkVPCAssociation() *schema.Resource {
 			Delete: schema.DefaultTimeout(5 * time.Minute),
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"created_by": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"dns_options": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				ForceNew: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"private_dns_preference": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							ForceNew:         true,
-							ValidateDiagFunc: enum.Validate[types.PrivateDnsPreference](),
-						},
-						"private_dns_specified_domains": {
-							Type:     schema.TypeSet,
-							MaxItems: 10,
-							Optional: true,
-							Computed: true,
-							ForceNew: true,
-							Elem: &schema.Schema{
-								Type:         schema.TypeString,
-								ValidateFunc: validation.StringLenBetween(1, 255),
-							},
-						},
-					},
-				},
-			},
-			"private_dns_enabled": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
-			names.AttrSecurityGroupIDs: {
-				Type:     schema.TypeList,
-				MaxItems: 5,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			"service_network_identifier": {
-				Type:             schema.TypeString,
-				Required:         true,
-				ForceNew:         true,
-				DiffSuppressFunc: suppressEquivalentIDOrARN,
-			},
-			names.AttrStatus: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			"vpc_identifier": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-		},
+		SchemaFunc: func() map[string]*schema.Schema {
+  	return map[string]*schema.Schema{
+  			names.AttrARN: {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			"created_by": {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			"dns_options": {
+  				Type:     schema.TypeList,
+  				Optional: true,
+  				MaxItems: 1,
+  				ForceNew: true,
+  				Elem: &schema.Resource{
+  					Schema: map[string]*schema.Schema{
+  						"private_dns_preference": {
+  							Type:             schema.TypeString,
+  							Optional:         true,
+  							ForceNew:         true,
+  							ValidateDiagFunc: enum.Validate[types.PrivateDnsPreference](),
+  						},
+  						"private_dns_specified_domains": {
+  							Type:     schema.TypeSet,
+  							MaxItems: 10,
+  							Optional: true,
+  							Computed: true,
+  							ForceNew: true,
+  							Elem: &schema.Schema{
+  								Type:         schema.TypeString,
+  								ValidateFunc: validation.StringLenBetween(1, 255),
+  							},
+  						},
+  					},
+  				},
+  			},
+  			"private_dns_enabled": {
+  				Type:     schema.TypeBool,
+  				Optional: true,
+  				Computed: true,
+  				ForceNew: true,
+  			},
+  			names.AttrSecurityGroupIDs: {
+  				Type:     schema.TypeList,
+  				MaxItems: 5,
+  				Optional: true,
+  				Elem:     &schema.Schema{Type: schema.TypeString},
+  			},
+  			"service_network_identifier": {
+  				Type:             schema.TypeString,
+  				Required:         true,
+  				ForceNew:         true,
+  				DiffSuppressFunc: suppressEquivalentIDOrARN,
+  			},
+  			names.AttrStatus: {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			names.AttrTags:    tftags.TagsSchema(),
+  			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+  			"vpc_identifier": {
+  				Type:     schema.TypeString,
+  				Required: true,
+  				ForceNew: true,
+  			},
+  		}
+  },
 	}
 }
 

--- a/internal/service/vpclattice/target_group.go
+++ b/internal/service/vpclattice/target_group.go
@@ -50,159 +50,161 @@ func resourceTargetGroup() *schema.Resource {
 			Delete: schema.DefaultTimeout(30 * time.Minute),
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"config": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrHealthCheck: {
-							Type:     schema.TypeList,
-							MaxItems: 1,
-							Optional: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									names.AttrEnabled: {
-										Type:     schema.TypeBool,
-										Optional: true,
-										Default:  true,
-									},
-									"health_check_interval_seconds": {
-										Type:         schema.TypeInt,
-										Optional:     true,
-										Default:      30,
-										ValidateFunc: validation.IntBetween(5, 300),
-									},
-									"health_check_timeout_seconds": {
-										Type:         schema.TypeInt,
-										Optional:     true,
-										Default:      5,
-										ValidateFunc: validation.IntBetween(1, 120),
-									},
-									"healthy_threshold_count": {
-										Type:         schema.TypeInt,
-										Optional:     true,
-										Default:      5,
-										ValidateFunc: validation.IntBetween(2, 10),
-									},
-									"matcher": {
-										Type:     schema.TypeList,
-										MaxItems: 1,
-										Optional: true,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												names.AttrValue: {
-													Type:     schema.TypeString,
-													Optional: true,
-													Default:  "200",
-												},
-											},
-										},
-										DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
-									},
-									names.AttrPath: {
-										Type:     schema.TypeString,
-										Optional: true,
-										Default:  "/",
-									},
-									names.AttrPort: {
-										Type:         schema.TypeInt,
-										Optional:     true,
-										Computed:     true,
-										ValidateFunc: validation.IsPortNumber,
-									},
-									names.AttrProtocol: {
-										Type:             schema.TypeString,
-										Optional:         true,
-										Computed:         true,
-										ValidateDiagFunc: enum.Validate[types.TargetGroupProtocol](),
-									},
-									"protocol_version": {
-										Type:             schema.TypeString,
-										Optional:         true,
-										Default:          types.HealthCheckProtocolVersionHttp1,
-										StateFunc:        sdkv2.ToUpperSchemaStateFunc,
-										ValidateDiagFunc: enum.Validate[types.HealthCheckProtocolVersion](),
-									},
-									"unhealthy_threshold_count": {
-										Type:         schema.TypeInt,
-										Optional:     true,
-										Default:      2,
-										ValidateFunc: validation.IntBetween(2, 10),
-									},
-								},
-							},
-							DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
-						},
-						names.AttrIPAddressType: {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Computed:         true,
-							ForceNew:         true,
-							ValidateDiagFunc: enum.Validate[types.IpAddressType](),
-						},
-						"lambda_event_structure_version": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Computed:         true,
-							ForceNew:         true,
-							ValidateDiagFunc: enum.Validate[types.LambdaEventStructureVersion](),
-						},
-						names.AttrPort: {
-							Type:         schema.TypeInt,
-							Optional:     true,
-							Computed:     true,
-							ForceNew:     true,
-							ValidateFunc: validation.IsPortNumber,
-						},
-						names.AttrProtocol: {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Computed:         true,
-							ForceNew:         true,
-							ValidateDiagFunc: enum.Validate[types.TargetGroupProtocol](),
-						},
-						"protocol_version": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Computed:         true,
-							ForceNew:         true,
-							StateFunc:        sdkv2.ToUpperSchemaStateFunc,
-							ValidateDiagFunc: enum.Validate[types.TargetGroupProtocolVersion](),
-						},
-						"vpc_identifier": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ForceNew: true,
-						},
-					},
-				},
-				DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
-			},
-			names.AttrName: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(3, 128),
-			},
-			names.AttrStatus: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			names.AttrType: {
-				Type:             schema.TypeString,
-				Required:         true,
-				ForceNew:         true,
-				ValidateDiagFunc: enum.Validate[types.TargetGroupType](),
-			},
-		},
+		SchemaFunc: func() map[string]*schema.Schema {
+  	return map[string]*schema.Schema{
+  			names.AttrARN: {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			"config": {
+  				Type:     schema.TypeList,
+  				Optional: true,
+  				MaxItems: 1,
+  				Elem: &schema.Resource{
+  					Schema: map[string]*schema.Schema{
+  						names.AttrHealthCheck: {
+  							Type:     schema.TypeList,
+  							MaxItems: 1,
+  							Optional: true,
+  							Elem: &schema.Resource{
+  								Schema: map[string]*schema.Schema{
+  									names.AttrEnabled: {
+  										Type:     schema.TypeBool,
+  										Optional: true,
+  										Default:  true,
+  									},
+  									"health_check_interval_seconds": {
+  										Type:         schema.TypeInt,
+  										Optional:     true,
+  										Default:      30,
+  										ValidateFunc: validation.IntBetween(5, 300),
+  									},
+  									"health_check_timeout_seconds": {
+  										Type:         schema.TypeInt,
+  										Optional:     true,
+  										Default:      5,
+  										ValidateFunc: validation.IntBetween(1, 120),
+  									},
+  									"healthy_threshold_count": {
+  										Type:         schema.TypeInt,
+  										Optional:     true,
+  										Default:      5,
+  										ValidateFunc: validation.IntBetween(2, 10),
+  									},
+  									"matcher": {
+  										Type:     schema.TypeList,
+  										MaxItems: 1,
+  										Optional: true,
+  										Elem: &schema.Resource{
+  											Schema: map[string]*schema.Schema{
+  												names.AttrValue: {
+  													Type:     schema.TypeString,
+  													Optional: true,
+  													Default:  "200",
+  												},
+  											},
+  										},
+  										DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
+  									},
+  									names.AttrPath: {
+  										Type:     schema.TypeString,
+  										Optional: true,
+  										Default:  "/",
+  									},
+  									names.AttrPort: {
+  										Type:         schema.TypeInt,
+  										Optional:     true,
+  										Computed:     true,
+  										ValidateFunc: validation.IsPortNumber,
+  									},
+  									names.AttrProtocol: {
+  										Type:             schema.TypeString,
+  										Optional:         true,
+  										Computed:         true,
+  										ValidateDiagFunc: enum.Validate[types.TargetGroupProtocol](),
+  									},
+  									"protocol_version": {
+  										Type:             schema.TypeString,
+  										Optional:         true,
+  										Default:          types.HealthCheckProtocolVersionHttp1,
+  										StateFunc:        sdkv2.ToUpperSchemaStateFunc,
+  										ValidateDiagFunc: enum.Validate[types.HealthCheckProtocolVersion](),
+  									},
+  									"unhealthy_threshold_count": {
+  										Type:         schema.TypeInt,
+  										Optional:     true,
+  										Default:      2,
+  										ValidateFunc: validation.IntBetween(2, 10),
+  									},
+  								},
+  							},
+  							DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
+  						},
+  						names.AttrIPAddressType: {
+  							Type:             schema.TypeString,
+  							Optional:         true,
+  							Computed:         true,
+  							ForceNew:         true,
+  							ValidateDiagFunc: enum.Validate[types.IpAddressType](),
+  						},
+  						"lambda_event_structure_version": {
+  							Type:             schema.TypeString,
+  							Optional:         true,
+  							Computed:         true,
+  							ForceNew:         true,
+  							ValidateDiagFunc: enum.Validate[types.LambdaEventStructureVersion](),
+  						},
+  						names.AttrPort: {
+  							Type:         schema.TypeInt,
+  							Optional:     true,
+  							Computed:     true,
+  							ForceNew:     true,
+  							ValidateFunc: validation.IsPortNumber,
+  						},
+  						names.AttrProtocol: {
+  							Type:             schema.TypeString,
+  							Optional:         true,
+  							Computed:         true,
+  							ForceNew:         true,
+  							ValidateDiagFunc: enum.Validate[types.TargetGroupProtocol](),
+  						},
+  						"protocol_version": {
+  							Type:             schema.TypeString,
+  							Optional:         true,
+  							Computed:         true,
+  							ForceNew:         true,
+  							StateFunc:        sdkv2.ToUpperSchemaStateFunc,
+  							ValidateDiagFunc: enum.Validate[types.TargetGroupProtocolVersion](),
+  						},
+  						"vpc_identifier": {
+  							Type:     schema.TypeString,
+  							Optional: true,
+  							ForceNew: true,
+  						},
+  					},
+  				},
+  				DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
+  			},
+  			names.AttrName: {
+  				Type:         schema.TypeString,
+  				Required:     true,
+  				ForceNew:     true,
+  				ValidateFunc: validation.StringLenBetween(3, 128),
+  			},
+  			names.AttrStatus: {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			names.AttrTags:    tftags.TagsSchema(),
+  			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+  			names.AttrType: {
+  				Type:             schema.TypeString,
+  				Required:         true,
+  				ForceNew:         true,
+  				ValidateDiagFunc: enum.Validate[types.TargetGroupType](),
+  			},
+  		}
+  },
 	}
 }
 

--- a/internal/service/vpclattice/target_group.go
+++ b/internal/service/vpclattice/target_group.go
@@ -51,160 +51,160 @@ func resourceTargetGroup() *schema.Resource {
 		},
 
 		SchemaFunc: func() map[string]*schema.Schema {
-  	return map[string]*schema.Schema{
-  			names.AttrARN: {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			"config": {
-  				Type:     schema.TypeList,
-  				Optional: true,
-  				MaxItems: 1,
-  				Elem: &schema.Resource{
-  					Schema: map[string]*schema.Schema{
-  						names.AttrHealthCheck: {
-  							Type:     schema.TypeList,
-  							MaxItems: 1,
-  							Optional: true,
-  							Elem: &schema.Resource{
-  								Schema: map[string]*schema.Schema{
-  									names.AttrEnabled: {
-  										Type:     schema.TypeBool,
-  										Optional: true,
-  										Default:  true,
-  									},
-  									"health_check_interval_seconds": {
-  										Type:         schema.TypeInt,
-  										Optional:     true,
-  										Default:      30,
-  										ValidateFunc: validation.IntBetween(5, 300),
-  									},
-  									"health_check_timeout_seconds": {
-  										Type:         schema.TypeInt,
-  										Optional:     true,
-  										Default:      5,
-  										ValidateFunc: validation.IntBetween(1, 120),
-  									},
-  									"healthy_threshold_count": {
-  										Type:         schema.TypeInt,
-  										Optional:     true,
-  										Default:      5,
-  										ValidateFunc: validation.IntBetween(2, 10),
-  									},
-  									"matcher": {
-  										Type:     schema.TypeList,
-  										MaxItems: 1,
-  										Optional: true,
-  										Elem: &schema.Resource{
-  											Schema: map[string]*schema.Schema{
-  												names.AttrValue: {
-  													Type:     schema.TypeString,
-  													Optional: true,
-  													Default:  "200",
-  												},
-  											},
-  										},
-  										DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
-  									},
-  									names.AttrPath: {
-  										Type:     schema.TypeString,
-  										Optional: true,
-  										Default:  "/",
-  									},
-  									names.AttrPort: {
-  										Type:         schema.TypeInt,
-  										Optional:     true,
-  										Computed:     true,
-  										ValidateFunc: validation.IsPortNumber,
-  									},
-  									names.AttrProtocol: {
-  										Type:             schema.TypeString,
-  										Optional:         true,
-  										Computed:         true,
-  										ValidateDiagFunc: enum.Validate[types.TargetGroupProtocol](),
-  									},
-  									"protocol_version": {
-  										Type:             schema.TypeString,
-  										Optional:         true,
-  										Default:          types.HealthCheckProtocolVersionHttp1,
-  										StateFunc:        sdkv2.ToUpperSchemaStateFunc,
-  										ValidateDiagFunc: enum.Validate[types.HealthCheckProtocolVersion](),
-  									},
-  									"unhealthy_threshold_count": {
-  										Type:         schema.TypeInt,
-  										Optional:     true,
-  										Default:      2,
-  										ValidateFunc: validation.IntBetween(2, 10),
-  									},
-  								},
-  							},
-  							DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
-  						},
-  						names.AttrIPAddressType: {
-  							Type:             schema.TypeString,
-  							Optional:         true,
-  							Computed:         true,
-  							ForceNew:         true,
-  							ValidateDiagFunc: enum.Validate[types.IpAddressType](),
-  						},
-  						"lambda_event_structure_version": {
-  							Type:             schema.TypeString,
-  							Optional:         true,
-  							Computed:         true,
-  							ForceNew:         true,
-  							ValidateDiagFunc: enum.Validate[types.LambdaEventStructureVersion](),
-  						},
-  						names.AttrPort: {
-  							Type:         schema.TypeInt,
-  							Optional:     true,
-  							Computed:     true,
-  							ForceNew:     true,
-  							ValidateFunc: validation.IsPortNumber,
-  						},
-  						names.AttrProtocol: {
-  							Type:             schema.TypeString,
-  							Optional:         true,
-  							Computed:         true,
-  							ForceNew:         true,
-  							ValidateDiagFunc: enum.Validate[types.TargetGroupProtocol](),
-  						},
-  						"protocol_version": {
-  							Type:             schema.TypeString,
-  							Optional:         true,
-  							Computed:         true,
-  							ForceNew:         true,
-  							StateFunc:        sdkv2.ToUpperSchemaStateFunc,
-  							ValidateDiagFunc: enum.Validate[types.TargetGroupProtocolVersion](),
-  						},
-  						"vpc_identifier": {
-  							Type:     schema.TypeString,
-  							Optional: true,
-  							ForceNew: true,
-  						},
-  					},
-  				},
-  				DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
-  			},
-  			names.AttrName: {
-  				Type:         schema.TypeString,
-  				Required:     true,
-  				ForceNew:     true,
-  				ValidateFunc: validation.StringLenBetween(3, 128),
-  			},
-  			names.AttrStatus: {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			names.AttrTags:    tftags.TagsSchema(),
-  			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-  			names.AttrType: {
-  				Type:             schema.TypeString,
-  				Required:         true,
-  				ForceNew:         true,
-  				ValidateDiagFunc: enum.Validate[types.TargetGroupType](),
-  			},
-  		}
-  },
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"config": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrHealthCheck: {
+								Type:     schema.TypeList,
+								MaxItems: 1,
+								Optional: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										names.AttrEnabled: {
+											Type:     schema.TypeBool,
+											Optional: true,
+											Default:  true,
+										},
+										"health_check_interval_seconds": {
+											Type:         schema.TypeInt,
+											Optional:     true,
+											Default:      30,
+											ValidateFunc: validation.IntBetween(5, 300),
+										},
+										"health_check_timeout_seconds": {
+											Type:         schema.TypeInt,
+											Optional:     true,
+											Default:      5,
+											ValidateFunc: validation.IntBetween(1, 120),
+										},
+										"healthy_threshold_count": {
+											Type:         schema.TypeInt,
+											Optional:     true,
+											Default:      5,
+											ValidateFunc: validation.IntBetween(2, 10),
+										},
+										"matcher": {
+											Type:     schema.TypeList,
+											MaxItems: 1,
+											Optional: true,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													names.AttrValue: {
+														Type:     schema.TypeString,
+														Optional: true,
+														Default:  "200",
+													},
+												},
+											},
+											DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
+										},
+										names.AttrPath: {
+											Type:     schema.TypeString,
+											Optional: true,
+											Default:  "/",
+										},
+										names.AttrPort: {
+											Type:         schema.TypeInt,
+											Optional:     true,
+											Computed:     true,
+											ValidateFunc: validation.IsPortNumber,
+										},
+										names.AttrProtocol: {
+											Type:             schema.TypeString,
+											Optional:         true,
+											Computed:         true,
+											ValidateDiagFunc: enum.Validate[types.TargetGroupProtocol](),
+										},
+										"protocol_version": {
+											Type:             schema.TypeString,
+											Optional:         true,
+											Default:          types.HealthCheckProtocolVersionHttp1,
+											StateFunc:        sdkv2.ToUpperSchemaStateFunc,
+											ValidateDiagFunc: enum.Validate[types.HealthCheckProtocolVersion](),
+										},
+										"unhealthy_threshold_count": {
+											Type:         schema.TypeInt,
+											Optional:     true,
+											Default:      2,
+											ValidateFunc: validation.IntBetween(2, 10),
+										},
+									},
+								},
+								DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
+							},
+							names.AttrIPAddressType: {
+								Type:             schema.TypeString,
+								Optional:         true,
+								Computed:         true,
+								ForceNew:         true,
+								ValidateDiagFunc: enum.Validate[types.IpAddressType](),
+							},
+							"lambda_event_structure_version": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								Computed:         true,
+								ForceNew:         true,
+								ValidateDiagFunc: enum.Validate[types.LambdaEventStructureVersion](),
+							},
+							names.AttrPort: {
+								Type:         schema.TypeInt,
+								Optional:     true,
+								Computed:     true,
+								ForceNew:     true,
+								ValidateFunc: validation.IsPortNumber,
+							},
+							names.AttrProtocol: {
+								Type:             schema.TypeString,
+								Optional:         true,
+								Computed:         true,
+								ForceNew:         true,
+								ValidateDiagFunc: enum.Validate[types.TargetGroupProtocol](),
+							},
+							"protocol_version": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								Computed:         true,
+								ForceNew:         true,
+								StateFunc:        sdkv2.ToUpperSchemaStateFunc,
+								ValidateDiagFunc: enum.Validate[types.TargetGroupProtocolVersion](),
+							},
+							"vpc_identifier": {
+								Type:     schema.TypeString,
+								Optional: true,
+								ForceNew: true,
+							},
+						},
+					},
+					DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
+				},
+				names.AttrName: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringLenBetween(3, 128),
+				},
+				names.AttrStatus: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				names.AttrType: {
+					Type:             schema.TypeString,
+					Required:         true,
+					ForceNew:         true,
+					ValidateDiagFunc: enum.Validate[types.TargetGroupType](),
+				},
+			}
+		},
 	}
 }
 

--- a/internal/service/vpclattice/target_group_attachment.go
+++ b/internal/service/vpclattice/target_group_attachment.go
@@ -42,38 +42,38 @@ func resourceTargetGroupAttachment() *schema.Resource {
 		},
 
 		SchemaFunc: func() map[string]*schema.Schema {
-  	return map[string]*schema.Schema{
-  			names.AttrTarget: {
-  				Type:     schema.TypeList,
-  				Required: true,
-  				ForceNew: true,
-  				MaxItems: 1,
-  				MinItems: 1,
-  				Elem: &schema.Resource{
-  					Schema: map[string]*schema.Schema{
-  						names.AttrID: {
-  							Type:         schema.TypeString,
-  							Required:     true,
-  							ForceNew:     true,
-  							ValidateFunc: validation.StringLenBetween(1, 2048),
-  						},
-  						names.AttrPort: {
-  							Type:         schema.TypeInt,
-  							Optional:     true,
-  							Computed:     true,
-  							ForceNew:     true,
-  							ValidateFunc: validation.IsPortNumber,
-  						},
-  					},
-  				},
-  			},
-  			"target_group_identifier": {
-  				Type:     schema.TypeString,
-  				Required: true,
-  				ForceNew: true,
-  			},
-  		}
-  },
+			return map[string]*schema.Schema{
+				names.AttrTarget: {
+					Type:     schema.TypeList,
+					Required: true,
+					ForceNew: true,
+					MaxItems: 1,
+					MinItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrID: {
+								Type:         schema.TypeString,
+								Required:     true,
+								ForceNew:     true,
+								ValidateFunc: validation.StringLenBetween(1, 2048),
+							},
+							names.AttrPort: {
+								Type:         schema.TypeInt,
+								Optional:     true,
+								Computed:     true,
+								ForceNew:     true,
+								ValidateFunc: validation.IsPortNumber,
+							},
+						},
+					},
+				},
+				"target_group_identifier": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+			}
+		},
 	}
 }
 

--- a/internal/service/vpclattice/target_group_attachment.go
+++ b/internal/service/vpclattice/target_group_attachment.go
@@ -41,37 +41,39 @@ func resourceTargetGroupAttachment() *schema.Resource {
 			Delete: schema.DefaultTimeout(30 * time.Minute),
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrTarget: {
-				Type:     schema.TypeList,
-				Required: true,
-				ForceNew: true,
-				MaxItems: 1,
-				MinItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrID: {
-							Type:         schema.TypeString,
-							Required:     true,
-							ForceNew:     true,
-							ValidateFunc: validation.StringLenBetween(1, 2048),
-						},
-						names.AttrPort: {
-							Type:         schema.TypeInt,
-							Optional:     true,
-							Computed:     true,
-							ForceNew:     true,
-							ValidateFunc: validation.IsPortNumber,
-						},
-					},
-				},
-			},
-			"target_group_identifier": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-		},
+		SchemaFunc: func() map[string]*schema.Schema {
+  	return map[string]*schema.Schema{
+  			names.AttrTarget: {
+  				Type:     schema.TypeList,
+  				Required: true,
+  				ForceNew: true,
+  				MaxItems: 1,
+  				MinItems: 1,
+  				Elem: &schema.Resource{
+  					Schema: map[string]*schema.Schema{
+  						names.AttrID: {
+  							Type:         schema.TypeString,
+  							Required:     true,
+  							ForceNew:     true,
+  							ValidateFunc: validation.StringLenBetween(1, 2048),
+  						},
+  						names.AttrPort: {
+  							Type:         schema.TypeInt,
+  							Optional:     true,
+  							Computed:     true,
+  							ForceNew:     true,
+  							ValidateFunc: validation.IsPortNumber,
+  						},
+  					},
+  				},
+  			},
+  			"target_group_identifier": {
+  				Type:     schema.TypeString,
+  				Required: true,
+  				ForceNew: true,
+  			},
+  		}
+  },
 	}
 }
 

--- a/internal/service/waf/byte_match_set.go
+++ b/internal/service/waf/byte_match_set.go
@@ -38,56 +38,56 @@ func resourceByteMatchSet() *schema.Resource {
 		},
 
 		SchemaFunc: func() map[string]*schema.Schema {
-  	return map[string]*schema.Schema{
-  			names.AttrARN: {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			"byte_match_tuples": {
-  				Type:     schema.TypeSet,
-  				Optional: true,
-  				Elem: &schema.Resource{
-  					Schema: map[string]*schema.Schema{
-  						"field_to_match": {
-  							Type:     schema.TypeList,
-  							Required: true,
-  							MaxItems: 1,
-  							Elem: &schema.Resource{
-  								Schema: map[string]*schema.Schema{
-  									"data": {
-  										Type:     schema.TypeString,
-  										Optional: true,
-  									},
-  									names.AttrType: {
-  										Type:             schema.TypeString,
-  										Required:         true,
-  										ValidateDiagFunc: enum.Validate[awstypes.MatchFieldType](),
-  									},
-  								},
-  							},
-  						},
-  						"positional_constraint": {
-  							Type:     schema.TypeString,
-  							Required: true,
-  						},
-  						"target_string": {
-  							Type:     schema.TypeString,
-  							Optional: true,
-  						},
-  						"text_transformation": {
-  							Type:     schema.TypeString,
-  							Required: true,
-  						},
-  					},
-  				},
-  			},
-  			names.AttrName: {
-  				Type:     schema.TypeString,
-  				Required: true,
-  				ForceNew: true,
-  			},
-  		}
-  },
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"byte_match_tuples": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"field_to_match": {
+								Type:     schema.TypeList,
+								Required: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"data": {
+											Type:     schema.TypeString,
+											Optional: true,
+										},
+										names.AttrType: {
+											Type:             schema.TypeString,
+											Required:         true,
+											ValidateDiagFunc: enum.Validate[awstypes.MatchFieldType](),
+										},
+									},
+								},
+							},
+							"positional_constraint": {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+							"target_string": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+							"text_transformation": {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+						},
+					},
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+			}
+		},
 	}
 }
 

--- a/internal/service/waf/byte_match_set.go
+++ b/internal/service/waf/byte_match_set.go
@@ -37,55 +37,57 @@ func resourceByteMatchSet() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"byte_match_tuples": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"field_to_match": {
-							Type:     schema.TypeList,
-							Required: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"data": {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
-									names.AttrType: {
-										Type:             schema.TypeString,
-										Required:         true,
-										ValidateDiagFunc: enum.Validate[awstypes.MatchFieldType](),
-									},
-								},
-							},
-						},
-						"positional_constraint": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"target_string": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"text_transformation": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-					},
-				},
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-		},
+		SchemaFunc: func() map[string]*schema.Schema {
+  	return map[string]*schema.Schema{
+  			names.AttrARN: {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			"byte_match_tuples": {
+  				Type:     schema.TypeSet,
+  				Optional: true,
+  				Elem: &schema.Resource{
+  					Schema: map[string]*schema.Schema{
+  						"field_to_match": {
+  							Type:     schema.TypeList,
+  							Required: true,
+  							MaxItems: 1,
+  							Elem: &schema.Resource{
+  								Schema: map[string]*schema.Schema{
+  									"data": {
+  										Type:     schema.TypeString,
+  										Optional: true,
+  									},
+  									names.AttrType: {
+  										Type:             schema.TypeString,
+  										Required:         true,
+  										ValidateDiagFunc: enum.Validate[awstypes.MatchFieldType](),
+  									},
+  								},
+  							},
+  						},
+  						"positional_constraint": {
+  							Type:     schema.TypeString,
+  							Required: true,
+  						},
+  						"target_string": {
+  							Type:     schema.TypeString,
+  							Optional: true,
+  						},
+  						"text_transformation": {
+  							Type:     schema.TypeString,
+  							Required: true,
+  						},
+  					},
+  				},
+  			},
+  			names.AttrName: {
+  				Type:     schema.TypeString,
+  				Required: true,
+  				ForceNew: true,
+  			},
+  		}
+  },
 	}
 }
 

--- a/internal/service/waf/geo_match_set.go
+++ b/internal/service/waf/geo_match_set.go
@@ -37,34 +37,34 @@ func resourceGeoMatchSet() *schema.Resource {
 		},
 
 		SchemaFunc: func() map[string]*schema.Schema {
-  	return map[string]*schema.Schema{
-  			names.AttrARN: {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			"geo_match_constraint": {
-  				Type:     schema.TypeSet,
-  				Optional: true,
-  				Elem: &schema.Resource{
-  					Schema: map[string]*schema.Schema{
-  						names.AttrType: {
-  							Type:     schema.TypeString,
-  							Required: true,
-  						},
-  						names.AttrValue: {
-  							Type:     schema.TypeString,
-  							Required: true,
-  						},
-  					},
-  				},
-  			},
-  			names.AttrName: {
-  				Type:     schema.TypeString,
-  				Required: true,
-  				ForceNew: true,
-  			},
-  		}
-  },
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"geo_match_constraint": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrType: {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+							names.AttrValue: {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+						},
+					},
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+			}
+		},
 	}
 }
 

--- a/internal/service/waf/geo_match_set.go
+++ b/internal/service/waf/geo_match_set.go
@@ -36,33 +36,35 @@ func resourceGeoMatchSet() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"geo_match_constraint": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrType: {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						names.AttrValue: {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-					},
-				},
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-		},
+		SchemaFunc: func() map[string]*schema.Schema {
+  	return map[string]*schema.Schema{
+  			names.AttrARN: {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			"geo_match_constraint": {
+  				Type:     schema.TypeSet,
+  				Optional: true,
+  				Elem: &schema.Resource{
+  					Schema: map[string]*schema.Schema{
+  						names.AttrType: {
+  							Type:     schema.TypeString,
+  							Required: true,
+  						},
+  						names.AttrValue: {
+  							Type:     schema.TypeString,
+  							Required: true,
+  						},
+  					},
+  				},
+  			},
+  			names.AttrName: {
+  				Type:     schema.TypeString,
+  				Required: true,
+  				ForceNew: true,
+  			},
+  		}
+  },
 	}
 }
 

--- a/internal/service/waf/ipset.go
+++ b/internal/service/waf/ipset.go
@@ -38,35 +38,37 @@ func resourceIPSet() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"ip_set_descriptors": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrType: {
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.IPSetDescriptorType](),
-						},
-						names.AttrValue: {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validation.IsCIDR,
-						},
-					},
-				},
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-		},
+		SchemaFunc: func() map[string]*schema.Schema {
+  	return map[string]*schema.Schema{
+  			names.AttrARN: {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			"ip_set_descriptors": {
+  				Type:     schema.TypeSet,
+  				Optional: true,
+  				Elem: &schema.Resource{
+  					Schema: map[string]*schema.Schema{
+  						names.AttrType: {
+  							Type:             schema.TypeString,
+  							Required:         true,
+  							ValidateDiagFunc: enum.Validate[awstypes.IPSetDescriptorType](),
+  						},
+  						names.AttrValue: {
+  							Type:         schema.TypeString,
+  							Required:     true,
+  							ValidateFunc: validation.IsCIDR,
+  						},
+  					},
+  				},
+  			},
+  			names.AttrName: {
+  				Type:     schema.TypeString,
+  				Required: true,
+  				ForceNew: true,
+  			},
+  		}
+  },
 	}
 }
 

--- a/internal/service/waf/ipset.go
+++ b/internal/service/waf/ipset.go
@@ -39,36 +39,36 @@ func resourceIPSet() *schema.Resource {
 		},
 
 		SchemaFunc: func() map[string]*schema.Schema {
-  	return map[string]*schema.Schema{
-  			names.AttrARN: {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			"ip_set_descriptors": {
-  				Type:     schema.TypeSet,
-  				Optional: true,
-  				Elem: &schema.Resource{
-  					Schema: map[string]*schema.Schema{
-  						names.AttrType: {
-  							Type:             schema.TypeString,
-  							Required:         true,
-  							ValidateDiagFunc: enum.Validate[awstypes.IPSetDescriptorType](),
-  						},
-  						names.AttrValue: {
-  							Type:         schema.TypeString,
-  							Required:     true,
-  							ValidateFunc: validation.IsCIDR,
-  						},
-  					},
-  				},
-  			},
-  			names.AttrName: {
-  				Type:     schema.TypeString,
-  				Required: true,
-  				ForceNew: true,
-  			},
-  		}
-  },
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"ip_set_descriptors": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrType: {
+								Type:             schema.TypeString,
+								Required:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.IPSetDescriptorType](),
+							},
+							names.AttrValue: {
+								Type:         schema.TypeString,
+								Required:     true,
+								ValidateFunc: validation.IsCIDR,
+							},
+						},
+					},
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+			}
+		},
 	}
 }
 

--- a/internal/service/waf/ipset_data_source.go
+++ b/internal/service/waf/ipset_data_source.go
@@ -25,12 +25,14 @@ func dataSourceIPSet() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceIPSetRead,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-		},
+		SchemaFunc: func() map[string]*schema.Schema {
+  	return map[string]*schema.Schema{
+  			names.AttrName: {
+  				Type:     schema.TypeString,
+  				Required: true,
+  			},
+  		}
+  },
 	}
 }
 

--- a/internal/service/waf/ipset_data_source.go
+++ b/internal/service/waf/ipset_data_source.go
@@ -26,13 +26,13 @@ func dataSourceIPSet() *schema.Resource {
 		ReadWithoutTimeout: dataSourceIPSetRead,
 
 		SchemaFunc: func() map[string]*schema.Schema {
-  	return map[string]*schema.Schema{
-  			names.AttrName: {
-  				Type:     schema.TypeString,
-  				Required: true,
-  			},
-  		}
-  },
+			return map[string]*schema.Schema{
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+			}
+		},
 	}
 }
 

--- a/internal/service/waf/rate_based_rule.go
+++ b/internal/service/waf/rate_based_rule.go
@@ -39,56 +39,58 @@ func resourceRateBasedRule() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrMetricName: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validMetricName,
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"predicates": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"data_id": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validation.StringLenBetween(0, 128),
-						},
-						"negated": {
-							Type:     schema.TypeBool,
-							Required: true,
-						},
-						names.AttrType: {
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.PredicateType](),
-						},
-					},
-				},
-			},
-			"rate_key": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"rate_limit": {
-				Type:         schema.TypeInt,
-				Required:     true,
-				ValidateFunc: validation.IntAtLeast(100),
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-		},
+		SchemaFunc: func() map[string]*schema.Schema {
+  	return map[string]*schema.Schema{
+  			names.AttrARN: {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			names.AttrMetricName: {
+  				Type:         schema.TypeString,
+  				Required:     true,
+  				ForceNew:     true,
+  				ValidateFunc: validMetricName,
+  			},
+  			names.AttrName: {
+  				Type:     schema.TypeString,
+  				Required: true,
+  				ForceNew: true,
+  			},
+  			"predicates": {
+  				Type:     schema.TypeSet,
+  				Optional: true,
+  				Elem: &schema.Resource{
+  					Schema: map[string]*schema.Schema{
+  						"data_id": {
+  							Type:         schema.TypeString,
+  							Required:     true,
+  							ValidateFunc: validation.StringLenBetween(0, 128),
+  						},
+  						"negated": {
+  							Type:     schema.TypeBool,
+  							Required: true,
+  						},
+  						names.AttrType: {
+  							Type:             schema.TypeString,
+  							Required:         true,
+  							ValidateDiagFunc: enum.Validate[awstypes.PredicateType](),
+  						},
+  					},
+  				},
+  			},
+  			"rate_key": {
+  				Type:     schema.TypeString,
+  				Required: true,
+  			},
+  			"rate_limit": {
+  				Type:         schema.TypeInt,
+  				Required:     true,
+  				ValidateFunc: validation.IntAtLeast(100),
+  			},
+  			names.AttrTags:    tftags.TagsSchema(),
+  			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+  		}
+  },
 	}
 }
 

--- a/internal/service/waf/rate_based_rule.go
+++ b/internal/service/waf/rate_based_rule.go
@@ -40,57 +40,57 @@ func resourceRateBasedRule() *schema.Resource {
 		},
 
 		SchemaFunc: func() map[string]*schema.Schema {
-  	return map[string]*schema.Schema{
-  			names.AttrARN: {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			names.AttrMetricName: {
-  				Type:         schema.TypeString,
-  				Required:     true,
-  				ForceNew:     true,
-  				ValidateFunc: validMetricName,
-  			},
-  			names.AttrName: {
-  				Type:     schema.TypeString,
-  				Required: true,
-  				ForceNew: true,
-  			},
-  			"predicates": {
-  				Type:     schema.TypeSet,
-  				Optional: true,
-  				Elem: &schema.Resource{
-  					Schema: map[string]*schema.Schema{
-  						"data_id": {
-  							Type:         schema.TypeString,
-  							Required:     true,
-  							ValidateFunc: validation.StringLenBetween(0, 128),
-  						},
-  						"negated": {
-  							Type:     schema.TypeBool,
-  							Required: true,
-  						},
-  						names.AttrType: {
-  							Type:             schema.TypeString,
-  							Required:         true,
-  							ValidateDiagFunc: enum.Validate[awstypes.PredicateType](),
-  						},
-  					},
-  				},
-  			},
-  			"rate_key": {
-  				Type:     schema.TypeString,
-  				Required: true,
-  			},
-  			"rate_limit": {
-  				Type:         schema.TypeInt,
-  				Required:     true,
-  				ValidateFunc: validation.IntAtLeast(100),
-  			},
-  			names.AttrTags:    tftags.TagsSchema(),
-  			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-  		}
-  },
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrMetricName: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validMetricName,
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"predicates": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"data_id": {
+								Type:         schema.TypeString,
+								Required:     true,
+								ValidateFunc: validation.StringLenBetween(0, 128),
+							},
+							"negated": {
+								Type:     schema.TypeBool,
+								Required: true,
+							},
+							names.AttrType: {
+								Type:             schema.TypeString,
+								Required:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.PredicateType](),
+							},
+						},
+					},
+				},
+				"rate_key": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"rate_limit": {
+					Type:         schema.TypeInt,
+					Required:     true,
+					ValidateFunc: validation.IntAtLeast(100),
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			}
+		},
 	}
 }
 

--- a/internal/service/waf/rate_based_rule_data_source.go
+++ b/internal/service/waf/rate_based_rule_data_source.go
@@ -26,13 +26,13 @@ func dataSourceRateBasedRule() *schema.Resource {
 		ReadWithoutTimeout: dataSourceRateBasedRuleRead,
 
 		SchemaFunc: func() map[string]*schema.Schema {
-  	return map[string]*schema.Schema{
-  			names.AttrName: {
-  				Type:     schema.TypeString,
-  				Required: true,
-  			},
-  		}
-  },
+			return map[string]*schema.Schema{
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+			}
+		},
 	}
 }
 

--- a/internal/service/waf/rate_based_rule_data_source.go
+++ b/internal/service/waf/rate_based_rule_data_source.go
@@ -25,12 +25,14 @@ func dataSourceRateBasedRule() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceRateBasedRuleRead,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-		},
+		SchemaFunc: func() map[string]*schema.Schema {
+  	return map[string]*schema.Schema{
+  			names.AttrName: {
+  				Type:     schema.TypeString,
+  				Required: true,
+  			},
+  		}
+  },
 	}
 }
 

--- a/internal/service/waf/regex_match_set.go
+++ b/internal/service/waf/regex_match_set.go
@@ -39,54 +39,56 @@ func resourceRegexMatchSet() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"regex_match_tuple": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Set:      regexMatchSetTupleHash,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"field_to_match": {
-							Type:     schema.TypeList,
-							Required: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"data": {
-										Type:     schema.TypeString,
-										Optional: true,
-										StateFunc: func(v any) string {
-											return strings.ToLower(v.(string))
-										},
-									},
-									names.AttrType: {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-								},
-							},
-						},
-						"regex_pattern_set_id": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"text_transformation": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-					},
-				},
-			},
-		},
+		SchemaFunc: func() map[string]*schema.Schema {
+  	return map[string]*schema.Schema{
+  			names.AttrARN: {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			names.AttrName: {
+  				Type:     schema.TypeString,
+  				Required: true,
+  				ForceNew: true,
+  			},
+  			"regex_match_tuple": {
+  				Type:     schema.TypeSet,
+  				Optional: true,
+  				Set:      regexMatchSetTupleHash,
+  				Elem: &schema.Resource{
+  					Schema: map[string]*schema.Schema{
+  						"field_to_match": {
+  							Type:     schema.TypeList,
+  							Required: true,
+  							MaxItems: 1,
+  							Elem: &schema.Resource{
+  								Schema: map[string]*schema.Schema{
+  									"data": {
+  										Type:     schema.TypeString,
+  										Optional: true,
+  										StateFunc: func(v any) string {
+  											return strings.ToLower(v.(string))
+  										},
+  									},
+  									names.AttrType: {
+  										Type:     schema.TypeString,
+  										Required: true,
+  									},
+  								},
+  							},
+  						},
+  						"regex_pattern_set_id": {
+  							Type:     schema.TypeString,
+  							Required: true,
+  						},
+  						"text_transformation": {
+  							Type:     schema.TypeString,
+  							Required: true,
+  						},
+  					},
+  				},
+  			},
+  		}
+  },
 	}
 }
 

--- a/internal/service/waf/regex_match_set.go
+++ b/internal/service/waf/regex_match_set.go
@@ -40,55 +40,55 @@ func resourceRegexMatchSet() *schema.Resource {
 		},
 
 		SchemaFunc: func() map[string]*schema.Schema {
-  	return map[string]*schema.Schema{
-  			names.AttrARN: {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			names.AttrName: {
-  				Type:     schema.TypeString,
-  				Required: true,
-  				ForceNew: true,
-  			},
-  			"regex_match_tuple": {
-  				Type:     schema.TypeSet,
-  				Optional: true,
-  				Set:      regexMatchSetTupleHash,
-  				Elem: &schema.Resource{
-  					Schema: map[string]*schema.Schema{
-  						"field_to_match": {
-  							Type:     schema.TypeList,
-  							Required: true,
-  							MaxItems: 1,
-  							Elem: &schema.Resource{
-  								Schema: map[string]*schema.Schema{
-  									"data": {
-  										Type:     schema.TypeString,
-  										Optional: true,
-  										StateFunc: func(v any) string {
-  											return strings.ToLower(v.(string))
-  										},
-  									},
-  									names.AttrType: {
-  										Type:     schema.TypeString,
-  										Required: true,
-  									},
-  								},
-  							},
-  						},
-  						"regex_pattern_set_id": {
-  							Type:     schema.TypeString,
-  							Required: true,
-  						},
-  						"text_transformation": {
-  							Type:     schema.TypeString,
-  							Required: true,
-  						},
-  					},
-  				},
-  			},
-  		}
-  },
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"regex_match_tuple": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Set:      regexMatchSetTupleHash,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"field_to_match": {
+								Type:     schema.TypeList,
+								Required: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"data": {
+											Type:     schema.TypeString,
+											Optional: true,
+											StateFunc: func(v any) string {
+												return strings.ToLower(v.(string))
+											},
+										},
+										names.AttrType: {
+											Type:     schema.TypeString,
+											Required: true,
+										},
+									},
+								},
+							},
+							"regex_pattern_set_id": {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+							"text_transformation": {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+						},
+					},
+				},
+			}
+		},
 	}
 }
 

--- a/internal/service/waf/regex_pattern_set.go
+++ b/internal/service/waf/regex_pattern_set.go
@@ -37,22 +37,24 @@ func resourceRegexPatternSet() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"regex_pattern_strings": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-		},
+		SchemaFunc: func() map[string]*schema.Schema {
+  	return map[string]*schema.Schema{
+  			names.AttrARN: {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			names.AttrName: {
+  				Type:     schema.TypeString,
+  				Required: true,
+  				ForceNew: true,
+  			},
+  			"regex_pattern_strings": {
+  				Type:     schema.TypeSet,
+  				Optional: true,
+  				Elem:     &schema.Schema{Type: schema.TypeString},
+  			},
+  		}
+  },
 	}
 }
 

--- a/internal/service/waf/regex_pattern_set.go
+++ b/internal/service/waf/regex_pattern_set.go
@@ -38,23 +38,23 @@ func resourceRegexPatternSet() *schema.Resource {
 		},
 
 		SchemaFunc: func() map[string]*schema.Schema {
-  	return map[string]*schema.Schema{
-  			names.AttrARN: {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			names.AttrName: {
-  				Type:     schema.TypeString,
-  				Required: true,
-  				ForceNew: true,
-  			},
-  			"regex_pattern_strings": {
-  				Type:     schema.TypeSet,
-  				Optional: true,
-  				Elem:     &schema.Schema{Type: schema.TypeString},
-  			},
-  		}
-  },
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"regex_pattern_strings": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+			}
+		},
 	}
 }
 

--- a/internal/service/waf/rule.go
+++ b/internal/service/waf/rule.go
@@ -43,48 +43,48 @@ func resourceRule() *schema.Resource {
 		},
 
 		SchemaFunc: func() map[string]*schema.Schema {
-  	return map[string]*schema.Schema{
-  			names.AttrARN: {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			names.AttrMetricName: {
-  				Type:         schema.TypeString,
-  				Required:     true,
-  				ForceNew:     true,
-  				ValidateFunc: validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z]+$`), "must contain only alphanumeric characters"),
-  			},
-  			names.AttrName: {
-  				Type:     schema.TypeString,
-  				Required: true,
-  				ForceNew: true,
-  			},
-  			"predicates": {
-  				Type:     schema.TypeSet,
-  				Optional: true,
-  				Elem: &schema.Resource{
-  					Schema: map[string]*schema.Schema{
-  						"data_id": {
-  							Type:         schema.TypeString,
-  							Required:     true,
-  							ValidateFunc: validation.StringLenBetween(0, 128),
-  						},
-  						"negated": {
-  							Type:     schema.TypeBool,
-  							Required: true,
-  						},
-  						names.AttrType: {
-  							Type:             schema.TypeString,
-  							Required:         true,
-  							ValidateDiagFunc: enum.Validate[awstypes.PredicateType](),
-  						},
-  					},
-  				},
-  			},
-  			names.AttrTags:    tftags.TagsSchema(),
-  			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-  		}
-  },
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrMetricName: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z]+$`), "must contain only alphanumeric characters"),
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"predicates": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"data_id": {
+								Type:         schema.TypeString,
+								Required:     true,
+								ValidateFunc: validation.StringLenBetween(0, 128),
+							},
+							"negated": {
+								Type:     schema.TypeBool,
+								Required: true,
+							},
+							names.AttrType: {
+								Type:             schema.TypeString,
+								Required:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.PredicateType](),
+							},
+						},
+					},
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			}
+		},
 	}
 }
 

--- a/internal/service/waf/rule.go
+++ b/internal/service/waf/rule.go
@@ -42,47 +42,49 @@ func resourceRule() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrMetricName: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z]+$`), "must contain only alphanumeric characters"),
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"predicates": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"data_id": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validation.StringLenBetween(0, 128),
-						},
-						"negated": {
-							Type:     schema.TypeBool,
-							Required: true,
-						},
-						names.AttrType: {
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.PredicateType](),
-						},
-					},
-				},
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-		},
+		SchemaFunc: func() map[string]*schema.Schema {
+  	return map[string]*schema.Schema{
+  			names.AttrARN: {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			names.AttrMetricName: {
+  				Type:         schema.TypeString,
+  				Required:     true,
+  				ForceNew:     true,
+  				ValidateFunc: validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z]+$`), "must contain only alphanumeric characters"),
+  			},
+  			names.AttrName: {
+  				Type:     schema.TypeString,
+  				Required: true,
+  				ForceNew: true,
+  			},
+  			"predicates": {
+  				Type:     schema.TypeSet,
+  				Optional: true,
+  				Elem: &schema.Resource{
+  					Schema: map[string]*schema.Schema{
+  						"data_id": {
+  							Type:         schema.TypeString,
+  							Required:     true,
+  							ValidateFunc: validation.StringLenBetween(0, 128),
+  						},
+  						"negated": {
+  							Type:     schema.TypeBool,
+  							Required: true,
+  						},
+  						names.AttrType: {
+  							Type:             schema.TypeString,
+  							Required:         true,
+  							ValidateDiagFunc: enum.Validate[awstypes.PredicateType](),
+  						},
+  					},
+  				},
+  			},
+  			names.AttrTags:    tftags.TagsSchema(),
+  			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+  		}
+  },
 	}
 }
 

--- a/internal/service/waf/rule_data_source.go
+++ b/internal/service/waf/rule_data_source.go
@@ -26,13 +26,13 @@ func dataSourceRule() *schema.Resource {
 		ReadWithoutTimeout: dataSourceRuleRead,
 
 		SchemaFunc: func() map[string]*schema.Schema {
-  	return map[string]*schema.Schema{
-  			names.AttrName: {
-  				Type:     schema.TypeString,
-  				Required: true,
-  			},
-  		}
-  },
+			return map[string]*schema.Schema{
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+			}
+		},
 	}
 }
 

--- a/internal/service/waf/rule_data_source.go
+++ b/internal/service/waf/rule_data_source.go
@@ -25,12 +25,14 @@ func dataSourceRule() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceRuleRead,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-		},
+		SchemaFunc: func() map[string]*schema.Schema {
+  	return map[string]*schema.Schema{
+  			names.AttrName: {
+  				Type:     schema.TypeString,
+  				Required: true,
+  			},
+  		}
+  },
 	}
 }
 

--- a/internal/service/waf/rule_group.go
+++ b/internal/service/waf/rule_group.go
@@ -38,59 +38,61 @@ func resourceRuleGroup() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"activated_rule": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrAction: {
-							Type:     schema.TypeList,
-							MaxItems: 1,
-							Required: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									names.AttrType: {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-								},
-							},
-						},
-						names.AttrPriority: {
-							Type:     schema.TypeInt,
-							Required: true,
-						},
-						"rule_id": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						names.AttrType: {
-							Type:     schema.TypeString,
-							Optional: true,
-							Default:  awstypes.WafRuleTypeRegular,
-						},
-					},
-				},
-			},
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrMetricName: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validMetricName,
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-		},
+		SchemaFunc: func() map[string]*schema.Schema {
+  	return map[string]*schema.Schema{
+  			"activated_rule": {
+  				Type:     schema.TypeSet,
+  				Optional: true,
+  				Elem: &schema.Resource{
+  					Schema: map[string]*schema.Schema{
+  						names.AttrAction: {
+  							Type:     schema.TypeList,
+  							MaxItems: 1,
+  							Required: true,
+  							Elem: &schema.Resource{
+  								Schema: map[string]*schema.Schema{
+  									names.AttrType: {
+  										Type:     schema.TypeString,
+  										Required: true,
+  									},
+  								},
+  							},
+  						},
+  						names.AttrPriority: {
+  							Type:     schema.TypeInt,
+  							Required: true,
+  						},
+  						"rule_id": {
+  							Type:     schema.TypeString,
+  							Required: true,
+  						},
+  						names.AttrType: {
+  							Type:     schema.TypeString,
+  							Optional: true,
+  							Default:  awstypes.WafRuleTypeRegular,
+  						},
+  					},
+  				},
+  			},
+  			names.AttrARN: {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			names.AttrMetricName: {
+  				Type:         schema.TypeString,
+  				Required:     true,
+  				ForceNew:     true,
+  				ValidateFunc: validMetricName,
+  			},
+  			names.AttrName: {
+  				Type:     schema.TypeString,
+  				Required: true,
+  				ForceNew: true,
+  			},
+  			names.AttrTags:    tftags.TagsSchema(),
+  			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+  		}
+  },
 	}
 }
 

--- a/internal/service/waf/rule_group.go
+++ b/internal/service/waf/rule_group.go
@@ -39,60 +39,60 @@ func resourceRuleGroup() *schema.Resource {
 		},
 
 		SchemaFunc: func() map[string]*schema.Schema {
-  	return map[string]*schema.Schema{
-  			"activated_rule": {
-  				Type:     schema.TypeSet,
-  				Optional: true,
-  				Elem: &schema.Resource{
-  					Schema: map[string]*schema.Schema{
-  						names.AttrAction: {
-  							Type:     schema.TypeList,
-  							MaxItems: 1,
-  							Required: true,
-  							Elem: &schema.Resource{
-  								Schema: map[string]*schema.Schema{
-  									names.AttrType: {
-  										Type:     schema.TypeString,
-  										Required: true,
-  									},
-  								},
-  							},
-  						},
-  						names.AttrPriority: {
-  							Type:     schema.TypeInt,
-  							Required: true,
-  						},
-  						"rule_id": {
-  							Type:     schema.TypeString,
-  							Required: true,
-  						},
-  						names.AttrType: {
-  							Type:     schema.TypeString,
-  							Optional: true,
-  							Default:  awstypes.WafRuleTypeRegular,
-  						},
-  					},
-  				},
-  			},
-  			names.AttrARN: {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			names.AttrMetricName: {
-  				Type:         schema.TypeString,
-  				Required:     true,
-  				ForceNew:     true,
-  				ValidateFunc: validMetricName,
-  			},
-  			names.AttrName: {
-  				Type:     schema.TypeString,
-  				Required: true,
-  				ForceNew: true,
-  			},
-  			names.AttrTags:    tftags.TagsSchema(),
-  			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-  		}
-  },
+			return map[string]*schema.Schema{
+				"activated_rule": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrAction: {
+								Type:     schema.TypeList,
+								MaxItems: 1,
+								Required: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										names.AttrType: {
+											Type:     schema.TypeString,
+											Required: true,
+										},
+									},
+								},
+							},
+							names.AttrPriority: {
+								Type:     schema.TypeInt,
+								Required: true,
+							},
+							"rule_id": {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+							names.AttrType: {
+								Type:     schema.TypeString,
+								Optional: true,
+								Default:  awstypes.WafRuleTypeRegular,
+							},
+						},
+					},
+				},
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrMetricName: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validMetricName,
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			}
+		},
 	}
 }
 

--- a/internal/service/waf/size_constraint_set.go
+++ b/internal/service/waf/size_constraint_set.go
@@ -36,54 +36,56 @@ func resourceSizeConstraintSet() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"size_constraints": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"comparison_operator": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"field_to_match": {
-							Type:     schema.TypeList,
-							Required: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"data": {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
-									names.AttrType: {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-								},
-							},
-						},
-						names.AttrSize: {
-							Type:     schema.TypeInt,
-							Required: true,
-						},
-						"text_transformation": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-					},
-				},
-			},
-		},
+		SchemaFunc: func() map[string]*schema.Schema {
+  	return map[string]*schema.Schema{
+  			names.AttrARN: {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			names.AttrName: {
+  				Type:     schema.TypeString,
+  				Required: true,
+  				ForceNew: true,
+  			},
+  			"size_constraints": {
+  				Type:     schema.TypeSet,
+  				Optional: true,
+  				Elem: &schema.Resource{
+  					Schema: map[string]*schema.Schema{
+  						"comparison_operator": {
+  							Type:     schema.TypeString,
+  							Required: true,
+  						},
+  						"field_to_match": {
+  							Type:     schema.TypeList,
+  							Required: true,
+  							MaxItems: 1,
+  							Elem: &schema.Resource{
+  								Schema: map[string]*schema.Schema{
+  									"data": {
+  										Type:     schema.TypeString,
+  										Optional: true,
+  									},
+  									names.AttrType: {
+  										Type:     schema.TypeString,
+  										Required: true,
+  									},
+  								},
+  							},
+  						},
+  						names.AttrSize: {
+  							Type:     schema.TypeInt,
+  							Required: true,
+  						},
+  						"text_transformation": {
+  							Type:     schema.TypeString,
+  							Required: true,
+  						},
+  					},
+  				},
+  			},
+  		}
+  },
 	}
 }
 

--- a/internal/service/waf/size_constraint_set.go
+++ b/internal/service/waf/size_constraint_set.go
@@ -37,55 +37,55 @@ func resourceSizeConstraintSet() *schema.Resource {
 		},
 
 		SchemaFunc: func() map[string]*schema.Schema {
-  	return map[string]*schema.Schema{
-  			names.AttrARN: {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			names.AttrName: {
-  				Type:     schema.TypeString,
-  				Required: true,
-  				ForceNew: true,
-  			},
-  			"size_constraints": {
-  				Type:     schema.TypeSet,
-  				Optional: true,
-  				Elem: &schema.Resource{
-  					Schema: map[string]*schema.Schema{
-  						"comparison_operator": {
-  							Type:     schema.TypeString,
-  							Required: true,
-  						},
-  						"field_to_match": {
-  							Type:     schema.TypeList,
-  							Required: true,
-  							MaxItems: 1,
-  							Elem: &schema.Resource{
-  								Schema: map[string]*schema.Schema{
-  									"data": {
-  										Type:     schema.TypeString,
-  										Optional: true,
-  									},
-  									names.AttrType: {
-  										Type:     schema.TypeString,
-  										Required: true,
-  									},
-  								},
-  							},
-  						},
-  						names.AttrSize: {
-  							Type:     schema.TypeInt,
-  							Required: true,
-  						},
-  						"text_transformation": {
-  							Type:     schema.TypeString,
-  							Required: true,
-  						},
-  					},
-  				},
-  			},
-  		}
-  },
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"size_constraints": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"comparison_operator": {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+							"field_to_match": {
+								Type:     schema.TypeList,
+								Required: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"data": {
+											Type:     schema.TypeString,
+											Optional: true,
+										},
+										names.AttrType: {
+											Type:     schema.TypeString,
+											Required: true,
+										},
+									},
+								},
+							},
+							names.AttrSize: {
+								Type:     schema.TypeInt,
+								Required: true,
+							},
+							"text_transformation": {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+						},
+					},
+				},
+			}
+		},
 	}
 }
 

--- a/internal/service/waf/sql_injection_match_set.go
+++ b/internal/service/waf/sql_injection_match_set.go
@@ -37,47 +37,47 @@ func resourceSQLInjectionMatchSet() *schema.Resource {
 		},
 
 		SchemaFunc: func() map[string]*schema.Schema {
-  	return map[string]*schema.Schema{
-  			names.AttrARN: {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			names.AttrName: {
-  				Type:     schema.TypeString,
-  				Required: true,
-  				ForceNew: true,
-  			},
-  			"sql_injection_match_tuples": {
-  				Type:     schema.TypeSet,
-  				Optional: true,
-  				Elem: &schema.Resource{
-  					Schema: map[string]*schema.Schema{
-  						"field_to_match": {
-  							Type:     schema.TypeList,
-  							Required: true,
-  							MaxItems: 1,
-  							Elem: &schema.Resource{
-  								Schema: map[string]*schema.Schema{
-  									"data": {
-  										Type:     schema.TypeString,
-  										Optional: true,
-  									},
-  									names.AttrType: {
-  										Type:     schema.TypeString,
-  										Required: true,
-  									},
-  								},
-  							},
-  						},
-  						"text_transformation": {
-  							Type:     schema.TypeString,
-  							Required: true,
-  						},
-  					},
-  				},
-  			},
-  		}
-  },
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"sql_injection_match_tuples": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"field_to_match": {
+								Type:     schema.TypeList,
+								Required: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"data": {
+											Type:     schema.TypeString,
+											Optional: true,
+										},
+										names.AttrType: {
+											Type:     schema.TypeString,
+											Required: true,
+										},
+									},
+								},
+							},
+							"text_transformation": {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+						},
+					},
+				},
+			}
+		},
 	}
 }
 

--- a/internal/service/waf/sql_injection_match_set.go
+++ b/internal/service/waf/sql_injection_match_set.go
@@ -36,46 +36,48 @@ func resourceSQLInjectionMatchSet() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"sql_injection_match_tuples": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"field_to_match": {
-							Type:     schema.TypeList,
-							Required: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"data": {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
-									names.AttrType: {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-								},
-							},
-						},
-						"text_transformation": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-					},
-				},
-			},
-		},
+		SchemaFunc: func() map[string]*schema.Schema {
+  	return map[string]*schema.Schema{
+  			names.AttrARN: {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			names.AttrName: {
+  				Type:     schema.TypeString,
+  				Required: true,
+  				ForceNew: true,
+  			},
+  			"sql_injection_match_tuples": {
+  				Type:     schema.TypeSet,
+  				Optional: true,
+  				Elem: &schema.Resource{
+  					Schema: map[string]*schema.Schema{
+  						"field_to_match": {
+  							Type:     schema.TypeList,
+  							Required: true,
+  							MaxItems: 1,
+  							Elem: &schema.Resource{
+  								Schema: map[string]*schema.Schema{
+  									"data": {
+  										Type:     schema.TypeString,
+  										Optional: true,
+  									},
+  									names.AttrType: {
+  										Type:     schema.TypeString,
+  										Required: true,
+  									},
+  								},
+  							},
+  						},
+  						"text_transformation": {
+  							Type:     schema.TypeString,
+  							Required: true,
+  						},
+  					},
+  				},
+  			},
+  		}
+  },
 	}
 }
 

--- a/internal/service/waf/subscribed_rule_group_data_source.go
+++ b/internal/service/waf/subscribed_rule_group_data_source.go
@@ -25,18 +25,20 @@ func dataSourceSubscribedRuleGroup() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceSubscribedRuleGroupRead,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrMetricName: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				AtLeastOneOf: []string{names.AttrName, names.AttrMetricName},
-			},
-			names.AttrName: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				AtLeastOneOf: []string{names.AttrName, names.AttrMetricName},
-			},
-		},
+		SchemaFunc: func() map[string]*schema.Schema {
+  	return map[string]*schema.Schema{
+  			names.AttrMetricName: {
+  				Type:         schema.TypeString,
+  				Optional:     true,
+  				AtLeastOneOf: []string{names.AttrName, names.AttrMetricName},
+  			},
+  			names.AttrName: {
+  				Type:         schema.TypeString,
+  				Optional:     true,
+  				AtLeastOneOf: []string{names.AttrName, names.AttrMetricName},
+  			},
+  		}
+  },
 	}
 }
 

--- a/internal/service/waf/subscribed_rule_group_data_source.go
+++ b/internal/service/waf/subscribed_rule_group_data_source.go
@@ -26,19 +26,19 @@ func dataSourceSubscribedRuleGroup() *schema.Resource {
 		ReadWithoutTimeout: dataSourceSubscribedRuleGroupRead,
 
 		SchemaFunc: func() map[string]*schema.Schema {
-  	return map[string]*schema.Schema{
-  			names.AttrMetricName: {
-  				Type:         schema.TypeString,
-  				Optional:     true,
-  				AtLeastOneOf: []string{names.AttrName, names.AttrMetricName},
-  			},
-  			names.AttrName: {
-  				Type:         schema.TypeString,
-  				Optional:     true,
-  				AtLeastOneOf: []string{names.AttrName, names.AttrMetricName},
-  			},
-  		}
-  },
+			return map[string]*schema.Schema{
+				names.AttrMetricName: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					AtLeastOneOf: []string{names.AttrName, names.AttrMetricName},
+				},
+				names.AttrName: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					AtLeastOneOf: []string{names.AttrName, names.AttrMetricName},
+				},
+			}
+		},
 	}
 }
 

--- a/internal/service/waf/web_acl.go
+++ b/internal/service/waf/web_acl.go
@@ -41,125 +41,125 @@ func resourceWebACL() *schema.Resource {
 		},
 
 		SchemaFunc: func() map[string]*schema.Schema {
-  	return map[string]*schema.Schema{
-  			names.AttrARN: {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			names.AttrName: {
-  				Type:     schema.TypeString,
-  				Required: true,
-  				ForceNew: true,
-  			},
-  			names.AttrDefaultAction: {
-  				Type:     schema.TypeList,
-  				Required: true,
-  				MaxItems: 1,
-  				Elem: &schema.Resource{
-  					Schema: map[string]*schema.Schema{
-  						names.AttrType: {
-  							Type:     schema.TypeString,
-  							Required: true,
-  						},
-  					},
-  				},
-  			},
-  			names.AttrMetricName: {
-  				Type:         schema.TypeString,
-  				Required:     true,
-  				ForceNew:     true,
-  				ValidateFunc: validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z]+$`), "must contain only alphanumeric characters"),
-  			},
-  			names.AttrLoggingConfiguration: {
-  				Type:     schema.TypeList,
-  				Optional: true,
-  				MaxItems: 1,
-  				Elem: &schema.Resource{
-  					Schema: map[string]*schema.Schema{
-  						"log_destination": {
-  							Type:     schema.TypeString,
-  							Required: true,
-  						},
-  						"redacted_fields": {
-  							Type:     schema.TypeList,
-  							Optional: true,
-  							MaxItems: 1,
-  							Elem: &schema.Resource{
-  								Schema: map[string]*schema.Schema{
-  									"field_to_match": {
-  										Type:     schema.TypeSet,
-  										Required: true,
-  										Elem: &schema.Resource{
-  											Schema: map[string]*schema.Schema{
-  												"data": {
-  													Type:     schema.TypeString,
-  													Optional: true,
-  												},
-  												names.AttrType: {
-  													Type:     schema.TypeString,
-  													Required: true,
-  												},
-  											},
-  										},
-  									},
-  								},
-  							},
-  						},
-  					},
-  				},
-  			},
-  			"rules": {
-  				Type:     schema.TypeSet,
-  				Optional: true,
-  				Elem: &schema.Resource{
-  					Schema: map[string]*schema.Schema{
-  						names.AttrAction: {
-  							Type:     schema.TypeList,
-  							Optional: true,
-  							MaxItems: 1,
-  							Elem: &schema.Resource{
-  								Schema: map[string]*schema.Schema{
-  									names.AttrType: {
-  										Type:     schema.TypeString,
-  										Required: true,
-  									},
-  								},
-  							},
-  						},
-  						"override_action": {
-  							Type:     schema.TypeList,
-  							Optional: true,
-  							MaxItems: 1,
-  							Elem: &schema.Resource{
-  								Schema: map[string]*schema.Schema{
-  									names.AttrType: {
-  										Type:     schema.TypeString,
-  										Required: true,
-  									},
-  								},
-  							},
-  						},
-  						names.AttrPriority: {
-  							Type:     schema.TypeInt,
-  							Required: true,
-  						},
-  						names.AttrType: {
-  							Type:             schema.TypeString,
-  							Optional:         true,
-  							Default:          awstypes.WafRuleTypeRegular,
-  							ValidateDiagFunc: enum.Validate[awstypes.WafRuleType](),
-  						},
-  						"rule_id": {
-  							Type:     schema.TypeString,
-  							Required: true,
-  						},
-  					},
-  				},
-  			},
-  			names.AttrTags:    tftags.TagsSchema(),
-  			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-  		}
-  },
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				names.AttrDefaultAction: {
+					Type:     schema.TypeList,
+					Required: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrType: {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+						},
+					},
+				},
+				names.AttrMetricName: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z]+$`), "must contain only alphanumeric characters"),
+				},
+				names.AttrLoggingConfiguration: {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"log_destination": {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+							"redacted_fields": {
+								Type:     schema.TypeList,
+								Optional: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"field_to_match": {
+											Type:     schema.TypeSet,
+											Required: true,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"data": {
+														Type:     schema.TypeString,
+														Optional: true,
+													},
+													names.AttrType: {
+														Type:     schema.TypeString,
+														Required: true,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				"rules": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrAction: {
+								Type:     schema.TypeList,
+								Optional: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										names.AttrType: {
+											Type:     schema.TypeString,
+											Required: true,
+										},
+									},
+								},
+							},
+							"override_action": {
+								Type:     schema.TypeList,
+								Optional: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										names.AttrType: {
+											Type:     schema.TypeString,
+											Required: true,
+										},
+									},
+								},
+							},
+							names.AttrPriority: {
+								Type:     schema.TypeInt,
+								Required: true,
+							},
+							names.AttrType: {
+								Type:             schema.TypeString,
+								Optional:         true,
+								Default:          awstypes.WafRuleTypeRegular,
+								ValidateDiagFunc: enum.Validate[awstypes.WafRuleType](),
+							},
+							"rule_id": {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+						},
+					},
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			}
+		},
 	}
 }
 

--- a/internal/service/waf/web_acl.go
+++ b/internal/service/waf/web_acl.go
@@ -40,124 +40,126 @@ func resourceWebACL() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			names.AttrDefaultAction: {
-				Type:     schema.TypeList,
-				Required: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrType: {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-					},
-				},
-			},
-			names.AttrMetricName: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z]+$`), "must contain only alphanumeric characters"),
-			},
-			names.AttrLoggingConfiguration: {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"log_destination": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"redacted_fields": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"field_to_match": {
-										Type:     schema.TypeSet,
-										Required: true,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"data": {
-													Type:     schema.TypeString,
-													Optional: true,
-												},
-												names.AttrType: {
-													Type:     schema.TypeString,
-													Required: true,
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			"rules": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrAction: {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									names.AttrType: {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-								},
-							},
-						},
-						"override_action": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									names.AttrType: {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-								},
-							},
-						},
-						names.AttrPriority: {
-							Type:     schema.TypeInt,
-							Required: true,
-						},
-						names.AttrType: {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Default:          awstypes.WafRuleTypeRegular,
-							ValidateDiagFunc: enum.Validate[awstypes.WafRuleType](),
-						},
-						"rule_id": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-					},
-				},
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-		},
+		SchemaFunc: func() map[string]*schema.Schema {
+  	return map[string]*schema.Schema{
+  			names.AttrARN: {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			names.AttrName: {
+  				Type:     schema.TypeString,
+  				Required: true,
+  				ForceNew: true,
+  			},
+  			names.AttrDefaultAction: {
+  				Type:     schema.TypeList,
+  				Required: true,
+  				MaxItems: 1,
+  				Elem: &schema.Resource{
+  					Schema: map[string]*schema.Schema{
+  						names.AttrType: {
+  							Type:     schema.TypeString,
+  							Required: true,
+  						},
+  					},
+  				},
+  			},
+  			names.AttrMetricName: {
+  				Type:         schema.TypeString,
+  				Required:     true,
+  				ForceNew:     true,
+  				ValidateFunc: validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z]+$`), "must contain only alphanumeric characters"),
+  			},
+  			names.AttrLoggingConfiguration: {
+  				Type:     schema.TypeList,
+  				Optional: true,
+  				MaxItems: 1,
+  				Elem: &schema.Resource{
+  					Schema: map[string]*schema.Schema{
+  						"log_destination": {
+  							Type:     schema.TypeString,
+  							Required: true,
+  						},
+  						"redacted_fields": {
+  							Type:     schema.TypeList,
+  							Optional: true,
+  							MaxItems: 1,
+  							Elem: &schema.Resource{
+  								Schema: map[string]*schema.Schema{
+  									"field_to_match": {
+  										Type:     schema.TypeSet,
+  										Required: true,
+  										Elem: &schema.Resource{
+  											Schema: map[string]*schema.Schema{
+  												"data": {
+  													Type:     schema.TypeString,
+  													Optional: true,
+  												},
+  												names.AttrType: {
+  													Type:     schema.TypeString,
+  													Required: true,
+  												},
+  											},
+  										},
+  									},
+  								},
+  							},
+  						},
+  					},
+  				},
+  			},
+  			"rules": {
+  				Type:     schema.TypeSet,
+  				Optional: true,
+  				Elem: &schema.Resource{
+  					Schema: map[string]*schema.Schema{
+  						names.AttrAction: {
+  							Type:     schema.TypeList,
+  							Optional: true,
+  							MaxItems: 1,
+  							Elem: &schema.Resource{
+  								Schema: map[string]*schema.Schema{
+  									names.AttrType: {
+  										Type:     schema.TypeString,
+  										Required: true,
+  									},
+  								},
+  							},
+  						},
+  						"override_action": {
+  							Type:     schema.TypeList,
+  							Optional: true,
+  							MaxItems: 1,
+  							Elem: &schema.Resource{
+  								Schema: map[string]*schema.Schema{
+  									names.AttrType: {
+  										Type:     schema.TypeString,
+  										Required: true,
+  									},
+  								},
+  							},
+  						},
+  						names.AttrPriority: {
+  							Type:     schema.TypeInt,
+  							Required: true,
+  						},
+  						names.AttrType: {
+  							Type:             schema.TypeString,
+  							Optional:         true,
+  							Default:          awstypes.WafRuleTypeRegular,
+  							ValidateDiagFunc: enum.Validate[awstypes.WafRuleType](),
+  						},
+  						"rule_id": {
+  							Type:     schema.TypeString,
+  							Required: true,
+  						},
+  					},
+  				},
+  			},
+  			names.AttrTags:    tftags.TagsSchema(),
+  			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+  		}
+  },
 	}
 }
 

--- a/internal/service/waf/web_acl_data_source.go
+++ b/internal/service/waf/web_acl_data_source.go
@@ -25,12 +25,14 @@ func dataSourceWebACL() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceWebACLRead,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-		},
+		SchemaFunc: func() map[string]*schema.Schema {
+  	return map[string]*schema.Schema{
+  			names.AttrName: {
+  				Type:     schema.TypeString,
+  				Required: true,
+  			},
+  		}
+  },
 	}
 }
 

--- a/internal/service/waf/web_acl_data_source.go
+++ b/internal/service/waf/web_acl_data_source.go
@@ -26,13 +26,13 @@ func dataSourceWebACL() *schema.Resource {
 		ReadWithoutTimeout: dataSourceWebACLRead,
 
 		SchemaFunc: func() map[string]*schema.Schema {
-  	return map[string]*schema.Schema{
-  			names.AttrName: {
-  				Type:     schema.TypeString,
-  				Required: true,
-  			},
-  		}
-  },
+			return map[string]*schema.Schema{
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+			}
+		},
 	}
 }
 

--- a/internal/service/waf/xss_match_set.go
+++ b/internal/service/waf/xss_match_set.go
@@ -38,49 +38,49 @@ func resourceXSSMatchSet() *schema.Resource {
 		},
 
 		SchemaFunc: func() map[string]*schema.Schema {
-  	return map[string]*schema.Schema{
-  			names.AttrARN: {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			names.AttrName: {
-  				Type:     schema.TypeString,
-  				Required: true,
-  				ForceNew: true,
-  			},
-  			"xss_match_tuples": {
-  				Type:     schema.TypeSet,
-  				Optional: true,
-  				Elem: &schema.Resource{
-  					Schema: map[string]*schema.Schema{
-  						"field_to_match": {
-  							Type:     schema.TypeList,
-  							Required: true,
-  							MaxItems: 1,
-  							Elem: &schema.Resource{
-  								Schema: map[string]*schema.Schema{
-  									"data": {
-  										Type:     schema.TypeString,
-  										Optional: true,
-  									},
-  									names.AttrType: {
-  										Type:             schema.TypeString,
-  										Required:         true,
-  										ValidateDiagFunc: enum.Validate[awstypes.MatchFieldType](),
-  									},
-  								},
-  							},
-  						},
-  						"text_transformation": {
-  							Type:             schema.TypeString,
-  							Required:         true,
-  							ValidateDiagFunc: enum.Validate[awstypes.TextTransformation](),
-  						},
-  					},
-  				},
-  			},
-  		}
-  },
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"xss_match_tuples": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"field_to_match": {
+								Type:     schema.TypeList,
+								Required: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"data": {
+											Type:     schema.TypeString,
+											Optional: true,
+										},
+										names.AttrType: {
+											Type:             schema.TypeString,
+											Required:         true,
+											ValidateDiagFunc: enum.Validate[awstypes.MatchFieldType](),
+										},
+									},
+								},
+							},
+							"text_transformation": {
+								Type:             schema.TypeString,
+								Required:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.TextTransformation](),
+							},
+						},
+					},
+				},
+			}
+		},
 	}
 }
 

--- a/internal/service/waf/xss_match_set.go
+++ b/internal/service/waf/xss_match_set.go
@@ -37,48 +37,50 @@ func resourceXSSMatchSet() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"xss_match_tuples": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"field_to_match": {
-							Type:     schema.TypeList,
-							Required: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"data": {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
-									names.AttrType: {
-										Type:             schema.TypeString,
-										Required:         true,
-										ValidateDiagFunc: enum.Validate[awstypes.MatchFieldType](),
-									},
-								},
-							},
-						},
-						"text_transformation": {
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.TextTransformation](),
-						},
-					},
-				},
-			},
-		},
+		SchemaFunc: func() map[string]*schema.Schema {
+  	return map[string]*schema.Schema{
+  			names.AttrARN: {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			names.AttrName: {
+  				Type:     schema.TypeString,
+  				Required: true,
+  				ForceNew: true,
+  			},
+  			"xss_match_tuples": {
+  				Type:     schema.TypeSet,
+  				Optional: true,
+  				Elem: &schema.Resource{
+  					Schema: map[string]*schema.Schema{
+  						"field_to_match": {
+  							Type:     schema.TypeList,
+  							Required: true,
+  							MaxItems: 1,
+  							Elem: &schema.Resource{
+  								Schema: map[string]*schema.Schema{
+  									"data": {
+  										Type:     schema.TypeString,
+  										Optional: true,
+  									},
+  									names.AttrType: {
+  										Type:             schema.TypeString,
+  										Required:         true,
+  										ValidateDiagFunc: enum.Validate[awstypes.MatchFieldType](),
+  									},
+  								},
+  							},
+  						},
+  						"text_transformation": {
+  							Type:             schema.TypeString,
+  							Required:         true,
+  							ValidateDiagFunc: enum.Validate[awstypes.TextTransformation](),
+  						},
+  					},
+  				},
+  			},
+  		}
+  },
 	}
 }
 

--- a/internal/service/wafregional/byte_match_set.go
+++ b/internal/service/wafregional/byte_match_set.go
@@ -36,50 +36,52 @@ func resourceByteMatchSet() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"byte_match_tuples": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"field_to_match": {
-							Type:     schema.TypeList,
-							Required: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"data": {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
-									names.AttrType: {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-								},
-							},
-						},
-						"positional_constraint": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"target_string": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"text_transformation": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-					},
-				},
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-		},
+		SchemaFunc: func() map[string]*schema.Schema {
+  	return map[string]*schema.Schema{
+  			"byte_match_tuples": {
+  				Type:     schema.TypeSet,
+  				Optional: true,
+  				Elem: &schema.Resource{
+  					Schema: map[string]*schema.Schema{
+  						"field_to_match": {
+  							Type:     schema.TypeList,
+  							Required: true,
+  							MaxItems: 1,
+  							Elem: &schema.Resource{
+  								Schema: map[string]*schema.Schema{
+  									"data": {
+  										Type:     schema.TypeString,
+  										Optional: true,
+  									},
+  									names.AttrType: {
+  										Type:     schema.TypeString,
+  										Required: true,
+  									},
+  								},
+  							},
+  						},
+  						"positional_constraint": {
+  							Type:     schema.TypeString,
+  							Required: true,
+  						},
+  						"target_string": {
+  							Type:     schema.TypeString,
+  							Optional: true,
+  						},
+  						"text_transformation": {
+  							Type:     schema.TypeString,
+  							Required: true,
+  						},
+  					},
+  				},
+  			},
+  			names.AttrName: {
+  				Type:     schema.TypeString,
+  				Required: true,
+  				ForceNew: true,
+  			},
+  		}
+  },
 	}
 }
 

--- a/internal/service/wafregional/byte_match_set.go
+++ b/internal/service/wafregional/byte_match_set.go
@@ -37,51 +37,51 @@ func resourceByteMatchSet() *schema.Resource {
 		},
 
 		SchemaFunc: func() map[string]*schema.Schema {
-  	return map[string]*schema.Schema{
-  			"byte_match_tuples": {
-  				Type:     schema.TypeSet,
-  				Optional: true,
-  				Elem: &schema.Resource{
-  					Schema: map[string]*schema.Schema{
-  						"field_to_match": {
-  							Type:     schema.TypeList,
-  							Required: true,
-  							MaxItems: 1,
-  							Elem: &schema.Resource{
-  								Schema: map[string]*schema.Schema{
-  									"data": {
-  										Type:     schema.TypeString,
-  										Optional: true,
-  									},
-  									names.AttrType: {
-  										Type:     schema.TypeString,
-  										Required: true,
-  									},
-  								},
-  							},
-  						},
-  						"positional_constraint": {
-  							Type:     schema.TypeString,
-  							Required: true,
-  						},
-  						"target_string": {
-  							Type:     schema.TypeString,
-  							Optional: true,
-  						},
-  						"text_transformation": {
-  							Type:     schema.TypeString,
-  							Required: true,
-  						},
-  					},
-  				},
-  			},
-  			names.AttrName: {
-  				Type:     schema.TypeString,
-  				Required: true,
-  				ForceNew: true,
-  			},
-  		}
-  },
+			return map[string]*schema.Schema{
+				"byte_match_tuples": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"field_to_match": {
+								Type:     schema.TypeList,
+								Required: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"data": {
+											Type:     schema.TypeString,
+											Optional: true,
+										},
+										names.AttrType: {
+											Type:     schema.TypeString,
+											Required: true,
+										},
+									},
+								},
+							},
+							"positional_constraint": {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+							"target_string": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+							"text_transformation": {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+						},
+					},
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+			}
+		},
 	}
 }
 

--- a/internal/service/wafregional/geo_match_set.go
+++ b/internal/service/wafregional/geo_match_set.go
@@ -36,29 +36,31 @@ func resourceGeoMatchSet() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"geo_match_constraint": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrType: {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						names.AttrValue: {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-					},
-				},
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-		},
+		SchemaFunc: func() map[string]*schema.Schema {
+  	return map[string]*schema.Schema{
+  			"geo_match_constraint": {
+  				Type:     schema.TypeSet,
+  				Optional: true,
+  				Elem: &schema.Resource{
+  					Schema: map[string]*schema.Schema{
+  						names.AttrType: {
+  							Type:     schema.TypeString,
+  							Required: true,
+  						},
+  						names.AttrValue: {
+  							Type:     schema.TypeString,
+  							Required: true,
+  						},
+  					},
+  				},
+  			},
+  			names.AttrName: {
+  				Type:     schema.TypeString,
+  				Required: true,
+  				ForceNew: true,
+  			},
+  		}
+  },
 	}
 }
 

--- a/internal/service/wafregional/geo_match_set.go
+++ b/internal/service/wafregional/geo_match_set.go
@@ -37,30 +37,30 @@ func resourceGeoMatchSet() *schema.Resource {
 		},
 
 		SchemaFunc: func() map[string]*schema.Schema {
-  	return map[string]*schema.Schema{
-  			"geo_match_constraint": {
-  				Type:     schema.TypeSet,
-  				Optional: true,
-  				Elem: &schema.Resource{
-  					Schema: map[string]*schema.Schema{
-  						names.AttrType: {
-  							Type:     schema.TypeString,
-  							Required: true,
-  						},
-  						names.AttrValue: {
-  							Type:     schema.TypeString,
-  							Required: true,
-  						},
-  					},
-  				},
-  			},
-  			names.AttrName: {
-  				Type:     schema.TypeString,
-  				Required: true,
-  				ForceNew: true,
-  			},
-  		}
-  },
+			return map[string]*schema.Schema{
+				"geo_match_constraint": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrType: {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+							names.AttrValue: {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+						},
+					},
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+			}
+		},
 	}
 }
 

--- a/internal/service/wafregional/ipset.go
+++ b/internal/service/wafregional/ipset.go
@@ -38,34 +38,34 @@ func resourceIPSet() *schema.Resource {
 		},
 
 		SchemaFunc: func() map[string]*schema.Schema {
-  	return map[string]*schema.Schema{
-  			names.AttrARN: {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			"ip_set_descriptor": {
-  				Type:     schema.TypeSet,
-  				Optional: true,
-  				Elem: &schema.Resource{
-  					Schema: map[string]*schema.Schema{
-  						names.AttrType: {
-  							Type:     schema.TypeString,
-  							Required: true,
-  						},
-  						names.AttrValue: {
-  							Type:     schema.TypeString,
-  							Required: true,
-  						},
-  					},
-  				},
-  			},
-  			names.AttrName: {
-  				Type:     schema.TypeString,
-  				Required: true,
-  				ForceNew: true,
-  			},
-  		}
-  },
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"ip_set_descriptor": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrType: {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+							names.AttrValue: {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+						},
+					},
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+			}
+		},
 	}
 }
 

--- a/internal/service/wafregional/ipset.go
+++ b/internal/service/wafregional/ipset.go
@@ -37,33 +37,35 @@ func resourceIPSet() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"ip_set_descriptor": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrType: {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						names.AttrValue: {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-					},
-				},
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-		},
+		SchemaFunc: func() map[string]*schema.Schema {
+  	return map[string]*schema.Schema{
+  			names.AttrARN: {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			"ip_set_descriptor": {
+  				Type:     schema.TypeSet,
+  				Optional: true,
+  				Elem: &schema.Resource{
+  					Schema: map[string]*schema.Schema{
+  						names.AttrType: {
+  							Type:     schema.TypeString,
+  							Required: true,
+  						},
+  						names.AttrValue: {
+  							Type:     schema.TypeString,
+  							Required: true,
+  						},
+  					},
+  				},
+  			},
+  			names.AttrName: {
+  				Type:     schema.TypeString,
+  				Required: true,
+  				ForceNew: true,
+  			},
+  		}
+  },
 	}
 }
 

--- a/internal/service/wafregional/ipset_data_source.go
+++ b/internal/service/wafregional/ipset_data_source.go
@@ -25,12 +25,14 @@ func dataSourceIPSet() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceIPSetRead,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-		},
+		SchemaFunc: func() map[string]*schema.Schema {
+  	return map[string]*schema.Schema{
+  			names.AttrName: {
+  				Type:     schema.TypeString,
+  				Required: true,
+  			},
+  		}
+  },
 	}
 }
 

--- a/internal/service/wafregional/ipset_data_source.go
+++ b/internal/service/wafregional/ipset_data_source.go
@@ -26,13 +26,13 @@ func dataSourceIPSet() *schema.Resource {
 		ReadWithoutTimeout: dataSourceIPSetRead,
 
 		SchemaFunc: func() map[string]*schema.Schema {
-  	return map[string]*schema.Schema{
-  			names.AttrName: {
-  				Type:     schema.TypeString,
-  				Required: true,
-  			},
-  		}
-  },
+			return map[string]*schema.Schema{
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+			}
+		},
 	}
 }
 

--- a/internal/service/wafregional/rate_based_rule.go
+++ b/internal/service/wafregional/rate_based_rule.go
@@ -40,56 +40,58 @@ func resourceRateBasedRule() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrMetricName: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validMetricName,
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"predicate": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"data_id": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validation.StringLenBetween(0, 128),
-						},
-						"negated": {
-							Type:     schema.TypeBool,
-							Required: true,
-						},
-						names.AttrType: {
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.PredicateType](),
-						},
-					},
-				},
-			},
-			"rate_key": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"rate_limit": {
-				Type:         schema.TypeInt,
-				Required:     true,
-				ValidateFunc: validation.IntAtLeast(100),
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-		},
+		SchemaFunc: func() map[string]*schema.Schema {
+  	return map[string]*schema.Schema{
+  			names.AttrARN: {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			names.AttrMetricName: {
+  				Type:         schema.TypeString,
+  				Required:     true,
+  				ForceNew:     true,
+  				ValidateFunc: validMetricName,
+  			},
+  			names.AttrName: {
+  				Type:     schema.TypeString,
+  				Required: true,
+  				ForceNew: true,
+  			},
+  			"predicate": {
+  				Type:     schema.TypeSet,
+  				Optional: true,
+  				Elem: &schema.Resource{
+  					Schema: map[string]*schema.Schema{
+  						"data_id": {
+  							Type:         schema.TypeString,
+  							Required:     true,
+  							ValidateFunc: validation.StringLenBetween(0, 128),
+  						},
+  						"negated": {
+  							Type:     schema.TypeBool,
+  							Required: true,
+  						},
+  						names.AttrType: {
+  							Type:             schema.TypeString,
+  							Required:         true,
+  							ValidateDiagFunc: enum.Validate[awstypes.PredicateType](),
+  						},
+  					},
+  				},
+  			},
+  			"rate_key": {
+  				Type:     schema.TypeString,
+  				Required: true,
+  			},
+  			"rate_limit": {
+  				Type:         schema.TypeInt,
+  				Required:     true,
+  				ValidateFunc: validation.IntAtLeast(100),
+  			},
+  			names.AttrTags:    tftags.TagsSchema(),
+  			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+  		}
+  },
 	}
 }
 

--- a/internal/service/wafregional/rate_based_rule.go
+++ b/internal/service/wafregional/rate_based_rule.go
@@ -41,57 +41,57 @@ func resourceRateBasedRule() *schema.Resource {
 		},
 
 		SchemaFunc: func() map[string]*schema.Schema {
-  	return map[string]*schema.Schema{
-  			names.AttrARN: {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			names.AttrMetricName: {
-  				Type:         schema.TypeString,
-  				Required:     true,
-  				ForceNew:     true,
-  				ValidateFunc: validMetricName,
-  			},
-  			names.AttrName: {
-  				Type:     schema.TypeString,
-  				Required: true,
-  				ForceNew: true,
-  			},
-  			"predicate": {
-  				Type:     schema.TypeSet,
-  				Optional: true,
-  				Elem: &schema.Resource{
-  					Schema: map[string]*schema.Schema{
-  						"data_id": {
-  							Type:         schema.TypeString,
-  							Required:     true,
-  							ValidateFunc: validation.StringLenBetween(0, 128),
-  						},
-  						"negated": {
-  							Type:     schema.TypeBool,
-  							Required: true,
-  						},
-  						names.AttrType: {
-  							Type:             schema.TypeString,
-  							Required:         true,
-  							ValidateDiagFunc: enum.Validate[awstypes.PredicateType](),
-  						},
-  					},
-  				},
-  			},
-  			"rate_key": {
-  				Type:     schema.TypeString,
-  				Required: true,
-  			},
-  			"rate_limit": {
-  				Type:         schema.TypeInt,
-  				Required:     true,
-  				ValidateFunc: validation.IntAtLeast(100),
-  			},
-  			names.AttrTags:    tftags.TagsSchema(),
-  			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-  		}
-  },
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrMetricName: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validMetricName,
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"predicate": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"data_id": {
+								Type:         schema.TypeString,
+								Required:     true,
+								ValidateFunc: validation.StringLenBetween(0, 128),
+							},
+							"negated": {
+								Type:     schema.TypeBool,
+								Required: true,
+							},
+							names.AttrType: {
+								Type:             schema.TypeString,
+								Required:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.PredicateType](),
+							},
+						},
+					},
+				},
+				"rate_key": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"rate_limit": {
+					Type:         schema.TypeInt,
+					Required:     true,
+					ValidateFunc: validation.IntAtLeast(100),
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			}
+		},
 	}
 }
 

--- a/internal/service/wafregional/rate_based_rule_data_source.go
+++ b/internal/service/wafregional/rate_based_rule_data_source.go
@@ -26,13 +26,13 @@ func dataSourceRateBasedRule() *schema.Resource {
 		ReadWithoutTimeout: dataSourceRateBasedRuleRead,
 
 		SchemaFunc: func() map[string]*schema.Schema {
-  	return map[string]*schema.Schema{
-  			names.AttrName: {
-  				Type:     schema.TypeString,
-  				Required: true,
-  			},
-  		}
-  },
+			return map[string]*schema.Schema{
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+			}
+		},
 	}
 }
 

--- a/internal/service/wafregional/rate_based_rule_data_source.go
+++ b/internal/service/wafregional/rate_based_rule_data_source.go
@@ -25,12 +25,14 @@ func dataSourceRateBasedRule() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceRateBasedRuleRead,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-		},
+		SchemaFunc: func() map[string]*schema.Schema {
+  	return map[string]*schema.Schema{
+  			names.AttrName: {
+  				Type:     schema.TypeString,
+  				Required: true,
+  			},
+  		}
+  },
 	}
 }
 

--- a/internal/service/wafregional/regex_match_set.go
+++ b/internal/service/wafregional/regex_match_set.go
@@ -40,51 +40,51 @@ func resourceRegexMatchSet() *schema.Resource {
 		},
 
 		SchemaFunc: func() map[string]*schema.Schema {
-  	return map[string]*schema.Schema{
-  			names.AttrName: {
-  				Type:     schema.TypeString,
-  				Required: true,
-  				ForceNew: true,
-  			},
-  			"regex_match_tuple": {
-  				Type:     schema.TypeSet,
-  				Optional: true,
-  				Set:      regexMatchSetTupleHash,
-  				Elem: &schema.Resource{
-  					Schema: map[string]*schema.Schema{
-  						"field_to_match": {
-  							Type:     schema.TypeList,
-  							Required: true,
-  							MaxItems: 1,
-  							Elem: &schema.Resource{
-  								Schema: map[string]*schema.Schema{
-  									"data": {
-  										Type:     schema.TypeString,
-  										Optional: true,
-  										StateFunc: func(v any) string {
-  											return strings.ToLower(v.(string))
-  										},
-  									},
-  									names.AttrType: {
-  										Type:     schema.TypeString,
-  										Required: true,
-  									},
-  								},
-  							},
-  						},
-  						"regex_pattern_set_id": {
-  							Type:     schema.TypeString,
-  							Required: true,
-  						},
-  						"text_transformation": {
-  							Type:     schema.TypeString,
-  							Required: true,
-  						},
-  					},
-  				},
-  			},
-  		}
-  },
+			return map[string]*schema.Schema{
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"regex_match_tuple": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Set:      regexMatchSetTupleHash,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"field_to_match": {
+								Type:     schema.TypeList,
+								Required: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"data": {
+											Type:     schema.TypeString,
+											Optional: true,
+											StateFunc: func(v any) string {
+												return strings.ToLower(v.(string))
+											},
+										},
+										names.AttrType: {
+											Type:     schema.TypeString,
+											Required: true,
+										},
+									},
+								},
+							},
+							"regex_pattern_set_id": {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+							"text_transformation": {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+						},
+					},
+				},
+			}
+		},
 	}
 }
 

--- a/internal/service/wafregional/regex_match_set.go
+++ b/internal/service/wafregional/regex_match_set.go
@@ -39,50 +39,52 @@ func resourceRegexMatchSet() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"regex_match_tuple": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Set:      regexMatchSetTupleHash,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"field_to_match": {
-							Type:     schema.TypeList,
-							Required: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"data": {
-										Type:     schema.TypeString,
-										Optional: true,
-										StateFunc: func(v any) string {
-											return strings.ToLower(v.(string))
-										},
-									},
-									names.AttrType: {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-								},
-							},
-						},
-						"regex_pattern_set_id": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"text_transformation": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-					},
-				},
-			},
-		},
+		SchemaFunc: func() map[string]*schema.Schema {
+  	return map[string]*schema.Schema{
+  			names.AttrName: {
+  				Type:     schema.TypeString,
+  				Required: true,
+  				ForceNew: true,
+  			},
+  			"regex_match_tuple": {
+  				Type:     schema.TypeSet,
+  				Optional: true,
+  				Set:      regexMatchSetTupleHash,
+  				Elem: &schema.Resource{
+  					Schema: map[string]*schema.Schema{
+  						"field_to_match": {
+  							Type:     schema.TypeList,
+  							Required: true,
+  							MaxItems: 1,
+  							Elem: &schema.Resource{
+  								Schema: map[string]*schema.Schema{
+  									"data": {
+  										Type:     schema.TypeString,
+  										Optional: true,
+  										StateFunc: func(v any) string {
+  											return strings.ToLower(v.(string))
+  										},
+  									},
+  									names.AttrType: {
+  										Type:     schema.TypeString,
+  										Required: true,
+  									},
+  								},
+  							},
+  						},
+  						"regex_pattern_set_id": {
+  							Type:     schema.TypeString,
+  							Required: true,
+  						},
+  						"text_transformation": {
+  							Type:     schema.TypeString,
+  							Required: true,
+  						},
+  					},
+  				},
+  			},
+  		}
+  },
 	}
 }
 

--- a/internal/service/wafregional/regex_pattern_set.go
+++ b/internal/service/wafregional/regex_pattern_set.go
@@ -37,18 +37,20 @@ func resourceRegexPatternSet() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"regex_pattern_strings": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-		},
+		SchemaFunc: func() map[string]*schema.Schema {
+  	return map[string]*schema.Schema{
+  			names.AttrName: {
+  				Type:     schema.TypeString,
+  				Required: true,
+  				ForceNew: true,
+  			},
+  			"regex_pattern_strings": {
+  				Type:     schema.TypeSet,
+  				Optional: true,
+  				Elem:     &schema.Schema{Type: schema.TypeString},
+  			},
+  		}
+  },
 	}
 }
 

--- a/internal/service/wafregional/regex_pattern_set.go
+++ b/internal/service/wafregional/regex_pattern_set.go
@@ -38,19 +38,19 @@ func resourceRegexPatternSet() *schema.Resource {
 		},
 
 		SchemaFunc: func() map[string]*schema.Schema {
-  	return map[string]*schema.Schema{
-  			names.AttrName: {
-  				Type:     schema.TypeString,
-  				Required: true,
-  				ForceNew: true,
-  			},
-  			"regex_pattern_strings": {
-  				Type:     schema.TypeSet,
-  				Optional: true,
-  				Elem:     &schema.Schema{Type: schema.TypeString},
-  			},
-  		}
-  },
+			return map[string]*schema.Schema{
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"regex_pattern_strings": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+			}
+		},
 	}
 }
 

--- a/internal/service/wafregional/rule.go
+++ b/internal/service/wafregional/rule.go
@@ -42,47 +42,47 @@ func resourceRule() *schema.Resource {
 		},
 
 		SchemaFunc: func() map[string]*schema.Schema {
-  	return map[string]*schema.Schema{
-  			names.AttrARN: {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			names.AttrMetricName: {
-  				Type:     schema.TypeString,
-  				Required: true,
-  				ForceNew: true,
-  			},
-  			names.AttrName: {
-  				Type:     schema.TypeString,
-  				Required: true,
-  				ForceNew: true,
-  			},
-  			"predicate": {
-  				Type:     schema.TypeSet,
-  				Optional: true,
-  				Elem: &schema.Resource{
-  					Schema: map[string]*schema.Schema{
-  						"data_id": {
-  							Type:         schema.TypeString,
-  							Required:     true,
-  							ValidateFunc: validation.StringLenBetween(1, 128),
-  						},
-  						"negated": {
-  							Type:     schema.TypeBool,
-  							Required: true,
-  						},
-  						names.AttrType: {
-  							Type:             schema.TypeString,
-  							Required:         true,
-  							ValidateDiagFunc: enum.Validate[awstypes.PredicateType](),
-  						},
-  					},
-  				},
-  			},
-  			names.AttrTags:    tftags.TagsSchema(),
-  			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-  		}
-  },
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrMetricName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"predicate": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"data_id": {
+								Type:         schema.TypeString,
+								Required:     true,
+								ValidateFunc: validation.StringLenBetween(1, 128),
+							},
+							"negated": {
+								Type:     schema.TypeBool,
+								Required: true,
+							},
+							names.AttrType: {
+								Type:             schema.TypeString,
+								Required:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.PredicateType](),
+							},
+						},
+					},
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			}
+		},
 	}
 }
 

--- a/internal/service/wafregional/rule.go
+++ b/internal/service/wafregional/rule.go
@@ -41,46 +41,48 @@ func resourceRule() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrMetricName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"predicate": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"data_id": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validation.StringLenBetween(1, 128),
-						},
-						"negated": {
-							Type:     schema.TypeBool,
-							Required: true,
-						},
-						names.AttrType: {
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.PredicateType](),
-						},
-					},
-				},
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-		},
+		SchemaFunc: func() map[string]*schema.Schema {
+  	return map[string]*schema.Schema{
+  			names.AttrARN: {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			names.AttrMetricName: {
+  				Type:     schema.TypeString,
+  				Required: true,
+  				ForceNew: true,
+  			},
+  			names.AttrName: {
+  				Type:     schema.TypeString,
+  				Required: true,
+  				ForceNew: true,
+  			},
+  			"predicate": {
+  				Type:     schema.TypeSet,
+  				Optional: true,
+  				Elem: &schema.Resource{
+  					Schema: map[string]*schema.Schema{
+  						"data_id": {
+  							Type:         schema.TypeString,
+  							Required:     true,
+  							ValidateFunc: validation.StringLenBetween(1, 128),
+  						},
+  						"negated": {
+  							Type:     schema.TypeBool,
+  							Required: true,
+  						},
+  						names.AttrType: {
+  							Type:             schema.TypeString,
+  							Required:         true,
+  							ValidateDiagFunc: enum.Validate[awstypes.PredicateType](),
+  						},
+  					},
+  				},
+  			},
+  			names.AttrTags:    tftags.TagsSchema(),
+  			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+  		}
+  },
 	}
 }
 

--- a/internal/service/wafregional/rule_data_source.go
+++ b/internal/service/wafregional/rule_data_source.go
@@ -26,13 +26,13 @@ func dataSourceRule() *schema.Resource {
 		ReadWithoutTimeout: dataSourceRuleRead,
 
 		SchemaFunc: func() map[string]*schema.Schema {
-  	return map[string]*schema.Schema{
-  			names.AttrName: {
-  				Type:     schema.TypeString,
-  				Required: true,
-  			},
-  		}
-  },
+			return map[string]*schema.Schema{
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+			}
+		},
 	}
 }
 

--- a/internal/service/wafregional/rule_data_source.go
+++ b/internal/service/wafregional/rule_data_source.go
@@ -25,12 +25,14 @@ func dataSourceRule() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceRuleRead,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-		},
+		SchemaFunc: func() map[string]*schema.Schema {
+  	return map[string]*schema.Schema{
+  			names.AttrName: {
+  				Type:     schema.TypeString,
+  				Required: true,
+  			},
+  		}
+  },
 	}
 }
 

--- a/internal/service/wafregional/rule_group.go
+++ b/internal/service/wafregional/rule_group.go
@@ -39,59 +39,61 @@ func resourceRuleGroup() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"activated_rule": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrAction: {
-							Type:     schema.TypeList,
-							MaxItems: 1,
-							Required: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									names.AttrType: {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-								},
-							},
-						},
-						names.AttrPriority: {
-							Type:     schema.TypeInt,
-							Required: true,
-						},
-						"rule_id": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						names.AttrType: {
-							Type:     schema.TypeString,
-							Optional: true,
-							Default:  awstypes.WafRuleTypeRegular,
-						},
-					},
-				},
-			},
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrMetricName: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validMetricName,
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-		},
+		SchemaFunc: func() map[string]*schema.Schema {
+  	return map[string]*schema.Schema{
+  			"activated_rule": {
+  				Type:     schema.TypeSet,
+  				Optional: true,
+  				Elem: &schema.Resource{
+  					Schema: map[string]*schema.Schema{
+  						names.AttrAction: {
+  							Type:     schema.TypeList,
+  							MaxItems: 1,
+  							Required: true,
+  							Elem: &schema.Resource{
+  								Schema: map[string]*schema.Schema{
+  									names.AttrType: {
+  										Type:     schema.TypeString,
+  										Required: true,
+  									},
+  								},
+  							},
+  						},
+  						names.AttrPriority: {
+  							Type:     schema.TypeInt,
+  							Required: true,
+  						},
+  						"rule_id": {
+  							Type:     schema.TypeString,
+  							Required: true,
+  						},
+  						names.AttrType: {
+  							Type:     schema.TypeString,
+  							Optional: true,
+  							Default:  awstypes.WafRuleTypeRegular,
+  						},
+  					},
+  				},
+  			},
+  			names.AttrARN: {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			names.AttrMetricName: {
+  				Type:         schema.TypeString,
+  				Required:     true,
+  				ForceNew:     true,
+  				ValidateFunc: validMetricName,
+  			},
+  			names.AttrName: {
+  				Type:     schema.TypeString,
+  				Required: true,
+  				ForceNew: true,
+  			},
+  			names.AttrTags:    tftags.TagsSchema(),
+  			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+  		}
+  },
 	}
 }
 

--- a/internal/service/wafregional/rule_group.go
+++ b/internal/service/wafregional/rule_group.go
@@ -40,60 +40,60 @@ func resourceRuleGroup() *schema.Resource {
 		},
 
 		SchemaFunc: func() map[string]*schema.Schema {
-  	return map[string]*schema.Schema{
-  			"activated_rule": {
-  				Type:     schema.TypeSet,
-  				Optional: true,
-  				Elem: &schema.Resource{
-  					Schema: map[string]*schema.Schema{
-  						names.AttrAction: {
-  							Type:     schema.TypeList,
-  							MaxItems: 1,
-  							Required: true,
-  							Elem: &schema.Resource{
-  								Schema: map[string]*schema.Schema{
-  									names.AttrType: {
-  										Type:     schema.TypeString,
-  										Required: true,
-  									},
-  								},
-  							},
-  						},
-  						names.AttrPriority: {
-  							Type:     schema.TypeInt,
-  							Required: true,
-  						},
-  						"rule_id": {
-  							Type:     schema.TypeString,
-  							Required: true,
-  						},
-  						names.AttrType: {
-  							Type:     schema.TypeString,
-  							Optional: true,
-  							Default:  awstypes.WafRuleTypeRegular,
-  						},
-  					},
-  				},
-  			},
-  			names.AttrARN: {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			names.AttrMetricName: {
-  				Type:         schema.TypeString,
-  				Required:     true,
-  				ForceNew:     true,
-  				ValidateFunc: validMetricName,
-  			},
-  			names.AttrName: {
-  				Type:     schema.TypeString,
-  				Required: true,
-  				ForceNew: true,
-  			},
-  			names.AttrTags:    tftags.TagsSchema(),
-  			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-  		}
-  },
+			return map[string]*schema.Schema{
+				"activated_rule": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrAction: {
+								Type:     schema.TypeList,
+								MaxItems: 1,
+								Required: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										names.AttrType: {
+											Type:     schema.TypeString,
+											Required: true,
+										},
+									},
+								},
+							},
+							names.AttrPriority: {
+								Type:     schema.TypeInt,
+								Required: true,
+							},
+							"rule_id": {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+							names.AttrType: {
+								Type:     schema.TypeString,
+								Optional: true,
+								Default:  awstypes.WafRuleTypeRegular,
+							},
+						},
+					},
+				},
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrMetricName: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validMetricName,
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			}
+		},
 	}
 }
 

--- a/internal/service/wafregional/size_constraint_set.go
+++ b/internal/service/wafregional/size_constraint_set.go
@@ -36,54 +36,56 @@ func resourceSizeConstraintSet() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"size_constraints": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"comparison_operator": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"field_to_match": {
-							Type:     schema.TypeList,
-							Required: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"data": {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
-									names.AttrType: {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-								},
-							},
-						},
-						names.AttrSize: {
-							Type:     schema.TypeInt,
-							Required: true,
-						},
-						"text_transformation": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-					},
-				},
-			},
-		},
+		SchemaFunc: func() map[string]*schema.Schema {
+  	return map[string]*schema.Schema{
+  			names.AttrARN: {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			names.AttrName: {
+  				Type:     schema.TypeString,
+  				Required: true,
+  				ForceNew: true,
+  			},
+  			"size_constraints": {
+  				Type:     schema.TypeSet,
+  				Optional: true,
+  				Elem: &schema.Resource{
+  					Schema: map[string]*schema.Schema{
+  						"comparison_operator": {
+  							Type:     schema.TypeString,
+  							Required: true,
+  						},
+  						"field_to_match": {
+  							Type:     schema.TypeList,
+  							Required: true,
+  							MaxItems: 1,
+  							Elem: &schema.Resource{
+  								Schema: map[string]*schema.Schema{
+  									"data": {
+  										Type:     schema.TypeString,
+  										Optional: true,
+  									},
+  									names.AttrType: {
+  										Type:     schema.TypeString,
+  										Required: true,
+  									},
+  								},
+  							},
+  						},
+  						names.AttrSize: {
+  							Type:     schema.TypeInt,
+  							Required: true,
+  						},
+  						"text_transformation": {
+  							Type:     schema.TypeString,
+  							Required: true,
+  						},
+  					},
+  				},
+  			},
+  		}
+  },
 	}
 }
 

--- a/internal/service/wafregional/size_constraint_set.go
+++ b/internal/service/wafregional/size_constraint_set.go
@@ -37,55 +37,55 @@ func resourceSizeConstraintSet() *schema.Resource {
 		},
 
 		SchemaFunc: func() map[string]*schema.Schema {
-  	return map[string]*schema.Schema{
-  			names.AttrARN: {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			names.AttrName: {
-  				Type:     schema.TypeString,
-  				Required: true,
-  				ForceNew: true,
-  			},
-  			"size_constraints": {
-  				Type:     schema.TypeSet,
-  				Optional: true,
-  				Elem: &schema.Resource{
-  					Schema: map[string]*schema.Schema{
-  						"comparison_operator": {
-  							Type:     schema.TypeString,
-  							Required: true,
-  						},
-  						"field_to_match": {
-  							Type:     schema.TypeList,
-  							Required: true,
-  							MaxItems: 1,
-  							Elem: &schema.Resource{
-  								Schema: map[string]*schema.Schema{
-  									"data": {
-  										Type:     schema.TypeString,
-  										Optional: true,
-  									},
-  									names.AttrType: {
-  										Type:     schema.TypeString,
-  										Required: true,
-  									},
-  								},
-  							},
-  						},
-  						names.AttrSize: {
-  							Type:     schema.TypeInt,
-  							Required: true,
-  						},
-  						"text_transformation": {
-  							Type:     schema.TypeString,
-  							Required: true,
-  						},
-  					},
-  				},
-  			},
-  		}
-  },
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"size_constraints": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"comparison_operator": {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+							"field_to_match": {
+								Type:     schema.TypeList,
+								Required: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"data": {
+											Type:     schema.TypeString,
+											Optional: true,
+										},
+										names.AttrType: {
+											Type:     schema.TypeString,
+											Required: true,
+										},
+									},
+								},
+							},
+							names.AttrSize: {
+								Type:     schema.TypeInt,
+								Required: true,
+							},
+							"text_transformation": {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+						},
+					},
+				},
+			}
+		},
 	}
 }
 

--- a/internal/service/wafregional/sql_injection_match_set.go
+++ b/internal/service/wafregional/sql_injection_match_set.go
@@ -40,48 +40,48 @@ func resourceSQLInjectionMatchSet() *schema.Resource {
 		},
 
 		SchemaFunc: func() map[string]*schema.Schema {
-  	return map[string]*schema.Schema{
-  			names.AttrName: {
-  				Type:     schema.TypeString,
-  				Required: true,
-  				ForceNew: true,
-  			},
-  			"sql_injection_match_tuple": {
-  				Type:     schema.TypeSet,
-  				Optional: true,
-  				Set:      resourceSQLInjectionMatchSetTupleHash,
-  				Elem: &schema.Resource{
-  					Schema: map[string]*schema.Schema{
-  						"field_to_match": {
-  							Type:     schema.TypeList,
-  							Required: true,
-  							MaxItems: 1,
-  							Elem: &schema.Resource{
-  								Schema: map[string]*schema.Schema{
-  									"data": {
-  										Type:     schema.TypeString,
-  										Optional: true,
-  										StateFunc: func(v any) string {
-  											value := v.(string)
-  											return strings.ToLower(value)
-  										},
-  									},
-  									names.AttrType: {
-  										Type:     schema.TypeString,
-  										Required: true,
-  									},
-  								},
-  							},
-  						},
-  						"text_transformation": {
-  							Type:     schema.TypeString,
-  							Required: true,
-  						},
-  					},
-  				},
-  			},
-  		}
-  },
+			return map[string]*schema.Schema{
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"sql_injection_match_tuple": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Set:      resourceSQLInjectionMatchSetTupleHash,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"field_to_match": {
+								Type:     schema.TypeList,
+								Required: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"data": {
+											Type:     schema.TypeString,
+											Optional: true,
+											StateFunc: func(v any) string {
+												value := v.(string)
+												return strings.ToLower(value)
+											},
+										},
+										names.AttrType: {
+											Type:     schema.TypeString,
+											Required: true,
+										},
+									},
+								},
+							},
+							"text_transformation": {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+						},
+					},
+				},
+			}
+		},
 	}
 }
 

--- a/internal/service/wafregional/sql_injection_match_set.go
+++ b/internal/service/wafregional/sql_injection_match_set.go
@@ -39,47 +39,49 @@ func resourceSQLInjectionMatchSet() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"sql_injection_match_tuple": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Set:      resourceSQLInjectionMatchSetTupleHash,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"field_to_match": {
-							Type:     schema.TypeList,
-							Required: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"data": {
-										Type:     schema.TypeString,
-										Optional: true,
-										StateFunc: func(v any) string {
-											value := v.(string)
-											return strings.ToLower(value)
-										},
-									},
-									names.AttrType: {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-								},
-							},
-						},
-						"text_transformation": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-					},
-				},
-			},
-		},
+		SchemaFunc: func() map[string]*schema.Schema {
+  	return map[string]*schema.Schema{
+  			names.AttrName: {
+  				Type:     schema.TypeString,
+  				Required: true,
+  				ForceNew: true,
+  			},
+  			"sql_injection_match_tuple": {
+  				Type:     schema.TypeSet,
+  				Optional: true,
+  				Set:      resourceSQLInjectionMatchSetTupleHash,
+  				Elem: &schema.Resource{
+  					Schema: map[string]*schema.Schema{
+  						"field_to_match": {
+  							Type:     schema.TypeList,
+  							Required: true,
+  							MaxItems: 1,
+  							Elem: &schema.Resource{
+  								Schema: map[string]*schema.Schema{
+  									"data": {
+  										Type:     schema.TypeString,
+  										Optional: true,
+  										StateFunc: func(v any) string {
+  											value := v.(string)
+  											return strings.ToLower(value)
+  										},
+  									},
+  									names.AttrType: {
+  										Type:     schema.TypeString,
+  										Required: true,
+  									},
+  								},
+  							},
+  						},
+  						"text_transformation": {
+  							Type:     schema.TypeString,
+  							Required: true,
+  						},
+  					},
+  				},
+  			},
+  		}
+  },
 	}
 }
 

--- a/internal/service/wafregional/subscribed_rule_group_data_source.go
+++ b/internal/service/wafregional/subscribed_rule_group_data_source.go
@@ -25,18 +25,20 @@ func dataSourceSubscribedRuleGroup() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceSubscribedRuleGroupRead,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrMetricName: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				AtLeastOneOf: []string{names.AttrName, names.AttrMetricName},
-			},
-			names.AttrName: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				AtLeastOneOf: []string{names.AttrName, names.AttrMetricName},
-			},
-		},
+		SchemaFunc: func() map[string]*schema.Schema {
+  	return map[string]*schema.Schema{
+  			names.AttrMetricName: {
+  				Type:         schema.TypeString,
+  				Optional:     true,
+  				AtLeastOneOf: []string{names.AttrName, names.AttrMetricName},
+  			},
+  			names.AttrName: {
+  				Type:         schema.TypeString,
+  				Optional:     true,
+  				AtLeastOneOf: []string{names.AttrName, names.AttrMetricName},
+  			},
+  		}
+  },
 	}
 }
 

--- a/internal/service/wafregional/subscribed_rule_group_data_source.go
+++ b/internal/service/wafregional/subscribed_rule_group_data_source.go
@@ -26,19 +26,19 @@ func dataSourceSubscribedRuleGroup() *schema.Resource {
 		ReadWithoutTimeout: dataSourceSubscribedRuleGroupRead,
 
 		SchemaFunc: func() map[string]*schema.Schema {
-  	return map[string]*schema.Schema{
-  			names.AttrMetricName: {
-  				Type:         schema.TypeString,
-  				Optional:     true,
-  				AtLeastOneOf: []string{names.AttrName, names.AttrMetricName},
-  			},
-  			names.AttrName: {
-  				Type:         schema.TypeString,
-  				Optional:     true,
-  				AtLeastOneOf: []string{names.AttrName, names.AttrMetricName},
-  			},
-  		}
-  },
+			return map[string]*schema.Schema{
+				names.AttrMetricName: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					AtLeastOneOf: []string{names.AttrName, names.AttrMetricName},
+				},
+				names.AttrName: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					AtLeastOneOf: []string{names.AttrName, names.AttrMetricName},
+				},
+			}
+		},
 	}
 }
 

--- a/internal/service/wafregional/web_acl.go
+++ b/internal/service/wafregional/web_acl.go
@@ -41,129 +41,129 @@ func resourceWebACL() *schema.Resource {
 		},
 
 		SchemaFunc: func() map[string]*schema.Schema {
-  	return map[string]*schema.Schema{
-  			names.AttrARN: {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			names.AttrDefaultAction: {
-  				Type:     schema.TypeList,
-  				Required: true,
-  				MaxItems: 1,
-  				Elem: &schema.Resource{
-  					Schema: map[string]*schema.Schema{
-  						names.AttrType: {
-  							Type:             schema.TypeString,
-  							Required:         true,
-  							ValidateDiagFunc: enum.Validate[awstypes.WafActionType](),
-  						},
-  					},
-  				},
-  			},
-  			names.AttrLoggingConfiguration: {
-  				Type:     schema.TypeList,
-  				Optional: true,
-  				MaxItems: 1,
-  				Elem: &schema.Resource{
-  					Schema: map[string]*schema.Schema{
-  						"log_destination": {
-  							Type:         schema.TypeString,
-  							Required:     true,
-  							ValidateFunc: verify.ValidARN,
-  						},
-  						"redacted_fields": {
-  							Type:     schema.TypeList,
-  							Optional: true,
-  							MaxItems: 1,
-  							Elem: &schema.Resource{
-  								Schema: map[string]*schema.Schema{
-  									"field_to_match": {
-  										Type:     schema.TypeSet,
-  										Required: true,
-  										Elem: &schema.Resource{
-  											Schema: map[string]*schema.Schema{
-  												"data": {
-  													Type:     schema.TypeString,
-  													Optional: true,
-  												},
-  												names.AttrType: {
-  													Type:             schema.TypeString,
-  													Required:         true,
-  													ValidateDiagFunc: enum.Validate[awstypes.MatchFieldType](),
-  												},
-  											},
-  										},
-  									},
-  								},
-  							},
-  						},
-  					},
-  				},
-  			},
-  			names.AttrMetricName: {
-  				Type:     schema.TypeString,
-  				Required: true,
-  				ForceNew: true,
-  			},
-  			names.AttrName: {
-  				Type:     schema.TypeString,
-  				Required: true,
-  				ForceNew: true,
-  			},
-  			names.AttrRule: {
-  				Type:     schema.TypeSet,
-  				Optional: true,
-  				Elem: &schema.Resource{
-  					Schema: map[string]*schema.Schema{
-  						names.AttrAction: {
-  							Type:     schema.TypeList,
-  							Optional: true,
-  							MaxItems: 1,
-  							Elem: &schema.Resource{
-  								Schema: map[string]*schema.Schema{
-  									names.AttrType: {
-  										Type:             schema.TypeString,
-  										Required:         true,
-  										ValidateDiagFunc: enum.Validate[awstypes.WafActionType](),
-  									},
-  								},
-  							},
-  						},
-  						"override_action": {
-  							Type:     schema.TypeList,
-  							Optional: true,
-  							MaxItems: 1,
-  							Elem: &schema.Resource{
-  								Schema: map[string]*schema.Schema{
-  									names.AttrType: {
-  										Type:             schema.TypeString,
-  										Required:         true,
-  										ValidateDiagFunc: enum.Validate[awstypes.WafOverrideActionType](),
-  									},
-  								},
-  							},
-  						},
-  						names.AttrPriority: {
-  							Type:     schema.TypeInt,
-  							Required: true,
-  						},
-  						names.AttrType: {
-  							Type:             schema.TypeString,
-  							Optional:         true,
-  							Default:          awstypes.WafRuleTypeRegular,
-  							ValidateDiagFunc: enum.Validate[awstypes.WafRuleType](),
-  						},
-  						"rule_id": {
-  							Type:     schema.TypeString,
-  							Required: true,
-  						},
-  					},
-  				},
-  			},
-  			names.AttrTags:    tftags.TagsSchema(),
-  			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-  		}
-  },
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrDefaultAction: {
+					Type:     schema.TypeList,
+					Required: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrType: {
+								Type:             schema.TypeString,
+								Required:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.WafActionType](),
+							},
+						},
+					},
+				},
+				names.AttrLoggingConfiguration: {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"log_destination": {
+								Type:         schema.TypeString,
+								Required:     true,
+								ValidateFunc: verify.ValidARN,
+							},
+							"redacted_fields": {
+								Type:     schema.TypeList,
+								Optional: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"field_to_match": {
+											Type:     schema.TypeSet,
+											Required: true,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"data": {
+														Type:     schema.TypeString,
+														Optional: true,
+													},
+													names.AttrType: {
+														Type:             schema.TypeString,
+														Required:         true,
+														ValidateDiagFunc: enum.Validate[awstypes.MatchFieldType](),
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				names.AttrMetricName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				names.AttrRule: {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrAction: {
+								Type:     schema.TypeList,
+								Optional: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										names.AttrType: {
+											Type:             schema.TypeString,
+											Required:         true,
+											ValidateDiagFunc: enum.Validate[awstypes.WafActionType](),
+										},
+									},
+								},
+							},
+							"override_action": {
+								Type:     schema.TypeList,
+								Optional: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										names.AttrType: {
+											Type:             schema.TypeString,
+											Required:         true,
+											ValidateDiagFunc: enum.Validate[awstypes.WafOverrideActionType](),
+										},
+									},
+								},
+							},
+							names.AttrPriority: {
+								Type:     schema.TypeInt,
+								Required: true,
+							},
+							names.AttrType: {
+								Type:             schema.TypeString,
+								Optional:         true,
+								Default:          awstypes.WafRuleTypeRegular,
+								ValidateDiagFunc: enum.Validate[awstypes.WafRuleType](),
+							},
+							"rule_id": {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+						},
+					},
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			}
+		},
 	}
 }
 

--- a/internal/service/wafregional/web_acl.go
+++ b/internal/service/wafregional/web_acl.go
@@ -40,128 +40,130 @@ func resourceWebACL() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrDefaultAction: {
-				Type:     schema.TypeList,
-				Required: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrType: {
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.WafActionType](),
-						},
-					},
-				},
-			},
-			names.AttrLoggingConfiguration: {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"log_destination": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: verify.ValidARN,
-						},
-						"redacted_fields": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"field_to_match": {
-										Type:     schema.TypeSet,
-										Required: true,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"data": {
-													Type:     schema.TypeString,
-													Optional: true,
-												},
-												names.AttrType: {
-													Type:             schema.TypeString,
-													Required:         true,
-													ValidateDiagFunc: enum.Validate[awstypes.MatchFieldType](),
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			names.AttrMetricName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			names.AttrRule: {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrAction: {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									names.AttrType: {
-										Type:             schema.TypeString,
-										Required:         true,
-										ValidateDiagFunc: enum.Validate[awstypes.WafActionType](),
-									},
-								},
-							},
-						},
-						"override_action": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									names.AttrType: {
-										Type:             schema.TypeString,
-										Required:         true,
-										ValidateDiagFunc: enum.Validate[awstypes.WafOverrideActionType](),
-									},
-								},
-							},
-						},
-						names.AttrPriority: {
-							Type:     schema.TypeInt,
-							Required: true,
-						},
-						names.AttrType: {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Default:          awstypes.WafRuleTypeRegular,
-							ValidateDiagFunc: enum.Validate[awstypes.WafRuleType](),
-						},
-						"rule_id": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-					},
-				},
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-		},
+		SchemaFunc: func() map[string]*schema.Schema {
+  	return map[string]*schema.Schema{
+  			names.AttrARN: {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			names.AttrDefaultAction: {
+  				Type:     schema.TypeList,
+  				Required: true,
+  				MaxItems: 1,
+  				Elem: &schema.Resource{
+  					Schema: map[string]*schema.Schema{
+  						names.AttrType: {
+  							Type:             schema.TypeString,
+  							Required:         true,
+  							ValidateDiagFunc: enum.Validate[awstypes.WafActionType](),
+  						},
+  					},
+  				},
+  			},
+  			names.AttrLoggingConfiguration: {
+  				Type:     schema.TypeList,
+  				Optional: true,
+  				MaxItems: 1,
+  				Elem: &schema.Resource{
+  					Schema: map[string]*schema.Schema{
+  						"log_destination": {
+  							Type:         schema.TypeString,
+  							Required:     true,
+  							ValidateFunc: verify.ValidARN,
+  						},
+  						"redacted_fields": {
+  							Type:     schema.TypeList,
+  							Optional: true,
+  							MaxItems: 1,
+  							Elem: &schema.Resource{
+  								Schema: map[string]*schema.Schema{
+  									"field_to_match": {
+  										Type:     schema.TypeSet,
+  										Required: true,
+  										Elem: &schema.Resource{
+  											Schema: map[string]*schema.Schema{
+  												"data": {
+  													Type:     schema.TypeString,
+  													Optional: true,
+  												},
+  												names.AttrType: {
+  													Type:             schema.TypeString,
+  													Required:         true,
+  													ValidateDiagFunc: enum.Validate[awstypes.MatchFieldType](),
+  												},
+  											},
+  										},
+  									},
+  								},
+  							},
+  						},
+  					},
+  				},
+  			},
+  			names.AttrMetricName: {
+  				Type:     schema.TypeString,
+  				Required: true,
+  				ForceNew: true,
+  			},
+  			names.AttrName: {
+  				Type:     schema.TypeString,
+  				Required: true,
+  				ForceNew: true,
+  			},
+  			names.AttrRule: {
+  				Type:     schema.TypeSet,
+  				Optional: true,
+  				Elem: &schema.Resource{
+  					Schema: map[string]*schema.Schema{
+  						names.AttrAction: {
+  							Type:     schema.TypeList,
+  							Optional: true,
+  							MaxItems: 1,
+  							Elem: &schema.Resource{
+  								Schema: map[string]*schema.Schema{
+  									names.AttrType: {
+  										Type:             schema.TypeString,
+  										Required:         true,
+  										ValidateDiagFunc: enum.Validate[awstypes.WafActionType](),
+  									},
+  								},
+  							},
+  						},
+  						"override_action": {
+  							Type:     schema.TypeList,
+  							Optional: true,
+  							MaxItems: 1,
+  							Elem: &schema.Resource{
+  								Schema: map[string]*schema.Schema{
+  									names.AttrType: {
+  										Type:             schema.TypeString,
+  										Required:         true,
+  										ValidateDiagFunc: enum.Validate[awstypes.WafOverrideActionType](),
+  									},
+  								},
+  							},
+  						},
+  						names.AttrPriority: {
+  							Type:     schema.TypeInt,
+  							Required: true,
+  						},
+  						names.AttrType: {
+  							Type:             schema.TypeString,
+  							Optional:         true,
+  							Default:          awstypes.WafRuleTypeRegular,
+  							ValidateDiagFunc: enum.Validate[awstypes.WafRuleType](),
+  						},
+  						"rule_id": {
+  							Type:     schema.TypeString,
+  							Required: true,
+  						},
+  					},
+  				},
+  			},
+  			names.AttrTags:    tftags.TagsSchema(),
+  			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+  		}
+  },
 	}
 }
 

--- a/internal/service/wafregional/web_acl_association.go
+++ b/internal/service/wafregional/web_acl_association.go
@@ -41,19 +41,21 @@ func resourceWebACLAssociation() *schema.Resource {
 			Create: schema.DefaultTimeout(10 * time.Minute),
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrResourceARN: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			"web_acl_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-		},
+		SchemaFunc: func() map[string]*schema.Schema {
+  	return map[string]*schema.Schema{
+  			names.AttrResourceARN: {
+  				Type:         schema.TypeString,
+  				Required:     true,
+  				ForceNew:     true,
+  				ValidateFunc: verify.ValidARN,
+  			},
+  			"web_acl_id": {
+  				Type:     schema.TypeString,
+  				Required: true,
+  				ForceNew: true,
+  			},
+  		}
+  },
 	}
 }
 

--- a/internal/service/wafregional/web_acl_association.go
+++ b/internal/service/wafregional/web_acl_association.go
@@ -42,20 +42,20 @@ func resourceWebACLAssociation() *schema.Resource {
 		},
 
 		SchemaFunc: func() map[string]*schema.Schema {
-  	return map[string]*schema.Schema{
-  			names.AttrResourceARN: {
-  				Type:         schema.TypeString,
-  				Required:     true,
-  				ForceNew:     true,
-  				ValidateFunc: verify.ValidARN,
-  			},
-  			"web_acl_id": {
-  				Type:     schema.TypeString,
-  				Required: true,
-  				ForceNew: true,
-  			},
-  		}
-  },
+			return map[string]*schema.Schema{
+				names.AttrResourceARN: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				"web_acl_id": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+			}
+		},
 	}
 }
 

--- a/internal/service/wafregional/web_acl_data_source.go
+++ b/internal/service/wafregional/web_acl_data_source.go
@@ -25,12 +25,14 @@ func dataSourceWebACL() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceWebACLRead,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-		},
+		SchemaFunc: func() map[string]*schema.Schema {
+  	return map[string]*schema.Schema{
+  			names.AttrName: {
+  				Type:     schema.TypeString,
+  				Required: true,
+  			},
+  		}
+  },
 	}
 }
 

--- a/internal/service/wafregional/web_acl_data_source.go
+++ b/internal/service/wafregional/web_acl_data_source.go
@@ -26,13 +26,13 @@ func dataSourceWebACL() *schema.Resource {
 		ReadWithoutTimeout: dataSourceWebACLRead,
 
 		SchemaFunc: func() map[string]*schema.Schema {
-  	return map[string]*schema.Schema{
-  			names.AttrName: {
-  				Type:     schema.TypeString,
-  				Required: true,
-  			},
-  		}
-  },
+			return map[string]*schema.Schema{
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+			}
+		},
 	}
 }
 

--- a/internal/service/wafregional/xss_match_set.go
+++ b/internal/service/wafregional/xss_match_set.go
@@ -37,44 +37,46 @@ func resourceXSSMatchSet() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"xss_match_tuple": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"field_to_match": {
-							Type:     schema.TypeList,
-							Required: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"data": {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
-									names.AttrType: {
-										Type:             schema.TypeString,
-										Required:         true,
-										ValidateDiagFunc: enum.Validate[awstypes.MatchFieldType](),
-									},
-								},
-							},
-						},
-						"text_transformation": {
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: enum.Validate[awstypes.TextTransformation](),
-						},
-					},
-				},
-			},
-		},
+		SchemaFunc: func() map[string]*schema.Schema {
+  	return map[string]*schema.Schema{
+  			names.AttrName: {
+  				Type:     schema.TypeString,
+  				Required: true,
+  				ForceNew: true,
+  			},
+  			"xss_match_tuple": {
+  				Type:     schema.TypeSet,
+  				Optional: true,
+  				Elem: &schema.Resource{
+  					Schema: map[string]*schema.Schema{
+  						"field_to_match": {
+  							Type:     schema.TypeList,
+  							Required: true,
+  							MaxItems: 1,
+  							Elem: &schema.Resource{
+  								Schema: map[string]*schema.Schema{
+  									"data": {
+  										Type:     schema.TypeString,
+  										Optional: true,
+  									},
+  									names.AttrType: {
+  										Type:             schema.TypeString,
+  										Required:         true,
+  										ValidateDiagFunc: enum.Validate[awstypes.MatchFieldType](),
+  									},
+  								},
+  							},
+  						},
+  						"text_transformation": {
+  							Type:             schema.TypeString,
+  							Required:         true,
+  							ValidateDiagFunc: enum.Validate[awstypes.TextTransformation](),
+  						},
+  					},
+  				},
+  			},
+  		}
+  },
 	}
 }
 

--- a/internal/service/wafregional/xss_match_set.go
+++ b/internal/service/wafregional/xss_match_set.go
@@ -38,45 +38,45 @@ func resourceXSSMatchSet() *schema.Resource {
 		},
 
 		SchemaFunc: func() map[string]*schema.Schema {
-  	return map[string]*schema.Schema{
-  			names.AttrName: {
-  				Type:     schema.TypeString,
-  				Required: true,
-  				ForceNew: true,
-  			},
-  			"xss_match_tuple": {
-  				Type:     schema.TypeSet,
-  				Optional: true,
-  				Elem: &schema.Resource{
-  					Schema: map[string]*schema.Schema{
-  						"field_to_match": {
-  							Type:     schema.TypeList,
-  							Required: true,
-  							MaxItems: 1,
-  							Elem: &schema.Resource{
-  								Schema: map[string]*schema.Schema{
-  									"data": {
-  										Type:     schema.TypeString,
-  										Optional: true,
-  									},
-  									names.AttrType: {
-  										Type:             schema.TypeString,
-  										Required:         true,
-  										ValidateDiagFunc: enum.Validate[awstypes.MatchFieldType](),
-  									},
-  								},
-  							},
-  						},
-  						"text_transformation": {
-  							Type:             schema.TypeString,
-  							Required:         true,
-  							ValidateDiagFunc: enum.Validate[awstypes.TextTransformation](),
-  						},
-  					},
-  				},
-  			},
-  		}
-  },
+			return map[string]*schema.Schema{
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"xss_match_tuple": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"field_to_match": {
+								Type:     schema.TypeList,
+								Required: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"data": {
+											Type:     schema.TypeString,
+											Optional: true,
+										},
+										names.AttrType: {
+											Type:             schema.TypeString,
+											Required:         true,
+											ValidateDiagFunc: enum.Validate[awstypes.MatchFieldType](),
+										},
+									},
+								},
+							},
+							"text_transformation": {
+								Type:             schema.TypeString,
+								Required:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.TextTransformation](),
+							},
+						},
+					},
+				},
+			}
+		},
 	}
 }
 

--- a/internal/service/workspaces/bundle_data_source.go
+++ b/internal/service/workspaces/bundle_data_source.go
@@ -25,63 +25,65 @@ func dataSourceBundle() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceWorkspaceBundleRead,
 
-		Schema: map[string]*schema.Schema{
-			"bundle_id": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				ConflictsWith: []string{names.AttrOwner, names.AttrName},
-			},
-			"compute_type": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrName: {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-					},
-				},
-			},
-			names.AttrDescription: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrName: {
-				Type:          schema.TypeString,
-				Optional:      true,
-				ConflictsWith: []string{"bundle_id"},
-			},
-			names.AttrOwner: {
-				Type:          schema.TypeString,
-				Optional:      true,
-				ConflictsWith: []string{"bundle_id"},
-			},
-			"root_storage": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"capacity": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-					},
-				},
-			},
-			"user_storage": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"capacity": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-					},
-				},
-			},
-		},
+		SchemaFunc: func() map[string]*schema.Schema {
+  	return map[string]*schema.Schema{
+  			"bundle_id": {
+  				Type:          schema.TypeString,
+  				Optional:      true,
+  				ConflictsWith: []string{names.AttrOwner, names.AttrName},
+  			},
+  			"compute_type": {
+  				Type:     schema.TypeList,
+  				Computed: true,
+  				Elem: &schema.Resource{
+  					Schema: map[string]*schema.Schema{
+  						names.AttrName: {
+  							Type:     schema.TypeString,
+  							Computed: true,
+  						},
+  					},
+  				},
+  			},
+  			names.AttrDescription: {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			names.AttrName: {
+  				Type:          schema.TypeString,
+  				Optional:      true,
+  				ConflictsWith: []string{"bundle_id"},
+  			},
+  			names.AttrOwner: {
+  				Type:          schema.TypeString,
+  				Optional:      true,
+  				ConflictsWith: []string{"bundle_id"},
+  			},
+  			"root_storage": {
+  				Type:     schema.TypeList,
+  				Computed: true,
+  				Elem: &schema.Resource{
+  					Schema: map[string]*schema.Schema{
+  						"capacity": {
+  							Type:     schema.TypeString,
+  							Computed: true,
+  						},
+  					},
+  				},
+  			},
+  			"user_storage": {
+  				Type:     schema.TypeList,
+  				Computed: true,
+  				Elem: &schema.Resource{
+  					Schema: map[string]*schema.Schema{
+  						"capacity": {
+  							Type:     schema.TypeString,
+  							Computed: true,
+  						},
+  					},
+  				},
+  			},
+  		}
+  },
 	}
 }
 

--- a/internal/service/workspaces/bundle_data_source.go
+++ b/internal/service/workspaces/bundle_data_source.go
@@ -26,64 +26,64 @@ func dataSourceBundle() *schema.Resource {
 		ReadWithoutTimeout: dataSourceWorkspaceBundleRead,
 
 		SchemaFunc: func() map[string]*schema.Schema {
-  	return map[string]*schema.Schema{
-  			"bundle_id": {
-  				Type:          schema.TypeString,
-  				Optional:      true,
-  				ConflictsWith: []string{names.AttrOwner, names.AttrName},
-  			},
-  			"compute_type": {
-  				Type:     schema.TypeList,
-  				Computed: true,
-  				Elem: &schema.Resource{
-  					Schema: map[string]*schema.Schema{
-  						names.AttrName: {
-  							Type:     schema.TypeString,
-  							Computed: true,
-  						},
-  					},
-  				},
-  			},
-  			names.AttrDescription: {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			names.AttrName: {
-  				Type:          schema.TypeString,
-  				Optional:      true,
-  				ConflictsWith: []string{"bundle_id"},
-  			},
-  			names.AttrOwner: {
-  				Type:          schema.TypeString,
-  				Optional:      true,
-  				ConflictsWith: []string{"bundle_id"},
-  			},
-  			"root_storage": {
-  				Type:     schema.TypeList,
-  				Computed: true,
-  				Elem: &schema.Resource{
-  					Schema: map[string]*schema.Schema{
-  						"capacity": {
-  							Type:     schema.TypeString,
-  							Computed: true,
-  						},
-  					},
-  				},
-  			},
-  			"user_storage": {
-  				Type:     schema.TypeList,
-  				Computed: true,
-  				Elem: &schema.Resource{
-  					Schema: map[string]*schema.Schema{
-  						"capacity": {
-  							Type:     schema.TypeString,
-  							Computed: true,
-  						},
-  					},
-  				},
-  			},
-  		}
-  },
+			return map[string]*schema.Schema{
+				"bundle_id": {
+					Type:          schema.TypeString,
+					Optional:      true,
+					ConflictsWith: []string{names.AttrOwner, names.AttrName},
+				},
+				"compute_type": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrName: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+						},
+					},
+				},
+				names.AttrDescription: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrName: {
+					Type:          schema.TypeString,
+					Optional:      true,
+					ConflictsWith: []string{"bundle_id"},
+				},
+				names.AttrOwner: {
+					Type:          schema.TypeString,
+					Optional:      true,
+					ConflictsWith: []string{"bundle_id"},
+				},
+				"root_storage": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"capacity": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+						},
+					},
+				},
+				"user_storage": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"capacity": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+						},
+					},
+				},
+			}
+		},
 	}
 }
 

--- a/internal/service/workspaces/directory.go
+++ b/internal/service/workspaces/directory.go
@@ -44,279 +44,279 @@ func resourceDirectory() *schema.Resource {
 		},
 
 		SchemaFunc: func() map[string]*schema.Schema {
-  	return map[string]*schema.Schema{
-  			"active_directory_config": {
-  				Type:     schema.TypeList,
-  				ForceNew: true,
-  				Optional: true,
-  				MaxItems: 1,
-  				Elem: &schema.Resource{
-  					Schema: map[string]*schema.Schema{
-  						names.AttrDomainName: {
-  							Type:     schema.TypeString,
-  							Required: true,
-  							ForceNew: true,
-  						},
-  						"service_account_secret_arn": {
-  							Type:         schema.TypeString,
-  							Required:     true,
-  							ForceNew:     true,
-  							ValidateFunc: verify.ValidARN,
-  						},
-  					},
-  				},
-  			},
-  			names.AttrAlias: {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			"certificate_based_auth_properties": {
-  				Type:     schema.TypeList,
-  				Computed: true,
-  				Optional: true,
-  				MaxItems: 1,
-  				Elem: &schema.Resource{
-  					Schema: map[string]*schema.Schema{
-  						"certificate_authority_arn": {
-  							Type:         schema.TypeString,
-  							Optional:     true,
-  							ValidateFunc: verify.ValidARN,
-  						},
-  						names.AttrStatus: {
-  							Type:             schema.TypeString,
-  							Optional:         true,
-  							Computed:         true,
-  							ValidateDiagFunc: enum.Validate[types.CertificateBasedAuthStatusEnum](),
-  						},
-  					},
-  				},
-  			},
-  			"customer_user_name": {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			"directory_id": {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  				ForceNew: true,
-  				Optional: true,
-  			},
-  			"directory_name": {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			"directory_type": {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			"dns_ip_addresses": {
-  				Type:     schema.TypeSet,
-  				Elem:     &schema.Schema{Type: schema.TypeString},
-  				Computed: true,
-  			},
-  			"iam_role_id": {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			"ip_group_ids": {
-  				Type:     schema.TypeSet,
-  				Elem:     &schema.Schema{Type: schema.TypeString},
-  				Computed: true,
-  				Optional: true,
-  			},
-  			"registration_code": {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			"saml_properties": {
-  				Type:     schema.TypeList,
-  				Computed: true,
-  				Optional: true,
-  				MaxItems: 1,
-  				Elem: &schema.Resource{
-  					Schema: map[string]*schema.Schema{
-  						"relay_state_parameter_name": {
-  							Type:     schema.TypeString,
-  							Optional: true,
-  							Default:  "RelayState",
-  						},
-  						names.AttrStatus: {
-  							Type:             schema.TypeString,
-  							Optional:         true,
-  							Default:          types.SamlStatusEnumDisabled,
-  							ValidateDiagFunc: enum.Validate[types.SamlStatusEnum](),
-  						},
-  						"user_access_url": {
-  							Type:     schema.TypeString,
-  							Optional: true,
-  						},
-  					},
-  				},
-  			},
-  			"self_service_permissions": {
-  				Type:     schema.TypeList,
-  				Computed: true,
-  				Optional: true,
-  				MaxItems: 1,
-  				Elem: &schema.Resource{
-  					Schema: map[string]*schema.Schema{
-  						"change_compute_type": {
-  							Type:     schema.TypeBool,
-  							Optional: true,
-  							Default:  false,
-  						},
-  						"increase_volume_size": {
-  							Type:     schema.TypeBool,
-  							Optional: true,
-  							Default:  false,
-  						},
-  						"rebuild_workspace": {
-  							Type:     schema.TypeBool,
-  							Optional: true,
-  							Default:  false,
-  						},
-  						"restart_workspace": {
-  							Type:     schema.TypeBool,
-  							Optional: true,
-  							Default:  true,
-  						},
-  						"switch_running_mode": {
-  							Type:     schema.TypeBool,
-  							Optional: true,
-  							Default:  false,
-  						},
-  					},
-  				},
-  			},
-  			names.AttrSubnetIDs: {
-  				Type:     schema.TypeSet,
-  				Optional: true,
-  				ForceNew: true,
-  				Computed: true,
-  				Elem:     &schema.Schema{Type: schema.TypeString},
-  			},
-  			names.AttrTags:    tftags.TagsSchema(),
-  			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-  			"tenancy": {
-  				Type:             schema.TypeString,
-  				Optional:         true,
-  				Computed:         true,
-  				ForceNew:         true,
-  				ValidateDiagFunc: enum.Validate[types.Tenancy](),
-  			},
-  			"user_identity_type": {
-  				Type:             schema.TypeString,
-  				Computed:         true,
-  				ForceNew:         true,
-  				Optional:         true,
-  				ValidateDiagFunc: enum.Validate[types.UserIdentityType](),
-  			},
-  			"workspace_access_properties": {
-  				Type:     schema.TypeList,
-  				Computed: true,
-  				Optional: true,
-  				MaxItems: 1,
-  				Elem: &schema.Resource{
-  					Schema: map[string]*schema.Schema{
-  						"device_type_android": {
-  							Type:             schema.TypeString,
-  							Optional:         true,
-  							ValidateDiagFunc: enum.Validate[types.AccessPropertyValue](),
-  						},
-  						"device_type_chromeos": {
-  							Type:             schema.TypeString,
-  							Optional:         true,
-  							ValidateDiagFunc: enum.Validate[types.AccessPropertyValue](),
-  						},
-  						"device_type_ios": {
-  							Type:             schema.TypeString,
-  							Optional:         true,
-  							ValidateDiagFunc: enum.Validate[types.AccessPropertyValue](),
-  						},
-  						"device_type_linux": {
-  							Type:             schema.TypeString,
-  							Optional:         true,
-  							ValidateDiagFunc: enum.Validate[types.AccessPropertyValue](),
-  						},
-  						"device_type_osx": {
-  							Type:             schema.TypeString,
-  							Optional:         true,
-  							ValidateDiagFunc: enum.Validate[types.AccessPropertyValue](),
-  						},
-  						"device_type_web": {
-  							Type:             schema.TypeString,
-  							Optional:         true,
-  							ValidateDiagFunc: enum.Validate[types.AccessPropertyValue](),
-  						},
-  						"device_type_windows": {
-  							Type:             schema.TypeString,
-  							Optional:         true,
-  							ValidateDiagFunc: enum.Validate[types.AccessPropertyValue](),
-  						},
-  						"device_type_zeroclient": {
-  							Type:             schema.TypeString,
-  							Optional:         true,
-  							ValidateDiagFunc: enum.Validate[types.AccessPropertyValue](),
-  						},
-  					},
-  				},
-  			},
-  			"workspace_creation_properties": {
-  				Type:     schema.TypeList,
-  				Computed: true,
-  				Optional: true,
-  				MaxItems: 1,
-  				Elem: &schema.Resource{
-  					Schema: map[string]*schema.Schema{
-  						"custom_security_group_id": {
-  							Type:     schema.TypeString,
-  							Optional: true,
-  						},
-  						"default_ou": {
-  							Type:     schema.TypeString,
-  							Optional: true,
-  						},
-  						"enable_internet_access": {
-  							Type:     schema.TypeBool,
-  							Optional: true,
-  							Default:  false,
-  						},
-  						"enable_maintenance_mode": {
-  							Type:     schema.TypeBool,
-  							Optional: true,
-  							Default:  false,
-  						},
-  						"user_enabled_as_local_administrator": {
-  							Type:     schema.TypeBool,
-  							Optional: true,
-  							Default:  false,
-  						},
-  					},
-  				},
-  			},
-  			"workspace_directory_description": {
-  				Type:     schema.TypeString,
-  				ForceNew: true,
-  				Optional: true,
-  			},
-  			"workspace_directory_name": {
-  				Type:     schema.TypeString,
-  				ForceNew: true,
-  				Optional: true,
-  			},
-  			"workspace_security_group_id": {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			"workspace_type": {
-  				Type:             schema.TypeString,
-  				Default:          types.WorkspaceTypePersonal,
-  				ForceNew:         true,
-  				Optional:         true,
-  				ValidateDiagFunc: enum.Validate[types.WorkspaceType](),
-  			},
-  		}
-  },
+			return map[string]*schema.Schema{
+				"active_directory_config": {
+					Type:     schema.TypeList,
+					ForceNew: true,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrDomainName: {
+								Type:     schema.TypeString,
+								Required: true,
+								ForceNew: true,
+							},
+							"service_account_secret_arn": {
+								Type:         schema.TypeString,
+								Required:     true,
+								ForceNew:     true,
+								ValidateFunc: verify.ValidARN,
+							},
+						},
+					},
+				},
+				names.AttrAlias: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"certificate_based_auth_properties": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"certificate_authority_arn": {
+								Type:         schema.TypeString,
+								Optional:     true,
+								ValidateFunc: verify.ValidARN,
+							},
+							names.AttrStatus: {
+								Type:             schema.TypeString,
+								Optional:         true,
+								Computed:         true,
+								ValidateDiagFunc: enum.Validate[types.CertificateBasedAuthStatusEnum](),
+							},
+						},
+					},
+				},
+				"customer_user_name": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"directory_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+					ForceNew: true,
+					Optional: true,
+				},
+				"directory_name": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"directory_type": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"dns_ip_addresses": {
+					Type:     schema.TypeSet,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+					Computed: true,
+				},
+				"iam_role_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"ip_group_ids": {
+					Type:     schema.TypeSet,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+					Computed: true,
+					Optional: true,
+				},
+				"registration_code": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"saml_properties": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"relay_state_parameter_name": {
+								Type:     schema.TypeString,
+								Optional: true,
+								Default:  "RelayState",
+							},
+							names.AttrStatus: {
+								Type:             schema.TypeString,
+								Optional:         true,
+								Default:          types.SamlStatusEnumDisabled,
+								ValidateDiagFunc: enum.Validate[types.SamlStatusEnum](),
+							},
+							"user_access_url": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+						},
+					},
+				},
+				"self_service_permissions": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"change_compute_type": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Default:  false,
+							},
+							"increase_volume_size": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Default:  false,
+							},
+							"rebuild_workspace": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Default:  false,
+							},
+							"restart_workspace": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Default:  true,
+							},
+							"switch_running_mode": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Default:  false,
+							},
+						},
+					},
+				},
+				names.AttrSubnetIDs: {
+					Type:     schema.TypeSet,
+					Optional: true,
+					ForceNew: true,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				"tenancy": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					Computed:         true,
+					ForceNew:         true,
+					ValidateDiagFunc: enum.Validate[types.Tenancy](),
+				},
+				"user_identity_type": {
+					Type:             schema.TypeString,
+					Computed:         true,
+					ForceNew:         true,
+					Optional:         true,
+					ValidateDiagFunc: enum.Validate[types.UserIdentityType](),
+				},
+				"workspace_access_properties": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"device_type_android": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								ValidateDiagFunc: enum.Validate[types.AccessPropertyValue](),
+							},
+							"device_type_chromeos": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								ValidateDiagFunc: enum.Validate[types.AccessPropertyValue](),
+							},
+							"device_type_ios": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								ValidateDiagFunc: enum.Validate[types.AccessPropertyValue](),
+							},
+							"device_type_linux": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								ValidateDiagFunc: enum.Validate[types.AccessPropertyValue](),
+							},
+							"device_type_osx": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								ValidateDiagFunc: enum.Validate[types.AccessPropertyValue](),
+							},
+							"device_type_web": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								ValidateDiagFunc: enum.Validate[types.AccessPropertyValue](),
+							},
+							"device_type_windows": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								ValidateDiagFunc: enum.Validate[types.AccessPropertyValue](),
+							},
+							"device_type_zeroclient": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								ValidateDiagFunc: enum.Validate[types.AccessPropertyValue](),
+							},
+						},
+					},
+				},
+				"workspace_creation_properties": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"custom_security_group_id": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+							"default_ou": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+							"enable_internet_access": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Default:  false,
+							},
+							"enable_maintenance_mode": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Default:  false,
+							},
+							"user_enabled_as_local_administrator": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Default:  false,
+							},
+						},
+					},
+				},
+				"workspace_directory_description": {
+					Type:     schema.TypeString,
+					ForceNew: true,
+					Optional: true,
+				},
+				"workspace_directory_name": {
+					Type:     schema.TypeString,
+					ForceNew: true,
+					Optional: true,
+				},
+				"workspace_security_group_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"workspace_type": {
+					Type:             schema.TypeString,
+					Default:          types.WorkspaceTypePersonal,
+					ForceNew:         true,
+					Optional:         true,
+					ValidateDiagFunc: enum.Validate[types.WorkspaceType](),
+				},
+			}
+		},
 		CustomizeDiff: func(ctx context.Context, diff *schema.ResourceDiff, meta any) error {
 			config := diff.GetRawConfig()
 

--- a/internal/service/workspaces/directory.go
+++ b/internal/service/workspaces/directory.go
@@ -43,278 +43,280 @@ func resourceDirectory() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"active_directory_config": {
-				Type:     schema.TypeList,
-				ForceNew: true,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrDomainName: {
-							Type:     schema.TypeString,
-							Required: true,
-							ForceNew: true,
-						},
-						"service_account_secret_arn": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ForceNew:     true,
-							ValidateFunc: verify.ValidARN,
-						},
-					},
-				},
-			},
-			names.AttrAlias: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"certificate_based_auth_properties": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"certificate_authority_arn": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							ValidateFunc: verify.ValidARN,
-						},
-						names.AttrStatus: {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Computed:         true,
-							ValidateDiagFunc: enum.Validate[types.CertificateBasedAuthStatusEnum](),
-						},
-					},
-				},
-			},
-			"customer_user_name": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"directory_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-				ForceNew: true,
-				Optional: true,
-			},
-			"directory_name": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"directory_type": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"dns_ip_addresses": {
-				Type:     schema.TypeSet,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Computed: true,
-			},
-			"iam_role_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"ip_group_ids": {
-				Type:     schema.TypeSet,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Computed: true,
-				Optional: true,
-			},
-			"registration_code": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"saml_properties": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"relay_state_parameter_name": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Default:  "RelayState",
-						},
-						names.AttrStatus: {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Default:          types.SamlStatusEnumDisabled,
-							ValidateDiagFunc: enum.Validate[types.SamlStatusEnum](),
-						},
-						"user_access_url": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-					},
-				},
-			},
-			"self_service_permissions": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"change_compute_type": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  false,
-						},
-						"increase_volume_size": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  false,
-						},
-						"rebuild_workspace": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  false,
-						},
-						"restart_workspace": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  true,
-						},
-						"switch_running_mode": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  false,
-						},
-					},
-				},
-			},
-			names.AttrSubnetIDs: {
-				Type:     schema.TypeSet,
-				Optional: true,
-				ForceNew: true,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			"tenancy": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Computed:         true,
-				ForceNew:         true,
-				ValidateDiagFunc: enum.Validate[types.Tenancy](),
-			},
-			"user_identity_type": {
-				Type:             schema.TypeString,
-				Computed:         true,
-				ForceNew:         true,
-				Optional:         true,
-				ValidateDiagFunc: enum.Validate[types.UserIdentityType](),
-			},
-			"workspace_access_properties": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"device_type_android": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							ValidateDiagFunc: enum.Validate[types.AccessPropertyValue](),
-						},
-						"device_type_chromeos": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							ValidateDiagFunc: enum.Validate[types.AccessPropertyValue](),
-						},
-						"device_type_ios": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							ValidateDiagFunc: enum.Validate[types.AccessPropertyValue](),
-						},
-						"device_type_linux": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							ValidateDiagFunc: enum.Validate[types.AccessPropertyValue](),
-						},
-						"device_type_osx": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							ValidateDiagFunc: enum.Validate[types.AccessPropertyValue](),
-						},
-						"device_type_web": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							ValidateDiagFunc: enum.Validate[types.AccessPropertyValue](),
-						},
-						"device_type_windows": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							ValidateDiagFunc: enum.Validate[types.AccessPropertyValue](),
-						},
-						"device_type_zeroclient": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							ValidateDiagFunc: enum.Validate[types.AccessPropertyValue](),
-						},
-					},
-				},
-			},
-			"workspace_creation_properties": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"custom_security_group_id": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"default_ou": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"enable_internet_access": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  false,
-						},
-						"enable_maintenance_mode": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  false,
-						},
-						"user_enabled_as_local_administrator": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  false,
-						},
-					},
-				},
-			},
-			"workspace_directory_description": {
-				Type:     schema.TypeString,
-				ForceNew: true,
-				Optional: true,
-			},
-			"workspace_directory_name": {
-				Type:     schema.TypeString,
-				ForceNew: true,
-				Optional: true,
-			},
-			"workspace_security_group_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"workspace_type": {
-				Type:             schema.TypeString,
-				Default:          types.WorkspaceTypePersonal,
-				ForceNew:         true,
-				Optional:         true,
-				ValidateDiagFunc: enum.Validate[types.WorkspaceType](),
-			},
-		},
+		SchemaFunc: func() map[string]*schema.Schema {
+  	return map[string]*schema.Schema{
+  			"active_directory_config": {
+  				Type:     schema.TypeList,
+  				ForceNew: true,
+  				Optional: true,
+  				MaxItems: 1,
+  				Elem: &schema.Resource{
+  					Schema: map[string]*schema.Schema{
+  						names.AttrDomainName: {
+  							Type:     schema.TypeString,
+  							Required: true,
+  							ForceNew: true,
+  						},
+  						"service_account_secret_arn": {
+  							Type:         schema.TypeString,
+  							Required:     true,
+  							ForceNew:     true,
+  							ValidateFunc: verify.ValidARN,
+  						},
+  					},
+  				},
+  			},
+  			names.AttrAlias: {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			"certificate_based_auth_properties": {
+  				Type:     schema.TypeList,
+  				Computed: true,
+  				Optional: true,
+  				MaxItems: 1,
+  				Elem: &schema.Resource{
+  					Schema: map[string]*schema.Schema{
+  						"certificate_authority_arn": {
+  							Type:         schema.TypeString,
+  							Optional:     true,
+  							ValidateFunc: verify.ValidARN,
+  						},
+  						names.AttrStatus: {
+  							Type:             schema.TypeString,
+  							Optional:         true,
+  							Computed:         true,
+  							ValidateDiagFunc: enum.Validate[types.CertificateBasedAuthStatusEnum](),
+  						},
+  					},
+  				},
+  			},
+  			"customer_user_name": {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			"directory_id": {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  				ForceNew: true,
+  				Optional: true,
+  			},
+  			"directory_name": {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			"directory_type": {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			"dns_ip_addresses": {
+  				Type:     schema.TypeSet,
+  				Elem:     &schema.Schema{Type: schema.TypeString},
+  				Computed: true,
+  			},
+  			"iam_role_id": {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			"ip_group_ids": {
+  				Type:     schema.TypeSet,
+  				Elem:     &schema.Schema{Type: schema.TypeString},
+  				Computed: true,
+  				Optional: true,
+  			},
+  			"registration_code": {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			"saml_properties": {
+  				Type:     schema.TypeList,
+  				Computed: true,
+  				Optional: true,
+  				MaxItems: 1,
+  				Elem: &schema.Resource{
+  					Schema: map[string]*schema.Schema{
+  						"relay_state_parameter_name": {
+  							Type:     schema.TypeString,
+  							Optional: true,
+  							Default:  "RelayState",
+  						},
+  						names.AttrStatus: {
+  							Type:             schema.TypeString,
+  							Optional:         true,
+  							Default:          types.SamlStatusEnumDisabled,
+  							ValidateDiagFunc: enum.Validate[types.SamlStatusEnum](),
+  						},
+  						"user_access_url": {
+  							Type:     schema.TypeString,
+  							Optional: true,
+  						},
+  					},
+  				},
+  			},
+  			"self_service_permissions": {
+  				Type:     schema.TypeList,
+  				Computed: true,
+  				Optional: true,
+  				MaxItems: 1,
+  				Elem: &schema.Resource{
+  					Schema: map[string]*schema.Schema{
+  						"change_compute_type": {
+  							Type:     schema.TypeBool,
+  							Optional: true,
+  							Default:  false,
+  						},
+  						"increase_volume_size": {
+  							Type:     schema.TypeBool,
+  							Optional: true,
+  							Default:  false,
+  						},
+  						"rebuild_workspace": {
+  							Type:     schema.TypeBool,
+  							Optional: true,
+  							Default:  false,
+  						},
+  						"restart_workspace": {
+  							Type:     schema.TypeBool,
+  							Optional: true,
+  							Default:  true,
+  						},
+  						"switch_running_mode": {
+  							Type:     schema.TypeBool,
+  							Optional: true,
+  							Default:  false,
+  						},
+  					},
+  				},
+  			},
+  			names.AttrSubnetIDs: {
+  				Type:     schema.TypeSet,
+  				Optional: true,
+  				ForceNew: true,
+  				Computed: true,
+  				Elem:     &schema.Schema{Type: schema.TypeString},
+  			},
+  			names.AttrTags:    tftags.TagsSchema(),
+  			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+  			"tenancy": {
+  				Type:             schema.TypeString,
+  				Optional:         true,
+  				Computed:         true,
+  				ForceNew:         true,
+  				ValidateDiagFunc: enum.Validate[types.Tenancy](),
+  			},
+  			"user_identity_type": {
+  				Type:             schema.TypeString,
+  				Computed:         true,
+  				ForceNew:         true,
+  				Optional:         true,
+  				ValidateDiagFunc: enum.Validate[types.UserIdentityType](),
+  			},
+  			"workspace_access_properties": {
+  				Type:     schema.TypeList,
+  				Computed: true,
+  				Optional: true,
+  				MaxItems: 1,
+  				Elem: &schema.Resource{
+  					Schema: map[string]*schema.Schema{
+  						"device_type_android": {
+  							Type:             schema.TypeString,
+  							Optional:         true,
+  							ValidateDiagFunc: enum.Validate[types.AccessPropertyValue](),
+  						},
+  						"device_type_chromeos": {
+  							Type:             schema.TypeString,
+  							Optional:         true,
+  							ValidateDiagFunc: enum.Validate[types.AccessPropertyValue](),
+  						},
+  						"device_type_ios": {
+  							Type:             schema.TypeString,
+  							Optional:         true,
+  							ValidateDiagFunc: enum.Validate[types.AccessPropertyValue](),
+  						},
+  						"device_type_linux": {
+  							Type:             schema.TypeString,
+  							Optional:         true,
+  							ValidateDiagFunc: enum.Validate[types.AccessPropertyValue](),
+  						},
+  						"device_type_osx": {
+  							Type:             schema.TypeString,
+  							Optional:         true,
+  							ValidateDiagFunc: enum.Validate[types.AccessPropertyValue](),
+  						},
+  						"device_type_web": {
+  							Type:             schema.TypeString,
+  							Optional:         true,
+  							ValidateDiagFunc: enum.Validate[types.AccessPropertyValue](),
+  						},
+  						"device_type_windows": {
+  							Type:             schema.TypeString,
+  							Optional:         true,
+  							ValidateDiagFunc: enum.Validate[types.AccessPropertyValue](),
+  						},
+  						"device_type_zeroclient": {
+  							Type:             schema.TypeString,
+  							Optional:         true,
+  							ValidateDiagFunc: enum.Validate[types.AccessPropertyValue](),
+  						},
+  					},
+  				},
+  			},
+  			"workspace_creation_properties": {
+  				Type:     schema.TypeList,
+  				Computed: true,
+  				Optional: true,
+  				MaxItems: 1,
+  				Elem: &schema.Resource{
+  					Schema: map[string]*schema.Schema{
+  						"custom_security_group_id": {
+  							Type:     schema.TypeString,
+  							Optional: true,
+  						},
+  						"default_ou": {
+  							Type:     schema.TypeString,
+  							Optional: true,
+  						},
+  						"enable_internet_access": {
+  							Type:     schema.TypeBool,
+  							Optional: true,
+  							Default:  false,
+  						},
+  						"enable_maintenance_mode": {
+  							Type:     schema.TypeBool,
+  							Optional: true,
+  							Default:  false,
+  						},
+  						"user_enabled_as_local_administrator": {
+  							Type:     schema.TypeBool,
+  							Optional: true,
+  							Default:  false,
+  						},
+  					},
+  				},
+  			},
+  			"workspace_directory_description": {
+  				Type:     schema.TypeString,
+  				ForceNew: true,
+  				Optional: true,
+  			},
+  			"workspace_directory_name": {
+  				Type:     schema.TypeString,
+  				ForceNew: true,
+  				Optional: true,
+  			},
+  			"workspace_security_group_id": {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			"workspace_type": {
+  				Type:             schema.TypeString,
+  				Default:          types.WorkspaceTypePersonal,
+  				ForceNew:         true,
+  				Optional:         true,
+  				ValidateDiagFunc: enum.Validate[types.WorkspaceType](),
+  			},
+  		}
+  },
 		CustomizeDiff: func(ctx context.Context, diff *schema.ResourceDiff, meta any) error {
 			config := diff.GetRawConfig()
 

--- a/internal/service/workspaces/directory_data_source.go
+++ b/internal/service/workspaces/directory_data_source.go
@@ -23,225 +23,225 @@ func dataSourceDirectory() *schema.Resource {
 		ReadWithoutTimeout: dataSourceDirectoryRead,
 
 		SchemaFunc: func() map[string]*schema.Schema {
-  	return map[string]*schema.Schema{
-  			"active_directory_config": {
-  				Type:     schema.TypeSet,
-  				Computed: true,
-  				Elem: &schema.Resource{
-  					Schema: map[string]*schema.Schema{
-  						names.AttrDomainName: {
-  							Type:     schema.TypeString,
-  							Computed: true,
-  						},
-  						"service_account_secret_arn": {
-  							Type:     schema.TypeString,
-  							Computed: true,
-  						},
-  					},
-  				},
-  			},
-  			names.AttrAlias: {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			"certificate_based_auth_properties": {
-  				Type:     schema.TypeList,
-  				Computed: true,
-  				Elem: &schema.Resource{
-  					Schema: map[string]*schema.Schema{
-  						"certificate_authority_arn": {
-  							Type:     schema.TypeString,
-  							Computed: true,
-  						},
-  						names.AttrStatus: {
-  							Type:     schema.TypeString,
-  							Computed: true,
-  						},
-  					},
-  				},
-  			},
-  			"customer_user_name": {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			"directory_id": {
-  				Type:     schema.TypeString,
-  				Required: true,
-  			},
-  			"directory_name": {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			"directory_type": {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			"dns_ip_addresses": {
-  				Type:     schema.TypeSet,
-  				Computed: true,
-  				Elem:     &schema.Schema{Type: schema.TypeString},
-  			},
-  			"iam_role_id": {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			"ip_group_ids": {
-  				Type:     schema.TypeSet,
-  				Computed: true,
-  				Elem:     &schema.Schema{Type: schema.TypeString},
-  			},
-  			"registration_code": {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			"saml_properties": {
-  				Type:     schema.TypeList,
-  				Computed: true,
-  				Elem: &schema.Resource{
-  					Schema: map[string]*schema.Schema{
-  						"relay_state_parameter_name": {
-  							Type:     schema.TypeString,
-  							Computed: true,
-  						},
-  						names.AttrStatus: {
-  							Type:     schema.TypeString,
-  							Computed: true,
-  						},
-  						"user_access_url": {
-  							Type:     schema.TypeString,
-  							Computed: true,
-  						},
-  					},
-  				},
-  			},
-  			"self_service_permissions": {
-  				Type:     schema.TypeList,
-  				Computed: true,
-  				Elem: &schema.Resource{
-  					Schema: map[string]*schema.Schema{
-  						"change_compute_type": {
-  							Type:     schema.TypeBool,
-  							Computed: true,
-  						},
-  						"increase_volume_size": {
-  							Type:     schema.TypeBool,
-  							Computed: true,
-  						},
-  						"rebuild_workspace": {
-  							Type:     schema.TypeBool,
-  							Computed: true,
-  						},
-  						"restart_workspace": {
-  							Type:     schema.TypeBool,
-  							Computed: true,
-  						},
-  						"switch_running_mode": {
-  							Type:     schema.TypeBool,
-  							Computed: true,
-  						},
-  					},
-  				},
-  			},
-  			names.AttrSubnetIDs: {
-  				Type:     schema.TypeSet,
-  				Computed: true,
-  				Elem:     &schema.Schema{Type: schema.TypeString},
-  			},
-  			names.AttrTags: tftags.TagsSchemaComputed(),
-  			"tenancy": {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			"user_identity_type": {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			"workspace_access_properties": {
-  				Type:     schema.TypeList,
-  				Computed: true,
-  				Elem: &schema.Resource{
-  					Schema: map[string]*schema.Schema{
-  						"device_type_android": {
-  							Type:     schema.TypeString,
-  							Computed: true,
-  						},
-  						"device_type_chromeos": {
-  							Type:     schema.TypeString,
-  							Computed: true,
-  						},
-  						"device_type_ios": {
-  							Type:     schema.TypeString,
-  							Computed: true,
-  						},
-  						"device_type_linux": {
-  							Type:     schema.TypeString,
-  							Computed: true,
-  						},
-  						"device_type_osx": {
-  							Type:     schema.TypeString,
-  							Computed: true,
-  						},
-  						"device_type_web": {
-  							Type:     schema.TypeString,
-  							Computed: true,
-  						},
-  						"device_type_windows": {
-  							Type:     schema.TypeString,
-  							Computed: true,
-  						},
-  						"device_type_zeroclient": {
-  							Type:     schema.TypeString,
-  							Computed: true,
-  						},
-  					},
-  				},
-  			},
-  			"workspace_creation_properties": {
-  				Type:     schema.TypeList,
-  				Computed: true,
-  				Elem: &schema.Resource{
-  					Schema: map[string]*schema.Schema{
-  						"custom_security_group_id": {
-  							Type:     schema.TypeString,
-  							Computed: true,
-  						},
-  						"default_ou": {
-  							Type:     schema.TypeString,
-  							Computed: true,
-  						},
-  						"enable_internet_access": {
-  							Type:     schema.TypeBool,
-  							Computed: true,
-  						},
-  						"enable_maintenance_mode": {
-  							Type:     schema.TypeBool,
-  							Computed: true,
-  						},
-  						"user_enabled_as_local_administrator": {
-  							Type:     schema.TypeBool,
-  							Computed: true,
-  						},
-  					},
-  				},
-  			},
-  			"workspace_directory_description": {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			"workspace_directory_name": {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			"workspace_security_group_id": {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			"workspace_type": {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  		}
-  },
+			return map[string]*schema.Schema{
+				"active_directory_config": {
+					Type:     schema.TypeSet,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrDomainName: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"service_account_secret_arn": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+						},
+					},
+				},
+				names.AttrAlias: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"certificate_based_auth_properties": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"certificate_authority_arn": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							names.AttrStatus: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+						},
+					},
+				},
+				"customer_user_name": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"directory_id": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"directory_name": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"directory_type": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"dns_ip_addresses": {
+					Type:     schema.TypeSet,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"iam_role_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"ip_group_ids": {
+					Type:     schema.TypeSet,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"registration_code": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"saml_properties": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"relay_state_parameter_name": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							names.AttrStatus: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"user_access_url": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+						},
+					},
+				},
+				"self_service_permissions": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"change_compute_type": {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
+							"increase_volume_size": {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
+							"rebuild_workspace": {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
+							"restart_workspace": {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
+							"switch_running_mode": {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
+						},
+					},
+				},
+				names.AttrSubnetIDs: {
+					Type:     schema.TypeSet,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				names.AttrTags: tftags.TagsSchemaComputed(),
+				"tenancy": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"user_identity_type": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"workspace_access_properties": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"device_type_android": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"device_type_chromeos": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"device_type_ios": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"device_type_linux": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"device_type_osx": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"device_type_web": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"device_type_windows": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"device_type_zeroclient": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+						},
+					},
+				},
+				"workspace_creation_properties": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"custom_security_group_id": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"default_ou": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"enable_internet_access": {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
+							"enable_maintenance_mode": {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
+							"user_enabled_as_local_administrator": {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
+						},
+					},
+				},
+				"workspace_directory_description": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"workspace_directory_name": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"workspace_security_group_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"workspace_type": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			}
+		},
 	}
 }
 

--- a/internal/service/workspaces/directory_data_source.go
+++ b/internal/service/workspaces/directory_data_source.go
@@ -22,224 +22,226 @@ func dataSourceDirectory() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceDirectoryRead,
 
-		Schema: map[string]*schema.Schema{
-			"active_directory_config": {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrDomainName: {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"service_account_secret_arn": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-					},
-				},
-			},
-			names.AttrAlias: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"certificate_based_auth_properties": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"certificate_authority_arn": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						names.AttrStatus: {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-					},
-				},
-			},
-			"customer_user_name": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"directory_id": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"directory_name": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"directory_type": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"dns_ip_addresses": {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			"iam_role_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"ip_group_ids": {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			"registration_code": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"saml_properties": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"relay_state_parameter_name": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						names.AttrStatus: {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"user_access_url": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-					},
-				},
-			},
-			"self_service_permissions": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"change_compute_type": {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
-						"increase_volume_size": {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
-						"rebuild_workspace": {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
-						"restart_workspace": {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
-						"switch_running_mode": {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
-					},
-				},
-			},
-			names.AttrSubnetIDs: {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			names.AttrTags: tftags.TagsSchemaComputed(),
-			"tenancy": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"user_identity_type": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"workspace_access_properties": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"device_type_android": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"device_type_chromeos": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"device_type_ios": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"device_type_linux": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"device_type_osx": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"device_type_web": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"device_type_windows": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"device_type_zeroclient": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-					},
-				},
-			},
-			"workspace_creation_properties": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"custom_security_group_id": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"default_ou": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"enable_internet_access": {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
-						"enable_maintenance_mode": {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
-						"user_enabled_as_local_administrator": {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
-					},
-				},
-			},
-			"workspace_directory_description": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"workspace_directory_name": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"workspace_security_group_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"workspace_type": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-		},
+		SchemaFunc: func() map[string]*schema.Schema {
+  	return map[string]*schema.Schema{
+  			"active_directory_config": {
+  				Type:     schema.TypeSet,
+  				Computed: true,
+  				Elem: &schema.Resource{
+  					Schema: map[string]*schema.Schema{
+  						names.AttrDomainName: {
+  							Type:     schema.TypeString,
+  							Computed: true,
+  						},
+  						"service_account_secret_arn": {
+  							Type:     schema.TypeString,
+  							Computed: true,
+  						},
+  					},
+  				},
+  			},
+  			names.AttrAlias: {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			"certificate_based_auth_properties": {
+  				Type:     schema.TypeList,
+  				Computed: true,
+  				Elem: &schema.Resource{
+  					Schema: map[string]*schema.Schema{
+  						"certificate_authority_arn": {
+  							Type:     schema.TypeString,
+  							Computed: true,
+  						},
+  						names.AttrStatus: {
+  							Type:     schema.TypeString,
+  							Computed: true,
+  						},
+  					},
+  				},
+  			},
+  			"customer_user_name": {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			"directory_id": {
+  				Type:     schema.TypeString,
+  				Required: true,
+  			},
+  			"directory_name": {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			"directory_type": {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			"dns_ip_addresses": {
+  				Type:     schema.TypeSet,
+  				Computed: true,
+  				Elem:     &schema.Schema{Type: schema.TypeString},
+  			},
+  			"iam_role_id": {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			"ip_group_ids": {
+  				Type:     schema.TypeSet,
+  				Computed: true,
+  				Elem:     &schema.Schema{Type: schema.TypeString},
+  			},
+  			"registration_code": {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			"saml_properties": {
+  				Type:     schema.TypeList,
+  				Computed: true,
+  				Elem: &schema.Resource{
+  					Schema: map[string]*schema.Schema{
+  						"relay_state_parameter_name": {
+  							Type:     schema.TypeString,
+  							Computed: true,
+  						},
+  						names.AttrStatus: {
+  							Type:     schema.TypeString,
+  							Computed: true,
+  						},
+  						"user_access_url": {
+  							Type:     schema.TypeString,
+  							Computed: true,
+  						},
+  					},
+  				},
+  			},
+  			"self_service_permissions": {
+  				Type:     schema.TypeList,
+  				Computed: true,
+  				Elem: &schema.Resource{
+  					Schema: map[string]*schema.Schema{
+  						"change_compute_type": {
+  							Type:     schema.TypeBool,
+  							Computed: true,
+  						},
+  						"increase_volume_size": {
+  							Type:     schema.TypeBool,
+  							Computed: true,
+  						},
+  						"rebuild_workspace": {
+  							Type:     schema.TypeBool,
+  							Computed: true,
+  						},
+  						"restart_workspace": {
+  							Type:     schema.TypeBool,
+  							Computed: true,
+  						},
+  						"switch_running_mode": {
+  							Type:     schema.TypeBool,
+  							Computed: true,
+  						},
+  					},
+  				},
+  			},
+  			names.AttrSubnetIDs: {
+  				Type:     schema.TypeSet,
+  				Computed: true,
+  				Elem:     &schema.Schema{Type: schema.TypeString},
+  			},
+  			names.AttrTags: tftags.TagsSchemaComputed(),
+  			"tenancy": {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			"user_identity_type": {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			"workspace_access_properties": {
+  				Type:     schema.TypeList,
+  				Computed: true,
+  				Elem: &schema.Resource{
+  					Schema: map[string]*schema.Schema{
+  						"device_type_android": {
+  							Type:     schema.TypeString,
+  							Computed: true,
+  						},
+  						"device_type_chromeos": {
+  							Type:     schema.TypeString,
+  							Computed: true,
+  						},
+  						"device_type_ios": {
+  							Type:     schema.TypeString,
+  							Computed: true,
+  						},
+  						"device_type_linux": {
+  							Type:     schema.TypeString,
+  							Computed: true,
+  						},
+  						"device_type_osx": {
+  							Type:     schema.TypeString,
+  							Computed: true,
+  						},
+  						"device_type_web": {
+  							Type:     schema.TypeString,
+  							Computed: true,
+  						},
+  						"device_type_windows": {
+  							Type:     schema.TypeString,
+  							Computed: true,
+  						},
+  						"device_type_zeroclient": {
+  							Type:     schema.TypeString,
+  							Computed: true,
+  						},
+  					},
+  				},
+  			},
+  			"workspace_creation_properties": {
+  				Type:     schema.TypeList,
+  				Computed: true,
+  				Elem: &schema.Resource{
+  					Schema: map[string]*schema.Schema{
+  						"custom_security_group_id": {
+  							Type:     schema.TypeString,
+  							Computed: true,
+  						},
+  						"default_ou": {
+  							Type:     schema.TypeString,
+  							Computed: true,
+  						},
+  						"enable_internet_access": {
+  							Type:     schema.TypeBool,
+  							Computed: true,
+  						},
+  						"enable_maintenance_mode": {
+  							Type:     schema.TypeBool,
+  							Computed: true,
+  						},
+  						"user_enabled_as_local_administrator": {
+  							Type:     schema.TypeBool,
+  							Computed: true,
+  						},
+  					},
+  				},
+  			},
+  			"workspace_directory_description": {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			"workspace_directory_name": {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			"workspace_security_group_id": {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			"workspace_type": {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  		}
+  },
 	}
 }
 

--- a/internal/service/workspaces/image_data_source.go
+++ b/internal/service/workspaces/image_data_source.go
@@ -23,32 +23,34 @@ func dataSourceImage() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceImageRead,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrDescription: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"image_id": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"operating_system_type": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"required_tenancy": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrState: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-		},
+		SchemaFunc: func() map[string]*schema.Schema {
+  	return map[string]*schema.Schema{
+  			names.AttrDescription: {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			"image_id": {
+  				Type:     schema.TypeString,
+  				Required: true,
+  			},
+  			names.AttrName: {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			"operating_system_type": {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			"required_tenancy": {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			names.AttrState: {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  		}
+  },
 	}
 }
 

--- a/internal/service/workspaces/image_data_source.go
+++ b/internal/service/workspaces/image_data_source.go
@@ -24,33 +24,33 @@ func dataSourceImage() *schema.Resource {
 		ReadWithoutTimeout: dataSourceImageRead,
 
 		SchemaFunc: func() map[string]*schema.Schema {
-  	return map[string]*schema.Schema{
-  			names.AttrDescription: {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			"image_id": {
-  				Type:     schema.TypeString,
-  				Required: true,
-  			},
-  			names.AttrName: {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			"operating_system_type": {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			"required_tenancy": {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			names.AttrState: {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  		}
-  },
+			return map[string]*schema.Schema{
+				names.AttrDescription: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"image_id": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"operating_system_type": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"required_tenancy": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrState: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			}
+		},
 	}
 }
 

--- a/internal/service/workspaces/ip_group.go
+++ b/internal/service/workspaces/ip_group.go
@@ -38,38 +38,38 @@ func resourceIPGroup() *schema.Resource {
 		},
 
 		SchemaFunc: func() map[string]*schema.Schema {
-  	return map[string]*schema.Schema{
-  			names.AttrDescription: {
-  				Type:     schema.TypeString,
-  				Optional: true,
-  				ForceNew: true,
-  			},
-  			names.AttrName: {
-  				Type:     schema.TypeString,
-  				Required: true,
-  				ForceNew: true,
-  			},
-  			"rules": {
-  				Type:     schema.TypeSet,
-  				Optional: true,
-  				Elem: &schema.Resource{
-  					Schema: map[string]*schema.Schema{
-  						names.AttrDescription: {
-  							Type:     schema.TypeString,
-  							Optional: true,
-  						},
-  						names.AttrSource: {
-  							Type:         schema.TypeString,
-  							Required:     true,
-  							ValidateFunc: validation.IsCIDR,
-  						},
-  					},
-  				},
-  			},
-  			names.AttrTags:    tftags.TagsSchema(),
-  			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-  		}
-  },
+			return map[string]*schema.Schema{
+				names.AttrDescription: {
+					Type:     schema.TypeString,
+					Optional: true,
+					ForceNew: true,
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"rules": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrDescription: {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+							names.AttrSource: {
+								Type:         schema.TypeString,
+								Required:     true,
+								ValidateFunc: validation.IsCIDR,
+							},
+						},
+					},
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			}
+		},
 	}
 }
 

--- a/internal/service/workspaces/ip_group.go
+++ b/internal/service/workspaces/ip_group.go
@@ -37,37 +37,39 @@ func resourceIPGroup() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrDescription: {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"rules": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrDescription: {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						names.AttrSource: {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validation.IsCIDR,
-						},
-					},
-				},
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-		},
+		SchemaFunc: func() map[string]*schema.Schema {
+  	return map[string]*schema.Schema{
+  			names.AttrDescription: {
+  				Type:     schema.TypeString,
+  				Optional: true,
+  				ForceNew: true,
+  			},
+  			names.AttrName: {
+  				Type:     schema.TypeString,
+  				Required: true,
+  				ForceNew: true,
+  			},
+  			"rules": {
+  				Type:     schema.TypeSet,
+  				Optional: true,
+  				Elem: &schema.Resource{
+  					Schema: map[string]*schema.Schema{
+  						names.AttrDescription: {
+  							Type:     schema.TypeString,
+  							Optional: true,
+  						},
+  						names.AttrSource: {
+  							Type:         schema.TypeString,
+  							Required:     true,
+  							ValidateFunc: validation.IsCIDR,
+  						},
+  					},
+  				},
+  			},
+  			names.AttrTags:    tftags.TagsSchema(),
+  			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+  		}
+  },
 	}
 }
 

--- a/internal/service/workspaces/workspace.go
+++ b/internal/service/workspaces/workspace.go
@@ -41,110 +41,112 @@ func resourceWorkspace() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"bundle_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"computer_name": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"directory_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			names.AttrIPAddress: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"root_volume_encryption_enabled": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				ForceNew: true,
-				Default:  false,
-			},
-			names.AttrState: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			names.AttrUserName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"user_volume_encryption_enabled": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				ForceNew: true,
-				Default:  false,
-			},
-			"volume_encryption_key": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
-			"workspace_properties": {
-				Type:     schema.TypeList,
-				MaxItems: 1,
-				Optional: true,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"compute_type_name": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Default:          types.ComputeValue,
-							ValidateDiagFunc: enum.Validate[types.Compute](),
-						},
-						"root_volume_size_gib": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							Default:  80,
-							ValidateFunc: validation.Any(
-								validation.IntInSlice([]int{80}),
-								validation.IntBetween(175, 2000),
-							),
-						},
-						"running_mode": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Default:  types.RunningModeAlwaysOn,
-							ValidateFunc: validation.StringInSlice(enum.Slice(
-								types.RunningModeAlwaysOn,
-								types.RunningModeAutoStop,
-							), false),
-						},
-						"running_mode_auto_stop_timeout_in_minutes": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							Computed: true,
-							ValidateFunc: func(v any, k string) (ws []string, errors []error) {
-								val := v.(int)
-								if val%60 != 0 {
-									errors = append(errors, fmt.Errorf(
-										"%q should be configured in 60-minute intervals, got: %d", k, val))
-								}
-								return
-							},
-						},
-						"user_volume_size_gib": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							Default:  10,
-							ValidateFunc: validation.Any(
-								validation.IntInSlice([]int{10, 50}),
-								validation.IntBetween(100, 2000),
-							),
-						},
-					},
-				},
-			},
-		},
+		SchemaFunc: func() map[string]*schema.Schema {
+  	return map[string]*schema.Schema{
+  			"bundle_id": {
+  				Type:     schema.TypeString,
+  				Required: true,
+  				ForceNew: true,
+  			},
+  			"computer_name": {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			"directory_id": {
+  				Type:     schema.TypeString,
+  				Required: true,
+  				ForceNew: true,
+  			},
+  			names.AttrIPAddress: {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			"root_volume_encryption_enabled": {
+  				Type:     schema.TypeBool,
+  				Optional: true,
+  				ForceNew: true,
+  				Default:  false,
+  			},
+  			names.AttrState: {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			names.AttrTags:    tftags.TagsSchema(),
+  			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+  			names.AttrUserName: {
+  				Type:     schema.TypeString,
+  				Required: true,
+  				ForceNew: true,
+  			},
+  			"user_volume_encryption_enabled": {
+  				Type:     schema.TypeBool,
+  				Optional: true,
+  				ForceNew: true,
+  				Default:  false,
+  			},
+  			"volume_encryption_key": {
+  				Type:     schema.TypeString,
+  				Optional: true,
+  				ForceNew: true,
+  			},
+  			"workspace_properties": {
+  				Type:     schema.TypeList,
+  				MaxItems: 1,
+  				Optional: true,
+  				Computed: true,
+  				Elem: &schema.Resource{
+  					Schema: map[string]*schema.Schema{
+  						"compute_type_name": {
+  							Type:             schema.TypeString,
+  							Optional:         true,
+  							Default:          types.ComputeValue,
+  							ValidateDiagFunc: enum.Validate[types.Compute](),
+  						},
+  						"root_volume_size_gib": {
+  							Type:     schema.TypeInt,
+  							Optional: true,
+  							Default:  80,
+  							ValidateFunc: validation.Any(
+  								validation.IntInSlice([]int{80}),
+  								validation.IntBetween(175, 2000),
+  							),
+  						},
+  						"running_mode": {
+  							Type:     schema.TypeString,
+  							Optional: true,
+  							Default:  types.RunningModeAlwaysOn,
+  							ValidateFunc: validation.StringInSlice(enum.Slice(
+  								types.RunningModeAlwaysOn,
+  								types.RunningModeAutoStop,
+  							), false),
+  						},
+  						"running_mode_auto_stop_timeout_in_minutes": {
+  							Type:     schema.TypeInt,
+  							Optional: true,
+  							Computed: true,
+  							ValidateFunc: func(v any, k string) (ws []string, errors []error) {
+  								val := v.(int)
+  								if val%60 != 0 {
+  									errors = append(errors, fmt.Errorf(
+  										"%q should be configured in 60-minute intervals, got: %d", k, val))
+  								}
+  								return
+  							},
+  						},
+  						"user_volume_size_gib": {
+  							Type:     schema.TypeInt,
+  							Optional: true,
+  							Default:  10,
+  							ValidateFunc: validation.Any(
+  								validation.IntInSlice([]int{10, 50}),
+  								validation.IntBetween(100, 2000),
+  							),
+  						},
+  					},
+  				},
+  			},
+  		}
+  },
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),

--- a/internal/service/workspaces/workspace.go
+++ b/internal/service/workspaces/workspace.go
@@ -42,111 +42,111 @@ func resourceWorkspace() *schema.Resource {
 		},
 
 		SchemaFunc: func() map[string]*schema.Schema {
-  	return map[string]*schema.Schema{
-  			"bundle_id": {
-  				Type:     schema.TypeString,
-  				Required: true,
-  				ForceNew: true,
-  			},
-  			"computer_name": {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			"directory_id": {
-  				Type:     schema.TypeString,
-  				Required: true,
-  				ForceNew: true,
-  			},
-  			names.AttrIPAddress: {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			"root_volume_encryption_enabled": {
-  				Type:     schema.TypeBool,
-  				Optional: true,
-  				ForceNew: true,
-  				Default:  false,
-  			},
-  			names.AttrState: {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			names.AttrTags:    tftags.TagsSchema(),
-  			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-  			names.AttrUserName: {
-  				Type:     schema.TypeString,
-  				Required: true,
-  				ForceNew: true,
-  			},
-  			"user_volume_encryption_enabled": {
-  				Type:     schema.TypeBool,
-  				Optional: true,
-  				ForceNew: true,
-  				Default:  false,
-  			},
-  			"volume_encryption_key": {
-  				Type:     schema.TypeString,
-  				Optional: true,
-  				ForceNew: true,
-  			},
-  			"workspace_properties": {
-  				Type:     schema.TypeList,
-  				MaxItems: 1,
-  				Optional: true,
-  				Computed: true,
-  				Elem: &schema.Resource{
-  					Schema: map[string]*schema.Schema{
-  						"compute_type_name": {
-  							Type:             schema.TypeString,
-  							Optional:         true,
-  							Default:          types.ComputeValue,
-  							ValidateDiagFunc: enum.Validate[types.Compute](),
-  						},
-  						"root_volume_size_gib": {
-  							Type:     schema.TypeInt,
-  							Optional: true,
-  							Default:  80,
-  							ValidateFunc: validation.Any(
-  								validation.IntInSlice([]int{80}),
-  								validation.IntBetween(175, 2000),
-  							),
-  						},
-  						"running_mode": {
-  							Type:     schema.TypeString,
-  							Optional: true,
-  							Default:  types.RunningModeAlwaysOn,
-  							ValidateFunc: validation.StringInSlice(enum.Slice(
-  								types.RunningModeAlwaysOn,
-  								types.RunningModeAutoStop,
-  							), false),
-  						},
-  						"running_mode_auto_stop_timeout_in_minutes": {
-  							Type:     schema.TypeInt,
-  							Optional: true,
-  							Computed: true,
-  							ValidateFunc: func(v any, k string) (ws []string, errors []error) {
-  								val := v.(int)
-  								if val%60 != 0 {
-  									errors = append(errors, fmt.Errorf(
-  										"%q should be configured in 60-minute intervals, got: %d", k, val))
-  								}
-  								return
-  							},
-  						},
-  						"user_volume_size_gib": {
-  							Type:     schema.TypeInt,
-  							Optional: true,
-  							Default:  10,
-  							ValidateFunc: validation.Any(
-  								validation.IntInSlice([]int{10, 50}),
-  								validation.IntBetween(100, 2000),
-  							),
-  						},
-  					},
-  				},
-  			},
-  		}
-  },
+			return map[string]*schema.Schema{
+				"bundle_id": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"computer_name": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"directory_id": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				names.AttrIPAddress: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"root_volume_encryption_enabled": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					ForceNew: true,
+					Default:  false,
+				},
+				names.AttrState: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				names.AttrUserName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"user_volume_encryption_enabled": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					ForceNew: true,
+					Default:  false,
+				},
+				"volume_encryption_key": {
+					Type:     schema.TypeString,
+					Optional: true,
+					ForceNew: true,
+				},
+				"workspace_properties": {
+					Type:     schema.TypeList,
+					MaxItems: 1,
+					Optional: true,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"compute_type_name": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								Default:          types.ComputeValue,
+								ValidateDiagFunc: enum.Validate[types.Compute](),
+							},
+							"root_volume_size_gib": {
+								Type:     schema.TypeInt,
+								Optional: true,
+								Default:  80,
+								ValidateFunc: validation.Any(
+									validation.IntInSlice([]int{80}),
+									validation.IntBetween(175, 2000),
+								),
+							},
+							"running_mode": {
+								Type:     schema.TypeString,
+								Optional: true,
+								Default:  types.RunningModeAlwaysOn,
+								ValidateFunc: validation.StringInSlice(enum.Slice(
+									types.RunningModeAlwaysOn,
+									types.RunningModeAutoStop,
+								), false),
+							},
+							"running_mode_auto_stop_timeout_in_minutes": {
+								Type:     schema.TypeInt,
+								Optional: true,
+								Computed: true,
+								ValidateFunc: func(v any, k string) (ws []string, errors []error) {
+									val := v.(int)
+									if val%60 != 0 {
+										errors = append(errors, fmt.Errorf(
+											"%q should be configured in 60-minute intervals, got: %d", k, val))
+									}
+									return
+								},
+							},
+							"user_volume_size_gib": {
+								Type:     schema.TypeInt,
+								Optional: true,
+								Default:  10,
+								ValidateFunc: validation.Any(
+									validation.IntInSlice([]int{10, 50}),
+									validation.IntBetween(100, 2000),
+								),
+							},
+						},
+					},
+				},
+			}
+		},
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),

--- a/internal/service/workspaces/workspace_data_source.go
+++ b/internal/service/workspaces/workspace_data_source.go
@@ -26,85 +26,87 @@ func dataSourceWorkspace() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceWorkspaceRead,
 
-		Schema: map[string]*schema.Schema{
-			"bundle_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"computer_name": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"directory_id": {
-				Type:          schema.TypeString,
-				Computed:      true,
-				Optional:      true,
-				RequiredWith:  []string{names.AttrUserName},
-				ConflictsWith: []string{"workspace_id"},
-			},
-			names.AttrIPAddress: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"root_volume_encryption_enabled": {
-				Type:     schema.TypeBool,
-				Computed: true,
-			},
-			names.AttrState: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrTags: tftags.TagsSchemaComputed(),
-			names.AttrUserName: {
-				Type:          schema.TypeString,
-				Computed:      true,
-				Optional:      true,
-				RequiredWith:  []string{"directory_id"},
-				ConflictsWith: []string{"workspace_id"},
-			},
-			"user_volume_encryption_enabled": {
-				Type:     schema.TypeBool,
-				Computed: true,
-			},
-			"volume_encryption_key": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"workspace_id": {
-				Type:          schema.TypeString,
-				Computed:      true,
-				Optional:      true,
-				ConflictsWith: []string{"directory_id", names.AttrUserName},
-			},
-			"workspace_properties": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"compute_type_name": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"root_volume_size_gib": {
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
-						"running_mode": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"running_mode_auto_stop_timeout_in_minutes": {
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
-						"user_volume_size_gib": {
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
-					},
-				},
-			},
-		},
+		SchemaFunc: func() map[string]*schema.Schema {
+  	return map[string]*schema.Schema{
+  			"bundle_id": {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			"computer_name": {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			"directory_id": {
+  				Type:          schema.TypeString,
+  				Computed:      true,
+  				Optional:      true,
+  				RequiredWith:  []string{names.AttrUserName},
+  				ConflictsWith: []string{"workspace_id"},
+  			},
+  			names.AttrIPAddress: {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			"root_volume_encryption_enabled": {
+  				Type:     schema.TypeBool,
+  				Computed: true,
+  			},
+  			names.AttrState: {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			names.AttrTags: tftags.TagsSchemaComputed(),
+  			names.AttrUserName: {
+  				Type:          schema.TypeString,
+  				Computed:      true,
+  				Optional:      true,
+  				RequiredWith:  []string{"directory_id"},
+  				ConflictsWith: []string{"workspace_id"},
+  			},
+  			"user_volume_encryption_enabled": {
+  				Type:     schema.TypeBool,
+  				Computed: true,
+  			},
+  			"volume_encryption_key": {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			"workspace_id": {
+  				Type:          schema.TypeString,
+  				Computed:      true,
+  				Optional:      true,
+  				ConflictsWith: []string{"directory_id", names.AttrUserName},
+  			},
+  			"workspace_properties": {
+  				Type:     schema.TypeList,
+  				Computed: true,
+  				Elem: &schema.Resource{
+  					Schema: map[string]*schema.Schema{
+  						"compute_type_name": {
+  							Type:     schema.TypeString,
+  							Computed: true,
+  						},
+  						"root_volume_size_gib": {
+  							Type:     schema.TypeInt,
+  							Computed: true,
+  						},
+  						"running_mode": {
+  							Type:     schema.TypeString,
+  							Computed: true,
+  						},
+  						"running_mode_auto_stop_timeout_in_minutes": {
+  							Type:     schema.TypeInt,
+  							Computed: true,
+  						},
+  						"user_volume_size_gib": {
+  							Type:     schema.TypeInt,
+  							Computed: true,
+  						},
+  					},
+  				},
+  			},
+  		}
+  },
 	}
 }
 

--- a/internal/service/workspaces/workspace_data_source.go
+++ b/internal/service/workspaces/workspace_data_source.go
@@ -27,86 +27,86 @@ func dataSourceWorkspace() *schema.Resource {
 		ReadWithoutTimeout: dataSourceWorkspaceRead,
 
 		SchemaFunc: func() map[string]*schema.Schema {
-  	return map[string]*schema.Schema{
-  			"bundle_id": {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			"computer_name": {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			"directory_id": {
-  				Type:          schema.TypeString,
-  				Computed:      true,
-  				Optional:      true,
-  				RequiredWith:  []string{names.AttrUserName},
-  				ConflictsWith: []string{"workspace_id"},
-  			},
-  			names.AttrIPAddress: {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			"root_volume_encryption_enabled": {
-  				Type:     schema.TypeBool,
-  				Computed: true,
-  			},
-  			names.AttrState: {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			names.AttrTags: tftags.TagsSchemaComputed(),
-  			names.AttrUserName: {
-  				Type:          schema.TypeString,
-  				Computed:      true,
-  				Optional:      true,
-  				RequiredWith:  []string{"directory_id"},
-  				ConflictsWith: []string{"workspace_id"},
-  			},
-  			"user_volume_encryption_enabled": {
-  				Type:     schema.TypeBool,
-  				Computed: true,
-  			},
-  			"volume_encryption_key": {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			"workspace_id": {
-  				Type:          schema.TypeString,
-  				Computed:      true,
-  				Optional:      true,
-  				ConflictsWith: []string{"directory_id", names.AttrUserName},
-  			},
-  			"workspace_properties": {
-  				Type:     schema.TypeList,
-  				Computed: true,
-  				Elem: &schema.Resource{
-  					Schema: map[string]*schema.Schema{
-  						"compute_type_name": {
-  							Type:     schema.TypeString,
-  							Computed: true,
-  						},
-  						"root_volume_size_gib": {
-  							Type:     schema.TypeInt,
-  							Computed: true,
-  						},
-  						"running_mode": {
-  							Type:     schema.TypeString,
-  							Computed: true,
-  						},
-  						"running_mode_auto_stop_timeout_in_minutes": {
-  							Type:     schema.TypeInt,
-  							Computed: true,
-  						},
-  						"user_volume_size_gib": {
-  							Type:     schema.TypeInt,
-  							Computed: true,
-  						},
-  					},
-  				},
-  			},
-  		}
-  },
+			return map[string]*schema.Schema{
+				"bundle_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"computer_name": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"directory_id": {
+					Type:          schema.TypeString,
+					Computed:      true,
+					Optional:      true,
+					RequiredWith:  []string{names.AttrUserName},
+					ConflictsWith: []string{"workspace_id"},
+				},
+				names.AttrIPAddress: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"root_volume_encryption_enabled": {
+					Type:     schema.TypeBool,
+					Computed: true,
+				},
+				names.AttrState: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrTags: tftags.TagsSchemaComputed(),
+				names.AttrUserName: {
+					Type:          schema.TypeString,
+					Computed:      true,
+					Optional:      true,
+					RequiredWith:  []string{"directory_id"},
+					ConflictsWith: []string{"workspace_id"},
+				},
+				"user_volume_encryption_enabled": {
+					Type:     schema.TypeBool,
+					Computed: true,
+				},
+				"volume_encryption_key": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"workspace_id": {
+					Type:          schema.TypeString,
+					Computed:      true,
+					Optional:      true,
+					ConflictsWith: []string{"directory_id", names.AttrUserName},
+				},
+				"workspace_properties": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"compute_type_name": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"root_volume_size_gib": {
+								Type:     schema.TypeInt,
+								Computed: true,
+							},
+							"running_mode": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"running_mode_auto_stop_timeout_in_minutes": {
+								Type:     schema.TypeInt,
+								Computed: true,
+							},
+							"user_volume_size_gib": {
+								Type:     schema.TypeInt,
+								Computed: true,
+							},
+						},
+					},
+				},
+			}
+		},
 	}
 }
 

--- a/internal/service/xray/encryption_config.go
+++ b/internal/service/xray/encryption_config.go
@@ -38,19 +38,19 @@ func resourceEncryptionConfig() *schema.Resource {
 		DeleteWithoutTimeout: schema.NoopContext,
 
 		SchemaFunc: func() map[string]*schema.Schema {
-  	return map[string]*schema.Schema{
-  			names.AttrKeyID: {
-  				Type:         schema.TypeString,
-  				Optional:     true,
-  				ValidateFunc: verify.ValidARN,
-  			},
-  			names.AttrType: {
-  				Type:             schema.TypeString,
-  				Required:         true,
-  				ValidateDiagFunc: enum.Validate[types.EncryptionType](),
-  			},
-  		}
-  },
+			return map[string]*schema.Schema{
+				names.AttrKeyID: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				names.AttrType: {
+					Type:             schema.TypeString,
+					Required:         true,
+					ValidateDiagFunc: enum.Validate[types.EncryptionType](),
+				},
+			}
+		},
 	}
 }
 

--- a/internal/service/xray/encryption_config.go
+++ b/internal/service/xray/encryption_config.go
@@ -37,18 +37,20 @@ func resourceEncryptionConfig() *schema.Resource {
 		UpdateWithoutTimeout: resourceEncryptionPutConfig,
 		DeleteWithoutTimeout: schema.NoopContext,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrKeyID: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			names.AttrType: {
-				Type:             schema.TypeString,
-				Required:         true,
-				ValidateDiagFunc: enum.Validate[types.EncryptionType](),
-			},
-		},
+		SchemaFunc: func() map[string]*schema.Schema {
+  	return map[string]*schema.Schema{
+  			names.AttrKeyID: {
+  				Type:         schema.TypeString,
+  				Optional:     true,
+  				ValidateFunc: verify.ValidARN,
+  			},
+  			names.AttrType: {
+  				Type:             schema.TypeString,
+  				Required:         true,
+  				ValidateDiagFunc: enum.Validate[types.EncryptionType](),
+  			},
+  		}
+  },
 	}
 }
 

--- a/internal/service/xray/group.go
+++ b/internal/service/xray/group.go
@@ -35,42 +35,44 @@ func resourceGroup() *schema.Resource {
 		UpdateWithoutTimeout: resourceGroupUpdate,
 		DeleteWithoutTimeout: resourceGroupDelete,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrGroupName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"filter_expression": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"insights_configuration": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Computed: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"insights_enabled": {
-							Type:     schema.TypeBool,
-							Required: true,
-						},
-						"notifications_enabled": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Computed: true,
-						},
-					},
-				},
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-		},
+		SchemaFunc: func() map[string]*schema.Schema {
+  	return map[string]*schema.Schema{
+  			names.AttrARN: {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			names.AttrGroupName: {
+  				Type:     schema.TypeString,
+  				Required: true,
+  				ForceNew: true,
+  			},
+  			"filter_expression": {
+  				Type:     schema.TypeString,
+  				Required: true,
+  			},
+  			"insights_configuration": {
+  				Type:     schema.TypeList,
+  				Optional: true,
+  				Computed: true,
+  				MaxItems: 1,
+  				Elem: &schema.Resource{
+  					Schema: map[string]*schema.Schema{
+  						"insights_enabled": {
+  							Type:     schema.TypeBool,
+  							Required: true,
+  						},
+  						"notifications_enabled": {
+  							Type:     schema.TypeBool,
+  							Optional: true,
+  							Computed: true,
+  						},
+  					},
+  				},
+  			},
+  			names.AttrTags:    tftags.TagsSchema(),
+  			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+  		}
+  },
 	}
 }
 

--- a/internal/service/xray/group.go
+++ b/internal/service/xray/group.go
@@ -36,43 +36,43 @@ func resourceGroup() *schema.Resource {
 		DeleteWithoutTimeout: resourceGroupDelete,
 
 		SchemaFunc: func() map[string]*schema.Schema {
-  	return map[string]*schema.Schema{
-  			names.AttrARN: {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			names.AttrGroupName: {
-  				Type:     schema.TypeString,
-  				Required: true,
-  				ForceNew: true,
-  			},
-  			"filter_expression": {
-  				Type:     schema.TypeString,
-  				Required: true,
-  			},
-  			"insights_configuration": {
-  				Type:     schema.TypeList,
-  				Optional: true,
-  				Computed: true,
-  				MaxItems: 1,
-  				Elem: &schema.Resource{
-  					Schema: map[string]*schema.Schema{
-  						"insights_enabled": {
-  							Type:     schema.TypeBool,
-  							Required: true,
-  						},
-  						"notifications_enabled": {
-  							Type:     schema.TypeBool,
-  							Optional: true,
-  							Computed: true,
-  						},
-  					},
-  				},
-  			},
-  			names.AttrTags:    tftags.TagsSchema(),
-  			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-  		}
-  },
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrGroupName: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"filter_expression": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"insights_configuration": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Computed: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"insights_enabled": {
+								Type:     schema.TypeBool,
+								Required: true,
+							},
+							"notifications_enabled": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Computed: true,
+							},
+						},
+					},
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			}
+		},
 	}
 }
 

--- a/internal/service/xray/sampling_rule.go
+++ b/internal/service/xray/sampling_rule.go
@@ -39,78 +39,78 @@ func resourceSamplingRule() *schema.Resource {
 		DeleteWithoutTimeout: resourceSamplingRuleDelete,
 
 		SchemaFunc: func() map[string]*schema.Schema {
-  	return map[string]*schema.Schema{
-  			names.AttrARN: {
-  				Type:     schema.TypeString,
-  				Computed: true,
-  			},
-  			names.AttrAttributes: {
-  				Type:     schema.TypeMap,
-  				Optional: true,
-  				Elem: &schema.Schema{
-  					Type:         schema.TypeString,
-  					ValidateFunc: validation.StringLenBetween(1, 32),
-  				},
-  			},
-  			"fixed_rate": {
-  				Type:     schema.TypeFloat,
-  				Required: true,
-  			},
-  			"host": {
-  				Type:         schema.TypeString,
-  				Required:     true,
-  				ValidateFunc: validation.StringLenBetween(0, 64),
-  			},
-  			"http_method": {
-  				Type:         schema.TypeString,
-  				Required:     true,
-  				ValidateFunc: validation.StringLenBetween(0, 10),
-  			},
-  			names.AttrPriority: {
-  				Type:         schema.TypeInt,
-  				Required:     true,
-  				ValidateFunc: validation.IntBetween(1, 9999),
-  			},
-  			"reservoir_size": {
-  				Type:         schema.TypeInt,
-  				Required:     true,
-  				ValidateFunc: validation.IntAtLeast(0),
-  			},
-  			names.AttrResourceARN: {
-  				Type:     schema.TypeString,
-  				Required: true,
-  			},
-  			"rule_name": {
-  				Type:         schema.TypeString,
-  				Optional:     true,
-  				ForceNew:     true,
-  				ValidateFunc: validation.StringLenBetween(1, 32),
-  			},
-  			names.AttrServiceName: {
-  				Type:         schema.TypeString,
-  				Required:     true,
-  				ValidateFunc: validation.StringLenBetween(0, 64),
-  			},
-  			"service_type": {
-  				Type:         schema.TypeString,
-  				Required:     true,
-  				ValidateFunc: validation.StringLenBetween(0, 64),
-  			},
-  			names.AttrTags:    tftags.TagsSchema(),
-  			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-  			"url_path": {
-  				Type:         schema.TypeString,
-  				Required:     true,
-  				ValidateFunc: validation.StringLenBetween(0, 128),
-  			},
-  			names.AttrVersion: {
-  				Type:         schema.TypeInt,
-  				Required:     true,
-  				ForceNew:     true,
-  				ValidateFunc: validation.IntAtLeast(1),
-  			},
-  		}
-  },
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrAttributes: {
+					Type:     schema.TypeMap,
+					Optional: true,
+					Elem: &schema.Schema{
+						Type:         schema.TypeString,
+						ValidateFunc: validation.StringLenBetween(1, 32),
+					},
+				},
+				"fixed_rate": {
+					Type:     schema.TypeFloat,
+					Required: true,
+				},
+				"host": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringLenBetween(0, 64),
+				},
+				"http_method": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringLenBetween(0, 10),
+				},
+				names.AttrPriority: {
+					Type:         schema.TypeInt,
+					Required:     true,
+					ValidateFunc: validation.IntBetween(1, 9999),
+				},
+				"reservoir_size": {
+					Type:         schema.TypeInt,
+					Required:     true,
+					ValidateFunc: validation.IntAtLeast(0),
+				},
+				names.AttrResourceARN: {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"rule_name": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringLenBetween(1, 32),
+				},
+				names.AttrServiceName: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringLenBetween(0, 64),
+				},
+				"service_type": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringLenBetween(0, 64),
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				"url_path": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringLenBetween(0, 128),
+				},
+				names.AttrVersion: {
+					Type:         schema.TypeInt,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.IntAtLeast(1),
+				},
+			}
+		},
 	}
 }
 

--- a/internal/service/xray/sampling_rule.go
+++ b/internal/service/xray/sampling_rule.go
@@ -38,77 +38,79 @@ func resourceSamplingRule() *schema.Resource {
 		UpdateWithoutTimeout: resourceSamplingRuleUpdate,
 		DeleteWithoutTimeout: resourceSamplingRuleDelete,
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			names.AttrAttributes: {
-				Type:     schema.TypeMap,
-				Optional: true,
-				Elem: &schema.Schema{
-					Type:         schema.TypeString,
-					ValidateFunc: validation.StringLenBetween(1, 32),
-				},
-			},
-			"fixed_rate": {
-				Type:     schema.TypeFloat,
-				Required: true,
-			},
-			"host": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringLenBetween(0, 64),
-			},
-			"http_method": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringLenBetween(0, 10),
-			},
-			names.AttrPriority: {
-				Type:         schema.TypeInt,
-				Required:     true,
-				ValidateFunc: validation.IntBetween(1, 9999),
-			},
-			"reservoir_size": {
-				Type:         schema.TypeInt,
-				Required:     true,
-				ValidateFunc: validation.IntAtLeast(0),
-			},
-			names.AttrResourceARN: {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"rule_name": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(1, 32),
-			},
-			names.AttrServiceName: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringLenBetween(0, 64),
-			},
-			"service_type": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringLenBetween(0, 64),
-			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
-			"url_path": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringLenBetween(0, 128),
-			},
-			names.AttrVersion: {
-				Type:         schema.TypeInt,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.IntAtLeast(1),
-			},
-		},
+		SchemaFunc: func() map[string]*schema.Schema {
+  	return map[string]*schema.Schema{
+  			names.AttrARN: {
+  				Type:     schema.TypeString,
+  				Computed: true,
+  			},
+  			names.AttrAttributes: {
+  				Type:     schema.TypeMap,
+  				Optional: true,
+  				Elem: &schema.Schema{
+  					Type:         schema.TypeString,
+  					ValidateFunc: validation.StringLenBetween(1, 32),
+  				},
+  			},
+  			"fixed_rate": {
+  				Type:     schema.TypeFloat,
+  				Required: true,
+  			},
+  			"host": {
+  				Type:         schema.TypeString,
+  				Required:     true,
+  				ValidateFunc: validation.StringLenBetween(0, 64),
+  			},
+  			"http_method": {
+  				Type:         schema.TypeString,
+  				Required:     true,
+  				ValidateFunc: validation.StringLenBetween(0, 10),
+  			},
+  			names.AttrPriority: {
+  				Type:         schema.TypeInt,
+  				Required:     true,
+  				ValidateFunc: validation.IntBetween(1, 9999),
+  			},
+  			"reservoir_size": {
+  				Type:         schema.TypeInt,
+  				Required:     true,
+  				ValidateFunc: validation.IntAtLeast(0),
+  			},
+  			names.AttrResourceARN: {
+  				Type:     schema.TypeString,
+  				Required: true,
+  			},
+  			"rule_name": {
+  				Type:         schema.TypeString,
+  				Optional:     true,
+  				ForceNew:     true,
+  				ValidateFunc: validation.StringLenBetween(1, 32),
+  			},
+  			names.AttrServiceName: {
+  				Type:         schema.TypeString,
+  				Required:     true,
+  				ValidateFunc: validation.StringLenBetween(0, 64),
+  			},
+  			"service_type": {
+  				Type:         schema.TypeString,
+  				Required:     true,
+  				ValidateFunc: validation.StringLenBetween(0, 64),
+  			},
+  			names.AttrTags:    tftags.TagsSchema(),
+  			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+  			"url_path": {
+  				Type:         schema.TypeString,
+  				Required:     true,
+  				ValidateFunc: validation.StringLenBetween(0, 128),
+  			},
+  			names.AttrVersion: {
+  				Type:         schema.TypeInt,
+  				Required:     true,
+  				ForceNew:     true,
+  				ValidateFunc: validation.IntAtLeast(1),
+  			},
+  		}
+  },
 	}
 }
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Use `SchemaFunc` instead of `Schema` for `t`, `v`, `w`, and `x` services. Completes replacement of `Schema` with `SchemaFunc`

Schema is unchanged according to the script in #47758
