### PR TITLE
aws_kms_external_key: read 'key_spec'

### DIFF
--- a/.changelog/48518.txt
+++ b/.changelog/48518.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_kms_external_key: Read 'key_spec' to allow importing with 'key_spec' set
+```

--- a/internal/service/kms/external_key.go
+++ b/internal/service/kms/external_key.go
@@ -252,6 +252,7 @@ func resourceExternalKeyRead(ctx context.Context, d *schema.ResourceData, meta a
 	d.Set(names.AttrDescription, key.metadata.Description)
 	d.Set(names.AttrEnabled, key.metadata.Enabled)
 	d.Set("expiration_model", key.metadata.ExpirationModel)
+	d.Set("key_spec", key.metadata.KeySpec)
 	d.Set("key_state", key.metadata.KeyState)
 	d.Set("key_usage", key.metadata.KeyUsage)
 	d.Set("multi_region", key.metadata.MultiRegion)


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

None

### Description
This allow to import 'aws_kms_external_key' and set 'key_spec' without recreating a new 'aws_kms_external_key'.


### Relations
Fixes #46080

### References


### Output from Acceptance Testing

<details>

```console
% make testacc TESTS=TestAccKMSExternalKey_*  PKG=kms
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2	(cached)
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider/framework	(cached)
make: Running acceptance tests on branch: 🌿 b-kms_external_key_read_key_spec 🌿...
TF_ACC=1 go1.26.4 test ./internal/service/kms/... -v -count 1 -parallel 20 -run='TestAccKMSExternalKey_*'  -timeout 360m -vet=off -buildvcs=false
2026/06/22 16:51:07 Creating Terraform AWS Provider (SDKv2-style)...
2026/06/22 16:51:07 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccKMSExternalKey_tags
=== PAUSE TestAccKMSExternalKey_tags
=== RUN   TestAccKMSExternalKey_Tags_null
=== PAUSE TestAccKMSExternalKey_Tags_null
=== RUN   TestAccKMSExternalKey_Tags_emptyMap
=== PAUSE TestAccKMSExternalKey_Tags_emptyMap
=== RUN   TestAccKMSExternalKey_Tags_addOnUpdate
=== PAUSE TestAccKMSExternalKey_Tags_addOnUpdate
=== RUN   TestAccKMSExternalKey_Tags_EmptyTag_onCreate
=== PAUSE TestAccKMSExternalKey_Tags_EmptyTag_onCreate
=== RUN   TestAccKMSExternalKey_Tags_EmptyTag_OnUpdate_add
=== PAUSE TestAccKMSExternalKey_Tags_EmptyTag_OnUpdate_add
=== RUN   TestAccKMSExternalKey_Tags_EmptyTag_OnUpdate_replace
=== PAUSE TestAccKMSExternalKey_Tags_EmptyTag_OnUpdate_replace
=== RUN   TestAccKMSExternalKey_Tags_DefaultTags_providerOnly
=== PAUSE TestAccKMSExternalKey_Tags_DefaultTags_providerOnly
=== RUN   TestAccKMSExternalKey_Tags_DefaultTags_nonOverlapping
=== PAUSE TestAccKMSExternalKey_Tags_DefaultTags_nonOverlapping
=== RUN   TestAccKMSExternalKey_Tags_DefaultTags_overlapping
=== PAUSE TestAccKMSExternalKey_Tags_DefaultTags_overlapping
=== RUN   TestAccKMSExternalKey_Tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccKMSExternalKey_Tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccKMSExternalKey_Tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccKMSExternalKey_Tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccKMSExternalKey_Tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccKMSExternalKey_Tags_DefaultTags_emptyResourceTag
=== RUN   TestAccKMSExternalKey_Tags_DefaultTags_emptyProviderOnlyTag
=== PAUSE TestAccKMSExternalKey_Tags_DefaultTags_emptyProviderOnlyTag
=== RUN   TestAccKMSExternalKey_Tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccKMSExternalKey_Tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccKMSExternalKey_Tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccKMSExternalKey_Tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccKMSExternalKey_Tags_ComputedTag_onCreate
=== PAUSE TestAccKMSExternalKey_Tags_ComputedTag_onCreate
=== RUN   TestAccKMSExternalKey_Tags_ComputedTag_OnUpdate_add
=== PAUSE TestAccKMSExternalKey_Tags_ComputedTag_OnUpdate_add
=== RUN   TestAccKMSExternalKey_Tags_ComputedTag_OnUpdate_replace
=== PAUSE TestAccKMSExternalKey_Tags_ComputedTag_OnUpdate_replace
=== RUN   TestAccKMSExternalKey_Tags_IgnoreTags_Overlap_defaultTag
=== PAUSE TestAccKMSExternalKey_Tags_IgnoreTags_Overlap_defaultTag
=== RUN   TestAccKMSExternalKey_Tags_IgnoreTags_Overlap_resourceTag
=== PAUSE TestAccKMSExternalKey_Tags_IgnoreTags_Overlap_resourceTag
=== RUN   TestAccKMSExternalKey_basic
=== PAUSE TestAccKMSExternalKey_basic
=== RUN   TestAccKMSExternalKey_disappears
=== PAUSE TestAccKMSExternalKey_disappears
=== RUN   TestAccKMSExternalKey_multiRegion
=== PAUSE TestAccKMSExternalKey_multiRegion
=== RUN   TestAccKMSExternalKey_deletionWindowInDays
=== PAUSE TestAccKMSExternalKey_deletionWindowInDays
=== RUN   TestAccKMSExternalKey_description
=== PAUSE TestAccKMSExternalKey_description
=== RUN   TestAccKMSExternalKey_enabled
=== PAUSE TestAccKMSExternalKey_enabled
=== RUN   TestAccKMSExternalKey_keyMaterialBase64
=== PAUSE TestAccKMSExternalKey_keyMaterialBase64
=== RUN   TestAccKMSExternalKey_policy
=== PAUSE TestAccKMSExternalKey_policy
=== RUN   TestAccKMSExternalKey_policyBypass
=== PAUSE TestAccKMSExternalKey_policyBypass
=== RUN   TestAccKMSExternalKey_validTo
=== PAUSE TestAccKMSExternalKey_validTo
=== RUN   TestAccKMSExternalKey_keyUsage
=== PAUSE TestAccKMSExternalKey_keyUsage
=== RUN   TestAccKMSExternalKey_keySpec
=== PAUSE TestAccKMSExternalKey_keySpec
=== CONT  TestAccKMSExternalKey_tags
=== CONT  TestAccKMSExternalKey_Tags_DefaultTags_overlapping
=== CONT  TestAccKMSExternalKey_enabled
=== CONT  TestAccKMSExternalKey_basic
=== CONT  TestAccKMSExternalKey_description
=== CONT  TestAccKMSExternalKey_deletionWindowInDays
=== CONT  TestAccKMSExternalKey_keySpec
=== CONT  TestAccKMSExternalKey_multiRegion
=== CONT  TestAccKMSExternalKey_policy
=== CONT  TestAccKMSExternalKey_disappears
=== CONT  TestAccKMSExternalKey_keyMaterialBase64
=== CONT  TestAccKMSExternalKey_Tags_IgnoreTags_Overlap_resourceTag
=== CONT  TestAccKMSExternalKey_Tags_IgnoreTags_Overlap_defaultTag
=== CONT  TestAccKMSExternalKey_Tags_EmptyTag_OnUpdate_add
=== CONT  TestAccKMSExternalKey_Tags_DefaultTags_nonOverlapping
=== CONT  TestAccKMSExternalKey_Tags_DefaultTags_providerOnly
=== CONT  TestAccKMSExternalKey_Tags_ComputedTag_OnUpdate_replace
=== CONT  TestAccKMSExternalKey_Tags_EmptyTag_OnUpdate_replace
=== CONT  TestAccKMSExternalKey_Tags_ComputedTag_OnUpdate_add
=== CONT  TestAccKMSExternalKey_policyBypass
--- PASS: TestAccKMSExternalKey_disappears (55.07s)
=== CONT  TestAccKMSExternalKey_keyUsage
--- PASS: TestAccKMSExternalKey_multiRegion (56.31s)
=== CONT  TestAccKMSExternalKey_Tags_DefaultTags_emptyProviderOnlyTag
--- PASS: TestAccKMSExternalKey_basic (59.36s)
=== CONT  TestAccKMSExternalKey_validTo
--- PASS: TestAccKMSExternalKey_policyBypass (67.87s)
=== CONT  TestAccKMSExternalKey_Tags_ComputedTag_onCreate
--- PASS: TestAccKMSExternalKey_deletionWindowInDays (97.14s)
=== CONT  TestAccKMSExternalKey_Tags_emptyMap
--- PASS: TestAccKMSExternalKey_description (101.06s)
=== CONT  TestAccKMSExternalKey_Tags_DefaultTags_nullNonOverlappingResourceTag
--- PASS: TestAccKMSExternalKey_keySpec (104.50s)
=== CONT  TestAccKMSExternalKey_Tags_DefaultTags_updateToResourceOnly
--- PASS: TestAccKMSExternalKey_policy (111.87s)
=== CONT  TestAccKMSExternalKey_Tags_DefaultTags_nullOverlappingResourceTag
--- PASS: TestAccKMSExternalKey_Tags_ComputedTag_OnUpdate_add (134.94s)
=== CONT  TestAccKMSExternalKey_Tags_DefaultTags_emptyResourceTag
--- PASS: TestAccKMSExternalKey_Tags_EmptyTag_OnUpdate_replace (138.06s)
=== CONT  TestAccKMSExternalKey_Tags_EmptyTag_onCreate
--- PASS: TestAccKMSExternalKey_Tags_ComputedTag_OnUpdate_replace (138.36s)
=== CONT  TestAccKMSExternalKey_Tags_addOnUpdate
--- PASS: TestAccKMSExternalKey_Tags_DefaultTags_emptyProviderOnlyTag (82.98s)
=== CONT  TestAccKMSExternalKey_Tags_null
--- PASS: TestAccKMSExternalKey_Tags_ComputedTag_onCreate (77.44s)
=== CONT  TestAccKMSExternalKey_Tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccKMSExternalKey_Tags_IgnoreTags_Overlap_defaultTag (160.44s)
--- PASS: TestAccKMSExternalKey_keyUsage (110.07s)
--- PASS: TestAccKMSExternalKey_Tags_DefaultTags_nullNonOverlappingResourceTag (79.07s)
--- PASS: TestAccKMSExternalKey_Tags_IgnoreTags_Overlap_resourceTag (187.02s)
--- PASS: TestAccKMSExternalKey_Tags_DefaultTags_nullOverlappingResourceTag (75.63s)
--- PASS: TestAccKMSExternalKey_keyMaterialBase64 (189.18s)
--- PASS: TestAccKMSExternalKey_Tags_emptyMap (100.09s)
--- PASS: TestAccKMSExternalKey_Tags_EmptyTag_OnUpdate_add (197.22s)
--- PASS: TestAccKMSExternalKey_Tags_DefaultTags_overlapping (199.60s)
--- PASS: TestAccKMSExternalKey_Tags_DefaultTags_emptyResourceTag (67.73s)
--- PASS: TestAccKMSExternalKey_Tags_DefaultTags_nonOverlapping (204.59s)
--- PASS: TestAccKMSExternalKey_Tags_DefaultTags_updateToResourceOnly (102.65s)
--- PASS: TestAccKMSExternalKey_enabled (215.95s)
--- PASS: TestAccKMSExternalKey_Tags_null (77.00s)
--- PASS: TestAccKMSExternalKey_Tags_addOnUpdate (86.24s)
--- PASS: TestAccKMSExternalKey_Tags_DefaultTags_updateToProviderOnly (79.65s)
--- PASS: TestAccKMSExternalKey_Tags_EmptyTag_onCreate (91.25s)
--- PASS: TestAccKMSExternalKey_tags (231.22s)
--- PASS: TestAccKMSExternalKey_Tags_DefaultTags_providerOnly (231.25s)
--- PASS: TestAccKMSExternalKey_validTo (198.35s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kms	257.847s
```

</details>