### PR TITLE
Restores Semgrep rule for domain names

### DIFF
--- a/.ci/.semgrep.yml
+++ b/.ci/.semgrep.yml
@@ -314,52 +314,6 @@ rules:
     severity: WARNING
     fix: "regexache.MustCompile($X)"
 
-  - id: domain-names
-    languages: [go]
-    message: Domain names should be in the namespaces defined in RFC 6761 (https://datatracker.ietf.org/doc/html/rfc6761) as reserved for testing
-    paths:
-      include:
-        - "/internal/service"
-      exclude:
-        - "/internal/service/firehose/delivery_stream_test.go"
-        - "/internal/service/fsx/windows_file_system_test.go"
-        - "/internal/service/iam/openid_connect_provider_test.go"
-        - "/internal/service/mq/broker_test.go"
-        - "/internal/service/mq/forge_test.go"
-        - "/internal/service/route53/sweep.go"
-        - "/internal/service/s3/bucket_test.go"
-        - "/internal/service/s3/object_test.go"
-        - "/internal/service/storagegateway/cached_iscsi_volume.go"
-        - "/internal/service/storagegateway/cached_iscsi_volume_test.go"
-        - "/internal/service/storagegateway/stored_iscsi_volume_test.go"
-        - "/internal/service/transfer/access_test.go"
-        - "/internal/service/transfer/server_test.go"
-        - "/internal/service/**/*_test.go"
-    patterns:
-      - patterns:
-          - pattern-regex: '(([-a-zA-Z0-9]{2,}\.)|(%[sdftq]))+(com|net|org)\b'
-      - pattern-inside: "($X : string)"
-      - pattern-not-regex: 'amazonaws\.com'
-      - pattern-not-regex: 'awsapps\.com'
-      - pattern-not-regex: '@(([-a-zA-Z0-9]{2,}\.)|(%[sdftq]))+(com|net|org)\b' # exclude domain names in email addresses
-      - pattern-not-regex: '[^-a-zA-Z0-9]example\.com'
-      - pattern-not-regex: '[^-a-zA-Z0-9]example\.net'
-      - pattern-not-regex: '[^-a-zA-Z0-9]example\.org'
-      - pattern-not-regex: 'github\.com'
-      - pattern-not-regex: 'aws\.amazon\.com'
-      - pattern-not-regex: 'graph\.facebook\.com'
-      - pattern-not-regex: 'people\.googleapis\.com'
-      - pattern-not-regex: 'www\.googleapis\.com'
-      - pattern-not-regex: 'accounts\.google\.com'
-      - pattern-not-regex: '[-a-z0-9]+\.apps\.googleusercontent\.com'
-      - pattern-not-regex: 'elasticbeanstalk\.com'
-      - pattern-not-regex: 'awsglobalaccelerator\.com'
-      - pattern-not-regex: 'cloudfront\.net'
-      - pattern-not-regex: 'http://json-schema\.org/draft-0\d/schema'
-      - pattern-not-regex: "http://activemq.apache.org/schema/core"
-      - pattern-not-regex: "mcr.microsoft.com"
-    severity: WARNING
-
   - id: email-address
     languages: [go]
     message: Use default email address or generate a random email address. https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing/running-and-writing-acceptance-tests.md#hardcoded-email-addresses

--- a/.ci/semgrep/domain-names/domain-names.yml
+++ b/.ci/semgrep/domain-names/domain-names.yml
@@ -1,0 +1,49 @@
+# Copyright IBM Corp. 2014, 2026
+# "SPDX-License-Identifier: MPL-2.0"
+
+rules:
+  - id: domain-names
+    languages: [go]
+    message: Domain names should be in the namespaces defined in RFC 6761 (https://datatracker.ietf.org/doc/html/rfc6761) as reserved for testing
+    paths:
+      include:
+        - "/internal/service"
+      exclude:
+        - "/internal/service/firehose/delivery_stream_test.go"
+        - "/internal/service/fsx/windows_file_system_test.go"
+        - "/internal/service/iam/openid_connect_provider_test.go"
+        - "/internal/service/mq/broker_test.go"
+        - "/internal/service/mq/forge_test.go"
+        - "/internal/service/route53/sweep.go"
+        - "/internal/service/s3/bucket_test.go"
+        - "/internal/service/s3/object_test.go"
+        - "/internal/service/storagegateway/cached_iscsi_volume.go"
+        - "/internal/service/storagegateway/cached_iscsi_volume_test.go"
+        - "/internal/service/storagegateway/stored_iscsi_volume_test.go"
+        - "/internal/service/transfer/access_test.go"
+        - "/internal/service/transfer/server_test.go"
+        - "/internal/service/**/*_test.go"
+    patterns:
+      - patterns:
+          - pattern-regex: '(([-a-zA-Z0-9]{2,}\.)|(%[sdftq]))+(com|net|org)\b'
+      - pattern-inside: "($X : string)"
+      - pattern-not-regex: 'amazonaws\.com'
+      - pattern-not-regex: 'awsapps\.com'
+      - pattern-not-regex: '@(([-a-zA-Z0-9]{2,}\.)|(%[sdftq]))+(com|net|org)\b' # exclude domain names in email addresses
+      - pattern-not-regex: '[^-a-zA-Z0-9]example\.com'
+      - pattern-not-regex: '[^-a-zA-Z0-9]example\.net'
+      - pattern-not-regex: '[^-a-zA-Z0-9]example\.org'
+      - pattern-not-regex: 'github\.com'
+      - pattern-not-regex: 'aws\.amazon\.com'
+      - pattern-not-regex: 'graph\.facebook\.com'
+      - pattern-not-regex: 'people\.googleapis\.com'
+      - pattern-not-regex: 'www\.googleapis\.com'
+      - pattern-not-regex: 'accounts\.google\.com'
+      - pattern-not-regex: '[-a-z0-9]+\.apps\.googleusercontent\.com'
+      - pattern-not-regex: 'elasticbeanstalk\.com'
+      - pattern-not-regex: 'awsglobalaccelerator\.com'
+      - pattern-not-regex: 'cloudfront\.net'
+      - pattern-not-regex: 'http://json-schema\.org/draft-0\d/schema'
+      - pattern-not-regex: "http://activemq.apache.org/schema/core"
+      - pattern-not-regex: "mcr.microsoft.com"
+    severity: WARNING

--- a/.ci/semgrep/domain-names/domain-names.yml
+++ b/.ci/semgrep/domain-names/domain-names.yml
@@ -15,7 +15,6 @@ rules:
         - "/internal/service/bedrockagentcore/harness_test.go"
         - "/internal/service/bedrockagentcore/oauth2_credential_provider_test.go"
         - "/internal/service/firehose/delivery_stream_test.go"
-        - "/internal/service/fsx/windows_file_system_test.go"
         - "/internal/service/iam/openid_connect_provider_test.go"
         - "/internal/service/mq/broker_test.go"
         - "/internal/service/mq/forge_test.go"
@@ -26,7 +25,6 @@ rules:
         - "/internal/service/storagegateway/cached_iscsi_volume_test.go"
         - "/internal/service/storagegateway/stored_iscsi_volume_test.go"
         - "/internal/service/transfer/access_test.go"
-        - "/internal/service/transfer/server_test.go"
         # TODO: Remove the following exclusions once the domain names are fixed
         - "/internal/service/datasync/location_azure_blob_test.go"
         - "/internal/service/ec2/verifiedaccess_instance_test.go"

--- a/.ci/semgrep/domain-names/domain-names.yml
+++ b/.ci/semgrep/domain-names/domain-names.yml
@@ -9,6 +9,11 @@ rules:
       include:
         - "/internal/service"
       exclude:
+        - "/internal/service/bedrockagentcore/agent_runtime_test.go"
+        - "/internal/service/bedrockagentcore/gateway_target_test.go"
+        - "/internal/service/bedrockagentcore/gateway_test.go"
+        - "/internal/service/bedrockagentcore/harness_test.go"
+        - "/internal/service/bedrockagentcore/oauth2_credential_provider_test.go"
         - "/internal/service/firehose/delivery_stream_test.go"
         - "/internal/service/fsx/windows_file_system_test.go"
         - "/internal/service/iam/openid_connect_provider_test.go"
@@ -22,11 +27,6 @@ rules:
         - "/internal/service/storagegateway/stored_iscsi_volume_test.go"
         - "/internal/service/transfer/access_test.go"
         - "/internal/service/transfer/server_test.go"
-        - "/internal/service/bedrockagentcore/agent_runtime_test.go"
-        - "/internal/service/bedrockagentcore/gateway_target_test.go"
-        - "/internal/service/bedrockagentcore/gateway_test.go"
-        - "/internal/service/bedrockagentcore/harness_test.go"
-        - "/internal/service/bedrockagentcore/oauth2_credential_provider_test.go"
         # TODO: Remove the following exclusions once the domain names are fixed
         - "/internal/service/datasync/location_azure_blob_test.go"
         - "/internal/service/ec2/verifiedaccess_instance_test.go"

--- a/.ci/semgrep/domain-names/domain-names.yml
+++ b/.ci/semgrep/domain-names/domain-names.yml
@@ -27,6 +27,34 @@ rules:
         - "/internal/service/bedrockagentcore/gateway_test.go"
         - "/internal/service/bedrockagentcore/harness_test.go"
         - "/internal/service/bedrockagentcore/oauth2_credential_provider_test.go"
+        # TODO: Remove the following exclusions once the domain names are fixed
+        - "/internal/service/datasync/location_azure_blob_test.go"
+        - "/internal/service/ec2/verifiedaccess_instance_test.go"
+        - "/internal/service/ec2/vpc_endpoint_data_source_test.go"
+        - "/internal/service/ec2/vpc_endpoint_test.go"
+        - "/internal/service/elbv2/listener_rule_data_source_test.go"
+        - "/internal/service/elbv2/listener_rule_test.go"
+        - "/internal/service/events/rule_test.go"
+        - "/internal/service/events/target_test.go"
+        - "/internal/service/events/validate_test.go"
+        - "/internal/service/finspace/kx_environment_test.go"
+        - "/internal/service/fsx/file_cache_test.go"
+        - "/internal/service/glue/connection_test.go"
+        - "/internal/service/iam/openid_connect_provider_data_source_test.go"
+        - "/internal/service/lambda/event_source_mapping_test.go"
+        - "/internal/service/lightsail/container_service_test.go"
+        - "/internal/service/meta/service_data_source_test.go"
+        - "/internal/service/odb/network_test.go"
+        - "/internal/service/opensearch/domain_test.go"
+        - "/internal/service/route53/equal_test.go"
+        - "/internal/service/route53domains/registered_domain_test.go"
+        - "/internal/service/route53profiles/resource_association_test.go"
+        - "/internal/service/s3/bucket_object_test.go"
+        - "/internal/service/sagemaker/domain_test.go"
+        - "/internal/service/schemas/schema_test.go"
+        - "/internal/service/ssoadmin/application_test.go"
+        - "/internal/service/wafv2/web_acl_test.go"
+        - "/internal/service/workspacesweb/user_settings_test.go"
     patterns:
       - patterns:
           - pattern-regex: '(([-a-zA-Z0-9]{2,}\.)|(%[sdftq]))+(com|net|org)\b'
@@ -34,6 +62,40 @@ rules:
       - pattern-not-regex: 'amazonaws\.com'
       - pattern-not-regex: 'awsapps\.com'
       - pattern-not-regex: '@(([-a-zA-Z0-9]{2,}\.)|(%[sdftq]))+(com|net|org)\b' # exclude domain names in email addresses
+      - pattern-not-regex: '[^-a-zA-Z0-9]example\.com'
+      - pattern-not-regex: '[^-a-zA-Z0-9]example\.net'
+      - pattern-not-regex: '[^-a-zA-Z0-9]example\.org'
+      - pattern-not-regex: 'github\.com'
+      - pattern-not-regex: 'aws\.amazon\.com'
+      - pattern-not-regex: 'graph\.facebook\.com'
+      - pattern-not-regex: 'people\.googleapis\.com'
+      - pattern-not-regex: 'www\.googleapis\.com'
+      - pattern-not-regex: 'accounts\.google\.com'
+      - pattern-not-regex: '[-a-z0-9]+\.apps\.googleusercontent\.com'
+      - pattern-not-regex: 'elasticbeanstalk\.com'
+      - pattern-not-regex: 'awsglobalaccelerator\.com'
+      - pattern-not-regex: 'cloudfront\.net'
+      - pattern-not-regex: 'http://json-schema\.org/draft-0\d/schema'
+      - pattern-not-regex: "http://activemq.apache.org/schema/core"
+      - pattern-not-regex: "mcr.microsoft.com"
+    severity: WARNING
+
+  - id: domain-names-tf
+    languages: [hcl]
+    message: Domain names should be in the namespaces defined in RFC 6761 (https://datatracker.ietf.org/doc/html/rfc6761) as reserved for testing
+    paths:
+      include:
+        - "/internal/service"
+      exclude:
+        # TODO: Remove the following exclusions once the domain names are fixed
+        - "/internal/service/datasync/testdata/LocationAzureBlob"
+        - "/internal/service/iam/testdata/OIDCProvider"
+        - "/internal/service/iam/testdata/OpenIDConnectProvider"
+    patterns:
+      - pattern-regex: '(([-a-zA-Z0-9]{2,}\.)|(%[sdftq]))+(com|net|org)\b'
+      - pattern-not-regex: 'amazonaws\.com'
+      - pattern-not-regex: 'awsapps\.com'
+      - pattern-not-regex: '@(([-a-zA-Z0-9]{2,}\.)|(%[sdftq]))+(com|net|org)\b'
       - pattern-not-regex: '[^-a-zA-Z0-9]example\.com'
       - pattern-not-regex: '[^-a-zA-Z0-9]example\.net'
       - pattern-not-regex: '[^-a-zA-Z0-9]example\.org'

--- a/.ci/semgrep/domain-names/domain-names.yml
+++ b/.ci/semgrep/domain-names/domain-names.yml
@@ -22,7 +22,11 @@ rules:
         - "/internal/service/storagegateway/stored_iscsi_volume_test.go"
         - "/internal/service/transfer/access_test.go"
         - "/internal/service/transfer/server_test.go"
-        - "/internal/service/**/*_test.go"
+        - "/internal/service/bedrockagentcore/agent_runtime_test.go"
+        - "/internal/service/bedrockagentcore/gateway_target_test.go"
+        - "/internal/service/bedrockagentcore/gateway_test.go"
+        - "/internal/service/bedrockagentcore/harness_test.go"
+        - "/internal/service/bedrockagentcore/oauth2_credential_provider_test.go"
     patterns:
       - patterns:
           - pattern-regex: '(([-a-zA-Z0-9]{2,}\.)|(%[sdftq]))+(com|net|org)\b'

--- a/internal/service/account/primary_contact_data_source_test.go
+++ b/internal/service/account/primary_contact_data_source_test.go
@@ -95,7 +95,7 @@ resource "aws_account_primary_contact" "test" {
   phone_number       = "+64211111111"
   postal_code        = "98101"
   state_or_region    = "WA"
-  website_url        = "https://www.examplecorp.com"
+  website_url        = "https://www.example.com"
 }
 
 data "aws_account_primary_contact" "test" {
@@ -123,7 +123,7 @@ resource "aws_account_primary_contact" "test" {
   phone_number       = "+64211111111"
   postal_code        = "98101"
   state_or_region    = "WA"
-  website_url        = "https://www.examplecorp.com"
+  website_url        = "https://www.example.com"
 }
 
 data "aws_account_primary_contact" "test" {

--- a/internal/service/account/primary_contact_test.go
+++ b/internal/service/account/primary_contact_test.go
@@ -41,7 +41,7 @@ func testAccPrimaryContact_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "phone_number", "+64211111111"),
 					resource.TestCheckResourceAttr(resourceName, "postal_code", "98101"),
 					resource.TestCheckResourceAttr(resourceName, "state_or_region", "WA"),
-					resource.TestCheckResourceAttr(resourceName, "website_url", "https://www.examplecorp.com"),
+					resource.TestCheckResourceAttr(resourceName, "website_url", "https://www.example.com"),
 				),
 			},
 			{
@@ -63,7 +63,7 @@ func testAccPrimaryContact_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "phone_number", "+64211111111"),
 					resource.TestCheckResourceAttr(resourceName, "postal_code", "98101"),
 					resource.TestCheckResourceAttr(resourceName, "state_or_region", "WA"),
-					resource.TestCheckResourceAttr(resourceName, "website_url", "https://www.examplecorp.com"),
+					resource.TestCheckResourceAttr(resourceName, "website_url", "https://www.example.com"),
 				),
 			},
 		},
