### PR TITLE
list resource/aws_route_table: Removes resource Read function from List

### DIFF
--- a/.ci/semgrep/list/no-resource-read.yml
+++ b/.ci/semgrep/list/no-resource-read.yml
@@ -9,7 +9,6 @@ rules:
       include:
         - "/internal/service"
       exclude:
-        - "/internal/service/ec2/vpc_route_table_list.go"
         - "/internal/service/ec2/vpc_security_group_list.go"
         - "/internal/service/iam/role_policy_list.go"
         - "/internal/service/lambda/layer_version_list.go"

--- a/.ci/semgrep/list/no-resource-read.yml
+++ b/.ci/semgrep/list/no-resource-read.yml
@@ -9,7 +9,6 @@ rules:
       include:
         - "/internal/service"
       exclude:
-        - "/internal/service/ec2/vpc_security_group_list.go"
         - "/internal/service/iam/role_policy_list.go"
         - "/internal/service/lambda/layer_version_list.go"
         - "/internal/service/route53/record_list.go"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ NOTES:
 
 FEATURES:
 
+* **New List Resource:** `aws_acm_certificate` ([#48283](https://github.com/hashicorp/terraform-provider-aws/issues/48283))
+* **New List Resource:** `aws_bedrockagentcore_evaluator` ([#47964](https://github.com/hashicorp/terraform-provider-aws/issues/47964))
 * **New List Resource:** `aws_sagemaker_hub_content_reference` ([#48379](https://github.com/hashicorp/terraform-provider-aws/issues/48379))
+* **New Resource:** `aws_bedrockagentcore_evaluator` ([#47964](https://github.com/hashicorp/terraform-provider-aws/issues/47964))
 * **New Resource:** `aws_sagemaker_hub_content_reference` ([#48379](https://github.com/hashicorp/terraform-provider-aws/issues/48379))
 
 ENHANCEMENTS:

--- a/internal/service/ec2/testdata/RouteTable/list_include_resource/main.tf
+++ b/internal/service/ec2/testdata/RouteTable/list_include_resource/main.tf
@@ -4,10 +4,20 @@
 resource "aws_route_table" "test" {
   count  = var.resource_count
   vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = "${var.rName}-${count.index}"
+  }
 }
 
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
 }
 
 variable "resource_count" {

--- a/internal/service/ec2/testdata/RouteTable/list_include_resource/query.tfquery.hcl
+++ b/internal/service/ec2/testdata/RouteTable/list_include_resource/query.tfquery.hcl
@@ -1,0 +1,15 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_route_table" "test" {
+  provider = aws
+
+  include_resource = true
+
+  config {
+    filter {
+      name   = "vpc-id"
+      values = [aws_vpc.test.id]
+    }
+  }
+}

--- a/internal/service/ec2/testdata/RouteTable/list_region_override/main.tf
+++ b/internal/service/ec2/testdata/RouteTable/list_region_override/main.tf
@@ -1,18 +1,17 @@
 # Copyright IBM Corp. 2014, 2026
 # SPDX-License-Identifier: MPL-2.0
 
-
-resource "aws_vpc" "test" {
-  region = var.region
-
-  cidr_block = "10.0.0.0/16"
-}
-
 resource "aws_route_table" "test" {
   count = 2
 
   region = var.region
   vpc_id = aws_vpc.test.id
+}
+
+resource "aws_vpc" "test" {
+  region = var.region
+
+  cidr_block = "10.0.0.0/16"
 }
 
 variable "region" {

--- a/internal/service/ec2/testdata/SecurityGroup/list_include_resource/main.tf
+++ b/internal/service/ec2/testdata/SecurityGroup/list_include_resource/main.tf
@@ -1,0 +1,29 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_security_group" "test" {
+  count = var.resource_count
+
+  name   = "${var.rName}-${count.index}"
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = "${var.rName}-${count.index}"
+  }
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}

--- a/internal/service/ec2/testdata/SecurityGroup/list_include_resource/query.tfquery.hcl
+++ b/internal/service/ec2/testdata/SecurityGroup/list_include_resource/query.tfquery.hcl
@@ -1,0 +1,15 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_security_group" "test" {
+  provider = aws
+
+  include_resource = true
+
+  config {
+    filter {
+      name   = "vpc-id"
+      values = [aws_vpc.test.id]
+    }
+  }
+}

--- a/internal/service/ec2/testdata/SecurityGroup/list_region_override/main.tf
+++ b/internal/service/ec2/testdata/SecurityGroup/list_region_override/main.tf
@@ -1,0 +1,33 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_security_group" "test" {
+  count = var.resource_count
+
+  region = var.region
+  name   = "${var.rName}-${count.index}"
+  vpc_id = aws_vpc.test.id
+}
+
+resource "aws_vpc" "test" {
+  region     = var.region
+  cidr_block = "10.0.0.0/16"
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}
+
+variable "region" {
+  description = "Region to deploy resource in"
+  type        = string
+  nullable    = false
+}

--- a/internal/service/ec2/testdata/SecurityGroup/list_region_override/query.tfquery.hcl
+++ b/internal/service/ec2/testdata/SecurityGroup/list_region_override/query.tfquery.hcl
@@ -1,0 +1,15 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_security_group" "test" {
+  provider = aws
+
+  config {
+    region = var.region
+
+    filter {
+      name   = "vpc-id"
+      values = [aws_vpc.test.id]
+    }
+  }
+}

--- a/internal/service/ec2/vpc_route_table.go
+++ b/internal/service/ec2/vpc_route_table.go
@@ -239,6 +239,12 @@ func resourceRouteTableRead(ctx context.Context, d *schema.ResourceData, meta an
 		return sdkdiag.AppendErrorf(diags, "reading Route Table (%s): %s", d.Id(), err)
 	}
 
+	return resourceRouteTableFlatten(ctx, c, conn, d, routeTable)
+}
+
+func resourceRouteTableFlatten(ctx context.Context, c *conns.AWSClient, conn *ec2.Client, d *schema.ResourceData, routeTable *awstypes.RouteTable) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	ownerID := aws.ToString(routeTable.OwnerId)
 	d.Set(names.AttrARN, routeTableARN(ctx, c, ownerID, d.Id()))
 	d.Set(names.AttrOwnerID, ownerID)

--- a/internal/service/ec2/vpc_route_table_list.go
+++ b/internal/service/ec2/vpc_route_table_list.go
@@ -115,22 +115,15 @@ func (l *routeTableListResource) List(ctx context.Context, request list.ListRequ
 			result := request.NewListResult(ctx)
 
 			tags := keyValueTags(ctx, routeTable.Tags)
-			setTagsOut(ctx, routeTable.Tags)
 
 			rd := l.ResourceData()
 			rd.SetId(aws.ToString(routeTable.RouteTableId))
 
-			tflog.Info(ctx, "Reading resource")
-			diags := resourceRouteTableRead(ctx, rd, awsClient)
+			diags := resourceRouteTableFlatten(ctx, awsClient, conn, rd, &routeTable)
 			if diags.HasError() {
 				tflog.Error(ctx, "Reading resource", map[string]any{
-					names.AttrID: aws.ToString(routeTable.RouteTableId),
-					"diags":      diags,
+					"diags": diags,
 				})
-				continue
-			}
-			if rd.Id() == "" {
-				// Resource is logically deleted
 				continue
 			}
 
@@ -143,8 +136,7 @@ func (l *routeTableListResource) List(ctx context.Context, request list.ListRequ
 			l.SetResult(ctx, awsClient, request.IncludeResource, rd, &result)
 			if result.Diagnostics.HasError() {
 				tflog.Error(ctx, "Setting result", map[string]any{
-					names.AttrID: aws.ToString(routeTable.RouteTableId),
-					"diags":      result.Diagnostics,
+					"diags": result.Diagnostics,
 				})
 				continue
 			}

--- a/internal/service/ec2/vpc_route_table_list_test.go
+++ b/internal/service/ec2/vpc_route_table_list_test.go
@@ -6,6 +6,7 @@ package ec2_test
 import (
 	"testing"
 
+	"github.com/YakDriver/regexache"
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
@@ -15,6 +16,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	tfknownvalue "github.com/hashicorp/terraform-provider-aws/internal/acctest/knownvalue"
+	tfquerycheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/querycheck"
+	tfqueryfilter "github.com/hashicorp/terraform-provider-aws/internal/acctest/queryfilter"
 	tfstatecheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/statecheck"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -24,7 +27,6 @@ func TestAccVPCRouteTable_List_basic(t *testing.T) {
 
 	resourceName1 := "aws_route_table.test[0]"
 	resourceName2 := "aws_route_table.test[1]"
-	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
 	id1 := tfstatecheck.StateValue()
 	id2 := tfstatecheck.StateValue()
@@ -42,7 +44,6 @@ func TestAccVPCRouteTable_List_basic(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/RouteTable/list_basic"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:  config.StringVariable(rName),
 					"resource_count": config.IntegerVariable(2),
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -55,7 +56,6 @@ func TestAccVPCRouteTable_List_basic(t *testing.T) {
 				Query:           true,
 				ConfigDirectory: config.StaticDirectory("testdata/RouteTable/list_basic"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:  config.StringVariable(rName),
 					"resource_count": config.IntegerVariable(2),
 				},
 				QueryResultChecks: []querycheck.QueryResultCheck{
@@ -121,6 +121,62 @@ func TestAccVPCRouteTable_List_regionOverride(t *testing.T) {
 						names.AttrAccountID: tfknownvalue.AccountID(),
 						names.AttrRegion:    knownvalue.StringExact(acctest.AlternateRegion()),
 						names.AttrID:        id2.ValueCheck(),
+					}),
+				},
+			},
+		},
+	})
+}
+
+func TestAccVPCRouteTable_List_includeResource(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_route_table.test[0]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity1 := tfstatecheck.Identity()
+	vpcID := tfstatecheck.StateValue()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		CheckDestroy:             testAccCheckRouteTableDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/RouteTable/list_include_resource"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(1),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+					vpcID.GetStateValue("aws_vpc.test", tfjsonpath.New(names.AttrID)),
+				},
+			},
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/RouteTable/list_include_resource"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(1),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_route_table.test", identity1.Checks()),
+					querycheck.ExpectResourceKnownValues("aws_route_table.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), []querycheck.KnownValueCheck{
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrARN), tfknownvalue.RegionalARNRegexp("ec2", regexache.MustCompile(`route-table/rtb-.+`))),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrOwnerID), tfknownvalue.AccountID()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("propagating_vgws"), knownvalue.SetExact([]knownvalue.Check{})),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("route"), knownvalue.SetExact([]knownvalue.Check{})),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrVPCID), vpcID.ValueCheck()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
+							"Name": knownvalue.StringExact(rName + "-0"),
+						})),
 					}),
 				},
 			},

