### PR TITLE
r/aws_api_gateway_gateway_response: mark `status_code` Computed to fix persistent diff

### DIFF
--- a/.changelog/48260.txt
+++ b/.changelog/48260.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_api_gateway_gateway_response: Fix persistent diff on `status_code` when the argument is omitted and API Gateway assigns the default for the `response_type`
+```

--- a/internal/service/apigateway/gateway_response.go
+++ b/internal/service/apigateway/gateway_response.go
@@ -73,6 +73,7 @@ func resourceGatewayResponse() *schema.Resource {
 				names.AttrStatusCode: {
 					Type:     schema.TypeString,
 					Optional: true,
+					Computed: true,
 				},
 			}
 		},

--- a/internal/service/apigateway/gateway_response_test.go
+++ b/internal/service/apigateway/gateway_response_test.go
@@ -60,6 +60,42 @@ func TestAccAPIGatewayGatewayResponse_basic(t *testing.T) {
 	})
 }
 
+func TestAccAPIGatewayGatewayResponse_defaultStatusCode(t *testing.T) {
+	ctx := acctest.Context(t)
+	var conf apigateway.GetGatewayResponseOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_api_gateway_gateway_response.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckGatewayResponseDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGatewayResponseConfig_defaultStatusCode(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGatewayResponseExists(ctx, t, resourceName, &conf),
+					// THROTTLED defaults to 429 per the API Gateway documentation.
+					resource.TestCheckResourceAttr(resourceName, names.AttrStatusCode, "429"),
+				),
+			},
+			{
+				// Re-applying the same configuration must produce an empty plan
+				// (status_code is Computed when omitted).
+				Config:   testAccGatewayResponseConfig_defaultStatusCode(rName),
+				PlanOnly: true,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccGatewayResponseImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAPIGatewayGatewayResponse_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetGatewayResponseOutput
@@ -167,6 +203,23 @@ resource "aws_api_gateway_gateway_response" "test" {
 
   response_parameters = {
     "gatewayresponse.header.Authorization" = "'Basic'"
+  }
+}
+`, rName)
+}
+
+func testAccGatewayResponseConfig_defaultStatusCode(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_api_gateway_rest_api" "test" {
+  name = %[1]q
+}
+
+resource "aws_api_gateway_gateway_response" "test" {
+  rest_api_id   = aws_api_gateway_rest_api.test.id
+  response_type = "THROTTLED"
+
+  response_templates = {
+    "application/json" = "{'message':$context.error.messageString}"
   }
 }
 `, rName)


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

### Description

`status_code` on `aws_api_gateway_gateway_response` is Optional. When it is omitted, API Gateway assigns the documented default for the `response_type` (e.g. `429` for `THROTTLED`), the Read writes that default into state, and every subsequent plan then reports

```
~ status_code = "429" -> null
```

forever, because the attribute is not `Computed`. Marking it `Optional + Computed` lets the API-assigned default persist in state without a diff, while explicit configuration values continue to behave exactly as before (set, drift-detected, and updatable).

### Relations

Closes #48260

### Output from Acceptance Testing

Added `TestAccAPIGatewayGatewayResponse_defaultStatusCode`: creates a `THROTTLED` gateway response with `status_code` omitted, asserts the API default `429` lands in state, then re-applies the same configuration with `PlanOnly: true` -- which fails on the current code with the perpetual diff and passes with this change. Import remains verified.

```
%  make testacc TESTS=TestAccAPIGatewayGatewayResponse PKG=apigateway
```

`go build`, `go vet`, and `gofmt` pass; the test package compiles and runs green locally. I don't have an AWS account suitable for the live acceptance run -- happy to iterate on the maintainer-triggered run.