### PR TITLE
r/aws_api_gateway_rest_api: apply `binary_media_types` removal when argument is deleted

### DIFF
--- a/.changelog/48385.txt
+++ b/.changelog/48385.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_api_gateway_rest_api: Fix `binary_media_types` removal being silently ignored when the argument is deleted from configuration without `body`
+```

--- a/internal/service/apigateway/rest_api.go
+++ b/internal/service/apigateway/rest_api.go
@@ -19,6 +19,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/apigateway/types"
 	awspolicy "github.com/hashicorp/awspolicyequivalence"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -183,7 +184,10 @@ func resourceRestAPI() *schema.Resource {
 			}
 		},
 
-		CustomizeDiff: endpointConfigurationPlantimeValidate,
+		CustomizeDiff: customdiff.All(
+			endpointConfigurationPlantimeValidate,
+			binaryMediaTypesPlantimeClear,
+		),
 	}
 }
 
@@ -603,6 +607,35 @@ func resourceRestAPIDelete(ctx context.Context, d *schema.ResourceData, meta any
 	}
 
 	return diags
+}
+
+// binaryMediaTypes is Optional+Computed so that values derived from an
+// imported OpenAPI body are not treated as drift. That combination, however,
+// makes removing the argument from configuration a no-op: the prior value is
+// retained from state and no diff is produced. When the API is managed without
+// a body, clear the planned value if the argument is absent from configuration
+// so the removal is applied. The body path keeps the Computed behavior.
+func binaryMediaTypesPlantimeClear(_ context.Context, diff *schema.ResourceDiff, v any) error {
+	if diff.Id() == "" {
+		return nil
+	}
+
+	rawConfig := diff.GetRawConfig()
+	if rawConfig.IsNull() || !rawConfig.Type().IsObjectType() {
+		return nil
+	}
+
+	if v := rawConfig.GetAttr("body"); v.IsKnown() && !v.IsNull() {
+		return nil
+	}
+
+	if v := rawConfig.GetAttr("binary_media_types"); v.IsKnown() && v.IsNull() {
+		if old, _ := diff.GetChange("binary_media_types"); len(old.([]any)) > 0 {
+			return diff.SetNew("binary_media_types", []any{})
+		}
+	}
+
+	return nil
 }
 
 func endpointConfigurationPlantimeValidate(_ context.Context, diff *schema.ResourceDiff, v any) error {

--- a/internal/service/apigateway/rest_api.go
+++ b/internal/service/apigateway/rest_api.go
@@ -20,6 +20,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/apigateway/types"
 	awspolicy "github.com/hashicorp/awspolicyequivalence"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -201,7 +202,10 @@ func resourceRestAPI() *schema.Resource {
 			}
 		},
 
-		CustomizeDiff: endpointConfigurationPlantimeValidate,
+		CustomizeDiff: customdiff.All(
+			endpointConfigurationPlantimeValidate,
+			binaryMediaTypesPlantimeClear,
+		),
 	}
 }
 
@@ -682,6 +686,35 @@ func resourceRestAPIDelete(ctx context.Context, d *schema.ResourceData, meta any
 	}
 
 	return diags
+}
+
+// binaryMediaTypes is Optional+Computed so that values derived from an
+// imported OpenAPI body are not treated as drift. That combination, however,
+// makes removing the argument from configuration a no-op: the prior value is
+// retained from state and no diff is produced. When the API is managed without
+// a body, clear the planned value if the argument is absent from configuration
+// so the removal is applied. The body path keeps the Computed behavior.
+func binaryMediaTypesPlantimeClear(_ context.Context, diff *schema.ResourceDiff, v any) error {
+	if diff.Id() == "" {
+		return nil
+	}
+
+	rawConfig := diff.GetRawConfig()
+	if rawConfig.IsNull() || !rawConfig.Type().IsObjectType() {
+		return nil
+	}
+
+	if v := rawConfig.GetAttr("body"); v.IsKnown() && !v.IsNull() {
+		return nil
+	}
+
+	if v := rawConfig.GetAttr("binary_media_types"); v.IsKnown() && v.IsNull() {
+		if old, _ := diff.GetChange("binary_media_types"); len(old.([]any)) > 0 {
+			return diff.SetNew("binary_media_types", []any{})
+		}
+	}
+
+	return nil
 }
 
 func endpointConfigurationPlantimeValidate(_ context.Context, diff *schema.ResourceDiff, v any) error {

--- a/internal/service/apigateway/rest_api_test.go
+++ b/internal/service/apigateway/rest_api_test.go
@@ -389,6 +389,19 @@ func TestAccAPIGatewayRestAPI_binaryMediaTypes(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "binary_media_types.0", "application/octet"),
 				),
 			},
+			{
+				// Removing the argument entirely must clear it on the API (not be ignored).
+				Config: testAccRestAPIConfig_binaryMediaTypesRemoved(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "binary_media_types.#", "0"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+			},
 		},
 	})
 }
@@ -2271,6 +2284,14 @@ resource "aws_api_gateway_rest_api" "test" {
   name               = %[1]q
 }
 `, rName, binaryMediaTypes1)
