### PR TITLE
r/aws_route53profiles_resource_association: mark resource_properties as ForceNew

### DIFF
--- a/.changelog/48279.txt
+++ b/.changelog/48279.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_route53profiles_resource_association: Mark `resource_properties` as ForceNew so changes recreate the association instead of erroring against the unsupported update operation
+```

--- a/internal/service/route53profiles/resource_association.go
+++ b/internal/service/route53profiles/resource_association.go
@@ -81,6 +81,9 @@ func (r *resourceAssociationResource) Schema(ctx context.Context, req resource.S
 				Computed:   true,
 				CustomType: types.StringType,
 				Optional:   true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			names.AttrResourceType: schema.StringAttribute{
 				Computed: true,

--- a/internal/service/route53profiles/resource_association_test.go
+++ b/internal/service/route53profiles/resource_association_test.go
@@ -80,7 +80,7 @@ func TestAccRoute53ProfilesResourceAssociation_firewallRuleGroup(t *testing.T) {
 		CheckDestroy:             testAccCheckResourceAssociationDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceAssociationConfig_firewallRuleGroup(rName),
+				Config: testAccResourceAssociationConfig_firewallRuleGroup(rName, 102),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceAssociationExists(ctx, t, resourceName, &resourceAssociation),
 				),
@@ -90,6 +90,17 @@ func TestAccRoute53ProfilesResourceAssociation_firewallRuleGroup(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{},
+			},
+			{
+				Config: testAccResourceAssociationConfig_firewallRuleGroup(rName, 103),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckResourceAssociationExists(ctx, t, resourceName, &resourceAssociation),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionReplace),
+					},
+				},
 			},
 		},
 	})
@@ -306,7 +317,7 @@ resource "aws_route53profiles_resource_association" "test" {
 `, rName)
 }
 
-func testAccResourceAssociationConfig_firewallRuleGroup(rName string) string {
+func testAccResourceAssociationConfig_firewallRuleGroup(rName string, priority int) string {
 	return fmt.Sprintf(`
 resource "aws_route53profiles_profile" "test" {
   name = %[1]q
@@ -320,9 +331,9 @@ resource "aws_route53profiles_resource_association" "test" {
   name                = %[1]q
   profile_id          = aws_route53profiles_profile.test.id
   resource_arn        = aws_route53_resolver_firewall_rule_group.test.arn
-  resource_properties = jsonencode({ "priority" = 102 })
+  resource_properties = jsonencode({ "priority" = %[2]d })
 }
-`, rName)
+`, rName, priority)
 }
 
 func testAccResourceAssociationConfig_resolverRule(rName string) string {


### PR DESCRIPTION
## Description

`aws_route53profiles_resource_association` has no Update operation, but `resource_properties` was missing a `RequiresReplace` plan modifier. Changing it produced an in-place update plan that errored at apply time.

This adds `stringplanmodifier.RequiresReplace()` to `resource_properties`, matching the existing behaviour of `name`, `profile_id`, and `resource_arn`.

## Testing

Extended `TestAccRoute53ProfilesResourceAssociation_firewallRuleGroup` with a third step that changes `resource_properties` (priority 102 → 103) and asserts `ResourceActionReplace` in the pre-apply plan check.

Output:

```
=== RUN   TestAccRoute53ProfilesResourceAssociation_firewallRuleGroup
=== PAUSE TestAccRoute53ProfilesResourceAssociation_firewallRuleGroup
=== CONT  TestAccRoute53ProfilesResourceAssociation_firewallRuleGroup
--- PASS: TestAccRoute53ProfilesResourceAssociation_firewallRuleGroup (290.16s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/route53profiles	296.533s
```