### PR TITLE
r/aws_kinesis_firehose_delivery_stream: broaden InvalidArgumentException match for unsupported ExtendedS3 fields

### DIFF
--- a/.changelog/48369.txt
+++ b/.changelog/48369.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_kinesis_firehose_delivery_stream: Fix `InvalidArgumentException` errors when creating or updating `extended_s3_configuration` in AWS partitions that report unsupported `custom_time_zone` and `file_extension` attributes in a combined error message
+```

--- a/internal/service/firehose/delivery_stream.go
+++ b/internal/service/firehose/delivery_stream.go
@@ -1572,7 +1572,7 @@ func resourceDeliveryStreamCreate(ctx context.Context, d *schema.ResourceData, m
 	// standard partition, strip the fields and retry.
 	if partition != endpoints.AwsPartitionID && input.ExtendedS3DestinationConfiguration != nil &&
 		(tfawserr.ErrMessageContains(err, errCodeValidationException, "ExtendedS3DestinationConfiguration") ||
-			tfawserr.ErrMessageContains(err, errCodeInvalidArgumentException, "S3 File Extension parameters")) {
+			tfawserr.ErrMessageContains(err, errCodeInvalidArgumentException, "S3 File Extension")) {
 		input.ExtendedS3DestinationConfiguration.CustomTimeZone = nil
 		input.ExtendedS3DestinationConfiguration.FileExtension = nil
 		_, err = retryDeliveryStreamOp(ctx, func(ctx context.Context) (any, error) {
@@ -1783,7 +1783,7 @@ func resourceDeliveryStreamUpdate(ctx context.Context, d *schema.ResourceData, m
 		// standard partition, strip the fields and retry.
 		if partition != endpoints.AwsPartitionID && input.ExtendedS3DestinationUpdate != nil &&
 			(tfawserr.ErrMessageContains(err, errCodeValidationException, "ExtendedS3DestinationUpdate") ||
-				tfawserr.ErrMessageContains(err, errCodeInvalidArgumentException, "S3 File Extension parameters")) {
+				tfawserr.ErrMessageContains(err, errCodeInvalidArgumentException, "S3 File Extension")) {
 			input.ExtendedS3DestinationUpdate.CustomTimeZone = nil
 			input.ExtendedS3DestinationUpdate.FileExtension = nil
 			_, err = retryDeliveryStreamOp(ctx, func(ctx context.Context) (any, error) {


### PR DESCRIPTION
### Description

The partition-aware retry that strips `custom_time_zone` and `file_extension`
from `extended_s3_configuration` (added in #48284) matches the
`InvalidArgumentException` path on the literal substring
`"S3 File Extension parameters"`. The control plane in affected partitions
actually returns:

> S3 File Extension and Custom Time Zone parameters is not available in the current region.

Here `S3 File Extension` and `parameters` are not adjacent, so the guard does not
fire and the apply fails.

This PR broadens both the create and update guards to match on the stable
substring `"S3 File Extension"`, which is present in both the original and the
combined message wordings. The `partition != endpoints.AwsPartitionID` check is
unchanged, so behavior in the standard AWS partition is unaffected.

### Relations

Closes #48368
Relates #48284

### References

* #48186
* #48282 / #48284

### Output from Acceptance Testing

Acceptance tests for this resource require a non-standard (e.g. ISO) partition
and cannot be exercised from the standard partition, so the relevant
`TestAccFirehoseDeliveryStream_*` cases are unaffected. The change is a
substring broadening with no behavioral change in supported partitions.
```