### PR TITLE
resource/aws_glue_catalog_database: Fix resource ID parsing for compound S3 Tables catalog IDs

### DIFF
--- a/.changelog/48454.txt
+++ b/.changelog/48454.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_glue_catalog_database: Fix resource ID parsing for compound S3 Tables catalog IDs containing colons
+```

--- a/internal/service/glue/catalog_database.go
+++ b/internal/service/glue/catalog_database.go
@@ -338,13 +338,13 @@ func catalogDatabaseCreateResourceID(catalogID, name string) string {
 }
 
 func catalogDatabaseParseResourceID(id string) (string, string, error) {
-	parts := strings.SplitN(id, catalogDatabaseResourceIDSeparator, 2)
+	idx := strings.LastIndex(id, catalogDatabaseResourceIDSeparator)
 
-	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+	if idx < 1 || idx == len(id)-1 {
 		return "", "", fmt.Errorf("unexpected format for ID (%[1]s), expected catalog-id%[2]sdatabase-name", id, catalogDatabaseResourceIDSeparator)
 	}
 
-	return parts[0], parts[1], nil
+	return id[:idx], id[idx+1:], nil
 }
 
 func createCatalogID(d *schema.ResourceData, accountid string) (catalogID string) {

--- a/internal/service/glue/catalog_database_test.go
+++ b/internal/service/glue/catalog_database_test.go
@@ -557,3 +557,73 @@ resource "aws_glue_catalog_database" "test" {
 }
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }
+
+func TestCatalogDatabaseParseResourceID(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name              string
+		id                string
+		expectedCatalogID string
+		expectedName      string
+		expectError       bool
+	}{
+		{
+			name:              "simple account ID",
+			id:                "123456789012:my_database",
+			expectedCatalogID: "123456789012",
+			expectedName:      "my_database",
+		},
+		{
+			name:              "compound S3 Tables catalog ID",
+			id:                "123456789012:s3tablescatalog/my-bucket:my_database",
+			expectedCatalogID: "123456789012:s3tablescatalog/my-bucket",
+			expectedName:      "my_database",
+		},
+		{
+			name:        "no separator",
+			id:          "my_database",
+			expectError: true,
+		},
+		{
+			name:        "trailing separator",
+			id:          "123456789012:",
+			expectError: true,
+		},
+		{
+			name:        "empty string",
+			id:          "",
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			catalogID, name, err := tfglue.CatalogDatabaseParseResourceID(tc.id)
+
+			if tc.expectError {
+				if err == nil {
+					t.Fatalf("expected error for id %q, got catalogID=%q name=%q", tc.id, catalogID, name)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error for id %q: %s", tc.id, err)
+			}
+			if catalogID != tc.expectedCatalogID {
+				t.Errorf("catalogID: got %q, want %q", catalogID, tc.expectedCatalogID)
+			}
+			if name != tc.expectedName {
+				t.Errorf("name: got %q, want %q", name, tc.expectedName)
+			}
+
+			roundTripped := tfglue.CatalogDatabaseCreateResourceID(catalogID, name)
+			if roundTripped != tc.id {
+				t.Errorf("round-trip: got %q, want %q", roundTripped, tc.id)
+			}
+		})
+	}
+}

--- a/internal/service/glue/exports_test.go
+++ b/internal/service/glue/exports_test.go
@@ -43,4 +43,7 @@ var (
 	FindSchemaByID                  = findSchemaByID
 	FindTableByThreePartKey         = findTableByThreePartKey
 	FindTriggerByName               = findTriggerByName
+
+	CatalogDatabaseCreateResourceID = catalogDatabaseCreateResourceID
+	CatalogDatabaseParseResourceID  = catalogDatabaseParseResourceID
 )


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

### Description

`catalogDatabaseParseResourceID` uses `strings.SplitN(id, ":", 2)` which splits on the **first** colon. When using S3 Tables federated catalogs, the `catalog_id` is a compound value containing a colon (e.g., `123456789012:s3tablescatalog/my-bucket`). The resulting resource ID becomes `123456789012:s3tablescatalog/my-bucket:my_database`.

Splitting on the first colon incorrectly produces:
- `catalogID = "123456789012"`
- `name = "s3tablescatalog/my-bucket:my_database"`

This causes the read-after-create to fail with `couldn't find resource`, and on retry the create fails with `AlreadyExistsException` because the database was actually created but never recorded in state.

**Fix**: Use `strings.LastIndex` to split on the **last** colon, which correctly produces:
- `catalogID = "123456789012:s3tablescatalog/my-bucket"`
- `name = "my_database"`

This is backward-compatible because simple catalog IDs (just an account ID like `123456789012`) contain exactly one colon, so first-colon and last-colon splitting produce identical results.

**AI Disclosure**: Used Windsurf/Cascade (Claude) to assist with code exploration, fix implementation, and test generation. All code was reviewed and validated by the human contributor.

### Relations

Closes #48454

### References

- [AWS S3 Tables + Glue federation docs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-tables-integrating-aws-glue.html)
- Compound catalog ID format: `account_id:s3tablescatalog/bucket_name`

### Output from Acceptance Testing

```console
% go test -run TestCatalogDatabaseParseResourceID -count=1 -v ./internal/service/glue/

=== RUN   TestCatalogDatabaseParseResourceID
=== RUN   TestCatalogDatabaseParseResourceID/simple_account_ID
=== RUN   TestCatalogDatabaseParseResourceID/compound_S3_Tables_catalog_ID
=== RUN   TestCatalogDatabaseParseResourceID/no_separator
=== RUN   TestCatalogDatabaseParseResourceID/trailing_separator
=== RUN   TestCatalogDatabaseParseResourceID/empty_string
--- PASS: TestCatalogDatabaseParseResourceID (0.00s)
    --- PASS: TestCatalogDatabaseParseResourceID/simple_account_ID (0.00s)
    --- PASS: TestCatalogDatabaseParseResourceID/compound_S3_Tables_catalog_ID (0.00s)
    --- PASS: TestCatalogDatabaseParseResourceID/no_separator (0.00s)
    --- PASS: TestCatalogDatabaseParseResourceID/trailing_separator (0.00s)
    --- PASS: TestCatalogDatabaseParseResourceID/empty_string (0.00s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/glue    9.517s
```

