### PR TITLE
`r/aws_glue_catalog_table`: Fix in-place update of `VIRTUAL_VIEW` tables

### DIFF
--- a/.changelog/48532.txt
+++ b/.changelog/48532.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_glue_catalog_table: Allow in-place update of a `VIRTUAL_VIEW` table's `view_definition` by passing `ViewUpdateAction` to the Glue `UpdateTable` API
+```

--- a/.changelog/48532.txt
+++ b/.changelog/48532.txt
@@ -1,3 +1,7 @@
 ```release-note:bug
 resource/aws_glue_catalog_table: Allow in-place update of a `VIRTUAL_VIEW` table's `view_definition` by passing `ViewUpdateAction` to the Glue `UpdateTable` API
 ```
+
+```release-note:note
+resource/aws_lakeformation_permissions: Grants on `aws_glue_catalog_table` views (`table_type = "VIRTUAL_VIEW"`) are now preserved when the view's `view_definition` is updated, as the underlying table is updated in place rather than recreated
+```

--- a/.ci/swissshepherd-full.hcl
+++ b/.ci/swissshepherd-full.hcl
@@ -197,6 +197,7 @@ check "schema_docs" {
 
   block_heading_styles = [
     "`{Parent}` `{Block}` Block",
+    "`{Path}` Block",
     "`{Block}` Block",
     "{Block} Block",
     "{Block} block",
@@ -206,12 +207,15 @@ check "schema_docs" {
     "{Title} Arguments",
     "{Title} Argument Reference",
     "{Title} Attribute Reference",
+    "Nested Schema for `{Path}`",
+    "`{Path}`",
     "`{Block}`",
     "{Block}",
     "{Title}",
   ]
 
   prefer_block_heading_styles = [
+    "`{Path}` Block",
     "`{Parent}` `{Block}` Block",
     "`{Block}` Block",
   ]

--- a/.ci/swissshepherd-weak.hcl
+++ b/.ci/swissshepherd-weak.hcl
@@ -198,6 +198,7 @@ check "schema_docs" {
 
   block_heading_styles = [
     "`{Parent}` `{Block}` Block",
+    "`{Path}` Block",
     "`{Block}` Block",
     "{Block} Block",
     "{Block} block",
@@ -207,12 +208,15 @@ check "schema_docs" {
     "{Title} Arguments",
     "{Title} Argument Reference",
     "{Title} Attribute Reference",
+    "Nested Schema for `{Path}`",
+    "`{Path}`",
     "`{Block}`",
     "{Block}",
     "{Title}",
   ]
 
   prefer_block_heading_styles = [
+    "`{Path}` Block",
     "`{Parent}` `{Block}` Block",
     "`{Block}` Block",
   ]
@@ -1441,7 +1445,6 @@ check "schema_docs" {
     "resource/aws_globalaccelerator_listener",
     "resource/aws_glue_catalog_database",
     "resource/aws_glue_catalog_table_optimizer",
-    "resource/aws_glue_catalog_table",
     "resource/aws_glue_catalog",
     "resource/aws_glue_classifier",
     "resource/aws_glue_connection",

--- a/.ci/tools/go.mod
+++ b/.ci/tools/go.mod
@@ -4,7 +4,7 @@ go 1.26.4
 
 require (
 	github.com/YakDriver/copyplop v0.10.0
-	github.com/YakDriver/swissshepherd v0.14.0
+	github.com/YakDriver/swissshepherd v0.15.0
 	github.com/client9/misspell v0.3.4
 	github.com/golangci/golangci-lint/v2 v2.12.2
 	github.com/hashicorp/go-changelog v0.0.0-20250127101332-effe3832fb0b

--- a/.ci/tools/go.sum
+++ b/.ci/tools/go.sum
@@ -99,8 +99,8 @@ github.com/ProtonMail/go-crypto v1.1.6 h1:ZcV+Ropw6Qn0AX9brlQLAUXfqLBc7Bl+f/DmNx
 github.com/ProtonMail/go-crypto v1.1.6/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
 github.com/YakDriver/copyplop v0.10.0 h1:vg9QZRDr2SSGWENkkx5BLNXUOB4BvHM+X+HorJFEwqw=
 github.com/YakDriver/copyplop v0.10.0/go.mod h1:+3ecv2Nc+4hd751qpr2PBtFUpKP1cTQhUOumkwK0sGg=
-github.com/YakDriver/swissshepherd v0.14.0 h1:aVpvw84Fy39Fjk8DyRkNEJ3uem8dxYG/6Im3ue+AFDU=
-github.com/YakDriver/swissshepherd v0.14.0/go.mod h1:u7VpJvCEqzj8pnMZuejTUfUZ5TKuXtvPraqncpmGs1o=
+github.com/YakDriver/swissshepherd v0.15.0 h1:z27g5nT+ydSnMIy8+mnBNImX57GybvcyXtB461IUve0=
+github.com/YakDriver/swissshepherd v0.15.0/go.mod h1:u7VpJvCEqzj8pnMZuejTUfUZ5TKuXtvPraqncpmGs1o=
 github.com/acomagu/bufpipe v1.0.3/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ2sYmHc4=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=

--- a/internal/service/glue/catalog_table.go
+++ b/internal/service/glue/catalog_table.go
@@ -804,11 +804,15 @@ func resourceCatalogTableUpdate(ctx context.Context, d *schema.ResourceData, met
 		}
 	}
 
-	// AWS Glue rejects UpdateTable on a VIRTUAL_VIEW unless ViewUpdateAction is
-	// set; mirrors `aws glue update-table --view-update-action REPLACE --force`.
-	// Required for in-place updates that preserve Lake Formation grants on the
-	// view (especially in cross-account sharing).
-	if input.TableInput != nil && aws.ToString(input.TableInput.TableType) == "VIRTUAL_VIEW" {
+	// AWS Glue rejects UpdateTable on a multi-dialect view (one configured via
+	// the `view_definition` block) unless ViewUpdateAction is set; conversely,
+	// it rejects ViewUpdateAction on a legacy view (view_original_text /
+	// view_expanded_text only) with "View update action is only supported on
+	// multi-dialect views." Gate on TableInput.ViewDefinition to pick the right
+	// branch. Force=true mirrors `aws glue update-table ... --force` and is
+	// required to apply in-place updates that preserve Lake Formation grants on
+	// the view (especially in cross-account sharing).
+	if input.TableInput != nil && input.TableInput.ViewDefinition != nil {
 		input.ViewUpdateAction = awstypes.ViewUpdateActionReplace
 		input.Force = true
 	}

--- a/internal/service/glue/catalog_table.go
+++ b/internal/service/glue/catalog_table.go
@@ -804,6 +804,15 @@ func resourceCatalogTableUpdate(ctx context.Context, d *schema.ResourceData, met
 		}
 	}
 
+	// AWS Glue rejects UpdateTable on a VIRTUAL_VIEW unless ViewUpdateAction is
+	// set; mirrors `aws glue update-table --view-update-action REPLACE --force`.
+	// Required for in-place updates that preserve Lake Formation grants on the
+	// view (especially in cross-account sharing).
+	if input.TableInput != nil && aws.ToString(input.TableInput.TableType) == "VIRTUAL_VIEW" {
+		input.ViewUpdateAction = awstypes.ViewUpdateActionReplace
+		input.Force = true
+	}
+
 	_, err = conn.UpdateTable(ctx, &input)
 
 	if err != nil {

--- a/internal/service/glue/catalog_table_test.go
+++ b/internal/service/glue/catalog_table_test.go
@@ -349,6 +349,51 @@ func TestAccGlueCatalogTable_Update_replaceValues(t *testing.T) {
 	})
 }
 
+// Reproduces a customer-reported failure: updating a VIRTUAL_VIEW's text in
+// place (while keeping table_type = "VIRTUAL_VIEW") fails because the provider
+// does not pass ViewUpdateAction to the Glue UpdateTable API. AWS responds with
+// "InvalidInputException: View update action must be one of: [ADD, REPLACE,
+// ADD_OR_REPLACE, DROP]". The AWS CLI succeeds in the same scenario by passing
+// `--view-update-action REPLACE --force`. Once the provider plumbs through
+// ViewUpdateAction (and Force) on UpdateTable, this test should be updated to
+// assert a successful in-place update instead of an expected error.
+//
+// The view_definition block (introduced in PR #45336 for cross-account /
+// Lake Formation views) is the path that actually triggers Glue's validation;
+// the legacy view_original_text / view_expanded_text top-level fields do not.
+func TestAccGlueCatalogTable_Update_viewInPlace(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_glue_catalog_table.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.GlueServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckCatalogTableDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCatalogTableConfig_viewDefinitionText(rName, "view_original_text_1", "view_expanded_text_1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCatalogTableExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "table_type", "VIRTUAL_VIEW"),
+					resource.TestCheckResourceAttr(resourceName, "view_definition.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "view_definition.0.representations.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "view_definition.0.representations.0.view_original_text", "view_original_text_1"),
+					resource.TestCheckResourceAttr(resourceName, "view_definition.0.representations.0.view_expanded_text", "view_expanded_text_1"),
+				),
+			},
+			{
+				// Updating only the view text while keeping table_type = "VIRTUAL_VIEW"
+				// must currently fail because resourceCatalogTableUpdate does not set
+				// UpdateTableInput.ViewUpdateAction.
+				Config:      testAccCatalogTableConfig_viewDefinitionText(rName, "view_original_text_2", "view_expanded_text_2"),
+				ExpectError: regexache.MustCompile(`View update action must be one of`),
+			},
+		},
+	})
+}
+
 // Reference: https://github.com/hashicorp/terraform-provider-aws/issues/11784
 func TestAccGlueCatalogTable_StorageDescriptor_emptyBlock(t *testing.T) {
 	ctx := acctest.Context(t)
@@ -969,6 +1014,36 @@ resource "aws_glue_catalog_table" "test" {
   }
 }
 `, rName, desc)