--- a/internal/service/ec2/vpc_security_group.go
+++ b/internal/service/ec2/vpc_security_group.go
@@ -284,14 +284,18 @@ func resourceSecurityGroupRead(ctx context.Context, d *schema.ResourceData, meta
 		return sdkdiag.AppendErrorf(diags, "reading Security Group (%s): %s", d.Id(), err)
 	}
 
+	return resourceSecurityGroupFlatten(ctx, c, d, sg)
+}
+
+func resourceSecurityGroupFlatten(ctx context.Context, c *conns.AWSClient, d *schema.ResourceData, sg *awstypes.SecurityGroup) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	remoteIngressRules := securityGroupIPPermGather(d.Id(), sg.IpPermissions, sg.OwnerId)
 	remoteEgressRules := securityGroupIPPermGather(d.Id(), sg.IpPermissionsEgress, sg.OwnerId)
 
 	localIngressRules := d.Get("ingress").(*schema.Set).List()
 	localEgressRules := d.Get("egress").(*schema.Set).List()
 
-	// Loop through the local state of rules, doing a match against the remote
-	// ruleSet we built above.
 	ingressRules := matchRules("ingress", localIngressRules, remoteIngressRules)
 	egressRules := matchRules("egress", localEgressRules, remoteEgressRules)
 
