### PR TITLE
efs: Replace `arn.ARN` structure initialization

### DIFF
--- a/internal/service/efs/access_point.go
+++ b/internal/service/efs/access_point.go
@@ -140,20 +140,20 @@ func resourceAccessPointCreate(ctx context.Context, d *schema.ResourceData, meta
 	conn := meta.(*conns.AWSClient).EFSClient(ctx)
 
 	fsID := d.Get(names.AttrFileSystemID).(string)
-	input := &efs.CreateAccessPointInput{
+	input := efs.CreateAccessPointInput{
 		FileSystemId: aws.String(fsID),
 		Tags:         getTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("posix_user"); ok {
-		input.PosixUser = expandAccessPointPOSIXUser(v.([]any))
+		input.PosixUser = expandPOSIXUser(v.([]any))
 	}
 
 	if v, ok := d.GetOk("root_directory"); ok {
-		input.RootDirectory = expandAccessPointRootDirectory(v.([]any))
+		input.RootDirectory = expandRootDirectory(v.([]any))
 	}
 
-	output, err := conn.CreateAccessPoint(ctx, input)
+	output, err := conn.CreateAccessPoint(ctx, &input)
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating EFS Access Point for File System (%s): %s", fsID, err)
@@ -190,10 +190,10 @@ func resourceAccessPointRead(ctx context.Context, d *schema.ResourceData, meta a
 	d.Set("file_system_arn", fileSystemARN(ctx, c, fsID))
 	d.Set(names.AttrFileSystemID, fsID)
 	d.Set(names.AttrOwnerID, ap.OwnerId)
-	if err := d.Set("posix_user", flattenAccessPointPOSIXUser(ap.PosixUser)); err != nil {
+	if err := d.Set("posix_user", flattenPOSIXUser(ap.PosixUser)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting posix_user: %s", err)
 	}
-	if err := d.Set("root_directory", flattenAccessPointRootDirectory(ap.RootDirectory)); err != nil {
+	if err := d.Set("root_directory", flattenRootDirectory(ap.RootDirectory)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting root_directory: %s", err)
 	}
 
@@ -215,9 +215,10 @@ func resourceAccessPointDelete(ctx context.Context, d *schema.ResourceData, meta
 	conn := meta.(*conns.AWSClient).EFSClient(ctx)
 
 	log.Printf("[DEBUG] Deleting EFS Access Point: %s", d.Id())
-	_, err := conn.DeleteAccessPoint(ctx, &efs.DeleteAccessPointInput{
+	input := efs.DeleteAccessPointInput{
 		AccessPointId: aws.String(d.Id()),
-	})
+	}
+	_, err := conn.DeleteAccessPoint(ctx, &input)
 
 	if errs.IsA[*awstypes.AccessPointNotFound](err) {
 		return diags
@@ -234,7 +235,7 @@ func resourceAccessPointDelete(ctx context.Context, d *schema.ResourceData, meta
 	return diags
 }
 
-func findAccessPoint(ctx context.Context, conn *efs.Client, input *efs.DescribeAccessPointsInput, filter tfslices.Predicate[*awstypes.AccessPointDescription]) (*awstypes.AccessPointDescription, error) {
+func findAccessPoint(ctx context.Context, conn *efs.Client, input *efs.DescribeAccessPointsInput, filter tfslices.Predicate[awstypes.AccessPointDescription]) (*awstypes.AccessPointDescription, error) {
 	output, err := findAccessPoints(ctx, conn, input, filter)
 
 	if err != nil {
@@ -244,7 +245,7 @@ func findAccessPoint(ctx context.Context, conn *efs.Client, input *efs.DescribeA
 	return tfresource.AssertSingleValueResult(output)
 }
 
-func findAccessPoints(ctx context.Context, conn *efs.Client, input *efs.DescribeAccessPointsInput, filter tfslices.Predicate[*awstypes.AccessPointDescription]) ([]awstypes.AccessPointDescription, error) {
+func findAccessPoints(ctx context.Context, conn *efs.Client, input *efs.DescribeAccessPointsInput, filter tfslices.Predicate[awstypes.AccessPointDescription]) ([]awstypes.AccessPointDescription, error) {
 	var output []awstypes.AccessPointDescription
 
 	pages := efs.NewDescribeAccessPointsPaginator(conn, input)
@@ -262,7 +263,7 @@ func findAccessPoints(ctx context.Context, conn *efs.Client, input *efs.Describe
 		}
 
 		for _, v := range page.AccessPoints {
-			if filter(&v) {
+			if filter(v) {
 				output = append(output, v)
 			}
 		}
@@ -272,11 +273,11 @@ func findAccessPoints(ctx context.Context, conn *efs.Client, input *efs.Describe
 }
 
 func findAccessPointByID(ctx context.Context, conn *efs.Client, id string) (*awstypes.AccessPointDescription, error) {
-	input := &efs.DescribeAccessPointsInput{
+	input := efs.DescribeAccessPointsInput{
 		AccessPointId: aws.String(id),
 	}
 
-	output, err := findAccessPoint(ctx, conn, input, tfslices.PredicateTrue[*awstypes.AccessPointDescription]())
+	output, err := findAccessPoint(ctx, conn, &input, tfslices.PredicateTrue[awstypes.AccessPointDescription]())
 
 	if err != nil {
 		return nil, err
@@ -348,7 +349,7 @@ func waitAccessPointDeleted(ctx context.Context, conn *efs.Client, id string) (*
 	return nil, err
 }
 
-func expandAccessPointPOSIXUser(tfList []any) *awstypes.PosixUser {
+func expandPOSIXUser(tfList []any) *awstypes.PosixUser {
 	if len(tfList) < 1 || tfList[0] == nil {
 		return nil
 	}
@@ -366,7 +367,7 @@ func expandAccessPointPOSIXUser(tfList []any) *awstypes.PosixUser {
 	return apiObject
 }
 
-func expandAccessPointRootDirectory(tfList []any) *awstypes.RootDirectory {
+func expandRootDirectory(tfList []any) *awstypes.RootDirectory {
 	if len(tfList) < 1 || tfList[0] == nil {
 		return nil
 	}
@@ -379,13 +380,13 @@ func expandAccessPointRootDirectory(tfList []any) *awstypes.RootDirectory {
 	}
 
 	if v, ok := tfMap["creation_info"]; ok {
-		apiObject.CreationInfo = expandAccessPointRootDirectoryCreationInfo(v.([]any))
+		apiObject.CreationInfo = expandCreationInfo(v.([]any))
 	}
 
 	return apiObject
 }
 
-func expandAccessPointRootDirectoryCreationInfo(tfList []any) *awstypes.CreationInfo {
+func expandCreationInfo(tfList []any) *awstypes.CreationInfo {
 	if len(tfList) < 1 || tfList[0] == nil {
 		return nil
 	}
@@ -400,7 +401,7 @@ func expandAccessPointRootDirectoryCreationInfo(tfList []any) *awstypes.Creation
 	return apiObject
 }
 
-func flattenAccessPointPOSIXUser(apiObject *awstypes.PosixUser) []any {
+func flattenPOSIXUser(apiObject *awstypes.PosixUser) []any {
 	if apiObject == nil {
 		return []any{}
 	}
@@ -414,20 +415,20 @@ func flattenAccessPointPOSIXUser(apiObject *awstypes.PosixUser) []any {
 	return []any{tfMap}
 }
 
-func flattenAccessPointRootDirectory(apiObject *awstypes.RootDirectory) []any {
+func flattenRootDirectory(apiObject *awstypes.RootDirectory) []any {
 	if apiObject == nil {
 		return []any{}
 	}
 
 	tfMap := map[string]any{
-		"creation_info": flattenAccessPointRootDirectoryCreationInfo(apiObject.CreationInfo),
+		"creation_info": flattenCreationInfo(apiObject.CreationInfo),
 		names.AttrPath:  aws.ToString(apiObject.Path),
 	}
 
 	return []any{tfMap}
 }
 
-func flattenAccessPointRootDirectoryCreationInfo(apiObject *awstypes.CreationInfo) []any {
+func flattenCreationInfo(apiObject *awstypes.CreationInfo) []any {
 	if apiObject == nil {
 		return []any{}
 	}

--- a/internal/service/efs/access_point.go
+++ b/internal/service/efs/access_point.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/efs"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/efs/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -171,7 +170,8 @@ func resourceAccessPointCreate(ctx context.Context, d *schema.ResourceData, meta
 
 func resourceAccessPointRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).EFSClient(ctx)
+	c := meta.(*conns.AWSClient)
+	conn := c.EFSClient(ctx)
 
 	ap, err := findAccessPointByID(ctx, conn, d.Id())
 
@@ -187,14 +187,7 @@ func resourceAccessPointRead(ctx context.Context, d *schema.ResourceData, meta a
 
 	d.Set(names.AttrARN, ap.AccessPointArn)
 	fsID := aws.ToString(ap.FileSystemId)
-	fsARN := arn.ARN{
-		AccountID: meta.(*conns.AWSClient).AccountID(ctx),
-		Partition: meta.(*conns.AWSClient).Partition(ctx),
-		Region:    meta.(*conns.AWSClient).Region(ctx),
-		Resource:  "file-system/" + fsID,
-		Service:   "elasticfilesystem",
-	}.String()
-	d.Set("file_system_arn", fsARN)
+	d.Set("file_system_arn", fileSystemARN(ctx, c, fsID))
 	d.Set(names.AttrFileSystemID, fsID)
 	d.Set(names.AttrOwnerID, ap.OwnerId)
 	if err := d.Set("posix_user", flattenAccessPointPOSIXUser(ap.PosixUser)); err != nil {

--- a/internal/service/efs/access_point_data_source.go
+++ b/internal/service/efs/access_point_data_source.go
@@ -123,10 +123,10 @@ func dataSourceAccessPointRead(ctx context.Context, d *schema.ResourceData, meta
 	d.Set("file_system_arn", fileSystemARN(ctx, c, fsID))
 	d.Set(names.AttrFileSystemID, fsID)
 	d.Set(names.AttrOwnerID, ap.OwnerId)
-	if err := d.Set("posix_user", flattenAccessPointPOSIXUser(ap.PosixUser)); err != nil {
+	if err := d.Set("posix_user", flattenPOSIXUser(ap.PosixUser)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting posix_user: %s", err)
 	}
-	if err := d.Set("root_directory", flattenAccessPointRootDirectory(ap.RootDirectory)); err != nil {
+	if err := d.Set("root_directory", flattenRootDirectory(ap.RootDirectory)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting root_directory: %s", err)
 	}
 

--- a/internal/service/efs/access_point_data_source.go
+++ b/internal/service/efs/access_point_data_source.go
@@ -9,7 +9,6 @@ import (
 	"context"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -108,7 +107,8 @@ func dataSourceAccessPoint() *schema.Resource {
 
 func dataSourceAccessPointRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).EFSClient(ctx)
+	c := meta.(*conns.AWSClient)
+	conn := c.EFSClient(ctx)
 
 	accessPointID := d.Get("access_point_id").(string)
 	ap, err := findAccessPointByID(ctx, conn, accessPointID)
@@ -120,14 +120,7 @@ func dataSourceAccessPointRead(ctx context.Context, d *schema.ResourceData, meta
 	d.SetId(aws.ToString(ap.AccessPointId))
 	d.Set(names.AttrARN, ap.AccessPointArn)
 	fsID := aws.ToString(ap.FileSystemId)
-	fsARN := arn.ARN{
-		AccountID: meta.(*conns.AWSClient).AccountID(ctx),
-		Partition: meta.(*conns.AWSClient).Partition(ctx),
-		Region:    meta.(*conns.AWSClient).Region(ctx),
-		Resource:  "file-system/" + fsID,
-		Service:   "elasticfilesystem",
-	}.String()
-	d.Set("file_system_arn", fsARN)
+	d.Set("file_system_arn", fileSystemARN(ctx, c, fsID))
 	d.Set(names.AttrFileSystemID, fsID)
 	d.Set(names.AttrOwnerID, ap.OwnerId)
 	if err := d.Set("posix_user", flattenAccessPointPOSIXUser(ap.PosixUser)); err != nil {

--- a/internal/service/efs/access_points_data_source.go
+++ b/internal/service/efs/access_points_data_source.go
@@ -51,11 +51,11 @@ func dataSourceAccessPointsRead(ctx context.Context, d *schema.ResourceData, met
 	conn := meta.(*conns.AWSClient).EFSClient(ctx)
 
 	fileSystemID := d.Get(names.AttrFileSystemID).(string)
-	input := &efs.DescribeAccessPointsInput{
+	input := efs.DescribeAccessPointsInput{
 		FileSystemId: aws.String(fileSystemID),
 	}
 
-	output, err := findAccessPointDescriptions(ctx, conn, input)
+	output, err := findAccessPointDescriptions(ctx, conn, &input)
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "reading EFS Access Points: %s", err)
@@ -79,7 +79,6 @@ func findAccessPointDescriptions(ctx context.Context, conn *efs.Client, input *e
 	var output []awstypes.AccessPointDescription
 
 	pages := efs.NewDescribeAccessPointsPaginator(conn, input)
-
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
 

--- a/internal/service/efs/file_system.go
+++ b/internal/service/efs/file_system.go
@@ -611,3 +611,7 @@ func flattenFileSystemProtectionDescription(apiObject *awstypes.FileSystemProtec
 
 	return []any{tfMap}
 }
+
+func fileSystemARN(ctx context.Context, c *conns.AWSClient, fsID string) string {
+	return c.RegionalARN(ctx, "elasticfilesystem", "file-system/"+fsID)
+}

--- a/internal/service/efs/mount_target.go
+++ b/internal/service/efs/mount_target.go
@@ -121,14 +121,15 @@ func resourceMountTarget() *schema.Resource {
 
 func resourceMountTargetCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).EFSClient(ctx)
+	c := meta.(*conns.AWSClient)
+	conn := c.EFSClient(ctx)
 
 	// CreateMountTarget would return the same Mount Target ID
 	// to parallel requests if they both include the same AZ
 	// and we would end up managing the same MT as 2 resources.
 	// So we make it fail by calling 1 request per AZ at a time.
 	subnetID := d.Get(names.AttrSubnetID).(string)
-	az, err := getAZFromSubnetID(ctx, meta.(*conns.AWSClient).EC2Client(ctx), subnetID)
+	az, err := getAZFromSubnetID(ctx, c.EC2Client(ctx), subnetID)
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "reading EC2 Subnet (%s): %s", subnetID, err)
@@ -139,7 +140,7 @@ func resourceMountTargetCreate(ctx context.Context, d *schema.ResourceData, meta
 	conns.GlobalMutexKV.Lock(mtKey)
 	defer conns.GlobalMutexKV.Unlock(mtKey)
 
-	input := &efs.CreateMountTargetInput{
+	input := efs.CreateMountTargetInput{
 		FileSystemId: aws.String(fsID),
 		SubnetId:     aws.String(subnetID),
 	}
@@ -160,7 +161,7 @@ func resourceMountTargetCreate(ctx context.Context, d *schema.ResourceData, meta
 		input.SecurityGroups = flex.ExpandStringValueSet(v.(*schema.Set))
 	}
 
-	mt, err := conn.CreateMountTarget(ctx, input)
+	mt, err := conn.CreateMountTarget(ctx, &input)
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating EFS Mount Target (%s): %s", fsID, err)
@@ -195,7 +196,7 @@ func resourceMountTargetRead(ctx context.Context, d *schema.ResourceData, meta a
 	fsID := aws.ToString(mt.FileSystemId)
 	d.Set("availability_zone_id", mt.AvailabilityZoneId)
 	d.Set("availability_zone_name", mt.AvailabilityZoneName)
-	d.Set(names.AttrDNSName, meta.(*conns.AWSClient).RegionalHostname(ctx, fsID+".efs"))
+	d.Set(names.AttrDNSName, c.RegionalHostname(ctx, fsID+".efs"))
 	d.Set("file_system_arn", fileSystemARN(ctx, c, fsID))
 	d.Set(names.AttrFileSystemID, fsID)
 	d.Set(names.AttrIPAddress, mt.IpAddress)
@@ -209,14 +210,15 @@ func resourceMountTargetRead(ctx context.Context, d *schema.ResourceData, meta a
 		d.Set(names.AttrIPAddressType, nil)
 	}
 	d.Set("ipv6_address", mt.Ipv6Address)
-	d.Set("mount_target_dns_name", meta.(*conns.AWSClient).RegionalHostname(ctx, fmt.Sprintf("%s.%s.efs", aws.ToString(mt.AvailabilityZoneName), aws.ToString(mt.FileSystemId))))
+	d.Set("mount_target_dns_name", c.RegionalHostname(ctx, fmt.Sprintf("%s.%s.efs", aws.ToString(mt.AvailabilityZoneName), aws.ToString(mt.FileSystemId))))
 	d.Set(names.AttrNetworkInterfaceID, mt.NetworkInterfaceId)
 	d.Set(names.AttrOwnerID, mt.OwnerId)
 	d.Set(names.AttrSubnetID, mt.SubnetId)
 
-	output, err := conn.DescribeMountTargetSecurityGroups(ctx, &efs.DescribeMountTargetSecurityGroupsInput{
+	input := efs.DescribeMountTargetSecurityGroupsInput{
 		MountTargetId: aws.String(d.Id()),
-	})
+	}
+	output, err := conn.DescribeMountTargetSecurityGroups(ctx, &input)
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "reading EFS Mount Target (%s) security groups: %s", d.Id(), err)
@@ -232,12 +234,12 @@ func resourceMountTargetUpdate(ctx context.Context, d *schema.ResourceData, meta
 	conn := meta.(*conns.AWSClient).EFSClient(ctx)
 
 	if d.HasChange(names.AttrSecurityGroups) {
-		input := &efs.ModifyMountTargetSecurityGroupsInput{
+		input := efs.ModifyMountTargetSecurityGroupsInput{
 			MountTargetId:  aws.String(d.Id()),
 			SecurityGroups: flex.ExpandStringValueSet(d.Get(names.AttrSecurityGroups).(*schema.Set)),
 		}
 
-		_, err := conn.ModifyMountTargetSecurityGroups(ctx, input)
+		_, err := conn.ModifyMountTargetSecurityGroups(ctx, &input)
 
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating EFS Mount Target (%s) security groups: %s", d.Id(), err)
@@ -252,9 +254,10 @@ func resourceMountTargetDelete(ctx context.Context, d *schema.ResourceData, meta
 	conn := meta.(*conns.AWSClient).EFSClient(ctx)
 
 	log.Printf("[DEBUG] Deleting EFS Mount Target: %s", d.Id())
-	_, err := conn.DeleteMountTarget(ctx, &efs.DeleteMountTargetInput{
+	input := efs.DeleteMountTargetInput{
 		MountTargetId: aws.String(d.Id()),
-	})
+	}
+	_, err := conn.DeleteMountTarget(ctx, &input)
 
 	if errs.IsA[*awstypes.MountTargetNotFound](err) {
 		return diags
@@ -281,7 +284,7 @@ func getAZFromSubnetID(ctx context.Context, conn *ec2.Client, subnetID string) (
 	return aws.ToString(subnet.AvailabilityZone), nil
 }
 
-func findMountTarget(ctx context.Context, conn *efs.Client, input *efs.DescribeMountTargetsInput, filter tfslices.Predicate[*awstypes.MountTargetDescription]) (*awstypes.MountTargetDescription, error) {
+func findMountTarget(ctx context.Context, conn *efs.Client, input *efs.DescribeMountTargetsInput, filter tfslices.Predicate[awstypes.MountTargetDescription]) (*awstypes.MountTargetDescription, error) {
 	output, err := findMountTargets(ctx, conn, input, filter)
 
 	if err != nil {
@@ -291,7 +294,7 @@ func findMountTarget(ctx context.Context, conn *efs.Client, input *efs.DescribeM
 	return tfresource.AssertSingleValueResult(output)
 }
 
-func findMountTargets(ctx context.Context, conn *efs.Client, input *efs.DescribeMountTargetsInput, filter tfslices.Predicate[*awstypes.MountTargetDescription]) ([]awstypes.MountTargetDescription, error) {
+func findMountTargets(ctx context.Context, conn *efs.Client, input *efs.DescribeMountTargetsInput, filter tfslices.Predicate[awstypes.MountTargetDescription]) ([]awstypes.MountTargetDescription, error) {
 	var output []awstypes.MountTargetDescription
 
 	pages := efs.NewDescribeMountTargetsPaginator(conn, input)
@@ -309,7 +312,7 @@ func findMountTargets(ctx context.Context, conn *efs.Client, input *efs.Describe
 		}
 
 		for _, v := range page.MountTargets {
-			if filter(&v) {
+			if filter(v) {
 				output = append(output, v)
 			}
 		}
@@ -319,11 +322,11 @@ func findMountTargets(ctx context.Context, conn *efs.Client, input *efs.Describe
 }
 
 func findMountTargetByID(ctx context.Context, conn *efs.Client, id string) (*awstypes.MountTargetDescription, error) {
-	input := &efs.DescribeMountTargetsInput{
+	input := efs.DescribeMountTargetsInput{
 		MountTargetId: aws.String(id),
 	}
 
-	output, err := findMountTarget(ctx, conn, input, tfslices.PredicateTrue[*awstypes.MountTargetDescription]())
+	output, err := findMountTarget(ctx, conn, &input, tfslices.PredicateTrue[awstypes.MountTargetDescription]())
 
 	if err != nil {
 		return nil, err

--- a/internal/service/efs/mount_target.go
+++ b/internal/service/efs/mount_target.go
@@ -12,7 +12,6 @@ import ( // nosemgrep:ci.semgrep.aws.multiple-service-imports
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/efs"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/efs/types"
@@ -178,7 +177,8 @@ func resourceMountTargetCreate(ctx context.Context, d *schema.ResourceData, meta
 
 func resourceMountTargetRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).EFSClient(ctx)
+	c := meta.(*conns.AWSClient)
+	conn := c.EFSClient(ctx)
 
 	mt, err := findMountTargetByID(ctx, conn, d.Id())
 
@@ -193,17 +193,10 @@ func resourceMountTargetRead(ctx context.Context, d *schema.ResourceData, meta a
 	}
 
 	fsID := aws.ToString(mt.FileSystemId)
-	fsARN := arn.ARN{
-		AccountID: meta.(*conns.AWSClient).AccountID(ctx),
-		Partition: meta.(*conns.AWSClient).Partition(ctx),
-		Region:    meta.(*conns.AWSClient).Region(ctx),
-		Resource:  "file-system/" + fsID,
-		Service:   "elasticfilesystem",
-	}.String()
 	d.Set("availability_zone_id", mt.AvailabilityZoneId)
 	d.Set("availability_zone_name", mt.AvailabilityZoneName)
 	d.Set(names.AttrDNSName, meta.(*conns.AWSClient).RegionalHostname(ctx, fsID+".efs"))
-	d.Set("file_system_arn", fsARN)
+	d.Set("file_system_arn", fileSystemARN(ctx, c, fsID))
 	d.Set(names.AttrFileSystemID, fsID)
 	d.Set(names.AttrIPAddress, mt.IpAddress)
 	if mt.IpAddress != nil && mt.Ipv6Address != nil {

--- a/internal/service/efs/mount_target_data_source.go
+++ b/internal/service/efs/mount_target_data_source.go
@@ -100,21 +100,21 @@ func dataSourceMountTargetRead(ctx context.Context, d *schema.ResourceData, meta
 	c := meta.(*conns.AWSClient)
 	conn := c.EFSClient(ctx)
 
-	input := &efs.DescribeMountTargetsInput{}
+	var inputDMT efs.DescribeMountTargetsInput
 
 	if v, ok := d.GetOk("access_point_id"); ok {
-		input.AccessPointId = aws.String(v.(string))
+		inputDMT.AccessPointId = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk(names.AttrFileSystemID); ok {
-		input.FileSystemId = aws.String(v.(string))
+		inputDMT.FileSystemId = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("mount_target_id"); ok {
-		input.MountTargetId = aws.String(v.(string))
+		inputDMT.MountTargetId = aws.String(v.(string))
 	}
 
-	mt, err := findMountTarget(ctx, conn, input, tfslices.PredicateTrue[*awstypes.MountTargetDescription]())
+	mt, err := findMountTarget(ctx, conn, &inputDMT, tfslices.PredicateTrue[awstypes.MountTargetDescription]())
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "reading EFS Mount Target: %s", err)
@@ -124,7 +124,7 @@ func dataSourceMountTargetRead(ctx context.Context, d *schema.ResourceData, meta
 	fsID := aws.ToString(mt.FileSystemId)
 	d.Set("availability_zone_id", mt.AvailabilityZoneId)
 	d.Set("availability_zone_name", mt.AvailabilityZoneName)
-	d.Set(names.AttrDNSName, meta.(*conns.AWSClient).RegionalHostname(ctx, fsID+".efs"))
+	d.Set(names.AttrDNSName, c.RegionalHostname(ctx, fsID+".efs"))
 	d.Set("file_system_arn", fileSystemARN(ctx, c, fsID))
 	d.Set(names.AttrFileSystemID, fsID)
 	d.Set(names.AttrIPAddress, mt.IpAddress)
@@ -138,21 +138,22 @@ func dataSourceMountTargetRead(ctx context.Context, d *schema.ResourceData, meta
 		d.Set(names.AttrIPAddressType, nil)
 	}
 	d.Set("ipv6_address", mt.Ipv6Address)
-	d.Set("mount_target_dns_name", meta.(*conns.AWSClient).RegionalHostname(ctx, fmt.Sprintf("%s.%s.efs", aws.ToString(mt.AvailabilityZoneName), aws.ToString(mt.FileSystemId))))
+	d.Set("mount_target_dns_name", c.RegionalHostname(ctx, fmt.Sprintf("%s.%s.efs", aws.ToString(mt.AvailabilityZoneName), aws.ToString(mt.FileSystemId))))
 	d.Set("mount_target_id", mt.MountTargetId)
 	d.Set(names.AttrNetworkInterfaceID, mt.NetworkInterfaceId)
 	d.Set(names.AttrOwnerID, mt.OwnerId)
 	d.Set(names.AttrSubnetID, mt.SubnetId)
 
-	output, err := conn.DescribeMountTargetSecurityGroups(ctx, &efs.DescribeMountTargetSecurityGroupsInput{
+	inputDMTSG := efs.DescribeMountTargetSecurityGroupsInput{
 		MountTargetId: aws.String(d.Id()),
-	})
+	}
+	outputDMTSG, err := conn.DescribeMountTargetSecurityGroups(ctx, &inputDMTSG)
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "reading EFS Mount Target (%s) security groups: %s", d.Id(), err)
 	}
 
-	d.Set(names.AttrSecurityGroups, output.SecurityGroups)
+	d.Set(names.AttrSecurityGroups, outputDMTSG.SecurityGroups)
 
 	return diags
 }

--- a/internal/service/efs/mount_target_data_source.go
+++ b/internal/service/efs/mount_target_data_source.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/efs"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/efs/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -98,7 +97,8 @@ func dataSourceMountTarget() *schema.Resource {
 
 func dataSourceMountTargetRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).EFSClient(ctx)
+	c := meta.(*conns.AWSClient)
+	conn := c.EFSClient(ctx)
 
 	input := &efs.DescribeMountTargetsInput{}
 
@@ -122,17 +122,10 @@ func dataSourceMountTargetRead(ctx context.Context, d *schema.ResourceData, meta
 
 	d.SetId(aws.ToString(mt.MountTargetId))
 	fsID := aws.ToString(mt.FileSystemId)
-	fsARN := arn.ARN{
-		AccountID: meta.(*conns.AWSClient).AccountID(ctx),
-		Partition: meta.(*conns.AWSClient).Partition(ctx),
-		Region:    meta.(*conns.AWSClient).Region(ctx),
-		Resource:  "file-system/" + fsID,
-		Service:   "elasticfilesystem",
-	}.String()
 	d.Set("availability_zone_id", mt.AvailabilityZoneId)
 	d.Set("availability_zone_name", mt.AvailabilityZoneName)
 	d.Set(names.AttrDNSName, meta.(*conns.AWSClient).RegionalHostname(ctx, fsID+".efs"))
-	d.Set("file_system_arn", fsARN)
+	d.Set("file_system_arn", fileSystemARN(ctx, c, fsID))
 	d.Set(names.AttrFileSystemID, fsID)
 	d.Set(names.AttrIPAddress, mt.IpAddress)
 	if mt.IpAddress != nil && mt.Ipv6Address != nil {


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Replaces direct `arn.ARN` structure initializations with calls to methods of `conns.AWSClient`.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/48387.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/45789.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccEFSAccessPoint\|TestAccEFSMountTarget' PKG=efs ACCTEST_PARALLELISM=4
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     5.861s
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework 5.820s
make: Running acceptance tests on branch: 🌿 f-efs-replace-arn-arn 🌿...
TF_ACC=1 go1.26.4 test ./internal/service/efs/... -v -count 1 -parallel 4  -run=TestAccEFSAccessPoint\|TestAccEFSMountTarget -timeout 360m -vet=off -buildvcs=false
2026/06/16 09:50:42 Creating Terraform AWS Provider (SDKv2-style)...
2026/06/16 09:50:42 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccEFSAccessPointDataSource_basic
=== PAUSE TestAccEFSAccessPointDataSource_basic
=== RUN   TestAccEFSAccessPoint_basic
=== PAUSE TestAccEFSAccessPoint_basic
=== RUN   TestAccEFSAccessPoint_Root_directory
=== PAUSE TestAccEFSAccessPoint_Root_directory
=== RUN   TestAccEFSAccessPoint_RootDirectoryCreation_info
=== PAUSE TestAccEFSAccessPoint_RootDirectoryCreation_info
=== RUN   TestAccEFSAccessPoint_POSIX_user
=== PAUSE TestAccEFSAccessPoint_POSIX_user
=== RUN   TestAccEFSAccessPoint_POSIXUserSecondary_gids
=== PAUSE TestAccEFSAccessPoint_POSIXUserSecondary_gids
=== RUN   TestAccEFSAccessPoint_tags
=== PAUSE TestAccEFSAccessPoint_tags
=== RUN   TestAccEFSAccessPoint_disappears
=== PAUSE TestAccEFSAccessPoint_disappears
=== RUN   TestAccEFSAccessPointsDataSource_basic
=== PAUSE TestAccEFSAccessPointsDataSource_basic
=== RUN   TestAccEFSAccessPointsDataSource_empty
=== PAUSE TestAccEFSAccessPointsDataSource_empty
=== RUN   TestAccEFSMountTargetDataSource_basic
=== PAUSE TestAccEFSMountTargetDataSource_basic
=== RUN   TestAccEFSMountTargetDataSource_byAccessPointID
=== PAUSE TestAccEFSMountTargetDataSource_byAccessPointID
=== RUN   TestAccEFSMountTargetDataSource_byFileSystemID
=== PAUSE TestAccEFSMountTargetDataSource_byFileSystemID
=== RUN   TestAccEFSMountTarget_basic
=== PAUSE TestAccEFSMountTarget_basic
=== RUN   TestAccEFSMountTarget_disappears
=== PAUSE TestAccEFSMountTarget_disappears
=== RUN   TestAccEFSMountTarget_ipAddress
=== PAUSE TestAccEFSMountTarget_ipAddress
=== RUN   TestAccEFSMountTarget_ipAddressTypeIPv6Only
=== PAUSE TestAccEFSMountTarget_ipAddressTypeIPv6Only
=== RUN   TestAccEFSMountTarget_ipAddressTypeIPv6OnlyWithIPv6Address
=== PAUSE TestAccEFSMountTarget_ipAddressTypeIPv6OnlyWithIPv6Address
=== RUN   TestAccEFSMountTarget_ipAddressTypeDualStack
=== PAUSE TestAccEFSMountTarget_ipAddressTypeDualStack
=== RUN   TestAccEFSMountTarget_ipAddressTypeDualStackWithIPv6Address
=== PAUSE TestAccEFSMountTarget_ipAddressTypeDualStackWithIPv6Address
=== RUN   TestAccEFSMountTarget_IPAddress_emptyString
=== PAUSE TestAccEFSMountTarget_IPAddress_emptyString
=== CONT  TestAccEFSAccessPointDataSource_basic
=== CONT  TestAccEFSMountTargetDataSource_byAccessPointID
=== CONT  TestAccEFSMountTarget_ipAddressTypeIPv6Only
=== CONT  TestAccEFSMountTarget_ipAddressTypeDualStackWithIPv6Address
--- PASS: TestAccEFSAccessPointDataSource_basic (26.15s)
=== CONT  TestAccEFSAccessPoint_tags
--- PASS: TestAccEFSAccessPoint_tags (48.31s)
=== CONT  TestAccEFSMountTargetDataSource_basic
--- PASS: TestAccEFSMountTargetDataSource_byAccessPointID (128.92s)
=== CONT  TestAccEFSMountTarget_IPAddress_emptyString
--- PASS: TestAccEFSMountTarget_ipAddressTypeIPv6Only (140.66s)
=== CONT  TestAccEFSAccessPointsDataSource_basic
--- PASS: TestAccEFSMountTarget_ipAddressTypeDualStackWithIPv6Address (151.14s)
=== CONT  TestAccEFSAccessPoint_disappears
--- PASS: TestAccEFSAccessPointsDataSource_basic (25.11s)
=== CONT  TestAccEFSAccessPoint_RootDirectoryCreation_info
--- PASS: TestAccEFSAccessPoint_disappears (26.33s)
=== CONT  TestAccEFSAccessPoint_Root_directory
--- PASS: TestAccEFSAccessPoint_RootDirectoryCreation_info (28.20s)
=== CONT  TestAccEFSAccessPoint_POSIXUserSecondary_gids
--- PASS: TestAccEFSAccessPoint_Root_directory (28.08s)
=== CONT  TestAccEFSAccessPoint_basic
--- PASS: TestAccEFSMountTargetDataSource_basic (139.17s)
=== CONT  TestAccEFSMountTarget_ipAddressTypeDualStack
--- PASS: TestAccEFSAccessPoint_POSIXUserSecondary_gids (27.94s)
=== CONT  TestAccEFSMountTarget_disappears
--- PASS: TestAccEFSAccessPoint_basic (28.00s)
=== CONT  TestAccEFSMountTarget_ipAddress
--- PASS: TestAccEFSMountTarget_IPAddress_emptyString (132.65s)
=== CONT  TestAccEFSMountTarget_ipAddressTypeIPv6OnlyWithIPv6Address
--- PASS: TestAccEFSMountTarget_disappears (130.38s)
=== CONT  TestAccEFSAccessPoint_POSIX_user
--- PASS: TestAccEFSMountTarget_ipAddressTypeDualStack (150.26s)
=== CONT  TestAccEFSMountTarget_basic
--- PASS: TestAccEFSMountTarget_ipAddress (131.92s)
=== CONT  TestAccEFSMountTargetDataSource_byFileSystemID
--- PASS: TestAccEFSAccessPoint_POSIX_user (28.11s)
=== CONT  TestAccEFSAccessPointsDataSource_empty
--- PASS: TestAccEFSAccessPointsDataSource_empty (20.63s)
--- PASS: TestAccEFSMountTarget_ipAddressTypeIPv6OnlyWithIPv6Address (140.44s)
--- PASS: TestAccEFSMountTargetDataSource_byFileSystemID (129.15s)
--- PASS: TestAccEFSMountTarget_basic (229.84s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/efs        599.556s
```
