### PR TITLE
d/aws_opensearch_package: add new data source

### DIFF
--- a/.changelog/48408.txt
+++ b/.changelog/48408.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_opensearch_package
+```

--- a/internal/service/opensearch/exports_test.go
+++ b/internal/service/opensearch/exports_test.go
@@ -18,6 +18,7 @@ var (
 	FindAuthorizeVPCEndpointAccessByTwoPartKey = findAuthorizeVPCEndpointAccessByTwoPartKey
 	FindDomainByName                           = findDomainByName
 	FindPackageByID                            = findPackageByID
+	FindPackageByName                          = findPackageByName
 	FindPackageAssociationByTwoPartKey         = findPackageAssociationByTwoPartKey
 	FindVPCEndpointByID                        = findVPCEndpointByID
 

--- a/internal/service/opensearch/package_data_source.go
+++ b/internal/service/opensearch/package_data_source.go
@@ -1,0 +1,109 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package opensearch
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/opensearch"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/opensearch/types"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkDataSource("aws_opensearch_package", name="Package")
+func newPackageDataSource(context.Context) (datasource.DataSourceWithConfigure, error) {
+	return &packageDataSource{}, nil
+}
+
+type packageDataSource struct {
+	framework.DataSourceWithModel[packageDataSourceModel]
+}
+
+func (d *packageDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"available_package_version": schema.StringAttribute{
+				Computed: true,
+			},
+			names.AttrEngineVersion: schema.StringAttribute{
+				Computed: true,
+			},
+			names.AttrID: schema.StringAttribute{
+				Computed: true,
+			},
+			"package_description": schema.StringAttribute{
+				Computed: true,
+			},
+			"package_id": schema.StringAttribute{
+				Computed: true,
+			},
+			"package_name": schema.StringAttribute{
+				Required: true,
+			},
+			"package_type": schema.StringAttribute{
+				CustomType: fwtypes.StringEnumType[awstypes.PackageType](),
+				Computed:   true,
+			},
+		},
+	}
+}
+
+func (d *packageDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data packageDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	conn := d.Meta().OpenSearchClient(ctx)
+
+	pkg, err := findPackageByName(ctx, conn, data.PackageName.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.OpenSearch, create.ErrActionReading, "Package", data.PackageName.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(fwflex.Flatten(ctx, pkg, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data.ID = data.PackageID
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+type packageDataSourceModel struct {
+	framework.WithRegionModel
+	AvailablePackageVersion types.String                             `tfsdk:"available_package_version"`
+	EngineVersion           types.String                             `tfsdk:"engine_version"`
+	ID                      types.String                             `tfsdk:"id"`
+	PackageDescription      types.String                             `tfsdk:"package_description"`
+	PackageID               types.String                             `tfsdk:"package_id"`
+	PackageName             types.String                             `tfsdk:"package_name"`
+	PackageType             fwtypes.StringEnum[awstypes.PackageType] `tfsdk:"package_type"`
+}
+
+func findPackageByName(ctx context.Context, conn *opensearch.Client, name string) (*awstypes.PackageDetails, error) {
+	input := &opensearch.DescribePackagesInput{
+		Filters: []awstypes.DescribePackagesFilter{
+			{
+				Name:  awstypes.DescribePackagesFilterNamePackageName,
+				Value: []string{name},
+			},
+		},
+	}
+
+	return findPackage(ctx, conn, input)
+}

--- a/internal/service/opensearch/package_data_source_test.go
+++ b/internal/service/opensearch/package_data_source_test.go
@@ -1,0 +1,68 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package opensearch_test
+
+import (
+	"fmt"
+	"testing"
+
+	awstypes "github.com/aws/aws-sdk-go-v2/service/opensearch/types"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccOpenSearchPackageDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	pkgName := testAccRandomDomainName(t)
+	resourceName := "aws_opensearch_package.test"
+	dataSourceName := "data.aws_opensearch_package.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.OpenSearchServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckPackageDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPackageDataSourceConfig_basic(pkgName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "available_package_version", resourceName, "available_package_version"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "id", dataSourceName, "package_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "package_id", resourceName, "package_id"),
+					resource.TestCheckResourceAttr(dataSourceName, "package_name", pkgName),
+					resource.TestCheckResourceAttr(dataSourceName, "package_type", string(awstypes.PackageTypeTxtDictionary)),
+				),
+			},
+		},
+	})
+}
+
+func testAccPackageDataSourceConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+}
+
+resource "aws_s3_object" "test" {
+  bucket = aws_s3_bucket.test.bucket
+  key    = %[1]q
+  source = "./test-fixtures/example-opensearch-custom-package.txt"
+  etag   = filemd5("./test-fixtures/example-opensearch-custom-package.txt")
+}
+
+resource "aws_opensearch_package" "test" {
+  package_name = %[1]q
+  package_source {
+    s3_bucket_name = aws_s3_bucket.test.bucket
+    s3_key         = aws_s3_object.test.key
+  }
+  package_type = "TXT-DICTIONARY"
+}
+
+data "aws_opensearch_package" "test" {
+  package_name = aws_opensearch_package.test.package_name
+}
+`, rName)
+}

