### PR TITLE
Add SSO Admin region resource

### DIFF
--- a/.changelog/48397.txt
+++ b/.changelog/48397.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_ssoadmin_region
+```

--- a/internal/service/ssoadmin/exports_test.go
+++ b/internal/service/ssoadmin/exports_test.go
@@ -18,6 +18,7 @@ var (
 	ResourcePermissionsBoundaryAttachment             = resourcePermissionsBoundaryAttachment
 	ResourcePermissionSet                             = resourcePermissionSet
 	ResourcePermissionSetInlinePolicy                 = resourcePermissionSetInlinePolicy
+	ResourceRegion                                    = newRegionResource
 	ResourceTrustedTokenIssuer                        = newTrustedTokenIssuerResource
 
 	FindAccountAssignmentByFivePartKey               = findAccountAssignmentByFivePartKey
@@ -33,5 +34,6 @@ var (
 	FindPermissionsBoundaryByTwoPartKey              = findPermissionsBoundaryByTwoPartKey
 	FindPermissionSetByTwoPartKey                    = findPermissionSetByTwoPartKey
 	FindPermissionSetInlinePolicyByTwoPartKey        = findPermissionSetInlinePolicyByTwoPartKey
+	FindRegionByID                                   = findRegionByID
 	FindTrustedTokenIssuerByARN                      = findTrustedTokenIssuerByARN
 )

--- a/internal/service/ssoadmin/region.go
+++ b/internal/service/ssoadmin/region.go
@@ -1,0 +1,324 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package ssoadmin
+
+import (
+	"context"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ssoadmin"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/ssoadmin/types"
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	intflex "github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkResource("aws_ssoadmin_region", name="Region")
+// @Testing(preCheck="github.com/hashicorp/terraform-provider-aws/internal/acctest;acctest.PreCheckSSOAdminInstances")
+func newRegionResource(_ context.Context) (resource.ResourceWithConfigure, error) {
+	r := &regionResource{}
+
+	r.SetDefaultCreateTimeout(120 * time.Minute)
+	r.SetDefaultDeleteTimeout(120 * time.Minute)
+
+	return r, nil
+}
+
+const (
+	ResNameRegion = "Region"
+
+	regionIDPartCount = 2
+)
+
+type regionResource struct {
+	framework.ResourceWithModel[regionResourceModel]
+	framework.WithImportByID
+	framework.WithTimeouts
+}
+
+func (r *regionResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"added_date": schema.StringAttribute{
+				CustomType: timetypes.RFC3339Type{},
+				Computed:   true,
+			},
+			names.AttrID: framework.IDAttribute(),
+			"instance_arn": schema.StringAttribute{
+				CustomType: fwtypes.ARNType,
+				Required:   true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"is_primary_region": schema.BoolAttribute{
+				Computed: true,
+			},
+			"region_name": schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			names.AttrStatus: schema.StringAttribute{
+				CustomType: fwtypes.StringEnumType[awstypes.RegionStatus](),
+				Computed:   true,
+			},
+		},
+		Blocks: map[string]schema.Block{
+			names.AttrTimeouts: timeouts.Block(ctx, timeouts.Opts{
+				Create: true,
+				Delete: true,
+			}),
+		},
+	}
+}
+
+func (r *regionResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	conn := r.Meta().SSOAdminClient(ctx)
+
+	var plan regionResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	id, err := regionCreateResourceID(plan.InstanceARN.ValueString(), plan.RegionName.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.SSOAdmin, create.ErrActionCreating, ResNameRegion, plan.RegionName.ValueString(), err),
+			err.Error(),
+		)
+		return
+	}
+	plan.ID = types.StringValue(id)
+
+	input := &ssoadmin.AddRegionInput{
+		InstanceArn: plan.InstanceARN.ValueStringPointer(),
+		RegionName:  plan.RegionName.ValueStringPointer(),
+	}
+
+	_, err = conn.AddRegion(ctx, input)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.SSOAdmin, create.ErrActionCreating, ResNameRegion, plan.ID.ValueString(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	out, err := waitRegionActive(ctx, conn, plan.InstanceARN.ValueString(), plan.RegionName.ValueString(), r.CreateTimeout(ctx, plan.Timeouts))
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.SSOAdmin, create.ErrActionWaitingForCreation, ResNameRegion, plan.ID.ValueString(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(flex.Flatten(ctx, out, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+}
+
+func (r *regionResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	conn := r.Meta().SSOAdminClient(ctx)
+
+	var state regionResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	out, err := findRegionByID(ctx, conn, state.ID.ValueString())
+	if retry.NotFound(err) {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.SSOAdmin, create.ErrActionReading, ResNameRegion, state.ID.ValueString(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	parts, err := regionParseResourceID(state.ID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.SSOAdmin, create.ErrActionReading, ResNameRegion, state.ID.ValueString(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(flex.Flatten(ctx, out, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	state.InstanceARN = fwtypes.ARNValue(parts[0])
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *regionResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan regionResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *regionResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	conn := r.Meta().SSOAdminClient(ctx)
+
+	var state regionResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	input := &ssoadmin.RemoveRegionInput{
+		InstanceArn: state.InstanceARN.ValueStringPointer(),
+		RegionName:  state.RegionName.ValueStringPointer(),
+	}
+
+	_, err := conn.RemoveRegion(ctx, input)
+	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+		return
+	}
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.SSOAdmin, create.ErrActionDeleting, ResNameRegion, state.ID.ValueString(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	if _, err := waitRegionDeleted(ctx, conn, state.InstanceARN.ValueString(), state.RegionName.ValueString(), r.DeleteTimeout(ctx, state.Timeouts)); err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.SSOAdmin, create.ErrActionWaitingForDeletion, ResNameRegion, state.ID.ValueString(), err),
+			err.Error(),
+		)
+		return
+	}
+}
+
+func regionCreateResourceID(instanceARN, regionName string) (string, error) {
+	return intflex.FlattenResourceId([]string{instanceARN, regionName}, regionIDPartCount, false)
+}
+
+func regionParseResourceID(id string) ([]string, error) {
+	return intflex.ExpandResourceId(id, regionIDPartCount, false)
+}
+
+func findRegionByID(ctx context.Context, conn *ssoadmin.Client, id string) (*ssoadmin.DescribeRegionOutput, error) {
+	parts, err := regionParseResourceID(id)
+	if err != nil {
+		return nil, err
+	}
+
+	return findRegionByTwoPartKey(ctx, conn, parts[0], parts[1])
+}
+
+func findRegionByTwoPartKey(ctx context.Context, conn *ssoadmin.Client, instanceARN, regionName string) (*ssoadmin.DescribeRegionOutput, error) {
+	input := &ssoadmin.DescribeRegionInput{
+		InstanceArn: aws.String(instanceARN),
+		RegionName:  aws.String(regionName),
+	}
+
+	output, err := conn.DescribeRegion(ctx, input)
+	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+		return nil, &retry.NotFoundError{
+			LastError: err,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	if output == nil {
+		return nil, tfresource.NewEmptyResultError()
+	}
+
+	return output, nil
+}
+
+func statusRegion(conn *ssoadmin.Client, instanceARN, regionName string) retry.StateRefreshFunc {
+	return func(ctx context.Context) (any, string, error) {
+		output, err := findRegionByTwoPartKey(ctx, conn, instanceARN, regionName)
+		if retry.NotFound(err) {
+			return nil, "", nil
+		}
+		if err != nil {
+			return nil, "", err
+		}
+
+		return output, string(output.Status), nil
+	}
+}
+
+func waitRegionActive(ctx context.Context, conn *ssoadmin.Client, instanceARN, regionName string, timeout time.Duration) (*ssoadmin.DescribeRegionOutput, error) {
+	stateConf := &retry.StateChangeConf{
+		Pending: enum.Slice(awstypes.RegionStatusAdding),
+		Target:  enum.Slice(awstypes.RegionStatusActive),
+		Refresh: statusRegion(conn, instanceARN, regionName),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+
+	if output, ok := outputRaw.(*ssoadmin.DescribeRegionOutput); ok {
+		return output, err
+	}
+
+	return nil, err
+}
+
+func waitRegionDeleted(ctx context.Context, conn *ssoadmin.Client, instanceARN, regionName string, timeout time.Duration) (*ssoadmin.DescribeRegionOutput, error) {
+	stateConf := &retry.StateChangeConf{
+		Pending: enum.Slice(awstypes.RegionStatusActive, awstypes.RegionStatusRemoving),
+		Target:  []string{},
+		Refresh: statusRegion(conn, instanceARN, regionName),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+
+	if output, ok := outputRaw.(*ssoadmin.DescribeRegionOutput); ok {
+		return output, err
+	}
+
+	return nil, err
+}
+
+type regionResourceModel struct {
+	framework.WithRegionModel
+	AddedDate       timetypes.RFC3339                         `tfsdk:"added_date"`
+	ID              types.String                              `tfsdk:"id"`
+	InstanceARN     fwtypes.ARN                               `tfsdk:"instance_arn"`
+	IsPrimaryRegion types.Bool                                `tfsdk:"is_primary_region"`
+	RegionName      types.String                              `tfsdk:"region_name"`
+	Status          fwtypes.StringEnum[awstypes.RegionStatus] `tfsdk:"status"`
+	Timeouts        timeouts.Value                            `tfsdk:"timeouts"`
+}

--- a/internal/service/ssoadmin/region_test.go
+++ b/internal/service/ssoadmin/region_test.go
@@ -1,0 +1,164 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package ssoadmin_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/ssoadmin"
+	"github.com/aws/aws-sdk-go-v2/service/ssoadmin/types"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
+	tfssoadmin "github.com/hashicorp/terraform-provider-aws/internal/service/ssoadmin"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccSSOAdminRegion_serial(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]func(t *testing.T){
+		acctest.CtBasic:      testAccSSOAdminRegion_basic,
+		acctest.CtDisappears: testAccSSOAdminRegion_disappears,
+	}
+
+	acctest.RunSerialTests1Level(t, testCases, 0)
+}
+
+func testAccSSOAdminRegion_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	var region ssoadmin.DescribeRegionOutput
+	resourceName := "aws_ssoadmin_region.test"
+
+	acctest.Test(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.SSOAdminEndpointID)
+			acctest.PreCheckMultipleRegion(t, 2)
+			acctest.PreCheckSSOAdminInstances(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.SSOAdminServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckRegionDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRegionConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRegionExists(ctx, t, resourceName, &region),
+					resource.TestCheckResourceAttr(resourceName, "region_name", acctest.AlternateRegion()),
+					resource.TestCheckResourceAttr(resourceName, "is_primary_region", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, names.AttrStatus, string(types.RegionStatusActive)),
+					resource.TestCheckResourceAttrSet(resourceName, "added_date"),
+					resource.TestCheckResourceAttrPair(resourceName, "instance_arn", "data.aws_ssoadmin_instances.test", "arns.0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccSSOAdminRegion_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+	var region ssoadmin.DescribeRegionOutput
+	resourceName := "aws_ssoadmin_region.test"
+
+	acctest.Test(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.SSOAdminEndpointID)
+			acctest.PreCheckMultipleRegion(t, 2)
+			acctest.PreCheckSSOAdminInstances(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.SSOAdminServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckRegionDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRegionConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRegionExists(ctx, t, resourceName, &region),
+					acctest.CheckFrameworkResourceDisappears(ctx, t, tfssoadmin.ResourceRegion, resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccCheckRegionDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.ProviderMeta(ctx, t).SSOAdminClient(ctx)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_ssoadmin_region" {
+				continue
+			}
+
+			_, err := tfssoadmin.FindRegionByID(ctx, conn, rs.Primary.ID)
+			if retry.NotFound(err) {
+				return nil
+			}
+			if err != nil {
+				return create.Error(names.SSOAdmin, create.ErrActionCheckingDestroyed, tfssoadmin.ResNameRegion, rs.Primary.ID, err)
+			}
+
+			return create.Error(names.SSOAdmin, create.ErrActionCheckingDestroyed, tfssoadmin.ResNameRegion, rs.Primary.ID, errors.New("not destroyed"))
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckRegionExists(ctx context.Context, t *testing.T, name string, v *ssoadmin.DescribeRegionOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return create.Error(names.SSOAdmin, create.ErrActionCheckingExistence, tfssoadmin.ResNameRegion, name, errors.New("not found"))
+		}
+
+		if rs.Primary.ID == "" {
+			return create.Error(names.SSOAdmin, create.ErrActionCheckingExistence, tfssoadmin.ResNameRegion, name, errors.New("not set"))
+		}
+
+		conn := acctest.ProviderMeta(ctx, t).SSOAdminClient(ctx)
+
+		output, err := tfssoadmin.FindRegionByID(ctx, conn, rs.Primary.ID)
+		if err != nil {
+			return create.Error(names.SSOAdmin, create.ErrActionCheckingExistence, tfssoadmin.ResNameRegion, rs.Primary.ID, err)
+		}
+
+		*v = *output
+
+		return nil
+	}
+}
+
+func testAccRegionConfig_basic() string {
+	return fmt.Sprintf(`
+data "aws_ssoadmin_instances" "test" {}
+
+resource "aws_ssoadmin_region" "test" {
+  instance_arn = one(data.aws_ssoadmin_instances.test.arns)
+  region_name  = %[1]q
+}
+`, acctest.AlternateRegion())
+}

--- a/internal/service/ssoadmin/service_package_gen.go
+++ b/internal/service/ssoadmin/service_package_gen.go
@@ -123,6 +123,12 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*inttypes.Ser
 			},
 		},
 		{
+			Factory:  newRegionResource,
+			TypeName: "aws_ssoadmin_region",
+			Name:     "Region",
+			Region:   inttypes.ResourceRegionDefault(),
+		},
+		{
 			Factory:  newTrustedTokenIssuerResource,
 			TypeName: "aws_ssoadmin_trusted_token_issuer",
 			Name:     "Trusted Token Issuer",

--- a/website/docs/r/ssoadmin_region.html.markdown
+++ b/website/docs/r/ssoadmin_region.html.markdown
@@ -30,6 +30,10 @@ The following arguments are required:
 * `instance_arn` - (Required, Forces new resource) ARN of the IAM Identity Center instance.
 * `region_name` - (Required, Forces new resource) Name of the additional AWS Region to add.
 
+The following arguments are optional:
+
+* `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
+
 ## Attribute Reference
 
 This resource exports the following attributes in addition to the arguments above:

