### PR TITLE
New List Resource: `aws_acm_certificate`

### DIFF
--- a/.changelog/48283.txt
+++ b/.changelog/48283.txt
@@ -1,0 +1,3 @@
+```release-note:new-list-resource
+aws_acm_certificate
+```

--- a/internal/service/acm/certificate.go
+++ b/internal/service/acm/certificate.go
@@ -496,7 +496,7 @@ func resourceCertificateRead(ctx context.Context, d *schema.ResourceData, meta a
 	return append(diags, resourceCertificateFlatten(ctx, d, certificate)...)
 }
 
-func resourceCertificateFlatten(ctx context.Context, d *schema.ResourceData, certificate *types.CertificateDetail) diag.Diagnostics {
+func resourceCertificateFlatten(_ context.Context, d *schema.ResourceData, certificate *types.CertificateDetail) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	domainValidationOptions, validationEmails := flattenDomainValidations(certificate.DomainValidationOptions)

--- a/internal/service/acm/certificate.go
+++ b/internal/service/acm/certificate.go
@@ -493,6 +493,12 @@ func resourceCertificateRead(ctx context.Context, d *schema.ResourceData, meta a
 		return sdkdiag.AppendErrorf(diags, "reading ACM Certificate (%s): %s", d.Id(), err)
 	}
 
+	return append(diags, resourceCertificateFlatten(ctx, d, certificate)...)
+}
+
+func resourceCertificateFlatten(ctx context.Context, d *schema.ResourceData, certificate *types.CertificateDetail) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	domainValidationOptions, validationEmails := flattenDomainValidations(certificate.DomainValidationOptions)
 
 	d.Set(names.AttrARN, certificate.CertificateArn)

--- a/internal/service/acm/certificate_list.go
+++ b/internal/service/acm/certificate_list.go
@@ -1,0 +1,128 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package acm
+
+import (
+	"context"
+	"fmt"
+	"iter"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/acm"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/acm/types"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/logging"
+	inttypes "github.com/hashicorp/terraform-provider-aws/internal/types"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @SDKListResource("aws_acm_certificate")
+func newCertificateResourceAsListResource() inttypes.ListResourceForSDK {
+	l := certificateListResource{}
+	l.SetResourceSchema(resourceCertificate())
+	return &l
+}
+
+var _ list.ListResource = &certificateListResource{}
+
+type certificateListResource struct {
+	framework.ListResourceWithSDKv2Resource
+}
+
+type certificateListResourceModel struct {
+	framework.WithRegionModel
+}
+
+func (l *certificateListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
+	awsClient := l.Meta()
+	conn := awsClient.ACMClient(ctx)
+
+	var query certificateListResourceModel
+	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
+		if diags := request.Config.Get(ctx, &query); diags.HasError() {
+			stream.Results = list.ListResultsStreamDiagnostics(diags)
+			return
+		}
+	}
+
+	tflog.Info(ctx, "Listing ACM Certificates")
+
+	stream.Results = func(yield func(list.ListResult) bool) {
+		input := acm.ListCertificatesInput{
+			Includes: &awstypes.Filters{
+				KeyTypes: enum.EnumValues[awstypes.KeyAlgorithm](),
+			},
+		}
+		for item, err := range listCertificates(ctx, conn, &input) {
+			if err != nil {
+				result := fwdiag.NewListResultErrorDiagnostic(err)
+				yield(result)
+				return
+			}
+
+			arn := aws.ToString(item.CertificateArn)
+			ctx := tflog.SetField(ctx, logging.ResourceAttributeKey(names.AttrARN), arn)
+
+			result := request.NewListResult(ctx)
+			rd := l.ResourceData()
+			rd.SetId(arn)
+			rd.Set(names.AttrARN, arn)
+
+			if request.IncludeResource {
+				tflog.Info(ctx, "Reading ACM Certificate")
+				certificate, err := findCertificateByARN(ctx, conn, arn)
+				if err != nil {
+					tflog.Error(ctx, "Reading ACM Certificate", map[string]any{
+						"err": err.Error(),
+					})
+					continue
+				}
+
+				diags := resourceCertificateFlatten(ctx, rd, certificate)
+				if diags.HasError() {
+					tflog.Error(ctx, "Reading ACM Certificate", map[string]any{
+						"diags": sdkdiag.DiagnosticsString(diags),
+					})
+					continue
+				}
+			}
+
+			result.DisplayName = aws.ToString(item.DomainName)
+
+			l.SetResult(ctx, awsClient, request.IncludeResource, rd, &result)
+			if result.Diagnostics.HasError() {
+				yield(result)
+				return
+			}
+
+			if !yield(result) {
+				return
+			}
+		}
+	}
+}
+
+func listCertificates(ctx context.Context, conn *acm.Client, input *acm.ListCertificatesInput) iter.Seq2[awstypes.CertificateSummary, error] {
+	return func(yield func(awstypes.CertificateSummary, error) bool) {
+		pages := acm.NewListCertificatesPaginator(conn, input)
+		for pages.HasMorePages() {
+			page, err := pages.NextPage(ctx)
+			if err != nil {
+				yield(awstypes.CertificateSummary{}, fmt.Errorf("listing ACM Certificates: %w", err))
+				return
+			}
+
+			for _, item := range page.CertificateSummaryList {
+				if !yield(item, nil) {
+					return
+				}
+			}
+		}
+	}
+}

