### PR TITLE
Add attribute_mappings to aws_rolesanywhere_profile

### DIFF
--- a/.changelog/48493.txt
+++ b/.changelog/48493.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_rolesanywhere_profile: Add `attribute_mappings` argument
+```

--- a/internal/service/rolesanywhere/profile.go
+++ b/internal/service/rolesanywhere/profile.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
@@ -47,6 +48,31 @@ func resourceProfile() *schema.Resource {
 				names.AttrARN: {
 					Type:     schema.TypeString,
 					Computed: true,
+				},
+				"attribute_mappings": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"certificate_field": {
+								Type:             schema.TypeString,
+								Required:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.CertificateField](),
+							},
+							"mapping_rules": {
+								Type:     schema.TypeSet,
+								Required: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"specifier": {
+											Type:     schema.TypeString,
+											Required: true,
+										},
+									},
+								},
+							},
+						},
+					},
 				},
 				"duration_seconds": {
 					Type:     schema.TypeInt,
@@ -135,6 +161,12 @@ func resourceProfileCreate(ctx context.Context, d *schema.ResourceData, meta any
 
 	d.SetId(aws.ToString(output.Profile.ProfileId))
 
+	if v, ok := d.GetOk("attribute_mappings"); ok {
+		if err := putProfileAttributeMappings(ctx, conn, d.Id(), v.(*schema.Set).List()); err != nil {
+			return sdkdiag.AppendErrorf(diags, "setting RolesAnywhere Profile (%s) attribute mappings: %s", d.Id(), err)
+		}
+	}
+
 	return append(diags, resourceProfileRead(ctx, d, meta)...)
 }
 
@@ -156,6 +188,9 @@ func resourceProfileRead(ctx context.Context, d *schema.ResourceData, meta any) 
 
 	d.Set("accept_role_session_name", profile.AcceptRoleSessionName)
 	d.Set(names.AttrARN, profile.ProfileArn)
+	if err := d.Set("attribute_mappings", flattenAttributeMappings(profile.AttributeMappings)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting attribute_mappings: %s", err)
+	}
 	d.Set("duration_seconds", profile.DurationSeconds)
 	d.Set(names.AttrEnabled, profile.Enabled)
 	d.Set("managed_policy_arns", profile.ManagedPolicyArns)
@@ -171,7 +206,7 @@ func resourceProfileUpdate(ctx context.Context, d *schema.ResourceData, meta any
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RolesAnywhereClient(ctx)
 
-	if d.HasChangesExcept(names.AttrTags, names.AttrTagsAll) {
+	if d.HasChangesExcept(names.AttrTags, names.AttrTagsAll, "attribute_mappings") {
 		input := rolesanywhere.UpdateProfileInput{
 			ProfileId: aws.String(d.Id()),
 		}
@@ -204,6 +239,27 @@ func resourceProfileUpdate(ctx context.Context, d *schema.ResourceData, meta any
 
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating RolesAnywhere Profile (%s): %s", d.Id(), err)
+		}
+	}
+
+	if d.HasChange("attribute_mappings") {
+		o, n := d.GetChange("attribute_mappings")
+		oldCertificateFields := attributeMappingCertificateFields(o.(*schema.Set).List())
+		newMappings := n.(*schema.Set).List()
+		newCertificateFields := attributeMappingCertificateFields(newMappings)
+
+		// Delete mappings for certificate fields that are no longer configured;
+		// PutAttributeMapping only replaces a field, it does not remove one.
+		for certificateField := range oldCertificateFields {
+			if _, ok := newCertificateFields[certificateField]; !ok {
+				if err := deleteProfileAttributeMapping(ctx, conn, d.Id(), awstypes.CertificateField(certificateField)); err != nil {
+					return sdkdiag.AppendErrorf(diags, "deleting RolesAnywhere Profile (%s) attribute mapping (%s): %s", d.Id(), certificateField, err)
+				}
+			}
+		}
+
+		if err := putProfileAttributeMappings(ctx, conn, d.Id(), newMappings); err != nil {
+			return sdkdiag.AppendErrorf(diags, "updating RolesAnywhere Profile (%s) attribute mappings: %s", d.Id(), err)
 		}
 	}
 
@@ -289,4 +345,99 @@ func enableProfile(ctx context.Context, conn *rolesanywhere.Client, id string) e
 
 	_, err := conn.EnableProfile(ctx, &input)
 	return err
+}
+
+func putProfileAttributeMappings(ctx context.Context, conn *rolesanywhere.Client, profileID string, tfList []any) error {
+	for _, tfMapRaw := range tfList {
+		tfMap, ok := tfMapRaw.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		input := rolesanywhere.PutAttributeMappingInput{
+			CertificateField: awstypes.CertificateField(tfMap["certificate_field"].(string)),
+			MappingRules:     expandMappingRules(tfMap["mapping_rules"].(*schema.Set).List()),
+			ProfileId:        aws.String(profileID),
+		}
+
+		if _, err := conn.PutAttributeMapping(ctx, &input); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func deleteProfileAttributeMapping(ctx context.Context, conn *rolesanywhere.Client, profileID string, certificateField awstypes.CertificateField) error {
+	input := rolesanywhere.DeleteAttributeMappingInput{
+		CertificateField: certificateField,
+		ProfileId:        aws.String(profileID),
+	}
+
+	_, err := conn.DeleteAttributeMapping(ctx, &input)
+	return err
+}
+
+func attributeMappingCertificateFields(tfList []any) map[string]struct{} {
+	fields := make(map[string]struct{}, len(tfList))
+	for _, tfMapRaw := range tfList {
+		if tfMap, ok := tfMapRaw.(map[string]any); ok {
+			fields[tfMap["certificate_field"].(string)] = struct{}{}
+		}
+	}
+
+	return fields
+}
+
+func expandMappingRules(tfList []any) []awstypes.MappingRule {
+	if len(tfList) == 0 {
+		return nil
+	}
+
+	var apiObjects []awstypes.MappingRule
+	for _, tfMapRaw := range tfList {
+		tfMap, ok := tfMapRaw.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		apiObjects = append(apiObjects, awstypes.MappingRule{
+			Specifier: aws.String(tfMap["specifier"].(string)),
+		})
+	}
+
+	return apiObjects
+}
+
+func flattenAttributeMappings(apiObjects []awstypes.AttributeMapping) []any {
+	if len(apiObjects) == 0 {
+		return []any{}
+	}
+
+	var tfList []any
+	for _, apiObject := range apiObjects {
+		tfMap := map[string]any{
+			"certificate_field": string(apiObject.CertificateField),
+			"mapping_rules":     flattenMappingRules(apiObject.MappingRules),
+		}
+		tfList = append(tfList, tfMap)
+	}
+
+	return tfList
+}
+
+func flattenMappingRules(apiObjects []awstypes.MappingRule) []any {
+	if len(apiObjects) == 0 {
+		return []any{}
+	}
+
+	var tfList []any
+	for _, apiObject := range apiObjects {
+		tfMap := map[string]any{
+			"specifier": aws.ToString(apiObject.Specifier),
+		}
+		tfList = append(tfList, tfMap)
+	}
+
+	return tfList
 }

--- a/internal/service/rolesanywhere/profile_test.go
+++ b/internal/service/rolesanywhere/profile_test.go
@@ -48,6 +48,56 @@ func TestAccRolesAnywhereProfile_basic(t *testing.T) {
 	})
 }
 
+func TestAccRolesAnywhereProfile_attributeMappings(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	roleName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_rolesanywhere_profile.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.RolesAnywhereServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckProfileDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProfileConfig_attributeMappings1(rName, roleName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckProfileExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "attribute_mappings.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "attribute_mappings.*", map[string]string{
+						"certificate_field": "x509Subject",
+						"mapping_rules.#":   "1",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccProfileConfig_attributeMappings2(rName, roleName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckProfileExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "attribute_mappings.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "attribute_mappings.*", map[string]string{
+						"certificate_field": "x509Issuer",
+						"mapping_rules.#":   "1",
+					}),
+				),
+			},
+			{
+				Config: testAccProfileConfig_attributeMappings1(rName, roleName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckProfileExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "attribute_mappings.#", "1"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccRolesAnywhereProfile_noRoleARNs(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
@@ -383,4 +433,50 @@ resource "aws_rolesanywhere_profile" "test" {
   accept_role_session_name = %[2]t
 }
 `, rName, acceptRoleSessionName))
