### PR TITLE
Feature: Add feature flagged batched reads for the`aws_route53_record` resource  to combat low API rate limits

### DIFF
--- a/.changelog/48525.txt
+++ b/.changelog/48525.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_route53_record: Add `batch_reads` argument to reduce AWS API calls when managing many records in a zone, improving plan and apply speeds at scale.
+```

--- a/.changelog/48525.txt
+++ b/.changelog/48525.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_route53_record: Add `batch_reads` argument to reduce AWS API calls when managing many records in a zone, improving plan and apply speeds at scale.
+resource/aws_route53_record: Addition of the `TF_AWS_ROUTE53_RECORD_BATCH_READS` feature flag environment variable to reduce AWS API calls when managing many records in a zone, improving plan and apply speeds at scale.
 ```

--- a/internal/service/route53/record.go
+++ b/internal/service/route53/record.go
@@ -48,7 +48,6 @@ import (
 // @Testing(subdomainTfVar="zoneName;recordName")
 // @Testing(generator=false)
 // @Testing(preIdentityVersion="6.4.0")
-// @Testing(importIgnore="batch_reads")
 func resourceRecord() *schema.Resource {
 	//lintignore:R011
 	return &schema.Resource{
@@ -93,11 +92,6 @@ func resourceRecord() *schema.Resource {
 					Type:     schema.TypeBool,
 					Optional: true,
 					Computed: true,
-				},
-				"batch_reads": {
-					Type:     schema.TypeBool,
-					Optional: true,
-					Default:  false,
 				},
 				"cidr_routing_policy": {
 					Type:     schema.TypeList,
@@ -395,7 +389,9 @@ func resourceRecordCreate(ctx context.Context, d *schema.ResourceData, meta any)
 		}
 	}
 
-	evictFromZoneRecordCache(zoneID, recordCacheKey(zoneID, d.Get(names.AttrName).(string), d.Get(names.AttrType).(string), d.Get("set_identifier").(string)))
+	if batchReadsEnabled() {
+		evictFromZoneRecordCache(zoneID, recordCacheKey(zoneID, d.Get(names.AttrName).(string), d.Get(names.AttrType).(string), d.Get("set_identifier").(string)))
+	}
 
 	return append(diags, resourceRecordRead(ctx, d, meta)...)
 }
@@ -408,7 +404,7 @@ func resourceRecordRead(ctx context.Context, d *schema.ResourceData, meta any) d
 	var record *awstypes.ResourceRecordSet
 	var fqdn *string
 	var err error
-	if d.Get("batch_reads").(bool) {
+	if batchReadsEnabled() {
 		record, fqdn, err = readRecordFromCache(ctx, conn, zoneID, d.Get(names.AttrName).(string), d.Get(names.AttrType).(string), d.Get("set_identifier").(string))
 	} else {
 		record, fqdn, err = findResourceRecordSetByFourPartKey(ctx, conn, zoneID, d.Get(names.AttrName).(string), d.Get(names.AttrType).(string), d.Get("set_identifier").(string))
@@ -705,8 +701,10 @@ func resourceRecordUpdate(ctx context.Context, d *schema.ResourceData, meta any)
 
 	d.SetId(createRecordImportID(d))
 
-	oldSetID, _ := d.GetChange("set_identifier")
-	evictFromZoneRecordCache(zoneID, recordCacheKey(zoneID, d.Get(names.AttrName).(string), oldRRType.(string), oldSetID.(string)))
+	if batchReadsEnabled() {
+		oldSetID, _ := d.GetChange("set_identifier")
+		evictFromZoneRecordCache(zoneID, recordCacheKey(zoneID, d.Get(names.AttrName).(string), oldRRType.(string), oldSetID.(string)))
+	}
 
 	return append(diags, resourceRecordRead(ctx, d, meta)...)
 }
@@ -766,7 +764,9 @@ func resourceRecordDelete(ctx context.Context, d *schema.ResourceData, meta any)
 		}
 	}
 
-	evictFromZoneRecordCache(zoneID, recordCacheKey(zoneID, name, d.Get(names.AttrType).(string), d.Get("set_identifier").(string)))
+	if batchReadsEnabled() {
+		evictFromZoneRecordCache(zoneID, recordCacheKey(zoneID, name, d.Get(names.AttrType).(string), d.Get("set_identifier").(string)))
+	}
 
 	return diags
 }

--- a/internal/service/route53/record.go
+++ b/internal/service/route53/record.go
@@ -93,6 +93,11 @@ func resourceRecord() *schema.Resource {
 					Optional: true,
 					Computed: true,
 				},
+				"batch_reads": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
 				"cidr_routing_policy": {
 					Type:     schema.TypeList,
 					MaxItems: 1,
@@ -389,6 +394,8 @@ func resourceRecordCreate(ctx context.Context, d *schema.ResourceData, meta any)
 		}
 	}
 
+	evictFromZoneRecordCache(zoneID, recordCacheKey(zoneID, d.Get(names.AttrName).(string), d.Get(names.AttrType).(string), d.Get("set_identifier").(string)))
+
 	return append(diags, resourceRecordRead(ctx, d, meta)...)
 }
 
@@ -396,7 +403,15 @@ func resourceRecordRead(ctx context.Context, d *schema.ResourceData, meta any) d
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).Route53Client(ctx)
 
-	record, fqdn, err := findResourceRecordSetByFourPartKey(ctx, conn, cleanZoneID(d.Get("zone_id").(string)), d.Get(names.AttrName).(string), d.Get(names.AttrType).(string), d.Get("set_identifier").(string))
+	zoneID := cleanZoneID(d.Get("zone_id").(string))
+	var record *awstypes.ResourceRecordSet
+	var fqdn *string
+	var err error
+	if d.Get("batch_reads").(bool) {
+		record, fqdn, err = readRecordFromCache(ctx, conn, zoneID, d.Get(names.AttrName).(string), d.Get(names.AttrType).(string), d.Get("set_identifier").(string))
+	} else {
+		record, fqdn, err = findResourceRecordSetByFourPartKey(ctx, conn, zoneID, d.Get(names.AttrName).(string), d.Get(names.AttrType).(string), d.Get("set_identifier").(string))
+	}
 
 	if !d.IsNewResource() && retry.NotFound(err) {
 		log.Printf("[WARN] Route 53 Record (%s) not found, removing from state", d.Id())
@@ -689,6 +704,9 @@ func resourceRecordUpdate(ctx context.Context, d *schema.ResourceData, meta any)
 
 	d.SetId(createRecordImportID(d))
 
+	oldSetID, _ := d.GetChange("set_identifier")
+	evictFromZoneRecordCache(zoneID, recordCacheKey(zoneID, d.Get(names.AttrName).(string), oldRRType.(string), oldSetID.(string)))
+
 	return append(diags, resourceRecordRead(ctx, d, meta)...)
 }
 
@@ -746,6 +764,8 @@ func resourceRecordDelete(ctx context.Context, d *schema.ResourceData, meta any)
 			return sdkdiag.AppendErrorf(diags, "waiting for Route 53 Record (%s) synchronize: %s", d.Id(), err)
 		}
 	}
+
+	evictFromZoneRecordCache(zoneID, recordCacheKey(zoneID, name, d.Get(names.AttrType).(string), d.Get("set_identifier").(string)))
 
 	return diags
 }

--- a/internal/service/route53/record.go
+++ b/internal/service/route53/record.go
@@ -48,6 +48,7 @@ import (
 // @Testing(subdomainTfVar="zoneName;recordName")
 // @Testing(generator=false)
 // @Testing(preIdentityVersion="6.4.0")
+// @Testing(importIgnore="batch_reads")
 func resourceRecord() *schema.Resource {
 	//lintignore:R011
 	return &schema.Resource{

--- a/internal/service/route53/record_cache.go
+++ b/internal/service/route53/record_cache.go
@@ -5,6 +5,8 @@ package route53
 
 import (
 	"context"
+	"os"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -13,6 +15,14 @@ import (
 	awstypes "github.com/aws/aws-sdk-go-v2/service/route53/types"
 	tfsync "github.com/hashicorp/terraform-provider-aws/internal/sync"
 )
+
+// batchReadsEnabled reports whether TF_AWS_ROUTE53_RECORD_BATCH_READS is set to
+// a true value ("1", "true", "t", etc.). When enabled, reads are served from the
+// zone-level cache and cache evictions are performed on write operations.
+func batchReadsEnabled() bool {
+	v, _ := strconv.ParseBool(os.Getenv("TF_AWS_ROUTE53_RECORD_BATCH_READS"))
+	return v
+}
 
 // zoneRecordCache holds all cached ResourceRecordSets for a single hosted zone,
 // keyed by the Terraform-style resource ID.

--- a/internal/service/route53/record_cache.go
+++ b/internal/service/route53/record_cache.go
@@ -1,0 +1,134 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package route53
+
+import (
+	"context"
+	"strings"
+	"sync"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/route53"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/route53/types"
+	tfsync "github.com/hashicorp/terraform-provider-aws/internal/sync"
+)
+
+// zoneRecordCache holds all cached ResourceRecordSets for a single hosted zone,
+// keyed by the Terraform-style resource ID.
+type zoneRecordCache struct {
+	mu      sync.RWMutex
+	records map[string]awstypes.ResourceRecordSet
+}
+
+// recordCacheZones maps cleaned hosted zone ID to its populated record cache.
+var recordCacheZones tfsync.Map[string, *zoneRecordCache]
+
+// recordCacheInitMu serializes the initial zone-wide listing per zone ID so that
+// only one goroutine pays the cost of the full ListResourceRecordSets scan.
+var recordCacheInitMu tfsync.Map[string, *sync.Mutex]
+
+// recordCacheKey returns the cache map key for a record within a zone.
+// The name is normalized via normalizeDomainName to consistently handle octal
+// escape sequences (e.g. \052 for *), trailing dots, and casing — matching
+// how the Route53 API and expandRecordName represent names internally.
+func recordCacheKey(zoneID, name, rrType, setIdentifier string) string {
+	parts := []string{
+		zoneID,
+		normalizeDomainName(name),
+		rrType,
+	}
+	if setIdentifier != "" {
+		parts = append(parts, setIdentifier)
+	}
+	return strings.Join(parts, "_")
+}
+
+// getOrLoadZoneRecordCache returns the record cache for zoneID, issuing a full
+// ListResourceRecordSets scan if the zone has not been loaded yet. A per-zone
+// mutex prevents duplicate scans under concurrent access.
+func getOrLoadZoneRecordCache(ctx context.Context, conn *route53.Client, zoneID string) (*zoneRecordCache, error) {
+	if v, ok := recordCacheZones.Load(zoneID); ok {
+		return v, nil
+	}
+
+	mu, _ := recordCacheInitMu.LoadOrStore(zoneID, &sync.Mutex{})
+	mu.Lock()
+	defer mu.Unlock()
+
+	// Prevent race conditions triggering multiple ListResourceRecordSets
+	if v, ok := recordCacheZones.Load(zoneID); ok {
+		return v, nil
+	}
+
+	cache := &zoneRecordCache{
+		records: make(map[string]awstypes.ResourceRecordSet),
+	}
+
+	input := &route53.ListResourceRecordSetsInput{
+		HostedZoneId: aws.String(zoneID),
+	}
+	for rrs, err := range listRecords(ctx, conn, input) {
+		if err != nil {
+			return nil, err
+		}
+		key := recordCacheKey(zoneID, aws.ToString(rrs.Name), string(rrs.Type), aws.ToString(rrs.SetIdentifier))
+		cache.records[key] = rrs
+	}
+
+	recordCacheZones.LoadOrStore(zoneID, cache)
+	return cache, nil
+}
+
+// lookupInZoneRecordCache retrieves a single record from the zone cache.
+func lookupInZoneRecordCache(cache *zoneRecordCache, key string) (awstypes.ResourceRecordSet, bool) {
+	cache.mu.RLock()
+	defer cache.mu.RUnlock()
+	v, ok := cache.records[key]
+	return v, ok
+}
+
+// storeInZoneRecordCache inserts or replaces a single record in the zone cache.
+func storeInZoneRecordCache(cache *zoneRecordCache, key string, rrs awstypes.ResourceRecordSet) {
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+	cache.records[key] = rrs
+}
+
+// evictFromZoneRecordCache removes a single record from the zone cache. It is a
+// no-op when the zone has not been cached or the key is not present.
+// Is used during record update and delete operations to remove cache entries
+// to ensure subsequent read operations call the AWS API instead of hittins stale cache
+func evictFromZoneRecordCache(zoneID, key string) {
+	if c, ok := recordCacheZones.Load(zoneID); ok {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		delete(c.records, key)
+	}
+}
+
+// readRecordFromCache looks up a record in the zone cache, falling back to a
+// direct API call on a cache miss. A miss result is stored back into the cache
+// fallback behavior is to ensure resource data is refreshed from the API after a record is updated or deleted
+func readRecordFromCache(ctx context.Context, conn *route53.Client, zoneID, name, rrType, setID string) (*awstypes.ResourceRecordSet, *string, error) {
+	cache, err := getOrLoadZoneRecordCache(ctx, conn, zoneID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	key := recordCacheKey(zoneID, name, rrType, setID)
+	rrs, ok := lookupInZoneRecordCache(cache, key)
+	if !ok {
+		record, fqdn, err := findResourceRecordSetByFourPartKey(ctx, conn, zoneID, name, rrType, setID)
+		if err != nil {
+			return nil, nil, err
+		}
+		storeInZoneRecordCache(cache, key, *record)
+		return record, fqdn, nil
+	}
+
+	// Derive the FQDN string in the same form returned by findResourceRecordSetByFourPartKey:
+	// normalized (no trailing dot, octal escape codes preserved).
+	fqdnStr := normalizeDomainName(aws.ToString(rrs.Name))
+	return &rrs, &fqdnStr, nil
+}

--- a/internal/service/route53/record_cache_test.go
+++ b/internal/service/route53/record_cache_test.go
@@ -1,0 +1,182 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package route53
+
+import (
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/route53/types"
+)
+
+func TestRecordCacheKey(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name          string
+		zoneID        string
+		recordName    string
+		rrType        string
+		setIdentifier string
+		want          string
+	}{
+		{
+			name:       "basic record",
+			zoneID:     "Z123456",
+			recordName: "www.example.com",
+			rrType:     "A",
+			want:       "Z123456_www.example.com_A",
+		},
+		{
+			name:       "trailing dot stripped",
+			zoneID:     "Z123456",
+			recordName: "www.example.com.",
+			rrType:     "CNAME",
+			want:       "Z123456_www.example.com_CNAME",
+		},
+		{
+			name:       "uppercase normalized to lowercase",
+			zoneID:     "Z123456",
+			recordName: "WWW.EXAMPLE.COM",
+			rrType:     "A",
+			want:       "Z123456_www.example.com_A",
+		},
+		{
+			// State stores "*" but the Route53 API returns "\052" (octal for '*').
+			// Both must produce the same key so cache hits work for wildcard records.
+			name:       "wildcard asterisk normalizes to octal",
+			zoneID:     "Z123456",
+			recordName: "*.example.com",
+			rrType:     "A",
+			want:       "Z123456_\\052.example.com_A",
+		},
+		{
+			name:       "wildcard octal from API response matches",
+			zoneID:     "Z123456",
+			recordName: `\052.example.com.`,
+			rrType:     "A",
+			want:       "Z123456_\\052.example.com_A",
+		},
+		{
+			name:          "record with set_identifier",
+			zoneID:        "Z123456",
+			recordName:    "www.example.com",
+			rrType:        "A",
+			setIdentifier: "primary",
+			want:          "Z123456_www.example.com_A_primary",
+		},
+		{
+			name:          "empty set_identifier omitted from key",
+			zoneID:        "Z123456",
+			recordName:    "www.example.com",
+			rrType:        "A",
+			setIdentifier: "",
+			want:          "Z123456_www.example.com_A",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := recordCacheKey(tc.zoneID, tc.recordName, tc.rrType, tc.setIdentifier)
+			if got != tc.want {
+				t.Errorf("recordCacheKey(%q, %q, %q, %q) = %q, want %q",
+					tc.zoneID, tc.recordName, tc.rrType, tc.setIdentifier, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRecordCacheKeyWildcardSymmetry(t *testing.T) {
+	t.Parallel()
+
+	// The key built from state ("*") and from the API ("\052") must be identical.
+	fromState := recordCacheKey("Z123456", "*.example.com", "A", "")
+	fromAPI := recordCacheKey("Z123456", `\052.example.com.`, "A", "")
+	if fromState != fromAPI {
+		t.Errorf("wildcard key mismatch: state=%q api=%q", fromState, fromAPI)
+	}
+}
+
+func TestZoneRecordCacheStoreAndLookup(t *testing.T) {
+	t.Parallel()
+
+	cache := &zoneRecordCache{
+		records: make(map[string]awstypes.ResourceRecordSet),
+	}
+	key := "Z123456_www.example.com_A"
+	rrs := awstypes.ResourceRecordSet{
+		Name: aws.String("www.example.com."),
+		Type: awstypes.RRTypeA,
+	}
+
+	if _, ok := lookupInZoneRecordCache(cache, key); ok {
+		t.Fatal("expected cache miss on empty cache")
+	}
+
+	storeInZoneRecordCache(cache, key, rrs)
+
+	got, ok := lookupInZoneRecordCache(cache, key)
+	if !ok {
+		t.Fatal("expected cache hit after store")
+	}
+	if aws.ToString(got.Name) != aws.ToString(rrs.Name) {
+		t.Errorf("got Name %q, want %q", aws.ToString(got.Name), aws.ToString(rrs.Name))
+	}
+}
+
+func TestZoneRecordCacheEvict(t *testing.T) {
+	t.Parallel()
+
+	zoneID := "Z_evict_test"
+	key := zoneID + "_www.example.com_A"
+	cache := &zoneRecordCache{
+		records: make(map[string]awstypes.ResourceRecordSet),
+	}
+	storeInZoneRecordCache(cache, key, awstypes.ResourceRecordSet{
+		Name: aws.String("www.example.com."),
+		Type: awstypes.RRTypeA,
+	})
+
+	// Register the cache in the global map so evictFromZoneRecordCache can find it.
+	recordCacheZones.LoadOrStore(zoneID, cache)
+
+	evictFromZoneRecordCache(zoneID, key)
+
+	if _, ok := lookupInZoneRecordCache(cache, key); ok {
+		t.Fatal("expected cache miss after eviction")
+	}
+}
+
+func TestZoneRecordCacheConcurrentReads(t *testing.T) {
+	t.Parallel()
+
+	cache := &zoneRecordCache{
+		records: make(map[string]awstypes.ResourceRecordSet),
+	}
+	key := "Z123456_www.example.com_A"
+	storeInZoneRecordCache(cache, key, awstypes.ResourceRecordSet{
+		Name: aws.String("www.example.com."),
+		Type: awstypes.RRTypeA,
+	})
+
+	// Multiple concurrent RLock reads must not block each other.
+	const readers = 10
+	doneCh := make(chan struct{}, readers)
+	for range readers {
+		go func() {
+			lookupInZoneRecordCache(cache, key)
+			doneCh <- struct{}{}
+		}()
+	}
+
+	for range readers {
+		select {
+		case <-doneCh:
+		case <-time.After(50 * time.Millisecond):
+			t.Fatal("concurrent reads blocked unexpectedly")
+		}
+	}
+}

--- a/internal/service/route53/record_identity_gen_test.go
+++ b/internal/service/route53/record_identity_gen_test.go
@@ -74,9 +74,6 @@ func TestAccRoute53Record_Identity_basic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"batch_reads",
-				},
 			},
 
 			// Step 3: Import block with Import ID
@@ -91,13 +88,11 @@ func TestAccRoute53Record_Identity_basic(t *testing.T) {
 				ImportStateKind: resource.ImportBlockWithID,
 				ImportPlanChecks: resource.ImportPlanChecks{
 					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
 						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New("zone_id"), knownvalue.NotNull()),
 						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrName), knownvalue.NotNull()),
 						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrType), knownvalue.NotNull()),
 					},
 				},
-				ExpectNonEmptyPlan: true,
 			},
 
 			// Step 4: Import block with Resource Identity
@@ -112,13 +107,11 @@ func TestAccRoute53Record_Identity_basic(t *testing.T) {
 				ImportStateKind: resource.ImportBlockWithResourceIdentity,
 				ImportPlanChecks: resource.ImportPlanChecks{
 					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
 						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New("zone_id"), knownvalue.NotNull()),
 						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrName), knownvalue.NotNull()),
 						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrType), knownvalue.NotNull()),
 					},
 				},