--- a/internal/service/acm/certificate_list_test.go
+++ b/internal/service/acm/certificate_list_test.go
@@ -1,0 +1,225 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package acm_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	tfquerycheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/querycheck"
+	tfqueryfilter "github.com/hashicorp/terraform-provider-aws/internal/acctest/queryfilter"
+	tfstatecheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/statecheck"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccACMCertificate_List_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_acm_certificate.test[0]"
+	resourceName2 := "aws_acm_certificate.test[1]"
+
+	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
+	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain(t).String())
+
+	arn1 := tfstatecheck.StateValue()
+	arn2 := tfstatecheck.StateValue()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ACMServiceID),
+		CheckDestroy:             testAccCheckCertificateDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Certificate/list_basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtCertificatePEM: config.StringVariable(certificatePEM),
+					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
+					"resource_count":         config.IntegerVariable(2),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					arn1.GetStateValue(resourceName1, tfjsonpath.New(names.AttrARN)),
+					arn2.GetStateValue(resourceName2, tfjsonpath.New(names.AttrARN)),
+				},
+			},
+
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/Certificate/list_basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtCertificatePEM: config.StringVariable(certificatePEM),
+					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
+					"resource_count":         config.IntegerVariable(2),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectIdentity("aws_acm_certificate.test", map[string]knownvalue.Check{
+						names.AttrARN: arn1.ValueCheck(),
+					}),
+
+					querycheck.ExpectIdentity("aws_acm_certificate.test", map[string]knownvalue.Check{
+						names.AttrARN: arn2.ValueCheck(),
+					}),
+				},
+			},
+		},
+	})
+}
+
+func TestAccACMCertificate_List_includeResource(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_acm_certificate.test[0]"
+
+	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
+	domain := acctest.RandomDomain(t).String()
+	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, domain)
+
+	identity1 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ACMServiceID),
+		CheckDestroy:             testAccCheckCertificateDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Certificate/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					acctest.CtCertificatePEM: config.StringVariable(certificatePEM),
+					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
+					"resource_count":         config.IntegerVariable(1),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
+						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
+					}),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+				},
+			},
+
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/Certificate/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					acctest.CtCertificatePEM: config.StringVariable(certificatePEM),
+					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
+					"resource_count":         config.IntegerVariable(1),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
+						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
+					}),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_acm_certificate.test", identity1.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_acm_certificate.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), knownvalue.StringExact(domain)),
+					querycheck.ExpectResourceKnownValues("aws_acm_certificate.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), []querycheck.KnownValueCheck{
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrARN), knownvalue.NotNull()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrID), knownvalue.NotNull()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("certificate_authority_arn"), knownvalue.StringExact("")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("certificate_body"), knownvalue.Null()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrCertificateChain), knownvalue.Null()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrDomainName), knownvalue.StringExact(domain)),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("domain_validation_options"), knownvalue.SetSizeExact(0)),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("early_renewal_duration"), knownvalue.StringExact("")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("key_algorithm"), knownvalue.StringExact("RSA_2048")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("not_after"), knownvalue.NotNull()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("not_before"), knownvalue.NotNull()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("options"), knownvalue.ListSizeExact(1)),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("pending_renewal"), knownvalue.Bool(false)),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrPrivateKey), knownvalue.Null()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("renewal_eligibility"), knownvalue.StringExact("INELIGIBLE")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("renewal_summary"), knownvalue.ListSizeExact(0)),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrStatus), knownvalue.StringExact("ISSUED")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("subject_alternative_names"), knownvalue.SetSizeExact(1)),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrType), knownvalue.StringExact("IMPORTED")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("validation_emails"), knownvalue.ListSizeExact(0)),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("validation_method"), knownvalue.StringExact("NONE")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
+							acctest.CtKey1: knownvalue.StringExact(acctest.CtValue1),
+						})),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrTagsAll), knownvalue.MapExact(map[string]knownvalue.Check{
+							acctest.CtKey1: knownvalue.StringExact(acctest.CtValue1),
+						})),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.Region())),
+					}),
+				},
+			},
+		},
+	})
+}
+
+func TestAccACMCertificate_List_regionOverride(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_acm_certificate.test[0]"
+	resourceName2 := "aws_acm_certificate.test[1]"
+
+	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
+	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain(t).String())
+
+	identity1 := tfstatecheck.Identity()
+	identity2 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ACMServiceID),
+		CheckDestroy:             testAccCheckCertificateDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Certificate/list_region_override/"),
+				ConfigVariables: config.Variables{
+					acctest.CtCertificatePEM: config.StringVariable(certificatePEM),
+					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
+					"resource_count":         config.IntegerVariable(2),
+					"region":                 config.StringVariable(acctest.AlternateRegion()),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+					identity2.GetIdentity(resourceName2),
+				},
+			},
+
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/Certificate/list_region_override/"),
+				ConfigVariables: config.Variables{
+					acctest.CtCertificatePEM: config.StringVariable(certificatePEM),
+					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
+					"resource_count":         config.IntegerVariable(2),
+					"region":                 config.StringVariable(acctest.AlternateRegion()),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_acm_certificate.test", identity1.Checks()),
+
+					tfquerycheck.ExpectIdentityFunc("aws_acm_certificate.test", identity2.Checks()),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/acm/service_package_gen.go
+++ b/internal/service/acm/service_package_gen.go
@@ -7,6 +7,8 @@ package acm
 
 import (
 	"context"
+	"iter"
+	"slices"
 	"unique"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -70,6 +72,21 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*inttypes.ServicePa
 			),
 		},
 	}
