### PR TITLE
eks: Introduce new CreateCluster parameters for Amazon EKS local clusters on AWS Outposts.

### DIFF
--- a/.changelog/48367.txt
+++ b/.changelog/48367.txt
@@ -1,11 +1,11 @@
 ```release-note:enhancement
-resource/aws_eks_cluster: Make `group_name` field in `control_plane_placement` optional  
+resource/aws_eks_cluster: Change `outpost_config.control_plane_placement.group_name` to Optional  
 ```
 
 ```release-note:enhancement
-resource/aws_eks_cluster: Add new optional `etcd_instance_type` field in `outpost_config`
+resource/aws_eks_cluster: Add `outpost_config.control_plane_placement.spread_level`, `outpost_config.etcd_instance_type`, and `outpost_config.etcd_placement` arguments
 ```
 
 ```release-note:enhancement
-resource/aws_eks_cluster: Add new optional `etcd_placement` block in `outpost_config`
+data-source/aws_eks_cluster: Add `outpost_config.control_plane_placement.spread_level`, `outpost_config.etcd_instance_type`, and `outpost_config.etcd_placement` attributes
 ```

--- a/.changelog/48367.txt
+++ b/.changelog/48367.txt
@@ -1,5 +1,5 @@
 ```release-note:enhancement
-resource/aws_eks_cluster: Change `outpost_config.control_plane_placement.group_name` to Optional  
+resource/aws_eks_cluster: Change `outpost_config.control_plane_placement.group_name` to Optional
 ```
 
 ```release-note:enhancement
@@ -8,4 +8,8 @@ resource/aws_eks_cluster: Add `outpost_config.control_plane_placement.spread_lev
 
 ```release-note:enhancement
 data-source/aws_eks_cluster: Add `outpost_config.control_plane_placement.spread_level`, `outpost_config.etcd_instance_type`, and `outpost_config.etcd_placement` attributes
+```
+
+```release-note:note
+resource/aws_eks_cluster: Because we cannot easily test the behavior of `outpost_config`, the changes are best effort and we ask for community help in testing
 ```

--- a/.changelog/48367.txt
+++ b/.changelog/48367.txt
@@ -1,0 +1,11 @@
+```release-note:enhancement
+resource/aws_eks_cluster: Make `group_name` field in `control_plane_placement` optional  
+```
+
+```release-note:enhancement
+resource/aws_eks_cluster: Add new optional `etcd_instance_type` field in `outpost_config`
+```
+
+```release-note:enhancement
+resource/aws_eks_cluster: Add new optional `etcd_placement` block in `outpost_config`
+```

--- a/go.mod
+++ b/go.mod
@@ -111,7 +111,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.39.6
 	github.com/aws/aws-sdk-go-v2/service/ecs v1.83.0
 	github.com/aws/aws-sdk-go-v2/service/efs v1.42.1
-	github.com/aws/aws-sdk-go-v2/service/eks v1.84.6
+	github.com/aws/aws-sdk-go-v2/service/eks v1.85.0
 	github.com/aws/aws-sdk-go-v2/service/elasticache v1.54.3
 	github.com/aws/aws-sdk-go-v2/service/elasticbeanstalk v1.35.4
 	github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing v1.34.6
@@ -281,7 +281,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/workspaces v1.69.1
 	github.com/aws/aws-sdk-go-v2/service/workspacesweb v1.40.7
 	github.com/aws/aws-sdk-go-v2/service/xray v1.37.3
-	github.com/aws/smithy-go v1.27.1
+	github.com/aws/smithy-go v1.27.2
 	github.com/beevik/etree v1.6.0
 	github.com/cedar-policy/cedar-go v1.8.0
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
@@ -397,5 +397,3 @@ require (
 	google.golang.org/grpc v1.79.3 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 )
-
-replace github.com/aws/aws-sdk-go-v2/service/eks v1.84.0 => /home/ANT.AMAZON.COM/kvetsins/pre-release-sdk/service/eks

--- a/go.mod
+++ b/go.mod
@@ -397,3 +397,5 @@ require (
 	google.golang.org/grpc v1.79.3 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 )
+
+replace github.com/aws/aws-sdk-go-v2/service/eks v1.84.0 => /home/ANT.AMAZON.COM/kvetsins/pre-release-sdk/service/eks

--- a/go.sum
+++ b/go.sum
@@ -231,8 +231,8 @@ github.com/aws/aws-sdk-go-v2/service/ecs v1.83.0 h1:LQKIHuVHqdbU9LUt5c2G9f+CcQAz
 github.com/aws/aws-sdk-go-v2/service/ecs v1.83.0/go.mod h1:0vahPCh3slyORHbSuAP8YDyJKLEUQAMX7+bzYGxEnVI=
 github.com/aws/aws-sdk-go-v2/service/efs v1.42.1 h1:Ii4N3TQ2wa18cOlFR2Kxcji4wVsaySku+ygiBeKGqTU=
 github.com/aws/aws-sdk-go-v2/service/efs v1.42.1/go.mod h1:AMhRvE41tgqPUU9hqtyCw8ektaKSnKbm10kyX9xL+FQ=
