### PR TITLE
list resource/aws_route: Removes resource Read function from List

### DIFF
--- a/.ci/semgrep/list/no-resource-read.yml
+++ b/.ci/semgrep/list/no-resource-read.yml
@@ -9,7 +9,6 @@ rules:
       include:
         - "/internal/service"
       exclude:
-        - "/internal/service/ec2/vpc_route_list.go"
         - "/internal/service/ec2/vpc_route_table_list.go"
         - "/internal/service/ec2/vpc_security_group_list.go"
         - "/internal/service/iam/role_policy_list.go"

--- a/internal/service/ec2/testdata/Route/list_basic/main.tf
+++ b/internal/service/ec2/testdata/Route/list_basic/main.tf
@@ -15,18 +15,8 @@ resource "aws_route_table" "test" {
 
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
-
-  tags = {
-    Name = var.rName
-  }
 }
 
 resource "aws_internet_gateway" "test" {
   vpc_id = aws_vpc.test.id
-}
-
-variable "rName" {
-  description = "Name for resource"
-  type        = string
-  nullable    = false
 }

--- a/internal/service/ec2/testdata/Route/list_basic/main.tf
+++ b/internal/service/ec2/testdata/Route/list_basic/main.tf
@@ -5,16 +5,12 @@ resource "aws_route" "test" {
   count = 2
 
   route_table_id         = aws_route_table.test.id
-  destination_cidr_block = "172.${16 + count.index}.0.0/16"
+  destination_cidr_block = cidrsubnet("172.16.0.0/12", 12, count.index)
   gateway_id             = aws_internet_gateway.test.id
 }
 
 resource "aws_route_table" "test" {
   vpc_id = aws_vpc.test.id
-
-  tags = {
-    Name = var.rName
-  }
 }
 
 resource "aws_vpc" "test" {
@@ -27,10 +23,6 @@ resource "aws_vpc" "test" {
 
 resource "aws_internet_gateway" "test" {
   vpc_id = aws_vpc.test.id
-
-  tags = {
-    Name = var.rName
-  }
 }
 
 variable "rName" {

--- a/internal/service/ec2/testdata/Route/list_include_resource/main.tf
+++ b/internal/service/ec2/testdata/Route/list_include_resource/main.tf
@@ -2,32 +2,33 @@
 # SPDX-License-Identifier: MPL-2.0
 
 resource "aws_route" "test" {
-  count = 2
+  count = var.resource_count
 
-  region                 = var.region
   route_table_id         = aws_route_table.test.id
   destination_cidr_block = cidrsubnet("172.16.0.0/12", 12, count.index)
   gateway_id             = aws_internet_gateway.test.id
 }
 
 resource "aws_route_table" "test" {
-  region = var.region
   vpc_id = aws_vpc.test.id
 }
 
 resource "aws_vpc" "test" {
-  region = var.region
-
   cidr_block = "10.0.0.0/16"
 }
 
 resource "aws_internet_gateway" "test" {
-  region = var.region
   vpc_id = aws_vpc.test.id
 }
 
-variable "region" {
-  description = "Region to deploy resource in"
+variable "rName" {
+  description = "Name for resource"
   type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
   nullable    = false
 }

--- a/internal/service/ec2/testdata/Route/list_include_resource/main.tf
+++ b/internal/service/ec2/testdata/Route/list_include_resource/main.tf
@@ -21,12 +21,6 @@ resource "aws_internet_gateway" "test" {
   vpc_id = aws_vpc.test.id
 }
 
-variable "rName" {
-  description = "Name for resource"
-  type        = string
-  nullable    = false
-}
-
 variable "resource_count" {
   description = "Number of resources to create"
   type        = number

--- a/internal/service/ec2/testdata/Route/list_include_resource/query.tfquery.hcl
+++ b/internal/service/ec2/testdata/Route/list_include_resource/query.tfquery.hcl
@@ -1,0 +1,12 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_route" "test" {
+  provider = aws
+
+  include_resource = true
+
+  config {
+    route_table_id = aws_route_table.test.id
+  }
+}

--- a/internal/service/ec2/testdata/Route/list_ipv6_destination/main.tf
+++ b/internal/service/ec2/testdata/Route/list_ipv6_destination/main.tf
@@ -9,27 +9,15 @@ resource "aws_route" "test" {
 
 resource "aws_route_table" "test" {
   vpc_id = aws_vpc.test.id
-
-  tags = {
-    Name = var.rName
-  }
 }
 
 resource "aws_vpc" "test" {
   cidr_block                       = "10.0.0.0/16"
   assign_generated_ipv6_cidr_block = true
-
-  tags = {
-    Name = var.rName
-  }
 }
 
 resource "aws_egress_only_internet_gateway" "test" {
   vpc_id = aws_vpc.test.id
-
-  tags = {
-    Name = var.rName
-  }
 }
 
 variable "rName" {

--- a/internal/service/ec2/testdata/Route/list_ipv6_destination/main.tf
+++ b/internal/service/ec2/testdata/Route/list_ipv6_destination/main.tf
@@ -19,9 +19,3 @@ resource "aws_vpc" "test" {
 resource "aws_egress_only_internet_gateway" "test" {
   vpc_id = aws_vpc.test.id
 }
-
-variable "rName" {
-  description = "Name for resource"
-  type        = string
-  nullable    = false
-}

--- a/internal/service/ec2/testdata/Route/list_prefix_list_destination/main.tf
+++ b/internal/service/ec2/testdata/Route/list_prefix_list_destination/main.tf
@@ -9,26 +9,14 @@ resource "aws_route" "test" {
 
 resource "aws_route_table" "test" {
   vpc_id = aws_vpc.test.id
-
-  tags = {
-    Name = var.rName
-  }
 }
 
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
-
-  tags = {
-    Name = var.rName
-  }
 }
 
 resource "aws_internet_gateway" "test" {
   vpc_id = aws_vpc.test.id
-
-  tags = {
-    Name = var.rName
-  }
 }
 
 resource "aws_ec2_managed_prefix_list" "test" {
@@ -39,10 +27,6 @@ resource "aws_ec2_managed_prefix_list" "test" {
   entry {
     cidr        = "172.16.0.0/16"
     description = "Test entry"
-  }
-
-  tags = {
-    Name = var.rName
   }
 }
 

--- a/internal/service/ec2/vpc_route.go
+++ b/internal/service/ec2/vpc_route.go
@@ -337,6 +337,12 @@ func resourceRouteRead(ctx context.Context, d *schema.ResourceData, meta any) di
 		return sdkdiag.AppendErrorf(diags, "reading Route in Route Table (%s) with destination (%s): %s", routeTableID, destination, err)
 	}
 
+	return resourceRouteFlatten(d, route)
+}
+
+func resourceRouteFlatten(d *schema.ResourceData, route *awstypes.Route) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	d.Set("carrier_gateway_id", route.CarrierGatewayId)
 	d.Set("core_network_arn", route.CoreNetworkArn)
 	d.Set(routeDestinationCIDRBlock, route.DestinationCidrBlock)

--- a/internal/service/ec2/vpc_route_list.go
+++ b/internal/service/ec2/vpc_route_list.go
@@ -107,11 +107,10 @@ func (l *routeListResource) List(ctx context.Context, request list.ListRequest, 
 			rd.Set("route_table_id", routeTableID)
 			rd.Set(destinationKey, destination)
 
-			diags := resourceRouteRead(ctx, rd, awsClient)
-			if diags.HasError() || rd.Id() == "" {
+			diags := resourceRouteFlatten(rd, &route)
+			if diags.HasError() {
 				tflog.Error(ctx, "Reading route", map[string]any{
-					names.AttrID: destination,
-					"diags":      sdkdiag.DiagnosticsString(diags),
+					"diags": sdkdiag.DiagnosticsString(diags),
 				})
 				continue
 			}
@@ -121,8 +120,7 @@ func (l *routeListResource) List(ctx context.Context, request list.ListRequest, 
 			l.SetResult(ctx, awsClient, request.IncludeResource, rd, &result)
 			if result.Diagnostics.HasError() {
 				tflog.Error(ctx, "Setting result", map[string]any{
-					names.AttrID: destination,
-					"diags":      result.Diagnostics,
+					"diags": result.Diagnostics,
 				})
 				continue
 			}

--- a/internal/service/ec2/vpc_route_list_test.go
+++ b/internal/service/ec2/vpc_route_list_test.go
@@ -6,6 +6,7 @@ package ec2_test
 import (
 	"testing"
 
+	"github.com/YakDriver/regexache"
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
@@ -15,6 +16,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	tfknownvalue "github.com/hashicorp/terraform-provider-aws/internal/acctest/knownvalue"
+	tfquerycheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/querycheck"
+	tfqueryfilter "github.com/hashicorp/terraform-provider-aws/internal/acctest/queryfilter"
 	tfstatecheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/statecheck"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -240,6 +243,75 @@ func TestAccVPCRoute_List_regionOverride(t *testing.T) {
 						"destination_cidr_block":      destination2.ValueCheck(),
 						"destination_ipv6_cidr_block": knownvalue.Null(),
 						"destination_prefix_list_id":  knownvalue.Null(),
+					}),
+				},
+			},
+		},
+	})
+}
+
+func TestAccVPCRoute_List_includeResource(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_route.test[0]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity1 := tfstatecheck.Identity()
+	routeTableID := tfstatecheck.StateValue()
+	gatewayID := tfstatecheck.StateValue()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckRouteDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Route/list_include_resource"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(1),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+					routeTableID.GetStateValue("aws_route_table.test", tfjsonpath.New(names.AttrID)),
+					gatewayID.GetStateValue("aws_internet_gateway.test", tfjsonpath.New(names.AttrID)),
+				},
+			},
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/Route/list_include_resource"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(1),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_route.test", identity1.Checks()),
+					querycheck.ExpectResourceKnownValues("aws_route.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), []querycheck.KnownValueCheck{
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("carrier_gateway_id"), knownvalue.StringExact("")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("core_network_arn"), knownvalue.StringExact("")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("destination_cidr_block"), knownvalue.StringRegexp(regexache.MustCompile(`.+`))),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("destination_ipv6_cidr_block"), knownvalue.StringExact("")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("destination_prefix_list_id"), knownvalue.StringExact("")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("egress_only_gateway_id"), knownvalue.StringExact("")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("gateway_id"), gatewayID.ValueCheck()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrInstanceID), knownvalue.StringExact("")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("instance_owner_id"), knownvalue.StringExact("")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("local_gateway_id"), knownvalue.StringExact("")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("nat_gateway_id"), knownvalue.StringExact("")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrNetworkInterfaceID), knownvalue.StringExact("")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("odb_network_arn"), knownvalue.StringExact("")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("origin"), knownvalue.StringExact("CreateRoute")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("route_table_id"), routeTableID.ValueCheck()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrState), knownvalue.StringExact("active")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrTransitGatewayID), knownvalue.StringExact("")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrVPCEndpointID), knownvalue.StringExact("")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("vpc_peering_connection_id"), knownvalue.StringExact("")),
 					}),
 				},
 			},

