### PR TITLE
🤖🤖🤖 [codex] Add Bedrock AgentCore harness api_format

### DIFF
--- a/.changelog/48521.txt
+++ b/.changelog/48521.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_bedrockagentcore_harness: Add `api_format` support to `bedrock_model_config` and `openai_model_config`
+```

--- a/internal/service/bedrockagentcore/harness.go
+++ b/internal/service/bedrockagentcore/harness.go
@@ -222,6 +222,13 @@ func (r *harnessResource) Schema(ctx context.Context, request resource.SchemaReq
 							},
 							NestedObject: schema.NestedBlockObject{
 								Attributes: map[string]schema.Attribute{
+									"api_format": schema.StringAttribute{
+										CustomType: fwtypes.StringEnumType[awstypes.HarnessBedrockApiFormat](),
+										Optional:   true,
+										Validators: []validator.String{
+											enum.FrameworkValidate[awstypes.HarnessBedrockApiFormat](),
+										},
+									},
 									"max_tokens": schema.Int32Attribute{
 										Optional: true,
 										Validators: []validator.Int32{
@@ -253,6 +260,13 @@ func (r *harnessResource) Schema(ctx context.Context, request resource.SchemaReq
 							},
 							NestedObject: schema.NestedBlockObject{
 								Attributes: map[string]schema.Attribute{
+									"api_format": schema.StringAttribute{
+										CustomType: fwtypes.StringEnumType[awstypes.HarnessOpenAiApiFormat](),
+										Optional:   true,
+										Validators: []validator.String{
+											enum.FrameworkValidate[awstypes.HarnessOpenAiApiFormat](),
+										},
+									},
 									"api_key_arn": schema.StringAttribute{
 										CustomType: fwtypes.ARNType,
 										Required:   true,
@@ -891,10 +905,11 @@ func (m harnessModelConfigurationModel) Expand(ctx context.Context) (any, diag.D
 }
 
 type harnessBedrockModelConfigModel struct {
-	MaxTokens   types.Int32   `tfsdk:"max_tokens"`
-	ModelID     types.String  `tfsdk:"model_id"`
-	Temperature types.Float32 `tfsdk:"temperature"`
-	TopP        types.Float32 `tfsdk:"top_p"`
+	ApiFormat   fwtypes.StringEnum[awstypes.HarnessBedrockApiFormat] `tfsdk:"api_format"`
+	MaxTokens   types.Int32                                          `tfsdk:"max_tokens"`
+	ModelID     types.String                                         `tfsdk:"model_id"`
+	Temperature types.Float32                                        `tfsdk:"temperature"`
+	TopP        types.Float32                                        `tfsdk:"top_p"`
 }
 
 type harnessGeminiModelConfigModel struct {
@@ -907,11 +922,12 @@ type harnessGeminiModelConfigModel struct {
 }
 
 type harnessOpenAIModelConfigModel struct {
-	ApiKeyARN   fwtypes.ARN   `tfsdk:"api_key_arn"`
-	MaxTokens   types.Int32   `tfsdk:"max_tokens"`
-	ModelID     types.String  `tfsdk:"model_id"`
-	Temperature types.Float32 `tfsdk:"temperature"`
-	TopP        types.Float32 `tfsdk:"top_p"`
+	ApiFormat   fwtypes.StringEnum[awstypes.HarnessOpenAiApiFormat] `tfsdk:"api_format"`
+	ApiKeyARN   fwtypes.ARN                                         `tfsdk:"api_key_arn"`
+	MaxTokens   types.Int32                                         `tfsdk:"max_tokens"`
+	ModelID     types.String                                        `tfsdk:"model_id"`
+	Temperature types.Float32                                       `tfsdk:"temperature"`
+	TopP        types.Float32                                       `tfsdk:"top_p"`
 }
 
 // System prompt union.

--- a/internal/service/bedrockagentcore/harness_test.go
+++ b/internal/service/bedrockagentcore/harness_test.go
@@ -264,6 +264,9 @@ func TestAccBedrockAgentCoreHarness_model_bedrock(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckHarnessExists(ctx, t, resourceName, &harness),
 				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("model").AtSliceIndex(0).AtMapKey("bedrock_model_config").AtSliceIndex(0).AtMapKey("api_format"), knownvalue.StringExact("converse_stream")),
+				},
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
@@ -801,6 +804,7 @@ resource "aws_bedrockagentcore_harness" "test" {
 
   model {
     bedrock_model_config {
+      api_format  = "converse_stream"
       model_id    = "anthropic.claude-sonnet-4-20250514"
       temperature = 0.7
       top_p       = 0.9

--- a/website/docs/r/bedrockagentcore_harness.html.markdown
+++ b/website/docs/r/bedrockagentcore_harness.html.markdown
@@ -154,6 +154,7 @@ The `model` block supports exactly one of the following:
 ### `bedrock_model_config` Block
 
 * `model_id` - (Required) Bedrock model ID (e.g., `anthropic.claude-sonnet-4-20250514`).
+* `api_format` - (Optional) API format for the model. Valid values are `converse_stream`, `responses`, and `chat_completions`.
 * `max_tokens` - (Optional) Maximum number of tokens to generate.
 * `temperature` - (Optional) Temperature for sampling. Must be between 0 and 2.
 * `top_p` - (Optional) Top-p (nucleus) sampling parameter. Must be between 0 and 1.
@@ -161,6 +162,7 @@ The `model` block supports exactly one of the following:
 ### `openai_model_config` Block
 
 * `model_id` - (Required) OpenAI model ID.
+* `api_format` - (Optional) API format for the model. Valid values are `responses` and `chat_completions`.
 * `api_key_arn` - (Required) ARN of the secret containing the API key.
 * `max_tokens` - (Optional) Maximum number of tokens to generate.
 * `temperature` - (Optional) Temperature for sampling.


### PR DESCRIPTION
## Summary

Adds Terraform schema support for AgentCore Harness model `api_format` on both `bedrock_model_config` and `openai_model_config`.

The new attributes use the AWS SDK enum types for typed state and validation:

- `HarnessBedrockApiFormat`: `converse_stream`, `responses`, `chat_completions`
- `HarnessOpenAiApiFormat`: `responses`, `chat_completions`

This allows Bedrock AgentCore Harness configurations that require an explicit API format, including OpenAI-compatible Bedrock model paths such as GPT-5.4 using `responses`.

Closes #48519.

## Changes

- Adds `api_format` to `aws_bedrockagentcore_harness.model.bedrock_model_config`
- Adds `api_format` to `aws_bedrockagentcore_harness.model.openai_model_config`
- Updates the Harness resource docs with valid enum values
- Adds focused Bedrock Harness acceptance-state coverage for `api_format`

## Validation

- `git diff --check`
- `GOMODCACHE=/Users/derekbrown/cadence/terraform-provider-aws-agentcore-api-format/.cache/gomod GOCACHE=/Users/derekbrown/cadence/terraform-provider-aws-agentcore-api-format/.cache/gocache GOTMPDIR=/Users/derekbrown/cadence/terraform-provider-aws-agentcore-api-format/.cache/gotmp go test ./internal/service/bedrockagentcore -run TestAccBedrockAgentCoreHarness_model_bedrock -count=0`

Acceptance tests were not run locally.

## AI Use

This PR was prepared with assistance from an LLM coding agent. The human author remains responsible for reviewing and understanding the submitted code.