### PR TITLE
feat: add CustomerActionStatus to MSK cluster attributes

### DIFF
--- a/.changelog/48536.txt
+++ b/.changelog/48536.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_msk_cluster: Add `customer_action_status` attribute
+```
+
+```release-note:enhancement
+data-source/aws_msk_cluster: Add `customer_action_status` attribute
+```

--- a/internal/service/kafka/cluster.go
+++ b/internal/service/kafka/cluster.go
@@ -354,6 +354,10 @@ func resourceCluster() *schema.Resource {
 					Type:     schema.TypeString,
 					Computed: true,
 				},
+				"customer_action_status": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
 				"encryption_info": {
 					Type:     schema.TypeList,
 					Optional: true,
@@ -1188,6 +1192,7 @@ func resourceClusterFlatten(ctx context.Context, cluster *types.ClusterInfo, out
 		d.Set("configuration_info", nil)
 	}
 	d.Set("current_version", cluster.CurrentVersion)
+	d.Set("customer_action_status", cluster.CustomerActionStatus)
 	d.Set("enhanced_monitoring", cluster.EnhancedMonitoring)
 	if cluster.EncryptionInfo != nil {
 		if err := d.Set("encryption_info", []any{flattenEncryptionInfo(cluster.EncryptionInfo)}); err != nil {

--- a/internal/service/kafka/cluster_data_source.go
+++ b/internal/service/kafka/cluster_data_source.go
@@ -198,6 +198,10 @@ func dataSourceCluster() *schema.Resource {
 					Type:     schema.TypeString,
 					Computed: true,
 				},
+				"customer_action_status": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
 				"kafka_version": {
 					Type:     schema.TypeString,
 					Computed: true,
@@ -257,6 +261,7 @@ func dataSourceClusterRead(ctx context.Context, d *schema.ResourceData, meta any
 	d.Set(names.AttrClusterName, cluster.ClusterName)
 	clusterUUID, _ := clusterUUIDFromARN(clusterARN)
 	d.Set("cluster_uuid", clusterUUID)
+	d.Set("customer_action_status", cluster.CustomerActionStatus)
 	d.Set("kafka_version", cluster.CurrentBrokerSoftwareInfo.KafkaVersion)
 	d.Set("number_of_broker_nodes", cluster.NumberOfBrokerNodes)
 	d.Set("zookeeper_connect_string", sortEndpointsString(aws.ToString(cluster.ZookeeperConnectString)))

--- a/internal/service/kafka/cluster_data_source_test.go
+++ b/internal/service/kafka/cluster_data_source_test.go
@@ -61,6 +61,7 @@ func TestAccKafkaClusterDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.0.storage_info.0.ebs_storage_info.0.provisioned_throughput.#", "0"),
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrClusterName, resourceName, names.AttrClusterName),
 					resource.TestCheckResourceAttrPair(dataSourceName, "cluster_uuid", resourceName, "cluster_uuid"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "customer_action_status", resourceName, "customer_action_status"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "kafka_version", resourceName, "kafka_version"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "number_of_broker_nodes", resourceName, "number_of_broker_nodes"),
 					resource.TestCheckResourceAttrPair(dataSourceName, acctest.CtTagsPercent, resourceName, acctest.CtTagsPercent),

--- a/internal/service/kafka/cluster_test.go
+++ b/internal/service/kafka/cluster_test.go
@@ -169,6 +169,7 @@ func TestAccKafkaCluster_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, names.AttrClusterName, rName),
 					resource.TestCheckResourceAttrSet(resourceName, "cluster_uuid"),
 					resource.TestCheckResourceAttr(resourceName, "configuration_info.#", "0"),
+					resource.TestCheckResourceAttrSet(resourceName, "customer_action_status"),
 					resource.TestCheckResourceAttr(resourceName, "encryption_info.#", "1"),
 					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, "encryption_info.0.encryption_at_rest_kms_key_arn", "kms", regexache.MustCompile(`key/.+`)),
 					resource.TestCheckResourceAttr(resourceName, "encryption_info.0.encryption_in_transit.#", "1"),

--- a/website/docs/d/msk_cluster.html.markdown
+++ b/website/docs/d/msk_cluster.html.markdown
@@ -41,8 +41,9 @@ This data source exports the following attributes in addition to the arguments a
 * `bootstrap_brokers_tls` - One or more DNS names (or IP addresses) and TLS port pairs. For example, `b-1.exampleClusterName.abcde.c2.kafka.us-east-1.amazonaws.com:9094,b-2.exampleClusterName.abcde.c2.kafka.us-east-1.amazonaws.com:9094,b-3.exampleClusterName.abcde.c2.kafka.us-east-1.amazonaws.com:9094`. This attribute will have a value if `encryption_info.0.encryption_in_transit.0.client_broker` is set to `TLS_PLAINTEXT` or `TLS`. The resource sorts the list alphabetically. AWS may not always return all endpoints so the values may not be stable across applies.
 * `broker_node_group_info` - Configuration block for the broker nodes of the Kafka cluster.
 * `cluster_uuid` - UUID of the MSK cluster, for use in IAM policies.
+* `customer_action_status` - Status indicating whether Amazon MSK requires customer action for the cluster. Valid values are `NONE`, `ACTION_RECOMMENDED`, and `CRITICAL_ACTION_REQUIRED`.
 * `kafka_version` - Apache Kafka version.
 * `number_of_broker_nodes` - Number of broker nodes in the cluster.
 * `tags` - Map of key-value pairs assigned to the cluster.
-* `zookeeper_connect_string` - A comma separated list of one or more hostname:port pairs to use to connect to the Apache Zookeeper cluster. The returned values are sorted alphbetically. The AWS API may not return all endpoints, so this value is not guaranteed to be stable across applies.
+* `zookeeper_connect_string` - A comma separated list of one or more hostname:port pairs to use to connect to the Apache Zookeeper cluster. The returned values are sorted alphabetically. The AWS API may not return all endpoints, so this value is not guaranteed to be stable across applies.
 * `zookeeper_connect_string_tls` - A comma separated list of one or more hostname:port pairs to use to connect to the Apache Zookeeper cluster via TLS. The returned values are sorted alphabetically. The AWS API may not return all endpoints, so this value is not guaranteed to be stable across applies.

--- a/website/docs/r/msk_cluster.html.markdown
+++ b/website/docs/r/msk_cluster.html.markdown
@@ -361,6 +361,7 @@ This resource exports the following attributes in addition to the arguments abov
 * `bootstrap_brokers_vpc_connectivity_tls` - A string containing one or more DNS names (or IP addresses) and TLS port pairs for VPC connectivity. AWS may not always return all endpoints so the values may not be stable across applies.
 * `cluster_uuid` - UUID of the MSK cluster, for use in IAM policies.
 * `current_version` - Current version of the MSK Cluster used for updates, e.g., `K13V1IB3VIYZZH`
+* `customer_action_status` - Status indicating whether Amazon MSK requires customer action for the cluster. Valid values are `NONE`, `ACTION_RECOMMENDED`, and `CRITICAL_ACTION_REQUIRED`.
 * `encryption_info.0.encryption_at_rest_kms_key_arn` - The ARN of the KMS key used for encryption at rest of the broker data volumes.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 * `zookeeper_connect_string` - A comma separated list of one or more hostname:port pairs to use to connect to the Apache Zookeeper cluster. The returned values are sorted alphabetically. The AWS API may not return all endpoints, so this value is not guaranteed to be stable across applies.


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->


## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

### Description

Add the attribute `customer_action_status` to the resource [`aws_msk_cluster`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/msk_cluster)

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

### References

- [AWS API reference](https://docs.aws.amazon.com/de_de/MSK/2.0/APIReference/v2-clusters.html#v2-clusters-prop-provisioned-customeractionstatus)

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
make testacc T=TestAccKafkaCluster_basic K=kafka
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework (cached)
make: Running acceptance tests on branch: 🌿 f-msk-cluster-customer-action-status 🌿...
TF_ACC=1 go1.26.4 test ./internal/service/kafka/... -v -count 1 -parallel 20 -run='TestAccKafkaCluster_basic'  -timeout 360m -vet=off -buildvcs=false
2026/06/23 17:34:17 Creating Terraform AWS Provider (SDKv2-style)...
2026/06/23 17:34:17 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccKafkaCluster_basic
=== PAUSE TestAccKafkaCluster_basic
=== CONT  TestAccKafkaCluster_basic
--- PASS: TestAccKafkaCluster_basic (1887.98s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/kafka      1888.118s
```

```console
make testacc T=TestAccKafkaClusterDataSource_basic K=kafka
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework (cached)
make: Running acceptance tests on branch: 🌿 f-msk-cluster-customer-action-status 🌿...
TF_ACC=1 go1.26.4 test ./internal/service/kafka/... -v -count 1 -parallel 20 -run='TestAccKafkaClusterDataSource_basic'  -timeout 360m -vet=off -buildvcs=false
2026/06/23 18:37:30 Creating Terraform AWS Provider (SDKv2-style)...
2026/06/23 18:37:30 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccKafkaClusterDataSource_basic
=== PAUSE TestAccKafkaClusterDataSource_basic
=== CONT  TestAccKafkaClusterDataSource_basic

--- PASS: TestAccKafkaClusterDataSource_basic (2575.98s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/kafka      2576.137s

```