+}
+
+func testAccCatalogTableConfig_viewDefinitionText(rName, viewOriginalText, viewExpandedText string) string {
+	return fmt.Sprintf(`
+resource "aws_glue_catalog_database" "test" {
+  name = %[1]q
+}
+
+resource "aws_glue_catalog_table" "test" {
+  name          = %[1]q
+  database_name = aws_glue_catalog_database.test.name
+  table_type    = "VIRTUAL_VIEW"
+
+  storage_descriptor {
+    columns {
+      name = "my_column_1"
+      type = "int"
+    }
+  }
+
+  view_definition {
+    representations {
+      dialect            = "SPARK"
+      dialect_version    = "1.0"
+      view_original_text = %[2]q
+      view_expanded_text = %[3]q
+    }
+  }
+}
+`, rName, viewOriginalText, viewExpandedText)
 }
 
 func testAccCatalogTableConfig_fullReplacedValues(rName string) string {

--- a/internal/service/glue/catalog_table_test.go
+++ b/internal/service/glue/catalog_table_test.go
@@ -349,18 +349,7 @@ func TestAccGlueCatalogTable_Update_replaceValues(t *testing.T) {
 	})
 }
 
-// Reproduces a customer-reported failure: updating a VIRTUAL_VIEW's text in
-// place (while keeping table_type = "VIRTUAL_VIEW") fails because the provider
-// does not pass ViewUpdateAction to the Glue UpdateTable API. AWS responds with
-// "InvalidInputException: View update action must be one of: [ADD, REPLACE,
-// ADD_OR_REPLACE, DROP]". The AWS CLI succeeds in the same scenario by passing
-// `--view-update-action REPLACE --force`. Once the provider plumbs through
-// ViewUpdateAction (and Force) on UpdateTable, this test should be updated to
-// assert a successful in-place update instead of an expected error.
-//
-// The view_definition block (introduced in PR #45336 for cross-account /
-// Lake Formation views) is the path that actually triggers Glue's validation;
-// the legacy view_original_text / view_expanded_text top-level fields do not.
+// Reference: https://github.com/hashicorp/terraform-provider-aws/pull/48534
 func TestAccGlueCatalogTable_Update_viewInPlace(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
@@ -382,13 +371,28 @@ func TestAccGlueCatalogTable_Update_viewInPlace(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "view_definition.0.representations.0.view_original_text", "view_original_text_1"),
 					resource.TestCheckResourceAttr(resourceName, "view_definition.0.representations.0.view_expanded_text", "view_expanded_text_1"),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
 			},
 			{
 				// Updating only the view text while keeping table_type = "VIRTUAL_VIEW"
-				// must currently fail because resourceCatalogTableUpdate does not set
-				// UpdateTableInput.ViewUpdateAction.
-				Config:      testAccCatalogTableConfig_viewDefinitionText(rName, "view_original_text_2", "view_expanded_text_2"),
-				ExpectError: regexache.MustCompile(`View update action must be one of`),
+				// must succeed in place — resourceCatalogTableUpdate sets
+				// UpdateTableInput.ViewUpdateAction = REPLACE on the view path.
+				Config: testAccCatalogTableConfig_viewDefinitionText(rName, "view_original_text_2", "view_expanded_text_2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCatalogTableExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "table_type", "VIRTUAL_VIEW"),
+					resource.TestCheckResourceAttr(resourceName, "view_definition.0.representations.0.view_original_text", "view_original_text_2"),
+					resource.TestCheckResourceAttr(resourceName, "view_definition.0.representations.0.view_expanded_text", "view_expanded_text_2"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
 			},
 		},
 	})