@@ -315,7 +319,6 @@ func resourceSecurityGroupRead(ctx context.Context, d *schema.ResourceData, meta
 
 	return diags
 }
-
 func resourceSecurityGroupUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)

--- a/internal/service/ec2/vpc_security_group_list.go
+++ b/internal/service/ec2/vpc_security_group_list.go
@@ -105,22 +105,15 @@ func (l *listResourceSecurityGroup) List(ctx context.Context, request list.ListR
 
 			result := request.NewListResult(ctx)
 			tags := keyValueTags(ctx, item.Tags)
-			setTagsOut(ctx, item.Tags)
 
 			rd := l.ResourceData()
 			rd.SetId(groupID)
 
-			tflog.Info(ctx, "Reading resource")
-			diags := resourceSecurityGroupRead(ctx, rd, awsClient)
+			diags := resourceSecurityGroupFlatten(ctx, awsClient, rd, &item)
 			if diags.HasError() {
 				tflog.Error(ctx, "Reading resource", map[string]any{
-					names.AttrID: groupID,
-					"diags":      sdkdiag.DiagnosticsString(diags),
+					"diags": sdkdiag.DiagnosticsString(diags),
 				})
-				continue
-			}
-			if rd.Id() == "" {
-				// Resource is logically deleted
 				continue
 			}
 

--- a/internal/service/ec2/vpc_security_group_list_test.go
+++ b/internal/service/ec2/vpc_security_group_list_test.go
@@ -6,6 +6,7 @@ package ec2_test
 import (
 	"testing"
 
+	"github.com/YakDriver/regexache"
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
@@ -15,6 +16,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	tfknownvalue "github.com/hashicorp/terraform-provider-aws/internal/acctest/knownvalue"
+	tfquerycheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/querycheck"
+	tfqueryfilter "github.com/hashicorp/terraform-provider-aws/internal/acctest/queryfilter"
+	tfstatecheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/statecheck"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -184,6 +188,118 @@ func TestAccVPCSecurityGroup_List_filterByVPCID(t *testing.T) {
 						names.AttrRegion:    tfknownvalue.StringExact(acctest.Region()),
 						names.AttrID:        tfknownvalue.StringPtrExact(&id2),
 					}),