--- a/internal/service/ec2/vpc_route_list_test.go
+++ b/internal/service/ec2/vpc_route_list_test.go
@@ -27,7 +27,6 @@ func TestAccVPCRoute_List_basic(t *testing.T) {
 
 	resourceName1 := "aws_route.test[0]"
 	resourceName2 := "aws_route.test[1]"
-	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
 	routeTableID := tfstatecheck.StateValue()
 	destination1 := tfstatecheck.StateValue()
@@ -45,9 +44,6 @@ func TestAccVPCRoute_List_basic(t *testing.T) {
 			// Step 1: Setup
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Route/list_basic"),
-				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
-				},
 				ConfigStateChecks: []statecheck.StateCheck{
 					routeTableID.GetStateValue("aws_route_table.test", tfjsonpath.New(names.AttrID)),
 					destination1.GetStateValue(resourceName1, tfjsonpath.New("destination_cidr_block")),
@@ -58,9 +54,6 @@ func TestAccVPCRoute_List_basic(t *testing.T) {
 			{
 				Query:           true,
 				ConfigDirectory: config.StaticDirectory("testdata/Route/list_basic"),
-				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
-				},
 				QueryResultChecks: []querycheck.QueryResultCheck{
 					querycheck.ExpectIdentity("aws_route.test", map[string]knownvalue.Check{
 						names.AttrAccountID:           tfknownvalue.AccountID(),
@@ -254,7 +247,6 @@ func TestAccVPCRoute_List_includeResource(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceName1 := "aws_route.test[0]"
-	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
 	identity1 := tfstatecheck.Identity()
 	routeTableID := tfstatecheck.StateValue()
@@ -273,7 +265,6 @@ func TestAccVPCRoute_List_includeResource(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Route/list_include_resource"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:  config.StringVariable(rName),
 					"resource_count": config.IntegerVariable(1),
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -287,7 +278,6 @@ func TestAccVPCRoute_List_includeResource(t *testing.T) {
 				Query:           true,
 				ConfigDirectory: config.StaticDirectory("testdata/Route/list_include_resource"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:  config.StringVariable(rName),
 					"resource_count": config.IntegerVariable(1),
 				},
 				QueryResultChecks: []querycheck.QueryResultCheck{


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Adds `_includeResource` test for `aws_codebuild_project`.

Removes resource Read function from `aws_codebuild_project` List

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=ec2 TESTS=TestAccVPCRoute_List_

--- PASS: TestAccVPCRoute_List_basic (26.87s)
--- PASS: TestAccVPCRoute_List_includeResource (26.98s)
--- PASS: TestAccVPCRoute_List_regionOverride (29.87s)
--- PASS: TestAccVPCRoute_List_prefixListDestination (32.64s)
--- PASS: TestAccVPCRoute_List_ipv6Destination (35.57s)
```