--- a/internal/service/glue/catalog_table_test.go
+++ b/internal/service/glue/catalog_table_test.go
@@ -349,7 +349,7 @@ func TestAccGlueCatalogTable_Update_replaceValues(t *testing.T) {
 	})
 }
 
-// Reference: https://github.com/hashicorp/terraform-provider-aws/pull/48534
+// Reference: https://github.com/hashicorp/terraform-provider-aws/issues/48534
 func TestAccGlueCatalogTable_Update_viewInPlace(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)

--- a/website/docs/r/glue_catalog_table.html.markdown
+++ b/website/docs/r/glue_catalog_table.html.markdown
@@ -177,8 +177,8 @@ resource "aws_glue_catalog_table" "example" {
 
 The following arguments are required:
 
-* `name` - (Required) Name of the table. For Hive compatibility, this must be entirely lowercase.
 * `database_name` - (Required) Name of the metadata database where the table metadata resides. For Hive compatibility, this must be all lowercase.
+* `name` - (Required) Name of the table. For Hive compatibility, this must be entirely lowercase.
 
 The following arguments are optional:
 
@@ -194,76 +194,76 @@ The following arguments are optional:
 * `storage_descriptor` - (Optional) Configuration block for information about the physical storage of this table. For more information, refer to the [Glue Developer Guide](https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-catalog-tables.html#aws-glue-api-catalog-tables-StorageDescriptor). See [`storage_descriptor`](#storage_descriptor) below.
 * `table_type` - (Optional) Type of this table (EXTERNAL_TABLE, VIRTUAL_VIEW, etc.). While optional, some Athena DDL queries such as `ALTER TABLE` and `SHOW CREATE TABLE` will fail if this argument is empty.
 * `target_table` - (Optional) Configuration block of a target table for resource linking. See [`target_table`](#target_table) below.
-* `view_definition` - (Optional) A structure that contains all the information that defines the view, including the dialect or dialects for the view, and the query. See [`view_definition`](#view_definition) below.
+* `view_definition` - (Optional) Structure that contains all the information that defines the view, including the dialect or dialects for the view, and the query. See [`view_definition`](#view_definition) below.
 * `view_expanded_text` - (Optional) If the table is a view, the expanded text of the view; otherwise null.
 * `view_original_text` - (Optional) If the table is a view, the original text of the view; otherwise null.
 
-### open_table_format_input
+### `open_table_format_input` Block
 
 ~> **NOTE:** A `open_table_format_input` cannot be added to an existing `glue_catalog_table`.
 This will destroy and recreate the table, possibly resulting in data loss.
 
 * `iceberg_input` - (Required) Configuration block for iceberg table config. See [`iceberg_input`](#iceberg_input) below.
 
-### iceberg_input
+### `iceberg_input` Block
 
 ~> **NOTE:** A `iceberg_input` cannot be added to an existing `open_table_format_input`.
 This will destroy and recreate the table, possibly resulting in data loss.
 
 * `iceberg_table_input` - (Optional) Configuration parameters, including table properties and metadata specifications. See [`iceberg_table_input`](#iceberg_table_input) below.
-* `metadata_operation` - (Required) A required metadata operation. Can only be set to CREATE.
-* `version` - (Optional) The table version for the Iceberg table. Defaults to 2.
+* `metadata_operation` - (Required) Required metadata operation. Can only be set to CREATE.
+* `version` - (Optional) Table version for the Iceberg table. Defaults to 2.
 
-### iceberg_table_input
+### `iceberg_table_input` Block
 
-* `location` - (Required) The S3 location where the Iceberg table data will be stored. Maximum length of 2056 characters.
-* `partition_spec` - (Optional) The partitioning specification that defines how the Iceberg table data will be organized and partitioned for optimal query performance. See [`partition_spec`](#partition_spec) below.
+* `location` - (Required) S3 location where the Iceberg table data will be stored. Maximum length of 2056 characters.
+* `partition_spec` - (Optional) Partitioning specification that defines how the Iceberg table data will be organized and partitioned for optimal query performance. See [`partition_spec`](#partition_spec) below.
 * `properties` - (Optional) Key-value pairs of additional table properties and configuration settings for the Iceberg table.
-* `schema` - (Required) The schema definition that specifies the structure, field types, and metadata for the Iceberg table. See [`schema`](#schema) below.
-* `sort_order` - (Optional) The sort order specification that defines how data should be ordered within each partition to optimize query performance. See [`sort_order`](#sort_order) below.
+* `schema` - (Required) Schema definition that specifies the structure, field types, and metadata for the Iceberg table. See [`schema`](#schema) below.
+* `sort_order` - (Optional) Sort order specification that defines how data should be ordered within each partition to optimize query performance. See [`sort_order`](#sort_order) below.
 
-### partition_spec
+### `partition_spec` Block
 
-* `fields` - (Required) The list of partition fields that define how the table data should be partitioned. See [`fields`](#partition-fields) below.
-* `spec_id` - (Optional) The unique identifier for this partition specification within the Iceberg table's metadata history.
+* `fields` - (Required) List of partition fields that define how the table data should be partitioned. See [`partition_spec.fields`](#partition_specfields-block) below.
+* `spec_id` - (Optional) Unique identifier for this partition specification within the Iceberg table's metadata history.
 
-#### partition fields
+#### `partition_spec.fields` Block
 
-* `field_id` - (Optional) The unique identifier assigned to this partition field within the Iceberg table's partition specification.
-* `name` - (Required) The name of the partition field as it will appear in the partitioned table structure. Length between 1 and 1024 characters.
-* `source_id` - (Required) The identifier of the source field from the table schema that this partition field is based on.
-* `transform` - (Required) The transformation function applied to the source field to create the partition. Common values: `identity`, `bucket`, `truncate`, `year`, `month`, `day`, `hour`.
+* `field_id` - (Optional) Unique identifier assigned to this partition field within the Iceberg table's partition specification.
+* `name` - (Required) Name of the partition field as it will appear in the partitioned table structure. Length between 1 and 1024 characters.
+* `source_id` - (Required) Identifier of the source field from the table schema that this partition field is based on.
+* `transform` - (Required) Transformation function applied to the source field to create the partition. Common values: `identity`, `bucket`, `truncate`, `year`, `month`, `day`, `hour`.
 
-### schema
+### `schema` Block
 
-* `fields` - (Required) The list of field definitions that make up the table schema. See [`fields`](#schema-fields) below.
-* `identifier_field_ids` - (Optional) The list of field identifiers that uniquely identify records in the table, used for row-level operations and deduplication.
-* `schema_id` - (Optional) The unique identifier for this schema version within the Iceberg table's schema evolution history.
-* `type` - (Optional) The root type of the schema structure. Valid value: `struct`.
+* `fields` - (Required) List of field definitions that make up the table schema. See [`schema.fields`](#schemafields-block) below.
+* `identifier_field_ids` - (Optional) List of field identifiers that uniquely identify records in the table, used for row-level operations and deduplication.
+* `schema_id` - (Optional) Unique identifier for this schema version within the Iceberg table's schema evolution history.
+* `type` - (Optional) Root type of the schema structure. Valid value: `struct`.
 
-#### schema fields
+#### `schema.fields` Block
 
-* `doc` - (Optional) Optional documentation or description text that provides additional context about the purpose and usage of this field. Length between 0 and 255 characters.
-* `id` - (Required) The unique identifier assigned to this field within the Iceberg table schema, used for schema evolution and field tracking.
+* `doc` - (Optional) Documentation or description text that provides additional context about the purpose and usage of this field. Length between 0 and 255 characters.
+* `id` - (Required) Unique identifier assigned to this field within the Iceberg table schema, used for schema evolution and field tracking.
 * `initial_default` - (Optional) Default value as JSON used to populate the field's value for all records that were written before the field was added to the schema.
-* `name` - (Required) The name of the field as it appears in the table schema and query operations. Length between 1 and 1024 characters.
-* `required` - (Required) Indicates whether this field is required (non-nullable) or optional (nullable) in the table schema.
-* `type` - (Required) The data type definition for this field as a JSON string, specifying the structure and format of the data it contains. Examples: `"long"`, `"string"`, `"timestamp"`, `"decimal(10,2)"`.
+* `name` - (Required) Name of the field as it appears in the table schema and query operations. Length between 1 and 1024 characters.
+* `required` - (Required) Whether this field is required (non-nullable) or optional (nullable) in the table schema.
+* `type` - (Required) Data type definition for this field as a JSON string, specifying the structure and format of the data it contains. Examples: `"long"`, `"string"`, `"timestamp"`, `"decimal(10,2)"`.
 * `write_default` - (Optional) Default value as JSON used to populate the field's value for any records written after the field was added to the schema, if the writer does not supply the field's value.
 
-### sort_order
+### `sort_order` Block
 
-* `fields` - (Required) The list of fields and their sort directions that define the ordering criteria for the Iceberg table data. See [`fields`](#sort-fields) below.
-* `order_id` - (Required) The unique identifier for this sort order specification within the Iceberg table's metadata.
+* `fields` - (Required) List of fields and their sort directions that define the ordering criteria for the Iceberg table data. See [`sort_order.fields`](#sort_orderfields-block) below.
+* `order_id` - (Required) Unique identifier for this sort order specification within the Iceberg table's metadata.
 
-#### sort fields
+#### `sort_order.fields` Block
 
-* `direction` - (Required) The sort direction for this field. Valid values: `asc`, `desc`.
-* `null_order` - (Required) The ordering behavior for null values in this field. Valid values: `nulls-first`, `nulls-last`.
-* `source_id` - (Required) The identifier of the source field from the table schema that this sort field is based on.
-* `transform` - (Required) The transformation function applied to the source field before sorting. Common values: `identity`, `bucket`, `truncate`.
+* `direction` - (Required) Sort direction for this field. Valid values: `asc`, `desc`.
+* `null_order` - (Required) Ordering behavior for null values in this field. Valid values: `nulls-first`, `nulls-last`.
+* `source_id` - (Required) Identifier of the source field from the table schema that this sort field is based on.
+* `transform` - (Required) Transformation function applied to the source field before sorting. Common values: `identity`, `bucket`, `truncate`.
 
-### partition_index
+### `partition_index` Block
 
 ~> **NOTE:** A `partition_index` cannot be added to an existing `glue_catalog_table`.
 This will destroy and recreate the table, possibly resulting in data loss.
@@ -272,14 +272,14 @@ To add an index to an existing table, see the [`glue_partition_index` resource](
 * `index_name` - (Required) Name of the partition index.
 * `keys` - (Required) Keys for the partition index.
 
-### partition_keys
+### `partition_keys` Block
 
 * `comment` - (Optional) Free-form text comment.
 * `name` - (Required) Name of the Partition Key.
 * `parameters` - (Optional) Map of key-value pairs.
 * `type` - (Optional) Datatype of data in the Partition Key.
 
-### storage_descriptor
+### `storage_descriptor` Block
 
 * `additional_locations` - (Optional) List of locations that point to the path where a Delta table is located.
 * `bucket_columns` - (Optional) List of reducer grouping columns, clustering columns, and bucketing columns in the table.
@@ -296,75 +296,78 @@ To add an index to an existing table, see the [`glue_partition_index` resource](
 * `sort_columns` - (Optional) Configuration block for the sort order of each bucket in the table. See [`sort_columns`](#sort_columns) below.
 * `stored_as_sub_directories` - (Optional) Whether the table data is stored in subdirectories.
 
-#### columns
+#### `columns` Block
 
 * `comment` - (Optional) Free-form text comment.
 * `name` - (Required) Name of the Column.
 * `parameters` - (Optional) Key-value pairs defining properties associated with the column.
 * `type` - (Optional) Datatype of data in the Column.
 
-#### schema_reference
+#### `schema_reference` Block
 
 * `schema_id` - (Optional) Configuration block that contains schema identity fields. Either this or the `schema_version_id` has to be provided. See [`schema_id`](#schema_id) below.
 * `schema_version_id` - (Optional) Unique ID assigned to a version of the schema. Either this or the `schema_id` has to be provided.
 * `schema_version_number` - (Required) Version number of the schema.
 
-##### schema_id
+##### `schema_id` Block
 
 * `registry_name` - (Optional) Name of the schema registry that contains the schema. Must be provided when `schema_name` is specified and conflicts with `schema_arn`.
 * `schema_arn` - (Optional) ARN of the schema. One of `schema_arn` or `schema_name` has to be provided.
 * `schema_name` - (Optional) Name of the schema. One of `schema_arn` or `schema_name` has to be provided.
 
-#### ser_de_info
+#### `ser_de_info` Block
 
 * `name` - (Optional) Name of the SerDe.
 * `parameters` - (Optional) Map of initialization parameters for the SerDe, in key-value form.
 * `serialization_library` - (Optional) Usually the class that implements the SerDe. An example is `org.apache.hadoop.hive.serde2.columnar.ColumnarSerDe`.
 
-#### sort_columns
+#### `sort_columns` Block
 
 * `column` - (Required) Name of the column.
 * `sort_order` - (Required) Whether the column is sorted in ascending (`1`) or descending order (`0`).
 
-#### skewed_info
+#### `skewed_info` Block
 
 * `skewed_column_names` - (Optional) List of names of columns that contain skewed values.
 * `skewed_column_value_location_maps` - (Optional) List of values that appear so frequently as to be considered skewed.
 * `skewed_column_values` - (Optional) Map of skewed values to the columns that contain them.
 
-### target_table
+### `target_table` Block
 
 * `catalog_id` - (Required) ID of the Data Catalog in which the table resides.
 * `database_name` - (Required) Name of the catalog database that contains the target table.
 * `name` - (Required) Name of the target table.
 * `region` - (Optional) Region of the target table.
 
-### view_definition
+### `view_definition` Block
 
-* `definer` - (Optional) The definer of a view in SQL.
+~> **NOTE:** Changes to a `VIRTUAL_VIEW` table's `view_definition`, `view_original_text`, or `view_expanded_text` are applied in place via Glue's [`UpdateTable`](https://docs.aws.amazon.com/glue/latest/webapi/API_UpdateTable.html) API with `ViewUpdateAction = REPLACE`. The table identity is preserved across the update, which preserves any [Lake Formation](https://docs.aws.amazon.com/lake-formation/latest/dg/access-control-overview.html) grants attached to the view.
+
+* `definer` - (Optional) Definer of a view in SQL.
 * `is_protected` - (Optional) You can set this flag as true to instruct the engine not to push user-provided operations into the logical plan of the view during query planning. However, setting this flag does not guarantee that the engine will comply. Refer to the engine's documentation to understand the guarantees provided, if any.
 * `last_refresh_type` - (Optional) Type of the materialized view's last refresh. Valid values: `Full`, `Incremental`.
 * `refresh_seconds` - (Optional) Auto refresh interval in seconds for the materialized view.
-* `representations` - (Optional) A list of structures that contains the dialect of the view, and the query that defines the view. See [`representations`](#representations) below.
+* `representations` - (Optional) List of structures that contains the dialect of the view, and the query that defines the view. See [`representations`](#representations) below.
 * `sub_object_version_ids` - (Optional) List of the Apache Iceberg table versions referenced by the materialized view.
-* `sub_objects` - (Optional) A list of base table ARNs that make up the view.
+* `sub_objects` - (Optional) List of base table ARNs that make up the view.
 * `view_version_id` - (Optional) ID value that identifies this view's version. For materialized views, the version ID is the Apache Iceberg table's snapshot ID.
 * `view_version_token` - (Optional) Version ID of the Apache Iceberg table.
 
-#### representations
+#### `representations` Block
 
-* `dialect` - (Optional) A parameter that specifies the engine type of a specific representation. Valid values are `REDSHIFT`, `ATHENA`, and `SPARK`.
-* `dialect_version` - (Optional) A parameter that specifies the version of the engine of a specific representation.
-* `validation_connection` - (Optional) The name of the connection to be used to validate the specific representation of the view.
-* `view_expanded_text` - (Optional) A string that represents the SQL query that describes the view with expanded resource ARNs.
-* `view_original_text` - (Optional) A string that represents the original SQL query that describes the view.
+* `dialect` - (Optional) Parameter that specifies the engine type of a specific representation. Valid values are `REDSHIFT`, `ATHENA`, and `SPARK`.
+* `dialect_version` - (Optional) Parameter that specifies the version of the engine of a specific representation.
+* `validation_connection` - (Optional) Name of the connection to be used to validate the specific representation of the view.
+* `view_expanded_text` - (Optional) String that represents the SQL query that describes the view with expanded resource ARNs.
+* `view_original_text` - (Optional) String that represents the original SQL query that describes the view.
 
 ## Attribute Reference
 
 This resource exports the following attributes in addition to the arguments above:
 
-* `arn` - The ARN of the Glue Table.
+* `arn` - ARN of the Glue Table.
 * `id` - Catalog ID, Database name and of the name table.
+* `partition_index[*].index_status` - Status of the partition index.
 
 ## Import
 

--- a/website/docs/r/glue_catalog_table.html.markdown
+++ b/website/docs/r/glue_catalog_table.html.markdown
@@ -341,7 +341,7 @@ To add an index to an existing table, see the [`glue_partition_index` resource](
 
 ### `view_definition` Block
 
-~> **NOTE:** Changes to a `VIRTUAL_VIEW` table's `view_definition`, `view_original_text`, or `view_expanded_text` are applied in place via Glue's [`UpdateTable`](https://docs.aws.amazon.com/glue/latest/webapi/API_UpdateTable.html) API with `ViewUpdateAction = REPLACE`. The table identity is preserved across the update, which preserves any [Lake Formation](https://docs.aws.amazon.com/lake-formation/latest/dg/access-control-overview.html) grants attached to the view.
+~> **NOTE:** Changes to a multi-dialect view (one configured via the `view_definition` block) are applied in place via Glue's [`UpdateTable`](https://docs.aws.amazon.com/glue/latest/webapi/API_UpdateTable.html) API with `ViewUpdateAction = REPLACE`. The table identity is preserved across the update, which preserves any [Lake Formation](https://docs.aws.amazon.com/lake-formation/latest/dg/access-control-overview.html) grants attached to the view. Legacy views configured only via the top-level `view_original_text` / `view_expanded_text` arguments are updated without `ViewUpdateAction`, as required by the Glue API.
 
 * `definer` - (Optional) Definer of a view in SQL.
 * `is_protected` - (Optional) You can set this flag as true to instruct the engine not to push user-provided operations into the logical plan of the view during query planning. However, setting this flag does not guarantee that the engine will comply. Refer to the engine's documentation to understand the guarantees provided, if any.

--- a/website/docs/r/glue_catalog_table.html.markdown
+++ b/website/docs/r/glue_catalog_table.html.markdown
@@ -200,14 +200,14 @@ The following arguments are optional:
 
 ### `open_table_format_input` Block
 
-~> **NOTE:** A `open_table_format_input` cannot be added to an existing `glue_catalog_table`.
+~> **NOTE:** An `open_table_format_input` cannot be added to an existing `glue_catalog_table`.
 This will destroy and recreate the table, possibly resulting in data loss.
 
 * `iceberg_input` - (Required) Configuration block for iceberg table config. See [`iceberg_input`](#iceberg_input) below.
 
 ### `iceberg_input` Block
 
-~> **NOTE:** A `iceberg_input` cannot be added to an existing `open_table_format_input`.
+~> **NOTE:** An `iceberg_input` cannot be added to an existing `open_table_format_input`.
 This will destroy and recreate the table, possibly resulting in data loss.
 
 * `iceberg_table_input` - (Optional) Configuration parameters, including table properties and metadata specifications. See [`iceberg_table_input`](#iceberg_table_input) below.
@@ -366,7 +366,7 @@ To add an index to an existing table, see the [`glue_partition_index` resource](
 This resource exports the following attributes in addition to the arguments above:
 
 * `arn` - ARN of the Glue Table.
-* `id` - Catalog ID, Database name and of the name table.
+* `id` - Catalog ID, database name, and table name, separated by colons (`:`).
 * `partition_index[*].index_status` - Status of the partition index.
 
 ## Import

--- a/website/docs/r/glue_catalog_table.html.markdown
+++ b/website/docs/r/glue_catalog_table.html.markdown
@@ -184,17 +184,17 @@ The following arguments are optional:
 
 * `catalog_id` - (Optional) ID of the Glue Catalog and database to create the table in. If omitted, this defaults to the AWS Account ID plus the database name.
 * `description` - (Optional) Description of the table.
-* `open_table_format_input` - (Optional) Configuration block for open table formats. See [`open_table_format_input`](#open_table_format_input) below.
+* `open_table_format_input` - (Optional) Configuration block for open table formats. See [`open_table_format_input`](#open_table_format_input-block) below.
 * `owner` - (Optional) Owner of the table.
 * `parameters` - (Optional) Properties associated with this table, as a list of key-value pairs.
-* `partition_index` - (Optional) Configuration block for a maximum of 3 partition indexes. See [`partition_index`](#partition_index) below.
-* `partition_keys` - (Optional) Configuration block of columns by which the table is partitioned. Only primitive types are supported as partition keys. See [`partition_keys`](#partition_keys) below.
+* `partition_index` - (Optional) Configuration block for a maximum of 3 partition indexes. See [`partition_index`](#partition_index-block) below.
+* `partition_keys` - (Optional) Configuration block of columns by which the table is partitioned. Only primitive types are supported as partition keys. See [`partition_keys`](#partition_keys-block) below.
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `retention` - (Optional) Retention time for this table.
-* `storage_descriptor` - (Optional) Configuration block for information about the physical storage of this table. For more information, refer to the [Glue Developer Guide](https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-catalog-tables.html#aws-glue-api-catalog-tables-StorageDescriptor). See [`storage_descriptor`](#storage_descriptor) below.
+* `storage_descriptor` - (Optional) Configuration block for information about the physical storage of this table. For more information, refer to the [Glue Developer Guide](https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-catalog-tables.html#aws-glue-api-catalog-tables-StorageDescriptor). See [`storage_descriptor`](#storage_descriptor-block) below.
 * `table_type` - (Optional) Type of this table (EXTERNAL_TABLE, VIRTUAL_VIEW, etc.). While optional, some Athena DDL queries such as `ALTER TABLE` and `SHOW CREATE TABLE` will fail if this argument is empty.
-* `target_table` - (Optional) Configuration block of a target table for resource linking. See [`target_table`](#target_table) below.
-* `view_definition` - (Optional) Structure that contains all the information that defines the view, including the dialect or dialects for the view, and the query. See [`view_definition`](#view_definition) below.
+* `target_table` - (Optional) Configuration block of a target table for resource linking. See [`target_table`](#target_table-block) below.
+* `view_definition` - (Optional) Structure that contains all the information that defines the view, including the dialect or dialects for the view, and the query. See [`view_definition`](#view_definition-block) below.
 * `view_expanded_text` - (Optional) If the table is a view, the expanded text of the view; otherwise null.
 * `view_original_text` - (Optional) If the table is a view, the original text of the view; otherwise null.
 
@@ -203,24 +203,24 @@ The following arguments are optional:
 ~> **NOTE:** An `open_table_format_input` cannot be added to an existing `glue_catalog_table`.
 This will destroy and recreate the table, possibly resulting in data loss.
 
-* `iceberg_input` - (Required) Configuration block for iceberg table config. See [`iceberg_input`](#iceberg_input) below.
+* `iceberg_input` - (Required) Configuration block for iceberg table config. See [`iceberg_input`](#iceberg_input-block) below.
 
 ### `iceberg_input` Block
 
 ~> **NOTE:** An `iceberg_input` cannot be added to an existing `open_table_format_input`.
 This will destroy and recreate the table, possibly resulting in data loss.
 
-* `iceberg_table_input` - (Optional) Configuration parameters, including table properties and metadata specifications. See [`iceberg_table_input`](#iceberg_table_input) below.
+* `iceberg_table_input` - (Optional) Configuration parameters, including table properties and metadata specifications. See [`iceberg_table_input`](#iceberg_table_input-block) below.
 * `metadata_operation` - (Required) Required metadata operation. Can only be set to CREATE.
 * `version` - (Optional) Table version for the Iceberg table. Defaults to 2.
 
 ### `iceberg_table_input` Block
 
 * `location` - (Required) S3 location where the Iceberg table data will be stored. Maximum length of 2056 characters.
-* `partition_spec` - (Optional) Partitioning specification that defines how the Iceberg table data will be organized and partitioned for optimal query performance. See [`partition_spec`](#partition_spec) below.
+* `partition_spec` - (Optional) Partitioning specification that defines how the Iceberg table data will be organized and partitioned for optimal query performance. See [`partition_spec`](#partition_spec-block) below.
 * `properties` - (Optional) Key-value pairs of additional table properties and configuration settings for the Iceberg table.
-* `schema` - (Required) Schema definition that specifies the structure, field types, and metadata for the Iceberg table. See [`schema`](#schema) below.
-* `sort_order` - (Optional) Sort order specification that defines how data should be ordered within each partition to optimize query performance. See [`sort_order`](#sort_order) below.
+* `schema` - (Required) Schema definition that specifies the structure, field types, and metadata for the Iceberg table. See [`schema`](#schema-block) below.
+* `sort_order` - (Optional) Sort order specification that defines how data should be ordered within each partition to optimize query performance. See [`sort_order`](#sort_order-block) below.
 
 ### `partition_spec` Block
 
@@ -283,17 +283,17 @@ To add an index to an existing table, see the [`glue_partition_index` resource](
 
 * `additional_locations` - (Optional) List of locations that point to the path where a Delta table is located.
 * `bucket_columns` - (Optional) List of reducer grouping columns, clustering columns, and bucketing columns in the table.
-* `columns` - (Optional) Configuration block for columns in the table. See [`columns`](#columns) below.
+* `columns` - (Optional) Configuration block for columns in the table. See [`columns`](#columns-block) below.
 * `compressed` - (Optional) Whether the data in the table is compressed.
 * `input_format` - (Optional) Input format: SequenceFileInputFormat (binary), or TextInputFormat, or a custom format.
 * `location` - (Optional) Physical location of the table. By default this takes the form of the warehouse location, followed by the database location in the warehouse, followed by the table name.
 * `number_of_buckets` - (Optional) Must be specified if the table contains any dimension columns.
 * `output_format` - (Optional) Output format: SequenceFileOutputFormat (binary), or IgnoreKeyTextOutputFormat, or a custom format.
 * `parameters` - (Optional) User-supplied properties in key-value form.
-* `schema_reference` - (Optional) Object that references a schema stored in the AWS Glue Schema Registry. When creating a table, you can pass an empty list of columns for the schema, and instead use a schema reference. See [Schema Reference](#schema_reference) below.
-* `ser_de_info` - (Optional) Configuration block for serialization and deserialization ("SerDe") information. See [`ser_de_info`](#ser_de_info) below.
-* `skewed_info` - (Optional) Configuration block with information about values that appear very frequently in a column (skewed values). See [`skewed_info`](#skewed_info) below.
-* `sort_columns` - (Optional) Configuration block for the sort order of each bucket in the table. See [`sort_columns`](#sort_columns) below.
+* `schema_reference` - (Optional) Object that references a schema stored in the AWS Glue Schema Registry. When creating a table, you can pass an empty list of columns for the schema, and instead use a schema reference. See [Schema Reference](#schema_reference-block) below.
+* `ser_de_info` - (Optional) Configuration block for serialization and deserialization ("SerDe") information. See [`ser_de_info`](#ser_de_info-block) below.
+* `skewed_info` - (Optional) Configuration block with information about values that appear very frequently in a column (skewed values). See [`skewed_info`](#skewed_info-block) below.
+* `sort_columns` - (Optional) Configuration block for the sort order of each bucket in the table. See [`sort_columns`](#sort_columns-block) below.
 * `stored_as_sub_directories` - (Optional) Whether the table data is stored in subdirectories.
 
 #### `columns` Block
@@ -305,7 +305,7 @@ To add an index to an existing table, see the [`glue_partition_index` resource](
 
 #### `schema_reference` Block
 
-* `schema_id` - (Optional) Configuration block that contains schema identity fields. Either this or the `schema_version_id` has to be provided. See [`schema_id`](#schema_id) below.
+* `schema_id` - (Optional) Configuration block that contains schema identity fields. Either this or the `schema_version_id` has to be provided. See [`schema_id`](#schema_id-block) below.
 * `schema_version_id` - (Optional) Unique ID assigned to a version of the schema. Either this or the `schema_id` has to be provided.
 * `schema_version_number` - (Required) Version number of the schema.
 
@@ -347,7 +347,7 @@ To add an index to an existing table, see the [`glue_partition_index` resource](
 * `is_protected` - (Optional) You can set this flag as true to instruct the engine not to push user-provided operations into the logical plan of the view during query planning. However, setting this flag does not guarantee that the engine will comply. Refer to the engine's documentation to understand the guarantees provided, if any.
 * `last_refresh_type` - (Optional) Type of the materialized view's last refresh. Valid values: `Full`, `Incremental`.
 * `refresh_seconds` - (Optional) Auto refresh interval in seconds for the materialized view.
-* `representations` - (Optional) List of structures that contains the dialect of the view, and the query that defines the view. See [`representations`](#representations) below.
+* `representations` - (Optional) List of structures that contains the dialect of the view, and the query that defines the view. See [`representations`](#representations-block) below.
 * `sub_object_version_ids` - (Optional) List of the Apache Iceberg table versions referenced by the materialized view.
 * `sub_objects` - (Optional) List of base table ARNs that make up the view.
 * `view_version_id` - (Optional) ID value that identifies this view's version. For materialized views, the version ID is the Apache Iceberg table's snapshot ID.

--- a/website/docs/r/glue_catalog_table.html.markdown
+++ b/website/docs/r/glue_catalog_table.html.markdown
@@ -186,7 +186,7 @@ The following arguments are optional:
 * `description` - (Optional) Description of the table.
 * `open_table_format_input` - (Optional) Configuration block for open table formats. See [`open_table_format_input`](#open_table_format_input-block) below.
 * `owner` - (Optional) Owner of the table.
-* `parameters` - (Optional) Properties associated with this table, as a list of key-value pairs.
+* `parameters` - (Optional) Properties associated with this table, as a map of key-value pairs.
 * `partition_index` - (Optional) Configuration block for a maximum of 3 partition indexes. See [`partition_index`](#partition_index-block) below.
 * `partition_keys` - (Optional) Configuration block of columns by which the table is partitioned. Only primitive types are supported as partition keys. See [`partition_keys`](#partition_keys-block) below.
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Sets `ViewUpdateAction = REPLACE` and `Force = true` on `glue.UpdateTableInput` when the table is a `VIRTUAL_VIEW`, mirroring `aws glue update-table --view-update-action REPLACE --force`. This allows the SQL in a Glue Data Catalog view to be changed in place without destroying and recreating the table (which would drop any Lake Formation grants attached to it).

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #48534

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t T=TestAccGlueCatalogTable_Update_viewInPlace K=glue
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 b-update-glue-in-place 🌿...
TF_ACC=1 go1.26.4 test ./internal/service/glue/... -v -count 1 -parallel 20 -run='TestAccGlueCatalogTable_Update_viewInPlace'  -timeout 360m -vet=off
2026/06/23 13:26:47 Creating Terraform AWS Provider (SDKv2-style)...
2026/06/23 13:26:47 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccGlueCatalogTable_Update_viewInPlace
=== PAUSE TestAccGlueCatalogTable_Update_viewInPlace
=== CONT  TestAccGlueCatalogTable_Update_viewInPlace
--- PASS: TestAccGlueCatalogTable_Update_viewInPlace (27.40s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/glue	39.066s
```
