### PR TITLE
resource/aws_s3_bucket_lifecycle_configuration: fix hang on S3-compatible endpoints

### DIFF
--- a/.changelog/48457.txt
+++ b/.changelog/48457.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_s3_bucket_lifecycle_configuration: Fix create/update hanging until timeout against S3-compatible endpoints (e.g. Ceph RADOS Gateway) that do not return the `transition_default_minimum_object_size` response header
+```

--- a/internal/service/s3/bucket_lifecycle_configuration.go
+++ b/internal/service/s3/bucket_lifecycle_configuration.go
@@ -656,7 +656,11 @@ func findBucketLifecycleConfiguration(ctx context.Context, conn *s3.Client, buck
 }
 
 func lifecycleConfigEqual(transitionMinSize1 awstypes.TransitionDefaultMinimumObjectSize, rules1 []awstypes.LifecycleRule, transitionMinSize2 awstypes.TransitionDefaultMinimumObjectSize, rules2 []awstypes.LifecycleRule) bool {
-	if transitionMinSize1 != transitionMinSize2 {
+	// Some S3-compatible implementations (e.g., Ceph RADOS Gateway, NetApp StorageGRID) do not return the
+	// x-amz-transition-default-minimum-object-size response header on GetBucketLifecycleConfiguration, so the
+	// value read back is empty. Treat an empty value on either side as a match (it just means the backend did
+	// not echo the field) rather than waiting until the Terraform timeout.
+	if transitionMinSize1 != transitionMinSize2 && transitionMinSize1 != "" && transitionMinSize2 != "" {
 		return false
 	}
 

--- a/internal/service/s3/bucket_lifecycle_configuration_test.go
+++ b/internal/service/s3/bucket_lifecycle_configuration_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/hashicorp/terraform-plugin-testing/compare"
@@ -5412,4 +5413,103 @@ resource "aws_s3_bucket" "test" {
 
 data "aws_caller_identity" "current" {}
 `, rName)
