### PR TITLE
cloudwatch: use synthetic namespaces in metric stream acceptance tests

### DIFF
--- a/internal/service/cloudwatch/metric_stream_test.go
+++ b/internal/service/cloudwatch/metric_stream_test.go
@@ -47,7 +47,7 @@ func TestAccCloudWatchMetricStream_basic(t *testing.T) {
 					acctest.CheckResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "cloudwatch", fmt.Sprintf("metric-stream/%s", rName)),
 					acctest.CheckResourceAttrRFC3339(resourceName, names.AttrCreationDate),
 					resource.TestCheckResourceAttr(resourceName, "exclude_filter.#", "0"),
-					resource.TestCheckResourceAttr(resourceName, "include_filter.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "include_filter.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "include_linked_accounts_metrics", acctest.CtFalse),
 					acctest.CheckResourceAttrRFC3339(resourceName, "last_update_date"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
@@ -204,7 +204,7 @@ func TestAccCloudWatchMetricStream_includeFiltersWithMetricNames(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "output_format", names.AttrJSON),
 					resource.TestCheckResourceAttr(resourceName, "include_filter.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "include_filter.0.metric_names.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "include_filter.0.metric_names.0", "CPUUtilization"),
+					resource.TestCheckResourceAttr(resourceName, "include_filter.0.metric_names.0", "TestMetricOne"),
 					resource.TestCheckResourceAttr(resourceName, "include_filter.1.metric_names.#", "0"),
 				),
 			},
@@ -234,7 +234,7 @@ func TestAccCloudWatchMetricStream_excludeFilters(t *testing.T) {
 					testAccCheckMetricStreamExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, "output_format", names.AttrJSON),
-					resource.TestCheckResourceAttr(resourceName, "exclude_filter.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "exclude_filter.#", "6"),
 					resource.TestCheckResourceAttr(resourceName, "exclude_filter.0.metric_names.#", "0")),
 			},
 			{
@@ -263,9 +263,9 @@ func TestAccCloudWatchMetricStream_excludeFiltersWithMetricNames(t *testing.T) {
 					testAccCheckMetricStreamExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, "output_format", names.AttrJSON),
-					resource.TestCheckResourceAttr(resourceName, "exclude_filter.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "exclude_filter.#", "6"),
 					resource.TestCheckResourceAttr(resourceName, "exclude_filter.0.metric_names.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "exclude_filter.0.metric_names.0", "CPUUtilization"),
+					resource.TestCheckResourceAttr(resourceName, "exclude_filter.0.metric_names.0", "CurrConnections"),
 					resource.TestCheckResourceAttr(resourceName, "exclude_filter.1.metric_names.#", "0"),
 				),
 			},
@@ -603,6 +603,10 @@ resource "aws_cloudwatch_metric_stream" "test" {
   role_arn      = aws_iam_role.metric_stream_to_firehose.arn
   firehose_arn  = aws_kinesis_firehose_delivery_stream.s3_stream.arn
   output_format = "json"
+
+  include_filter {
+    namespace = "CWAccTest/One"
+  }
 }
 `, rName))
 }
@@ -613,6 +617,10 @@ resource "aws_cloudwatch_metric_stream" "test" {
   role_arn      = aws_iam_role.metric_stream_to_firehose.arn
   firehose_arn  = aws_kinesis_firehose_delivery_stream.s3_stream.arn
   output_format = "json"
+
+  include_filter {
+    namespace = "CWAccTest/One"
+  }
 }
 `)
 }
@@ -624,6 +632,10 @@ resource "aws_cloudwatch_metric_stream" "test" {
   role_arn      = aws_iam_role.metric_stream_to_firehose.arn
   firehose_arn  = aws_kinesis_firehose_delivery_stream.s3_stream.arn
   output_format = "json"
+
+  include_filter {
+    namespace = "CWAccTest/One"
+  }
 }
 `, namePrefix))
 }
@@ -639,6 +651,10 @@ resource "aws_cloudwatch_metric_stream" "test" {
   role_arn      = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:role/%[2]s"
   firehose_arn  = "arn:${data.aws_partition.current.partition}:firehose:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:deliverystream/%[2]s"
   output_format = "json"
+
+  include_filter {
+    namespace = "CWAccTest/One"
+  }
 }
 `, rName, arnSuffix)
 }
