### PR TITLE
Document tflint-opa-tests target

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1276,6 +1276,7 @@ yamllint: ## [CI] YAML Linting / yamllint
 	testacc-tflint-dir-fix \
 	testacc-tflint-embedded \
 	tflint-init \
+	tflint-opa-tests \
 	tools \
 	ts \
 	update \

--- a/docs/makefile-cheat-sheet.md
+++ b/docs/makefile-cheat-sheet.md
@@ -193,6 +193,7 @@ Variables are often defined before the `make` call on the same line, such as `MY
 | `testacc-tflint-dir-fix` | Fix `tflint` issues in Terraform acceptance test directories |  |  | `K`, `PKG`, `SVC_DIR` |
 | `testacc-tflint-embedded` | Run `tflint` on embedded Terraform configurations |  |  | `K`, `PKG`, `SVC_DIR` |
 | `tflint-init` | Initialize tflint |  |  |  |
+| `tflint-opa-tests` | Run OPA policy tests |  |  |  |
 | `tools`<sup>D</sup> | Install tools |  |  | `GO_VER` |
 | `ts`<sup>M</sup> | Alias to `testacc-short` |  |  |  |
 | `update` | Update dependencies |  |  | `GO_VER` |


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Add tflint-opa-tests to the GNUmakefile .PHONY list and to the
docs/makefile-cheat-sheet.md so that 'make makefile-lint' passes.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #48104

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
