### PR TITLE
r/aws_msk_replicator: Add sweeper

### DIFF
--- a/internal/service/kafka/sweep.go
+++ b/internal/service/kafka/sweep.go
@@ -16,8 +16,9 @@ import (
 )
 
 func RegisterSweepers() {
-	awsv2.Register("aws_msk_cluster", sweepClusters, "aws_mskconnect_connector")
+	awsv2.Register("aws_msk_cluster", sweepClusters, "aws_mskconnect_connector", "aws_msk_replicator")
 	awsv2.Register("aws_msk_configuration", sweepConfigurations, "aws_msk_cluster")
+	awsv2.Register("aws_msk_replicator", sweepReplicators)
 }
 
 func sweepClusters(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepable, error) {
@@ -74,6 +75,38 @@ func sweepConfigurations(ctx context.Context, client *conns.AWSClient) ([]sweep.
 			}
 
 			r := resourceConfiguration()
+			d := r.Data(nil)
+			d.SetId(arn)
+
+			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+		}
+	}
+
+	return sweepResources, nil
+}
+
+func sweepReplicators(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepable, error) {
+	conn := client.KafkaClient(ctx)
+	var input kafka.ListReplicatorsInput
+	sweepResources := make([]sweep.Sweepable, 0)
+
+	pages := kafka.NewListReplicatorsPaginator(conn, &input)
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
+
+		if err != nil {
+			return nil, err
+		}
+
+		for _, v := range page.Replicators {
+			arn := aws.ToString(v.ReplicatorArn)
+
+			if state := v.ReplicatorState; state == types.ReplicatorStateDeleting {
+				log.Printf("[INFO] Skipping MSK Replicator %s: State=%s", arn, state)
+				continue
+			}
+
+			r := resourceReplicator()
 			d := r.Data(nil)
 			d.SetId(arn)
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Adds a sweeper for the `aws_msk_replicator` resource.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/48338.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% SWEEPERS=aws_msk_cluster make sweep
# make sweep SWEEPARGS=-sweep-run=aws_example_thing
# set SWEEPARGS=-sweep-allow-failures to continue after first failure
WARNING: This will destroy infrastructure. Use only in development accounts.
go1.26.3 test ./internal/sweep -v -sweep=us-west-2,us-east-1,us-east-2,us-west-1 -sweep-run='aws_msk_cluster' -timeout 360m -vet=off
2026/06/11 11:48:55 [DEBUG] Running Sweepers for region (us-west-2):
2026/06/11 11:48:55 [DEBUG] Sweeper (aws_msk_cluster) has dependency (aws_mskconnect_connector), running..
2026/06/11 11:48:55 [DEBUG] Running Sweeper (aws_mskconnect_connector) in region (us-west-2)
2026/06/11 11:48:55 [DEBUG] sweeper: Configuring Terraform AWS Provider: sweeper_region=us-west-2 tf_resource_type=aws_mskconnect_connector
2026-06-11T11:48:55.020-0400 [DEBUG] sweeper.aws-base: Resolving credentials provider: sweeper_region=us-west-2 tf_resource_type=aws_mskconnect_connector
2026-06-11T11:48:55.021-0400 [DEBUG] sweeper.aws-base: Loading configuration: sweeper_region=us-west-2 tf_resource_type=aws_mskconnect_connector
2026-06-11T11:48:55.021-0400 [DEBUG] sweeper.aws-base: Retrieving credentials: sweeper_region=us-west-2 tf_resource_type=aws_mskconnect_connector
2026-06-11T11:48:55.021-0400 [INFO]  sweeper.aws-base: Retrieved credentials: sweeper_region=us-west-2 tf_resource_type=aws_mskconnect_connector tf_aws.credentials_source=EnvConfigCredentials
2026-06-11T11:48:55.021-0400 [DEBUG] sweeper.aws-base: Loading configuration: sweeper_region=us-west-2 tf_resource_type=aws_mskconnect_connector
2026/06/11 11:48:55 [DEBUG] sweeper: Retrieving AWS account details: sweeper_region=us-west-2 tf_resource_type=aws_mskconnect_connector
2026-06-11T11:48:55.021-0400 [DEBUG] sweeper.aws-base: Retrieving caller identity from STS: sweeper_region=us-west-2 tf_resource_type=aws_mskconnect_connector
2026-06-11T11:48:55.501-0400 [INFO]  sweeper.aws-base: Retrieved caller identity from STS: tf_resource_type=aws_mskconnect_connector sweeper_region=us-west-2
2026/06/11 11:48:55 [INFO]  sweeper: listing resources: sweeper_region=us-west-2 tf_resource_type=aws_mskconnect_connector
2026/06/11 11:48:55 [INFO]  sweeper: No resources to sweep: tf_resource_type=aws_mskconnect_connector sweeper_region=us-west-2
2026/06/11 11:48:55 [DEBUG] Completed Sweeper (aws_mskconnect_connector) in region (us-west-2) in 950.778041ms
2026/06/11 11:48:55 [DEBUG] Sweeper (aws_msk_cluster) has dependency (aws_msk_replicator), running..
2026/06/11 11:48:55 [DEBUG] Running Sweeper (aws_msk_replicator) in region (us-west-2)
2026/06/11 11:48:55 [INFO]  sweeper: listing resources: sweeper_region=us-west-2 tf_resource_type=aws_msk_replicator
2026/06/11 11:48:56 [INFO] Deleting MSK Replicator: arn:aws:kafka:us-west-2:123456789012:replicator/tf-acc-test-4680824924744827780/e8e24e69-cb5d-4625-86e7-989c3671a68c-3
2026/06/11 11:49:23 [DEBUG] Completed Sweeper (aws_msk_replicator) in region (us-west-2) in 27.3783975s
2026/06/11 11:49:23 [DEBUG] Running Sweeper (aws_msk_cluster) in region (us-west-2)
2026/06/11 11:49:23 [INFO]  sweeper: listing resources: sweeper_region=us-west-2 tf_resource_type=aws_msk_cluster
2026/06/11 11:49:23 [INFO]  sweeper: No resources to sweep: sweeper_region=us-west-2 tf_resource_type=aws_msk_cluster
2026/06/11 11:49:23 [DEBUG] Completed Sweeper (aws_msk_cluster) in region (us-west-2) in 350.213375ms
2026/06/11 11:49:23 [DEBUG] Sweeper (aws_mskconnect_connector) already ran in region (us-west-2)
2026/06/11 11:49:23 [DEBUG] Sweeper (aws_msk_replicator) already ran in region (us-west-2)
2026/06/11 11:49:23 Completed Sweepers for region (us-west-2) in 28.679665625s
2026/06/11 11:49:23 Sweeper Tests for region (us-west-2) ran successfully:
2026/06/11 11:49:23     - aws_msk_cluster
2026/06/11 11:49:23     - aws_mskconnect_connector
2026/06/11 11:49:23     - aws_msk_replicator
2026/06/11 11:49:23 [DEBUG] Running Sweepers for region (us-east-1):
2026/06/11 11:49:23 [DEBUG] Sweeper (aws_msk_cluster) has dependency (aws_mskconnect_connector), running..
2026/06/11 11:49:23 [DEBUG] Running Sweeper (aws_mskconnect_connector) in region (us-east-1)
2026/06/11 11:49:23 [DEBUG] sweeper: Configuring Terraform AWS Provider: sweeper_region=us-east-1 tf_resource_type=aws_mskconnect_connector
2026-06-11T11:49:23.699-0400 [DEBUG] sweeper.aws-base: Resolving credentials provider: sweeper_region=us-east-1 tf_resource_type=aws_mskconnect_connector
2026-06-11T11:49:23.699-0400 [DEBUG] sweeper.aws-base: Loading configuration: sweeper_region=us-east-1 tf_resource_type=aws_mskconnect_connector
2026-06-11T11:49:23.699-0400 [DEBUG] sweeper.aws-base: Retrieving credentials: sweeper_region=us-east-1 tf_resource_type=aws_mskconnect_connector
2026-06-11T11:49:23.700-0400 [INFO]  sweeper.aws-base: Retrieved credentials: sweeper_region=us-east-1 tf_resource_type=aws_mskconnect_connector tf_aws.credentials_source=EnvConfigCredentials
2026-06-11T11:49:23.700-0400 [DEBUG] sweeper.aws-base: Loading configuration: tf_resource_type=aws_mskconnect_connector sweeper_region=us-east-1
2026/06/11 11:49:23 [DEBUG] sweeper: Retrieving AWS account details: sweeper_region=us-east-1 tf_resource_type=aws_mskconnect_connector
2026-06-11T11:49:23.700-0400 [DEBUG] sweeper.aws-base: Retrieving caller identity from STS: tf_resource_type=aws_mskconnect_connector sweeper_region=us-east-1
2026-06-11T11:49:23.824-0400 [INFO]  sweeper.aws-base: Retrieved caller identity from STS: sweeper_region=us-east-1 tf_resource_type=aws_mskconnect_connector
2026/06/11 11:49:23 [INFO]  sweeper: listing resources: sweeper_region=us-east-1 tf_resource_type=aws_mskconnect_connector
2026/06/11 11:49:24 [INFO]  sweeper: No resources to sweep: sweeper_region=us-east-1 tf_resource_type=aws_mskconnect_connector
2026/06/11 11:49:24 [DEBUG] Completed Sweeper (aws_mskconnect_connector) in region (us-east-1) in 462.165ms
2026/06/11 11:49:24 [DEBUG] Sweeper (aws_msk_cluster) has dependency (aws_msk_replicator), running..
2026/06/11 11:49:24 [DEBUG] Running Sweeper (aws_msk_replicator) in region (us-east-1)
2026/06/11 11:49:24 [INFO]  sweeper: listing resources: sweeper_region=us-east-1 tf_resource_type=aws_msk_replicator
2026/06/11 11:49:24 [INFO] Deleting MSK Replicator: arn:aws:kafka:us-east-1:123456789012:replicator/tf-acc-test-3183320421276870111/a9f26976-f988-4a99-912b-6c4206a5ab79-3
2026/06/11 11:49:26 [DEBUG] Completed Sweeper (aws_msk_replicator) in region (us-east-1) in 2.217106667s
2026/06/11 11:49:26 [DEBUG] Running Sweeper (aws_msk_cluster) in region (us-east-1)
2026/06/11 11:49:26 [INFO]  sweeper: listing resources: sweeper_region=us-east-1 tf_resource_type=aws_msk_cluster
2026/06/11 11:49:26 [DEBUG] Deleting MSK Cluster: arn:aws:kafka:us-east-1:123456789012:cluster/tf-acc-test-3183320421276870111-t/80bdc297-a79c-44aa-8313-494fadbc7096-6
2026/06/11 11:49:26 [DEBUG] Deleting MSK Cluster: arn:aws:kafka:us-east-1:123456789012:cluster/tf-acc-test-3183320421276870111-s/c90e99f5-1c00-4e65-a360-2d4ff1424178-6
2026/06/11 11:53:55 [DEBUG] Completed Sweeper (aws_msk_cluster) in region (us-east-1) in 4m29.288277791s
2026/06/11 11:53:55 [DEBUG] Sweeper (aws_mskconnect_connector) already ran in region (us-east-1)
2026/06/11 11:53:55 [DEBUG] Sweeper (aws_msk_replicator) already ran in region (us-east-1)
2026/06/11 11:53:55 Completed Sweepers for region (us-east-1) in 4m31.967687834s
2026/06/11 11:53:55 Sweeper Tests for region (us-east-1) ran successfully:
2026/06/11 11:53:55     - aws_msk_replicator
2026/06/11 11:53:55     - aws_msk_cluster
2026/06/11 11:53:55     - aws_mskconnect_connector
2026/06/11 11:53:55 [DEBUG] Running Sweepers for region (us-east-2):
2026/06/11 11:53:55 [DEBUG] Sweeper (aws_msk_cluster) has dependency (aws_mskconnect_connector), running..
2026/06/11 11:53:55 [DEBUG] Running Sweeper (aws_mskconnect_connector) in region (us-east-2)
2026/06/11 11:53:55 [DEBUG] sweeper: Configuring Terraform AWS Provider: sweeper_region=us-east-2 tf_resource_type=aws_mskconnect_connector
2026-06-11T11:53:55.667-0400 [DEBUG] sweeper.aws-base: Resolving credentials provider: tf_resource_type=aws_mskconnect_connector sweeper_region=us-east-2
2026-06-11T11:53:55.667-0400 [DEBUG] sweeper.aws-base: Loading configuration: sweeper_region=us-east-2 tf_resource_type=aws_mskconnect_connector
2026-06-11T11:53:55.668-0400 [DEBUG] sweeper.aws-base: Retrieving credentials: sweeper_region=us-east-2 tf_resource_type=aws_mskconnect_connector
2026-06-11T11:53:55.668-0400 [INFO]  sweeper.aws-base: Retrieved credentials: sweeper_region=us-east-2 tf_resource_type=aws_mskconnect_connector tf_aws.credentials_source=EnvConfigCredentials
2026-06-11T11:53:55.668-0400 [DEBUG] sweeper.aws-base: Loading configuration: sweeper_region=us-east-2 tf_resource_type=aws_mskconnect_connector
2026/06/11 11:53:55 [DEBUG] sweeper: Retrieving AWS account details: sweeper_region=us-east-2 tf_resource_type=aws_mskconnect_connector
2026-06-11T11:53:55.668-0400 [DEBUG] sweeper.aws-base: Retrieving caller identity from STS: tf_resource_type=aws_mskconnect_connector sweeper_region=us-east-2
2026-06-11T11:53:55.869-0400 [INFO]  sweeper.aws-base: Retrieved caller identity from STS: sweeper_region=us-east-2 tf_resource_type=aws_mskconnect_connector
2026/06/11 11:53:55 [INFO]  sweeper: listing resources: sweeper_region=us-east-2 tf_resource_type=aws_mskconnect_connector
2026/06/11 11:53:56 [INFO]  sweeper: No resources to sweep: sweeper_region=us-east-2 tf_resource_type=aws_mskconnect_connector
2026/06/11 11:53:56 [DEBUG] Completed Sweeper (aws_mskconnect_connector) in region (us-east-2) in 693.469542ms
2026/06/11 11:53:56 [DEBUG] Sweeper (aws_msk_cluster) has dependency (aws_msk_replicator), running..
2026/06/11 11:53:56 [DEBUG] Running Sweeper (aws_msk_replicator) in region (us-east-2)
2026/06/11 11:53:56 [INFO]  sweeper: listing resources: sweeper_region=us-east-2 tf_resource_type=aws_msk_replicator
2026/06/11 11:53:56 [INFO]  sweeper: No resources to sweep: sweeper_region=us-east-2 tf_resource_type=aws_msk_replicator
2026/06/11 11:53:56 [DEBUG] Completed Sweeper (aws_msk_replicator) in region (us-east-2) in 261.483875ms
2026/06/11 11:53:56 [DEBUG] Running Sweeper (aws_msk_cluster) in region (us-east-2)
2026/06/11 11:53:56 [INFO]  sweeper: listing resources: tf_resource_type=aws_msk_cluster sweeper_region=us-east-2
2026/06/11 11:53:56 [INFO]  sweeper: No resources to sweep: sweeper_region=us-east-2 tf_resource_type=aws_msk_cluster
2026/06/11 11:53:56 [DEBUG] Completed Sweeper (aws_msk_cluster) in region (us-east-2) in 145.17075ms
2026/06/11 11:53:56 [DEBUG] Sweeper (aws_mskconnect_connector) already ran in region (us-east-2)
2026/06/11 11:53:56 [DEBUG] Sweeper (aws_msk_replicator) already ran in region (us-east-2)
2026/06/11 11:53:56 Completed Sweepers for region (us-east-2) in 1.100197375s
2026/06/11 11:53:56 Sweeper Tests for region (us-east-2) ran successfully:
2026/06/11 11:53:56     - aws_mskconnect_connector
2026/06/11 11:53:56     - aws_msk_replicator
2026/06/11 11:53:56     - aws_msk_cluster
2026/06/11 11:53:56 [DEBUG] Running Sweepers for region (us-west-1):
2026/06/11 11:53:56 [DEBUG] Sweeper (aws_msk_cluster) has dependency (aws_mskconnect_connector), running..
2026/06/11 11:53:56 [DEBUG] Running Sweeper (aws_mskconnect_connector) in region (us-west-1)
2026/06/11 11:53:56 [DEBUG] sweeper: Configuring Terraform AWS Provider: sweeper_region=us-west-1 tf_resource_type=aws_mskconnect_connector
2026-06-11T11:53:56.767-0400 [DEBUG] sweeper.aws-base: Resolving credentials provider: sweeper_region=us-west-1 tf_resource_type=aws_mskconnect_connector
2026-06-11T11:53:56.767-0400 [DEBUG] sweeper.aws-base: Loading configuration: sweeper_region=us-west-1 tf_resource_type=aws_mskconnect_connector
2026-06-11T11:53:56.767-0400 [DEBUG] sweeper.aws-base: Retrieving credentials: sweeper_region=us-west-1 tf_resource_type=aws_mskconnect_connector
2026-06-11T11:53:56.768-0400 [INFO]  sweeper.aws-base: Retrieved credentials: sweeper_region=us-west-1 tf_resource_type=aws_mskconnect_connector tf_aws.credentials_source=EnvConfigCredentials
2026-06-11T11:53:56.768-0400 [DEBUG] sweeper.aws-base: Loading configuration: sweeper_region=us-west-1 tf_resource_type=aws_mskconnect_connector
2026/06/11 11:53:56 [DEBUG] sweeper: Retrieving AWS account details: sweeper_region=us-west-1 tf_resource_type=aws_mskconnect_connector
2026-06-11T11:53:56.768-0400 [DEBUG] sweeper.aws-base: Retrieving caller identity from STS: tf_resource_type=aws_mskconnect_connector sweeper_region=us-west-1
2026-06-11T11:53:57.180-0400 [INFO]  sweeper.aws-base: Retrieved caller identity from STS: tf_resource_type=aws_mskconnect_connector sweeper_region=us-west-1
2026/06/11 11:53:57 [INFO]  sweeper: listing resources: sweeper_region=us-west-1 tf_resource_type=aws_mskconnect_connector
2026/06/11 11:53:57 [INFO]  sweeper: No resources to sweep: tf_resource_type=aws_mskconnect_connector sweeper_region=us-west-1
2026/06/11 11:53:57 [DEBUG] Completed Sweeper (aws_mskconnect_connector) in region (us-west-1) in 795.617958ms
2026/06/11 11:53:57 [DEBUG] Sweeper (aws_msk_cluster) has dependency (aws_msk_replicator), running..
2026/06/11 11:53:57 [DEBUG] Running Sweeper (aws_msk_replicator) in region (us-west-1)
2026/06/11 11:53:57 [INFO]  sweeper: listing resources: tf_resource_type=aws_msk_replicator sweeper_region=us-west-1
2026/06/11 11:53:57 [INFO]  sweeper: No resources to sweep: sweeper_region=us-west-1 tf_resource_type=aws_msk_replicator
2026/06/11 11:53:57 [DEBUG] Completed Sweeper (aws_msk_replicator) in region (us-west-1) in 312.92375ms
2026/06/11 11:53:57 [DEBUG] Running Sweeper (aws_msk_cluster) in region (us-west-1)
2026/06/11 11:53:57 [INFO]  sweeper: listing resources: sweeper_region=us-west-1 tf_resource_type=aws_msk_cluster
2026/06/11 11:53:58 [INFO]  sweeper: No resources to sweep: sweeper_region=us-west-1 tf_resource_type=aws_msk_cluster
2026/06/11 11:53:58 [DEBUG] Completed Sweeper (aws_msk_cluster) in region (us-west-1) in 142.665875ms
2026/06/11 11:53:58 [DEBUG] Sweeper (aws_mskconnect_connector) already ran in region (us-west-1)
2026/06/11 11:53:58 [DEBUG] Sweeper (aws_msk_replicator) already ran in region (us-west-1)
2026/06/11 11:53:58 Completed Sweepers for region (us-west-1) in 1.2512775s
2026/06/11 11:53:58 Sweeper Tests for region (us-west-1) ran successfully:
2026/06/11 11:53:58     - aws_mskconnect_connector
2026/06/11 11:53:58     - aws_msk_replicator
2026/06/11 11:53:58     - aws_msk_cluster
ok      github.com/hashicorp/terraform-provider-aws/internal/sweep      309.371s
```
