### PR TITLE
resource/aws_wafv2_web_acl: add monetize action and monetization_config

### DIFF
--- a/.changelog/48419.txt
+++ b/.changelog/48419.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_wafv2_web_acl: Add `monetize` action to the rule `action` block and add the `monetization_config` argument
+```
+
+```release-note:enhancement
+resource/aws_wafv2_rule_group: Add `monetize` action to the rule `action` block and add the `monetization_config` argument
+```

--- a/internal/service/wafv2/flex.go
+++ b/internal/service/wafv2/flex.go
@@ -219,6 +219,29 @@ func expandRuleAction(l []any) *awstypes.RuleAction {
 		action.Count = expandCountAction(v.([]any))
 	}
 
+	if v, ok := m["monetize"]; ok && len(v.([]any)) > 0 {
+		action.Monetize = expandMonetizeAction(v.([]any))
+	}
+
+	return action
+}
+
+func expandMonetizeAction(l []any) *awstypes.MonetizeAction {
+	action := &awstypes.MonetizeAction{}
+
+	if len(l) == 0 || l[0] == nil {
+		return action
+	}
+
+	m, ok := l[0].(map[string]any)
+	if !ok {
+		return action
+	}
+
+	if v, ok := m["price_multiplier"].(string); ok && v != "" {
+		action.PriceMultiplier = aws.String(v)
+	}
+
 	return action
 }
 
@@ -2087,6 +2110,23 @@ func flattenRuleAction(a *awstypes.RuleAction) any {
 		m["count"] = flattenCount(a.Count)
 	}
 
+	if a.Monetize != nil {
+		m["monetize"] = flattenMonetize(a.Monetize)
+	}
+
+	return []any{m}
+}
+
+func flattenMonetize(a *awstypes.MonetizeAction) []any {
+	if a == nil {
+		return []any{}
+	}
+	m := map[string]any{}
+
+	if a.PriceMultiplier != nil {
+		m["price_multiplier"] = aws.ToString(a.PriceMultiplier)
+	}
+
 	return []any{m}
 }
 
@@ -3634,4 +3674,157 @@ func flattenFieldToProtect(apiObject *awstypes.FieldToProtect) any {
 	}
 
 	return []any{tfMap}
+}
+
+func expandMonetizationConfig(l []any) *awstypes.MonetizationConfig {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	m := l[0].(map[string]any)
+	config := &awstypes.MonetizationConfig{}
+
+	if v, ok := m["crypto_config"].([]any); ok && len(v) > 0 {
+		config.CryptoConfig = expandCryptoConfig(v)
+	}
+
+	if v, ok := m["currency_mode"].(string); ok && v != "" {
+		config.CurrencyMode = awstypes.CurrencyMode(v)
+	}
+
+	return config
+}
+
+func expandCryptoConfig(l []any) *awstypes.CryptoConfig {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	m := l[0].(map[string]any)
+	config := &awstypes.CryptoConfig{}
+
+	if v, ok := m["payment_network"].([]any); ok && len(v) > 0 {
+		config.PaymentNetworks = expandPaymentNetworks(v)
+	}
+
+	return config
+}
+
+func expandPaymentNetworks(l []any) []awstypes.PaymentNetwork {
+	if len(l) == 0 {
+		return nil
+	}
+
+	networks := make([]awstypes.PaymentNetwork, 0, len(l))
+	for _, tfMapRaw := range l {
+		m, ok := tfMapRaw.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		network := awstypes.PaymentNetwork{}
+		if v, ok := m["chain"].(string); ok && v != "" {
+			network.Chain = awstypes.BlockchainChain(v)
+		}
+		if v, ok := m["wallet_address"].(string); ok && v != "" {
+			network.WalletAddress = aws.String(v)
+		}
+		if v, ok := m["prices"].([]any); ok && len(v) > 0 {
+			network.Prices = expandPrices(v)
+		}
+		networks = append(networks, network)
+	}
+
+	return networks
+}
+
+func expandPrices(l []any) []awstypes.Price {
+	if len(l) == 0 {
+		return nil
+	}
+
+	prices := make([]awstypes.Price, 0, len(l))
+	for _, tfMapRaw := range l {
+		m, ok := tfMapRaw.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		price := awstypes.Price{}
+		if v, ok := m["amount"].(string); ok && v != "" {
+			price.Amount = aws.String(v)
+		}
+		if v, ok := m["currency"].(string); ok && v != "" {
+			price.Currency = awstypes.CryptoCurrency(v)
+		}
+		prices = append(prices, price)
+	}
+
+	return prices
+}
+
+func flattenMonetizationConfig(apiObject *awstypes.MonetizationConfig) []any {
+	if apiObject == nil {
+		return []any{}
+	}
+
+	m := map[string]any{
+		"currency_mode": string(apiObject.CurrencyMode),
+	}
+
+	if apiObject.CryptoConfig != nil {
+		m["crypto_config"] = flattenCryptoConfig(apiObject.CryptoConfig)
+	}
+
+	return []any{m}
+}
+
+func flattenCryptoConfig(apiObject *awstypes.CryptoConfig) []any {
+	if apiObject == nil {
+		return []any{}
+	}
+
+	m := map[string]any{}
+	if apiObject.PaymentNetworks != nil {
+		m["payment_network"] = flattenPaymentNetworks(apiObject.PaymentNetworks)
+	}
+
+	return []any{m}
+}
+
+func flattenPaymentNetworks(apiObjects []awstypes.PaymentNetwork) []any {
+	if len(apiObjects) == 0 {
+		return []any{}
+	}
+
+	l := make([]any, 0, len(apiObjects))
+	for _, apiObject := range apiObjects {
+		m := map[string]any{
+			"chain":          string(apiObject.Chain),
+			"wallet_address": aws.ToString(apiObject.WalletAddress),
+		}
+		if apiObject.Prices != nil {
+			m["prices"] = flattenPrices(apiObject.Prices)
+		}
+		l = append(l, m)
+	}
+
+	return l
+}
+
+func flattenPrices(apiObjects []awstypes.Price) []any {
+	if len(apiObjects) == 0 {
+		return []any{}
+	}
+
+	l := make([]any, 0, len(apiObjects))
+	for _, apiObject := range apiObjects {
+		m := map[string]any{
+			"amount":   aws.ToString(apiObject.Amount),
+			"currency": string(apiObject.Currency),
+		}
+		l = append(l, m)
+	}
+
+	return l
 }

--- a/internal/service/wafv2/flex.go
+++ b/internal/service/wafv2/flex.go
@@ -219,6 +219,29 @@ func expandRuleAction(l []any) *awstypes.RuleAction {
 		action.Count = expandCountAction(v.([]any))
 	}
 
+	if v, ok := m["monetize"]; ok && len(v.([]any)) > 0 {
+		action.Monetize = expandMonetizeAction(v.([]any))
+	}
+
+	return action
+}
+
+func expandMonetizeAction(l []any) *awstypes.MonetizeAction {
+	action := &awstypes.MonetizeAction{}
+
+	if len(l) == 0 || l[0] == nil {
+		return action
+	}
+
+	m, ok := l[0].(map[string]any)
+	if !ok {
+		return action
+	}
+
+	if v, ok := m["price_multiplier"].(string); ok && v != "" {
+		action.PriceMultiplier = aws.String(v)
+	}
+
 	return action
 }
 
@@ -2117,6 +2140,23 @@ func flattenRuleAction(a *awstypes.RuleAction) any {
 		m["count"] = flattenCount(a.Count)
 	}
 
+	if a.Monetize != nil {
+		m["monetize"] = flattenMonetize(a.Monetize)
+	}
+
+	return []any{m}
+}
+
+func flattenMonetize(a *awstypes.MonetizeAction) []any {
+	if a == nil {
+		return []any{}
+	}
+	m := map[string]any{}
+
+	if a.PriceMultiplier != nil {
+		m["price_multiplier"] = aws.ToString(a.PriceMultiplier)
+	}
+
 	return []any{m}
 }
 
@@ -3681,4 +3721,157 @@ func flattenFieldToProtect(apiObject *awstypes.FieldToProtect) any {
 	}
 
 	return []any{tfMap}
+}
+
+func expandMonetizationConfig(l []any) *awstypes.MonetizationConfig {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	m := l[0].(map[string]any)
+	config := &awstypes.MonetizationConfig{}
+
+	if v, ok := m["crypto_config"].([]any); ok && len(v) > 0 {
+		config.CryptoConfig = expandCryptoConfig(v)
+	}
+
+	if v, ok := m["currency_mode"].(string); ok && v != "" {
+		config.CurrencyMode = awstypes.CurrencyMode(v)
+	}
+
+	return config
+}
+
+func expandCryptoConfig(l []any) *awstypes.CryptoConfig {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	m := l[0].(map[string]any)
+	config := &awstypes.CryptoConfig{}
+
+	if v, ok := m["payment_network"].([]any); ok && len(v) > 0 {
+		config.PaymentNetworks = expandPaymentNetworks(v)
+	}
+
+	return config
+}
+
+func expandPaymentNetworks(l []any) []awstypes.PaymentNetwork {
+	if len(l) == 0 {
+		return nil
+	}
+
+	networks := make([]awstypes.PaymentNetwork, 0, len(l))
+	for _, tfMapRaw := range l {
+		m, ok := tfMapRaw.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		network := awstypes.PaymentNetwork{}
+		if v, ok := m["chain"].(string); ok && v != "" {
+			network.Chain = awstypes.BlockchainChain(v)
+		}
+		if v, ok := m["wallet_address"].(string); ok && v != "" {
+			network.WalletAddress = aws.String(v)
+		}
+		if v, ok := m["prices"].([]any); ok && len(v) > 0 {
+			network.Prices = expandPrices(v)
+		}
+		networks = append(networks, network)
+	}
+
+	return networks
+}
+
+func expandPrices(l []any) []awstypes.Price {
+	if len(l) == 0 {
+		return nil
+	}
+
+	prices := make([]awstypes.Price, 0, len(l))
+	for _, tfMapRaw := range l {
+		m, ok := tfMapRaw.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		price := awstypes.Price{}
+		if v, ok := m["amount"].(string); ok && v != "" {
+			price.Amount = aws.String(v)
+		}
+		if v, ok := m["currency"].(string); ok && v != "" {
+			price.Currency = awstypes.CryptoCurrency(v)
+		}
+		prices = append(prices, price)
+	}
+
+	return prices
+}
+
+func flattenMonetizationConfig(apiObject *awstypes.MonetizationConfig) []any {
+	if apiObject == nil {
+		return []any{}
+	}
+
+	m := map[string]any{
+		"currency_mode": string(apiObject.CurrencyMode),
+	}
+
+	if apiObject.CryptoConfig != nil {
+		m["crypto_config"] = flattenCryptoConfig(apiObject.CryptoConfig)
+	}
+
+	return []any{m}
+}
+
+func flattenCryptoConfig(apiObject *awstypes.CryptoConfig) []any {
+	if apiObject == nil {
+		return []any{}
+	}
+
+	m := map[string]any{}
+	if apiObject.PaymentNetworks != nil {
+		m["payment_network"] = flattenPaymentNetworks(apiObject.PaymentNetworks)
+	}
+
+	return []any{m}
+}
+
+func flattenPaymentNetworks(apiObjects []awstypes.PaymentNetwork) []any {
+	if len(apiObjects) == 0 {
+		return []any{}
+	}
+
+	l := make([]any, 0, len(apiObjects))
+	for _, apiObject := range apiObjects {
+		m := map[string]any{
+			"chain":          string(apiObject.Chain),
+			"wallet_address": aws.ToString(apiObject.WalletAddress),
+		}
+		if apiObject.Prices != nil {
+			m["prices"] = flattenPrices(apiObject.Prices)
+		}
+		l = append(l, m)
+	}
+
+	return l
+}
+
+func flattenPrices(apiObjects []awstypes.Price) []any {
+	if len(apiObjects) == 0 {
+		return []any{}
+	}
+
+	l := make([]any, 0, len(apiObjects))
+	for _, apiObject := range apiObjects {
+		m := map[string]any{
+			"amount":   aws.ToString(apiObject.Amount),
+			"currency": string(apiObject.Currency),
+		}
+		l = append(l, m)
+	}
+
+	return l
 }

--- a/internal/service/wafv2/rule_group.go
+++ b/internal/service/wafv2/rule_group.go
@@ -80,6 +80,7 @@ func resourceRuleGroup() *schema.Resource {
 					Type:     schema.TypeString,
 					Computed: true,
 				},
+				"monetization_config": monetizationConfigSchema(),
 				names.AttrName: {
 					Type:          schema.TypeString,
 					Optional:      true,
@@ -130,6 +131,7 @@ func resourceRuleGroup() *schema.Resource {
 										"captcha":   captchaConfigSchema(),
 										"challenge": challengeConfigSchema(),
 										"count":     countConfigSchema(),
+										"monetize":  monetizeConfigSchema(),
 									},
 								},
 							},
@@ -196,6 +198,10 @@ func resourceRuleGroupCreate(ctx context.Context, d *schema.ResourceData, meta a
 		input.Description = aws.String(v.(string))
 	}
 
+	if v, ok := d.GetOk("monetization_config"); ok && len(v.([]any)) > 0 {
+		input.MonetizationConfig = expandMonetizationConfig(v.([]any))
+	}
+
 	const (
 		timeout = 5 * time.Minute
 	)
@@ -237,6 +243,9 @@ func resourceRuleGroupRead(ctx context.Context, d *schema.ResourceData, meta any
 	}
 	d.Set(names.AttrDescription, ruleGroup.Description)
 	d.Set("lock_token", output.LockToken)
+	if err := d.Set("monetization_config", flattenMonetizationConfig(ruleGroup.MonetizationConfig)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting monetization_config: %s", err)
+	}
 	d.Set(names.AttrName, ruleGroup.Name)
 	d.Set(names.AttrNamePrefix, create.NamePrefixFromName(aws.ToString(ruleGroup.Name)))
 	if _, ok := d.GetOk("rules_json"); !ok {
@@ -285,6 +294,10 @@ func resourceRuleGroupUpdate(ctx context.Context, d *schema.ResourceData, meta a
 
 		if v, ok := d.GetOk(names.AttrDescription); ok {
 			input.Description = aws.String(v.(string))
+		}
+
+		if v, ok := d.GetOk("monetization_config"); ok && len(v.([]any)) > 0 {
+			input.MonetizationConfig = expandMonetizationConfig(v.([]any))
 		}
 
 		const (

--- a/internal/service/wafv2/rule_group_test.go
+++ b/internal/service/wafv2/rule_group_test.go
@@ -22,6 +22,40 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
+func TestAccWAFV2RuleGroup_monetize(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v awstypes.RuleGroup
+	ruleGroupName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_wafv2_rule_group.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.WAFV2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckRuleGroupDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRuleGroupConfig_monetize(ruleGroupName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRuleGroupExists(ctx, t, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, names.AttrScope, string(awstypes.ScopeCloudfront)),
+					resource.TestCheckResourceAttr(resourceName, "monetization_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "monetization_config.0.currency_mode", "TEST"),
+					resource.TestCheckResourceAttr(resourceName, "monetization_config.0.crypto_config.0.payment_network.0.chain", "BASE_SEPOLIA"),
+					resource.TestCheckResourceAttr(resourceName, "rule.0.action.0.monetize.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rule.0.action.0.monetize.0.price_multiplier", "2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccRuleGroupImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
 func TestAccWAFV2RuleGroup_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.RuleGroup
@@ -5771,6 +5805,71 @@ resource "aws_wafv2_rule_group" "test" {
       SampledRequestsEnabled   = false
     }
   }])
+
+  visibility_config {
+    cloudwatch_metrics_enabled = false
+    metric_name                = "friendly-metric-name"
+    sampled_requests_enabled   = false
+  }
+}
+`, rName)
+}
+
+func testAccRuleGroupConfig_monetize(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_wafv2_rule_group" "test" {
+  capacity = 2
+  name     = %[1]q
+  scope    = "CLOUDFRONT"
+
+  monetization_config {
+    currency_mode = "TEST"
+
+    crypto_config {
+      payment_network {
+        chain          = "BASE_SEPOLIA"
+        wallet_address = "0xAf7e757119d123ea29714493A1725724EfCFCc7B"
+
+        prices {
+          amount   = "0.001"
+          currency = "USDC"
+        }
+      }
+    }
+  }
+
+  rule {
+    name     = "monetize-api"
+    priority = 1
+
+    statement {
+      byte_match_statement {
+        search_string         = "/api"
+        positional_constraint = "STARTS_WITH"
+
+        field_to_match {
+          uri_path {}
+        }
+
+        text_transformation {
+          priority = 0
+          type     = "NONE"
+        }
+      }
+    }
+
+    action {
+      monetize {
+        price_multiplier = "2"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = false
+      metric_name                = "monetize-api"
+      sampled_requests_enabled   = false
+    }
+  }
 
   visibility_config {
     cloudwatch_metrics_enabled = false

--- a/internal/service/wafv2/rule_group_test.go
+++ b/internal/service/wafv2/rule_group_test.go
@@ -22,6 +22,40 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
+func TestAccWAFV2RuleGroup_monetize(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v awstypes.RuleGroup
+	ruleGroupName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_wafv2_rule_group.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.WAFV2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckRuleGroupDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRuleGroupConfig_monetize(ruleGroupName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRuleGroupExists(ctx, t, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, names.AttrScope, string(awstypes.ScopeCloudfront)),
+					resource.TestCheckResourceAttr(resourceName, "monetization_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "monetization_config.0.currency_mode", "TEST"),
+					resource.TestCheckResourceAttr(resourceName, "monetization_config.0.crypto_config.0.payment_network.0.chain", "BASE_SEPOLIA"),
+					resource.TestCheckResourceAttr(resourceName, "rule.0.action.0.monetize.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rule.0.action.0.monetize.0.price_multiplier", "2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccRuleGroupImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
 func TestAccWAFV2RuleGroup_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.RuleGroup
@@ -5884,6 +5918,71 @@ resource "aws_wafv2_rule_group" "test" {
       SampledRequestsEnabled   = false
     }
   }])
+
+  visibility_config {
+    cloudwatch_metrics_enabled = false
+    metric_name                = "friendly-metric-name"
+    sampled_requests_enabled   = false
+  }
+}
+`, rName)
+}
+
+func testAccRuleGroupConfig_monetize(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_wafv2_rule_group" "test" {
+  capacity = 2
+  name     = %[1]q
+  scope    = "CLOUDFRONT"
+
+  monetization_config {
+    currency_mode = "TEST"
+
+    crypto_config {
+      payment_network {
+        chain          = "BASE_SEPOLIA"
+        wallet_address = "0xAf7e757119d123ea29714493A1725724EfCFCc7B"
+
+        prices {
+          amount   = "0.001"
+          currency = "USDC"
+        }
+      }
+    }
+  }
+
+  rule {
+    name     = "monetize-api"
+    priority = 1
+
+    statement {
+      byte_match_statement {
+        search_string         = "/api"
+        positional_constraint = "STARTS_WITH"
+
+        field_to_match {
+          uri_path {}
+        }
+
+        text_transformation {
+          priority = 0
+          type     = "NONE"
+        }
+      }
+    }
+
+    action {
+      monetize {
+        price_multiplier = "2"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = false
+      metric_name                = "monetize-api"
+      sampled_requests_enabled   = false
+    }
+  }
 
   visibility_config {
     cloudwatch_metrics_enabled = false

--- a/internal/service/wafv2/schemas.go
+++ b/internal/service/wafv2/schemas.go
@@ -737,6 +737,100 @@ var countConfigSchema = sync.OnceValue(func() *schema.Schema {
 	}
 })
 
+var monetizeConfigSchema = sync.OnceValue(func() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"price_multiplier": {
+					Type:     schema.TypeString,
+					Optional: true,
+					ValidateFunc: validation.All(
+						validation.StringLenBetween(1, 3),
+						validation.StringMatch(regexache.MustCompile(`^([1-9][0-9]?|100)$`), "must be an integer between 1 and 100"),
+					),
+				},
+			},
+		},
+	}
+})
+
+// monetizationConfigSchema is the WebACL/RuleGroup-level monetization configuration.
+// Required by the API when any rule uses the monetize action.
+var monetizationConfigSchema = sync.OnceValue(func() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"crypto_config": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"payment_network": {
+								Type:     schema.TypeList,
+								Required: true,
+								MinItems: 1,
+								MaxItems: 2,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"chain": {
+											Type:             schema.TypeString,
+											Required:         true,
+											ValidateDiagFunc: enum.Validate[awstypes.BlockchainChain](),
+										},
+										"prices": {
+											Type:     schema.TypeList,
+											Required: true,
+											MinItems: 1,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"amount": {
+														Type:     schema.TypeString,
+														Required: true,
+														ValidateFunc: validation.All(
+															validation.StringLenBetween(1, 13),
+															validation.StringMatch(regexache.MustCompile(`^([1-9][0-9]*(\.[0-9]{1,3})?|0\.([1-9][0-9]{0,2}|0[1-9][0-9]?|00[1-9]))$`), "must be a decimal amount between 0.001 and 999999999.999 with up to 3 decimal places"),
+														),
+													},
+													"currency": {
+														Type:             schema.TypeString,
+														Required:         true,
+														ValidateDiagFunc: enum.Validate[awstypes.CryptoCurrency](),
+													},
+												},
+											},
+										},
+										"wallet_address": {
+											Type:     schema.TypeString,
+											Required: true,
+											ValidateFunc: validation.All(
+												validation.StringLenBetween(26, 44),
+												validation.StringMatch(regexache.MustCompile(`^.*\S.*$`), "must not be blank"),
+											),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				"currency_mode": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.CurrencyMode](),
+				},
+			},
+		},
+	}
+})
+
 var blockConfigSchema = sync.OnceValue(func() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,

--- a/internal/service/wafv2/schemas.go
+++ b/internal/service/wafv2/schemas.go
@@ -764,6 +764,100 @@ var countConfigSchema = sync.OnceValue(func() *schema.Schema {
 	}
 })
 
+var monetizeConfigSchema = sync.OnceValue(func() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"price_multiplier": {
+					Type:     schema.TypeString,
+					Optional: true,
+					ValidateFunc: validation.All(
+						validation.StringLenBetween(1, 3),
+						validation.StringMatch(regexache.MustCompile(`^([1-9][0-9]?|100)$`), "must be an integer between 1 and 100"),
+					),
+				},
+			},
+		},
+	}
+})
+
+// monetizationConfigSchema is the WebACL/RuleGroup-level monetization configuration.
+// Required by the API when any rule uses the monetize action.
+var monetizationConfigSchema = sync.OnceValue(func() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"crypto_config": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"payment_network": {
+								Type:     schema.TypeList,
+								Required: true,
+								MinItems: 1,
+								MaxItems: 2,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"chain": {
+											Type:             schema.TypeString,
+											Required:         true,
+											ValidateDiagFunc: enum.Validate[awstypes.BlockchainChain](),
+										},
+										"prices": {
+											Type:     schema.TypeList,
+											Required: true,
+											MinItems: 1,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"amount": {
+														Type:     schema.TypeString,
+														Required: true,
+														ValidateFunc: validation.All(
+															validation.StringLenBetween(1, 13),
+															validation.StringMatch(regexache.MustCompile(`^([1-9][0-9]*(\.[0-9]{1,3})?|0\.([1-9][0-9]{0,2}|0[1-9][0-9]?|00[1-9]))$`), "must be a decimal amount between 0.001 and 999999999.999 with up to 3 decimal places"),
+														),
+													},
+													"currency": {
+														Type:             schema.TypeString,
+														Required:         true,
+														ValidateDiagFunc: enum.Validate[awstypes.CryptoCurrency](),
+													},
+												},
+											},
+										},
+										"wallet_address": {
+											Type:     schema.TypeString,
+											Required: true,
+											ValidateFunc: validation.All(
+												validation.StringLenBetween(26, 44),
+												validation.StringMatch(regexache.MustCompile(`^.*\S.*$`), "must not be blank"),
+											),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				"currency_mode": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.CurrencyMode](),
+				},
+			},
+		},
+	}
+})
+
 var blockConfigSchema = sync.OnceValue(func() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,

--- a/internal/service/wafv2/web_acl.go
+++ b/internal/service/wafv2/web_acl.go
@@ -154,6 +154,7 @@ func resourceWebACL() *schema.Resource {
 					Type:     schema.TypeString,
 					Computed: true,
 				},
+				"monetization_config": monetizationConfigSchema(),
 				names.AttrName: {
 					Type:          schema.TypeString,
 					Optional:      true,
@@ -204,6 +205,7 @@ func resourceWebACL() *schema.Resource {
 										"captcha":   captchaConfigSchema(),
 										"challenge": challengeConfigSchema(),
 										"count":     countConfigSchema(),
+										"monetize":  monetizeConfigSchema(),
 									},
 								},
 							},
@@ -300,6 +302,10 @@ func resourceWebACLCreate(ctx context.Context, d *schema.ResourceData, meta any)
 		input.Description = aws.String(v.(string))
 	}
 
+	if v, ok := d.GetOk("monetization_config"); ok && len(v.([]any)) > 0 {
+		input.MonetizationConfig = expandMonetizationConfig(v.([]any))
+	}
+
 	if v, ok := d.GetOk("token_domains"); ok && v.(*schema.Set).Len() > 0 {
 		input.TokenDomains = flex.ExpandStringValueSet(v.(*schema.Set))
 	}
@@ -363,6 +369,9 @@ func resourceWebACLRead(ctx context.Context, d *schema.ResourceData, meta any) d
 	}
 	d.Set(names.AttrDescription, webACL.Description)
 	d.Set("lock_token", output.LockToken)
+	if err := d.Set("monetization_config", flattenMonetizationConfig(webACL.MonetizationConfig)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting monetization_config: %s", err)
+	}
 	d.Set(names.AttrName, webACL.Name)
 	d.Set(names.AttrNamePrefix, create.NamePrefixFromName(aws.ToString(webACL.Name)))
 	if _, ok := d.GetOk("rule_json"); !ok {
@@ -396,6 +405,7 @@ func resourceWebACLUpdate(ctx context.Context, d *schema.ResourceData, meta any)
 		"data_protection_config",
 		names.AttrDefaultAction,
 		names.AttrDescription,
+		"monetization_config",
 		"rule_json",
 		names.AttrRule,
 		"token_domains",
@@ -444,6 +454,7 @@ func resourceWebACLUpdate(ctx context.Context, d *schema.ResourceData, meta any)
 			DefaultAction:        expandDefaultAction(d.Get(names.AttrDefaultAction).([]any)),
 			Id:                   aws.String(d.Id()),
 			LockToken:            aws.String(aclLockToken),
+			MonetizationConfig:   expandMonetizationConfig(d.Get("monetization_config").([]any)),
 			Name:                 aws.String(aclName),
 			Rules:                rules,
 			Scope:                awstypes.Scope(aclScope),

--- a/internal/service/wafv2/web_acl_test.go
+++ b/internal/service/wafv2/web_acl_test.go
@@ -35,6 +35,44 @@ func testAccErrorCheckSkip(t *testing.T) resource.ErrorCheckFunc {
 	)
 }
 
+func TestAccWAFV2WebACL_monetize(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v awstypes.WebACL
+	webACLName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_wafv2_web_acl.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.WAFV2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckWebACLDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWebACLConfig_monetize(webACLName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWebACLExists(ctx, t, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, names.AttrScope, string(awstypes.ScopeCloudfront)),
+					resource.TestCheckResourceAttr(resourceName, "monetization_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "monetization_config.0.currency_mode", "TEST"),
+					resource.TestCheckResourceAttr(resourceName, "monetization_config.0.crypto_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "monetization_config.0.crypto_config.0.payment_network.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "monetization_config.0.crypto_config.0.payment_network.0.chain", "BASE_SEPOLIA"),
+					resource.TestCheckResourceAttr(resourceName, "monetization_config.0.crypto_config.0.payment_network.0.prices.0.amount", "0.001"),
+					resource.TestCheckResourceAttr(resourceName, "monetization_config.0.crypto_config.0.payment_network.0.prices.0.currency", "USDC"),
+					resource.TestCheckResourceAttr(resourceName, "rule.0.action.0.monetize.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rule.0.action.0.monetize.0.price_multiplier", "5"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccWebACLImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
 func TestAccWAFV2WebACL_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.WebACL
@@ -7764,6 +7802,74 @@ resource "aws_wafv2_web_acl" "test" {
   tags = {
     Tag1 = "Value1"
     Tag2 = "Value2"
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = false
+    metric_name                = "friendly-metric-name"
+    sampled_requests_enabled   = false
+  }
+}
+`, rName)
+}
+
+func testAccWebACLConfig_monetize(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_wafv2_web_acl" "test" {
+  name  = %[1]q
+  scope = "CLOUDFRONT"
+
+  default_action {
+    allow {}
+  }
+
+  monetization_config {
+    currency_mode = "TEST"
+
+    crypto_config {
+      payment_network {
+        chain          = "BASE_SEPOLIA"
+        wallet_address = "0xAf7e757119d123ea29714493A1725724EfCFCc7B"
+
+        prices {
+          amount   = "0.001"
+          currency = "USDC"
+        }
+      }
+    }
+  }
+
+  rule {
+    name     = "monetize-api"
+    priority = 1
+
+    statement {
+      byte_match_statement {
+        search_string         = "/api"
+        positional_constraint = "STARTS_WITH"
+
+        field_to_match {
+          uri_path {}
+        }
+
+        text_transformation {
+          priority = 0
+          type     = "NONE"
+        }
+      }
+    }
+
+    action {
+      monetize {
+        price_multiplier = "5"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = false
+      metric_name                = "monetize-api"
+      sampled_requests_enabled   = false
+    }
   }
 
   visibility_config {

--- a/internal/service/wafv2/web_acl_test.go
+++ b/internal/service/wafv2/web_acl_test.go
@@ -35,6 +35,44 @@ func testAccErrorCheckSkip(t *testing.T) resource.ErrorCheckFunc {
 	)
 }
 
+func TestAccWAFV2WebACL_monetize(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v awstypes.WebACL
+	webACLName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_wafv2_web_acl.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.WAFV2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckWebACLDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWebACLConfig_monetize(webACLName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWebACLExists(ctx, t, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, names.AttrScope, string(awstypes.ScopeCloudfront)),
+					resource.TestCheckResourceAttr(resourceName, "monetization_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "monetization_config.0.currency_mode", "TEST"),
+					resource.TestCheckResourceAttr(resourceName, "monetization_config.0.crypto_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "monetization_config.0.crypto_config.0.payment_network.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "monetization_config.0.crypto_config.0.payment_network.0.chain", "BASE_SEPOLIA"),
+					resource.TestCheckResourceAttr(resourceName, "monetization_config.0.crypto_config.0.payment_network.0.prices.0.amount", "0.001"),
+					resource.TestCheckResourceAttr(resourceName, "monetization_config.0.crypto_config.0.payment_network.0.prices.0.currency", "USDC"),
+					resource.TestCheckResourceAttr(resourceName, "rule.0.action.0.monetize.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rule.0.action.0.monetize.0.price_multiplier", "5"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccWebACLImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
 func TestAccWAFV2WebACL_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.WebACL
@@ -7953,6 +7991,74 @@ resource "aws_wafv2_web_acl" "test" {
   tags = {
     Tag1 = "Value1"
     Tag2 = "Value2"
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = false
+    metric_name                = "friendly-metric-name"
+    sampled_requests_enabled   = false
+  }
+}
+`, rName)
+}
+
+func testAccWebACLConfig_monetize(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_wafv2_web_acl" "test" {
+  name  = %[1]q
+  scope = "CLOUDFRONT"
+
+  default_action {
+    allow {}
+  }
+
+  monetization_config {
+    currency_mode = "TEST"
+
+    crypto_config {
+      payment_network {
+        chain          = "BASE_SEPOLIA"
+        wallet_address = "0xAf7e757119d123ea29714493A1725724EfCFCc7B"
+
+        prices {
+          amount   = "0.001"
+          currency = "USDC"
+        }
+      }
+    }
+  }
+
+  rule {
+    name     = "monetize-api"
+    priority = 1
+
+    statement {
+      byte_match_statement {
+        search_string         = "/api"
+        positional_constraint = "STARTS_WITH"
+
+        field_to_match {
+          uri_path {}
+        }
+
+        text_transformation {
+          priority = 0
+          type     = "NONE"
+        }
+      }
+    }
+
+    action {
+      monetize {
+        price_multiplier = "5"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = false
+      metric_name                = "monetize-api"
+      sampled_requests_enabled   = false
+    }
   }
 
   visibility_config {

--- a/website/docs/r/wafv2_rule_group.html.markdown
+++ b/website/docs/r/wafv2_rule_group.html.markdown
@@ -362,6 +362,7 @@ This resource supports the following arguments:
 * `capacity` - (Required, Forces new resource) The web ACL capacity units (WCUs) required for this rule group. See [here](https://docs.aws.amazon.com/waf/latest/APIReference/API_CreateRuleGroup.html#API_CreateRuleGroup_RequestSyntax) for general information and [here](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statements-list.html) for capacity specific information.
 * `custom_response_body` - (Optional) Defines custom response bodies that can be referenced by `custom_response` actions. See [Custom Response Body](#custom-response-body) below for details.
 * `description` - (Optional) A friendly description of the rule group.
+* `monetization_config` - (Optional) Specifies the monetization configuration for the rule group. Required when any rule uses the `monetize` action. See [`monetization_config`](#monetization_config-block) below for details.
 * `name` - (Required, Forces new resource) A friendly name of the rule group.
 * `name_prefix` - (Optional) Creates a unique name beginning with the specified prefix. Conflicts with `name`.
 * `rule` - (Optional) The rule blocks used to identify the web requests that you want to `allow`, `block`, or `count`. See [Rules](#rules) below for details.
@@ -401,6 +402,7 @@ The `action` block supports the following arguments:
 * `captcha` - (Optional) Instructs AWS WAF to run a `CAPTCHA` check against the web request. See [Captcha](#captcha) below for details.
 * `challenge` - (Optional) Instructs AWS WAF to run a check against the request to verify that the request is coming from a legitimate client session. See [Challenge](#challenge) below for details.
 * `count` - (Optional) Instructs AWS WAF to count the web request and allow it. See [Count](#count) below for details.
+* `monetize` - (Optional) Instructs AWS WAF to monetize the web request, charging per request according to the monetization configuration of the web ACL that references this rule group. See [Monetize](#monetize) below for details.
 
 ### Allow
 
@@ -431,6 +433,40 @@ The `challenge` block supports the following arguments:
 The `count` block supports the following arguments:
 
 * `custom_request_handling` - (Optional) Defines custom handling for the web request. See [Custom Request Handling](#custom-request-handling) below for details.
+
+### Monetize
+
+The `monetize` block supports the following arguments:
+
+* `price_multiplier` - (Optional) Integer multiplier applied to the base price defined in the rule group's [`monetization_config`](#monetization_config-block) when charging for a matching request. Expressed as a string. Valid values are `1` to `100` (for example, `"5"`).
+
+### `monetization_config` Block
+
+The `monetization_config` block supports the following arguments:
+
+* `crypto_config` - (Optional) Cryptocurrency payment configuration for the rule group. See [`crypto_config`](#crypto_config-block) below for details.
+* `currency_mode` - (Optional) Currency mode for monetized requests. Valid values are `TEST` and `REAL`.
+
+### `crypto_config` Block
+
+The `crypto_config` block supports the following arguments:
+
+* `payment_network` - (Required) Blockchain payment networks configured to receive payments. You can specify 1 to 2 networks. See [`payment_network`](#payment_network-block) below for details.
+
+### `payment_network` Block
+
+The `payment_network` block supports the following arguments:
+
+* `chain` - (Required) Blockchain network used for settlement. Valid values are `BASE`, `SOLANA`, `BASE_SEPOLIA`, and `SOLANA_DEVNET`.
+* `prices` - (Required) Price configuration for this payment network. Currently supports a single price entry. See [`prices`](#prices-block) below for details.
+* `wallet_address` - (Required) Payee wallet address on the specified blockchain that receives payments.
+
+### `prices` Block
+
+The `prices` block supports the following arguments:
+
+* `amount` - (Required) Base price amount per request, expressed as a decimal string with up to 3 decimal places. Minimum `0.001`, maximum `999999999.999` (for example, `"0.001"`).
+* `currency` - (Required) Currency of the price amount. Valid value is `USDC`.
 
 ### Custom Request Handling
 

--- a/website/docs/r/wafv2_web_acl.html.markdown
+++ b/website/docs/r/wafv2_web_acl.html.markdown
@@ -466,6 +466,7 @@ This resource supports the following arguments:
 * `data_protection_config` - (Optional) Specifies data protection to apply to the web request data for the web ACL. This is a web ACL level data protection option. See [`data_protection_config`](#data_protection_config-block) below for details.
 * `default_action` - (Required) Action to perform if none of the `rules` contained in the WebACL match. See [`default_action`](#default_action-block) below for details.
 * `description` - (Optional) Friendly description of the WebACL.
+* `monetization_config` - (Optional) Specifies the monetization configuration for the web ACL. Provide this when any rule in the web ACL uses the `monetize` action. See [`monetization_config`](#monetization_config-block) below for details.
 * `name` - (Optional, Forces new resource) Friendly name of the WebACL. If omitted, Terraform will assign a random, unique name. Conflicts with `name_prefix`.
 * `name_prefix` - (Optional) Creates a unique name beginning with the specified prefix. Conflicts with `name`.
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
@@ -550,6 +551,7 @@ The `action` block supports the following arguments:
 * `captcha` - (Optional) Instructs AWS WAF to run a Captcha check against the web request. See [`captcha`](#captcha-block) below for details.
 * `challenge` - (Optional) Instructs AWS WAF to run a check against the request to verify that the request is coming from a legitimate client session. See [`challenge`](#challenge-block) below for details.
 * `count` - (Optional) Instructs AWS WAF to count the web request and allow it. See [`count`](#count-block) below for details.
+* `monetize` - (Optional) Instructs AWS WAF to monetize the web request, charging per request according to the web ACL [`monetization_config`](#monetization_config-block). See [`monetize`](#monetize-block) below for details.
 
 ### `override_action` Block
 
@@ -589,6 +591,12 @@ The `challenge` block supports the following arguments:
 The `count` block supports the following arguments:
 
 * `custom_request_handling` - (Optional) Defines custom handling for the web request. See [`custom_request_handling`](#custom_request_handling-block) below for details.
+
+### `monetize` Block
+
+The `monetize` block supports the following arguments:
+
+* `price_multiplier` - (Optional) Integer multiplier applied to the base price defined in the web ACL [`monetization_config`](#monetization_config-block) when charging for a matching request. Expressed as a string. Valid values are `1` to `100` (for example, `"5"`).
 
 ### `custom_request_handling` Block
 
@@ -1083,6 +1091,34 @@ The `challenge_config` block supports the following arguments:
 The `immunity_time_property` block supports the following arguments:
 
 * `immunity_time` - (Optional) The amount of time, in seconds, that a CAPTCHA or challenge timestamp is considered valid by AWS WAF. The default setting is 300.
+
+### `monetization_config` Block
+
+The `monetization_config` block supports the following arguments:
+
+* `crypto_config` - (Optional) Cryptocurrency payment configuration for the web ACL. See [`crypto_config`](#crypto_config-block) below for details.
+* `currency_mode` - (Optional) Currency mode for monetized requests. Valid values are `TEST` and `REAL`.
+
+### `crypto_config` Block
+
+The `crypto_config` block supports the following arguments:
+
+* `payment_network` - (Required) Blockchain payment networks configured to receive payments. You can specify 1 to 2 networks. See [`payment_network`](#payment_network-block) below for details.
+
+### `payment_network` Block
+
+The `payment_network` block supports the following arguments:
+
+* `chain` - (Required) Blockchain network used for settlement. Valid values are `BASE`, `SOLANA`, `BASE_SEPOLIA`, and `SOLANA_DEVNET`.
+* `prices` - (Required) Price configuration for this payment network. Currently supports a single price entry. See [`prices`](#prices-block) below for details.
+* `wallet_address` - (Required) Payee wallet address on the specified blockchain that receives payments.
+
+### `prices` Block
+
+The `prices` block supports the following arguments:
+
+* `amount` - (Required) Base price amount per request, expressed as a decimal string with up to 3 decimal places. Minimum `0.001`, maximum `999999999.999` (for example, `"0.001"`).
+* `currency` - (Required) Currency of the price amount. Valid value is `USDC`.
 
 ### `request_body` Block
 

--- a/website/docs/r/wafv2_web_acl.html.markdown
+++ b/website/docs/r/wafv2_web_acl.html.markdown
@@ -466,6 +466,7 @@ This resource supports the following arguments:
 * `data_protection_config` - (Optional) Specifies data protection to apply to the web request data for the web ACL. This is a web ACL level data protection option. See [`data_protection_config`](#data_protection_config-block) below for details.
 * `default_action` - (Required) Action to perform if none of the `rules` contained in the WebACL match. See [`default_action`](#default_action-block) below for details.
 * `description` - (Optional) Friendly description of the WebACL.
+* `monetization_config` - (Optional) Specifies the monetization configuration for the web ACL. Provide this when any rule in the web ACL uses the `monetize` action. See [`monetization_config`](#monetization_config-block) below for details.
 * `name` - (Optional, Forces new resource) Friendly name of the WebACL. If omitted, Terraform will assign a random, unique name. Conflicts with `name_prefix`.
 * `name_prefix` - (Optional) Creates a unique name beginning with the specified prefix. Conflicts with `name`.
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
@@ -550,6 +551,7 @@ The `action` block supports the following arguments:
 * `captcha` - (Optional) Instructs AWS WAF to run a Captcha check against the web request. See [`captcha`](#captcha-block) below for details.
 * `challenge` - (Optional) Instructs AWS WAF to run a check against the request to verify that the request is coming from a legitimate client session. See [`challenge`](#challenge-block) below for details.
 * `count` - (Optional) Instructs AWS WAF to count the web request and allow it. See [`count`](#count-block) below for details.
+* `monetize` - (Optional) Instructs AWS WAF to monetize the web request, charging per request according to the web ACL [`monetization_config`](#monetization_config-block). See [`monetize`](#monetize-block) below for details.
 
 ### `override_action` Block
 
@@ -589,6 +591,12 @@ The `challenge` block supports the following arguments:
 The `count` block supports the following arguments:
 
 * `custom_request_handling` - (Optional) Defines custom handling for the web request. See [`custom_request_handling`](#custom_request_handling-block) below for details.
+
+### `monetize` Block
+
+The `monetize` block supports the following arguments:
+
+* `price_multiplier` - (Optional) Integer multiplier applied to the base price defined in the web ACL [`monetization_config`](#monetization_config-block) when charging for a matching request. Expressed as a string. Valid values are `1` to `100` (for example, `"5"`).
 
 ### `custom_request_handling` Block
 
@@ -1098,6 +1106,34 @@ The `challenge_config` block supports the following arguments:
 The `immunity_time_property` block supports the following arguments:
 
 * `immunity_time` - (Optional) The amount of time, in seconds, that a CAPTCHA or challenge timestamp is considered valid by AWS WAF. The default setting is 300.
+
+### `monetization_config` Block
+
+The `monetization_config` block supports the following arguments:
+
+* `crypto_config` - (Optional) Cryptocurrency payment configuration for the web ACL. See [`crypto_config`](#crypto_config-block) below for details.
+* `currency_mode` - (Optional) Currency mode for monetized requests. Valid values are `TEST` and `REAL`.
+
+### `crypto_config` Block
+
+The `crypto_config` block supports the following arguments:
+
+* `payment_network` - (Required) Blockchain payment networks configured to receive payments. You can specify 1 to 2 networks. See [`payment_network`](#payment_network-block) below for details.
+
+### `payment_network` Block
+
+The `payment_network` block supports the following arguments:
+
+* `chain` - (Required) Blockchain network used for settlement. Valid values are `BASE`, `SOLANA`, `BASE_SEPOLIA`, and `SOLANA_DEVNET`.
+* `prices` - (Required) Price configuration for this payment network. Currently supports a single price entry. See [`prices`](#prices-block) below for details.
+* `wallet_address` - (Required) Payee wallet address on the specified blockchain that receives payments.
+
+### `prices` Block
+
+The `prices` block supports the following arguments:
+
+* `amount` - (Required) Base price amount per request, expressed as a decimal string with up to 3 decimal places. Minimum `0.001`, maximum `999999999.999` (for example, `"0.001"`).
+* `currency` - (Required) Currency of the price amount. Valid value is `USDC`.
 
 ### `request_body` Block
 


### PR DESCRIPTION
### Description

AWS WAF now supports charging for a web request natively — a new per-rule `monetize` action (alongside `allow` / `block` / `count` / `captcha` / `challenge`) plus a WebACL/RuleGroup-level `monetization_config`. This PR adds Terraform support to `aws_wafv2_web_acl` and `aws_wafv2_rule_group`.

Announced GA 2026-06-15: https://aws.amazon.com/blogs/aws/aws-waf-adds-ai-traffic-monetization-capability-to-help-content-owners-charge-ai-bots-for-content-access/

### Changes

- `aws_wafv2_web_acl` / `aws_wafv2_rule_group`: new `monetize` rule action with `price_multiplier` (integer 1–100).
- `aws_wafv2_web_acl` / `aws_wafv2_rule_group`: new `monetization_config` block — `crypto_config.payment_network[].{chain, wallet_address, prices[].{amount, currency}}` and `currency_mode`. The API requires this when any rule uses the `monetize` action.
- Field validation mirrors the WAF API Reference (enums for `chain`/`currency`/`currency_mode`; length + pattern for `amount`, `wallet_address`, `price_multiplier`).
- Acceptance tests (CLOUDFRONT scope), website docs, and changelog.

Depends on `aws-sdk-go-v2/service/wafv2` v1.73.0 (merged via #48423).

### Relations

Closes #48418

### References

- https://aws.amazon.com/blogs/aws/aws-waf-adds-ai-traffic-monetization-capability-to-help-content-owners-charge-ai-bots-for-content-access/
- https://docs.aws.amazon.com/waf/latest/APIReference/API_CreateWebACL.html

### Output from Acceptance Testing

```
$ make testacc TESTS=TestAccWAFV2WebACL_monetize\|TestAccWAFV2RuleGroup_monetize PKG=wafv2

--- PASS: TestAccWAFV2RuleGroup_monetize (30.82s)
--- PASS: TestAccWAFV2WebACL_monetize (32.59s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/wafv2	41.321s
```
