### PR TITLE
.ci/semgrep: enforce use of `internal/retry` state refresh helpers 

### DIFF
--- a/.ci/semgrep/pluginsdk/retry.yml
+++ b/.ci/semgrep/pluginsdk/retry.yml
@@ -45,7 +45,7 @@ rules:
     message: "The internal retry.StateRefreshFunc accepts a context argument"
     severity: WARNING
     patterns:
-      - pattern-inside: "func $F(...) retry.StateRefreshFunc{ ... }"
+      - pattern-inside: "func $F(...) retry.StateRefreshFunc { ... }"
       - pattern: |
           return func() (any, string, error) {
             $...BODY
@@ -84,7 +84,7 @@ rules:
 
   - id: internal-retry-statechangeconf-refresh-remove-context
     languages: [go]
-    message: "The internal retry.StateRefreshConf.Refresh function no longer needs a context argument"
+    message: "The internal retry.StateChangeConf.Refresh function no longer needs a context argument"
     severity: WARNING
     patterns:
       - pattern-inside: "retry.StateChangeConf{ ... }"
@@ -105,12 +105,12 @@ rules:
     message: "The internal retry.NotFoundError struct drops the LastRequest argument"
     severity: WARNING
     pattern: |
-        retry.NotFoundError {
+        retry.NotFoundError{
           $...ARGS,
           LastRequest: ...,
         }
     fix: |
-      retry.NotFoundError {
+      retry.NotFoundError{
         $...ARGS,
       }
     paths:

--- a/.ci/semgrep/pluginsdk/retry.yml
+++ b/.ci/semgrep/pluginsdk/retry.yml
@@ -4,7 +4,7 @@
 rules:
   - id: retry
     languages: [go]
-    message: Don't use Plugin SDK retry functionality, use internal/retry instead
+    message: Don't use Plugin SDK V2 retry functionality, use internal/retry instead
     patterns:
       - pattern: |
           retry.RetryContext(...)
@@ -19,3 +19,104 @@ rules:
       - pattern: |
           sdkretry.NonRetryableError(...)
     severity: WARNING
+
+  - id: use-internal-retry
+    languages: [go]
+    message: "Use internal/retry instead of github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry for VCR-compatible state change helpers"
+    severity: WARNING
+    pattern-either:
+      - pattern: |
+          import "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+      - pattern: |
+          import $ALIAS "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+    fix-regex:
+      regex: 'github\.com/hashicorp/terraform-plugin-sdk/v2/helper/retry'
+      replacement: 'github.com/hashicorp/terraform-provider-aws/internal/retry'
+    paths:
+      exclude:
+        # packages wrap SDK error types for compatibility
+        - "internal/retry"
+        - "internal/tfresource"
+        # out of scope for go-vcr support
+        - "internal/service/odb"
+
+  - id: internal-retry-staterefreshfunc-pass-context
+    languages: [go]
+    message: "The internal retry.StateRefreshFunc accepts a context argument"
+    severity: WARNING
+    patterns:
+      - pattern-inside: "func $F(...) retry.StateRefreshFunc{ ... }"
+      - pattern: |
+          return func() (any, string, error) {
+            $...BODY
+          }
+    fix: |
+      return func(ctx context.Context) (any, string, error) {
+        $...BODY
+      }
+    paths:
+      include:
+        - "**/*.go"
+      exclude:
+        - "internal/retry"
+        - "internal/tfresource"
+        - "internal/service/odb"
+
+  - id: internal-retry-staterefreshfunc-remove-parent-context
+    languages: [go]
+    message: "The parent function returning an internal retry.StateRefreshFunc no longer needs a context argument"
+    severity: WARNING
+    pattern: |
+      func $F(ctx context.Context, $...ARGS) retry.StateRefreshFunc {
+        $...BODY
+      }
+    fix: |
+      func $F($...ARGS) retry.StateRefreshFunc {
+        $...BODY
+      }
+    paths:
+      include:
+        - "**/*.go"
+      exclude:
+        - "internal/retry"
+        - "internal/tfresource"
+        - "internal/service/odb"
+
+  - id: internal-retry-statechangeconf-refresh-remove-context
+    languages: [go]
+    message: "The internal retry.StateRefreshConf.Refresh function no longer needs a context argument"
+    severity: WARNING
+    patterns:
+      - pattern-inside: "retry.StateChangeConf{ ... }"
+      - pattern: |
+          Refresh: $F(ctx, $...ARGS)
+    fix: |
+      Refresh: $F($...ARGS)
+    paths:
+      include:
+        - "**/*.go"
+      exclude:
+        - "internal/retry"
+        - "internal/tfresource"
+        - "internal/service/odb"
+
+  - id: internal-retry-notfounderror-drop-lastrequest
+    languages: [go]
+    message: "The internal retry.NotFoundError struct drops the LastRequest argument"
+    severity: WARNING
+    pattern: |
+        retry.NotFoundError {
+          $...ARGS,
+          LastRequest: ...,
+        }
+    fix: |
+      retry.NotFoundError {
+        $...ARGS,
+      }
+    paths:
+      include:
+        - "**/*.go"
+      exclude:
+        - "internal/retry"
+        - "internal/tfresource"
+        - "internal/service/odb"

--- a/internal/service/cloudformation/stack.go
+++ b/internal/service/cloudformation/stack.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -388,9 +387,8 @@ func findStackByName(ctx context.Context, conn *cloudformation.Client, name stri
 	}
 
 	if status := output.StackStatus; status == awstypes.StackStatusDeleteComplete {
-		return nil, &sdkretry.NotFoundError{
-			LastRequest: input,
-			Message:     string(status),
+		return nil, &retry.NotFoundError{
+			Message: string(status),
 		}
 	}
 
@@ -415,9 +413,8 @@ func findStacks(ctx context.Context, conn *cloudformation.Client, input *cloudfo
 		page, err := pages.NextPage(ctx)
 
 		if tfawserr.ErrMessageContains(err, errCodeValidationError, "does not exist") {
-			return nil, &sdkretry.NotFoundError{
-				LastError:   err,
-				LastRequest: input,
+			return nil, &retry.NotFoundError{
+				LastError: err,
 			}
 		}
 
@@ -431,8 +428,8 @@ func findStacks(ctx context.Context, conn *cloudformation.Client, input *cloudfo
 	return output, nil
 }
 
-func statusStack(ctx context.Context, conn *cloudformation.Client, name string) sdkretry.StateRefreshFunc {
-	return func() (any, string, error) {
+func statusStack(conn *cloudformation.Client, name string) retry.StateRefreshFunc {
+	return func(ctx context.Context) (any, string, error) {
 		// Don't call FindStackByName as it maps useful status codes to NotFoundError.
 		output, err := findStack(ctx, conn, &cloudformation.DescribeStacksInput{
 			StackName: aws.String(name),
@@ -454,13 +451,13 @@ func waitStackCreated(ctx context.Context, conn *cloudformation.Client, name, re
 	const (
 		minTimeout = 1 * time.Second
 	)
-	stateConf := sdkretry.StateChangeConf{
+	stateConf := retry.StateChangeConf{
 		Pending:    enum.Slice(awstypes.StackStatusCreateInProgress, awstypes.StackStatusDeleteInProgress, awstypes.StackStatusRollbackInProgress),
 		Target:     enum.Slice(awstypes.StackStatusCreateComplete, awstypes.StackStatusCreateFailed, awstypes.StackStatusDeleteComplete, awstypes.StackStatusDeleteFailed, awstypes.StackStatusRollbackComplete, awstypes.StackStatusRollbackFailed),
 		Timeout:    timeout,
 		MinTimeout: minTimeout,
 		Delay:      10 * time.Second,
-		Refresh:    statusStack(ctx, conn, name),
+		Refresh:    statusStack(conn, name),
 	}
 
 	outputRaw, err := stateConf.WaitForStateContext(ctx)
@@ -512,13 +509,13 @@ func waitStackUpdated(ctx context.Context, conn *cloudformation.Client, name, re
 	const (
 		minTimeout = 5 * time.Second
 	)
-	stateConf := sdkretry.StateChangeConf{
+	stateConf := retry.StateChangeConf{
 		Pending:    enum.Slice(awstypes.StackStatusUpdateCompleteCleanupInProgress, awstypes.StackStatusUpdateInProgress, awstypes.StackStatusUpdateRollbackInProgress, awstypes.StackStatusUpdateRollbackCompleteCleanupInProgress),
 		Target:     enum.Slice(awstypes.StackStatusCreateComplete, awstypes.StackStatusUpdateComplete, awstypes.StackStatusUpdateRollbackComplete, awstypes.StackStatusUpdateRollbackFailed),
 		Timeout:    timeout,
 		MinTimeout: minTimeout,
 		Delay:      10 * time.Second,
-		Refresh:    statusStack(ctx, conn, name),
+		Refresh:    statusStack(conn, name),
 	}
 
 	outputRaw, err := stateConf.WaitForStateContext(ctx)
@@ -553,13 +550,13 @@ func waitStackDeleted(ctx context.Context, conn *cloudformation.Client, name, re
 	const (
 		minTimeout = 5 * time.Second
 	)
-	stateConf := sdkretry.StateChangeConf{
+	stateConf := retry.StateChangeConf{
 		Pending:        enum.Slice(awstypes.StackStatusDeleteInProgress, awstypes.StackStatusRollbackInProgress),
 		Target:         enum.Slice(awstypes.StackStatusDeleteComplete, awstypes.StackStatusDeleteFailed),
 		Timeout:        timeout,
 		MinTimeout:     minTimeout,
 		Delay:          10 * time.Second,
-		Refresh:        statusStack(ctx, conn, name),
+		Refresh:        statusStack(conn, name),
 		NotFoundChecks: 1,
 	}
 

--- a/internal/service/cloudformation/type.go
+++ b/internal/service/cloudformation/type.go
@@ -15,7 +15,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -328,9 +327,8 @@ func findTypeByARN(ctx context.Context, conn *cloudformation.Client, arn string)
 	}
 
 	if status := output.DeprecatedStatus; status == awstypes.DeprecatedStatusDeprecated {
-		return nil, &sdkretry.NotFoundError{
-			LastRequest: input,
-			Message:     string(status),
+		return nil, &retry.NotFoundError{
+			Message: string(status),
 		}
 	}
 
@@ -350,9 +348,8 @@ func findType(ctx context.Context, conn *cloudformation.Client, input *cloudform
 	output, err := conn.DescribeType(ctx, input)
 
 	if errs.IsA[*awstypes.TypeNotFoundException](err) {
-		return nil, &sdkretry.NotFoundError{
-			LastError:   err,
-			LastRequest: input,
+		return nil, &retry.NotFoundError{
+			LastError: err,
 		}
 	}
 
@@ -375,9 +372,8 @@ func findTypeRegistrationByToken(ctx context.Context, conn *cloudformation.Clien
 	output, err := conn.DescribeTypeRegistration(ctx, input)
 
 	if errs.IsA[*awstypes.CFNRegistryException](err) {
-		return nil, &sdkretry.NotFoundError{
-			LastError:   err,
-			LastRequest: input,
+		return nil, &retry.NotFoundError{
+			LastError: err,
 		}
 	}
 
@@ -392,8 +388,8 @@ func findTypeRegistrationByToken(ctx context.Context, conn *cloudformation.Clien
 	return output, nil
 }
 
-func statusTypeRegistrationProgress(ctx context.Context, conn *cloudformation.Client, registrationToken string) sdkretry.StateRefreshFunc {
-	return func() (any, string, error) {
+func statusTypeRegistrationProgress(conn *cloudformation.Client, registrationToken string) retry.StateRefreshFunc {
+	return func(ctx context.Context) (any, string, error) {
 		output, err := findTypeRegistrationByToken(ctx, conn, registrationToken)
 
 		if retry.NotFound(err) {
@@ -412,10 +408,10 @@ func waitTypeRegistrationProgressStatusComplete(ctx context.Context, conn *cloud
 	const (
 		timeout = 5 * time.Minute
 	)
-	stateConf := &sdkretry.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending: enum.Slice(awstypes.RegistrationStatusInProgress),
 		Target:  enum.Slice(awstypes.RegistrationStatusComplete),
-		Refresh: statusTypeRegistrationProgress(ctx, conn, registrationToken),
+		Refresh: statusTypeRegistrationProgress(conn, registrationToken),
 		Timeout: timeout,
 	}
 

--- a/internal/service/ecr/repository.go
+++ b/internal/service/ecr/repository.go
@@ -18,7 +18,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ecr/types"
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -328,9 +327,7 @@ func findRepositoryByName(ctx context.Context, conn *ecr.Client, name string) (*
 
 	// Eventual consistency check.
 	if aws.ToString(output.RepositoryName) != name {
-		return nil, &sdkretry.NotFoundError{
-			LastRequest: input,
-		}
+		return nil, &retry.NotFoundError{}
 	}
 
 	return output, nil

--- a/internal/service/ecs/daemon.go
+++ b/internal/service/ecs/daemon.go
@@ -28,7 +28,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
@@ -465,9 +464,8 @@ func findDaemonByARN(ctx context.Context, conn *ecs.Client, arn string) (*awstyp
 	output, err := conn.DescribeDaemon(ctx, input)
 
 	if errs.IsA[*awstypes.DaemonNotFoundException](err) {
-		return nil, &sdkretry.NotFoundError{
-			LastError:   err,
-			LastRequest: input,
+		return nil, &retry.NotFoundError{
+			LastError: err,
 		}
 	}
 
@@ -480,9 +478,8 @@ func findDaemonByARN(ctx context.Context, conn *ecs.Client, arn string) (*awstyp
 	}
 
 	if output.Daemon.Status == awstypes.DaemonStatusDeleteInProgress {
-		return nil, &sdkretry.NotFoundError{
-			Message:     string(awstypes.DaemonStatusDeleteInProgress),
-			LastRequest: input,
+		return nil, &retry.NotFoundError{
+			Message: string(awstypes.DaemonStatusDeleteInProgress),
 		}
 	}
 
@@ -503,8 +500,8 @@ func findDaemonRevisionByARN(ctx context.Context, conn *ecs.Client, arn string) 
 	return tfresource.AssertSingleValueResult(output.DaemonRevisions)
 }
 
-func statusDaemon(ctx context.Context, conn *ecs.Client, arn string) sdkretry.StateRefreshFunc {
-	return func() (any, string, error) {
+func statusDaemon(conn *ecs.Client, arn string) retry.StateRefreshFunc {
+	return func(ctx context.Context) (any, string, error) {
 		output, err := findDaemonByARN(ctx, conn, arn)
 
 		if retry.NotFound(err) {
@@ -520,10 +517,10 @@ func statusDaemon(ctx context.Context, conn *ecs.Client, arn string) sdkretry.St
 }
 
 func waitDaemonActive(ctx context.Context, conn *ecs.Client, arn string, timeout time.Duration) error {
-	stateConf := &sdkretry.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending: []string{},
 		Target:  enum.Slice(awstypes.DaemonStatusActive),
-		Refresh: statusDaemon(ctx, conn, arn),
+		Refresh: statusDaemon(conn, arn),
 		Timeout: timeout,
 	}
 
@@ -533,10 +530,10 @@ func waitDaemonActive(ctx context.Context, conn *ecs.Client, arn string, timeout
 }
 
 func waitDaemonDeleted(ctx context.Context, conn *ecs.Client, arn string, timeout time.Duration) error {
-	stateConf := &sdkretry.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending: enum.Slice(awstypes.DaemonStatusActive, awstypes.DaemonStatusDeleteInProgress),
 		Target:  []string{},
-		Refresh: statusDaemon(ctx, conn, arn),
+		Refresh: statusDaemon(conn, arn),
 		Timeout: timeout,
 	}
 

--- a/internal/service/ecs/daemon_task_definition.go
+++ b/internal/service/ecs/daemon_task_definition.go
@@ -24,7 +24,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
@@ -643,9 +642,8 @@ func findDaemonTaskDefinitionByARN(ctx context.Context, conn *ecs.Client, arn st
 	output, err := conn.DescribeDaemonTaskDefinition(ctx, input)
 
 	if errs.Contains(err, "DaemonTaskDefinitionNotFoundException") || errs.Contains(err, "not found") {
-		return nil, &sdkretry.NotFoundError{
-			LastError:   err,
-			LastRequest: input,
+		return nil, &retry.NotFoundError{
+			LastError: err,
 		}
 	}
 
@@ -658,9 +656,8 @@ func findDaemonTaskDefinitionByARN(ctx context.Context, conn *ecs.Client, arn st
 	}
 
 	if output.DaemonTaskDefinition.Status == awstypes.DaemonTaskDefinitionStatusDeleteInProgress || output.DaemonTaskDefinition.Status == awstypes.DaemonTaskDefinitionStatusDeleted {
-		return nil, &sdkretry.NotFoundError{
-			Message:     string(output.DaemonTaskDefinition.Status),
-			LastRequest: input,
+		return nil, &retry.NotFoundError{
+			Message: string(output.DaemonTaskDefinition.Status),
 		}
 	}
 

--- a/internal/service/ecs/express_gateway_service.go
+++ b/internal/service/ecs/express_gateway_service.go
@@ -33,7 +33,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
@@ -534,10 +533,10 @@ const (
 )
 
 func waitExpressGatewayServiceActive(ctx context.Context, conn *ecs.Client, ARN string, timeout time.Duration) (*awstypes.ECSExpressGatewayService, error) {
-	stateConf := &sdkretry.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending: []string{gatewayServiceStatusInactive, gatewayServiceStatusDraining},
 		Target:  []string{gatewayServiceStatusActive},
-		Refresh: statusExpressGatewayService(ctx, conn, ARN),
+		Refresh: statusExpressGatewayService(conn, ARN),
 		Timeout: timeout,
 	}
 
@@ -550,10 +549,10 @@ func waitExpressGatewayServiceActive(ctx context.Context, conn *ecs.Client, ARN 
 }
 
 func waitExpressGatewayServiceStable(ctx context.Context, conn *ecs.Client, gatewayServiceARN string, operationTime time.Time, timeout time.Duration) (*awstypes.ECSExpressGatewayService, error) {
-	stateConf := &sdkretry.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending: []string{gatewayServiceStatusInactive, gatewayServiceStatusDraining, gatewayServiceStatusPending},
 		Target:  []string{gatewayServiceStatusActive, gatewayServiceStatusStable},
-		Refresh: statusExpressGatewayServiceWaitForStable(ctx, conn, gatewayServiceARN, operationTime),
+		Refresh: statusExpressGatewayServiceWaitForStable(conn, gatewayServiceARN, operationTime),
 		Timeout: timeout,
 	}
 
@@ -566,10 +565,10 @@ func waitExpressGatewayServiceStable(ctx context.Context, conn *ecs.Client, gate
 }
 
 func waitExpressGatewayServiceInactive(ctx context.Context, conn *ecs.Client, id string, timeout time.Duration) (*awstypes.ECSExpressGatewayService, error) {
-	stateConf := &sdkretry.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending:    []string{gatewayServiceStatusActive, gatewayServiceStatusDraining},
 		Target:     []string{gatewayServiceStatusInactive},
-		Refresh:    statusExpressGatewayServiceForDeletion(ctx, conn, id),
+		Refresh:    statusExpressGatewayServiceForDeletion(conn, id),
 		Timeout:    timeout,
 		MinTimeout: 1 * time.Second,
 	}
@@ -582,8 +581,8 @@ func waitExpressGatewayServiceInactive(ctx context.Context, conn *ecs.Client, id
 	return nil, smarterr.NewError(err)
 }
 
-func statusExpressGatewayService(ctx context.Context, conn *ecs.Client, gatewayServiceARN string) sdkretry.StateRefreshFunc {
-	return func() (any, string, error) {
+func statusExpressGatewayService(conn *ecs.Client, gatewayServiceARN string) retry.StateRefreshFunc {
+	return func(ctx context.Context) (any, string, error) {
 		output, err := findExpressGatewayServiceNoTagsByARN(ctx, conn, gatewayServiceARN)
 		if retry.NotFound(err) {
 			return nil, "", nil
@@ -597,8 +596,8 @@ func statusExpressGatewayService(ctx context.Context, conn *ecs.Client, gatewayS
 	}
 }
 
-func statusExpressGatewayServiceForDeletion(ctx context.Context, conn *ecs.Client, gatewayServiceARN string) sdkretry.StateRefreshFunc {
-	return func() (any, string, error) {
+func statusExpressGatewayServiceForDeletion(conn *ecs.Client, gatewayServiceARN string) retry.StateRefreshFunc {
+	return func(ctx context.Context) (any, string, error) {
 		output, err := findExpressGatewayServiceNoTagsByARN(ctx, conn, gatewayServiceARN)
 		if err != nil {
 			if retry.NotFound(err) || errs.IsAErrorMessageContains[*awstypes.InvalidParameterException](err, "Resource not found") {
@@ -645,16 +644,14 @@ func findExpressGatewayService(ctx context.Context, conn *ecs.Client, input *ecs
 	out, err := conn.DescribeExpressGatewayService(ctx, input)
 	if err != nil {
 		if errs.IsA[*awstypes.ResourceNotFoundException](err) {
-			return nil, smarterr.NewError(&sdkretry.NotFoundError{
-				LastError:   err,
-				LastRequest: input,
+			return nil, smarterr.NewError(&retry.NotFoundError{
+				LastError: err,
 			})
 		}
 
 		if errs.IsAErrorMessageContains[*awstypes.InvalidParameterException](err, "Resource not found") {
-			return nil, smarterr.NewError(&sdkretry.NotFoundError{
-				LastError:   err,
-				LastRequest: input,
+			return nil, smarterr.NewError(&retry.NotFoundError{
+				LastError: err,
 			})
 		}
 
@@ -691,11 +688,11 @@ func checkExpressGatewayServiceExists(ctx context.Context, conn *ecs.Client, ser
 	return err
 }
 
-func statusExpressGatewayServiceWaitForStable(ctx context.Context, conn *ecs.Client, gatewayServiceARN string, operationTime time.Time) sdkretry.StateRefreshFunc {
+func statusExpressGatewayServiceWaitForStable(conn *ecs.Client, gatewayServiceARN string, operationTime time.Time) retry.StateRefreshFunc {
 	var deploymentArn *string
 
-	return func() (any, string, error) {
-		outputRaw, serviceStatus, err := statusExpressGatewayService(ctx, conn, gatewayServiceARN)()
+	return func(ctx context.Context) (any, string, error) {
+		outputRaw, serviceStatus, err := statusExpressGatewayService(conn, gatewayServiceARN)(ctx)
 		if err != nil {
 			return nil, "", err
 		}

--- a/internal/service/ecs/service.go
+++ b/internal/service/ecs/service.go
@@ -27,7 +27,6 @@ import (
 	"github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -2003,9 +2002,8 @@ func findServices(ctx context.Context, conn *ecs.Client, input *ecs.DescribeServ
 	output, err := conn.DescribeServices(ctx, input)
 
 	if errs.IsA[*awstypes.ClusterNotFoundException](err) || errs.IsA[*awstypes.ServiceNotFoundException](err) {
-		return nil, &sdkretry.NotFoundError{
-			LastError:   err,
-			LastRequest: input,
+		return nil, &retry.NotFoundError{
+			LastError: err,
 		}
 	}
 
@@ -2020,9 +2018,8 @@ func findServices(ctx context.Context, conn *ecs.Client, input *ecs.DescribeServ
 	// When an ECS Service is not found by DescribeServices(), it will return a Failure struct with Reason = "MISSING"
 	for _, v := range output.Failures {
 		if aws.ToString(v.Reason) == failureReasonMissing {
-			return nil, &sdkretry.NotFoundError{
-				LastError:   failureError(&v),
-				LastRequest: input,
+			return nil, &retry.NotFoundError{
+				LastError: failureError(&v),
 			}
 		}
 	}
@@ -2106,7 +2103,7 @@ func findServiceByTwoPartKeyWaitForActive(ctx context.Context, conn *ecs.Client,
 	})
 
 	if errs.IsA[*expectServiceActiveError](err) {
-		return nil, &sdkretry.NotFoundError{
+		return nil, &retry.NotFoundError{
 			LastError: err,
 		}
 	}
@@ -2131,8 +2128,8 @@ var deploymentTerminalStates = enum.Slice(
 	awstypes.ServiceDeploymentStatusRollbackSuccessful,
 )
 
-func statusService(ctx context.Context, conn *ecs.Client, serviceName, clusterNameOrARN string) sdkretry.StateRefreshFunc {
-	return func() (any, string, error) {
+func statusService(conn *ecs.Client, serviceName, clusterNameOrARN string) retry.StateRefreshFunc {
+	return func(ctx context.Context) (any, string, error) {
 		output, err := findServiceNoTagsByTwoPartKey(ctx, conn, serviceName, clusterNameOrARN)
 
 		if retry.NotFound(err) {
@@ -2147,13 +2144,13 @@ func statusService(ctx context.Context, conn *ecs.Client, serviceName, clusterNa
 	}
 }
 
-func statusServiceWaitForStable(ctx context.Context, conn *ecs.Client, serviceName, clusterNameOrARN string, sigintConfig *rollbackState, operationTime time.Time) sdkretry.StateRefreshFunc {
+func statusServiceWaitForStable(conn *ecs.Client, serviceName, clusterNameOrARN string, sigintConfig *rollbackState, operationTime time.Time) retry.StateRefreshFunc {
 	var primaryTaskSet *awstypes.Deployment
 	var primaryDeploymentArn *string
 	var isNewPrimaryDeployment bool
 
-	return func() (any, string, error) {
-		outputRaw, serviceStatus, err := statusService(ctx, conn, serviceName, clusterNameOrARN)()
+	return func(ctx context.Context) (any, string, error) {
+		outputRaw, serviceStatus, err := statusService(conn, serviceName, clusterNameOrARN)(ctx)
 		if err != nil {
 			return nil, "", err
 		}
@@ -2292,9 +2289,8 @@ func findServiceDeployments(ctx context.Context, conn *ecs.Client, input *ecs.De
 	output, err := conn.DescribeServiceDeployments(ctx, input)
 
 	if errs.IsA[*awstypes.ClusterNotFoundException](err) || errs.IsA[*awstypes.ServiceNotFoundException](err) {
-		return nil, &sdkretry.NotFoundError{
-			LastError:   err,
-			LastRequest: input,
+		return nil, &retry.NotFoundError{
+			LastError: err,
 		}
 	}
 
@@ -2323,9 +2319,8 @@ func findServiceDeploymentBriefs(ctx context.Context, conn *ecs.Client, input *e
 	})
 
 	if errs.IsA[*awstypes.ClusterNotFoundException](err) || errs.IsA[*awstypes.ServiceNotFoundException](err) {
-		return nil, &sdkretry.NotFoundError{
-			LastError:   err,
-			LastRequest: input,
+		return nil, &retry.NotFoundError{
+			LastError: err,
 		}
 	}
 
@@ -2389,7 +2384,7 @@ func rollbackDeployment(ctx context.Context, conn *ecs.Client, primaryDeployment
 }
 
 func waitForDeploymentTerminalStatus(ctx context.Context, conn *ecs.Client, primaryDeploymentArn string) error {
-	stateConf := &sdkretry.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending: enum.Slice(
 			awstypes.ServiceDeploymentStatusPending,
 			awstypes.ServiceDeploymentStatusInProgress,
@@ -2397,7 +2392,7 @@ func waitForDeploymentTerminalStatus(ctx context.Context, conn *ecs.Client, prim
 			awstypes.ServiceDeploymentStatusRollbackInProgress,
 		),
 		Target: deploymentTerminalStates,
-		Refresh: func() (any, string, error) {
+		Refresh: func(ctx context.Context) (any, string, error) {
 			status, err := findDeploymentStatus(ctx, conn, primaryDeploymentArn)
 			return nil, status, err
 		},
@@ -2418,10 +2413,10 @@ func waitServiceStable(ctx context.Context, conn *ecs.Client, serviceName, clust
 		waitGroup:              sync.WaitGroup{},
 	}
 
-	stateConf := &sdkretry.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending: []string{serviceStatusInactive, serviceStatusDraining, serviceStatusPending},
 		Target:  []string{serviceStatusStable},
-		Refresh: statusServiceWaitForStable(ctx, conn, serviceName, clusterNameOrARN, sigintConfig, operationTime),
+		Refresh: statusServiceWaitForStable(conn, serviceName, clusterNameOrARN, sigintConfig, operationTime),
 		Timeout: timeout,
 	}
 
@@ -2441,10 +2436,10 @@ func waitServiceStable(ctx context.Context, conn *ecs.Client, serviceName, clust
 
 // Does not return tags.
 func waitServiceActive(ctx context.Context, conn *ecs.Client, serviceName, clusterNameOrARN string, timeout time.Duration) (*awstypes.Service, error) { //nolint:unparam
-	stateConf := &sdkretry.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending: []string{serviceStatusInactive, serviceStatusDraining},
 		Target:  []string{serviceStatusActive},
-		Refresh: statusService(ctx, conn, serviceName, clusterNameOrARN),
+		Refresh: statusService(conn, serviceName, clusterNameOrARN),
 		Timeout: timeout,
 	}
 
@@ -2459,10 +2454,10 @@ func waitServiceActive(ctx context.Context, conn *ecs.Client, serviceName, clust
 
 // Does not return tags.
 func waitServiceInactive(ctx context.Context, conn *ecs.Client, serviceName, clusterNameOrARN string, timeout time.Duration) (*awstypes.Service, error) {
-	stateConf := &sdkretry.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending:    []string{serviceStatusActive, serviceStatusDraining},
 		Target:     []string{serviceStatusInactive},
-		Refresh:    statusService(ctx, conn, serviceName, clusterNameOrARN),
+		Refresh:    statusService(conn, serviceName, clusterNameOrARN),
 		Timeout:    timeout,
 		MinTimeout: 1 * time.Second,
 	}

--- a/internal/service/elasticbeanstalk/environment.go
+++ b/internal/service/elasticbeanstalk/environment.go
@@ -22,7 +22,6 @@ import ( // nosemgrep:ci.semgrep.aws.multiple-service-imports
 	awstypes "github.com/aws/aws-sdk-go-v2/service/elasticbeanstalk/types"
 	"github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -608,17 +607,14 @@ func findEnvironmentByID(ctx context.Context, conn *elasticbeanstalk.Client, id 
 	}
 
 	if status := output.Status; status == awstypes.EnvironmentStatusTerminated {
-		return nil, &sdkretry.NotFoundError{
-			Message:     string(status),
-			LastRequest: input,
+		return nil, &retry.NotFoundError{
+			Message: string(status),
 		}
 	}
 
 	// Eventual consistency check.
 	if aws.ToString(output.EnvironmentId) != id {
-		return nil, &sdkretry.NotFoundError{
-			LastRequest: input,
-		}
+		return nil, &retry.NotFoundError{}
 	}
 
 	return output, nil
@@ -702,8 +698,8 @@ func findEvents(ctx context.Context, conn *elasticbeanstalk.Client, input *elast
 	return output, nil
 }
 
-func statusEnvironment(ctx context.Context, conn *elasticbeanstalk.Client, id string) sdkretry.StateRefreshFunc {
-	return func() (any, string, error) {
+func statusEnvironment(conn *elasticbeanstalk.Client, id string) retry.StateRefreshFunc {
+	return func(ctx context.Context) (any, string, error) {
 		output, err := findEnvironmentByID(ctx, conn, id)
 
 		if retry.NotFound(err) {
@@ -719,10 +715,10 @@ func statusEnvironment(ctx context.Context, conn *elasticbeanstalk.Client, id st
 }
 
 func waitEnvironmentReady(ctx context.Context, conn *elasticbeanstalk.Client, id string, pollInterval, timeout time.Duration) (*awstypes.EnvironmentDescription, error) { //nolint:unparam
-	stateConf := &sdkretry.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending:      enum.Slice(awstypes.EnvironmentStatusLaunching, awstypes.EnvironmentStatusUpdating),
 		Target:       enum.Slice(awstypes.EnvironmentStatusReady),
-		Refresh:      statusEnvironment(ctx, conn, id),
+		Refresh:      statusEnvironment(conn, id),
 		Timeout:      timeout,
 		Delay:        10 * time.Second,
 		PollInterval: pollInterval,
@@ -739,10 +735,10 @@ func waitEnvironmentReady(ctx context.Context, conn *elasticbeanstalk.Client, id
 }
 
 func waitEnvironmentDeleted(ctx context.Context, conn *elasticbeanstalk.Client, id string, pollInterval, timeout time.Duration) (*awstypes.EnvironmentDescription, error) {
-	stateConf := &sdkretry.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending:      enum.Slice(awstypes.EnvironmentStatusTerminating),
 		Target:       []string{},
-		Refresh:      statusEnvironment(ctx, conn, id),
+		Refresh:      statusEnvironment(conn, id),
 		Timeout:      timeout,
 		Delay:        10 * time.Second,
 		PollInterval: pollInterval,

--- a/internal/service/emr/cluster.go
+++ b/internal/service/emr/cluster.go
@@ -23,7 +23,6 @@ import (
 	smithyjson "github.com/aws/smithy-go/encoding/json"
 	"github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -1461,15 +1460,12 @@ func findClusterByID(ctx context.Context, conn *emr.Client, id string) (*awstype
 
 	// Eventual consistency check.
 	if aws.ToString(output.Id) != id {
-		return nil, &sdkretry.NotFoundError{
-			LastRequest: input,
-		}
+		return nil, &retry.NotFoundError{}
 	}
 
 	if output.Status.State == awstypes.ClusterStateTerminated || output.Status.State == awstypes.ClusterStateTerminatedWithErrors {
-		return nil, &sdkretry.NotFoundError{
-			Message:     string(output.Status.State),
-			LastRequest: input,
+		return nil, &retry.NotFoundError{
+			Message: string(output.Status.State),
 		}
 	}
 
@@ -1480,9 +1476,8 @@ func findCluster(ctx context.Context, conn *emr.Client, input *emr.DescribeClust
 	output, err := conn.DescribeCluster(ctx, input)
 
 	if tfawserr.ErrCodeEquals(err, errCodeClusterNotFound) || errs.IsAErrorMessageContains[*awstypes.InvalidRequestException](err, "is not valid") {
-		return nil, &sdkretry.NotFoundError{
-			LastError:   err,
-			LastRequest: input,
+		return nil, &retry.NotFoundError{
+			LastError: err,
 		}
 	}
 
@@ -1497,8 +1492,8 @@ func findCluster(ctx context.Context, conn *emr.Client, input *emr.DescribeClust
 	return output.Cluster, nil
 }
 
-func statusCluster(ctx context.Context, conn *emr.Client, id string) sdkretry.StateRefreshFunc {
-	return func() (any, string, error) {
+func statusCluster(conn *emr.Client, id string) retry.StateRefreshFunc {
+	return func(ctx context.Context) (any, string, error) {
 		input := &emr.DescribeClusterInput{
 			ClusterId: aws.String(id),
 		}
@@ -1520,10 +1515,10 @@ func waitClusterCreated(ctx context.Context, conn *emr.Client, id string) (*awst
 	const (
 		timeout = 75 * time.Minute
 	)
-	stateConf := &sdkretry.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending:    enum.Slice(awstypes.ClusterStateBootstrapping, awstypes.ClusterStateStarting),
 		Target:     enum.Slice(awstypes.ClusterStateRunning, awstypes.ClusterStateWaiting),
-		Refresh:    statusCluster(ctx, conn, id),
+		Refresh:    statusCluster(conn, id),
 		Timeout:    timeout,
 		MinTimeout: 10 * time.Second,
 		Delay:      30 * time.Second,
@@ -1546,10 +1541,10 @@ func waitClusterDeleted(ctx context.Context, conn *emr.Client, id string) (*awst
 	const (
 		timeout = 20 * time.Minute
 	)
-	stateConf := &sdkretry.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending:    enum.Slice(awstypes.ClusterStateTerminating),
 		Target:     enum.Slice(awstypes.ClusterStateTerminated, awstypes.ClusterStateTerminatedWithErrors),
-		Refresh:    statusCluster(ctx, conn, id),
+		Refresh:    statusCluster(conn, id),
 		Timeout:    timeout,
 		MinTimeout: 10 * time.Second,
 		Delay:      30 * time.Second,
@@ -1584,9 +1579,8 @@ func findBootstrapActions(ctx context.Context, conn *emr.Client, input *emr.List
 		page, err := pages.NextPage(ctx)
 
 		if errs.IsAErrorMessageContains[*awstypes.InvalidRequestException](err, "is not valid") {
-			return nil, &sdkretry.NotFoundError{
-				LastError:   err,
-				LastRequest: input,
+			return nil, &retry.NotFoundError{
+				LastError: err,
 			}
 		}
 
@@ -1608,9 +1602,8 @@ func findStepSummaries(ctx context.Context, conn *emr.Client, input *emr.ListSte
 		page, err := pages.NextPage(ctx)
 
 		if errs.IsAErrorMessageContains[*awstypes.InvalidRequestException](err, "is not valid") {
-			return nil, &sdkretry.NotFoundError{
-				LastError:   err,
-				LastRequest: input,
+			return nil, &retry.NotFoundError{
+				LastError: err,
 			}
 		}
 
@@ -1641,9 +1634,8 @@ func findAutoTerminationPolicy(ctx context.Context, conn *emr.Client, input *emr
 	if errs.IsAErrorMessageContains[*awstypes.InvalidRequestException](err, "is not valid") ||
 		tfawserr.ErrMessageContains(err, errCodeUnknownOperationException, "Could not find operation GetAutoTerminationPolicy") ||
 		tfawserr.ErrMessageContains(err, errCodeValidationException, "Auto-termination is not available for this account when using this release of EMR") {
-		return nil, &sdkretry.NotFoundError{
-			LastError:   err,
-			LastRequest: input,
+		return nil, &retry.NotFoundError{
+			LastError: err,
 		}
 	}
 

--- a/internal/service/invoicing/invoice_unit.go
+++ b/internal/service/invoicing/invoice_unit.go
@@ -301,7 +301,7 @@ func waitInvoiceUnitCreated(ctx context.Context, conn *invoicing.Client, arn str
 	stateConf := &retry.StateChangeConf{
 		Pending: []string{},
 		Target:  []string{"AVAILABLE"},
-		Refresh: statusInvoiceUnit(ctx, conn, arn),
+		Refresh: statusInvoiceUnit(conn, arn),
 		Timeout: timeout,
 	}
 
@@ -318,7 +318,7 @@ func waitInvoiceUnitUpdated(ctx context.Context, conn *invoicing.Client, arn str
 	stateConf := &retry.StateChangeConf{
 		Pending: []string{},
 		Target:  []string{"AVAILABLE"},
-		Refresh: statusInvoiceUnit(ctx, conn, arn),
+		Refresh: statusInvoiceUnit(conn, arn),
 		Timeout: timeout,
 	}
 
@@ -335,7 +335,7 @@ func waitInvoiceUnitDeleted(ctx context.Context, conn *invoicing.Client, arn str
 	stateConf := &retry.StateChangeConf{
 		Pending: []string{"AVAILABLE"},
 		Target:  []string{},
-		Refresh: statusInvoiceUnit(ctx, conn, arn),
+		Refresh: statusInvoiceUnit(conn, arn),
 		Timeout: timeout,
 	}
 
@@ -348,7 +348,7 @@ func waitInvoiceUnitDeleted(ctx context.Context, conn *invoicing.Client, arn str
 	return nil, smarterr.NewError(err)
 }
 
-func statusInvoiceUnit(_ context.Context, conn *invoicing.Client, arn string) retry.StateRefreshFunc {
+func statusInvoiceUnit(conn *invoicing.Client, arn string) retry.StateRefreshFunc {
 	return func(ctx context.Context) (any, string, error) {
 		output, err := findInvoiceUnitByARN(ctx, conn, arn)
 

--- a/internal/service/ivs/find.go
+++ b/internal/service/ivs/find.go
@@ -9,8 +9,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ivs"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/ivs/types"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
@@ -20,9 +20,8 @@ func FindPlaybackKeyPairByID(ctx context.Context, conn *ivs.Client, id string) (
 	}
 	out, err := conn.GetPlaybackKeyPair(ctx, in)
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
-		return nil, &sdkretry.NotFoundError{
-			LastError:   err,
-			LastRequest: in,
+		return nil, &retry.NotFoundError{
+			LastError: err,
 		}
 	}
 
@@ -43,9 +42,8 @@ func FindRecordingConfigurationByID(ctx context.Context, conn *ivs.Client, id st
 	}
 	out, err := conn.GetRecordingConfiguration(ctx, in)
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
-		return nil, &sdkretry.NotFoundError{
-			LastError:   err,
-			LastRequest: in,
+		return nil, &retry.NotFoundError{
+			LastError: err,
 		}
 	}
 
@@ -67,9 +65,8 @@ func FindChannelByID(ctx context.Context, conn *ivs.Client, arn string) (*awstyp
 	out, err := conn.GetChannel(ctx, in)
 	if err != nil {
 		if errs.IsA[*awstypes.ResourceNotFoundException](err) {
-			return nil, &sdkretry.NotFoundError{
-				LastError:   err,
-				LastRequest: in,
+			return nil, &retry.NotFoundError{
+				LastError: err,
 			}
 		}
 
@@ -89,9 +86,8 @@ func FindStreamKeyByChannelID(ctx context.Context, conn *ivs.Client, channelArn 
 	}
 	out, err := conn.ListStreamKeys(ctx, in)
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
-		return nil, &sdkretry.NotFoundError{
-			LastError:   err,
-			LastRequest: in,
+		return nil, &retry.NotFoundError{
+			LastError: err,
 		}
 	}
 
@@ -100,9 +96,7 @@ func FindStreamKeyByChannelID(ctx context.Context, conn *ivs.Client, channelArn 
 	}
 
 	if len(out.StreamKeys) < 1 {
-		return nil, &sdkretry.NotFoundError{
-			LastRequest: in,
-		}
+		return nil, &retry.NotFoundError{}
 	}
 
 	streamKeyArn := out.StreamKeys[0].Arn
@@ -116,9 +110,8 @@ func findStreamKeyByID(ctx context.Context, conn *ivs.Client, id string) (*awsty
 	}
 	out, err := conn.GetStreamKey(ctx, in)
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
-		return nil, &sdkretry.NotFoundError{
-			LastError:   err,
-			LastRequest: in,
+		return nil, &retry.NotFoundError{
+			LastError: err,
 		}
 	}
 

--- a/internal/service/s3files/access_point.go
+++ b/internal/service/s3files/access_point.go
@@ -371,7 +371,7 @@ func waitAccessPointCreated(ctx context.Context, conn *s3files.Client, id string
 	stateConf := &retry.StateChangeConf{
 		Pending: enum.Slice(awstypes.LifeCycleStateCreating),
 		Target:  enum.Slice(awstypes.LifeCycleStateAvailable, awstypes.LifeCycleStateError),
-		Refresh: statusAccessPoint(ctx, conn, id),
+		Refresh: statusAccessPoint(conn, id),
 		Timeout: timeout,
 	}
 
@@ -388,7 +388,7 @@ func waitAccessPointDeleted(ctx context.Context, conn *s3files.Client, id string
 	stateConf := &retry.StateChangeConf{
 		Pending: enum.Slice(awstypes.LifeCycleStateAvailable, awstypes.LifeCycleStateDeleting),
 		Target:  []string{},
-		Refresh: statusAccessPoint(ctx, conn, id),
+		Refresh: statusAccessPoint(conn, id),
 		Timeout: timeout,
 	}
 
@@ -401,7 +401,7 @@ func waitAccessPointDeleted(ctx context.Context, conn *s3files.Client, id string
 	return nil, smarterr.NewError(err)
 }
 
-func statusAccessPoint(_ context.Context, conn *s3files.Client, id string) retry.StateRefreshFunc {
+func statusAccessPoint(conn *s3files.Client, id string) retry.StateRefreshFunc {
 	return func(ctx context.Context) (any, string, error) {
 		output, err := findAccessPointByID(ctx, conn, id)
 

--- a/internal/service/s3files/file_system.go
+++ b/internal/service/s3files/file_system.go
@@ -304,7 +304,7 @@ func waitFileSystemCreated(ctx context.Context, conn *s3files.Client, id string,
 	stateConf := &retry.StateChangeConf{
 		Pending:    enum.Slice(awstypes.LifeCycleStateCreating),
 		Target:     enum.Slice(awstypes.LifeCycleStateAvailable, awstypes.LifeCycleStateError),
-		Refresh:    statusFileSystem(ctx, conn, id),
+		Refresh:    statusFileSystem(conn, id),
 		Timeout:    timeout,
 		MinTimeout: 10 * time.Second,
 	}
@@ -322,7 +322,7 @@ func waitFileSystemDeleted(ctx context.Context, conn *s3files.Client, id string,
 	stateConf := &retry.StateChangeConf{
 		Pending: enum.Slice(awstypes.LifeCycleStateAvailable, awstypes.LifeCycleStateDeleting),
 		Target:  []string{},
-		Refresh: statusFileSystem(ctx, conn, id),
+		Refresh: statusFileSystem(conn, id),
 		Timeout: timeout,
 	}
 
@@ -335,7 +335,7 @@ func waitFileSystemDeleted(ctx context.Context, conn *s3files.Client, id string,
 	return nil, smarterr.NewError(err)
 }
 
-func statusFileSystem(_ context.Context, conn *s3files.Client, id string) retry.StateRefreshFunc {
+func statusFileSystem(conn *s3files.Client, id string) retry.StateRefreshFunc {
 	const iamPropagationBuffer = 3 * time.Minute
 	firstErrorTime := time.Time{}
 

--- a/internal/service/s3files/mount_target.go
+++ b/internal/service/s3files/mount_target.go
@@ -328,7 +328,7 @@ func waitMountTargetCreated(ctx context.Context, conn *s3files.Client, id string
 	stateConf := &retry.StateChangeConf{
 		Pending: enum.Slice(awstypes.LifeCycleStateCreating),
 		Target:  enum.Slice(awstypes.LifeCycleStateAvailable, awstypes.LifeCycleStateError),
-		Refresh: statusMountTarget(ctx, conn, id),
+		Refresh: statusMountTarget(conn, id),
 		Timeout: timeout,
 	}
 
@@ -345,7 +345,7 @@ func waitMountTargetUpdated(ctx context.Context, conn *s3files.Client, id string
 	stateConf := &retry.StateChangeConf{
 		Pending: enum.Slice(awstypes.LifeCycleStateUpdating),
 		Target:  enum.Slice(awstypes.LifeCycleStateAvailable, awstypes.LifeCycleStateError),
-		Refresh: statusMountTarget(ctx, conn, id),
+		Refresh: statusMountTarget(conn, id),
 		Timeout: timeout,
 	}
 
@@ -362,7 +362,7 @@ func waitMountTargetDeleted(ctx context.Context, conn *s3files.Client, id string
 	stateConf := &retry.StateChangeConf{
 		Pending: enum.Slice(awstypes.LifeCycleStateAvailable, awstypes.LifeCycleStateDeleting),
 		Target:  []string{},
-		Refresh: statusMountTarget(ctx, conn, id),
+		Refresh: statusMountTarget(conn, id),
 		Timeout: timeout,
 	}
 
@@ -375,7 +375,7 @@ func waitMountTargetDeleted(ctx context.Context, conn *s3files.Client, id string
 	return nil, smarterr.NewError(err)
 }
 
-func statusMountTarget(_ context.Context, conn *s3files.Client, id string) retry.StateRefreshFunc {
+func statusMountTarget(conn *s3files.Client, id string) retry.StateRefreshFunc {
 	return func(ctx context.Context) (any, string, error) {
 		output, err := findMountTargetByID(ctx, conn, id)
 


### PR DESCRIPTION

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This was previously implemented by the `go-vcr` migration workflow, but was not correctly migrated from the migration tooling to a permanent linting rule once all service migrations were completed.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #46961

