### PR TITLE
🤖🤖🤖 r/aws_directory_service_directory: Add write-only `password_wo` argument

### DIFF
--- a/.changelog/48515.txt
+++ b/.changelog/48515.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_directory_service_directory: Add `password_wo` and `password_wo_version` write-only arguments
+```

--- a/internal/service/ds/directory.go
+++ b/internal/service/ds/directory.go
@@ -15,6 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/directoryservice"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/directoryservice/types"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -145,10 +146,25 @@ func resourceDirectory() *schema.Resource {
 					ValidateFunc: domainValidator,
 				},
 				names.AttrPassword: {
-					Type:      schema.TypeString,
-					Required:  true,
-					ForceNew:  true,
-					Sensitive: true,
+					Type:         schema.TypeString,
+					Optional:     true,
+					ForceNew:     true,
+					Sensitive:    true,
+					ExactlyOneOf: []string{names.AttrPassword, "password_wo"},
+				},
+				"password_wo": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					WriteOnly:    true,
+					Sensitive:    true,
+					ExactlyOneOf: []string{names.AttrPassword, "password_wo"},
+					RequiredWith: []string{"password_wo_version"},
+				},
+				"password_wo_version": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					ForceNew:     true,
+					RequiredWith: []string{"password_wo"},
 				},
 				"security_group_id": {
 					Type:     schema.TypeString,
@@ -217,6 +233,17 @@ func resourceDirectoryCreate(ctx context.Context, d *schema.ResourceData, meta a
 	conn := meta.(*conns.AWSClient).DSClient(ctx)
 
 	name := d.Get(names.AttrName).(string)
+
+	passwordWO, di := flex.GetWriteOnlyStringValue(d, cty.GetAttrPath("password_wo"))
+	diags = append(diags, di...)
+	if diags.HasError() {
+		return diags
+	}
+	password := d.Get(names.AttrPassword).(string)
+	if passwordWO != "" {
+		password = passwordWO
+	}
+
 	var creator directoryCreator
 	switch directoryType := awstypes.DirectoryType(d.Get(names.AttrType).(string)); directoryType {
 	case awstypes.DirectoryTypeAdConnector:
@@ -234,7 +261,7 @@ func resourceDirectoryCreate(ctx context.Context, d *schema.ResourceData, meta a
 	// When it fails, it will typically be within the first few minutes of creation, so there is no need
 	// to wait for deletion.
 	err := tfresource.Retry(ctx, d.Timeout(schema.TimeoutCreate), func(ctx context.Context) *tfresource.RetryError {
-		if err := creator.Create(ctx, conn, name, d); err != nil {
+		if err := creator.Create(ctx, conn, name, password, d); err != nil {
 			return tfresource.NonRetryableError(err)
 		}
 
@@ -463,7 +490,7 @@ func resourceDirectoryDelete(ctx context.Context, d *schema.ResourceData, meta a
 
 type directoryCreator interface {
 	TypeName() string
-	Create(ctx context.Context, conn *directoryservice.Client, name string, d *schema.ResourceData) error
+	Create(ctx context.Context, conn *directoryservice.Client, name, password string, d *schema.ResourceData) error
 }
 
 type adConnectorCreator struct{}
@@ -472,10 +499,10 @@ func (c adConnectorCreator) TypeName() string {
 	return "AD Connector"
 }
 
-func (c adConnectorCreator) Create(ctx context.Context, conn *directoryservice.Client, name string, d *schema.ResourceData) error {
+func (c adConnectorCreator) Create(ctx context.Context, conn *directoryservice.Client, name, password string, d *schema.ResourceData) error {
 	input := &directoryservice.ConnectDirectoryInput{
 		Name:     aws.String(name),
-		Password: aws.String(d.Get(names.AttrPassword).(string)),
+		Password: aws.String(password),
 		Tags:     getTagsIn(ctx),
 	}
 
@@ -514,10 +541,10 @@ func (c microsoftADCreator) TypeName() string {
 	return "Microsoft AD"
 }
 
-func (c microsoftADCreator) Create(ctx context.Context, conn *directoryservice.Client, name string, d *schema.ResourceData) error {
+func (c microsoftADCreator) Create(ctx context.Context, conn *directoryservice.Client, name, password string, d *schema.ResourceData) error {
 	input := &directoryservice.CreateMicrosoftADInput{
 		Name:     aws.String(name),
-		Password: aws.String(d.Get(names.AttrPassword).(string)),
+		Password: aws.String(password),
 		Tags:     getTagsIn(ctx),
 	}
 
@@ -553,10 +580,10 @@ func (c simpleADCreator) TypeName() string {
 	return "Simple AD"
 }
 
-func (c simpleADCreator) Create(ctx context.Context, conn *directoryservice.Client, name string, d *schema.ResourceData) error {
+func (c simpleADCreator) Create(ctx context.Context, conn *directoryservice.Client, name, password string, d *schema.ResourceData) error {
 	input := &directoryservice.CreateDirectoryInput{
 		Name:     aws.String(name),
-		Password: aws.String(d.Get(names.AttrPassword).(string)),
+		Password: aws.String(password),
 		Tags:     getTagsIn(ctx),
 	}
 

--- a/internal/service/ds/directory_test.go
+++ b/internal/service/ds/directory_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfds "github.com/hashicorp/terraform-provider-aws/internal/service/ds"
@@ -66,6 +67,62 @@ func TestAccDSDirectory_basic(t *testing.T) {
 				ImportStateVerifyIgnore: []string{
 					names.AttrPassword,
 				},
+			},
+		},
+	})
+}
+
+func TestAccDSDirectory_passwordWriteOnly(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v awstypes.DirectoryDescription
+	resourceName := "aws_directory_service_directory.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	domainName := acctest.RandomDomainName(t)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckDirectoryService(ctx, t)
+			acctest.PreCheckDirectoryServiceSimpleDirectory(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.DSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_11_0),
+		},
+		CheckDestroy: testAccCheckDirectoryDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDirectoryConfig_passwordWriteOnly(rName, domainName, "SuperSecretPassw0rd", 1),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckDirectoryExists(ctx, t, resourceName, &v),
+					resource.TestCheckNoResourceAttr(resourceName, "password_wo"),
+					resource.TestCheckResourceAttr(resourceName, "password_wo_version", "1"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrPassword, ""),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					names.AttrPassword,
+					"password_wo",
+					"password_wo_version",
+				},
+			},
+			{
+				// password_wo_version is ForceNew, so a bump replaces the directory.
+				Config: testAccDirectoryConfig_passwordWriteOnly(rName, domainName, "SuperSecretPassw0rd-2", 2),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionReplace),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckDirectoryExists(ctx, t, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "password_wo_version", "2"),
+				),
 			},
 		},
 	})
@@ -565,6 +622,25 @@ resource "aws_directory_service_directory" "test" {
   }
 }
 `, domain),
