### PR TITLE
Add `control_plane_egress_mode` to `aws_eks_cluster` resource and data source

### DIFF
--- a/.changelog/48497.txt
+++ b/.changelog/48497.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_eks_cluster: Add `control_plane_egress_mode` argument to `vpc_config` block
+```
+
+```release-note:enhancement
+data-source/aws_eks_cluster: Add `control_plane_egress_mode` attribute to `vpc_config` block
+```

--- a/internal/service/eks/cluster.go
+++ b/internal/service/eks/cluster.go
@@ -65,6 +65,10 @@ func resourceCluster() *schema.Resource {
 				// You cannot disable envelope encryption after enabling it. This action is irreversible.
 				return len(old.([]any)) == 1 && len(new.([]any)) == 0
 			}),
+			customdiff.ForceNewIfChange("vpc_config.0.control_plane_egress_mode", func(_ context.Context, old, new, meta any) bool {
+				// Changing from CUSTOMER_ROUTED back to AWS_MANAGED is not supported in-place.
+				return old.(string) == string(types.ControlPlaneEgressModeTypeCustomerRouted) && new.(string) == string(types.ControlPlaneEgressModeTypeAwsManaged)
+			}),
 		),
 
 		Timeouts: &schema.ResourceTimeout{
@@ -502,6 +506,12 @@ func resourceCluster() *schema.Resource {
 								Type:     schema.TypeString,
 								Computed: true,
 							},
+							"control_plane_egress_mode": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								Computed:         true,
+								ValidateDiagFunc: enum.Validate[types.ControlPlaneEgressModeType](),
+							},
 							"endpoint_private_access": {
 								Type:     schema.TypeBool,
 								Optional: true,
@@ -852,6 +862,16 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta any
 
 		if _, err := waitClusterUpdateSuccessful(ctx, conn, d.Id(), updateID, d.Timeout(schema.TimeoutUpdate)); err != nil {
 			return sdkdiag.AppendErrorf(diags, "waiting for EKS Cluster (%s) upgrade policy update (%s): %s", d.Id(), updateID, err)
+		}
+	}
+
+	if d.HasChange("vpc_config.0.control_plane_egress_mode") {
+		config := types.VpcConfigRequest{
+			ControlPlaneEgressMode: types.ControlPlaneEgressModeType(d.Get("vpc_config.0.control_plane_egress_mode").(string)),
+		}
+
+		if err := updateClusterVPCConfig(ctx, conn, d.Id(), &config, d.Timeout(schema.TimeoutUpdate)); err != nil {
+			return sdkdiag.AppendFromErr(diags, err)
 		}
 	}
 
@@ -1507,6 +1527,10 @@ func expandVpcConfigRequest(tfList []any) *types.VpcConfigRequest { // nosemgrep
 		SubnetIds:             flex.ExpandStringValueSet(tfMap[names.AttrSubnetIDs].(*schema.Set)),
 	}
 
+	if v, ok := tfMap["control_plane_egress_mode"].(string); ok && v != "" {
+		apiObject.ControlPlaneEgressMode = types.ControlPlaneEgressModeType(v)
+	}
+
 	if v, ok := tfMap["public_access_cidrs"].(*schema.Set); ok && v.Len() > 0 {
 		apiObject.PublicAccessCidrs = flex.ExpandStringValueSet(v)
 	}
@@ -1841,6 +1865,7 @@ func flattenVPCConfigResponse(apiObject *types.VpcConfigResponse) []map[string]a
 
 	tfMap := map[string]any{
 		"cluster_security_group_id": aws.ToString(apiObject.ClusterSecurityGroupId),
+		"control_plane_egress_mode": string(apiObject.ControlPlaneEgressMode),
 		"endpoint_private_access":   apiObject.EndpointPrivateAccess,
 		"endpoint_public_access":    apiObject.EndpointPublicAccess,
 		names.AttrSecurityGroupIDs:  securityGroupIds,

--- a/internal/service/eks/cluster_data_source.go
+++ b/internal/service/eks/cluster_data_source.go
@@ -314,6 +314,10 @@ func dataSourceCluster() *schema.Resource {
 								Type:     schema.TypeString,
 								Computed: true,
 							},
+							"control_plane_egress_mode": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
 							"endpoint_private_access": {
 								Type:     schema.TypeBool,
 								Computed: true,

--- a/internal/service/eks/cluster_data_source_test.go
+++ b/internal/service/eks/cluster_data_source_test.go
@@ -67,6 +67,7 @@ func TestAccEKSClusterDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "vpc_config.0.security_group_ids.#", dataSourceResourceName, "vpc_config.0.security_group_ids.#"),
 					resource.TestCheckResourceAttrPair(resourceName, "vpc_config.0.subnet_ids.#", dataSourceResourceName, "vpc_config.0.subnet_ids.#"),
 					resource.TestCheckResourceAttrPair(resourceName, "vpc_config.0.public_access_cidrs.#", dataSourceResourceName, "vpc_config.0.public_access_cidrs.#"),
+					resource.TestCheckResourceAttr(dataSourceResourceName, "vpc_config.0.control_plane_egress_mode", "AWS_MANAGED"),
 					resource.TestCheckResourceAttrPair(resourceName, "vpc_config.0.vpc_id", dataSourceResourceName, "vpc_config.0.vpc_id"),
 					resource.TestCheckResourceAttr(resourceName, "zonal_shift_config.#", "0"),
 				),

--- a/internal/service/eks/cluster_test.go
+++ b/internal/service/eks/cluster_test.go
@@ -93,6 +93,7 @@ func TestAccEKSCluster_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "upgrade_policy.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "upgrade_policy.0.support_type", "EXTENDED"),
 					resource.TestCheckResourceAttr(resourceName, "vpc_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "vpc_config.0.control_plane_egress_mode", "AWS_MANAGED"),
 					resource.TestCheckResourceAttr(resourceName, "vpc_config.0.endpoint_private_access", acctest.CtFalse),
 					resource.TestCheckResourceAttr(resourceName, "vpc_config.0.endpoint_public_access", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "vpc_config.0.security_group_ids.#", "0"),
@@ -1233,6 +1234,38 @@ func TestAccEKSCluster_VPC_publicAccessCIDRs(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "vpc_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "vpc_config.0.public_access_cidrs.#", "2"),
 				),
+			},
+		},
+	})
+}
+
+// TestAccEKSCluster_VPC_controlPlaneEgressMode requires internet access: the VPC includes
+// a NAT gateway so the EKS control plane can reach AWS APIs in CUSTOMER_ROUTED egress mode.
+func TestAccEKSCluster_VPC_controlPlaneEgressMode(t *testing.T) {
+	ctx := acctest.Context(t)
+	var cluster types.Cluster
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_eks_cluster.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EKSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterConfig_vpcControlPlaneEgressMode(rName, "CUSTOMER_ROUTED"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckClusterExists(ctx, t, resourceName, &cluster),
+					resource.TestCheckResourceAttr(resourceName, "vpc_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "vpc_config.0.control_plane_egress_mode", "CUSTOMER_ROUTED"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"bootstrap_self_managed_addons"},
 			},
 		},
 	})
@@ -2515,6 +2548,165 @@ resource "aws_eks_cluster" "test" {
   depends_on = [aws_iam_role_policy_attachment.cluster_AmazonEKSClusterPolicy]
 }
 `, rName, publicAccessCidr))
