### PR TITLE
list resource/aws_codebuild_project: Removes resource Read function from List

### DIFF
--- a/.ci/semgrep/list/no-resource-read.yml
+++ b/.ci/semgrep/list/no-resource-read.yml
@@ -34,3 +34,30 @@ rules:
           metavariable: $FN
           regex: ^resource\w+Read$
     severity: WARNING
+
+  - id: no-empty-id-check-after-flatten
+    languages: [go]
+    message: Do not check for empty ID after calling a flatten function in a List Resource. The flatten function does not clear the ID.
+    paths:
+      include:
+        - "/internal/service"
+      exclude:
+        - "/internal/service/dynamodb/table_list.go"
+        - "/internal/service/ecs/task_definition_list.go"
+        - "/internal/service/kms/alias_list.go"
+        - "/internal/service/kms/key_list.go"
+        - "/internal/service/lambda/permission_list.go"
+        - "/internal/service/route53/zone_list.go"
+    patterns:
+      - pattern-either:
+          - pattern: |
+              $DIAGS := $FN(...)
+              if $DIAGS.HasError() || $RD.Id() == "" { ... }
+          - pattern: |
+              $DIAGS := $FN(...)
+              ...
+              if $RD.Id() == "" { ... }
+      - metavariable-regex:
+          metavariable: $FN
+          regex: ^resource\w+Flatten$
+    severity: WARNING

--- a/.ci/semgrep/list/no-resource-read.yml
+++ b/.ci/semgrep/list/no-resource-read.yml
@@ -1,0 +1,37 @@
+# Copyright IBM Corp. 2014, 2026
+# "SPDX-License-Identifier: MPL-2.0"
+
+rules:
+  - id: no-sdkv2-resource-read
+    languages: [go]
+    message: Do not call the resource Read function in a List Resource's List function.
+    paths:
+      include:
+        - "/internal/service"
+      exclude:
+        - "/internal/service/codebuild/project_list.go"
+        - "/internal/service/ec2/vpc_route_list.go"
+        - "/internal/service/ec2/vpc_route_table_list.go"
+        - "/internal/service/ec2/vpc_security_group_list.go"
+        - "/internal/service/iam/role_policy_list.go"
+        - "/internal/service/lambda/layer_version_list.go"
+        - "/internal/service/route53/record_list.go"
+        - "/internal/service/route53resolver/rule_association_list.go"
+        - "/internal/service/s3/bucket_acl_list.go"
+        - "/internal/service/s3/bucket_public_access_block_list.go"
+        - "/internal/service/s3/object_list.go"
+        - "/internal/service/secretsmanager/secret_list.go"
+        - "/internal/service/secretsmanager/secret_version_list.go"
+        - "/internal/service/sqs/queue_list.go"
+        - "/internal/service/ssm/parameter_list.go"
+    patterns:
+      - pattern: |
+          func ($L *$TYPE) List($CTX context.Context, $REQ list.ListRequest, $STREAM *list.ListResultsStream) {
+            ...
+            $RESULT := $FN(...)
+            ...
+          }
+      - metavariable-regex:
+          metavariable: $FN
+          regex: ^resource\w+Read$
+    severity: WARNING

--- a/.ci/semgrep/list/no-resource-read.yml
+++ b/.ci/semgrep/list/no-resource-read.yml
@@ -9,7 +9,6 @@ rules:
       include:
         - "/internal/service"
       exclude:
-        - "/internal/service/codebuild/project_list.go"
         - "/internal/service/ec2/vpc_route_list.go"
         - "/internal/service/ec2/vpc_route_table_list.go"
         - "/internal/service/ec2/vpc_security_group_list.go"

--- a/internal/service/codebuild/project.go
+++ b/internal/service/codebuild/project.go
@@ -949,6 +949,17 @@ func resourceProjectRead(ctx context.Context, d *schema.ResourceData, meta any) 
 		return sdkdiag.AppendErrorf(diags, "reading CodeBuild Project (%s): %s", d.Id(), err)
 	}
 
