### PR TITLE
aws_vpc_ipam_pool_cidr: Correct the create function to use the create timeout

### DIFF
--- a/internal/service/ec2/vpc_ipam_pool_cidr.go
+++ b/internal/service/ec2/vpc_ipam_pool_cidr.go
@@ -132,7 +132,7 @@ func resourceIPAMPoolCIDRCreate(ctx context.Context, d *schema.ResourceData, met
 	cidrBlock := aws.ToString(output.IpamPoolCidr.Cidr)
 	poolCidrID := aws.ToString(output.IpamPoolCidr.IpamPoolCidrId)
 
-	ipamPoolCidr, err := waitIPAMPoolCIDRCreated(ctx, conn, poolCidrID, poolID, cidrBlock, d.Timeout(schema.TimeoutDelete))
+	ipamPoolCidr, err := waitIPAMPoolCIDRCreated(ctx, conn, poolCidrID, poolID, cidrBlock, d.Timeout(schema.TimeoutCreate))
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "waiting for IPAM Pool CIDR (%s) create: %s", poolCidrID, err)


### PR DESCRIPTION
Trivial timeout reference nit.

Arguably, the create timeout should be updated to 32min too.

<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

n/a

### Description

copypasta


### Relations

n/a

### References

n/a

### Output from Acceptance Testing

n/a
