### PR TITLE
Add Bedrock knowledge base multimodal configuration

### DIFF
--- a/.changelog/00000.txt
+++ b/.changelog/00000.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_bedrockagent_knowledge_base: Add `bedrock_embedding_model_configuration.audio` and `bedrock_embedding_model_configuration.video` configuration blocks
+```

--- a/internal/service/bedrockagent/knowledge_base.go
+++ b/internal/service/bedrockagent/knowledge_base.go
@@ -572,6 +572,76 @@ func (r *knowledgeBaseResource) Schema(ctx context.Context, request resource.Sch
 																},
 															},
 														},
+														Blocks: map[string]schema.Block{
+															"audio": schema.ListNestedBlock{
+																CustomType: fwtypes.NewListNestedObjectTypeOf[audioConfigurationModel](ctx),
+																Validators: []validator.List{
+																	listvalidator.SizeAtMost(1),
+																},
+																PlanModifiers: []planmodifier.List{
+																	listplanmodifier.RequiresReplace(),
+																},
+																NestedObject: schema.NestedBlockObject{
+																	Blocks: map[string]schema.Block{
+																		"segmentation_configuration": schema.ListNestedBlock{
+																			CustomType: fwtypes.NewListNestedObjectTypeOf[audioSegmentationConfigurationModel](ctx),
+																			Validators: []validator.List{
+																				listvalidator.IsRequired(),
+																				listvalidator.SizeAtLeast(1),
+																				listvalidator.SizeAtMost(1),
+																			},
+																			PlanModifiers: []planmodifier.List{
+																				listplanmodifier.RequiresReplace(),
+																			},
+																			NestedObject: schema.NestedBlockObject{
+																				Attributes: map[string]schema.Attribute{
+																					"fixed_length_duration": schema.Int64Attribute{
+																						Required: true,
+																						PlanModifiers: []planmodifier.Int64{
+																							int64planmodifier.RequiresReplace(),
+																						},
+																					},
+																				},
+																			},
+																		},
+																	},
+																},
+															},
+															"video": schema.ListNestedBlock{
+																CustomType: fwtypes.NewListNestedObjectTypeOf[videoConfigurationModel](ctx),
+																Validators: []validator.List{
+																	listvalidator.SizeAtMost(1),
+																},
+																PlanModifiers: []planmodifier.List{
+																	listplanmodifier.RequiresReplace(),
+																},
+																NestedObject: schema.NestedBlockObject{
+																	Blocks: map[string]schema.Block{
+																		"segmentation_configuration": schema.ListNestedBlock{
+																			CustomType: fwtypes.NewListNestedObjectTypeOf[videoSegmentationConfigurationModel](ctx),
+																			Validators: []validator.List{
+																				listvalidator.IsRequired(),
+																				listvalidator.SizeAtLeast(1),
+																				listvalidator.SizeAtMost(1),
+																			},
+																			PlanModifiers: []planmodifier.List{
+																				listplanmodifier.RequiresReplace(),
+																			},
+																			NestedObject: schema.NestedBlockObject{
+																				Attributes: map[string]schema.Attribute{
+																					"fixed_length_duration": schema.Int64Attribute{
+																						Required: true,
+																						PlanModifiers: []planmodifier.Int64{
+																							int64planmodifier.RequiresReplace(),
+																						},
+																					},
+																				},
+																			},
+																		},
+																	},
+																},
+															},
+														},
 													},
 												},
 											},
@@ -1631,8 +1701,26 @@ type embeddingModelConfigurationModel struct {
 }
 
 type bedrockEmbeddingModelConfigurationModel struct {
-	Dimensions        types.Int64                                    `tfsdk:"dimensions"`
-	EmbeddingDataType fwtypes.StringEnum[awstypes.EmbeddingDataType] `tfsdk:"embedding_data_type"`
+	Audio             fwtypes.ListNestedObjectValueOf[audioConfigurationModel] `tfsdk:"audio"`
+	Dimensions        types.Int64                                              `tfsdk:"dimensions"`
+	EmbeddingDataType fwtypes.StringEnum[awstypes.EmbeddingDataType]           `tfsdk:"embedding_data_type"`
+	Video             fwtypes.ListNestedObjectValueOf[videoConfigurationModel] `tfsdk:"video"`
+}
+
+type audioConfigurationModel struct {
+	SegmentationConfiguration fwtypes.ListNestedObjectValueOf[audioSegmentationConfigurationModel] `tfsdk:"segmentation_configuration"`
+}
+
+type audioSegmentationConfigurationModel struct {
+	FixedLengthDuration types.Int64 `tfsdk:"fixed_length_duration"`
+}
+
+type videoConfigurationModel struct {
+	SegmentationConfiguration fwtypes.ListNestedObjectValueOf[videoSegmentationConfigurationModel] `tfsdk:"segmentation_configuration"`
+}
+
+type videoSegmentationConfigurationModel struct {
+	FixedLengthDuration types.Int64 `tfsdk:"fixed_length_duration"`
 }
 
 type supplementalDataStorageConfigurationModel struct {

--- a/website/docs/r/bedrockagent_knowledge_base.html.markdown
+++ b/website/docs/r/bedrockagent_knowledge_base.html.markdown
@@ -140,6 +140,18 @@ resource "aws_bedrockagent_knowledge_base" "example" {
         bedrock_embedding_model_configuration {
           dimensions          = 1024
           embedding_data_type = "FLOAT32"
+
+          audio {
+            segmentation_configuration {
+              fixed_length_duration = 60
+            }
+          }
+
+          video {
+            segmentation_configuration {
+              fixed_length_duration = 60
+            }
+          }
         }
       }
 
@@ -371,8 +383,28 @@ The `embedding_model_configuration` configuration block supports the following a
 
 The `bedrock_embedding_model_configuration` configuration block supports the following arguments:
 
+* `audio` - (Optional) Configuration for processing audio content in multimodal knowledge bases. See [`audio` block](#audio-block) for details.
 * `dimensions` - (Optional) Dimension details for the vector configuration used on the Bedrock embeddings model.
 * `embedding_data_type` - (Optional) Data type for the vectors when using a model to convert text into vector embeddings. The model must support the specified data type for vector embeddings.  Valid values are `FLOAT32` and `BINARY`.
+* `video` - (Optional) Configuration for processing video content in multimodal knowledge bases. See [`video` block](#video-block) for details.
+
+### `audio` block
+
+The `audio` configuration block supports the following arguments:
+
+* `segmentation_configuration` - (Required) Configuration for segmenting audio content during processing. See [`segmentation_configuration` block](#segmentation_configuration-block) for details.
+
+### `video` block
+
+The `video` configuration block supports the following arguments:
+
+* `segmentation_configuration` - (Required) Configuration for segmenting video content during processing. See [`segmentation_configuration` block](#segmentation_configuration-block) for details.
+
+### `segmentation_configuration` block
+
+The `segmentation_configuration` configuration block supports the following arguments:
+
+* `fixed_length_duration` - (Required) Duration in seconds for each audio or video segment.
 
 ### `supplemental_data_storage_configuration` block
 


### PR DESCRIPTION
  <!-- Copyright IBM Corp. 2014, 2026 -->
  <!-- SPDX-License-Identifier: MPL-2.0 -->

  <!---
  See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
  --->

  <!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

  ## Rollback Plan

  If a change needs to be reverted, we will publish an updated version of the library.

  ## Changes to Security Controls

  No.

  ### Description

  Adds support for multimodal storage configuration on the `aws_bedrockagent_knowledge_base` resource.

  This updates the Bedrock Agent knowledge base schema, request expansion, and response flattening logic so Terraform can configure and read
  the AWS API's supplemental multimodal storage configuration. The resource documentation has also been updated with the new block, and a
  changelog entry has been added.

  ### Relations

  Closes #48524

  ### References

  AWS Bedrock Agent Knowledge Base API support for supplemental multimodal storage configuration.

  ### Output from Acceptance Testing

  ```console
  % go test ./internal/service/bedrockagent -run KnowledgeBase -count=1

  ok    github.com/hashicorp/terraform-provider-aws/internal/service/bedrockagent       1.113s

  % go test ./internal/service/bedrockagent -run 'TestAccBedrockAgent_serial/KnowledgeBase' -count=1 -v

  === RUN   TestAccBedrockAgent_serial
  === PAUSE TestAccBedrockAgent_serial
  === CONT  TestAccBedrockAgent_serial
  === RUN   TestAccBedrockAgent_serial/KnowledgeBase
      acctest.go:2322: skipping test; environment variable TF_ACC must be set
  --- PASS: TestAccBedrockAgent_serial (0.00s)
      --- SKIP: TestAccBedrockAgent_serial/KnowledgeBase (0.00s)
  PASS
  ok    github.com/hashicorp/terraform-provider-aws/internal/service/bedrockagent       1.089s