-				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/internal/service/route53/record_identity_gen_test.go
+++ b/internal/service/route53/record_identity_gen_test.go
@@ -70,11 +70,13 @@ func TestAccRoute53Record_Identity_basic(t *testing.T) {
 					"recordName": config.StringVariable(recordName.String()),
 					"zoneName":   config.StringVariable(zoneName.String()),
 				},
-				ImportStateKind:         resource.ImportCommandWithID,
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"batch_reads"},
+				ImportStateKind:   resource.ImportCommandWithID,
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"batch_reads",
+				},
 			},
 
 			// Step 3: Import block with Import ID
@@ -89,11 +91,13 @@ func TestAccRoute53Record_Identity_basic(t *testing.T) {
 				ImportStateKind: resource.ImportBlockWithID,
 				ImportPlanChecks: resource.ImportPlanChecks{
 					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
 						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New("zone_id"), knownvalue.NotNull()),
 						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrName), knownvalue.NotNull()),
 						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrType), knownvalue.NotNull()),
 					},
 				},
+				ExpectNonEmptyPlan: true,
 			},
 
 			// Step 4: Import block with Resource Identity
@@ -108,11 +112,13 @@ func TestAccRoute53Record_Identity_basic(t *testing.T) {
 				ImportStateKind: resource.ImportBlockWithResourceIdentity,
 				ImportPlanChecks: resource.ImportPlanChecks{
 					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
 						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New("zone_id"), knownvalue.NotNull()),
 						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrName), knownvalue.NotNull()),
 						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrType), knownvalue.NotNull()),
 					},
 				},
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/internal/service/route53/record_identity_gen_test.go
+++ b/internal/service/route53/record_identity_gen_test.go
@@ -70,10 +70,11 @@ func TestAccRoute53Record_Identity_basic(t *testing.T) {
 					"recordName": config.StringVariable(recordName.String()),
 					"zoneName":   config.StringVariable(zoneName.String()),
 				},
-				ImportStateKind:   resource.ImportCommandWithID,
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ImportStateKind:         resource.ImportCommandWithID,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"batch_reads"},
 			},
 
 			// Step 3: Import block with Import ID

--- a/internal/service/route53/record_test.go
+++ b/internal/service/route53/record_test.go
@@ -2036,7 +2036,7 @@ func TestAccRoute53Record_BatchReads_wildcard(t *testing.T) {
 	})
 }
 
-func TestAccRoute53Record_BatchReads_disappears(t *testing.T) {
+func TestAccRoute53Record_BatchReads_outOfBandChangeIgnored(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.ResourceRecordSet
 	var zoneID string
@@ -2091,10 +2091,13 @@ func TestAccRoute53Record_BatchReads_disappears(t *testing.T) {
 						t.Fatalf("deleting Route 53 record outside Terraform: %s", err)
 					}
 				},
-				Config:   testAccRecordConfig_batchReads(zoneName.String(), recordName.String()),
-				PlanOnly: true,
+				Config: testAccRecordConfig_batchReads(zoneName.String(), recordName.String()),
 				// Stale cache: the out-of-band deletion is not detected.
-				ExpectNonEmptyPlan: false,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 		},
 	})
@@ -3891,11 +3894,11 @@ resource "aws_route53_zone" "test" {
 }
 
 resource "aws_route53_record" "test" {
-  zone_id          = aws_route53_zone.test.zone_id
-  name             = %[2]q
-  type             = "A"
-  ttl              = "30"
-  records          = ["127.0.0.1"]
+  zone_id     = aws_route53_zone.test.zone_id
+  name        = %[2]q
+  type        = "A"
+  ttl         = "30"
+  records     = ["127.0.0.1"]
   batch_reads = true
 }
 `, zoneName, recordName)
@@ -3908,29 +3911,29 @@ resource "aws_route53_zone" "test" {
 }
 
 resource "aws_route53_record" "a" {
-  zone_id          = aws_route53_zone.test.zone_id
-  name             = "a.%[1]s"
-  type             = "A"
-  ttl              = %[2]q
-  records          = ["127.0.0.1"]
+  zone_id     = aws_route53_zone.test.zone_id
+  name        = "a.%[1]s"
+  type        = "A"
+  ttl         = %[2]q
+  records     = ["127.0.0.1"]
   batch_reads = true
 }
 
 resource "aws_route53_record" "b" {
-  zone_id          = aws_route53_zone.test.zone_id
-  name             = "b.%[1]s"
-  type             = "A"
-  ttl              = "30"
-  records          = ["127.0.0.2"]
+  zone_id     = aws_route53_zone.test.zone_id
+  name        = "b.%[1]s"
+  type        = "A"
+  ttl         = "30"
+  records     = ["127.0.0.2"]
   batch_reads = true
 }
 
 resource "aws_route53_record" "c" {
-  zone_id          = aws_route53_zone.test.zone_id
-  name             = "c.%[1]s"
-  type             = "A"
-  ttl              = "30"
-  records          = ["127.0.0.3"]
+  zone_id     = aws_route53_zone.test.zone_id
+  name        = "c.%[1]s"
+  type        = "A"
+  ttl         = "30"
+  records     = ["127.0.0.3"]
   batch_reads = true
 }
 `, zoneName, ttlA)
@@ -3943,11 +3946,11 @@ resource "aws_route53_zone" "test" {
 }
 
 resource "aws_route53_record" "wildcard" {
-  zone_id          = aws_route53_zone.test.zone_id
-  name             = "*.%[1]s"
-  type             = "A"
-  ttl              = "30"
-  records          = ["127.0.0.1"]
+  zone_id     = aws_route53_zone.test.zone_id
+  name        = "*.%[1]s"
+  type        = "A"
+  ttl         = "30"
+  records     = ["127.0.0.1"]
   batch_reads = true
 }
 `, zoneName)
@@ -3960,11 +3963,11 @@ resource "aws_route53_zone" "test" {
 }
 
 resource "aws_route53_record" "test" {
-  zone_id          = aws_route53_zone.test.zone_id
-  name             = "www.%[1]s"
-  type             = %[2]q
-  ttl              = "30"
-  records          = [%[3]q]
+  zone_id     = aws_route53_zone.test.zone_id
+  name        = "www.%[1]s"
+  type        = %[2]q
+  ttl         = "30"
+  records     = [%[3]q]
   batch_reads = true
 }
 `, zoneName, rrType, record)

