### PR TITLE
r/aws_bedrockagentcore_harness: add `additional_params` to `bedrock_model_config`

### DIFF
--- a/.changelog/48363.txt
+++ b/.changelog/48363.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_bedrockagentcore_harness: Add `additional_params` argument to `model.bedrock_model_config` block
+```

--- a/internal/service/bedrockagentcore/harness.go
+++ b/internal/service/bedrockagentcore/harness.go
@@ -222,6 +222,10 @@ func (r *harnessResource) Schema(ctx context.Context, request resource.SchemaReq
 							},
 							NestedObject: schema.NestedBlockObject{
 								Attributes: map[string]schema.Attribute{
+									"additional_params": schema.StringAttribute{
+										CustomType: jsontypes.NormalizedType{},
+										Optional:   true,
+									},
 									"max_tokens": schema.Int32Attribute{
 										Optional: true,
 										Validators: []validator.Int32{
@@ -835,6 +839,11 @@ func (m *harnessModelConfigurationModel) Flatten(ctx context.Context, v any) dia
 		if diags.HasError() {
 			return diags
 		}
+		if t.Value.AdditionalParams != nil {
+			if json, err := tfsmithy.DocumentToJSONString(t.Value.AdditionalParams); err == nil {
+				data.AdditionalParams = jsontypes.NewNormalizedValue(json)
+			}
+		}
 		m.BedrockModelConfig = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &data)
 	case awstypes.HarnessModelConfigurationMemberGeminiModelConfig:
 		var data harnessGeminiModelConfigModel
@@ -867,6 +876,11 @@ func (m harnessModelConfigurationModel) Expand(ctx context.Context) (any, diag.D
 		}
 		var r awstypes.HarnessModelConfigurationMemberBedrockModelConfig
 		smerr.AddEnrich(ctx, &diags, fwflex.Expand(ctx, data, &r.Value))
+		if !data.AdditionalParams.IsNull() {
+			if json, err := tfsmithy.DocumentFromJSONString(fwflex.StringValueFromFramework(ctx, data.AdditionalParams), document.NewLazyDocument); err == nil {
+				r.Value.AdditionalParams = json
+			}
+		}
 		return &r, diags
 	case !m.GeminiModelConfig.IsNull():
 		data, d := m.GeminiModelConfig.ToPtr(ctx)
@@ -891,10 +905,11 @@ func (m harnessModelConfigurationModel) Expand(ctx context.Context) (any, diag.D
 }
 
 type harnessBedrockModelConfigModel struct {
-	MaxTokens   types.Int32   `tfsdk:"max_tokens"`
-	ModelID     types.String  `tfsdk:"model_id"`
-	Temperature types.Float32 `tfsdk:"temperature"`
-	TopP        types.Float32 `tfsdk:"top_p"`
+	AdditionalParams jsontypes.Normalized `tfsdk:"additional_params" autoflex:"-"`
+	MaxTokens        types.Int32          `tfsdk:"max_tokens"`
+	ModelID          types.String         `tfsdk:"model_id"`
+	Temperature      types.Float32        `tfsdk:"temperature"`
+	TopP             types.Float32        `tfsdk:"top_p"`
 }
 
 type harnessGeminiModelConfigModel struct {

--- a/internal/service/bedrockagentcore/harness.go
+++ b/internal/service/bedrockagentcore/harness.go
@@ -364,6 +364,10 @@ func (r *harnessResource) Schema(ctx context.Context, request resource.SchemaReq
 							},
 							NestedObject: schema.NestedBlockObject{
 								Attributes: map[string]schema.Attribute{
+									"additional_params": schema.StringAttribute{
+										CustomType: jsontypes.NormalizedType{},
+										Optional:   true,
+									},
 									"max_tokens": schema.Int32Attribute{
 										Optional: true,
 										Validators: []validator.Int32{
@@ -1068,6 +1072,11 @@ func (m *harnessModelConfigurationModel) Flatten(ctx context.Context, v any) dia
 		if diags.HasError() {
 			return diags
 		}
+		if t.Value.AdditionalParams != nil {
+			if json, err := tfsmithy.DocumentToJSONString(t.Value.AdditionalParams); err == nil {
+				data.AdditionalParams = jsontypes.NewNormalizedValue(json)
+			}
+		}
 		m.BedrockModelConfig = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &data)
 	case awstypes.HarnessModelConfigurationMemberGeminiModelConfig:
 		var data harnessGeminiModelConfigModel
@@ -1100,6 +1109,11 @@ func (m harnessModelConfigurationModel) Expand(ctx context.Context) (any, diag.D
 		}
 		var r awstypes.HarnessModelConfigurationMemberBedrockModelConfig
 		smerr.AddEnrich(ctx, &diags, fwflex.Expand(ctx, data, &r.Value))
+		if !data.AdditionalParams.IsNull() {
+			if json, err := tfsmithy.DocumentFromJSONString(fwflex.StringValueFromFramework(ctx, data.AdditionalParams), document.NewLazyDocument); err == nil {
+				r.Value.AdditionalParams = json
+			}
+		}
 		return &r, diags
 	case !m.GeminiModelConfig.IsNull():
 		data, d := m.GeminiModelConfig.ToPtr(ctx)
@@ -1124,10 +1138,11 @@ func (m harnessModelConfigurationModel) Expand(ctx context.Context) (any, diag.D
 }
 
 type harnessBedrockModelConfigModel struct {
-	MaxTokens   types.Int32   `tfsdk:"max_tokens"`
-	ModelID     types.String  `tfsdk:"model_id"`
-	Temperature types.Float32 `tfsdk:"temperature"`
-	TopP        types.Float32 `tfsdk:"top_p"`
+	AdditionalParams jsontypes.Normalized `tfsdk:"additional_params" autoflex:"-"`
+	MaxTokens        types.Int32          `tfsdk:"max_tokens"`
+	ModelID          types.String         `tfsdk:"model_id"`
+	Temperature      types.Float32        `tfsdk:"temperature"`
+	TopP             types.Float32        `tfsdk:"top_p"`
 }
 
 type harnessGeminiModelConfigModel struct {

--- a/internal/service/bedrockagentcore/harness_test.go
+++ b/internal/service/bedrockagentcore/harness_test.go
@@ -271,12 +271,24 @@ func TestAccBedrockAgentCoreHarness_model_bedrock(t *testing.T) {
 				},
 			},
 			{
+				Config: testAccHarnessConfig_bedrockModelAdditionalParams(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckHarnessExists(ctx, t, resourceName, &harness),
+					resource.TestCheckResourceAttrSet(resourceName, "model.0.bedrock_model_config.0.additional_params"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
 				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, "harness_id"),
 				ResourceName:                         resourceName,
 				ImportState:                          true,
 				ImportStateVerify:                    true,
 				ImportStateVerifyIdentifierAttribute: "harness_id",
-				ImportStateVerifyIgnore:              []string{"model.0.bedrock_model_config.0.temperature", "model.0.bedrock_model_config.0.top_p"},
+				ImportStateVerifyIgnore:              []string{"model.0.bedrock_model_config.0.temperature", "model.0.bedrock_model_config.0.top_p", "model.0.bedrock_model_config.0.additional_params"},
 			},
 		},
 	})
@@ -804,6 +816,36 @@ resource "aws_bedrockagentcore_harness" "test" {
       model_id    = "anthropic.claude-sonnet-4-20250514"
       temperature = 0.7
       top_p       = 0.9
+    }
+  }
+
+  system_prompt {
+    text = "You are a helpful assistant."
+  }
+}
+`, rName))
+}
+
+func testAccHarnessConfig_bedrockModelAdditionalParams(rName string) string {
+	return acctest.ConfigCompose(testAccHarnessConfig_iamRole(rName), fmt.Sprintf(`
+resource "aws_bedrockagentcore_harness" "test" {
+  harness_name       = %[1]q
+  execution_role_arn = aws_iam_role.test.arn
+
+  model {
+    bedrock_model_config {
+      model_id    = "anthropic.claude-sonnet-4-20250514"
+      temperature = 0.7
+      top_p       = 0.9
+
+      additional_params = jsonencode({
+        additionalModelRequestFields = {
+          thinking = {
+            type          = "enabled"
+            budget_tokens = 2048
+          }
+        }
+      })
     }
   }
 

--- a/internal/service/bedrockagentcore/harness_test.go
+++ b/internal/service/bedrockagentcore/harness_test.go
@@ -403,6 +403,18 @@ func TestAccBedrockAgentCoreHarness_model_bedrock(t *testing.T) {
 				},
 			},
 			{
+				Config: testAccHarnessConfig_bedrockModelAdditionalParams(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckHarnessExists(ctx, t, resourceName, &harness),
+					resource.TestCheckResourceAttrSet(resourceName, "model.0.bedrock_model_config.0.additional_params"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
 				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, "harness_id"),
 				ResourceName:                         resourceName,
 				ImportState:                          true,
@@ -413,6 +425,7 @@ func TestAccBedrockAgentCoreHarness_model_bedrock(t *testing.T) {
 					"memory",
 					"model.0.bedrock_model_config.0.temperature",
 					"model.0.bedrock_model_config.0.top_p",
+					"model.0.bedrock_model_config.0.additional_params",
 				},
 			},
 		},
@@ -2750,6 +2763,36 @@ resource "aws_bedrockagentcore_harness" "test" {
   }
 
   depends_on = [aws_iam_role_policy.test]
+}
+`, rName))
+}
+
+func testAccHarnessConfig_bedrockModelAdditionalParams(rName string) string {
+	return acctest.ConfigCompose(testAccHarnessConfig_iamRole(rName), fmt.Sprintf(`
+resource "aws_bedrockagentcore_harness" "test" {
+  harness_name       = %[1]q
+  execution_role_arn = aws_iam_role.test.arn
+
+  model {
+    bedrock_model_config {
+      model_id    = "anthropic.claude-sonnet-4-20250514"
+      temperature = 0.7
+      top_p       = 0.9
+
+      additional_params = jsonencode({
+        additionalModelRequestFields = {
+          thinking = {
+            type          = "enabled"
+            budget_tokens = 2048
+          }
+        }
+      })
+    }
+  }
+
+  system_prompt {
+    text = "You are a helpful assistant."
+  }
 }
 `, rName))
 }

