### PR TITLE
Add ECS daemon task definition namespace modes

### DIFF
--- a/.changelog/48431.txt
+++ b/.changelog/48431.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_ecs_daemon_task_definition: Add `ipc_mode` and `pid_mode` arguments
+```

--- a/internal/service/ecs/daemon_task_definition.go
+++ b/internal/service/ecs/daemon_task_definition.go
@@ -81,8 +81,22 @@ func (r *daemonTaskDefinitionResource) Schema(ctx context.Context, request resou
 					stringvalidator.RegexMatches(regexache.MustCompile("^[0-9A-Za-z_-]+$"), "must contain only alphanumeric characters, hyphens, and underscores"),
 				},
 			},
+			"ipc_mode": schema.StringAttribute{
+				CustomType: fwtypes.StringEnumType[awstypes.DaemonIpcMode](),
+				Optional:   true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
 			"memory": schema.StringAttribute{
 				Optional: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"pid_mode": schema.StringAttribute{
+				CustomType: fwtypes.StringEnumType[awstypes.DaemonPidMode](),
+				Optional:   true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
@@ -674,7 +688,9 @@ type daemonTaskDefinitionResourceModel struct {
 	Cpu                     types.String                                              `tfsdk:"cpu"`
 	ExecutionRoleArn        fwtypes.ARN                                               `tfsdk:"execution_role_arn"`
 	Family                  types.String                                              `tfsdk:"family"`
+	IpcMode                 fwtypes.StringEnum[awstypes.DaemonIpcMode]                `tfsdk:"ipc_mode"`
 	Memory                  types.String                                              `tfsdk:"memory"`
+	PidMode                 fwtypes.StringEnum[awstypes.DaemonPidMode]                `tfsdk:"pid_mode"`
 	Revision                types.Int64                                               `tfsdk:"revision"`
 	Status                  fwtypes.StringEnum[awstypes.DaemonTaskDefinitionStatus]   `tfsdk:"status"`
 	Tags                    tftags.Map                                                `tfsdk:"tags"`

--- a/internal/service/ecs/daemon_task_definition_test.go
+++ b/internal/service/ecs/daemon_task_definition_test.go
@@ -9,6 +9,10 @@ import (
 	"testing"
 
 	"github.com/YakDriver/regexache"
+	"github.com/hashicorp/terraform-plugin-framework/attr/xattr"
+	fwresource "github.com/hashicorp/terraform-plugin-framework/resource"
+	fwschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -17,6 +21,70 @@ import (
 	tfecs "github.com/hashicorp/terraform-provider-aws/internal/service/ecs"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
+
+func TestECSDaemonTaskDefinitionSchema_ipcModePidMode(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	r, err := tfecs.ResourceDaemonTaskDefinition(ctx)
+	if err != nil {
+		t.Fatalf("creating resource: %s", err)
+	}
+
+	response := fwresource.SchemaResponse{}
+	r.Schema(ctx, fwresource.SchemaRequest{}, &response)
+	if response.Diagnostics.HasError() {
+		t.Fatalf("getting schema: %s", response.Diagnostics)
+	}
+
+	for _, name := range []string{"ipc_mode", "pid_mode"} {
+		attr, ok := response.Schema.Attributes[name]
+		if !ok {
+			t.Fatalf("expected %q attribute in schema", name)
+		}
+
+		stringAttr, ok := attr.(fwschema.StringAttribute)
+		if !ok {
+			t.Fatalf("expected %q to be a string attribute, got %T", name, attr)
+		}
+
+		if !stringAttr.Optional {
+			t.Fatalf("expected %q to be optional", name)
+		}
+
+		if len(stringAttr.PlanModifiers) == 0 {
+			t.Fatalf("expected %q to require replacement", name)
+		}
+
+		for _, value := range []string{"none", "shared"} {
+			checkDaemonTaskDefinitionStringEnumValue(t, ctx, name, stringAttr, value, false)
+		}
+
+		for _, value := range []string{"host", "task"} {
+			checkDaemonTaskDefinitionStringEnumValue(t, ctx, name, stringAttr, value, true)
+		}
+	}
+}
+
+func checkDaemonTaskDefinitionStringEnumValue(t *testing.T, ctx context.Context, name string, attr fwschema.StringAttribute, value string, expectError bool) {
+	t.Helper()
+
+	stringValuable, diags := attr.CustomType.ValueFromString(ctx, types.StringValue(value))
+	if diags.HasError() {
+		t.Fatalf("creating %q value %q: %s", name, value, diags)
+	}
+
+	validateable, ok := stringValuable.(xattr.ValidateableAttribute)
+	if !ok {
+		t.Fatalf("expected %q value to be validateable, got %T", name, stringValuable)
+	}
+
+	resp := xattr.ValidateAttributeResponse{}
+	validateable.ValidateAttribute(ctx, xattr.ValidateAttributeRequest{}, &resp)
+	if got := resp.Diagnostics.HasError(); got != expectError {
+		t.Fatalf("expected %q value %q validation error = %t, got %t", name, value, expectError, got)
+	}
+}
 
 func TestAccECSDaemonTaskDefinition_basic(t *testing.T) {
 	ctx := acctest.Context(t)
@@ -45,6 +113,64 @@ func TestAccECSDaemonTaskDefinition_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "container_definition.0.cpu", "256"),
 					resource.TestCheckResourceAttr(resourceName, "container_definition.0.memory", "512"),
 					resource.TestCheckResourceAttr(resourceName, "container_definition.0.essential", acctest.CtTrue),
+				),
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, names.AttrARN),
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: names.AttrARN,
+			},
+		},
+	})
+}
+
+func TestAccECSDaemonTaskDefinition_ipcMode(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_ecs_daemon_task_definition.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ECSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDaemonTaskDefinitionDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDaemonTaskDefinitionConfig_ipcMode(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDaemonTaskDefinitionExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "ipc_mode", "shared"),
+				),
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, names.AttrARN),
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: names.AttrARN,
+			},
+		},
+	})
+}
+
+func TestAccECSDaemonTaskDefinition_pidMode(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_ecs_daemon_task_definition.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ECSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDaemonTaskDefinitionDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDaemonTaskDefinitionConfig_pidMode(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDaemonTaskDefinitionExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "pid_mode", "shared"),
 				),
 			},
 			{
@@ -642,6 +768,44 @@ resource "aws_ecs_daemon_task_definition" "test" {
   family = %[1]q
   cpu    = "512"
   memory = "1024"
+
+  container_definition {
+    name      = "nginx"
+    image     = "nginx:latest"
+    cpu       = 256
+    memory    = 512
+    essential = true
+  }
+}
+`, rName)
+}
+
+func testAccDaemonTaskDefinitionConfig_ipcMode(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_ecs_daemon_task_definition" "test" {
+  family   = %[1]q
+  cpu      = "512"
+  memory   = "1024"
+  ipc_mode = "shared"
+
+  container_definition {
+    name      = "nginx"
+    image     = "nginx:latest"
+    cpu       = 256
+    memory    = 512
+    essential = true
+  }
+}
+`, rName)
+}
+
+func testAccDaemonTaskDefinitionConfig_pidMode(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_ecs_daemon_task_definition" "test" {
+  family   = %[1]q
+  cpu      = "512"
+  memory   = "1024"
+  pid_mode = "shared"
 
   container_definition {
     name      = "nginx"

--- a/website/docs/r/ecs_daemon_task_definition.html.markdown
+++ b/website/docs/r/ecs_daemon_task_definition.html.markdown
@@ -138,6 +138,26 @@ resource "aws_ecs_daemon_task_definition" "example" {
 }
 ```
 