+				},
+			},
+		},
+	})
+}
+
+func TestAccVPCSecurityGroup_List_includeResource(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_security_group.test[0]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity1 := tfstatecheck.Identity()
+	vpcID := tfstatecheck.StateValue()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckSecurityGroupDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/SecurityGroup/list_include_resource"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(1),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+					vpcID.GetStateValue("aws_vpc.test", tfjsonpath.New(names.AttrID)),
+				},
+			},
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/SecurityGroup/list_include_resource"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(1),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_security_group.test", identity1.Checks()),
+					querycheck.ExpectResourceKnownValues("aws_security_group.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), []querycheck.KnownValueCheck{
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrARN), tfknownvalue.RegionalARNRegexp("ec2", regexache.MustCompile(`security-group/sg-.+`))),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrDescription), knownvalue.StringExact("Managed by Terraform")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("egress"), knownvalue.SetExact([]knownvalue.Check{})),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("ingress"), knownvalue.SetExact([]knownvalue.Check{})),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrName), knownvalue.StringExact(rName+"-0")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrNamePrefix), knownvalue.StringExact("")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrOwnerID), tfknownvalue.AccountID()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrVPCID), vpcID.ValueCheck()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
+							"Name": knownvalue.StringExact(rName + "-0"),
+						})),
+					}),
+				},
+			},
+		},
+	})
+}
+
+func TestAccVPCSecurityGroup_List_regionOverride(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_security_group.test[0]"
+	resourceName2 := "aws_security_group.test[1]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity1 := tfstatecheck.Identity()
+	identity2 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		CheckDestroy:             acctest.CheckDestroyNoop,
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/SecurityGroup/list_region_override"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+					"region":         config.StringVariable(acctest.AlternateRegion()),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+					identity2.GetIdentity(resourceName2),
+				},
+			},
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/SecurityGroup/list_region_override"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+					"region":         config.StringVariable(acctest.AlternateRegion()),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_security_group.test", identity1.Checks()),
+					tfquerycheck.ExpectIdentityFunc("aws_security_group.test", identity2.Checks()),
 				},
 			},
 		},


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Adds `_includeResource` test for `aws_route_table`.

Removes resource Read function from `aws_route_table` List

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=ec2 TESTS=TestAccVPCRouteTable_List_

--- PASS: TestAccVPCRouteTable_List_includeResource (21.61s)
--- PASS: TestAccVPCRouteTable_List_basic (21.86s)
--- PASS: TestAccVPCRouteTable_List_regionOverride (25.19s)
```
