### PR TITLE
resource/aws_rolesanywhere_profile: add enhanced region support

### DIFF
--- a/.changelog/48377.txt
+++ b/.changelog/48377.txt
@@ -1,0 +1,2 @@
+```release-note:enhancement
+resource/aws_rolesanywhere_profile: Add enhanced Region support

--- a/internal/service/rolesanywhere/profile.go
+++ b/internal/service/rolesanywhere/profile.go
@@ -26,6 +26,7 @@ import (
 )
 
 // @SDKResource("aws_rolesanywhere_profile", name="Profile")
+// @V60SDKv2Fix
 // @Tags(identifierAttribute="arn")
 func resourceProfile() *schema.Resource {
 	return &schema.Resource{
@@ -171,7 +172,7 @@ func resourceProfileUpdate(ctx context.Context, d *schema.ResourceData, meta any
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RolesAnywhereClient(ctx)
 
-	if d.HasChangesExcept(names.AttrTags, names.AttrTagsAll) {
+	if d.HasChangesExcept(names.AttrRegion, names.AttrTags, names.AttrTagsAll) {
 		input := rolesanywhere.UpdateProfileInput{
 			ProfileId: aws.String(d.Id()),
 		}

--- a/internal/service/rolesanywhere/profile_test.go
+++ b/internal/service/rolesanywhere/profile_test.go
@@ -48,6 +48,32 @@ func TestAccRolesAnywhereProfile_basic(t *testing.T) {
 	})
 }
 
+func TestAccRolesAnywhereProfile_region(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	roleName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_rolesanywhere_profile.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.RolesAnywhereServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckProfileDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProfileConfig_region(rName, roleName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					resource.TestCheckResourceAttr(resourceName, names.AttrRegion, acctest.AlternateRegion()),
+					resource.TestCheckResourceAttr(resourceName, "role_arns.#", "1"),
+					acctest.CheckResourceAttrGlobalARN(ctx, resourceName, "role_arns.0", "iam", fmt.Sprintf("role/%s", roleName)),
+					resource.TestCheckResourceAttr(resourceName, "duration_seconds", "3600"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccRolesAnywhereProfile_noRoleARNs(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
@@ -322,6 +348,18 @@ resource "aws_rolesanywhere_profile" "test" {
   role_arns = [aws_iam_role.test.arn]
 }
 `, rName))
+}
+
+func testAccProfileConfig_region(rName, roleName string) string {
+	return acctest.ConfigCompose(
+		testAccProfileConfig_base(roleName),
+		fmt.Sprintf(`
+resource "aws_rolesanywhere_profile" "test" {
+  region    = %[1]q
+  name      = %[2]q
+  role_arns = [aws_iam_role.test.arn]
+}
+`, acctest.AlternateRegion(), rName))
 }
 
 func testAccProfileConfig_noRoleARNs(rName string) string {

--- a/internal/service/rolesanywhere/service_package_gen.go
+++ b/internal/service/rolesanywhere/service_package_gen.go
@@ -41,7 +41,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*inttypes.ServicePa
 			Tags: unique.Make(inttypes.ServicePackageResourceTags{
 				IdentifierAttribute: names.AttrARN,
 			}),
-			Region: inttypes.ResourceRegionDisabled(),
+			Region: inttypes.ResourceRegionDefault(),
 		},
 		{
 			Factory:  resourceTrustAnchor,

--- a/internal/service/rolesanywhere/service_package_gen.go
+++ b/internal/service/rolesanywhere/service_package_gen.go
@@ -50,7 +50,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*inttypes.ServicePa
 			Tags: unique.Make(inttypes.ServicePackageResourceTags{
 				IdentifierAttribute: names.AttrARN,
 			}),
-			Region: inttypes.ResourceRegionDisabled(),
+			Region: inttypes.ResourceRegionDefault(),
 		},
 	}
 }

--- a/names/data/names_data.hcl
+++ b/names/data/names_data.hcl
@@ -7336,7 +7336,6 @@ service "rolesanywhere" {
   doc_prefix               = ["rolesanywhere_"]
   brand                    = "AWS"
 
-  is_global = true
 }
 
 service "route53" {

--- a/website/docs/r/rolesanywhere_profile.html.markdown
+++ b/website/docs/r/rolesanywhere_profile.html.markdown
@@ -44,6 +44,7 @@ resource "aws_rolesanywhere_profile" "test" {
 
 This resource supports the following arguments:
 
+* `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `duration_seconds` - (Optional) The number of seconds the vended session credentials are valid for. Defaults to 3600.
 * `enabled` - (Optional) Whether or not the Profile is enabled.
 * `managed_policy_arns` - (Optional) A list of managed policy ARNs that apply to the vended session credentials.


### PR DESCRIPTION
## Rollback Plan

If this change needs to be reverted, it can be reverted in a follow-up provider release.

## Changes to Security Controls

No direct changes to security controls.

### Description

Adds enhanced resource-level `region` support for `aws_rolesanywhere_profile`.

IAM Roles Anywhere profiles are regional resources. This change enables the resource to use the provider's enhanced Region support so a single provider configuration can manage profiles in multiple Regions.

Changes included:

- Adds `@V60SDKv2Fix` to `aws_rolesanywhere_profile`
- Excludes `names.AttrRegion` from normal update diff handling
- Corrects IAM Roles Anywhere service metadata so generated resource metadata enables enhanced Region support.
- Adds documentation for the `region` argument
- Adds an acceptance test for resource-level Region support

### Relations

Closes #48376

### References

- AWS IAM Roles Anywhere resources are regional:
  https://docs.aws.amazon.com/rolesanywhere/latest/userguide/introduction.html

- AWS IAM Roles Anywhere regional endpoints:
  https://docs.aws.amazon.com/general/latest/gr/rolesanywhere.html

- AWS CLI `rolesanywhere create-profile` supports `--region`:
  https://docs.aws.amazon.com/cli/latest/reference/rolesanywhere/create-profile.html#global-options

### Output from Acceptance Testing

```console
% make testacc TESTS=TestAccRolesAnywhereProfile_region PKG=rolesanywhere
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2  (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework (cached)
make: Running acceptance tests on branch: 🌿 enhancement/rolesanywhere-profile-region 🌿...
TF_ACC=1 go1.26.3 test ./internal/service/rolesanywhere/... -v -count 1 -parallel 20 -run='TestAccRolesAnywhereProfile_region'  -timeout 360m -vet=off -buildvcs=false
2026/06/14 22:37:02 Creating Terraform AWS Provider (SDKv2-style)...
2026/06/14 22:37:02 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccRolesAnywhereProfile_region
=== PAUSE TestAccRolesAnywhereProfile_region
=== CONT  TestAccRolesAnywhereProfile_region
--- PASS: TestAccRolesAnywhereProfile_region (15.18s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/rolesanywhere      22.439s
```