### PR TITLE
Added a new ARC Region Switch execution block for Lambda ESM

### DIFF
--- a/.changelog/48382.txt
+++ b/.changelog/48382.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_arcregionswitch_plan: Add `lambda_event_source_mapping_config` execution block support
+```

--- a/internal/service/arcregionswitch/plan.go
+++ b/internal/service/arcregionswitch/plan.go
@@ -397,6 +397,58 @@ func eksResourceScalingConfigBlock(ctx context.Context) fwschema.Block {
 	}
 }
 
+func lambdaEventSourceMappingConfigBlock(ctx context.Context) fwschema.Block {
+	return fwschema.ListNestedBlock{
+		CustomType: fwtypes.NewListNestedObjectTypeOf[lambdaEventSourceMappingConfigModel](ctx),
+		NestedObject: fwschema.NestedBlockObject{
+			Attributes: map[string]fwschema.Attribute{
+				names.AttrAction: fwschema.StringAttribute{
+					CustomType: fwtypes.StringEnumType[awstypes.EventSourceMappingAction](),
+					Required:   true,
+				},
+				"timeout_minutes": fwschema.Int32Attribute{
+					Optional: true,
+				},
+			},
+			Blocks: map[string]fwschema.Block{
+				"event_source_mapping": fwschema.SetNestedBlock{
+					CustomType: fwtypes.NewSetNestedObjectTypeOf[eventSourceMappingModel](ctx),
+					NestedObject: fwschema.NestedBlockObject{
+						Attributes: map[string]fwschema.Attribute{
+							names.AttrARN: fwschema.StringAttribute{
+								Required: true,
+							},
+							"cross_account_role": fwschema.StringAttribute{
+								Optional: true,
+							},
+							names.AttrExternalID: fwschema.StringAttribute{
+								Optional: true,
+							},
+							names.AttrRegion: fwschema.StringAttribute{
+								Required: true,
+							},
+						},
+					},
+				},
+				"ungraceful": fwschema.ListNestedBlock{
+					CustomType: fwtypes.NewListNestedObjectTypeOf[lambdaESMUngracefulModel](ctx),
+					NestedObject: fwschema.NestedBlockObject{
+						Attributes: map[string]fwschema.Attribute{
+							"behavior": fwschema.StringAttribute{
+								CustomType: fwtypes.StringEnumType[awstypes.LambdaEventSourceMappingUngracefulBehavior](),
+								Required:   true,
+							},
+						},
+					},
+					Validators: []validator.List{
+						listvalidator.SizeAtMost(1),
+					},
+				},
+			},
+		},
+	}
+}
+
 func executionApprovalConfigBlock(ctx context.Context) fwschema.Block {
 	return fwschema.ListNestedBlock{
 		CustomType: fwtypes.NewListNestedObjectTypeOf[executionApprovalConfigModel](ctx),
@@ -731,6 +783,7 @@ func (r *resourcePlan) Schema(ctx context.Context, req resource.SchemaRequest, r
 									"eks_resource_scaling_config":                 eksResourceScalingConfigBlock(ctx),
 									"execution_approval_config":                   executionApprovalConfigBlock(ctx),
 									"global_aurora_config":                        globalAuroraConfigBlock(ctx),
+									"lambda_event_source_mapping_config":          lambdaEventSourceMappingConfigBlock(ctx),
 									"rds_create_cross_region_read_replica_config": rdsCreateCrossRegionReadReplicaConfigBlock(ctx),
 									"rds_promote_read_replica_config":             rdsPromoteReadReplicaConfigBlock(ctx),
 									"region_switch_plan_config":                   regionSwitchPlanConfigBlock(ctx),
@@ -762,6 +815,7 @@ func (r *resourcePlan) Schema(ctx context.Context, req resource.SchemaRequest, r
 															"eks_resource_scaling_config":                 eksResourceScalingConfigBlock(ctx),
 															"execution_approval_config":                   executionApprovalConfigBlock(ctx),
 															"global_aurora_config":                        globalAuroraConfigBlock(ctx),
+															"lambda_event_source_mapping_config":          lambdaEventSourceMappingConfigBlock(ctx),
 															"rds_create_cross_region_read_replica_config": rdsCreateCrossRegionReadReplicaConfigBlock(ctx),
 															"rds_promote_read_replica_config":             rdsPromoteReadReplicaConfigBlock(ctx),
 															"region_switch_plan_config":                   regionSwitchPlanConfigBlock(ctx),
@@ -1141,6 +1195,7 @@ type stepModel struct {
 	ExecutionApprovalConfig               fwtypes.ListNestedObjectValueOf[executionApprovalConfigModel]               `tfsdk:"execution_approval_config" autoflex:"-"`
 	ExecutionBlockType                    fwtypes.StringEnum[awstypes.ExecutionBlockType]                             `tfsdk:"execution_block_type"`
 	GlobalAuroraConfig                    fwtypes.ListNestedObjectValueOf[globalAuroraConfigModel]                    `tfsdk:"global_aurora_config" autoflex:"-"`
+	LambdaEventSourceMappingConfig        fwtypes.ListNestedObjectValueOf[lambdaEventSourceMappingConfigModel]        `tfsdk:"lambda_event_source_mapping_config" autoflex:"-"`
 	Name                                  types.String                                                                `tfsdk:"name"`
 	ParallelConfig                        fwtypes.ListNestedObjectValueOf[parallelConfigModel]                        `tfsdk:"parallel_config" autoflex:"-"`
 	RdsCreateCrossRegionReadReplicaConfig fwtypes.ListNestedObjectValueOf[rdsCreateCrossRegionReadReplicaConfigModel] `tfsdk:"rds_create_cross_region_read_replica_config" autoflex:"-"`
@@ -1264,6 +1319,18 @@ func (m stepModel) Expand(ctx context.Context) (any, fwdiag.Diagnostics) {
 			return nil, diags
 		}
 		result.ExecutionBlockConfiguration = &r
+	case !m.LambdaEventSourceMappingConfig.IsNull():
+		config, d := m.LambdaEventSourceMappingConfig.ToPtr(ctx)
+		diags.Append(d...)
+		if diags.HasError() {
+			return nil, diags
+		}
+		var r awstypes.ExecutionBlockConfigurationMemberLambdaEventSourceMappingConfig
+		diags.Append(flex.Expand(ctx, config, &r.Value)...)
+		if diags.HasError() {
+			return nil, diags
+		}
+		result.ExecutionBlockConfiguration = &r
 	case !m.ParallelConfig.IsNull():
 		config, d := m.ParallelConfig.ToPtr(ctx)
 		diags.Append(d...)
@@ -1365,6 +1432,8 @@ func (m *stepModel) Flatten(ctx context.Context, v any) fwdiag.Diagnostics {
 			diags.Append(flex.Flatten(ctx, &v.Value, &m.ExecutionApprovalConfig)...)
 		case *awstypes.ExecutionBlockConfigurationMemberGlobalAuroraConfig:
 			diags.Append(flex.Flatten(ctx, &v.Value, &m.GlobalAuroraConfig)...)
+		case *awstypes.ExecutionBlockConfigurationMemberLambdaEventSourceMappingConfig:
+			diags.Append(flex.Flatten(ctx, &v.Value, &m.LambdaEventSourceMappingConfig)...)
 		case *awstypes.ExecutionBlockConfigurationMemberParallelConfig:
 			diags.Append(flex.Flatten(ctx, &v.Value, &m.ParallelConfig)...)
 		case *awstypes.ExecutionBlockConfigurationMemberRegionSwitchPlanConfig:
@@ -1712,6 +1781,107 @@ type executionApprovalConfigModel struct {
 	TimeoutMinutes types.Int32  `tfsdk:"timeout_minutes"`
 }
 
+// Lambda Event Source Mapping Configuration Models
+type lambdaEventSourceMappingConfigModel struct {
+	Action              fwtypes.StringEnum[awstypes.EventSourceMappingAction]     `tfsdk:"action"`
+	EventSourceMappings fwtypes.SetNestedObjectValueOf[eventSourceMappingModel]   `tfsdk:"event_source_mapping" autoflex:"-"`
+	TimeoutMinutes      types.Int32                                               `tfsdk:"timeout_minutes"`
+	Ungraceful          fwtypes.ListNestedObjectValueOf[lambdaESMUngracefulModel] `tfsdk:"ungraceful"`
+}
+
+var (
+	_ flex.Expander  = lambdaEventSourceMappingConfigModel{}
+	_ flex.Flattener = &lambdaEventSourceMappingConfigModel{}
+)
+
+func (m lambdaEventSourceMappingConfigModel) Expand(ctx context.Context) (any, fwdiag.Diagnostics) {
+	var result awstypes.LambdaEventSourceMappingConfiguration
+	var diags fwdiag.Diagnostics
+
+	diags.Append(flex.Expand(ctx, m.Action, &result.Action)...)
+	diags.Append(flex.Expand(ctx, m.TimeoutMinutes, &result.TimeoutMinutes)...)
+	diags.Append(flex.Expand(ctx, m.Ungraceful, &result.Ungraceful)...)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	if !m.EventSourceMappings.IsNull() && !m.EventSourceMappings.IsUnknown() {
+		var mappings []eventSourceMappingModel
+		diags.Append(m.EventSourceMappings.ElementsAs(ctx, &mappings, false)...)
+		if diags.HasError() {
+			return nil, diags
+		}
+
+		result.RegionEventSourceMappings = make(map[string]awstypes.EventSourceMapping, len(mappings))
+		for _, mapping := range mappings {
+			region := mapping.Region.ValueString()
+			esm := awstypes.EventSourceMapping{
+				Arn: mapping.ARN.ValueStringPointer(),
+			}
+			if !mapping.CrossAccountRole.IsNull() && !mapping.CrossAccountRole.IsUnknown() {
+				esm.CrossAccountRole = mapping.CrossAccountRole.ValueStringPointer()
+			}
+			if !mapping.ExternalID.IsNull() && !mapping.ExternalID.IsUnknown() {
+				esm.ExternalId = mapping.ExternalID.ValueStringPointer()
+			}
+			result.RegionEventSourceMappings[region] = esm
+		}
+	}
+
+	return &result, diags
+}
+
+func (m *lambdaEventSourceMappingConfigModel) Flatten(ctx context.Context, v any) fwdiag.Diagnostics {
+	var diags fwdiag.Diagnostics
+
+	config, ok := v.(awstypes.LambdaEventSourceMappingConfiguration)
+	if !ok {
+		diags.AddError("Unexpected Type", "Expected awstypes.LambdaEventSourceMappingConfiguration")
+		return diags
+	}
+
+	diags.Append(flex.Flatten(ctx, config.Action, &m.Action)...)
+	diags.Append(flex.Flatten(ctx, config.TimeoutMinutes, &m.TimeoutMinutes)...)
+	diags.Append(flex.Flatten(ctx, config.Ungraceful, &m.Ungraceful)...)
+	if diags.HasError() {
+		return diags
+	}
+
+	if len(config.RegionEventSourceMappings) > 0 {
+		mappings := make([]eventSourceMappingModel, 0, len(config.RegionEventSourceMappings))
+		for region, esm := range config.RegionEventSourceMappings {
+			mapping := eventSourceMappingModel{
+				ARN:    types.StringValue(aws.ToString(esm.Arn)),
+				Region: types.StringValue(region),
+			}
+			if esm.CrossAccountRole != nil {
+				mapping.CrossAccountRole = types.StringValue(aws.ToString(esm.CrossAccountRole))
+			}
+			if esm.ExternalId != nil {
+				mapping.ExternalID = types.StringValue(aws.ToString(esm.ExternalId))
+			}
+			mappings = append(mappings, mapping)
+		}
+
+		var d fwdiag.Diagnostics
+		m.EventSourceMappings, d = fwtypes.NewSetNestedObjectValueOfValueSlice(ctx, mappings)
+		diags.Append(d...)
+	}
+
+	return diags
+}
+
+type eventSourceMappingModel struct {
+	ARN              types.String `tfsdk:"arn"`
+	CrossAccountRole types.String `tfsdk:"cross_account_role"`
+	ExternalID       types.String `tfsdk:"external_id"`
+	Region           types.String `tfsdk:"region"`
+}
+
+type lambdaESMUngracefulModel struct {
+	Behavior fwtypes.StringEnum[awstypes.LambdaEventSourceMappingUngracefulBehavior] `tfsdk:"behavior"`
+}
+
 // Global Aurora Configuration Models
 type globalAuroraConfigModel struct {
 	Behavior                fwtypes.StringEnum[awstypes.GlobalAuroraDefaultBehavior]     `tfsdk:"behavior"`
@@ -1743,6 +1913,7 @@ type parallelStepModel struct {
 	ExecutionApprovalConfig               fwtypes.ListNestedObjectValueOf[executionApprovalConfigModel]               `tfsdk:"execution_approval_config" autoflex:"-"`
 	ExecutionBlockType                    fwtypes.StringEnum[awstypes.ExecutionBlockType]                             `tfsdk:"execution_block_type"`
 	GlobalAuroraConfig                    fwtypes.ListNestedObjectValueOf[globalAuroraConfigModel]                    `tfsdk:"global_aurora_config" autoflex:"-"`
+	LambdaEventSourceMappingConfig        fwtypes.ListNestedObjectValueOf[lambdaEventSourceMappingConfigModel]        `tfsdk:"lambda_event_source_mapping_config" autoflex:"-"`
 	Name                                  types.String                                                                `tfsdk:"name"`
 	RdsCreateCrossRegionReadReplicaConfig fwtypes.ListNestedObjectValueOf[rdsCreateCrossRegionReadReplicaConfigModel] `tfsdk:"rds_create_cross_region_read_replica_config" autoflex:"-"`
 	RdsPromoteReadReplicaConfig           fwtypes.ListNestedObjectValueOf[rdsPromoteReadReplicaConfigModel]           `tfsdk:"rds_promote_read_replica_config" autoflex:"-"`
@@ -1865,6 +2036,18 @@ func (m parallelStepModel) Expand(ctx context.Context) (any, fwdiag.Diagnostics)
 			return nil, diags
 		}
 		result.ExecutionBlockConfiguration = &r
+	case !m.LambdaEventSourceMappingConfig.IsNull():
+		config, d := m.LambdaEventSourceMappingConfig.ToPtr(ctx)
+		diags.Append(d...)
+		if diags.HasError() {
+			return nil, diags
+		}
+		var r awstypes.ExecutionBlockConfigurationMemberLambdaEventSourceMappingConfig
+		diags.Append(flex.Expand(ctx, config, &r.Value)...)
+		if diags.HasError() {
+			return nil, diags
+		}
+		result.ExecutionBlockConfiguration = &r
 	case !m.RegionSwitchPlanConfig.IsNull():
 		config, d := m.RegionSwitchPlanConfig.ToPtr(ctx)
 		diags.Append(d...)
@@ -1954,6 +2137,8 @@ func (m *parallelStepModel) Flatten(ctx context.Context, v any) fwdiag.Diagnosti
 			diags.Append(flex.Flatten(ctx, &v.Value, &m.ExecutionApprovalConfig)...)
 		case *awstypes.ExecutionBlockConfigurationMemberGlobalAuroraConfig:
 			diags.Append(flex.Flatten(ctx, &v.Value, &m.GlobalAuroraConfig)...)
+		case *awstypes.ExecutionBlockConfigurationMemberLambdaEventSourceMappingConfig:
+			diags.Append(flex.Flatten(ctx, &v.Value, &m.LambdaEventSourceMappingConfig)...)
 		case *awstypes.ExecutionBlockConfigurationMemberRegionSwitchPlanConfig:
 			diags.Append(flex.Flatten(ctx, &v.Value, &m.RegionSwitchPlanConfig)...)
 		case *awstypes.ExecutionBlockConfigurationMemberRdsCreateCrossRegionReadReplicaConfig:

--- a/internal/service/arcregionswitch/plan_test.go
+++ b/internal/service/arcregionswitch/plan_test.go
@@ -810,6 +810,123 @@ func TestAccARCRegionSwitchPlan_rdsPromoteReadReplica(t *testing.T) {
 	})
 }
 
+func TestAccARCRegionSwitchPlan_lambdaEventSourceMapping(t *testing.T) {
+	ctx := acctest.Context(t)
+	var plan awstypes.Plan
+	rName := acctest.RandomWithPrefix(t, "tf-acc-test")
+	resourceName := "aws_arcregionswitch_plan.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ARCRegionSwitch),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckPlanDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPlanConfig_lambdaEventSourceMapping(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPlanExists(ctx, t, resourceName, &plan),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					resource.TestCheckResourceAttr(resourceName, "recovery_approach", "activePassive"),
+					resource.TestCheckResourceAttr(resourceName, "regions.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "workflow.#", "1"),
+					acctest.MatchResourceAttrGlobalARN(ctx, resourceName, names.AttrARN, "arc-region-switch", regexache.MustCompile(`plan/.+$`)),
+					resource.TestCheckResourceAttrPair(resourceName, "execution_role", "aws_iam_role.test", names.AttrARN),
+
+					// Verify disable step
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "workflow.*.step.*", map[string]string{
+						"execution_block_type": string(awstypes.ExecutionBlockTypeLambdaEventSourceMapping),
+						names.AttrName:         "disable-esm",
+						names.AttrDescription:  "Disable ESM in deactivating region",
+					}),
+
+					// Verify enable step
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "workflow.*.step.*", map[string]string{
+						"execution_block_type": string(awstypes.ExecutionBlockTypeLambdaEventSourceMapping),
+						names.AttrName:         "enable-esm",
+						names.AttrDescription:  "Enable ESM in activating region",
+					}),
+
+					// Verify disable config
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "workflow.*.step.*.lambda_event_source_mapping_config.*", map[string]string{
+						names.AttrAction:  string(awstypes.EventSourceMappingActionDisable),
+						"timeout_minutes": "10",
+					}),
+
+					// Verify enable config
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "workflow.*.step.*.lambda_event_source_mapping_config.*", map[string]string{
+						names.AttrAction:  string(awstypes.EventSourceMappingActionEnable),
+						"timeout_minutes": "10",
+					}),
+
+					// Verify ungraceful on disable step
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "workflow.*.step.*.lambda_event_source_mapping_config.*.ungraceful.*", map[string]string{
+						"behavior": string(awstypes.LambdaEventSourceMappingUngracefulBehaviorSkip),
+					}),
+
+					// Verify event_source_mapping entries
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "workflow.*.step.*.lambda_event_source_mapping_config.*.event_source_mapping.*", map[string]string{
+						names.AttrRegion: acctest.AlternateRegion(),
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "workflow.*.step.*.lambda_event_source_mapping_config.*.event_source_mapping.*", map[string]string{
+						names.AttrRegion: acctest.Region(),
+					}),
+				),
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: names.AttrARN,
+				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, names.AttrARN),
+			},
+			{
+				Config: testAccPlanConfig_lambdaEventSourceMapping(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPlanExists(ctx, t, resourceName, &plan),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					resource.TestCheckResourceAttr(resourceName, "recovery_approach", "activePassive"),
+					resource.TestCheckResourceAttr(resourceName, "regions.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "workflow.#", "1"),
+					acctest.MatchResourceAttrGlobalARN(ctx, resourceName, names.AttrARN, "arc-region-switch", regexache.MustCompile(`plan/.+$`)),
+					resource.TestCheckResourceAttrPair(resourceName, "execution_role", "aws_iam_role.test", names.AttrARN),
+
+					// Verify both steps still present
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "workflow.*.step.*", map[string]string{
+						"execution_block_type": string(awstypes.ExecutionBlockTypeLambdaEventSourceMapping),
+						names.AttrName:         "disable-esm",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "workflow.*.step.*", map[string]string{
+						"execution_block_type": string(awstypes.ExecutionBlockTypeLambdaEventSourceMapping),
+						names.AttrName:         "enable-esm",
+					}),
+
+					// Verify timeout was updated
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "workflow.*.step.*.lambda_event_source_mapping_config.*", map[string]string{
+						names.AttrAction:  string(awstypes.EventSourceMappingActionDisable),
+						"timeout_minutes": "15",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "workflow.*.step.*.lambda_event_source_mapping_config.*", map[string]string{
+						names.AttrAction:  string(awstypes.EventSourceMappingActionEnable),
+						"timeout_minutes": "15",
+					}),
+
+					// Verify event_source_mapping entries still present
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "workflow.*.step.*.lambda_event_source_mapping_config.*.event_source_mapping.*", map[string]string{
+						names.AttrRegion: acctest.AlternateRegion(),
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "workflow.*.step.*.lambda_event_source_mapping_config.*.event_source_mapping.*", map[string]string{
+						names.AttrRegion: acctest.Region(),
+					}),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckPlanDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.ProviderMeta(ctx, t).ARCRegionSwitchClient(ctx)
@@ -2360,4 +2477,163 @@ resource "aws_arcregionswitch_plan" "test" {
   }
 }
 `, rName, acctest.AlternateRegion(), acctest.Region())