--- a/internal/service/route53/record_test.go
+++ b/internal/service/route53/record_test.go
@@ -6,6 +6,8 @@ package route53_test
 import (
 	"context"
 	"fmt"
+	"os"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -1911,14 +1913,13 @@ func TestAccRoute53Record_escapedJustSpace(t *testing.T) {
 
 func TestAccRoute53Record_BatchReads_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	t.Setenv("TF_AWS_ROUTE53_RECORD_BATCH_READS", "true")
 	var v awstypes.ResourceRecordSet
 	resourceName := "aws_route53_record.test"
 	zoneName := acctest.RandomDomain(t)
 	recordName := zoneName.RandomSubdomain(t)
 
-	acctest.Test(ctx, t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckBatchReads(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.Route53ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckRecordDestroy(ctx, t),
@@ -1950,12 +1951,11 @@ func TestAccRoute53Record_BatchReads_basic(t *testing.T) {
 
 func TestAccRoute53Record_BatchReads_multipleInZone(t *testing.T) {
 	ctx := acctest.Context(t)
-	t.Setenv("TF_AWS_ROUTE53_RECORD_BATCH_READS", "true")
 	var r1, r2, r3 awstypes.ResourceRecordSet
 	zoneName := acctest.RandomDomain(t)
 
-	acctest.Test(ctx, t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckBatchReads(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.Route53ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckRecordDestroy(ctx, t),
@@ -1996,13 +1996,12 @@ func TestAccRoute53Record_BatchReads_multipleInZone(t *testing.T) {
 
 func TestAccRoute53Record_BatchReads_wildcard(t *testing.T) {
 	ctx := acctest.Context(t)
-	t.Setenv("TF_AWS_ROUTE53_RECORD_BATCH_READS", "true")
 	var v awstypes.ResourceRecordSet
 	resourceName := "aws_route53_record.wildcard"
 	zoneName := acctest.RandomDomain(t)
 
-	acctest.Test(ctx, t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckBatchReads(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.Route53ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckRecordDestroy(ctx, t),
@@ -2036,7 +2035,6 @@ func TestAccRoute53Record_BatchReads_wildcard(t *testing.T) {
 
 func TestAccRoute53Record_BatchReads_outOfBandChangeIgnored(t *testing.T) {
 	ctx := acctest.Context(t)
-	t.Setenv("TF_AWS_ROUTE53_RECORD_BATCH_READS", "true")
 	var v awstypes.ResourceRecordSet
 	var zoneID string
 	resourceName := "aws_route53_record.test"
@@ -2046,8 +2044,8 @@ func TestAccRoute53Record_BatchReads_outOfBandChangeIgnored(t *testing.T) {
 	// enabled. Modifications outsite of terraform will not be detected if
 	// performed after the cache is populated and during the current terraform
 	// run.
-	acctest.Test(ctx, t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckBatchReads(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.Route53ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckRecordDestroy(ctx, t),
@@ -2104,13 +2102,12 @@ func TestAccRoute53Record_BatchReads_outOfBandChangeIgnored(t *testing.T) {
 
 func TestAccRoute53Record_BatchReads_typeChange(t *testing.T) {
 	ctx := acctest.Context(t)
-	t.Setenv("TF_AWS_ROUTE53_RECORD_BATCH_READS", "true")
 	var r1, r2 awstypes.ResourceRecordSet
 	resourceName := "aws_route53_record.test"
 	zoneName := acctest.RandomDomain(t)
 
-	acctest.Test(ctx, t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckBatchReads(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.Route53ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckRecordDestroy(ctx, t),
@@ -2149,15 +2146,14 @@ func TestAccRoute53Record_BatchReads_typeChange(t *testing.T) {
 
 func TestAccRoute53Record_BatchReads_cacheSharing(t *testing.T) {
 	ctx := acctest.Context(t)
-	t.Setenv("TF_AWS_ROUTE53_RECORD_BATCH_READS", "true")
 	zoneName := acctest.RandomDomain(t)
 
 	factories, rec := acctest.ProtoV5ProviderFactoriesWithCallRecorder(ctx, t)
 
 	var cacheWarmMark apicall.Cursor
 
-	acctest.Test(ctx, t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckBatchReads(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.Route53ServiceID),
 		ProtoV5ProviderFactories: factories,
 		CheckDestroy:             testAccCheckRecordDestroy(ctx, t),
@@ -2183,6 +2179,12 @@ func TestAccRoute53Record_BatchReads_cacheSharing(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testAccPreCheckBatchReads(t *testing.T) {
+	if v, _ := strconv.ParseBool(os.Getenv("TF_AWS_ROUTE53_RECORD_BATCH_READS")); !v {
+		t.Skip("Environment variable TF_AWS_ROUTE53_RECORD_BATCH_READS is not set to a true value")
+	}
 }
 
 // testAccErrorCheckSkip skips Route53 tests that have error messages indicating unsupported features
@@ -3895,11 +3897,11 @@ resource "aws_route53_zone" "test" {
 }
 
 resource "aws_route53_record" "test" {
-  zone_id     = aws_route53_zone.test.zone_id
-  name        = %[2]q
-  type        = "A"
-  ttl         = "30"
-  records     = ["127.0.0.1"]
+  zone_id = aws_route53_zone.test.zone_id
+  name    = %[2]q
+  type    = "A"
+  ttl     = "30"
+  records = ["127.0.0.1"]
 }
 `, zoneName, recordName)
 }
@@ -3911,27 +3913,27 @@ resource "aws_route53_zone" "test" {
 }
 
 resource "aws_route53_record" "a" {
-  zone_id     = aws_route53_zone.test.zone_id
-  name        = "a.%[1]s"
-  type        = "A"
-  ttl         = %[2]q
-  records     = ["127.0.0.1"]
+  zone_id = aws_route53_zone.test.zone_id
+  name    = "a.%[1]s"
+  type    = "A"
+  ttl     = %[2]q
+  records = ["127.0.0.1"]
 }
 
 resource "aws_route53_record" "b" {
-  zone_id     = aws_route53_zone.test.zone_id
-  name        = "b.%[1]s"
-  type        = "A"
-  ttl         = "30"
-  records     = ["127.0.0.2"]
+  zone_id = aws_route53_zone.test.zone_id
+  name    = "b.%[1]s"
+  type    = "A"
+  ttl     = "30"
+  records = ["127.0.0.2"]
 }
 
 resource "aws_route53_record" "c" {
-  zone_id     = aws_route53_zone.test.zone_id
-  name        = "c.%[1]s"
-  type        = "A"
-  ttl         = "30"
-  records     = ["127.0.0.3"]
+  zone_id = aws_route53_zone.test.zone_id
+  name    = "c.%[1]s"
+  type    = "A"
+  ttl     = "30"
+  records = ["127.0.0.3"]
 }
 `, zoneName, ttlA)
 }
@@ -3943,11 +3945,11 @@ resource "aws_route53_zone" "test" {
 }
 
 resource "aws_route53_record" "wildcard" {
-  zone_id     = aws_route53_zone.test.zone_id
-  name        = "*.%[1]s"
-  type        = "A"
-  ttl         = "30"
-  records     = ["127.0.0.1"]
+  zone_id = aws_route53_zone.test.zone_id
+  name    = "*.%[1]s"
+  type    = "A"
+  ttl     = "30"
+  records = ["127.0.0.1"]
 }
 `, zoneName)
 }
@@ -3959,11 +3961,11 @@ resource "aws_route53_zone" "test" {
 }
 
 resource "aws_route53_record" "test" {
-  zone_id     = aws_route53_zone.test.zone_id
-  name        = "www.%[1]s"
-  type        = %[2]q
-  ttl         = "30"
-  records     = [%[3]q]
+  zone_id = aws_route53_zone.test.zone_id
+  name    = "www.%[1]s"
+  type    = %[2]q
+  ttl     = "30"
+  records = [%[3]q]
 }
 `, zoneName, rrType, record)
 }

--- a/internal/service/route53/record_test.go
+++ b/internal/service/route53/record_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 
 	"github.com/YakDriver/regexache"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/route53"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/route53/types"
 	"github.com/hashicorp/aws-sdk-go-base/v2/endpoints"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -22,6 +24,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	tfknownvalue "github.com/hashicorp/terraform-provider-aws/internal/acctest/knownvalue"
 	tfstatecheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/statecheck"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns/apicall"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfroute53 "github.com/hashicorp/terraform-provider-aws/internal/service/route53"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -76,7 +79,7 @@ func TestAccRoute53Record_basic(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
 			},
 		},
 	})
@@ -120,10 +123,11 @@ func TestAccRoute53Record_Identity_SetIdentifier(t *testing.T) {
 
 			// Step 2: Import command
 			{
-				ImportStateKind:   resource.ImportCommandWithID,
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ImportStateKind:         resource.ImportCommandWithID,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"batch_reads"},
 			},
 
 			// Step 3: Import block with Import ID
@@ -284,10 +288,10 @@ func TestAccRoute53Record_Disappears_multipleRecords(t *testing.T) {
 				ExpectNonEmptyPlan: true,
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction("aws_route53_record.test.0", plancheck.ResourceActionCreate),
+						plancheck.ExpectResourceAction("aws_route53_record.test[0]", plancheck.ResourceActionCreate),
 					},
 					PostApplyPostRefresh: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction("aws_route53_record.test.0", plancheck.ResourceActionCreate),
+						plancheck.ExpectResourceAction("aws_route53_record.test[0]", plancheck.ResourceActionCreate),
 					},
 				},
 			},
@@ -316,7 +320,7 @@ func TestAccRoute53Record_underscored(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
 			},
 		},
 	})
@@ -343,7 +347,7 @@ func TestAccRoute53Record_fqdn(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
 			},
 
 			// Ensure that changing the name to include a trailing "dot" results in
@@ -385,7 +389,7 @@ func TestAccRoute53Record_trailingPeriodAndZoneID(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
 			},
 		},
 	})
@@ -412,7 +416,7 @@ func TestAccRoute53Record_Support_txt(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite", "zone_id"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "zone_id", "batch_reads"},
 			},
 		},
 	})
@@ -440,7 +444,7 @@ func TestAccRoute53Record_Support_spf(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
 			},
 		},
 	})
@@ -468,7 +472,7 @@ func TestAccRoute53Record_Support_caa(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
 			},
 		},
 	})
@@ -495,7 +499,7 @@ func TestAccRoute53Record_Support_ds(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
 			},
 		},
 	})
@@ -522,7 +526,7 @@ func TestAccRoute53Record_generatesSuffix(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
 			},
 		},
 	})
@@ -558,7 +562,7 @@ func TestAccRoute53Record_wildcard(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
 			},
 
 			// Cause a change, which will trigger a refresh
@@ -603,7 +607,7 @@ func TestAccRoute53Record_failover(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
 			},
 		},
 	})
@@ -632,7 +636,7 @@ func TestAccRoute53Record_Weighted_basic(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
 			},
 		},
 	})
@@ -659,7 +663,7 @@ func TestAccRoute53Record_WeightedToSimple_basic(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
 			},
 			{
 				Config: testAccRecordConfig_simpleRoutingPolicy,
@@ -693,7 +697,7 @@ func TestAccRoute53Record_Alias_elb(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
 			},
 		},
 	})
@@ -721,7 +725,7 @@ func TestAccRoute53Record_Alias_s3(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
 			},
 		},
 	})
@@ -753,7 +757,7 @@ func TestAccRoute53Record_Alias_vpcEndpoint(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
 			},
 		},
 	})
@@ -781,7 +785,7 @@ func TestAccRoute53Record_Alias_uppercase(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
 			},
 		},
 	})
@@ -810,7 +814,7 @@ func TestAccRoute53Record_Weighted_alias(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
 			},
 
 			{
@@ -871,7 +875,7 @@ func TestAccRoute53Record_cidr(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
 			},
 			{
 				Config: testAccRecordConfig_cidr(rName, locationName, zoneName.String(), recordName.String(), "cidr-location-2"),
@@ -921,7 +925,7 @@ func TestAccRoute53Record_Geolocation_basic(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
 			},
 		},
 	})
@@ -950,7 +954,7 @@ func TestAccRoute53Record_Geoproximity_basic(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
 			},
 		},
 	})
@@ -977,7 +981,7 @@ func TestAccRoute53Record_HealthCheckID_setIdentifierChange(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
 			},
 			{
 				Config: testAccRecordConfig_healthCheckIdSetIdentifier("test2"),
@@ -1013,7 +1017,7 @@ func TestAccRoute53Record_HealthCheckID_typeChange(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
 			},
 			{
 				Config: testAccRecordConfig_healthCheckIdTypeA(),
@@ -1051,7 +1055,7 @@ func TestAccRoute53Record_Latency_basic(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
 			},
 		},
 	})
@@ -1084,7 +1088,7 @@ func TestAccRoute53Record_typeChange(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
 			},
 			{
 				Config: testAccRecordConfig_typeChangePost,
@@ -1132,7 +1136,7 @@ func TestAccRoute53Record_nameChange(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
 			},
 			{
 				Config: testAccRecordConfig_nameChangePost,
@@ -1174,7 +1178,7 @@ func TestAccRoute53Record_setIdentifierChangeBasicToWeighted(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
 			},
 
 			// Cause a change, which will trigger a refresh
@@ -1209,7 +1213,7 @@ func TestAccRoute53Record_SetIdentifierRename_geolocationContinent(t *testing.T)
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
 			},
 			{
 				Config: testAccRecordConfig_setIdentifierRenameGeolocationContinent("AN", "after"),
@@ -1242,7 +1246,7 @@ func TestAccRoute53Record_SetIdentifierRename_geolocationCountryDefault(t *testi
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
 			},
 			{
 				Config: testAccRecordConfig_setIdentifierRenameGeolocationCountry("*", "after"),
@@ -1275,7 +1279,7 @@ func TestAccRoute53Record_SetIdentifierRename_geolocationCountrySpecified(t *tes
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
 			},
 			{
 				Config: testAccRecordConfig_setIdentifierRenameGeolocationCountry("US", "after"),
@@ -1308,7 +1312,7 @@ func TestAccRoute53Record_SetIdentifierRename_geolocationCountrySubdivision(t *t
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
 			},
 			{
 				Config: testAccRecordConfig_setIdentifierRenameGeolocationCountrySubdivision("US", "CA", "after"),
@@ -1341,7 +1345,7 @@ func TestAccRoute53Record_SetIdentifierRename_geoproximityRegion(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
 			},
 			{
 				Config: testAccRecordConfig_setIdentifierRenameGeoproximityRegion(endpoints.UsEast1RegionID, "after"),
@@ -1374,7 +1378,7 @@ func TestAccRoute53Record_SetIdentifierRename_geoproximityLocalZoneGroup(t *test
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
 			},
 			{
 				Config: testAccRecordConfig_setIdentifierRenameGeoproximityLocalZoneGroup(fmt.Sprintf("%s-atl-1", endpoints.UsEast1RegionID), "after"),
@@ -1407,7 +1411,7 @@ func TestAccRoute53Record_SetIdentifierRename_geoproximityCoordinates(t *testing
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
 			},
 			{
 				Config: testAccRecordConfig_setIdentifierRenameGeoproximityCoordinates("49.22", "-74.01", "after"),
@@ -1440,7 +1444,7 @@ func TestAccRoute53Record_SetIdentifierRename_failover(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
 			},
 			{
 				Config: testAccRecordConfig_setIdentifierRenameFailover("after"),
@@ -1473,7 +1477,7 @@ func TestAccRoute53Record_SetIdentifierRename_latency(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
 			},
 			{
 				Config: testAccRecordConfig_setIdentifierRenameLatency(endpoints.UsEast1RegionID, "after"),
@@ -1506,7 +1510,7 @@ func TestAccRoute53Record_SetIdentifierRename_multiValueAnswer(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
 			},
 			{
 				Config: testAccRecordConfig_setIdentifierRenameMultiValueAnswer("after"),
@@ -1539,7 +1543,7 @@ func TestAccRoute53Record_SetIdentifierRename_weighted(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
 			},
 			{
 				Config: testAccRecordConfig_setIdentifierRenameWeighted("after"),
@@ -1573,7 +1577,7 @@ func TestAccRoute53Record_Alias_change(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
 			},
 
 			// Cause a change, which will trigger a refresh
@@ -1610,7 +1614,7 @@ func TestAccRoute53Record_Alias_changeDualstack(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
 			},
 			// Cause a change, which will trigger a refresh
 			{
@@ -1645,7 +1649,7 @@ func TestAccRoute53Record_empty(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
 			},
 		},
 	})
@@ -1673,7 +1677,7 @@ func TestAccRoute53Record_longTXTrecord(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
 			},
 		},
 	})
@@ -1701,7 +1705,7 @@ func TestAccRoute53Record_MultiValueAnswer_basic(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
 			},
 		},
 	})
@@ -1741,7 +1745,7 @@ func TestAccRoute53Record_Allow_overwrite(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
 			},
 		},
 	})
@@ -1771,7 +1775,7 @@ func TestAccRoute53Record_ttl0(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
 			},
 			{
 				Config: testAccRecordConfig_ttl(zoneName.String(), strings.ToUpper(recordName.String()), 45),
@@ -1814,7 +1818,7 @@ func TestAccRoute53Record_aliasWildcardName(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
 			},
 		},
 	})
@@ -1840,9 +1844,10 @@ func TestAccRoute53Record_escapedSlash(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"batch_reads"},
 			},
 		},
 	})
@@ -1868,9 +1873,10 @@ func TestAccRoute53Record_escapedSpace(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"batch_reads"},
 			},
 		},
 	})