+}
+
+func testAccProfileConfig_attributeMappings1(rName, roleName string) string {
+	return acctest.ConfigCompose(
+		testAccProfileConfig_base(roleName),
+		fmt.Sprintf(`
+resource "aws_rolesanywhere_profile" "test" {
+  name      = %[1]q
+  role_arns = [aws_iam_role.test.arn]
+
+  attribute_mappings {
+    certificate_field = "x509Subject"
+
+    mapping_rules {
+      specifier = "CN"
+    }
+  }
+}
+`, rName))
+}
+
+func testAccProfileConfig_attributeMappings2(rName, roleName string) string {
+	return acctest.ConfigCompose(
+		testAccProfileConfig_base(roleName),
+		fmt.Sprintf(`
+resource "aws_rolesanywhere_profile" "test" {
+  name      = %[1]q
+  role_arns = [aws_iam_role.test.arn]
+
+  attribute_mappings {
+    certificate_field = "x509Subject"
+
+    mapping_rules {
+      specifier = "CN"
+    }
+  }
+
+  attribute_mappings {
+    certificate_field = "x509Issuer"
+
+    mapping_rules {
+      specifier = "CN"
+    }
+  }
+}
+`, rName))
 }

--- a/website/docs/r/rolesanywhere_profile.html.markdown
+++ b/website/docs/r/rolesanywhere_profile.html.markdown
@@ -52,7 +52,17 @@ This resource supports the following arguments:
 * `role_arns` - (Optional) A list of IAM roles that this profile can assume
 * `session_policy` - (Optional) A session policy that applies to the trust boundary of the vended session credentials.
 * `accept_role_session_name` - (Optional) Whether or not a custom role session name is accepted.