+}
+
+func testAccPlanConfig_lambdaEventSourceMapping(rName string, includeUngraceful bool) string {
+	timeoutMinutes := 10
+	if !includeUngraceful {
+		timeoutMinutes = 15
+	}
+
+	if includeUngraceful {
+		return fmt.Sprintf(`
+resource "aws_iam_role" "test" {
+  name = %[1]q
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "arc-region-switch.amazonaws.com"
+        }
+      },
+    ]
+  })
+}
+
+resource "aws_arcregionswitch_plan" "test" {
+  name              = %[1]q
+  execution_role    = aws_iam_role.test.arn
+  recovery_approach = "activePassive"
+  regions           = [%[3]q, %[2]q]
+  primary_region    = %[3]q
+
+  workflow {
+    workflow_target_action = "activate"
+
+    step {
+      name                 = "disable-esm"
+      execution_block_type = "LambdaEventSourceMapping"
+      description          = "Disable ESM in deactivating region"
+
+      lambda_event_source_mapping_config {
+        action          = "disable"
+        timeout_minutes = %[4]d
+
+        event_source_mapping {
+          region = %[2]q
+          arn    = "arn:aws:lambda:%[2]s:123456789012:event-source-mapping:a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+        }
+
+        event_source_mapping {
+          region = %[3]q
+          arn    = "arn:aws:lambda:%[3]s:123456789012:event-source-mapping:f9e8d7c6-b5a4-3210-fedc-ba9876543210"
+        }
+
+        ungraceful {
+          behavior = "skip"
+        }
+      }
+    }
+
+    step {
+      name                 = "enable-esm"
+      execution_block_type = "LambdaEventSourceMapping"
+      description          = "Enable ESM in activating region"
+
+      lambda_event_source_mapping_config {
+        action          = "enable"
+        timeout_minutes = %[4]d
+
+        event_source_mapping {
+          region = %[2]q
+          arn    = "arn:aws:lambda:%[2]s:123456789012:event-source-mapping:a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+        }
+
+        event_source_mapping {
+          region = %[3]q
+          arn    = "arn:aws:lambda:%[3]s:123456789012:event-source-mapping:f9e8d7c6-b5a4-3210-fedc-ba9876543210"
+        }
+      }
+    }
+  }
+}
+`, rName, acctest.AlternateRegion(), acctest.Region(), timeoutMinutes)
+	}
+
+	return fmt.Sprintf(`
+resource "aws_iam_role" "test" {
+  name = %[1]q
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "arc-region-switch.amazonaws.com"
+        }
+      },
+    ]
+  })
+}
+
+resource "aws_arcregionswitch_plan" "test" {
+  name              = %[1]q
+  execution_role    = aws_iam_role.test.arn
+  recovery_approach = "activePassive"
+  regions           = [%[3]q, %[2]q]
+  primary_region    = %[3]q
+
+  workflow {
+    workflow_target_action = "activate"
+
+    step {
+      name                 = "disable-esm"
+      execution_block_type = "LambdaEventSourceMapping"
+      description          = "Disable ESM in deactivating region"
+
+      lambda_event_source_mapping_config {
+        action          = "disable"
+        timeout_minutes = %[4]d
+
+        event_source_mapping {
+          region = %[2]q
+          arn    = "arn:aws:lambda:%[2]s:123456789012:event-source-mapping:a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+        }
+
+        event_source_mapping {
+          region = %[3]q
+          arn    = "arn:aws:lambda:%[3]s:123456789012:event-source-mapping:f9e8d7c6-b5a4-3210-fedc-ba9876543210"
+        }
+      }
+    }
+
+    step {
+      name                 = "enable-esm"
+      execution_block_type = "LambdaEventSourceMapping"
+      description          = "Enable ESM in activating region"
+
+      lambda_event_source_mapping_config {
+        action          = "enable"
+        timeout_minutes = %[4]d
+
+        event_source_mapping {
+          region = %[2]q
+          arn    = "arn:aws:lambda:%[2]s:123456789012:event-source-mapping:a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+        }
+
+        event_source_mapping {
+          region = %[3]q
+          arn    = "arn:aws:lambda:%[3]s:123456789012:event-source-mapping:f9e8d7c6-b5a4-3210-fedc-ba9876543210"
+        }
+      }
+    }
+  }
+}
+`, rName, acctest.AlternateRegion(), acctest.Region(), timeoutMinutes)
 }

