### PR TITLE
`acmpca`: Use AWS SDK for Go v2 default retry count

### DIFF
--- a/.changelog/48365.txt
+++ b/.changelog/48365.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_acmpca_certificate_authority: Prevents hang when trying to create resources over the quota limit.
+```

--- a/internal/service/acmpca/certificate_authority_test.go
+++ b/internal/service/acmpca/certificate_authority_test.go
@@ -116,7 +116,7 @@ func TestAccACMPCACertificateAuthority_enabledDeprecated(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCertificateAuthorityConfig_enabled(commonName, string(awstypes.CertificateAuthorityTypeRoot), true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCertificateAuthorityExists(ctx, t, resourceName, &certificateAuthority),
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, string(awstypes.CertificateAuthorityTypeRoot)),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEnabled, acctest.CtTrue),
@@ -125,7 +125,7 @@ func TestAccACMPCACertificateAuthority_enabledDeprecated(t *testing.T) {
 			},
 			{
 				Config: testAccCertificateAuthorityConfig_enabled(commonName, string(awstypes.CertificateAuthorityTypeRoot), true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCertificateAuthorityExists(ctx, t, resourceName, &certificateAuthority),
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, string(awstypes.CertificateAuthorityTypeRoot)),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEnabled, acctest.CtTrue),
@@ -133,7 +133,7 @@ func TestAccACMPCACertificateAuthority_enabledDeprecated(t *testing.T) {
 			},
 			{
 				Config: testAccCertificateAuthorityConfig_enabled(commonName, string(awstypes.CertificateAuthorityTypeRoot), false),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCertificateAuthorityExists(ctx, t, resourceName, &certificateAuthority),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEnabled, acctest.CtFalse),
 				),
@@ -164,7 +164,7 @@ func TestAccACMPCACertificateAuthority_usageMode(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCertificateAuthorityConfig_usageMode(commonName, string(awstypes.CertificateAuthorityTypeRoot), "SHORT_LIVED_CERTIFICATE"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCertificateAuthorityExists(ctx, t, resourceName, &certificateAuthority),
 					resource.TestCheckResourceAttr(resourceName, "usage_mode", "SHORT_LIVED_CERTIFICATE"),
 				),
@@ -199,7 +199,7 @@ func TestAccACMPCACertificateAuthority_keyStorageSecurityStandard(t *testing.T) 
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCertificateAuthorityConfig_keyStorageSecurityStandard(commonName, string(awstypes.CertificateAuthorityTypeRoot), "FIPS_140_2_LEVEL_2_OR_HIGHER"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCertificateAuthorityExists(ctx, t, resourceName, &certificateAuthority),
 					resource.TestCheckResourceAttr(resourceName, "key_storage_security_standard", "FIPS_140_2_LEVEL_2_OR_HIGHER"),
 				),
@@ -254,7 +254,7 @@ func TestAccACMPCACertificateAuthority_RevocationConfiguration_empty(t *testing.
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCertificateAuthorityConfig_revocationConfigurationEmpty(commonName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCertificateAuthorityExists(ctx, t, resourceName, &certificateAuthority),
 					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "acm-pca", regexache.MustCompile(`certificate-authority/.+`)),
 					resource.TestCheckResourceAttr(resourceName, "certificate_authority_configuration.#", "1"),
@@ -307,7 +307,7 @@ func TestAccACMPCACertificateAuthority_RevocationCrl_customCNAME(t *testing.T) {
 			// Test creating revocation configuration on resource creation
 			{
 				Config: testAccCertificateAuthorityConfig_revocationConfigurationCrlConfigurationCustomCNAME(rName, commonName, customCName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCertificateAuthorityExists(ctx, t, resourceName, &certificateAuthority),
 					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.crl_configuration.#", "1"),
@@ -329,7 +329,7 @@ func TestAccACMPCACertificateAuthority_RevocationCrl_customCNAME(t *testing.T) {
 			// Test updating revocation configuration
 			{
 				Config: testAccCertificateAuthorityConfig_revocationConfigurationCrlConfigurationCustomCNAME(rName, commonName, customCName2),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCertificateAuthorityExists(ctx, t, resourceName, &certificateAuthority),
 					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.crl_configuration.#", "1"),
@@ -342,7 +342,7 @@ func TestAccACMPCACertificateAuthority_RevocationCrl_customCNAME(t *testing.T) {
 			// Test removing custom cname on resource update
 			{
 				Config: testAccCertificateAuthorityConfig_revocationConfigurationCrlConfigurationEnabled(rName, commonName, true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCertificateAuthorityExists(ctx, t, resourceName, &certificateAuthority),
 					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.crl_configuration.#", "1"),
@@ -355,7 +355,7 @@ func TestAccACMPCACertificateAuthority_RevocationCrl_customCNAME(t *testing.T) {
 			// Test adding custom cname on resource update
 			{
 				Config: testAccCertificateAuthorityConfig_revocationConfigurationCrlConfigurationCustomCNAME(rName, commonName, customCName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCertificateAuthorityExists(ctx, t, resourceName, &certificateAuthority),
 					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.crl_configuration.#", "1"),
@@ -397,7 +397,7 @@ func TestAccACMPCACertificateAuthority_RevocationCrl_customPath(t *testing.T) {
 			// Test creating revocation configuration with custom_path on resource creation
 			{
 				Config: testAccCertificateAuthorityConfig_revocationConfigurationCrlConfigurationCustomPath(rName, commonName, customPath1),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCertificateAuthorityExists(ctx, t, resourceName, &certificateAuthority),
 					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.crl_configuration.#", "1"),
@@ -419,7 +419,7 @@ func TestAccACMPCACertificateAuthority_RevocationCrl_customPath(t *testing.T) {
 			// Test updating custom_path
 			{
 				Config: testAccCertificateAuthorityConfig_revocationConfigurationCrlConfigurationCustomPath(rName, commonName, customPath2),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCertificateAuthorityExists(ctx, t, resourceName, &certificateAuthority),
 					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.crl_configuration.#", "1"),
@@ -432,7 +432,7 @@ func TestAccACMPCACertificateAuthority_RevocationCrl_customPath(t *testing.T) {
 			// Test removing custom_path on resource update
 			{
 				Config: testAccCertificateAuthorityConfig_revocationConfigurationCrlConfigurationEnabled(rName, commonName, true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCertificateAuthorityExists(ctx, t, resourceName, &certificateAuthority),
 					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.crl_configuration.#", "1"),
@@ -462,7 +462,7 @@ func TestAccACMPCACertificateAuthority_RevocationCrl_enabled(t *testing.T) {
 			// Test creating revocation configuration on resource creation
 			{
 				Config: testAccCertificateAuthorityConfig_revocationConfigurationCrlConfigurationEnabled(rName, commonName, true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCertificateAuthorityExists(ctx, t, resourceName, &certificateAuthority),
 					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.crl_configuration.#", "1"),
@@ -484,7 +484,7 @@ func TestAccACMPCACertificateAuthority_RevocationCrl_enabled(t *testing.T) {
 			// Test disabling revocation configuration
 			{
 				Config: testAccCertificateAuthorityConfig_revocationConfigurationCrlConfigurationEnabled(rName, commonName, false),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCertificateAuthorityExists(ctx, t, resourceName, &certificateAuthority),
 					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.crl_configuration.#", "1"),
@@ -494,7 +494,7 @@ func TestAccACMPCACertificateAuthority_RevocationCrl_enabled(t *testing.T) {
 			// Test enabling revocation configuration
 			{
 				Config: testAccCertificateAuthorityConfig_revocationConfigurationCrlConfigurationEnabled(rName, commonName, true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCertificateAuthorityExists(ctx, t, resourceName, &certificateAuthority),
 					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.crl_configuration.#", "1"),
@@ -534,7 +534,7 @@ func TestAccACMPCACertificateAuthority_RevocationCrl_expirationInDays(t *testing
 			// Test creating revocation configuration on resource creation
 			{
 				Config: testAccCertificateAuthorityConfig_revocationConfigurationCrlConfigurationExpirationInDays(rName, commonName, 1),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCertificateAuthorityExists(ctx, t, resourceName, &certificateAuthority),
 					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.crl_configuration.#", "1"),
@@ -557,7 +557,7 @@ func TestAccACMPCACertificateAuthority_RevocationCrl_expirationInDays(t *testing
 			// Test updating revocation configuration
 			{
 				Config: testAccCertificateAuthorityConfig_revocationConfigurationCrlConfigurationExpirationInDays(rName, commonName, 2),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCertificateAuthorityExists(ctx, t, resourceName, &certificateAuthority),
 					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.crl_configuration.#", "1"),
@@ -596,7 +596,7 @@ func TestAccACMPCACertificateAuthority_RevocationCrl_s3ObjectACL(t *testing.T) {
 			// Test creating revocation configuration on resource creation
 			{
 				Config: testAccCertificateAuthorityConfig_revocationConfigurationCrlConfigurationS3ObjectACL(rName, commonName, "BUCKET_OWNER_FULL_CONTROL"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCertificateAuthorityExists(ctx, t, resourceName, &certificateAuthority),
 					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.crl_configuration.#", "1"),
@@ -618,7 +618,7 @@ func TestAccACMPCACertificateAuthority_RevocationCrl_s3ObjectACL(t *testing.T) {
 			// Test updating revocation configuration
 			{
 				Config: testAccCertificateAuthorityConfig_revocationConfigurationCrlConfigurationS3ObjectACL(rName, commonName, "PUBLIC_READ"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCertificateAuthorityExists(ctx, t, resourceName, &certificateAuthority),
 					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.crl_configuration.#", "1"),
@@ -647,7 +647,7 @@ func TestAccACMPCACertificateAuthority_RevocationOcsp_enabled(t *testing.T) {
 			// Test creating OCSP revocation configuration on resource creation
 			{
 				Config: testAccCertificateAuthorityConfig_revocationConfigurationOcspConfigurationEnabled(commonName, true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCertificateAuthorityExists(ctx, t, resourceName, &certificateAuthority),
 					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.ocsp_configuration.#", "1"),
@@ -667,7 +667,7 @@ func TestAccACMPCACertificateAuthority_RevocationOcsp_enabled(t *testing.T) {
 			// Test disabling OCSP revocation configuration
 			{
 				Config: testAccCertificateAuthorityConfig_revocationConfigurationOcspConfigurationEnabled(commonName, false),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCertificateAuthorityExists(ctx, t, resourceName, &certificateAuthority),
 					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.ocsp_configuration.#", "1"),
@@ -677,7 +677,7 @@ func TestAccACMPCACertificateAuthority_RevocationOcsp_enabled(t *testing.T) {
 			// Test enabling OCSP revocation configuration
 			{
 				Config: testAccCertificateAuthorityConfig_revocationConfigurationOcspConfigurationEnabled(commonName, true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCertificateAuthorityExists(ctx, t, resourceName, &certificateAuthority),
 					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.ocsp_configuration.#", "1"),
@@ -717,7 +717,7 @@ func TestAccACMPCACertificateAuthority_RevocationOcsp_customCNAME(t *testing.T) 
 			// Test creating revocation configuration on resource creation
 			{
 				Config: testAccCertificateAuthorityConfig_revocationConfigurationOcspConfigurationCustomCNAME(commonName, customCName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCertificateAuthorityExists(ctx, t, resourceName, &certificateAuthority),
 					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.ocsp_configuration.#", "1"),
@@ -737,7 +737,7 @@ func TestAccACMPCACertificateAuthority_RevocationOcsp_customCNAME(t *testing.T) 
 			// Test updating OCSP revocation configuration
 			{
 				Config: testAccCertificateAuthorityConfig_revocationConfigurationOcspConfigurationCustomCNAME(commonName, customCName2),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCertificateAuthorityExists(ctx, t, resourceName, &certificateAuthority),
 					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.ocsp_configuration.#", "1"),
@@ -748,7 +748,7 @@ func TestAccACMPCACertificateAuthority_RevocationOcsp_customCNAME(t *testing.T) 
 			// Test removing OCSP custom cname on resource update
 			{
 				Config: testAccCertificateAuthorityConfig_revocationConfigurationOcspConfigurationEnabled(commonName, true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCertificateAuthorityExists(ctx, t, resourceName, &certificateAuthority),
 					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.ocsp_configuration.#", "1"),
@@ -759,7 +759,7 @@ func TestAccACMPCACertificateAuthority_RevocationOcsp_customCNAME(t *testing.T) 
 			// Test adding OCSP custom cname on resource update
 			{
 				Config: testAccCertificateAuthorityConfig_revocationConfigurationOcspConfigurationCustomCNAME(commonName, customCName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCertificateAuthorityExists(ctx, t, resourceName, &certificateAuthority),
 					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.ocsp_configuration.#", "1"),

--- a/internal/service/acmpca/certificate_authority_test.go
+++ b/internal/service/acmpca/certificate_authority_test.go
@@ -70,6 +70,37 @@ func TestAccACMPCACertificateAuthority_basic(t *testing.T) {
 	})
 }
 
+func TestAccACMPCACertificateAuthority_permanentDeletionTime(t *testing.T) {
+	ctx := acctest.Context(t)
+	var certificateAuthority awstypes.CertificateAuthority
+	resourceName := "aws_acmpca_certificate_authority.test"
+	commonName := acctest.RandomDomainName(t)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ACMPCAServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckCertificateAuthorityDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCertificateAuthorityConfig_basicSevenDays(commonName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckCertificateAuthorityExists(ctx, t, resourceName, &certificateAuthority),
+					resource.TestCheckResourceAttr(resourceName, "permanent_deletion_time_in_days", "7"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"permanent_deletion_time_in_days",
+				},
+			},
+		},
+	})
+}
+
 func TestAccACMPCACertificateAuthority_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var certificateAuthority awstypes.CertificateAuthority

--- a/internal/service/acmpca/certificate_authority_test.go
+++ b/internal/service/acmpca/certificate_authority_test.go
@@ -35,8 +35,8 @@ func TestAccACMPCACertificateAuthority_basic(t *testing.T) {
 		CheckDestroy:             testAccCheckCertificateAuthorityDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCertificateAuthorityConfig_required(commonName),
-				Check: resource.ComposeTestCheckFunc(
+				Config: testAccCertificateAuthorityConfig_defaultsOnly(commonName),
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCertificateAuthorityExists(ctx, t, resourceName, &certificateAuthority),
 					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "acm-pca", regexache.MustCompile(`certificate-authority/.+`)),
 					resource.TestCheckResourceAttr(resourceName, "certificate_authority_configuration.#", "1"),
@@ -114,8 +114,8 @@ func TestAccACMPCACertificateAuthority_disappears(t *testing.T) {
 		CheckDestroy:             testAccCheckCertificateAuthorityDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCertificateAuthorityConfig_required(commonName),
-				Check: resource.ComposeTestCheckFunc(
+				Config: testAccCertificateAuthorityConfig_basicSevenDays(commonName),
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCertificateAuthorityExists(ctx, t, resourceName, &certificateAuthority),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfacmpca.ResourceCertificateAuthority(), resourceName),
 				),
@@ -300,7 +300,7 @@ func TestAccACMPCACertificateAuthority_RevocationConfiguration_empty(t *testing.
 					resource.TestCheckResourceAttr(resourceName, "key_storage_security_standard", "FIPS_140_2_LEVEL_3_OR_HIGHER"),
 					acctest.CheckResourceAttrRFC3339(resourceName, "not_after"),
 					acctest.CheckResourceAttrRFC3339(resourceName, "not_before"),
-					resource.TestCheckResourceAttr(resourceName, "permanent_deletion_time_in_days", "30"),
+					resource.TestCheckResourceAttr(resourceName, "permanent_deletion_time_in_days", "7"),
 					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.crl_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.crl_configuration.0.enabled", acctest.CtFalse),
@@ -314,6 +314,9 @@ func TestAccACMPCACertificateAuthority_RevocationConfiguration_empty(t *testing.
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"permanent_deletion_time_in_days",
+				},
 			},
 		},
 	})
@@ -398,12 +401,15 @@ func TestAccACMPCACertificateAuthority_RevocationCrl_customCNAME(t *testing.T) {
 			},
 			// Test removing revocation configuration on resource update
 			{
-				Config: testAccCertificateAuthorityConfig_required(commonName),
-				Check: resource.ComposeTestCheckFunc(
+				Config: testAccCertificateAuthorityConfig_basicSevenDays(commonName),
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCertificateAuthorityExists(ctx, t, resourceName, &certificateAuthority),
 					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.crl_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.crl_configuration.0.custom_cname", ""),
 					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.crl_configuration.0.enabled", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.crl_configuration.0.expiration_in_days", "0"),
+					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.crl_configuration.0.s3_bucket_name", ""),
 				),
 			},
 		},
@@ -537,12 +543,15 @@ func TestAccACMPCACertificateAuthority_RevocationCrl_enabled(t *testing.T) {
 			},
 			// Test removing revocation configuration on resource update
 			{
-				Config: testAccCertificateAuthorityConfig_required(commonName),
-				Check: resource.ComposeTestCheckFunc(
+				Config: testAccCertificateAuthorityConfig_basicSevenDays(commonName),
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCertificateAuthorityExists(ctx, t, resourceName, &certificateAuthority),
 					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.crl_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.crl_configuration.0.custom_cname", ""),
 					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.crl_configuration.0.enabled", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.crl_configuration.0.expiration_in_days", "0"),
+					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.crl_configuration.0.s3_bucket_name", ""),
 				),
 			},
 		},
@@ -599,12 +608,15 @@ func TestAccACMPCACertificateAuthority_RevocationCrl_expirationInDays(t *testing
 			},
 			// Test removing revocation configuration on resource update
 			{
-				Config: testAccCertificateAuthorityConfig_required(commonName),
-				Check: resource.ComposeTestCheckFunc(
+				Config: testAccCertificateAuthorityConfig_basicSevenDays(commonName),
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCertificateAuthorityExists(ctx, t, resourceName, &certificateAuthority),
 					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.crl_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.crl_configuration.0.custom_cname", ""),
 					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.crl_configuration.0.enabled", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.crl_configuration.0.expiration_in_days", "0"),
+					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.crl_configuration.0.s3_bucket_name", ""),
 				),
 			},
 		},
@@ -718,12 +730,15 @@ func TestAccACMPCACertificateAuthority_RevocationOcsp_enabled(t *testing.T) {
 			},
 			// Test removing revocation configuration on resource update
 			{
-				Config: testAccCertificateAuthorityConfig_required(commonName),
-				Check: resource.ComposeTestCheckFunc(
+				Config: testAccCertificateAuthorityConfig_basicSevenDays(commonName),
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCertificateAuthorityExists(ctx, t, resourceName, &certificateAuthority),
 					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.ocsp_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.crl_configuration.0.custom_cname", ""),
 					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.ocsp_configuration.0.enabled", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.crl_configuration.0.expiration_in_days", "0"),
+					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.crl_configuration.0.s3_bucket_name", ""),
 				),
 			},
 		},
@@ -800,12 +815,15 @@ func TestAccACMPCACertificateAuthority_RevocationOcsp_customCNAME(t *testing.T) 
 			},
 			// Test removing revocation configuration on resource update
 			{
-				Config: testAccCertificateAuthorityConfig_required(commonName),
-				Check: resource.ComposeTestCheckFunc(
+				Config: testAccCertificateAuthorityConfig_basicSevenDays(commonName),
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCertificateAuthorityExists(ctx, t, resourceName, &certificateAuthority),
 					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.ocsp_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.crl_configuration.0.custom_cname", ""),
 					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.ocsp_configuration.0.enabled", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.crl_configuration.0.expiration_in_days", "0"),
+					resource.TestCheckResourceAttr(resourceName, "revocation_configuration.0.crl_configuration.0.s3_bucket_name", ""),
 				),
 			},
 		},
@@ -919,9 +937,33 @@ data "aws_partition" "current" {}
 `, commonName)
 }
 