+	diags = append(diags, resourceProjectFlatten(ctx, d, project)...)
+	if diags.HasError() {
+		return diags
+	}
+
+	return diags
+}
+
+func resourceProjectFlatten(ctx context.Context, d *schema.ResourceData, project *types.Project) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	d.Set(names.AttrARN, project.Arn)
 	if project.Artifacts != nil {
 		if err := d.Set("artifacts", []any{flattenProjectArtifacts(project.Artifacts)}); err != nil {

--- a/internal/service/codebuild/project_list.go
+++ b/internal/service/codebuild/project_list.go
@@ -6,12 +6,14 @@ package codebuild
 import (
 	"context"
 	"fmt"
-	"iter"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/codebuild"
+	"github.com/aws/aws-sdk-go-v2/service/codebuild/types"
 	"github.com/hashicorp/terraform-plugin-framework/list"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
 	"github.com/hashicorp/terraform-provider-aws/internal/logging"
 	inttypes "github.com/hashicorp/terraform-provider-aws/internal/types"
@@ -50,62 +52,66 @@ func (l *projectListResource) List(ctx context.Context, request list.ListRequest
 	tflog.Info(ctx, "Listing CodeBuild projects")
 
 	stream.Results = func(yield func(list.ListResult) bool) {
-		for projectName, err := range listProjects(ctx, conn, &input) {
-			if err != nil {
-				result := fwdiag.NewListResultErrorDiagnostic(err)
-				yield(result)
-				return
-			}
-			ctx := tflog.SetField(ctx, logging.ResourceAttributeKey(names.AttrID), projectName)
-
-			result := request.NewListResult(ctx)
-			rd := l.ResourceData()
-			rd.SetId(projectName)
-
-			tflog.Info(ctx, "Listing CodeBuild project")
-			diags := resourceProjectRead(ctx, rd, awsClient)
-			if diags.HasError() {
-				tflog.Error(ctx, "Error reading CodeBuild project", map[string]any{
-					"project_name": projectName,
-					"error":        diags,
-				})
-				continue
-			}
-
-			if rd.Id() == "" {
-				continue
-			}
-
-			result.DisplayName = projectName
-
-			l.SetResult(ctx, awsClient, request.IncludeResource, rd, &result)
-			if result.Diagnostics.HasError() {
-				tflog.Error(ctx, "Error setting result for CodeBuild project", map[string]any{
-					"project_name": projectName,
-					"error":        result.Diagnostics,
-				})
-				continue
-			}
-
-			if !yield(result) {
-				return
-			}
-		}
-	}
-}
-
-func listProjects(ctx context.Context, conn *codebuild.Client, input *codebuild.ListProjectsInput) iter.Seq2[string, error] {
-	return func(yield func(string, error) bool) {
-		pages := codebuild.NewListProjectsPaginator(conn, input)
+		pages := codebuild.NewListProjectsPaginator(conn, &input)
 		for pages.HasMorePages() {
 			page, err := pages.NextPage(ctx)
 			if err != nil {
-				yield("", fmt.Errorf("listing CodeBuild Projects: %w", err))
+				result := fwdiag.NewListResultErrorDiagnostic(fmt.Errorf("listing CodeBuild Projects: %w", err))
+				yield(result)
 				return
 			}
 
+			if len(page.Projects) == 0 {
+				continue
+			}
+
+			// Batch-get full project details when IncludeResource is set.
+			var projects []types.Project
+			if request.IncludeResource {
+				projects, err = findProjects(ctx, conn, &codebuild.BatchGetProjectsInput{
+					Names: page.Projects,
+				})
+				if err != nil {
+					result := fwdiag.NewListResultErrorDiagnostic(fmt.Errorf("reading CodeBuild Projects: %w", err))
+					yield(result)
+					return
+				}
+			}
+
+			// Build a map for lookup by name.
+			projectsByName := make(map[string]*types.Project, len(projects))
+			for i := range projects {
+				projectsByName[aws.ToString(projects[i].Name)] = &projects[i]
+			}
+
 			for _, projectName := range page.Projects {
-				if !yield(projectName, nil) {
+				ctx := tflog.SetField(ctx, logging.ResourceAttributeKey(names.AttrName), projectName)
+
+				result := request.NewListResult(ctx)
+				rd := l.ResourceData()
+				rd.SetId(projectName)
+				rd.Set(names.AttrARN, awsClient.RegionalARN(ctx, "codebuild", "project/"+projectName))
+
+				if project, ok := projectsByName[projectName]; ok {
+					diags := resourceProjectFlatten(ctx, rd, project)
+					if diags.HasError() {
+						tflog.Error(ctx, "Error reading CodeBuild project", map[string]any{
+							"error": sdkdiag.DiagnosticsString(diags),
+						})
+						continue
+					}
+				}
+				result.DisplayName = projectName
+
+				l.SetResult(ctx, awsClient, request.IncludeResource, rd, &result)
+				if result.Diagnostics.HasError() {
+					tflog.Error(ctx, "Error setting result for CodeBuild project", map[string]any{
+						"error": result.Diagnostics,
+					})
+					continue
+				}
+
+				if !yield(result) {
 					return
 				}
 			}

--- a/internal/service/codebuild/project_list_test.go
+++ b/internal/service/codebuild/project_list_test.go
@@ -6,6 +6,7 @@ package codebuild_test
 import (
 	"testing"
 
+	"github.com/YakDriver/regexache"
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
@@ -15,6 +16,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	tfknownvalue "github.com/hashicorp/terraform-provider-aws/internal/acctest/knownvalue"
+	tfquerycheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/querycheck"
+	tfqueryfilter "github.com/hashicorp/terraform-provider-aws/internal/acctest/queryfilter"
+	tfstatecheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/statecheck"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -61,6 +65,137 @@ func TestAccCodeBuildProject_List_basic(t *testing.T) {
 					querycheck.ExpectIdentity("aws_codebuild_project.test", map[string]knownvalue.Check{
 						names.AttrARN: knownvalue.NotNull(),
 					}),
+				},
+			},
+		},
+	})
+}
+
+func TestAccCodeBuildProject_List_includeResource(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName1 := "aws_codebuild_project.test[0]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	identity1 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CodeBuildServiceID),
+		CheckDestroy:             testAccCheckProjectDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Project/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(1),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+					statecheck.ExpectKnownValue(resourceName1, tfjsonpath.New(names.AttrARN), tfknownvalue.RegionalARNExact("codebuild", "project/"+rName+"-0")),
+				},
+			},
+
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/Project/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(1),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_codebuild_project.test", identity1.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_codebuild_project.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), knownvalue.StringExact(rName+"-0")),
+					querycheck.ExpectResourceKnownValues("aws_codebuild_project.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), []querycheck.KnownValueCheck{
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrARN), tfknownvalue.RegionalARNExact("codebuild", "project/"+rName+"-0")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("artifacts"), knownvalue.ListSizeExact(1)),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("auto_retry_limit"), knownvalue.Int64Exact(0)),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("badge_enabled"), knownvalue.Bool(false)),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("badge_url"), knownvalue.StringExact("")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("build_batch_config"), knownvalue.ListExact([]knownvalue.Check{})),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("build_timeout"), knownvalue.Int64Exact(60)),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("cache"), knownvalue.ListSizeExact(1)),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("concurrent_build_limit"), knownvalue.Int64Exact(0)),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrDescription), knownvalue.StringExact("")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("encryption_key"), knownvalue.StringRegexp(regexache.MustCompile(`.+`))),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrEnvironment), knownvalue.ListSizeExact(1)),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("file_system_locations"), knownvalue.ListExact([]knownvalue.Check{})),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("logs_config"), knownvalue.ListSizeExact(1)),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrName), knownvalue.StringExact(rName+"-0")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("project_visibility"), knownvalue.StringExact("PRIVATE")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("public_project_alias"), knownvalue.StringExact("")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("resource_access_role"), knownvalue.StringExact("")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("queued_timeout"), knownvalue.Int64Exact(480)),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("secondary_artifacts"), knownvalue.SetExact([]knownvalue.Check{})),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("secondary_sources"), knownvalue.SetExact([]knownvalue.Check{})),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("secondary_source_version"), knownvalue.SetExact([]knownvalue.Check{})),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrServiceRole), knownvalue.StringRegexp(regexache.MustCompile(`.+`))),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrSource), knownvalue.ListSizeExact(1)),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("source_version"), knownvalue.StringExact("")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrVPCConfig), knownvalue.ListExact([]knownvalue.Check{})),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
+							"Name": knownvalue.StringExact(rName + "-0"),
+						})),
+					}),
+				},
+			},
+		},
+	})
+}
+
+func TestAccCodeBuildProject_List_regionOverride(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName1 := "aws_codebuild_project.test[0]"
+	resourceName2 := "aws_codebuild_project.test[1]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	identity1 := tfstatecheck.Identity()
+	identity2 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.CodeBuildServiceID),
+		CheckDestroy:             acctest.CheckDestroyNoop,
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Project/list_region_override/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+					"region":         config.StringVariable(acctest.AlternateRegion()),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+					statecheck.ExpectKnownValue(resourceName1, tfjsonpath.New(names.AttrARN), tfknownvalue.RegionalARNAlternateRegionExact("codebuild", "project/"+rName+"-0")),
+
+					identity2.GetIdentity(resourceName2),
+					statecheck.ExpectKnownValue(resourceName2, tfjsonpath.New(names.AttrARN), tfknownvalue.RegionalARNAlternateRegionExact("codebuild", "project/"+rName+"-1")),
+				},
+			},
+
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/Project/list_region_override/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+					"region":         config.StringVariable(acctest.AlternateRegion()),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_codebuild_project.test", identity1.Checks()),
+					tfquerycheck.ExpectIdentityFunc("aws_codebuild_project.test", identity2.Checks()),
 				},
 			},
 		},