+}
+
+func (p *servicePackage) SDKListResources(ctx context.Context) iter.Seq[*inttypes.ServicePackageSDKListResource] {
+	return slices.Values([]*inttypes.ServicePackageSDKListResource{
+		{
+			Factory:  newCertificateResourceAsListResource,
+			TypeName: "aws_acm_certificate",
+			Name:     "Certificate",
+			Region:   inttypes.ResourceRegionDefault(),
+			Tags: unique.Make(inttypes.ServicePackageResourceTags{
+				IdentifierAttribute: names.AttrARN,
+			}),
+			Identity: inttypes.RegionalARNIdentity(),
+		},
+	})
 }
 
 func (p *servicePackage) ServicePackageName() string {

--- a/internal/service/acm/testdata/Certificate/list_basic/main.tf
+++ b/internal/service/acm/testdata/Certificate/list_basic/main.tf
@@ -1,0 +1,25 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_acm_certificate" "test" {
+  count = var.resource_count
+
+  certificate_body = var.certificate_pem
+  private_key      = var.private_key_pem
+}
+
+variable "certificate_pem" {
+  type     = string
+  nullable = false
+}
+
+variable "private_key_pem" {
+  type     = string
+  nullable = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}

--- a/internal/service/acm/testdata/Certificate/list_basic/query.tfquery.hcl
+++ b/internal/service/acm/testdata/Certificate/list_basic/query.tfquery.hcl
@@ -1,0 +1,6 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_acm_certificate" "test" {
+  provider = aws
+}

