### PR TITLE
Add explicit `permissions` blocks to workflows

### DIFF
--- a/.github/workflows/acctest-terraform-embedded-lint.yml
+++ b/.github/workflows/acctest-terraform-embedded-lint.yml
@@ -24,6 +24,9 @@ on:
 ##   - Documentation: docs/makefile-cheat-sheet.md
 ##   - Makefile: ./GNUmakefile
 
+permissions:
+  contents: read # required for checkout
+
 jobs:
   tflint-opa-policy-tests:
     uses: ./.github/workflows/tflint-opa-policy-tests.yml

--- a/.github/workflows/acctest-terraform-lint.yml
+++ b/.github/workflows/acctest-terraform-lint.yml
@@ -22,6 +22,9 @@ on:
 ##   - Documentation: docs/makefile-cheat-sheet.md
 ##   - Makefile: ./GNUmakefile
 
+permissions:
+  contents: read # required for checkout
+
 jobs:
   tflint-opa-policy-tests:
     uses: ./.github/workflows/tflint-opa-policy-tests.yml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,9 @@ on: [workflow_dispatch, push]
 env:
   PKG_NAME: "terraform-provider-aws"
 
+permissions:
+  contents: read # required for checkout
+
 jobs:
   # Detects the Go toolchain version to use for product builds.
   #

--- a/.github/workflows/changelog_misspell.yml
+++ b/.github/workflows/changelog_misspell.yml
@@ -19,6 +19,9 @@ on:
 ##   - Documentation: docs/makefile-cheat-sheet.md
 ##   - Makefile: ./GNUmakefile
 
+permissions:
+  contents: read # required for checkout
+
 jobs:
   misspell:
     runs-on: ubuntu-latest

--- a/.github/workflows/close_stale_draft_prs.yml
+++ b/.github/workflows/close_stale_draft_prs.yml
@@ -14,7 +14,7 @@ on:
         default: false
 
 permissions:
-  pull-requests: write
+  pull-requests: write # required to comment on and close pull requests
 
 jobs:
   close-stale-drafts:

--- a/.github/workflows/closed_items.yml
+++ b/.github/workflows/closed_items.yml
@@ -13,9 +13,9 @@ on:
       - closed
 
 permissions:
-  contents: read
-  issues: write
-  pull-requests: write
+  contents: read        # required for checkout
+  issues: write         # required to remove labels and post comments on issues
+  pull-requests: write  # required to remove labels and post comments on pull requests
 
 jobs:
   process:

--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -4,9 +4,9 @@
 name: Comment Automations
 
 permissions:
-  contents: read
-  issues: write
-  pull-requests: write
+  contents: read        # required for checkout
+  issues: write         # required to remove labels and post comments on issues
+  pull-requests: write  # required to remove labels and post comments on pull requests
 
 on:
   issue_comment:

--- a/.github/workflows/community_note.yml
+++ b/.github/workflows/community_note.yml
@@ -13,8 +13,8 @@ on:
       - opened
 
 permissions:
-  issues: write
-  pull-requests: write
+  issues: write         # required to comment on issues
+  pull-requests: write  # required to comment on pull requests
 
 jobs:
   add_note:

--- a/.github/workflows/copyright.yml
+++ b/.github/workflows/copyright.yml
@@ -22,6 +22,9 @@ on:
 ##   - Documentation: docs/makefile-cheat-sheet.md
 ##   - Makefile: ./GNUmakefile
 
+permissions:
+  contents: read # required for checkout
+
 jobs:
   copyplop:
     name: headers check

--- a/.github/workflows/crt-post-promote-production.yml
+++ b/.github/workflows/crt-post-promote-production.yml
@@ -10,7 +10,7 @@ on:
       - crt-post-promote-production::*
 
 permissions:
-  actions: write
+  actions: write # required to dispatch workflows
 
 jobs:
   start-registry-check:

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -4,7 +4,7 @@
 name: Dependency Checks
 
 permissions:
