### PR TITLE
bugfix: HTTP requests and responses always masked in logs

### DIFF
--- a/.changelog/48463.txt
+++ b/.changelog/48463.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+provider: Restore HTTP request and response body content in `TF_LOG=DEBUG` output for resources, data sources, and list resources. Redaction continues to apply to ephemeral resources and actions
+```

--- a/internal/conns/awsclient.go
+++ b/internal/conns/awsclient.go
@@ -147,10 +147,15 @@ func (c *AWSClient) SetCallRecorder(r *apicall.Recorder) {
 //   - the VCR randomness source, when VCR testing is active
 //   - the API-call recorder, when one is attached for the test
 //   - the AutoFlex logger
-//   - HTTP request/response body redaction
 //
 // Each element is a no-op when the corresponding feature is inactive.
 // Safe to call on a nil receiver, in which case ctx is returned unchanged.
+//
+// HTTP request and response body redaction is intentionally NOT included
+// here, because debug-level logs of normal AWS API traffic are useful and
+// should not be globally redacted. Ephemeral resources and actions, whose
+// API responses commonly carry secrets, must use [AWSClient.EphemeralRequestContext]
+// instead.
 func (c *AWSClient) RequestContext(ctx context.Context) context.Context {
 	if c == nil {
 		return ctx
@@ -161,8 +166,23 @@ func (c *AWSClient) RequestContext(ctx context.Context) context.Context {
 		ctx = vcr.NewContext(ctx, s)
 	}
 	ctx = apicall.NewContext(ctx, c.callRecorder)
-	ctx = fwflex.RegisterLogger(ctx)
-	return logging.MaskSensitiveValuesByKey(ctx, logging.HTTPKeyRequestBody, logging.HTTPKeyResponseBody)
+	return fwflex.RegisterLogger(ctx)
+}
+
+// EphemeralRequestContext is [AWSClient.RequestContext] plus tflog
+// redaction of the http.request.body and http.response.body fields.
+//
+// Use for ephemeral resources and actions whose API responses commonly
+// carry secrets that must not appear in provider logs. Use
+// [AWSClient.RequestContext] for everything else; redacting every HTTP
+// body across the provider would defeat ordinary debug logging.
+//
+// Safe to call on a nil receiver, in which case ctx is returned unchanged.
+func (c *AWSClient) EphemeralRequestContext(ctx context.Context) context.Context {
+	if c == nil {
+		return ctx
+	}
+	return logging.MaskSensitiveValuesByKey(c.RequestContext(ctx), logging.HTTPKeyRequestBody, logging.HTTPKeyResponseBody)
 }
 
 // Region returns the ID of the effective AWS Region.

--- a/internal/conns/awsclient_request_context_test.go
+++ b/internal/conns/awsclient_request_context_test.go
@@ -1,0 +1,115 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package conns
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	baselogging "github.com/hashicorp/aws-sdk-go-base/v2/logging"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-log/tflogtest"
+	"github.com/hashicorp/terraform-provider-aws/internal/logging"
+)
+
+const (
+	requestBodyPayload  = "request-body-payload"
+	responseBodyPayload = "response-body-payload"
+)
+
+// requestContextTestSetup builds a context with a tflog root logger backed
+// by buf and a non-null baselogging logger registered, so that
+// MaskSensitiveValuesByKey does not short-circuit on a NullLogger and
+// tflog records flow into buf where the test can inspect them. It also
+// returns an AWSClient configured with that same logger so that
+// c.RegisterLogger is a real operation.
+func requestContextTestSetup(t *testing.T) (context.Context, *AWSClient, *bytes.Buffer) {
+	t.Helper()
+
+	var buf bytes.Buffer
+	ctx := tflogtest.RootLogger(context.Background(), &buf)
+
+	// baselogging.NewTfLogger reads the tflog logger from ctx and wraps it
+	// into a non-null aws-sdk-go-base logger; without this,
+	// MaskSensitiveValuesByKey treats the logger as a no-op and returns ctx
+	// unchanged, which would hide a regression in its own behavior.
+	ctx, logger := baselogging.NewTfLogger(ctx)
+
+	c := &AWSClient{logger: logger}
+	return ctx, c, &buf
+}
+
+// emitHTTPBodyRecord writes a tflog record carrying both HTTP body fields,
+// so tests can assert how the active context masks (or doesn't mask) them.
+func emitHTTPBodyRecord(ctx context.Context) {
+	tflog.Info(ctx, "AWS request", map[string]any{
+		logging.HTTPKeyRequestBody:  requestBodyPayload,
+		logging.HTTPKeyResponseBody: responseBodyPayload,
+	})
+}
+
+// TestAWSClientRequestContext_DoesNotMaskHTTPBodies guards #48461: the
+// per-request context wired into ordinary resources, data sources, and
+// list resources must not redact http.request.body / http.response.body
+// in tflog output, since doing so removes the AWS SDK debug trace
+// developers rely on.
+func TestAWSClientRequestContext_DoesNotMaskHTTPBodies(t *testing.T) { // nosemgrep:ci.aws-in-func-name
+	t.Parallel()
+
+	ctx, c, buf := requestContextTestSetup(t)
+	ctx = c.RequestContext(ctx)
+
+	emitHTTPBodyRecord(ctx)
+
+	out := buf.String()
+	if !strings.Contains(out, requestBodyPayload) {
+		t.Errorf("RequestContext masked http.request.body unexpectedly; output: %s", out)
+	}
+	if !strings.Contains(out, responseBodyPayload) {
+		t.Errorf("RequestContext masked http.response.body unexpectedly; output: %s", out)
+	}
+}
+
+// TestAWSClientEphemeralRequestContext_MasksHTTPBodies covers the
+// invariant that ephemeral resources and actions, whose API responses
+// commonly carry secrets, get http.request.body / http.response.body
+// redacted in tflog output.
+func TestAWSClientEphemeralRequestContext_MasksHTTPBodies(t *testing.T) { // nosemgrep:ci.aws-in-func-name
+	t.Parallel()
+
+	ctx, c, buf := requestContextTestSetup(t)
+	ctx = c.EphemeralRequestContext(ctx)
+
+	emitHTTPBodyRecord(ctx)
+
+	out := buf.String()
+	if strings.Contains(out, requestBodyPayload) {
+		t.Errorf("EphemeralRequestContext failed to mask http.request.body; output: %s", out)
+	}
+	if strings.Contains(out, responseBodyPayload) {
+		t.Errorf("EphemeralRequestContext failed to mask http.response.body; output: %s", out)
+	}
+	if !strings.Contains(out, "***") {
+		t.Errorf("EphemeralRequestContext output is missing the redaction marker; output: %s", out)
+	}
+}
+
+// TestAWSClientRequestContext_NilReceiverIsSafe documents the contract
+// that the RequestContext family is callable on a nil *AWSClient (e.g.
+// during early test setup), returning ctx unchanged.
+func TestAWSClientRequestContext_NilReceiverIsSafe(t *testing.T) { // nosemgrep:ci.aws-in-func-name
+	t.Parallel()
+
+	ctx := context.Background()
+	var c *AWSClient
+
+	if got := c.RequestContext(ctx); got != ctx {
+		t.Errorf("RequestContext on nil receiver mutated ctx")
+	}
+	if got := c.EphemeralRequestContext(ctx); got != ctx {
+		t.Errorf("EphemeralRequestContext on nil receiver mutated ctx")
+	}
+}

--- a/internal/provider/framework/wrap.go
+++ b/internal/provider/framework/wrap.go
@@ -261,7 +261,7 @@ func (w *wrappedEphemeralResource) context(ctx context.Context, getAttribute get
 
 	ctx = conns.NewResourceContext(ctx, w.servicePackageName, w.spec.Name, w.spec.TypeName, overrideRegion)
 	if c != nil {
-		ctx = c.RequestContext(ctx)
+		ctx = c.EphemeralRequestContext(ctx)
 	}
 
 	return ctx, diags
@@ -429,7 +429,7 @@ func (w *wrappedAction) context(ctx context.Context, getAttribute getAttributeFu
 
 	ctx = conns.NewResourceContext(ctx, w.servicePackageName, w.spec.Name, w.spec.TypeName, overrideRegion)
 	if c != nil {
-		ctx = c.RequestContext(ctx)
+		ctx = c.EphemeralRequestContext(ctx)
 	}
 
 	return ctx, diags


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Restore HTTP request and response body content in `TF_LOG=DEBUG` output for resources, data sources, and list resources. Redaction continues to apply to ephemeral resources and actions.

- **provider: scope HTTP body masking to ephemeral resources and actions**
- **provider: test masking scope for {Request,EphemeralRequest}Context**

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #48461

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% go test -count=1 -v -run 'TestAWSClient(Request|EphemeralRequest)Context' ./internal/conns/
=== RUN   TestAWSClientRequestContext_DoesNotMaskHTTPBodies
=== PAUSE TestAWSClientRequestContext_DoesNotMaskHTTPBodies
=== RUN   TestAWSClientEphemeralRequestContext_MasksHTTPBodies
=== PAUSE TestAWSClientEphemeralRequestContext_MasksHTTPBodies
=== RUN   TestAWSClientRequestContext_NilReceiverIsSafe
=== PAUSE TestAWSClientRequestContext_NilReceiverIsSafe
=== CONT  TestAWSClientRequestContext_DoesNotMaskHTTPBodies
=== CONT  TestAWSClientRequestContext_NilReceiverIsSafe
--- PASS: TestAWSClientRequestContext_NilReceiverIsSafe (0.00s)
=== CONT  TestAWSClientEphemeralRequestContext_MasksHTTPBodies
--- PASS: TestAWSClientRequestContext_DoesNotMaskHTTPBodies (0.00s)
--- PASS: TestAWSClientEphemeralRequestContext_MasksHTTPBodies (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/conns	11.583s
```