+### With Shared IPC and PID Namespaces
+
+```terraform
+resource "aws_ecs_daemon_task_definition" "example" {
+  family   = "my-daemon-service"
+  cpu      = "512"
+  memory   = "1024"
+  ipc_mode = "shared"
+  pid_mode = "shared"
+
+  container_definition {
+    name      = "agent"
+    image     = "example/security-agent:latest"
+    cpu       = 256
+    memory    = 512
+    essential = true
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are required:
@@ -149,7 +169,9 @@ The following arguments are optional:
 
 * `cpu` - (Optional) Number of CPU units used by the task.
 * `execution_role_arn` - (Optional) ARN of the task execution role that the Amazon ECS container agent and the Docker daemon can assume.
+* `ipc_mode` - (Optional) IPC namespace mode for the daemon. Valid values: `none`, `shared`.
 * `memory` - (Optional) Amount (in MiB) of memory used by the task.
+* `pid_mode` - (Optional) Process namespace mode for the daemon. Valid values: `none`, `shared`.
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `task_role_arn` - (Optional) ARN of IAM role that allows your Amazon ECS container task to make calls to other AWS services.


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

Users can remove the new optional `ipc_mode` and `pid_mode` arguments from `aws_ecs_daemon_task_definition` configurations or pin to a provider version before this change.

## Changes to Security Controls

Yes. This PR exposes ECS Managed Daemon IPC and PID namespace mode settings through `aws_ecs_daemon_task_definition`.

This does not change provider authentication, authorization, encryption, or logging behavior. It allows users to opt into ECS daemon runtime namespace sharing by setting `ipc_mode = "shared"` and/or `pid_mode = "shared"`. When unset, the provider leaves the values omitted and AWS applies its default behavior.

### Description

This PR adds `ipc_mode` and `pid_mode` arguments to `aws_ecs_daemon_task_definition`.

The new arguments map to the ECS `RegisterDaemonTaskDefinition` and `DescribeDaemonTaskDefinition` API fields for Managed Daemons. Both arguments are optional and force replacement, matching the immutable nature of daemon task definition revisions.

Valid values are:

* `ipc_mode`: `none`, `shared`
* `pid_mode`: `none`, `shared`

This also adds acceptance test coverage and documentation for the new arguments.

AI assistance disclosure: this PR was prepared with assistance from an LLM agent. The human author is responsible for the submitted code and has reviewed the changes.

### Relations

Closes #50006

### References

* https://aws.amazon.com/about-aws/whats-new/2026/06/ecs-managed-daemons-pid-ipc-modes/

### Output from Acceptance Testing

Acceptance tests were not run locally because they create real AWS resources.

```console
% make testacc TESTS='TestAccECSDaemonTaskDefinition_(ipcMode|pidMode)' PKG=ecs

Not run.