--- a/internal/service/opensearch/service_package_gen.go
+++ b/internal/service/opensearch/service_package_gen.go
@@ -21,7 +21,14 @@ import (
 type servicePackage struct{}
 
 func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*inttypes.ServicePackageFrameworkDataSource {
-	return []*inttypes.ServicePackageFrameworkDataSource{}
+	return []*inttypes.ServicePackageFrameworkDataSource{
+		{
+			Factory:  newPackageDataSource,
+			TypeName: "aws_opensearch_package",
+			Name:     "Package",
+			Region:   inttypes.ResourceRegionDefault(),
+		},
+	}
 }
 
 func (p *servicePackage) FrameworkResources(ctx context.Context) []*inttypes.ServicePackageFrameworkResource {

--- a/website/docs/d/opensearch_package.html.markdown
+++ b/website/docs/d/opensearch_package.html.markdown
@@ -1,0 +1,54 @@
+---
+subcategory: "OpenSearch"
+layout: "aws"
+page_title: "AWS: aws_opensearch_package"
+description: |-
+  Get information on an AWS OpenSearch Package.
+---
+
+# Data Source: aws_opensearch_package
+
+Use this data source to get information about an AWS OpenSearch Package.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_opensearch_package" "example" {
+  package_name = "example-txt"
+}
+```
+
+### Cross-State Reference with Package Association
+
+Look up a package managed in another Terraform state and associate it with a domain.
+
+```terraform
+data "aws_opensearch_package" "example" {
+  package_name = "example-txt"
+}
+
+resource "aws_opensearch_package_association" "example" {
+  package_id  = data.aws_opensearch_package.example.package_id
+  domain_name = aws_opensearch_domain.example.domain_name
+}
+```
+
+## Argument Reference
+
+This data source supports the following arguments:
+
+* `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
+* `package_name` - (Required) Name of the package to look up.
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `id` - ID of the package.
+* `available_package_version` - Current version of the package.
+* `engine_version` - Engine version that the package is compatible with.
+* `package_description` - Description of the package.
+* `package_id` - ID of the package.
+* `package_type` - Type of the package. Valid values are `TXT-DICTIONARY`, `ZIP-PLUGIN`, `PACKAGE-LICENSE` and `PACKAGE-CONFIG`.


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

### Description
Adds a new data source `aws_opensearch_package` that allows users to look up an existing OpenSearch package by name.

When an OpenSearch package (e.g. a custom dictionary or analysis plugin) is shared across multiple OpenSearch domains managed in separate Terraform states, there is currently no data source to reference it by name. Users are forced to hardcode the `package_id` or use workarounds such as an `external` data source with the AWS CLI.

This data source was originally planned alongside the `aws_opensearch_package` resource in #32648 but was never implemented.



### Relations
Closes #48405

### References
- #32648 (original issue where this data source was planned but not implemented)
- AWS Go SDK v2 DescribePackages: https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/opensearch#Client.DescribePackages


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=opensearch TESTS=TestAccOpenSearchPackageDataSource_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework (cached)
make: Running acceptance tests on branch: 🌿 f-aws_opensearch_package_data_source 🌿...
TF_ACC=1 go1.26.3 test ./internal/service/opensearch/... -v -count 1 -parallel 20 -run='TestAccOpenSearchPackageDataSource_'  -timeout 360m -vet=off -buildvcs=false
2026/06/15 20:32:16 Creating Terraform AWS Provider (SDKv2-style)...
2026/06/15 20:32:16 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccOpenSearchPackageDataSource_basic
=== PAUSE TestAccOpenSearchPackageDataSource_basic
=== CONT  TestAccOpenSearchPackageDataSource_basic
--- PASS: TestAccOpenSearchPackageDataSource_basic (47.20s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/opensearch 53.593s
```

### AI Usage
Claude Code was used to assist in generating the implementation, tests, and documentation for this data source. All code has been reviewed, tested against a real AWS account, and understood by the author.