@@ -101,7 +101,7 @@ resource "aws_account_primary_contact" "test" {
   phone_number       = "+64211111111"
   postal_code        = "98101"
   state_or_region    = "WA"
-  website_url        = "https://www.examplecorp.com"
+  website_url        = "https://www.example.com"
 }
 `, name)
 }

--- a/internal/service/appintegrations/event_integration_data_source_test.go
+++ b/internal/service/appintegrations/event_integration_data_source_test.go
@@ -25,7 +25,7 @@ func TestAccAppIntegrationsEventIntegrationDataSource_name(t *testing.T) {
 	key := "EVENT_BRIDGE_PARTNER_EVENT_SOURCE_NAME"
 	sourceName := os.Getenv(key)
 	if sourceName == "" {
-		sourceName = "aws.partner/examplepartner.com"
+		sourceName = "aws.partner/example.com"
 	}
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{

--- a/internal/service/appintegrations/event_integration_test.go
+++ b/internal/service/appintegrations/event_integration_test.go
@@ -32,7 +32,7 @@ func TestAccAppIntegrationsEventIntegration_basic(t *testing.T) {
 	var sourceName string
 	sourceName = os.Getenv(key)
 	if sourceName == "" {
-		sourceName = "aws.partner/examplepartner.com"
+		sourceName = "aws.partner/example.com"
 	}
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
@@ -88,7 +88,7 @@ func TestAccAppIntegrationsEventIntegration_disappears(t *testing.T) {
 	var sourceName string
 	sourceName = os.Getenv(key)
 	if sourceName == "" {
-		sourceName = "aws.partner/examplepartner.com"
+		sourceName = "aws.partner/example.com"
 	}
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{

--- a/internal/service/appintegrations/testdata/EventIntegration/data.tags/main_gen.tf
+++ b/internal/service/appintegrations/testdata/EventIntegration/data.tags/main_gen.tf
@@ -11,7 +11,7 @@ resource "aws_appintegrations_event_integration" "test" {
   eventbridge_bus = "default"
 
   event_filter {
-    source = "aws.partner/examplepartner.com"
+    source = "aws.partner/example.com"
   }
 
   tags = var.resource_tags

--- a/internal/service/appintegrations/testdata/EventIntegration/data.tags_defaults/main_gen.tf
+++ b/internal/service/appintegrations/testdata/EventIntegration/data.tags_defaults/main_gen.tf
@@ -17,7 +17,7 @@ resource "aws_appintegrations_event_integration" "test" {
   eventbridge_bus = "default"
 
   event_filter {
-    source = "aws.partner/examplepartner.com"
+    source = "aws.partner/example.com"
   }
 
   tags = var.resource_tags

--- a/internal/service/appintegrations/testdata/EventIntegration/data.tags_ignore/main_gen.tf
+++ b/internal/service/appintegrations/testdata/EventIntegration/data.tags_ignore/main_gen.tf
@@ -20,7 +20,7 @@ resource "aws_appintegrations_event_integration" "test" {
   eventbridge_bus = "default"
 
   event_filter {
-    source = "aws.partner/examplepartner.com"
+    source = "aws.partner/example.com"
   }
 
   tags = var.resource_tags

--- a/internal/service/appintegrations/testdata/EventIntegration/tags/main_gen.tf
+++ b/internal/service/appintegrations/testdata/EventIntegration/tags/main_gen.tf
@@ -6,7 +6,7 @@ resource "aws_appintegrations_event_integration" "test" {
   eventbridge_bus = "default"
 
   event_filter {
-    source = "aws.partner/examplepartner.com"
+    source = "aws.partner/example.com"
   }
 
   tags = var.resource_tags

--- a/internal/service/appintegrations/testdata/EventIntegration/tagsComputed1/main_gen.tf
+++ b/internal/service/appintegrations/testdata/EventIntegration/tagsComputed1/main_gen.tf
@@ -8,7 +8,7 @@ resource "aws_appintegrations_event_integration" "test" {
   eventbridge_bus = "default"
 
   event_filter {
-    source = "aws.partner/examplepartner.com"
+    source = "aws.partner/example.com"
   }
 
   tags = {

--- a/internal/service/appintegrations/testdata/EventIntegration/tagsComputed2/main_gen.tf
+++ b/internal/service/appintegrations/testdata/EventIntegration/tagsComputed2/main_gen.tf
@@ -8,7 +8,7 @@ resource "aws_appintegrations_event_integration" "test" {
   eventbridge_bus = "default"
 
   event_filter {
-    source = "aws.partner/examplepartner.com"
+    source = "aws.partner/example.com"
   }
 
   tags = {

--- a/internal/service/appintegrations/testdata/EventIntegration/tags_defaults/main_gen.tf
+++ b/internal/service/appintegrations/testdata/EventIntegration/tags_defaults/main_gen.tf
@@ -12,7 +12,7 @@ resource "aws_appintegrations_event_integration" "test" {
   eventbridge_bus = "default"
 
   event_filter {
-    source = "aws.partner/examplepartner.com"
+    source = "aws.partner/example.com"
   }
 
   tags = var.resource_tags

--- a/internal/service/appintegrations/testdata/EventIntegration/tags_ignore/main_gen.tf
+++ b/internal/service/appintegrations/testdata/EventIntegration/tags_ignore/main_gen.tf
@@ -15,7 +15,7 @@ resource "aws_appintegrations_event_integration" "test" {
   eventbridge_bus = "default"
 
   event_filter {
-    source = "aws.partner/examplepartner.com"
+    source = "aws.partner/example.com"
   }
 
   tags = var.resource_tags

--- a/internal/service/appintegrations/testdata/tmpl/event_integration_basic.gtpl
+++ b/internal/service/appintegrations/testdata/tmpl/event_integration_basic.gtpl
@@ -3,7 +3,7 @@ resource "aws_appintegrations_event_integration" "test" {
   eventbridge_bus = "default"
 
   event_filter {
-    source = "aws.partner/examplepartner.com"
+    source = "aws.partner/example.com"
   }
 
 {{- template "tags" . }}

--- a/internal/service/cognitoidentity/validate_test.go
+++ b/internal/service/cognitoidentity/validate_test.go
@@ -290,7 +290,7 @@ func TestValidSupportedLoginProviders(t *testing.T) {
 	validValues := []string{
 		"foo",
 		"7346241598935552",
-		"123456789012.apps.googleusercontent.com", // nosemgrep:ci.domain-names
+		"123456789012.apps.googleusercontent.com", // nosemgrep:ci.semgrep.domain-names.domain-names
 		"foo_bar",
 		"foo;bar",
 		"foo/bar",

--- a/internal/service/cognitoidp/identity_provider_test.go
+++ b/internal/service/cognitoidp/identity_provider_test.go
@@ -403,7 +403,7 @@ resource "aws_cognito_identity_provider" "test" {
 
   provider_details = {
     EncryptedResponses    = %[4]q
-    MetadataFile          = templatefile("./test-fixtures/saml-metadata.xml.tpl", {entity_id = %[3]q})
+    MetadataFile          = templatefile("./test-fixtures/saml-metadata.xml.tpl", { entity_id = %[3]q })
     SSORedirectBindingURI = "%[3]s/idp/endpoint/HttpRedirect"
   }
 

--- a/internal/service/cognitoidp/identity_provider_test.go
+++ b/internal/service/cognitoidp/identity_provider_test.go
@@ -125,6 +125,8 @@ func TestAccCognitoIDPIdentityProvider_saml(t *testing.T) {
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	rNameUTF8 := strings.Repeat("あ", 32)
 
+	idpEntityId := fmt.Sprintf("https://%s", acctest.RandomDomainName(t))
+
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckIdentityProvider(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CognitoIDPServiceID),
@@ -132,7 +134,7 @@ func TestAccCognitoIDPIdentityProvider_saml(t *testing.T) {
 		CheckDestroy:             testAccCheckIdentityProviderDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIdentityProviderConfig_saml(rName, rName, acctest.CtFalse),
+				Config: testAccIdentityProviderConfig_saml(rName, rName, idpEntityId, acctest.CtFalse),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckIdentityProviderExists(ctx, t, resourceName, &identityProvider),
 					resource.TestCheckResourceAttr(resourceName, "attribute_mapping.%", "1"),
@@ -142,7 +144,7 @@ func TestAccCognitoIDPIdentityProvider_saml(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "provider_details.ActiveEncryptionCertificate"),
 					resource.TestCheckResourceAttr(resourceName, "provider_details.EncryptedResponses", acctest.CtFalse),
 					resource.TestCheckResourceAttrSet(resourceName, "provider_details.MetadataFile"),
-					resource.TestCheckResourceAttr(resourceName, "provider_details.SSORedirectBindingURI", "https://terraform-dev-ed.my.salesforce.com/idp/endpoint/HttpRedirect"),
+					resource.TestCheckResourceAttr(resourceName, "provider_details.SSORedirectBindingURI", fmt.Sprintf("%s/idp/endpoint/HttpRedirect", idpEntityId)),
 					resource.TestCheckResourceAttr(resourceName, names.AttrProviderName, rName),
 					resource.TestCheckResourceAttr(resourceName, "provider_type", "SAML"),
 				),
@@ -153,7 +155,7 @@ func TestAccCognitoIDPIdentityProvider_saml(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccIdentityProviderConfig_saml(rName, rName, acctest.CtTrue),
+				Config: testAccIdentityProviderConfig_saml(rName, rName, idpEntityId, acctest.CtTrue),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckIdentityProviderExists(ctx, t, resourceName, &identityProvider),
 					resource.TestCheckResourceAttr(resourceName, "attribute_mapping.%", "1"),
@@ -163,13 +165,13 @@ func TestAccCognitoIDPIdentityProvider_saml(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "provider_details.ActiveEncryptionCertificate"),
 					resource.TestCheckResourceAttr(resourceName, "provider_details.EncryptedResponses", acctest.CtTrue),
 					resource.TestCheckResourceAttrSet(resourceName, "provider_details.MetadataFile"),
-					resource.TestCheckResourceAttr(resourceName, "provider_details.SSORedirectBindingURI", "https://terraform-dev-ed.my.salesforce.com/idp/endpoint/HttpRedirect"),
+					resource.TestCheckResourceAttr(resourceName, "provider_details.SSORedirectBindingURI", fmt.Sprintf("%s/idp/endpoint/HttpRedirect", idpEntityId)),
 					resource.TestCheckResourceAttr(resourceName, names.AttrProviderName, rName),
 					resource.TestCheckResourceAttr(resourceName, "provider_type", "SAML"),
 				),
 			},
 			{
-				Config: testAccIdentityProviderConfig_saml(rNameUTF8, rName, acctest.CtTrue),
+				Config: testAccIdentityProviderConfig_saml(rNameUTF8, rName, idpEntityId, acctest.CtTrue),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckIdentityProviderExists(ctx, t, resourceName, &identityProvider),
 					resource.TestCheckResourceAttr(resourceName, "attribute_mapping.%", "1"),
@@ -179,7 +181,7 @@ func TestAccCognitoIDPIdentityProvider_saml(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "provider_details.ActiveEncryptionCertificate"),
 					resource.TestCheckResourceAttr(resourceName, "provider_details.EncryptedResponses", acctest.CtTrue),
 					resource.TestCheckResourceAttrSet(resourceName, "provider_details.MetadataFile"),
-					resource.TestCheckResourceAttr(resourceName, "provider_details.SSORedirectBindingURI", "https://terraform-dev-ed.my.salesforce.com/idp/endpoint/HttpRedirect"),
+					resource.TestCheckResourceAttr(resourceName, "provider_details.SSORedirectBindingURI", fmt.Sprintf("%s/idp/endpoint/HttpRedirect", idpEntityId)),
 					resource.TestCheckResourceAttr(resourceName, names.AttrProviderName, rNameUTF8),
 					resource.TestCheckResourceAttr(resourceName, "provider_type", "SAML"),
 				),
@@ -387,7 +389,7 @@ resource "aws_cognito_identity_provider" "test" {
 `, rName, attribute)
 }
 
