### PR TITLE
Add name argument to aws_vpclattice_service_network data source

### DIFF
--- a/.changelog/48508.txt
+++ b/.changelog/48508.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data-source/aws_vpclattice_service_network: Add `name` attribute
+```

--- a/internal/service/vpclattice/service_network.go
+++ b/internal/service/vpclattice/service_network.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
+	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -182,6 +183,40 @@ func findServiceNetwork(ctx context.Context, conn *vpclattice.Client, input *vpc
 
 	if output == nil {
 		return nil, tfresource.NewEmptyResultError()
+	}
+
+	return output, nil
+}
+
+func findServiceNetworkSummary(ctx context.Context, conn *vpclattice.Client, filter tfslices.Predicate[types.ServiceNetworkSummary]) (*types.ServiceNetworkSummary, error) {
+	output, err := findServiceNetworkSummaries(ctx, conn, filter)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return tfresource.AssertSingleValueResult(output)
+}
+
+func findServiceNetworkSummaries(ctx context.Context, conn *vpclattice.Client, filter tfslices.Predicate[types.ServiceNetworkSummary]) ([]types.ServiceNetworkSummary, error) {
+	input := &vpclattice.ListServiceNetworksInput{}
+	var output []types.ServiceNetworkSummary
+	paginator := vpclattice.NewListServiceNetworksPaginator(conn, input, func(options *vpclattice.ListServiceNetworksPaginatorOptions) {
+		options.Limit = 100
+	})
+
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+
+		if err != nil {
+			return nil, err
+		}
+
+		for _, v := range page.Items {
+			if filter(v) {
+				output = append(output, v)
+			}
+		}
 	}
 
 	return output, nil

--- a/internal/service/vpclattice/service_network_data_source.go
+++ b/internal/service/vpclattice/service_network_data_source.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/vpclattice"
+	"github.com/aws/aws-sdk-go-v2/service/vpclattice/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -53,8 +54,10 @@ func dataSourceServiceNetwork() *schema.Resource {
 					Computed: true,
 				},
 				names.AttrName: {
-					Type:     schema.TypeString,
-					Computed: true,
+					Type:         schema.TypeString,
+					Optional:     true,
+					Computed:     true,
+					ExactlyOneOf: []string{names.AttrName, "service_network_identifier"},
 				},
 				"number_of_associated_services": {
 					Type:     schema.TypeInt,
@@ -65,8 +68,10 @@ func dataSourceServiceNetwork() *schema.Resource {
 					Computed: true,
 				},
 				"service_network_identifier": {
-					Type:     schema.TypeString,
-					Required: true,
+					Type:         schema.TypeString,
+					Optional:     true,
+					Computed:     true,
+					ExactlyOneOf: []string{names.AttrName, "service_network_identifier"},
 				},
 				names.AttrTags: tftags.TagsSchemaComputed(),
 			}
@@ -78,11 +83,35 @@ func dataSourceServiceNetworkRead(ctx context.Context, d *schema.ResourceData, m
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).VPCLatticeClient(ctx)
 
-	serviceNetworkID := d.Get("service_network_identifier").(string)
-	output, err := findServiceNetworkByID(ctx, conn, serviceNetworkID)
+	var output *vpclattice.GetServiceNetworkOutput
 
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "reading VPCLattice Service Network (%s): %s", serviceNetworkID, err)
+	if v, ok := d.GetOk("service_network_identifier"); ok {
+		serviceNetworkID := v.(string)
+		out, err := findServiceNetworkByID(ctx, conn, serviceNetworkID)
+
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "reading VPCLattice Service Network (%s): %s", serviceNetworkID, err)
+		}
+
+		output = out
+	} else if v, ok := d.GetOk(names.AttrName); ok {
+		name := v.(string)
+		filter := func(x types.ServiceNetworkSummary) bool {
+			return aws.ToString(x.Name) == name
+		}
+		summary, err := findServiceNetworkSummary(ctx, conn, filter)
+
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "reading VPCLattice Service Network (%s): %s", name, err)
+		}
+
+		out, err := findServiceNetworkByID(ctx, conn, aws.ToString(summary.Id))
+
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "reading VPCLattice Service Network (%s): %s", name, err)
+		}
+
+		output = out
 	}
 
 	d.SetId(aws.ToString(output.Id))

--- a/internal/service/vpclattice/service_network_data_source_test.go
+++ b/internal/service/vpclattice/service_network_data_source_test.go
@@ -44,6 +44,39 @@ func TestAccVPCLatticeServiceNetworkDataSource_basic(t *testing.T) {
 	})
 }
 
+func TestAccVPCLatticeServiceNetworkDataSource_byName(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_vpclattice_service_network.test"
+	dataSourceName := "data.aws_vpclattice_service_network.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.VPCLatticeEndpointID)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.VPCLatticeServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceNetworkDataSourceConfig_byName(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrARN, dataSourceName, names.AttrARN),
+					resource.TestCheckResourceAttrPair(resourceName, "auth_type", dataSourceName, "auth_type"),
+					resource.TestCheckResourceAttrSet(dataSourceName, names.AttrCreatedAt),
+					resource.TestCheckResourceAttrSet(dataSourceName, "last_updated_at"),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrName, dataSourceName, names.AttrName),
+					resource.TestCheckResourceAttr(dataSourceName, "number_of_associated_services", "0"),
+					resource.TestCheckResourceAttr(dataSourceName, "number_of_associated_vpcs", "0"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "service_network_identifier"),
+					resource.TestCheckResourceAttrPair(resourceName, acctest.CtTagsPercent, dataSourceName, acctest.CtTagsPercent),
+				),
+			},
+		},
+	})
+}
+
 func TestAccVPCLatticeServiceNetworkDataSource_shared(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
@@ -89,6 +122,22 @@ resource "aws_vpclattice_service_network" "test" {
 
 data "aws_vpclattice_service_network" "test" {
   service_network_identifier = aws_vpclattice_service_network.test.id
+}
+`, rName)
+}
+
+func testAccServiceNetworkDataSourceConfig_byName(rName string) string {
+	return fmt.Sprintf(`  
+resource "aws_vpclattice_service_network" "test" {
+  name = %[1]q
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+data "aws_vpclattice_service_network" "test" {
+  name = aws_vpclattice_service_network.test.name
 }
 `, rName)
 }