-  contents: read
+  contents: read # required for checkout
 
 on:
   push:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -20,6 +20,9 @@ on:
 ##   - Documentation: docs/makefile-cheat-sheet.md
 ##   - Makefile: ./GNUmakefile
 
+permissions:
+  contents: read # required for checkout
+
 jobs:
   markdown-link-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -24,6 +24,9 @@ on:
 env:
   AWS_DEFAULT_REGION: us-west-2
 
+permissions:
+  contents: read # required for checkout
+
 jobs:
   tflint-opa-policy-tests:
     uses: ./.github/workflows/tflint-opa-policy-tests.yml

--- a/.github/workflows/firewatch.yml
+++ b/.github/workflows/firewatch.yml
@@ -6,6 +6,11 @@ on:
     - cron: '0 * * * *'
   workflow_dispatch:
 name: Firewatch
+
+permissions:
+  actions: read # required to list and download previous firewatch artifacts
+  issues: read  # required to search open issues
+
 jobs:
   FirewatchJob:
     if: github.repository_owner == 'hashicorp'

--- a/.github/workflows/gen-teamcity.yml
+++ b/.github/workflows/gen-teamcity.yml
@@ -11,6 +11,9 @@ on:
     paths:
       - .teamcity/**
 
+permissions:
+  contents: read # required for checkout
+
 jobs:
   validate-teamcity-config:
     name: Validate TeamCity Configuration

--- a/.github/workflows/generate_changelog.yml
+++ b/.github/workflows/generate_changelog.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     types: [closed]
   workflow_dispatch:
+
+permissions: {} # explicit deny all scopes; workflow uses a GitHub App token
+
 jobs:
   GenerateChangelog:
     if: github.event.pull_request.merged || github.event_name == 'workflow_dispatch'

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -25,6 +25,9 @@ on:
 ##   - Documentation: docs/makefile-cheat-sheet.md
 ##   - Makefile: ./GNUmakefile
 
+permissions:
+  contents: read # required for checkout
+
 jobs:
   golangci-linta:
     name: 1 of 5

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -7,6 +7,10 @@ on:
   schedule:
     - cron: '50 1 * * *'
 
+permissions:
+  issues: write        # required to lock issues
+  pull-requests: write # required to lock pull requests
+
 jobs:
   lock:
     runs-on: ubuntu-latest

--- a/.github/workflows/maintainer_helpers.yml
+++ b/.github/workflows/maintainer_helpers.yml
@@ -4,9 +4,9 @@
 name: Maintainer Helpers
 
 permissions:
-  contents: read
-  issues: write
-  pull-requests: write
+  contents: read        # required for checkout
+  issues: write         # required to update labels on issues
+  pull-requests: write  # required to update labels on pull requests
 
 on:
   issues:

--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -8,8 +8,8 @@ on:
     types: [closed]
 
 permissions:
-  issues: write
-  pull-requests: write
+  issues: write         # required to update labels and post comments on issues
+  pull-requests: write  # required to update labels and post comments on pull requests
 
 jobs:
   Comment:

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -9,6 +9,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: write # required for `mkdocs-deploy-gh-pages` to push generated docs
+
 jobs:
   build:
     name: Deploy docs

--- a/.github/workflows/modern_go.yml
+++ b/.github/workflows/modern_go.yml
@@ -19,6 +19,9 @@ on:
 ##   - Documentation: docs/makefile-cheat-sheet.md
 ##   - Makefile: ./GNUmakefile
 
+permissions:
+  contents: read # required for checkout
+
 jobs:
   modern:
     name: Check for modern Go code

--- a/.github/workflows/naming.yml
+++ b/.github/workflows/naming.yml
@@ -13,6 +13,9 @@ on:
       - .github/workflows/naming.yml
       - "**/*_test.go"
 
+permissions:
+  contents: read # required for checkout
+
 jobs:
   test_naming:
     name: test naming

