### PR TITLE
New Resource: aws_lexv2models_bot_alias

### DIFF
--- a/.changelog/48400.txt
+++ b/.changelog/48400.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_lexv2models_bot_alias
+```

--- a/internal/service/lexv2models/bot_alias.go
+++ b/internal/service/lexv2models/bot_alias.go
@@ -1,0 +1,750 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+// DONOTCOPY: Copying old resources spreads bad habits. Use skaff instead.
+
+package lexv2models
+
+// **PLEASE DELETE THIS AND ALL TIP COMMENTS BEFORE SUBMITTING A PR FOR REVIEW!**
+//
+// TIP: ==== INTRODUCTION ====
+// Thank you for trying the skaff tool!
+//
+// You have opted to include these helpful comments. They all include "TIP:"
+// to help you find and remove them when you're done with them.
+//
+// While some aspects of this file are customized to your input, the
+// scaffold tool does *not* look at the AWS API and ensure it has correct
+// function, structure, and variable names. It makes guesses based on
+// commonalities. You will need to make significant adjustments.
+//
+// In other words, as generated, this is a rough outline of the work you will
+// need to do. If something doesn't make sense for your situation, get rid of
+// it.
+
+import (
+	// TIP: ==== IMPORTS ====
+	// This is a common set of imports but not customized to your code since
+	// your code hasn't been written yet. Make sure you, your IDE, or
+	// goimports -w <file> fixes these imports.
+	//
+	// The provider linter wants your imports to be in two groups: first,
+	// standard library (i.e., "fmt" or "strings"), second, everything else.
+	//
+	// Also, AWS Go SDK v2 may handle nested structures differently than v1,
+	// using the services/lexmodelsv2/types package. If so, you'll
+	// need to import types and reference the nested types, e.g., as
+	// awstypes.<Type Name>.
+	"context"
+	"errors"
+	"time"
+
+	"github.com/YakDriver/smarterr"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/lexmodelsv2"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/lexmodelsv2/types"
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
+	"github.com/hashicorp/terraform-provider-aws/internal/smerr"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
+	sweepfw "github.com/hashicorp/terraform-provider-aws/internal/sweep/framework"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+// TIP: ==== FILE STRUCTURE ====
+// All resources should follow this basic outline. Improve this resource's
+// maintainability by sticking to it.
+//
+// 1. Package declaration
+// 2. Imports
+// 3. Main resource struct with schema method
+// 4. Create, read, update, delete methods (in that order)
+// 5. Other functions (flatteners, expanders, waiters, finders, etc.)
+
+// Function annotations are used for resource registration to the Provider. DO NOT EDIT.
+// @FrameworkResource("aws_lexv2models_bot_alias", name="Bot Alias")
+// @Tags(identifierAttribute="arn")
+
+// TIP: ==== RESOURCE IDENTITY ====
+// Identify which attributes can be used to uniquely identify the resource.
+// 
+// * If the AWS APIs for the resource take the ARN as an identifier, use
+// ARN Identity.
+// * If the resource is a singleton (i.e., there is only one instance per region, or account for global resource types), use Singleton Identity.
+// * Otherwise, use Parameterized Identity with one or more identity attributes.
+//
+// For more information about resource identity, see
+// https://hashicorp.github.io/terraform-provider-aws/resource-identity/
+//
+// Keep one of the following sets of annotations as appropriate:
+//
+// * ARN Identity
+// @ArnIdentity
+// or
+// @ArnIdentity("arn_attribute")
+//
+// * Singleton Identity
+// @SingletonIdentity
+//
+// * Parameterized Identity
+// @IdentityAttribute("id_attribute")
+// // @IdentityAttribute("another_id_attribute")
+//
+// TIP: ==== GENERATED ACCEPTANCE TESTS ====
+// Resource Identity and tagging make use of automatically generated acceptance tests.
+// For more information about automatically generated acceptance tests, see
+// https://hashicorp.github.io/terraform-provider-aws/acc-test-generation/
+//
+// Some common annotations are included below:
+// @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/lexmodelsv2;lexmodelsv2.DescribeBotAliasResponse")
+// @Testing(preCheck="testAccPreCheck")
+// @Testing(importIgnore="...;...")
+// @Testing(hasNoPreExistingResource=true)
+func newBotAliasResource(_ context.Context) (resource.ResourceWithConfigure, error) {
+	r := &botAliasResource{}
+
+	// TIP: ==== CONFIGURABLE TIMEOUTS ====
+	// Users can configure timeout lengths but you need to use the times they
+	// provide. Access the timeout they configure (or the defaults) using,
+	// e.g., r.CreateTimeout(ctx, plan.Timeouts) (see below). The times here are
+	// the defaults if they don't configure timeouts.
+	r.SetDefaultCreateTimeout(30 * time.Minute)
+	r.SetDefaultUpdateTimeout(30 * time.Minute)
+	r.SetDefaultDeleteTimeout(30 * time.Minute)
+
+	return r, nil
+}
+
+const (
+	ResNameBotAlias = "Bot Alias"
+)
+
+type botAliasResource struct {
+	framework.ResourceWithModel[botAliasResourceModel]
+	framework.WithTimeouts
+	framework.WithImportByIdentity
+}
+
+
+// TIP: ==== SCHEMA ====
+// In the schema, add each of the attributes in snake case (e.g.,
+// delete_automated_backups).
+//
+// Formatting rules:
+// * Alphabetize attributes to make them easier to find.
+// * Do not add a blank line between attributes.
+//
+// Attribute basics:
+// * If a user can provide a value ("configure a value") for an
+//   attribute (e.g., instances = 5), we call the attribute an
+//   "argument."
+// * You change the way users interact with attributes using:
+//     - Required
+//     - Optional
+//     - Computed
+// * There are only four valid combinations:
+//
+// 1. Required only - the user must provide a value
+// Required: true,
+//
+// 2. Optional only - the user can configure or omit a value; do not
+//    use Default or DefaultFunc
+// Optional: true,
+//
+// 3. Computed only - the provider can provide a value but the user
+//    cannot, i.e., read-only
+// Computed: true,
+//
+// 4. Optional AND Computed - the provider or user can provide a value;
+//    use this combination if you are using Default
+// Optional: true,
+// Computed: true,
+//
+// You will typically find arguments in the input struct
+// (e.g., CreateDBInstanceInput) for the create operation. Sometimes
+// they are only in the input struct (e.g., ModifyDBInstanceInput) for
+// the modify operation.
+//
+// For more about schema options, visit
+// https://developer.hashicorp.com/terraform/plugin/framework/handling-data/schemas?page=schemas
+func (r *botAliasResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			names.AttrARN: framework.ARNAttributeComputedOnly(),
+			names.AttrDescription: schema.StringAttribute{
+				Optional: true,
+			},
+			// TIP: ==== "ID" ATTRIBUTE ====
+			// When using the Terraform Plugin Framework, there is no required "id" attribute.
+			// This is different from the Terraform Plugin SDK.
+			//
+			// Only include an "id" attribute if the AWS API has an "Id" field, such as "BotAliasId"
+			names.AttrID: framework.IDAttribute(),
+			names.AttrName: schema.StringAttribute{
+				Required: true,
+				// TIP: ==== PLAN MODIFIERS ====
+				// Plan modifiers were introduced with Plugin-Framework to provide a mechanism
+				// for adjusting planned changes prior to apply. The planmodifier subpackage
+				// provides built-in modifiers for many common use cases such as
+				// requiring replacement on a value change ("ForceNew: true" in Plugin-SDK
+				// resources).
+				//
+				// See more:
+				// https://developer.hashicorp.com/terraform/plugin/framework/resources/plan-modification
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			names.AttrTags:    tftags.TagsAttribute(),
+			names.AttrTagsAll: tftags.TagsAttributeComputedOnly(),
+			"type": schema.StringAttribute{
+				Required: true,
+			},
+		},
+		Blocks: map[string]schema.Block{
+			"complex_argument": schema.ListNestedBlock{
+				// TIP: ==== CUSTOM TYPES ====
+				// Use a custom type to identify the model type of the tested object
+				CustomType: fwtypes.NewListNestedObjectTypeOf[complexArgumentModel](ctx),
+				// TIP: ==== LIST VALIDATORS ====
+				// List and set validators take the place of MaxItems and MinItems in
+				// Plugin-Framework based resources. Use listvalidator.SizeAtLeast(1) to
+				// make a nested object required. Similar to Plugin-SDK, complex objects
+				// can be represented as lists or sets with listvalidator.SizeAtMost(1).
+				//
+				// For a complete mapping of Plugin-SDK to Plugin-Framework schema fields,
+				// see:
+				// https://developer.hashicorp.com/terraform/plugin/framework/migrating/attributes-blocks/blocks
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"nested_required": schema.StringAttribute{
+							Required: true,
+						},
+						"nested_computed": schema.StringAttribute{
+							Computed: true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
+						},
+					},
+				},
+			},
+			names.AttrTimeouts: timeouts.Block(ctx, timeouts.Opts{
+				Create: true,
+				Update: true,
+				Delete: true,
+			}),
+		},
+	}
+}
+
+func (r *botAliasResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	// TIP: ==== RESOURCE CREATE ====
+	// Generally, the Create function should do the following things. Make
+	// sure there is a good reason if you don't do one of these.
+	//
+	// 1. Get a client connection to the relevant service
+	// 2. Fetch the plan
+	// 3. Populate a create input structure
+	// 4. Call the AWS create/put function
+	// 5. Using the output from the create function, set the minimum arguments
+	//    and attributes for the Read function to work, as well as any computed
+	//    only attributes.
+	// 6. Use a waiter to wait for create to complete
+	// 7. Save the request plan to response state
+
+	// TIP: -- 1. Get a client connection to the relevant service
+	conn := r.Meta().LexV2ModelsClient(ctx)
+	
+	// TIP: -- 2. Fetch the plan
+	var plan botAliasResourceModel
+	smerr.AddEnrich(ctx, &resp.Diagnostics, req.Plan.Get(ctx, &plan))
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// TIP: -- 3. Populate a Create input structure
+	var input lexmodelsv2.CreateBotAliasInput
+	// TIP: Using a field name prefix allows mapping fields such as `ID` to `BotAliasId`
+	smerr.AddEnrich(ctx, &resp.Diagnostics, flex.Expand(ctx, plan, &input, flex.WithFieldNamePrefix("BotAlias")))
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	input.Tags = getTagsIn(ctx)
+
+	// TIP: -- 4. Call the AWS Create function
+	out, err := conn.CreateBotAlias(ctx, &input)
+	if err != nil {
+		// TIP: Since ID has not been set yet, you cannot use plan.ID.String()
+		// in error messages at this point.
+		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, plan.Name.String())
+		return
+	}
+	if out == nil || out.BotAlias == nil {
+		smerr.AddError(ctx, &resp.Diagnostics, errors.New("empty output"), smerr.ID, plan.Name.String())
+		return
+	}
+
+	// TIP: -- 5. Using the output from the create function, set attributes
+	smerr.AddEnrich(ctx, &resp.Diagnostics, flex.Flatten(ctx, out, &plan))
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// TIP: -- 6. Use a waiter to wait for create to complete
+	createTimeout := r.CreateTimeout(ctx, plan.Timeouts)
+	_, err = waitBotAliasCreated(ctx, conn, plan.ID.ValueString(), createTimeout)
+	if err != nil {
+		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, plan.Name.String())
+		return
+	}
+	
+	// TIP: -- 7. Save the request plan to response state
+	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, plan))
+}
+
+func (r *botAliasResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	// TIP: ==== RESOURCE READ ====
+	// Generally, the Read function should do the following things. Make
+	// sure there is a good reason if you don't do one of these.
+	//
+	// 1. Get a client connection to the relevant service
+	// 2. Fetch the state
+	// 3. Get the resource from AWS
+	// 4. Remove resource from state if it is not found
+	// 5. Set the arguments and attributes
+	// 6. Set the state
+
+	// TIP: -- 1. Get a client connection to the relevant service
+	conn := r.Meta().LexV2ModelsClient(ctx)
+	
+	// TIP: -- 2. Fetch the state
+	var state botAliasResourceModel
+	smerr.AddEnrich(ctx, &resp.Diagnostics, req.State.Get(ctx, &state))
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	
+	// TIP: -- 3. Get the resource from AWS using an API Get, List, or Describe-
+	// type function, or, better yet, using a finder.
+	out, err := findBotAliasByID(ctx, conn, state.ID.ValueString())
+	// TIP: -- 4. Remove resource from state if it is not found
+	if retry.NotFound(err) {
+		resp.Diagnostics.Append(fwdiag.NewResourceNotFoundWarningDiagnostic(err))
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	if err != nil {
+		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, state.ID.String())
+		return
+	}
+	
+	// TIP: -- 5. Set the arguments and attributes
+	smerr.AddEnrich(ctx, &resp.Diagnostics, r.flatten(ctx, out, &state))
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	
+	// TIP: -- 6. Set the state
+	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, &state))
+}
+
+func (r *botAliasResource) flatten(ctx context.Context, botAlias *awstypes.BotAlias, data *botAliasResourceModel) (diags diag.Diagnostics) {
+	diags.Append(fwflex.Flatten(ctx, botAlias, data)...)
+	return diags
+}
+
+func (r *botAliasResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	// TIP: ==== RESOURCE UPDATE ====
+	// Not all resources have Update functions. There are a few reasons:
+	// a. The AWS API does not support changing a resource
+	// b. All arguments have RequiresReplace() plan modifiers
+	// c. The AWS API uses a create call to modify an existing resource
+	//
+	// In the cases of a. and b., the resource will not have an update method
+	// defined. In the case of c., Update and Create can be refactored to call
+	// the same underlying function.
+	//
+	// The rest of the time, there should be an Update function and it should
+	// do the following things. Make sure there is a good reason if you don't
+	// do one of these.
+	//
+	// 1. Get a client connection to the relevant service
+	// 2. Fetch the plan and state
+	// 3. Populate a modify input structure and check for changes
+	// 4. Call the AWS modify/update function
+	// 5. Use a waiter to wait for update to complete
+	// 6. Save the request plan to response state
+	// TIP: -- 1. Get a client connection to the relevant service
+	conn := r.Meta().LexV2ModelsClient(ctx)
+	
+	// TIP: -- 2. Fetch the plan
+	var plan, state botAliasResourceModel
+	smerr.AddEnrich(ctx, &resp.Diagnostics, req.Plan.Get(ctx, &plan))
+	smerr.AddEnrich(ctx, &resp.Diagnostics, req.State.Get(ctx, &state))
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	
+	// TIP: -- 3. Get the difference between the plan and state, if any
+	diff, d := flex.Diff(ctx, plan, state)
+	smerr.AddEnrich(ctx, &resp.Diagnostics, d)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if diff.HasChanges() {
+		var input lexmodelsv2.UpdateBotAliasInput
+		smerr.AddEnrich(ctx, &resp.Diagnostics, flex.Expand(ctx, plan, &input, flex.WithFieldNamePrefix("Test")))
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		
+		// TIP: -- 4. Call the AWS modify/update function
+		out, err := conn.UpdateBotAlias(ctx, &input)
+		if err != nil {
+			smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, plan.ID.String())
+			return
+		}
+		if out == nil || out.BotAlias == nil {
+			smerr.AddError(ctx, &resp.Diagnostics, errors.New("empty output"), smerr.ID, plan.ID.String())
+			return
+		}
+		
+		// TIP: Using the output from the update function, re-set any computed attributes
+		smerr.AddEnrich(ctx, &resp.Diagnostics, flex.Flatten(ctx, out, &plan))
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
+	// TIP: -- 5. Use a waiter to wait for update to complete
+	updateTimeout := r.UpdateTimeout(ctx, plan.Timeouts)
+	_, err := waitBotAliasUpdated(ctx, conn, plan.ID.ValueString(), updateTimeout)
+	if err != nil {
+		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, plan.ID.String())
+		return
+	}
+
+	// TIP: -- 6. Save the request plan to response state
+	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, &plan))
+}
+
+func (r *botAliasResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	// TIP: ==== RESOURCE DELETE ====
+	// Most resources have Delete functions. There are rare situations
+	// where you might not need a delete:
+	// a. The AWS API does not provide a way to delete the resource
+	// b. The point of your resource is to perform an action (e.g., reboot a
+	//    server) and deleting serves no purpose.
+	//
+	// The Delete function should do the following things. Make sure there
+	// is a good reason if you don't do one of these.
+	//
+	// 1. Get a client connection to the relevant service
+	// 2. Fetch the state
+	// 3. Populate a delete input structure
+	// 4. Call the AWS delete function
+	// 5. Use a waiter to wait for delete to complete
+	// TIP: -- 1. Get a client connection to the relevant service
+	conn := r.Meta().LexV2ModelsClient(ctx)
+	
+	// TIP: -- 2. Fetch the state
+	var state botAliasResourceModel
+	smerr.AddEnrich(ctx, &resp.Diagnostics, req.State.Get(ctx, &state))
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	
+	// TIP: -- 3. Populate a delete input structure
+	input := lexv2models.DeleteBotAliasInput{
+		BotAliasId: state.ID.ValueStringPointer(),
+	}
+	
+	// TIP: -- 4. Call the AWS delete function
+	_, err := conn.DeleteBotAlias(ctx, &input)
+	// TIP: On rare occassions, the API returns a not found error after deleting a
+	// resource. If that happens, we don't want it to show up as an error.
+	if err != nil {
+		if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+			return
+		}
+
+		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, state.ID.String())
+		return
+	}
+	
+	// TIP: -- 5. Use a waiter to wait for delete to complete
+	deleteTimeout := r.DeleteTimeout(ctx, state.Timeouts)
+	_, err = waitBotAliasDeleted(ctx, conn, state.ID.ValueString(), deleteTimeout)
+	if err != nil {
+		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, state.ID.String())
+		return
+	}
+}
+
+// TIP: ==== TERRAFORM IMPORTING ====
+// The built-in import function, and Import ID Handler, if any, should handle populating the required
+// attributes from the Import ID or Resource Identity.
+// In some cases, additional attributes must be set when importing.
+// Adding a custom ImportState function can handle those.
+//
+// See more:
+// https://hashicorp.github.io/terraform-provider-aws/add-resource-identity-support/
+// func (r *botAliasResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+// 	r.WithImportByIdentity.ImportState(ctx, req, resp)
+// 
+// 	// Set needed attribute values here
+// }
+
+
+// TIP: ==== STATUS CONSTANTS ====
+// Create constants for states and statuses if the service does not
+// already have suitable constants. We prefer that you use the constants
+// provided in the service if available (e.g., awstypes.StatusInProgress).
+const (
+	statusChangePending = "Pending"
+	statusDeleting      = "Deleting"
+	statusNormal        = "Normal"
+	statusUpdated       = "Updated"
+)
+
+// TIP: ==== WAITERS ====
+// Some resources of some services have waiters provided by the AWS API.
+// Unless they do not work properly, use them rather than defining new ones
+// here.
+//
+// Sometimes we define the wait, status, and find functions in separate
+// files, wait.go, status.go, and find.go. Follow the pattern set out in the
+// service and define these where it makes the most sense.
+//
+// If these functions are used in the _test.go file, they will need to be
+// exported (i.e., capitalized).
+//
+// You will need to adjust the parameters and names to fit the service.
+func waitBotAliasCreated(ctx context.Context, conn *lexv2models.Client, id string, timeout time.Duration) (*awstypes.BotAlias, error) {
+	stateConf := &retry.StateChangeConf{
+		Pending:                   []string{},
+		Target:                    []string{statusNormal},
+		Refresh:                   statusBotAlias(conn, id),
+		Timeout:                   timeout,
+		NotFoundChecks:            20,
+		ContinuousTargetOccurence: 2,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+	if out, ok := outputRaw.(*awstypes.BotAlias); ok {
+		return out, smarterr.NewError(err)
+	}
+
+	return nil, smarterr.NewError(err)
+}
+
+// TIP: It is easier to determine whether a resource is updated for some
+// resources than others. The best case is a status flag that tells you when
+// the update has been fully realized. Other times, you can check to see if a
+// key resource argument is updated to a new value or not.
+func waitBotAliasUpdated(ctx context.Context, conn *lexv2models.Client, id string, timeout time.Duration) (*awstypes.BotAlias, error) {
+	stateConf := &retry.StateChangeConf{
+		Pending:                   []string{statusChangePending},
+		Target:                    []string{statusUpdated},
+		Refresh:                   statusBotAlias(conn, id),
+		Timeout:                   timeout,
+		NotFoundChecks:            20,
+		ContinuousTargetOccurence: 2,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+	if out, ok := outputRaw.(*awstypes.BotAlias); ok {
+		return out, smarterr.NewError(err)
+	}
+
+	return nil, smarterr.NewError(err)
+}
+
+// TIP: A deleted waiter is almost like a backwards created waiter. There may
+// be additional pending states, however.
+func waitBotAliasDeleted(ctx context.Context, conn *lexv2models.Client, id string, timeout time.Duration) (*awstypes.BotAlias, error) {
+	stateConf := &retry.StateChangeConf{
+		Pending: []string{statusDeleting, statusNormal},
+		Target:  []string{},
+		Refresh: statusBotAlias(conn, id),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+	if out, ok := outputRaw.(*awstypes.BotAlias); ok {
+		return out, smarterr.NewError(err)
+	}
+
+	return nil, smarterr.NewError(err)
+}
+
+// TIP: ==== STATUS ====
+// The status function can return an actual status when that field is
+// available from the API (e.g., out.Status). Otherwise, you can use custom
+// statuses to communicate the states of the resource.
+//
+// Waiters consume the values returned by status functions. Design status so
+// that it can be reused by a create, update, and delete waiter, if possible.
+func statusBotAlias(conn *lexv2models.Client, id string) retry.StateRefreshFunc {
+	return func(ctx context.Context) (any, string, error) {
+		out, err := findBotAliasByID(ctx, conn, id)
+		if retry.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", smarterr.NewError(err)
+		}
+
+		return out, aws.ToString(out.Status), nil
+	}
+}
+
+// TIP: ==== FINDERS ====
+// The find function is not strictly necessary. You could do the API
+// request from the status function. However, we have found that find often
+// comes in handy in other places besides the status function. As a result, it
+// is good practice to define it separately.
+func findBotAliasByID(ctx context.Context, conn *lexv2models.Client, id string) (*awstypes.BotAlias, error) {
+	input := lexv2models.GetBotAliasInput{
+		Id: aws.String(id),
+	}
+
+	out, err := conn.GetBotAlias(ctx, &input)
+	if err != nil {
+		if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+			return nil, smarterr.NewError(&retry.NotFoundError{
+				LastError:   err,
+			})
+		}
+
+		return nil, smarterr.NewError(err)
+	}
+
+	if out == nil || out.BotAlias == nil {
+		return nil, smarterr.NewError(tfresource.NewEmptyResultError())
+	}
+
+	return out.BotAlias, nil
+}
+
+// TIP: ==== DATA STRUCTURES ====
+// With Terraform Plugin-Framework configurations are deserialized into
+// Go types, providing type safety without the need for type assertions.
+// These structs should match the schema definition exactly, and the `tfsdk`
+// tag value should match the attribute name.
+//
+// Nested objects are represented in their own data struct. These will
+// also have a corresponding attribute type mapping for use inside flex
+// functions.
+//
+// See more:
+// https://developer.hashicorp.com/terraform/plugin/framework/handling-data/accessing-values
+type botAliasResourceModel struct {
+	framework.WithRegionModel
+	ARN             types.String                                          `tfsdk:"arn"`
+	ComplexArgument fwtypes.ListNestedObjectValueOf[complexArgumentModel] `tfsdk:"complex_argument"`
+	Description     types.String                                          `tfsdk:"description"`
+	ID              types.String                                          `tfsdk:"id"`
+	Name            types.String                                          `tfsdk:"name"`
+	Tags            tftags.Map                                            `tfsdk:"tags"`
+	TagsAll         tftags.Map                                            `tfsdk:"tags_all"`
+	Timeouts        timeouts.Value                                        `tfsdk:"timeouts"`
+	Type            types.String                                          `tfsdk:"type"`
+}
+
+type complexArgumentModel struct {
+	NestedRequired types.String `tfsdk:"nested_required"`
+	NestedOptional types.String `tfsdk:"nested_optional"`
+}
+
+
+// TIP: ==== IMPORT ID HANDLER ====
+// When a resource type has a Resource Identity with multiple attributes, it needs a handler to
+// parse the Import ID used for the `terraform import` command or an `import` block with the `id` parameter.
+//
+// The parser takes the string value of the Import ID and returns:
+// * A string value that is typically ignored. See documentation for more details.
+// * A map of the resource attributes derived from the Import ID.
+// * An error value if there are parsing errors.
+//
+// For more information, see https://hashicorp.github.io/terraform-provider-aws/resource-identity/#plugin-framework
+var (
+	_ inttypes.ImportIDParser = botAliasImportID{}
+)
+
+type botAliasImportID struct{}
+
+func (botAliasImportID) Parse(id string) (string, map[string]string, error) {
+	someValue, anotherValue, found := strings.Cut(id, intflex.ResourceIdSeparator)
+	if !found {
+		return "", nil, fmt.Errorf("id \"%s\" should be in the format <some-value>"+intflex.ResourceIdSeparator+"<another-value>", id)
+	}
+
+	result := map[string]string{
+		"some-value":    someValue,
+		"another-value": anotherValue,
+	}
+
+	return id, result, nil
+}
+
+
+// TIP: ==== SWEEPERS ====
+// When acceptance testing resources, interrupted or failed tests may
+// leave behind orphaned resources in an account. To facilitate cleaning
+// up lingering resources, each resource implementation should include
+// a corresponding "sweeper" function.
+//
+// The sweeper function lists all resources of a given type and sets the
+// appropriate identifers required to delete the resource via the Delete
+// method implemented above.
+//
+// Once the sweeper function is implemented, register it in sweep.go
+// as follows:
+//
+//  awsv2.Register("aws_lexv2models_bot_alias", sweepBotAliass)
+//
+// See more:
+// https://hashicorp.github.io/terraform-provider-aws/running-and-writing-acceptance-tests/#acceptance-test-sweepers
+func sweepBotAliass(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepable, error) {
+	input := lexv2models.ListBotAliassInput{}
+	conn := client.LexV2ModelsClient(ctx)
+	var sweepResources []sweep.Sweepable
+
+	pages := lexv2models.NewListBotAliassPaginator(conn, &input)
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
+		if err != nil {
+			return nil, smarterr.NewError(err)
+		}
+
+		for _, v := range page.BotAliass {
+			sweepResources = append(sweepResources, sweepfw.NewSweepResource(newBotAliasResource, client,
+				sweepfw.NewAttribute(names.AttrID, aws.ToString(v.BotAliasId))),
+			)
+		}
+	}
+
+	return sweepResources, nil
+}

--- a/internal/service/lexv2models/bot_alias.go
+++ b/internal/service/lexv2models/bot_alias.go
@@ -156,7 +156,7 @@ func (r *botAliasResource) Schema(ctx context.Context, request resource.SchemaRe
 										},
 										NestedObject: schema.NestedBlockObject{
 											Blocks: map[string]schema.Block{
-												"s3_bucket": schema.ListNestedBlock{
+												names.AttrS3Bucket: schema.ListNestedBlock{
 													CustomType: fwtypes.NewListNestedObjectTypeOf[s3BucketLogDestinationModel](ctx),
 													Validators: []validator.List{
 														listvalidator.IsRequired(),
@@ -165,7 +165,7 @@ func (r *botAliasResource) Schema(ctx context.Context, request resource.SchemaRe
 													},
 													NestedObject: schema.NestedBlockObject{
 														Attributes: map[string]schema.Attribute{
-															"kms_key_arn": schema.StringAttribute{
+															names.AttrKMSKeyARN: schema.StringAttribute{
 																CustomType: fwtypes.ARNType,
 																Optional:   true,
 															},
@@ -212,7 +212,7 @@ func (r *botAliasResource) Schema(ctx context.Context, request resource.SchemaRe
 													},
 													NestedObject: schema.NestedBlockObject{
 														Attributes: map[string]schema.Attribute{
-															"cloudwatch_log_group_arn": schema.StringAttribute{
+															names.AttrCloudWatchLogGroupARN: schema.StringAttribute{
 																CustomType: fwtypes.ARNType,
 																Required:   true,
 															},

--- a/internal/service/lexv2models/bot_alias.go
+++ b/internal/service/lexv2models/bot_alias.go
@@ -5,41 +5,11 @@
 
 package lexv2models
 
-// **PLEASE DELETE THIS AND ALL TIP COMMENTS BEFORE SUBMITTING A PR FOR REVIEW!**
-//
-// TIP: ==== INTRODUCTION ====
-// Thank you for trying the skaff tool!
-//
-// You have opted to include these helpful comments. They all include "TIP:"
-// to help you find and remove them when you're done with them.
-//
-// While some aspects of this file are customized to your input, the
-// scaffold tool does *not* look at the AWS API and ensure it has correct
-// function, structure, and variable names. It makes guesses based on
-// commonalities. You will need to make significant adjustments.
-//
-// In other words, as generated, this is a rough outline of the work you will
-// need to do. If something doesn't make sense for your situation, get rid of
-// it.
-
 import (
-	// TIP: ==== IMPORTS ====
-	// This is a common set of imports but not customized to your code since
-	// your code hasn't been written yet. Make sure you, your IDE, or
-	// goimports -w <file> fixes these imports.
-	//
-	// The provider linter wants your imports to be in two groups: first,
-	// standard library (i.e., "fmt" or "strings"), second, everything else.
-	//
-	// Also, AWS Go SDK v2 may handle nested structures differently than v1,
-	// using the services/lexmodelsv2/types package. If so, you'll
-	// need to import types and reference the nested types, e.g., as
-	// awstypes.<Type Name>.
 	"context"
-	"errors"
+	"fmt"
 	"time"
 
-	"github.com/YakDriver/smarterr"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/lexmodelsv2"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/lexmodelsv2/types"
@@ -52,77 +22,24 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
+	intflex "github.com/hashicorp/terraform-provider-aws/internal/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
-	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
 	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
-	"github.com/hashicorp/terraform-provider-aws/internal/smerr"
-	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
-	sweepfw "github.com/hashicorp/terraform-provider-aws/internal/sweep/framework"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
-// TIP: ==== FILE STRUCTURE ====
-// All resources should follow this basic outline. Improve this resource's
-// maintainability by sticking to it.
-//
-// 1. Package declaration
-// 2. Imports
-// 3. Main resource struct with schema method
-// 4. Create, read, update, delete methods (in that order)
-// 5. Other functions (flatteners, expanders, waiters, finders, etc.)
 
-// Function annotations are used for resource registration to the Provider. DO NOT EDIT.
 // @FrameworkResource("aws_lexv2models_bot_alias", name="Bot Alias")
 // @Tags(identifierAttribute="arn")
-
-// TIP: ==== RESOURCE IDENTITY ====
-// Identify which attributes can be used to uniquely identify the resource.
-// 
-// * If the AWS APIs for the resource take the ARN as an identifier, use
-// ARN Identity.
-// * If the resource is a singleton (i.e., there is only one instance per region, or account for global resource types), use Singleton Identity.
-// * Otherwise, use Parameterized Identity with one or more identity attributes.
-//
-// For more information about resource identity, see
-// https://hashicorp.github.io/terraform-provider-aws/resource-identity/
-//
-// Keep one of the following sets of annotations as appropriate:
-//
-// * ARN Identity
-// @ArnIdentity
-// or
-// @ArnIdentity("arn_attribute")
-//
-// * Singleton Identity
-// @SingletonIdentity
-//
-// * Parameterized Identity
-// @IdentityAttribute("id_attribute")
-// // @IdentityAttribute("another_id_attribute")
-//
-// TIP: ==== GENERATED ACCEPTANCE TESTS ====
-// Resource Identity and tagging make use of automatically generated acceptance tests.
-// For more information about automatically generated acceptance tests, see
-// https://hashicorp.github.io/terraform-provider-aws/acc-test-generation/
-//
-// Some common annotations are included below:
-// @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/lexmodelsv2;lexmodelsv2.DescribeBotAliasResponse")
-// @Testing(preCheck="testAccPreCheck")
-// @Testing(importIgnore="...;...")
-// @Testing(hasNoPreExistingResource=true)
 func newBotAliasResource(_ context.Context) (resource.ResourceWithConfigure, error) {
 	r := &botAliasResource{}
 
-	// TIP: ==== CONFIGURABLE TIMEOUTS ====
-	// Users can configure timeout lengths but you need to use the times they
-	// provide. Access the timeout they configure (or the defaults) using,
-	// e.g., r.CreateTimeout(ctx, plan.Timeouts) (see below). The times here are
-	// the defaults if they don't configure timeouts.
 	r.SetDefaultCreateTimeout(30 * time.Minute)
 	r.SetDefaultUpdateTimeout(30 * time.Minute)
 	r.SetDefaultDeleteTimeout(30 * time.Minute)
@@ -130,119 +47,199 @@ func newBotAliasResource(_ context.Context) (resource.ResourceWithConfigure, err
 	return r, nil
 }
 
-const (
-	ResNameBotAlias = "Bot Alias"
-)
-
 type botAliasResource struct {
 	framework.ResourceWithModel[botAliasResourceModel]
+	framework.WithImportByID
 	framework.WithTimeouts
-	framework.WithImportByIdentity
 }
 
-
-// TIP: ==== SCHEMA ====
-// In the schema, add each of the attributes in snake case (e.g.,
-// delete_automated_backups).
-//
-// Formatting rules:
-// * Alphabetize attributes to make them easier to find.
-// * Do not add a blank line between attributes.
-//
-// Attribute basics:
-// * If a user can provide a value ("configure a value") for an
-//   attribute (e.g., instances = 5), we call the attribute an
-//   "argument."
-// * You change the way users interact with attributes using:
-//     - Required
-//     - Optional
-//     - Computed
-// * There are only four valid combinations:
-//
-// 1. Required only - the user must provide a value
-// Required: true,
-//
-// 2. Optional only - the user can configure or omit a value; do not
-//    use Default or DefaultFunc
-// Optional: true,
-//
-// 3. Computed only - the provider can provide a value but the user
-//    cannot, i.e., read-only
-// Computed: true,
-//
-// 4. Optional AND Computed - the provider or user can provide a value;
-//    use this combination if you are using Default
-// Optional: true,
-// Computed: true,
-//
-// You will typically find arguments in the input struct
-// (e.g., CreateDBInstanceInput) for the create operation. Sometimes
-// they are only in the input struct (e.g., ModifyDBInstanceInput) for
-// the modify operation.
-//
-// For more about schema options, visit
-// https://developer.hashicorp.com/terraform/plugin/framework/handling-data/schemas?page=schemas
-func (r *botAliasResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
-	resp.Schema = schema.Schema{
+func (r *botAliasResource) Schema(ctx context.Context, request resource.SchemaRequest, response *resource.SchemaResponse) {
+	response.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			names.AttrARN: framework.ARNAttributeComputedOnly(),
-			names.AttrDescription: schema.StringAttribute{
-				Optional: true,
+			"bot_alias_id": schema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
-			// TIP: ==== "ID" ATTRIBUTE ====
-			// When using the Terraform Plugin Framework, there is no required "id" attribute.
-			// This is different from the Terraform Plugin SDK.
-			//
-			// Only include an "id" attribute if the AWS API has an "Id" field, such as "BotAliasId"
-			names.AttrID: framework.IDAttribute(),
-			names.AttrName: schema.StringAttribute{
+			"bot_alias_name": schema.StringAttribute{
 				Required: true,
-				// TIP: ==== PLAN MODIFIERS ====
-				// Plan modifiers were introduced with Plugin-Framework to provide a mechanism
-				// for adjusting planned changes prior to apply. The planmodifier subpackage
-				// provides built-in modifiers for many common use cases such as
-				// requiring replacement on a value change ("ForceNew: true" in Plugin-SDK
-				// resources).
-				//
-				// See more:
-				// https://developer.hashicorp.com/terraform/plugin/framework/resources/plan-modification
+			},
+			"bot_id": schema.StringAttribute{
+				Required: true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
+			"bot_version": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			names.AttrDescription: schema.StringAttribute{
+				Optional: true,
+			},
+			names.AttrID:      framework.IDAttribute(),
 			names.AttrTags:    tftags.TagsAttribute(),
 			names.AttrTagsAll: tftags.TagsAttributeComputedOnly(),
-			"type": schema.StringAttribute{
-				Required: true,
-			},
 		},
 		Blocks: map[string]schema.Block{
-			"complex_argument": schema.ListNestedBlock{
-				// TIP: ==== CUSTOM TYPES ====
-				// Use a custom type to identify the model type of the tested object
-				CustomType: fwtypes.NewListNestedObjectTypeOf[complexArgumentModel](ctx),
-				// TIP: ==== LIST VALIDATORS ====
-				// List and set validators take the place of MaxItems and MinItems in
-				// Plugin-Framework based resources. Use listvalidator.SizeAtLeast(1) to
-				// make a nested object required. Similar to Plugin-SDK, complex objects
-				// can be represented as lists or sets with listvalidator.SizeAtMost(1).
-				//
-				// For a complete mapping of Plugin-SDK to Plugin-Framework schema fields,
-				// see:
-				// https://developer.hashicorp.com/terraform/plugin/framework/migrating/attributes-blocks/blocks
+			"bot_alias_locale_settings": schema.SetNestedBlock{
+				CustomType: fwtypes.NewSetNestedObjectTypeOf[botAliasLocaleSettingsModel](ctx),
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						names.AttrEnabled: schema.BoolAttribute{
+							Required: true,
+						},
+						"locale_id": schema.StringAttribute{
+							Required: true,
+						},
+					},
+					Blocks: map[string]schema.Block{
+						"code_hook_specification": schema.ListNestedBlock{
+							CustomType: fwtypes.NewListNestedObjectTypeOf[codeHookSpecificationModel](ctx),
+							Validators: []validator.List{
+								listvalidator.SizeAtMost(1),
+							},
+							NestedObject: schema.NestedBlockObject{
+								Blocks: map[string]schema.Block{
+									"lambda_code_hook": schema.ListNestedBlock{
+										CustomType: fwtypes.NewListNestedObjectTypeOf[lambdaCodeHookModel](ctx),
+										Validators: []validator.List{
+											listvalidator.IsRequired(),
+											listvalidator.SizeAtLeast(1),
+											listvalidator.SizeAtMost(1),
+										},
+										NestedObject: schema.NestedBlockObject{
+											Attributes: map[string]schema.Attribute{
+												"code_hook_interface_version": schema.StringAttribute{
+													Required: true,
+												},
+												"lambda_arn": schema.StringAttribute{
+													CustomType: fwtypes.ARNType,
+													Required:   true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"conversation_log_settings": schema.ListNestedBlock{
+				CustomType: fwtypes.NewListNestedObjectTypeOf[conversationLogSettingsModel](ctx),
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Blocks: map[string]schema.Block{
+						"audio_log_settings": schema.SetNestedBlock{
+							CustomType: fwtypes.NewSetNestedObjectTypeOf[audioLogSettingModel](ctx),
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									names.AttrEnabled: schema.BoolAttribute{
+										Required: true,
+									},
+								},
+								Blocks: map[string]schema.Block{
+									names.AttrDestination: schema.ListNestedBlock{
+										CustomType: fwtypes.NewListNestedObjectTypeOf[audioLogDestinationModel](ctx),
+										Validators: []validator.List{
+											listvalidator.IsRequired(),
+											listvalidator.SizeAtLeast(1),
+											listvalidator.SizeAtMost(1),
+										},
+										NestedObject: schema.NestedBlockObject{
+											Blocks: map[string]schema.Block{
+												"s3_bucket": schema.ListNestedBlock{
+													CustomType: fwtypes.NewListNestedObjectTypeOf[s3BucketLogDestinationModel](ctx),
+													Validators: []validator.List{
+														listvalidator.IsRequired(),
+														listvalidator.SizeAtLeast(1),
+														listvalidator.SizeAtMost(1),
+													},
+													NestedObject: schema.NestedBlockObject{
+														Attributes: map[string]schema.Attribute{
+															"kms_key_arn": schema.StringAttribute{
+																CustomType: fwtypes.ARNType,
+																Optional:   true,
+															},
+															"log_prefix": schema.StringAttribute{
+																Required: true,
+															},
+															"s3_bucket_arn": schema.StringAttribute{
+																CustomType: fwtypes.ARNType,
+																Required:   true,
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"text_log_settings": schema.SetNestedBlock{
+							CustomType: fwtypes.NewSetNestedObjectTypeOf[textLogSettingModel](ctx),
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									names.AttrEnabled: schema.BoolAttribute{
+										Required: true,
+									},
+								},
+								Blocks: map[string]schema.Block{
+									names.AttrDestination: schema.ListNestedBlock{
+										CustomType: fwtypes.NewListNestedObjectTypeOf[textLogDestinationModel](ctx),
+										Validators: []validator.List{
+											listvalidator.IsRequired(),
+											listvalidator.SizeAtLeast(1),
+											listvalidator.SizeAtMost(1),
+										},
+										NestedObject: schema.NestedBlockObject{
+											Blocks: map[string]schema.Block{
+												"cloudwatch": schema.ListNestedBlock{
+													CustomType: fwtypes.NewListNestedObjectTypeOf[cloudWatchLogGroupLogDestinationModel](ctx),
+													Validators: []validator.List{
+														listvalidator.IsRequired(),
+														listvalidator.SizeAtLeast(1),
+														listvalidator.SizeAtMost(1),
+													},
+													NestedObject: schema.NestedBlockObject{
+														Attributes: map[string]schema.Attribute{
+															"cloudwatch_log_group_arn": schema.StringAttribute{
+																CustomType: fwtypes.ARNType,
+																Required:   true,
+															},
+															"log_prefix": schema.StringAttribute{
+																Required: true,
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"sentiment_analysis_settings": schema.ListNestedBlock{
+				CustomType: fwtypes.NewListNestedObjectTypeOf[sentimentAnalysisSettingsModel](ctx),
 				Validators: []validator.List{
 					listvalidator.SizeAtMost(1),
 				},
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
-						"nested_required": schema.StringAttribute{
+						"detect_sentiment": schema.BoolAttribute{
 							Required: true,
-						},
-						"nested_computed": schema.StringAttribute{
-							Computed: true,
-							PlanModifiers: []planmodifier.String{
-								stringplanmodifier.UseStateForUnknown(),
-							},
 						},
 					},
 				},
@@ -256,495 +253,358 @@ func (r *botAliasResource) Schema(ctx context.Context, req resource.SchemaReques
 	}
 }
 
-func (r *botAliasResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	// TIP: ==== RESOURCE CREATE ====
-	// Generally, the Create function should do the following things. Make
-	// sure there is a good reason if you don't do one of these.
-	//
-	// 1. Get a client connection to the relevant service
-	// 2. Fetch the plan
-	// 3. Populate a create input structure
-	// 4. Call the AWS create/put function
-	// 5. Using the output from the create function, set the minimum arguments
-	//    and attributes for the Read function to work, as well as any computed
-	//    only attributes.
-	// 6. Use a waiter to wait for create to complete
-	// 7. Save the request plan to response state
-
-	// TIP: -- 1. Get a client connection to the relevant service
-	conn := r.Meta().LexV2ModelsClient(ctx)
-	
-	// TIP: -- 2. Fetch the plan
-	var plan botAliasResourceModel
-	smerr.AddEnrich(ctx, &resp.Diagnostics, req.Plan.Get(ctx, &plan))
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	// TIP: -- 3. Populate a Create input structure
-	var input lexmodelsv2.CreateBotAliasInput
-	// TIP: Using a field name prefix allows mapping fields such as `ID` to `BotAliasId`
-	smerr.AddEnrich(ctx, &resp.Diagnostics, flex.Expand(ctx, plan, &input, flex.WithFieldNamePrefix("BotAlias")))
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	input.Tags = getTagsIn(ctx)
-
-	// TIP: -- 4. Call the AWS Create function
-	out, err := conn.CreateBotAlias(ctx, &input)
-	if err != nil {
-		// TIP: Since ID has not been set yet, you cannot use plan.ID.String()
-		// in error messages at this point.
-		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, plan.Name.String())
-		return
-	}
-	if out == nil || out.BotAlias == nil {
-		smerr.AddError(ctx, &resp.Diagnostics, errors.New("empty output"), smerr.ID, plan.Name.String())
-		return
-	}
-
-	// TIP: -- 5. Using the output from the create function, set attributes
-	smerr.AddEnrich(ctx, &resp.Diagnostics, flex.Flatten(ctx, out, &plan))
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	// TIP: -- 6. Use a waiter to wait for create to complete
-	createTimeout := r.CreateTimeout(ctx, plan.Timeouts)
-	_, err = waitBotAliasCreated(ctx, conn, plan.ID.ValueString(), createTimeout)
-	if err != nil {
-		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, plan.Name.String())
-		return
-	}
-	
-	// TIP: -- 7. Save the request plan to response state
-	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, plan))
-}
-
-func (r *botAliasResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
-	// TIP: ==== RESOURCE READ ====
-	// Generally, the Read function should do the following things. Make
-	// sure there is a good reason if you don't do one of these.
-	//
-	// 1. Get a client connection to the relevant service
-	// 2. Fetch the state
-	// 3. Get the resource from AWS
-	// 4. Remove resource from state if it is not found
-	// 5. Set the arguments and attributes
-	// 6. Set the state
-
-	// TIP: -- 1. Get a client connection to the relevant service
-	conn := r.Meta().LexV2ModelsClient(ctx)
-	
-	// TIP: -- 2. Fetch the state
-	var state botAliasResourceModel
-	smerr.AddEnrich(ctx, &resp.Diagnostics, req.State.Get(ctx, &state))
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	
-	// TIP: -- 3. Get the resource from AWS using an API Get, List, or Describe-
-	// type function, or, better yet, using a finder.
-	out, err := findBotAliasByID(ctx, conn, state.ID.ValueString())
-	// TIP: -- 4. Remove resource from state if it is not found
-	if retry.NotFound(err) {
-		resp.Diagnostics.Append(fwdiag.NewResourceNotFoundWarningDiagnostic(err))
-		resp.State.RemoveResource(ctx)
-		return
-	}
-	if err != nil {
-		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, state.ID.String())
-		return
-	}
-	
-	// TIP: -- 5. Set the arguments and attributes
-	smerr.AddEnrich(ctx, &resp.Diagnostics, r.flatten(ctx, out, &state))
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	
-	// TIP: -- 6. Set the state
-	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, &state))
-}
-
-func (r *botAliasResource) flatten(ctx context.Context, botAlias *awstypes.BotAlias, data *botAliasResourceModel) (diags diag.Diagnostics) {
-	diags.Append(fwflex.Flatten(ctx, botAlias, data)...)
-	return diags
-}
-
-func (r *botAliasResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	// TIP: ==== RESOURCE UPDATE ====
-	// Not all resources have Update functions. There are a few reasons:
-	// a. The AWS API does not support changing a resource
-	// b. All arguments have RequiresReplace() plan modifiers
-	// c. The AWS API uses a create call to modify an existing resource
-	//
-	// In the cases of a. and b., the resource will not have an update method
-	// defined. In the case of c., Update and Create can be refactored to call
-	// the same underlying function.
-	//
-	// The rest of the time, there should be an Update function and it should
-	// do the following things. Make sure there is a good reason if you don't
-	// do one of these.
-	//
-	// 1. Get a client connection to the relevant service
-	// 2. Fetch the plan and state
-	// 3. Populate a modify input structure and check for changes
-	// 4. Call the AWS modify/update function
-	// 5. Use a waiter to wait for update to complete
-	// 6. Save the request plan to response state
-	// TIP: -- 1. Get a client connection to the relevant service
-	conn := r.Meta().LexV2ModelsClient(ctx)
-	
-	// TIP: -- 2. Fetch the plan
-	var plan, state botAliasResourceModel
-	smerr.AddEnrich(ctx, &resp.Diagnostics, req.Plan.Get(ctx, &plan))
-	smerr.AddEnrich(ctx, &resp.Diagnostics, req.State.Get(ctx, &state))
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	
-	// TIP: -- 3. Get the difference between the plan and state, if any
-	diff, d := flex.Diff(ctx, plan, state)
-	smerr.AddEnrich(ctx, &resp.Diagnostics, d)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	if diff.HasChanges() {
-		var input lexmodelsv2.UpdateBotAliasInput
-		smerr.AddEnrich(ctx, &resp.Diagnostics, flex.Expand(ctx, plan, &input, flex.WithFieldNamePrefix("Test")))
-		if resp.Diagnostics.HasError() {
-			return
-		}
-		
-		// TIP: -- 4. Call the AWS modify/update function
-		out, err := conn.UpdateBotAlias(ctx, &input)
-		if err != nil {
-			smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, plan.ID.String())
-			return
-		}
-		if out == nil || out.BotAlias == nil {
-			smerr.AddError(ctx, &resp.Diagnostics, errors.New("empty output"), smerr.ID, plan.ID.String())
-			return
-		}
-		
-		// TIP: Using the output from the update function, re-set any computed attributes
-		smerr.AddEnrich(ctx, &resp.Diagnostics, flex.Flatten(ctx, out, &plan))
-		if resp.Diagnostics.HasError() {
-			return
-		}
-	}
-
-	// TIP: -- 5. Use a waiter to wait for update to complete
-	updateTimeout := r.UpdateTimeout(ctx, plan.Timeouts)
-	_, err := waitBotAliasUpdated(ctx, conn, plan.ID.ValueString(), updateTimeout)
-	if err != nil {
-		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, plan.ID.String())
-		return
-	}
-
-	// TIP: -- 6. Save the request plan to response state
-	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, &plan))
-}
-
-func (r *botAliasResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	// TIP: ==== RESOURCE DELETE ====
-	// Most resources have Delete functions. There are rare situations
-	// where you might not need a delete:
-	// a. The AWS API does not provide a way to delete the resource
-	// b. The point of your resource is to perform an action (e.g., reboot a
-	//    server) and deleting serves no purpose.
-	//
-	// The Delete function should do the following things. Make sure there
-	// is a good reason if you don't do one of these.
-	//
-	// 1. Get a client connection to the relevant service
-	// 2. Fetch the state
-	// 3. Populate a delete input structure
-	// 4. Call the AWS delete function
-	// 5. Use a waiter to wait for delete to complete
-	// TIP: -- 1. Get a client connection to the relevant service
-	conn := r.Meta().LexV2ModelsClient(ctx)
-	
-	// TIP: -- 2. Fetch the state
-	var state botAliasResourceModel
-	smerr.AddEnrich(ctx, &resp.Diagnostics, req.State.Get(ctx, &state))
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	
-	// TIP: -- 3. Populate a delete input structure
-	input := lexv2models.DeleteBotAliasInput{
-		BotAliasId: state.ID.ValueStringPointer(),
-	}
-	
-	// TIP: -- 4. Call the AWS delete function
-	_, err := conn.DeleteBotAlias(ctx, &input)
-	// TIP: On rare occassions, the API returns a not found error after deleting a
-	// resource. If that happens, we don't want it to show up as an error.
-	if err != nil {
-		if errs.IsA[*awstypes.ResourceNotFoundException](err) {
-			return
-		}
-
-		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, state.ID.String())
-		return
-	}
-	
-	// TIP: -- 5. Use a waiter to wait for delete to complete
-	deleteTimeout := r.DeleteTimeout(ctx, state.Timeouts)
-	_, err = waitBotAliasDeleted(ctx, conn, state.ID.ValueString(), deleteTimeout)
-	if err != nil {
-		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, state.ID.String())
-		return
-	}
-}
-
-// TIP: ==== TERRAFORM IMPORTING ====
-// The built-in import function, and Import ID Handler, if any, should handle populating the required
-// attributes from the Import ID or Resource Identity.
-// In some cases, additional attributes must be set when importing.
-// Adding a custom ImportState function can handle those.
-//
-// See more:
-// https://hashicorp.github.io/terraform-provider-aws/add-resource-identity-support/
-// func (r *botAliasResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-// 	r.WithImportByIdentity.ImportState(ctx, req, resp)
-// 
-// 	// Set needed attribute values here
-// }
-
-
-// TIP: ==== STATUS CONSTANTS ====
-// Create constants for states and statuses if the service does not
-// already have suitable constants. We prefer that you use the constants
-// provided in the service if available (e.g., awstypes.StatusInProgress).
 const (
-	statusChangePending = "Pending"
-	statusDeleting      = "Deleting"
-	statusNormal        = "Normal"
-	statusUpdated       = "Updated"
+	botAliasResourceIDPartCount = 2
 )
 
-// TIP: ==== WAITERS ====
-// Some resources of some services have waiters provided by the AWS API.
-// Unless they do not work properly, use them rather than defining new ones
-// here.
-//
-// Sometimes we define the wait, status, and find functions in separate
-// files, wait.go, status.go, and find.go. Follow the pattern set out in the
-// service and define these where it makes the most sense.
-//
-// If these functions are used in the _test.go file, they will need to be
-// exported (i.e., capitalized).
-//
-// You will need to adjust the parameters and names to fit the service.
-func waitBotAliasCreated(ctx context.Context, conn *lexv2models.Client, id string, timeout time.Duration) (*awstypes.BotAlias, error) {
-	stateConf := &retry.StateChangeConf{
-		Pending:                   []string{},
-		Target:                    []string{statusNormal},
-		Refresh:                   statusBotAlias(conn, id),
-		Timeout:                   timeout,
-		NotFoundChecks:            20,
-		ContinuousTargetOccurence: 2,
+func (r *botAliasResource) Create(ctx context.Context, request resource.CreateRequest, response *resource.CreateResponse) {
+	var data botAliasResourceModel
+	response.Diagnostics.Append(request.Plan.Get(ctx, &data)...)
+	if response.Diagnostics.HasError() {
+		return
 	}
 
-	outputRaw, err := stateConf.WaitForStateContext(ctx)
-	if out, ok := outputRaw.(*awstypes.BotAlias); ok {
-		return out, smarterr.NewError(err)
+	conn := r.Meta().LexV2ModelsClient(ctx)
+
+	var input lexmodelsv2.CreateBotAliasInput
+	response.Diagnostics.Append(fwflex.Expand(ctx, data, &input)...)
+	if response.Diagnostics.HasError() {
+		return
 	}
 
-	return nil, smarterr.NewError(err)
+	// Additional fields.
+	input.Tags = getTagsIn(ctx)
+
+	output, err := conn.CreateBotAlias(ctx, &input)
+
+	if err != nil {
+		response.Diagnostics.AddError(fmt.Sprintf("creating Lex v2 Bot Alias (%s)", data.BotAliasName.ValueString()), err.Error())
+
+		return
+	}
+
+	// Set values for unknowns.
+	botID, botAliasID := aws.ToString(output.BotId), aws.ToString(output.BotAliasId)
+	id, _ := intflex.FlattenResourceId([]string{botID, botAliasID}, botAliasResourceIDPartCount, false)
+	data.ARN = fwflex.StringValueToFramework(ctx, r.botAliasARN(ctx, botID, botAliasID))
+	data.BotAliasID = fwflex.StringValueToFramework(ctx, botAliasID)
+	data.BotVersion = fwflex.StringToFramework(ctx, output.BotVersion)
+	data.ID = fwflex.StringValueToFramework(ctx, id)
+
+	if _, err := waitBotAliasCreated(ctx, conn, botID, botAliasID, r.CreateTimeout(ctx, data.Timeouts)); err != nil {
+		response.State.SetAttribute(ctx, path.Root(names.AttrID), data.ID) // Set 'id' so as to taint the resource.
+		response.Diagnostics.AddError(fmt.Sprintf("waiting for Lex v2 Bot Alias (%s) create", id), err.Error())
+
+		return
+	}
+
+	response.Diagnostics.Append(response.State.Set(ctx, data)...)
 }
 
-// TIP: It is easier to determine whether a resource is updated for some
-// resources than others. The best case is a status flag that tells you when
-// the update has been fully realized. Other times, you can check to see if a
-// key resource argument is updated to a new value or not.
-func waitBotAliasUpdated(ctx context.Context, conn *lexv2models.Client, id string, timeout time.Duration) (*awstypes.BotAlias, error) {
-	stateConf := &retry.StateChangeConf{
-		Pending:                   []string{statusChangePending},
-		Target:                    []string{statusUpdated},
-		Refresh:                   statusBotAlias(conn, id),
-		Timeout:                   timeout,
-		NotFoundChecks:            20,
-		ContinuousTargetOccurence: 2,
+func (r *botAliasResource) Read(ctx context.Context, request resource.ReadRequest, response *resource.ReadResponse) {
+	var data botAliasResourceModel
+	response.Diagnostics.Append(request.State.Get(ctx, &data)...)
+	if response.Diagnostics.HasError() {
+		return
 	}
 
-	outputRaw, err := stateConf.WaitForStateContext(ctx)
-	if out, ok := outputRaw.(*awstypes.BotAlias); ok {
-		return out, smarterr.NewError(err)
+	conn := r.Meta().LexV2ModelsClient(ctx)
+
+	id := fwflex.StringValueFromFramework(ctx, data.ID)
+	parts, err := intflex.ExpandResourceId(id, botAliasResourceIDPartCount, false)
+	if err != nil {
+		response.Diagnostics.Append(fwdiag.NewParsingResourceIDErrorDiagnostic(err))
+
+		return
 	}
 
-	return nil, smarterr.NewError(err)
+	botID, botAliasID := parts[0], parts[1]
+	output, err := findBotAliasByTwoPartKey(ctx, conn, botID, botAliasID)
+
+	if retry.NotFound(err) {
+		response.Diagnostics.Append(fwdiag.NewResourceNotFoundWarningDiagnostic(err))
+		response.State.RemoveResource(ctx)
+
+		return
+	}
+
+	if err != nil {
+		response.Diagnostics.AddError(fmt.Sprintf("reading Lex v2 Bot Alias (%s)", id), err.Error())
+
+		return
+	}
+
+	response.Diagnostics.Append(fwflex.Flatten(ctx, output, &data)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+	data.ARN = fwflex.StringValueToFramework(ctx, r.botAliasARN(ctx, botID, botAliasID))
+
+	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
 }
 
-// TIP: A deleted waiter is almost like a backwards created waiter. There may
-// be additional pending states, however.
-func waitBotAliasDeleted(ctx context.Context, conn *lexv2models.Client, id string, timeout time.Duration) (*awstypes.BotAlias, error) {
-	stateConf := &retry.StateChangeConf{
-		Pending: []string{statusDeleting, statusNormal},
-		Target:  []string{},
-		Refresh: statusBotAlias(conn, id),
-		Timeout: timeout,
+func (r *botAliasResource) Update(ctx context.Context, request resource.UpdateRequest, response *resource.UpdateResponse) {
+	var new, old botAliasResourceModel
+	response.Diagnostics.Append(request.Plan.Get(ctx, &new)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+	response.Diagnostics.Append(request.State.Get(ctx, &old)...)
+	if response.Diagnostics.HasError() {
+		return
 	}
 
-	outputRaw, err := stateConf.WaitForStateContext(ctx)
-	if out, ok := outputRaw.(*awstypes.BotAlias); ok {
-		return out, smarterr.NewError(err)
+	conn := r.Meta().LexV2ModelsClient(ctx)
+
+	id := fwflex.StringValueFromFramework(ctx, new.ID)
+	parts, err := intflex.ExpandResourceId(id, botAliasResourceIDPartCount, false)
+	if err != nil {
+		response.Diagnostics.Append(fwdiag.NewParsingResourceIDErrorDiagnostic(err))
+
+		return
 	}
 
-	return nil, smarterr.NewError(err)
+	botID, botAliasID := parts[0], parts[1]
+
+	if !new.BotAliasLocaleSettings.Equal(old.BotAliasLocaleSettings) ||
+		!new.BotAliasName.Equal(old.BotAliasName) ||
+		!new.BotVersion.Equal(old.BotVersion) ||
+		!new.ConversationLogSettings.Equal(old.ConversationLogSettings) ||
+		!new.Description.Equal(old.Description) ||
+		!new.SentimentAnalysisSettings.Equal(old.SentimentAnalysisSettings) {
+		var input lexmodelsv2.UpdateBotAliasInput
+		response.Diagnostics.Append(fwflex.Expand(ctx, new, &input)...)
+		if response.Diagnostics.HasError() {
+			return
+		}
+
+		_, err := conn.UpdateBotAlias(ctx, &input)
+
+		if err != nil {
+			response.Diagnostics.AddError(fmt.Sprintf("updating Lex v2 Bot Alias (%s)", id), err.Error())
+
+			return
+		}
+
+		if _, err := waitBotAliasUpdated(ctx, conn, botID, botAliasID, r.UpdateTimeout(ctx, new.Timeouts)); err != nil {
+			response.Diagnostics.AddError(fmt.Sprintf("waiting for Lex v2 Bot Alias (%s) update", id), err.Error())
+
+			return
+		}
+	}
+
+	response.Diagnostics.Append(response.State.Set(ctx, &new)...)
 }
 
-// TIP: ==== STATUS ====
-// The status function can return an actual status when that field is
-// available from the API (e.g., out.Status). Otherwise, you can use custom
-// statuses to communicate the states of the resource.
-//
-// Waiters consume the values returned by status functions. Design status so
-// that it can be reused by a create, update, and delete waiter, if possible.
-func statusBotAlias(conn *lexv2models.Client, id string) retry.StateRefreshFunc {
+func (r *botAliasResource) Delete(ctx context.Context, request resource.DeleteRequest, response *resource.DeleteResponse) {
+	var data botAliasResourceModel
+	response.Diagnostics.Append(request.State.Get(ctx, &data)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	conn := r.Meta().LexV2ModelsClient(ctx)
+
+	id := fwflex.StringValueFromFramework(ctx, data.ID)
+	parts, err := intflex.ExpandResourceId(id, botAliasResourceIDPartCount, false)
+	if err != nil {
+		response.Diagnostics.Append(fwdiag.NewParsingResourceIDErrorDiagnostic(err))
+
+		return
+	}
+
+	botID, botAliasID := parts[0], parts[1]
+	input := lexmodelsv2.DeleteBotAliasInput{
+		BotAliasId: aws.String(botAliasID),
+		BotId:      aws.String(botID),
+	}
+	_, err = conn.DeleteBotAlias(ctx, &input)
+
+	if errs.IsA[*awstypes.ResourceNotFoundException](err) ||
+		errs.IsAErrorMessageContains[*awstypes.PreconditionFailedException](err, "does not exist") {
+		return
+	}
+
+	if err != nil {
+		response.Diagnostics.AddError(fmt.Sprintf("deleting Lex v2 Bot Alias (%s)", id), err.Error())
+
+		return
+	}
+
+	if _, err := waitBotAliasDeleted(ctx, conn, botID, botAliasID, r.DeleteTimeout(ctx, data.Timeouts)); err != nil {
+		response.Diagnostics.AddError(fmt.Sprintf("waiting for Lex v2 Bot Alias (%s) delete", id), err.Error())
+
+		return
+	}
+}
+
+func (r *botAliasResource) botAliasARN(ctx context.Context, botID, botAliasID string) string {
+	return r.Meta().RegionalARN(ctx, "lex", fmt.Sprintf("bot-alias/%s/%s", botID, botAliasID))
+}
+
+func findBotAliasByTwoPartKey(ctx context.Context, conn *lexmodelsv2.Client, botID, botAliasID string) (*lexmodelsv2.DescribeBotAliasOutput, error) {
+	input := lexmodelsv2.DescribeBotAliasInput{
+		BotAliasId: aws.String(botAliasID),
+		BotId:      aws.String(botID),
+	}
+	output, err := conn.DescribeBotAlias(ctx, &input)
+
+	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+		return nil, &retry.NotFoundError{
+			LastError: err,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || output.BotAliasId == nil {
+		return nil, tfresource.NewEmptyResultError()
+	}
+
+	return output, nil
+}
+
+func statusBotAlias(conn *lexmodelsv2.Client, botID, botAliasID string) retry.StateRefreshFunc {
 	return func(ctx context.Context) (any, string, error) {
-		out, err := findBotAliasByID(ctx, conn, id)
+		output, err := findBotAliasByTwoPartKey(ctx, conn, botID, botAliasID)
+
 		if retry.NotFound(err) {
 			return nil, "", nil
 		}
 
 		if err != nil {
-			return nil, "", smarterr.NewError(err)
+			return nil, "", err
 		}
 
-		return out, aws.ToString(out.Status), nil
+		return output, string(output.BotAliasStatus), nil
 	}
 }
 
-// TIP: ==== FINDERS ====
-// The find function is not strictly necessary. You could do the API
-// request from the status function. However, we have found that find often
-// comes in handy in other places besides the status function. As a result, it
-// is good practice to define it separately.
-func findBotAliasByID(ctx context.Context, conn *lexv2models.Client, id string) (*awstypes.BotAlias, error) {
-	input := lexv2models.GetBotAliasInput{
-		Id: aws.String(id),
+func waitBotAliasCreated(ctx context.Context, conn *lexmodelsv2.Client, botID, botAliasID string, timeout time.Duration) (*lexmodelsv2.DescribeBotAliasOutput, error) {
+	stateConf := &retry.StateChangeConf{
+		Pending:                   enum.Slice(awstypes.BotAliasStatusCreating),
+		Target:                    enum.Slice(awstypes.BotAliasStatusAvailable),
+		Refresh:                   statusBotAlias(conn, botID, botAliasID),
+		Timeout:                   timeout,
+		ContinuousTargetOccurence: 2,
 	}
 
-	out, err := conn.GetBotAlias(ctx, &input)
-	if err != nil {
-		if errs.IsA[*awstypes.ResourceNotFoundException](err) {
-			return nil, smarterr.NewError(&retry.NotFoundError{
-				LastError:   err,
-			})
-		}
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
 
-		return nil, smarterr.NewError(err)
+	if output, ok := outputRaw.(*lexmodelsv2.DescribeBotAliasOutput); ok {
+		return output, err
 	}
 
-	if out == nil || out.BotAlias == nil {
-		return nil, smarterr.NewError(tfresource.NewEmptyResultError())
-	}
-
-	return out.BotAlias, nil
+	return nil, err
 }
 
-// TIP: ==== DATA STRUCTURES ====
-// With Terraform Plugin-Framework configurations are deserialized into
-// Go types, providing type safety without the need for type assertions.
-// These structs should match the schema definition exactly, and the `tfsdk`
-// tag value should match the attribute name.
-//
-// Nested objects are represented in their own data struct. These will
-// also have a corresponding attribute type mapping for use inside flex
-// functions.
-//
-// See more:
-// https://developer.hashicorp.com/terraform/plugin/framework/handling-data/accessing-values
+func waitBotAliasUpdated(ctx context.Context, conn *lexmodelsv2.Client, botID, botAliasID string, timeout time.Duration) (*lexmodelsv2.DescribeBotAliasOutput, error) {
+	// The AWS API for Bot Alias does not expose a distinct "Updating" status; once
+	// UpdateBotAlias returns the alias is briefly back in Creating before it
+	// settles on Available. Treat Creating as the pending state and Available as
+	// the target.
+	stateConf := &retry.StateChangeConf{
+		Pending:                   enum.Slice(awstypes.BotAliasStatusCreating),
+		Target:                    enum.Slice(awstypes.BotAliasStatusAvailable),
+		Refresh:                   statusBotAlias(conn, botID, botAliasID),
+		Timeout:                   timeout,
+		ContinuousTargetOccurence: 2,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+
+	if output, ok := outputRaw.(*lexmodelsv2.DescribeBotAliasOutput); ok {
+		return output, err
+	}
+
+	return nil, err
+}
+
+func waitBotAliasDeleted(ctx context.Context, conn *lexmodelsv2.Client, botID, botAliasID string, timeout time.Duration) (*lexmodelsv2.DescribeBotAliasOutput, error) {
+	stateConf := &retry.StateChangeConf{
+		Pending: enum.Slice(awstypes.BotAliasStatusDeleting),
+		Target:  []string{},
+		Refresh: statusBotAlias(conn, botID, botAliasID),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+
+	if output, ok := outputRaw.(*lexmodelsv2.DescribeBotAliasOutput); ok {
+		return output, err
+	}
+
+	return nil, err
+}
+
 type botAliasResourceModel struct {
 	framework.WithRegionModel
-	ARN             types.String                                          `tfsdk:"arn"`
-	ComplexArgument fwtypes.ListNestedObjectValueOf[complexArgumentModel] `tfsdk:"complex_argument"`
-	Description     types.String                                          `tfsdk:"description"`
-	ID              types.String                                          `tfsdk:"id"`
-	Name            types.String                                          `tfsdk:"name"`
-	Tags            tftags.Map                                            `tfsdk:"tags"`
-	TagsAll         tftags.Map                                            `tfsdk:"tags_all"`
-	Timeouts        timeouts.Value                                        `tfsdk:"timeouts"`
-	Type            types.String                                          `tfsdk:"type"`
+	ARN                       types.String                                                    `tfsdk:"arn"`
+	BotAliasID                types.String                                                    `tfsdk:"bot_alias_id"`
+	BotAliasLocaleSettings    fwtypes.SetNestedObjectValueOf[botAliasLocaleSettingsModel]     `tfsdk:"bot_alias_locale_settings"`
+	BotAliasName              types.String                                                    `tfsdk:"bot_alias_name"`
+	BotID                     types.String                                                    `tfsdk:"bot_id"`
+	BotVersion                types.String                                                    `tfsdk:"bot_version"`
+	ConversationLogSettings   fwtypes.ListNestedObjectValueOf[conversationLogSettingsModel]   `tfsdk:"conversation_log_settings"`
+	Description               types.String                                                    `tfsdk:"description"`
+	ID                        types.String                                                    `tfsdk:"id"`
+	SentimentAnalysisSettings fwtypes.ListNestedObjectValueOf[sentimentAnalysisSettingsModel] `tfsdk:"sentiment_analysis_settings"`
+	Tags                      tftags.Map                                                      `tfsdk:"tags"`
+	TagsAll                   tftags.Map                                                      `tfsdk:"tags_all"`
+	Timeouts                  timeouts.Value                                                  `tfsdk:"timeouts"`
 }
 
-type complexArgumentModel struct {
-	NestedRequired types.String `tfsdk:"nested_required"`
-	NestedOptional types.String `tfsdk:"nested_optional"`
+type botAliasLocaleSettingsModel struct {
+	CodeHookSpecification fwtypes.ListNestedObjectValueOf[codeHookSpecificationModel] `tfsdk:"code_hook_specification"`
+	Enabled               types.Bool                                                  `tfsdk:"enabled"`
+	MapBlockKey           types.String                                                `tfsdk:"locale_id"`
 }
 
-
-// TIP: ==== IMPORT ID HANDLER ====
-// When a resource type has a Resource Identity with multiple attributes, it needs a handler to
-// parse the Import ID used for the `terraform import` command or an `import` block with the `id` parameter.
-//
-// The parser takes the string value of the Import ID and returns:
-// * A string value that is typically ignored. See documentation for more details.
-// * A map of the resource attributes derived from the Import ID.
-// * An error value if there are parsing errors.
-//
-// For more information, see https://hashicorp.github.io/terraform-provider-aws/resource-identity/#plugin-framework
-var (
-	_ inttypes.ImportIDParser = botAliasImportID{}
-)
-
-type botAliasImportID struct{}
-
-func (botAliasImportID) Parse(id string) (string, map[string]string, error) {
-	someValue, anotherValue, found := strings.Cut(id, intflex.ResourceIdSeparator)
-	if !found {
-		return "", nil, fmt.Errorf("id \"%s\" should be in the format <some-value>"+intflex.ResourceIdSeparator+"<another-value>", id)
-	}
-
-	result := map[string]string{
-		"some-value":    someValue,
-		"another-value": anotherValue,
-	}
-
-	return id, result, nil
+type codeHookSpecificationModel struct {
+	LambdaCodeHook fwtypes.ListNestedObjectValueOf[lambdaCodeHookModel] `tfsdk:"lambda_code_hook"`
 }
 
+type lambdaCodeHookModel struct {
+	CodeHookInterfaceVersion types.String `tfsdk:"code_hook_interface_version"`
+	LambdaARN                fwtypes.ARN  `tfsdk:"lambda_arn"`
+}
 
-// TIP: ==== SWEEPERS ====
-// When acceptance testing resources, interrupted or failed tests may
-// leave behind orphaned resources in an account. To facilitate cleaning
-// up lingering resources, each resource implementation should include
-// a corresponding "sweeper" function.
-//
-// The sweeper function lists all resources of a given type and sets the
-// appropriate identifers required to delete the resource via the Delete
-// method implemented above.
-//
-// Once the sweeper function is implemented, register it in sweep.go
-// as follows:
-//
-//  awsv2.Register("aws_lexv2models_bot_alias", sweepBotAliass)
-//
-// See more:
-// https://hashicorp.github.io/terraform-provider-aws/running-and-writing-acceptance-tests/#acceptance-test-sweepers
-func sweepBotAliass(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepable, error) {
-	input := lexv2models.ListBotAliassInput{}
-	conn := client.LexV2ModelsClient(ctx)
-	var sweepResources []sweep.Sweepable
+type conversationLogSettingsModel struct {
+	AudioLogSettings fwtypes.SetNestedObjectValueOf[audioLogSettingModel] `tfsdk:"audio_log_settings"`
+	TextLogSettings  fwtypes.SetNestedObjectValueOf[textLogSettingModel]  `tfsdk:"text_log_settings"`
+}
 
-	pages := lexv2models.NewListBotAliassPaginator(conn, &input)
-	for pages.HasMorePages() {
-		page, err := pages.NextPage(ctx)
-		if err != nil {
-			return nil, smarterr.NewError(err)
-		}
+type audioLogSettingModel struct {
+	Destination fwtypes.ListNestedObjectValueOf[audioLogDestinationModel] `tfsdk:"destination"`
+	Enabled     types.Bool                                                `tfsdk:"enabled"`
+}
 
-		for _, v := range page.BotAliass {
-			sweepResources = append(sweepResources, sweepfw.NewSweepResource(newBotAliasResource, client,
-				sweepfw.NewAttribute(names.AttrID, aws.ToString(v.BotAliasId))),
-			)
-		}
-	}
+type audioLogDestinationModel struct {
+	S3Bucket fwtypes.ListNestedObjectValueOf[s3BucketLogDestinationModel] `tfsdk:"s3_bucket"`
+}
 
-	return sweepResources, nil
+type s3BucketLogDestinationModel struct {
+	KmsKeyArn   fwtypes.ARN  `tfsdk:"kms_key_arn"`
+	LogPrefix   types.String `tfsdk:"log_prefix"`
+	S3BucketArn fwtypes.ARN  `tfsdk:"s3_bucket_arn"`
+}
+
+type textLogSettingModel struct {
+	Destination fwtypes.ListNestedObjectValueOf[textLogDestinationModel] `tfsdk:"destination"`
+	Enabled     types.Bool                                               `tfsdk:"enabled"`
+}
+
+type textLogDestinationModel struct {
+	CloudWatch fwtypes.ListNestedObjectValueOf[cloudWatchLogGroupLogDestinationModel] `tfsdk:"cloudwatch"`
+}
+
+type cloudWatchLogGroupLogDestinationModel struct {
+	CloudWatchLogGroupArn fwtypes.ARN  `tfsdk:"cloudwatch_log_group_arn"`
+	LogPrefix             types.String `tfsdk:"log_prefix"`
+}
+
+type sentimentAnalysisSettingsModel struct {
+	DetectSentiment types.Bool `tfsdk:"detect_sentiment"`
 }

--- a/internal/service/lexv2models/bot_alias_test.go
+++ b/internal/service/lexv2models/bot_alias_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/lexmodelsv2"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
@@ -52,6 +53,56 @@ func TestAccLexV2ModelsBotAlias_basic(t *testing.T) {
 	})
 }
 
+func TestAccLexV2ModelsBotAlias_tags(t *testing.T) {
+	ctx := acctest.Context(t)
+	var botalias lexmodelsv2.DescribeBotAliasOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_lexv2models_bot_alias.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.LexV2ModelsEndpointID)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.LexV2ModelsServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckBotAliasDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBotAliasConfig_tags1(rName, acctest.CtKey1, acctest.CtValue1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBotAliasExists(ctx, t, resourceName, &botalias),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey1, acctest.CtValue1),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccBotAliasConfig_tags2(rName, acctest.CtKey1, acctest.CtValue1Updated, acctest.CtKey2, acctest.CtValue2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBotAliasExists(ctx, t, resourceName, &botalias),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "2"),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey1, acctest.CtValue1Updated),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey2, acctest.CtValue2),
+				),
+			},
+			{
+				Config: testAccBotAliasConfig_tags1(rName, acctest.CtKey2, acctest.CtValue2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBotAliasExists(ctx, t, resourceName, &botalias),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey2, acctest.CtValue2),
+				),
+			},
+		},
+	})
+}
+
 func TestAccLexV2ModelsBotAlias_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var botalias lexmodelsv2.DescribeBotAliasOutput
@@ -75,6 +126,14 @@ func TestAccLexV2ModelsBotAlias_disappears(t *testing.T) {
 					acctest.CheckFrameworkResourceDisappears(ctx, t, tflexv2models.ResourceBotAlias, resourceName),
 				),
 				ExpectNonEmptyPlan: true,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
 			},
 		},
 	})
@@ -321,4 +380,39 @@ resource "aws_lexv2models_bot_alias" "test" {
   depends_on = [aws_lexv2models_bot_locale.test]
 }
 `, rName, detect))