--- a/internal/service/acm/testdata/Certificate/list_include_resource/main.tf
+++ b/internal/service/acm/testdata/Certificate/list_include_resource/main.tf
@@ -1,0 +1,33 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_acm_certificate" "test" {
+  count = var.resource_count
+
+  certificate_body = var.certificate_pem
+  private_key      = var.private_key_pem
+
+  tags = var.resource_tags
+}
+
+variable "certificate_pem" {
+  type     = string
+  nullable = false
+}
+
+variable "private_key_pem" {
+  type     = string
+  nullable = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}
+
+variable "resource_tags" {
+  description = "Tags to set on resource"
+  type        = map(string)
+  nullable    = false
+}

--- a/internal/service/acm/testdata/Certificate/list_include_resource/query.tfquery.hcl
+++ b/internal/service/acm/testdata/Certificate/list_include_resource/query.tfquery.hcl
@@ -1,0 +1,8 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_acm_certificate" "test" {
+  provider = aws
+
+  include_resource = true
+}

--- a/internal/service/acm/testdata/Certificate/list_region_override/main.tf
+++ b/internal/service/acm/testdata/Certificate/list_region_override/main.tf
@@ -1,0 +1,32 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_acm_certificate" "test" {
+  count  = var.resource_count
+  region = var.region
+
+  certificate_body = var.certificate_pem
+  private_key      = var.private_key_pem
+}
+
+variable "certificate_pem" {
+  type     = string
+  nullable = false
+}
+
+variable "private_key_pem" {
+  type     = string
+  nullable = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}
+
+variable "region" {
+  description = "Region to deploy resource in"
+  type        = string
+  nullable    = false
+}

--- a/internal/service/acm/testdata/Certificate/list_region_override/query.tfquery.hcl
+++ b/internal/service/acm/testdata/Certificate/list_region_override/query.tfquery.hcl
@@ -1,0 +1,10 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_acm_certificate" "test" {
+  provider = aws
+
+  config {
+    region = var.region
+  }
+}

--- a/website/docs/list-resources/acm_certificate.html.markdown
+++ b/website/docs/list-resources/acm_certificate.html.markdown
@@ -1,0 +1,25 @@
+---
+subcategory: "ACM (Certificate Manager)"
+layout: "aws"
+page_title: "AWS: aws_acm_certificate"
+description: |-
+  Lists ACM (Certificate Manager) Certificate resources.
+---
+
+# List Resource: aws_acm_certificate
+
+Lists ACM (Certificate Manager) Certificate resources.
+
+## Example Usage
+
+```terraform
+list "aws_acm_certificate" "example" {
+  provider = aws
+}
+```
+
+## Argument Reference
+
+This list resource supports the following arguments:
+
+* `region` - (Optional) Region to query. Defaults to provider region.


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

New List Resource: `aws_acm_certificate`

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #47217

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=acm TESTS=TestAccACMCertificate_

