### PR TITLE
r/aws_lakeformation_data_cells_filter(test): additional `data_cells_filter` cases

### DIFF
--- a/internal/service/lakeformation/data_cells_filter_test.go
+++ b/internal/service/lakeformation/data_cells_filter_test.go
@@ -91,7 +91,55 @@ func testAccDataCellsFilter_columnWildcard(t *testing.T) {
 	})
 }
 
-func testAccDataCellsFilter_columnWildcardMultiple(t *testing.T) {
+func testAccDataCellsFilter_ColumnWildcard_update(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var datacellsfilter awstypes.DataCellsFilter
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_lakeformation_data_cells_filter.test"
+
+	acctest.Test(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.LakeFormationEndpointID)
+			testAccDataCellsFilterPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.LakeFormationServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDataCellsFilterDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			// Create with multiple excluded_column_names
+			{
+				Config: testAccDataCellsFilterConfig_columnWildcardMultiple(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataCellsFilterExists(ctx, t, resourceName, &datacellsfilter),
+					resource.TestCheckResourceAttr(resourceName, "table_data.0.column_wildcard.0.excluded_column_names.#", "2"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "table_data.0.column_wildcard.0.excluded_column_names.*", "my_column_12"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "table_data.0.column_wildcard.0.excluded_column_names.*", "my_column_22"),
+				),
+			},
+			// Set excluded_column_names to empty list
+			{
+				Config: testAccDataCellsFilterConfig_columnWildcardEmpty(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataCellsFilterExists(ctx, t, resourceName, &datacellsfilter),
+					resource.TestCheckResourceAttr(resourceName, "table_data.0.column_wildcard.0.excluded_column_names.#", "0"),
+				),
+			},
+			// Update to non-empty excluded_column_names
+			{
+				Config: testAccDataCellsFilterConfig_columnWildcard(rName, "my_column_12"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataCellsFilterExists(ctx, t, resourceName, &datacellsfilter),
+					resource.TestCheckResourceAttr(resourceName, "table_data.0.column_wildcard.0.excluded_column_names.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "table_data.0.column_wildcard.0.excluded_column_names.*", "my_column_12"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataCellsFilter_ColumnWildcard_empty(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	var datacellsfilter awstypes.DataCellsFilter
@@ -109,19 +157,11 @@ func testAccDataCellsFilter_columnWildcardMultiple(t *testing.T) {
 		CheckDestroy:             testAccCheckDataCellsFilterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				// Test with columns in non-alphabetical order to verify no ordering issues
-				Config: testAccDataCellsFilterConfig_columnWildcardMultiple(rName),
+				Config: testAccDataCellsFilterConfig_columnWildcardEmpty(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataCellsFilterExists(ctx, t, resourceName, &datacellsfilter),
-					resource.TestCheckResourceAttr(resourceName, "table_data.0.column_wildcard.0.excluded_column_names.#", "2"),
-					resource.TestCheckTypeSetElemAttr(resourceName, "table_data.0.column_wildcard.0.excluded_column_names.*", "my_column_12"),
-					resource.TestCheckTypeSetElemAttr(resourceName, "table_data.0.column_wildcard.0.excluded_column_names.*", "my_column_22"),
+					resource.TestCheckResourceAttr(resourceName, "table_data.0.column_wildcard.0.excluded_column_names.#", "0"),
 				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
 			},
 		},
 	})
@@ -401,6 +441,31 @@ resource "aws_lakeformation_data_cells_filter" "test" {
     column_wildcard {
       # Columns specified in non-alphabetical order to test ordering fix
       excluded_column_names = ["my_column_22", "my_column_12"]
+    }
+
+    row_filter {
+      filter_expression = "my_column_23='testing'"
+    }
+  }
+
+  depends_on = [aws_lakeformation_data_lake_settings.test]
+}
+`, rName))
+}
+
+func testAccDataCellsFilterConfig_columnWildcardEmpty(rName string) string {
+	return acctest.ConfigCompose(
+		testAccDataCellsFilterConfigBase(rName),
+		fmt.Sprintf(`
+resource "aws_lakeformation_data_cells_filter" "test" {
+  table_data {
+    database_name    = aws_glue_catalog_database.test.name
+    name             = %[1]q
+    table_catalog_id = data.aws_caller_identity.current.account_id
+    table_name       = aws_glue_catalog_table.test.name
+
+    column_wildcard {
+      excluded_column_names = []
     }
 
     row_filter {

--- a/internal/service/lakeformation/lakeformation_test.go
+++ b/internal/service/lakeformation/lakeformation_test.go
@@ -21,11 +21,12 @@ func TestAccLakeFormation_serial(t *testing.T) {
 			"parameters":         testAccDataLakeSettings_parameters,
 		},
 		"DataCellsFilter": {
-			acctest.CtBasic:          testAccDataCellsFilter_basic,
-			"columnWildcard":         testAccDataCellsFilter_columnWildcard,
-			"columnWildcardMultiple": testAccDataCellsFilter_columnWildcardMultiple,
-			acctest.CtDisappears:     testAccDataCellsFilter_disappears,
-			"rowFilter":              testAccDataCellsFilter_rowFilter,
+			acctest.CtBasic:        testAccDataCellsFilter_basic,
+			"columnWildcard":       testAccDataCellsFilter_columnWildcard,
+			"columnWildcardUpdate": testAccDataCellsFilter_ColumnWildcard_update,
+			"columnWildcardEmpty":  testAccDataCellsFilter_ColumnWildcard_empty,
+			acctest.CtDisappears:   testAccDataCellsFilter_disappears,
+			"rowFilter":            testAccDataCellsFilter_rowFilter,
 		},
 		"DataLakeSettingsDataSource": {
 			acctest.CtBasic:  testAccDataLakeSettingsDataSource_basic,


### PR DESCRIPTION


### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Specifically, adding test cases which exercise the modification of `data_cells_filter.excluded_column_names` and explicitly setting the value to an empty set (`[]`).

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #48208


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->




```console
% make t K=lakeformation T=TestAccLakeFormation_serial/DataCellsFilter
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 b-lf-excluded_column_filters-empty 🌿...
TF_ACC=1 go1.26.3 test ./internal/service/lakeformation/... -v -count 1 -parallel 20 -run='TestAccLakeFormation_serial/DataCellsFilter'  -timeout 360m -vet=off
2026/06/08 15:10:53 Creating Terraform AWS Provider (SDKv2-style)...
2026/06/08 15:10:53 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccLakeFormation_serial (153.70s)
    --- PASS: TestAccLakeFormation_serial/DataCellsFilter (153.70s)
        --- PASS: TestAccLakeFormation_serial/DataCellsFilter/columnWildcard (19.13s)
        --- PASS: TestAccLakeFormation_serial/DataCellsFilter/columnWildcardUpdate (43.88s)
        --- PASS: TestAccLakeFormation_serial/DataCellsFilter/columnWildcardEmpty (17.99s)
        --- PASS: TestAccLakeFormation_serial/DataCellsFilter/disappears (20.02s)
        --- PASS: TestAccLakeFormation_serial/DataCellsFilter/rowFilter (30.81s)
        --- PASS: TestAccLakeFormation_serial/DataCellsFilter/basic (21.87s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lakeformation      162.112s
```