### PR TITLE
`cloudfront`: Enables tag test generation with all resource types disabled

### DIFF
--- a/internal/service/cloudfront/anycast_ip_list.go
+++ b/internal/service/cloudfront/anycast_ip_list.go
@@ -39,6 +39,7 @@ import (
 
 // @FrameworkResource("aws_cloudfront_anycast_ip_list", name="Anycast IP List")
 // @Tags(identifierAttribute="arn")
+// @Testing(tagsTest=false)
 func newAnycastIPListResource(context.Context) (resource.ResourceWithConfigure, error) {
 	r := &anycastIPListResource{}
 

--- a/internal/service/cloudfront/connection_function.go
+++ b/internal/service/cloudfront/connection_function.go
@@ -36,6 +36,7 @@ import (
 
 // @FrameworkResource("aws_cloudfront_connection_function", name="Connection Function")
 // @Tags(identifierAttribute="connection_function_arn")
+// @Testing(tagsTest=false)
 func newResourceConnectionFunction(_ context.Context) (resource.ResourceWithConfigure, error) {
 	r := &connectionFunctionResource{}
 	return r, nil

--- a/internal/service/cloudfront/connection_group.go
+++ b/internal/service/cloudfront/connection_group.go
@@ -33,6 +33,7 @@ import (
 
 // @FrameworkResource("aws_cloudfront_connection_group", name="Connection Group")
 // @Tags(identifierAttribute="arn")
+// @Testing(tagsTest=false)
 func newConnectionGroupResource(context.Context) (resource.ResourceWithConfigure, error) {
 	r := &connectionGroupResource{}
 

--- a/internal/service/cloudfront/connection_group_data_source.go
+++ b/internal/service/cloudfront/connection_group_data_source.go
@@ -25,6 +25,7 @@ import (
 
 // @FrameworkDataSource("aws_cloudfront_connection_group", name="Connection Group")
 // @Tags(identifierAttribute="arn")
+// @Testing(tagsTest=false)
 func newConnectionGroupDataSource(_ context.Context) (datasource.DataSourceWithConfigure, error) {
 	d := &connectionGroupDataSource{}
 	return d, nil

--- a/internal/service/cloudfront/distribution.go
+++ b/internal/service/cloudfront/distribution.go
@@ -38,6 +38,7 @@ import (
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/cloudfront/types;awstypes;awstypes.Distribution")
 // @Testing(importIgnore="retain_on_delete;wait_for_deployment", plannableImportAction="NoOp")
 // @Testing(preIdentityVersion="v6.40.0")
+// @Testing(tagsTest=false)
 func resourceDistribution() *schema.Resource {
 	//lintignore:R011
 	return &schema.Resource{

--- a/internal/service/cloudfront/distribution_data_source.go
+++ b/internal/service/cloudfront/distribution_data_source.go
@@ -19,6 +19,7 @@ import (
 
 // @SDKDataSource("aws_cloudfront_distribution", name="Distribution")
 // @Tags(identifierAttribute="arn")
+// @Testing(tagsTest=false)
 func dataSourceDistribution() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceDistributionRead,

--- a/internal/service/cloudfront/distribution_tenant.go
+++ b/internal/service/cloudfront/distribution_tenant.go
@@ -35,6 +35,7 @@ import (
 
 // @FrameworkResource("aws_cloudfront_distribution_tenant", name="Distribution Tenant")
 // @Tags(identifierAttribute="arn")
+// @Testing(tagsTest=false)
 func newDistributionTenantResource(context.Context) (resource.ResourceWithConfigure, error) {
 	r := &distributionTenantResource{}
 

--- a/internal/service/cloudfront/distribution_tenant_data_source.go
+++ b/internal/service/cloudfront/distribution_tenant_data_source.go
@@ -29,6 +29,7 @@ import (
 
 // @FrameworkDataSource("aws_cloudfront_distribution_tenant", name="Distribution Tenant")
 // @Tags(identifierAttribute="arn")
+// @Testing(tagsTest=false)
 func newDistributionTenantDataSource(_ context.Context) (datasource.DataSourceWithConfigure, error) {
 	d := &distributionTenantDataSource{}
 	return d, nil

--- a/internal/service/cloudfront/function.go
+++ b/internal/service/cloudfront/function.go
@@ -28,6 +28,7 @@ import (
 
 // @SDKResource("aws_cloudfront_function", name="Function")
 // @Tags(identifierAttribute="arn")
+// @Testing(tagsTest=false)
 func resourceFunction() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceFunctionCreate,

--- a/internal/service/cloudfront/generate.go
+++ b/internal/service/cloudfront/generate.go
@@ -15,6 +15,7 @@
 //go:generate go run ../../generate/tags/main.go -ListTags -ListTagsInIDElem=Resource -ListTagsOutTagsElem=Tags.Items -ServiceTagsSlice "-TagInCustomVal=&awstypes.Tags{Items: svcTags(updatedTags)}" -TagInIDElem=Resource "-UntagInCustomVal=&awstypes.TagKeys{Items: removedTags.Keys()}" -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
 //go:generate go run ../../generate/identitytests/main.go
+//go:generate go run ../../generate/tagstests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package cloudfront

--- a/internal/service/cloudfront/multitenant_distribution.go
+++ b/internal/service/cloudfront/multitenant_distribution.go
@@ -47,6 +47,7 @@ const (
 
 // @FrameworkResource("aws_cloudfront_multitenant_distribution", name="Multi-tenant Distribution")
 // @Tags(identifierAttribute="arn")
+// @Testing(tagsTest=false)
 //
 // Multi-tenant Distribution Limitations:
 // The following fields are NOT supported for multi-tenant distributions and have been excluded from the schema:

--- a/internal/service/cloudfront/vpc_origin.go
+++ b/internal/service/cloudfront/vpc_origin.go
@@ -33,6 +33,7 @@ import (
 
 // @FrameworkResource("aws_cloudfront_vpc_origin", name="VPC Origin")
 // @Tags(identifierAttribute="arn")
+// @Testing(tagsTest=false)
 func newVPCOriginResource(context.Context) (resource.ResourceWithConfigure, error) {
 	r := &vpcOriginResource{}
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Enables tag test generation for `cloudfront` with all resource types initially disabled