--- a/website/docs/r/bedrockagentcore_harness.html.markdown
+++ b/website/docs/r/bedrockagentcore_harness.html.markdown
@@ -154,6 +154,7 @@ The `model` block supports exactly one of the following:
 ### `bedrock_model_config` Block
 
 * `model_id` - (Required) Bedrock model ID (e.g., `anthropic.claude-sonnet-4-20250514`).
+* `additional_params` - (Optional) JSON string of additional parameters passed through to the underlying model, such as `additionalModelRequestFields` (e.g., `jsonencode({ additionalModelRequestFields = { thinking = { type = "enabled", budget_tokens = 2048 } } })`).
 * `max_tokens` - (Optional) Maximum number of tokens to generate.
 * `temperature` - (Optional) Temperature for sampling. Must be between 0 and 2.
 * `top_p` - (Optional) Top-p (nucleus) sampling parameter. Must be between 0 and 1.

--- a/website/docs/r/bedrockagentcore_harness.html.markdown
+++ b/website/docs/r/bedrockagentcore_harness.html.markdown
@@ -180,6 +180,7 @@ The `model` block supports exactly one of the following:
 ### `bedrock_model_config` Block
 
 * `model_id` - (Required) Bedrock model ID (e.g., `anthropic.claude-sonnet-4-20250514`).
