### PR TITLE
Linting: Adds `tflint` rule to detect `aws_acmpca_certificate_authority` resources with `permanent_deletion_time_in_days` other than 7

### DIFF
--- a/.ci/.tflint.hcl
+++ b/.ci/.tflint.hcl
@@ -7,6 +7,12 @@ plugin "aws" {
   source  = "github.com/terraform-linters/tflint-ruleset-aws"
 }
 
+plugin "opa" {
+  enabled = true
+  version = "0.10.0"
+  source  = "github.com/terraform-linters/tflint-ruleset-opa"
+}
+
 # Terraform Rules
 # https://github.com/terraform-linters/tflint-ruleset-terraform/blob/main/docs/rules/README.md
 

--- a/.ci/.tflint.hcl
+++ b/.ci/.tflint.hcl
@@ -3,7 +3,7 @@
 
 plugin "aws" {
   enabled = true
-  version = "0.45.0"
+  version = "0.47.0"
   source  = "github.com/terraform-linters/tflint-ruleset-aws"
 }
 

--- a/.ci/.tflint_opa.hcl
+++ b/.ci/.tflint_opa.hcl
@@ -1,0 +1,16 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+# OPA-only configuration for embedded test linting.
+# The main .tflint.hcl uses --only for standard rules, which is
+# incompatible with OPA rules. This config runs OPA rules separately.
+
+plugin "terraform" {
+  enabled = false
+}
+
+plugin "opa" {
+  enabled = true
+  version = "0.10.0"
+  source  = "github.com/terraform-linters/tflint-ruleset-opa"
+}