+* `attribute_mappings` - (Optional) A mapping applied to the incoming end-entity certificate during the authentication process. See [`attribute_mappings`](#attribute_mappings) below.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+### attribute_mappings
+
+* `certificate_field` - (Required) Field within the X.509 certificate to map attributes from. Valid values are `x509Subject`, `x509Issuer`, and `x509SAN`.
+* `mapping_rules` - (Required) A list of mapping entries for every supported specifier or sub-field in the certificate field. See [`mapping_rules`](#mapping_rules) below.
+
+### mapping_rules
+
+* `specifier` - (Required) Specifier within the certificate field, such as `CN`, `OU`, or `UID` from the Subject field.
 
 ## Attribute Reference
 


### PR DESCRIPTION
### Description

Adds an `attribute_mappings` argument to `aws_rolesanywhere_profile`, so a profile can map fields from the authenticating X.509 certificate (Subject, Issuer, SAN) into the vended session. AWS manages these through the `PutAttributeMapping` and `DeleteAttributeMapping` APIs, which are separate from `CreateProfile`/`UpdateProfile`, so the mappings are set after the profile is created and reconciled on update: certificate fields that were removed are deleted, then the current set is put.

### Relations

Closes #48211

### Output from Acceptance Testing

I don't have an AWS account wired up to run the RolesAnywhere acceptance tests against, so I haven't run `TestAccRolesAnywhereProfile_attributeMappings` myself. It covers create, adding a second certificate field, removing one again, and import. Would appreciate a maintainer running it.