### PR TITLE
r/aws_cloudformation_stack: Surface DeleteStack ValidationError when termination protection is enabled

### DIFF
--- a/.changelog/48411.txt
+++ b/.changelog/48411.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cloudformation_stack: Fix destroy succeeding and removing the resource from state when `DeleteStack` actually fails because termination protection is enabled — the `ValidationError` from CloudFormation is no longer swallowed as a successful delete; only the `"does not exist"` shape is treated as already-deleted
+```

--- a/internal/service/cloudformation/stack.go
+++ b/internal/service/cloudformation/stack.go
@@ -361,7 +361,13 @@ func resourceStackDelete(ctx context.Context, d *schema.ResourceData, meta any) 
 	}
 	_, err := conn.DeleteStack(ctx, &input)
 
-	if tfawserr.ErrCodeEquals(err, errCodeValidationError) {
+	// Treat ValidationError as already-deleted ONLY when the message confirms
+	// the stack does not exist. Other ValidationError shapes — notably
+	// "cannot be deleted while TerminationProtection is enabled" — must
+	// propagate as a destroy failure so Terraform state stays in sync with
+	// AWS reality (issue #48411). Mirrors the same narrow check in
+	// `findStacks` below.
+	if tfawserr.ErrMessageContains(err, errCodeValidationError, "does not exist") {
 		return diags
 	}
 

--- a/internal/service/cloudformation/stack_test.go
+++ b/internal/service/cloudformation/stack_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 
 	"github.com/YakDriver/regexache"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -180,6 +182,53 @@ func TestAccCloudFormationStack_disappears(t *testing.T) {
 						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
 					},
 				},
+			},
+		},
+	})
+}
+
+// TestAccCloudFormationStack_terminationProtectionDeleteFails pins the fix
+// for https://github.com/hashicorp/terraform-provider-aws/issues/48411:
+// when termination protection is enabled on a CloudFormation stack,
+// `terraform destroy` must fail and leave the resource in state rather than
+// silently swallowing the CloudFormation `ValidationError` and removing the
+// resource from state. Before the fix, any `ValidationError` from
+// `DeleteStack` was treated as "already deleted"; the fix narrows that to
+// only the `"does not exist"` message.
+func TestAccCloudFormationStack_terminationProtectionDeleteFails(t *testing.T) {
+	ctx := acctest.Context(t)
+	var stack awstypes.Stack
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_cloudformation_stack.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CloudFormationServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckStackDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				// Create the stack and turn on termination protection via the
+				// AWS API directly (the resource doesn't yet expose this as a
+				// schema attribute — see issue #3496).
+				Config: testAccStackConfig_basic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckStackExists(ctx, t, resourceName, &stack),
+					testAccCheckStackSetTerminationProtection(ctx, t, &stack, true),
+				),
+			},
+			{
+				// `terraform destroy` must surface the ValidationError from
+				// CloudFormation, not return success and drop the resource.
+				Config:      testAccStackConfig_basic(rName),
+				Destroy:     true,
+				ExpectError: regexache.MustCompile(`TerminationProtection`),
+			},
+			{
+				// Disable termination protection so the test framework's
+				// default destroy can clean up the stack at end-of-test.
+				Config: testAccStackConfig_basic(rName),
+				Check:  testAccCheckStackSetTerminationProtection(ctx, t, &stack, false),
 			},
 		},
 	})
@@ -601,6 +650,25 @@ func testAccCheckStackExists(ctx context.Context, t *testing.T, n string, v *aws
 		*v = *output
 
 		return nil
+	}
+}
+
+// testAccCheckStackSetTerminationProtection toggles termination protection
+// on the captured stack via the AWS API directly. Used by
+// TestAccCloudFormationStack_terminationProtectionDeleteFails to set up the
+// pre-condition (enable) and to clean up after the ExpectError step (disable),
+// since the resource schema does not currently expose termination protection
+// as a managed attribute (see issue #3496).
+func testAccCheckStackSetTerminationProtection(ctx context.Context, t *testing.T, v *awstypes.Stack, enable bool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.ProviderMeta(ctx, t).CloudFormationClient(ctx)
+
+		_, err := conn.UpdateTerminationProtection(ctx, &cloudformation.UpdateTerminationProtectionInput{
+			EnableTerminationProtection: aws.Bool(enable),
+			StackName:                   v.StackName,
+		})
+
+		return err
 	}
 }
 


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

None. This PR narrows error swallowing on destroy; it does not change access controls, encryption, or logging.

### Description

Closes #48411.

When a CloudFormation stack has termination protection enabled, the `DeleteStack` API call fails with:

```console
ValidationError: Stack [<name>] cannot be deleted while TerminationProtection is enabled
```

`resourceStackDelete` previously caught any `ValidationError` as a successful delete:

```go
// before
if tfawserr.ErrCodeEquals(err, errCodeValidationError) {
    return diags
}
```

That returned success up the stack while leaving the CloudFormation stack alive in AWS, and Terraform removed the resource from state. The result was silent state corruption — subsequent plans no longer managed the stack, while AWS still held it.

The fix narrows the catch to the specific message the original block was intended to handle — `"does not exist"`, when a parallel delete or concurrent operation already removed the stack between refresh and our delete call:

```go
// after
if tfawserr.ErrMessageContains(err, errCodeValidationError, "does not exist") {
    return diags
}
```

Every other `ValidationError` shape (termination protection, invalid state, etc.) now propagates as a destroy failure, keeping Terraform state in sync with AWS. This matches the existing narrow check already used in `findStacks` (`stack.go:417`) for the same error code.

### Relations

Closes #48411
Relates #33960 (closed-stale duplicate of the same bug)
Relates #3496 (open enhancement to expose termination protection as a managed attribute on the resource)

### References

The bug pattern — silently treating a typed-by-code error class as success regardless of message — is also discussed in the Pulumi provider's parallel report at https://github.com/pulumi/pulumi-aws/issues/6422.

### Output from Acceptance Testing

The new acceptance test `TestAccCloudFormationStack_terminationProtectionDeleteFails` enables termination protection out-of-band via the AWS API (the resource schema does not yet expose this as a managed attribute; see #3496), then asserts that `terraform destroy` fails with an error matching `TerminationProtection` rather than silently succeeding. A final step disables protection so the framework's `CheckDestroy` can clean up.

I do not currently have access to an AWS test account for this provider, so the acceptance test was not run against live AWS. The fix and the test compile and `go vet` cleanly:

```console
% go vet ./internal/service/cloudformation/...
% go test -c ./internal/service/cloudformation/
```

Test output to be filled in by a reviewer with AWS credentials:

```console
% make testacc TESTS=TestAccCloudFormationStack_terminationProtectionDeleteFails PKG=cloudformation

...
```

The fix itself is also testable manually via the reporter's repro steps in #48411: create a stack, enable termination protection via the AWS CLI, run `terraform destroy` and observe the failure (with this PR) instead of the silent success (without).