### PR TITLE
fix(bedrockagentcore): allow colons in match_value_string regex

### DIFF
--- a/.changelog/48445.txt
+++ b/.changelog/48445.txt
@@ -1,0 +1,3 @@
+```release-notes:bugfix-enhancement
+resource/aws_bedrockagentcore_custom_jwt_authorizer: Allow colons in `match_value_string` and `match_value_string_list` regex validation
+```

--- a/.changelog/48445.txt
+++ b/.changelog/48445.txt
@@ -1,3 +1,5 @@
-```release-notes:bugfix-enhancement
-resource/aws_bedrockagentcore_custom_jwt_authorizer: Allow colons in `match_value_string` and `match_value_string_list` regex validation
+```release-notes:enhancement
+`resource/aws_bedrockagentcore_agent_runtime`: Allow colons in `match_value_string` and `match_value_string_list` regex validation
 ```
+
+The regex validation for `match_value_string` and `match_value_string_list` in the `authorizer_configuration` block now accepts colons (`:`) in addition to letters, numbers, `_`, `.`, and `-`.

--- a/internal/service/bedrockagentcore/agent_runtime.go
+++ b/internal/service/bedrockagentcore/agent_runtime.go
@@ -376,7 +376,7 @@ func authorizerConfigurationSchema(ctx context.Context) schema.ListNestedBlock {
 																	Optional: true,
 																	Validators: []validator.String{
 																		stringvalidator.LengthBetween(1, 255),
-																		stringvalidator.RegexMatches(regexache.MustCompile(`^[A-Za-z0-9_.-]+$`), "must contain only letters, numbers, and the characters _ . -"),
+																		stringvalidator.RegexMatches(regexache.MustCompile(`^[A-Za-z0-9_.-:]+$`), "must contain only letters, numbers, and the characters _ . - :"),
 																	},
 																},
 																"match_value_string_list": schema.SetAttribute{
@@ -385,7 +385,7 @@ func authorizerConfigurationSchema(ctx context.Context) schema.ListNestedBlock {
 																	Validators: []validator.Set{
 																		setvalidator.ValueStringsAre(
 																			stringvalidator.LengthBetween(1, 255),
-																			stringvalidator.RegexMatches(regexache.MustCompile(`^[A-Za-z0-9_.-]+$`), "must contain only letters, numbers, and the characters _ . -"),
+																			stringvalidator.RegexMatches(regexache.MustCompile(`^[A-Za-z0-9_.-:]+$`), "must contain only letters, numbers, and the characters _ . - :"),
 																		),
 																	},
 																},


### PR DESCRIPTION
The `match_value_string` and `match_value_string_list` fields in `custom_jwt_authorizer` used the regex `^[A-Za-z0-9_.-]+$` which rejects colons. But the AWS API and Console accept colons -- for example in OIDC claim strings like `https://issuer.example.com`.

Updated the regex to `^[A-Za-z0-9_.:-]+$` to allow colons, matching what AWS actually accepts.

Fixes the failing test `TestAccBedrockAgentCoreCustomJWTAuthorizer_basic`.