-github.com/aws/aws-sdk-go-v2/service/eks v1.84.6 h1:RSCziGPe92ZoBreWKOJsLhK45Nx7+2b2y8hNbOUvHLQ=
-github.com/aws/aws-sdk-go-v2/service/eks v1.84.6/go.mod h1:rbIASs+SfCDUXx2EdfMkNpDGptlW8hvMZ9AawRiUBqE=
+github.com/aws/aws-sdk-go-v2/service/eks v1.85.0 h1:PX1X82jI4OEpsB7zrEuU0/V0Tq0+ylEJEu/CjhorV1c=
+github.com/aws/aws-sdk-go-v2/service/eks v1.85.0/go.mod h1:rbIASs+SfCDUXx2EdfMkNpDGptlW8hvMZ9AawRiUBqE=
 github.com/aws/aws-sdk-go-v2/service/elasticache v1.54.3 h1:KZDlMf8V5riU8xBCMJLWhfa+RP/MIagz2qJFwRg/b1g=
 github.com/aws/aws-sdk-go-v2/service/elasticache v1.54.3/go.mod h1:nsMdHtF/ned4F5GCAfoerJaa/Q6cx+G+WYNsb/TFN7Q=
 github.com/aws/aws-sdk-go-v2/service/elasticbeanstalk v1.35.4 h1:hS5ilJrr1xgHvrw0pwb+xKwZDx0KA1LULHbN+OzwBDM=
@@ -587,6 +587,8 @@ github.com/aws/aws-sdk-go-v2/service/xray v1.37.3 h1:ozG9CuAEB1zS7hBI7BYWYvr798L
 github.com/aws/aws-sdk-go-v2/service/xray v1.37.3/go.mod h1:8bpZogGTIFDJBAXh9Le/rVo6rCcxOMMtZh8fG8lR6Po=
 github.com/aws/smithy-go v1.27.1 h1:4T340VFndXtADGF52gYa1POyL7s9E4Z1OeZ1hCscIw8=
 github.com/aws/smithy-go v1.27.1/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
+github.com/aws/smithy-go v1.27.2 h1:y9NPmSE6am6LjEFPfqHqG/jJk7AauQvhCJONKh7kpzk=
+github.com/aws/smithy-go v1.27.2/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/beevik/etree v1.6.0 h1:u8Kwy8pp9D9XeITj2Z0XtA5qqZEmtJtuXZRQi+j03eE=
 github.com/beevik/etree v1.6.0/go.mod h1:bh4zJxiIr62SOf9pRzN7UUYaEDa9HEKafK25+sLc0Gc=
 github.com/bgentry/speakeasy v0.1.0 h1:ByYyxL9InA1OWqxJqqp2A5pYHUrCiAL6K3J+LKSsQkY=

--- a/go.sum
+++ b/go.sum
@@ -585,8 +585,6 @@ github.com/aws/aws-sdk-go-v2/service/workspacesweb v1.40.7 h1:vxI8SJwwF9n0oB2fST
 github.com/aws/aws-sdk-go-v2/service/workspacesweb v1.40.7/go.mod h1:ywjfHG0obHdo3cIOpPrIju2/M5oMnpD8HzwFMkAfToU=
 github.com/aws/aws-sdk-go-v2/service/xray v1.37.3 h1:ozG9CuAEB1zS7hBI7BYWYvr798LD7G+Tiw1ccS5sAms=
 github.com/aws/aws-sdk-go-v2/service/xray v1.37.3/go.mod h1:8bpZogGTIFDJBAXh9Le/rVo6rCcxOMMtZh8fG8lR6Po=
-github.com/aws/smithy-go v1.27.1 h1:4T340VFndXtADGF52gYa1POyL7s9E4Z1OeZ1hCscIw8=
-github.com/aws/smithy-go v1.27.1/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/aws/smithy-go v1.27.2 h1:y9NPmSE6am6LjEFPfqHqG/jJk7AauQvhCJONKh7kpzk=
 github.com/aws/smithy-go v1.27.2/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/beevik/etree v1.6.0 h1:u8Kwy8pp9D9XeITj2Z0XtA5qqZEmtJtuXZRQi+j03eE=

