### PR TITLE
aws_cloudfront_distribution_tenant: Fix inconsistent result after app…

### DIFF
--- a/.changelog/48343.txt
+++ b/.changelog/48343.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cloudfront_distribution_tenant: Fix `Provider produced inconsistent result after apply` error when using `managed_certificate_request` without an explicit `customizations` block
+```

--- a/internal/service/cloudfront/distribution_tenant.go
+++ b/internal/service/cloudfront/distribution_tenant.go
@@ -273,6 +273,12 @@ func (r *distributionTenantResource) Create(ctx context.Context, req resource.Cr
 		return
 	}
 
+	// When managed_certificate_request is used without an explicit
+	// customizations block, the API auto-populates customizations.certificate.
+	// Preserve the planned (null) value so the post-apply consistency check passes.
+	plannedCustomizations := data.Customizations
+	managedCertRequested := !data.ManagedCertificateRequest.IsNull() && !data.ManagedCertificateRequest.IsUnknown()
+
 	conn := r.Meta().CloudFrontClient(ctx)
 
 	name := fwflex.StringValueFromFramework(ctx, data.Name)
@@ -354,6 +360,14 @@ func (r *distributionTenantResource) Create(ctx context.Context, req resource.Cr
 		}
 	}
 
+	// Restore planned customizations to maintain plan/state consistency.
+	// The API auto-populates customizations.certificate when managed_certificate_request
+	// is used. Restore the planned value whether customizations was entirely null or
+	// present but without a certificate sub-block.
+	if managedCertRequested {
+		data.Customizations = suppressManagedCertificateCustomizations(ctx, plannedCustomizations, data.Customizations)
+	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -363,6 +377,10 @@ func (r *distributionTenantResource) Read(ctx context.Context, req resource.Read
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	// Preserve prior customizations state before flatten overwrites it.
+	priorCustomizations := data.Customizations
+	managedCertRequested := !data.ManagedCertificateRequest.IsNull() && !data.ManagedCertificateRequest.IsUnknown()
 
 	conn := r.Meta().CloudFrontClient(ctx)
 
@@ -394,6 +412,11 @@ func (r *distributionTenantResource) Read(ctx context.Context, req resource.Read
 	// Set computed fields that need special handling
 	data.ETag = fwflex.StringToFramework(ctx, output.ETag)
 
+	// Restore prior customizations to prevent drift when managed cert is active.
+	if managedCertRequested {
+		data.Customizations = suppressManagedCertificateCustomizations(ctx, priorCustomizations, data.Customizations)
+	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -404,6 +427,10 @@ func (r *distributionTenantResource) Update(ctx context.Context, req resource.Up
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	// Preserve planned customizations for managed cert consistency.
+	plannedCustomizations := new.Customizations
+	managedCertRequested := !new.ManagedCertificateRequest.IsNull() && !new.ManagedCertificateRequest.IsUnknown()
 
 	conn := r.Meta().CloudFrontClient(ctx)
 
@@ -528,6 +555,11 @@ func (r *distributionTenantResource) Update(ctx context.Context, req resource.Up
 		}
 
 		new.ETag = fwflex.StringToFramework(ctx, getOutput.ETag)
+	}
+
+	// Restore planned customizations to maintain plan/state consistency.
+	if managedCertRequested {
+		new.Customizations = suppressManagedCertificateCustomizations(ctx, plannedCustomizations, new.Customizations)
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &new)...)
@@ -905,4 +937,32 @@ func convertDomainResultsToDomainItems(domainResults []awstypes.DomainResult) []
 	}
 
 	return domainItems
+}
+
+// suppressManagedCertificateCustomizations returns the planned/prior customizations
+// value when the API would have injected a certificate sub-block that wasn't in config.
+// This handles two cases:
+//   - customizations entirely null (no block in HCL) → return planned (null)
+//   - customizations non-null but certificate sub-block null (e.g. only web_acl set) → return planned
+// If the user explicitly configured a certificate sub-block, the flattened value is returned unchanged.
+func suppressManagedCertificateCustomizations(ctx context.Context, planned, flattened fwtypes.ListNestedObjectValueOf[customizationsModel]) fwtypes.ListNestedObjectValueOf[customizationsModel] {
+	// Case 1: No customizations block in config at all.
+	if planned.IsNull() {
+		return planned
+	}
+
+	// Case 2: Customizations block present — check if certificate sub-block was configured.
+	plannedElems, diags := planned.ToSlice(ctx)
+	if diags.HasError() || len(plannedElems) == 0 {
+		return planned
+	}
+
+	// If the user configured a certificate sub-block, don't suppress — let the flattened value through.
+	if !plannedElems[0].Certificate.IsNull() {
+		return flattened
+	}
+
+	// User didn't configure certificate; return planned which preserves their other sub-blocks
+	// (geo_restriction, web_acl) without the API-injected certificate.
+	return planned
 }

--- a/internal/service/cloudfront/distribution_tenant_test.go
+++ b/internal/service/cloudfront/distribution_tenant_test.go
@@ -247,6 +247,50 @@ func TestAccCloudFrontDistributionTenant_customCertificateWithWebACL(t *testing.
 	})
 }
 
+func TestAccCloudFrontDistributionTenant_managedCertificateRequest(t *testing.T) {
+	ctx := acctest.Context(t)
+	var tenant awstypes.DistributionTenant
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	rootDomain := acctest.ACMCertificateDomainFromEnv(t)
+	domain := acctest.ACMCertificateRandomSubDomain(rootDomain)
+	resourceName := "aws_cloudfront_distribution_tenant.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.CloudFrontEndpointID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.CloudFrontServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDistributionTenantDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDistributionTenantConfig_managedCertificateRequest(rName, rootDomain, domain),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDistributionTenantExists(ctx, t, resourceName, &tenant),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("customizations"), knownvalue.ListExact([]knownvalue.Check{})),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("managed_certificate_request"), knownvalue.ListSizeExact(1)),
+				},
+			},
+			{
+				Config: testAccDistributionTenantConfig_managedCertificateRequest(rName, rootDomain, domain),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
 func TestAccCloudFrontDistributionTenant_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var tenant awstypes.DistributionTenant
@@ -809,4 +853,78 @@ resource "aws_cloudfront_distribution_tenant" "test" {
   }
 }
 `, rName, tenantDomain, tagKey1, tagValue1, tagKey2, tagValue2))
