### PR TITLE
resource/aws_secretsmanager_secret_version: fix inconsistent final plan when secret_string is unknown at plan time

### DIFF
--- a/.changelog/48318.txt
+++ b/.changelog/48318.txt
@@ -1,0 +1,15 @@
+```release-note:bug
+resource/aws_secretsmanager_secret_version: Fix `Provider produced inconsistent final plan` errors when `secret_string` or `secret_string_wo_version` references a resource being created or replaced in the same apply
+```
+
+```release-note:bug
+resource/aws_secretsmanager_secret_version: Fix unnecessary resource replacement when switching between `secret_string` and `secret_string_wo` (or vice versa) without changing the secret value
+```
+
+```release-note:bug
+resource/aws_secretsmanager_secret_version: Fix eventual consistency issues on resource creation that could result in `version_stages` being empty in state
+```
+
+```release-note:bug
+data-source/aws_secretsmanager_secret_version: Fix eventual consistency issues that could result in `couldn't find resource` errors when reading a version immediately after creation
+```

--- a/internal/sdkv2/resource_differ.go
+++ b/internal/sdkv2/resource_differ.go
@@ -25,6 +25,25 @@ type ResourceDiffer interface {
 	Id() string
 }
 
+// ResourceForceNewDiffer is a ResourceDiffer that can also force resource
+// replacement. Only *schema.ResourceDiff (i.e., the value passed to
+// CustomizeDiff functions) implements this; *schema.ResourceData does not.
+type ResourceForceNewDiffer interface {
+	ResourceDiffer
+	ForceNew(key string) error
+}
+
+// ForceNewIfChanged calls ForceNew on the given key only when the underlying
+// diff records a change for it. This avoids the "ForceNew: No changes for X"
+// error from the SDK during apply expansion when a previously-unknown
+// configured value resolves to the same value already in state.
+func ForceNewIfChanged(diff ResourceForceNewDiffer, key string) error {
+	if !diff.HasChange(key) {
+		return nil
+	}
+	return diff.ForceNew(key)
+}
+
 // AnyValues returns whether or not any of the given keys has a value.
 func AnyValues(d ResourceDiffer, keys ...string) bool {
 	for _, key := range keys {

--- a/internal/service/secretsmanager/secret_version.go
+++ b/internal/service/secretsmanager/secret_version.go
@@ -159,11 +159,6 @@ func resourceSecretVersionCreate(ctx context.Context, d *schema.ResourceData, me
 	versionID := aws.ToString(output.VersionId)
 	d.SetId(secretVersionCreateResourceID(secretID, versionID))
 
-	// Wait for the new version to be visible. Staging-label propagation is
-	// handled in resourceSecretVersionRead via tfresource.RetryWhenNewResourceNotFound,
-	// gated on d.IsNewResource(), which matches the conventional eventual-
-	// consistency idiom used elsewhere in the provider (see, e.g.,
-	// resourceUserRead in the iam package).
 	_, err = tfresource.RetryWhenNotFound(ctx, propagationTimeout, func(ctx context.Context) (any, error) {
 		return findSecretVersionForExistence(ctx, conn, secretID, versionID, secretStringWO != "")
 	})
@@ -217,8 +212,6 @@ func resourceSecretVersionRead(ctx context.Context, d *schema.ResourceData, meta
 	d.Set("secret_id", secretID)
 
 	if hasWriteOnly {
-		// Use the canonical eventual-consistency idiom (see iam.resourceUserRead):
-		// retry on NotFound only while d.IsNewResource() is true. We also
 		// synthesize a NotFoundError when staging labels have not yet
 		// propagated for a freshly-created version, ensuring state is
 		// populated with a non-empty `version_stages`.
@@ -257,8 +250,6 @@ func resourceSecretVersionRead(ctx context.Context, d *schema.ResourceData, meta
 		return diags
 	}
 
-	// See note above re: eventual consistency. Same idiom for the
-	// non-write-only path.
 	output, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func(ctx context.Context) (*secretsmanager.GetSecretValueOutput, error) {
 		o, err := findSecretVersionByTwoPartKey(ctx, conn, secretID, versionID)
 		if err != nil {

--- a/internal/service/secretsmanager/secret_version.go
+++ b/internal/service/secretsmanager/secret_version.go
@@ -159,6 +159,11 @@ func resourceSecretVersionCreate(ctx context.Context, d *schema.ResourceData, me
 	versionID := aws.ToString(output.VersionId)
 	d.SetId(secretVersionCreateResourceID(secretID, versionID))
 
+	// Wait for the new version to be visible. Staging-label propagation is
+	// handled in resourceSecretVersionRead via tfresource.RetryWhenNewResourceNotFound,
+	// gated on d.IsNewResource(), which matches the conventional eventual-
+	// consistency idiom used elsewhere in the provider (see, e.g.,
+	// resourceUserRead in the iam package).
 	_, err = tfresource.RetryWhenNotFound(ctx, propagationTimeout, func(ctx context.Context) (any, error) {
 		return findSecretVersionForExistence(ctx, conn, secretID, versionID, secretStringWO != "")
 	})
@@ -212,7 +217,26 @@ func resourceSecretVersionRead(ctx context.Context, d *schema.ResourceData, meta
 	d.Set("secret_id", secretID)
 
 	if hasWriteOnly {
-		arn, versionEntry, err := findSecretVersionEntryByTwoPartKey(ctx, conn, secretID, versionID)
+		// Use the canonical eventual-consistency idiom (see iam.resourceUserRead):
+		// retry on NotFound only while d.IsNewResource() is true. We also
+		// synthesize a NotFoundError when staging labels have not yet
+		// propagated for a freshly-created version, ensuring state is
+		// populated with a non-empty `version_stages`.
+		type writeOnlyEntry struct {
+			arn          *string
+			versionEntry *types.SecretVersionsListEntry
+		}
+		entry, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func(ctx context.Context) (*writeOnlyEntry, error) {
+			arn, versionEntry, err := findSecretVersionEntryByTwoPartKey(ctx, conn, secretID, versionID)
+			if err != nil {
+				return nil, err
+			}
+			if d.IsNewResource() && len(versionEntry.VersionStages) == 0 {
+				return nil, &retry.NotFoundError{}
+			}
+			return &writeOnlyEntry{arn: arn, versionEntry: versionEntry}, nil
+		}, d.IsNewResource())
+
 		if !d.IsNewResource() && retry.NotFound(err) {
 			log.Printf("[WARN] Secrets Manager Secret Version (%s) not found, removing from state", d.Id())
 			d.SetId("")
@@ -222,18 +246,30 @@ func resourceSecretVersionRead(ctx context.Context, d *schema.ResourceData, meta
 			return sdkdiag.AppendErrorf(diags, "reading Secrets Manager Secret Version (%s): %s", d.Id(), err)
 		}
 
-		d.Set(names.AttrARN, arn)
-		d.Set("secret_arn", arn)
+		d.Set(names.AttrARN, entry.arn)
+		d.Set("secret_arn", entry.arn)
 		d.Set("secret_binary", nil)
 		d.Set("secret_string", nil)
-		d.Set("version_id", versionEntry.VersionId)
-		d.Set("version_stages", versionEntry.VersionStages)
+		d.Set("version_id", entry.versionEntry.VersionId)
+		d.Set("version_stages", entry.versionEntry.VersionStages)
 		d.Set("has_secret_string_wo", true)
 
 		return diags
 	}
 
-	output, err := findSecretVersionByTwoPartKey(ctx, conn, secretID, versionID)
+	// See note above re: eventual consistency. Same idiom for the
+	// non-write-only path.
+	output, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func(ctx context.Context) (*secretsmanager.GetSecretValueOutput, error) {
+		o, err := findSecretVersionByTwoPartKey(ctx, conn, secretID, versionID)
+		if err != nil {
+			return nil, err
+		}
+		if d.IsNewResource() && len(o.VersionStages) == 0 {
+			return nil, &retry.NotFoundError{}
+		}
+		return o, nil
+	}, d.IsNewResource())
+
 	if !d.IsNewResource() && retry.NotFound(err) {
 		log.Printf("[WARN] Secrets Manager Secret Version (%s) not found, removing from state", d.Id())
 		d.SetId("")

--- a/internal/service/secretsmanager/secret_version.go
+++ b/internal/service/secretsmanager/secret_version.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
+	"github.com/hashicorp/terraform-provider-aws/internal/sdkv2"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	inttypes "github.com/hashicorp/terraform-provider-aws/internal/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -548,14 +549,6 @@ func secretVersionForceNewCustomDiff(ctx context.Context, rd *schema.ResourceDif
 	return secretVersionForceNewCustomDiffInner(ctx, rd, meta)
 }
 
-type rawDiffer interface {
-	GetRawState() cty.Value
-	GetRawConfig() cty.Value
-	GetRawPlan() cty.Value
-	ForceNew(key string) error
-	HasChange(key string) bool
-}
-
 // secretVersionForceNewCustomDiffInner determines when to force resource
 // replacement vs. allow in-place update based on changes between
 // `secret_string`, `secret_string_wo`, and `secret_string_wo_version`.
@@ -575,7 +568,7 @@ type rawDiffer interface {
 //  2. At apply expansion, detect a previously-planned recreation by checking
 //     whether the planned `id` is unknown. If so, ForceNew again even when
 //     the resolved config value happens to match state.
-func secretVersionForceNewCustomDiffInner(ctx context.Context, diff rawDiffer, meta any) error {
+func secretVersionForceNewCustomDiffInner(ctx context.Context, diff sdkv2.ResourceForceNewDiffer, meta any) error {
 	rawState := diff.GetRawState()
 	if rawState.IsNull() {
 		return nil
@@ -611,7 +604,7 @@ func secretVersionForceNewCustomDiffInner(ctx context.Context, diff rawDiffer, m
 		// expansion (after the value resolves and differs) would require
 		// recreation, raising "Provider produced inconsistent final plan".
 		if !configStringValue.IsKnown() {
-			return forceNewIfChanged(diff, "secret_string")
+			return sdkv2.ForceNewIfChanged(diff, "secret_string")
 		}
 
 		hasConfigString := !configStringValue.IsNull()
@@ -623,7 +616,7 @@ func secretVersionForceNewCustomDiffInner(ctx context.Context, diff rawDiffer, m
 			stateString := stateStringValue.AsString()
 			configString := configStringValue.AsString()
 			if stateString != configString || plannedRecreation {
-				return forceNewIfChanged(diff, "secret_string")
+				return sdkv2.ForceNewIfChanged(diff, "secret_string")
 			}
 			return nil
 		}
@@ -633,10 +626,10 @@ func secretVersionForceNewCustomDiffInner(ctx context.Context, diff rawDiffer, m
 		// `secret_string_wo` may also be unknown at plan time when its value
 		// references a not-yet-resolved upstream attribute.
 		if !configStringWOValue.IsKnown() {
-			if err := forceNewIfChanged(diff, "secret_string"); err != nil {
+			if err := sdkv2.ForceNewIfChanged(diff, "secret_string"); err != nil {
 				return err
 			}
-			return forceNewIfChanged(diff, "secret_string_wo")
+			return sdkv2.ForceNewIfChanged(diff, "secret_string_wo")
 		}
 
 		hasConfigStringWO := !configStringWOValue.IsNull()
@@ -644,10 +637,10 @@ func secretVersionForceNewCustomDiffInner(ctx context.Context, diff rawDiffer, m
 			stateString := stateStringValue.AsString()
 			configString := configStringWOValue.AsString()
 			if stateString != configString || plannedRecreation {
-				if err := forceNewIfChanged(diff, "secret_string"); err != nil {
+				if err := sdkv2.ForceNewIfChanged(diff, "secret_string"); err != nil {
 					return err
 				}
-				if err := forceNewIfChanged(diff, "secret_string_wo"); err != nil {
+				if err := sdkv2.ForceNewIfChanged(diff, "secret_string_wo"); err != nil {
 					return err
 				}
 			}
@@ -664,12 +657,12 @@ func secretVersionForceNewCustomDiffInner(ctx context.Context, diff rawDiffer, m
 		// Issue #47907: If the configured `secret_string_wo_version` is
 		// unknown at plan time, ForceNew proactively for consistency.
 		if !configStringWoVersionValue.IsKnown() {
-			return forceNewIfChanged(diff, "secret_string_wo_version")
+			return sdkv2.ForceNewIfChanged(diff, "secret_string_wo_version")
 		}
 
 		if !configStringWoVersionValue.IsNull() {
 			if configStringWoVersionValue.Equals(stateStringWoVersionValue).False() || plannedRecreation {
-				return forceNewIfChanged(diff, "secret_string_wo_version")
+				return sdkv2.ForceNewIfChanged(diff, "secret_string_wo_version")
 			}
 			return nil
 		}
@@ -678,23 +671,12 @@ func secretVersionForceNewCustomDiffInner(ctx context.Context, diff rawDiffer, m
 		// recreation; treat unknown `secret_string` the same as a known value.
 		configStringValue := rawConfig.GetAttr("secret_string")
 		if !configStringValue.IsKnown() {
-			return forceNewIfChanged(diff, "secret_string")
+			return sdkv2.ForceNewIfChanged(diff, "secret_string")
 		}
 		if !configStringValue.IsNull() {
-			return forceNewIfChanged(diff, "secret_string")
+			return sdkv2.ForceNewIfChanged(diff, "secret_string")
 		}
 	}
 
 	return nil
-}
-
-// forceNewIfChanged calls ForceNew on the given key only when the underlying
-// diff records a change for it. This avoids the "ForceNew: No changes for X"
-// error from the SDK when, at apply expansion, a previously-unknown value
-// happens to resolve to the same value already in state.
-func forceNewIfChanged(diff rawDiffer, key string) error {
-	if !diff.HasChange(key) {
-		return nil
-	}
-	return diff.ForceNew(key)
 }

--- a/internal/service/secretsmanager/secret_version.go
+++ b/internal/service/secretsmanager/secret_version.go
@@ -524,9 +524,30 @@ func secretVersionForceNewCustomDiff(ctx context.Context, rd *schema.ResourceDif
 type rawDiffer interface {
 	GetRawState() cty.Value
 	GetRawConfig() cty.Value
+	GetRawPlan() cty.Value
 	ForceNew(key string) error
+	HasChange(key string) bool
 }
 
+// secretVersionForceNewCustomDiffInner determines when to force resource
+// replacement vs. allow in-place update based on changes between
+// `secret_string`, `secret_string_wo`, and `secret_string_wo_version`.
+//
+// CustomizeDiff is invoked twice for a typical update with unknowns: once
+// during plan (with whatever values the config provides, including unknowns)
+// and again during apply expansion (after upstream values become known). The
+// ForceNew decision _must_ be the same on both invocations or Terraform Core
+// reports "Provider produced inconsistent final plan" with the planned action
+// changing between Update and DeleteThenCreate (issue #47907).
+//
+// To keep both invocations consistent we:
+//  1. ForceNew proactively at plan time when a relevant config attribute is
+//     unknown (we cannot know if the value differs from state, so assume it
+//     does). At apply expansion the value will be known and either differs
+//     (ForceNew via the value-comparison path) or matches (handled by 2).
+//  2. At apply expansion, detect a previously-planned recreation by checking
+//     whether the planned `id` is unknown. If so, ForceNew again even when
+//     the resolved config value happens to match state.
 func secretVersionForceNewCustomDiffInner(ctx context.Context, diff rawDiffer, meta any) error {
 	rawState := diff.GetRawState()
 	if rawState.IsNull() {
@@ -538,6 +559,16 @@ func secretVersionForceNewCustomDiffInner(ctx context.Context, diff rawDiffer, m
 		return nil
 	}
 
+	// At apply expansion, a non-null `RawPlan` reflects what plan decided.
+	// If the planned `id` is unknown then plan required recreation; we must
+	// force replacement again here even if the resolved config matches state.
+	plannedRecreation := false
+	if rawPlan := diff.GetRawPlan(); !rawPlan.IsNull() {
+		if planID := rawPlan.GetAttr(names.AttrID); !planID.IsKnown() {
+			plannedRecreation = true
+		}
+	}
+
 	stateStringValue := rawState.GetAttr("secret_string")
 	hasStateString := stateStringValue.IsKnown() && !stateStringValue.IsNull()
 	if hasStateString {
@@ -546,7 +577,17 @@ func secretVersionForceNewCustomDiffInner(ctx context.Context, diff rawDiffer, m
 
 	if hasStateString {
 		configStringValue := rawConfig.GetAttr("secret_string")
-		hasConfigString := configStringValue.IsKnown() && !configStringValue.IsNull()
+
+		// Issue #47907: If the configured `secret_string` is unknown at plan
+		// time, ForceNew proactively to keep plan and apply decisions
+		// consistent. Without this, plan would show Update but apply
+		// expansion (after the value resolves and differs) would require
+		// recreation, raising "Provider produced inconsistent final plan".
+		if !configStringValue.IsKnown() {
+			return forceNewIfChanged(diff, "secret_string")
+		}
+
+		hasConfigString := !configStringValue.IsNull()
 		if hasConfigString {
 			hasConfigString = configStringValue.AsString() != ""
 		}
@@ -554,24 +595,32 @@ func secretVersionForceNewCustomDiffInner(ctx context.Context, diff rawDiffer, m
 		if hasConfigString {
 			stateString := stateStringValue.AsString()
 			configString := configStringValue.AsString()
-			if stateString != configString {
-				if err := diff.ForceNew("secret_string"); err != nil {
-					return err
-				}
+			if stateString != configString || plannedRecreation {
+				return forceNewIfChanged(diff, "secret_string")
 			}
 			return nil
 		}
 
 		configStringWOValue := rawConfig.GetAttr("secret_string_wo")
-		hasStateStringWO := configStringWOValue.IsKnown() && !configStringWOValue.IsNull()
-		if hasStateStringWO {
+
+		// `secret_string_wo` may also be unknown at plan time when its value
+		// references a not-yet-resolved upstream attribute.
+		if !configStringWOValue.IsKnown() {
+			if err := forceNewIfChanged(diff, "secret_string"); err != nil {
+				return err
+			}
+			return forceNewIfChanged(diff, "secret_string_wo")
+		}
+
+		hasConfigStringWO := !configStringWOValue.IsNull()
+		if hasConfigStringWO {
 			stateString := stateStringValue.AsString()
 			configString := configStringWOValue.AsString()
-			if stateString != configString {
-				if err := diff.ForceNew("secret_string"); err != nil {
+			if stateString != configString || plannedRecreation {
+				if err := forceNewIfChanged(diff, "secret_string"); err != nil {
 					return err
 				}
-				if err := diff.ForceNew("secret_string_wo"); err != nil {
+				if err := forceNewIfChanged(diff, "secret_string_wo"); err != nil {
 					return err
 				}
 			}
@@ -584,29 +633,41 @@ func secretVersionForceNewCustomDiffInner(ctx context.Context, diff rawDiffer, m
 
 	if hasStateStringWoVersion {
 		configStringWoVersionValue := rawConfig.GetAttr("secret_string_wo_version")
+
+		// Issue #47907: If the configured `secret_string_wo_version` is
+		// unknown at plan time, ForceNew proactively for consistency.
 		if !configStringWoVersionValue.IsKnown() {
-			return nil
+			return forceNewIfChanged(diff, "secret_string_wo_version")
 		}
 
 		if !configStringWoVersionValue.IsNull() {
-			if configStringWoVersionValue.Equals(stateStringWoVersionValue).False() {
-				if err := diff.ForceNew("secret_string_wo_version"); err != nil {
-					return err
-				}
+			if configStringWoVersionValue.Equals(stateStringWoVersionValue).False() || plannedRecreation {
+				return forceNewIfChanged(diff, "secret_string_wo_version")
 			}
 			return nil
 		}
 
+		// Switching from `secret_string_wo` to `secret_string` always requires
+		// recreation; treat unknown `secret_string` the same as a known value.
 		configStringValue := rawConfig.GetAttr("secret_string")
 		if !configStringValue.IsKnown() {
-			return nil
+			return forceNewIfChanged(diff, "secret_string")
 		}
 		if !configStringValue.IsNull() {
-			if err := diff.ForceNew("secret_string"); err != nil {
-				return err
-			}
+			return forceNewIfChanged(diff, "secret_string")
 		}
 	}
 
 	return nil
+}
+
+// forceNewIfChanged calls ForceNew on the given key only when the underlying
+// diff records a change for it. This avoids the "ForceNew: No changes for X"
+// error from the SDK when, at apply expansion, a previously-unknown value
+// happens to resolve to the same value already in state.
+func forceNewIfChanged(diff rawDiffer, key string) error {
+	if !diff.HasChange(key) {
+		return nil
+	}
+	return diff.ForceNew(key)
 }

--- a/internal/service/secretsmanager/secret_version_data_source.go
+++ b/internal/service/secretsmanager/secret_version_data_source.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -93,7 +94,16 @@ func dataSourceSecretVersionRead(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	id := secretVersionCreateResourceID(secretID, version)
-	output, err := findSecretVersion(ctx, conn, input)
+	// Secrets Manager has eventual-consistency windows for both the version's
+	// existence and for staging-label propagation across backend replicas.
+	// When this data source is read in the same plan as a freshly-created
+	// version, the lookup (especially by stage) may briefly return
+	// NotFound. Retry within the standard propagation timeout to handle
+	// this; genuinely-missing resources will still surface an error after
+	// the timeout elapses.
+	output, err := tfresource.RetryWhenNotFound(ctx, propagationTimeout, func(ctx context.Context) (*secretsmanager.GetSecretValueOutput, error) {
+		return findSecretVersion(ctx, conn, input)
+	})
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "reading Secrets Manager Secret Version (%s): %s", id, err)

--- a/internal/service/secretsmanager/secret_version_test.go
+++ b/internal/service/secretsmanager/secret_version_test.go
@@ -542,16 +542,22 @@ func TestAccSecretsManagerSecretVersion_disappears(t *testing.T) {
 				Config: testAccSecretVersionConfig_string(rName, "test-string"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSecretVersionExists(ctx, t, resourceName, &version),
-					acctest.CheckSDKResourceDisappears(ctx, t, tfsecretsmanager.ResourceSecretVersion(), resourceName),
+					acctest.CheckSDKResourceDisappears(ctx, t, tfsecretsmanager.ResourceSecretVersion(), resourceName), // nosemgrep:ci.semgrep.acctest.disappears-expect-resource-action
 				),
-				// Because resource Delete leaves a secret version with a single stage ("AWSCURRENT"), the resource is still there.
-				// ExpectNonEmptyPlan: true,
+				// Unlike most resources, the Delete function for
+				// aws_secretsmanager_secret_version does not actually delete
+				// the underlying AWS resource: AWS does not permit removing
+				// the AWSCURRENT staging label, so when no other staging
+				// labels are set the version remains in place. As a result,
+				// post-refresh the resource is still present and consistent
+				// with config, so the planned action is NoOp rather than
+				// Create.
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction("aws_secretsmanager_secret_version.test", plancheck.ResourceActionCreate),
 					},
 					PostApplyPostRefresh: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction("aws_secretsmanager_secret_version.test", plancheck.ResourceActionCreate),
+						plancheck.ExpectResourceAction("aws_secretsmanager_secret_version.test", plancheck.ResourceActionNoop),
 					},
 				},
 			},

--- a/internal/service/secretsmanager/secret_version_test.go
+++ b/internal/service/secretsmanager/secret_version_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"slices"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -75,6 +76,17 @@ func (d *mockRawDiffer) HasChange(key string) bool {
 	}
 	return !stateVal.Equals(configVal).True()
 }
+
+// The following methods round out the sdkv2.ResourceDiffer interface but are
+// not exercised by secretVersionForceNewCustomDiffInner; they return zero
+// values to satisfy the interface contract.
+func (d *mockRawDiffer) Get(string) any              { return nil }
+func (d *mockRawDiffer) GetChange(string) (any, any) { return nil, nil }
+func (d *mockRawDiffer) GetOk(string) (any, bool)    { return nil, false }
+func (d *mockRawDiffer) HasChanges(keys ...string) bool {
+	return slices.ContainsFunc(keys, d.HasChange)
+}
+func (d *mockRawDiffer) Id() string { return "" }
 
 func secretVersionValuesObjectState(values map[string]cty.Value) cty.Value {
 	allValues := map[string]cty.Value{

--- a/internal/service/secretsmanager/secret_version_test.go
+++ b/internal/service/secretsmanager/secret_version_test.go
@@ -634,12 +634,7 @@ func TestAccSecretsManagerSecretVersion_UpdateForcesReplacement_string(t *testin
 }
 
 // TestAccSecretsManagerSecretVersion_unknownSecretString reproduces issue
-// #47907: when `secret_string` references an upstream resource being created
-// (or replaced) in the same apply, its value is unknown at plan time. Prior
-// to the fix, the plan reported "Update" but the apply expansion (after the
-// upstream value resolved and differed from state) flipped the planned
-// action to "DeleteThenCreate", causing Terraform Core to raise
-// "Provider produced inconsistent final plan".
+// https://github.com/hashicorp/terraform-provider-aws/issues/47907
 func TestAccSecretsManagerSecretVersion_unknownSecretString(t *testing.T) {
 	ctx := acctest.Context(t)
 	var version secretsmanager.GetSecretValueOutput
@@ -682,10 +677,8 @@ func TestAccSecretsManagerSecretVersion_unknownSecretString(t *testing.T) {
 }
 
 // TestAccSecretsManagerSecretVersion_unknownSecretStringWriteOnlyVersion
-// reproduces the rotation scenario reported in the comments on issue #47907:
-// using `secret_string_wo` with a `secret_string_wo_version` that is unknown
-// at plan time (e.g., derived from an upstream value being computed) raised
-// the same "Provider produced inconsistent final plan" error before the fix.
+// reproduces the rotation scenario reported in the comments on issue
+// https://github.com/hashicorp/terraform-provider-aws/issues/47907
 func TestAccSecretsManagerSecretVersion_unknownSecretStringWriteOnlyVersion(t *testing.T) {
 	ctx := acctest.Context(t)
 	var version secretsmanager.GetSecretValueOutput

--- a/internal/service/secretsmanager/secret_version_test.go
+++ b/internal/service/secretsmanager/secret_version_test.go
@@ -78,7 +78,7 @@ func (d *mockRawDiffer) HasChange(key string) bool {
 
 func secretVersionValuesObjectState(values map[string]cty.Value) cty.Value {
 	allValues := map[string]cty.Value{
-		names.AttrID:               cty.StringVal("arn:aws:secretsmanager:us-east-1:123456789012:secret:test|version-id"),
+		names.AttrID:               cty.StringVal("arn:aws:secretsmanager:us-east-1:123456789012:secret:test|version-id"), //lintignore:AWSAT003,AWSAT005
 		"secret_binary":            cty.StringVal(""),
 		"secret_string":            cty.StringVal(""),
 		"secret_string_wo":         cty.NullVal(cty.String),

--- a/internal/service/secretsmanager/secret_version_test.go
+++ b/internal/service/secretsmanager/secret_version_test.go
@@ -28,6 +28,7 @@ import (
 type mockRawDiffer struct {
 	state    cty.Value
 	config   cty.Value
+	plan     cty.Value
 	forceNew []string
 }
 
@@ -39,13 +40,45 @@ func (d *mockRawDiffer) GetRawConfig() cty.Value {
 	return d.config
 }
 
+func (d *mockRawDiffer) GetRawPlan() cty.Value {
+	if d.plan.IsNull() && d.plan.Type() == cty.NilType {
+		return cty.NullVal(cty.DynamicPseudoType)
+	}
+	return d.plan
+}
+
 func (d *mockRawDiffer) ForceNew(key string) error {
 	d.forceNew = append(d.forceNew, key)
 	return nil
 }
 
+// HasChange returns true unless the value in state is known, non-null, and
+// equal to the value in config (mirroring schema.ResourceDiff.HasChange
+// closely enough for these tests).
+func (d *mockRawDiffer) HasChange(key string) bool {
+	if d.state.IsNull() || !d.state.Type().HasAttribute(key) {
+		return true
+	}
+	if d.config.IsNull() || !d.config.Type().HasAttribute(key) {
+		return true
+	}
+	stateVal := d.state.GetAttr(key)
+	configVal := d.config.GetAttr(key)
+	if !stateVal.IsKnown() || !configVal.IsKnown() {
+		return true
+	}
+	if stateVal.IsNull() != configVal.IsNull() {
+		return true
+	}
+	if stateVal.IsNull() && configVal.IsNull() {
+		return false
+	}
+	return !stateVal.Equals(configVal).True()
+}
+
 func secretVersionValuesObjectState(values map[string]cty.Value) cty.Value {
 	allValues := map[string]cty.Value{
+		names.AttrID:               cty.StringVal("arn:aws:secretsmanager:us-east-1:123456789012:secret:test|version-id"),
 		"secret_binary":            cty.StringVal(""),
 		"secret_string":            cty.StringVal(""),
 		"secret_string_wo":         cty.NullVal(cty.String),
@@ -59,6 +92,25 @@ func secretVersionValuesObjectState(values map[string]cty.Value) cty.Value {
 
 func secretVersionValuesObjectConfig(values map[string]cty.Value) cty.Value {
 	allValues := map[string]cty.Value{
+		names.AttrID:               cty.NullVal(cty.String),
+		"secret_binary":            cty.NullVal(cty.String),
+		"secret_string":            cty.NullVal(cty.String),
+		"secret_string_wo":         cty.NullVal(cty.String),
+		"secret_string_wo_version": cty.NullVal(cty.Number),
+	}
+
+	maps.Copy(allValues, values)
+
+	return cty.ObjectVal(allValues)
+}
+
+// secretVersionValuesObjectPlan builds a value approximating Terraform's
+// proposed plan state. At apply expansion, computed attributes that the plan
+// already decided would change (e.g., when the resource is being recreated)
+// are reported as unknown via this value.
+func secretVersionValuesObjectPlan(values map[string]cty.Value) cty.Value {
+	allValues := map[string]cty.Value{
+		names.AttrID:               cty.UnknownVal(cty.String),
 		"secret_binary":            cty.NullVal(cty.String),
 		"secret_string":            cty.NullVal(cty.String),
 		"secret_string_wo":         cty.NullVal(cty.String),
@@ -76,6 +128,7 @@ func TestSecretVersionForceNewXXX(t *testing.T) {
 	testcases := map[string]struct {
 		state            cty.Value
 		config           cty.Value
+		plan             cty.Value
 		expectedForceNew []string
 	}{
 		"new resource": {},
@@ -97,6 +150,10 @@ func TestSecretVersionForceNewXXX(t *testing.T) {
 			}),
 			expectedForceNew: []string{"secret_string"},
 		},
+		// Issue #47907: previously unknown config silently skipped ForceNew at
+		// plan time, causing the planned action to flip from Update to
+		// DeleteThenCreate at apply expansion. The fix forces replacement
+		// proactively at plan time when config is unknown.
 		"secret_string unknown": {
 			state: secretVersionValuesObjectState(map[string]cty.Value{
 				"secret_string": cty.StringVal("old"),
@@ -104,6 +161,27 @@ func TestSecretVersionForceNewXXX(t *testing.T) {
 			config: secretVersionValuesObjectConfig(map[string]cty.Value{
 				"secret_string": cty.UnknownVal(cty.String),
 			}),
+			expectedForceNew: []string{"secret_string"},
+		},
+		// Apply-expansion of the regression: rawPlan reports the planned `id`
+		// as unknown (i.e., plan required recreation), but the resolved config
+		// happens to match state. The fix preserves the plan's recreate
+		// decision via the plannedRecreation flag.
+		"secret_string apply expand recreation planned same value": {
+			state: secretVersionValuesObjectState(map[string]cty.Value{
+				"secret_string": cty.StringVal("same"),
+			}),
+			config: secretVersionValuesObjectConfig(map[string]cty.Value{
+				"secret_string": cty.StringVal("same"),
+			}),
+			plan: secretVersionValuesObjectPlan(map[string]cty.Value{
+				"secret_string": cty.StringVal("same"),
+				names.AttrID:    cty.UnknownVal(cty.String),
+			}),
+			// HasChange is false (state and config match), so ForceNew is a
+			// no-op via the forceNewIfChanged helper. The SDK preserves the
+			// planned RequiresReplace through the apply path when Terraform
+			// Core sees the plan already required recreation.
 		},
 
 		"secret_string_wo_version no change": {
@@ -123,6 +201,8 @@ func TestSecretVersionForceNewXXX(t *testing.T) {
 			}),
 			expectedForceNew: []string{"secret_string_wo_version"},
 		},
+		// Issue #47907 (also reported with `secret_string_wo_version` unknown
+		// at plan time, e.g., during rotation).
 		"secret_string_wo_version unknown": {
 			state: secretVersionValuesObjectState(map[string]cty.Value{
 				"secret_string_wo_version": cty.NumberIntVal(1),
@@ -130,6 +210,7 @@ func TestSecretVersionForceNewXXX(t *testing.T) {
 			config: secretVersionValuesObjectConfig(map[string]cty.Value{
 				"secret_string_wo_version": cty.UnknownVal(cty.Number),
 			}),
+			expectedForceNew: []string{"secret_string_wo_version"},
 		},
 
 		"secret_string to secret_string_wo no change": {
@@ -169,6 +250,19 @@ func TestSecretVersionForceNewXXX(t *testing.T) {
 				"secret_string_wo_version": cty.UnknownVal(cty.Number),
 			}),
 		},
+		// New: switching from `secret_string` to `secret_string_wo` where the
+		// `secret_string_wo` value is unknown at plan time. Force replacement
+		// of both attributes for consistency.
+		"secret_string to secret_string_wo unknown wo value": {
+			state: secretVersionValuesObjectState(map[string]cty.Value{
+				"secret_string": cty.StringVal("old"),
+			}),
+			config: secretVersionValuesObjectConfig(map[string]cty.Value{
+				"secret_string_wo":         cty.UnknownVal(cty.String),
+				"secret_string_wo_version": cty.NumberIntVal(1),
+			}),
+			expectedForceNew: []string{"secret_string", "secret_string_wo"},
+		},
 
 		"secret_string_wo to secret_string no change": {
 			state: secretVersionValuesObjectState(map[string]cty.Value{
@@ -190,6 +284,9 @@ func TestSecretVersionForceNewXXX(t *testing.T) {
 			}),
 			expectedForceNew: []string{"secret_string"},
 		},
+		// Switching from `secret_string_wo` to `secret_string` always requires
+		// recreation. Previously this code path silently returned without
+		// calling ForceNew when the new value was unknown.
 		"secret_string_wo to secret_string unknown": {
 			state: secretVersionValuesObjectState(map[string]cty.Value{
 				"secret_string_wo":         cty.StringVal(names.AttrValue),
@@ -198,6 +295,7 @@ func TestSecretVersionForceNewXXX(t *testing.T) {
 			config: secretVersionValuesObjectConfig(map[string]cty.Value{
 				"secret_string": cty.UnknownVal(cty.String),
 			}),
+			expectedForceNew: []string{"secret_string"},
 		},
 	}
 
@@ -205,9 +303,14 @@ func TestSecretVersionForceNewXXX(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
+			plan := testcase.plan
+			if plan == cty.NilVal {
+				plan = cty.NullVal(cty.DynamicPseudoType)
+			}
 			diff := mockRawDiffer{
 				state:  testcase.state,
 				config: testcase.config,
+				plan:   plan,
 			}
 
 			err := tfsecretsmanager.SecretVersionForceNewCustomDiffInner(t.Context(), &diff, nil)
@@ -513,6 +616,101 @@ func TestAccSecretsManagerSecretVersion_UpdateForcesReplacement_string(t *testin
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSecretVersionExists(ctx, t, resourceName, &version),
 					resource.TestCheckResourceAttr(resourceName, "secret_string", "test-string-updated"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionReplace),
+					},
+				},
+			},
+		},
+	})
+}
+
+// TestAccSecretsManagerSecretVersion_unknownSecretString reproduces issue
+// #47907: when `secret_string` references an upstream resource being created
+// (or replaced) in the same apply, its value is unknown at plan time. Prior
+// to the fix, the plan reported "Update" but the apply expansion (after the
+// upstream value resolved and differed from state) flipped the planned
+// action to "DeleteThenCreate", causing Terraform Core to raise
+// "Provider produced inconsistent final plan".
+func TestAccSecretsManagerSecretVersion_unknownSecretString(t *testing.T) {
+	ctx := acctest.Context(t)
+	var version secretsmanager.GetSecretValueOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_secretsmanager_secret_version.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SecretsManagerServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckSecretVersionDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			// Step 1: create with a known `secret_string`.
+			{
+				Config: testAccSecretVersionConfig_string(rName, "initial-value"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckSecretVersionExists(ctx, t, resourceName, &version),
+					resource.TestCheckResourceAttr(resourceName, "secret_string", "initial-value"),
+				),
+			},
+			// Step 2: introduce an upstream resource (`aws_secretsmanager_secret.upstream`)
+			// that is being created in this same apply and whose ARN is consumed
+			// by `secret_string`. The ARN is unknown at plan time, mirroring
+			// the regression scenario in the issue. With the fix, the plan
+			// shows "Replace" upfront and the apply succeeds.
+			{
+				Config: testAccSecretVersionConfig_unknownSecretString(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckSecretVersionExists(ctx, t, resourceName, &version),
+					resource.TestCheckResourceAttrSet(resourceName, "secret_string"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionReplace),
+					},
+				},
+			},
+		},
+	})
+}
+
+// TestAccSecretsManagerSecretVersion_unknownSecretStringWriteOnlyVersion
+// reproduces the rotation scenario reported in the comments on issue #47907:
+// using `secret_string_wo` with a `secret_string_wo_version` that is unknown
+// at plan time (e.g., derived from an upstream value being computed) raised
+// the same "Provider produced inconsistent final plan" error before the fix.
+func TestAccSecretsManagerSecretVersion_unknownSecretStringWriteOnlyVersion(t *testing.T) {
+	ctx := acctest.Context(t)
+	var version secretsmanager.GetSecretValueOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_secretsmanager_secret_version.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:   func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck: acctest.ErrorCheck(t, names.SecretsManagerServiceID),
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfcversion.Must(tfcversion.NewVersion("1.11.0"))),
+		},
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckSecretVersionDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			// Step 1: create with a known `secret_string_wo` and version.
+			{
+				Config: testAccSecretVersionConfig_stringWriteOnly(rName, "initial-secret", 1),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckSecretVersionExists(ctx, t, resourceName, &version),
+					resource.TestCheckResourceAttr(resourceName, "secret_string_wo_version", "1"),
+				),
+			},
+			// Step 2: derive `secret_string_wo_version` from an upstream
+			// resource being created in the same apply, making it unknown at
+			// plan time.
+			{
+				Config: testAccSecretVersionConfig_unknownSecretStringWriteOnlyVersion(rName, "rotated-secret"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckSecretVersionExists(ctx, t, resourceName, &version),
+					resource.TestCheckResourceAttrSet(resourceName, "secret_string_wo_version"),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -1251,4 +1449,46 @@ resource "aws_secretsmanager_secret" "test" {
   name = %[1]q
 }
 `, rName, secret, version)
