### PR TITLE
🤖🤖🤖 rds: Allow in-place rename of clusters and cluster instances

### DIFF
--- a/.changelog/00000.txt
+++ b/.changelog/00000.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_rds_cluster: Changing `cluster_identifier` now renames the cluster in place via `ModifyDBCluster` instead of forcing resource recreation. Requires `apply_immediately = true`.
+```
+
+```release-note:enhancement
+resource/aws_rds_cluster_instance: Changing `identifier` now renames the instance in place via `ModifyDBInstance` instead of forcing resource recreation. Requires `apply_immediately = true`. Renaming the parent cluster's `cluster_identifier` no longer forces the instance to be recreated.
+```

--- a/internal/service/rds/cluster.go
+++ b/internal/service/rds/cluster.go
@@ -125,7 +125,6 @@ func resourceCluster() *schema.Resource {
 					Type:          schema.TypeString,
 					Optional:      true,
 					Computed:      true,
-					ForceNew:      true,
 					ValidateFunc:  validIdentifier,
 					ConflictsWith: []string{"cluster_identifier_prefix"},
 				},
@@ -1626,6 +1625,18 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta any
 			DBClusterIdentifier: aws.String(d.Id()),
 		}
 
+		// Renaming a cluster (NewDBClusterIdentifier) is only honored when
+		// ApplyImmediately is true; otherwise AWS defers it to the next maintenance
+		// window. Because this resource's ID is the cluster identifier, a deferred
+		// rename would leave the ID out of sync with the actual cluster name. Require
+		// apply_immediately to keep the rename and the resource ID consistent.
+		if d.HasChange(names.AttrClusterIdentifier) {
+			if !applyImmediately {
+				return sdkdiag.AppendErrorf(diags, "renaming RDS Cluster (%s) requires apply_immediately = true", d.Id())
+			}
+			input.NewDBClusterIdentifier = aws.String(d.Get(names.AttrClusterIdentifier).(string))
+		}
+
 		storageType := d.Get(names.AttrStorageType).(string)
 		if d.HasChange(names.AttrAllocatedStorage) {
 			input.AllocatedStorage = aws.Int32(int32(d.Get(names.AttrAllocatedStorage).(int)))
@@ -1851,6 +1862,13 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta any
 
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating RDS Cluster (%s): %s", d.Id(), err)
+		}
+
+		// A successful rename changes the cluster identifier, which is this
+		// resource's ID. Update it so the wait and subsequent read target the new
+		// name rather than the old one.
+		if input.NewDBClusterIdentifier != nil {
+			d.SetId(aws.ToString(input.NewDBClusterIdentifier))
 		}
 
 		if _, err := waitDBClusterUpdated(ctx, conn, d.Id(), applyImmediately, d.Timeout(schema.TimeoutUpdate)); err != nil {

--- a/internal/service/rds/cluster_instance.go
+++ b/internal/service/rds/cluster_instance.go
@@ -82,7 +82,6 @@ func resourceClusterInstance() *schema.Resource {
 				names.AttrClusterIdentifier: {
 					Type:     schema.TypeString,
 					Required: true,
-					ForceNew: true,
 				},
 				"copy_tags_to_snapshot": {
 					Type:     schema.TypeBool,
@@ -141,7 +140,6 @@ func resourceClusterInstance() *schema.Resource {
 					Type:          schema.TypeString,
 					Optional:      true,
 					Computed:      true,
-					ForceNew:      true,
 					ConflictsWith: []string{"identifier_prefix"},
 					ValidateFunc:  validIdentifier,
 				},
@@ -449,10 +447,28 @@ func resourceClusterInstanceRead(ctx context.Context, d *schema.ResourceData, me
 func resourceClusterInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta any) (diags diag.Diagnostics) {
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
-	if d.HasChangesExcept(names.AttrTags, names.AttrTagsAll) {
+	// cluster_identifier is excluded: when the parent aws_rds_cluster is renamed,
+	// this attribute changes to follow it, but the instance's cluster membership
+	// moves with the cluster automatically and needs no ModifyDBInstance call.
+	// Excluding it also avoids issuing an empty modify request (which AWS rejects)
+	// when a parent rename is the only change.
+	if d.HasChangesExcept(names.AttrTags, names.AttrTagsAll, names.AttrClusterIdentifier) {
+		applyImmediately := d.Get(names.AttrApplyImmediately).(bool)
 		input := &rds.ModifyDBInstanceInput{
-			ApplyImmediately:     aws.Bool(d.Get(names.AttrApplyImmediately).(bool)),
+			ApplyImmediately:     aws.Bool(applyImmediately),
 			DBInstanceIdentifier: aws.String(d.Id()),
+		}
+
+		// Renaming the instance (NewDBInstanceIdentifier) is only honored when
+		// ApplyImmediately is true; otherwise AWS defers it to the next maintenance
+		// window. Because this resource's ID is the instance identifier, a deferred
+		// rename would leave the ID out of sync with the actual instance name.
+		// Require apply_immediately to keep the rename and the resource ID consistent.
+		if d.HasChange(names.AttrIdentifier) {
+			if !applyImmediately {
+				return sdkdiag.AppendErrorf(diags, "renaming RDS Cluster Instance (%s) requires apply_immediately = true", d.Id())
+			}
+			input.NewDBInstanceIdentifier = aws.String(d.Get(names.AttrIdentifier).(string))
 		}
 
 		if d.HasChange(names.AttrAutoMinorVersionUpgrade) {
@@ -521,8 +537,25 @@ func resourceClusterInstanceUpdate(ctx context.Context, d *schema.ResourceData, 
 			return sdkdiag.AppendErrorf(diags, "updating RDS Cluster Instance (%s): %s", d.Id(), err)
 		}
 
+		// A successful rename changes the instance identifier, which is this
+		// resource's ID. Update it so the wait and subsequent read target the new
+		// name rather than the old one.
+		if input.NewDBInstanceIdentifier != nil {
+			d.SetId(aws.ToString(input.NewDBInstanceIdentifier))
+		}
+
 		if _, err := waitDBClusterInstanceAvailable(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
 			return sdkdiag.AppendErrorf(diags, "waiting for RDS Cluster Instance (%s) update: %s", d.Id(), err)
+		}
+	}
+
+	// A parent cluster rename propagates to this instance's cluster_identifier
+	// without a ModifyDBInstance call, but DescribeDBInstances is eventually
+	// consistent, so wait for the new cluster identifier before reading to avoid
+	// persisting a stale value.
+	if d.HasChange(names.AttrClusterIdentifier) {
+		if err := waitDBClusterInstanceClusterIdentifier(ctx, conn, d.Id(), d.Get(names.AttrClusterIdentifier).(string)); err != nil {
+			return sdkdiag.AppendErrorf(diags, "waiting for RDS Cluster Instance (%s) to reflect renamed cluster: %s", d.Id(), err)
 		}
 	}
 
@@ -578,6 +611,38 @@ func resourceClusterInstanceDelete(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	return diags
+}
+
+// waitDBClusterInstanceClusterIdentifier waits until the instance reports the
+// expected DBClusterIdentifier. The value is eventually consistent after the
+// parent cluster is renamed, so this avoids reading a stale cluster identifier
+// into state (which would otherwise produce a persistent diff).
+func waitDBClusterInstanceClusterIdentifier(ctx context.Context, conn *rds.Client, id, expected string) error {
+	const (
+		statusPending   = "pending"
+		statusReflected = "reflected"
+	)
+	stateConf := &retry.StateChangeConf{
+		Pending: []string{statusPending},
+		Target:  []string{statusReflected},
+		Refresh: func(ctx context.Context) (any, string, error) {
+			db, err := findDBInstanceByID(ctx, conn, id)
+			if err != nil {
+				return nil, "", err
+			}
+			if aws.ToString(db.DBClusterIdentifier) == expected {
+				return db, statusReflected, nil
+			}
+			return db, statusPending, nil
+		},
+		Timeout:    propagationTimeout,
+		MinTimeout: 5 * time.Second,
+		Delay:      10 * time.Second,
+	}
+
+	_, err := stateConf.WaitForStateContext(ctx)
+
+	return err
 }
 
 func waitDBClusterInstanceAvailable(ctx context.Context, conn *rds.Client, id string, timeout time.Duration) (*types.DBInstance, error) { //nolint:unparam

--- a/internal/service/rds/cluster_instance_test.go
+++ b/internal/service/rds/cluster_instance_test.go
@@ -80,6 +80,85 @@ func TestAccRDSClusterInstance_basic(t *testing.T) {
 	})
 }
 
+// Renaming a cluster instance must update in place, not recreate.
+func TestAccRDSClusterInstance_identifierRename(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v1, v2 types.DBInstance
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	instanceID := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	instanceIDUpdated := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_rds_cluster_instance.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckClusterInstanceDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterInstanceConfig_identifierRename(rName, instanceID),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckClusterInstanceExists(ctx, t, resourceName, &v1),
+					resource.TestCheckResourceAttr(resourceName, names.AttrIdentifier, instanceID),
+				),
+			},
+			{
+				Config: testAccClusterInstanceConfig_identifierRename(rName, instanceIDUpdated),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						// Renaming must be an in-place update, never a replacement.
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckClusterInstanceExists(ctx, t, resourceName, &v2),
+					testAccCheckClusterInstanceNotRecreated(&v1, &v2),
+					resource.TestCheckResourceAttr(resourceName, names.AttrIdentifier, instanceIDUpdated),
+				),
+			},
+			{
+				// The renamed instance's ID must still be a valid import handle.
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					names.AttrApplyImmediately,
+					names.AttrForceDestroy,
+				},
+			},
+		},
+	})
+}
+
+// Renaming without apply_immediately must fail fast rather than defer the rename.
+func TestAccRDSClusterInstance_identifierRenameRequiresApplyImmediately(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v types.DBInstance
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	instanceID := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	instanceIDUpdated := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_rds_cluster_instance.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckClusterInstanceDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterInstanceConfig_identifierRenameApplyImmediately(rName, instanceID, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClusterInstanceExists(ctx, t, resourceName, &v),
+				),
+			},
+			{
+				Config:      testAccClusterInstanceConfig_identifierRenameApplyImmediately(rName, instanceIDUpdated, false),
+				ExpectError: regexache.MustCompile(`renaming RDS Cluster Instance \(.+\) requires apply_immediately = true`),
+			},
+		},
+	})
+}
+
 func TestAccRDSClusterInstance_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
@@ -1159,6 +1238,16 @@ func testAccCheckClusterInstanceDestroy(ctx context.Context, t *testing.T) resou
 	}
 }
 
+func testAccCheckClusterInstanceNotRecreated(i, j *types.DBInstance) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if aws.ToString(i.DbiResourceId) != aws.ToString(j.DbiResourceId) {
+			return fmt.Errorf("RDS Cluster Instance was recreated (%s -> %s)", aws.ToString(i.DbiResourceId), aws.ToString(j.DbiResourceId))
+		}
+
+		return nil
+	}
+}
+
 func testAccClusterInstanceConfig_orderableEngineBase(engine string, performanceInsights bool) string {
 	if performanceInsights {
 		return fmt.Sprintf(`