+}
+
+func testAccBotAliasConfig_tags1(rName, tagKey1, tagValue1 string) string {
+	return acctest.ConfigCompose(
+		testAccBotAliasConfig_base(rName),
+		fmt.Sprintf(`
+resource "aws_lexv2models_bot_alias" "test" {
+  bot_id         = aws_lexv2models_bot.test.id
+  bot_alias_name = %[1]q
+
+  tags = {
+    %[2]q = %[3]q
+  }
+
+  depends_on = [aws_lexv2models_bot_locale.test]
+}
+`, rName, tagKey1, tagValue1))
+}
+
+func testAccBotAliasConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return acctest.ConfigCompose(
+		testAccBotAliasConfig_base(rName),
+		fmt.Sprintf(`
+resource "aws_lexv2models_bot_alias" "test" {
+  bot_id         = aws_lexv2models_bot.test.id
+  bot_alias_name = %[1]q
+
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+
+  depends_on = [aws_lexv2models_bot_locale.test]
+}
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2))
 }

--- a/internal/service/lexv2models/bot_alias_test.go
+++ b/internal/service/lexv2models/bot_alias_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go-v2/service/lexmodelsv2"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -41,7 +42,7 @@ func TestAccLexV2ModelsBotAlias_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "bot_alias_name", rName),
 					resource.TestCheckResourceAttrSet(resourceName, "bot_alias_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "bot_id"),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "lex", regexache.MustCompile(`bot-alias/.+$`)),
 				),
 			},
 			{
@@ -195,7 +196,7 @@ func TestAccLexV2ModelsBotAlias_conversationLogSettings(t *testing.T) {
 					testAccCheckBotAliasExists(ctx, t, resourceName, &botalias),
 					resource.TestCheckResourceAttr(resourceName, "conversation_log_settings.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "conversation_log_settings.0.text_log_settings.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "conversation_log_settings.0.text_log_settings.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "conversation_log_settings.0.text_log_settings.0.enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttrSet(resourceName, "conversation_log_settings.0.text_log_settings.0.destination.0.cloudwatch.0.cloudwatch_log_group_arn"),
 				),
 			},
@@ -224,14 +225,14 @@ func TestAccLexV2ModelsBotAlias_sentimentAnalysisSettings(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBotAliasExists(ctx, t, resourceName, &botalias),
 					resource.TestCheckResourceAttr(resourceName, "sentiment_analysis_settings.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "sentiment_analysis_settings.0.detect_sentiment", "true"),
+					resource.TestCheckResourceAttr(resourceName, "sentiment_analysis_settings.0.detect_sentiment", acctest.CtTrue),
 				),
 			},
 			{
 				Config: testAccBotAliasConfig_sentimentAnalysisSettings(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBotAliasExists(ctx, t, resourceName, &botalias),
-					resource.TestCheckResourceAttr(resourceName, "sentiment_analysis_settings.0.detect_sentiment", "false"),
+					resource.TestCheckResourceAttr(resourceName, "sentiment_analysis_settings.0.detect_sentiment", acctest.CtFalse),
 				),
 			},
 		},

--- a/internal/service/lexv2models/bot_alias_test.go
+++ b/internal/service/lexv2models/bot_alias_test.go
@@ -1,0 +1,341 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package lexv2models_test
+// **PLEASE DELETE THIS AND ALL TIP COMMENTS BEFORE SUBMITTING A PR FOR REVIEW!**
+//
+// TIP: ==== INTRODUCTION ====
+// Thank you for trying the skaff tool!
+//
+// You have opted to include these helpful comments. They all include "TIP:"
+// to help you find and remove them when you're done with them.
+//
+// While some aspects of this file are customized to your input, the
+// scaffold tool does *not* look at the AWS API and ensure it has correct
+// function, structure, and variable names. It makes guesses based on
+// commonalities. You will need to make significant adjustments.
+//
+// In other words, as generated, this is a rough outline of the work you will
+// need to do. If something doesn't make sense for your situation, get rid of
+// it.
+
+import (
+	// TIP: ==== IMPORTS ====
+	// This is a common set of imports but not customized to your code since
+	// your code hasn't been written yet. Make sure you, your IDE, or
+	// goimports -w <file> fixes these imports.
+	//
+	// The provider linter wants your imports to be in two groups: first,
+	// standard library (i.e., "fmt" or "strings"), second, everything else.
+	//
+	// Also, AWS Go SDK v2 may handle nested structures differently than v1,
+	// using the service/lexmodelsv2/types package. If so, you'll
+	// need to import types and reference the nested types, e.g., as
+	// awstypes.<Type Name>.
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/YakDriver/regexache"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/lexmodelsv2"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/lexmodelsv2/types"
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
+	"github.com/hashicorp/terraform-provider-aws/names"
+
+	// TIP: You will often need to import the package that this test file lives
+	// in. Since it is in the "test" context, it must import the package to use
+	// any normal context constants, variables, or functions.
+	tflexv2models "github.com/hashicorp/terraform-provider-aws/internal/service/lexv2models"
+)
+
+// TIP: File Structure. The basic outline for all test files should be as
+// follows. Improve this resource's maintainability by following this
+// outline.
+//
+// 1. Package declaration (add "_test" since this is a test file)
+// 2. Imports
+// 3. Unit tests
+// 4. Basic test
+// 5. Disappears test
+// 6. All the other tests
+// 7. Helper functions (exists, destroy, check, etc.)
+// 8. Functions that return Terraform configurations
+
+// TIP: ==== UNIT TESTS ====
+// This is an example of a unit test. Its name is not prefixed with
+// "TestAcc" like an acceptance test.
+//
+// Unlike acceptance tests, unit tests do not access AWS and are focused on a
+// function (or method). Because of this, they are quick and cheap to run.
+//
+// In designing a resource's implementation, isolate complex bits from AWS bits
+// so that they can be tested through a unit test. We encourage more unit tests
+// in the provider.
+//
+// Cut and dry functions using well-used patterns, like typical flatteners and
+// expanders, don't need unit testing. However, if they are complex or
+// intricate, they should be unit tested.
+func TestBotAliasExampleUnitTest(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		TestName string
+		Input    string
+		Expected string
+		Error    bool
+	}{
+		{
+			TestName: "empty",
+			Input:    "",
+			Expected: "",
+			Error:    true,
+		},
+		{
+			TestName: "descriptive name",
+			Input:    "some input",
+			Expected: "some output",
+			Error:    false,
+		},
+		{
+			TestName: "another descriptive name",
+			Input:    "more input",
+			Expected: "more output",
+			Error:    false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.TestName, func(t *testing.T) {
+			t.Parallel()
+			got, err := tflexv2models.FunctionFromResource(testCase.Input)
+
+			if err != nil && !testCase.Error {
+				t.Errorf("got error (%s), expected no error", err)
+			}
+
+			if err == nil && testCase.Error {
+				t.Errorf("got (%s) and no error, expected error", got)
+			}
+
+			if got != testCase.Expected {
+				t.Errorf("got %s, expected %s", got, testCase.Expected)
+			}
+		})
+	}
+}
+
+// TIP: ==== ACCEPTANCE TESTS ====
+// This is an example of a basic acceptance test. This should test as much of
+// standard functionality of the resource as possible, and test importing, if
+// applicable. We prefix its name with "TestAcc", the service, and the
+// resource name.
+//
+// Acceptance tests access AWS and cost money to run.
+func TestAccLexV2ModelsBotAlias_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	// TIP: This is a long-running test guard for tests that run longer than
+	// 300s (5 min) generally.
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var botalias lexmodelsv2.DescribeBotAliasResponse
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_lexv2models_bot_alias.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.LexV2ModelsEndpointID)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.LexV2ModelsServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckBotAliasDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBotAliasConfig_basic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckBotAliasExists(ctx, t, resourceName, &botalias),
+					resource.TestCheckResourceAttr(resourceName, "auto_minor_version_upgrade", "false"),
+					resource.TestCheckResourceAttrSet(resourceName, "maintenance_window_start_time.0.day_of_week"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "user.*", map[string]string{
+						"console_access": "false",
+						"groups.#":       "0",
+						"username":       "Test",
+						"password":       "TestTest1234",
+					}),
+					// TIP: If the ARN can be partially or completely determined by the parameters passed, e.g. it contains the
+					// value of `rName`, either include the values in the regex or check for an exact match using `acctest.CheckResourceAttrRegionalARN`
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "lexv2models", regexache.MustCompile(`botalias:.+$`)),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately", "user"},
+			},
+		},
+	})
+}
+
+func TestAccLexV2ModelsBotAlias_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var botalias lexmodelsv2.DescribeBotAliasResponse
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_lexv2models_bot_alias.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.LexV2ModelsEndpointID)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.LexV2ModelsServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckBotAliasDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBotAliasConfig_basic(rName, testAccBotAliasVersionNewer),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckBotAliasExists(ctx, t, resourceName, &botalias),
+					// TIP: The Plugin-Framework disappears helper is similar to the Plugin-SDK version,
+					// but expects a new resource factory function as the third argument. To expose this
+					// private function to the testing package, you may need to add a line like the following
+					// to exports_test.go:
+					//
+					//   var ResourceBotAlias = newBotAliasResource
+					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tflexv2models.ResourceBotAlias, resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccCheckBotAliasDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.ProviderMeta(ctx, t).LexV2ModelsClient(ctx)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_lexv2models_bot_alias" {
+				continue
+			}
+
+			
+			// TIP: ==== FINDERS ====
+			// The find function should be exported. Since it won't be used outside of the package, it can be exported
+			// in the `exports_test.go` file.
+			_, err := tflexv2models.FindBotAliasByID(ctx, conn, rs.Primary.ID)
+			if retry.NotFound(err) {
+				return nil
+			}
+			if err != nil {
+			    return create.Error(names.LexV2Models, create.ErrActionCheckingDestroyed, tflexv2models.ResNameBotAlias, rs.Primary.ID, err)
+			}
+
+			return create.Error(names.LexV2Models, create.ErrActionCheckingDestroyed, tflexv2models.ResNameBotAlias, rs.Primary.ID, errors.New("not destroyed"))
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckBotAliasExists(ctx context.Context, t *testing.T, name string, botalias *lexmodelsv2.DescribeBotAliasResponse) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return create.Error(names.LexV2Models, create.ErrActionCheckingExistence, tflexv2models.ResNameBotAlias, name, errors.New("not found"))
+		}
+
+		if rs.Primary.ID == "" {
+			return create.Error(names.LexV2Models, create.ErrActionCheckingExistence, tflexv2models.ResNameBotAlias, name, errors.New("not set"))
+		}
+
+		conn := acctest.ProviderMeta(ctx, t).LexV2ModelsClient(ctx)
+
+		resp, err := tflexv2models.FindBotAliasByID(ctx, conn, rs.Primary.ID)
+		if err != nil {
+			return create.Error(names.LexV2Models, create.ErrActionCheckingExistence, tflexv2models.ResNameBotAlias, rs.Primary.ID, err)
+		}
+
+		*botalias = *resp
+
+		return nil
+	}
+}
+
+func testAccPreCheck(ctx context.Context, t *testing.T) {
+	conn := acctest.ProviderMeta(ctx, t).LexV2ModelsClient(ctx)
+
+	input := &lexmodelsv2.ListBotAliassInput{}
+
+	_, err := conn.ListBotAliass(ctx, input)
+
+	if acctest.PreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
+}
+
+func testAccCheckBotAliasNotRecreated(before, after *lexmodelsv2.DescribeBotAliasResponse) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if before, after := aws.ToString(before.BotAliasId), aws.ToString(after.BotAliasId); before != after {
+			return create.Error(names.LexV2Models, create.ErrActionCheckingNotRecreated, tflexv2models.ResNameBotAlias, aws.ToString(before.BotAliasId), errors.New("recreated"))
+		}
+
+		return nil
+	}
+}
+
+func testAccBotAliasConfig_basic(rName, version string) string {
+	return fmt.Sprintf(`
+resource "aws_security_group" "test" {
+  name = %[1]q
+}
+
+resource "aws_lexv2models_bot_alias" "test" {
+  bot_alias_name             = %[1]q
+  engine_type             = "ActiveLexV2Models"
+  engine_version          = %[2]q
+  host_instance_type      = "lexv2models.t2.micro"
+  security_groups         = [aws_security_group.test.id]
+  authentication_strategy = "simple"
+  storage_type            = "efs"
+
+  logs {
+    general = true
+  }
+
+  user {
+    username = "Test"
+    password = "TestTest1234"
+  }
+}
+`, rName, version)
+}

--- a/internal/service/lexv2models/bot_alias_test.go
+++ b/internal/service/lexv2models/bot_alias_test.go
@@ -2,155 +2,25 @@
 // SPDX-License-Identifier: MPL-2.0
 
 package lexv2models_test
-// **PLEASE DELETE THIS AND ALL TIP COMMENTS BEFORE SUBMITTING A PR FOR REVIEW!**
-//
-// TIP: ==== INTRODUCTION ====
-// Thank you for trying the skaff tool!
-//
-// You have opted to include these helpful comments. They all include "TIP:"
-// to help you find and remove them when you're done with them.
-//
-// While some aspects of this file are customized to your input, the
-// scaffold tool does *not* look at the AWS API and ensure it has correct
-// function, structure, and variable names. It makes guesses based on
-// commonalities. You will need to make significant adjustments.
-//
-// In other words, as generated, this is a rough outline of the work you will
-// need to do. If something doesn't make sense for your situation, get rid of
-// it.
 
 import (
-	// TIP: ==== IMPORTS ====
-	// This is a common set of imports but not customized to your code since
-	// your code hasn't been written yet. Make sure you, your IDE, or
-	// goimports -w <file> fixes these imports.
-	//
-	// The provider linter wants your imports to be in two groups: first,
-	// standard library (i.e., "fmt" or "strings"), second, everything else.
-	//
-	// Also, AWS Go SDK v2 may handle nested structures differently than v1,
-	// using the service/lexmodelsv2/types package. If so, you'll
-	// need to import types and reference the nested types, e.g., as
-	// awstypes.<Type Name>.
 	"context"
-	"errors"
 	"fmt"
 	"testing"
 
-	"github.com/YakDriver/regexache"
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/lexmodelsv2"
-	awstypes "github.com/aws/aws-sdk-go-v2/service/lexmodelsv2/types"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
-	"github.com/hashicorp/terraform-provider-aws/internal/create"
-	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
-	"github.com/hashicorp/terraform-provider-aws/names"
-
-	// TIP: You will often need to import the package that this test file lives
-	// in. Since it is in the "test" context, it must import the package to use
-	// any normal context constants, variables, or functions.
 	tflexv2models "github.com/hashicorp/terraform-provider-aws/internal/service/lexv2models"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// TIP: File Structure. The basic outline for all test files should be as
-// follows. Improve this resource's maintainability by following this
-// outline.
-//
-// 1. Package declaration (add "_test" since this is a test file)
-// 2. Imports
-// 3. Unit tests
-// 4. Basic test
-// 5. Disappears test
-// 6. All the other tests
-// 7. Helper functions (exists, destroy, check, etc.)
-// 8. Functions that return Terraform configurations
-
-// TIP: ==== UNIT TESTS ====
-// This is an example of a unit test. Its name is not prefixed with
-// "TestAcc" like an acceptance test.
-//
-// Unlike acceptance tests, unit tests do not access AWS and are focused on a
-// function (or method). Because of this, they are quick and cheap to run.
-//
-// In designing a resource's implementation, isolate complex bits from AWS bits
-// so that they can be tested through a unit test. We encourage more unit tests
-// in the provider.
-//
-// Cut and dry functions using well-used patterns, like typical flatteners and
-// expanders, don't need unit testing. However, if they are complex or
-// intricate, they should be unit tested.
-func TestBotAliasExampleUnitTest(t *testing.T) {
-	t.Parallel()
-
-	testCases := []struct {
-		TestName string
-		Input    string
-		Expected string
-		Error    bool
-	}{
-		{
-			TestName: "empty",
-			Input:    "",
-			Expected: "",
-			Error:    true,
-		},
-		{
-			TestName: "descriptive name",
-			Input:    "some input",
-			Expected: "some output",
-			Error:    false,
-		},
-		{
-			TestName: "another descriptive name",
-			Input:    "more input",
-			Expected: "more output",
-			Error:    false,
-		},
-	}
-
-	for _, testCase := range testCases {
-		t.Run(testCase.TestName, func(t *testing.T) {
-			t.Parallel()
-			got, err := tflexv2models.FunctionFromResource(testCase.Input)
-
-			if err != nil && !testCase.Error {
-				t.Errorf("got error (%s), expected no error", err)
-			}
-
-			if err == nil && testCase.Error {
-				t.Errorf("got (%s) and no error, expected error", got)
-			}
-
-			if got != testCase.Expected {
-				t.Errorf("got %s, expected %s", got, testCase.Expected)
-			}
-		})
-	}
-}
-
-// TIP: ==== ACCEPTANCE TESTS ====
-// This is an example of a basic acceptance test. This should test as much of
-// standard functionality of the resource as possible, and test importing, if
-// applicable. We prefix its name with "TestAcc", the service, and the
-// resource name.
-//
-// Acceptance tests access AWS and cost money to run.
 func TestAccLexV2ModelsBotAlias_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	// TIP: This is a long-running test guard for tests that run longer than
-	// 300s (5 min) generally.
-	if testing.Short() {
-		t.Skip("skipping long-running test in short mode")
-	}
-
-	var botalias lexmodelsv2.DescribeBotAliasResponse
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	var botalias lexmodelsv2.DescribeBotAliasOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_lexv2models_bot_alias.test"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -165,26 +35,18 @@ func TestAccLexV2ModelsBotAlias_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccBotAliasConfig_basic(rName),
-				Check: resource.ComposeAggregateTestCheckFunc(
+				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBotAliasExists(ctx, t, resourceName, &botalias),
-					resource.TestCheckResourceAttr(resourceName, "auto_minor_version_upgrade", "false"),
-					resource.TestCheckResourceAttrSet(resourceName, "maintenance_window_start_time.0.day_of_week"),
-					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "user.*", map[string]string{
-						"console_access": "false",
-						"groups.#":       "0",
-						"username":       "Test",
-						"password":       "TestTest1234",
-					}),
-					// TIP: If the ARN can be partially or completely determined by the parameters passed, e.g. it contains the
-					// value of `rName`, either include the values in the regex or check for an exact match using `acctest.CheckResourceAttrRegionalARN`
-					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "lexv2models", regexache.MustCompile(`botalias:.+$`)),
+					resource.TestCheckResourceAttr(resourceName, "bot_alias_name", rName),
+					resource.TestCheckResourceAttrSet(resourceName, "bot_alias_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "bot_id"),
+					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"apply_immediately", "user"},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -192,12 +54,8 @@ func TestAccLexV2ModelsBotAlias_basic(t *testing.T) {
 
 func TestAccLexV2ModelsBotAlias_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
-	if testing.Short() {
-		t.Skip("skipping long-running test in short mode")
-	}
-
-	var botalias lexmodelsv2.DescribeBotAliasResponse
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	var botalias lexmodelsv2.DescribeBotAliasOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_lexv2models_bot_alias.test"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -211,26 +69,111 @@ func TestAccLexV2ModelsBotAlias_disappears(t *testing.T) {
 		CheckDestroy:             testAccCheckBotAliasDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBotAliasConfig_basic(rName, testAccBotAliasVersionNewer),
-				Check: resource.ComposeAggregateTestCheckFunc(
+				Config: testAccBotAliasConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBotAliasExists(ctx, t, resourceName, &botalias),
-					// TIP: The Plugin-Framework disappears helper is similar to the Plugin-SDK version,
-					// but expects a new resource factory function as the third argument. To expose this
-					// private function to the testing package, you may need to add a line like the following
-					// to exports_test.go:
-					//
-					//   var ResourceBotAlias = newBotAliasResource
-					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tflexv2models.ResourceBotAlias, resourceName),
+					acctest.CheckFrameworkResourceDisappears(ctx, t, tflexv2models.ResourceBotAlias, resourceName),
 				),
 				ExpectNonEmptyPlan: true,
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
-					},
-					PostApplyPostRefresh: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
-					},
-				},
+			},
+		},
+	})
+}
+
+func TestAccLexV2ModelsBotAlias_description(t *testing.T) {
+	ctx := acctest.Context(t)
+	var botalias lexmodelsv2.DescribeBotAliasOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_lexv2models_bot_alias.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.LexV2ModelsEndpointID)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.LexV2ModelsServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckBotAliasDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBotAliasConfig_description(rName, "first"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBotAliasExists(ctx, t, resourceName, &botalias),
+					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "first"),
+				),
+			},
+			{
+				Config: testAccBotAliasConfig_description(rName, "second"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBotAliasExists(ctx, t, resourceName, &botalias),
+					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "second"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccLexV2ModelsBotAlias_conversationLogSettings(t *testing.T) {
+	ctx := acctest.Context(t)
+	var botalias lexmodelsv2.DescribeBotAliasOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_lexv2models_bot_alias.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.LexV2ModelsEndpointID)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.LexV2ModelsServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckBotAliasDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBotAliasConfig_conversationLogSettings(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBotAliasExists(ctx, t, resourceName, &botalias),
+					resource.TestCheckResourceAttr(resourceName, "conversation_log_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "conversation_log_settings.0.text_log_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "conversation_log_settings.0.text_log_settings.0.enabled", "true"),
+					resource.TestCheckResourceAttrSet(resourceName, "conversation_log_settings.0.text_log_settings.0.destination.0.cloudwatch.0.cloudwatch_log_group_arn"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccLexV2ModelsBotAlias_sentimentAnalysisSettings(t *testing.T) {
+	ctx := acctest.Context(t)
+	var botalias lexmodelsv2.DescribeBotAliasOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_lexv2models_bot_alias.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.LexV2ModelsEndpointID)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.LexV2ModelsServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckBotAliasDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBotAliasConfig_sentimentAnalysisSettings(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBotAliasExists(ctx, t, resourceName, &botalias),
+					resource.TestCheckResourceAttr(resourceName, "sentiment_analysis_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "sentiment_analysis_settings.0.detect_sentiment", "true"),
+				),
+			},
+			{
+				Config: testAccBotAliasConfig_sentimentAnalysisSettings(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBotAliasExists(ctx, t, resourceName, &botalias),
+					resource.TestCheckResourceAttr(resourceName, "sentiment_analysis_settings.0.detect_sentiment", "false"),
+				),
 			},
 		},
 	})
@@ -245,97 +188,137 @@ func testAccCheckBotAliasDestroy(ctx context.Context, t *testing.T) resource.Tes
 				continue
 			}
 
-			
-			// TIP: ==== FINDERS ====
-			// The find function should be exported. Since it won't be used outside of the package, it can be exported
-			// in the `exports_test.go` file.
-			_, err := tflexv2models.FindBotAliasByID(ctx, conn, rs.Primary.ID)
+			_, err := tflexv2models.FindBotAliasByTwoPartKey(ctx, conn, rs.Primary.Attributes["bot_id"], rs.Primary.Attributes["bot_alias_id"])
+
 			if retry.NotFound(err) {
-				return nil
-			}
-			if err != nil {
-			    return create.Error(names.LexV2Models, create.ErrActionCheckingDestroyed, tflexv2models.ResNameBotAlias, rs.Primary.ID, err)
+				continue
 			}
 
-			return create.Error(names.LexV2Models, create.ErrActionCheckingDestroyed, tflexv2models.ResNameBotAlias, rs.Primary.ID, errors.New("not destroyed"))
+			if err != nil {
+				return err
+			}
+
+			return fmt.Errorf("Lex v2 Bot Alias %s still exists", rs.Primary.ID)
 		}
 
 		return nil
 	}
 }
 
-func testAccCheckBotAliasExists(ctx context.Context, t *testing.T, name string, botalias *lexmodelsv2.DescribeBotAliasResponse) resource.TestCheckFunc {
+func testAccCheckBotAliasExists(ctx context.Context, t *testing.T, n string, v *lexmodelsv2.DescribeBotAliasOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return create.Error(names.LexV2Models, create.ErrActionCheckingExistence, tflexv2models.ResNameBotAlias, name, errors.New("not found"))
-		}
-
-		if rs.Primary.ID == "" {
-			return create.Error(names.LexV2Models, create.ErrActionCheckingExistence, tflexv2models.ResNameBotAlias, name, errors.New("not set"))
+			return fmt.Errorf("Not found: %s", n)
 		}
 
 		conn := acctest.ProviderMeta(ctx, t).LexV2ModelsClient(ctx)
 
-		resp, err := tflexv2models.FindBotAliasByID(ctx, conn, rs.Primary.ID)
+		output, err := tflexv2models.FindBotAliasByTwoPartKey(ctx, conn, rs.Primary.Attributes["bot_id"], rs.Primary.Attributes["bot_alias_id"])
+
 		if err != nil {
-			return create.Error(names.LexV2Models, create.ErrActionCheckingExistence, tflexv2models.ResNameBotAlias, rs.Primary.ID, err)
+			return err
 		}
 
-		*botalias = *resp
+		*v = *output
 
 		return nil
 	}
 }
 
-func testAccPreCheck(ctx context.Context, t *testing.T) {
-	conn := acctest.ProviderMeta(ctx, t).LexV2ModelsClient(ctx)
+func testAccBotAliasConfig_base(rName string) string {
+	return acctest.ConfigCompose(
+		testAccBotConfig_base(rName),
+		fmt.Sprintf(`
+resource "aws_lexv2models_bot" "test" {
+  name                        = %[1]q
+  idle_session_ttl_in_seconds = 60
+  role_arn                    = aws_iam_role.test.arn
 
-	input := &lexmodelsv2.ListBotAliassInput{}
-
-	_, err := conn.ListBotAliass(ctx, input)
-
-	if acctest.PreCheckSkipError(err) {
-		t.Skipf("skipping acceptance testing: %s", err)
-	}
-	if err != nil {
-		t.Fatalf("unexpected PreCheck error: %s", err)
-	}
+  data_privacy {
+    child_directed = "true"
+  }
 }
 
-func testAccCheckBotAliasNotRecreated(before, after *lexmodelsv2.DescribeBotAliasResponse) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if before, after := aws.ToString(before.BotAliasId), aws.ToString(after.BotAliasId); before != after {
-			return create.Error(names.LexV2Models, create.ErrActionCheckingNotRecreated, tflexv2models.ResNameBotAlias, aws.ToString(before.BotAliasId), errors.New("recreated"))
-		}
-
-		return nil
-	}
+resource "aws_lexv2models_bot_locale" "test" {
+  locale_id                        = "en_US"
+  bot_id                           = aws_lexv2models_bot.test.id
+  bot_version                      = "DRAFT"
+  n_lu_intent_confidence_threshold = 0.7
+}
+`, rName))
 }
 
-func testAccBotAliasConfig_basic(rName, version string) string {
-	return fmt.Sprintf(`
-resource "aws_security_group" "test" {
+func testAccBotAliasConfig_basic(rName string) string {
+	return acctest.ConfigCompose(
+		testAccBotAliasConfig_base(rName),
+		fmt.Sprintf(`
+resource "aws_lexv2models_bot_alias" "test" {
+  bot_id         = aws_lexv2models_bot.test.id
+  bot_alias_name = %[1]q
+
+  depends_on = [aws_lexv2models_bot_locale.test]
+}
+`, rName))
+}
+
+func testAccBotAliasConfig_description(rName, description string) string {
+	return acctest.ConfigCompose(
+		testAccBotAliasConfig_base(rName),
+		fmt.Sprintf(`
+resource "aws_lexv2models_bot_alias" "test" {
+  bot_id         = aws_lexv2models_bot.test.id
+  bot_alias_name = %[1]q
+  description    = %[2]q
+
+  depends_on = [aws_lexv2models_bot_locale.test]
+}
+`, rName, description))
+}
+
+func testAccBotAliasConfig_conversationLogSettings(rName string) string {
+	return acctest.ConfigCompose(
+		testAccBotAliasConfig_base(rName),
+		fmt.Sprintf(`
+resource "aws_cloudwatch_log_group" "test" {
   name = %[1]q
 }
 
 resource "aws_lexv2models_bot_alias" "test" {
-  bot_alias_name             = %[1]q
-  engine_type             = "ActiveLexV2Models"
-  engine_version          = %[2]q
-  host_instance_type      = "lexv2models.t2.micro"
-  security_groups         = [aws_security_group.test.id]
-  authentication_strategy = "simple"
-  storage_type            = "efs"
+  bot_id         = aws_lexv2models_bot.test.id
+  bot_alias_name = %[1]q
 
-  logs {
-    general = true
+  conversation_log_settings {
+    text_log_settings {
+      enabled = true
+
+      destination {
+        cloudwatch {
+          cloudwatch_log_group_arn = aws_cloudwatch_log_group.test.arn
+          log_prefix               = "lex/"
+        }
+      }
+    }
   }
 
-  user {
-    username = "Test"
-    password = "TestTest1234"
-  }
+  depends_on = [aws_lexv2models_bot_locale.test]
 }
-`, rName, version)
+`, rName))
+}
+
+func testAccBotAliasConfig_sentimentAnalysisSettings(rName string, detect bool) string {
+	return acctest.ConfigCompose(
+		testAccBotAliasConfig_base(rName),
+		fmt.Sprintf(`
+resource "aws_lexv2models_bot_alias" "test" {
+  bot_id         = aws_lexv2models_bot.test.id
+  bot_alias_name = %[1]q
+
+  sentiment_analysis_settings {
+    detect_sentiment = %[2]t
+  }
+
+  depends_on = [aws_lexv2models_bot_locale.test]
+}
+`, rName, detect))
 }

--- a/internal/service/lexv2models/exports_test.go
+++ b/internal/service/lexv2models/exports_test.go
@@ -6,12 +6,14 @@ package lexv2models
 // Exports for use in tests only.
 var (
 	ResourceBot        = newBotResource
+	ResourceBotAlias   = newBotAliasResource
 	ResourceBotLocale  = newBotLocaleResource
 	ResourceBotVersion = newBotVersionResource
 	ResourceIntent     = newIntentResource
 	ResourceSlot       = newSlotResource
 	ResourceSlotType   = newSlotTypeResource
 
+	FindBotAliasByTwoPartKey    = findBotAliasByTwoPartKey
 	FindBotByID                 = findBotByID
 	FindBotLocaleByThreePartKey = findBotLocaleByThreePartKey
 	FindBotVersionByTwoPartKey  = findBotVersionByTwoPartKey

--- a/internal/service/lexv2models/service_package_gen.go
+++ b/internal/service/lexv2models/service_package_gen.go
@@ -36,6 +36,15 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*inttypes.Ser
 			Region: inttypes.ResourceRegionDefault(),
 		},
 		{
+			Factory:  newBotAliasResource,
+			TypeName: "aws_lexv2models_bot_alias",
+			Name:     "Bot Alias",
+			Tags: unique.Make(inttypes.ServicePackageResourceTags{
+				IdentifierAttribute: names.AttrARN,
+			}),
+			Region: inttypes.ResourceRegionDefault(),
+		},
+		{
 			Factory:  newBotLocaleResource,
 			TypeName: "aws_lexv2models_bot_locale",
 			Name:     "Bot Locale",

--- a/internal/service/lexv2models/sweep.go
+++ b/internal/service/lexv2models/sweep.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/lexmodelsv2"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	intflex "github.com/hashicorp/terraform-provider-aws/internal/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv2"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep/framework"
@@ -17,9 +18,15 @@ import (
 )
 
 func RegisterSweepers() {
+	resource.AddTestSweepers("aws_lexv2models_bot_alias", &resource.Sweeper{
+		Name: "aws_lexv2models_bot_alias",
+		F:    sweepBotAliases,
+	})
+
 	resource.AddTestSweepers("aws_lexv2models_bot", &resource.Sweeper{
-		Name: "aws_lexv2models_bot",
-		F:    sweepBots,
+		Name:         "aws_lexv2models_bot",
+		F:            sweepBots,
+		Dependencies: []string{"aws_lexv2models_bot_alias"},
 	})
 }
 
@@ -57,6 +64,59 @@ func sweepBots(region string) error {
 
 	if err := sweep.SweepOrchestrator(ctx, sweepResources); err != nil {
 		return fmt.Errorf("error sweeping Lex V2 Models Bots for %s: %w", region, err)
+	}
+
+	return nil
+}
+
+func sweepBotAliases(region string) error {
+	ctx := sweep.Context(region)
+	client, err := sweep.SharedRegionalSweepClient(ctx, region)
+	if err != nil {
+		return fmt.Errorf("getting client: %w", err)
+	}
+	conn := client.LexV2ModelsClient(ctx)
+	sweepResources := make([]sweep.Sweepable, 0)
+
+	botPages := lexmodelsv2.NewListBotsPaginator(conn, &lexmodelsv2.ListBotsInput{})
+	for botPages.HasMorePages() {
+		botPage, err := botPages.NextPage(ctx)
+		if awsv2.SkipSweepError(err) {
+			log.Printf("[WARN] Skipping Lex V2 Models Bot Alias sweep for %s: %s", region, err)
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("error listing Lex V2 Models Bots: %w", err)
+		}
+
+		for _, b := range botPage.BotSummaries {
+			botID := aws.ToString(b.BotId)
+			aliasPages := lexmodelsv2.NewListBotAliasesPaginator(conn, &lexmodelsv2.ListBotAliasesInput{
+				BotId: aws.String(botID),
+			})
+			for aliasPages.HasMorePages() {
+				aliasPage, err := aliasPages.NextPage(ctx)
+				if err != nil {
+					return fmt.Errorf("error listing Lex V2 Models Bot Aliases for bot %s: %w", botID, err)
+				}
+
+				for _, a := range aliasPage.BotAliasSummaries {
+					botAliasID := aws.ToString(a.BotAliasId)
+					id, _ := intflex.FlattenResourceId([]string{botID, botAliasID}, botAliasResourceIDPartCount, false)
+
+					log.Printf("[INFO] Deleting Lex V2 Models Bot Alias: %s", id)
+					sweepResources = append(sweepResources, framework.NewSweepResource(newBotAliasResource, client,
+						framework.NewAttribute(names.AttrID, id),
+						framework.NewAttribute("bot_id", botID),
+						framework.NewAttribute("bot_alias_id", botAliasID),
+					))
+				}
+			}
+		}
+	}
+
+	if err := sweep.SweepOrchestrator(ctx, sweepResources); err != nil {
+		return fmt.Errorf("error sweeping Lex V2 Models Bot Aliases for %s: %w", region, err)
 	}
 
 	return nil

--- a/website/docs/r/lexv2models_bot_alias.html.markdown
+++ b/website/docs/r/lexv2models_bot_alias.html.markdown
@@ -5,20 +5,10 @@ page_title: "AWS: aws_lexv2models_bot_alias"
 description: |-
   Manages an AWS Lex V2 Models Bot Alias.
 ---
-<!---
-Documentation guidelines:
-- Begin resource descriptions with "Manages..."
-- Use simple language and avoid jargon
-- Focus on brevity and clarity
-- Use present tense and active voice
-- Don't begin argument/attribute descriptions with "An", "The", "Defines", "Indicates", or "Specifies"
-- Boolean arguments should begin with "Whether to"
-- Use "example" instead of "test" in examples
---->
 
 # Resource: aws_lexv2models_bot_alias
 
-Manages an AWS Lex V2 Models Bot Alias.
+Manages an AWS Lex V2 Models Bot Alias. An alias points to a specific version of a bot so client applications can use a stable name to invoke that version.
 
 ## Example Usage
 
@@ -26,6 +16,52 @@ Manages an AWS Lex V2 Models Bot Alias.
 
 ```terraform
 resource "aws_lexv2models_bot_alias" "example" {
+  bot_id         = aws_lexv2models_bot.example.id
+  bot_alias_name = "production"
+}
+```
+
+### Lambda Code Hook and CloudWatch Conversation Logs
+
+```terraform
+resource "aws_cloudwatch_log_group" "example" {
+  name = "lex/example"
+}
+
+resource "aws_lexv2models_bot_alias" "example" {
+  bot_id         = aws_lexv2models_bot.example.id
+  bot_alias_name = "production"
+  bot_version    = aws_lexv2models_bot_version.example.bot_version
+  description    = "Production alias for the example bot"
+
+  bot_alias_locale_settings {
+    locale_id = "en_US"
+    enabled   = true
+
+    code_hook_specification {
+      lambda_code_hook {
+        code_hook_interface_version = "1.0"
+        lambda_arn                  = aws_lambda_function.example.arn
+      }
+    }
+  }
+
+  conversation_log_settings {
+    text_log_settings {
+      enabled = true
+
+      destination {
+        cloudwatch {
+          cloudwatch_log_group_arn = aws_cloudwatch_log_group.example.arn
+          log_prefix               = "lex/"
+        }
+      }
+    }
+  }
+
+  sentiment_analysis_settings {
+    detect_sentiment = true
+  }
 }
 ```
 
@@ -33,80 +69,96 @@ resource "aws_lexv2models_bot_alias" "example" {
 
 The following arguments are required:
 
-* `example_arg` - (Required) Brief description of the required argument.
+* `bot_alias_name` - (Required) Name of the bot alias. Must be unique for the bot.
+* `bot_id` - (Required) Identifier of the bot that the alias applies to. Forces replacement on change.
 
 The following arguments are optional:
 
-* `optional_arg` - (Optional) Brief description of the optional argument.
-* `tags` - (Optional) Map of tags assigned to the resource. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+* `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
+* `bot_version` - (Optional) Version of the bot that this alias points to. When omitted, Lex creates the alias without a bot version and the alias must be updated before it can be used to converse with the bot.
+* `description` - (Optional) Description of the alias.
+* `bot_alias_locale_settings` - (Optional) Per-locale settings that override the bot's locale defaults. [See below](#bot_alias_locale_settings).
+* `conversation_log_settings` - (Optional) Conversation logging configuration. [See below](#conversation_log_settings).
+* `sentiment_analysis_settings` - (Optional) Sentiment analysis configuration. [See below](#sentiment_analysis_settings).
+* `tags` - (Optional) Map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+### bot_alias_locale_settings
+
+* `enabled` - (Required) Whether to enable the locale for this alias.
+* `locale_id` - (Required) String used to identify the locale (for example, `en_US`).
+* `code_hook_specification` - (Optional) Lambda code hook to invoke for this locale. [See below](#code_hook_specification).
+
+### code_hook_specification
+
+* `lambda_code_hook` - (Required) Lambda function configuration.
+
+The `lambda_code_hook` block supports:
+
+* `code_hook_interface_version` - (Required) Version of the request-response interface that Lex uses to invoke the Lambda function.
+* `lambda_arn` - (Required) ARN of the Lambda function.
+
+### conversation_log_settings
+
+At least one of `audio_log_settings` or `text_log_settings` must be configured for logging to be active.
+
+* `audio_log_settings` - (Optional) One or more audio log destinations. [See below](#audio_log_settings).
+* `text_log_settings` - (Optional) One or more text log destinations. [See below](#text_log_settings).
+
+### audio_log_settings
+
+* `enabled` - (Required) Whether to enable audio logging.
+* `destination` - (Required) S3 destination for audio logs.
+
+The `destination` block supports a single `s3_bucket` block with:
+
+* `kms_key_arn` - (Optional) ARN of a KMS key used to encrypt the audio log files.
+* `log_prefix` - (Required) S3 key prefix to apply to audio log files.
+* `s3_bucket_arn` - (Required) ARN of the S3 bucket where audio logs are stored.
+
+### text_log_settings
+
+* `enabled` - (Required) Whether to enable text logging.
+* `destination` - (Required) CloudWatch destination for text logs.
+
+The `destination` block supports a single `cloudwatch` block with:
+
+* `cloudwatch_log_group_arn` - (Required) ARN of the CloudWatch Logs log group that receives text logs.
+* `log_prefix` - (Required) Prefix applied to the log stream name within the log group.
+
+### sentiment_analysis_settings
+
+* `detect_sentiment` - (Required) Whether to use Amazon Comprehend to detect the sentiment of user utterances.
 
 ## Attribute Reference
 
 This resource exports the following attributes in addition to the arguments above:
 
-* `arn` - ARN of the Bot Alias.
-* `example_attribute` - Brief description of the attribute.
+* `arn` - ARN of the bot alias.
+* `bot_alias_id` - Unique identifier of the bot alias.
+* `id` - Comma-delimited string concatenating `bot_id` and `bot_alias_id`.
 * `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 
 ## Timeouts
 
 [Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
 
-* `create` - (Default `60m`)
-* `update` - (Default `180m`)
-* `delete` - (Default `90m`)
+* `create` - (Default `30m`)
+* `update` - (Default `30m`)
+* `delete` - (Default `30m`)
 
 ## Import
 
-In Terraform v1.12.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `identity` attribute. For example:
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Lex V2 Models Bot Alias using the `id`. For example:
 
 ```terraform
 import {
   to = aws_lexv2models_bot_alias.example
-  identity = {
-<!---
-Add only required attributes in this example.
---->
-  }
-}
-
-resource "aws_lexv2models_bot_alias" "example" {
-  ### Configuration omitted for brevity ###
+  id = "ABCDEF1234,GHIJKL5678"
 }
 ```
 
-### Identity Schema
-
-#### Required
-<!---
-Required attributes here:
-> ARN Identity:
-* `arn` - ARN of the Bot Alias.
-> Parameterized Identity:
-* `example_id_arg` - ID argument of the Bot Alias.
-> Singleton Identity: no required attributes.
---->
-
-#### Optional
-<!---
-Optional attributes here:
-> ARN Identity: no optional attributes.
-> Parameterized Identity and Singleton Identity: remove `region` if the resource is global.
---->
-* `account_id` (String) AWS Account where this resource is managed.
-* `region` (String) Region where this resource is managed.
-
-In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Lex V2 Models Bot Alias using the `example_id_arg`. For example:
-
-```terraform
-import {
-  to = aws_lexv2models_bot_alias.example
-  id = "bot_alias-id-12345678"
-}
-```
-
-Using `terraform import`, import Lex V2 Models Bot Alias using the `example_id_arg`. For example:
+Using `terraform import`, import Lex V2 Models Bot Alias using the `id`. For example:
 
 ```console
-% terraform import aws_lexv2models_bot_alias.example bot_alias-id-12345678
+% terraform import aws_lexv2models_bot_alias.example ABCDEF1234,GHIJKL5678
 ```

--- a/website/docs/r/lexv2models_bot_alias.html.markdown
+++ b/website/docs/r/lexv2models_bot_alias.html.markdown
@@ -1,0 +1,112 @@
+---
+subcategory: "Lex V2 Models"
+layout: "aws"
+page_title: "AWS: aws_lexv2models_bot_alias"
+description: |-
+  Manages an AWS Lex V2 Models Bot Alias.
+---
+<!---
+Documentation guidelines:
+- Begin resource descriptions with "Manages..."
+- Use simple language and avoid jargon
+- Focus on brevity and clarity
+- Use present tense and active voice
+- Don't begin argument/attribute descriptions with "An", "The", "Defines", "Indicates", or "Specifies"
+- Boolean arguments should begin with "Whether to"
+- Use "example" instead of "test" in examples
+--->
+
+# Resource: aws_lexv2models_bot_alias
+
+Manages an AWS Lex V2 Models Bot Alias.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_lexv2models_bot_alias" "example" {
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `example_arg` - (Required) Brief description of the required argument.
+
+The following arguments are optional:
+
+* `optional_arg` - (Optional) Brief description of the optional argument.
+* `tags` - (Optional) Map of tags assigned to the resource. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+## Attribute Reference
+
+This resource exports the following attributes in addition to the arguments above:
+
+* `arn` - ARN of the Bot Alias.
+* `example_attribute` - Brief description of the attribute.
+* `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
+
+## Timeouts
+
+[Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
+
+* `create` - (Default `60m`)
+* `update` - (Default `180m`)
+* `delete` - (Default `90m`)
+
+## Import
+
+In Terraform v1.12.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `identity` attribute. For example:
+
+```terraform
+import {
+  to = aws_lexv2models_bot_alias.example
+  identity = {
+<!---
+Add only required attributes in this example.
+--->
+  }
+}
+
+resource "aws_lexv2models_bot_alias" "example" {
+  ### Configuration omitted for brevity ###
+}
+```
+
+### Identity Schema
+
+#### Required
+<!---
+Required attributes here:
+> ARN Identity:
+* `arn` - ARN of the Bot Alias.
+> Parameterized Identity:
+* `example_id_arg` - ID argument of the Bot Alias.
+> Singleton Identity: no required attributes.
+--->
+
+#### Optional
+<!---
+Optional attributes here:
+> ARN Identity: no optional attributes.
+> Parameterized Identity and Singleton Identity: remove `region` if the resource is global.
+--->
+* `account_id` (String) AWS Account where this resource is managed.
+* `region` (String) Region where this resource is managed.
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Lex V2 Models Bot Alias using the `example_id_arg`. For example:
+
+```terraform
+import {
+  to = aws_lexv2models_bot_alias.example
+  id = "bot_alias-id-12345678"
+}
+```
+
+Using `terraform import`, import Lex V2 Models Bot Alias using the `example_id_arg`. For example:
+
+```console
+% terraform import aws_lexv2models_bot_alias.example bot_alias-id-12345678
+```

--- a/website/docs/r/lexv2models_bot_alias.html.markdown
+++ b/website/docs/r/lexv2models_bot_alias.html.markdown
@@ -74,58 +74,86 @@ The following arguments are required:
 
 The following arguments are optional:
 
-* `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
+* `bot_alias_locale_settings` - (Optional) Per-locale settings that override the bot's locale defaults. See [`bot_alias_locale_settings` Block](#bot_alias_locale_settings-block) for details.
 * `bot_version` - (Optional) Version of the bot that this alias points to. When omitted, Lex creates the alias without a bot version and the alias must be updated before it can be used to converse with the bot.
+* `conversation_log_settings` - (Optional) Conversation logging configuration. See [`conversation_log_settings` Block](#conversation_log_settings-block) for details.
 * `description` - (Optional) Description of the alias.
-* `bot_alias_locale_settings` - (Optional) Per-locale settings that override the bot's locale defaults. [See below](#bot_alias_locale_settings).
-* `conversation_log_settings` - (Optional) Conversation logging configuration. [See below](#conversation_log_settings).
-* `sentiment_analysis_settings` - (Optional) Sentiment analysis configuration. [See below](#sentiment_analysis_settings).
+* `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
+* `sentiment_analysis_settings` - (Optional) Sentiment analysis configuration. See [`sentiment_analysis_settings` Block](#sentiment_analysis_settings-block) for details.
 * `tags` - (Optional) Map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
-### bot_alias_locale_settings
+### `bot_alias_locale_settings` Block
 
+The `bot_alias_locale_settings` configuration block supports the following arguments:
+
+* `code_hook_specification` - (Optional) Lambda code hook to invoke for this locale. See [`code_hook_specification` Block](#code_hook_specification-block) for details.
 * `enabled` - (Required) Whether to enable the locale for this alias.
 * `locale_id` - (Required) String used to identify the locale (for example, `en_US`).
-* `code_hook_specification` - (Optional) Lambda code hook to invoke for this locale. [See below](#code_hook_specification).
 
-### code_hook_specification
+### `code_hook_specification` Block
 
-* `lambda_code_hook` - (Required) Lambda function configuration.
+The `code_hook_specification` configuration block supports the following arguments:
 
-The `lambda_code_hook` block supports:
+* `lambda_code_hook` - (Required) Lambda function configuration. See [`lambda_code_hook` Block](#lambda_code_hook-block) for details.
+
+### `lambda_code_hook` Block
+
+The `lambda_code_hook` configuration block supports the following arguments:
 
 * `code_hook_interface_version` - (Required) Version of the request-response interface that Lex uses to invoke the Lambda function.
 * `lambda_arn` - (Required) ARN of the Lambda function.
 
-### conversation_log_settings
+### `conversation_log_settings` Block
 
-At least one of `audio_log_settings` or `text_log_settings` must be configured for logging to be active.
+The `conversation_log_settings` configuration block supports the following arguments. At least one of `audio_log_settings` or `text_log_settings` must be configured for logging to be active.
 
-* `audio_log_settings` - (Optional) One or more audio log destinations. [See below](#audio_log_settings).
-* `text_log_settings` - (Optional) One or more text log destinations. [See below](#text_log_settings).
+* `audio_log_settings` - (Optional) One or more audio log destinations. See [`audio_log_settings` Block](#audio_log_settings-block) for details.
+* `text_log_settings` - (Optional) One or more text log destinations. See [`text_log_settings` Block](#text_log_settings-block) for details.
 
-### audio_log_settings
+### `audio_log_settings` Block
 
+The `audio_log_settings` configuration block supports the following arguments:
+
+* `destination` - (Required) S3 destination for audio logs. See [`audio_log_settings` `destination` Block](#audio_log_settings-destination-block) for details.
 * `enabled` - (Required) Whether to enable audio logging.
-* `destination` - (Required) S3 destination for audio logs.
 
-The `destination` block supports a single `s3_bucket` block with:
+### `audio_log_settings` `destination` Block
+
+The `destination` configuration block supports the following arguments:
+
+* `s3_bucket` - (Required) S3 bucket configuration for audio logs. See [`s3_bucket` Block](#s3_bucket-block) for details.
+
+### `s3_bucket` Block
+
+The `s3_bucket` configuration block supports the following arguments:
 
 * `kms_key_arn` - (Optional) ARN of a KMS key used to encrypt the audio log files.
 * `log_prefix` - (Required) S3 key prefix to apply to audio log files.
 * `s3_bucket_arn` - (Required) ARN of the S3 bucket where audio logs are stored.
 
-### text_log_settings
+### `text_log_settings` Block
 
+The `text_log_settings` configuration block supports the following arguments:
+
+* `destination` - (Required) CloudWatch destination for text logs. See [`text_log_settings` `destination` Block](#text_log_settings-destination-block) for details.
 * `enabled` - (Required) Whether to enable text logging.
-* `destination` - (Required) CloudWatch destination for text logs.
 
-The `destination` block supports a single `cloudwatch` block with:
+### `text_log_settings` `destination` Block
+
+The `destination` configuration block supports the following arguments:
+
+* `cloudwatch` - (Required) CloudWatch Logs configuration for text logs. See [`cloudwatch` Block](#cloudwatch-block) for details.
+
+### `cloudwatch` Block
+
+The `cloudwatch` configuration block supports the following arguments:
 
 * `cloudwatch_log_group_arn` - (Required) ARN of the CloudWatch Logs log group that receives text logs.
 * `log_prefix` - (Required) Prefix applied to the log stream name within the log group.
 
-### sentiment_analysis_settings
+### `sentiment_analysis_settings` Block
+
+The `sentiment_analysis_settings` configuration block supports the following arguments:
 
 * `detect_sentiment` - (Required) Whether to use Amazon Comprehend to detect the sentiment of user utterances.
 


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls. The resource manages AWS Lex V2 bot aliases; conversation log destinations (S3/CloudWatch) and Lambda code hook ARNs are user-supplied and validated as ARNs.

### Description

Adds a new resource `aws_lexv2models_bot_alias` for managing [Amazon Lex V2 bot aliases](https://docs.aws.amazon.com/lexv2/latest/dg/aliases.html). An alias points to a specific version of a bot so client applications can use a stable name to invoke that version.

The resource is built on the Terraform Plugin Framework and supports:

- `bot_alias_name`, `bot_id`, `bot_version`, and `description`
- `bot_alias_locale_settings` — per-locale enablement and Lambda `code_hook_specification`
- `conversation_log_settings` — `audio_log_settings` (S3 destination) and `text_log_settings` (CloudWatch destination)
- `sentiment_analysis_settings`
- Tagging (`identifierAttribute = arn`)
- Import by `bot_id,bot_alias_id`
- A sweeper, registered as a dependency of the `aws_lexv2models_bot` sweeper

### Relations

Closes #35780

### References

* [Amazon Lex V2 — Versions and aliases](https://docs.aws.amazon.com/lexv2/latest/dg/aliases.html)
* [`CreateBotAlias` API reference](https://docs.aws.amazon.com/lexv2/latest/APIReference/API_CreateBotAlias.html)

### Output from Acceptance Testing

```console
% make testacc TESTS=TestAccLexV2ModelsBotAlias_ PKG=lexv2models

--- PASS: TestAccLexV2ModelsBotAlias_conversationLogSettings (51.12s)
--- PASS: TestAccLexV2ModelsBotAlias_disappears (52.64s)
--- PASS: TestAccLexV2ModelsBotAlias_basic (57.44s)
--- PASS: TestAccLexV2ModelsBotAlias_description (74.20s)
--- PASS: TestAccLexV2ModelsBotAlias_sentimentAnalysisSettings (74.88s)
--- PASS: TestAccLexV2ModelsBotAlias_tags (98.56s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/lexv2models
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