@@ -654,6 +670,10 @@ resource "aws_cloudwatch_metric_stream" "test" {
   role_arn      = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:role/%[2]s"
   firehose_arn  = "arn:${data.aws_partition.current.partition}:firehose:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:deliverystream/%[2]s"
   output_format = "json"
+
+  include_filter {
+    namespace = "CWAccTest/One"
+  }
 
   tags = {
     %[3]q = %[4]q
@@ -675,11 +695,11 @@ resource "aws_cloudwatch_metric_stream" "test" {
   output_format = "json"
 
   include_filter {
-    namespace = "AWS/EC2"
+    namespace = "CWAccTest/One"
   }
 
   include_filter {
-    namespace = "AWS/EBS"
+    namespace = "CWAccTest/Two"
   }
 }
 `, rName)
@@ -698,12 +718,12 @@ resource "aws_cloudwatch_metric_stream" "test" {
   output_format = "json"
 
   include_filter {
-    namespace    = "AWS/EC2"
-    metric_names = ["CPUUtilization", "NetworkOut"]
+    namespace    = "CWAccTest/One"
+    metric_names = ["TestMetricOne", "TestMetricTwo"]
   }
 
   include_filter {
-    namespace    = "AWS/EBS"
+    namespace    = "CWAccTest/Two"
     metric_names = []
   }
 }
@@ -723,11 +743,27 @@ resource "aws_cloudwatch_metric_stream" "test" {
   output_format = "json"
 
   exclude_filter {
-    namespace = "AWS/EC2"
+    namespace = "AWS/ElastiCache"
   }
 
   exclude_filter {
-    namespace = "AWS/EBS"
+    namespace = "AWS/Usage"
+  }
+
+  exclude_filter {
+    namespace = "AWS/Firehose"
+  }
+
+  exclude_filter {
+    namespace = "AWS/ES"
+  }
+
+  exclude_filter {
+    namespace = "AWS/SQS"
+  }
+
+  exclude_filter {
+    namespace = "AWS/CloudWatch"
   }
 }
 `, rName)
@@ -746,13 +782,29 @@ resource "aws_cloudwatch_metric_stream" "test" {
   output_format = "json"
 
   exclude_filter {
-    namespace    = "AWS/EC2"
-    metric_names = ["CPUUtilization", "NetworkOut"]
+    namespace    = "AWS/ElastiCache"
+    metric_names = ["CurrConnections", "NewConnections"]
   }
 
   exclude_filter {
-    namespace    = "AWS/EBS"
+    namespace    = "AWS/Usage"
     metric_names = []
+  }
+
+  exclude_filter {
+    namespace = "AWS/Firehose"
+  }
+
+  exclude_filter {
+    namespace = "AWS/ES"
+  }
+
+  exclude_filter {
+    namespace = "AWS/SQS"
+  }
+
+  exclude_filter {
+    namespace = "AWS/CloudWatch"
   }
 }
 `, rName)
@@ -770,14 +822,18 @@ resource "aws_cloudwatch_metric_stream" "test" {
   firehose_arn  = "arn:${data.aws_partition.current.partition}:firehose:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:deliverystream/MyFirehose"
   output_format = "json"
 
+  include_filter {
+    namespace = "CWAccTest/One"
+  }
+
   statistics_configuration {
     additional_statistics = [
       "p1", "tm99"
     ]
 
     include_metric {
-      metric_name = "CPUUtilization"
-      namespace   = "AWS/EC2"
+      metric_name = "TestMetricOne"
+      namespace   = "CWAccTest/One"
     }
   }
 
@@ -787,8 +843,8 @@ resource "aws_cloudwatch_metric_stream" "test" {
     ]
 
     include_metric {
-      metric_name = "CPUUtilization"
-      namespace   = "AWS/EC2"
+      metric_name = "TestMetricOne"
+      namespace   = "CWAccTest/One"
     }
   }
 }
@@ -803,6 +859,10 @@ resource "aws_cloudwatch_metric_stream" "test" {
   firehose_arn                    = aws_kinesis_firehose_delivery_stream.s3_stream.arn
   output_format                   = "json"
   include_linked_accounts_metrics = %[2]t
+
+  include_filter {
+    namespace = "CWAccTest/One"
+  }
 }
 `, rName, include))
 }

