### PR TITLE
[bug] - `r/aws_lakeformation_opt_in`, make `principal` block required in schema to prevent nilpointer

### DIFF
--- a/.changelog/48416.txt
+++ b/.changelog/48416.txt
@@ -1,3 +1,6 @@
 ```release-note:bug
 resource/aws_lakeformation_opt_in: Prevent crash by making the `principal` block required
 ```
+```release-note:bug
+resource/aws_lakeformation_opt_in: Fix handling of out-of-band deletion of linked resource
+```

--- a/.changelog/48416.txt
+++ b/.changelog/48416.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_lakeformation_opt_in: Prevent crash by making principal and resource_data blocks required
+resource/aws_lakeformation_opt_in: Prevent crash by making the `principal` block required
 ```

--- a/.changelog/48416.txt
+++ b/.changelog/48416.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_lakeformation_opt_in: Prevent crash by making principal and resource_data blocks required
+```

--- a/.ci/swissshepherd-weak.hcl
+++ b/.ci/swissshepherd-weak.hcl
@@ -1590,7 +1590,6 @@ check "schema_docs" {
     "resource/aws_lakeformation_identity_center_configuration",
     "resource/aws_lakeformation_lf_tag_expression",
     "resource/aws_lakeformation_lf_tag",
-    "resource/aws_lakeformation_opt_in",
     "resource/aws_lakeformation_permissions",
     "resource/aws_lakeformation_resource_lf_tag",
     "resource/aws_lakeformation_resource_lf_tags",

--- a/internal/service/glue/exports.go
+++ b/internal/service/glue/exports.go
@@ -1,0 +1,9 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package glue
+
+// Exports for use across packages.
+var (
+	ResourceCatalogDatabase = resourceCatalogDatabase
+)

--- a/internal/service/glue/exports_test.go
+++ b/internal/service/glue/exports_test.go
@@ -6,7 +6,6 @@ package glue
 // Exports for use in tests only.
 var (
 	ResourceCatalog                       = newCatalogResource
-	ResourceCatalogDatabase               = resourceCatalogDatabase
 	ResourceCatalogTable                  = resourceCatalogTable
 	ResourceCatalogTableOptimizer         = newCatalogTableOptimizerResource
 	ResourceClassifier                    = resourceClassifier

--- a/internal/service/lakeformation/lakeformation_test.go
+++ b/internal/service/lakeformation/lakeformation_test.go
@@ -37,9 +37,9 @@ func TestAccLakeFormation_serial(t *testing.T) {
 			"Identity":           testAccLakeFormationIdentityCenterConfiguration_identitySerial,
 		},
 		"OptIn": {
-			acctest.CtBasic:      testAccOptIn_basic,
-			acctest.CtDisappears: testAccOptIn_disappears,
-			"table":              testAccOptIn_table,
+			acctest.CtBasic:             testAccOptIn_basic,
+			"disappearsCatalogDatabase": testAccOptIn_Disappears_catalogDatabase,
+			"table":                     testAccOptIn_table,
 		},
 		"PermissionsBasic": {
 			acctest.CtBasic:         testAccPermissions_basic,

--- a/internal/service/lakeformation/opt_in.go
+++ b/internal/service/lakeformation/opt_in.go
@@ -338,6 +338,7 @@ func (r *optInResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 				Validators: []validator.List{
 					listvalidator.SizeAtLeast(1),
 					listvalidator.IsRequired(),
+					listvalidator.SizeAtMost(1),
 				},
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{

--- a/internal/service/lakeformation/opt_in.go
+++ b/internal/service/lakeformation/opt_in.go
@@ -539,7 +539,7 @@ func (r *optInResource) Delete(ctx context.Context, req resource.DeleteRequest, 
 	}
 
 	if _, err := conn.DeleteLakeFormationOptIn(ctx, in); err != nil {
-		if errs.IsA[*awstypes.EntityNotFoundException](err) {
+		if errs.IsA[*awstypes.EntityNotFoundException](err) || errs.IsAErrorMessageContains[*awstypes.AccessDeniedException](err, "resource does not exist") {
 			return
 		}
 		resp.Diagnostics.AddError(
@@ -573,7 +573,7 @@ func findOptIns(ctx context.Context, conn *lakeformation.Client, input *lakeform
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
 
-		if errs.IsA[*awstypes.EntityNotFoundException](err) {
+		if errs.IsA[*awstypes.EntityNotFoundException](err) || errs.IsAErrorMessageContains[*awstypes.AccessDeniedException](err, "resource does not exist") {
 			return nil, &retry.NotFoundError{
 				LastError: err,
 			}

--- a/internal/service/lakeformation/opt_in.go
+++ b/internal/service/lakeformation/opt_in.go
@@ -349,9 +349,6 @@ func (r *optInResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 			},
 			"resource_data": schema.ListNestedBlock{
 				CustomType: fwtypes.NewListNestedObjectTypeOf[resourceData](ctx),
-				Validators: []validator.List{
-					listvalidator.IsRequired(),
-				},
 				NestedObject: schema.NestedBlockObject{
 					Blocks: map[string]schema.Block{
 						"catalog":            catalogLNB,

--- a/internal/service/lakeformation/opt_in.go
+++ b/internal/service/lakeformation/opt_in.go
@@ -337,6 +337,7 @@ func (r *optInResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 				CustomType: fwtypes.NewListNestedObjectTypeOf[dataLakePrincipal](ctx),
 				Validators: []validator.List{
 					listvalidator.SizeAtLeast(1),
+					listvalidator.IsRequired(),
 				},
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
@@ -348,6 +349,9 @@ func (r *optInResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 			},
 			"resource_data": schema.ListNestedBlock{
 				CustomType: fwtypes.NewListNestedObjectTypeOf[resourceData](ctx),
+				Validators: []validator.List{
+					listvalidator.IsRequired(),
+				},
 				NestedObject: schema.NestedBlockObject{
 					Blocks: map[string]schema.Block{
 						"catalog":            catalogLNB,

--- a/internal/service/lakeformation/opt_in_test.go
+++ b/internal/service/lakeformation/opt_in_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	tfglue "github.com/hashicorp/terraform-provider-aws/internal/service/glue"
 	tflakeformation "github.com/hashicorp/terraform-provider-aws/internal/service/lakeformation"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -107,11 +108,12 @@ func testAccOptIn_table(t *testing.T) {
 	})
 }
 
-func testAccOptIn_disappears(t *testing.T) {
+func testAccOptIn_Disappears_catalogDatabase(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	var optin lakeformation.ListLakeFormationOptInsOutput
 	resourceName := "aws_lakeformation_opt_in.test"
+	catalogDatabaseResourceName := "aws_glue_catalog_database.test"
 	rName := acctest.RandomWithPrefix(t, "tf-acc-test")
 
 	acctest.Test(ctx, t, resource.TestCase{
@@ -127,17 +129,19 @@ func testAccOptIn_disappears(t *testing.T) {
 				Config: testAccOptInConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckOptInExists(ctx, t, resourceName, &optin),
-					acctest.CheckFrameworkResourceDisappears(ctx, t, tflakeformation.ResourceOptIn, resourceName),
+					acctest.CheckSDKResourceDisappears(ctx, t, tfglue.ResourceCatalogDatabase(), catalogDatabaseResourceName),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+						plancheck.ExpectResourceAction(catalogDatabaseResourceName, plancheck.ResourceActionCreate),
 					},
 					PostApplyPostRefresh: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+						plancheck.ExpectResourceAction(catalogDatabaseResourceName, plancheck.ResourceActionCreate),
 					},
 				},
-				ExpectNonEmptyPlan: false,
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/website/docs/r/lakeformation_opt_in.html.markdown
+++ b/website/docs/r/lakeformation_opt_in.html.markdown
@@ -62,7 +62,7 @@ This resource supports the following arguments:
 ### `database` Block
 
 * `catalog_id` - (Optional) Identifier for the Data Catalog. By default, it is the account ID of the caller.
-* `name` - (Required) Name of the database resource.Unique to the Data Catalog.
+* `name` - (Required) Name of the database resource. Unique to the Data Catalog.
 
 ### `lf_tag` Block
 
@@ -73,13 +73,13 @@ This resource supports the following arguments:
 ### `lf_tag_expression` Block
 
 * `catalog_id` - (Optional) Identifier for the Data Catalog. By default, it is the account ID of the caller.
-* `name` - (Required) Name of the LF-Tag expression to grand permissions on.
+* `name` - (Required) Name of the LF-Tag expression to grant permissions on.
 
 ### `lf_tag_policy` Block
 
 * `catalog_id` - (Optional) Identifier for the Data Catalog. By default, it is the account ID of the caller. The Data Catalog is the persistent metadata store. It contains database definitions, table definitions, and other control information to manage your Lake Formation environment.
 * `expression` - (Optional) List of LF-tag conditions or a saved expression that apply to the resource's LF-Tag policy.
-* `expression_name` - (Required) If provided, permissions are granted to the Data Catalog resources whose assigned LF-Tags match the expression body of the saved expression under the provided ExpressionName .
+* `expression_name` - (Optional) Name of the saved expression to match. If provided, permissions are granted to the Data Catalog resources whose assigned LF-Tags match the expression body of the saved expression under the provided expression name.
 * `resource_type` - (Required) Resource type for which the LF-tag policy applies.
 
 ### `table` Block

--- a/website/docs/r/lakeformation_opt_in.html.markdown
+++ b/website/docs/r/lakeformation_opt_in.html.markdown
@@ -23,9 +23,84 @@ resource "aws_lakeformation_opt_in" "example" {
 
 This resource supports the following arguments:
 
+* `principal` - (Required) Lake Formation principal. Supported principals are IAM users or IAM roles. See [`principal` Block](#principal-block) for more details.
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
-* `principal` - (Required) Lake Formation principal. Supported principals are IAM users or IAM roles. See [Principal](#principal) for more details.
-* `resource_data` - (Required) Structure for the resource. See [Resource](#resource) for more details.
+* `resource_data` - (Required) Structure for the resource. See [`resource_data` Block](#resource_data-block) for more details.
+
+
+### `principal` Block
+
+* `data_lake_principal_identifier` - (Required) Identifier for the Lake Formation principal.
+
+### `resource_data` Block
+
+* `catalog` - (Optional) Identifier for the Data Catalog. By default, the account ID. The Data Catalog is the persistent metadata store. It contains database definitions, table definitions, and other control information to manage your Lake Formation environment. See [Catalog](#catalog) for more details.
+* `data_cells_filter` - (Optional) Data cell filter. See [Data Cells Filter](#data-cells-filter) for more details.
+* `data_location` - (Optional) Location of an Amazon S3 path where permissions are granted or revoked. See [`data_location` Block](#data_location-block) for more details.
+* `database` - (Optional) Database for the resource. Unique to the Data Catalog. A database is a set of associated table definitions organized into a logical group. You can Grant and Revoke database permissions to a principal. See [`database` Block](#database-block) for more details.
+* `lf_tag` - (Optional) LF-tag key and values attached to a resource.
+* `lf_tag_expression` - (Optional) Logical expression composed of one or more LF-Tag key:value pairs. See [`lf_tag_expression` Block](#lf_tag_expression-block) for more details.
+* `lf_tag_policy` - (Optional) List of LF-Tag conditions or saved LF-Tag expressions that define a resource's LF-Tag policy. See [`lf_tag_policy` Block](#lf_tag_policy-block) for more details.
+* `table` - (Optional) Table for the resource. A table is a metadata definition that represents your data. You can Grant and Revoke table privileges to a principal. See [`table` Block](#table-block) for more details.
+* `table_with_columns` - (Optional) Table with columns for the resource. A principal with permissions to this resource can select metadata from the columns of a table in the Data Catalog and the underlying data in Amazon S3. See [`table_with_columns` Block](#table_with_columns-block) for more details.
+
+### `catalog` Block
+
+* `id` - (Optional) Identifier for the catalog resource.
+
+### `data_cells_filter` Block
+
+* `database_name` - (Optional) Database in the Glue Data Catalog.
+* `name` - (Optional) Name of the data cells filter.
+* `table_catalog_id` - (Optional) ID of the catalog to which the table belongs.
+* `table_name` - (Optional) Name of the table.
+
+### `data_location` Block
+
+* `catalog_id` - (Optional) Identifier for the Data Catalog where the location is registered with Lake Formation. By default, it is the account ID of the caller.
+* `resource_arn` - (Required) ARN that uniquely identifies the data location resource.
+
+### `database` Block
+
+* `catalog_id` - (Optional) Identifier for the Data Catalog. By default, it is the account ID of the caller.
+* `name` - (Required) Name of the database resource.Unique to the Data Catalog.
+
+### `lf_tag` Block
+
+* `catalog_id` - (Optional) Identifier for the Data Catalog. By default, it is the account ID of the caller.
+* `key` - (Required) Key name for the LF-Tag.
+* `values` - (Required) Set of tag values for the LF-Tag key. At least one value is required. Each value can be 1-255 characters.
+
+### `lf_tag_expression` Block
+
+* `catalog_id` - (Optional) Identifier for the Data Catalog. By default, it is the account ID of the caller.
+* `name` - (Required) Name of the LF-Tag expression to grand permissions on.
+
+### `lf_tag_policy` Block
+
+* `catalog_id` - (Optional) Identifier for the Data Catalog. By default, it is the account ID of the caller. The Data Catalog is the persistent metadata store. It contains database definitions, table definitions, and other control information to manage your Lake Formation environment.
+* `expression` - (Optional) List of LF-tag conditions or a saved expression that apply to the resource's LF-Tag policy.
+* `expression_name` - (Required) If provided, permissions are granted to the Data Catalog resources whose assigned LF-Tags match the expression body of the saved expression under the provided ExpressionName .
+* `resource_type` - (Required) Resource type for which the LF-tag policy applies.
+
+### `table` Block
+
+* `catalog_id` - (Optional) Identifier for the Data Catalog. By default, it is the account ID of the caller.
+* `database_name` - (Required) Name of the database for the table. Unique to a Data Catalog. A database is a set of associated table definitions organized into a logical group. You can Grant and Revoke database privileges to a principal.
+* `name` - (Optional) Name of the table.
+* `wildcard` - (Optional) Boolean value that indicates whether to use a wildcard representing every table under the specified database. When set to true, this represents all tables within the specified database. At least one of TableResource$Name or TableResource$Wildcard is required.
+
+### `table_with_columns` Block
+
+* `catalog_id` - (Optional) Identifier for the Data Catalog. By default, it is the account ID of the caller.
+* `column_names` - (Optional) List of column names for the table. At least one of ColumnNames or ColumnWildcard is required.
+* `column_wildcard` - (Optional) Wildcard specified by a ColumnWildcard object. At least one of ColumnNames or ColumnWildcard is required. See [`column_wildcard` Block](#column_wildcard-block) for more details.
+* `database_name` - (Required) Name of the database for the table. Unique to a Data Catalog. A database is a set of associated table definitions organized into a logical group. You can Grant and Revoke database privileges to a principal.
+* `name` - (Required) Name of the table.
+
+### `column_wildcard` Block
+
+* `excluded_column_names` - (Optional) Excludes column names. Any column with this name will be excluded.
 
 ## Attribute Reference
 
@@ -33,74 +108,8 @@ This resource exports the following attributes in addition to the arguments abov
 
 * `condition` - Lake Formation condition, which applies to permissions and opt-ins that contain an expression.
 * `last_modified` - Last modified date and time of the record.
-* `last_updated` - User who updated the record.
+* `last_updated_by` - User who updated the record.
 
-### Principal
+### `condition` Block
 
-* `data_lake_principal` - Identifier for the Lake Formation principal.
-
-### Resource
-
-* `catalog` - Identifier for the Data Catalog. By default, the account ID. The Data Catalog is the persistent metadata store. It contains database definitions, table definitions, and other control information to manage your Lake Formation environment. See [Catalog](#catalog) for more details.
-* `data_cells_filter` - Data cell filter. See [Data Cells Filter](#data-cells-filter) for more details.
-* `data_location` - Location of an Amazon S3 path where permissions are granted or revoked. See [Data Location](#data-location) for more details.
-* `database` - Database for the resource. Unique to the Data Catalog. A database is a set of associated table definitions organized into a logical group. You can Grant and Revoke database permissions to a principal. See [Database](#database) for more details.
-* `lf_tag` - LF-tag key and values attached to a resource.
-* `lf_tag_expression` - Logical expression composed of one or more LF-Tag key:value pairs. See [LF-Tag Expression](#lf-tag-expression) for more details.
-* `lf_tag_policy` - List of LF-Tag conditions or saved LF-Tag expressions that define a resource's LF-Tag policy. See [LF-Tag Policy](#lf-tag-policy) for more details.
-* `table` - Table for the resource. A table is a metadata definition that represents your data. You can Grant and Revoke table privileges to a principal. See [Table](#table) for more details.
-* `table_with_columns` - Table with columns for the resource. A principal with permissions to this resource can select metadata from the columns of a table in the Data Catalog and the underlying data in Amazon S3. See [Table With Columns](#table-with-columns) for more details.
-
-### Catalog
-
-* `id` - Identifier for the catalog resource.
-
-### Data Cells Filter
-
-* `database_name` - Database in the Glue Data Catalog.
-* `name` - Name of the data cells filter.
-* `table_catalog_id` - ID of the catalog to which the table belongs.
-* `table_name` - Name of the table.
-
-### Data Location
-
-* `resource_arn` - ARN that uniquely identifies the data location resource.
-* `catalog_id` - Identifier for the Data Catalog where the location is registered with Lake Formation. By default, it is the account ID of the caller.
-
-### Database
-
-* `name` - Name of the database resource.Unique to the Data Catalog.
-* `catalog_id` - Identifier for the Data Catalog. By default, it is the account ID of the caller.
-
-### LF-Tag
-
-* `key` - (Required) Key name for the LF-Tag.
-* `values` - (Required) Set of tag values for the LF-Tag key. At least one value is required. Each value can be 1-255 characters.
-* `catalog_id` - (Optional) Identifier for the Data Catalog. By default, it is the account ID of the caller.
-
-### LF-Tag Expression
-
-* `name` - Name of the LF-Tag expression to grand permissions on.
-* `catalog_id` - Identifier for the Data Catalog. By default, it is the account ID of the caller.
-
-### LF-Tag Policy
-
-* `resource_type` - Resource type for which the LF-tag policy applies.
-* `catalog_id` - Identifier for the Data Catalog. By default, it is the account ID of the caller. The Data Catalog is the persistent metadata store. It contains database definitions, table definitions, and other control information to manage your Lake Formation environment.
-* `expression` - List of LF-tag conditions or a saved expression that apply to the resource's LF-Tag policy.
-* `expression_name` - If provided, permissions are granted to the Data Catalog resources whose assigned LF-Tags match the expression body of the saved expression under the provided ExpressionName .
-
-### Table
-
-* `database_name` - The name of the database for the table. Unique to a Data Catalog. A database is a set of associated table definitions organized into a logical group. You can Grant and Revoke database privileges to a principal.
-* `name` - Name of the table.
-* `catalog_id` - Identifier for the Data Catalog. By default, it is the account ID of the caller.
-* `wildcard` - Boolean value that indicates whether to use a wildcard representing every table under the specified database. When set to true, this represents all tables within the specified database. At least one of TableResource$Name or TableResource$Wildcard is required.
-
-### Table With Columns
-
-* `database_name` - The name of the database for the table. Unique to a Data Catalog. A database is a set of associated table definitions organized into a logical group. You can Grant and Revoke database privileges to a principal.
-* `name` - Name of the table.
-* `catalog_id` - Identifier for the Data Catalog. By default, it is the account ID of the caller.
-* `column_names` - List of column names for the table. At least one of ColumnNames or ColumnWildcard is required.
-* `column_wildcard` - Wildcard specified by a ColumnWildcard object. At least one of ColumnNames or ColumnWildcard is required.
+* `expression` - Expression written based on the Cedar Policy Language used to match the principal attributes.

--- a/website/docs/r/lakeformation_opt_in.html.markdown
+++ b/website/docs/r/lakeformation_opt_in.html.markdown
@@ -33,8 +33,8 @@ This resource supports the following arguments:
 
 ### `resource_data` Block
 
-* `catalog` - (Optional) Identifier for the Data Catalog. By default, the account ID. The Data Catalog is the persistent metadata store. It contains database definitions, table definitions, and other control information to manage your Lake Formation environment. See [Catalog](#catalog) for more details.
-* `data_cells_filter` - (Optional) Data cell filter. See [Data Cells Filter](#data-cells-filter) for more details.
+* `catalog` - (Optional) Identifier for the Data Catalog. By default, the account ID. The Data Catalog is the persistent metadata store. It contains database definitions, table definitions, and other control information to manage your Lake Formation environment. See [`catalog` Block](#catalog-block) for more details.
+* `data_cells_filter` - (Optional) Data cell filter. See [`data_cells_filter` Block](#data_cells_filter-block) for more details.
 * `data_location` - (Optional) Location of an Amazon S3 path where permissions are granted or revoked. See [`data_location` Block](#data_location-block) for more details.
 * `database` - (Optional) Database for the resource. Unique to the Data Catalog. A database is a set of associated table definitions organized into a logical group. You can Grant and Revoke database permissions to a principal. See [`database` Block](#database-block) for more details.
 * `lf_tag` - (Optional) LF-tag key and values attached to a resource.

--- a/website/docs/r/lakeformation_opt_in.html.markdown
+++ b/website/docs/r/lakeformation_opt_in.html.markdown
@@ -16,6 +16,16 @@ Terraform resource for managing an AWS Lake Formation Opt In.
 
 ```terraform
 resource "aws_lakeformation_opt_in" "example" {
+  principal {
+    data_lake_principal_identifier = aws_iam_role.example.arn
+  }
+
+  resource_data {
+    database {
+      name       = aws_glue_catalog_database.example.name
+      catalog_id = data.aws_caller_identity.current.account_id
+    }
+  }
 }
 ```
 

--- a/website/docs/r/lakeformation_opt_in.html.markdown
+++ b/website/docs/r/lakeformation_opt_in.html.markdown
@@ -27,7 +27,6 @@ This resource supports the following arguments:
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `resource_data` - (Required) Structure for the resource. See [`resource_data` Block](#resource_data-block) for more details.
 
-
 ### `principal` Block
 
 * `data_lake_principal_identifier` - (Required) Identifier for the Lake Formation principal.

--- a/website/docs/r/lakeformation_opt_in.html.markdown
+++ b/website/docs/r/lakeformation_opt_in.html.markdown
@@ -105,7 +105,7 @@ This resource supports the following arguments:
 
 This resource exports the following attributes in addition to the arguments above:
 
-* `condition` - Lake Formation condition, which applies to permissions and opt-ins that contain an expression.
+* `condition` - Lake Formation condition, which applies to permissions and opt-ins that contain an expression. See [`condition` Block](#condition-block) for more details.
 * `last_modified` - Last modified date and time of the record.
 * `last_updated_by` - User who updated the record.
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
Make the required blocks as in docs required in schema

### Relations
Closes #48406

### References

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->


```console
% make testacc TESTS=TestAccLakeFormation_serial/OptIn/basic  PKG=lakeformation                                                <aws:test> <region:us-west-2>
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework (cached)
make: Running acceptance tests on branch: 🌿 main 🌿...
TF_ACC=1 go1.26.4 test ./internal/service/lakeformation/... -v -count 1 -parallel 20 -run='TestAccLakeFormation_serial/OptIn/basic'  -timeout 360m -vet=off -buildvcs=false
2026/06/15 20:40:59 Creating Terraform AWS Provider (SDKv2-style)...
2026/06/15 20:40:59 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccLakeFormation_serial
=== PAUSE TestAccLakeFormation_serial
=== CONT  TestAccLakeFormation_serial
=== RUN   TestAccLakeFormation_serial/OptIn
=== RUN   TestAccLakeFormation_serial/OptIn/basic
--- PASS: TestAccLakeFormation_serial (35.34s)
    --- PASS: TestAccLakeFormation_serial/OptIn (35.34s)
        --- PASS: TestAccLakeFormation_serial/OptIn/basic (35.34s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lakeformation      44.187s
```