+}
+
+func testAccDistributionTenantConfig_managedCertificateRequest(rName, rootDomain, tenantDomain string) string {
+	return acctest.ConfigCompose(testAccDistributionTenantConfig_baseCertificate(rootDomain, tenantDomain), fmt.Sprintf(`
+resource "aws_cloudfront_multitenant_distribution" "test" {
+  enabled = true
+  comment = "Test multi-tenant distribution"
+
+  origin {
+    domain_name = "www.example.com"
+    id          = "test"
+
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "http-only"
+      origin_ssl_protocols   = ["TLSv1.2"]
+    }
+  }
+
+  default_cache_behavior {
+    target_origin_id       = "test"
+    viewer_protocol_policy = "allow-all"
+    cache_policy_id        = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad" # AWS Managed CachingDisabled policy
+
+    allowed_methods {
+      items          = ["GET", "HEAD"]
+      cached_methods = ["GET", "HEAD"]
+    }
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn = data.aws_acm_certificate.test.arn
+    ssl_support_method  = "sni-only"
+  }
+
+  tenant_config {
+    parameter_definition {
+      name = "origin_domain"
+      definition {
+        string_schema {
+          required = true
+          comment  = "Origin domain parameter for tenants"
+        }
+      }
+    }
+  }
+}
+
+resource "aws_cloudfront_distribution_tenant" "test" {
+  distribution_id = aws_cloudfront_multitenant_distribution.test.id
+  enabled         = true
+  domain {
+    domain = %[2]q
+  }
+  name = %[1]q
+
+  managed_certificate_request {
+    primary_domain_name   = %[2]q
+    validation_token_host = "cloudfront"
+  }
+
+  parameter {
+    name  = "origin_domain"
+    value = "www.example.com"
+  }
+}
+`, rName, tenantDomain))
 }


### PR DESCRIPTION
  ## Summary

  Fixes the "Provider produced inconsistent result after apply" error when
  creating an `aws_cloudfront_distribution_tenant` with `managed_certificate_request`
  and no explicit `customizations` block.

  When `managed_certificate_request` is used, CloudFront auto-populates
  `customizations.certificate` in the API response. The provider flattened this
  into state, causing a block count mismatch (plan: 0, state: 1) that Terraform
  core rejects. The resource gets tainted and the next plan schedules a
  destroy+recreate of a working tenant.

  The fix preserves the planned/prior `customizations` value when
  `managed_certificate_request` is active and the user did not explicitly
  configure a `certificate` sub-block. This covers both:
  - No `customizations` block at all (the reported case)
  - `customizations` with `web_acl`/`geo_restriction` but no `certificate`

  ## Testing
  -`terraform apply` succeeds (no inconsistent result error)
  - `go vet` passes
  - Acceptance test `TestAccCloudFrontDistributionTenant_managedCertificateRequest` passes
  - Verified end-to-end against live AWS account

  ---

  ## Rollback Plan

  If a change needs to be reverted, we will publish an updated version of the library.

  ## Changes to Security Controls

  No changes to security controls.

  ### Description

  Fixes the "Provider produced inconsistent result after apply" error when creating an `aws_cloudfront_distribution_tenant` with `managed_certificate_request` and no explicit
  `customizations` block.

  When `managed_certificate_request` is used, CloudFront auto-populates `customizations.certificate` in the API response. The provider flattened this into state, causing a
  block count mismatch (plan: 0, state: 1) that Terraform core rejects. The resource gets tainted and the next plan schedules a destroy+recreate of a working tenant.

  The fix preserves the planned/prior `customizations` value in Create, Read, and Update when `managed_certificate_request` is active and the user did not explicitly configure
  a `certificate` sub-block. This covers both:
  - No `customizations` block at all (the reported case)
  - `customizations` with `web_acl`/`geo_restriction` but no `certificate`

  #### AI Usage Disclosure

  AI tools (Claude) were used to assist with code analysis, implementation, and test authoring. All code was reviewed, understood, and verified end-to-end by the human
  contributor.

  ### Relations
  Closes #45987

  ### References

  - [Issue #45987](https://github.com/hashicorp/terraform-provider-aws/issues/45987)

<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console

  === PAUSE TestAccCloudFrontDistributionTenant_managedCertificateRequest
  === CONT  TestAccCloudFrontDistributionTenant_managedCertificateRequest
  --- PASS: TestAccCloudFrontDistributionTenant_managedCertificateRequest (649.43s)
  PASS
  ok    github.com/hashicorp/terraform-provider-aws/internal/service/cloudfront 654.571s


...
```