--- a/website/docs/r/arcregionswitch_plan.html.markdown
+++ b/website/docs/r/arcregionswitch_plan.html.markdown
@@ -210,8 +210,9 @@ The following arguments are optional:
 * `ecs_capacity_increase_config` - Configuration for ECS service capacity increase. See [ECS Capacity Increase Config](#ecs-capacity-increase-config) below.
 * `eks_resource_scaling_config` - Configuration for EKS resource scaling. See [EKS Resource Scaling Config](#eks-resource-scaling-config) below.
 * `execution_approval_config` - Configuration for manual approval steps. See [Execution Approval Config](#execution-approval-config) below.
-* `execution_block_type` - (Required) Type of execution block. Valid values: `ARCRegionSwitchPlan`, `ARCRoutingControl`, `AuroraGlobalDatabase`, `CustomActionLambda`, `DocumentDb`, `EC2AutoScaling`, `ECSServiceScaling`, `EKSResourceScaling`, `ManualApproval`, `Parallel`, `RdsCreateCrossRegionReplica`, `RdsPromoteReadReplica`, `Route53HealthCheck`.
+* `execution_block_type` - (Required) Type of execution block. Valid values: `ARCRegionSwitchPlan`, `ARCRoutingControl`, `AuroraGlobalDatabase`, `CustomActionLambda`, `DocumentDb`, `EC2AutoScaling`, `ECSServiceScaling`, `EKSResourceScaling`, `LambdaEventSourceMapping`, `ManualApproval`, `Parallel`, `RdsCreateCrossRegionReplica`, `RdsPromoteReadReplica`, `Route53HealthCheck`.
 * `global_aurora_config` - Configuration for Aurora Global Database operations. See [Global Aurora Config](#global-aurora-config) below.
+* `lambda_event_source_mapping_config` - Configuration for Lambda event source mapping operations. See [Lambda Event Source Mapping Config](#lambda-event-source-mapping-config) below.
 * `name` - (Required) Name of the step.
 * `parallel_config` - Configuration for parallel execution of multiple steps. See [Parallel Config](#parallel-config) below.
 * `rds_create_cross_region_read_replica_config` - Configuration for creating cross-region RDS read replicas. See [RDS Create Cross Region Read Replica Config](#rds-create-cross-region-read-replica-config) below.
@@ -324,6 +325,24 @@ The following arguments are optional:
 ### Ungraceful Aurora
 
 * `ungraceful` - (Required) Ungraceful behavior. Valid values: `failover`.
+
+### Lambda Event Source Mapping Config
+
+* `action` - (Required) Action to perform on the event source mapping. Valid values: `enable`, `disable`.
+* `event_source_mapping` - (Required) Set of per-region event source mapping configurations. See [Event Source Mapping](#event-source-mapping) below.
+* `timeout_minutes` - (Optional) Timeout in minutes.
+* `ungraceful` - (Optional) Ungraceful behavior configuration. See [Lambda ESM Ungraceful](#lambda-esm-ungraceful) below.
+
+### Event Source Mapping
+
+* `arn` - (Required) ARN of the Lambda event source mapping.
+* `region` - (Required) AWS region where the event source mapping resides.
+* `cross_account_role` - (Optional) ARN of the cross-account role to assume.
+* `external_id` - (Optional) External ID for cross-account role assumption.
+
+### Lambda ESM Ungraceful
+
+* `behavior` - (Required) Behavior when running in ungraceful mode. Valid values: `skip`.
 
 ### ECS Capacity Increase Config
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Added a new execution block for Lambda ESM

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Partially addresses #48312

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- [ARC Region switch adds Lambda event source mapping execution block (May 2026)](https://aws.amazon.com/about-aws/whats-new/2026/05/region-switch-lambda-esm-execution-block/)
- [Lambda event source mapping execution block documentation](https://docs.aws.amazon.com/r53recovery/latest/dg/lambda-event-source-mapping-block.html)
- [CloudFormation ExecutionBlockConfiguration property reference](https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-properties-arcregionswitch-plan-executionblockconfiguration.html)


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=arcregionswitch TESTS=TestAccARCRegionSwitchPlan_lambdaEventSourceMapping
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     5.176s
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework 5.218s
make: Running acceptance tests on branch: 🌿 f_arc_region_switch_lambda_event_source_mapping 🌿...
TF_ACC=1 go test ./internal/service/arcregionswitch/... -v -count 1 -parallel 20 -run='TestAccARCRegionSwitchPlan_lambdaEventSourceMapping'  -timeout 360m -vet=off -buildvcs=false
2026/06/12 14:50:47 Creating Terraform AWS Provider (SDKv2-style)...
2026/06/12 14:50:47 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccARCRegionSwitchPlan_lambdaEventSourceMapping
=== PAUSE TestAccARCRegionSwitchPlan_lambdaEventSourceMapping
=== CONT  TestAccARCRegionSwitchPlan_lambdaEventSourceMapping
--- PASS: TestAccARCRegionSwitchPlan_lambdaEventSourceMapping (39.45s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/arcregionswitch    46.313s
```