+}
+
+// testAccSecretVersionConfig_unknownSecretString returns a configuration in
+// which `secret_string` references a resource being created in the same plan
+// (`aws_secretsmanager_secret.upstream`). Its ARN is unknown at plan time,
+// reproducing the conditions under which issue #47907 fires.
+func testAccSecretVersionConfig_unknownSecretString(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_secretsmanager_secret" "test" {
+  name = %[1]q
+}
+
+resource "aws_secretsmanager_secret" "upstream" {
+  name = "%[1]s-upstream"
+}
+
+resource "aws_secretsmanager_secret_version" "test" {
+  secret_id     = aws_secretsmanager_secret.test.id
+  secret_string = aws_secretsmanager_secret.upstream.arn
+}
+`, rName)
+}
+
+// testAccSecretVersionConfig_unknownSecretStringWriteOnlyVersion returns a
+// configuration in which `secret_string_wo_version` is derived from a string
+// length of an upstream resource's ARN (computed, unknown at plan time).
+func testAccSecretVersionConfig_unknownSecretStringWriteOnlyVersion(rName, secret string) string {
+	return fmt.Sprintf(`
+resource "aws_secretsmanager_secret" "test" {
+  name = %[1]q
+}
+
+resource "aws_secretsmanager_secret" "upstream" {
+  name = "%[1]s-upstream"
+}
+
+resource "aws_secretsmanager_secret_version" "test" {
+  secret_id                = aws_secretsmanager_secret.test.id
+  secret_string_wo         = %[2]q
+  secret_string_wo_version = length(aws_secretsmanager_secret.upstream.arn)
+}
+`, rName, secret)
 }


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This fixes 4 issues with `aws_secretsmanager_secret_version`:

1. **(original bug)** unnecessary resource replacement when switching between `secret_string` and `secret_string_wo` (or vice versa) without changing the secret value (#41635)
2. **(regression caused by attempted fix)** fix inconsistent final plan when `secret_string` is unknown at plan time (#47907)
3. **(pre-existing test failure)** fix `_disappears` test `PostApplyPostRefresh` expectation
4. **(flaky eventual consistency)**  use `RetryWhenNewResourceNotFound` in `Read` to handle staging-label propagation, retry on `NotFound` to handle eventual consistency (data source)

### History

* Issue #41635 (March 2025): User reports that switching an existing `aws_secretsmanager_secret_version` from `secret_string` to `secret_string_wo` forces delete+create. Since `secret_string_wo` is write-only and the underlying secret value hasn't changed, a replacement should not be required.
* PR #47815 (merged May 7, 2026, shipped in v6.45.0): @gdavison adds a `CustomizeDiff` (`secretVersionForceNewCustomDiffInner`) that compares the old and new values at plan time to determine whether a replacement is truly needed. This partially fixed #41635 — switching with the same value is now an in-place update. However, the diff function had a gap: when the config value for `secret_string` is unknown at plan time (i.e., it references an upstream resource being replaced in the same apply), the function fell through without calling `ForceNew`, so the plan showed Update. During apply expansion, after the upstream value resolved and differed from state, the SDK re-ran `CustomizeDiff` with a now-known value and did call `ForceNew` — flipping the action from Update to DeleteThenCreate mid-apply.
* Issue #47907 (May 14, 2026): Multiple users report "Provider produced inconsistent final plan" / "changed the planned action from Update to DeleteThenCreate" after upgrading to 6.45.0. The bug fires any time `secret_string` is computed from an upstream resource being replaced in the same apply. Workaround: pin to 6.44.0.
* This work: Fixes the `CustomizeDiff` to call `ForceNew` proactively at plan time when a relevant config attribute is unknown — ensuring plan and apply make the same decision. Also fixes the previously-unhandled case of switching from `secret_string_wo` to an unknown `secret_string`.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #47907
Closes #41635

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

#### BEFORE FIXES

This PR adds two tests that reproduce error if fixes aren't in place:

```console
% make t T=TestAccSecretsManagerSecretVersion_unknownSecretString K=secretsmanager
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 main4 🌿...
TF_ACC=1 go1.26.3 test ./internal/service/secretsmanager/... -v -count 1 -parallel 20 -run='TestAccSecretsManagerSecretVersion_unknownSecretString'  -timeout 360m -vet=off
2026/06/09 18:31:49 Creating Terraform AWS Provider (SDKv2-style)...
2026/06/09 18:31:49 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccSecretsManagerSecretVersion_unknownSecretString
=== PAUSE TestAccSecretsManagerSecretVersion_unknownSecretString
=== RUN   TestAccSecretsManagerSecretVersion_unknownSecretStringWriteOnlyVersion
=== PAUSE TestAccSecretsManagerSecretVersion_unknownSecretStringWriteOnlyVersion
=== CONT  TestAccSecretsManagerSecretVersion_unknownSecretString
=== CONT  TestAccSecretsManagerSecretVersion_unknownSecretStringWriteOnlyVersion
    secret_version_test.go:691: Step 2/2 error: Pre-apply plan check(s) failed:
        aws_secretsmanager_secret_version.test - expected Replace, got action(s): [update]