--- PASS: TestAccACMCertificate_Imported_validityDates (109.38s)
--- PASS: TestAccACMCertificate_Imported_ipAddress (118.52s)
--- PASS: TestAccACMCertificate_Tags_ComputedTag_onCreate (127.83s)
--- PASS: TestAccACMCertificate_Tags_DefaultTags_nullOverlappingResourceTag (127.97s)
--- PASS: TestAccACMCertificate_Identity_basic (191.21s)
--- PASS: TestAccACMCertificate_Imported_PrivateKeyWo (191.75s)
--- PASS: TestAccACMCertificate_Tags_ComputedTag_OnUpdate_replace (220.79s)
--- PASS: TestAccACMCertificate_Tags_ComputedTag_OnUpdate_add (221.49s)
--- PASS: TestAccACMCertificate_Imported_ReimportWithTags (231.04s)
--- PASS: TestAccACMCertificate_Private_removeEarlyRenewal (241.35s)
--- PASS: TestAccACMCertificate_Tags_EmptyTag_onCreate (249.37s)
--- PASS: TestAccACMCertificate_Tags_DefaultTags_emptyProviderOnlyTag (141.06s)
--- PASS: TestAccACMCertificate_Private_addEarlyRenewalFuture (270.59s)
--- PASS: TestAccACMCertificate_Tags_IgnoreTags_Overlap_defaultTag (280.18s)
--- PASS: TestAccACMCertificate_Tags_DefaultTags_emptyResourceTag (153.50s)
--- PASS: TestAccACMCertificate_List_regionOverride (113.03s)
--- PASS: TestAccACMCertificate_Private_renewable (335.03s)
--- PASS: TestAccACMCertificate_Private_addEarlyRenewalPast (346.39s)
--- PASS: TestAccACMCertificate_Tags_IgnoreTags_Overlap_resourceTag (346.69s)
--- PASS: TestAccACMCertificate_Private_pendingRenewalRFC3339Duration (361.71s)
--- PASS: TestAccACMCertificate_Private_pendingRenewalGoDuration (362.57s)
--- PASS: TestAccACMCertificate_Tags_DefaultTags_updateToResourceOnly (248.67s)
--- PASS: TestAccACMCertificate_Tags_DefaultTags_nullNonOverlappingResourceTag (176.15s)
--- PASS: TestAccACMCertificate_Imported_domainName (409.39s)
--- PASS: TestAccACMCertificate_Private_addEarlyRenewalPastIneligible (227.91s)
--- PASS: TestAccACMCertificate_Tags_DefaultTags_updateToProviderOnly (276.75s)
--- PASS: TestAccACMCertificate_Private_noRenewalPermission (477.56s)
--- PASS: TestAccACMCertificate_List_includeResource (138.01s)
--- PASS: TestAccACMCertificate_Tags_emptyMap (243.25s)
--- PASS: TestAccACMCertificate_List_basic (123.15s)
--- PASS: TestAccACMCertificate_Tags_null (242.72s)
--- PASS: TestAccACMCertificate_Identity_ExistingResource_noRefreshNoChange (162.89s)
--- PASS: TestAccACMCertificate_Tags_addOnUpdate (267.45s)
--- PASS: TestAccACMCertificate_Tags_DefaultTags_overlapping (400.76s)
--- PASS: TestAccACMCertificate_Tags_EmptyTag_OnUpdate_replace (235.89s)
--- PASS: TestAccACMCertificate_Identity_ExistingResource_basic (168.02s)
--- PASS: TestAccACMCertificate_Private_updateEarlyRenewalFuture (193.35s)
--- PASS: TestAccACMCertificate_Identity_regionOverride (171.83s)
--- PASS: TestAccACMCertificate_Tags_DefaultTags_nonOverlapping (278.41s)
--- PASS: TestAccACMCertificate_Tags_EmptyTag_OnUpdate_add (227.95s)
--- PASS: TestAccACMCertificate_tags (313.71s)
--- PASS: TestAccACMCertificate_Tags_DefaultTags_providerOnly (305.41s)
```