@@ -1898,9 +1904,278 @@ func TestAccRoute53Record_escapedJustSpace(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"batch_reads"},
+			},
+		},
+	})
+}
+
+func TestAccRoute53Record_BatchReads_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v awstypes.ResourceRecordSet
+	resourceName := "aws_route53_record.test"
+	zoneName := acctest.RandomDomain(t)
+	recordName := zoneName.RandomSubdomain(t)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.Route53ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckRecordDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRecordConfig_batchReads(zoneName.String(), recordName.String()),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckRecordExists(ctx, t, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "batch_reads", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, recordName.String()),
+					resource.TestCheckResourceAttr(resourceName, names.AttrType, "A"),
+					resource.TestCheckResourceAttr(resourceName, "ttl", "30"),
+				),
+				// Verify no phantom diff after the initial creation read-back.
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
+			},
+		},
+	})
+}
+
+func TestAccRoute53Record_BatchReads_multipleInZone(t *testing.T) {
+	ctx := acctest.Context(t)
+	var r1, r2, r3 awstypes.ResourceRecordSet
+	zoneName := acctest.RandomDomain(t)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.Route53ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckRecordDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			// All three records must be found via a single zone scan.
+			{
+				Config: testAccRecordConfig_batchReadsMultiple(zoneName.String(), "30"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRecordExists(ctx, t, "aws_route53_record.a", &r1),
+					testAccCheckRecordExists(ctx, t, "aws_route53_record.b", &r2),
+					testAccCheckRecordExists(ctx, t, "aws_route53_record.c", &r3),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			// Update one record's TTL — only that resource should show a change; the
+			// other two must produce no diff, confirming stale cache entries are not
+			// returned after a write.
+			{
+				Config: testAccRecordConfig_batchReadsMultiple(zoneName.String(), "60"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("aws_route53_record.a", plancheck.ResourceActionUpdate),
+						plancheck.ExpectResourceAction("aws_route53_record.b", plancheck.ResourceActionNoop),
+						plancheck.ExpectResourceAction("aws_route53_record.c", plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccRoute53Record_BatchReads_wildcard(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v awstypes.ResourceRecordSet
+	resourceName := "aws_route53_record.wildcard"
+	zoneName := acctest.RandomDomain(t)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.Route53ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckRecordDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			// The API returns "\052.zone." for wildcard names; verify the cache key
+			// normalization resolves that back to "*" so the record is found.
+			{
+				Config: testAccRecordConfig_batchReadsWildcard(zoneName.String()),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRecordExists(ctx, t, resourceName, &v),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrName), knownvalue.StringExact("*."+zoneName.String())),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("fqdn"), knownvalue.StringExact("*."+zoneName.String())),
+				},
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
+			},
+		},
+	})
+}
+
+func TestAccRoute53Record_BatchReads_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v awstypes.ResourceRecordSet
+	var zoneID string
+	resourceName := "aws_route53_record.test"
+	zoneName := acctest.RandomDomain(t)
+	recordName := zoneName.RandomSubdomain(t)
+	// This test is to validate the documented lmitations once batching is
+	// enabled. Modifications outsite of terraform will not be detected if
+	// performed after the cache is populated and during the current terraform
+	// run.
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.Route53ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckRecordDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			// Step 1: apply the record, populating the zone cache. Capture the
+			// record set and zone ID so Step 2 can delete them directly.
+			{
+				Config: testAccRecordConfig_batchReads(zoneName.String(), recordName.String()),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRecordExists(ctx, t, resourceName, &v),
+					func(s *terraform.State) error {
+						rs := s.RootModule().Resources["aws_route53_zone.test"]
+						zoneID = tfroute53.CleanZoneID(rs.Primary.ID)
+						return nil
+					},
+				),
+			},
+			// Step 2: delete the record directly via the AWS API, bypassing
+			// resourceRecordDelete so the zone cache is NOT invalidated. Because
+			// the cache still holds the stale entry, the refresh reads it as
+			// present and the plan is empty — Terraform does not detect the
+			// out-of-band drift. This is a known limitation of batch_reads:
+			// changes made outside Terraform are invisible until the cache is
+			// cleared (e.g. by a provider restart).
+			{
+				PreConfig: func() {
+					conn := acctest.ProviderMeta(ctx, t).Route53Client(ctx)
+					_, err := conn.ChangeResourceRecordSets(ctx, &route53.ChangeResourceRecordSetsInput{
+						HostedZoneId: aws.String(zoneID),
+						ChangeBatch: &awstypes.ChangeBatch{
+							Changes: []awstypes.Change{
+								{
+									Action:            awstypes.ChangeActionDelete,
+									ResourceRecordSet: &v,
+								},
+							},
+						},
+					})
+					if err != nil {
+						t.Fatalf("deleting Route 53 record outside Terraform: %s", err)
+					}
+				},
+				Config:   testAccRecordConfig_batchReads(zoneName.String(), recordName.String()),
+				PlanOnly: true,
+				// Stale cache: the out-of-band deletion is not detected.
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+func TestAccRoute53Record_BatchReads_typeChange(t *testing.T) {
+	ctx := acctest.Context(t)
+	var r1, r2 awstypes.ResourceRecordSet
+	resourceName := "aws_route53_record.test"
+	zoneName := acctest.RandomDomain(t)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.Route53ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckRecordDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRecordConfig_batchReadsTypeChange(zoneName.String(), "CNAME", "www.terraform.io"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRecordExists(ctx, t, resourceName, &r1),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrType), knownvalue.StringExact("CNAME")),
+				},
+			},
+			// Changing the type takes the delete+create code path and evicts the old
+			// cache key. Verify the new record is readable without a phantom diff.
+			{
+				Config: testAccRecordConfig_batchReadsTypeChange(zoneName.String(), "A", "127.0.0.1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRecordExists(ctx, t, resourceName, &r2),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrType), knownvalue.StringExact("A")),
+				},
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionReplace),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccRoute53Record_BatchReads_cacheSharing(t *testing.T) {
+	ctx := acctest.Context(t)
+	zoneName := acctest.RandomDomain(t)
+
+	factories, rec := acctest.ProtoV5ProviderFactoriesWithCallRecorder(ctx, t)
+
+	var cacheWarmMark apicall.Cursor
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.Route53ServiceID),
+		ProtoV5ProviderFactories: factories,
+		CheckDestroy:             testAccCheckRecordDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			// Step 1: apply 3 batched records in the same zone, warming the zone cache.
+			{
+				Config: testAccRecordConfig_batchReadsMultiple(zoneName.String(), "30"),
+			},
+			// Step 2: re-plan the identical config. Terraform refreshes all 3 records;
+			// every read should be served from the in-process zone cache so no
+			// ListResourceRecordSets call should reach the AWS API.
+			{
+				PreConfig: func() { cacheWarmMark = rec.Mark() },
+				Config:    testAccRecordConfig_batchReadsMultiple(zoneName.String(), "30"),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckAPICallNotMade(rec, &cacheWarmMark, "Route 53", "ListResourceRecordSets"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 		},
 	})
@@ -3607,4 +3882,90 @@ resource "aws_route53_record" "test" {
   }
 }
 `, rName, zoneName))
+}
+
+func testAccRecordConfig_batchReads(zoneName, recordName string) string {
+	return fmt.Sprintf(`
+resource "aws_route53_zone" "test" {
+  name = %[1]q
+}
+
+resource "aws_route53_record" "test" {
+  zone_id          = aws_route53_zone.test.zone_id
+  name             = %[2]q
+  type             = "A"
+  ttl              = "30"
+  records          = ["127.0.0.1"]
+  batch_reads = true
+}
+`, zoneName, recordName)
+}
+
+func testAccRecordConfig_batchReadsMultiple(zoneName, ttlA string) string {
+	return fmt.Sprintf(`
+resource "aws_route53_zone" "test" {
+  name = %[1]q
+}
+
+resource "aws_route53_record" "a" {
+  zone_id          = aws_route53_zone.test.zone_id
+  name             = "a.%[1]s"
+  type             = "A"
+  ttl              = %[2]q
+  records          = ["127.0.0.1"]
+  batch_reads = true
+}
+
+resource "aws_route53_record" "b" {
+  zone_id          = aws_route53_zone.test.zone_id
+  name             = "b.%[1]s"
+  type             = "A"
+  ttl              = "30"
+  records          = ["127.0.0.2"]
+  batch_reads = true
+}
+
+resource "aws_route53_record" "c" {
+  zone_id          = aws_route53_zone.test.zone_id
+  name             = "c.%[1]s"
+  type             = "A"
+  ttl              = "30"
+  records          = ["127.0.0.3"]
+  batch_reads = true
+}
+`, zoneName, ttlA)
+}
+
+func testAccRecordConfig_batchReadsWildcard(zoneName string) string {
+	return fmt.Sprintf(`
+resource "aws_route53_zone" "test" {
+  name = %[1]q
+}
+
+resource "aws_route53_record" "wildcard" {
+  zone_id          = aws_route53_zone.test.zone_id
+  name             = "*.%[1]s"
+  type             = "A"
+  ttl              = "30"
+  records          = ["127.0.0.1"]
+  batch_reads = true
+}
+`, zoneName)
+}
+
+func testAccRecordConfig_batchReadsTypeChange(zoneName, rrType, record string) string {
+	return fmt.Sprintf(`
+resource "aws_route53_zone" "test" {
+  name = %[1]q
+}
+
+resource "aws_route53_record" "test" {
+  zone_id          = aws_route53_zone.test.zone_id
+  name             = "www.%[1]s"
+  type             = %[2]q
+  ttl              = "30"
+  records          = [%[3]q]
+  batch_reads = true
+}
+`, zoneName, rrType, record)
 }

--- a/internal/service/route53/record_test.go
+++ b/internal/service/route53/record_test.go
@@ -79,7 +79,7 @@ func TestAccRoute53Record_basic(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite"},
 			},
 		},
 	})
@@ -123,11 +123,10 @@ func TestAccRoute53Record_Identity_SetIdentifier(t *testing.T) {
 
 			// Step 2: Import command
 			{
-				ImportStateKind:         resource.ImportCommandWithID,
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"batch_reads"},
+				ImportStateKind:   resource.ImportCommandWithID,
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 
 			// Step 3: Import block with Import ID
@@ -320,7 +319,7 @@ func TestAccRoute53Record_underscored(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite"},
 			},
 		},
 	})
@@ -347,7 +346,7 @@ func TestAccRoute53Record_fqdn(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite"},
 			},
 
 			// Ensure that changing the name to include a trailing "dot" results in
@@ -389,7 +388,7 @@ func TestAccRoute53Record_trailingPeriodAndZoneID(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite"},
 			},
 		},
 	})
@@ -416,7 +415,7 @@ func TestAccRoute53Record_Support_txt(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite", "zone_id", "batch_reads"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "zone_id"},
 			},
 		},
 	})
@@ -444,7 +443,7 @@ func TestAccRoute53Record_Support_spf(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite"},
 			},
 		},
 	})
@@ -472,7 +471,7 @@ func TestAccRoute53Record_Support_caa(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite"},
 			},
 		},
 	})
@@ -499,7 +498,7 @@ func TestAccRoute53Record_Support_ds(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite"},
 			},
 		},
 	})
@@ -526,7 +525,7 @@ func TestAccRoute53Record_generatesSuffix(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite"},
 			},
 		},
 	})
@@ -562,7 +561,7 @@ func TestAccRoute53Record_wildcard(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite"},
 			},
 
 			// Cause a change, which will trigger a refresh
@@ -607,7 +606,7 @@ func TestAccRoute53Record_failover(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite"},
 			},
 		},
 	})
@@ -636,7 +635,7 @@ func TestAccRoute53Record_Weighted_basic(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite"},
 			},
 		},
 	})
@@ -663,7 +662,7 @@ func TestAccRoute53Record_WeightedToSimple_basic(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite"},
 			},
 			{
 				Config: testAccRecordConfig_simpleRoutingPolicy,
@@ -697,7 +696,7 @@ func TestAccRoute53Record_Alias_elb(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite"},
 			},
 		},
 	})
@@ -725,7 +724,7 @@ func TestAccRoute53Record_Alias_s3(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite"},
 			},
 		},
 	})
@@ -757,7 +756,7 @@ func TestAccRoute53Record_Alias_vpcEndpoint(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite"},
 			},
 		},
 	})
@@ -785,7 +784,7 @@ func TestAccRoute53Record_Alias_uppercase(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite"},
 			},
 		},
 	})
@@ -814,7 +813,7 @@ func TestAccRoute53Record_Weighted_alias(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite"},
 			},
 
 			{
@@ -875,7 +874,7 @@ func TestAccRoute53Record_cidr(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite"},
 			},
 			{
 				Config: testAccRecordConfig_cidr(rName, locationName, zoneName.String(), recordName.String(), "cidr-location-2"),
@@ -925,7 +924,7 @@ func TestAccRoute53Record_Geolocation_basic(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite"},
 			},
 		},
 	})
@@ -954,7 +953,7 @@ func TestAccRoute53Record_Geoproximity_basic(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite"},
 			},
 		},
 	})
@@ -981,7 +980,7 @@ func TestAccRoute53Record_HealthCheckID_setIdentifierChange(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite"},
 			},
 			{
 				Config: testAccRecordConfig_healthCheckIdSetIdentifier("test2"),
@@ -1017,7 +1016,7 @@ func TestAccRoute53Record_HealthCheckID_typeChange(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite"},
 			},
 			{
 				Config: testAccRecordConfig_healthCheckIdTypeA(),
@@ -1055,7 +1054,7 @@ func TestAccRoute53Record_Latency_basic(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite"},
 			},
 		},
 	})
@@ -1088,7 +1087,7 @@ func TestAccRoute53Record_typeChange(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite"},
 			},
 			{
 				Config: testAccRecordConfig_typeChangePost,
@@ -1136,7 +1135,7 @@ func TestAccRoute53Record_nameChange(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite"},
 			},
 			{
 				Config: testAccRecordConfig_nameChangePost,
@@ -1178,7 +1177,7 @@ func TestAccRoute53Record_setIdentifierChangeBasicToWeighted(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite"},
 			},
 
 			// Cause a change, which will trigger a refresh
@@ -1213,7 +1212,7 @@ func TestAccRoute53Record_SetIdentifierRename_geolocationContinent(t *testing.T)
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite"},
 			},
 			{
 				Config: testAccRecordConfig_setIdentifierRenameGeolocationContinent("AN", "after"),
@@ -1246,7 +1245,7 @@ func TestAccRoute53Record_SetIdentifierRename_geolocationCountryDefault(t *testi
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite"},
 			},
 			{
 				Config: testAccRecordConfig_setIdentifierRenameGeolocationCountry("*", "after"),
@@ -1279,7 +1278,7 @@ func TestAccRoute53Record_SetIdentifierRename_geolocationCountrySpecified(t *tes
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite"},
 			},
 			{
 				Config: testAccRecordConfig_setIdentifierRenameGeolocationCountry("US", "after"),
@@ -1312,7 +1311,7 @@ func TestAccRoute53Record_SetIdentifierRename_geolocationCountrySubdivision(t *t
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite"},
 			},
 			{
 				Config: testAccRecordConfig_setIdentifierRenameGeolocationCountrySubdivision("US", "CA", "after"),
@@ -1345,7 +1344,7 @@ func TestAccRoute53Record_SetIdentifierRename_geoproximityRegion(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite"},
 			},
 			{
 				Config: testAccRecordConfig_setIdentifierRenameGeoproximityRegion(endpoints.UsEast1RegionID, "after"),
@@ -1378,7 +1377,7 @@ func TestAccRoute53Record_SetIdentifierRename_geoproximityLocalZoneGroup(t *test
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite"},
 			},
 			{
 				Config: testAccRecordConfig_setIdentifierRenameGeoproximityLocalZoneGroup(fmt.Sprintf("%s-atl-1", endpoints.UsEast1RegionID), "after"),
@@ -1411,7 +1410,7 @@ func TestAccRoute53Record_SetIdentifierRename_geoproximityCoordinates(t *testing
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite"},
 			},
 			{
 				Config: testAccRecordConfig_setIdentifierRenameGeoproximityCoordinates("49.22", "-74.01", "after"),
@@ -1444,7 +1443,7 @@ func TestAccRoute53Record_SetIdentifierRename_failover(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite"},
 			},
 			{
 				Config: testAccRecordConfig_setIdentifierRenameFailover("after"),
@@ -1477,7 +1476,7 @@ func TestAccRoute53Record_SetIdentifierRename_latency(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite"},
 			},
 			{
 				Config: testAccRecordConfig_setIdentifierRenameLatency(endpoints.UsEast1RegionID, "after"),
@@ -1510,7 +1509,7 @@ func TestAccRoute53Record_SetIdentifierRename_multiValueAnswer(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite"},
 			},
 			{
 				Config: testAccRecordConfig_setIdentifierRenameMultiValueAnswer("after"),
@@ -1543,7 +1542,7 @@ func TestAccRoute53Record_SetIdentifierRename_weighted(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite"},
 			},
 			{
 				Config: testAccRecordConfig_setIdentifierRenameWeighted("after"),
@@ -1577,7 +1576,7 @@ func TestAccRoute53Record_Alias_change(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite"},
 			},
 
 			// Cause a change, which will trigger a refresh
@@ -1614,7 +1613,7 @@ func TestAccRoute53Record_Alias_changeDualstack(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite"},
 			},
 			// Cause a change, which will trigger a refresh
 			{
@@ -1649,7 +1648,7 @@ func TestAccRoute53Record_empty(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite"},
 			},
 		},
 	})
@@ -1677,7 +1676,7 @@ func TestAccRoute53Record_longTXTrecord(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite"},
 			},
 		},
 	})
@@ -1705,7 +1704,7 @@ func TestAccRoute53Record_MultiValueAnswer_basic(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite"},
 			},
 		},
 	})
@@ -1745,7 +1744,7 @@ func TestAccRoute53Record_Allow_overwrite(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite"},
 			},
 		},
 	})
@@ -1775,7 +1774,7 @@ func TestAccRoute53Record_ttl0(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite"},
 			},
 			{
 				Config: testAccRecordConfig_ttl(zoneName.String(), strings.ToUpper(recordName.String()), 45),
@@ -1818,7 +1817,7 @@ func TestAccRoute53Record_aliasWildcardName(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite"},
 			},
 		},
 	})
@@ -1844,10 +1843,9 @@ func TestAccRoute53Record_escapedSlash(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"batch_reads"},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -1873,10 +1871,9 @@ func TestAccRoute53Record_escapedSpace(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"batch_reads"},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -1904,10 +1901,9 @@ func TestAccRoute53Record_escapedJustSpace(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"batch_reads"},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -1915,12 +1911,13 @@ func TestAccRoute53Record_escapedJustSpace(t *testing.T) {
 
 func TestAccRoute53Record_BatchReads_basic(t *testing.T) {
 	ctx := acctest.Context(t)
+	t.Setenv("TF_AWS_ROUTE53_RECORD_BATCH_READS", "true")
 	var v awstypes.ResourceRecordSet
 	resourceName := "aws_route53_record.test"
 	zoneName := acctest.RandomDomain(t)
 	recordName := zoneName.RandomSubdomain(t)
 
-	acctest.ParallelTest(ctx, t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.Route53ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1930,7 +1927,6 @@ func TestAccRoute53Record_BatchReads_basic(t *testing.T) {
 				Config: testAccRecordConfig_batchReads(zoneName.String(), recordName.String()),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckRecordExists(ctx, t, resourceName, &v),
-					resource.TestCheckResourceAttr(resourceName, "batch_reads", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, recordName.String()),
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, "A"),
 					resource.TestCheckResourceAttr(resourceName, "ttl", "30"),
@@ -1946,7 +1942,7 @@ func TestAccRoute53Record_BatchReads_basic(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite"},
 			},
 		},
 	})
@@ -1954,10 +1950,11 @@ func TestAccRoute53Record_BatchReads_basic(t *testing.T) {
 
 func TestAccRoute53Record_BatchReads_multipleInZone(t *testing.T) {
 	ctx := acctest.Context(t)
+	t.Setenv("TF_AWS_ROUTE53_RECORD_BATCH_READS", "true")
 	var r1, r2, r3 awstypes.ResourceRecordSet
 	zoneName := acctest.RandomDomain(t)
 
-	acctest.ParallelTest(ctx, t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.Route53ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1999,11 +1996,12 @@ func TestAccRoute53Record_BatchReads_multipleInZone(t *testing.T) {
 
 func TestAccRoute53Record_BatchReads_wildcard(t *testing.T) {
 	ctx := acctest.Context(t)
+	t.Setenv("TF_AWS_ROUTE53_RECORD_BATCH_READS", "true")
 	var v awstypes.ResourceRecordSet
 	resourceName := "aws_route53_record.wildcard"
 	zoneName := acctest.RandomDomain(t)
 
-	acctest.ParallelTest(ctx, t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.Route53ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -2030,7 +2028,7 @@ func TestAccRoute53Record_BatchReads_wildcard(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite", "batch_reads"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite"},
 			},
 		},
 	})
@@ -2038,6 +2036,7 @@ func TestAccRoute53Record_BatchReads_wildcard(t *testing.T) {
 
 func TestAccRoute53Record_BatchReads_outOfBandChangeIgnored(t *testing.T) {
 	ctx := acctest.Context(t)
+	t.Setenv("TF_AWS_ROUTE53_RECORD_BATCH_READS", "true")
 	var v awstypes.ResourceRecordSet
 	var zoneID string
 	resourceName := "aws_route53_record.test"
@@ -2047,7 +2046,7 @@ func TestAccRoute53Record_BatchReads_outOfBandChangeIgnored(t *testing.T) {
 	// enabled. Modifications outsite of terraform will not be detected if
 	// performed after the cache is populated and during the current terraform
 	// run.
-	acctest.ParallelTest(ctx, t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.Route53ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -2070,7 +2069,7 @@ func TestAccRoute53Record_BatchReads_outOfBandChangeIgnored(t *testing.T) {
 			// resourceRecordDelete so the zone cache is NOT invalidated. Because
 			// the cache still holds the stale entry, the refresh reads it as
 			// present and the plan is empty — Terraform does not detect the
-			// out-of-band drift. This is a known limitation of batch_reads:
+			// out-of-band drift. This is a known limitation of batched reads:
 			// changes made outside Terraform are invisible until the cache is
 			// cleared (e.g. by a provider restart).
 			{
@@ -2105,11 +2104,12 @@ func TestAccRoute53Record_BatchReads_outOfBandChangeIgnored(t *testing.T) {
 
 func TestAccRoute53Record_BatchReads_typeChange(t *testing.T) {
 	ctx := acctest.Context(t)
+	t.Setenv("TF_AWS_ROUTE53_RECORD_BATCH_READS", "true")
 	var r1, r2 awstypes.ResourceRecordSet
 	resourceName := "aws_route53_record.test"
 	zoneName := acctest.RandomDomain(t)
 
-	acctest.ParallelTest(ctx, t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.Route53ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -2149,13 +2149,14 @@ func TestAccRoute53Record_BatchReads_typeChange(t *testing.T) {
 
 func TestAccRoute53Record_BatchReads_cacheSharing(t *testing.T) {
 	ctx := acctest.Context(t)
+	t.Setenv("TF_AWS_ROUTE53_RECORD_BATCH_READS", "true")
 	zoneName := acctest.RandomDomain(t)
 
 	factories, rec := acctest.ProtoV5ProviderFactoriesWithCallRecorder(ctx, t)
 
 	var cacheWarmMark apicall.Cursor
 
-	acctest.ParallelTest(ctx, t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.Route53ServiceID),
 		ProtoV5ProviderFactories: factories,
@@ -3899,7 +3900,6 @@ resource "aws_route53_record" "test" {
   type        = "A"
   ttl         = "30"
   records     = ["127.0.0.1"]
-  batch_reads = true
 }
 `, zoneName, recordName)
 }
