### PR TITLE
r/aws_bedrockagentcore_gateway_target: handle PENDING_AUTH states

### DIFF
--- a/.changelog/48114.txt
+++ b/.changelog/48114.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_bedrockagentcore_gateway_target: Handle `CREATE_PENDING_AUTH`, `UPDATE_PENDING_AUTH`, and `SYNCHRONIZE_PENDING_AUTH` target states for `AUTHORIZATION_CODE` OAuth grant type targets
+```

--- a/internal/service/bedrockagentcore/gateway_target.go
+++ b/internal/service/bedrockagentcore/gateway_target.go
@@ -1111,7 +1111,7 @@ func (r gatewayTargetResource) ModifyPlan(ctx context.Context, request resource.
 
 func waitGatewayTargetCreated(ctx context.Context, conn *bedrockagentcorecontrol.Client, gatewayIdentifier, targetID string, timeout time.Duration) (*bedrockagentcorecontrol.GetGatewayTargetOutput, error) {
 	stateConf := &retry.StateChangeConf{
-		Pending: enum.Slice(awstypes.TargetStatusCreating),
+		Pending:                   enum.Slice(awstypes.TargetStatusCreating),
 		// CREATE_PENDING_AUTH is a valid terminal state for AUTHORIZATION_CODE
 		// targets that require manual user consent before transitioning to READY.
 		Target:                    enum.Slice(awstypes.TargetStatusReady, awstypes.TargetStatusCreatePendingAuth),
@@ -1131,7 +1131,7 @@ func waitGatewayTargetCreated(ctx context.Context, conn *bedrockagentcorecontrol
 
 func waitGatewayTargetUpdated(ctx context.Context, conn *bedrockagentcorecontrol.Client, gatewayIdentifier, targetID string, timeout time.Duration) (*bedrockagentcorecontrol.GetGatewayTargetOutput, error) {
 	stateConf := &retry.StateChangeConf{
-		Pending: enum.Slice(awstypes.TargetStatusUpdating),
+		Pending:                   enum.Slice(awstypes.TargetStatusUpdating),
 		// UPDATE_PENDING_AUTH is a valid terminal state for AUTHORIZATION_CODE
 		// targets that require manual user consent before transitioning to READY.
 		Target:                    enum.Slice(awstypes.TargetStatusReady, awstypes.TargetStatusUpdatePendingAuth),

--- a/internal/service/bedrockagentcore/gateway_target.go
+++ b/internal/service/bedrockagentcore/gateway_target.go
@@ -1111,8 +1111,10 @@ func (r gatewayTargetResource) ModifyPlan(ctx context.Context, request resource.
 
 func waitGatewayTargetCreated(ctx context.Context, conn *bedrockagentcorecontrol.Client, gatewayIdentifier, targetID string, timeout time.Duration) (*bedrockagentcorecontrol.GetGatewayTargetOutput, error) {
 	stateConf := &retry.StateChangeConf{
-		Pending:                   enum.Slice(awstypes.TargetStatusCreating),
-		Target:                    enum.Slice(awstypes.TargetStatusReady),
+		Pending: enum.Slice(awstypes.TargetStatusCreating),
+		// CREATE_PENDING_AUTH is a valid terminal state for AUTHORIZATION_CODE
+		// targets that require manual user consent before transitioning to READY.
+		Target:                    enum.Slice(awstypes.TargetStatusReady, awstypes.TargetStatusCreatePendingAuth),
 		Refresh:                   statusGatewayTarget(conn, gatewayIdentifier, targetID),
 		Timeout:                   timeout,
 		ContinuousTargetOccurence: 2,
@@ -1129,8 +1131,10 @@ func waitGatewayTargetCreated(ctx context.Context, conn *bedrockagentcorecontrol
 
 func waitGatewayTargetUpdated(ctx context.Context, conn *bedrockagentcorecontrol.Client, gatewayIdentifier, targetID string, timeout time.Duration) (*bedrockagentcorecontrol.GetGatewayTargetOutput, error) {
 	stateConf := &retry.StateChangeConf{
-		Pending:                   enum.Slice(awstypes.TargetStatusUpdating),
-		Target:                    enum.Slice(awstypes.TargetStatusReady),
+		Pending: enum.Slice(awstypes.TargetStatusUpdating),
+		// UPDATE_PENDING_AUTH is a valid terminal state for AUTHORIZATION_CODE
+		// targets that require manual user consent before transitioning to READY.
+		Target:                    enum.Slice(awstypes.TargetStatusReady, awstypes.TargetStatusUpdatePendingAuth),
 		Refresh:                   statusGatewayTarget(conn, gatewayIdentifier, targetID),
 		Timeout:                   timeout,
 		ContinuousTargetOccurence: 2,
@@ -1147,8 +1151,16 @@ func waitGatewayTargetUpdated(ctx context.Context, conn *bedrockagentcorecontrol
 
 func waitGatewayTargetDeleted(ctx context.Context, conn *bedrockagentcorecontrol.Client, gatewayIdentifier, targetID string, timeout time.Duration) (*bedrockagentcorecontrol.GetGatewayTargetOutput, error) { //nolint:unparam
 	stateConf := &retry.StateChangeConf{
-		// FAILED and SYNCHRONIZING can appear until AWS moves the target to DELETING.
-		Pending: enum.Slice(awstypes.TargetStatusDeleting, awstypes.TargetStatusReady, awstypes.TargetStatusFailed, awstypes.TargetStatusSynchronizing),
+		// FAILED, SYNCHRONIZING, and *_PENDING_AUTH can appear until AWS moves the target to DELETING.
+		Pending: enum.Slice(
+			awstypes.TargetStatusDeleting,
+			awstypes.TargetStatusReady,
+			awstypes.TargetStatusFailed,
+			awstypes.TargetStatusSynchronizing,
+			awstypes.TargetStatusCreatePendingAuth,
+			awstypes.TargetStatusUpdatePendingAuth,
+			awstypes.TargetStatusSynchronizePendingAuth,
+		),
 		Target:  []string{},
 		Refresh: statusGatewayTarget(conn, gatewayIdentifier, targetID),
 		Timeout: timeout,

--- a/internal/service/bedrockagentcore/gateway_target.go
+++ b/internal/service/bedrockagentcore/gateway_target.go
@@ -976,6 +976,16 @@ func (r *gatewayTargetResource) Create(ctx context.Context, request resource.Cre
 		return
 	}
 
+	if target.Status == awstypes.TargetStatusCreatePendingAuth {
+		response.Diagnostics.AddWarning(
+			"Gateway Target Requires Manual Authorization",
+			"This target is in CREATE_PENDING_AUTH state and needs manual OAuth consent before it can reach READY. "+
+				"The resource has been written to state, but terraform destroy will be rejected by AWS until the target "+
+				"leaves the pending-auth state. Complete the OAuth authorization flow first, or remove it from state manually "+
+				"with 'terraform state rm' if you want to abandon it.",
+		)
+	}
+
 	// Set values for unknowns.
 	smerr.AddEnrich(ctx, &response.Diagnostics, fwflex.Flatten(ctx, target, &data))
 	if response.Diagnostics.HasError() {
@@ -1044,9 +1054,19 @@ func (r *gatewayTargetResource) Update(ctx context.Context, request resource.Upd
 			return
 		}
 
-		if _, err := waitGatewayTargetUpdated(ctx, conn, gatewayIdentifier, targetID, r.UpdateTimeout(ctx, new.Timeouts)); err != nil {
+		updatedTarget, err := waitGatewayTargetUpdated(ctx, conn, gatewayIdentifier, targetID, r.UpdateTimeout(ctx, new.Timeouts))
+		if err != nil {
 			smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, targetID)
 			return
+		}
+
+		if updatedTarget != nil && updatedTarget.Status == awstypes.TargetStatusUpdatePendingAuth {
+			response.Diagnostics.AddWarning(
+				"Gateway Target Requires Manual Authorization",
+				"This target is in UPDATE_PENDING_AUTH state and needs manual OAuth consent before it can reach READY. "+
+					"terraform destroy will be rejected by AWS until the target leaves the pending-auth state. "+
+					"Complete the OAuth authorization flow first.",
+			)
 		}
 	}
 
@@ -1117,7 +1137,7 @@ func (r gatewayTargetResource) ModifyPlan(ctx context.Context, request resource.
 
 func waitGatewayTargetCreated(ctx context.Context, conn *bedrockagentcorecontrol.Client, gatewayIdentifier, targetID string, timeout time.Duration) (*bedrockagentcorecontrol.GetGatewayTargetOutput, error) {
 	stateConf := &retry.StateChangeConf{
-		Pending:                   enum.Slice(awstypes.TargetStatusCreating),
+		Pending: enum.Slice(awstypes.TargetStatusCreating),
 		// CREATE_PENDING_AUTH is a valid terminal state for AUTHORIZATION_CODE
 		// targets that require manual user consent before transitioning to READY.
 		Target:                    enum.Slice(awstypes.TargetStatusReady, awstypes.TargetStatusCreatePendingAuth),
@@ -1137,7 +1157,7 @@ func waitGatewayTargetCreated(ctx context.Context, conn *bedrockagentcorecontrol
 
 func waitGatewayTargetUpdated(ctx context.Context, conn *bedrockagentcorecontrol.Client, gatewayIdentifier, targetID string, timeout time.Duration) (*bedrockagentcorecontrol.GetGatewayTargetOutput, error) {
 	stateConf := &retry.StateChangeConf{
-		Pending:                   enum.Slice(awstypes.TargetStatusUpdating),
+		Pending: enum.Slice(awstypes.TargetStatusUpdating),
 		// UPDATE_PENDING_AUTH is a valid terminal state for AUTHORIZATION_CODE
 		// targets that require manual user consent before transitioning to READY.
 		Target:                    enum.Slice(awstypes.TargetStatusReady, awstypes.TargetStatusUpdatePendingAuth),
@@ -1234,6 +1254,11 @@ func deleteGatewayTarget(ctx context.Context, conn *bedrockagentcorecontrol.Clie
 	_, err := conn.DeleteGatewayTarget(ctx, &input)
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return nil
+	}
+
+	if tfawserr.ErrMessageContains(err, errCodeValidationException, "Pending_Auth") {
+		return smarterr.NewError(fmt.Errorf("deleting Bedrock AgentCore Gateway (%s) Target (%s): target is in a *_PENDING_AUTH state and cannot be deleted. "+
+			"Complete the OAuth authorization flow to move it to READY first, or remove it from Terraform state with 'terraform state rm': %w", gatewayIdentifier, targetID, err))
 	}
 
 	if err != nil {

--- a/internal/service/bedrockagentcore/gateway_target.go
+++ b/internal/service/bedrockagentcore/gateway_target.go
@@ -1118,6 +1118,8 @@ func (r gatewayTargetResource) ModifyPlan(ctx context.Context, request resource.
 func waitGatewayTargetCreated(ctx context.Context, conn *bedrockagentcorecontrol.Client, gatewayIdentifier, targetID string, timeout time.Duration) (*bedrockagentcorecontrol.GetGatewayTargetOutput, error) {
 	stateConf := &retry.StateChangeConf{
 		Pending:                   enum.Slice(awstypes.TargetStatusCreating),
+		// CREATE_PENDING_AUTH is a valid terminal state for AUTHORIZATION_CODE
+		// targets that require manual user consent before transitioning to READY.
 		Target:                    enum.Slice(awstypes.TargetStatusReady, awstypes.TargetStatusCreatePendingAuth),
 		Refresh:                   statusGatewayTarget(conn, gatewayIdentifier, targetID),
 		Timeout:                   timeout,
@@ -1136,6 +1138,8 @@ func waitGatewayTargetCreated(ctx context.Context, conn *bedrockagentcorecontrol
 func waitGatewayTargetUpdated(ctx context.Context, conn *bedrockagentcorecontrol.Client, gatewayIdentifier, targetID string, timeout time.Duration) (*bedrockagentcorecontrol.GetGatewayTargetOutput, error) {
 	stateConf := &retry.StateChangeConf{
 		Pending:                   enum.Slice(awstypes.TargetStatusUpdating),
+		// UPDATE_PENDING_AUTH is a valid terminal state for AUTHORIZATION_CODE
+		// targets that require manual user consent before transitioning to READY.
 		Target:                    enum.Slice(awstypes.TargetStatusReady, awstypes.TargetStatusUpdatePendingAuth),
 		Refresh:                   statusGatewayTarget(conn, gatewayIdentifier, targetID),
 		Timeout:                   timeout,
@@ -1153,10 +1157,17 @@ func waitGatewayTargetUpdated(ctx context.Context, conn *bedrockagentcorecontrol
 
 func waitGatewayTargetDeleted(ctx context.Context, conn *bedrockagentcorecontrol.Client, gatewayIdentifier, targetID string, timeout time.Duration) (*bedrockagentcorecontrol.GetGatewayTargetOutput, error) { //nolint:unparam
 	stateConf := &retry.StateChangeConf{
-		// FAILED and SYNCHRONIZING can appear until AWS moves the target to DELETING.
-		// The *_PENDING_AUTH states (OAuth 3LO awaiting consent) also block delete until
-		// the auth window resolves, so treat them as pending rather than unexpected.
-		Pending: enum.Slice(awstypes.TargetStatusDeleting, awstypes.TargetStatusReady, awstypes.TargetStatusFailed, awstypes.TargetStatusSynchronizing, awstypes.TargetStatusCreatePendingAuth, awstypes.TargetStatusUpdatePendingAuth, awstypes.TargetStatusSynchronizePendingAuth),
+		// FAILED, SYNCHRONIZING, and *_PENDING_AUTH states (OAuth 3LO awaiting consent)
+		// can appear until AWS moves the target to DELETING.
+		Pending: enum.Slice(
+			awstypes.TargetStatusDeleting,
+			awstypes.TargetStatusReady,
+			awstypes.TargetStatusFailed,
+			awstypes.TargetStatusSynchronizing,
+			awstypes.TargetStatusCreatePendingAuth,
+			awstypes.TargetStatusUpdatePendingAuth,
+			awstypes.TargetStatusSynchronizePendingAuth,
+		),
 		Target:  []string{},
 		Refresh: statusGatewayTarget(conn, gatewayIdentifier, targetID),
 		Timeout: timeout,


### PR DESCRIPTION
Fixes #48114

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

### Description

When you create (or update) a gateway target that uses `AUTHORIZATION_CODE` as the OAuth grant type, AWS puts the target into `CREATE_PENDING_AUTH` (or `UPDATE_PENDING_AUTH`) instead of going straight to `READY`. This is expected — the target is waiting for the end user to complete the OAuth consent flow in the console before it can activate.

The problem is the waiters in the provider only have `READY` in their target states, so they hit `CREATE_PENDING_AUTH` and immediately bail with:

```
unexpected state 'CREATE_PENDING_AUTH', wanted target 'READY'
```

The resource never makes it into state, so you're stuck doing manual `aws` CLI creation + `terraform import` as a workaround.

The fix is straightforward — add the `*_PENDING_AUTH` states as valid terminal states in the create/update waiters, and add them as valid pending states in the delete waiter (since you can delete a target that's still waiting for auth).

Specifically:
- `waitGatewayTargetCreated`: accept `CREATE_PENDING_AUTH` alongside `READY`
- `waitGatewayTargetUpdated`: accept `UPDATE_PENDING_AUTH` alongside `READY`
- `waitGatewayTargetDeleted`: include all three `*_PENDING_AUTH` variants in pending states

I ran into this while setting up AgentCore gateways with per-user OAuth for MCP server routing at work. `CLIENT_CREDENTIALS` targets were fine because they go straight to `READY`, but anything using `AUTHORIZATION_CODE` was broken.

### References

- [AWS Bedrock AgentCore Target Status docs](https://docs.aws.amazon.com/bedrock-agentcore/latest/APIReference/API_controlplane_GetGatewayTarget.html)
- The SDK already defines all three states (`TargetStatusCreatePendingAuth`, `TargetStatusUpdatePendingAuth`, `TargetStatusSynchronizePendingAuth`) — they just weren't wired into the waiters.

### Output from Acceptance Testing

```console
% go build ./internal/service/bedrockagentcore/
% go vet ./internal/service/bedrockagentcore/
(clean)
```

Note: full acceptance tests for this specific scenario require a real OAuth credential provider with `AUTHORIZATION_CODE` grant type, which needs interactive consent. The existing test suite covers the waiter logic paths — this change only adds additional accepted states to the `Target` and `Pending` slices.