### PR TITLE
Add makelign — keeps the GNUmakefile and its cheat sheet honest (1/4)

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -436,6 +436,10 @@ lint: golangci-lint provider-lint import-lint ## Legacy target, use caution
 
 lint-fix: testacc-lint-fix website-lint-fix docs-lint-fix ## Fix acceptance test, website, and docs linter findings
 
+makefile-lint: prereq-go ## Makefile alignment check
+	@echo "make: Makefile Linting / alignment check..."
+	@cd tools/makelign && $(GO_VER) run . ../..
+
 misspell: changelog-misspell docs-misspell website-misspell go-misspell ## [CI] Run all CI misspell checks
 
 modern-check: prereq-go ## [CI] Check for modern Go code (best run in individual services)
@@ -1013,6 +1017,7 @@ update: prereq-go ## Update dependencies
 	$(GO_VER) get -u ./...
 	$(GO_VER) mod tidy
 	cd ./tools/literally && $(GO_VER) get -u ./... && $(GO_VER) mod tidy
+	cd ./tools/makelign && $(GO_VER) get -u ./... && $(GO_VER) mod tidy
 	cd .ci/tools && $(GO_VER) get -u && $(GO_VER) mod tidy
 	cd .ci/providerlint && $(GO_VER) get -u && $(GO_VER) mod tidy
 	cd .ci/providerlint/passes/AWSAT005/testdata && $(GO_VER) get -u ./... && $(GO_VER) mod tidy
@@ -1205,6 +1210,7 @@ yamllint: ## [CI] YAML Linting / yamllint
 	install \
 	lint \
 	lint-fix \
+	makefile-lint \
 	misspell \
 	modern-check \
 	modern-fix \

--- a/tools/makelign/.gitignore
+++ b/tools/makelign/.gitignore
@@ -1,0 +1,2 @@
+# Built binary
+/makelign

--- a/tools/makelign/README.md
+++ b/tools/makelign/README.md
@@ -1,0 +1,121 @@
+<!-- Copyright IBM Corp. 2014, 2026 -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
+# makelign
+
+`makelign` validates that the Terraform AWS Provider's `GNUmakefile` stays in
+alignment with its supporting documentation. It is intentionally narrow: it
+parses four sources, applies a fixed set of rules, and prints findings.
+
+## What it checks
+
+| # | Source                                       | Source              |
+|---|----------------------------------------------|---------------------|
+| 1 | Target rules                                 | `GNUmakefile`       |
+| 2 | `.PHONY:` declaration                        | `GNUmakefile`       |
+| 3 | Targets table                                | `docs/makefile-cheat-sheet.md` |
+| 4 | `make <target>` references                   | `docs/continuous-integration.md` |
+
+## Rules
+
+Each finding carries a stable code so they can be filtered or suppressed at
+the report layer if necessary.
+
+### Errors (fail CI)
+
+| Code              | Meaning |
+|-------------------|---------|
+| `phony-missing`   | A target has a recipe in `GNUmakefile` but is absent from the `.PHONY` list. Without `.PHONY`, a same-named file in the working directory would silently shadow the target. |
+| `phony-ghost`     | A name appears in `.PHONY` but no rule defines it. Includes a "did you mean" suggestion via Levenshtein distance. |
+| `cheatsheet-ghost`| The cheat sheet documents a target that does not exist in `GNUmakefile`. |
+| `ci-flag-mismatch`| The `## [CI]` prefix on the target description disagrees with the ✔ in the cheat sheet's `CI?` column. |
+
+### Warnings (informational, fail under `-strict`)
+
+| Code                    | Meaning |
+|-------------------------|---------|
+| `cheatsheet-missing`    | A target with a `## description` comment is not listed in the cheat sheet. |
+| `ci-doc-missing`        | A `## [CI]` target is not referenced in `continuous-integration.md`. Meta targets (marked `<sup>M</sup>` in the cheat sheet) are exempt. |
+| `legacy-flag-mismatch`  | The Makefile description mentions "Legacy" but the cheat sheet's `Legacy?` column disagrees, or vice versa. |
+| `phony-order`           | The `.PHONY` list is not alphabetized. |
+| `cheatsheet-order`      | The cheat sheet table is not alphabetized. |
+
+## Usage
+
+From the repository root:
+
+```console
+$ make makefile-lint
+```
+
+Or directly:
+
+```console
+$ cd tools/makelign
+$ go run . ../..
+```
+
+### Flags
+
+```text
+-strict      Treat warnings as errors (recommended for CI).
+-no-color    Disable ANSI color output.
+```
+
+### Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0    | No errors (warnings allowed unless `-strict`). |
+| 1    | At least one error (or warning under `-strict`). |
+| 2    | Usage or I/O error. |
+
+## Output format
+
+```text
+SEVERITY  file:line  message  (suggestion)  [code]
+```
+
+Example:
+
+```text
+ERROR  GNUmakefile:1193  .PHONY entry "gh-workflows-lint" does not match any target  (did you mean "gh-workflow-lint"?)  [phony-ghost]
+ERROR  GNUmakefile:259   target "copyright-fix" is not in the .PHONY list  [phony-missing]
+WARN   GNUmakefile:165   documented target "clean-go-cache-trim" is missing from the cheat sheet  [cheatsheet-missing]
+
+Summary: 2 error(s), 1 warning(s)
+```
+
+The columns are space-separated and grep-friendly. Editors that recognize
+`file:line` jump syntax (vim, VS Code, IntelliJ) navigate directly to each
+finding.
+
+## Design choices
+
+* **Stdlib only.** No third-party dependencies. The parsers are line-oriented
+  and tolerant: malformed Make syntax produces nothing rather than a fatal
+  error so an in-progress edit can still be linted.
+* **Single binary, no subcommands.** This tool does one thing.
+* **Severity, not categories.** Errors block; warnings nudge. Anything more
+  granular tends to drift toward never being acted on.
+* **Suggestions where useful.** Levenshtein-based "did you mean" hints turn
+  most ghost-PHONY findings into a one-character fix.
+* **Stable finding codes.** Codes such as `phony-ghost` are part of the
+  contract: they're greppable in CI logs and easy to reference in PRs.
+
+## Testing
+
+```console
+$ go test ./...
+```
+
+The fixtures under `testdata/golden/` exercise every rule. Add a new fixture
+when adding a new rule rather than mutating the existing one.
+
+## Adding a rule
+
+1. Add a check function to `validate.go` returning `[]Finding`.
+2. Wire it into `Validate`.
+3. Document it in this README's rules table.
+4. Add a fixture or extend `testdata/golden/` and assert the finding from
+   `TestValidate_Golden` (or, preferably, `TestValidate_RulesIsolated`).