=== NAME  TestAccSecretsManagerSecretVersion_unknownSecretString
    secret_version_test.go:643: Step 2/2 error: Error running apply: exit status 1
        
        Error: Provider produced inconsistent final plan
        
        When expanding the plan for aws_secretsmanager_secret_version.test to include
        new values learned so far during apply, provider
        "registry.terraform.io/hashicorp/aws" changed the planned action from Update
        to DeleteThenCreate.
        
        This is a bug in the provider, which should be reported in the provider's own
        issue tracker.
        
        Error: Provider produced inconsistent final plan
        
        When expanding the plan for aws_secretsmanager_secret_version.test to include
        new values learned so far during apply, provider
        "registry.terraform.io/hashicorp/aws" produced an invalid new value for .arn:
        was known, but now unknown.
        
        This is a bug in the provider, which should be reported in the provider's own
        issue tracker.
        
        Error: Provider produced inconsistent final plan
        
        When expanding the plan for aws_secretsmanager_secret_version.test to include
        new values learned so far during apply, provider
        "registry.terraform.io/hashicorp/aws" produced an invalid new value for
        .secret_arn: was known, but now unknown.
        
        This is a bug in the provider, which should be reported in the provider's own
        issue tracker.
        
        Error: Provider produced inconsistent final plan
        
        When expanding the plan for aws_secretsmanager_secret_version.test to include
        new values learned so far during apply, provider
        "registry.terraform.io/hashicorp/aws" produced an invalid new value for
        .secret_binary: inconsistent values for sensitive attribute.
        
        This is a bug in the provider, which should be reported in the provider's own
        issue tracker.
        
        Error: Provider produced inconsistent final plan
        
        When expanding the plan for aws_secretsmanager_secret_version.test to include
        new values learned so far during apply, provider
        "registry.terraform.io/hashicorp/aws" produced an invalid new value for
        .version_id: was known, but now unknown.
        
        This is a bug in the provider, which should be reported in the provider's own
        issue tracker.
        
        Error: Provider produced inconsistent final plan
        
        When expanding the plan for aws_secretsmanager_secret_version.test to include
        new values learned so far during apply, provider
        "registry.terraform.io/hashicorp/aws" produced an invalid new value for
        .version_stages: was known, but now unknown.
        
        This is a bug in the provider, which should be reported in the provider's own
        issue tracker.
        
        Error: Provider produced inconsistent final plan
        
        When expanding the plan for aws_secretsmanager_secret_version.test to include
        new values learned so far during apply, provider
        "registry.terraform.io/hashicorp/aws" produced an invalid new value for
        .has_secret_string_wo: was null, but now cty.UnknownVal(cty.Bool).
        
        This is a bug in the provider, which should be reported in the provider's own
        issue tracker.
        
        Error: Provider produced inconsistent final plan
        
        When expanding the plan for aws_secretsmanager_secret_version.test to include
        new values learned so far during apply, provider
        "registry.terraform.io/hashicorp/aws" produced an invalid new value for .id:
        was known, but now unknown.
        
        This is a bug in the provider, which should be reported in the provider's own
        issue tracker.
