### PR TITLE
resource/aws_sagemaker_endpoint_configuration: Add instance_pools, metrics_config, and variant_instance_provision_timeout_in_seconds

### DIFF
--- a/.changelog/48494.txt
+++ b/.changelog/48494.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_sagemaker_endpoint_configuration: Add `instance_pools` argument to `production_variants`
+```
+
+```release-note:enhancement
+resource/aws_sagemaker_endpoint_configuration: Add `metrics_config` argument
+```

--- a/.changelog/48494.txt
+++ b/.changelog/48494.txt
@@ -5,3 +5,7 @@ resource/aws_sagemaker_endpoint_configuration: Add `instance_pools` argument to 
 ```release-note:enhancement
 resource/aws_sagemaker_endpoint_configuration: Add `metrics_config` argument
 ```
+
+```release-note:enhancement
+resource/aws_sagemaker_endpoint_configuration: Add `variant_instance_provision_timeout_in_seconds` argument to `production_variants`
+```

--- a/internal/service/sagemaker/endpoint_configuration.go
+++ b/internal/service/sagemaker/endpoint_configuration.go
@@ -513,6 +513,12 @@ func resourceEndpointConfiguration() *schema.Resource {
 									},
 								},
 							},
+							"variant_instance_provision_timeout_in_seconds": {
+								Type:         schema.TypeInt,
+								Optional:     true,
+								ForceNew:     true,
+								ValidateFunc: validation.IntBetween(300, 3600),
+							},
 							"variant_name": {
 								Type:     schema.TypeString,
 								Optional: true,
@@ -1010,6 +1016,10 @@ func expandProductionVariants(configured []any) []awstypes.ProductionVariant {
 			l.ModelDataDownloadTimeoutInSeconds = aws.Int32(int32(v))
 		}
 
+		if v, ok := data["variant_instance_provision_timeout_in_seconds"].(int); ok && v > 0 {
+			l.VariantInstanceProvisionTimeoutInSeconds = aws.Int32(int32(v))
+		}
+
 		if v, ok := data["volume_size_in_gb"].(int); ok && v > 0 {
 			l.VolumeSizeInGB = aws.Int32(int32(v))
 		}
@@ -1098,6 +1108,10 @@ func flattenProductionVariants(list []awstypes.ProductionVariant) []map[string]a
 
 		if i.ModelDataDownloadTimeoutInSeconds != nil {
 			l["model_data_download_timeout_in_seconds"] = aws.ToInt32(i.ModelDataDownloadTimeoutInSeconds)
+		}
+
+		if i.VariantInstanceProvisionTimeoutInSeconds != nil {
+			l["variant_instance_provision_timeout_in_seconds"] = aws.ToInt32(i.VariantInstanceProvisionTimeoutInSeconds)
 		}
 
 		if i.VolumeSizeInGB != nil {

--- a/internal/service/sagemaker/endpoint_configuration.go
+++ b/internal/service/sagemaker/endpoint_configuration.go
@@ -7,6 +7,7 @@ package sagemaker
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"strings"
 
@@ -261,6 +262,36 @@ func resourceEndpointConfiguration() *schema.Resource {
 					ForceNew:     true,
 					ValidateFunc: verify.ValidARN,
 				},
+				"metrics_config": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Computed: true,
+					MaxItems: 1,
+					ForceNew: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"enable_detailed_observability": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Computed: true,
+								ForceNew: true,
+							},
+							"enable_enhanced_metrics": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Computed: true,
+								ForceNew: true,
+							},
+							"metric_publish_frequency_in_seconds": {
+								Type:         schema.TypeInt,
+								Optional:     true,
+								Computed:     true,
+								ForceNew:     true,
+								ValidateFunc: validation.IntInSlice([]int{10, 30, 60, 120, 180, 240, 300}),
+							},
+						},
+					},
+				},
 				"production_variants": {
 					Type:     schema.TypeList,
 					Required: true,
@@ -448,6 +479,36 @@ func resourceEndpointConfiguration() *schema.Resource {
 											Optional:         true,
 											ForceNew:         true,
 											ValidateDiagFunc: enum.Validate[awstypes.ManagedInstanceScalingStatus](),
+										},
+									},
+								},
+							},
+							"instance_pools": {
+								Type:     schema.TypeList,
+								Optional: true,
+								ForceNew: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										names.AttrInstanceType: {
+											Type:             schema.TypeString,
+											Required:         true,
+											ForceNew:         true,
+											ValidateDiagFunc: enum.Validate[awstypes.ProductionVariantInstanceType](),
+										},
+										"priority": {
+											Type:         schema.TypeInt,
+											Required:     true,
+											ForceNew:     true,
+											ValidateFunc: validation.IntBetween(1, 5),
+										},
+										"model_name_override": {
+											Type:     schema.TypeString,
+											Optional: true,
+											ForceNew: true,
+											ValidateFunc: validation.All(
+												validation.StringLenBetween(1, 63),
+												validation.StringMatch(regexache.MustCompile(`^[a-zA-Z0-9]([\-a-zA-Z0-9]*[a-zA-Z0-9])?$`), ""),
+											),
 										},
 									},
 								},
@@ -679,11 +740,11 @@ func resourceEndpointConfiguration() *schema.Resource {
 			}
 		},
 
-		CustomizeDiff: validateDataCaptureConfigCustomDiff,
+		CustomizeDiff: endpointConfigurationCustomizeDiff,
 	}
 }
 
-func validateDataCaptureConfigCustomDiff(ctx context.Context, d *schema.ResourceDiff, meta any) error {
+func endpointConfigurationCustomizeDiff(ctx context.Context, d *schema.ResourceDiff, meta any) error {
 	var diags diag.Diagnostics
 
 	configRaw := d.GetRawConfig()
@@ -695,6 +756,25 @@ func validateDataCaptureConfigCustomDiff(ctx context.Context, d *schema.Resource
 	dataCaptures := configRaw.GetAttr("data_capture_config")
 	if dataCaptures.IsKnown() && !dataCaptures.IsNull() {
 		dataCaptureConfigPlanTimeValidate(dataCapturesPath, dataCaptures, &diags)
+	}
+
+	// Validate instance_type and instance_pools mutual exclusivity
+	for _, variantKey := range []string{"production_variants"} {
+		if v, ok := d.GetOk(variantKey); ok {
+			for i, variant := range v.([]any) {
+				data := variant.(map[string]any)
+				hasInstanceType := data[names.AttrInstanceType].(string) != ""
+				hasInstancePools := len(data["instance_pools"].([]any)) > 0
+				if hasInstanceType && hasInstancePools {
+					diags = append(diags, diag.Diagnostic{
+						Severity:      diag.Error,
+						Summary:       "Conflicting attributes",
+						Detail:        fmt.Sprintf("%s.%d: \"instance_type\" and \"instance_pools\" are mutually exclusive", variantKey, i),
+						AttributePath: cty.GetAttrPath(variantKey),
+					})
+				}
+			}
+		}
 	}
 
 	return sdkdiag.DiagnosticsError(diags)
@@ -775,6 +855,10 @@ func resourceEndpointConfigurationCreate(ctx context.Context, d *schema.Resource
 		input.KmsKeyId = aws.String(v.(string))
 	}
 
+	if v, ok := d.GetOk("metrics_config"); ok {
+		input.MetricsConfig = expandMetricsConfig(v.([]any))
+	}
+
 	if v, ok := d.GetOk("shadow_production_variants"); ok && len(v.([]any)) > 0 {
 		input.ShadowProductionVariants = expandProductionVariants(v.([]any))
 	}
@@ -821,6 +905,10 @@ func resourceEndpointConfigurationRead(ctx context.Context, d *schema.ResourceDa
 	}
 	if err := d.Set("shadow_production_variants", flattenProductionVariants(endpointConfig.ShadowProductionVariants)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting shadow_production_variants: %s", err)
+	}
+
+	if err := d.Set("metrics_config", flattenMetricsConfig(endpointConfig.MetricsConfig)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting metrics_config for SageMaker AI Endpoint Configuration (%s): %s", d.Id(), err)
 	}
 
 	return diags
@@ -956,6 +1044,10 @@ func expandProductionVariants(configured []any) []awstypes.ProductionVariant {
 			l.ManagedInstanceScaling = expandManagedInstanceScaling(v)
 		}
 
+		if v, ok := data["instance_pools"].([]any); ok && len(v) > 0 {
+			l.InstancePools = expandInstancePools(v)
+		}
+
 		if v, ok := data["inference_ami_version"].(string); ok && v != "" {
 			l.InferenceAmiVersion = awstypes.ProductionVariantInferenceAmiVersion(v)
 		}
@@ -1030,6 +1122,10 @@ func flattenProductionVariants(list []awstypes.ProductionVariant) []map[string]a
 
 		if i.CapacityReservationConfig != nil {
 			l["capacity_reservation_config"] = flattenCapacityReservationConfig(i.CapacityReservationConfig)
+		}
+
+		if len(i.InstancePools) > 0 {
+			l["instance_pools"] = flattenInstancePools(i.InstancePools)
 		}
 
 		result = append(result, l)
@@ -1510,4 +1606,79 @@ func flattenCapacityReservationConfig(apiObject *awstypes.ProductionVariantCapac
 	}
 
 	return []any{tfMap}
+}
+
+func expandInstancePools(configured []any) []awstypes.InstancePool {
+	if len(configured) == 0 {
+		return nil
+	}
+
+	pools := make([]awstypes.InstancePool, 0, len(configured))
+	for _, lRaw := range configured {
+		if lRaw == nil {
+			continue
+		}
+		data := lRaw.(map[string]any)
+		pool := awstypes.InstancePool{
+			InstanceType: awstypes.ProductionVariantInstanceType(data[names.AttrInstanceType].(string)),
+			Priority:     aws.Int32(int32(data["priority"].(int))),
+		}
+		if v, ok := data["model_name_override"].(string); ok && v != "" {
+			pool.ModelNameOverride = aws.String(v)
+		}
+		pools = append(pools, pool)
+	}
+	return pools
+}
+
+func flattenInstancePools(pools []awstypes.InstancePool) []map[string]any {
+	if len(pools) == 0 {
+		return nil
+	}
+
+	result := make([]map[string]any, 0, len(pools))
+	for _, pool := range pools {
+		m := map[string]any{
+			names.AttrInstanceType: pool.InstanceType,
+			"priority":             aws.ToInt32(pool.Priority),
+		}
+		if pool.ModelNameOverride != nil {
+			m["model_name_override"] = aws.ToString(pool.ModelNameOverride)
+		}
+		result = append(result, m)
+	}
+	return result
+}
+
+func expandMetricsConfig(configured []any) *awstypes.MetricsConfig {
+	if len(configured) == 0 || configured[0] == nil {
+		return nil
+	}
+
+	m := configured[0].(map[string]any)
+	c := &awstypes.MetricsConfig{}
+
+	if v, ok := m["enable_detailed_observability"].(bool); ok {
+		c.EnableDetailedObservability = aws.Bool(v)
+	}
+	if v, ok := m["enable_enhanced_metrics"].(bool); ok {
+		c.EnableEnhancedMetrics = aws.Bool(v)
+	}
+	if v, ok := m["metric_publish_frequency_in_seconds"].(int); ok && v > 0 {
+		c.MetricPublishFrequencyInSeconds = int32(v)
+	}
+	return c
+}
+
+func flattenMetricsConfig(config *awstypes.MetricsConfig) []map[string]any {
+	if config == nil {
+		return []map[string]any{}
+	}
+
+	cfg := map[string]any{
+		"enable_detailed_observability":       aws.ToBool(config.EnableDetailedObservability),
+		"enable_enhanced_metrics":             aws.ToBool(config.EnableEnhancedMetrics),
+		"metric_publish_frequency_in_seconds": int(config.MetricPublishFrequencyInSeconds),
+	}
+	return []map[string]any{cfg}
 }

--- a/internal/service/sagemaker/endpoint_configuration_test.go
+++ b/internal/service/sagemaker/endpoint_configuration_test.go
@@ -1981,3 +1981,224 @@ resource "aws_sagemaker_endpoint_configuration" "test" {
 }
 `, rName)
 }
