### PR TITLE
Add user_data_replace_on_change field to aws_lightsail_instance

### DIFF
--- a/internal/service/lightsail/instance.go
+++ b/internal/service/lightsail/instance.go
@@ -111,7 +111,12 @@ func ResourceInstance() *schema.Resource {
 				"user_data": {
 					Type:     schema.TypeString,
 					Optional: true,
-					ForceNew: true,
+				},
+
+				"user_data_replace_on_change": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  false,
 				},
 
 				// additional info returned from the API
@@ -170,6 +175,10 @@ func ResourceInstance() *schema.Resource {
 				return nil
 			}),
 		),
+		customdiff.ForceNewIf("user_data", func(_ context.Context, diff *schema.ResourceDiff, meta interface{}) bool {
+			replace := diff.Get("user_data_replace_on_change")
+			return replace.(bool)
+		}),
 	}
 }
 

--- a/website/docs/r/lightsail_instance.html.markdown
+++ b/website/docs/r/lightsail_instance.html.markdown
@@ -78,7 +78,8 @@ The following arguments are optional:
 * `key_pair_name` - (Optional) Name of your key pair. Created in the Lightsail console (cannot use `aws_key_pair` at this time).
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `tags` - (Optional) Map of tags to assign to the resource. To create a key-only tag, use an empty string as the value. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
-* `user_data` - (Optional) Single lined launch script as a string to configure server with additional user data.
+* `user_data` - (Optional) Single lined launch script as a string to configure server with additional user data. If the `user_data_replace_on_change` is set then updates to this field will trigger a destroy and recreate.
+* `user_data_replace_on_change` - (Optional) When used in combination with `user_data` this will trigger a destroy and recreate when set to `true`. Defaults to `false` if not set.
 
 ### `add_on`
 


### PR DESCRIPTION
### Description

This changes the default such that changes to user_date to not destroy and recreate the instance. The `user_data_replace_on_change` when set to true will replicate the previous behaviour if the `user_data` is changed.

This matches the aws_instance setup and hence makes this consistent and no longer surprising. This is especially important as destroying a lightsail instance will also delete all the auto snapshots for the instance.

### Relations

Relates #23604
