### PR TITLE
r/aws_dms_endpoint: Add map_boolean_as_boolean to redshift_settings

### DIFF
--- a/.changelog/38814.txt
+++ b/.changelog/38814.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_dms_endpoint: Add `map_boolean_as_boolean` argument to `redshift_settings`
+```
+
+```release-note:enhancement
+data-source/aws_dms_endpoint: Add `map_boolean_as_boolean` attribute to `redshift_settings`
+```

--- a/internal/service/dms/endpoint.go
+++ b/internal/service/dms/endpoint.go
@@ -789,6 +789,10 @@ func resourceEndpoint() *schema.Resource {
 								Default:      encryptionModeSseS3,
 								ValidateFunc: validation.StringInSlice(encryptionMode_Values(), false),
 							},
+							"map_boolean_as_boolean": {
+								Type:     schema.TypeBool,
+								Optional: true,
+							},
 							"server_side_encryption_kms_key_id": {
 								Type:             schema.TypeString,
 								Optional:         true,
@@ -1047,6 +1051,10 @@ func resourceEndpointCreate(ctx context.Context, d *schema.ResourceData, meta an
 
 			if v, ok := tfMap["service_access_role_arn"].(string); ok && v != "" {
 				settings.ServiceAccessRoleArn = aws.String(v)
+			}
+
+			if v, ok := tfMap["map_boolean_as_boolean"].(bool); ok {
+				settings.MapBooleanAsBoolean = aws.Bool(v)
 			}
 		}
 
@@ -1403,6 +1411,10 @@ func resourceEndpointUpdate(ctx context.Context, d *schema.ResourceData, meta an
 
 						if v, ok := tfMap["service_access_role_arn"].(string); ok && v != "" {
 							settings.ServiceAccessRoleArn = aws.String(v)
+						}
+
+						if v, ok := tfMap["map_boolean_as_boolean"].(bool); ok {
+							settings.MapBooleanAsBoolean = aws.Bool(v)
 						}
 
 						input.RedshiftSettings = settings
@@ -2225,6 +2237,7 @@ func flattenRedshiftSettings(apiObject *awstypes.RedshiftSettings) []any {
 		"bucket_folder":                     aws.ToString(apiObject.BucketFolder),
 		names.AttrBucketName:                aws.ToString(apiObject.BucketName),
 		"encryption_mode":                   apiObject.EncryptionMode,
+		"map_boolean_as_boolean":            aws.ToBool(apiObject.MapBooleanAsBoolean),
 		"server_side_encryption_kms_key_id": aws.ToString(apiObject.ServerSideEncryptionKmsKeyId),
 		"service_access_role_arn":           aws.ToString(apiObject.ServiceAccessRoleArn),
 	}

--- a/internal/service/dms/endpoint_data_source.go
+++ b/internal/service/dms/endpoint_data_source.go
@@ -441,6 +441,10 @@ func dataSourceEndpoint() *schema.Resource {
 								Type:     schema.TypeString,
 								Computed: true,
 							},
+							"map_boolean_as_boolean": {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
 							"server_side_encryption_kms_key_id": {
 								Type:     schema.TypeString,
 								Computed: true,

--- a/internal/service/dms/endpoint_test.go
+++ b/internal/service/dms/endpoint_test.go
@@ -2147,6 +2147,7 @@ func TestAccDMSEndpoint_Redshift_update(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "redshift_settings.0.encryption_mode", "SSE_S3"),
 					resource.TestCheckResourceAttr(resourceName, "redshift_settings.0.server_side_encryption_kms_key_id", ""),
 					resource.TestCheckResourceAttrPair(resourceName, "redshift_settings.0.service_access_role_arn", iamRoleResourceName, names.AttrARN),
+					resource.TestCheckResourceAttr(resourceName, "redshift_settings.0.map_boolean_as_boolean", acctest.CtTrue),
 				),
 			},
 			{
@@ -4268,6 +4269,7 @@ resource "aws_dms_endpoint" "test" {
     bucket_name             = "bucket_name"
     bucket_folder           = "bucket_folder"
     encryption_mode         = "SSE_S3"
+    map_boolean_as_boolean  = true
   }
 
   tags = {

--- a/website/docs/r/dms_endpoint.html.markdown
+++ b/website/docs/r/dms_endpoint.html.markdown
@@ -237,6 +237,7 @@ The following arguments are optional:
 * `encryption_mode` - (Optional) The server-side encryption mode that you want to encrypt your intermediate .csv object files copied to S3. Defaults to `SSE_S3`. Valid values are `SSE_S3` and `SSE_KMS`.
 * `server_side_encryption_kms_key_id` - (Required when `encryption_mode` is  `SSE_KMS`, must not be set otherwise) ARN or Id of KMS Key to use when `encryption_mode` is `SSE_KMS`.
 * `service_access_role_arn` - (Optional) Amazon Resource Name (ARN) of the IAM Role with permissions to read from or write to the S3 Bucket for intermediate storage.
+* `map_boolean_as_boolean` - (Optional) Whether to map booleans as booleans from the source to the Redshift target. Default value is `false`.
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

No. This change only adds an optional `map_boolean_as_boolean` data-mapping argument to the `redshift_settings` block of `aws_dms_endpoint`. It does not affect access controls, encryption, or logging.

### Description

The `redshift_settings` block of `aws_dms_endpoint` did not expose `map_boolean_as_boolean`, even though the AWS DMS API supports `RedshiftSettings.MapBooleanAsBoolean`. As documented by AWS, this setting must be enabled on **both** the source (e.g. Postgres) and the Redshift target so that boolean columns are created as `BOOL` in Redshift instead of `varchar(1)`. The source side (`postgres_settings.map_boolean_as_boolean`) was already supported; this PR adds parity on the Redshift target side.

Changes:

- `resource/aws_dms_endpoint`: add `map_boolean_as_boolean` (Optional, bool) to the `redshift_settings` block, wired into Create, Update (Modify), and Read (flatten).
- `data-source/aws_dms_endpoint`: add `map_boolean_as_boolean` (Computed) to the `redshift_settings` block.
- Documentation and acceptance test coverage updated.

This mirrors the existing `postgres_settings.map_boolean_as_boolean` implementation.

### Relations

Relates #38814

### References

- [Using Amazon Redshift as a target for AWS DMS - MapBooleanAsBoolean](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Target.Redshift.html)
- [RedshiftSettings API reference](https://docs.aws.amazon.com/dms/latest/APIReference/API_RedshiftSettings.html)


```console
% make testacc TESTS=TestAccDMSEndpoint_Redshift PKG=dms

...