-func testAccIdentityProviderConfig_saml(rName, userPoolName, encryptedResponses string) string {
+func testAccIdentityProviderConfig_saml(rName, userPoolName, idpEntityId, encryptedResponses string) string {
 	return fmt.Sprintf(`
 resource "aws_cognito_user_pool" "test" {
   name                     = %[2]q
@@ -400,9 +402,9 @@ resource "aws_cognito_identity_provider" "test" {
   provider_type = "SAML"
 
   provider_details = {
-    EncryptedResponses    = %[3]q
-    MetadataFile          = file("./test-fixtures/saml-metadata.xml")
-    SSORedirectBindingURI = "https://terraform-dev-ed.my.salesforce.com/idp/endpoint/HttpRedirect"
+    EncryptedResponses    = %[4]q
+    MetadataFile          = templatefile("./test-fixtures/saml-metadata.xml.tpl", {entity_id = %[3]q})
+    SSORedirectBindingURI = "%[3]s/idp/endpoint/HttpRedirect"
   }
 
   attribute_mapping = {
@@ -413,5 +415,5 @@ resource "aws_cognito_identity_provider" "test" {
     ignore_changes = [provider_details["ActiveEncryptionCertificate"]]
   }
 }
-`, rName, userPoolName, encryptedResponses)
+`, rName, userPoolName, idpEntityId, encryptedResponses)
 }

--- a/internal/service/cognitoidp/log_delivery_configuration_test.go
+++ b/internal/service/cognitoidp/log_delivery_configuration_test.go
@@ -222,7 +222,7 @@ func testAccCheckLogDeliveryConfigurationDestroy(ctx context.Context, t *testing
 				return err
 			}
 
-			return create.Error(names.CognitoIDP, create.ErrActionCheckingDestroyed, "Log Delivery Configuration", rs.Primary.ID, errors.New("not destroyed"))
+			return create.Error(names.CognitoIDP, create.ErrActionCheckingDestroyed, "Log Delivery Configuration", rs.Primary.Attributes[names.AttrUserPoolID], errors.New("not destroyed"))
 		}
 
 		return nil
@@ -236,7 +236,7 @@ func testAccCheckLogDeliveryConfigurationExists(ctx context.Context, t *testing.
 			return create.Error(names.CognitoIDP, create.ErrActionCheckingExistence, "Log Delivery Configuration", name, errors.New("not found"))
 		}
 
-		if rs.Primary.ID == "" {
+		if rs.Primary.Attributes[names.AttrUserPoolID] == "" {
 			return create.Error(names.CognitoIDP, create.ErrActionCheckingExistence, "Log Delivery Configuration", name, errors.New("not set"))
 		}
 
@@ -245,7 +245,7 @@ func testAccCheckLogDeliveryConfigurationExists(ctx context.Context, t *testing.
 		resp, err := tfcognitoidp.FindLogDeliveryConfigurationByUserPoolID(ctx, conn, rs.Primary.Attributes[names.AttrUserPoolID])
 
 		if err != nil {
-			return create.Error(names.CognitoIDP, create.ErrActionCheckingExistence, "Log Delivery Configuration", rs.Primary.ID, err)
+			return create.Error(names.CognitoIDP, create.ErrActionCheckingExistence, "Log Delivery Configuration", rs.Primary.Attributes[names.AttrUserPoolID], err)
 		}
 
 		*logDeliveryConfiguration = *resp

--- a/internal/service/cognitoidp/test-fixtures/saml-metadata.xml.tpl
+++ b/internal/service/cognitoidp/test-fixtures/saml-metadata.xml.tpl
@@ -2,7 +2,7 @@
 <!-- Copyright IBM Corp. 2014, 2026 -->
 <!-- SPDX-License-Identifier: MPL-2.0 -->
 
-<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" entityID="https://terraform-dev-ed.my.salesforce.com" validUntil="2070-08-31T14:30:09Z">
+<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" entityID="${entity_id}" validUntil="2070-08-31T14:30:09Z">
   <md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
     <md:KeyDescriptor use="signing">
       <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
@@ -12,7 +12,7 @@
       </ds:KeyInfo>
     </md:KeyDescriptor>
     <md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified</md:NameIDFormat>
-    <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://terraform-dev-ed.my.salesforce.com/idp/endpoint/HttpPost"/>
-    <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://terraform-dev-ed.my.salesforce.com/idp/endpoint/HttpRedirect"/>
+    <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="${entity_id}/idp/endpoint/HttpPost"/>
+    <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="${entity_id}/idp/endpoint/HttpRedirect"/>
   </md:IDPSSODescriptor>
 </md:EntityDescriptor>

--- a/internal/service/cognitoidp/user_pool_client_test.go
+++ b/internal/service/cognitoidp/user_pool_client_test.go
@@ -1253,6 +1253,8 @@ func TestAccCognitoIDPUserPoolClient_supportedIdentityProviders_utf8(t *testing.
 	resourceName := "aws_cognito_user_pool_client.test"
 	identityProvider := strings.Repeat("あ", 32)
 
+	idpEntityId := fmt.Sprintf("https://%s", acctest.RandomDomainName(t))
+
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckIdentityProvider(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CognitoIDPServiceID),
@@ -1260,7 +1262,7 @@ func TestAccCognitoIDPUserPoolClient_supportedIdentityProviders_utf8(t *testing.
 		CheckDestroy:             testAccCheckUserPoolClientDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccUserPoolClientConfig_supportedIdentityProviders_utf8(rName, identityProvider),
+				Config: testAccUserPoolClientConfig_supportedIdentityProviders_utf8(rName, identityProvider, idpEntityId),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckUserPoolClientExists(ctx, t, resourceName, &client),
 					resource.TestCheckResourceAttr(resourceName, "supported_identity_providers.0", identityProvider),
@@ -1952,9 +1954,9 @@ resource "aws_cognito_user_pool_client" "test" {
 `, rName))
 }
 
