### PR TITLE
resource/aws_acm_certificate: Fixes to `subject_alternative_names`, `pending_renewal`, and various tests

### DIFF
--- a/.changelog/48362.txt
+++ b/.changelog/48362.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_acm_certificate: Correctly updates `subject_alternative_names` for Imported certificates
+```
+
+```release-note:enhacement
+resource/aws_acm_certificate: `pending_renewal` is always `false` for Imported certificates
+```

--- a/internal/service/acm/certificate.go
+++ b/internal/service/acm/certificate.go
@@ -529,7 +529,6 @@ func resourceCertificateRead(ctx context.Context, d *schema.ResourceData, meta a
 	} else {
 		d.Set("options", nil)
 	}
-	d.Set("pending_renewal", certificateSetPendingRenewal(d))
 	d.Set("renewal_eligibility", certificate.RenewalEligibility)
 	if certificate.RenewalSummary != nil {
 		if err := d.Set("renewal_summary", []any{flattenRenewalSummary(certificate.RenewalSummary)}); err != nil {
@@ -545,6 +544,9 @@ func resourceCertificateRead(ctx context.Context, d *schema.ResourceData, meta a
 	d.Set(names.AttrType, certificate.Type)
 	d.Set("validation_emails", validationEmails)
 	d.Set("validation_method", certificateValidationMethod(certificate))
+
+	// Value of `pending_renewal` depends on several other attribute values
+	d.Set("pending_renewal", certificateSetPendingRenewal(d))
 
 	return diags
 }

--- a/internal/service/acm/certificate.go
+++ b/internal/service/acm/certificate.go
@@ -98,7 +98,6 @@ func resourceCertificate() *schema.Resource {
 					Type:          schema.TypeString,
 					Optional:      true,
 					Computed:      true,
-					ForceNew:      true,
 					ValidateFunc:  validation.StringDoesNotMatch(regexache.MustCompile(`\.$`), "cannot end with a period"),
 					ExactlyOneOf:  []string{names.AttrDomainName, names.AttrPrivateKey, "private_key_wo"},
 					ConflictsWith: []string{"certificate_body", names.AttrCertificateChain, names.AttrPrivateKey},
@@ -227,7 +226,6 @@ func resourceCertificate() *schema.Resource {
 					Type:     schema.TypeSet,
 					Optional: true,
 					Computed: true,
-					ForceNew: true,
 					Elem: &schema.Schema{
 						Type: schema.TypeString,
 						ValidateFunc: validation.All(
@@ -342,6 +340,38 @@ func resourceCertificate() *schema.Resource {
 					// Trigger a diff
 					if err := diff.SetNewComputed("pending_renewal"); err != nil {
 						return err
+					}
+				}
+
+				return nil
+			},
+			func(_ context.Context, diff *schema.ResourceDiff, _ any) error {
+				if diff.Id() == "" {
+					return nil
+				}
+
+				switch diff.Get(names.AttrType).(string) {
+				case string(types.CertificateTypeImported):
+					// Domain and Subject Alternative Names are derived from the certificate body for imported certificates
+					if diff.HasChange("certificate_body") {
+						if err := diff.SetNewComputed(names.AttrDomainName); err != nil {
+							return err
+						}
+						if err := diff.SetNewComputed("subject_alternative_names"); err != nil {
+							return err
+						}
+					}
+
+				default:
+					if diff.HasChange(names.AttrDomainName) {
+						if err := diff.ForceNew(names.AttrDomainName); err != nil {
+							return err
+						}
+					}
+					if diff.HasChange("subject_alternative_names") {
+						if err := diff.ForceNew("subject_alternative_names"); err != nil {
+							return err
+						}
 					}
 				}
 
@@ -501,7 +531,9 @@ func resourceCertificateRead(ctx context.Context, d *schema.ResourceData, meta a
 		d.Set("renewal_summary", nil)
 	}
 	d.Set(names.AttrStatus, certificate.Status)
-	d.Set("subject_alternative_names", certificate.SubjectAlternativeNames)
+	if err := d.Set("subject_alternative_names", certificate.SubjectAlternativeNames); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting subject_alternative_names: %s", err)
+	}
 	d.Set(names.AttrType, certificate.Type)
 	d.Set("validation_emails", validationEmails)
 	d.Set("validation_method", certificateValidationMethod(certificate))

--- a/internal/service/acm/certificate.go
+++ b/internal/service/acm/certificate.go
@@ -326,6 +326,14 @@ func resourceCertificate() *schema.Resource {
 					return nil
 				}
 
+				switch diff.Get(names.AttrType).(string) {
+				case string(types.CertificateTypeImported):
+					// Pending renewal is never true for imported certificates
+					if err := diff.SetNew("pending_renewal", false); err != nil {
+						return err
+					}
+				}
+
 				if diff.HasChange("early_renewal_duration") {
 					if duration := diff.Get("early_renewal_duration").(string); duration == "" {
 						if err := diff.SetNew("pending_renewal", false); err != nil {

--- a/internal/service/acm/certificate_test.go
+++ b/internal/service/acm/certificate_test.go
@@ -1625,6 +1625,12 @@ func TestAccACMCertificate_Imported_PrivateKeyWo(t *testing.T) {
 					resource.TestCheckNoResourceAttr(resourceName, "private_key_wo"),
 					resource.TestCheckResourceAttr(resourceName, "private_key_wo_version", "1"),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("pending_renewal")),
+					},
+				},
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrType), tfknownvalue.StringExact(types.CertificateTypeImported)),
 				},
@@ -1637,6 +1643,12 @@ func TestAccACMCertificate_Imported_PrivateKeyWo(t *testing.T) {
 					resource.TestCheckNoResourceAttr(resourceName, "private_key_wo"),
 					resource.TestCheckResourceAttr(resourceName, "private_key_wo_version", "2"),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New("pending_renewal"), knownvalue.Bool(false)),
+					},
+				},
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrType), tfknownvalue.StringExact(types.CertificateTypeImported)),
 				},
@@ -1680,6 +1692,7 @@ func TestAccACMCertificate_Imported_domainName(t *testing.T) {
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("pending_renewal")),
 					},
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -1732,6 +1745,7 @@ func TestAccACMCertificate_Imported_domainName(t *testing.T) {
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
 						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New(names.AttrDomainName)),
+						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New("pending_renewal"), knownvalue.Bool(false)),
 						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("subject_alternative_names")),
 					},
 				},
@@ -1766,6 +1780,7 @@ func TestAccACMCertificate_Imported_domainName(t *testing.T) {
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
 						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New(names.AttrDomainName)),
+						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New("pending_renewal"), knownvalue.Bool(false)),
 						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("subject_alternative_names")),
 					},
 				},

--- a/internal/service/acm/certificate_test.go
+++ b/internal/service/acm/certificate_test.go
@@ -169,9 +169,10 @@ func TestAccACMCertificate_AmazonIssued_root(t *testing.T) {
 				},
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"not_after", "not_before", names.AttrStatus},
 			},
 		},
 	})
@@ -1150,9 +1151,10 @@ func TestAccACMCertificate_AmazonIssued_rootAndWildcardSan(t *testing.T) {
 				},
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"not_after", "not_before", names.AttrStatus},
 			},
 		},
 	})
@@ -1457,9 +1459,10 @@ func TestAccACMCertificate_AmazonIssued_wildcard(t *testing.T) {
 				},
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"not_after", "not_before", names.AttrStatus},
 			},
 		},
 	})
@@ -1505,9 +1508,10 @@ func TestAccACMCertificate_AmazonIssued_wildcardAndRootSan(t *testing.T) {
 				},
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"not_after", "not_before", names.AttrStatus},
 			},
 		},
 	})
@@ -1548,9 +1552,10 @@ func TestAccACMCertificate_AmazonIssued_keyAlgorithm(t *testing.T) {
 				},
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"not_after", "not_before", names.AttrStatus},
 			},
 		},
 	})
@@ -1592,9 +1597,10 @@ func TestAccACMCertificate_AmazonIssued_disableCTLogging(t *testing.T) {
 				},
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"not_after", "not_before", names.AttrStatus},
 			},
 		},
 	})

--- a/internal/service/acm/certificate_test.go
+++ b/internal/service/acm/certificate_test.go
@@ -1830,7 +1830,7 @@ func TestAccACMCertificate_Imported_ipAddress(t *testing.T) {
 }
 
 // Reference: https://github.com/hashicorp/terraform-provider-aws/issues/15055
-func TestAccACMCertificate_PrivateKey_ReimportWithTags(t *testing.T) {
+func TestAccACMCertificate_Imported_ReimportWithTags(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_acm_certificate.test"
 	privateKeyPEM1 := acctest.TLSRSAPrivateKeyPEM(t, 2048)
@@ -1862,6 +1862,7 @@ func TestAccACMCertificate_PrivateKey_ReimportWithTags(t *testing.T) {
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
 						acctest.CtKey1: knownvalue.StringExact(acctest.CtValue1),
 					})),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrType), tfknownvalue.StringExact(types.CertificateTypeImported)),
 				},
 			},
 			{

--- a/internal/service/acm/certificate_test.go
+++ b/internal/service/acm/certificate_test.go
@@ -65,6 +65,12 @@ func TestAccACMCertificate_AmazonIssued_emailValidation(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "validation_method", string(types.ValidationMethodEmail)),
 					resource.TestCheckResourceAttr(resourceName, "validation_option.#", "0"),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("pending_renewal")),
+					},
+				},
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("subject_alternative_names"), knownvalue.SetExact([]knownvalue.Check{
 						knownvalue.StringExact(domain),
@@ -219,7 +225,7 @@ func TestAccACMCertificate_Private_renewable(t *testing.T) {
 	resourceName := "aws_acm_certificate.test"
 	commonName := acctest.RandomDomain(t)
 	certificateDomainName := commonName.RandomSubdomain(t).String()
-	var v1, v2, v3, v4 types.CertificateDetail
+	var v1, v2, v3 types.CertificateDetail
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -249,12 +255,19 @@ func TestAccACMCertificate_Private_renewable(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "validation_method", "NONE"),
 					resource.TestCheckResourceAttr(resourceName, "validation_option.#", "0"),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("pending_renewal")),
+					},
+				},
 			},
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			// Export to make certificate eligible for renewal
 			{
 				PreConfig: func() {
 					conn := acctest.ProviderMeta(ctx, t).ACMClient(ctx)
@@ -278,6 +291,12 @@ func TestAccACMCertificate_Private_renewable(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, names.AttrStatus, string(types.CertificateStatusIssued)),
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, string(types.CertificateTypePrivate)),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New("pending_renewal"), knownvalue.Bool(false)),
+					},
+				},
 			},
 			{
 				ResourceName:      resourceName,
@@ -295,33 +314,15 @@ func TestAccACMCertificate_Private_renewable(t *testing.T) {
 					if err != nil {
 						t.Fatalf("renewing ACM Certificate (%s): %s", aws.ToString(v1.CertificateArn), err)
 					}
-				},
-				Config: testAccCertificateConfig_privateCertificate_renewable(commonName.String(), certificateDomainName),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckCertificateExists(ctx, t, resourceName, &v3),
-					resource.TestCheckResourceAttr(resourceName, "pending_renewal", acctest.CtFalse),
-					resource.TestCheckResourceAttr(resourceName, "renewal_eligibility", string(types.RenewalEligibilityEligible)),
-					resource.TestCheckResourceAttr(resourceName, "renewal_summary.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "renewal_summary.0.renewal_status", string(types.RenewalStatusPendingAutoRenewal)),
-					resource.TestCheckResourceAttr(resourceName, "renewal_summary.0.renewal_status_reason", ""),
-					acctest.CheckResourceAttrRFC3339(resourceName, "renewal_summary.0.updated_at"),
-					resource.TestCheckResourceAttr(resourceName, names.AttrStatus, string(types.CertificateStatusIssued)),
-					resource.TestCheckResourceAttr(resourceName, names.AttrType, string(types.CertificateTypePrivate)),
-				),
-			},
-			{
-				PreConfig: func() {
-					conn := acctest.ProviderMeta(ctx, t).ACMClient(ctx)
 
-					_, err := tfacm.WaitCertificateRenewed(ctx, conn, aws.ToString(v1.CertificateArn), tfacm.CertificateRenewalTimeout)
+					_, err = tfacm.WaitCertificateRenewed(ctx, conn, aws.ToString(v1.CertificateArn), tfacm.CertificateRenewalTimeout)
 					if err != nil {
 						t.Fatalf("waiting for ACM Certificate (%s) renewal: %s", aws.ToString(v1.CertificateArn), err)
 					}
 				},
 				Config: testAccCertificateConfig_privateCertificate_renewable(commonName.String(), certificateDomainName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckCertificateExists(ctx, t, resourceName, &v4),
-					testAccCheckCertificateRenewed(&v3, &v4),
+					testAccCheckCertificateExists(ctx, t, resourceName, &v3),
 					resource.TestCheckResourceAttr(resourceName, "pending_renewal", acctest.CtFalse),
 					resource.TestCheckResourceAttr(resourceName, "renewal_eligibility", string(types.RenewalEligibilityIneligible)),
 					resource.TestCheckResourceAttr(resourceName, "renewal_summary.#", "1"),
@@ -331,6 +332,12 @@ func TestAccACMCertificate_Private_renewable(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, names.AttrStatus, string(types.CertificateStatusIssued)),
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, string(types.CertificateTypePrivate)),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New("pending_renewal"), knownvalue.Bool(false)),
+					},
+				},
 			},
 			{
 				ResourceName:      resourceName,
@@ -475,8 +482,11 @@ func TestAccACMCertificate_Private_pendingRenewalGoDuration(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckCertificateDestroy(ctx, t),
 		Steps: []resource.TestStep{
+			// Step 1: Create with `early_renewal_duration`
+			// Ineligible for renewal because it has not been exported
+			// See https://docs.aws.amazon.com/acm/latest/userguide/managed-renewal.html for details on certificate renewal
 			{
-				Config: testAccCertificateConfig_privateCertificate_pendingRenewal(commonName.String(), certificateDomainName, duration),
+				Config: testAccCertificateConfig_privateCertificate_earlyRenewalDuration(commonName.String(), certificateDomainName, duration),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCertificateExists(ctx, t, resourceName, &v1),
 					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "acm", regexache.MustCompile("certificate/.+$")),
@@ -488,13 +498,22 @@ func TestAccACMCertificate_Private_pendingRenewalGoDuration(t *testing.T) {
 					resource.TestCheckTypeSetElemAttr(resourceName, "subject_alternative_names.*", certificateDomainName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, string(types.CertificateTypePrivate)),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("pending_renewal")),
+					},
+				},
 			},
+			// Step 2: Import
 			{
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"early_renewal_duration"},
 			},
+			// Step 3: Export to make certificate eligible for renewal
+			// Plan is non-empty to trigger Update on subsequent apply
 			{
 				PreConfig: func() {
 					conn := acctest.ProviderMeta(ctx, t).ACMClient(ctx)
@@ -508,10 +527,27 @@ func TestAccACMCertificate_Private_pendingRenewalGoDuration(t *testing.T) {
 						t.Fatalf("exporting ACM Certificate (%s): %s", aws.ToString(v1.CertificateArn), err)
 					}
 				},
-				// Ideally, we'd have a `RefreshOnly` test step here to validate that `pending_renewal` is true and `renewal_eligibility` is `ELIGIBLE` after exporting
-				// before actually performing the renewal.
-				// https://github.com/hashicorp/terraform-plugin-sdk/issues/1069
-				Config: testAccCertificateConfig_privateCertificate_pendingRenewal(commonName.String(), certificateDomainName, duration),
+				RefreshState: true,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckCertificateExists(ctx, t, resourceName, &v2),
+					resource.TestCheckResourceAttr(resourceName, "early_renewal_duration", duration),
+					resource.TestCheckResourceAttr(resourceName, "pending_renewal", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "renewal_eligibility", string(types.RenewalEligibilityEligible)),
+					resource.TestCheckResourceAttr(resourceName, names.AttrStatus, string(types.CertificateStatusIssued)),
+					resource.TestCheckResourceAttr(resourceName, names.AttrType, string(types.CertificateTypePrivate)),
+				),
+				RefreshPlanChecks: resource.RefreshPlanChecks{
+					PostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("pending_renewal")),
+					},
+				},
+				ExpectNonEmptyPlan: true,
+			},
+			// Step 4: Update renews the certificate as `pending_renewal` is true
+			// This will reset the renewal eligiblity and pending renewal status
+			{
+				Config: testAccCertificateConfig_privateCertificate_earlyRenewalDuration(commonName.String(), certificateDomainName, duration),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCertificateExists(ctx, t, resourceName, &v2),
 					testAccCheckCertificateRenewed(&v1, &v2),
@@ -525,6 +561,12 @@ func TestAccACMCertificate_Private_pendingRenewalGoDuration(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, names.AttrStatus, string(types.CertificateStatusIssued)),
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, string(types.CertificateTypePrivate)),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("pending_renewal")),
+					},
+				},
 			},
 			{
 				ResourceName:            resourceName,
@@ -550,8 +592,11 @@ func TestAccACMCertificate_Private_pendingRenewalRFC3339Duration(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckCertificateDestroy(ctx, t),
 		Steps: []resource.TestStep{
+			// Step 1: Create with `early_renewal_duration`
+			// Ineligible for renewal because it has not been exported
+			// See https://docs.aws.amazon.com/acm/latest/userguide/managed-renewal.html for details on certificate renewal
 			{
-				Config: testAccCertificateConfig_privateCertificate_pendingRenewal(commonName.String(), certificateDomainName, duration),
+				Config: testAccCertificateConfig_privateCertificate_earlyRenewalDuration(commonName.String(), certificateDomainName, duration),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCertificateExists(ctx, t, resourceName, &v1),
 					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "acm", regexache.MustCompile("certificate/.+$")),
@@ -563,13 +608,22 @@ func TestAccACMCertificate_Private_pendingRenewalRFC3339Duration(t *testing.T) {
 					resource.TestCheckTypeSetElemAttr(resourceName, "subject_alternative_names.*", certificateDomainName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, string(types.CertificateTypePrivate)),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("pending_renewal")),
+					},
+				},
 			},
+			// Step 2: Import
 			{
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"early_renewal_duration"},
 			},
+			// Step 3: Export to make certificate eligible for renewal
+			// Plan is non-empty to trigger Update on subsequent apply
 			{
 				PreConfig: func() {
 					conn := acctest.ProviderMeta(ctx, t).ACMClient(ctx)
@@ -583,10 +637,28 @@ func TestAccACMCertificate_Private_pendingRenewalRFC3339Duration(t *testing.T) {
 						t.Fatalf("exporting ACM Certificate (%s): %s", aws.ToString(v1.CertificateArn), err)
 					}
 				},
-				// Ideally, we'd have a `RefreshOnly` test step here to validate that `pending_renewal` is true and `renewal_eligibility` is `ELIGIBLE` after exporting
-				// before actually performing the renewal.
-				// https://github.com/hashicorp/terraform-plugin-sdk/issues/1069
-				Config: testAccCertificateConfig_privateCertificate_pendingRenewal(commonName.String(), certificateDomainName, duration),
+				RefreshState: true,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckCertificateExists(ctx, t, resourceName, &v2),
+					resource.TestCheckResourceAttr(resourceName, "early_renewal_duration", duration),
+					resource.TestCheckResourceAttr(resourceName, "pending_renewal", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "renewal_eligibility", string(types.RenewalEligibilityEligible)),
+					resource.TestCheckResourceAttr(resourceName, "renewal_summary.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrStatus, string(types.CertificateStatusIssued)),
+					resource.TestCheckResourceAttr(resourceName, names.AttrType, string(types.CertificateTypePrivate)),
+				),
+				RefreshPlanChecks: resource.RefreshPlanChecks{
+					PostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("pending_renewal")),
+					},
+				},
+				ExpectNonEmptyPlan: true,
+			},
+			// Step 4: Update renews the certificate as `pending_renewal` is true
+			// This will reset the renewal eligiblity and pending renewal status
+			{
+				Config: testAccCertificateConfig_privateCertificate_earlyRenewalDuration(commonName.String(), certificateDomainName, duration),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCertificateExists(ctx, t, resourceName, &v2),
 					testAccCheckCertificateRenewed(&v1, &v2),
@@ -600,6 +672,12 @@ func TestAccACMCertificate_Private_pendingRenewalRFC3339Duration(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, names.AttrStatus, string(types.CertificateStatusIssued)),
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, string(types.CertificateTypePrivate)),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("pending_renewal")),
+					},
+				},
 			},
 			{
 				ResourceName:            resourceName,
@@ -611,6 +689,8 @@ func TestAccACMCertificate_Private_pendingRenewalRFC3339Duration(t *testing.T) {
 	})
 }
 
+// This certificate will be eligible because it is exported
+// See https://docs.aws.amazon.com/acm/latest/userguide/managed-renewal.html for details on certificate renewal
 func TestAccACMCertificate_Private_addEarlyRenewalPast(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_acm_certificate.test"
@@ -625,6 +705,9 @@ func TestAccACMCertificate_Private_addEarlyRenewalPast(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckCertificateDestroy(ctx, t),
 		Steps: []resource.TestStep{
+			// Step 1: Create potentially renewable certificate
+			// Ineligible for renewal because it has not been exported
+			// See https://docs.aws.amazon.com/acm/latest/userguide/managed-renewal.html for details on certificate renewal
 			{
 				Config: testAccCertificateConfig_privateCertificate_renewable(commonName.String(), certificateDomainName),
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -638,13 +721,21 @@ func TestAccACMCertificate_Private_addEarlyRenewalPast(t *testing.T) {
 					resource.TestCheckTypeSetElemAttr(resourceName, "subject_alternative_names.*", certificateDomainName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, string(types.CertificateTypePrivate)),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+						// plancheck.ExpectKnownValue(resourceName, tfjsonpath.New("pending_renewal"), knownvalue.Bool(false)),
+					},
+				},
 			},
+			// Step 2: Import
 			{
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"early_renewal_duration"},
 			},
+			// Step 3: Export to make certificate eligible for renewal
 			{
 				PreConfig: func() {
 					conn := acctest.ProviderMeta(ctx, t).ACMClient(ctx)
@@ -671,17 +762,17 @@ func TestAccACMCertificate_Private_addEarlyRenewalPast(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, names.AttrStatus, string(types.CertificateStatusIssued)),
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, string(types.CertificateTypePrivate)),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New("pending_renewal"), knownvalue.Bool(false)),
+					},
+				},
 			},
+			// Step 4: Update renews the certificate as `pending_renewal` is true
+			// This will reset the renewal eligiblity and pending renewal status
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"early_renewal_duration"},
-			},
-			{
-				// Ideally, we'd have a `RefreshOnly` test step here to validate that `pending_renewal` is true after setting `early_renewal_duration`.
-				// https://github.com/hashicorp/terraform-plugin-sdk/issues/1069
-				Config: testAccCertificateConfig_privateCertificate_pendingRenewal(commonName.String(), certificateDomainName, duration),
+				Config: testAccCertificateConfig_privateCertificate_earlyRenewalDuration(commonName.String(), certificateDomainName, duration),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCertificateExists(ctx, t, resourceName, &v3),
 					testAccCheckCertificateRenewed(&v2, &v3),
@@ -695,11 +786,19 @@ func TestAccACMCertificate_Private_addEarlyRenewalPast(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, names.AttrStatus, string(types.CertificateStatusIssued)),
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, string(types.CertificateTypePrivate)),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New("pending_renewal"), knownvalue.Bool(true)),
+					},
+				},
 			},
 		},
 	})
 }
 
+// This certificate will be ineligible because it has not been exported or otherwise made eligible
+// See https://docs.aws.amazon.com/acm/latest/userguide/managed-renewal.html for details on certificate renewal
 func TestAccACMCertificate_Private_addEarlyRenewalPastIneligible(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_acm_certificate.test"
@@ -714,6 +813,9 @@ func TestAccACMCertificate_Private_addEarlyRenewalPastIneligible(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckCertificateDestroy(ctx, t),
 		Steps: []resource.TestStep{
+			// Step 1: Create potentially renewable certificate
+			// Ineligible for renewal because it has not been exported
+			// See https://docs.aws.amazon.com/acm/latest/userguide/managed-renewal.html for details on certificate renewal
 			{
 				Config: testAccCertificateConfig_privateCertificate_renewable(commonName.String(), certificateDomainName),
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -728,16 +830,9 @@ func TestAccACMCertificate_Private_addEarlyRenewalPastIneligible(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, string(types.CertificateTypePrivate)),
 				),
 			},
+			// Step 2: Update does not trigger renewal because the certificate is not eligible for renewal
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"early_renewal_duration"},
-			},
-			{
-				// Ideally, we'd have a `RefreshOnly` test step here to validate that `pending_renewal` is true after setting `early_renewal_duration`.
-				// https://github.com/hashicorp/terraform-plugin-sdk/issues/1069
-				Config: testAccCertificateConfig_privateCertificate_pendingRenewal(commonName.String(), certificateDomainName, duration),
+				Config: testAccCertificateConfig_privateCertificate_earlyRenewalDuration(commonName.String(), certificateDomainName, duration),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCertificateExists(ctx, t, resourceName, &v2),
 					testAccCheckCertificateNotRenewed(&v1, &v2),
@@ -767,6 +862,9 @@ func TestAccACMCertificate_Private_addEarlyRenewalFuture(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckCertificateDestroy(ctx, t),
 		Steps: []resource.TestStep{
+			// Step 1: Create potentially renewable certificate
+			// Ineligible for renewal because it has not been exported
+			// See https://docs.aws.amazon.com/acm/latest/userguide/managed-renewal.html for details on certificate renewal
 			{
 				Config: testAccCertificateConfig_privateCertificate_renewable(commonName.String(), certificateDomainName),
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -781,12 +879,15 @@ func TestAccACMCertificate_Private_addEarlyRenewalFuture(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, string(types.CertificateTypePrivate)),
 				),
 			},
+			// Step 2: Import
 			{
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"early_renewal_duration"},
 			},
+			// Step 3: Export to make certificate eligible for renewal
+			// Plan is non-empty to trigger Update on subsequent apply
 			{
 				PreConfig: func() {
 					conn := acctest.ProviderMeta(ctx, t).ACMClient(ctx)
@@ -800,9 +901,7 @@ func TestAccACMCertificate_Private_addEarlyRenewalFuture(t *testing.T) {
 						t.Fatalf("exporting ACM Certificate (%s): %s", aws.ToString(v1.CertificateArn), err)
 					}
 				},
-				// Ideally, we'd have a `RefreshOnly` test step here to validate that `pending_renewal` is false and `renewal_eligibility` is `ELIGIBLE` after exporting.
-				// https://github.com/hashicorp/terraform-plugin-sdk/issues/1069
-				Config: testAccCertificateConfig_privateCertificate_renewable(commonName.String(), certificateDomainName),
+				RefreshState: true,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCertificateExists(ctx, t, resourceName, &v2),
 					testAccCheckCertificateNotRenewed(&v1, &v2),
@@ -813,17 +912,17 @@ func TestAccACMCertificate_Private_addEarlyRenewalFuture(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, names.AttrStatus, string(types.CertificateStatusIssued)),
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, string(types.CertificateTypePrivate)),
 				),
+				RefreshPlanChecks: resource.RefreshPlanChecks{
+					PostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("pending_renewal")),
+					},
+				},
+				ExpectNonEmptyPlan: true,
 			},
+			// Step 4: The renewal window is in the future, so it is not renewed
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"early_renewal_duration"},
-			},
-			{
-				// Ideally, we'd have a `RefreshOnly` test step here to validate that `pending_renewal` is true after setting `early_renewal_duration`.
-				// https://github.com/hashicorp/terraform-plugin-sdk/issues/1069
-				Config: testAccCertificateConfig_privateCertificate_pendingRenewal(commonName.String(), certificateDomainName, duration),
+				Config: testAccCertificateConfig_privateCertificate_earlyRenewalDuration(commonName.String(), certificateDomainName, duration),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCertificateExists(ctx, t, resourceName, &v3),
 					testAccCheckCertificateNotRenewed(&v2, &v3),
@@ -834,6 +933,12 @@ func TestAccACMCertificate_Private_addEarlyRenewalFuture(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, names.AttrStatus, string(types.CertificateStatusIssued)),
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, string(types.CertificateTypePrivate)),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("pending_renewal")),
+					},
+				},
 			},
 		},
 	})
@@ -855,7 +960,7 @@ func TestAccACMCertificate_Private_updateEarlyRenewalFuture(t *testing.T) {
 		CheckDestroy:             testAccCheckCertificateDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCertificateConfig_privateCertificate_pendingRenewal(commonName.String(), certificateDomainName, duration),
+				Config: testAccCertificateConfig_privateCertificate_earlyRenewalDuration(commonName.String(), certificateDomainName, duration),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCertificateExists(ctx, t, resourceName, &v1),
 					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "acm", regexache.MustCompile("certificate/.+$")),
@@ -874,6 +979,7 @@ func TestAccACMCertificate_Private_updateEarlyRenewalFuture(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"early_renewal_duration"},
 			},
+			// Export to make certificate eligible for renewal
 			{
 				PreConfig: func() {
 					conn := acctest.ProviderMeta(ctx, t).ACMClient(ctx)
@@ -889,7 +995,7 @@ func TestAccACMCertificate_Private_updateEarlyRenewalFuture(t *testing.T) {
 				},
 				// Ideally, we'd have a `RefreshOnly` test step here to validate that `pending_renewal` is false and `renewal_eligibility` is `ELIGIBLE` after exporting.
 				// https://github.com/hashicorp/terraform-plugin-sdk/issues/1069
-				Config: testAccCertificateConfig_privateCertificate_pendingRenewal(commonName.String(), certificateDomainName, durationUpdated),
+				Config: testAccCertificateConfig_privateCertificate_earlyRenewalDuration(commonName.String(), certificateDomainName, durationUpdated),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCertificateExists(ctx, t, resourceName, &v2),
 					testAccCheckCertificateNotRenewed(&v1, &v2),
@@ -926,7 +1032,7 @@ func TestAccACMCertificate_Private_removeEarlyRenewal(t *testing.T) {
 		CheckDestroy:             testAccCheckCertificateDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCertificateConfig_privateCertificate_pendingRenewal(commonName.String(), certificateDomainName, duration),
+				Config: testAccCertificateConfig_privateCertificate_earlyRenewalDuration(commonName.String(), certificateDomainName, duration),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCertificateExists(ctx, t, resourceName, &v1),
 					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "acm", regexache.MustCompile("certificate/.+$")),
@@ -945,6 +1051,7 @@ func TestAccACMCertificate_Private_removeEarlyRenewal(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"early_renewal_duration"},
 			},
+			// Export to make certificate eligible for renewal
 			{
 				PreConfig: func() {
 					conn := acctest.ProviderMeta(ctx, t).ACMClient(ctx)
@@ -2201,7 +2308,7 @@ resource "aws_acm_certificate" "test" {
 `, certificateDomainName))
 }
 