@@ -1232,6 +1321,30 @@ resource "aws_db_parameter_group" "test" {
   }
 }
 `, rName))
+}
+
+func testAccClusterInstanceConfig_identifierRename(rName, instanceID string) string {
+	return acctest.ConfigCompose(testAccClusterInstanceConfig_base(rName, "aurora-mysql"), fmt.Sprintf(`
+resource "aws_rds_cluster_instance" "test" {
+  identifier         = %[2]q
+  engine             = data.aws_rds_engine_version.default.engine
+  cluster_identifier = aws_rds_cluster.test.id
+  instance_class     = data.aws_rds_orderable_db_instance.test.instance_class
+  apply_immediately  = true
+}
+`, rName, instanceID))
+}
+
+func testAccClusterInstanceConfig_identifierRenameApplyImmediately(rName, instanceID string, applyImmediately bool) string {
+	return acctest.ConfigCompose(testAccClusterInstanceConfig_base(rName, "aurora-mysql"), fmt.Sprintf(`
+resource "aws_rds_cluster_instance" "test" {
+  identifier         = %[2]q
+  engine             = data.aws_rds_engine_version.default.engine
+  cluster_identifier = aws_rds_cluster.test.id
+  instance_class     = data.aws_rds_orderable_db_instance.test.instance_class
+  apply_immediately  = %[3]t
+}
+`, rName, instanceID, applyImmediately))
 }
 
 func testAccClusterInstanceConfig_identifierGenerated(rName string) string {

--- a/internal/service/rds/cluster_test.go
+++ b/internal/service/rds/cluster_test.go
@@ -246,6 +246,126 @@ func TestAccRDSCluster_tags(t *testing.T) {
 	})
 }
 
+// Renaming a cluster (and an attached instance) must update in place, not recreate.
+func TestAccRDSCluster_identifierRename(t *testing.T) {
+	ctx := acctest.Context(t)
+	var dbCluster1, dbCluster2, dbCluster3 types.DBCluster
+	var dbInstance1, dbInstance2, dbInstance3 types.DBInstance
+	clusterID := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	clusterIDUpdated := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	clusterIDFinal := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	instanceID := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	instanceIDUpdated := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_rds_cluster.test"
+	instanceResourceName := "aws_rds_cluster_instance.test"
+
+	planChecksUpdate := resource.ConfigPlanChecks{
+		PreApply: []plancheck.PlanCheck{
+			// Renaming must be an in-place update, never a replacement.
+			plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+			plancheck.ExpectResourceAction(instanceResourceName, plancheck.ResourceActionUpdate),
+		},
+	}
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterConfig_identifierRename(instanceID, clusterID, 1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClusterExists(ctx, t, resourceName, &dbCluster1),
+					testAccCheckClusterInstanceExists(ctx, t, instanceResourceName, &dbInstance1),
+					resource.TestCheckResourceAttr(resourceName, names.AttrClusterIdentifier, clusterID),
+					resource.TestCheckResourceAttr(instanceResourceName, names.AttrIdentifier, instanceID),
+					resource.TestCheckResourceAttr(instanceResourceName, names.AttrClusterIdentifier, clusterID),
+				),
+			},
+			{
+				// Rename only the cluster. The instance must not be recreated and
+				// its cluster_identifier must follow the renamed cluster.
+				Config:           testAccClusterConfig_identifierRename(instanceID, clusterIDUpdated, 1),
+				ConfigPlanChecks: planChecksUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClusterExists(ctx, t, resourceName, &dbCluster2),
+					testAccCheckClusterInstanceExists(ctx, t, instanceResourceName, &dbInstance2),
+					testAccCheckClusterNotRecreated(&dbCluster1, &dbCluster2),
+					testAccCheckClusterInstanceNotRecreated(&dbInstance1, &dbInstance2),
+					resource.TestCheckResourceAttr(resourceName, names.AttrClusterIdentifier, clusterIDUpdated),
+					resource.TestCheckResourceAttr(instanceResourceName, names.AttrIdentifier, instanceID),
+					resource.TestCheckResourceAttr(instanceResourceName, names.AttrClusterIdentifier, clusterIDUpdated),
+				),
+			},
+			{
+				// Rename the cluster and the instance, and change a non-identifier
+				// attribute (backup_retention_period) in the same apply. Nothing
+				// must be recreated and the combined modify must succeed.
+				Config:           testAccClusterConfig_identifierRename(instanceIDUpdated, clusterIDFinal, 7),
+				ConfigPlanChecks: planChecksUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClusterExists(ctx, t, resourceName, &dbCluster3),
+					testAccCheckClusterInstanceExists(ctx, t, instanceResourceName, &dbInstance3),
+					testAccCheckClusterNotRecreated(&dbCluster2, &dbCluster3),
+					testAccCheckClusterInstanceNotRecreated(&dbInstance2, &dbInstance3),
+					resource.TestCheckResourceAttr(resourceName, names.AttrClusterIdentifier, clusterIDFinal),
+					resource.TestCheckResourceAttr(resourceName, "backup_retention_period", "7"),
+					resource.TestCheckResourceAttr(instanceResourceName, names.AttrIdentifier, instanceIDUpdated),
+					resource.TestCheckResourceAttr(instanceResourceName, names.AttrClusterIdentifier, clusterIDFinal),
+				),
+			},
+			{
+				// The renamed cluster's ID must still be a valid import handle.
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					names.AttrAllowMajorVersionUpgrade,
+					names.AttrApplyImmediately,
+					"cluster_members",
+					"db_instance_parameter_group_name",
+					"enable_global_write_forwarding",
+					"enable_local_write_forwarding",
+					"manage_master_user_password",
+					"master_password",
+					"master_password_wo",
+					"master_user_secret_kms_key_id",
+					"skip_final_snapshot",
+				},
+			},
+		},
+	})
+}
+
+// Renaming without apply_immediately must fail fast rather than defer the rename.
+func TestAccRDSCluster_identifierRenameRequiresApplyImmediately(t *testing.T) {
+	ctx := acctest.Context(t)
+	var dbCluster types.DBCluster
+	clusterID := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	clusterIDUpdated := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_rds_cluster.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterConfig_identifierRenameApplyImmediately(clusterID, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClusterExists(ctx, t, resourceName, &dbCluster),
+				),
+			},
+			{
+				Config:      testAccClusterConfig_identifierRenameApplyImmediately(clusterIDUpdated, false),
+				ExpectError: regexache.MustCompile(`renaming RDS Cluster \(.+\) requires apply_immediately = true`),
+			},
+		},
+	})
+}
+
 // Test case for verifying that the security groups can be destroyed, recreated,
 // and number changed whilst Terraform handles it correctly.
 // https://github.com/hashicorp/terraform-provider-aws/issues/9692
@@ -4193,6 +4313,53 @@ resource "aws_rds_cluster" "test" {
   skip_final_snapshot = true
 }
 `, rName, tfrds.ClusterEngineAuroraMySQL)