+}
+
+func testAccClusterConfig_vpcControlPlaneEgressMode(rName string, egressMode string) string {
+	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+data "aws_service_principal" "eks" {
+  service_name = "eks"
+}
+
+resource "aws_iam_role" "cluster" {
+  name = %[1]q
+
+  assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "${data.aws_service_principal.eks.name}"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_iam_role_policy_attachment" "cluster_AmazonEKSClusterPolicy" {
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonEKSClusterPolicy"
+  role       = aws_iam_role.cluster.name
+}
+
+resource "aws_vpc" "test" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_internet_gateway" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_subnet" "public" {
+  count = 2
+
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+  cidr_block        = "10.0.${count.index}.0/24"
+  vpc_id            = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.test.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.test.id
+  }
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_route_table_association" "public" {
+  count = 2
+
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_eip" "nat" {
+  count = 2
+
+  domain = "vpc"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_nat_gateway" "test" {
+  count = 2
+
+  allocation_id = aws_eip.nat[count.index].id
+  subnet_id     = aws_subnet.public[count.index].id
+
+  tags = {
+    Name = %[1]q
+  }
+
+  depends_on = [aws_internet_gateway.test]
+}
+
+resource "aws_subnet" "test" {
+  count = 2
+
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+  cidr_block        = "10.0.${count.index + 2}.0/24"
+  vpc_id            = aws_vpc.test.id
+
+  tags = {
+    Name                          = %[1]q
+    "kubernetes.io/cluster/%[1]s" = "shared"
+  }
+}
+
+resource "aws_route_table" "private" {
+  count = 2
+
+  vpc_id = aws_vpc.test.id
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.test[count.index].id
+  }
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_route_table_association" "test" {
+  count = 2
+
+  subnet_id      = aws_subnet.test[count.index].id
+  route_table_id = aws_route_table.private[count.index].id
+}
+
+resource "aws_eks_cluster" "test" {
+  name     = %[1]q
+  role_arn = aws_iam_role.cluster.arn
+
+  vpc_config {
+    control_plane_egress_mode = %[2]q
+    endpoint_private_access   = true
+    endpoint_public_access    = false
+    subnet_ids                = aws_subnet.test[*].id
+  }
+
+  depends_on = [
+    aws_iam_role_policy_attachment.cluster_AmazonEKSClusterPolicy,
+    aws_route_table_association.test,
+  ]
+}
+`, rName, egressMode))
 }
 
 func testAccClusterConfig_networkServiceIPv4CIDR(rName string, serviceIpv4Cidr string) string {

--- a/website/docs/d/eks_cluster.html.markdown
+++ b/website/docs/d/eks_cluster.html.markdown
@@ -90,6 +90,7 @@ This data source exports the following attributes in addition to the arguments a
 * `version` - Kubernetes server version for the cluster.
 * `vpc_config` - Nested list containing VPC configuration for the cluster.
     * `cluster_security_group_id` - The cluster security group that was created by Amazon EKS for the cluster.
+    * `control_plane_egress_mode` - The egress mode for the EKS control plane. Possible values are `AWS_MANAGED` and `CUSTOMER_ROUTED`.
     * `endpoint_private_access` - Indicates whether or not the Amazon EKS private API server endpoint is enabled.
     * `endpoint_public_access` - Indicates whether or not the Amazon EKS public API server endpoint is enabled.
     * `public_access_cidrs` - List of CIDR blocks. Indicates which CIDR blocks can access the Amazon EKS public API server endpoint.

--- a/website/docs/r/eks_cluster.html.markdown
+++ b/website/docs/r/eks_cluster.html.markdown
@@ -418,6 +418,7 @@ The `remote_pod_networks` configuration block supports the following arguments:
 ### vpc_config Arguments
 
 * `cluster_security_group_id` - (Computed) Cluster security group that is created by Amazon EKS for the cluster. Managed node groups use this security group for control-plane-to-data-plane communication.
+* `control_plane_egress_mode` - (Optional, Computed) Egress mode for the EKS control plane. Valid values are `AWS_MANAGED` and `CUSTOMER_ROUTED`. Defaults to `AWS_MANAGED`. Changing from `CUSTOMER_ROUTED` back to `AWS_MANAGED` forces a new resource.
 * `endpoint_private_access` - (Optional) Whether the Amazon EKS private API server endpoint is enabled. Default is `false`.
 * `endpoint_public_access` - (Optional) Whether the Amazon EKS public API server endpoint is enabled. Default is `true`.
 * `public_access_cidrs` - (Optional) List of CIDR blocks. Indicates which CIDR blocks can access the Amazon EKS public API server endpoint when enabled. EKS defaults this to a list with `0.0.0.0/0`. Terraform will only perform drift detection of its value when present in a configuration.


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
No

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
 - Adds a new `control_plane_egress_mode` attribute to the `vpc_config` block on the `aws_eks_cluster` resource and `aws_eks_cluster` data source
- Supports values `AWS_MANAGED` (default) and `CUSTOMER_ROUTED`, as documented in the [EKS control plane egress guide](https://docs.aws.amazon.com/eks/latest/userguide/control-plane-egress.html)
- Changing from `CUSTOMER_ROUTED` back to `AWS_MANAGED` forces cluster replacement, as this transition is not supported in-place by the EKS API
- Adds acceptance test `TestAccEKSCluster_VPC_controlPlaneEgressMode` covering cluster creation with `CUSTOMER_ROUTED` mode, including the full networking prerequisites (VPC with DNS, internet gateway, public subnets, NAT gateways, and private subnets with route tables) required by AWS

## Test plan

- `TestAccEKSCluster_VPC_controlPlaneEgressMode` — creates a cluster with `CUSTOMER_ROUTED` egress mode and verifies the attribute is set correctly on read/import 
- `TestAccEKSCluster_basic` — verifies `AWS_MANAGED` is returned as the default value
- `TestAccEKSClusterDataSource_basic` — verifies `AWS_MANAGED` is returned as the default value via the data source

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #48470

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Requires AWS SDK for Go v2 [Release 2026-06-18](https://github.com/aws/aws-sdk-go-v2/commit/a38ec5b2045ca0e865c72aef2385800e343839c4): https://github.com/hashicorp/terraform-provider-aws/pull/48483.

AWS Documentation: [Configuring control plane egress routing ](https://docs.aws.amazon.com/eks/latest/userguide/control-plane-egress.html)

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% TF_ACC=1 go test ./internal/service/eks/ -v -run TestAccEKSCluster_VPC_controlPlaneEgressMode -timeout 60m                    
2026/06/20 21:27:51 Creating Terraform AWS Provider (SDKv2-style)...
2026/06/20 21:27:51 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccEKSCluster_VPC_controlPlaneEgressMode
=== PAUSE TestAccEKSCluster_VPC_controlPlaneEgressMode
=== CONT  TestAccEKSCluster_VPC_controlPlaneEgressMode
--- PASS: TestAccEKSCluster_VPC_controlPlaneEgressMode (912.08s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/eks        917.173s

...
```
```console
% TF_ACC=1 go test ./internal/service/eks/ -v -run TestAccEKSClusterDataSource_basic -timeout 60m   
2026/06/20 21:44:29 Creating Terraform AWS Provider (SDKv2-style)...
2026/06/20 21:44:29 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccEKSClusterDataSource_basic
=== PAUSE TestAccEKSClusterDataSource_basic
=== CONT  TestAccEKSClusterDataSource_basic
--- PASS: TestAccEKSClusterDataSource_basic (656.42s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/eks        661.446s

...
```