--- a/website/docs/d/vpclattice_service_network.html.markdown
+++ b/website/docs/d/vpclattice_service_network.html.markdown
@@ -12,11 +12,19 @@ Terraform data source for managing an AWS VPC Lattice Service Network.
 
 ## Example Usage
 
-### Basic Usage
+### By Identifier
 
 ```terraform
 data "aws_vpclattice_service_network" "example" {
   service_network_identifier = "snsa-01112223334445556"
+}
+```
+
+### By Name
+
+```terraform
+data "aws_vpclattice_service_network" "example" {
+  name = "my-service-network"
 }
 ```
 
@@ -25,7 +33,10 @@ data "aws_vpclattice_service_network" "example" {
 This data source supports the following arguments:
 
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
-* `service_network_identifier` - (Required) Identifier of the service network.
+* `name` - (Optional) Name of the service network.
+* `service_network_identifier` - (Optional) ID or ARN of the service network.
+
+~> **NOTE:** One of `name` or `service_network_identifier` must be specified.
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Adds a `name` argument to the aws_vpclattice_service_network data source.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
[AWS API reference for GetServiceNetwork](https://docs.aws.amazon.com/vpc-lattice/latest/APIReference/API_GetServiceNetwork.html) only accepts `serviceNetworkIdentifier` as argument. Similar to [GetService](https://docs.aws.amazon.com/vpc-lattice/latest/APIReference/API_GetService.html), where the corresponding data source already have support for the `name` argument.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccVPCLatticeServiceNetworkDataSource_byName PKG=vpclattice
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     5.851s
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework 5.718s
make: Running acceptance tests on branch: 🌿 f-vpclattice_service_network-name-argument 🌿...
TF_ACC=1 go1.26.4 test ./internal/service/vpclattice/... -v -count 1 -parallel 20 -run='TestAccVPCLatticeServiceNetworkDataSource_byName'  -timeout 360m -vet=off -buildvcs=false
2026/06/22 18:32:55 Creating Terraform AWS Provider (SDKv2-style)...
2026/06/22 18:32:55 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccVPCLatticeServiceNetworkDataSource_byName
=== PAUSE TestAccVPCLatticeServiceNetworkDataSource_byName
=== CONT  TestAccVPCLatticeServiceNetworkDataSource_byName
--- PASS: TestAccVPCLatticeServiceNetworkDataSource_byName (18.26s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/vpclattice 23.894s
...
```

### AI Disclosure

As it is my first time working in this repository, Claude Opus 4.6 was used to explore and explain similar implementations in other data sources (`aws_vpclattice_service`, specifically). The provided implementation in this PR turned out very similar.