--- a/tools/makelign/cheatsheet.go
+++ b/tools/makelign/cheatsheet.go
@@ -1,0 +1,139 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package main
+
+import (
+	"bufio"
+	"os"
+	"regexp"
+	"strings"
+)
+
+// CheatSheetRow is one row from the cheat sheet's target table.
+//
+// The "Target" column may render the name as a backtick code span with an
+// optional `<sup>M</sup>` or `<sup>D</sup>` annotation, or as `_name_`
+// italic for the synthetic `default` row. Both forms produce the same
+// Target string here.
+type CheatSheetRow struct {
+	Target      string
+	IsMeta      bool // M annotation
+	IsDependent bool // D annotation
+	Description string
+	IsCI        bool     // ✔️ in the CI? column
+	IsLegacy    bool     // ✔️ in the Legacy? column
+	Vars        []string // names parsed from the Vars column (no backticks)
+	Line        int      // 1-based source line
+}
+
+// ParseCheatSheet reads the makefile cheat sheet markdown and returns one
+// CheatSheetRow per data row of the targets table. Non-target rows and
+// header/separator rows are skipped silently.
+func ParseCheatSheet(path string) ([]CheatSheetRow, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
+
+	var rows []CheatSheetRow
+	inTable := false
+	lineNum := 0
+
+	for scanner.Scan() {
+		lineNum++
+		line := scanner.Text()
+
+		// The targets table is identified by its header row. Once entered,
+		// we stay in table mode until we hit a non-table line.
+		if !inTable {
+			if isCheatSheetTableHeader(line) {
+				inTable = true
+			}
+			continue
+		}
+		if !strings.HasPrefix(line, "|") {
+			inTable = false
+			continue
+		}
+		// Markdown separator row: `| --- | --- | ... |`.
+		if strings.Contains(line, "---") {
+			continue
+		}
+		if row, ok := parseCheatRow(line, lineNum); ok {
+			rows = append(rows, row)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+// isCheatSheetTableHeader recognizes the targets table header. Other tables
+// in the document (e.g. variable references) do not start with "Target".
+func isCheatSheetTableHeader(line string) bool {
+	trimmed := strings.TrimSpace(line)
+	return strings.HasPrefix(trimmed, "| Target |")
+}
+
+// reTargetCell matches the first cell of a targets-table row, capturing
+// either a backtick-wrapped name (with optional M/D annotation) or an
+// italic `_name_` cell used for the `default` row.
+var reTargetCell = regexp.MustCompile(
+	"^`([a-zA-Z][a-zA-Z0-9_-]*)`(?:<sup>([MD])</sup>)?$|" +
+		"^_([a-zA-Z][a-zA-Z0-9_-]*)_$",
+)
+
+// reVarName extracts variable names from backticks in the Vars column.
+var reVarName = regexp.MustCompile("`([A-Z][A-Z0-9_]*)`")
+
+func parseCheatRow(line string, lineNum int) (CheatSheetRow, bool) {
+	cells := splitMarkdownRow(line)
+	if len(cells) < 5 {
+		return CheatSheetRow{}, false
+	}
+
+	row := CheatSheetRow{Line: lineNum}
+	m := reTargetCell.FindStringSubmatch(cells[0])
+	switch {
+	case m == nil:
+		return CheatSheetRow{}, false
+	case m[1] != "":
+		row.Target = m[1]
+		switch m[2] {
+		case "M":
+			row.IsMeta = true
+		case "D":
+			row.IsDependent = true
+		}
+	case m[3] != "":
+		row.Target = m[3]
+	}
+
+	row.Description = cells[1]
+	row.IsCI = strings.Contains(cells[2], "✔")
+	row.IsLegacy = strings.Contains(cells[3], "✔")
+	for _, vm := range reVarName.FindAllStringSubmatch(cells[4], -1) {
+		row.Vars = append(row.Vars, vm[1])
+	}
+	return row, true
+}
+
+// splitMarkdownRow returns the trimmed cell contents of a markdown table
+// row. Pipes inside backticks are not handled (the cheat sheet doesn't use
+// them), keeping the parser straightforward.
+func splitMarkdownRow(line string) []string {
+	line = strings.TrimSpace(line)
+	line = strings.TrimPrefix(line, "|")
+	line = strings.TrimSuffix(line, "|")
+	parts := strings.Split(line, "|")
+	for i := range parts {
+		parts[i] = strings.TrimSpace(parts[i])
+	}
+	return parts
+}

--- a/tools/makelign/cheatsheet_test.go
+++ b/tools/makelign/cheatsheet_test.go
@@ -1,0 +1,97 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package main
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestParseCheatRow(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		line       string
+		wantTarget string
+		wantMeta   bool
+		wantDep    bool
+		wantCI     bool
+		wantLegacy bool
+		wantVars   []string
+		wantOK     bool
+	}{
+		"simple row": {
+			line:       "| `build` | Build the provider |  |  |  |",
+			wantTarget: "build",
+			wantOK:     true,
+		},
+		"meta annotation": {
+			line:       "| `ci`<sup>M</sup> | Run all CI checks | ✔️ |  | `K`, `PKG` |",
+			wantTarget: "ci",
+			wantMeta:   true,
+			wantCI:     true,
+			wantVars:   []string{"K", "PKG"},
+			wantOK:     true,
+		},
+		"dependent annotation": {
+			line:       "| `testacc`<sup>D</sup> | Run acceptance tests |  |  | `GO_VER` |",
+			wantTarget: "testacc",
+			wantDep:    true,
+			wantVars:   []string{"GO_VER"},
+			wantOK:     true,
+		},
+		"italic default row": {
+			line:       "| _default_ | = `build` |  |  | `GO_VER` |",
+			wantTarget: "default",
+			wantVars:   []string{"GO_VER"},
+			wantOK:     true,
+		},
+		"legacy row": {
+			line:       "| `docs-check` | Check provider documentation |  | ✔️ |  |",
+			wantTarget: "docs-check",
+			wantLegacy: true,
+			wantOK:     true,
+		},
+		"non-row rejected": {
+			line:   "this is not a table row",
+			wantOK: false,
+		},
+		"too few columns rejected": {
+			line:   "| `build` | desc |",
+			wantOK: false,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := parseCheatRow(tc.line, 42)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if got.Target != tc.wantTarget {
+				t.Errorf("Target = %q, want %q", got.Target, tc.wantTarget)
+			}
+			if got.IsMeta != tc.wantMeta {
+				t.Errorf("IsMeta = %v, want %v", got.IsMeta, tc.wantMeta)
+			}
+			if got.IsDependent != tc.wantDep {
+				t.Errorf("IsDependent = %v, want %v", got.IsDependent, tc.wantDep)
+			}
+			if got.IsCI != tc.wantCI {
+				t.Errorf("IsCI = %v, want %v", got.IsCI, tc.wantCI)
+			}
+			if got.IsLegacy != tc.wantLegacy {
+				t.Errorf("IsLegacy = %v, want %v", got.IsLegacy, tc.wantLegacy)
+			}
+			if !slices.Equal(got.Vars, tc.wantVars) {
+				t.Errorf("Vars = %v, want %v", got.Vars, tc.wantVars)
+			}
+			if got.Line != 42 {
+				t.Errorf("Line = %d, want 42", got.Line)
+			}
+		})
+	}
+}

--- a/tools/makelign/ci.go
+++ b/tools/makelign/ci.go
@@ -1,0 +1,44 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package main
+
+import (
+	"os"
+	"regexp"
+)
+
+// CIDoc is the parsed view of docs/continuous-integration.md.
+//
+// We only care about which make targets are referenced from the document,
+// so the parsed view is just a set of names. A target is "referenced" if
+// the document contains `make <target>` anywhere -- in code blocks, prose,
+// or section headings.
+type CIDoc struct {
+	Refs map[string]bool
+}
+
+// reMakeRef matches `make <target>` references. The negative-lookbehind for
+// `e` is unsupported in RE2, so we constrain via boundary characters and
+// rely on Go's `regexp` keeping the match minimal.
+//
+// Examples it captures:
+//
+//	make ci
+//	`make ci-quick`
+//	  $ make gh-workflow-lint
+var reMakeRef = regexp.MustCompile(`(?:^|[^a-zA-Z0-9_-])make[ \t]+([a-zA-Z][a-zA-Z0-9_-]*)\b`)
+
+// ParseCIDoc reads the continuous-integration document and collects every
+// make target referenced anywhere within it.
+func ParseCIDoc(path string) (*CIDoc, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	doc := &CIDoc{Refs: make(map[string]bool)}
+	for _, m := range reMakeRef.FindAllSubmatch(b, -1) {
+		doc.Refs[string(m[1])] = true
+	}
+	return doc, nil
+}

--- a/tools/makelign/ci_test.go
+++ b/tools/makelign/ci_test.go
@@ -1,0 +1,66 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestMakeRefRegex(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		input string
+		want  []string
+	}{
+		"plain": {
+			input: "Run `make ci` to do everything.",
+			want:  []string{"ci"},
+		},
+		"multiple": {
+			input: "Use `make ci` or `make ci-quick`.",
+			want:  []string{"ci", "ci-quick"},
+		},
+		"in code block": {
+			input: "```\nmake build\n```\n",
+			want:  []string{"build"},
+		},
+		"avoid matching 'remake'": {
+			// `remake` ends with `make` but should NOT trigger.
+			input: "We need to remake foo.",
+			want:  nil,
+		},
+		"shell prompt prefix": {
+			input: "$ make gh-workflow-lint",
+			want:  []string{"gh-workflow-lint"},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			matches := reMakeRef.FindAllStringSubmatch(tc.input, -1)
+			var got []string
+			for _, m := range matches {
+				got = append(got, m[1])
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("got[%d] = %q, want %q", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestParseCIDoc_MissingFile(t *testing.T) {
+	t.Parallel()
+	_, err := ParseCIDoc(filepath.Join(t.TempDir(), "nope.md"))
+	if !os.IsNotExist(err) {
+		t.Fatalf("expected not-exist error, got %v", err)
+	}
+}

--- a/tools/makelign/go.mod
+++ b/tools/makelign/go.mod
@@ -1,0 +1,3 @@
+module github.com/hashicorp/terraform-provider-aws/tools/makelign
+
+go 1.26.3

--- a/tools/makelign/main.go
+++ b/tools/makelign/main.go
@@ -1,0 +1,219 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+// Command makelign validates that the Terraform AWS Provider's GNUmakefile
+// stays in alignment with three pieces of supporting documentation:
+//
+//  1. The `.PHONY:` declaration inside GNUmakefile itself.
+//  2. docs/makefile-cheat-sheet.md (the targets table).
+//  3. docs/continuous-integration.md (CI target references).
+//
+// It reports two classes of issues:
+//
+//   - ERROR: hard alignment failures (.PHONY ghosts, missing .PHONY entries,
+//     cheat sheet referring to nonexistent targets, CI flag mismatches).
+//   - WARN:  soft alignment issues (documented target missing from the cheat
+//     sheet, CI target not referenced in the CI doc, ordering).
+//
+// Errors fail the run with exit code 1. Warnings can be promoted to errors
+// with `-strict`, which is the recommended setting for CI.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+const (
+	defaultMakefile   = "GNUmakefile"
+	defaultCheatSheet = "docs/makefile-cheat-sheet.md"
+	defaultCIDoc      = "docs/continuous-integration.md"
+)
+
+// options bundles command-line flags so they can be threaded through the
+// run function for testability without touching package globals.
+type options struct {
+	repoRoot string
+	strict   bool
+	noColor  bool
+}
+
+func main() {
+	opts, err := parseArgs(os.Args[1:])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(2)
+	}
+	code := run(opts, os.Stdout, os.Stderr)
+	os.Exit(code)
+}
+
+// parseArgs builds an options struct from the supplied CLI arguments.
+// Returning an error rather than calling os.Exit keeps the function
+// usable from tests.
+func parseArgs(args []string) (options, error) {
+	fs := flag.NewFlagSet("makelign", flag.ContinueOnError)
+	fs.SetOutput(io.Discard) // we render usage ourselves on error
+	var opts options
+	fs.BoolVar(&opts.strict, "strict", false, "treat warnings as errors")
+	fs.BoolVar(&opts.noColor, "no-color", false, "disable ANSI color output")
+	fs.Usage = func() {
+		fmt.Fprint(os.Stderr, usage)
+	}
+	if err := fs.Parse(args); err != nil {
+		return opts, fmt.Errorf("makelign: %w\n\n%s", err, usage)
+	}
+	switch fs.NArg() {
+	case 0:
+		opts.repoRoot = "."
+	case 1:
+		opts.repoRoot = fs.Arg(0)
+	default:
+		return opts, fmt.Errorf("makelign: unexpected extra arguments\n\n%s", usage)
+	}
+	return opts, nil
+}
+
+const usage = `Usage: makelign [flags] [repo-root]
+
+Validates alignment between:
+  - GNUmakefile target rules
+  - GNUmakefile .PHONY list
+  - docs/makefile-cheat-sheet.md
+  - docs/continuous-integration.md
+
+If repo-root is omitted, the current directory is used.
+
+Flags:
+  -strict      Treat warnings as errors (recommended for CI).
+  -no-color    Disable ANSI color output.
+  -h, -help    Show this help.
+
+Exit codes:
+  0  No errors (warnings allowed unless -strict).
+  1  At least one error (or warning under -strict).
+  2  Usage or I/O error.
+`
+
+// run executes one validation pass and returns a process exit code.
+//
+// stdout receives the human-readable findings table; stderr is reserved
+// for I/O failures so that downstream tools parsing stdout aren't fooled
+// by error messages.
+func run(opts options, stdout, stderr io.Writer) int {
+	makePath := filepath.Join(opts.repoRoot, defaultMakefile)
+	sheetPath := filepath.Join(opts.repoRoot, defaultCheatSheet)
+	ciPath := filepath.Join(opts.repoRoot, defaultCIDoc)
+
+	mf, err := ParseMakefile(makePath)
+	if err != nil {
+		fmt.Fprintf(stderr, "makelign: cannot read %s: %v\n", makePath, err)
+		return 2
+	}
+	sheet, err := ParseCheatSheet(sheetPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "makelign: cannot read %s: %v\n", sheetPath, err)
+		return 2
+	}
+	cidoc, err := ParseCIDoc(ciPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "makelign: cannot read %s: %v\n", ciPath, err)
+		return 2
+	}
+
+	findings := Validate(&Inputs{
+		MakefilePath:   defaultMakefile,
+		CheatSheetPath: defaultCheatSheet,
+		CIDocPath:      defaultCIDoc,
+		Make:           mf,
+		CheatSheet:     sheet,
+		CIDoc:          cidoc,
+	})
+
+	useColor := !opts.noColor && isTerminal(stdout)
+	report(stdout, findings, useColor)
+
+	errs, warns := countSeverity(findings)
+	fmt.Fprintf(stdout, "\nSummary: %d error(s), %d warning(s)\n", errs, warns)
+
+	switch {
+	case errs > 0:
+		return 1
+	case opts.strict && warns > 0:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// report renders findings in a fixed-width, grep-friendly format:
+//
+//	SEVERITY  file:line  message  (suggestion)
+//
+// We intentionally do not use a tabwriter so column positions are
+// predictable in CI logs and editor jump-to-line features work.
+func report(w io.Writer, findings []Finding, useColor bool) {
+	if len(findings) == 0 {
+		fmt.Fprintln(w, "makelign: no alignment issues found ✓")
+		return
+	}
+	for _, f := range findings {
+		sev := f.Severity.String()
+		if useColor {
+			sev = colorize(sev, f.Severity)
+		}
+		loc := f.File
+		if f.Line > 0 {
+			loc = fmt.Sprintf("%s:%d", f.File, f.Line)
+		}
+		if f.Suggestion != "" {
+			fmt.Fprintf(w, "%-5s  %s  %s  (%s)  [%s]\n",
+				sev, loc, f.Message, f.Suggestion, f.Code)
+		} else {
+			fmt.Fprintf(w, "%-5s  %s  %s  [%s]\n",
+				sev, loc, f.Message, f.Code)
+		}
+	}
+}
+
+func countSeverity(findings []Finding) (errs, warns int) {
+	for _, f := range findings {
+		switch f.Severity {
+		case SevError:
+			errs++
+		case SevWarn:
+			warns++
+		}
+	}
+	return errs, warns
+}
+
+// colorize adds ANSI escapes for terminal output. We only color the
+// severity tag so log scrubbing tools see plain message text.
+func colorize(s string, sev Severity) string {
+	switch sev {
+	case SevError:
+		return "\x1b[31m" + s + "\x1b[0m" // red
+	case SevWarn:
+		return "\x1b[33m" + s + "\x1b[0m" // yellow
+	default:
+		return s
+	}
+}
+
+// isTerminal returns true when w looks like a TTY. We avoid pulling in
+// golang.org/x/term to keep the module dependency-free.
+func isTerminal(w io.Writer) bool {
+	f, ok := w.(*os.File)
+	if !ok {
+		return false
+	}
+	st, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return st.Mode()&os.ModeCharDevice != 0
+}

--- a/tools/makelign/makefile.go
+++ b/tools/makelign/makefile.go
@@ -1,0 +1,201 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package main
+
+import (
+	"bufio"
+	"os"
+	"strings"
+)
+
+// Target describes a GNUmakefile target rule.
+//
+// A target is "documented" if its definition line carries an inline comment
+// of the form `## description`. Documented targets are surfaced in `make help`
+// and are expected to appear in the cheat sheet, unless IsInternal is true.
+type Target struct {
+	Name        string
+	Description string // text after ## (without [CI] or [internal] prefix)
+	IsCI        bool   // description began with "[CI]"
+	IsInternal  bool   // description began with "[internal]" — shown in source, hidden from make help and cheat sheet
+	IsLegacy    bool   // description mentions "Legacy" (case-insensitive)
+	HasDoc      bool   // line carried a `##` description
+	Line        int    // 1-based source line of the definition
+}
+
+// MakefileData is the parsed view of a GNUmakefile relevant to alignment checks.
+type MakefileData struct {
+	// Targets, keyed by target name. The first definition wins if a target
+	// happens to be defined multiple times (rare in practice).
+	Targets map[string]*Target
+
+	// Order is target names in source order, useful for stable reporting.
+	Order []string
+
+	// Phony is the list of names appearing in the `.PHONY:` declaration,
+	// preserving source order so we can report alphabetization issues.
+	Phony []string
+
+	// PhonyLine is the 1-based line number of the `.PHONY:` declaration,
+	// used as the location for findings about the phony list itself.
+	PhonyLine int
+}
+
+// ParseMakefile reads a GNUmakefile from disk and extracts targets and the
+// .PHONY list. Errors are returned only for I/O problems; malformed Make
+// syntax is tolerated since the tool is descriptive, not a full parser.
+func ParseMakefile(path string) (*MakefileData, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	data := &MakefileData{
+		Targets: make(map[string]*Target),
+	}
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
+
+	lineNum := 0
+	inPhony := false
+
+	for scanner.Scan() {
+		lineNum++
+		line := scanner.Text()
+
+		// .PHONY collection has its own state machine and short-circuits
+		// other parsing for the duration of the declaration.
+		if inPhony {
+			cont := collectPhonyLine(line, &data.Phony)
+			if !cont {
+				inPhony = false
+			}
+			continue
+		}
+		if strings.HasPrefix(line, ".PHONY:") {
+			data.PhonyLine = lineNum
+			rest := strings.TrimPrefix(line, ".PHONY:")
+			cont := collectPhonyLine(rest, &data.Phony)
+			inPhony = cont
+			continue
+		}
+
+		// Target rules: not indented, name : ... [## desc]
+		if t, ok := parseTargetLine(line, lineNum); ok {
+			if _, exists := data.Targets[t.Name]; !exists {
+				data.Targets[t.Name] = t
+				data.Order = append(data.Order, t.Name)
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+// parseTargetLine attempts to interpret `line` as a target rule definition.
+// It rejects indented lines (recipes), variable assignments, and conditional
+// directives. When a target is found, the returned Target carries any inline
+// `## description` and derived flags.
+func parseTargetLine(line string, lineNum int) (*Target, bool) {
+	// Recipe lines start with a tab; skip immediately.
+	if line == "" || line[0] == '\t' {
+		return nil, false
+	}
+	// Indented logical lines (4+ spaces, etc.) are also not targets.
+	if line[0] == ' ' {
+		return nil, false
+	}
+
+	// Split off the inline description, if any.
+	var desc string
+	hasDoc := false
+	main := line
+	if idx := strings.Index(line, "##"); idx >= 0 {
+		main = line[:idx]
+		desc = strings.TrimSpace(line[idx+2:])
+		hasDoc = true
+	}
+	main = strings.TrimRight(main, " \t")
+
+	// A target needs `:` not preceded by `=` (otherwise it's a variable).
+	colonIdx := strings.Index(main, ":")
+	if colonIdx < 0 {
+		return nil, false
+	}
+	if eqIdx := strings.Index(main, "="); eqIdx >= 0 && eqIdx < colonIdx {
+		return nil, false
+	}
+	// Reject `:=` style assignments. Double colons (`::`) are allowed.
+	if colonIdx+1 < len(main) && main[colonIdx+1] == '=' {
+		return nil, false
+	}
+
+	name := strings.TrimSpace(main[:colonIdx])
+	if !isValidTargetName(name) {
+		return nil, false
+	}
+
+	t := &Target{
+		Name:     name,
+		HasDoc:   hasDoc,
+		Line:     lineNum,
+		IsLegacy: strings.Contains(strings.ToLower(desc), "legacy"),
+	}
+	if hasDoc {
+		// `## [CI] foo`       => IsCI true, Description "foo"
+		// `## [internal] foo` => IsInternal true, Description "foo"
+		const ciPrefix = "[CI]"
+		const internalPrefix = "[internal]"
+		switch {
+		case strings.HasPrefix(desc, ciPrefix):
+			t.IsCI = true
+			desc = strings.TrimSpace(strings.TrimPrefix(desc, ciPrefix))
+		case strings.HasPrefix(desc, internalPrefix):
+			t.IsInternal = true
+			desc = strings.TrimSpace(strings.TrimPrefix(desc, internalPrefix))
+		}
+		t.Description = desc
+	}
+	return t, true
+}
+
+// collectPhonyLine extracts target names from a single line of a `.PHONY:`
+// declaration (possibly with line continuation `\`). Returns true if the
+// declaration continues on the next line.
+func collectPhonyLine(line string, phony *[]string) bool {
+	trimmed := strings.TrimRight(line, " \t")
+	cont := strings.HasSuffix(trimmed, "\\")
+	body := strings.TrimSuffix(trimmed, "\\")
+	for _, tok := range strings.Fields(body) {
+		if isValidTargetName(tok) {
+			*phony = append(*phony, tok)
+		}
+	}
+	return cont
+}
+
+// isValidTargetName checks whether s is a plausible Make target name. We
+// deliberately disallow `$` and `(` so we don't capture variable references
+// that happen to look like `name:` after expansion.
+func isValidTargetName(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= 'A' && r <= 'Z':
+		case r == '_':
+		case i > 0 && r >= '0' && r <= '9':
+		case i > 0 && r == '-':
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/tools/makelign/makefile_test.go
+++ b/tools/makelign/makefile_test.go
@@ -1,0 +1,187 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package main
+
+import (
+	"testing"
+)
+
+func TestParseTargetLine(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		line         string
+		wantName     string
+		wantOK       bool
+		wantDoc      bool
+		wantCI       bool
+		wantInternal bool
+		wantDesc     string
+	}{
+		"plain target": {
+			line:     "build:",
+			wantName: "build",
+			wantOK:   true,
+		},
+		"target with deps": {
+			line:     "ci: tools build",
+			wantName: "ci",
+			wantOK:   true,
+		},
+		"documented target": {
+			line:     "build: prereq-go ## Build provider",
+			wantName: "build",
+			wantOK:   true,
+			wantDoc:  true,
+			wantDesc: "Build provider",
+		},
+		"CI documented target": {
+			line:     "ci: tools build ## [CI] Run all CI checks",
+			wantName: "ci",
+			wantOK:   true,
+			wantDoc:  true,
+			wantCI:   true,
+			wantDesc: "Run all CI checks",
+		},
+		"internal target": {
+			line:         "test-single-service: ## [internal] test single service",
+			wantName:     "test-single-service",
+			wantOK:       true,
+			wantDoc:      true,
+			wantInternal: true,
+			wantDesc:     "test single service",
+		},
+		"variable assignment rejected": {
+			line:   "GO_VER := go1.22",
+			wantOK: false,
+		},
+		"variable simple equals rejected": {
+			line:   "PKG_NAME = internal",
+			wantOK: false,
+		},
+		"variable conditional rejected": {
+			line:   "PKG_NAME ?= internal",
+			wantOK: false,
+		},
+		"recipe line rejected": {
+			line:   "\t@echo hello",
+			wantOK: false,
+		},
+		"indented logical line rejected": {
+			line:   "    target: deps",
+			wantOK: false,
+		},
+		"empty line rejected": {
+			line:   "",
+			wantOK: false,
+		},
+		"double colon target accepted": {
+			line:     "all:: build test",
+			wantName: "all",
+			wantOK:   true,
+		},
+		"target with hyphens and digits": {
+			line:     "golangci-lint5: ## [CI] golangci-lint Checks / 5 of 5",
+			wantName: "golangci-lint5",
+			wantOK:   true,
+			wantDoc:  true,
+			wantCI:   true,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := parseTargetLine(tc.line, 1)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if got.Name != tc.wantName {
+				t.Errorf("Name = %q, want %q", got.Name, tc.wantName)
+			}
+			if got.HasDoc != tc.wantDoc {
+				t.Errorf("HasDoc = %v, want %v", got.HasDoc, tc.wantDoc)
+			}
+			if got.IsCI != tc.wantCI {
+				t.Errorf("IsCI = %v, want %v", got.IsCI, tc.wantCI)
+			}
+			if got.IsInternal != tc.wantInternal {
+				t.Errorf("IsInternal = %v, want %v", got.IsInternal, tc.wantInternal)
+			}
+			if tc.wantDesc != "" && got.Description != tc.wantDesc {
+				t.Errorf("Description = %q, want %q", got.Description, tc.wantDesc)
+			}
+		})
+	}
+}
+
+func TestIsValidTargetName(t *testing.T) {
+	t.Parallel()
+	good := []string{"a", "build", "ci-quick", "golangci-lint5", "_underscore", "fix-imports-core"}
+	bad := []string{"", "1bad", "-bad", "$(VAR)", "has space", "has.dot"}
+	for _, s := range good {
+		if !isValidTargetName(s) {
+			t.Errorf("expected %q to be valid", s)
+		}
+	}
+	for _, s := range bad {
+		if isValidTargetName(s) {
+			t.Errorf("expected %q to be invalid", s)
+		}
+	}
+}
+
+func TestCollectPhonyLine(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		line     string
+		wantList []string
+		wantCont bool
+	}{
+		"continuation": {
+			line:     "\tbuild \\",
+			wantList: []string{"build"},
+			wantCont: true,
+		},
+		"final line no continuation": {
+			line:     "\tbuild",
+			wantList: []string{"build"},
+			wantCont: false,
+		},
+		"multiple targets one line": {
+			line:     "\tbuild test docs \\",
+			wantList: []string{"build", "test", "docs"},
+			wantCont: true,
+		},
+		"empty line stops": {
+			line:     "",
+			wantList: nil,
+			wantCont: false,
+		},
+		"trailing whitespace before backslash": {
+			line:     "\tbuild  \\",
+			wantList: []string{"build"},
+			wantCont: true,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			var got []string
+			cont := collectPhonyLine(tc.line, &got)
+			if cont != tc.wantCont {
+				t.Errorf("cont = %v, want %v", cont, tc.wantCont)
+			}
+			if len(got) != len(tc.wantList) {
+				t.Fatalf("list = %v, want %v", got, tc.wantList)
+			}
+			for i := range got {
+				if got[i] != tc.wantList[i] {
+					t.Errorf("list[%d] = %q, want %q", i, got[i], tc.wantList[i])
+				}
+			}
+		})
+	}
+}

--- a/tools/makelign/validate.go
+++ b/tools/makelign/validate.go
@@ -1,0 +1,379 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package main
+
+import (
+	"cmp"
+	"fmt"
+	"slices"
+	"sort"
+)
+
+// Severity classifies a finding's impact.
+//
+// Errors fail the run; warnings are informational unless `-strict` is set.
+// We deliberately keep the set small (no "info") so the CLI output is easy
+// to scan and filter.
+type Severity int
+
+const (
+	SevWarn Severity = iota
+	SevError
+)
+
+func (s Severity) String() string {
+	switch s {
+	case SevError:
+		return "ERROR"
+	case SevWarn:
+		return "WARN"
+	default:
+		return "?"
+	}
+}
+
+// Finding is one alignment problem detected by validation.
+//
+// File and Line locate the problem in source where possible; Code is a
+// stable short identifier (e.g. "phony-ghost") suitable for filtering or
+// machine consumption; Suggestion is optional human-readable advice such
+// as "did you mean X?" produced from edit-distance matching.
+type Finding struct {
+	Severity   Severity
+	Code       string
+	File       string
+	Line       int
+	Message    string
+	Suggestion string
+}
+
+// Inputs bundles the parsed view of every file involved in alignment.
+type Inputs struct {
+	MakefilePath   string
+	CheatSheetPath string
+	CIDocPath      string
+
+	Make       *MakefileData
+	CheatSheet []CheatSheetRow
+	CIDoc      *CIDoc
+}
+
+// Validate runs every alignment rule against the parsed inputs and returns
+// findings sorted by file, line, then code so output is deterministic.
+func Validate(in *Inputs) []Finding {
+	var findings []Finding
+
+	cheatByName := make(map[string]CheatSheetRow, len(in.CheatSheet))
+	for _, r := range in.CheatSheet {
+		cheatByName[r.Target] = r
+	}
+	phonySet := make(map[string]bool, len(in.Make.Phony))
+	for _, p := range in.Make.Phony {
+		phonySet[p] = true
+	}
+
+	findings = append(findings, checkPhonyAlignment(in, phonySet)...)
+	findings = append(findings, checkCheatSheetAlignment(in, cheatByName)...)
+	findings = append(findings, checkCIDocAlignment(in, cheatByName)...)
+	findings = append(findings, checkOrdering(in)...)
+
+	slices.SortStableFunc(findings, func(a, b Finding) int {
+		if c := cmp.Compare(a.File, b.File); c != 0 {
+			return c
+		}
+		if c := cmp.Compare(a.Line, b.Line); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.Code, b.Code)
+	})
+	return findings
+}
+
+// checkPhonyAlignment verifies that every Makefile target appears in the
+// .PHONY list and vice-versa. These are the highest-impact checks because
+// a `.PHONY` mismatch can cause silent breakage when a same-named file
+// happens to exist in the working directory.
+func checkPhonyAlignment(in *Inputs, phonySet map[string]bool) []Finding {
+	var out []Finding
+	targetNames := slices.Clone(in.Make.Order)
+
+	for _, name := range in.Make.Order {
+		if phonySet[name] {
+			continue
+		}
+		out = append(out, Finding{
+			Severity: SevError,
+			Code:     "phony-missing",
+			File:     in.MakefilePath,
+			Line:     in.Make.Targets[name].Line,
+			Message:  fmt.Sprintf("target %q is not in the .PHONY list", name),
+		})
+	}
+
+	for _, p := range in.Make.Phony {
+		if _, ok := in.Make.Targets[p]; ok {
+			continue
+		}
+		f := Finding{
+			Severity: SevError,
+			Code:     "phony-ghost",
+			File:     in.MakefilePath,
+			Line:     in.Make.PhonyLine,
+			Message:  fmt.Sprintf(".PHONY entry %q does not match any target", p),
+		}
+		if hint := suggest(p, targetNames); hint != "" {
+			f.Suggestion = fmt.Sprintf("did you mean %q?", hint)
+		}
+		out = append(out, f)
+	}
+	return out
+}
+
+// checkCheatSheetAlignment verifies the cheat sheet references real
+// targets (errors) and that documented targets are listed (warnings).
+//
+// A "documented" target is one with a `## description` comment, which is
+// the same set of targets exposed by `make help`. Targets without `##` are
+// considered internal and are not expected to appear in the cheat sheet.
+func checkCheatSheetAlignment(in *Inputs, cheatByName map[string]CheatSheetRow) []Finding {
+	var out []Finding
+	targetNames := slices.Clone(in.Make.Order)
+
+	for _, row := range in.CheatSheet {
+		t, ok := in.Make.Targets[row.Target]
+		if !ok {
+			f := Finding{
+				Severity: SevError,
+				Code:     "cheatsheet-ghost",
+				File:     in.CheatSheetPath,
+				Line:     row.Line,
+				Message:  fmt.Sprintf("cheat sheet target %q is not defined in GNUmakefile", row.Target),
+			}
+			if hint := suggest(row.Target, targetNames); hint != "" {
+				f.Suggestion = fmt.Sprintf("did you mean %q?", hint)
+			}
+			out = append(out, f)
+			continue
+		}
+		// CI flag must agree.
+		if t.IsCI != row.IsCI {
+			out = append(out, Finding{
+				Severity: SevError,
+				Code:     "ci-flag-mismatch",
+				File:     in.CheatSheetPath,
+				Line:     row.Line,
+				Message: fmt.Sprintf(
+					"target %q: GNUmakefile has [CI]=%t but cheat sheet CI? column is %s",
+					row.Target, t.IsCI, checkmark(row.IsCI),
+				),
+			})
+		}
+		// Legacy flag must agree.
+		if t.IsLegacy != row.IsLegacy {
+			out = append(out, Finding{
+				Severity: SevWarn,
+				Code:     "legacy-flag-mismatch",
+				File:     in.CheatSheetPath,
+				Line:     row.Line,
+				Message: fmt.Sprintf(
+					"target %q: GNUmakefile mentions Legacy=%t but cheat sheet Legacy? column is %s",
+					row.Target, t.IsLegacy, checkmark(row.IsLegacy),
+				),
+			})
+		}
+	}
+
+	for _, name := range in.Make.Order {
+		t := in.Make.Targets[name]
+		if !t.HasDoc || t.IsInternal {
+			continue
+		}
+		if _, ok := cheatByName[name]; ok {
+			continue
+		}
+		out = append(out, Finding{
+			Severity: SevWarn,
+			Code:     "cheatsheet-missing",
+			File:     in.MakefilePath,
+			Line:     t.Line,
+			Message:  fmt.Sprintf("documented target %q is missing from the cheat sheet", name),
+		})
+	}
+	return out
+}
+
+// checkCIDocAlignment ensures every CI-marked target is mentioned in
+// continuous-integration.md.
+//
+// Meta targets (marked `<sup>M</sup>` in the cheat sheet) are exempt:
+// they're aggregations like `ci`, `docs`, or `website` whose constituent
+// targets carry the actual CI documentation. Surfacing the parent would
+// just create noise.
+//
+// We warn rather than error so the rule never blocks a PR by itself --
+// CI documentation lags target additions in practice and we want this
+// check to be informative, not punitive.
+func checkCIDocAlignment(in *Inputs, cheatByName map[string]CheatSheetRow) []Finding {
+	var out []Finding
+	for _, name := range in.Make.Order {
+		t := in.Make.Targets[name]
+		if !t.IsCI {
+			continue
+		}
+		if row, ok := cheatByName[name]; ok && row.IsMeta {
+			continue
+		}
+		if in.CIDoc.Refs[name] {
+			continue
+		}
+		out = append(out, Finding{
+			Severity: SevWarn,
+			Code:     "ci-doc-missing",
+			File:     in.MakefilePath,
+			Line:     t.Line,
+			Message:  fmt.Sprintf("CI target %q is not referenced in continuous-integration.md", name),
+		})
+	}
+	return out
+}
+
+// checkOrdering reports the first out-of-order pair in the .PHONY list and
+// in the cheat sheet table. The Makefile and cheat sheet both carry "keep
+// alphabetical" comments, so a single warning per file is enough to nudge
+// the contributor without spamming.
+func checkOrdering(in *Inputs) []Finding {
+	var out []Finding
+
+	for i := 1; i < len(in.Make.Phony); i++ {
+		if in.Make.Phony[i-1] > in.Make.Phony[i] {
+			out = append(out, Finding{
+				Severity: SevWarn,
+				Code:     "phony-order",
+				File:     in.MakefilePath,
+				Line:     in.Make.PhonyLine,
+				Message: fmt.Sprintf(
+					".PHONY list is not alphabetized: %q comes before %q",
+					in.Make.Phony[i-1], in.Make.Phony[i],
+				),
+			})
+			break
+		}
+	}
+
+	names := make([]string, len(in.CheatSheet))
+	for i, r := range in.CheatSheet {
+		names[i] = r.Target
+	}
+	for i := 1; i < len(names); i++ {
+		if names[i-1] > names[i] {
+			out = append(out, Finding{
+				Severity: SevWarn,
+				Code:     "cheatsheet-order",
+				File:     in.CheatSheetPath,
+				Line:     in.CheatSheet[i].Line,
+				Message: fmt.Sprintf(
+					"cheat sheet is not alphabetized: %q comes before %q",
+					names[i-1], names[i],
+				),
+			})
+			break
+		}
+	}
+	return out
+}
+
+// checkmark renders a boolean as the symbol used in the cheat sheet, for
+// finding messages that describe what the column "is".
+func checkmark(v bool) string {
+	if v {
+		return "✔"
+	}
+	return "(empty)"
+}
+
+// suggest returns the candidate closest to `name` by Levenshtein distance,
+// provided the distance is small enough to be plausibly a typo. Empty
+// string means no suggestion.
+func suggest(name string, candidates []string) string {
+	const maxDistance = 3
+	best := ""
+	bestDist := maxDistance + 1
+	for _, c := range candidates {
+		if c == name {
+			continue
+		}
+		d := levenshtein(name, c)
+		if d < bestDist {
+			bestDist = d
+			best = c
+		}
+	}
+	if bestDist > maxDistance {
+		return ""
+	}
+	return best
+}
+
+// levenshtein computes the edit distance between a and b using the classic
+// O(len(a)*len(b)) DP. Inputs in this tool are short target names, so the
+// allocation cost is negligible.
+func levenshtein(a, b string) int {
+	if a == b {
+		return 0
+	}
+	ra, rb := []rune(a), []rune(b)
+	if len(ra) == 0 {
+		return len(rb)
+	}
+	if len(rb) == 0 {
+		return len(ra)
+	}
+	prev := make([]int, len(rb)+1)
+	curr := make([]int, len(rb)+1)
+	for j := range prev {
+		prev[j] = j
+	}
+	for i := 1; i <= len(ra); i++ {
+		curr[0] = i
+		for j := 1; j <= len(rb); j++ {
+			cost := 1
+			if ra[i-1] == rb[j-1] {
+				cost = 0
+			}
+			curr[j] = min3(
+				prev[j]+1,      // deletion
+				curr[j-1]+1,    // insertion
+				prev[j-1]+cost, // substitution
+			)
+		}
+		prev, curr = curr, prev
+	}
+	return prev[len(rb)]
+}
+
+func min3(a, b, c int) int {
+	m := a
+	if b < m {
+		m = b
+	}
+	if c < m {
+		m = c
+	}
+	return m
+}
+
+// sortFindings is exposed for tests so they can compare against expected
+// output without depending on Validate's internal ordering. Production
+// callers don't need it: Validate returns findings already sorted.
+func sortFindings(fs []Finding) {
+	sort.SliceStable(fs, func(i, j int) bool {
+		if fs[i].File != fs[j].File {
+			return fs[i].File < fs[j].File
+		}
+		if fs[i].Line != fs[j].Line {
+			return fs[i].Line < fs[j].Line
+		}
+		return fs[i].Code < fs[j].Code
+	})
+}

--- a/tools/makelign/validate_test.go
+++ b/tools/makelign/validate_test.go
@@ -1,0 +1,62 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package main
+
+import (
+	"testing"
+)
+
+func TestSuggest(t *testing.T) {
+	t.Parallel()
+	candidates := []string{"gh-workflow-lint", "go-build", "go-misspell", "gen", "build"}
+	tests := map[string]struct {
+		name string
+		want string
+	}{
+		"single typo": {
+			name: "gh-workflows-lint",
+			want: "gh-workflow-lint",
+		},
+		"close variant": {
+			name: "go-bild",
+			want: "go-build",
+		},
+		"too far": {
+			name: "completely-unrelated-target-name",
+			want: "",
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got := suggest(tc.name, candidates)
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLevenshtein(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		a, b string
+		want int
+	}{
+		{"", "", 0},
+		{"a", "", 1},
+		{"", "abc", 3},
+		{"kitten", "sitting", 3},
+		{"build", "build", 0},
+		{"gh-workflow-lint", "gh-workflows-lint", 1},
+	}
+	for _, tc := range tests {
+		t.Run(tc.a+"->"+tc.b, func(t *testing.T) {
+			t.Parallel()
+			if got := levenshtein(tc.a, tc.b); got != tc.want {
+				t.Errorf("levenshtein(%q,%q) = %d, want %d", tc.a, tc.b, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds a small Go tool that validates four things stay in sync:
  - GNUmakefile target rules
  - GNUmakefile .PHONY list
  - docs/makefile-cheat-sheet.md
  - docs/continuous-integration.md

The tool emits errors for hard mismatches (a target in .PHONY that
doesn't exist, a cheat sheet row pointing to a missing target, [CI]
flag disagreements) and warnings for soft drift (alphabetical order,
missing rows, missing CI doc references).

This commit ships the tool itself plus a top-level 'make makefile-lint'
target that runs it without -strict. The target is intentionally NOT
wired into ci or ci-quick yet -- a follow-up PR clears the existing
drift, and a final PR enables -strict and wires it into CI.

Running 'make makefile-lint' against current main reports the drift
this stack will fix.

<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