+}
+
+func testAccRestAPIConfig_binaryMediaTypesRemoved(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_api_gateway_rest_api" "test" {
+  name = %[1]q
+}
+`, rName)
 }
 
 func testAccRestAPIConfig_binaryMediaTypes1OverrideBody(rName string, binaryMediaTypes1 string, bodyBinaryMediaTypes1 string) string {

--- a/internal/service/apigateway/rest_api_test.go
+++ b/internal/service/apigateway/rest_api_test.go
@@ -450,6 +450,17 @@ func TestAccAPIGatewayRestAPI_BinaryMediaTypes_overrideBody(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "binary_media_types.0", "application/octet"),
 				),
 			},
+			// Dropping the argument while the body still sets binary media types must
+			// not clear the value: the plan-time clear skips the OpenAPI-import path,
+			// so the value derived from the body is retained rather than forced empty.
+			{
+				Config: testAccRestAPIConfig_binaryMediaTypes1SetByBody(rName, "image/png"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "binary_media_types.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "binary_media_types.0", "image/png"),
+				),
+			},
 		},
 	})
 }
@@ -479,6 +490,17 @@ func TestAccAPIGatewayRestAPI_BinaryMediaTypes_setByBody(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"body", "put_rest_api_mode"},
+			},
+			// Updating the body-derived binary media type must still apply: the
+			// argument is never set in config, so the plan-time clear skips this
+			// OpenAPI-import path and the Computed value tracks the body.
+			{
+				Config: testAccRestAPIConfig_binaryMediaTypes1SetByBody(rName, "image/jpeg"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "binary_media_types.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "binary_media_types.0", "image/jpeg"),
+				),
 			},
 		},
 	})

--- a/internal/service/apigateway/rest_api_test.go
+++ b/internal/service/apigateway/rest_api_test.go
@@ -417,6 +417,19 @@ func TestAccAPIGatewayRestAPI_binaryMediaTypes(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "binary_media_types.0", "application/octet"),
 				),
 			},
+			{
+				// Removing the argument entirely must clear it on the API (not be ignored).
+				Config: testAccRestAPIConfig_binaryMediaTypesRemoved(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "binary_media_types.#", "0"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+			},
 		},
 	})
 }
@@ -2354,6 +2367,14 @@ resource "aws_api_gateway_rest_api" "test" {
   name               = %[1]q
 }
 `, rName, binaryMediaTypes1)
+}
+
+func testAccRestAPIConfig_binaryMediaTypesRemoved(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_api_gateway_rest_api" "test" {
+  name = %[1]q
+}
+`, rName)
 }
 
 func testAccRestAPIConfig_binaryMediaTypes1OverrideBody(rName string, binaryMediaTypes1 string, bodyBinaryMediaTypes1 string) string {

--- a/internal/service/apigateway/rest_api_test.go
+++ b/internal/service/apigateway/rest_api_test.go
@@ -478,6 +478,17 @@ func TestAccAPIGatewayRestAPI_BinaryMediaTypes_overrideBody(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "binary_media_types.0", "application/octet"),
 				),
 			},
+			// Dropping the argument while the body still sets binary media types must
+			// not clear the value: the plan-time clear skips the OpenAPI-import path,
+			// so the value derived from the body is retained rather than forced empty.
+			{
+				Config: testAccRestAPIConfig_binaryMediaTypes1SetByBody(rName, "image/png"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "binary_media_types.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "binary_media_types.0", "image/png"),
+				),
+			},
 		},
 	})
 }
@@ -507,6 +518,17 @@ func TestAccAPIGatewayRestAPI_BinaryMediaTypes_setByBody(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"body", "put_rest_api_mode"},
+			},
+			// Updating the body-derived binary media type must still apply: the
+			// argument is never set in config, so the plan-time clear skips this
+			// OpenAPI-import path and the Computed value tracks the body.
+			{
+				Config: testAccRestAPIConfig_binaryMediaTypes1SetByBody(rName, "image/jpeg"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "binary_media_types.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "binary_media_types.0", "image/jpeg"),
+				),
 			},
 		},
 	})


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

### Description

`binary_media_types` is `Optional + Computed` so that values derived from an imported OpenAPI `body` are not treated as drift. That combination has a side effect: removing the argument from configuration is a no-op. The prior value is retained from state, no diff is planned, and the media types remain on the deployed REST API indefinitely.

This adds a plan-time `CustomizeDiff` (`binaryMediaTypesPlantimeClear`) that, **only when no `body` is configured**, clears the planned `binary_media_types` value if the argument is absent from configuration but a non-empty value exists in state. The existing update logic already emits the `OpRemove` patch operations once a diff is present, so no change to the update path is needed. The `body`/OpenAPI-import path is explicitly skipped, preserving the Computed behavior there.

The new diff function is composed with the existing `endpointConfigurationPlantimeValidate` via `customdiff.All`, and guards against the null raw-config seen during destroy (same pattern as `resourceRestAPIPolicyConfigured`).

### Relations

Closes #48385

### Output from Acceptance Testing

Added a removal step to `TestAccAPIGatewayRestAPI_binaryMediaTypes`: after setting a media type, the config drops the argument entirely; the step asserts `binary_media_types.# = 0` with a plan-check expecting an `Update` action (this step shows no diff / no update on the current code, demonstrating the bug). The existing `_overrideBody` test continues to exercise the unchanged `body` path.

```
%  make testacc TESTS=TestAccAPIGatewayRestAPI_binaryMediaTypes PKG=apigateway
```

`go build`, `go vet`, and `gofmt` pass; the test package compiles and runs green locally. I don't have an AWS account suitable for the live acceptance run -- happy to iterate on the maintainer-triggered run.