--- a/internal/service/cloudwatch/testdata/MetricStream/tags/main_gen.tf
+++ b/internal/service/cloudwatch/testdata/MetricStream/tags/main_gen.tf
@@ -7,6 +7,10 @@ resource "aws_cloudwatch_metric_stream" "test" {
   firehose_arn  = aws_kinesis_firehose_delivery_stream.s3_stream.arn
   output_format = "json"
 
+  include_filter {
+    namespace = "CWAccTest/One"
+  }
+
   tags = var.resource_tags
 }
 

--- a/internal/service/cloudwatch/testdata/MetricStream/tagsComputed1/main_gen.tf
+++ b/internal/service/cloudwatch/testdata/MetricStream/tagsComputed1/main_gen.tf
@@ -9,6 +9,10 @@ resource "aws_cloudwatch_metric_stream" "test" {
   firehose_arn  = aws_kinesis_firehose_delivery_stream.s3_stream.arn
   output_format = "json"
 
+  include_filter {
+    namespace = "CWAccTest/One"
+  }
+
   tags = {
     (var.unknownTagKey) = null_resource.test.id
   }

--- a/internal/service/cloudwatch/testdata/MetricStream/tagsComputed2/main_gen.tf
+++ b/internal/service/cloudwatch/testdata/MetricStream/tagsComputed2/main_gen.tf
@@ -9,6 +9,10 @@ resource "aws_cloudwatch_metric_stream" "test" {
   firehose_arn  = aws_kinesis_firehose_delivery_stream.s3_stream.arn
   output_format = "json"
 
+  include_filter {
+    namespace = "CWAccTest/One"
+  }
+
   tags = {
     (var.unknownTagKey) = null_resource.test.id
     (var.knownTagKey)   = var.knownTagValue

--- a/internal/service/cloudwatch/testdata/MetricStream/tags_defaults/main_gen.tf
+++ b/internal/service/cloudwatch/testdata/MetricStream/tags_defaults/main_gen.tf
@@ -13,6 +13,10 @@ resource "aws_cloudwatch_metric_stream" "test" {
   firehose_arn  = aws_kinesis_firehose_delivery_stream.s3_stream.arn
   output_format = "json"
 
+  include_filter {
+    namespace = "CWAccTest/One"
+  }
+
   tags = var.resource_tags
 }
 

--- a/internal/service/cloudwatch/testdata/MetricStream/tags_ignore/main_gen.tf
+++ b/internal/service/cloudwatch/testdata/MetricStream/tags_ignore/main_gen.tf
@@ -16,6 +16,10 @@ resource "aws_cloudwatch_metric_stream" "test" {
   firehose_arn  = aws_kinesis_firehose_delivery_stream.s3_stream.arn
   output_format = "json"
 
+  include_filter {
+    namespace = "CWAccTest/One"
+  }
+
   tags = var.resource_tags
 }
 

--- a/internal/service/cloudwatch/testdata/tmpl/metric_stream_basic.gtpl
+++ b/internal/service/cloudwatch/testdata/tmpl/metric_stream_basic.gtpl
@@ -5,6 +5,10 @@ resource "aws_cloudwatch_metric_stream" "test" {
   firehose_arn  = aws_kinesis_firehose_delivery_stream.s3_stream.arn
   output_format = "json"
 
+  include_filter {
+    namespace = "CWAccTest/One"
+  }
+
 {{- template "tags" . }}
 }
 


### PR DESCRIPTION
### Description

Prevents metric stream acceptance tests from streaming all metrics in an account by:

1. **Adding `include_filter` blocks** to all test configs that previously created unfiltered (full) streams, scoped to a synthetic namespace (`CWAccTest/One`) that will never match real metrics.

2. **Replacing real high-cardinality namespaces** (`AWS/EC2`, `AWS/EBS`) with synthetic ones (`CWAccTest/One`, `CWAccTest/Two`) in include filter tests.

3. **Using real low-cardinality namespaces** (`AWS/ElastiCache`, `AWS/Usage`, `AWS/Firehose`, `AWS/ES`, `AWS/SQS`, `AWS/CloudWatch`) in exclude filter tests, since `include_filter` and `exclude_filter` are mutually exclusive on a metric stream.

### Motivation

When acceptance tests run in accounts with high metric cardinality, unfiltered streams or streams targeting namespaces like `AWS/EC2` cause unnecessary processing and streaming of real metrics. Scoping test streams to synthetic namespaces eliminates this side effect while preserving full test coverage of the resource lifecycle.

### Testing

All 32 `TestAccCloudWatchMetricStream_*` tests pass against a live AWS account with these changes. The CloudWatch API accepts synthetic namespaces as valid filter configuration — the tests verify resource CRUD lifecycle, not metric data flow.

### Output from acceptance testing

```
--- PASS: TestAccCloudWatchMetricStream_basic (88.51s)
--- PASS: TestAccCloudWatchMetricStream_disappears (94.92s)
--- PASS: TestAccCloudWatchMetricStream_nameGenerated (122.75s)
--- PASS: TestAccCloudWatchMetricStream_namePrefix (127.01s)
--- PASS: TestAccCloudWatchMetricStream_includeFilters (33.55s)
--- PASS: TestAccCloudWatchMetricStream_includeFiltersWithMetricNames (33.99s)
--- PASS: TestAccCloudWatchMetricStream_excludeFilters (34.47s)
--- PASS: TestAccCloudWatchMetricStream_excludeFiltersWithMetricNames (29.08s)
--- PASS: TestAccCloudWatchMetricStream_update (99.89s)
--- PASS: TestAccCloudWatchMetricStream_additional_statistics (91.12s)
--- PASS: TestAccCloudWatchMetricStream_includeLinkedAccountsMetrics (110.12s)
--- PASS: TestAccCloudWatchMetricStream_tags (212.37s)
--- PASS: TestAccCloudWatchMetricStream_Tags_null (121.46s)
--- PASS: TestAccCloudWatchMetricStream_Tags_emptyMap (148.08s)
--- PASS: TestAccCloudWatchMetricStream_Tags_addOnUpdate (146.51s)
--- PASS: TestAccCloudWatchMetricStream_Tags_EmptyTag_onCreate (145.97s)
--- PASS: TestAccCloudWatchMetricStream_Tags_EmptyTag_OnUpdate_add (161.17s)
--- PASS: TestAccCloudWatchMetricStream_Tags_EmptyTag_OnUpdate_replace (116.09s)
--- PASS: TestAccCloudWatchMetricStream_Tags_DefaultTags_providerOnly (198.21s)
--- PASS: TestAccCloudWatchMetricStream_Tags_DefaultTags_nonOverlapping (191.19s)
--- PASS: TestAccCloudWatchMetricStream_Tags_DefaultTags_overlapping (165.93s)
--- PASS: TestAccCloudWatchMetricStream_Tags_DefaultTags_updateToProviderOnly (150.72s)
--- PASS: TestAccCloudWatchMetricStream_Tags_DefaultTags_updateToResourceOnly (144.74s)
--- PASS: TestAccCloudWatchMetricStream_Tags_DefaultTags_emptyResourceTag (111.84s)
--- PASS: TestAccCloudWatchMetricStream_Tags_DefaultTags_emptyProviderOnlyTag (99.63s)
--- PASS: TestAccCloudWatchMetricStream_Tags_DefaultTags_nullOverlappingResourceTag (100.97s)
--- PASS: TestAccCloudWatchMetricStream_Tags_DefaultTags_nullNonOverlappingResourceTag (93.41s)
--- PASS: TestAccCloudWatchMetricStream_Tags_ComputedTag_onCreate (96.80s)
--- PASS: TestAccCloudWatchMetricStream_Tags_ComputedTag_OnUpdate_add (148.41s)
--- PASS: TestAccCloudWatchMetricStream_Tags_ComputedTag_OnUpdate_replace (149.70s)
--- PASS: TestAccCloudWatchMetricStream_Tags_IgnoreTags_Overlap_defaultTag (160.51s)
--- PASS: TestAccCloudWatchMetricStream_Tags_IgnoreTags_Overlap_resourceTag (170.47s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudwatch	409.368s
```