--- a/.ci/opa-policies/acmpca_deletion_time.rego
+++ b/.ci/opa-policies/acmpca_deletion_time.rego
@@ -11,7 +11,7 @@ deny_acmpca_deletion_time contains issue if {
 	attr := r.config.permanent_deletion_time_in_days
 	attr.value > 7
 
-	issue := tflint.issue("permanent_deletion_time_in_days should be 7 in acceptance tests to minimize costs", attr.range)
+	issue := tflint.issue("permanent_deletion_time_in_days should be 7 in acceptance tests", attr.range)
 }
 
 deny_acmpca_deletion_time contains issue if {
@@ -19,5 +19,5 @@ deny_acmpca_deletion_time contains issue if {
 	r := resources[_]
 	not r.config.permanent_deletion_time_in_days
 
-	issue := tflint.issue("permanent_deletion_time_in_days should be explicitly set to 7 in acceptance tests to minimize costs", r.decl_range)
+	issue := tflint.issue("permanent_deletion_time_in_days should be explicitly set to 7 in acceptance tests", r.decl_range)
 }

--- a/.ci/opa-policies/acmpca_deletion_time.rego
+++ b/.ci/opa-policies/acmpca_deletion_time.rego
@@ -1,0 +1,23 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+package tflint
+
+import rego.v1
+
+deny_acmpca_deletion_time contains issue if {
+	resources := terraform.resources("aws_acmpca_certificate_authority", {"permanent_deletion_time_in_days": "number"}, {})
+	r := resources[_]
+	attr := r.config.permanent_deletion_time_in_days
+	attr.value > 7
+
+	issue := tflint.issue("permanent_deletion_time_in_days should be 7 in acceptance tests to minimize costs", attr.range)
+}
+
+deny_acmpca_deletion_time contains issue if {
+	resources := terraform.resources("aws_acmpca_certificate_authority", {"permanent_deletion_time_in_days": "number"}, {})
+	r := resources[_]
+	not r.config.permanent_deletion_time_in_days
+
+	issue := tflint.issue("permanent_deletion_time_in_days should be explicitly set to 7 in acceptance tests to minimize costs", r.decl_range)
+}

--- a/.ci/opa-policies/tests/acmpca_deletion_time/missing/main.tf
+++ b/.ci/opa-policies/tests/acmpca_deletion_time/missing/main.tf
@@ -1,3 +1,6 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
 resource "aws_acmpca_certificate_authority" "test" {
   type = "ROOT"
 

--- a/.ci/opa-policies/tests/acmpca_deletion_time/missing/main.tf
+++ b/.ci/opa-policies/tests/acmpca_deletion_time/missing/main.tf
@@ -1,0 +1,12 @@
+resource "aws_acmpca_certificate_authority" "test" {
+  type = "ROOT"
+
+  certificate_authority_configuration {
+    key_algorithm     = "RSA_2048"
+    signing_algorithm = "SHA256WITHRSA"
+
+    subject {
+      common_name = "example.com"
+    }
+  }
+}

--- a/.ci/opa-policies/tests/acmpca_deletion_time/no_resource/main.tf
+++ b/.ci/opa-policies/tests/acmpca_deletion_time/no_resource/main.tf
@@ -1,3 +1,6 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
 resource "aws_s3_bucket" "test" {
   bucket = "my-bucket"
 }

--- a/.ci/opa-policies/tests/acmpca_deletion_time/no_resource/main.tf
+++ b/.ci/opa-policies/tests/acmpca_deletion_time/no_resource/main.tf
@@ -1,0 +1,3 @@
+resource "aws_s3_bucket" "test" {
+  bucket = "my-bucket"
+}

--- a/.ci/opa-policies/tests/acmpca_deletion_time/pass/main.tf
+++ b/.ci/opa-policies/tests/acmpca_deletion_time/pass/main.tf
@@ -1,0 +1,13 @@
+resource "aws_acmpca_certificate_authority" "test" {
+  permanent_deletion_time_in_days = 7
+  type                            = "ROOT"
+
+  certificate_authority_configuration {
+    key_algorithm     = "RSA_2048"
+    signing_algorithm = "SHA256WITHRSA"
+
+    subject {
+      common_name = "example.com"
+    }
+  }
+}

--- a/.ci/opa-policies/tests/acmpca_deletion_time/pass/main.tf
+++ b/.ci/opa-policies/tests/acmpca_deletion_time/pass/main.tf
@@ -1,3 +1,6 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
 resource "aws_acmpca_certificate_authority" "test" {
   permanent_deletion_time_in_days = 7
   type                            = "ROOT"

--- a/.ci/opa-policies/tests/acmpca_deletion_time/too_high/main.tf
+++ b/.ci/opa-policies/tests/acmpca_deletion_time/too_high/main.tf
@@ -1,3 +1,6 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
 resource "aws_acmpca_certificate_authority" "test" {
   permanent_deletion_time_in_days = 30
   type                            = "ROOT"

--- a/.ci/opa-policies/tests/acmpca_deletion_time/too_high/main.tf
+++ b/.ci/opa-policies/tests/acmpca_deletion_time/too_high/main.tf
@@ -1,0 +1,13 @@
+resource "aws_acmpca_certificate_authority" "test" {
+  permanent_deletion_time_in_days = 30
+  type                            = "ROOT"
+
+  certificate_authority_configuration {
+    key_algorithm     = "RSA_2048"
+    signing_algorithm = "SHA256WITHRSA"
+
+    subject {
+      common_name = "example.com"
+    }
+  }
+}

--- a/.ci/opa-policies/tests/run_tests.sh
+++ b/.ci/opa-policies/tests/run_tests.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+# Integration tests for OPA policies.
+# Each test case is a directory containing a main.tf file.
+# Directories named "pass" or "no_resource" are expected to produce no issues.
+# All other directories are expected to produce issues (non-zero exit).
+
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+POLICY_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+TFLINT_CONFIG="${SCRIPT_DIR}/tflint.hcl"
+
+exit_code=0
+
+for test_dir in "${SCRIPT_DIR}"/*/; do
+    for case_dir in "${test_dir}"*/; do
+        case_name=$(basename "${case_dir}")
+        rule_name=$(basename "${test_dir}")
+
+        # Determine expected result from directory name
+        case "${case_name}" in
+            pass*|no_resource*)
+                expect_pass=true
+                ;;
+            *)
+                expect_pass=false
+                ;;
+        esac
+
+        # Run tflint
+        set +e
+        output=$(tflint --config "${TFLINT_CONFIG}" --chdir="${case_dir}" 2>&1)
+        result=$?
+        set -e
+
+        if [[ "${expect_pass}" == "true" ]] && [[ ${result} -ne 0 ]]; then
+            echo "FAIL: ${rule_name}/${case_name} (expected pass, got failure)"
+            echo "${output}"
+            echo
+            exit_code=1
+        elif [[ "${expect_pass}" == "false" ]] && [[ ${result} -eq 0 ]]; then
+            echo "FAIL: ${rule_name}/${case_name} (expected failure, got pass)"
+            echo
+            exit_code=1
+        else
+            echo "OK:   ${rule_name}/${case_name}"
+        fi
+    done
+done
+
+exit "${exit_code}"

--- a/.ci/opa-policies/tests/tflint.hcl
+++ b/.ci/opa-policies/tests/tflint.hcl
@@ -1,0 +1,12 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+plugin "terraform" {
+  enabled = false
+}
+
+plugin "opa" {
+  enabled = true
+  version = "0.10.0"
+  source  = "github.com/terraform-linters/tflint-ruleset-opa"
+}

--- a/.ci/scripts/validate-terraform.sh
+++ b/.ci/scripts/validate-terraform.sh
@@ -16,6 +16,7 @@ exit_code=0
 
 # tflint always resolves config flies relative to the working directory when using --recursive
 TFLINT_CONFIG="$(pwd -P)/.ci/.tflint.hcl"
+TFLINT_OPA_CONFIG="$(pwd -P)/.ci/.tflint_opa.hcl"
 
 # Configure the rules for tflint.
 rules=(
@@ -55,6 +56,19 @@ while read -r filename ; do
         set -e
 
         if [[ ${tflint_exitcode} -ne 0 ]]; then
+            echo "ERROR: File \"${filename}\", block #${block_number} (lines ${start_line}-${end_line}):"
+            echo "${tflint_output}"
+            echo
+            exit_code=1
+        fi
+
+        # Run OPA rules separately (--only is incompatible with OPA rules)
+        set +e
+        tflint_output=$(${TFLINT_CMD} --config "${TFLINT_OPA_CONFIG}" --chdir="${td}" 2>&1)
+        tflint_exitcode=$?
+        set -e
+
+        if [[ ${tflint_exitcode} -ne 0 ]] && [[ "${tflint_output}" != *"eval_builtin_error"* ]]; then
             echo "ERROR: File \"${filename}\", block #${block_number} (lines ${start_line}-${end_line}):"
             echo "${tflint_output}"
             echo

--- a/.ci/scripts/validate-terraform.sh
+++ b/.ci/scripts/validate-terraform.sh
@@ -4,6 +4,8 @@
 
 set -eo pipefail
 
+trap 'exit 130' INT TERM
+
 # This script works from stdin and expects one filename per line.
 # To call it, e.g.
 # find ./website/docs -type f \( -name '*.md' -o -name '*.markdown' \) \

--- a/.github/workflows/acctest-terraform-embedded-lint.yml
+++ b/.github/workflows/acctest-terraform-embedded-lint.yml
@@ -11,6 +11,8 @@ on:
     paths:
       - .github/workflows/acctest-terraform-embedded-lint.yml
       - .ci/.tflint.hcl
+      - .ci/.tflint_opa.hcl
+      - .ci/opa-policies/**
       - .ci/scripts/validate-terraform.sh
       - .ci/tools/go.mod
       - go.sum
@@ -23,6 +25,9 @@ on:
 ##   - Makefile: ./GNUmakefile
 
 jobs:
+  tflint-opa-policy-tests:
+    uses: ./.github/workflows/tflint-opa-policy-tests.yml
+
   terrafmt:
     runs-on: ubuntu-latest
     steps:
@@ -46,6 +51,7 @@ jobs:
 
   tflint:
     name: Validate Acceptance Test Terraform
+    needs: tflint-opa-policy-tests
     runs-on: custom-ubuntu-22.04-xl
     strategy:
       matrix:
@@ -81,3 +87,5 @@ jobs:
       - run: |
           find ./internal -type f -regextype egrep -regex ${{ env.TEST_FILES_PARTITION }} \
             | .ci/scripts/validate-terraform.sh
+        env:
+          TFLINT_OPA_POLICY_DIR: ${{ github.workspace }}/.ci/opa-policies

--- a/.github/workflows/acctest-terraform-lint.yml
+++ b/.github/workflows/acctest-terraform-lint.yml
@@ -11,6 +11,7 @@ on:
     paths:
       - .github/workflows/acctest-terraform-lint.yml
       - .ci/.tflint.hcl
+      - .ci/opa-policies/**
       - .ci/tools/go.mod
       - go.sum
       - 'internal/service/**/*.tf'
@@ -22,6 +23,9 @@ on:
 ##   - Makefile: ./GNUmakefile
 
 jobs:
+  tflint-opa-policy-tests:
+    uses: ./.github/workflows/tflint-opa-policy-tests.yml
+
   terrafmt:
     runs-on: ubuntu-latest
     steps:
@@ -41,6 +45,7 @@ jobs:
 
   tflint:
     name: Validate Acceptance Test Terraform
+    needs: tflint-opa-policy-tests
     runs-on: ubuntu-latest
 
     steps:
@@ -70,3 +75,5 @@ jobs:
           # tflint always resolves config flies relative to the working directory when using --recursive
           TFLINT_CONFIG="$(pwd -P)/.ci/.tflint.hcl"
           tflint --config  "${TFLINT_CONFIG}" --chdir=./internal/service --recursive
+        env:
+          TFLINT_OPA_POLICY_DIR: ${{ github.workspace }}/.ci/opa-policies

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -10,6 +10,7 @@ on:
     paths:
       - .github/workflows/examples.yml
       - .ci/.tflint.hcl
+      - .ci/opa-policies/**
       - .ci/tools/go.mod
       - examples/**
       - go.mod
@@ -24,7 +25,11 @@ env:
   AWS_DEFAULT_REGION: us-west-2
 
 jobs:
+  tflint-opa-policy-tests:
+    uses: ./.github/workflows/tflint-opa-policy-tests.yml
+
   tflint:
+    needs: tflint-opa-policy-tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -54,6 +59,8 @@ jobs:
           TFLINT_CONFIG="$(pwd -P)/.ci/.tflint.hcl"
           tflint --config="${TFLINT_CONFIG}" --chdir=./examples --recursive \
             --disable-rule=terraform_typed_variables
+        env:
+          TFLINT_OPA_POLICY_DIR: ${{ github.workspace }}/.ci/opa-policies
 
   validate-terraform:
     runs-on: custom-ubuntu-22.04-large

--- a/.github/workflows/tflint-opa-policy-tests.yml
+++ b/.github/workflows/tflint-opa-policy-tests.yml
@@ -1,0 +1,30 @@
+# Copyright IBM Corp. 2014, 2026
+# "SPDX-License-Identifier: MPL-2.0"
+
+name: OPA Policy Tests
+
+on:
+  workflow_call:
+
+jobs:
+  opa-tests:
+    name: OPA Policy Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        name: Cache plugin dir
+        continue-on-error: true
+        timeout-minutes: 2
+        with:
+          path: ~/.tflint.d/plugins
+          key: ${{ runner.os }}-tflint-${{ hashFiles('.ci/.tflint.hcl') }}
+
+      - run: cd .ci/tools && go install github.com/terraform-linters/tflint
+      - run: tflint --config .ci/.tflint.hcl --init
+      - run: .ci/opa-policies/tests/run_tests.sh
+        env:
+          TFLINT_OPA_POLICY_DIR: ${{ github.workspace }}/.ci/opa-policies

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -15,6 +15,7 @@ on:
       - .github/workflows/website.yml
       - .ci/.markdownlinkcheck.json
       - .ci/.tflint.hcl
+      - .ci/opa-policies/**
       - .ci/tools/go.mod
       - .markdownlint.yml
       - website/docs/**
@@ -26,6 +27,9 @@ on:
 ##   - Makefile: ./GNUmakefile
 
 jobs:
+  tflint-opa-policy-tests:
+    uses: ./.github/workflows/tflint-opa-policy-tests.yml
+
   markdown-link-check-a-h-markdown:
     runs-on: ubuntu-latest
     steps:
@@ -116,6 +120,7 @@ jobs:
       - run: terrafmt diff ./website --check --pattern '*.markdown'
 
   tflint:
+    needs: tflint-opa-policy-tests
     runs-on: custom-ubuntu-22.04-xl
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -150,6 +155,7 @@ jobs:
 
             # Configure the rules for tflint.
             shared_rules=(
+                "--disable-rule=opa_deny_acmpca_deletion_time"
                 "--disable-rule=aws_cloudwatch_event_target_invalid_arn"
                 "--disable-rule=aws_db_instance_default_parameter_group"
                 "--disable-rule=aws_elasticache_cluster_default_parameter_group"
@@ -194,3 +200,5 @@ jobs:
           find ./website/docs -type f -name '*.markdown' | \
             sort -u | \
             parallel -j 16 --halt soon,fail=1 validate_file {}
+        env:
+          TFLINT_OPA_POLICY_DIR: ${{ github.workspace }}/.ci/opa-policies

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -971,22 +971,25 @@ testacc-short: prereq-go fmt-check ## Run acceptace tests with the -short flag
 
 testacc-tflint: testacc-tflint-dir testacc-tflint-embedded ## [CI] Acceptance Test Linting / tflint
 
-testacc-tflint-dir: tflint-init ## Run tflint on Terraform directories
+testacc-tflint-dir: tflint-init tflint-opa-tests ## Run tflint on Terraform directories
 	@echo "make: Acceptance Test Linting (standalone) / tflint..."
 	@# tflint always resolves config flies relative to the working directory when using --recursive
 	@tflint_config="$(PWD)/.ci/.tflint.hcl" ; \
-	tflint --config  "$$tflint_config" --chdir=./internal/service --recursive
+	TFLINT_OPA_POLICY_DIR="$(PWD)/.ci/opa-policies" tflint --config  "$$tflint_config" --chdir=./internal/service --recursive
 
 testacc-tflint-dir-fix: tflint-init ## fix Terraform directory linter findings
 	@echo "make: Acceptance Test Linting (standalone) / tflint..."
 	@# tflint always resolves config flies relative to the working directory when using --recursive
 	@tflint_config="$(PWD)/.ci/.tflint.hcl" ; \
-	tflint --config  "$$tflint_config" --chdir=./internal/service --recursive --fix
+	TFLINT_OPA_POLICY_DIR="$(PWD)/.ci/opa-policies" tflint --config  "$$tflint_config" --chdir=./internal/service --recursive --fix
 
 testacc-tflint-embedded: tflint-init ## Run tflint on embedded Terraform configs
 	@echo "make: Acceptance Test Linting (embedded) / tflint..."
 	@find $(SVC_DIR) -type f -name '*_test.go' \
 		| .ci/scripts/validate-terraform.sh
+
+tflint-opa-tests: tflint-init ## Run OPA policy tests
+	@TFLINT_OPA_POLICY_DIR="$(PWD)/.ci/opa-policies" .ci/opa-policies/tests/run_tests.sh
 
 tflint-init: ## Initialize tflint
 	@tflint --config .ci/.tflint.hcl --init

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -984,9 +984,10 @@ testacc-tflint-dir-fix: tflint-init ## fix Terraform directory linter findings
 	@tflint_config="$(PWD)/.ci/.tflint.hcl" ; \
 	TFLINT_OPA_POLICY_DIR="$(PWD)/.ci/opa-policies" tflint --config  "$$tflint_config" --chdir=./internal/service --recursive --fix
 
-testacc-tflint-embedded: tflint-init ## Run tflint on embedded Terraform configs
+testacc-tflint-embedded: tflint-init tflint-opa-tests ## Run tflint on embedded Terraform configs
 	@echo "make: Acceptance Test Linting (embedded) / tflint..."
-	@find $(SVC_DIR) -type f -name '*_test.go' \
+	@export TFLINT_OPA_POLICY_DIR="$(PWD)/.ci/opa-policies" ; \
+	find $(SVC_DIR) -type f -name '*_test.go' \
 		| .ci/scripts/validate-terraform.sh
 
 tflint-opa-tests: tflint-init ## Run OPA policy tests

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -311,8 +311,9 @@ docs-misspell: ## [CI] Documentation Checks / misspell
 	@echo "make: Documentation Checks / misspell..."
 	@misspell -error -source text docs/
 
-examples-tflint: tflint-init ## [CI] Examples Checks / tflint
+examples-tflint: tflint-init tflint-opa-tests ## [CI] Examples Checks / tflint
 	@echo "make: Examples Checks / tflint..."
+	TFLINT_OPA_POLICY_DIR="$(PWD)/.ci/opa-policies" \
 	TFLINT_CONFIG="$(PWD)/.ci/.tflint.hcl" ; \
 	tflint --config="$$TFLINT_CONFIG" --chdir=./examples --recursive \
 		--disable-rule=terraform_typed_variables

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1110,10 +1110,13 @@ website-terrafmt-fix: ## [CI] Fix Website / terrafmt
 		terrafmt fmt $$dir --pattern '*.markdown'; \
 	done
 
-website-tflint: tflint-init ## [CI] Website Checks / tflint
+website-tflint: tflint-init tflint-opa-tests ## [CI] Website Checks / tflint
 	@echo "make: Website Checks / tflint..."
 	@exit_code=0 ; \
+	TFLINT_OPA_POLICY_DIR="$(PWD)/.ci/opa-policies" ; \
+	export TFLINT_OPA_POLICY_DIR ; \
 	shared_rules=( \
+		"--disable-rule=opa_deny_acmpca_deletion_time" \
 		"--disable-rule=aws_cloudwatch_event_target_invalid_arn" \
 		"--disable-rule=aws_db_instance_default_parameter_group" \
 		"--disable-rule=aws_elasticache_cluster_default_parameter_group" \

--- a/internal/service/acmpca/certificate_authority_test.go
+++ b/internal/service/acmpca/certificate_authority_test.go
@@ -942,6 +942,7 @@ data "aws_partition" "current" {}
 // `permanent_deletion_time_in_days` of 30.
 func testAccCertificateAuthorityConfig_defaultsOnly(commonName string) string {
 	return fmt.Sprintf(`
+# tflint-ignore: opa_deny_acmpca_deletion_time
 resource "aws_acmpca_certificate_authority" "test" {
   usage_mode = "SHORT_LIVED_CERTIFICATE"
 

--- a/internal/service/appstream/directory_config_test.go
+++ b/internal/service/appstream/directory_config_test.go
@@ -386,6 +386,8 @@ resource "aws_directory_service_directory" "test" {
 }
 
 resource "aws_acmpca_certificate_authority" "test_ca" {
+  permanent_deletion_time_in_days = 7
+
   type       = "ROOT"
   usage_mode = "SHORT_LIVED_CERTIFICATE"
 

--- a/internal/service/workspacesweb/testdata/TrustStore/tags/main_gen.tf
+++ b/internal/service/workspacesweb/testdata/TrustStore/tags/main_gen.tf
@@ -1,7 +1,17 @@
 # Copyright IBM Corp. 2014, 2026
 # SPDX-License-Identifier: MPL-2.0
 
+resource "aws_workspacesweb_trust_store" "test" {
+  certificate {
+    body = aws_acmpca_certificate.test.certificate
+  }
+
+  tags = var.resource_tags
+}
+
 resource "aws_acmpca_certificate_authority" "test" {
+  permanent_deletion_time_in_days = 7
+
   type = "ROOT"
 
   certificate_authority_configuration {
@@ -25,14 +35,6 @@ resource "aws_acmpca_certificate" "test" {
     type  = "YEARS"
     value = 1
   }
-}
-
-resource "aws_workspacesweb_trust_store" "test" {
-  certificate {
-    body = aws_acmpca_certificate.test.certificate
-  }
-
-  tags = var.resource_tags
 }
 
 variable "resource_tags" {

--- a/internal/service/workspacesweb/testdata/TrustStore/tagsComputed1/main_gen.tf
+++ b/internal/service/workspacesweb/testdata/TrustStore/tagsComputed1/main_gen.tf
@@ -3,7 +3,19 @@
 
 provider "null" {}
 
+resource "aws_workspacesweb_trust_store" "test" {
+  certificate {
+    body = aws_acmpca_certificate.test.certificate
+  }
+
+  tags = {
+    (var.unknownTagKey) = null_resource.test.id
+  }
+}
+
 resource "aws_acmpca_certificate_authority" "test" {
+  permanent_deletion_time_in_days = 7
+
   type = "ROOT"
 
   certificate_authority_configuration {
@@ -26,16 +38,6 @@ resource "aws_acmpca_certificate" "test" {
   validity {
     type  = "YEARS"
     value = 1
-  }
-}
-
-resource "aws_workspacesweb_trust_store" "test" {
-  certificate {
-    body = aws_acmpca_certificate.test.certificate
-  }
-
-  tags = {
-    (var.unknownTagKey) = null_resource.test.id
   }
 }
 

--- a/internal/service/workspacesweb/testdata/TrustStore/tagsComputed2/main_gen.tf
+++ b/internal/service/workspacesweb/testdata/TrustStore/tagsComputed2/main_gen.tf
@@ -3,7 +3,20 @@
 
 provider "null" {}
 
+resource "aws_workspacesweb_trust_store" "test" {
+  certificate {
+    body = aws_acmpca_certificate.test.certificate
+  }
+
+  tags = {
+    (var.unknownTagKey) = null_resource.test.id
+    (var.knownTagKey)   = var.knownTagValue
+  }
+}
+
 resource "aws_acmpca_certificate_authority" "test" {
+  permanent_deletion_time_in_days = 7
+
   type = "ROOT"
 
   certificate_authority_configuration {
@@ -26,17 +39,6 @@ resource "aws_acmpca_certificate" "test" {
   validity {
     type  = "YEARS"
     value = 1
-  }
-}
-
-resource "aws_workspacesweb_trust_store" "test" {
-  certificate {
-    body = aws_acmpca_certificate.test.certificate
-  }
-
-  tags = {
-    (var.unknownTagKey) = null_resource.test.id
-    (var.knownTagKey)   = var.knownTagValue
   }
 }
 

--- a/internal/service/workspacesweb/testdata/TrustStore/tags_defaults/main_gen.tf
+++ b/internal/service/workspacesweb/testdata/TrustStore/tags_defaults/main_gen.tf
@@ -7,7 +7,17 @@ provider "aws" {
   }
 }
 
+resource "aws_workspacesweb_trust_store" "test" {
+  certificate {
+    body = aws_acmpca_certificate.test.certificate
+  }
+
+  tags = var.resource_tags
+}
+
 resource "aws_acmpca_certificate_authority" "test" {
+  permanent_deletion_time_in_days = 7
+
   type = "ROOT"
 
   certificate_authority_configuration {
@@ -31,14 +41,6 @@ resource "aws_acmpca_certificate" "test" {
     type  = "YEARS"
     value = 1
   }
-}
-
-resource "aws_workspacesweb_trust_store" "test" {
-  certificate {
-    body = aws_acmpca_certificate.test.certificate
-  }
-
-  tags = var.resource_tags
 }
 
 variable "resource_tags" {

--- a/internal/service/workspacesweb/testdata/TrustStore/tags_ignore/main_gen.tf
+++ b/internal/service/workspacesweb/testdata/TrustStore/tags_ignore/main_gen.tf
@@ -10,7 +10,17 @@ provider "aws" {
   }
 }
 
+resource "aws_workspacesweb_trust_store" "test" {
+  certificate {
+    body = aws_acmpca_certificate.test.certificate
+  }
+
+  tags = var.resource_tags
+}
+
 resource "aws_acmpca_certificate_authority" "test" {
+  permanent_deletion_time_in_days = 7
+
   type = "ROOT"
 
   certificate_authority_configuration {
@@ -34,14 +44,6 @@ resource "aws_acmpca_certificate" "test" {
     type  = "YEARS"
     value = 1
   }
-}
-
-resource "aws_workspacesweb_trust_store" "test" {
-  certificate {
-    body = aws_acmpca_certificate.test.certificate
-  }
-
-  tags = var.resource_tags
 }
 
 variable "resource_tags" {

--- a/internal/service/workspacesweb/testdata/tmpl/trust_store_basic.gtpl
+++ b/internal/service/workspacesweb/testdata/tmpl/trust_store_basic.gtpl
@@ -1,4 +1,15 @@
+resource "aws_workspacesweb_trust_store" "test" {
+{{- template "region" }}
+  certificate {
+    body = aws_acmpca_certificate.test.certificate
+  }
+{{- template "tags" . }}
+}
+
 resource "aws_acmpca_certificate_authority" "test" {
+{{- template "region" }}
+  permanent_deletion_time_in_days = 7
+
   type = "ROOT"
 
   certificate_authority_configuration {
@@ -12,6 +23,7 @@ resource "aws_acmpca_certificate_authority" "test" {
 }
 
 resource "aws_acmpca_certificate" "test" {
+{{- template "region" }}
   certificate_authority_arn   = aws_acmpca_certificate_authority.test.arn
   certificate_signing_request = aws_acmpca_certificate_authority.test.certificate_signing_request
   signing_algorithm           = "SHA256WITHRSA"
@@ -22,11 +34,4 @@ resource "aws_acmpca_certificate" "test" {
     type  = "YEARS"
     value = 1
   }
-}
-
-resource "aws_workspacesweb_trust_store" "test" {
-  certificate {
-    body = aws_acmpca_certificate.test.certificate
-  }
-{{- template "tags" . }}
 }

--- a/internal/service/workspacesweb/trust_store_test.go
+++ b/internal/service/workspacesweb/trust_store_test.go
@@ -272,6 +272,8 @@ func testAccTrustStoreConfig_acmBase() string {
 data "aws_partition" "current" {}
 
 resource "aws_acmpca_certificate_authority" "test" {
+  permanent_deletion_time_in_days = 7
+
   type = "ROOT"
 
   certificate_authority_configuration {


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Adds `tflint` rule to detect `aws_acmpca_certificate_authority` resources with `permanent_deletion_time_in_days` other than 7

Uses OPA rule with `github.com/terraform-linters/tflint-ruleset-opa`