+}
+
+func testAccClusterConfig_identifierRename(instanceID, clusterID string, backupRetentionPeriod int) string {
+	return fmt.Sprintf(`
+data "aws_rds_engine_version" "default" {
+  engine = %[3]q
+}
+
+data "aws_rds_orderable_db_instance" "test" {
+  engine                     = data.aws_rds_engine_version.default.engine
+  engine_version             = data.aws_rds_engine_version.default.version
+  preferred_instance_classes = ["db.t3.medium", "db.t3.small", "db.r5.large"]
+}
+
+resource "aws_rds_cluster" "test" {
+  cluster_identifier      = %[2]q
+  database_name           = "test"
+  engine                  = data.aws_rds_engine_version.default.engine
+  engine_version          = data.aws_rds_engine_version.default.version
+  master_username         = "tfacctest"
+  master_password         = "avoid-plaintext-passwords"
+  skip_final_snapshot     = true
+  apply_immediately       = true
+  backup_retention_period = %[4]d
+}
+
+resource "aws_rds_cluster_instance" "test" {
+  identifier         = %[1]q
+  cluster_identifier = aws_rds_cluster.test.cluster_identifier
+  engine             = data.aws_rds_engine_version.default.engine
+  instance_class     = data.aws_rds_orderable_db_instance.test.instance_class
+  apply_immediately  = true
+}
+`, instanceID, clusterID, tfrds.ClusterEngineAuroraMySQL, backupRetentionPeriod)
+}
+
+func testAccClusterConfig_identifierRenameApplyImmediately(clusterID string, applyImmediately bool) string {
+	return fmt.Sprintf(`
+resource "aws_rds_cluster" "test" {
+  cluster_identifier  = %[1]q
+  engine              = %[2]q
+  master_username     = "tfacctest"
+  master_password     = "avoid-plaintext-passwords"
+  skip_final_snapshot = true
+  apply_immediately   = %[3]t
+}
+`, clusterID, tfrds.ClusterEngineAuroraMySQL, applyImmediately)
 }
 
 func testAccClusterConfig_tags1(rName, tagKey1, tagValue1 string) string {

--- a/website/docs/r/rds_cluster.html.markdown
+++ b/website/docs/r/rds_cluster.html.markdown
@@ -20,6 +20,8 @@ Changes to an RDS Cluster can occur when you manually change a parameter, such a
 
 ~> **Note:** using `apply_immediately` can result in a brief downtime as the server reboots. See the AWS Docs on [RDS Maintenance](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.Maintenance.html) for more information.
 
+~> **Note:** Changing `cluster_identifier` renames the cluster in place and requires `apply_immediately = true`. The rename reboots the cluster and changes its endpoints, so update anything that references the old endpoints. Attached `aws_rds_cluster_instance` resources are not recreated; reference the cluster from them with `cluster_identifier = aws_rds_cluster.example.cluster_identifier` so the rename propagates in the same apply (referencing `.id` instead reconciles on the next plan).
+
 ~> **Note:** All arguments including the username and password will be stored in the raw state as plain-text.
 [Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html).
 
@@ -122,7 +124,7 @@ resource "aws_rds_cluster" "example" {
 }
 
 resource "aws_rds_cluster_instance" "example" {
-  cluster_identifier = aws_rds_cluster.example.id
+  cluster_identifier = aws_rds_cluster.example.cluster_identifier
   instance_class     = "db.serverless"
   engine             = aws_rds_cluster.example.engine
   engine_version     = aws_rds_cluster.example.engine_version
@@ -210,7 +212,7 @@ This resource supports the following arguments:
 * `backtrack_window` - (Optional) Target backtrack window, in seconds. Only available for `aurora` and `aurora-mysql` engines currently. To disable backtracking, set this value to `0`. Defaults to `0`. Must be between `0` and `259200` (72 hours)
 * `backup_retention_period` - (Optional) Days to retain backups for. Default `1`
 * `ca_certificate_identifier` - (Optional) The CA certificate identifier to use for the DB cluster's server certificate.
-* `cluster_identifier` - (Optional, Forces new resources) The cluster identifier. If omitted, Terraform will assign a random, unique identifier.
+* `cluster_identifier` - (Optional) The cluster identifier. If omitted, Terraform will assign a random, unique identifier. Changing this value renames the cluster in place and requires `apply_immediately = true` (see the note above).
 * `cluster_identifier_prefix` - (Optional, Forces new resource) Creates a unique cluster identifier beginning with the specified prefix. Conflicts with `cluster_identifier`.
 * `cluster_scalability_type` - (Optional, Forces new resources) Specifies the scalability mode of the Aurora DB cluster. When set to `limitless`, the cluster operates as an Aurora Limitless Database. When set to `standard` (the default), the cluster uses normal DB instance creation. Valid values: `limitless`, `standard`.
 * `copy_tags_to_snapshot` - (Optional, boolean) Copy all Cluster `tags` to snapshots. Default is `false`.
@@ -387,7 +389,7 @@ resource "aws_rds_cluster" "example" {
 This resource exports the following attributes in addition to the arguments above:
 
 * `arn` - Amazon Resource Name (ARN) of cluster
-* `id` - RDS Cluster Identifier
+* `id` - RDS Cluster Identifier. Use `cluster_identifier` instead.
 * `cluster_identifier` - RDS Cluster Identifier
 * `cluster_resource_id` - RDS Cluster Resource ID
 * `cluster_members` - List of RDS Instances that are a part of this cluster

--- a/website/docs/r/rds_cluster_instance.html.markdown
+++ b/website/docs/r/rds_cluster_instance.html.markdown
@@ -25,13 +25,15 @@ For more information on Amazon Aurora, see [Aurora on Amazon RDS](https://docs.a
 
 ~> **NOTE:** `aurora` is no longer a valid `engine` because of [Amazon Aurora's MySQL-Compatible Edition version 1 end of life](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.MySQL56.EOL.html).
 
+~> **Note:** Changing `identifier` renames the instance in place and requires `apply_immediately = true`. The rename reboots the instance and changes its endpoint, so update anything that references the old endpoint.
+
 ## Example Usage
 
 ```terraform
 resource "aws_rds_cluster_instance" "cluster_instances" {
   count              = 2
   identifier         = "aurora-cluster-demo-${count.index}"
-  cluster_identifier = aws_rds_cluster.default.id
+  cluster_identifier = aws_rds_cluster.default.cluster_identifier
   instance_class     = "db.r4.large"
   engine             = aws_rds_cluster.default.engine
   engine_version     = aws_rds_cluster.default.engine_version
@@ -55,7 +57,7 @@ This resource supports the following arguments:
 * `auto_minor_version_upgrade` - (Optional) Indicates that minor engine upgrades will be applied automatically to the DB instance during the maintenance window. Default `true`.
 * `availability_zone` - (Optional, Computed, Forces new resource) EC2 Availability Zone that the DB instance is created in. See [docs](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBInstance.html) about the details.
 * `ca_cert_identifier` - (Optional) Identifier of the CA certificate for the DB instance.
-* `cluster_identifier` - (Required, Forces new resource) Identifier of the [`aws_rds_cluster`](/docs/providers/aws/r/rds_cluster.html) in which to launch this instance.
+* `cluster_identifier` - (Required) Identifier of the [`aws_rds_cluster`](/docs/providers/aws/r/rds_cluster.html) to launch this instance in. You can't move instances between clusters by changing this value.
 * `copy_tags_to_snapshot` - (Optional, boolean) Indicates whether to copy all of the user-defined tags from the DB instance to snapshots of the DB instance. Default `false`.
 * `custom_iam_instance_profile` - (Optional) Instance profile associated with the underlying Amazon EC2 instance of an RDS Custom DB instance.
 * `db_parameter_group_name` - (Optional) Name of the DB parameter group to associate with this instance.
@@ -65,7 +67,7 @@ This resource supports the following arguments:
   Valid Values: `aurora-mysql`, `aurora-postgresql`, `mysql`, `postgres`.(Note that `mysql` and `postgres` are Multi-AZ RDS clusters).
 * `force_destroy` - (Optional) Forces an instance to be destroyed when a part of a read replica cluster. **Note:** will promote the read replica to a standalone cluster before instance deletion.
 * `identifier_prefix` - (Optional, Forces new resource) Creates a unique identifier beginning with the specified prefix. Conflicts with `identifier`.
-* `identifier` - (Optional, Forces new resource) Identifier for the RDS instance, if omitted, Terraform will assign a random, unique identifier.
+* `identifier` - (Optional) Identifier for the RDS instance, if omitted, Terraform will assign a random, unique identifier. Changing this value renames the instance in place rather than recreating it; `apply_immediately` must be set to `true` for the rename to take effect. Note that renaming changes the instance's endpoint and reboots the instance.
 * `instance_class` - (Required) Instance class to use. For details on CPU and memory, see [Scaling Aurora DB Instances](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Aurora.Managing.html). Aurora uses `db.*` instance classes/types. Please see [AWS Documentation](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.html) for currently available instance classes and complete details. For Aurora Serverless v2 use `db.serverless`.
 * `monitoring_interval` - (Optional) Interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. The default is 0. Valid Values: 0, 1, 5, 10, 15, 30, 60.
 * `monitoring_role_arn` - (Optional) ARN for the IAM role that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. You can find more information on the [AWS Documentation](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Monitoring.html) what IAM permissions are needed to allow Enhanced Monitoring for RDS Instances.


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

Revert the PR.

## Changes to Security Controls

No changes.

### Description

This PR makes two RDS Cluster identifier attributes renamable in place:
* `cluster_identifier` on `aws_rds_cluster`
* `identifier` on `aws_rds_cluster_instance`

AWS supports renaming in-place, but Terraform can only update them with recreation. This is problematic for users because:
* Recreating a cluster is data-destroying
* Recreating a cluster instance can cause cluster downtime

Making the attributes renamable mirrors the behavior already shipped for `aws_db_instance` (#507 / #31232).

This change is backwards-compatible. Resource IDs are automatically updated when a rename occurs.

#### Renaming clusters that have instances

Attached `aws_rds_cluster_instance` resources are **not** recreated when the parent cluster is renamed. When an instance references its cluster via the attribute (`cluster_identifier = aws_rds_cluster.x.cluster_identifier`), the rename propagates and the instance is updated in place in the same apply.

**Corner case:** When a cluster instance references `aws_rds_cluster.x.id` instead, Terraform resolves `.id` to the pre-update value (an in-place update doesn't change a resource's `id`), so the instance's `cluster_identifier` reconciles on the next refresh/plan rather than the same apply.

#### Why apply_immediately is required for a rename

AWS only applies `NewDBClusterIdentifier`/`NewDBInstanceIdentifier` immediately when `ApplyImmediately` is true; otherwise the rename is deferred to the next maintenance window. Because the Terraform ID tracks the identifier, a deferred rename would leave the ID out of sync with the actual resource name. To keep them consistent, a rename returns a clear error unless `apply_immediately = true`.

We could support renames better by using the RDS cluster/instance ID as the Terraform ID, rather than the human readable identifier. However that is a breaking change :sob:.

#### Why the previous PR (#41030) was insufficient

[#41030](https://github.com/hashicorp/terraform-provider-aws/pull/41030) was a prior attempt that only deleted the `ForceNew` flags. Terraform still couldn't update the values. It was just a bit easier to rename clusters with state surgery.

### Relations

* Fixes #38644. (and duplicates #40793 and #41829)
* Supersedes #41030.

### References

- [Renaming a DB instance](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_RenameInstance.html)
- [ModifyDBCluster API](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_ModifyDBCluster.html)
- [ModifyDBInstance API](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_ModifyDBInstance.html)
- Prior art for `aws_db_instance`: #507 / #31232

### Output from Acceptance Testing

```console
% make testacc TESTS='TestAccRDSCluster_identifierRename|TestAccRDSCluster_identifierRenameRequiresApplyImmediately|TestAccRDSClusterInstance_identifierRename|TestAccRDSClusterInstance_identifierRenameRequiresApplyImmediately' PKG=rds

--- PASS: TestAccRDSCluster_identifierRenameRequiresApplyImmediately (134.17s)
--- PASS: TestAccRDSClusterInstance_identifierRenameRequiresApplyImmediately (724.48s)
--- PASS: TestAccRDSClusterInstance_identifierRename (1156.20s)
--- PASS: TestAccRDSCluster_identifierRename (1291.61s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/rds
```

(Run against us-east-1. `TestAccRDSCluster_identifierRename` exercises renaming a cluster that has an attached instance — asserting via `plancheck` that both are updated in place, not replaced — and renaming both plus a non-identifier attribute in one apply.)

---

### AI Usage Disclosure

This pull request was prepared with assistance from Claude Code. It reviewed existing issues in the repo, implemented the code changes (including tests), and wrote the commit message. Documentation & PR are by me :sparkles: Every line has been reviewed by me and I'm comfortable discussing the design decisions (in particular, the `apply_immediately` and `cluster_identifier` warts above).