@@ -3916,7 +3916,6 @@ resource "aws_route53_record" "a" {
   type        = "A"
   ttl         = %[2]q
   records     = ["127.0.0.1"]
-  batch_reads = true
 }
 
 resource "aws_route53_record" "b" {
@@ -3925,7 +3924,6 @@ resource "aws_route53_record" "b" {
   type        = "A"
   ttl         = "30"
   records     = ["127.0.0.2"]
-  batch_reads = true
 }
 
 resource "aws_route53_record" "c" {
@@ -3934,7 +3932,6 @@ resource "aws_route53_record" "c" {
   type        = "A"
   ttl         = "30"
   records     = ["127.0.0.3"]
-  batch_reads = true
 }
 `, zoneName, ttlA)
 }
@@ -3951,7 +3948,6 @@ resource "aws_route53_record" "wildcard" {
   type        = "A"
   ttl         = "30"
   records     = ["127.0.0.1"]
-  batch_reads = true
 }
 `, zoneName)
 }
@@ -3968,7 +3964,6 @@ resource "aws_route53_record" "test" {
   type        = %[2]q
   ttl         = "30"
   records     = [%[3]q]
-  batch_reads = true
 }
 `, zoneName, rrType, record)
 }

--- a/website/docs/r/route53_record.html.markdown
+++ b/website/docs/r/route53_record.html.markdown
@@ -162,44 +162,13 @@ resource "aws_route53_record" "example" {
 
 AWS Route 53 enforces a [5 requests-per-second rate limit](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/DNSLimitations.html#limits-api-requests) on all AWS Route 53 APIs for an AWS account. Plans that manage many records in the same AWS account trigger throttling and cause slow plan and apply times because each record issues its own API calls during read/write operations.
 
-Setting `batch_reads = true` on all records in a zone causes the provider to fetch the entire zone and its records once and cache the results in memory for the duration of the plan or apply, regardless of how many records are managed.
+Setting the `TF_AWS_ROUTE53_RECORD_BATCH_READS` environment variable to `true` causes the provider to fetch all records for hosted zones referrenced by `aws_route53_records` once and cache the results in memory for the duration of the plan or apply, regardless of how many records are managed. No per-resource configuration is required.
 
-```terraform
-resource "aws_route53_zone" "example" {
-  name = "example.com"
-}
-
-resource "aws_route53_record" "a" {
-  zone_id     = aws_route53_zone.example.zone_id
-  name        = "a.example.com"
-  type        = "A"
-  ttl         = 300
-  records     = ["10.0.0.1"]
-  batch_reads = true
-}
-
-resource "aws_route53_record" "b" {
-  zone_id     = aws_route53_zone.example.zone_id
-  name        = "b.example.com"
-  type        = "A"
-  ttl         = 300
-  records     = ["10.0.0.2"]
-  batch_reads = true
-}
-
-resource "aws_route53_record" "c" {
-  zone_id     = aws_route53_zone.example.zone_id
-  name        = "c.example.com"
-  type        = "A"
-  ttl         = 300
-  records     = ["10.0.0.3"]
-  batch_reads = true
-}
+```console
+% TF_AWS_ROUTE53_RECORD_BATCH_READS=true terraform plan
 ```
 
-~> **Note:** All records in a zone must set `batch_reads = true` to share the zone-level cache. Records that leave the argument at its default of `false` continue to issue individual API calls and do not benefit from the cache.
-
-~> **Warning:** When `batch_reads = true`, the provider caches the full zone state at the start of the run and serves all subsequent reads from that cache.  The caching layer ensures removal of cache for any records that are updated during terarform apply operations; however, any changes made to records outside of Terraform (e.g. via the AWS Console or CLI) after the cache is populated will not be detected for the duration of that plan or apply. To pick up out-of-band changes, run `terraform refresh` or a new `terraform plan` to start with a fresh cache.
+~> **Warning:** When `TF_AWS_ROUTE53_RECORD_BATCH_READS` is set, the provider caches the full zone state at the start of the run and serves all subsequent reads from that cache. The caching layer ensures removal of cache entries for any records that are updated during Terraform apply operations; however, any changes made to records outside of Terraform (e.g. via the AWS Console or CLI) after the cache is populated will not be detected for the duration of that plan or apply. To pick up out-of-band changes, run `terraform refresh` or a new `terraform plan` to start with a fresh cache.
 
 ## Argument Reference
 
