### PR TITLE
service/apigateway: fix ip_address_type for private REST APIs in regi…

### DIFF
--- a/.changelog/48370.txt
+++ b/.changelog/48370.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_api_gatewway_rest_api: Allow ip_address_type of ipv4 for PRIVATE endpoint type in regions where dualstack is not supported
+resource/aws_api_gateway_rest_api: Allow ip_address_type of ipv4 for PRIVATE endpoint type in regions where dualstack is not supported
 ```

--- a/.changelog/48370.txt
+++ b/.changelog/48370.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_api_gatewway_rest_api: Allow ip_address_type of ipv4 for PRIVATE endpoint type in regions where dualstack is not supported
+```

--- a/internal/service/apigateway/rest_api.go
+++ b/internal/service/apigateway/rest_api.go
@@ -17,6 +17,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
 	"github.com/aws/aws-sdk-go-v2/service/apigateway/types"
+	"github.com/hashicorp/aws-sdk-go-base/v2/endpoints"
 	awspolicy "github.com/hashicorp/awspolicyequivalence"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -605,15 +606,29 @@ func resourceRestAPIDelete(ctx context.Context, d *schema.ResourceData, meta any
 	return diags
 }
 
-func endpointConfigurationPlantimeValidate(_ context.Context, diff *schema.ResourceDiff, v any) error {
+func isDualStackUnsupportedPartition(partition string) bool {
+	switch partition {
+	case endpoints.AwsIsoPartitionID,
+		endpoints.AwsIsoBPartitionID,
+		endpoints.AwsIsoEPartitionID,
+		endpoints.AwsIsoFPartitionID:
+		return true
+	}
+	return false
+}
+
+func endpointConfigurationPlantimeValidate(ctx context.Context, diff *schema.ResourceDiff, meta any) error {
 	if v, ok := diff.GetOk("endpoint_configuration"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
 		if apiObject := expandEndpointConfiguration(v.([]any)[0].(map[string]any)); apiObject != nil {
 			if apiObject.Types[0] == types.EndpointTypePrivate && apiObject.IpAddressType == types.IpAddressTypeIpv4 {
-				return fmt.Errorf("endpoint_configuration type %[1]q requires ip_address_type %[2]q", types.EndpointTypePrivate, types.IpAddressTypeDualstack)
+				if client, ok := meta.(*conns.AWSClient); ok && client != nil {
+					if !isDualStackUnsupportedPartition(client.Partition(ctx)) {
+						return fmt.Errorf("endpoint_configuration type %[1]q requires ip_address_type %[2]q", types.EndpointTypePrivate, types.IpAddressTypeDualstack)
+					}
+				}
 			}
 		}
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
**N/A**

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Fixes plan time validation for private REST APIs in regions where dual stack/ipv6 are not supported. Essentially skipping the validation for these partitions allowing the API remain the source of truth since API Gateway returns `ipv4` in these partitions where `dualstack` is the only supported endpoint type elsewhere.
- Updated `v` param to `meta` to prevent variable shadowing

Running **`TestAccAPIGatewayRestAPI_ipAddressType_privateError`** to ensure no regression in standard partitions.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #48356

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccAPIGatewayRestAPI_ipAddressType_privateError PKG=apigateway
make: Running acceptance tests on branch: 🌿 main 🌿...
TF_ACC=1 go1.26.3 test ./internal/service/apigateway/... -v -count 1 -parallel 20 -run='TestAccAPIGatewayRestAPI_ipAddressType_privateError'  -timeout 360m -vet=off -buildvcs=false
2026/06/11 23:38:41 Creating Terraform AWS Provider (SDKv2-style)...2026/06/11 23:38:41 Initializing Terraform AWS Provider (SDKv2-style)...=== RUN   TestAccAPIGatewayRestAPI_ipAddressType_privateError=== PAUSE TestAccAPIGatewayRestAPI_ipAddressType_privateError=== CONT  TestAccAPIGatewayRestAPI_ipAddressType_privateError--- PASS: TestAccAPIGatewayRestAPI_ipAddressType_privateError (2.92s)PASSok      github.com/hashicorp/terraform-provider-aws/internal/service/apigateway 3.056s

...
```