-func testAccCertificateConfig_privateCertificate_pendingRenewal(commonName, certificateDomainName, duration string) string {
+func testAccCertificateConfig_privateCertificate_earlyRenewalDuration(commonName, certificateDomainName, duration string) string {
 	return acctest.ConfigCompose(testAccCertificateConfig_privateCertificateBase(commonName), fmt.Sprintf(`
 resource "aws_acm_certificate" "test" {
   domain_name               = %[1]q

--- a/internal/service/acm/certificate_test.go
+++ b/internal/service/acm/certificate_test.go
@@ -1710,6 +1710,7 @@ func TestAccACMCertificate_AmazonIssued_disableReenableCTLogging(t *testing.T) {
 	})
 }
 
+// lintignore:AT002
 func TestAccACMCertificate_Imported_PrivateKeyWo(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_acm_certificate.test"
@@ -2004,6 +2005,7 @@ func TestAccACMCertificate_Imported_ipAddress(t *testing.T) {
 }
 
 // Reference: https://github.com/hashicorp/terraform-provider-aws/issues/15055
+// lintignore:AT002
 func TestAccACMCertificate_Imported_ReimportWithTags(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_acm_certificate.test"

--- a/internal/service/acm/certificate_test.go
+++ b/internal/service/acm/certificate_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccACMCertificate_emailValidation(t *testing.T) {
+func TestAccACMCertificate_AmazonIssued_emailValidation(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_acm_certificate.test"
 	rootDomain := acctest.ACMCertificateDomainFromEnv(t)
@@ -80,7 +80,7 @@ func TestAccACMCertificate_emailValidation(t *testing.T) {
 	})
 }
 
-func TestAccACMCertificate_dnsValidation(t *testing.T) {
+func TestAccACMCertificate_AmazonIssued_dnsValidation(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_acm_certificate.test"
 	rootDomain := acctest.ACMCertificateDomainFromEnv(t)
@@ -128,7 +128,7 @@ func TestAccACMCertificate_dnsValidation(t *testing.T) {
 	})
 }
 
-func TestAccACMCertificate_root(t *testing.T) {
+func TestAccACMCertificate_AmazonIssued_root(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_acm_certificate.test"
 	rootDomain := acctest.ACMCertificateDomainFromEnv(t)
@@ -171,7 +171,7 @@ func TestAccACMCertificate_root(t *testing.T) {
 	})
 }
 
-func TestAccACMCertificate_validationOptions(t *testing.T) {
+func TestAccACMCertificate_AmazonIssued_validationOptions(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_acm_certificate.test"
 	rootDomain := acctest.ACMCertificateDomainFromEnv(t)
@@ -213,7 +213,7 @@ func TestAccACMCertificate_validationOptions(t *testing.T) {
 	})
 }
 
-func TestAccACMCertificate_privateCertificate_renewable(t *testing.T) {
+func TestAccACMCertificate_Private_renewable(t *testing.T) {
 	ctx := acctest.Context(t)
 	certificateAuthorityResourceName := "aws_acmpca_certificate_authority.test"
 	resourceName := "aws_acm_certificate.test"
@@ -341,7 +341,7 @@ func TestAccACMCertificate_privateCertificate_renewable(t *testing.T) {
 	})
 }
 
-func TestAccACMCertificate_privateCertificate_noRenewalPermission(t *testing.T) {
+func TestAccACMCertificate_Private_noRenewalPermission(t *testing.T) {
 	ctx := acctest.Context(t)
 	certificateAuthorityResourceName := "aws_acmpca_certificate_authority.test"
 	resourceName := "aws_acm_certificate.test"
@@ -461,7 +461,7 @@ func TestAccACMCertificate_privateCertificate_noRenewalPermission(t *testing.T) 
 	})
 }
 
-func TestAccACMCertificate_privateCertificate_pendingRenewalGoDuration(t *testing.T) {
+func TestAccACMCertificate_Private_pendingRenewalGoDuration(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_acm_certificate.test"
 	commonName := acctest.RandomDomain(t)
@@ -536,7 +536,7 @@ func TestAccACMCertificate_privateCertificate_pendingRenewalGoDuration(t *testin
 	})
 }
 
-func TestAccACMCertificate_privateCertificate_pendingRenewalRFC3339Duration(t *testing.T) {
+func TestAccACMCertificate_Private_pendingRenewalRFC3339Duration(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_acm_certificate.test"
 	commonName := acctest.RandomDomain(t)
@@ -611,7 +611,7 @@ func TestAccACMCertificate_privateCertificate_pendingRenewalRFC3339Duration(t *t
 	})
 }
 
-func TestAccACMCertificate_privateCertificate_addEarlyRenewalPast(t *testing.T) {
+func TestAccACMCertificate_Private_addEarlyRenewalPast(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_acm_certificate.test"
 	commonName := acctest.RandomDomain(t)
@@ -700,7 +700,7 @@ func TestAccACMCertificate_privateCertificate_addEarlyRenewalPast(t *testing.T) 
 	})
 }
 
-func TestAccACMCertificate_privateCertificate_addEarlyRenewalPastIneligible(t *testing.T) {
+func TestAccACMCertificate_Private_addEarlyRenewalPastIneligible(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_acm_certificate.test"
 	commonName := acctest.RandomDomain(t)
@@ -753,7 +753,7 @@ func TestAccACMCertificate_privateCertificate_addEarlyRenewalPastIneligible(t *t
 	})
 }
 
-func TestAccACMCertificate_privateCertificate_addEarlyRenewalFuture(t *testing.T) {
+func TestAccACMCertificate_Private_addEarlyRenewalFuture(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_acm_certificate.test"
 	commonName := acctest.RandomDomain(t)
@@ -839,7 +839,7 @@ func TestAccACMCertificate_privateCertificate_addEarlyRenewalFuture(t *testing.T
 	})
 }
 
-func TestAccACMCertificate_privateCertificate_updateEarlyRenewalFuture(t *testing.T) {
+func TestAccACMCertificate_Private_updateEarlyRenewalFuture(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_acm_certificate.test"
 	commonName := acctest.RandomDomain(t)
@@ -911,7 +911,7 @@ func TestAccACMCertificate_privateCertificate_updateEarlyRenewalFuture(t *testin
 	})
 }
 
-func TestAccACMCertificate_privateCertificate_removeEarlyRenewal(t *testing.T) {
+func TestAccACMCertificate_Private_removeEarlyRenewal(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_acm_certificate.test"
 	commonName := acctest.RandomDomain(t)
@@ -982,9 +982,9 @@ func TestAccACMCertificate_privateCertificate_removeEarlyRenewal(t *testing.T) {
 	})
 }
 
-// TestAccACMCertificate_Root_trailingPeriod updated in 3.0 to account for domain_name plan-time validation
+// TestAccACMCertificate_AmazonIssued_Root_trailingPeriod updated in 3.0 to account for domain_name plan-time validation
 // Reference: https://github.com/hashicorp/terraform-provider-aws/issues/13510
-func TestAccACMCertificate_Root_trailingPeriod(t *testing.T) {
+func TestAccACMCertificate_AmazonIssued_Root_trailingPeriod(t *testing.T) {
 	ctx := acctest.Context(t)
 	rootDomain := acctest.ACMCertificateDomainFromEnv(t)
 	domain := fmt.Sprintf("%s.", rootDomain)
@@ -1003,7 +1003,7 @@ func TestAccACMCertificate_Root_trailingPeriod(t *testing.T) {
 	})
 }
 
-func TestAccACMCertificate_rootAndWildcardSan(t *testing.T) {
+func TestAccACMCertificate_AmazonIssued_rootAndWildcardSan(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_acm_certificate.test"
 	rootDomain := acctest.ACMCertificateDomainFromEnv(t)
@@ -1051,7 +1051,7 @@ func TestAccACMCertificate_rootAndWildcardSan(t *testing.T) {
 	})
 }
 
-func TestAccACMCertificate_SubjectAlternativeNames_emptyString(t *testing.T) {
+func TestAccACMCertificate_AmazonIssued_SubjectAlternativeNames_emptyString(t *testing.T) {
 	ctx := acctest.Context(t)
 	rootDomain := acctest.ACMCertificateDomainFromEnv(t)
 	domain := acctest.ACMCertificateRandomSubDomain(rootDomain)
@@ -1070,7 +1070,7 @@ func TestAccACMCertificate_SubjectAlternativeNames_emptyString(t *testing.T) {
 	})
 }
 
-func TestAccACMCertificate_San_single(t *testing.T) {
+func TestAccACMCertificate_AmazonIssued_San_single(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_acm_certificate.test"
 	rootDomain := acctest.ACMCertificateDomainFromEnv(t)
@@ -1162,7 +1162,7 @@ func TestAccACMCertificate_San_single(t *testing.T) {
 	})
 }
 
-func TestAccACMCertificate_San_multiple(t *testing.T) {
+func TestAccACMCertificate_AmazonIssued_San_multiple(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_acm_certificate.test"
 	rootDomain := acctest.ACMCertificateDomainFromEnv(t)
@@ -1217,7 +1217,7 @@ func TestAccACMCertificate_San_multiple(t *testing.T) {
 	})
 }
 
-func TestAccACMCertificate_San_trailingPeriod(t *testing.T) {
+func TestAccACMCertificate_AmazonIssued_San_trailingPeriod(t *testing.T) {
 	ctx := acctest.Context(t)
 	rootDomain := acctest.ACMCertificateDomainFromEnv(t)
 	domain := acctest.ACMCertificateRandomSubDomain(rootDomain)
@@ -1266,7 +1266,7 @@ func TestAccACMCertificate_San_trailingPeriod(t *testing.T) {
 	})
 }
 
-func TestAccACMCertificate_San_matches_domain(t *testing.T) {
+func TestAccACMCertificate_AmazonIssued_San_matches_domain(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_acm_certificate.test"
 	rootDomain := acctest.ACMCertificateDomainFromEnv(t)
@@ -1315,7 +1315,7 @@ func TestAccACMCertificate_San_matches_domain(t *testing.T) {
 	})
 }
 
-func TestAccACMCertificate_wildcard(t *testing.T) {
+func TestAccACMCertificate_AmazonIssued_wildcard(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_acm_certificate.test"
 	rootDomain := acctest.ACMCertificateDomainFromEnv(t)
@@ -1358,7 +1358,7 @@ func TestAccACMCertificate_wildcard(t *testing.T) {
 	})
 }
 
-func TestAccACMCertificate_wildcardAndRootSan(t *testing.T) {
+func TestAccACMCertificate_AmazonIssued_wildcardAndRootSan(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_acm_certificate.test"
 	rootDomain := acctest.ACMCertificateDomainFromEnv(t)
@@ -1406,7 +1406,7 @@ func TestAccACMCertificate_wildcardAndRootSan(t *testing.T) {
 	})
 }
 
-func TestAccACMCertificate_keyAlgorithm(t *testing.T) {
+func TestAccACMCertificate_AmazonIssued_keyAlgorithm(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_acm_certificate.test"
 	rootDomain := acctest.ACMCertificateDomainFromEnv(t)
@@ -1449,7 +1449,7 @@ func TestAccACMCertificate_keyAlgorithm(t *testing.T) {
 	})
 }
 
-func TestAccACMCertificate_disableCTLogging(t *testing.T) {
+func TestAccACMCertificate_AmazonIssued_disableCTLogging(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_acm_certificate.test"
 	rootDomain := acctest.ACMCertificateDomainFromEnv(t)
@@ -1493,7 +1493,7 @@ func TestAccACMCertificate_disableCTLogging(t *testing.T) {
 	})
 }
 
-func TestAccACMCertificate_disableReenableCTLogging(t *testing.T) {
+func TestAccACMCertificate_AmazonIssued_disableReenableCTLogging(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_acm_certificate.test"
 	rootDomain := acctest.ACMCertificateDomainFromEnv(t)
@@ -1598,7 +1598,7 @@ func TestAccACMCertificate_disableReenableCTLogging(t *testing.T) {
 	})
 }
 
-func TestAccACMCertificate_PrivateKeyWo(t *testing.T) {
+func TestAccACMCertificate_Imported_PrivateKeyWo(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_acm_certificate.test"
 	commonName := "example.com"
@@ -1967,7 +1967,7 @@ func TestAccACMCertificate_Imported_ReimportWithTags(t *testing.T) {
 	})
 }
 
-func TestAccACMCertificate_optionExport(t *testing.T) {
+func TestAccACMCertificate_AmazonIssued_optionExport(t *testing.T) {
 	// Issuing an exportable ACM Certificate is expensive.
 	// Skip the test by default and only run if the environment variable is set.
 	acctest.SkipIfEnvVarNotSet(t, "ACM_TEST_CERTIFICATE_EXPORT")

--- a/internal/service/acm/certificate_test.go
+++ b/internal/service/acm/certificate_test.go
@@ -158,6 +158,9 @@ func TestAccACMCertificate_root(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "validation_method", string(types.ValidationMethodDns)),
 					resource.TestCheckResourceAttr(resourceName, "validation_option.#", "0"),
 				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrType), tfknownvalue.StringExact(types.CertificateTypeAmazonIssued)),
+				},
 			},
 			{
 				ResourceName:      resourceName,
@@ -196,6 +199,9 @@ func TestAccACMCertificate_validationOptions(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "validation_method", string(types.ValidationMethodEmail)),
 					resource.TestCheckResourceAttr(resourceName, "validation_option.#", "1"),
 				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrType), tfknownvalue.StringExact(types.CertificateTypeAmazonIssued)),
+				},
 			},
 			{
 				ResourceName:            resourceName,
@@ -1032,6 +1038,9 @@ func TestAccACMCertificate_rootAndWildcardSan(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "validation_emails.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "validation_method", string(types.ValidationMethodDns)),
 				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrType), tfknownvalue.StringExact(types.CertificateTypeAmazonIssued)),
+				},
 			},
 			{
 				ResourceName:      resourceName,
@@ -1101,6 +1110,7 @@ func TestAccACMCertificate_San_single(t *testing.T) {
 					},
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrType), tfknownvalue.StringExact(types.CertificateTypeAmazonIssued)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("subject_alternative_names"), knownvalue.SetExact([]knownvalue.Check{
 						knownvalue.StringExact(domain),
 						knownvalue.StringExact(sanDomain),
@@ -1141,6 +1151,7 @@ func TestAccACMCertificate_San_single(t *testing.T) {
 					},
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrType), tfknownvalue.StringExact(types.CertificateTypeAmazonIssued)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("subject_alternative_names"), knownvalue.SetExact([]knownvalue.Check{
 						knownvalue.StringExact(domain),
 						knownvalue.StringExact(sanDomainUpdated),
@@ -1193,6 +1204,9 @@ func TestAccACMCertificate_San_multiple(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "validation_emails.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "validation_method", string(types.ValidationMethodDns)),
 				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrType), tfknownvalue.StringExact(types.CertificateTypeAmazonIssued)),
+				},
 			},
 			{
 				ResourceName:      resourceName,
@@ -1239,6 +1253,9 @@ func TestAccACMCertificate_San_trailingPeriod(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "validation_emails.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "validation_method", string(types.ValidationMethodDns)),
 				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrType), tfknownvalue.StringExact(types.CertificateTypeAmazonIssued)),
+				},
 			},
 			{
 				ResourceName:      resourceName,
@@ -1285,6 +1302,9 @@ func TestAccACMCertificate_San_matches_domain(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "validation_emails.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "validation_method", string(types.ValidationMethodDns)),
 				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrType), tfknownvalue.StringExact(types.CertificateTypeAmazonIssued)),
+				},
 			},
 			{
 				ResourceName:      resourceName,
@@ -1325,6 +1345,9 @@ func TestAccACMCertificate_wildcard(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "validation_emails.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "validation_method", string(types.ValidationMethodDns)),
 				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrType), tfknownvalue.StringExact(types.CertificateTypeAmazonIssued)),
+				},
 			},
 			{
 				ResourceName:      resourceName,
@@ -1370,6 +1393,9 @@ func TestAccACMCertificate_wildcardAndRootSan(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "validation_emails.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "validation_method", string(types.ValidationMethodDns)),
 				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrType), tfknownvalue.StringExact(types.CertificateTypeAmazonIssued)),
+				},
 			},
 			{
 				ResourceName:      resourceName,
@@ -1410,6 +1436,9 @@ func TestAccACMCertificate_keyAlgorithm(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "validation_method", string(types.ValidationMethodDns)),
 					resource.TestCheckResourceAttr(resourceName, "key_algorithm", string(types.KeyAlgorithmEcPrime256v1)),
 				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrType), tfknownvalue.StringExact(types.CertificateTypeAmazonIssued)),
+				},
 			},
 			{
 				ResourceName:      resourceName,
@@ -1451,6 +1480,9 @@ func TestAccACMCertificate_disableCTLogging(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "options.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "options.0.certificate_transparency_logging_preference", string(types.CertificateTransparencyLoggingPreferenceDisabled)),
 				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrType), tfknownvalue.StringExact(types.CertificateTypeAmazonIssued)),
+				},
 			},
 			{
 				ResourceName:      resourceName,
@@ -1497,6 +1529,9 @@ func TestAccACMCertificate_disableReenableCTLogging(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "options.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "options.0.certificate_transparency_logging_preference", string(types.CertificateTransparencyLoggingPreferenceEnabled)),
 				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrType), tfknownvalue.StringExact(types.CertificateTypeAmazonIssued)),
+				},
 			},
 			{
 				ResourceName:      resourceName,
@@ -1522,6 +1557,9 @@ func TestAccACMCertificate_disableReenableCTLogging(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "options.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "options.0.certificate_transparency_logging_preference", string(types.CertificateTransparencyLoggingPreferenceDisabled)),
 				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrType), tfknownvalue.StringExact(types.CertificateTypeAmazonIssued)),
+				},
 			},
 			{
 				ResourceName:      resourceName,
@@ -1547,6 +1585,9 @@ func TestAccACMCertificate_disableReenableCTLogging(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "options.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "options.0.certificate_transparency_logging_preference", string(types.CertificateTransparencyLoggingPreferenceEnabled)),
 				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrType), tfknownvalue.StringExact(types.CertificateTypeAmazonIssued)),
+				},
 			},
 			{
 				ResourceName:      resourceName,
@@ -1584,6 +1625,9 @@ func TestAccACMCertificate_PrivateKeyWo(t *testing.T) {
 					resource.TestCheckNoResourceAttr(resourceName, "private_key_wo"),
 					resource.TestCheckResourceAttr(resourceName, "private_key_wo_version", "1"),
 				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrType), tfknownvalue.StringExact(types.CertificateTypeImported)),
+				},
 			},
 			{
 				Config: testAccCertificateConfig_privateKeyWoUpdate(newCertificate, newKey),
@@ -1593,6 +1637,9 @@ func TestAccACMCertificate_PrivateKeyWo(t *testing.T) {
 					resource.TestCheckNoResourceAttr(resourceName, "private_key_wo"),
 					resource.TestCheckResourceAttr(resourceName, "private_key_wo_version", "2"),
 				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrType), tfknownvalue.StringExact(types.CertificateTypeImported)),
+				},
 			},
 		},
 	})
@@ -1897,6 +1944,7 @@ func TestAccACMCertificate_Imported_ReimportWithTags(t *testing.T) {
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
 						acctest.CtKey1: knownvalue.StringExact(acctest.CtValue1Updated),
 					})),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrType), tfknownvalue.StringExact(types.CertificateTypeImported)),
 				},
 			},
 			{
@@ -1953,6 +2001,9 @@ func TestAccACMCertificate_optionExport(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "validation_emails.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "validation_method", string(types.ValidationMethodDns)),
 				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrType), tfknownvalue.StringExact(types.CertificateTypeAmazonIssued)),
+				},
 			},
 			{
 				ResourceName:      resourceName,

--- a/internal/service/acm/certificate_test.go
+++ b/internal/service/acm/certificate_test.go
@@ -234,6 +234,9 @@ func TestAccACMCertificate_Private_renewable(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckCertificateDestroy(ctx, t),
 		Steps: []resource.TestStep{
+			// Step 1: Create potentially renewable certificate
+			// Ineligible for renewal because it has not been exported
+			// See https://docs.aws.amazon.com/acm/latest/userguide/managed-renewal.html for details on certificate renewal
 			{
 				Config: testAccCertificateConfig_privateCertificate_renewable(commonName.String(), certificateDomainName),
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -263,12 +266,15 @@ func TestAccACMCertificate_Private_renewable(t *testing.T) {
 					},
 				},
 			},
+			// Step 2: Import
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"early_renewal_duration"},
 			},
-			// Export to make certificate eligible for renewal
+			// Step 3: Export to make certificate eligible for renewal
+			// Because the early renewal date is unset, the certificate is not pending renewal.
 			{
 				PreConfig: func() {
 					conn := acctest.ProviderMeta(ctx, t).ACMClient(ctx)
@@ -286,6 +292,7 @@ func TestAccACMCertificate_Private_renewable(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCertificateExists(ctx, t, resourceName, &v2),
 					testAccCheckCertificateNotRenewed(&v1, &v2),
+					resource.TestCheckResourceAttr(resourceName, "early_renewal_duration", ""),
 					resource.TestCheckResourceAttr(resourceName, "pending_renewal", acctest.CtFalse),
 					resource.TestCheckResourceAttr(resourceName, "renewal_eligibility", string(types.RenewalEligibilityEligible)),
 					resource.TestCheckResourceAttr(resourceName, "renewal_summary.#", "0"),
@@ -299,11 +306,8 @@ func TestAccACMCertificate_Private_renewable(t *testing.T) {
 					},
 				},
 			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
+			// Step 4: Renew the certificate out-of-band
+			// This will reset the renewal eligiblity and pending renewal status
 			{
 				PreConfig: func() {
 					conn := acctest.ProviderMeta(ctx, t).ACMClient(ctx)
@@ -335,15 +339,10 @@ func TestAccACMCertificate_Private_renewable(t *testing.T) {
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						plancheck.ExpectEmptyPlan(),
 						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New("pending_renewal"), knownvalue.Bool(false)),
 					},
 				},
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
 			},
 		},
 	})
@@ -888,7 +887,7 @@ func TestAccACMCertificate_Private_addEarlyRenewalFuture(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"early_renewal_duration"},
 			},
 			// Step 3: Export to make certificate eligible for renewal
-			// Plan is non-empty to trigger Update on subsequent apply
+			// Because the early renewal date is unset, the certificate is not pending renewal.
 			{
 				PreConfig: func() {
 					conn := acctest.ProviderMeta(ctx, t).ACMClient(ctx)
@@ -915,8 +914,8 @@ func TestAccACMCertificate_Private_addEarlyRenewalFuture(t *testing.T) {
 				),
 				RefreshPlanChecks: resource.RefreshPlanChecks{
 					PostRefresh: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
-						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("pending_renewal")),
+						plancheck.ExpectEmptyPlan(),
+						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New("pending_renewal"), knownvalue.Bool(false)),
 					},
 				},
 				ExpectNonEmptyPlan: true,
@@ -937,7 +936,7 @@ func TestAccACMCertificate_Private_addEarlyRenewalFuture(t *testing.T) {
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
-						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("pending_renewal")),
+						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New("pending_renewal"), knownvalue.Bool(false)),
 					},
 				},
 			},

--- a/internal/service/acm/certificate_test.go
+++ b/internal/service/acm/certificate_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/acm"
 	"github.com/aws/aws-sdk-go-v2/service/acm/types"
+	"github.com/hashicorp/terraform-plugin-testing/compare"
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
@@ -56,8 +57,6 @@ func TestAccACMCertificate_emailValidation(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "options.0.export", string(types.CertificateExportDisabled)),
 					resource.TestCheckResourceAttr(resourceName, "pending_renewal", acctest.CtFalse),
 					resource.TestCheckResourceAttr(resourceName, names.AttrStatus, string(types.CertificateStatusPendingValidation)),
-					resource.TestCheckResourceAttr(resourceName, "subject_alternative_names.#", "1"),
-					resource.TestCheckTypeSetElemAttr(resourceName, "subject_alternative_names.*", domain),
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, string(types.CertificateTypeAmazonIssued)),
 					resource.TestCheckResourceAttr(resourceName, "renewal_eligibility", string(types.RenewalEligibilityIneligible)),
 					resource.TestCheckResourceAttr(resourceName, "renewal_summary.#", "0"),
@@ -66,6 +65,11 @@ func TestAccACMCertificate_emailValidation(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "validation_method", string(types.ValidationMethodEmail)),
 					resource.TestCheckResourceAttr(resourceName, "validation_option.#", "0"),
 				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("subject_alternative_names"), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.StringExact(domain),
+					})),
+				},
 			},
 			{
 				ResourceName:      resourceName,
@@ -1063,6 +1067,7 @@ func TestAccACMCertificate_San_single(t *testing.T) {
 	rootDomain := acctest.ACMCertificateDomainFromEnv(t)
 	domain := acctest.ACMCertificateRandomSubDomain(rootDomain)
 	sanDomain := acctest.ACMCertificateRandomSubDomain(rootDomain)
+	sanDomainUpdated := acctest.ACMCertificateRandomSubDomain(rootDomain)
 	var v types.CertificateDetail
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -1087,17 +1092,60 @@ func TestAccACMCertificate_San_single(t *testing.T) {
 						"resource_record_type": "CNAME",
 					}),
 					resource.TestCheckResourceAttr(resourceName, names.AttrStatus, string(types.CertificateStatusPendingValidation)),
-					resource.TestCheckResourceAttr(resourceName, "subject_alternative_names.#", "2"),
-					resource.TestCheckTypeSetElemAttr(resourceName, "subject_alternative_names.*", domain),
-					resource.TestCheckTypeSetElemAttr(resourceName, "subject_alternative_names.*", sanDomain),
 					resource.TestCheckResourceAttr(resourceName, "validation_emails.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "validation_method", string(types.ValidationMethodDns)),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("subject_alternative_names"), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.StringExact(domain),
+						knownvalue.StringExact(sanDomain),
+					})),
+				},
 			},
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+			{
+				Config: testAccCertificateConfig_subjectAlternativeNames(domain, strconv.Quote(sanDomainUpdated), types.ValidationMethodDns),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckCertificateExists(ctx, t, resourceName, &v),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "acm", regexache.MustCompile("certificate/.+$")),
+					resource.TestCheckResourceAttr(resourceName, names.AttrDomainName, domain),
+					resource.TestCheckResourceAttr(resourceName, "domain_validation_options.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "domain_validation_options.*", map[string]string{
+						names.AttrDomainName:   domain,
+						"resource_record_type": "CNAME",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "domain_validation_options.*", map[string]string{
+						names.AttrDomainName:   sanDomainUpdated,
+						"resource_record_type": "CNAME",
+					}),
+					resource.TestCheckResourceAttr(resourceName, names.AttrStatus, string(types.CertificateStatusPendingValidation)),
+					resource.TestCheckResourceAttr(resourceName, "validation_emails.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "validation_method", string(types.ValidationMethodDns)),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionReplace),
+						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New("subject_alternative_names"), knownvalue.SetExact([]knownvalue.Check{
+							knownvalue.StringExact(domain),
+							knownvalue.StringExact(sanDomainUpdated),
+						})),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("subject_alternative_names"), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.StringExact(domain),
+						knownvalue.StringExact(sanDomainUpdated),
+					})),
+				},
 			},
 		},
 	})
@@ -1565,6 +1613,10 @@ func TestAccACMCertificate_Imported_domainName(t *testing.T) {
 	withoutChainDomain := acctest.RandomDomainName(t)
 	var v1, v2, v3 types.CertificateDetail
 
+	arnNoChange := statecheck.CompareValue(compare.ValuesSame())
+	certificateBodyExpectChange := statecheck.CompareValue(compare.ValuesDiffer())
+	privateKeyExpectChange := statecheck.CompareValue(compare.ValuesDiffer())
+
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ACMServiceID),
@@ -1575,30 +1627,113 @@ func TestAccACMCertificate_Imported_domainName(t *testing.T) {
 				Config: testAccCertificateConfig_privateKey(certificate, key, caCertificate),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCertificateExists(ctx, t, resourceName, &v1),
-					resource.TestCheckResourceAttr(resourceName, names.AttrStatus, string(types.CertificateStatusIssued)),
-					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "0"),
-					resource.TestCheckResourceAttr(resourceName, names.AttrDomainName, commonName),
+					acctest.CheckResourceAttrRFC3339(resourceName, "not_after"),
+					acctest.CheckResourceAttrRFC3339(resourceName, "not_before"),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrARN), tfknownvalue.RegionalARNRegexp("acm", regexache.MustCompile("certificate/.+$"))),
+					arnNoChange.AddStateValue(resourceName, tfjsonpath.New(names.AttrARN)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("certificate_authority_arn"), knownvalue.StringExact("")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("certificate_body"), knownvalue.StringExact(certificate)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrCertificateChain), knownvalue.StringExact(caCertificate)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrDomainName), knownvalue.StringExact(commonName)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("domain_validation_options"), knownvalue.SetSizeExact(0)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("early_renewal_duration"), knownvalue.StringExact("")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("key_algorithm"), tfknownvalue.StringExact(types.KeyAlgorithmRsa2048)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("options"), knownvalue.ListExact([]knownvalue.Check{
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"certificate_transparency_logging_preference": tfknownvalue.StringExact(types.CertificateTransparencyLoggingPreferenceDisabled),
+							"export": tfknownvalue.StringExact(types.CertificateExportDisabled),
+						}),
+					})),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("pending_renewal"), knownvalue.Bool(false)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrPrivateKey), knownvalue.StringExact(key)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("private_key_wo"), knownvalue.Null()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("private_key_wo_version"), knownvalue.Null()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("renewal_eligibility"), tfknownvalue.StringExact(types.RenewalEligibilityIneligible)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("renewal_summary"), knownvalue.ListSizeExact(0)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrStatus), tfknownvalue.StringExact(types.CertificateStatusIssued)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("subject_alternative_names"), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.StringExact(commonName),
+					})),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTagsAll), knownvalue.MapExact(map[string]knownvalue.Check{})),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrType), tfknownvalue.StringExact(types.CertificateTypeImported)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("validation_emails"), knownvalue.ListSizeExact(0)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("validation_method"), tfknownvalue.StringExact("NONE")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("validation_option"), knownvalue.SetSizeExact(0)),
+				},
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				// These are not returned by the API
+				ImportStateVerifyIgnore: []string{names.AttrPrivateKey, "certificate_body", names.AttrCertificateChain},
 			},
 			{
 				Config: testAccCertificateConfig_privateKey(newCertificate, key, newCaCertificate),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCertificateExists(ctx, t, resourceName, &v2),
-					testAccCheckCertificateNotRecreated(&v1, &v2),
-					resource.TestCheckResourceAttr(resourceName, names.AttrStatus, string(types.CertificateStatusIssued)),
-					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "0"),
-					resource.TestCheckResourceAttr(resourceName, names.AttrDomainName, commonName),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New(names.AttrDomainName)),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("subject_alternative_names")),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					arnNoChange.AddStateValue(resourceName, tfjsonpath.New(names.AttrARN)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("certificate_body"), knownvalue.StringExact(newCertificate)),
+					certificateBodyExpectChange.AddStateValue(resourceName, tfjsonpath.New("certificate_body")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrCertificateChain), knownvalue.StringExact(newCaCertificate)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrDomainName), knownvalue.StringExact(commonName)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrPrivateKey), knownvalue.StringExact(key)),
+					privateKeyExpectChange.AddStateValue(resourceName, tfjsonpath.New(names.AttrPrivateKey)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrStatus), tfknownvalue.StringExact(types.CertificateStatusIssued)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("subject_alternative_names"), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.StringExact(commonName),
+					})),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrType), tfknownvalue.StringExact(types.CertificateTypeImported)),
+				},
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				// These are not returned by the API
+				ImportStateVerifyIgnore: []string{names.AttrPrivateKey, "certificate_body", names.AttrCertificateChain},
 			},
 			{
 				Config: testAccCertificateConfig_privateKeyNoChain(t, withoutChainDomain),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCertificateExists(ctx, t, resourceName, &v3),
-					testAccCheckCertificateNotRecreated(&v2, &v3),
-					resource.TestCheckResourceAttr(resourceName, names.AttrStatus, string(types.CertificateStatusIssued)),
-					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "0"),
-					resource.TestCheckResourceAttr(resourceName, names.AttrDomainName, withoutChainDomain),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New(names.AttrDomainName)),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("subject_alternative_names")),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					arnNoChange.AddStateValue(resourceName, tfjsonpath.New(names.AttrARN)),
+					certificateBodyExpectChange.AddStateValue(resourceName, tfjsonpath.New("certificate_body")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrCertificateChain), knownvalue.StringExact("")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrDomainName), knownvalue.StringExact(withoutChainDomain)),
+					privateKeyExpectChange.AddStateValue(resourceName, tfjsonpath.New(names.AttrPrivateKey)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrStatus), tfknownvalue.StringExact(types.CertificateStatusIssued)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("subject_alternative_names"), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.StringExact(withoutChainDomain),
+					})),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrType), tfknownvalue.StringExact(types.CertificateTypeImported)),
+				},
 			},
 			{
 				ResourceName:      resourceName,

--- a/internal/service/acm/certificate_test.go
+++ b/internal/service/acm/certificate_test.go
@@ -18,10 +18,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	tfknownvalue "github.com/hashicorp/terraform-provider-aws/internal/acctest/knownvalue"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfacm "github.com/hashicorp/terraform-provider-aws/internal/service/acm"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -1667,10 +1669,19 @@ func TestAccACMCertificate_Imported_ipAddress(t *testing.T) {
 				Config: testAccCertificateConfig_privateKeyNoChain(t, "1.2.3.4"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCertificateExists(ctx, t, resourceName, &v),
-					resource.TestCheckResourceAttr(resourceName, names.AttrDomainName, ""),
-					resource.TestCheckResourceAttr(resourceName, names.AttrStatus, string(types.CertificateStatusIssued)),
-					resource.TestCheckResourceAttr(resourceName, "subject_alternative_names.#", "0"),
 				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("certificate_authority_arn"), knownvalue.StringExact("")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("certificate_body"), knownvalue.StringRegexp(regexache.MustCompile(`.+`))),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrCertificateChain), knownvalue.Null()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrDomainName), knownvalue.StringExact("1.2.3.4")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrPrivateKey), knownvalue.StringRegexp(regexache.MustCompile(`.+`))),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrStatus), tfknownvalue.StringExact(types.CertificateStatusIssued)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("subject_alternative_names"), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.StringExact("1.2.3.4"),
+					})),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrType), tfknownvalue.StringExact(types.CertificateTypeImported)),
+				},
 			},
 			{
 				ResourceName:      resourceName,


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Fixes various `aws_acm_certificate` tests.

Correctly updates `subject_alternative_names` for customer-managed certificates

`pending_renewal` is always false for Imported certificates. Uses a known value on Plan.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=acm TESTS='TestAccACMCertificate_'

--- PASS: TestAccACMCertificate_Imported_validityDates (204.78s)
--- PASS: TestAccACMCertificate_Imported_ipAddress (215.30s)
--- PASS: TestAccACMCertificate_AmazonIssued_dnsValidation (222.63s)
--- PASS: TestAccACMCertificate_Tags_ComputedTag_onCreate (224.05s)
--- PASS: TestAccACMCertificate_Tags_DefaultTags_nullOverlappingResourceTag (224.35s)
--- PASS: TestAccACMCertificate_AmazonIssued_root (224.31s)
--- PASS: TestAccACMCertificate_AmazonIssued_emailValidation (236.86s)
--- PASS: TestAccACMCertificate_AmazonIssued_validationOptions (237.61s)
--- PASS: TestAccACMCertificate_AmazonIssued_San_multiple (237.73s)
--- PASS: TestAccACMCertificate_Identity_basic (341.81s)
--- PASS: TestAccACMCertificate_Imported_PrivateKeyWo (342.08s)
--- PASS: TestAccACMCertificate_Tags_addOnUpdate (369.45s)
--- PASS: TestAccACMCertificate_Tags_ComputedTag_OnUpdate_add (371.63s)
--- PASS: TestAccACMCertificate_Tags_ComputedTag_OnUpdate_replace (371.52s)
--- PASS: TestAccACMCertificate_Tags_DefaultTags_updateToProviderOnly (372.78s)
--- PASS: TestAccACMCertificate_Imported_ReimportWithTags (376.30s)
--- PASS: TestAccACMCertificate_AmazonIssued_SubjectAlternativeNames_emptyString (11.58s)
--- PASS: TestAccACMCertificate_AmazonIssued_Root_trailingPeriod (10.68s)
--- PASS: TestAccACMCertificate_AmazonIssued_disableCTLogging (189.87s)
--- PASS: TestAccACMCertificate_AmazonIssued_keyAlgorithm (213.68s)
--- PASS: TestAccACMCertificate_AmazonIssued_wildcardAndRootSan (238.86s)
--- PASS: TestAccACMCertificate_Tags_IgnoreTags_Overlap_defaultTag (479.39s)
--- PASS: TestAccACMCertificate_AmazonIssued_wildcard (258.76s)
--- PASS: TestAccACMCertificate_AmazonIssued_San_matches_domain (258.84s)
--- PASS: TestAccACMCertificate_Tags_IgnoreTags_Overlap_resourceTag (620.77s)
--- PASS: TestAccACMCertificate_Tags_EmptyTag_OnUpdate_replace (463.32s)
--- PASS: TestAccACMCertificate_AmazonIssued_San_trailingPeriod (329.56s)
--- PASS: TestAccACMCertificate_Imported_domainName (701.55s)
--- PASS: TestAccACMCertificate_AmazonIssued_rootAndWildcardSan (329.34s)
--- PASS: TestAccACMCertificate_Tags_DefaultTags_emptyResourceTag (313.45s)
--- PASS: TestAccACMCertificate_Private_addEarlyRenewalFuture (535.51s)
--- PASS: TestAccACMCertificate_Private_removeEarlyRenewal (484.16s)
--- PASS: TestAccACMCertificate_Private_updateEarlyRenewalFuture (477.67s)
--- PASS: TestAccACMCertificate_Tags_DefaultTags_emptyProviderOnlyTag (260.65s)
--- PASS: TestAccACMCertificate_AmazonIssued_San_single (507.01s)
--- PASS: TestAccACMCertificate_Tags_EmptyTag_OnUpdate_add (661.11s)
--- PASS: TestAccACMCertificate_Tags_DefaultTags_providerOnly (886.23s)
--- PASS: TestAccACMCertificate_Tags_DefaultTags_updateToResourceOnly (419.45s)
--- PASS: TestAccACMCertificate_Tags_EmptyTag_onCreate (500.41s)
--- PASS: TestAccACMCertificate_Tags_DefaultTags_nullNonOverlappingResourceTag (212.50s)
--- PASS: TestAccACMCertificate_Tags_DefaultTags_overlapping (701.10s)
--- PASS: TestAccACMCertificate_Tags_DefaultTags_nonOverlapping (709.74s)
--- PASS: TestAccACMCertificate_Private_addEarlyRenewalPastIneligible (334.11s)
--- PASS: TestAccACMCertificate_Tags_emptyMap (236.16s)
--- PASS: TestAccACMCertificate_Identity_ExistingResource_noRefreshNoChange (134.10s)
--- PASS: TestAccACMCertificate_Private_pendingRenewalRFC3339Duration (516.56s)
--- PASS: TestAccACMCertificate_Identity_ExistingResource_basic (225.02s)
--- PASS: TestAccACMCertificate_Tags_null (128.92s)
--- PASS: TestAccACMCertificate_Identity_regionOverride (150.34s)
--- PASS: TestAccACMCertificate_AmazonIssued_disableReenableCTLogging (811.23s)
--- PASS: TestAccACMCertificate_Private_renewable (318.78s)
--- PASS: TestAccACMCertificate_Private_pendingRenewalGoDuration (326.49s)
--- PASS: TestAccACMCertificate_Private_addEarlyRenewalPast (329.82s)
--- PASS: TestAccACMCertificate_tags (190.81s)
--- PASS: TestAccACMCertificate_Private_noRenewalPermission (478.62s)
```