+	)
+}
+
+func testAccDirectoryConfig_passwordWriteOnly(rName, domain, password string, passwordVersion int) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigVPCWithSubnets(rName, 2),
+		fmt.Sprintf(`
+resource "aws_directory_service_directory" "test" {
+  name                = %[1]q
+  password_wo         = %[2]q
+  password_wo_version = %[3]d
+  size                = "Small"
+
+  vpc_settings {
+    vpc_id     = aws_vpc.test.id
+    subnet_ids = aws_subnet.test[*].id
+  }
+}
+`, domain, password, passwordVersion),
 	)
 }
 

--- a/website/docs/r/directory_service_directory.html.markdown
+++ b/website/docs/r/directory_service_directory.html.markdown
@@ -11,7 +11,7 @@ description: |-
 Provides a Simple or Managed Microsoft directory in AWS Directory Service.
 
 ~> **Note:** All arguments including the password and customer username will be stored in the raw state as plain-text.
-[Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html).
+[Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html). Use `password_wo` instead of `password` to avoid storing the password in state.
 
 ## Example Usage
 
@@ -126,7 +126,9 @@ This resource supports the following arguments:
 
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `name` - (Required) The fully qualified name for the directory, such as `corp.example.com`
-* `password` - (Required) The password for the directory administrator or connector user.
+* `password` - (Optional) The password for the directory administrator or connector user. Exactly one of `password` or `password_wo` is required.
+* `password_wo` - (Optional, [Write-Only](https://developer.hashicorp.com/terraform/language/resources/ephemeral/write-only)) The password for the directory administrator or connector user. The value is not stored in state. Exactly one of `password` or `password_wo` is required. Requires `password_wo_version`.
+* `password_wo_version` - (Optional) Used together with `password_wo` to trigger an update. Increment this value when an update to `password_wo` is required.
 * `size` - (Optional) (For `SimpleAD` and `ADConnector` types) The size of the directory (`Small` or `Large` are accepted values). `Large` by default.
 * `vpc_settings` - (Required for `SimpleAD` and `MicrosoftAD`) VPC related information about the directory. Fields documented below.
 * `connect_settings` - (Required for `ADConnector`) Connector related information about the directory. Fields documented below.

--- a/website/docs/r/directory_service_directory.html.markdown
+++ b/website/docs/r/directory_service_directory.html.markdown
@@ -128,7 +128,7 @@ This resource supports the following arguments:
 * `name` - (Required) The fully qualified name for the directory, such as `corp.example.com`
 * `password` - (Optional) The password for the directory administrator or connector user. Exactly one of `password` or `password_wo` is required.
 * `password_wo` - (Optional, [Write-Only](https://developer.hashicorp.com/terraform/language/resources/ephemeral/write-only)) The password for the directory administrator or connector user. The value is not stored in state. Exactly one of `password` or `password_wo` is required. Requires `password_wo_version`.
-* `password_wo_version` - (Optional) Used together with `password_wo` to trigger an update. Increment this value when an update to `password_wo` is required.
+* `password_wo_version` - (Optional) Used together with `password_wo` to trigger a password change. Because the directory password cannot be changed in place, incrementing this value replaces the directory.
 * `size` - (Optional) (For `SimpleAD` and `ADConnector` types) The size of the directory (`Small` or `Large` are accepted values). `Large` by default.
 * `vpc_settings` - (Required for `SimpleAD` and `MicrosoftAD`) VPC related information about the directory. Fields documented below.
 * `connect_settings` - (Required for `ADConnector`) Connector related information about the directory. Fields documented below.


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Yes. This adds a write-only `password_wo` argument so the Directory Service administrator/connector password can be supplied without being stored in Terraform state, reducing exposure of a sensitive credential.

### Description

Adds `password_wo` and `password_wo_version` write-only arguments to `aws_directory_service_directory`, following the existing pattern in `aws_db_instance`. The write-only value is read from configuration at apply time and sent to the create API, but is never written to state.

`password` becomes `Optional` with `ExactlyOneOf: [password, password_wo]`, so exactly one must be set. Existing configurations that use `password` are unaffected.

The directory password is immutable: Directory Service has no API to change the administrator password after creation, and `password` was already `ForceNew`. The SDK forbids `WriteOnly` together with `ForceNew`, so immutability is enforced on `password_wo_version` (which is `ForceNew`): incrementing it rotates the password by replacing the directory. This differs from `aws_db_instance`, where a `password_wo_version` bump issues a `ModifyDBInstance` call.

The effective password is resolved once in the create function with `flex.GetWriteOnlyStringValue` and threaded through the three `directoryCreator` implementations (`SimpleAD`, `MicrosoftAD`, `AD Connector`).

### Relations

Closes #48242

### References

- Write-only arguments: https://developer.hashicorp.com/terraform/language/manage-sensitive-data/write-only
- Pattern reference: `aws_db_instance` (`internal/service/rds/instance.go`)

### Output from Acceptance Testing

Acceptance tests create live Managed Microsoft AD / Simple AD directories and require AWS credentials, so they were not run in this environment. They are ready for a maintainer to run:

```console
% make testacc TESTS=TestAccDSDirectory_passwordWriteOnly PKG=ds
```

Local verification (Go 1.26, in Docker):

- `go build ./internal/service/ds/...`
- `go vet ./internal/service/ds/...`
- `schema.Resource.InternalValidate` passes for the resource (this is what surfaced the `WriteOnly`+`ForceNew` constraint)
- `gofmt` clean

### AI usage

Per the provider's AI usage policy: this PR was prepared with AI assistance (Claude). The implementation mirrors the established write-only argument pattern; schema, validation, and the create-path threading were reviewed against `aws_db_instance` and validated with `InternalValidate`, which surfaced the `WriteOnly`+`ForceNew` constraint and drove the `password_wo_version` design. The `🤖🤖🤖` title marker is included as requested for agent-assisted submissions.
