### PR TITLE
[IGNORE]r/aws_ecs_capacity_provider: fix recreation issue (for changelog testing)

### DIFF
--- a/.changelog/48544.txt
+++ b/.changelog/48544.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ecs_capacity_provider: Fix resource recreation caused by `ResourceInUseException` errors on delete when the capacity provider is still associated with a cluster due to eventual consistency
+```

--- a/internal/service/ecs/capacity_provider.go
+++ b/internal/service/ecs/capacity_provider.go
@@ -663,11 +663,19 @@ func resourceCapacityProviderDelete(ctx context.Context, d *schema.ResourceData,
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ECSClient(ctx)
 
+	const (
+		timeout = 20 * time.Minute
+	)
 	log.Printf("[DEBUG] Deleting ECS Capacity Provider: %s", d.Id())
 	input := ecs.DeleteCapacityProviderInput{
 		CapacityProvider: aws.String(d.Id()),
 	}
-	_, err := conn.DeleteCapacityProvider(ctx, &input)
+	// The capacity provider may still be associated with a cluster after the
+	// association is removed, as disassociation is eventually consistent. Retry
+	// while the capacity provider is reported as in use.
+	_, err := tfresource.RetryWhenIsA[any, *awstypes.ResourceInUseException](ctx, timeout, func(ctx context.Context) (any, error) {
+		return conn.DeleteCapacityProvider(ctx, &input)
+	})
 
 	// "An error occurred (ClientException) when calling the DeleteCapacityProvider operation: The specified capacity provider does not exist. Specify a valid name or ARN and try again."
 	if errs.IsAErrorMessageContains[*awstypes.ClientException](err, "capacity provider does not exist") {
@@ -678,9 +686,6 @@ func resourceCapacityProviderDelete(ctx context.Context, d *schema.ResourceData,
 		return sdkdiag.AppendErrorf(diags, "deleting ECS Capacity Provider (%s): %s", d.Id(), err)
 	}
 
-	const (
-		timeout = 20 * time.Minute
-	)
 	if _, err := waitCapacityProviderDeleted(ctx, conn, d.Id(), timeout); err != nil {
 		return sdkdiag.AppendErrorf(diags, "waiting for ECS Capacity Provider (%s) delete: %s", d.Id(), err)
 	}


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