--- a/website/docs/r/ssoadmin_region.html.markdown
+++ b/website/docs/r/ssoadmin_region.html.markdown
@@ -1,0 +1,64 @@
+---
+subcategory: "SSO Admin"
+layout: "aws"
+page_title: "AWS: aws_ssoadmin_region"
+description: |-
+  Manages an IAM Identity Center Region.
+---
+
+# Resource: aws_ssoadmin_region
+
+Manages an additional Region for an IAM Identity Center instance.
+
+~> Removing this resource removes the additional Region from the IAM Identity Center instance. The primary Region cannot be removed.
+
+## Example Usage
+
+```terraform
+data "aws_ssoadmin_instances" "example" {}
+
+resource "aws_ssoadmin_region" "example" {
+  instance_arn = one(data.aws_ssoadmin_instances.example.arns)
+  region_name  = "us-west-2"
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `instance_arn` - (Required, Forces new resource) ARN of the IAM Identity Center instance.
+* `region_name` - (Required, Forces new resource) Name of the additional AWS Region to add.
+
+## Attribute Reference
+
+This resource exports the following attributes in addition to the arguments above:
+
+* `added_date` - Timestamp when the Region was added.
+* `id` - Resource ID in the format `instance_arn,region_name`.
+* `is_primary_region` - Whether the Region is the primary Region for the IAM Identity Center instance.
+* `status` - Current Region status.
+
+## Timeouts
+
+[Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
+
+* `create` - (Default `120m`)
+* `delete` - (Default `120m`)
+
+## Import
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import IAM Identity Center Regions using the `instance_arn,region_name`. For example:
+
+```terraform
+import {
+  to = aws_ssoadmin_region.example
+  id = "arn:aws:sso:::instance/ssoins-1234567890abcdef,us-west-2"
+}
+```
+
+Using `terraform import`, import IAM Identity Center Regions using the `instance_arn,region_name`. For example:
+
+```console
+% terraform import aws_ssoadmin_region.example arn:aws:sso:::instance/ssoins-1234567890abcdef,us-west-2
+```


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

This pull request adds support for managing IAM Identity Center Region configuration. It does not change provider-side access controls, encryption, or logging behavior. Users will need IAM permissions for the relevant SSO Admin Region management APIs, such as `sso:AddRegion`, `sso:DescribeRegion`, and `sso:RemoveRegion`.

### Description

Adds the `aws_ssoadmin_region` resource for managing additional AWS Regions for an IAM Identity Center instance.

The resource supports adding an additional Region, reading Region status, removing the Region, and importing existing Region associations using `instance_arn,region_name`.

### Relations

Closes #48397

### References

* AWS SDK for Go v2 SSO Admin `AddRegion`: https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/ssoadmin#Client.AddRegion
* AWS SDK for Go v2 SSO Admin `DescribeRegion`: https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/ssoadmin#Client.DescribeRegion
* AWS SDK for Go v2 SSO Admin `RemoveRegion`: https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/ssoadmin#Client.RemoveRegion
* AWS SDK for Go v2 SSO Admin `ListRegions`: https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/ssoadmin#Client.ListRegions

### Output from Acceptance Testing

```console
% go1.26.3 test -vet=off -p=1 -run '^$' ./internal/service/ssoadmin

ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ssoadmin	7.011s [no tests to run]