### PR TITLE
list resource/aws_iam_role_policy: Removes resource Read function from List

### DIFF
--- a/.ci/semgrep/list/no-resource-read.yml
+++ b/.ci/semgrep/list/no-resource-read.yml
@@ -9,7 +9,6 @@ rules:
       include:
         - "/internal/service"
       exclude:
-        - "/internal/service/iam/role_policy_list.go"
         - "/internal/service/lambda/layer_version_list.go"
         - "/internal/service/route53/record_list.go"
         - "/internal/service/route53resolver/rule_association_list.go"

--- a/internal/service/iam/role_policy.go
+++ b/internal/service/iam/role_policy.go
@@ -146,6 +146,12 @@ func resourceRolePolicyRead(ctx context.Context, d *schema.ResourceData, meta an
 		return sdkdiag.AppendErrorf(diags, "reading IAM Role Policy (%s): %s", d.Id(), err)
 	}
 
+	return resourceRolePolicyFlatten(d, roleName, policyName, policyDocument)
+}
+
+func resourceRolePolicyFlatten(d *schema.ResourceData, roleName, policyName, policyDocument string) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	policy, err := url.QueryUnescape(policyDocument)
 	if err != nil {
 		return sdkdiag.AppendFromErr(diags, err)

--- a/internal/service/iam/role_policy_list.go
+++ b/internal/service/iam/role_policy_list.go
@@ -78,19 +78,25 @@ func (l *listResourceRolePolicy) List(ctx context.Context, request list.ListRequ
 			result := request.NewListResult(ctx)
 			rd := l.ResourceData()
 			rd.SetId(id)
+			rd.Set(names.AttrRole, roleName)
+			rd.Set(names.AttrName, policyName)
 
-			tflog.Info(ctx, "Reading IAM (Identity & Access Management) Role Policy")
-			diags := resourceRolePolicyRead(ctx, rd, awsClient)
-			if diags.HasError() {
-				tflog.Error(ctx, "Reading IAM (Identity & Access Management) Role Policy", map[string]any{
-					names.AttrID: id,
-					"diags":      sdkdiag.DiagnosticsString(diags),
-				})
-				continue
-			}
-			if rd.Id() == "" {
-				// Resource is logically deleted
-				continue
+			if request.IncludeResource {
+				policyDocument, err := findRolePolicyByTwoPartKey(ctx, conn, roleName, policyName)
+				if err != nil {
+					tflog.Error(ctx, "Reading IAM (Identity & Access Management) Role Policy", map[string]any{
+						"diags": err.Error(),
+					})
+					continue
+				}
+
+				diags := resourceRolePolicyFlatten(rd, roleName, policyName, policyDocument)
+				if diags.HasError() {
+					tflog.Error(ctx, "Reading IAM (Identity & Access Management) Role Policy", map[string]any{
+						"diags": sdkdiag.DiagnosticsString(diags),
+					})
+					continue
+				}
 			}
 
 			result.DisplayName = policyName


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Removes resource Read function from `aws_iam_role_policy` List

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=iam TESTS=TestAccIAMRolePolicy_List_

--- PASS: TestAccIAMRolePolicy_List_includeResource (27.84s)
--- PASS: TestAccIAMRolePolicy_List_basic (27.88s)
```
