### PR TITLE
r/aws_kinesis_firehose_delivery_stream: Add `testAccDeliveryStreamConfig_s3CloudWatchLoggingUpdate`

### DIFF
--- a/internal/service/firehose/delivery_stream_test.go
+++ b/internal/service/firehose/delivery_stream_test.go
@@ -220,6 +220,23 @@ func TestAccFirehoseDeliveryStream_s3WithCloudWatchLogging(t *testing.T) {
 					testAccCheckDeliveryStreamExists(ctx, t, resourceName, &stream),
 					testAccCheckDeliveryStreamAttributes(&stream, nil, nil, nil, nil, nil, nil, nil),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+			},
+			{
+				Config: testAccDeliveryStreamConfig_s3CloudWatchLoggingUpdate(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDeliveryStreamExists(ctx, t, resourceName, &stream),
+					testAccCheckDeliveryStreamAttributes(&stream, nil, nil, nil, nil, nil, nil, nil),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
 			},
 		},
 	})
@@ -3133,7 +3150,7 @@ EOF
 `, rName))
 }
 
-func testAccDeliveryStreamConfig_s3CloudWatchLogging(rName string) string {
+func testAccDeliveryStreamConfig_baseS3CloudWatchLogging(rName string) string {
 	return fmt.Sprintf(`
 data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
@@ -3210,10 +3227,16 @@ resource "aws_cloudwatch_log_group" "test" {
 }
 
 resource "aws_cloudwatch_log_stream" "test" {
-  name           = %[1]q
+  count = 2
+
+  name           = "%[1]s-${count.index}"
   log_group_name = aws_cloudwatch_log_group.test.name
 }
+`, rName)
+}
 
+func testAccDeliveryStreamConfig_s3CloudWatchLogging(rName string) string {
+	return acctest.ConfigCompose(testAccDeliveryStreamConfig_baseS3CloudWatchLogging(rName), fmt.Sprintf(`
 resource "aws_kinesis_firehose_delivery_stream" "test" {
   depends_on  = [aws_iam_role_policy.firehose]
   name        = %[1]q
@@ -3226,11 +3249,45 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
     cloudwatch_logging_options {
       enabled         = true
       log_group_name  = aws_cloudwatch_log_group.test.name
-      log_stream_name = aws_cloudwatch_log_stream.test.name
+      log_stream_name = aws_cloudwatch_log_stream.test[0].name
     }
   }
 }
-`, rName)
+`, rName))
+}
+
+func testAccDeliveryStreamConfig_s3CloudWatchLoggingUpdate(rName string) string {
+	return acctest.ConfigCompose(testAccDeliveryStreamConfig_baseS3CloudWatchLogging(rName), fmt.Sprintf(`
+resource "aws_kinesis_firehose_delivery_stream" "test" {
+  depends_on  = [aws_iam_role_policy.firehose]
+  name        = %[1]q
+  destination = "extended_s3"
+
+  extended_s3_configuration {
+    role_arn   = aws_iam_role.firehose.arn
+    bucket_arn = aws_s3_bucket.bucket.arn
+
+    cloudwatch_logging_options {
+      enabled         = true
+      log_group_name  = aws_cloudwatch_log_group.test.name
+      log_stream_name = aws_cloudwatch_log_stream.test[0].name
+    }
+
+    s3_backup_mode = "Enabled"
+    s3_backup_configuration {
+      role_arn            = aws_iam_role.firehose.arn
+      bucket_arn          = aws_s3_bucket.bucket.arn
+      error_output_prefix = "prefix1"
+
+      cloudwatch_logging_options {
+        enabled         = true
+        log_group_name  = aws_cloudwatch_log_group.test.name
+        log_stream_name = aws_cloudwatch_log_stream.test[1].name
+      }
+    }
+  }
+}
+`, rName))
 }
 
 func testAccDeliveryStreamConfig_baseSecretsManager(rName, privateKey string) string {


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Adds an `aws_kinesis_firehose_delivery_stream` test for `extended_s3_configuration.s3_backup_configuration.cloudwatch_logging_options`.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/48261.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccFirehoseDeliveryStream_s3WithCloudWatchLogging' PKG=firehose
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     5.901s
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework 5.959s
make: Running acceptance tests on branch: 🌿 b-aws_kinesis_firehose_delivery_stream.extended_s3_configuration.cloudwatch_logging_options 🌿...
TF_ACC=1 go1.26.3 test ./internal/service/firehose/... -v -count 1 -parallel 20  -run=TestAccFirehoseDeliveryStream_s3WithCloudWatchLogging -timeout 360m -vet=off -buildvcs=false
2026/06/08 15:07:25 Creating Terraform AWS Provider (SDKv2-style)...
2026/06/08 15:07:25 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccFirehoseDeliveryStream_s3WithCloudWatchLogging
=== PAUSE TestAccFirehoseDeliveryStream_s3WithCloudWatchLogging
=== CONT  TestAccFirehoseDeliveryStream_s3WithCloudWatchLogging
--- PASS: TestAccFirehoseDeliveryStream_s3WithCloudWatchLogging (90.78s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/firehose   96.863s
```
