### PR TITLE
Add additional params to Bedrock AgentCore harness

### DIFF
--- a/.changelog/48498.txt
+++ b/.changelog/48498.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_bedrockagentcore_harness: Add `additional_params` argument to `bedrock_model_config`
+```

--- a/internal/service/bedrockagentcore/harness.go
+++ b/internal/service/bedrockagentcore/harness.go
@@ -839,6 +839,11 @@ func (m *harnessModelConfigurationModel) Flatten(ctx context.Context, v any) dia
 		if diags.HasError() {
 			return diags
 		}
+		if t.Value.AdditionalParams != nil {
+			if json, err := tfsmithy.DocumentToJSONString(t.Value.AdditionalParams); err == nil {
+				data.AdditionalParams = fwtypes.NewSmithyJSONValue(json, document.NewLazyDocument)
+			}
+		}
 		m.BedrockModelConfig = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &data)
 	case awstypes.HarnessModelConfigurationMemberGeminiModelConfig:
 		var data harnessGeminiModelConfigModel
@@ -871,6 +876,11 @@ func (m harnessModelConfigurationModel) Expand(ctx context.Context) (any, diag.D
 		}
 		var r awstypes.HarnessModelConfigurationMemberBedrockModelConfig
 		smerr.AddEnrich(ctx, &diags, fwflex.Expand(ctx, data, &r.Value))
+		if !data.AdditionalParams.IsNull() {
+			if doc, err := tfsmithy.DocumentFromJSONString(fwflex.StringValueFromFramework(ctx, data.AdditionalParams), document.NewLazyDocument); err == nil {
+				r.Value.AdditionalParams = doc
+			}
+		}
 		return &r, diags
 	case !m.GeminiModelConfig.IsNull():
 		data, d := m.GeminiModelConfig.ToPtr(ctx)
@@ -895,7 +905,7 @@ func (m harnessModelConfigurationModel) Expand(ctx context.Context) (any, diag.D
 }
 
 type harnessBedrockModelConfigModel struct {
-	AdditionalParams fwtypes.SmithyJSON[document.Interface] `tfsdk:"additional_params"`
+	AdditionalParams fwtypes.SmithyJSON[document.Interface] `tfsdk:"additional_params" autoflex:"-"`
 	MaxTokens        types.Int32                            `tfsdk:"max_tokens"`
 	ModelID          types.String                           `tfsdk:"model_id"`
 	Temperature      types.Float32                          `tfsdk:"temperature"`

--- a/internal/service/bedrockagentcore/harness.go
+++ b/internal/service/bedrockagentcore/harness.go
@@ -222,6 +222,10 @@ func (r *harnessResource) Schema(ctx context.Context, request resource.SchemaReq
 							},
 							NestedObject: schema.NestedBlockObject{
 								Attributes: map[string]schema.Attribute{
+									"additional_params": schema.StringAttribute{
+										CustomType: fwtypes.NewSmithyJSONType(ctx, document.NewLazyDocument),
+										Optional:   true,
+									},
 									"max_tokens": schema.Int32Attribute{
 										Optional: true,
 										Validators: []validator.Int32{
@@ -891,10 +895,11 @@ func (m harnessModelConfigurationModel) Expand(ctx context.Context) (any, diag.D
 }
 
 type harnessBedrockModelConfigModel struct {
-	MaxTokens   types.Int32   `tfsdk:"max_tokens"`
-	ModelID     types.String  `tfsdk:"model_id"`
-	Temperature types.Float32 `tfsdk:"temperature"`
-	TopP        types.Float32 `tfsdk:"top_p"`
+	AdditionalParams fwtypes.SmithyJSON[document.Interface] `tfsdk:"additional_params"`
+	MaxTokens        types.Int32                            `tfsdk:"max_tokens"`
+	ModelID          types.String                           `tfsdk:"model_id"`
+	Temperature      types.Float32                          `tfsdk:"temperature"`
+	TopP             types.Float32                          `tfsdk:"top_p"`
 }
 
 type harnessGeminiModelConfigModel struct {

--- a/internal/service/bedrockagentcore/harness_expand_test.go
+++ b/internal/service/bedrockagentcore/harness_expand_test.go
@@ -1,0 +1,82 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package bedrockagentcore
+
+import (
+	"context"
+	"testing"
+
+	awstypes "github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	tfsmithy "github.com/hashicorp/terraform-provider-aws/internal/smithy"
+)
+
+// Builds the bedrock_model_config value through the reflected object type
+// (which yields SmithyJSONType with a nil document constructor, as after a
+// plan round-trip) and round-trips it through Expand and Flatten.
+// Regression test for a panic (reflect: call of reflect.Value.Set on zero
+// Value) when additional_params was expanded via generic autoflex.
+func TestHarnessBedrockModelConfigExpand_additionalParams(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	listType := fwtypes.NewListNestedObjectTypeOf[harnessBedrockModelConfigModel](ctx)
+	tfListType := listType.TerraformType(ctx)
+	tfObjType := tfListType.(tftypes.List).ElementType.(tftypes.Object)
+
+	rawObj := tftypes.NewValue(tfObjType, map[string]tftypes.Value{
+		"additional_params": tftypes.NewValue(tftypes.String, `{"reasoning_effort":"high"}`),
+		"max_tokens":        tftypes.NewValue(tftypes.Number, 1024),
+		"model_id":          tftypes.NewValue(tftypes.String, "anthropic.claude-3-5-sonnet-20241022-v2:0"),
+		"temperature":       tftypes.NewValue(tftypes.Number, nil),
+		"top_p":             tftypes.NewValue(tftypes.Number, nil),
+	})
+	rawList := tftypes.NewValue(tfListType, []tftypes.Value{rawObj})
+
+	listVal, err := listType.ValueFromTerraform(ctx, rawList)
+	if err != nil {
+		t.Fatalf("ValueFromTerraform: %s", err)
+	}
+
+	m := harnessModelConfigurationModel{
+		BedrockModelConfig: listVal.(fwtypes.ListNestedObjectValueOf[harnessBedrockModelConfigModel]),
+		GeminiModelConfig:  fwtypes.NewListNestedObjectValueOfNull[harnessGeminiModelConfigModel](ctx),
+		OpenAiModelConfig:  fwtypes.NewListNestedObjectValueOfNull[harnessOpenAIModelConfigModel](ctx),
+	}
+
+	// This panicked before the fix: reflect: call of reflect.Value.Set on zero Value.
+	v, diags := m.Expand(ctx)
+	if diags.HasError() {
+		t.Fatalf("Expand diags: %v", diags)
+	}
+
+	member, ok := v.(*awstypes.HarnessModelConfigurationMemberBedrockModelConfig)
+	if !ok {
+		t.Fatalf("unexpected type %T", v)
+	}
+	if member.Value.AdditionalParams == nil {
+		t.Fatal("AdditionalParams not set on API value")
+	}
+	json, err := tfsmithy.DocumentToJSONString(member.Value.AdditionalParams)
+	if err != nil {
+		t.Fatalf("DocumentToJSONString: %s", err)
+	}
+	if json != `{"reasoning_effort":"high"}` {
+		t.Fatalf("unexpected AdditionalParams JSON: %s", json)
+	}
+
+	// Round-trip: Flatten the API value back and check the string survives.
+	var flat harnessModelConfigurationModel
+	if d := flat.Flatten(ctx, *member); d.HasError() {
+		t.Fatalf("Flatten diags: %v", d)
+	}
+	data, d := flat.BedrockModelConfig.ToPtr(ctx)
+	if d.HasError() {
+		t.Fatalf("ToPtr diags: %v", d)
+	}
+	if got := data.AdditionalParams.ValueString(); got != `{"reasoning_effort":"high"}` {
+		t.Fatalf("unexpected flattened AdditionalParams: %s", got)
+	}
+}

--- a/internal/service/bedrockagentcore/harness_test.go
+++ b/internal/service/bedrockagentcore/harness_test.go
@@ -282,6 +282,51 @@ func TestAccBedrockAgentCoreHarness_model_bedrock(t *testing.T) {
 	})
 }
 
+func TestAccBedrockAgentCoreHarness_model_bedrockAdditionalParams(t *testing.T) {
+	ctx := acctest.Context(t)
+	var harness awstypes.Harness
+	rName := testAccRandomHarnessName(t)
+	resourceName := "aws_bedrockagentcore_harness.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID)
+			testAccPreCheckHarness(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockAgentCoreServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckHarnessDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccHarnessConfig_bedrockModelAdditionalParams(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckHarnessExists(ctx, t, resourceName, &harness),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						resourceName,
+						tfjsonpath.New("model").AtSliceIndex(0).AtMapKey("bedrock_model_config").AtSliceIndex(0).AtMapKey("additional_params"),
+						knownvalue.StringExact(`{"additionalModelRequestFields":{"thinking":{"budget_tokens":2048,"type":"enabled"}}}`),
+					),
+				},
+			},
+			{
+				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, "harness_id"),
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "harness_id",
+			},
+		},
+	})
+}
+
 func TestAccBedrockAgentCoreHarness_truncation_slidingWindow(t *testing.T) {
 	ctx := acctest.Context(t)
 	var harness awstypes.Harness
@@ -804,6 +849,35 @@ resource "aws_bedrockagentcore_harness" "test" {
       model_id    = "anthropic.claude-sonnet-4-20250514"
       temperature = 0.7
       top_p       = 0.9
+    }
+  }
+
+  system_prompt {
+    text = "You are a helpful assistant."
+  }
+}
+`, rName))
+}
+
+func testAccHarnessConfig_bedrockModelAdditionalParams(rName string) string {
+	return acctest.ConfigCompose(testAccHarnessConfig_iamRole(rName), fmt.Sprintf(`
+resource "aws_bedrockagentcore_harness" "test" {
+  harness_name       = %[1]q
+  execution_role_arn = aws_iam_role.test.arn
+
+  model {
+    bedrock_model_config {
+      model_id    = "anthropic.claude-sonnet-4-20250514"
+      max_tokens  = 4096
+
+      additional_params = jsonencode({
+        additionalModelRequestFields = {
+          thinking = {
+            type          = "enabled"
+            budget_tokens = 2048
+          }
+        }
+      })
     }
   }
 

--- a/website/docs/r/bedrockagentcore_harness.html.markdown
+++ b/website/docs/r/bedrockagentcore_harness.html.markdown
@@ -72,6 +72,14 @@ resource "aws_bedrockagentcore_harness" "example" {
       model_id    = "anthropic.claude-sonnet-4-20250514"
       temperature = 0.7
       top_p       = 0.9
+      additional_params = jsonencode({
+        additionalModelRequestFields = {
+          thinking = {
+            type          = "enabled"
+            budget_tokens = 2048
+          }
+        }
+      })
     }
   }
 
@@ -154,6 +162,7 @@ The `model` block supports exactly one of the following:
 ### `bedrock_model_config` Block
 
 * `model_id` - (Required) Bedrock model ID (e.g., `anthropic.claude-sonnet-4-20250514`).
+* `additional_params` - (Optional) JSON string containing provider-specific parameters to pass through to the Bedrock model provider unchanged.
 * `max_tokens` - (Optional) Maximum number of tokens to generate.
 * `temperature` - (Optional) Temperature for sampling. Must be between 0 and 2.
 * `top_p` - (Optional) Top-p (nucleus) sampling parameter. Must be between 0 and 1.


### PR DESCRIPTION
### Description

Adds `additional_params` to the `aws_bedrockagentcore_harness` `model.bedrock_model_config` block and maps it to the AWS SDK `HarnessBedrockModelConfig.AdditionalParams` field.

The Terraform attribute uses snake_case (`additional_params`) while the AWS API field is `additionalParams`, matching provider schema conventions.

Closes #48363.

### Relations

Closes #48363

### References

- AWS SDK `HarnessBedrockModelConfig.AdditionalParams`

### Output from Acceptance Testing

```console
$ go test ./internal/service/bedrockagentcore -run TestAccBedrockAgentCoreHarness_model_bedrockAdditionalParams -count=0
ok  github.com/hashicorp/terraform-provider-aws/internal/service/bedrockagentcore  5.338s [no tests to run]
```

Acceptance tests were not run locally against AWS.