+}
+
+func TestLifecycleConfigEqual(t *testing.T) {
+	t.Parallel()
+
+	// baseRule returns a canonical rule for comparison. A non-empty filter prefix mirrors the configs
+	// reported in https://github.com/hashicorp/terraform-provider-aws/issues/43333, which are fixed by
+	// tolerating a non-echoed transition header alone.
+	baseRule := func(id string) types.LifecycleRule {
+		return types.LifecycleRule{
+			ID:     aws.String(id),
+			Status: types.ExpirationStatusEnabled,
+			Expiration: &types.LifecycleExpiration{
+				Days: aws.Int32(30),
+			},
+			Filter: &types.LifecycleRuleFilter{
+				Prefix: aws.String("logs/"),
+			},
+		}
+	}
+
+	tests := []struct {
+		name               string
+		transitionMinSize1 types.TransitionDefaultMinimumObjectSize
+		rules1             []types.LifecycleRule
+		transitionMinSize2 types.TransitionDefaultMinimumObjectSize
+		rules2             []types.LifecycleRule
+		want               bool
+	}{
+		{
+			// Ceph RADOS Gateway (e.g. 19.2.x) does not echo the transition header, so the value read
+			// back is empty while the configured value is non-empty. These must compare equal.
+			name:               "transition response empty vs configured, equal rules",
+			transitionMinSize1: "",
+			rules1:             []types.LifecycleRule{baseRule("rule-one")},
+			transitionMinSize2: types.TransitionDefaultMinimumObjectSizeAllStorageClasses128k,
+			rules2:             []types.LifecycleRule{baseRule("rule-one")},
+			want:               true,
+		},
+		{
+			name:               "transition both empty, equal rules",
+			transitionMinSize1: "",
+			rules1:             []types.LifecycleRule{baseRule("rule-one")},
+			transitionMinSize2: "",
+			rules2:             []types.LifecycleRule{baseRule("rule-one")},
+			want:               true,
+		},
+		{
+			// Genuine drift: both values are non-empty and differ. Must still be detected.
+			name:               "transition differs both non-empty",
+			transitionMinSize1: types.TransitionDefaultMinimumObjectSizeAllStorageClasses128k,
+			rules1:             []types.LifecycleRule{baseRule("rule-one")},
+			transitionMinSize2: types.TransitionDefaultMinimumObjectSizeVariesByStorageClass,
+			rules2:             []types.LifecycleRule{baseRule("rule-one")},
+			want:               false,
+		},
+		{
+			name:               "equal rules, different order",
+			transitionMinSize1: types.TransitionDefaultMinimumObjectSizeAllStorageClasses128k,
+			rules1:             []types.LifecycleRule{baseRule("rule-one"), baseRule("rule-two")},
+			transitionMinSize2: types.TransitionDefaultMinimumObjectSizeAllStorageClasses128k,
+			rules2:             []types.LifecycleRule{baseRule("rule-two"), baseRule("rule-one")},
+			want:               true,
+		},
+		{
+			name:               "rules differ in content",
+			transitionMinSize1: types.TransitionDefaultMinimumObjectSizeAllStorageClasses128k,
+			rules1:             []types.LifecycleRule{baseRule("rule-one")},
+			transitionMinSize2: types.TransitionDefaultMinimumObjectSizeAllStorageClasses128k,
+			rules2: []types.LifecycleRule{{
+				ID:     aws.String("rule-one"),
+				Status: types.ExpirationStatusEnabled,
+				Expiration: &types.LifecycleExpiration{
+					Days: aws.Int32(7),
+				},
+				Filter: &types.LifecycleRuleFilter{
+					Prefix: aws.String("logs/"),
+				},
+			}},
+			want: false,
+		},
+		{
+			name:               "rules differ in length",
+			transitionMinSize1: types.TransitionDefaultMinimumObjectSizeAllStorageClasses128k,
+			rules1:             []types.LifecycleRule{baseRule("rule-one")},
+			transitionMinSize2: types.TransitionDefaultMinimumObjectSizeAllStorageClasses128k,
+			rules2:             []types.LifecycleRule{baseRule("rule-one"), baseRule("rule-two")},
+			want:               false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tfs3.LifecycleConfigEqual(tt.transitionMinSize1, tt.rules1, tt.transitionMinSize2, tt.rules2); got != tt.want {
+				t.Errorf("LifecycleConfigEqual() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Description

`aws_s3_bucket_lifecycle_configuration` applies successfully but never finishes — it polls `GetBucketLifecycleConfiguration` until the Terraform timeout — when the target is an S3-compatible backend such as Ceph RADOS Gateway or NetApp StorageGRID. Real AWS is unaffected.

### Root cause

`Create`/`Update` call `waitLifecycleConfigEquals`, which requires consecutive matches via `lifecycleConfigEqual`. That function treated a difference in `transition_default_minimum_object_size` as a mismatch. S3-compatible backends do **not** echo the `x-amz-transition-default-minimum-object-size` response header on `GetBucketLifecycleConfiguration`, so the value read back is always `""` while the configured value is non-empty — the check never stabilizes.

`Read`/import is unaffected because it compares two GET outputs against each other (both from the same backend, so they agree), which is why importing "unsticks" the resource.

### Change

In `lifecycleConfigEqual`, treat an empty `transition_default_minimum_object_size` on either side as a match (the backend did not echo the field). Genuine drift — both values non-empty and differing — is still detected.

### Testing

- Added `TestLifecycleConfigEqual` table-driven unit tests. This is the only practical automated gate: every existing test in the file is `TestAcc*` against real AWS, which echoes the header and cannot reproduce the bug. Cases cover the empty-header regression, drift detection, rule ordering, and length/content differences.
- `gofmt` clean; `go vet ./internal/service/s3/...` clean.

## References

Fixes #43333

## Changelog

`.changelog/48457.txt` adds a `release-note:bug` entry for this change.