@@ -222,7 +191,6 @@ This resource supports the following arguments:
 * `multivalue_answer_routing_policy` - (Optional) Set to `true` to indicate a multivalue answer routing policy. Conflicts with any other routing policy.
 * `weighted_routing_policy` - (Optional) A block indicating a weighted routing policy. Conflicts with any other routing policy. [Documented below](#weighted-routing-policy).
 * `allow_overwrite` - (Optional) Allow creation of this record in Terraform to overwrite an existing record, if any. This does not affect the ability to update the record in Terraform and does not prevent other resources within Terraform or manual Route 53 changes outside Terraform from overwriting this record. `false` by default. This configuration is not recommended for most environments.
-* `batch_reads` - (Optional) When `true`, the provider fetches all records for the hosted zone using batched API calls and caches the results in memory for the duration of the plan or apply. Subsequent reads for other `aws_route53_records` with `batch_reads` in the same zone are served from the cache without additional API calls, reducing throttling triggered by the AWS Route53 API. Defaults to `false`. See [Batched reads for zones with many records](#batched-reads-for-zones-with-many-records) for usage guidance. This argument is not stored in the AWS API and must be re-specified after [`import`](#import).
 
 Exactly one of `records` or `alias` must be specified: this determines whether it's an alias record.
 
@@ -292,8 +260,6 @@ This resource exports the following attributes in addition to the arguments abov
 * `delete` - (Default `30m`)
 
 ## Import
-
-~> **Note:** `batch_reads` has no representation in the AWS API and not populated during import. Set it explicitly in the resource configuration after importing if you want batched reads.
 
 In Terraform v1.12.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `identity` attribute. For example:
 

--- a/website/docs/r/route53_record.html.markdown
+++ b/website/docs/r/route53_record.html.markdown
@@ -158,6 +158,49 @@ resource "aws_route53_record" "example" {
 }
 ```
 
+### Batched reads for zones with many records
+
+AWS Route 53 enforces a [5 requests-per-second rate limit](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/DNSLimitations.html#limits-api-requests) on all AWS Route 53 APIs for an AWS account. Plans that manage many records in the same AWS account trigger throttling and cause slow plan and apply times because each record issues its own API calls during read/write operations.
+
+Setting `batch_reads = true` on all records in a zone causes the provider to fetch the entire zone and its records once and cache the results in memory for the duration of the plan or apply, regardless of how many records are managed.
+
+```terraform
+resource "aws_route53_zone" "example" {
+  name = "example.com"
+}
+
+resource "aws_route53_record" "a" {
+  zone_id          = aws_route53_zone.example.zone_id
+  name             = "a.example.com"
+  type             = "A"
+  ttl              = 300
+  records          = ["10.0.0.1"]
+  batch_reads = true
+}
+
+resource "aws_route53_record" "b" {
+  zone_id          = aws_route53_zone.example.zone_id
+  name             = "b.example.com"
+  type             = "A"
+  ttl              = 300
+  records          = ["10.0.0.2"]
+  batch_reads = true
+}
+
+resource "aws_route53_record" "c" {
+  zone_id          = aws_route53_zone.example.zone_id
+  name             = "c.example.com"
+  type             = "A"
+  ttl              = 300
+  records          = ["10.0.0.3"]
+  batch_reads = true
+}
+```
+
+~> **Note:** All records in a zone must set `batch_reads = true` to share the zone-level cache. Records that leave the argument at its default of `false` continue to issue individual API calls and do not benefit from the cache.
+
+~> **Warning:** When `batch_reads = true`, the provider caches the full zone state at the start of the run and serves all subsequent reads from that cache.  The caching layer ensures removal of cache for any records that are updated during terarform apply operations; however, any changes made to records outside of Terraform (e.g. via the AWS Console or CLI) after the cache is populated will not be detected for the duration of that plan or apply. To pick up out-of-band changes, run `terraform refresh` or a new `terraform plan` to start with a fresh cache.
+
 ## Argument Reference
 
 This resource supports the following arguments:
@@ -179,6 +222,7 @@ This resource supports the following arguments:
 * `multivalue_answer_routing_policy` - (Optional) Set to `true` to indicate a multivalue answer routing policy. Conflicts with any other routing policy.
 * `weighted_routing_policy` - (Optional) A block indicating a weighted routing policy. Conflicts with any other routing policy. [Documented below](#weighted-routing-policy).
 * `allow_overwrite` - (Optional) Allow creation of this record in Terraform to overwrite an existing record, if any. This does not affect the ability to update the record in Terraform and does not prevent other resources within Terraform or manual Route 53 changes outside Terraform from overwriting this record. `false` by default. This configuration is not recommended for most environments.
+* `batch_reads` - (Optional) When `true`, the provider fetches all records for the hosted zone using batched API calls and caches the results in memory for the duration of the plan or apply. Subsequent reads for other `aws_route53_records` with `batch_reads` in the same zone are served from the cache without additional API calls, reducing throttling triggered by the AWS Route53 API. Defaults to `false`. See [Batched reads for zones with many records](#batched-reads-for-zones-with-many-records) for usage guidance. This argument is not stored in the AWS API and must be re-specified after [`import`](#import).
 
 Exactly one of `records` or `alias` must be specified: this determines whether it's an alias record.
 
@@ -248,6 +292,8 @@ This resource exports the following attributes in addition to the arguments abov
 * `delete` - (Default `30m`)
 
 ## Import
+
+~> **Note:** `batch_reads` has no representation in the AWS API and not populated during import. Set it explicitly in the resource configuration after importing if you want batched reads.
 
 In Terraform v1.12.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `identity` attribute. For example:
 

--- a/website/docs/r/route53_record.html.markdown
+++ b/website/docs/r/route53_record.html.markdown
@@ -170,29 +170,29 @@ resource "aws_route53_zone" "example" {
 }
 
 resource "aws_route53_record" "a" {
-  zone_id          = aws_route53_zone.example.zone_id
-  name             = "a.example.com"
-  type             = "A"
-  ttl              = 300
-  records          = ["10.0.0.1"]
+  zone_id     = aws_route53_zone.example.zone_id
+  name        = "a.example.com"
+  type        = "A"
+  ttl         = 300
+  records     = ["10.0.0.1"]
   batch_reads = true
 }
 
 resource "aws_route53_record" "b" {
-  zone_id          = aws_route53_zone.example.zone_id
-  name             = "b.example.com"
-  type             = "A"
-  ttl              = 300
-  records          = ["10.0.0.2"]
+  zone_id     = aws_route53_zone.example.zone_id
+  name        = "b.example.com"
+  type        = "A"
+  ttl         = 300
+  records     = ["10.0.0.2"]
   batch_reads = true
 }
 
 resource "aws_route53_record" "c" {
-  zone_id          = aws_route53_zone.example.zone_id
-  name             = "c.example.com"
-  type             = "A"
-  ttl              = 300
-  records          = ["10.0.0.3"]
+  zone_id     = aws_route53_zone.example.zone_id
+  name        = "c.example.com"
+  type        = "A"
+  ttl         = 300
+  records     = ["10.0.0.3"]
   batch_reads = true
 }
 ```


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

none

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

 AWS Route 53 enforces a 5 req/s rate limit on AWS Route53 APIs for an AWS Account. Plans managing many `aws_route53_record` resources in the same AWS account trigger throttling and slow plan/apply because each `aws_route53_recod` issues its own API calls.

This PR adds an opt-in `TF_AWS_ROUTE53_RECORD_BATCH_READS` environment variable to. When containing a `true` value, the provider fetches all records for a route53 zone of defined `aws_route53_record`s once and caches the results in memory for the life
  of the plan or apply. All further records in the zone are served from that cache, significantly lowering the number of API calls during read operations.

This pull request only solves the API inefficiencies of the `aws_route53_records` for read operations. It will have a significant affect on terraform plans; however, write operations will invalidate the cache of the record and perform a read API operation just as it did before to validate the changes. 

I originally looked into batching all route 53 records, but ran into the following issues when attempting to batch update/delete operations. Terraform resources do not share information with each other in any way, this means there is no way to know:

1. How many `aws_route53_record` resources are defined. 
2. How many will be updated/deleted during the apply operation?

These prevent batching of update/delete operations. 

## Notes

This PR was developed with AI assistance (Claude) used for boilerplate generation, test scaffolding, and as a paired programmer for ensuring code matches existing patterns within the provider. All code has been reviewed and validated by the author.

## Limitations

 1. In-process only — cache is cold at the start of every terraform plan or terraform apply. For terraform apply (no saved plan), the plan refresh warms the cache for the apply phase.
 2. Opt-in environment variable— TF_AWS_ROUTE53_RECORD_BATCH_READS environment variable must be set to leverage the batched reads for all defined records. 
3. No TTL — out-of-band changes made after the cache is warmed won't be reflected until the next provider process.

Relevant limitations have been added to the resource documentation. 

## Opt-In Approach

This PR uses an Opt-In approach where users must concisely decide to use the batched reads and caching layer. This involves specifying the `TF_AWS_ROUTE53_RECORD_BATCH_READS` environment variable with a `true` value.

This could be rolled out initially as Opt-In and eventually be switched to the default behavior at some point when/if the provider team decides to do so. 



### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #3230

This issue only solves half of the problem described in this work item. It solves batching the read operations during a plan operation. All writes remain individual API calls. From my experience most of the pains are how long it takes on every terraform plan when most remain unchanged. DNS records are usually read many times, but updated infrequently. 


### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

Test output with `TF_AWS_ROUTE53_RECORD_BATCH_READS` set to true.
All tests pass, the 403 error on the last test is because my SSO session credentials expired. 

```console
❯ terraform-provider-aws (f-route53-batch) ✔ export TF_AWS_ROUTE53_RECORD_BATCH_READS=true
❯ terraform-provider-aws (f-route53-batch) ✔ make testacc TESTARGS='-run=TestAccRoute53Record_' PKG=route53
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2	(cached)
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider/framework	(cached)
make: Running acceptance tests on branch: 🌿 f-route53-batch 🌿...
TF_ACC=1 go1.26.4 test ./internal/service/route53/... -v -count 1 -parallel 20  -run=TestAccRoute53Record_ -timeout 360m -vet=off -buildvcs=false
2026/06/24 16:07:33 Creating Terraform AWS Provider (SDKv2-style)...
2026/06/24 16:07:33 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccRoute53Record_Identity_basic
=== PAUSE TestAccRoute53Record_Identity_basic
=== RUN   TestAccRoute53Record_Identity_ExistingResource_basic
=== PAUSE TestAccRoute53Record_Identity_ExistingResource_basic
=== RUN   TestAccRoute53Record_Identity_ExistingResource_noRefreshNoChange
=== PAUSE TestAccRoute53Record_Identity_ExistingResource_noRefreshNoChange
=== RUN   TestAccRoute53Record_List_basic
=== PAUSE TestAccRoute53Record_List_basic
=== RUN   TestAccRoute53Record_basic
=== PAUSE TestAccRoute53Record_basic
=== RUN   TestAccRoute53Record_Identity_SetIdentifier
=== PAUSE TestAccRoute53Record_Identity_SetIdentifier
=== RUN   TestAccRoute53Record_Identity_ChangeOnUpdate
=== PAUSE TestAccRoute53Record_Identity_ChangeOnUpdate
=== RUN   TestAccRoute53Record_disappears
=== PAUSE TestAccRoute53Record_disappears
=== RUN   TestAccRoute53Record_Disappears_multipleRecords
=== PAUSE TestAccRoute53Record_Disappears_multipleRecords
=== RUN   TestAccRoute53Record_underscored
=== PAUSE TestAccRoute53Record_underscored
=== RUN   TestAccRoute53Record_fqdn
=== PAUSE TestAccRoute53Record_fqdn
=== RUN   TestAccRoute53Record_trailingPeriodAndZoneID
=== PAUSE TestAccRoute53Record_trailingPeriodAndZoneID
=== RUN   TestAccRoute53Record_Support_txt
=== PAUSE TestAccRoute53Record_Support_txt
=== RUN   TestAccRoute53Record_Support_spf
=== PAUSE TestAccRoute53Record_Support_spf
=== RUN   TestAccRoute53Record_Support_caa
=== PAUSE TestAccRoute53Record_Support_caa
=== RUN   TestAccRoute53Record_Support_ds
=== PAUSE TestAccRoute53Record_Support_ds
=== RUN   TestAccRoute53Record_generatesSuffix
=== PAUSE TestAccRoute53Record_generatesSuffix
=== RUN   TestAccRoute53Record_wildcard
=== PAUSE TestAccRoute53Record_wildcard
=== RUN   TestAccRoute53Record_failover
=== PAUSE TestAccRoute53Record_failover
=== RUN   TestAccRoute53Record_Weighted_basic
=== PAUSE TestAccRoute53Record_Weighted_basic
=== RUN   TestAccRoute53Record_WeightedToSimple_basic
=== PAUSE TestAccRoute53Record_WeightedToSimple_basic
=== RUN   TestAccRoute53Record_Alias_elb
=== PAUSE TestAccRoute53Record_Alias_elb
=== RUN   TestAccRoute53Record_Alias_s3
=== PAUSE TestAccRoute53Record_Alias_s3
=== RUN   TestAccRoute53Record_Alias_vpcEndpoint
=== PAUSE TestAccRoute53Record_Alias_vpcEndpoint
=== RUN   TestAccRoute53Record_Alias_uppercase
=== PAUSE TestAccRoute53Record_Alias_uppercase
=== RUN   TestAccRoute53Record_Weighted_alias
=== PAUSE TestAccRoute53Record_Weighted_alias
=== RUN   TestAccRoute53Record_cidr
=== PAUSE TestAccRoute53Record_cidr
=== RUN   TestAccRoute53Record_Geolocation_basic
=== PAUSE TestAccRoute53Record_Geolocation_basic
=== RUN   TestAccRoute53Record_Geoproximity_basic
=== PAUSE TestAccRoute53Record_Geoproximity_basic
=== RUN   TestAccRoute53Record_HealthCheckID_setIdentifierChange
=== PAUSE TestAccRoute53Record_HealthCheckID_setIdentifierChange
=== RUN   TestAccRoute53Record_HealthCheckID_typeChange
=== PAUSE TestAccRoute53Record_HealthCheckID_typeChange
=== RUN   TestAccRoute53Record_Latency_basic
=== PAUSE TestAccRoute53Record_Latency_basic
=== RUN   TestAccRoute53Record_typeChange
=== PAUSE TestAccRoute53Record_typeChange
=== RUN   TestAccRoute53Record_nameChange
=== PAUSE TestAccRoute53Record_nameChange
=== RUN   TestAccRoute53Record_setIdentifierChangeBasicToWeighted
=== PAUSE TestAccRoute53Record_setIdentifierChangeBasicToWeighted
=== RUN   TestAccRoute53Record_SetIdentifierRename_geolocationContinent
=== PAUSE TestAccRoute53Record_SetIdentifierRename_geolocationContinent
=== RUN   TestAccRoute53Record_SetIdentifierRename_geolocationCountryDefault
=== PAUSE TestAccRoute53Record_SetIdentifierRename_geolocationCountryDefault
=== RUN   TestAccRoute53Record_SetIdentifierRename_geolocationCountrySpecified
=== PAUSE TestAccRoute53Record_SetIdentifierRename_geolocationCountrySpecified
=== RUN   TestAccRoute53Record_SetIdentifierRename_geolocationCountrySubdivision
=== PAUSE TestAccRoute53Record_SetIdentifierRename_geolocationCountrySubdivision
=== RUN   TestAccRoute53Record_SetIdentifierRename_geoproximityRegion
=== PAUSE TestAccRoute53Record_SetIdentifierRename_geoproximityRegion
=== RUN   TestAccRoute53Record_SetIdentifierRename_geoproximityLocalZoneGroup
=== PAUSE TestAccRoute53Record_SetIdentifierRename_geoproximityLocalZoneGroup
=== RUN   TestAccRoute53Record_SetIdentifierRename_geoproximityCoordinates
=== PAUSE TestAccRoute53Record_SetIdentifierRename_geoproximityCoordinates
=== RUN   TestAccRoute53Record_SetIdentifierRename_failover
=== PAUSE TestAccRoute53Record_SetIdentifierRename_failover
=== RUN   TestAccRoute53Record_SetIdentifierRename_latency
=== PAUSE TestAccRoute53Record_SetIdentifierRename_latency
=== RUN   TestAccRoute53Record_SetIdentifierRename_multiValueAnswer
=== PAUSE TestAccRoute53Record_SetIdentifierRename_multiValueAnswer
=== RUN   TestAccRoute53Record_SetIdentifierRename_weighted
=== PAUSE TestAccRoute53Record_SetIdentifierRename_weighted
=== RUN   TestAccRoute53Record_Alias_change
=== PAUSE TestAccRoute53Record_Alias_change
=== RUN   TestAccRoute53Record_Alias_changeDualstack
=== PAUSE TestAccRoute53Record_Alias_changeDualstack
=== RUN   TestAccRoute53Record_empty
=== PAUSE TestAccRoute53Record_empty
=== RUN   TestAccRoute53Record_longTXTrecord
=== PAUSE TestAccRoute53Record_longTXTrecord
=== RUN   TestAccRoute53Record_MultiValueAnswer_basic
=== PAUSE TestAccRoute53Record_MultiValueAnswer_basic
=== RUN   TestAccRoute53Record_Allow_doNotOverwrite
=== PAUSE TestAccRoute53Record_Allow_doNotOverwrite
=== RUN   TestAccRoute53Record_Allow_overwrite
=== PAUSE TestAccRoute53Record_Allow_overwrite
=== RUN   TestAccRoute53Record_ttl0
=== PAUSE TestAccRoute53Record_ttl0
=== RUN   TestAccRoute53Record_aliasWildcardName
=== PAUSE TestAccRoute53Record_aliasWildcardName
=== RUN   TestAccRoute53Record_escapedSlash
=== PAUSE TestAccRoute53Record_escapedSlash
=== RUN   TestAccRoute53Record_escapedSpace
=== PAUSE TestAccRoute53Record_escapedSpace
=== RUN   TestAccRoute53Record_escapedJustSpace
=== PAUSE TestAccRoute53Record_escapedJustSpace
=== RUN   TestAccRoute53Record_BatchReads_basic
=== PAUSE TestAccRoute53Record_BatchReads_basic
=== RUN   TestAccRoute53Record_BatchReads_multipleInZone
=== PAUSE TestAccRoute53Record_BatchReads_multipleInZone
=== RUN   TestAccRoute53Record_BatchReads_wildcard
=== PAUSE TestAccRoute53Record_BatchReads_wildcard
=== RUN   TestAccRoute53Record_BatchReads_outOfBandChangeIgnored
=== PAUSE TestAccRoute53Record_BatchReads_outOfBandChangeIgnored
=== RUN   TestAccRoute53Record_BatchReads_typeChange
=== PAUSE TestAccRoute53Record_BatchReads_typeChange
=== RUN   TestAccRoute53Record_BatchReads_cacheSharing
=== PAUSE TestAccRoute53Record_BatchReads_cacheSharing
=== CONT  TestAccRoute53Record_Identity_basic
=== CONT  TestAccRoute53Record_typeChange
=== CONT  TestAccRoute53Record_empty
=== CONT  TestAccRoute53Record_HealthCheckID_typeChange
=== CONT  TestAccRoute53Record_SetIdentifierRename_geoproximityLocalZoneGroup
=== CONT  TestAccRoute53Record_generatesSuffix
=== CONT  TestAccRoute53Record_SetIdentifierRename_multiValueAnswer
=== CONT  TestAccRoute53Record_Latency_basic
=== CONT  TestAccRoute53Record_Alias_changeDualstack
=== CONT  TestAccRoute53Record_SetIdentifierRename_weighted
=== CONT  TestAccRoute53Record_Alias_change
=== CONT  TestAccRoute53Record_SetIdentifierRename_latency
=== CONT  TestAccRoute53Record_Alias_vpcEndpoint
=== CONT  TestAccRoute53Record_HealthCheckID_setIdentifierChange
=== CONT  TestAccRoute53Record_Geoproximity_basic
=== CONT  TestAccRoute53Record_Geolocation_basic
=== CONT  TestAccRoute53Record_cidr
=== CONT  TestAccRoute53Record_Weighted_alias
=== CONT  TestAccRoute53Record_Alias_uppercase
=== CONT  TestAccRoute53Record_SetIdentifierRename_failover
--- PASS: TestAccRoute53Record_Alias_uppercase (157.64s)
=== CONT  TestAccRoute53Record_SetIdentifierRename_geolocationCountryDefault
--- PASS: TestAccRoute53Record_Geolocation_basic (161.55s)
=== CONT  TestAccRoute53Record_SetIdentifierRename_geoproximityRegion
--- PASS: TestAccRoute53Record_empty (169.11s)
=== CONT  TestAccRoute53Record_SetIdentifierRename_geolocationCountrySubdivision
--- PASS: TestAccRoute53Record_generatesSuffix (169.35s)
=== CONT  TestAccRoute53Record_SetIdentifierRename_geolocationCountrySpecified
--- PASS: TestAccRoute53Record_Latency_basic (179.93s)
=== CONT  TestAccRoute53Record_setIdentifierChangeBasicToWeighted
--- PASS: TestAccRoute53Record_Identity_basic (192.09s)
=== CONT  TestAccRoute53Record_SetIdentifierRename_geolocationContinent
--- PASS: TestAccRoute53Record_SetIdentifierRename_geoproximityLocalZoneGroup (197.58s)
=== CONT  TestAccRoute53Record_WeightedToSimple_basic
--- PASS: TestAccRoute53Record_SetIdentifierRename_weighted (203.16s)
=== CONT  TestAccRoute53Record_Alias_s3
--- PASS: TestAccRoute53Record_Geoproximity_basic (205.09s)
=== CONT  TestAccRoute53Record_Alias_elb
--- PASS: TestAccRoute53Record_HealthCheckID_setIdentifierChange (212.54s)
=== CONT  TestAccRoute53Record_nameChange
--- PASS: TestAccRoute53Record_SetIdentifierRename_multiValueAnswer (213.33s)
=== CONT  TestAccRoute53Record_SetIdentifierRename_geoproximityCoordinates
--- PASS: TestAccRoute53Record_SetIdentifierRename_latency (215.50s)
=== CONT  TestAccRoute53Record_failover
--- PASS: TestAccRoute53Record_HealthCheckID_typeChange (235.23s)
=== CONT  TestAccRoute53Record_Weighted_basic
--- PASS: TestAccRoute53Record_typeChange (245.30s)
=== CONT  TestAccRoute53Record_Disappears_multipleRecords
--- PASS: TestAccRoute53Record_Alias_change (252.73s)
=== CONT  TestAccRoute53Record_Support_ds
--- PASS: TestAccRoute53Record_cidr (254.97s)
=== CONT  TestAccRoute53Record_Support_caa
--- PASS: TestAccRoute53Record_SetIdentifierRename_failover (258.17s)
=== CONT  TestAccRoute53Record_Support_spf
--- PASS: TestAccRoute53Record_Alias_changeDualstack (264.37s)
=== CONT  TestAccRoute53Record_Support_txt
--- PASS: TestAccRoute53Record_Weighted_alias (281.03s)
=== CONT  TestAccRoute53Record_trailingPeriodAndZoneID
--- PASS: TestAccRoute53Record_SetIdentifierRename_geolocationCountryDefault (179.92s)
=== CONT  TestAccRoute53Record_fqdn
--- PASS: TestAccRoute53Record_SetIdentifierRename_geoproximityRegion (184.58s)
=== CONT  TestAccRoute53Record_underscored
--- PASS: TestAccRoute53Record_Alias_s3 (144.87s)
=== CONT  TestAccRoute53Record_Allow_overwrite
--- PASS: TestAccRoute53Record_Alias_elb (145.86s)
=== CONT  TestAccRoute53Record_escapedSlash
--- PASS: TestAccRoute53Record_SetIdentifierRename_geolocationCountrySpecified (185.40s)
=== CONT  TestAccRoute53Record_aliasWildcardName
--- PASS: TestAccRoute53Record_SetIdentifierRename_geolocationCountrySubdivision (187.47s)
=== CONT  TestAccRoute53Record_ttl0
--- PASS: TestAccRoute53Record_failover (143.83s)
=== CONT  TestAccRoute53Record_basic
--- PASS: TestAccRoute53Record_setIdentifierChangeBasicToWeighted (183.49s)
=== CONT  TestAccRoute53Record_disappears
--- PASS: TestAccRoute53Record_Alias_vpcEndpoint (371.74s)
=== CONT  TestAccRoute53Record_Identity_ChangeOnUpdate
--- PASS: TestAccRoute53Record_SetIdentifierRename_geolocationContinent (179.78s)
=== CONT  TestAccRoute53Record_Identity_SetIdentifier
--- PASS: TestAccRoute53Record_Weighted_basic (142.79s)
=== CONT  TestAccRoute53Record_MultiValueAnswer_basic
--- PASS: TestAccRoute53Record_WeightedToSimple_basic (184.44s)
=== CONT  TestAccRoute53Record_Allow_doNotOverwrite
--- PASS: TestAccRoute53Record_Support_ds (140.31s)
=== CONT  TestAccRoute53Record_wildcard
--- PASS: TestAccRoute53Record_Support_caa (142.40s)
=== CONT  TestAccRoute53Record_BatchReads_wildcard
--- PASS: TestAccRoute53Record_Support_spf (142.52s)
=== CONT  TestAccRoute53Record_BatchReads_cacheSharing
--- PASS: TestAccRoute53Record_SetIdentifierRename_geoproximityCoordinates (187.59s)
=== CONT  TestAccRoute53Record_BatchReads_typeChange
--- PASS: TestAccRoute53Record_Support_txt (144.89s)
=== CONT  TestAccRoute53Record_BatchReads_outOfBandChangeIgnored
--- PASS: TestAccRoute53Record_Disappears_multipleRecords (171.14s)
=== CONT  TestAccRoute53Record_Identity_ExistingResource_noRefreshNoChange
--- PASS: TestAccRoute53Record_trailingPeriodAndZoneID (141.48s)
=== CONT  TestAccRoute53Record_List_basic
--- PASS: TestAccRoute53Record_nameChange (214.82s)
=== CONT  TestAccRoute53Record_longTXTrecord
--- PASS: TestAccRoute53Record_fqdn (148.76s)
=== CONT  TestAccRoute53Record_Identity_ExistingResource_basic
--- PASS: TestAccRoute53Record_underscored (141.03s)
=== CONT  TestAccRoute53Record_escapedSpace
--- PASS: TestAccRoute53Record_escapedSlash (141.40s)
=== CONT  TestAccRoute53Record_escapedJustSpace
--- PASS: TestAccRoute53Record_basic (141.58s)
=== CONT  TestAccRoute53Record_BatchReads_multipleInZone
--- PASS: TestAccRoute53Record_disappears (139.49s)
=== CONT  TestAccRoute53Record_BatchReads_basic
--- PASS: TestAccRoute53Record_Allow_doNotOverwrite (133.05s)
--- PASS: TestAccRoute53Record_Allow_overwrite (170.83s)
--- PASS: TestAccRoute53Record_MultiValueAnswer_basic (141.88s)
--- PASS: TestAccRoute53Record_Identity_SetIdentifier (151.81s)
--- PASS: TestAccRoute53Record_BatchReads_outOfBandChangeIgnored (115.10s)
--- PASS: TestAccRoute53Record_BatchReads_wildcard (141.52s)
--- PASS: TestAccRoute53Record_BatchReads_cacheSharing (145.97s)
--- PASS: TestAccRoute53Record_Identity_ChangeOnUpdate (179.54s)
--- PASS: TestAccRoute53Record_List_basic (140.21s)
--- PASS: TestAccRoute53Record_longTXTrecord (141.05s)
--- PASS: TestAccRoute53Record_wildcard (184.48s)
--- PASS: TestAccRoute53Record_ttl0 (221.37s)
--- PASS: TestAccRoute53Record_Identity_ExistingResource_noRefreshNoChange (166.33s)
--- PASS: TestAccRoute53Record_BatchReads_typeChange (210.35s)
--- PASS: TestAccRoute53Record_escapedSpace (141.24s)
--- PASS: TestAccRoute53Record_escapedJustSpace (140.84s)
--- PASS: TestAccRoute53Record_BatchReads_basic (141.03s)
--- PASS: TestAccRoute53Record_Identity_ExistingResource_basic (166.39s)
--- PASS: TestAccRoute53Record_BatchReads_multipleInZone (179.93s)
=== NAME  TestAccRoute53Record_aliasWildcardName
    record_test.go:1806: Error running post-test destroy, there may be dangling resources: exit status 1

        Error: reading Route 53 Record (Z097486214M0CBC8ST6W_*.71vilf0z.test_A): operation error Route 53: GetHostedZone, https response error StatusCode: 403, RequestID: ccbbcf3a-4fc5-4789-a1ad-bc6946aa88c6, api error ExpiredToken: The security token included in the request is expired

--- FAIL: TestAccRoute53Record_aliasWildcardName (345.69s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/route53	706.533s
FAIL
make: *** [testacc] Error 1
...
```

Test results with the environment variable unset:

```console
❯ terraform-provider-aws (f-route53-batch) ✔ unset TF_AWS_ROUTE53_RECORD_BATCH_READS
❯ terraform-provider-aws (f-route53-batch) ✔ make testacc TESTARGS='-run=TestAccRoute53Record_' PKG=route53
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2	(cached)
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider/framework	(cached)
make: Running acceptance tests on branch: 🌿 f-route53-batch 🌿...
TF_ACC=1 go1.26.4 test ./internal/service/route53/... -v -count 1 -parallel 20  -run=TestAccRoute53Record_ -timeout 360m -vet=off -buildvcs=false
2026/06/24 16:26:12 Creating Terraform AWS Provider (SDKv2-style)...
2026/06/24 16:26:12 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccRoute53Record_Identity_basic
=== PAUSE TestAccRoute53Record_Identity_basic
=== RUN   TestAccRoute53Record_Identity_ExistingResource_basic
=== PAUSE TestAccRoute53Record_Identity_ExistingResource_basic
=== RUN   TestAccRoute53Record_Identity_ExistingResource_noRefreshNoChange
=== PAUSE TestAccRoute53Record_Identity_ExistingResource_noRefreshNoChange
=== RUN   TestAccRoute53Record_List_basic
=== PAUSE TestAccRoute53Record_List_basic
=== RUN   TestAccRoute53Record_basic
=== PAUSE TestAccRoute53Record_basic
=== RUN   TestAccRoute53Record_Identity_SetIdentifier
=== PAUSE TestAccRoute53Record_Identity_SetIdentifier
=== RUN   TestAccRoute53Record_Identity_ChangeOnUpdate
=== PAUSE TestAccRoute53Record_Identity_ChangeOnUpdate
=== RUN   TestAccRoute53Record_disappears
=== PAUSE TestAccRoute53Record_disappears
=== RUN   TestAccRoute53Record_Disappears_multipleRecords
=== PAUSE TestAccRoute53Record_Disappears_multipleRecords
=== RUN   TestAccRoute53Record_underscored
=== PAUSE TestAccRoute53Record_underscored
=== RUN   TestAccRoute53Record_fqdn
=== PAUSE TestAccRoute53Record_fqdn
=== RUN   TestAccRoute53Record_trailingPeriodAndZoneID
=== PAUSE TestAccRoute53Record_trailingPeriodAndZoneID
=== RUN   TestAccRoute53Record_Support_txt
=== PAUSE TestAccRoute53Record_Support_txt
=== RUN   TestAccRoute53Record_Support_spf
=== PAUSE TestAccRoute53Record_Support_spf
=== RUN   TestAccRoute53Record_Support_caa
=== PAUSE TestAccRoute53Record_Support_caa
=== RUN   TestAccRoute53Record_Support_ds
=== PAUSE TestAccRoute53Record_Support_ds
=== RUN   TestAccRoute53Record_generatesSuffix
=== PAUSE TestAccRoute53Record_generatesSuffix
=== RUN   TestAccRoute53Record_wildcard
=== PAUSE TestAccRoute53Record_wildcard
=== RUN   TestAccRoute53Record_failover
=== PAUSE TestAccRoute53Record_failover
=== RUN   TestAccRoute53Record_Weighted_basic
=== PAUSE TestAccRoute53Record_Weighted_basic
=== RUN   TestAccRoute53Record_WeightedToSimple_basic
=== PAUSE TestAccRoute53Record_WeightedToSimple_basic
=== RUN   TestAccRoute53Record_Alias_elb
=== PAUSE TestAccRoute53Record_Alias_elb
=== RUN   TestAccRoute53Record_Alias_s3
=== PAUSE TestAccRoute53Record_Alias_s3
=== RUN   TestAccRoute53Record_Alias_vpcEndpoint
=== PAUSE TestAccRoute53Record_Alias_vpcEndpoint
=== RUN   TestAccRoute53Record_Alias_uppercase
=== PAUSE TestAccRoute53Record_Alias_uppercase
=== RUN   TestAccRoute53Record_Weighted_alias
=== PAUSE TestAccRoute53Record_Weighted_alias
=== RUN   TestAccRoute53Record_cidr
=== PAUSE TestAccRoute53Record_cidr
=== RUN   TestAccRoute53Record_Geolocation_basic
=== PAUSE TestAccRoute53Record_Geolocation_basic
=== RUN   TestAccRoute53Record_Geoproximity_basic
=== PAUSE TestAccRoute53Record_Geoproximity_basic
=== RUN   TestAccRoute53Record_HealthCheckID_setIdentifierChange
=== PAUSE TestAccRoute53Record_HealthCheckID_setIdentifierChange
=== RUN   TestAccRoute53Record_HealthCheckID_typeChange
=== PAUSE TestAccRoute53Record_HealthCheckID_typeChange
=== RUN   TestAccRoute53Record_Latency_basic
=== PAUSE TestAccRoute53Record_Latency_basic
=== RUN   TestAccRoute53Record_typeChange
=== PAUSE TestAccRoute53Record_typeChange
=== RUN   TestAccRoute53Record_nameChange
=== PAUSE TestAccRoute53Record_nameChange
=== RUN   TestAccRoute53Record_setIdentifierChangeBasicToWeighted
=== PAUSE TestAccRoute53Record_setIdentifierChangeBasicToWeighted
=== RUN   TestAccRoute53Record_SetIdentifierRename_geolocationContinent
=== PAUSE TestAccRoute53Record_SetIdentifierRename_geolocationContinent
=== RUN   TestAccRoute53Record_SetIdentifierRename_geolocationCountryDefault
=== PAUSE TestAccRoute53Record_SetIdentifierRename_geolocationCountryDefault
=== RUN   TestAccRoute53Record_SetIdentifierRename_geolocationCountrySpecified
=== PAUSE TestAccRoute53Record_SetIdentifierRename_geolocationCountrySpecified
=== RUN   TestAccRoute53Record_SetIdentifierRename_geolocationCountrySubdivision
=== PAUSE TestAccRoute53Record_SetIdentifierRename_geolocationCountrySubdivision
=== RUN   TestAccRoute53Record_SetIdentifierRename_geoproximityRegion
=== PAUSE TestAccRoute53Record_SetIdentifierRename_geoproximityRegion
=== RUN   TestAccRoute53Record_SetIdentifierRename_geoproximityLocalZoneGroup
=== PAUSE TestAccRoute53Record_SetIdentifierRename_geoproximityLocalZoneGroup
=== RUN   TestAccRoute53Record_SetIdentifierRename_geoproximityCoordinates
=== PAUSE TestAccRoute53Record_SetIdentifierRename_geoproximityCoordinates
=== RUN   TestAccRoute53Record_SetIdentifierRename_failover
=== PAUSE TestAccRoute53Record_SetIdentifierRename_failover
=== RUN   TestAccRoute53Record_SetIdentifierRename_latency
=== PAUSE TestAccRoute53Record_SetIdentifierRename_latency
=== RUN   TestAccRoute53Record_SetIdentifierRename_multiValueAnswer
=== PAUSE TestAccRoute53Record_SetIdentifierRename_multiValueAnswer
=== RUN   TestAccRoute53Record_SetIdentifierRename_weighted
=== PAUSE TestAccRoute53Record_SetIdentifierRename_weighted
=== RUN   TestAccRoute53Record_Alias_change
=== PAUSE TestAccRoute53Record_Alias_change
=== RUN   TestAccRoute53Record_Alias_changeDualstack
=== PAUSE TestAccRoute53Record_Alias_changeDualstack
=== RUN   TestAccRoute53Record_empty
=== PAUSE TestAccRoute53Record_empty
=== RUN   TestAccRoute53Record_longTXTrecord
=== PAUSE TestAccRoute53Record_longTXTrecord
=== RUN   TestAccRoute53Record_MultiValueAnswer_basic
=== PAUSE TestAccRoute53Record_MultiValueAnswer_basic
=== RUN   TestAccRoute53Record_Allow_doNotOverwrite
=== PAUSE TestAccRoute53Record_Allow_doNotOverwrite
=== RUN   TestAccRoute53Record_Allow_overwrite
=== PAUSE TestAccRoute53Record_Allow_overwrite
=== RUN   TestAccRoute53Record_ttl0
=== PAUSE TestAccRoute53Record_ttl0
=== RUN   TestAccRoute53Record_aliasWildcardName
=== PAUSE TestAccRoute53Record_aliasWildcardName
=== RUN   TestAccRoute53Record_escapedSlash
=== PAUSE TestAccRoute53Record_escapedSlash
=== RUN   TestAccRoute53Record_escapedSpace
=== PAUSE TestAccRoute53Record_escapedSpace
=== RUN   TestAccRoute53Record_escapedJustSpace
=== PAUSE TestAccRoute53Record_escapedJustSpace
=== RUN   TestAccRoute53Record_BatchReads_basic
=== PAUSE TestAccRoute53Record_BatchReads_basic
=== RUN   TestAccRoute53Record_BatchReads_multipleInZone
=== PAUSE TestAccRoute53Record_BatchReads_multipleInZone
=== RUN   TestAccRoute53Record_BatchReads_wildcard
=== PAUSE TestAccRoute53Record_BatchReads_wildcard
=== RUN   TestAccRoute53Record_BatchReads_outOfBandChangeIgnored
=== PAUSE TestAccRoute53Record_BatchReads_outOfBandChangeIgnored
=== RUN   TestAccRoute53Record_BatchReads_typeChange
=== PAUSE TestAccRoute53Record_BatchReads_typeChange
=== RUN   TestAccRoute53Record_BatchReads_cacheSharing
=== PAUSE TestAccRoute53Record_BatchReads_cacheSharing
=== CONT  TestAccRoute53Record_Identity_basic
=== CONT  TestAccRoute53Record_typeChange
=== CONT  TestAccRoute53Record_generatesSuffix
=== CONT  TestAccRoute53Record_empty
=== CONT  TestAccRoute53Record_Latency_basic
=== CONT  TestAccRoute53Record_SetIdentifierRename_geolocationCountryDefault
=== CONT  TestAccRoute53Record_SetIdentifierRename_geolocationCountrySubdivision
=== CONT  TestAccRoute53Record_Disappears_multipleRecords
=== CONT  TestAccRoute53Record_SetIdentifierRename_geoproximityLocalZoneGroup
=== CONT  TestAccRoute53Record_Alias_changeDualstack
=== CONT  TestAccRoute53Record_SetIdentifierRename_weighted
=== CONT  TestAccRoute53Record_SetIdentifierRename_multiValueAnswer
=== CONT  TestAccRoute53Record_SetIdentifierRename_latency
=== CONT  TestAccRoute53Record_SetIdentifierRename_failover
=== CONT  TestAccRoute53Record_SetIdentifierRename_geoproximityCoordinates
=== CONT  TestAccRoute53Record_Alias_uppercase
=== CONT  TestAccRoute53Record_Support_ds
=== CONT  TestAccRoute53Record_Support_caa
=== CONT  TestAccRoute53Record_Support_spf
=== CONT  TestAccRoute53Record_Alias_change
--- PASS: TestAccRoute53Record_Support_caa (148.05s)
=== CONT  TestAccRoute53Record_Support_txt
--- PASS: TestAccRoute53Record_Latency_basic (164.52s)
=== CONT  TestAccRoute53Record_trailingPeriodAndZoneID
--- PASS: TestAccRoute53Record_empty (176.06s)
=== CONT  TestAccRoute53Record_fqdn
--- PASS: TestAccRoute53Record_generatesSuffix (176.73s)
=== CONT  TestAccRoute53Record_underscored
--- PASS: TestAccRoute53Record_Alias_uppercase (176.79s)
=== CONT  TestAccRoute53Record_setIdentifierChangeBasicToWeighted
--- PASS: TestAccRoute53Record_Support_spf (179.71s)
=== CONT  TestAccRoute53Record_SetIdentifierRename_geolocationContinent
--- PASS: TestAccRoute53Record_Support_ds (180.29s)
=== CONT  TestAccRoute53Record_WeightedToSimple_basic
--- PASS: TestAccRoute53Record_Identity_basic (182.39s)
=== CONT  TestAccRoute53Record_Alias_vpcEndpoint
--- PASS: TestAccRoute53Record_SetIdentifierRename_geoproximityLocalZoneGroup (195.58s)
=== CONT  TestAccRoute53Record_Alias_s3
--- PASS: TestAccRoute53Record_Disappears_multipleRecords (210.81s)
=== CONT  TestAccRoute53Record_Alias_elb
--- PASS: TestAccRoute53Record_SetIdentifierRename_weighted (213.16s)
=== CONT  TestAccRoute53Record_escapedSpace
--- PASS: TestAccRoute53Record_SetIdentifierRename_geolocationCountryDefault (213.24s)
=== CONT  TestAccRoute53Record_BatchReads_cacheSharing
    record_test.go:2186: Environment variable TF_AWS_ROUTE53_RECORD_BATCH_READS is not set to a true value
--- SKIP: TestAccRoute53Record_BatchReads_cacheSharing (0.00s)
=== CONT  TestAccRoute53Record_BatchReads_typeChange
    record_test.go:2186: Environment variable TF_AWS_ROUTE53_RECORD_BATCH_READS is not set to a true value
--- SKIP: TestAccRoute53Record_BatchReads_typeChange (0.00s)
=== CONT  TestAccRoute53Record_BatchReads_outOfBandChangeIgnored
    record_test.go:2186: Environment variable TF_AWS_ROUTE53_RECORD_BATCH_READS is not set to a true value
--- SKIP: TestAccRoute53Record_BatchReads_outOfBandChangeIgnored (0.00s)
=== CONT  TestAccRoute53Record_BatchReads_wildcard
    record_test.go:2186: Environment variable TF_AWS_ROUTE53_RECORD_BATCH_READS is not set to a true value
--- SKIP: TestAccRoute53Record_BatchReads_wildcard (0.00s)
=== CONT  TestAccRoute53Record_BatchReads_multipleInZone
    record_test.go:2186: Environment variable TF_AWS_ROUTE53_RECORD_BATCH_READS is not set to a true value
--- SKIP: TestAccRoute53Record_BatchReads_multipleInZone (0.00s)
=== CONT  TestAccRoute53Record_BatchReads_basic
    record_test.go:2186: Environment variable TF_AWS_ROUTE53_RECORD_BATCH_READS is not set to a true value
--- SKIP: TestAccRoute53Record_BatchReads_basic (0.00s)
=== CONT  TestAccRoute53Record_escapedJustSpace
--- PASS: TestAccRoute53Record_SetIdentifierRename_geolocationCountrySubdivision (213.70s)
=== CONT  TestAccRoute53Record_Allow_overwrite
--- PASS: TestAccRoute53Record_SetIdentifierRename_multiValueAnswer (216.72s)
=== CONT  TestAccRoute53Record_escapedSlash
--- PASS: TestAccRoute53Record_SetIdentifierRename_geoproximityCoordinates (217.64s)
=== CONT  TestAccRoute53Record_aliasWildcardName
=== CONT  TestAccRoute53Record_ttl0
--- PASS: TestAccRoute53Record_SetIdentifierRename_latency (219.26s)
--- PASS: TestAccRoute53Record_SetIdentifierRename_failover (222.46s)
=== CONT  TestAccRoute53Record_MultiValueAnswer_basic
--- PASS: TestAccRoute53Record_Alias_changeDualstack (227.50s)
=== CONT  TestAccRoute53Record_Allow_doNotOverwrite
--- PASS: TestAccRoute53Record_typeChange (249.22s)
=== CONT  TestAccRoute53Record_basic
--- PASS: TestAccRoute53Record_Alias_change (252.74s)
=== CONT  TestAccRoute53Record_disappears
--- PASS: TestAccRoute53Record_Support_txt (143.03s)
=== CONT  TestAccRoute53Record_Identity_ChangeOnUpdate
--- PASS: TestAccRoute53Record_trailingPeriodAndZoneID (142.00s)
=== CONT  TestAccRoute53Record_Identity_SetIdentifier
--- PASS: TestAccRoute53Record_underscored (149.35s)
=== CONT  TestAccRoute53Record_nameChange
--- PASS: TestAccRoute53Record_fqdn (150.77s)
=== CONT  TestAccRoute53Record_Geoproximity_basic
--- PASS: TestAccRoute53Record_Alias_s3 (145.38s)
=== CONT  TestAccRoute53Record_HealthCheckID_typeChange
--- PASS: TestAccRoute53Record_escapedJustSpace (144.34s)
=== CONT  TestAccRoute53Record_HealthCheckID_setIdentifierChange
--- PASS: TestAccRoute53Record_escapedSpace (144.53s)
=== CONT  TestAccRoute53Record_Identity_ExistingResource_noRefreshNoChange
--- PASS: TestAccRoute53Record_Alias_elb (148.44s)
=== CONT  TestAccRoute53Record_List_basic
--- PASS: TestAccRoute53Record_escapedSlash (145.87s)
=== CONT  TestAccRoute53Record_SetIdentifierRename_geolocationCountrySpecified
--- PASS: TestAccRoute53Record_setIdentifierChangeBasicToWeighted (187.29s)
=== CONT  TestAccRoute53Record_SetIdentifierRename_geoproximityRegion
--- PASS: TestAccRoute53Record_SetIdentifierRename_geolocationContinent (186.62s)
=== CONT  TestAccRoute53Record_cidr
--- PASS: TestAccRoute53Record_WeightedToSimple_basic (186.50s)
=== CONT  TestAccRoute53Record_Geolocation_basic
--- PASS: TestAccRoute53Record_Allow_doNotOverwrite (139.31s)
=== CONT  TestAccRoute53Record_failover
--- PASS: TestAccRoute53Record_MultiValueAnswer_basic (148.94s)
=== CONT  TestAccRoute53Record_Weighted_basic
--- PASS: TestAccRoute53Record_Allow_overwrite (175.57s)
=== CONT  TestAccRoute53Record_longTXTrecord
--- PASS: TestAccRoute53Record_basic (143.15s)
=== CONT  TestAccRoute53Record_Identity_ExistingResource_basic
--- PASS: TestAccRoute53Record_disappears (139.83s)
=== CONT  TestAccRoute53Record_wildcard
--- PASS: TestAccRoute53Record_ttl0 (234.45s)
=== CONT  TestAccRoute53Record_Weighted_alias
--- PASS: TestAccRoute53Record_Identity_ChangeOnUpdate (184.24s)
--- PASS: TestAccRoute53Record_Geoproximity_basic (152.61s)
--- PASS: TestAccRoute53Record_Identity_SetIdentifier (186.31s)
--- PASS: TestAccRoute53Record_failover (153.27s)
--- PASS: TestAccRoute53Record_Weighted_basic (161.71s)
--- PASS: TestAccRoute53Record_Geolocation_basic (168.09s)
--- PASS: TestAccRoute53Record_Identity_ExistingResource_noRefreshNoChange (177.32s)
--- PASS: TestAccRoute53Record_HealthCheckID_setIdentifierChange (191.02s)
--- PASS: TestAccRoute53Record_HealthCheckID_typeChange (219.72s)
--- PASS: TestAccRoute53Record_SetIdentifierRename_geoproximityRegion (200.83s)
--- PASS: TestAccRoute53Record_Identity_ExistingResource_basic (175.90s)
--- PASS: TestAccRoute53Record_longTXTrecord (180.66s)
--- PASS: TestAccRoute53Record_SetIdentifierRename_geolocationCountrySpecified (216.89s)
--- PASS: TestAccRoute53Record_wildcard (196.70s)
--- PASS: TestAccRoute53Record_nameChange (263.22s)
--- PASS: TestAccRoute53Record_cidr (241.63s)
--- PASS: TestAccRoute53Record_List_basic (261.42s)
--- PASS: TestAccRoute53Record_Alias_vpcEndpoint (466.21s)
--- PASS: TestAccRoute53Record_aliasWildcardName (450.94s)
--- PASS: TestAccRoute53Record_Weighted_alias (251.23s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/route53	711.106s
```