--- a/internal/service/codebuild/testdata/Project/list_include_resource/main.tf
+++ b/internal/service/codebuild/testdata/Project/list_include_resource/main.tf
@@ -1,0 +1,55 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_codebuild_project" "test" {
+  count = var.resource_count
+
+  name         = "${var.rName}-${count.index}"
+  service_role = aws_iam_role.test.arn
+
+  artifacts {
+    type = "NO_ARTIFACTS"
+  }
+
+  environment {
+    compute_type = "BUILD_GENERAL1_SMALL"
+    image        = "aws/codebuild/amazonlinux2-x86_64-standard:2.0"
+    type         = "LINUX_CONTAINER"
+  }
+
+  source {
+    type      = "NO_SOURCE"
+    buildspec = "version: 0.2\nphases:\n  build:\n    commands:\n      - echo hello"
+  }
+
+  tags = {
+    Name = "${var.rName}-${count.index}"
+  }
+}
+
+resource "aws_iam_role" "test" {
+  name = var.rName
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "codebuild.amazonaws.com"
+      }
+    }]
+  })
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}

--- a/internal/service/codebuild/testdata/Project/list_include_resource/main.tfquery.hcl
+++ b/internal/service/codebuild/testdata/Project/list_include_resource/main.tfquery.hcl
@@ -1,0 +1,8 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_codebuild_project" "test" {
+  provider = aws
+
+  include_resource = true
+}