-func testAccCertificateAuthorityConfig_required(commonName string) string {
+// testAccCertificateAuthorityConfig_defaultsOnly should ONLY be used with
+// the `TestAccACMPCACertificateAuthority_basic` test, as it uses the default
+// `permanent_deletion_time_in_days` of 30.
+func testAccCertificateAuthorityConfig_defaultsOnly(commonName string) string {
 	return fmt.Sprintf(`
 resource "aws_acmpca_certificate_authority" "test" {
+  usage_mode = "SHORT_LIVED_CERTIFICATE"
+
+  certificate_authority_configuration {
+    key_algorithm     = "RSA_4096"
+    signing_algorithm = "SHA512WITHRSA"
+
+    subject {
+      common_name = %[1]q
+    }
+  }
+}
+`, commonName)
+}
+
+// testAccCertificateAuthorityConfig_basicSevenDays only sets required values except
+// for `permanent_deletion_time_in_days`, which is set to the minimum
+func testAccCertificateAuthorityConfig_basicSevenDays(commonName string) string {
+	return fmt.Sprintf(`
+resource "aws_acmpca_certificate_authority" "test" {
+  permanent_deletion_time_in_days = 7
+
   usage_mode = "SHORT_LIVED_CERTIFICATE"
 
   certificate_authority_configuration {
@@ -939,6 +981,8 @@ resource "aws_acmpca_certificate_authority" "test" {
 func testAccCertificateAuthorityConfig_revocationConfigurationEmpty(commonName string) string {
 	return fmt.Sprintf(`
 resource "aws_acmpca_certificate_authority" "test" {
+  permanent_deletion_time_in_days = 7
+
   usage_mode = "SHORT_LIVED_CERTIFICATE"
 
   certificate_authority_configuration {

--- a/internal/service/acmpca/service_package.go
+++ b/internal/service/acmpca/service_package.go
@@ -1,0 +1,32 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package acmpca
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/retry"
+	"github.com/aws/aws-sdk-go-v2/service/acmpca"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+func (p *servicePackage) withExtraOptions(ctx context.Context, config map[string]any) []func(*acmpca.Options) {
+	cfg := *(config["aws_sdkv2_config"].(*aws.Config))
+
+	// No one would reasonably set retries to this value manually, so assume it's the provider default
+	if cfg.RetryMaxAttempts != 25 {
+		return nil
+	}
+
+	tflog.Debug(ctx, "Overriding provider default retry attempts with AWS SDK for Go v2 default", map[string]any{
+		"retry_max_attempts": retry.DefaultMaxAttempts,
+	})
+
+	return []func(*acmpca.Options){
+		func(o *acmpca.Options) {
+			o.RetryMaxAttempts = retry.DefaultMaxAttempts
+		},
+	}
+}


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

The provider's default of 25 retries causes API operations to be retried for over an hour! While some services currently rely on this to function, `acmpca` does not.

The AWS SDK for Go v2 internally retries a number of error codes as throttling errors (see https://github.com/aws/aws-sdk-go-v2/blob/fa1c7ba0b94e6bb6a3c5f04accd9083e84bffd32/aws/retry/standard.go#L69-L84), including `LimitExceededException`.

However, `acmpca` also returns `LimitExceededException` if too many Private Certificate Authorities are created. This causes the Provider to appear to hang for over an hour, because the AWS SDK is handling retries instead of returning control to the Provider.

Updates `acmpca` client configuration to use the AWS SDK for Go v2 default retry count if the Provider is configured with the provider default of 25. If the practitioner has set a different value, the retry count is left as-is.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=acmpca

--- PASS: TestAccACMPCAPermission_basic (141.73s)
--- PASS: TestAccACMPCAPermission_sourceAccount (142.20s)
--- PASS: TestAccACMPCAPermission_disappears (166.35s)
--- PASS: TestAccACMPCACertificate_rootCertificateWithAPIPassthrough (174.33s)
--- PASS: TestAccACMPCAPolicy_basic (174.56s)
--- PASS: TestAccACMPCACertificate_endEntityCertificate (175.38s)
--- PASS: TestAccACMPCACertificate_subordinateCertificate (175.51s)
--- PASS: TestAccACMPCACertificate_Validity_endDate (185.45s)
--- PASS: TestAccACMPCACertificate_Validity_absolute (187.31s)
--- PASS: TestAccACMPCACertificateAuthority_Tags_DefaultTags_emptyProviderOnlyTag (196.74s)
--- PASS: TestAccACMPCACertificateAuthority_Tags_ComputedTag_onCreate (198.49s)
--- PASS: TestAccACMPCACertificateAuthority_Tags_DefaultTags_nullOverlappingResourceTag (198.62s)
--- PASS: TestAccACMPCACertificateAuthority_Tags_DefaultTags_nullNonOverlappingResourceTag (202.68s)
--- PASS: TestAccACMPCAPolicy_Identity_ExistingResource_noRefreshNoChange (210.50s)
--- PASS: TestAccACMPCAPolicy_Identity_ExistingResource_basic (310.27s)
--- PASS: TestAccACMPCACertificateAuthorityCertificate_Identity_basic (329.68s)
--- PASS: TestAccACMPCAPolicy_Identity_basic (329.72s)
--- PASS: TestAccACMPCACertificate_rootCertificate (190.33s)
--- PASS: TestAccACMPCACertificateAuthority_Tags_ComputedTag_OnUpdate_add (332.13s)
--- PASS: TestAccACMPCACertificateAuthority_Tags_ComputedTag_OnUpdate_replace (332.36s)
--- PASS: TestAccACMPCACertificateDataSource_basic (164.10s)
--- PASS: TestAccACMPCACertificateAuthority_Tags_DefaultTags_emptyResourceTag (220.59s)
--- PASS: TestAccACMPCAPolicy_Identity_regionOverride (363.49s)
--- PASS: TestAccACMPCACertificate_Identity_ExistingResource_noRefreshNoChange (222.48s)
--- PASS: TestAccACMPCACertificate_Identity_ExistingResource_basic (275.38s)
--- PASS: TestAccACMPCACertificateAuthority_Tags_DefaultTags_updateToResourceOnly (284.65s)
--- PASS: TestAccACMPCACertificate_Identity_basic (274.44s)
--- SKIP: TestAccACMPCACertificateAuthority_keyStorageSecurityStandard (0.00s)
--- PASS: TestAccACMPCACertificateAuthority_Tags_DefaultTags_updateToProviderOnly (310.59s)
--- PASS: TestAccACMPCACertificate_Identity_regionOverride (367.09s)
--- PASS: TestAccACMPCACertificateAuthority_RevocationCrl_s3ObjectACL (254.34s)
--- PASS: TestAccACMPCACertificateAuthority_deleteFromActiveState (132.07s)
--- PASS: TestAccACMPCACertificateAuthority_Tags_emptyMap (250.38s)
--- PASS: TestAccACMPCACertificateAuthority_usageMode (155.02s)
--- PASS: TestAccACMPCACertificateAuthority_Tags_EmptyTag_OnUpdate_replace (304.80s)
--- PASS: TestAccACMPCACertificateAuthority_RevocationConfiguration_empty (165.41s)
--- PASS: TestAccACMPCACertificateAuthority_RevocationOcsp_enabled (438.17s)
--- PASS: TestAccACMPCACertificateAuthority_Tags_EmptyTag_onCreate (316.79s)
--- PASS: TestAccACMPCACertificateAuthority_RevocationCrl_expirationInDays (316.90s)
--- PASS: TestAccACMPCACertificateAuthority_Tags_addOnUpdate (286.39s)
--- PASS: TestAccACMPCACertificateAuthority_disappears (107.98s)
--- PASS: TestAccACMPCACertificateAuthority_Tags_DefaultTags_nonOverlapping (498.94s)
--- PASS: TestAccACMPCACertificateAuthority_Tags_DefaultTags_overlapping (513.32s)
--- PASS: TestAccACMPCACertificateAuthority_RevocationCrl_enabled (415.78s)
--- PASS: TestAccACMPCACertificateAuthorityDataSource_Tags_DefaultTags_nonOverlapping (133.04s)
--- PASS: TestAccACMPCACertificateAuthority_permanentDeletionTime (167.81s)
--- PASS: TestAccACMPCACertificateAuthority_basic (161.82s)
--- PASS: TestAccACMPCACertificateAuthority_Tags_EmptyTag_OnUpdate_add (423.29s)
--- PASS: TestAccACMPCACertificateAuthority_RevocationCrl_customPath (391.26s)
--- PASS: TestAccACMPCACertificateAuthorityDataSource_s3ObjectACL (133.49s)
--- PASS: TestAccACMPCACertificateAuthority_RevocationOcsp_customCNAME (581.74s)
--- PASS: TestAccACMPCACertificateAuthorityDataSource_basic (123.73s)
--- PASS: TestAccACMPCACertificateAuthority_enabledDeprecated (334.52s)
--- PASS: TestAccACMPCACertificateAuthorityDataSource_tags (126.13s)
--- PASS: TestAccACMPCACertificateAuthorityDataSource_Tags_nullMap (126.32s)
--- PASS: TestAccACMPCACertificateAuthorityDataSource_Tags_IgnoreTags_Overlap_defaultTag (131.17s)
--- PASS: TestAccACMPCACertificateAuthorityDataSource_Tags_emptyMap (127.59s)
--- PASS: TestAccACMPCACertificateAuthorityDataSource_Tags_IgnoreTags_Overlap_resourceTag (188.20s)
--- PASS: TestAccACMPCACertificateAuthority_Identity_ExistingResource_noRefreshNoChange (248.18s)
--- PASS: TestAccACMPCACertificateAuthority_Identity_basic (254.62s)
--- PASS: TestAccACMPCACertificateAuthorityCertificate_subordinateCA (150.69s)
--- PASS: TestAccACMPCACertificateAuthority_Tags_IgnoreTags_Overlap_defaultTag (306.09s)
--- PASS: TestAccACMPCACertificateAuthority_RevocationCrl_customCNAME (532.01s)
--- PASS: TestAccACMPCACertificateAuthority_Tags_DefaultTags_providerOnly (722.22s)
--- PASS: TestAccACMPCACertificateAuthorityCertificate_updateRootCA (172.47s)
--- PASS: TestAccACMPCACertificateAuthority_Identity_ExistingResource_basic (272.02s)
--- PASS: TestAccACMPCACertificateAuthorityCertificate_rootCA (148.82s)
--- PASS: TestAccACMPCACertificateAuthorityCertificate_Identity_ExistingResource_noRefreshNoChange (149.20s)
--- PASS: TestAccACMPCACertificateAuthority_Identity_regionOverride (284.46s)
--- PASS: TestAccACMPCACertificateAuthority_Tags_IgnoreTags_Overlap_resourceTag (335.16s)
--- PASS: TestAccACMPCACertificateAuthorityCertificate_Identity_regionOverride (144.32s)
--- PASS: TestAccACMPCACertificateAuthority_Tags_null (85.40s)
--- PASS: TestAccACMPCACertificateAuthorityCertificate_Identity_ExistingResource_basic (146.13s)
--- PASS: TestAccACMPCACertificateAuthority_tags (366.09s)
```