--- a/internal/service/eks/cluster.go
+++ b/internal/service/eks/cluster.go
@@ -329,11 +329,11 @@ func resourceCluster() *schema.Resource {
 											ForceNew: true,
 										},
 										"spread_level": {
-											Type:         schema.TypeString,
-											Optional:     true,
-											ForceNew:     true,
-											Computed:     true,
-											ValidateFunc: validation.StringInSlice([]string{"host", "rack"}, false),
+											Type:             schema.TypeString,
+											Optional:         true,
+											ForceNew:         true,
+											Computed:         true,
+											ValidateDiagFunc: enum.Validate[types.SpreadLevel](),
 											DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool {
 												// in some case the EKS API might not return spread_level in DescribeCluster
 												// even though the value is set in TF. In order to not force cluster delete in
@@ -358,11 +358,11 @@ func resourceCluster() *schema.Resource {
 								Elem: &schema.Resource{
 									Schema: map[string]*schema.Schema{
 										"spread_level": {
-											Type:         schema.TypeString,
-											Optional:     true,
-											ForceNew:     true,
-											Computed:     true,
-											ValidateFunc: validation.StringInSlice([]string{"host", "rack"}, false),
+											Type:             schema.TypeString,
+											Optional:         true,
+											ForceNew:         true,
+											Computed:         true,
+											ValidateDiagFunc: enum.Validate[types.SpreadLevel](),
 										},
 									},
 								},

--- a/internal/service/eks/cluster.go
+++ b/internal/service/eks/cluster.go
@@ -1970,8 +1970,9 @@ func flattenControlPlanePlacementResponse(apiObject *types.ControlPlanePlacement
 	}
 
 	if apiObject.SpreadLevel != "" {
-		tfMap["spread_level"] = string(apiObject.SpreadLevel)
+		tfMap["spread_level"] = apiObject.SpreadLevel
 	}
+
 	return []any{tfMap}
 }
 
@@ -1981,8 +1982,9 @@ func flattenEtcdPlacementResponse(apiObject *types.EtcdPlacementResponse) []any 
 	}
 
 	tfMap := map[string]any{
-		"spread_level": string(apiObject.SpreadLevel),
+		"spread_level": apiObject.SpreadLevel,
 	}
+
 	return []any{tfMap}
 }
 

--- a/internal/service/eks/cluster.go
+++ b/internal/service/eks/cluster.go
@@ -325,8 +325,44 @@ func resourceCluster() *schema.Resource {
 									Schema: map[string]*schema.Schema{
 										names.AttrGroupName: {
 											Type:     schema.TypeString,
-											Required: true,
+											Optional: true,
 											ForceNew: true,
+										},
+										"spread_level": {
+											Type:         schema.TypeString,
+											Optional:     true,
+											ForceNew:     true,
+											Computed:     true,
+											ValidateFunc: validation.StringInSlice([]string{"host", "rack"}, false),
+											DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool {
+												// in some case the EKS API might not return spread_level in DescribeCluster
+												// even though the value is set in TF. In order to not force cluster delete in
+												// that case, we'll suppress diff when spread_level is ""
+												return oldValue == "" && d.Id() != ""
+											},
+										},
+									},
+								},
+							},
+							"etcd_instance_type": {
+								Type:     schema.TypeString,
+								Optional: true,
+								Computed: true,
+								ForceNew: true,
+							},
+							"etcd_placement": {
+								Type:     schema.TypeList,
+								MaxItems: 1,
+								Optional: true,
+								Computed: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"spread_level": {
+											Type:         schema.TypeString,
+											Optional:     true,
+											ForceNew:     true,
+											Computed:     true,
+											ValidateFunc: validation.StringInSlice([]string{"host", "rack"}, false),
 										},
 									},
 								},