--- a/internal/service/codebuild/testdata/Project/list_region_override/main.tf
+++ b/internal/service/codebuild/testdata/Project/list_region_override/main.tf
@@ -1,0 +1,58 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_codebuild_project" "test" {
+  region = var.region
+  count  = var.resource_count
+
+  name         = "${var.rName}-${count.index}"
+  service_role = aws_iam_role.test.arn
+
+  artifacts {
+    type = "NO_ARTIFACTS"
+  }
+
+  environment {
+    compute_type = "BUILD_GENERAL1_SMALL"
+    image        = "aws/codebuild/amazonlinux2-x86_64-standard:2.0"
+    type         = "LINUX_CONTAINER"
+  }
+
+  source {
+    type      = "NO_SOURCE"
+    buildspec = "version: 0.2\nphases:\n  build:\n    commands:\n      - echo hello"
+  }
+}
+
+resource "aws_iam_role" "test" {
+  name = var.rName
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "codebuild.amazonaws.com"
+      }
+    }]
+  })
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}
+
+variable "region" {
+  description = "Region to deploy resource in"
+  type        = string
+  nullable    = false
+}

--- a/internal/service/codebuild/testdata/Project/list_region_override/main.tfquery.hcl
+++ b/internal/service/codebuild/testdata/Project/list_region_override/main.tfquery.hcl
@@ -1,0 +1,10 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_codebuild_project" "test" {
+  provider = aws
+
+  config {
+    region = var.region
+  }
+}


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Adds `_includeResource` test for `aws_codebuild_project`.

Removes resource Read function from `aws_codebuild_project` List

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=codebuild TESTS=TestAccCodeBuildProject_List_

--- PASS: TestAccCodeBuildProject_List_includeResource (32.49s)
--- PASS: TestAccCodeBuildProject_List_basic (32.51s)
--- PASS: TestAccCodeBuildProject_List_regionOverride (33.22s)
```
