### PR TITLE
r/aws_route53_records_exclusive: change resource_record_set from SetNestedBlock to ListNestedBlock for performance

### DIFF
--- a/.changelog/48472.txt
+++ b/.changelog/48472.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_route53_records_exclusive: Fix severe performance regression for large hosted zones by changing `resource_record_set` from `SetNestedBlock` to `ListNestedBlock`, eliminating per-element SHA256 hashing during state flatten
+```

--- a/internal/service/route53/records_exclusive.go
+++ b/internal/service/route53/records_exclusive.go
@@ -67,8 +67,8 @@ func (r *recordsExclusiveResource) Schema(ctx context.Context, req resource.Sche
 			},
 		},
 		Blocks: map[string]schema.Block{
-			"resource_record_set": schema.SetNestedBlock{
-				CustomType: fwtypes.NewSetNestedObjectTypeOf[resourceRecordSetModel](ctx),
+			"resource_record_set": schema.ListNestedBlock{
+				CustomType: fwtypes.NewListNestedObjectTypeOf[resourceRecordSetModel](ctx),
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
 						"failover": schema.StringAttribute{
@@ -441,9 +441,9 @@ func findResourceRecordSetsForHostedZone(ctx context.Context, conn *route53.Clie
 }
 
 type recordsExclusiveResourceModel struct {
-	ResourceRecordSet fwtypes.SetNestedObjectValueOf[resourceRecordSetModel] `tfsdk:"resource_record_set"`
-	Timeouts          timeouts.Value                                         `tfsdk:"timeouts"`
-	ZoneID            types.String                                           `tfsdk:"zone_id"`
+	ResourceRecordSet fwtypes.ListNestedObjectValueOf[resourceRecordSetModel] `tfsdk:"resource_record_set"`
+	Timeouts          timeouts.Value                                          `tfsdk:"timeouts"`
+	ZoneID            types.String                                            `tfsdk:"zone_id"`
 }
 
 type resourceRecordSetModel struct {

--- a/internal/service/route53/records_exclusive_test.go
+++ b/internal/service/route53/records_exclusive_test.go
@@ -138,7 +138,7 @@ func TestAccRoute53RecordsExclusive_multiple(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("resource_record_set"),
-						knownvalue.SetPartial([]knownvalue.Check{
+						knownvalue.ListPartial([]knownvalue.Check{
 							knownvalue.ObjectPartial(map[string]knownvalue.Check{
 								names.AttrName: knownvalue.StringRegexp(regexache.MustCompile("a." + zoneName.String())),
 								names.AttrType: knownvalue.StringExact(string(types.RRTypeA)),
@@ -268,7 +268,7 @@ func TestAccRoute53RecordsExclusive_upsert(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("resource_record_set"),
-						knownvalue.SetPartial([]knownvalue.Check{
+						knownvalue.ListPartial([]knownvalue.Check{
 							knownvalue.ObjectPartial(map[string]knownvalue.Check{
 								names.AttrName: knownvalue.StringRegexp(regexache.MustCompile(recordName.String())),
 								"ttl":          knownvalue.Int64Exact(30),
@@ -293,7 +293,7 @@ func TestAccRoute53RecordsExclusive_upsert(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("resource_record_set"),
-						knownvalue.SetPartial([]knownvalue.Check{
+						knownvalue.ListPartial([]knownvalue.Check{
 							knownvalue.ObjectPartial(map[string]knownvalue.Check{
 								names.AttrName: knownvalue.StringRegexp(regexache.MustCompile(recordName.String())),
 								"ttl":          knownvalue.Int64Exact(20),
@@ -318,7 +318,7 @@ func TestAccRoute53RecordsExclusive_upsert(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("resource_record_set"),
-						knownvalue.SetPartial([]knownvalue.Check{
+						knownvalue.ListPartial([]knownvalue.Check{
 							knownvalue.ObjectPartial(map[string]knownvalue.Check{
 								names.AttrName: knownvalue.StringRegexp(regexache.MustCompile(recordName.String())),
 								"ttl":          knownvalue.Int64Exact(30),
@@ -359,7 +359,7 @@ func TestAccRoute53RecordsExclusive_empty(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("resource_record_set"),
-						knownvalue.SetExact([]knownvalue.Check{}),
+						knownvalue.ListExact([]knownvalue.Check{}),
 					),
 				},
 				// The _exclusive resource will remove the record set created by the _record resource,


### PR DESCRIPTION
## Description

Closes #48468

`resource_record_set` was declared as `schema.SetNestedBlock`. This PR changes it to `schema.ListNestedBlock`. The change is a **single-line schema change** with significant performance impact.

## Root Cause Analysis

The `resource_record_set` block uses `schema.SetNestedBlock`, which triggers expensive operations at multiple points. Through full instrumentation of both the provider and Terraform Core, the complete **sequential execution flow** is:

```
── ReadResource (riNode.refresh) ───────────────────────────────────────────────
Step 1:  AWS API — ListResourceRecordSets (paginated bulk read)
Step 2:  flex.Flatten — []awstypes → Set-typed model                ← SET BOTTLENECK
Step 3:  resp.State.Set — model → state protobuf                    ← SET BOTTLENECK
Step 4:  SchemaSemanticEquality — O(N²) comparison loop             ← SET BOTTLENECK
Step 4★: msgpack Set serialization — cty.Set → protobuf bytes       ← SET BOTTLENECK (~32m for 5,168 records)
Step 4.5: decodeDynamicValue — protobuf bytes → cty.Value (Terraform Core)