@@ -926,16 +962,19 @@ func resourceClusterDelete(ctx context.Context, d *schema.ResourceData, meta any
 }
 
 func resourceClusterFlatten(ctx context.Context, cluster *types.Cluster, d *schema.ResourceData) error {
+	// access_config as a whole is not always returned and
 	// bootstrap_cluster_creator_admin_permissions isn't returned from the AWS API.
 	// See https://github.com/aws/containers-roadmap/issues/185#issuecomment-1863025784.
-	var bootstrapClusterCreatorAdminPermissions *bool
-	if v, ok := d.GetOk("access_config"); ok {
-		if apiObject := expandCreateAccessConfigRequest(v.([]any)); apiObject != nil {
-			bootstrapClusterCreatorAdminPermissions = apiObject.BootstrapClusterCreatorAdminPermissions
+	if cluster.AccessConfig != nil {
+		var bootstrapClusterCreatorAdminPermissions *bool
+		if v, ok := d.GetOk("access_config"); ok {
+			if apiObject := expandCreateAccessConfigRequest(v.([]any)); apiObject != nil {
+				bootstrapClusterCreatorAdminPermissions = apiObject.BootstrapClusterCreatorAdminPermissions
+			}
 		}
-	}
-	if err := d.Set("access_config", flattenAccessConfigResponse(cluster.AccessConfig, bootstrapClusterCreatorAdminPermissions)); err != nil {
-		return fmt.Errorf("setting access_config: %w", err)
+		if err := d.Set("access_config", flattenAccessConfigResponse(cluster.AccessConfig, bootstrapClusterCreatorAdminPermissions)); err != nil {
+			return fmt.Errorf("setting access_config: %w", err)
+		}
 	}
 	d.Set(names.AttrARN, cluster.Arn)
 	d.Set("bootstrap_self_managed_addons", d.Get("bootstrap_self_managed_addons"))
@@ -1394,6 +1433,14 @@ func expandOutpostConfigRequest(tfList []any) *types.OutpostConfigRequest {
 		outpostConfigRequest.ControlPlanePlacement = expandControlPlanePlacementRequest(v)
 	}
 
+	if v, ok := tfMap["etcd_instance_type"].(string); ok && v != "" {
+		outpostConfigRequest.EtcdInstanceType = aws.String(v)
+	}
+
+	if v, ok := tfMap["etcd_placement"].([]any); ok && len(v) > 0 {
+		outpostConfigRequest.EtcdPlacement = expandEtcdPlacementRequest(v)
+	}
+
 	if v, ok := tfMap["outpost_arns"].(*schema.Set); ok && v.Len() > 0 {
 		outpostConfigRequest.OutpostArns = flex.ExpandStringValueSet(v)
 	}
@@ -1415,6 +1462,29 @@ func expandControlPlanePlacementRequest(tfList []any) *types.ControlPlanePlaceme
 
 	if v, ok := tfMap[names.AttrGroupName].(string); ok && v != "" {
 		apiObject.GroupName = aws.String(v)
+	}
+
+	if v, ok := tfMap["spread_level"].(string); ok && v != "" {
+		apiObject.SpreadLevel = types.SpreadLevel(v)
+	}
+
+	return apiObject
+}
+
+func expandEtcdPlacementRequest(tfList []any) *types.EtcdPlacementRequest {
+	if len(tfList) == 0 {
+		return nil
+	}
+
+	tfMap, ok := tfList[0].(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	apiObject := &types.EtcdPlacementRequest{}
+
+	if v, ok := tfMap["spread_level"].(string); ok && v != "" {
+		apiObject.SpreadLevel = types.SpreadLevel(v)
 	}
 
 	return apiObject
@@ -1708,12 +1778,14 @@ func flattenOIDC(apiObject *types.OIDC) []map[string]any {
 }
 
 func flattenAccessConfigResponse(apiObject *types.AccessConfigResponse, bootstrapClusterCreatorAdminPermissions *bool) []any {
-	if apiObject == nil {
+	if apiObject == nil && bootstrapClusterCreatorAdminPermissions == nil {
 		return nil
 	}
 
-	tfMap := map[string]any{
-		"authentication_mode": apiObject.AuthenticationMode,
+	tfMap := map[string]any{}
+
+	if apiObject != nil {
+		tfMap["authentication_mode"] = apiObject.AuthenticationMode
 	}
 
 	if bootstrapClusterCreatorAdminPermissions != nil {
@@ -1831,6 +1903,8 @@ func flattenOutpostConfigResponse(apiObject *types.OutpostConfigResponse) []any 
 	tfMap := map[string]any{
 		"control_plane_instance_type": aws.ToString(apiObject.ControlPlaneInstanceType),
 		"control_plane_placement":     flattenControlPlanePlacementResponse(apiObject.ControlPlanePlacement),
+		"etcd_instance_type":          aws.ToString(apiObject.EtcdInstanceType),
+		"etcd_placement":              flattenEtcdPlacementResponse(apiObject.EtcdPlacement),
 		"outpost_arns":                apiObject.OutpostArns,
 	}
 
@@ -1895,6 +1969,20 @@ func flattenControlPlanePlacementResponse(apiObject *types.ControlPlanePlacement
 		names.AttrGroupName: aws.ToString(apiObject.GroupName),
 	}
 
+	if apiObject.SpreadLevel != "" {
+		tfMap["spread_level"] = string(apiObject.SpreadLevel)
+	}
+	return []any{tfMap}
+}
+
+func flattenEtcdPlacementResponse(apiObject *types.EtcdPlacementResponse) []any {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]any{
+		"spread_level": string(apiObject.SpreadLevel),
+	}
 	return []any{tfMap}
 }
 

--- a/internal/service/eks/cluster_data_source.go
+++ b/internal/service/eks/cluster_data_source.go
@@ -189,6 +189,26 @@ func dataSourceCluster() *schema.Resource {
 											Type:     schema.TypeString,
 											Computed: true,
 										},
+										"spread_level": {
+											Type:     schema.TypeString,
+											Computed: true,
+										},
+									},
+								},
+							},
+							"etcd_instance_type": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"etcd_placement": {
+								Type:     schema.TypeList,
+								Computed: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"spread_level": {
+											Type:     schema.TypeString,
+											Computed: true,
+										},
 									},
 								},
 							},

--- a/internal/service/eks/cluster_test.go
+++ b/internal/service/eks/cluster_test.go
@@ -1381,8 +1381,7 @@ func TestAccEKSCluster_Outpost_create(t *testing.T) {
 	var cluster types.Cluster
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_eks_cluster.test"
-	controlPlaneInstanceType := "m5d.large"
-
+	controlPlaneInstanceType, etcdInstanceType := "r7izde.4xlarge", "r7izde.4xlarge"
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckOutpostsOutposts(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EKSServiceID),
@@ -1393,9 +1392,9 @@ func TestAccEKSCluster_Outpost_create(t *testing.T) {
 				Config: testAccClusterConfig_outpost(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, t, resourceName, &cluster),
-					resource.TestMatchResourceAttr(resourceName, "cluster_id", regexache.MustCompile(`^[0-9A-Fa-f]{8}\b-[0-9A-Fa-f]{4}\b-[0-9A-Fa-f]{4}\b-[0-9A-Fa-f]{4}\b-[0-9A-Fa-f]{12}$`)),
 					resource.TestCheckResourceAttr(resourceName, "outpost_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "outpost_config.0.control_plane_instance_type", controlPlaneInstanceType),
+					resource.TestCheckResourceAttr(resourceName, "outpost_config.0.etcd_instance_type", etcdInstanceType),
 					resource.TestCheckResourceAttr(resourceName, "outpost_config.0.outpost_arns.#", "1"),
 				),
 			},
@@ -1414,7 +1413,7 @@ func TestAccEKSCluster_Outpost_placement(t *testing.T) {
 	var cluster types.Cluster
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_eks_cluster.test"
-	controlPlaneInstanceType := "m5d.large"
+	controlPlaneInstanceType, etcdInstanceType := "r7izde.4xlarge", "r7izde.4xlarge"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckOutpostsOutposts(ctx, t) },
@@ -1426,11 +1425,12 @@ func TestAccEKSCluster_Outpost_placement(t *testing.T) {
 				Config: testAccClusterConfig_outpostPlacement(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, t, resourceName, &cluster),
-					resource.TestMatchResourceAttr(resourceName, "cluster_id", regexache.MustCompile(`^[0-9A-Fa-f]{8}\b-[0-9A-Fa-f]{4}\b-[0-9A-Fa-f]{4}\b-[0-9A-Fa-f]{4}\b-[0-9A-Fa-f]{12}$`)),
 					resource.TestCheckResourceAttr(resourceName, "outpost_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "outpost_config.0.control_plane_instance_type", controlPlaneInstanceType),
+					resource.TestCheckResourceAttr(resourceName, "outpost_config.0.etcd_instance_type", etcdInstanceType),
 					resource.TestCheckResourceAttr(resourceName, "outpost_config.0.outpost_arns.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "outpost_config.0.control_plane_placement.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "outpost_config.0.etcd_placement.#", "1"),
 				),
 			},
 			{
@@ -2561,14 +2561,7 @@ data "aws_iam_role" "test" {
 }
 
 data "aws_outposts_outpost" "test" {
-  id = "op-XXXXXXXX"
-}
-
-data "aws_subnets" test {
-  filter {
-    name   = "outpost-arn"
-    values = [data.aws_outposts_outpost.test.arn]
-  }
+  id = "op-081f5c708b9fd009d"
 }
 
 resource "aws_eks_cluster" "test" {
@@ -2576,8 +2569,14 @@ resource "aws_eks_cluster" "test" {
   role_arn = data.aws_iam_role.test.arn
 
   outpost_config {
-    control_plane_instance_type = "m5d.large"
+    control_plane_instance_type = "r7izde.4xlarge"
+    etcd_instance_type          = "r7izde.4xlarge"
     outpost_arns                = [data.aws_outposts_outpost.test.arn]
+  }
+  access_config {
+    # Either "API" or "API_AND_CONFIG_MAP" is required with remote network config
+    authentication_mode                         = "API"
+    bootstrap_cluster_creator_admin_permissions = true
   }
 
   remote_network_config {
@@ -2589,7 +2588,7 @@ resource "aws_eks_cluster" "test" {
   vpc_config {
     endpoint_private_access = true
     endpoint_public_access  = false
-    subnet_ids              = [tolist(data.aws_subnets.test.ids)[0]]
+    subnet_ids              = ["subnet-064e055b1fd305a0d"]
   }
 }
 `, rName))
@@ -2601,17 +2600,8 @@ data "aws_iam_role" "test" {
   name = "AmazonEKSLocalOutpostClusterRole"
 }
 
-data "aws_outposts_outposts" "test" {}
-
 data "aws_outposts_outpost" "test" {
-  id = tolist(data.aws_outposts_outposts.test.ids)[0]
-}
-
-data "aws_subnets" test {
-  filter {
-    name   = "outpost-arn"
-    values = [data.aws_outposts_outpost.test.arn]
-  }
+  id = "op-081f5c708b9fd009d"
 }
 
 resource "aws_placement_group" "test" {
@@ -2624,17 +2614,27 @@ resource "aws_eks_cluster" "test" {
   role_arn = data.aws_iam_role.test.arn
 
   outpost_config {
-    control_plane_instance_type = "m5d.large"
+    control_plane_instance_type = "r7izde.4xlarge"
     control_plane_placement {
-      group_name = aws_placement_group.test.name
+      spread_level = "host"
+    }
+    etcd_instance_type          = "r7izde.4xlarge"
+    etcd_placement {
+      spread_level = "host"
     }
     outpost_arns = [data.aws_outposts_outpost.test.arn]
+  }
+
+  access_config {
+    # Either "API" or "API_AND_CONFIG_MAP" is required with remote network config
+    authentication_mode                         = "API"
+    bootstrap_cluster_creator_admin_permissions = true
   }
 
   vpc_config {
     endpoint_private_access = true
     endpoint_public_access  = false
-    subnet_ids              = [tolist(data.aws_subnets.test.ids)[0]]
+    subnet_ids              = ["subnet-064e055b1fd305a0d"]
   }
 }
 `, rName))

--- a/internal/service/eks/cluster_test.go
+++ b/internal/service/eks/cluster_test.go
@@ -2619,7 +2619,7 @@ resource "aws_eks_cluster" "test" {
     control_plane_placement {
       spread_level = "host"
     }
-    etcd_instance_type          = "r7izde.4xlarge"
+    etcd_instance_type = "r7izde.4xlarge"
     etcd_placement {
       spread_level = "host"
     }

--- a/internal/service/eks/cluster_test.go
+++ b/internal/service/eks/cluster_test.go
@@ -1381,7 +1381,8 @@ func TestAccEKSCluster_Outpost_create(t *testing.T) {
 	var cluster types.Cluster
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_eks_cluster.test"
-	controlPlaneInstanceType, etcdInstanceType := "r7izde.4xlarge", "r7izde.4xlarge"
+	controlPlaneInstanceType := "r7izde.4xlarge"
+	etcdInstanceType := "r7izde.4xlarge"
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckOutpostsOutposts(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EKSServiceID),
@@ -1413,8 +1414,8 @@ func TestAccEKSCluster_Outpost_placement(t *testing.T) {
 	var cluster types.Cluster
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_eks_cluster.test"
-	controlPlaneInstanceType, etcdInstanceType := "r7izde.4xlarge", "r7izde.4xlarge"
-
+	controlPlaneInstanceType := "r7izde.4xlarge"
+	etcdInstanceType := "r7izde.4xlarge"
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckOutpostsOutposts(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EKSServiceID),
@@ -2561,7 +2562,7 @@ data "aws_iam_role" "test" {
 }
 
 data "aws_outposts_outpost" "test" {
-  id = "op-081f5c708b9fd009d"
+  id = "op-XXXXXXXX"
 }
 
 resource "aws_eks_cluster" "test" {
@@ -2588,7 +2589,7 @@ resource "aws_eks_cluster" "test" {
   vpc_config {
     endpoint_private_access = true
     endpoint_public_access  = false
-    subnet_ids              = ["subnet-064e055b1fd305a0d"]
+    subnet_ids              = ["subnet-XXX"]
   }
 }
 `, rName))
@@ -2601,7 +2602,7 @@ data "aws_iam_role" "test" {
 }
 
 data "aws_outposts_outpost" "test" {
-  id = "op-081f5c708b9fd009d"
+  id = "op-XXXXXXXX"
 }
 
 resource "aws_placement_group" "test" {
@@ -2634,7 +2635,7 @@ resource "aws_eks_cluster" "test" {
   vpc_config {
     endpoint_private_access = true
     endpoint_public_access  = false
-    subnet_ids              = ["subnet-064e055b1fd305a0d"]
+    subnet_ids              = ["subnet-XXX"]
   }
 }
 `, rName))

--- a/website/docs/d/eks_cluster.html.markdown
+++ b/website/docs/d/eks_cluster.html.markdown
@@ -68,6 +68,10 @@ This data source exports the following attributes in addition to the arguments a
     * `control_plane_instance_type` - The Amazon EC2 instance type for all Kubernetes control plane instances.
     * `control_plane_placement` - An object representing the placement configuration for all the control plane instances of your local Amazon EKS cluster on AWS Outpost.
         * `group_name` - The name of the placement group for the Kubernetes control plane instances.
+        * `spread_level` - Placement group spread level for control plane instances.
+    * `etcd_instance_type` - Amazon EC2 instance type for etcd instances.
+    * `etcd_placement` -  Placement configuration for the etcd instances.
+        * `spread_level` - Placement group spread level for etcd instances.
     * `outpost_arns` - List of ARNs of the Outposts hosting the EKS cluster. Only a single ARN is supported currently.
 * `platform_version` - Platform version for the cluster.
 * `remote_network_config` - Contains remote network configuration for EKS Hybrid Nodes.

--- a/website/docs/d/eks_cluster.html.markdown
+++ b/website/docs/d/eks_cluster.html.markdown
@@ -70,7 +70,7 @@ This data source exports the following attributes in addition to the arguments a
         * `group_name` - The name of the placement group for the Kubernetes control plane instances.
         * `spread_level` - Placement group spread level for control plane instances.
     * `etcd_instance_type` - Amazon EC2 instance type for etcd instances.
-    * `etcd_placement` -  Placement configuration for the etcd instances.
+    * `etcd_placement` - Placement configuration for the etcd instances.
         * `spread_level` - Placement group spread level for etcd instances.
     * `outpost_arns` - List of ARNs of the Outposts hosting the EKS cluster. Only a single ARN is supported currently.
 * `platform_version` - Platform version for the cluster.

--- a/website/docs/r/eks_cluster.html.markdown
+++ b/website/docs/r/eks_cluster.html.markdown
@@ -464,8 +464,15 @@ The `outpost_config` configuration block supports the following arguments:
 * `control_plane_placement` - (Optional) An object representing the placement configuration for all the control plane instances of your local Amazon EKS cluster on AWS Outpost.
 The `control_plane_placement` configuration block supports the following arguments:
 
-    * `group_name` - (Required) The name of the placement group for the Kubernetes control plane instances. This setting can't be changed after cluster creation.
+    * `group_name` - (Optional) The name of the placement group for the Kubernetes control plane instances. This setting can't be changed after cluster creation.
+    * `spread_level` - (Optional) Placement group spread level for control plane instances. Valid values: `host`, `rack`.
 
+* `etcd_instance_type` - (Optional) Amazon EC2 instance type for etcd instances of your local Amazon EKS cluster on AWS Outposts.
+* `etcd_placement` - (Optional) Placement configuration for the etcd instances of your local Amazon EKS cluster on an AWS Outpost.
+The `etcd_placement` configuration block supports the following arguments:
+
+    * `spread_level` - (Optional) Placement group spread level for etcd instances. Valid values: `host`, `rack`.
+  
 * `outpost_arns` - (Required) The ARN of the Outpost that you want to use for your local Amazon EKS cluster on Outposts. This argument is a list of arns, but only a single Outpost ARN is supported currently.
 
 ### storage_config

--- a/website/docs/r/eks_cluster.html.markdown
+++ b/website/docs/r/eks_cluster.html.markdown
@@ -464,7 +464,7 @@ The `outpost_config` configuration block supports the following arguments:
 * `control_plane_placement` - (Optional) An object representing the placement configuration for all the control plane instances of your local Amazon EKS cluster on AWS Outpost.
 The `control_plane_placement` configuration block supports the following arguments:
 
-    * `group_name` - (Optional) The name of the placement group for the Kubernetes control plane instances. This setting can't be changed after cluster creation.
+    * `group_name` - (Optional) Name of the placement group for the Kubernetes control plane instances. This setting can't be changed after cluster creation.
     * `spread_level` - (Optional) Placement group spread level for control plane instances. Valid values: `host`, `rack`.
 
 * `etcd_instance_type` - (Optional) Amazon EC2 instance type for etcd instances of your local Amazon EKS cluster on AWS Outposts.
@@ -472,7 +472,7 @@ The `control_plane_placement` configuration block supports the following argumen
 The `etcd_placement` configuration block supports the following arguments:
 
     * `spread_level` - (Optional) Placement group spread level for etcd instances. Valid values: `host`, `rack`.
-  
+
 * `outpost_arns` - (Required) The ARN of the Outpost that you want to use for your local Amazon EKS cluster on Outposts. This argument is a list of arns, but only a single Outpost ARN is supported currently.
 
 ### storage_config


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

No changes to Security Controls 

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

* [Announcement](https://aws.amazon.com/about-aws/whats-new/2026/06/amazon-eks-aws-outposts-ec2-instance-store/)

AWS is launching a new version for Amazon EKS local clusters on AWS Outposts that comes with changes in the `outpost_config` object and some API changes. The API and SDK's are already released [[ref](https://github.com/aws/aws-sdk-go-v2/blob/release-2026-06-11/service/eks/CHANGELOG.md)]. Public documentation and announcement will be available at later point (either on Friday or Monday). Below is the updated `outpost_config` object:

```
outpost_config {
  control_plane_instance_type = "m5d.large"
  control_plane_placement {
    group_name   = "my-group"   # OLD, becomes optional
    spread_level = "rack"               # NEW - optional, values: "host" | "rack"
  }
  outpost_arns           = ["arn:aws:outposts:us-west-2:1234:outpost/op-1234"]
  etcd_instance_type     = "m5d.large"  # NEW - optional string
  etcd_placement {                      # NEW - optional block
    spread_level = "rack"               # optional, values: "host" | "rack"
  }
}
``` 
The EKS API will route requests based on 1) the new parameters introduced with this update, and 2) whether the AWS Outpost boots EC2 instance from Amazon EBS or EC2 instance store. To launch a local Amazon EKS cluster on an Outpost backed by Amazon EC2 instance store, customers must pass the new `etcd_instance_type` parameter. Previously, Amazon EBS was a prerequisite for running local EKS clusters on Outposts. Customers creating local clusters on Amazon EBS-backed Outposts will not pass the new parameters, maintaining backward compatibility.

Acceptance tests have been modified to handle the case of Outpost backed by EC2 instance store and passed `etcd_instance_type`.

### Output from Acceptance Testing
Running the tests in 2 passes, because of constrained Outpost capacity 


```console
$ make build && make testacc TESTARGS="-run='TestAccEKSCluster_Outpost_create'" PKG=eks

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Building provider...
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2	(cached)
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider/framework	(cached)
make: Running acceptance tests on branch: 🌿 f-aw_eks-new-outpost-version 🌿...
TF_ACC=1 go1.26.3 test ./internal/service/eks/... -v -count 1 -parallel 20  -run='TestAccEKSCluster_Outpost_create' -timeout 360m -vet=off -buildvcs=false
2026/06/11 13:26:28 Creating Terraform AWS Provider (SDKv2-style)...
2026/06/11 13:26:28 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccEKSCluster_Outpost_create
=== PAUSE TestAccEKSCluster_Outpost_create
=== CONT  TestAccEKSCluster_Outpost_create
--- PASS: TestAccEKSCluster_Outpost_create (1087.66s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/eks	1087.925s


$ make build && make testacc TESTARGS="-run='TestAccEKSCluster_Outpost_placement|TestAccEKSCluster_VPC_securityGroupIDs$|TestAccEKSCluster_VPC_securityGroupIDsAndSubnetIDs_update|TestAccEKSCluster_RemoteNetwork_Node_OnCreate|TestAccEKSCluster_RemoteNetwork_Node_OnUpdate|TestAccEKSCluster_RemoteNetwork_Pod_OnCreate|TestAccEKSCluster_RemoteNetwork_Pod_OnUpdate'" PKG=eks


make build && make testacc TESTARGS="-run='TestAccEKSCluster_Outpost_placement|TestAccEKSCluster_VPC_securityGroupIDs$|TestAccEKSCluster_VPC_securityGroupIDsAndSubnetIDs_update|TestAccEKSCluster_RemoteNetwork_Node_OnCreate|TestAccEKSCluster_RemoteNetwork_Node_OnUpdate|TestAccEKSCluster_RemoteNetwork_Pod_OnCreate|TestAccEKSCluster_RemoteNetwork_Pod_OnUpdate'" PKG=eks
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Building provider...
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2	(cached)
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider/framework	(cached)
make: Running acceptance tests on branch: 🌿 f-aw_eks-new-outpost-version 🌿...
TF_ACC=1 go1.26.3 test ./internal/service/eks/... -v -count 1 -parallel 20  -run='TestAccEKSCluster_Outpost_placement|TestAccEKSCluster_VPC_securityGroupIDsTestAccEKSCluster_VPC_securityGroupIDsAndSubnetIDs_update|TestAccEKSCluster_RemoteNetwork_Node_OnCreate|TestAccEKSCluster_RemoteNetwork_Node_OnUpdate|TestAccEKSCluster_RemoteNetwork_Pod_OnCreate|TestAccEKSCluster_RemoteNetwork_Pod_OnUpdate' -timeout 360m -vet=off -buildvcs=false
2026/06/11 14:17:00 Creating Terraform AWS Provider (SDKv2-style)...
2026/06/11 14:17:00 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccEKSCluster_Outpost_placement
=== PAUSE TestAccEKSCluster_Outpost_placement
=== RUN   TestAccEKSCluster_RemoteNetwork_Node_OnCreate
=== PAUSE TestAccEKSCluster_RemoteNetwork_Node_OnCreate
=== RUN   TestAccEKSCluster_RemoteNetwork_Node_OnUpdate
=== PAUSE TestAccEKSCluster_RemoteNetwork_Node_OnUpdate
=== RUN   TestAccEKSCluster_RemoteNetwork_Pod_OnCreate
=== PAUSE TestAccEKSCluster_RemoteNetwork_Pod_OnCreate
=== RUN   TestAccEKSCluster_RemoteNetwork_Pod_OnUpdate
=== PAUSE TestAccEKSCluster_RemoteNetwork_Pod_OnUpdate
=== CONT  TestAccEKSCluster_Outpost_placement
=== CONT  TestAccEKSCluster_RemoteNetwork_Pod_OnCreate
=== CONT  TestAccEKSCluster_RemoteNetwork_Node_OnUpdate
=== CONT  TestAccEKSCluster_RemoteNetwork_Pod_OnUpdate
=== CONT  TestAccEKSCluster_RemoteNetwork_Node_OnCreate
--- PASS: TestAccEKSCluster_RemoteNetwork_Pod_OnCreate (590.25s)
--- PASS: TestAccEKSCluster_RemoteNetwork_Node_OnCreate (705.95s)
--- PASS: TestAccEKSCluster_Outpost_placement (1179.57s)
--- PASS: TestAccEKSCluster_RemoteNetwork_Node_OnUpdate (1697.62s)
--- PASS: TestAccEKSCluster_RemoteNetwork_Pod_OnUpdate (1701.62s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/eks	1702.054s

...
```