--- a/.github/workflows/post-publish.yml
+++ b/.github/workflows/post-publish.yml
@@ -11,6 +11,10 @@ on:
         description: "Semver release tag e.g. 1.1.0 (v prefix will be added automatically)"
         required: true
 
+permissions:
+  issues: read         # required to search issues
+  pull-requests: read  # required to search pull requests
+
 jobs:
   tidy-jira:
     runs-on: ubuntu-latest

--- a/.github/workflows/provider-release.yml
+++ b/.github/workflows/provider-release.yml
@@ -42,6 +42,8 @@ env:
   repo_name: "terraform-provider-aws"
   deployment_environment_name: "tf-provider-aws-oss"
 
+permissions: {} # explicit deny all scopes; workflow uses `BOB_GITHUB_TOKEN` for promotion actions
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/provider.yml
+++ b/.github/workflows/provider.yml
@@ -39,6 +39,9 @@ env:
   AWS_DEFAULT_REGION: us-west-2
   TERRAFORM_VERSION: "1.8.3"
 
+permissions:
+  contents: read # required for checkout
+
 jobs:
   go_mod_download:
     name: go mod download

--- a/.github/workflows/providerlint.yml
+++ b/.github/workflows/providerlint.yml
@@ -22,6 +22,9 @@ on:
 ##   - Documentation: docs/makefile-cheat-sheet.md
 ##   - Makefile: ./GNUmakefile
 
+permissions:
+  contents: read # required for checkout
+
 jobs:
   providerlint:
     runs-on: custom-ubuntu-22.04-large

--- a/.github/workflows/pull_request_review.yml
+++ b/.github/workflows/pull_request_review.yml
@@ -4,7 +4,7 @@
 name: Pull Request Review
 
 permissions:
-  contents: read
+  contents: read # required for checkout
 
 on:
   pull_request_review:

--- a/.github/workflows/pull_request_target.yml
+++ b/.github/workflows/pull_request_target.yml
@@ -4,7 +4,7 @@
 name: Pull Request Target Check
 
 permissions:
-  contents: read
+  contents: read # required for checkout
 
 on:
   push:
@@ -28,8 +28,6 @@ jobs:
   checks:
     name: pr-target-check
     runs-on: custom-ubuntu-22.04-medium
-    permissions:
-      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/readiness_comment.yml
+++ b/.github/workflows/readiness_comment.yml
@@ -4,8 +4,8 @@
 name: Readiness Comment
 
 permissions:
-  contents: read
-  pull-requests: write
+  contents: read        # required for checkout
+  pull-requests: write  # required to comment on pull requests
 
 on:
   pull_request_target:

--- a/.github/workflows/registry-check.yml
+++ b/.github/workflows/registry-check.yml
@@ -9,7 +9,7 @@ on:
       timeout:
         description: The number of minutes to wait for Registry ingest
         required: true
-        default: 120
+        default: '120'
       version:
         description: |
           The version of the provider to test initialization for (without the preceding 'v'). If unset, will use the version pulled from the latest GitHub release
@@ -20,7 +20,7 @@ defaults:
     shell: bash
 
 permissions:
-  contents: read
+  contents: read # required for reading release metadata and repository state
 
 jobs:
   registry-check:

--- a/.github/workflows/resource-counts.yml
+++ b/.github/workflows/resource-counts.yml
@@ -6,9 +6,11 @@ on:
   workflow_dispatch: {}
   schedule:
     - cron: '0 9 * * WED'
+
 permissions:
-  contents: write
-  pull-requests: write
+  contents: write       # required to push commits
+  pull-requests: write  # required to create or update the automation pull request
+
 jobs:
   coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/semgrep-ci.yml
+++ b/.github/workflows/semgrep-ci.yml
@@ -27,6 +27,9 @@ env:
   SEMGREP_TIMEOUT: 300
   SEMGREP_ARGS: --error --quiet
 
+permissions:
+  contents: read # required for checkout
+
 jobs:
   semgrep-validate:
     name: Validate Code Quality Rules