+
+func TestAccSageMakerEndpointConfiguration_ProductionVariants_instancePools(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_sagemaker_endpoint_configuration.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SageMakerServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEndpointConfigurationDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEndpointConfigurationConfig_instancePools(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckEndpointConfigurationExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "production_variants.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "production_variants.0.instance_pools.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "production_variants.0.instance_pools.0.instance_type", "ml.m5.xlarge"),
+					resource.TestCheckResourceAttr(resourceName, "production_variants.0.instance_pools.0.priority", "1"),
+					resource.TestCheckResourceAttr(resourceName, "production_variants.0.instance_pools.1.instance_type", "ml.m5.2xlarge"),
+					resource.TestCheckResourceAttr(resourceName, "production_variants.0.instance_pools.1.priority", "2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccSageMakerEndpointConfiguration_ProductionVariants_instancePoolsModelNameOverride(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_sagemaker_endpoint_configuration.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SageMakerServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEndpointConfigurationDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEndpointConfigurationConfig_instancePoolsModelNameOverride(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckEndpointConfigurationExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "production_variants.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "production_variants.0.instance_pools.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "production_variants.0.instance_pools.0.instance_type", "ml.m5.xlarge"),
+					resource.TestCheckResourceAttr(resourceName, "production_variants.0.instance_pools.0.priority", "1"),
+					resource.TestCheckResourceAttr(resourceName, "production_variants.0.instance_pools.1.instance_type", "ml.m5.2xlarge"),
+					resource.TestCheckResourceAttr(resourceName, "production_variants.0.instance_pools.1.priority", "2"),
+					resource.TestCheckResourceAttrPair(resourceName, "production_variants.0.instance_pools.1.model_name_override", "aws_sagemaker_model.test2", names.AttrName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccSageMakerEndpointConfiguration_metricsConfig(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_sagemaker_endpoint_configuration.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SageMakerServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEndpointConfigurationDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEndpointConfigurationConfig_metricsConfig(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckEndpointConfigurationExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "metrics_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metrics_config.0.enable_detailed_observability", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "metrics_config.0.enable_enhanced_metrics", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "metrics_config.0.metric_publish_frequency_in_seconds", "30"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccEndpointConfigurationConfig_instancePools(rName string) string {
+	return acctest.ConfigCompose(testAccEndpointConfigurationConfig_base(rName), fmt.Sprintf(`
+resource "aws_sagemaker_endpoint_configuration" "test" {
+  name = %[1]q
+
+  production_variants {
+    variant_name           = "variant-1"
+    model_name             = aws_sagemaker_model.test.name
+    initial_instance_count = 2
+
+    instance_pools {
+      instance_type = "ml.m5.xlarge"
+      priority      = 1
+    }
+
+    instance_pools {
+      instance_type = "ml.m5.2xlarge"
+      priority      = 2
+    }
+  }
+}
+`, rName))
+}
+
+func testAccEndpointConfigurationConfig_instancePoolsModelNameOverride(rName string) string {
+	return acctest.ConfigCompose(testAccEndpointConfigurationConfig_base(rName), fmt.Sprintf(`
+resource "aws_sagemaker_model" "test2" {
+  name               = "%[1]s-2"
+  execution_role_arn = aws_iam_role.test.arn
+
+  primary_container {
+    image = data.aws_sagemaker_prebuilt_ecr_image.test.registry_path
+  }
+}
+
+resource "aws_sagemaker_endpoint_configuration" "test" {
+  name = %[1]q
+
+  production_variants {
+    variant_name           = "variant-1"
+    model_name             = aws_sagemaker_model.test.name
+    initial_instance_count = 2
+
+    instance_pools {
+      instance_type = "ml.m5.xlarge"
+      priority      = 1
+    }
+
+    instance_pools {
+      instance_type       = "ml.m5.2xlarge"
+      priority            = 2
+      model_name_override = aws_sagemaker_model.test2.name
+    }
+  }
+}
+`, rName))
+}
+
+func testAccEndpointConfigurationConfig_metricsConfig(rName string) string {
+	return acctest.ConfigCompose(testAccEndpointConfigurationConfig_base(rName), fmt.Sprintf(`
+resource "aws_sagemaker_endpoint_configuration" "test" {
+  name = %[1]q
+
+  metrics_config {
+    enable_detailed_observability       = true
+    enable_enhanced_metrics             = true
+    metric_publish_frequency_in_seconds = 30
+  }
+
+  production_variants {
+    variant_name           = "variant-1"
+    model_name             = aws_sagemaker_model.test.name
+    initial_instance_count = 2
+    instance_type          = "ml.t2.medium"
+  }
+}
+`, rName))
+}
+
+func TestAccSageMakerEndpointConfiguration_metricsConfigPartial(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_sagemaker_endpoint_configuration.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SageMakerServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEndpointConfigurationDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEndpointConfigurationConfig_metricsConfigPartial(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckEndpointConfigurationExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "metrics_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metrics_config.0.enable_enhanced_metrics", acctest.CtTrue),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccEndpointConfigurationConfig_metricsConfigPartial(rName string) string {
+	return acctest.ConfigCompose(testAccEndpointConfigurationConfig_base(rName), fmt.Sprintf(`
+resource "aws_sagemaker_endpoint_configuration" "test" {
+  name = %[1]q
+
+  metrics_config {
+    enable_enhanced_metrics = true
+  }
+
+  production_variants {
+    variant_name           = "variant-1"
+    model_name             = aws_sagemaker_model.test.name
+    initial_instance_count = 2
+    instance_type          = "ml.t2.medium"
+  }
+}
+`, rName))
+}

--- a/internal/service/sagemaker/endpoint_configuration_test.go
+++ b/internal/service/sagemaker/endpoint_configuration_test.go
@@ -2202,3 +2202,47 @@ resource "aws_sagemaker_endpoint_configuration" "test" {
 }
 `, rName))
 }
+
+func TestAccSageMakerEndpointConfiguration_ProductionVariants_variantInstanceProvisionTimeout(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_sagemaker_endpoint_configuration.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SageMakerServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEndpointConfigurationDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEndpointConfigurationConfig_variantInstanceProvisionTimeout(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckEndpointConfigurationExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "production_variants.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "production_variants.0.variant_instance_provision_timeout_in_seconds", "600"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccEndpointConfigurationConfig_variantInstanceProvisionTimeout(rName string) string {
+	return acctest.ConfigCompose(testAccEndpointConfigurationConfig_base(rName), fmt.Sprintf(`
+resource "aws_sagemaker_endpoint_configuration" "test" {
+  name = %[1]q
+
+  production_variants {
+    variant_name                                 = "variant-1"
+    model_name                                   = aws_sagemaker_model.test.name
+    initial_instance_count                       = 1
+    instance_type                                = "ml.m5.xlarge"
+    variant_instance_provision_timeout_in_seconds = 600
+  }
+}
+`, rName))
+}

--- a/website/docs/r/sagemaker_endpoint_configuration.html.markdown
+++ b/website/docs/r/sagemaker_endpoint_configuration.html.markdown
@@ -64,6 +64,7 @@ This resource supports the following arguments:
 * `model_name` - (Optional) Name of the model to use. Required unless using Inference Components (in which case `execution_role_arn` must be specified at the endpoint configuration level).
 * `routing_config` - (Optional) How the endpoint routes incoming traffic. See [routing_config](#routing_config) below.
 * `serverless_config` - (Optional) How an endpoint performs asynchronous inference.
+* `variant_instance_provision_timeout_in_seconds` - (Optional) The timeout value, in seconds, for provisioning instances for the production variant. When SageMaker AI encounters an insufficient capacity error while provisioning instances, it retries with the next instance pool (if configured via `instance_pools`) or waits until the timeout expires. This timeout applies only to capacity provisioning and does not include the time for model download or container startup. Valid values between `300` and `3600`.
 * `variant_name` - (Optional) Name of the variant. If omitted, Terraform will assign a random, unique name.
 * `volume_size_in_gb` - (Optional) Size, in GB, of the ML storage volume attached to individual inference instance associated with the production variant. Valid values between `1` and `512`.
 

--- a/website/docs/r/sagemaker_endpoint_configuration.html.markdown
+++ b/website/docs/r/sagemaker_endpoint_configuration.html.markdown
@@ -41,6 +41,7 @@ This resource supports the following arguments:
 * `kms_key_arn` - (Optional) ARN of a AWS KMS key that SageMaker AI uses to encrypt data on the storage volume attached to the ML compute instance that hosts the endpoint.
 * `name_prefix` - (Optional) Unique endpoint configuration name beginning with the specified prefix. Conflicts with `name`.
 * `name` - (Optional) Name of the endpoint configuration. If omitted, Terraform will assign a random, unique name. Conflicts with `name_prefix`.
+* `metrics_config` - (Optional) Configuration for endpoint utilization metrics. See [metrics_config](#metrics_config) below.
 * `production_variants` - (Required) List each model that you want to host at this endpoint. [See below](#production_variants).
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `shadow_production_variants` - (Optional) Models that you want to host at this endpoint in shadow mode with production traffic replicated from the model specified on `production_variants`. If you use this field, you can only specify one variant for `production_variants` and one variant for `shadow_production_variants`. [See below](#production_variants) (same arguments as `production_variants`).
@@ -56,6 +57,7 @@ This resource supports the following arguments:
 * `inference_ami_version` - (Optional) Option from a collection of preconfigured AMI images. Each image is configured by AWS with a set of software and driver versions. AWS optimizes these configurations for different machine learning workloads.
 * `initial_instance_count` - (Optional) Initial number of instances used for auto-scaling.
 * `initial_variant_weight` - (Optional) Initial traffic distribution among all of the models that you specify in the endpoint configuration. If unspecified, defaults to `1.0`. Ignored if `model_name` is not set (Inference Components endpoint).
+* `instance_pools` - (Optional) List of instance pools for heterogeneous endpoint deployments. Allows configuring multiple instance types with priority-based provisioning. See [instance_pools](#instance_pools) below.
 * `instance_type` - (Optional)  Type of instance to start.
 * `managed_instance_scaling` - (Optional) Control the range in the number of instances that the endpoint provisions as it scales up or down to accommodate traffic.
 * `model_data_download_timeout_in_seconds` - (Optional) Timeout value, in seconds, to download and extract the model that you want to host from S3 to the individual inference instance associated with this production variant. Valid values between `60` and `3600`.
@@ -90,6 +92,18 @@ This resource supports the following arguments:
 * `max_instance_count` - (Optional) Maximum number of instances that the endpoint can provision when it scales up to accommodate an increase in traffic.
 * `min_instance_count` - (Optional) Minimum number of instances that the endpoint must retain when it scales down to accommodate a decrease in traffic.
 * `status` - (Optional) Whether managed instance scaling is enabled. Valid values are `ENABLED` and `DISABLED`.
+
+#### instance_pools
+
+* `instance_type` - (Required) The ML compute instance type for the instance pool.
+* `priority` - (Required) The priority for the instance pool. SageMaker attempts to provision instances in order of priority, starting with the lowest value. Valid values are `1` to `5`, where `1` is the highest priority.
+* `model_name_override` - (Optional) Name of a SageMaker model to use for this instance pool instead of the model specified for the production variant. Use this to deploy a different model optimized for the instance type in this pool.
+
+### metrics_config
+
+* `enable_detailed_observability` - (Optional) Whether detailed observability is enabled. When `true`, publishes container Prometheus metrics, per-GPU metrics, per-instance host metrics, and inference component placement metrics. Defaults to `true` for new endpoint configurations.
+* `enable_enhanced_metrics` - (Optional) Whether enhanced metrics are enabled. Enhanced metrics provide utilization and invocation data at instance and container granularity. Defaults to `false`.
+* `metric_publish_frequency_in_seconds` - (Optional) The interval, in seconds, at which metrics are published to CloudWatch. Valid values are `10`, `30`, `60`, `120`, `180`, `240`, `300`. Defaults to `60`.
 
 ### data_capture_config
 


### PR DESCRIPTION
Community Note

- Please vote on this PR by adding a 👍 reaction to the original PR to help the community and maintainers prioritize this request.
- Please do not leave "+1" or "me too" comments, they generate extra noise for PR reviewers.

### Description

Adds support for three new features on `aws_sagemaker_endpoint_configuration`:

- **`instance_pools`**: Allows configuring heterogeneous endpoints with multiple instance types and priority-based provisioning on production variants.
- **`metrics_config`**: Configures endpoint observability including detailed metrics, enhanced metrics, and custom publish frequency.
- **`variant_instance_provision_timeout_in_seconds`**: The timeout for capacity provisioning on production variants. When SageMaker AI encounters an insufficient capacity error, it retries with the next instance pool (if configured) or waits until the timeout expires. This is a companion field to `instance_pools` — it controls how long SageMaker AI waits before falling back to the next pool in the priority order, making it part of the same heterogeneous instance provisioning feature.

Closes #48469

### PR Checklist

- [x] Acceptance test coverage for all new features
- [x] Documentation update in `website/docs/r/`
- [x] Changelog entries in `.changelog/`
- [x] No dependency updates

### New/Affected Resource(s)

- `aws_sagemaker_endpoint_configuration`

### Acceptance test output

```
--- PASS: TestAccSageMakerEndpointConfiguration_ProductionVariants_instancePools (34.66s)
--- PASS: TestAccSageMakerEndpointConfiguration_ProductionVariants_instancePoolsModelNameOverride (35.00s)
--- PASS: TestAccSageMakerEndpointConfiguration_metricsConfig (35.06s)
--- PASS: TestAccSageMakerEndpointConfiguration_metricsConfigPartial (35.08s)
--- PASS: TestAccSageMakerEndpointConfiguration_ProductionVariants_variantInstanceProvisionTimeout (34.99s)
```

Full test suite for `TestAccSageMakerEndpointConfiguration_*`: 32/34 pass. 2 pre-existing failures (`managedInstanceScaling` tests) confirmed failing on `main` with the same API error (`ManagedInstanceScaling is only supported for inference component endpoints`).