### PR TITLE
fix: aws_rds_cluster storage_type change no longer forces replacement

### DIFF
--- a/.changelog/48545.txt
+++ b/.changelog/48545.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_rds_cluster: Fix `storage_type` changes incorrectly forcing resource replacement for non-Aurora clusters
+```

--- a/internal/service/rds/cluster.go
+++ b/internal/service/rds/cluster.go
@@ -20,7 +20,6 @@ import (
 	"github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -696,27 +695,19 @@ func resourceCluster() *schema.Resource {
 			}
 		},
 
-		CustomizeDiff: customdiff.Sequence(
-			customdiff.ForceNewIf(names.AttrStorageType, func(_ context.Context, d *schema.ResourceDiff, meta any) bool {
-				// Aurora supports mutation of the storage_type parameter, other engines do not
-				return !strings.HasPrefix(d.Get(names.AttrEngine).(string), "aurora")
-			}),
-			func(_ context.Context, diff *schema.ResourceDiff, _ any) error {
-				if diff.Id() == "" {
-					return nil
-				}
-				// The control plane will always return an empty string if a cluster is created with a storage_type of aurora
-				old, new := diff.GetChange(names.AttrStorageType)
-
-				if new.(string) == "aurora" && old.(string) == "" {
-					if err := diff.SetNew(names.AttrStorageType, ""); err != nil {
-						return err
-					}
-					return nil
-				}
+		CustomizeDiff: func(_ context.Context, diff *schema.ResourceDiff, _ any) error {
+			if diff.Id() == "" {
 				return nil
-			},
-		),
+			}
+			// The control plane will always return an empty string if a cluster is created with a storage_type of aurora
+			old, new := diff.GetChange(names.AttrStorageType)
+			if new.(string) == "aurora" && old.(string) == "" {
+				if err := diff.SetNew(names.AttrStorageType, ""); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
 	}
 }
 

--- a/internal/service/rds/cluster_test.go
+++ b/internal/service/rds/cluster_test.go
@@ -4656,9 +4656,9 @@ resource "aws_rds_cluster" "test" {
 }
 
 func testAccClusterConfig_storageTypeNonAurora(rName, sType string) string {
-	iopsLine := "iops = 1000\n"
-	if sType == "gp3" {
-		iopsLine = ""
+	var iopsConfig string
+	if sType != "gp3" {
+		iopsConfig = `  iops = 1000`
 	}
 
 	return acctest.ConfigCompose(
@@ -4672,21 +4672,23 @@ data "aws_rds_orderable_db_instance" "test" {
   supports_iops              = true
   supports_clusters          = true
 }
-
+`, tfrds.ClusterEnginePostgres, mainInstanceClasses),
+		fmt.Sprintf(`
 resource "aws_rds_cluster" "test" {
   apply_immediately         = true
-  cluster_identifier        = %[3]q
+  cluster_identifier        = %[1]q
   db_cluster_instance_class = data.aws_rds_orderable_db_instance.test.instance_class
   db_subnet_group_name      = aws_db_subnet_group.test.name
   engine                    = data.aws_rds_orderable_db_instance.test.engine
   engine_version            = data.aws_rds_orderable_db_instance.test.engine_version
-  storage_type              = %[4]q
+  storage_type              = %[2]q
   allocated_storage         = 100
-  %[5]smaster_password           = "mustbeeightcharaters"
+  master_password           = "mustbeeightcharaters"
   master_username           = "test"
   skip_final_snapshot       = true
+%[3]s
 }
-`, tfrds.ClusterEnginePostgres, mainInstanceClasses, rName, sType, iopsLine))
+`, rName, sType, iopsConfig))
 }
 
 func testAccClusterConfig_storageChange(rName string, sType string) string {

--- a/internal/service/rds/cluster_test.go
+++ b/internal/service/rds/cluster_test.go
@@ -864,6 +864,41 @@ func TestAccRDSCluster_storageTypeAuroraIopt1UpdateAurora(t *testing.T) {
 	})
 }
 
+func TestAccRDSCluster_storageTypeUpdateNonAurora(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	ctx := acctest.Context(t)
+	var dbCluster1, dbCluster2 types.DBCluster
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_rds_cluster.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterConfig_storageTypeNonAurora(rName, "io2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClusterExists(ctx, t, resourceName, &dbCluster1),
+					resource.TestCheckResourceAttr(resourceName, names.AttrStorageType, "io2"),
+				),
+			},
+			{
+				Config: testAccClusterConfig_storageTypeNonAurora(rName, "gp3"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClusterExists(ctx, t, resourceName, &dbCluster2),
+					testAccCheckClusterNotRecreated(&dbCluster1, &dbCluster2),
+					resource.TestCheckResourceAttr(resourceName, names.AttrStorageType, "gp3"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccRDSCluster_iops(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
@@ -4618,6 +4653,40 @@ resource "aws_rds_cluster" "test" {
   skip_final_snapshot       = true
 }
 `, tfrds.ClusterEngineMySQL, mainInstanceClasses, rName, sType))
+}
+
+func testAccClusterConfig_storageTypeNonAurora(rName, sType string) string {
+	iopsLine := "iops = 1000\n"
+	if sType == "gp3" {
+		iopsLine = ""
+	}
+
+	return acctest.ConfigCompose(
+		testAccClusterConfig_clusterSubnetGroup(rName),
+		fmt.Sprintf(`
+data "aws_rds_orderable_db_instance" "test" {
+  engine                     = %[1]q
+  engine_latest_version      = true
+  preferred_instance_classes = [%[2]s]
+  storage_type               = "io2"
+  supports_iops              = true
+  supports_clusters          = true
+}
+
+resource "aws_rds_cluster" "test" {
+  apply_immediately         = true
+  cluster_identifier        = %[3]q
+  db_cluster_instance_class = data.aws_rds_orderable_db_instance.test.instance_class
+  db_subnet_group_name      = aws_db_subnet_group.test.name
+  engine                    = data.aws_rds_orderable_db_instance.test.engine
+  engine_version            = data.aws_rds_orderable_db_instance.test.engine_version
+  storage_type              = %[4]q
+  allocated_storage         = 100
+  %[5]smaster_password           = "mustbeeightcharaters"
+  master_username           = "test"
+  skip_final_snapshot       = true
+}
+`, tfrds.ClusterEnginePostgres, mainInstanceClasses, rName, sType, iopsLine))
 }
 
 func testAccClusterConfig_storageChange(rName string, sType string) string {


### PR DESCRIPTION
Changing storage_type on a non-Aurora multi-AZ RDS cluster (e.g. postgres or mysql) was incorrectly triggering a forced resource replacement. 

The AWS ModifyDBCluster API supports in-place storage_type changes for these clusters, and the update handler already sent StorageType in the modify call. T

The customdiff.ForceNewIf guard was incorrect. Removes the guard and adds an acceptance test to verify in-place update from io2 to gp3 without recreation.

Fixes #48438