+* `additional_params` - (Optional) JSON string of additional parameters passed through to the underlying model, such as `additionalModelRequestFields` (e.g., `jsonencode({ additionalModelRequestFields = { thinking = { type = "enabled", budget_tokens = 2048 } } })`).
 * `max_tokens` - (Optional) Maximum number of tokens to generate.
 * `temperature` - (Optional) Temperature for sampling. Must be between 0 and 2.
 * `top_p` - (Optional) Top-p (nucleus) sampling parameter. Must be between 0 and 1.


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

### Description

Adds an optional `additional_params` argument to the `model.bedrock_model_config` block of `aws_bedrockagentcore_harness`, exposing the AWS API's JSON-valued `additionalParams` field that is passed through to the underlying model (e.g. `additionalModelRequestFields` for extended-thinking configuration).

The attribute uses `jsontypes.NormalizedType` and is marshalled to/from the SDK's `document.Interface` with `tfsmithy.DocumentFromJSONString` / `DocumentToJSONString`, following the existing pattern used by this resource's `inline_function.input_schema` attribute. The model struct field is tagged `autoflex:"-"` with explicit handling in the union's `Expand`/`Flatten`.

```hcl
resource "aws_bedrockagentcore_harness" "main" {
  model {
    bedrock_model_config {
      model_id   = "global.anthropic.claude-sonnet-4-6"
      max_tokens = 16384

      additional_params = jsonencode({
        additionalModelRequestFields = {
          thinking = { type = "enabled", budget_tokens = 2048 }
        }
      })
    }
  }
}
```

### Relations

Closes #48363

### Output from Acceptance Testing

A new step exercising `additional_params` (with plan-check `Update`) was added to `TestAccBedrockAgentCoreHarness_model_bedrock`, plus `ImportStateVerifyIgnore` for the new attribute (the API does not return it on read, matching `temperature`/`top_p` behavior).

```
%  make testacc TESTS=TestAccBedrockAgentCoreHarness_model_bedrock PKG=bedrockagentcore
```

I don't have AWS account access with BedrockAgentCore harness quota to run this acceptance test; `go build`, `go vet`, and `gofmt` all pass, and the unit-test package compiles and runs green. Happy to iterate if the acceptance run surfaces anything.