── Terraform Core: HCL generation ─────────────────────────────────────────────
Step 5:  generateHCLResourceDef — cty.Value → HCL string
Step 6:  hclsyntax.ParseConfig — HCL string → AST

── Terraform Core: state + plan ────────────────────────────────────────────────
Step 7:  writeResourceInstanceState — persist state to disk
Step 8:  n.plan — PlanResourceChange RPC                            ← SET BOTTLENECK

── Final ────────────────────────────────────────────────────────────────────────
Step 9:  maybeWriteGeneratedConfig — write records.tf to disk
```

> **Note:** This resource's `ImportState` only sets `zone_id` from the import block. `ReadResource` runs **once**, from `riNode.refresh()`.

### Why Set is slow

**Steps 2–3: O(N × tree_size) hashing on every element insert.**
The `go-cty` Set requires `appendSetHashBytes` to recursively walk the entire nested object before each insert. For `resourceRecordSetModel` this walks 15+ attributes plus `alias_target`, `geolocation`, `geoproximity_location`, `resource_records`, etc.

**Step 4: O(N²) semantic equality loop.**
`SchemaSemanticEquality` runs `ValueSemanticEqualitySetElements` — a nested loop comparing every proposed element against every prior element.

**Step 4★: msgpack Set serialization — the largest bottleneck.**
When the framework serializes the `ReadResource` response back to protobuf (msgpack), it must write the `cty.Set` as a sorted sequence. This requires computing the hash of every element again to maintain insertion order. For 5,168 records this step takes **~32 minutes** — larger than Steps 2–4 combined. It scales at approximately O(N² × tree_size).

**Step 8: PlanResourceChange re-processes the full Set state.**
Terraform Core's plan diff over a 5,168-element Set takes **1 hour 6 minutes** vs 1m 45s with List.

Total cost: **O(N² × tree_size)** across multiple phases.

## Benchmark Data

Measured against real AWS hosted zones using instrumented builds of both the provider and Terraform Core.

### 432 records

| Step | Set | List | Speedup |
|---|---|---|---|
| Step 2: flex.Flatten | 908ms | 175ms | ~5x |
| Step 3: resp.State.Set | 1.5s | 58ms | ~26x |
| Step 4: SchemaSemanticEquality | 834ms | 24ms | ~35x |
| **ReadResource total** | **22.9s** | **2.4s** | **~10x** |
| Step 8: n.plan | **40.9s** | **1.5s** | **~27x** |
| **Total wall time** | **~65s** | **~5s** | **~13x** |

### 5,168 records

All values measured on actual runs against real AWS hosted zones.

| Step | Set | List | Speedup |
|---|---|---|---|
| Step 1: AWS API | 10.6s | 10.9s | ~1x |
| Step 2: flex.Flatten | 1m 45s | 2.5s | ~42x |
| Step 3: resp.State.Set | 3m 12s | 721ms | ~266x |
| Step 4: SchemaSemanticEquality | 1m 59s | 358ms | ~332x |
| **Step 4★: msgpack Set serialization** | **~32m** | **~0s** | **∞** |
| **ReadResource total** | **39m 09s** | **2m 01s** | **~19x** |
| Step 5: generateHCLResourceDef | 7.1s | 2.4s | ~3x |
| Step 6: hclsyntax.ParseConfig | 188ms | 241ms | ~1x |
| Step 7: writeResourceInstanceState | 3.1s | 276ms | ~11x |
| Step 8: n.plan (PlanResourceChange) | **1h 06m 09s** | **1m 45s** | **~38x** |
| **Total wall time** | **~1h 46m** | **~4m** | **~28x** |

### ~28,923 records

Set: left running for **4+ hours, never completed**.

## Tradeoffs of This Approach

### What changes behaviorally

**Ordering becomes significant.** With Set, `[A, B]` and `[B, A]` are identical. With List they differ — reordering `resource_record_set` blocks manually will cause phantom diffs on the next plan.

In practice this is safe because the Route53 API always returns records in consistent alphabetical order, and `Read()` preserves that order. As long as users don&#39;t manually reorder HCL blocks, there are no phantom diffs.

**Duplicates are no longer rejected at schema validation.** With Set, duplicate records in HCL are caught immediately. With List, they&#39;re silently accepted and only rejected later by the Route53 API with a less actionable error.

### Better long-term alternatives

This PR is the **minimal fix** that unblocks users. Two architecturally cleaner alternatives exist and are presented here for discussion:

**Option A: Sorted List + Validator** (recommended long-term)
```go
"resource_record_set": schema.ListNestedBlock{
    PlanModifiers: []planmodifier.List{sortByIdentityFields()},
    Validators: []validator.List{noDuplicateIdentifiers()},
}
```
Eliminates phantom diffs and preserves duplicate detection. Explicitly models the domain: Route53 returns records alphabetically, uniqueness is keyed by `name + type + set_identifier`.

**Option B: Custom identity-field hash**
Implement `SetValuableWithSemanticEquals` with a hash covering only the 3 identity fields (`name + type + set_identifier`) instead of the full nested object. Keeps Set semantics, reduces cost from O(N² × tree_size) to O(N × 3 fields).

**Broader note:** This Set performance issue is not unique to `aws_route53_records_exclusive`. Any resource using `SetNestedBlock` with large numbers of complex nested elements will exhibit similar degradation. This may warrant a broader audit across providers and guidance in the Plugin Framework docs about when Set is inappropriate for performance-sensitive resources.

## Testing

Updated acceptance test assertions from `knownvalue.SetPartial`/`SetExact` to `knownvalue.ListPartial`/`ListExact`.

Validated locally against real hosted zones with 432 and 5,168 records.

## References

- Issue: #48468
- Related batching issue: #3230