-func testAccUserPoolClientConfig_supportedIdentityProviders_utf8(rName, identityProvider string) string {
+func testAccUserPoolClientConfig_supportedIdentityProviders_utf8(rName, identityProvider, idpEntityId string) string {
 	return acctest.ConfigCompose(
-		testAccIdentityProviderConfig_saml(identityProvider, rName, acctest.CtTrue),
+		testAccIdentityProviderConfig_saml(identityProvider, rName, idpEntityId, acctest.CtTrue),
 		fmt.Sprintf(`
 resource "aws_cognito_user_pool_client" "test" {
   name         = %[1]q

--- a/internal/service/cognitoidp/user_pool_signing_certificate_data_source_test.go
+++ b/internal/service/cognitoidp/user_pool_signing_certificate_data_source_test.go
@@ -47,7 +47,7 @@ resource "aws_cognito_identity_provider" "test" {
   provider_type = "SAML"
 
   provider_details = {
-    MetadataFile          = templatefile("./test-fixtures/saml-metadata.xml.tpl", {entity_id = %[2]q})
+    MetadataFile          = templatefile("./test-fixtures/saml-metadata.xml.tpl", { entity_id = %[2]q })
     SSORedirectBindingURI = "%[2]s/idp/endpoint/HttpRedirect"
   }
 

--- a/internal/service/cognitoidp/user_pool_signing_certificate_data_source_test.go
+++ b/internal/service/cognitoidp/user_pool_signing_certificate_data_source_test.go
@@ -17,13 +17,15 @@ func TestAccCognitoIDPUserPoolSigningCertificateDataSource_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	datasourceName := "data.aws_cognito_user_pool_signing_certificate.test"
 
+	idpEntityId := fmt.Sprintf("https://%s", acctest.RandomDomainName(t))
+
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckIdentityProvider(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CognitoIDPServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccUserPoolSigningCertificateDataSourceConfig_basic(rName),
+				Config: testAccUserPoolSigningCertificateDataSourceConfig_basic(rName, idpEntityId),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(datasourceName, names.AttrCertificate),
 				),
@@ -32,7 +34,7 @@ func TestAccCognitoIDPUserPoolSigningCertificateDataSource_basic(t *testing.T) {
 	})
 }
 
-func testAccUserPoolSigningCertificateDataSourceConfig_basic(rName string) string {
+func testAccUserPoolSigningCertificateDataSourceConfig_basic(rName, idpEntityId string) string {
 	return fmt.Sprintf(`
 resource "aws_cognito_user_pool" "test" {
   name                     = %[1]q
@@ -45,8 +47,8 @@ resource "aws_cognito_identity_provider" "test" {
   provider_type = "SAML"
 
   provider_details = {
-    MetadataFile          = file("./test-fixtures/saml-metadata.xml")
-    SSORedirectBindingURI = "https://terraform-dev-ed.my.salesforce.com/idp/endpoint/HttpRedirect"
+    MetadataFile          = templatefile("./test-fixtures/saml-metadata.xml.tpl", {entity_id = %[2]q})
+    SSORedirectBindingURI = "%[2]s/idp/endpoint/HttpRedirect"
   }
 
   attribute_mapping = {
@@ -63,5 +65,5 @@ resource "aws_cognito_identity_provider" "test" {
 data "aws_cognito_user_pool_signing_certificate" "test" {
   user_pool_id = aws_cognito_user_pool.test.id
 }
-`, rName)
+`, rName, idpEntityId)
 }

--- a/internal/service/cognitoidp/user_pool_ui_customization_test.go
+++ b/internal/service/cognitoidp/user_pool_ui_customization_test.go
@@ -441,7 +441,7 @@ func TestAccCognitoIDPUserPoolUICustomization_ClientAndAll_cSS(t *testing.T) {
 	})
 }
 
-func TestAccCognitoIDPUserPoolUICustomization_UpdateClientToAll_cSS(t *testing.T) {
+func TestAccCognitoIDPUserPoolUICustomization_UpdateClientToAll_css(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_cognito_user_pool_ui_customization.test"

--- a/internal/service/eks/token_test.go
+++ b/internal/service/eks/token_test.go
@@ -161,7 +161,7 @@ func TestVerifyTokenPreSTSValidations(t *testing.T) {
 	validationErrorTest(t, "k8s-aws-v1.decodingerror", "illegal base64 data")
 	validationErrorTest(t, toToken(":ab:cd.af:/asda"), "missing protocol scheme")
 	validationErrorTest(t, toToken("http://"), "unexpected scheme")
-	validationErrorTest(t, toToken("https://google.com"), fmt.Sprintf("unexpected hostname %q in pre-signed URL", "google.com")) // nosemgrep:ci.domain-names
+	validationErrorTest(t, toToken("https://google.com"), fmt.Sprintf("unexpected hostname %q in pre-signed URL", "google.com")) // nosemgrep:ci.semgrep.domain-names.domain-names
 	validationErrorTest(t, toToken("https://sts.cn-north-1.amazonaws.com.cn/abc"), "unexpected path in pre-signed URL")          //lintignore:AWSAT003
 	validationErrorTest(t, toToken("https://sts.amazonaws.com/abc"), "unexpected path in pre-signed URL")
 	validationErrorTest(t, toToken("https://sts.amazonaws.com/?NoInWhiteList=abc"), "non-whitelisted query parameter")

--- a/internal/service/elbv2/listener_rule_data_source_test.go
+++ b/internal/service/elbv2/listener_rule_data_source_test.go
@@ -1048,8 +1048,8 @@ func TestAccELBV2ListenerRuleDataSource_transform(t *testing.T) {
 								knownvalue.ObjectExact(map[string]knownvalue.Check{
 									"rewrite": knownvalue.ListExact([]knownvalue.Check{
 										knownvalue.ObjectExact(map[string]knownvalue.Check{
-											"regex":   knownvalue.StringExact("^mywebsite-(.+).com$"),
-											"replace": knownvalue.StringExact("internal.dev.$1.myweb.com"),
+											"regex":   knownvalue.StringExact(`^mywebsite-(.+)\.test$`),
+											"replace": knownvalue.StringExact("internal.dev.$1.myweb.test"),
 										}),
 									}),
 								}),
@@ -1738,8 +1738,8 @@ resource "aws_lb_listener_rule" "test" {
     type = "host-header-rewrite"
     host_header_rewrite_config {
       rewrite {
-        regex   = "^mywebsite-(.+).com$"
-        replace = "internal.dev.$1.myweb.com"
+        regex   = "^mywebsite-(.+)\.test$"
+        replace = "internal.dev.$1.myweb.test"
       }
     }
   }

--- a/internal/service/elbv2/listener_rule_data_source_test.go
+++ b/internal/service/elbv2/listener_rule_data_source_test.go
@@ -1048,7 +1048,7 @@ func TestAccELBV2ListenerRuleDataSource_transform(t *testing.T) {
 								knownvalue.ObjectExact(map[string]knownvalue.Check{
 									"rewrite": knownvalue.ListExact([]knownvalue.Check{
 										knownvalue.ObjectExact(map[string]knownvalue.Check{
-											"regex":   knownvalue.StringExact(`^mywebsite-(.+)\.test$`),
+											"regex":   knownvalue.StringExact("^mywebsite-(.+)\\.test$"),
 											"replace": knownvalue.StringExact("internal.dev.$1.myweb.test"),
 										}),
 									}),
@@ -1738,7 +1738,7 @@ resource "aws_lb_listener_rule" "test" {
     type = "host-header-rewrite"
     host_header_rewrite_config {
       rewrite {
-        regex   = "^mywebsite-(.+)\.test$"
+        regex   = "^mywebsite-(.+)\\.test$"
         replace = "internal.dev.$1.myweb.test"
       }
     }

--- a/internal/service/elbv2/listener_rule_test.go
+++ b/internal/service/elbv2/listener_rule_test.go
@@ -2306,8 +2306,8 @@ func TestAccELBV2ListenerRule_transform(t *testing.T) {
 						names.AttrType:                                   string(awstypes.TransformTypeEnumHostHeaderRewrite),
 						"host_header_rewrite_config.#":                   "1",
 						"host_header_rewrite_config.0.rewrite.#":         "1",
-						"host_header_rewrite_config.0.rewrite.0.regex":   "^mywebsite-(.+).com$",
-						"host_header_rewrite_config.0.rewrite.0.replace": "internal.dev.$1.myweb.com",
+						"host_header_rewrite_config.0.rewrite.0.regex":   "^mywebsite-(.+).test$",
+						"host_header_rewrite_config.0.rewrite.0.replace": "internal.dev.$1.myweb.test",
 					}),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "transform.*", map[string]string{
 						names.AttrType:                           string(awstypes.TransformTypeEnumUrlRewrite),
@@ -2327,8 +2327,8 @@ func TestAccELBV2ListenerRule_transform(t *testing.T) {
 						names.AttrType:                                   string(awstypes.TransformTypeEnumHostHeaderRewrite),
 						"host_header_rewrite_config.#":                   "1",
 						"host_header_rewrite_config.0.rewrite.#":         "1",
-						"host_header_rewrite_config.0.rewrite.0.regex":   "^mywebsite2-(.+).com$",
-						"host_header_rewrite_config.0.rewrite.0.replace": "internal.dev.$1.myweb.com",
+						"host_header_rewrite_config.0.rewrite.0.regex":   "^mywebsite2-(.+).test$",
+						"host_header_rewrite_config.0.rewrite.0.replace": "internal.dev.$1.myweb.test",
 					}),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "transform.*", map[string]string{
 						names.AttrType:                           string(awstypes.TransformTypeEnumUrlRewrite),
@@ -5127,8 +5127,8 @@ resource "aws_lb_listener_rule" "test" {
     type = "host-header-rewrite"
     host_header_rewrite_config {
       rewrite {
-        regex   = "^mywebsite-(.+).com$"
-        replace = "internal.dev.$1.myweb.com"
+        regex   = "^mywebsite-(.+).test$"
+        replace = "internal.dev.$1.myweb.test"
       }
     }
   }
@@ -5177,8 +5177,8 @@ resource "aws_lb_listener_rule" "test" {
     type = "host-header-rewrite"
     host_header_rewrite_config {
       rewrite {
-        regex   = "^mywebsite2-(.+).com$"
-        replace = "internal.dev.$1.myweb.com"
+        regex   = "^mywebsite2-(.+).test$"
+        replace = "internal.dev.$1.myweb.test"
       }
     }
   }

--- a/internal/service/events/validate_test.go
+++ b/internal/service/events/validate_test.go
@@ -112,7 +112,7 @@ func TestValidBusNameOrARN(t *testing.T) {
 		"HelloWorl_d",
 		"hello-world",
 		"hello.World0125",
-		"aws.partner/mongodb.com/stitch.trigger/something",                   // nosemgrep:ci.domain-names
+		"aws.partner/mongodb.com/stitch.trigger/something",                   // nosemgrep:ci.semgrep.domain-names.domain-names
 		"arn:aws:events:us-east-1:123456789012:event-bus/default",            // lintignore:AWSAT003,AWSAT005
 		"arn:aws-eusc:events:eusc-de-east-1:123456789012:event-bus/test-bus", // lintignore:AWSAT003,AWSAT005
 	}

--- a/website/docs/d/cloudwatch_event_source.html.markdown
+++ b/website/docs/d/cloudwatch_event_source.html.markdown
@@ -16,7 +16,7 @@ Use this data source to get information about an EventBridge Partner Event Sourc
 
 ```terraform
 data "aws_cloudwatch_event_source" "examplepartner" {
-  name_prefix = "aws.partner/examplepartner.com"
+  name_prefix = "aws.partner/example.com"
 }
 ```
 

--- a/website/docs/r/account_primary_contact.html.markdown
+++ b/website/docs/r/account_primary_contact.html.markdown
@@ -23,7 +23,7 @@ resource "aws_account_primary_contact" "test" {
   phone_number       = "+64211111111"
   postal_code        = "98101"
   state_or_region    = "WA"
-  website_url        = "https://www.examplecorp.com"
+  website_url        = "https://www.example.com"
 }
 ```
 

--- a/website/docs/r/appintegrations_event_integration.html.markdown
+++ b/website/docs/r/appintegrations_event_integration.html.markdown
@@ -19,7 +19,7 @@ resource "aws_appintegrations_event_integration" "example" {
   eventbridge_bus = "default"
 
   event_filter {
-    source = "aws.partner/examplepartner.com"
+    source = "aws.partner/example.com"
   }
 
   tags = {

--- a/website/docs/r/cloudwatch_event_bus.html.markdown
+++ b/website/docs/r/cloudwatch_event_bus.html.markdown
@@ -24,7 +24,7 @@ resource "aws_cloudwatch_event_bus" "messenger" {
 
 ```terraform
 data "aws_cloudwatch_event_source" "examplepartner" {
-  name_prefix = "aws.partner/examplepartner.com"
+  name_prefix = "aws.partner/example.com"
 }
 
 resource "aws_cloudwatch_event_bus" "examplepartner" {

--- a/website/docs/r/lb_listener_rule.html.markdown
+++ b/website/docs/r/lb_listener_rule.html.markdown
@@ -253,8 +253,8 @@ resource "aws_lb_listener_rule" "transform" {
     type = "host-header-rewrite"
     host_header_rewrite_config {
       rewrite {
-        regex   = "^mywebsite-(.+).com$"
-        replace = "internal.dev.$1.myweb.com"
+        regex   = "^mywebsite-(.+).test$"
+        replace = "internal.dev.$1.myweb.test"
       }
     }
   }


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Restores Semgrep rule to require random, RFC 6761 (https://datatracker.ietf.org/doc/html/rfc6761) domain names for tests

Adds check for Terraform configuration files