--- FAIL: TestAccSecretsManagerSecretVersion_unknownSecretStringWriteOnlyVersion (31.29s)
--- FAIL: TestAccSecretsManagerSecretVersion_unknownSecretString (32.72s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/secretsmanager	40.374s
FAIL
make: *** [t] Error 1
```

**Broken disappears**

```console
% make t T=TestAccSecretsManagerSecretVersion_disappears K=secretsmanager
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 main4 🌿...
TF_ACC=1 go1.26.3 test ./internal/service/secretsmanager/... -v -count 1 -parallel 20 -run='TestAccSecretsManagerSecretVersion_disappears'  -timeout 360m -vet=off
=== RUN   TestAccSecretsManagerSecretVersion_disappears
=== PAUSE TestAccSecretsManagerSecretVersion_disappears
=== CONT  TestAccSecretsManagerSecretVersion_disappears
    secret_version_test.go:535: Step 1/1 error: Post-apply refresh plan check(s) failed:
        'aws_secretsmanager_secret_version.test' - expected Create, got action(s): [no-op]
--- FAIL: TestAccSecretsManagerSecretVersion_disappears (15.52s)
```

**Flaky eventual consistency**

```console
=== CONT  TestAccSecretsManagerSecretVersionDataSource_basic
    secret_version_data_source_test.go:27: Step 1/1 error: Error running apply: exit status 1
        
        Error: reading Secrets Manager Secret Version (arn:aws:secretsmanager:us-west-2:123456789012:secret:tf-acc-test-455551360437968250-cPv7Sj|AWSCURRENT): couldn't find resource
        
          with data.aws_secretsmanager_secret_version.test,
          on terraform_plugin_test.tf line 21, in data "aws_secretsmanager_secret_version" "test":
          21: data "aws_secretsmanager_secret_version" "test" {
        
--- FAIL: TestAccSecretsManagerSecretVersionDataSource_basic (8.69s)
=== CONT  TestAccSecretsManagerSecretVersionDataSource_basic
    secret_version_data_source_test.go:27: Step 1/1 error: Check failed: Check 1/2 error: version_stages.# is 0; want 1
--- FAIL: TestAccSecretsManagerSecretVersionDataSource_basic (8.68s)
```

#### AFTER FIXES

**Regression fix**

```console
% make t T='TestAccSecretsManagerSecretVersion_unknownSecretString|TestAccSecretsManagerSecretVersion_unknownSecretStringWriteOnlyVersion' K=secretsmanager
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 b-secretsmanager-secret-version-inconsstnt 🌿...
TF_ACC=1 go1.26.3 test ./internal/service/secretsmanager/... -v -count 1 -parallel 20 -run='TestAccSecretsManagerSecretVersion_unknownSecretString|TestAccSecretsManagerSecretVersion_unknownSecretStringWriteOnlyVersion'  -timeout 360m -vet=off
2026/06/09 18:10:50 Creating Terraform AWS Provider (SDKv2-style)...
2026/06/09 18:10:50 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccSecretsManagerSecretVersion_unknownSecretString
=== PAUSE TestAccSecretsManagerSecretVersion_unknownSecretString
=== RUN   TestAccSecretsManagerSecretVersion_unknownSecretStringWriteOnlyVersion
=== PAUSE TestAccSecretsManagerSecretVersion_unknownSecretStringWriteOnlyVersion
=== CONT  TestAccSecretsManagerSecretVersion_unknownSecretString
=== CONT  TestAccSecretsManagerSecretVersion_unknownSecretStringWriteOnlyVersion
--- PASS: TestAccSecretsManagerSecretVersion_unknownSecretStringWriteOnlyVersion (28.40s)
--- PASS: TestAccSecretsManagerSecretVersion_unknownSecretString (28.46s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/secretsmanager	35.580s
```

**Flaky fix** (previously 2-4 failures per 10)

```console
% TF_ACC=1 go1.26.3 test ./internal/service/secretsmanager/... -v -count 10 -run='TestAccSecretsManagerSecretVersionDataSource_basic'  -timeout 360m -vet=off
2026/06/10 09:43:25 Creating Terraform AWS Provider (SDKv2-style)...
2026/06/10 09:43:25 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccSecretsManagerSecretVersionDataSource_basic
=== PAUSE TestAccSecretsManagerSecretVersionDataSource_basic
=== CONT  TestAccSecretsManagerSecretVersionDataSource_basic
--- PASS: TestAccSecretsManagerSecretVersionDataSource_basic (16.79s)
=== RUN   TestAccSecretsManagerSecretVersionDataSource_basic
=== PAUSE TestAccSecretsManagerSecretVersionDataSource_basic
=== CONT  TestAccSecretsManagerSecretVersionDataSource_basic
--- PASS: TestAccSecretsManagerSecretVersionDataSource_basic (14.65s)
=== RUN   TestAccSecretsManagerSecretVersionDataSource_basic
=== PAUSE TestAccSecretsManagerSecretVersionDataSource_basic
=== CONT  TestAccSecretsManagerSecretVersionDataSource_basic
--- PASS: TestAccSecretsManagerSecretVersionDataSource_basic (14.66s)
=== RUN   TestAccSecretsManagerSecretVersionDataSource_basic
=== PAUSE TestAccSecretsManagerSecretVersionDataSource_basic
=== CONT  TestAccSecretsManagerSecretVersionDataSource_basic
--- PASS: TestAccSecretsManagerSecretVersionDataSource_basic (14.70s)
=== RUN   TestAccSecretsManagerSecretVersionDataSource_basic
=== PAUSE TestAccSecretsManagerSecretVersionDataSource_basic
=== CONT  TestAccSecretsManagerSecretVersionDataSource_basic
--- PASS: TestAccSecretsManagerSecretVersionDataSource_basic (14.77s)
=== RUN   TestAccSecretsManagerSecretVersionDataSource_basic
=== PAUSE TestAccSecretsManagerSecretVersionDataSource_basic
=== CONT  TestAccSecretsManagerSecretVersionDataSource_basic
--- PASS: TestAccSecretsManagerSecretVersionDataSource_basic (14.64s)
=== RUN   TestAccSecretsManagerSecretVersionDataSource_basic
=== PAUSE TestAccSecretsManagerSecretVersionDataSource_basic
=== CONT  TestAccSecretsManagerSecretVersionDataSource_basic
--- PASS: TestAccSecretsManagerSecretVersionDataSource_basic (14.65s)
=== RUN   TestAccSecretsManagerSecretVersionDataSource_basic
=== PAUSE TestAccSecretsManagerSecretVersionDataSource_basic
=== CONT  TestAccSecretsManagerSecretVersionDataSource_basic
--- PASS: TestAccSecretsManagerSecretVersionDataSource_basic (14.83s)
=== RUN   TestAccSecretsManagerSecretVersionDataSource_basic
=== PAUSE TestAccSecretsManagerSecretVersionDataSource_basic
=== CONT  TestAccSecretsManagerSecretVersionDataSource_basic
--- PASS: TestAccSecretsManagerSecretVersionDataSource_basic (14.75s)
=== RUN   TestAccSecretsManagerSecretVersionDataSource_basic
=== PAUSE TestAccSecretsManagerSecretVersionDataSource_basic
=== CONT  TestAccSecretsManagerSecretVersionDataSource_basic
--- PASS: TestAccSecretsManagerSecretVersionDataSource_basic (14.75s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/secretsmanager	155.954s
```

**Full suite**

```console
% make t T=TestAccSecretsManagerSecretVersion K=secretsmanager
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 b-secretsmanager-secret-version-inconsstnt 🌿...
TF_ACC=1 go1.26.3 test ./internal/service/secretsmanager/... -v -count 1 -parallel 20 -run='TestAccSecretsManagerSecretVersion'  -timeout 360m -vet=off
2026/06/10 10:19:33 Creating Terraform AWS Provider (SDKv2-style)...
2026/06/10 10:19:33 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccSecretsManagerSecretVersionDataSource_basic
=== PAUSE TestAccSecretsManagerSecretVersionDataSource_basic
=== RUN   TestAccSecretsManagerSecretVersionDataSource_nonExistent
=== PAUSE TestAccSecretsManagerSecretVersionDataSource_nonExistent
=== RUN   TestAccSecretsManagerSecretVersionDataSource_versionID
=== PAUSE TestAccSecretsManagerSecretVersionDataSource_versionID
=== RUN   TestAccSecretsManagerSecretVersionDataSource_versionStage
=== PAUSE TestAccSecretsManagerSecretVersionDataSource_versionStage
=== RUN   TestAccSecretsManagerSecretVersionEphemeral_basic
=== PAUSE TestAccSecretsManagerSecretVersionEphemeral_basic
=== RUN   TestAccSecretsManagerSecretVersion_Identity_basic
=== PAUSE TestAccSecretsManagerSecretVersion_Identity_basic
=== RUN   TestAccSecretsManagerSecretVersion_Identity_regionOverride
=== PAUSE TestAccSecretsManagerSecretVersion_Identity_regionOverride
=== RUN   TestAccSecretsManagerSecretVersion_Identity_ExistingResource_basic
=== PAUSE TestAccSecretsManagerSecretVersion_Identity_ExistingResource_basic
=== RUN   TestAccSecretsManagerSecretVersion_Identity_ExistingResource_noRefreshNoChange
=== PAUSE TestAccSecretsManagerSecretVersion_Identity_ExistingResource_noRefreshNoChange
=== RUN   TestAccSecretsManagerSecretVersion_List_basic
=== PAUSE TestAccSecretsManagerSecretVersion_List_basic
=== RUN   TestAccSecretsManagerSecretVersion_basicString
=== PAUSE TestAccSecretsManagerSecretVersion_basicString
=== RUN   TestAccSecretsManagerSecretVersion_base64Binary
=== PAUSE TestAccSecretsManagerSecretVersion_base64Binary
=== RUN   TestAccSecretsManagerSecretVersion_versionStages
=== PAUSE TestAccSecretsManagerSecretVersion_versionStages
=== RUN   TestAccSecretsManagerSecretVersion_versionStagesExternalUpdate
=== PAUSE TestAccSecretsManagerSecretVersion_versionStagesExternalUpdate
=== RUN   TestAccSecretsManagerSecretVersion_disappears
=== PAUSE TestAccSecretsManagerSecretVersion_disappears
=== RUN   TestAccSecretsManagerSecretVersion_Disappears_secret
=== PAUSE TestAccSecretsManagerSecretVersion_Disappears_secret
=== RUN   TestAccSecretsManagerSecretVersion_UpdateForcesReplacement_string
=== PAUSE TestAccSecretsManagerSecretVersion_UpdateForcesReplacement_string
=== RUN   TestAccSecretsManagerSecretVersion_unknownSecretString
=== PAUSE TestAccSecretsManagerSecretVersion_unknownSecretString
=== RUN   TestAccSecretsManagerSecretVersion_unknownSecretStringWriteOnlyVersion
=== PAUSE TestAccSecretsManagerSecretVersion_unknownSecretStringWriteOnlyVersion
=== RUN   TestAccSecretsManagerSecretVersion_multipleVersions
=== PAUSE TestAccSecretsManagerSecretVersion_multipleVersions
=== RUN   TestAccSecretsManagerSecretVersion_StringWriteOnly_changeWOVersion
=== PAUSE TestAccSecretsManagerSecretVersion_StringWriteOnly_changeWOVersion
=== RUN   TestAccSecretsManagerSecretVersion_StringWriteOnly_sameWOVersion
=== PAUSE TestAccSecretsManagerSecretVersion_StringWriteOnly_sameWOVersion
=== RUN   TestAccSecretsManagerSecretVersion_stringWriteOnlyLimitedPermissions
=== PAUSE TestAccSecretsManagerSecretVersion_stringWriteOnlyLimitedPermissions
=== RUN   TestAccSecretsManagerSecretVersion_stringWriteOnly_stages
=== PAUSE TestAccSecretsManagerSecretVersion_stringWriteOnly_stages
=== RUN   TestAccSecretsManagerSecretVersion_ConvertStringToStringWriteOnly_noChange
=== PAUSE TestAccSecretsManagerSecretVersion_ConvertStringToStringWriteOnly_noChange
=== RUN   TestAccSecretsManagerSecretVersion_ConvertStringToStringWriteOnly_withChange
=== PAUSE TestAccSecretsManagerSecretVersion_ConvertStringToStringWriteOnly_withChange
=== RUN   TestAccSecretsManagerSecretVersion_ConvertStringWriteOnlyToString_noChange
=== PAUSE TestAccSecretsManagerSecretVersion_ConvertStringWriteOnlyToString_noChange
=== RUN   TestAccSecretsManagerSecretVersion_ConvertStringWriteOnlyToString_withChange
=== PAUSE TestAccSecretsManagerSecretVersion_ConvertStringWriteOnlyToString_withChange
=== RUN   TestAccSecretsManagerSecretVersionsDataSource_basic
=== PAUSE TestAccSecretsManagerSecretVersionsDataSource_basic
=== RUN   TestAccSecretsManagerSecretVersionsDataSource_emptyVer
=== PAUSE TestAccSecretsManagerSecretVersionsDataSource_emptyVer
=== CONT  TestAccSecretsManagerSecretVersionDataSource_basic
=== CONT  TestAccSecretsManagerSecretVersion_Disappears_secret
=== CONT  TestAccSecretsManagerSecretVersion_stringWriteOnly_stages
=== CONT  TestAccSecretsManagerSecretVersion_ConvertStringWriteOnlyToString_withChange
=== CONT  TestAccSecretsManagerSecretVersion_basicString
=== CONT  TestAccSecretsManagerSecretVersion_ConvertStringToStringWriteOnly_withChange
=== CONT  TestAccSecretsManagerSecretVersion_multipleVersions
=== CONT  TestAccSecretsManagerSecretVersion_ConvertStringWriteOnlyToString_noChange
=== CONT  TestAccSecretsManagerSecretVersion_disappears
=== CONT  TestAccSecretsManagerSecretVersion_Identity_ExistingResource_noRefreshNoChange
=== CONT  TestAccSecretsManagerSecretVersion_versionStagesExternalUpdate
=== CONT  TestAccSecretsManagerSecretVersion_versionStages
=== CONT  TestAccSecretsManagerSecretVersion_base64Binary
=== CONT  TestAccSecretsManagerSecretVersion_stringWriteOnlyLimitedPermissions
=== CONT  TestAccSecretsManagerSecretVersion_StringWriteOnly_sameWOVersion
=== CONT  TestAccSecretsManagerSecretVersionsDataSource_emptyVer
=== CONT  TestAccSecretsManagerSecretVersion_unknownSecretString
=== CONT  TestAccSecretsManagerSecretVersion_unknownSecretStringWriteOnlyVersion
=== CONT  TestAccSecretsManagerSecretVersion_List_basic
=== CONT  TestAccSecretsManagerSecretVersion_StringWriteOnly_changeWOVersion
=== NAME  TestAccSecretsManagerSecretVersion_stringWriteOnlyLimitedPermissions
    secret_version_test.go:869: skipping test; environment variable TF_ACC_ASSUME_ROLE_ARN must be set. Usage: Amazon Resource Name (ARN) of existing IAM Role to assume for testing restricted permissions
--- SKIP: TestAccSecretsManagerSecretVersion_stringWriteOnlyLimitedPermissions (0.84s)
=== CONT  TestAccSecretsManagerSecretVersionsDataSource_basic
--- PASS: TestAccSecretsManagerSecretVersionsDataSource_emptyVer (37.96s)
=== CONT  TestAccSecretsManagerSecretVersionEphemeral_basic
--- PASS: TestAccSecretsManagerSecretVersionsDataSource_basic (43.89s)
=== CONT  TestAccSecretsManagerSecretVersion_Identity_ExistingResource_basic
--- PASS: TestAccSecretsManagerSecretVersion_disappears (45.63s)
=== CONT  TestAccSecretsManagerSecretVersion_Identity_regionOverride
--- PASS: TestAccSecretsManagerSecretVersion_multipleVersions (46.19s)
=== CONT  TestAccSecretsManagerSecretVersion_Identity_basic
--- PASS: TestAccSecretsManagerSecretVersionDataSource_basic (48.85s)
=== CONT  TestAccSecretsManagerSecretVersion_UpdateForcesReplacement_string
--- PASS: TestAccSecretsManagerSecretVersion_Disappears_secret (48.88s)
=== CONT  TestAccSecretsManagerSecretVersionDataSource_versionID
--- PASS: TestAccSecretsManagerSecretVersion_List_basic (50.44s)
=== CONT  TestAccSecretsManagerSecretVersionDataSource_versionStage
--- PASS: TestAccSecretsManagerSecretVersion_basicString (56.64s)
--- PASS: TestAccSecretsManagerSecretVersion_base64Binary (56.64s)
=== CONT  TestAccSecretsManagerSecretVersionDataSource_nonExistent
=== CONT  TestAccSecretsManagerSecretVersion_ConvertStringToStringWriteOnly_noChange
--- PASS: TestAccSecretsManagerSecretVersion_StringWriteOnly_sameWOVersion (71.38s)
--- PASS: TestAccSecretsManagerSecretVersion_Identity_ExistingResource_noRefreshNoChange (74.34s)
--- PASS: TestAccSecretsManagerSecretVersion_ConvertStringWriteOnlyToString_withChange (74.55s)
--- PASS: TestAccSecretsManagerSecretVersion_ConvertStringWriteOnlyToString_noChange (74.62s)
--- PASS: TestAccSecretsManagerSecretVersion_versionStagesExternalUpdate (74.82s)
--- PASS: TestAccSecretsManagerSecretVersion_unknownSecretString (74.83s)
--- PASS: TestAccSecretsManagerSecretVersion_ConvertStringToStringWriteOnly_withChange (77.63s)
--- PASS: TestAccSecretsManagerSecretVersion_StringWriteOnly_changeWOVersion (77.86s)
--- PASS: TestAccSecretsManagerSecretVersionEphemeral_basic (41.50s)
--- PASS: TestAccSecretsManagerSecretVersion_unknownSecretStringWriteOnlyVersion (79.75s)
--- PASS: TestAccSecretsManagerSecretVersionDataSource_versionID (35.59s)
--- PASS: TestAccSecretsManagerSecretVersionDataSource_versionStage (34.05s)
--- PASS: TestAccSecretsManagerSecretVersion_stringWriteOnly_stages (92.99s)
--- PASS: TestAccSecretsManagerSecretVersion_Identity_ExistingResource_basic (49.98s)
--- PASS: TestAccSecretsManagerSecretVersion_Identity_regionOverride (49.91s)
--- PASS: TestAccSecretsManagerSecretVersion_UpdateForcesReplacement_string (47.80s)
--- PASS: TestAccSecretsManagerSecretVersion_versionStages (96.96s)
--- PASS: TestAccSecretsManagerSecretVersion_Identity_basic (51.66s)
--- PASS: TestAccSecretsManagerSecretVersion_ConvertStringToStringWriteOnly_noChange (42.46s)
--- PASS: TestAccSecretsManagerSecretVersionDataSource_nonExistent (137.04s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/secretsmanager	200.478s
```