--- a/.github/workflows/skaff.yml
+++ b/.github/workflows/skaff.yml
@@ -19,6 +19,9 @@ on:
 ##   - Documentation: docs/makefile-cheat-sheet.md
 ##   - Makefile: ./GNUmakefile
 
+permissions:
+  contents: read # required for checkout
+
 jobs:
   compile_skaff:
     name: Compile skaff

--- a/.github/workflows/smarterr.yml
+++ b/.github/workflows/smarterr.yml
@@ -19,6 +19,9 @@ on:
 ##   - Documentation: docs/makefile-cheat-sheet.md
 ##   - Makefile: ./GNUmakefile
 
+permissions:
+  contents: read # required for checkout
+
 jobs:
   modern:
     name: Check smarterr config

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,6 +6,10 @@ on:
   schedule:
     - cron: "40 17 * * *"
 
+permissions:
+  issues: write        # required to label and close issues
+  pull-requests: write # required to label and close pull requests
+
 jobs:
   stale:
     runs-on: ubuntu-latest

--- a/.github/workflows/swissshepherd.yml
+++ b/.github/workflows/swissshepherd.yml
@@ -19,6 +19,9 @@ on:
 ##   - Documentation: docs/makefile-cheat-sheet.md
 ##   - Makefile: ./GNUmakefile
 
+permissions:
+  contents: read # required for checkout
+
 jobs:
   swissshepherd:
     name: documentation checks

--- a/.github/workflows/tflint-opa-policy-tests.yml
+++ b/.github/workflows/tflint-opa-policy-tests.yml
@@ -6,6 +6,9 @@ name: OPA Policy Tests
 on:
   workflow_call:
 
+permissions:
+  contents: read # required for checkout
+
 jobs:
   opa-tests:
     name: OPA Policy Tests

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -4,9 +4,9 @@
 name: Auto Triage
 
 permissions:
-  contents: read
-  issues: write
-  pull-requests: write
+  contents: read        # required for checkout
+  issues: write         # required to apply labels to issues
+  pull-requests: write  # required to apply labels to pull requests
 
 on:
   pull_request_target:

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -11,6 +11,10 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: write      # required to create a branch and push changes
+  pull-requests: write # required to create a pull request
+
 jobs:
   update-changelog:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-list-tracking.yml
+++ b/.github/workflows/update-list-tracking.yml
@@ -13,12 +13,13 @@ on:
     - cron: "0 0 * * *" # Run nightly at midnight UTC
   workflow_dispatch:
 
+permissions:
+  contents: read  # required for checkout
+  issues: write   # required to update tracking issues
+
 jobs:
   update-issue:
     runs-on: ubuntu-latest
-    permissions:
-      issues: write
-      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -26,6 +26,9 @@ on:
 ##   - Documentation: docs/makefile-cheat-sheet.md
 ##   - Makefile: ./GNUmakefile
 
+permissions:
+  contents: read # required for checkout
+
 jobs:
   tflint-opa-policy-tests:
     uses: ./.github/workflows/tflint-opa-policy-tests.yml

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -18,6 +18,9 @@ on:
 ##   - Documentation: docs/makefile-cheat-sheet.md
 ##   - Makefile: ./GNUmakefile
 
+permissions:
+  contents: read # required for checkout
+
 jobs:
   actionlint:
     runs-on: ubuntu-latest

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -19,6 +19,9 @@ on:
 ##   - Documentation: docs/makefile-cheat-sheet.md
 ##   - Makefile: ./GNUmakefile
 
+permissions:
+  contents: read # required for checkout
+
 jobs:
   yamllint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

None

### Description

This PR adds explicit `permissions` blocks and/or refines the permissions defined in our workflows to make them least privileged. This is intended to ensure the workflows keep functioning once our organization default permissions scopes are updated.

I took the opportunity to add a comment to any new/updated `permissions` blocks to indicate why a particular permission is needed.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

None

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

- [GitHub docs on permissions](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#permissions)

### Output from Acceptance Testing

N/a, workflows