### PR TITLE
 r/aws_lakeformation_resource_lf_tag: handle nil tag pointers in `findTag` methods

### DIFF
--- a/.changelog/48417.txt
+++ b/.changelog/48417.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_lakeformation_resource_lf_tag: Prevent crash when processing null tag values during read operations
+```

--- a/internal/service/lakeformation/resource_lf_tag.go
+++ b/internal/service/lakeformation/resource_lf_tag.go
@@ -36,6 +36,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
 	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
 	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
@@ -408,6 +409,7 @@ func (r *resourceLFTagResource) Read(ctx context.Context, req resource.ReadReque
 		return
 	}
 	if outputTag.IsNull() {
+		resp.Diagnostics.Append(fwdiag.NewResourceNotFoundWarningDiagnostic(err))
 		resp.State.RemoveResource(ctx)
 		return
 	}

--- a/internal/service/lakeformation/resource_lf_tag.go
+++ b/internal/service/lakeformation/resource_lf_tag.go
@@ -582,6 +582,9 @@ func (d *dbTagger) findTag(ctx context.Context, input *lakeformation.GetResource
 		diags.Append(err...)
 		return fwtypes.NewListNestedObjectValueOfNull[LFTag](ctx)
 	}
+	if tag == nil {
+		return fwtypes.NewListNestedObjectValueOfNull[LFTag](ctx)
+	}
 
 	for _, v := range input.LFTagOnDatabase {
 		if aws.ToString(v.TagKey) == tag.Key.ValueString() {
@@ -630,6 +633,9 @@ func (d *tbTagger) findTag(ctx context.Context, input *lakeformation.GetResource
 		diags.Append(err...)
 		return fwtypes.NewListNestedObjectValueOfNull[LFTag](ctx)
 	}
+	if tag == nil {
+		return fwtypes.NewListNestedObjectValueOfNull[LFTag](ctx)
+	}
 
 	for _, v := range input.LFTagsOnTable {
 		if aws.ToString(v.TagKey) == tag.Key.ValueString() {
@@ -675,6 +681,9 @@ func (d *tbcTagger) findTag(ctx context.Context, input *lakeformation.GetResourc
 	tag, err := d.data.LFTag.ToPtr(ctx)
 	if err != nil {
 		diags.Append(err...)
+		return fwtypes.NewListNestedObjectValueOfNull[LFTag](ctx)
+	}
+	if tag == nil {
 		return fwtypes.NewListNestedObjectValueOfNull[LFTag](ctx)
 	}
 

--- a/internal/service/lakeformation/resource_lf_tag.go
+++ b/internal/service/lakeformation/resource_lf_tag.go
@@ -407,6 +407,10 @@ func (r *resourceLFTagResource) Read(ctx context.Context, req resource.ReadReque
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	if outputTag.IsNull() {
+		resp.State.RemoveResource(ctx)
+		return
+	}
 
 	state.LFTag = outputTag
 

--- a/internal/service/lakeformation/resource_lf_tags_test.go
+++ b/internal/service/lakeformation/resource_lf_tags_test.go
@@ -70,14 +70,17 @@ func testAccResourceLFTags_disappears(t *testing.T) {
 				Config: testAccResourceLFTagsConfig_basic(rName, []string{"copse"}, "copse"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDatabaseLFTagsExists(ctx, t, resourceName),
-					acctest.CheckSDKResourceDisappears(ctx, t, tflakeformation.ResourceResourceLFTags(), resourceName),
+					acctest.CheckSDKResourceDisappears(ctx, t, tflakeformation.ResourceResourceLFTags(), resourceName), // nosemgrep:ci.semgrep.acctest.disappears-expect-resource-action
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
 					},
+					// Expect a destroy + re-create. An empty set is technically a valid value
+					// so Read cannot trigger replacement just based on an empty list of tags
+					// when deleted out of band.
 					PostApplyPostRefresh: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionDestroyBeforeCreate),
 					},
 				},
 				ExpectNonEmptyPlan: true,


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->


### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This prevents a crash when the method receiver struct has a nil `LFTag` value. The same patch is applied for the `dbTagger`, `tbTagger`, and `tbcTagger` types.

Also, 
- Fixes the behavior of the `aws_lakeformation_resource_tf_tag` `Read` operation when a tag is deleted out of band.
- Corrects the `_disappears` test assertions for the `aws_lakeformation_resource_tf_tags` `Read` resource.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #48410


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t K=lakeformation T='TestAccLakeFormation_serial/ResourceLFTag'
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 b-tf_tag-crash 🌿...
TF_ACC=1 go1.26.4 test ./internal/service/lakeformation/... -v -count 1 -parallel 20 -run='TestAccLakeFormation_serial/ResourceLFTag'  -timeout 360m -vet=off
2026/06/15 15:27:47 Creating Terraform AWS Provider (SDKv2-style)...
2026/06/15 15:27:47 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccLakeFormation_serial (269.13s)
    --- PASS: TestAccLakeFormation_serial/ResourceLFTag (73.69s)
        --- PASS: TestAccLakeFormation_serial/ResourceLFTag/basic (17.94s)
        --- PASS: TestAccLakeFormation_serial/ResourceLFTag/disappears (19.19s)
        --- PASS: TestAccLakeFormation_serial/ResourceLFTag/table (18.35s)
        --- PASS: TestAccLakeFormation_serial/ResourceLFTag/tableWithColumns (18.21s)
    --- PASS: TestAccLakeFormation_serial/ResourceLFTags (195.45s)
        --- PASS: TestAccLakeFormation_serial/ResourceLFTags/basic (17.23s)
        --- PASS: TestAccLakeFormation_serial/ResourceLFTags/database (30.67s)
        --- PASS: TestAccLakeFormation_serial/ResourceLFTags/databaseMultipleTags (30.36s)
        --- PASS: TestAccLakeFormation_serial/ResourceLFTags/disappears (18.64s)
        --- PASS: TestAccLakeFormation_serial/ResourceLFTags/hierarchy (35.39s)
        --- PASS: TestAccLakeFormation_serial/ResourceLFTags/table (31.49s)
        --- PASS: TestAccLakeFormation_serial/ResourceLFTags/tableWithColumns (31.66s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lakeformation      277.839s
```
