### PR TITLE
ci pipeline: Low hanging fru-its

### DIFF
--- a/.ci/scripts/validate-terraform.sh
+++ b/.ci/scripts/validate-terraform.sh
@@ -123,13 +123,15 @@ fi
 JOBS="${JOBS:-$(nproc 2>/dev/null || echo 4)}"
 
 # xargs flags:
-#   -r / --no-run-if-empty: don't invoke the worker on empty stdin.
 #   -P JOBS: run up to JOBS workers in parallel.
 #   -I {}:   substitute {} with each filename (one per invocation).
 # We re-invoke this same script in --process-file mode for each filename;
 # ${BASH_SOURCE[0]} is used (rather than $0) so the fan-out still works when
 # the script is invoked as `bash validate-terraform.sh ...`.
 #
+# Both GNU xargs (findutils 4.5.2+, 2009) and BSD xargs default to not running
+# the worker when stdin is empty, so no -r/--no-run-if-empty flag is needed.
+#
 # xargs exits 123 if any worker exits non-zero (1-125), so the workflow step
 # still fails when any file has lint errors.
-xargs -r -P "${JOBS}" -I {} "${BASH_SOURCE[0]}" --process-file {}
+xargs -P "${JOBS}" -I {} "${BASH_SOURCE[0]}" --process-file {}

--- a/.ci/scripts/validate-terraform.sh
+++ b/.ci/scripts/validate-terraform.sh
@@ -106,6 +106,14 @@ fi
 # Default (orchestrator) mode: read filenames from stdin and fan out.
 JOBS="${JOBS:-$(nproc 2>/dev/null || echo 4)}"
 
-# xargs -P exits 123 if any worker exits non-zero (1-125), so the workflow
-# step still fails when any file has lint errors.
-xargs -P "${JOBS}" -n 1 -I {} "$0" --process-file "{}"
+# xargs flags:
+#   -r / --no-run-if-empty: don't invoke the worker on empty stdin.
+#   -P JOBS: run up to JOBS workers in parallel.
+#   -I {}:   substitute {} with each filename (one per invocation).
+# We re-invoke this same script in --process-file mode for each filename;
+# ${BASH_SOURCE[0]} is used (rather than $0) so the fan-out still works when
+# the script is invoked as `bash validate-terraform.sh ...`.
+#
+# xargs exits 123 if any worker exits non-zero (1-125), so the workflow step
+# still fails when any file has lint errors.
+xargs -r -P "${JOBS}" -I {} "${BASH_SOURCE[0]}" --process-file {}

--- a/.ci/scripts/validate-terraform.sh
+++ b/.ci/scripts/validate-terraform.sh
@@ -6,22 +6,33 @@ set -eo pipefail
 
 trap 'exit 130' INT TERM
 
-# This script works from stdin and expects one filename per line.
-# To call it, e.g.
-# find ./website/docs -type f \( -name '*.md' -o -name '*.markdown' \) \
-#   | ./.ci/scripts/validate-terraform.sh
+# Validate embedded Terraform/HCL blocks inside Go test files (or any other
+# files terrafmt understands) with tflint.
+#
+# Two modes:
+#
+#   1. Default - read filenames from stdin and validate each in parallel.
+#
+#        find ./internal -name '*_test.go' | ./.ci/scripts/validate-terraform.sh
+#
+#      Set the JOBS env var to control parallelism (default: number of cores).
+#
+#   2. Internal - validate a single file. Mode 1 fans out to mode 2 to spread
+#      the work across cores via xargs -P.
+#
+#        ./.ci/scripts/validate-terraform.sh --process-file <path>
 
 if [[ -z "${TERRAFMT_CMD}" ]]; then TERRAFMT_CMD="terrafmt"; fi
 if [[ -z "${TFLINT_CMD}" ]]; then TFLINT_CMD="tflint"; fi
 
-exit_code=0
+# tflint resolves config paths relative to the working directory.
+TFLINT_CONFIG="${TFLINT_CONFIG:-$(pwd -P)/.ci/.tflint.hcl}"
+TFLINT_OPA_CONFIG="${TFLINT_OPA_CONFIG:-$(pwd -P)/.ci/.tflint_opa.hcl}"
+export TERRAFMT_CMD TFLINT_CMD TFLINT_CONFIG TFLINT_OPA_CONFIG
 
-# tflint always resolves config flies relative to the working directory when using --recursive
-TFLINT_CONFIG="$(pwd -P)/.ci/.tflint.hcl"
-TFLINT_OPA_CONFIG="$(pwd -P)/.ci/.tflint_opa.hcl"
-
-# Configure the rules for tflint.
-rules=(
+# Rules used for the standard (non-OPA) pass. --only is incompatible with the
+# OPA plugin, so OPA rules run in a separate tflint invocation.
+RULES=(
     # Syntax checks
     "--only=terraform_comment_syntax"
     "--only=terraform_deprecated_index"
@@ -37,46 +48,64 @@ rules=(
     "--only=aws_db_instance_invalid_engine"
     "--only=aws_mq_broker_invalid_engine_type"
 )
-while read -r filename ; do
-    block_number=0
+
+process_one_file() {
+    local filename=$1
+    local exit_code=0
+    local block_number=0
 
     while IFS= read -r block ; do
         ((block_number+=1))
-        start_line=$(echo "${block}" | jq '.start_line')
-        end_line=$(echo "${block}" | jq '.end_line')
-        text=$(echo "${block}" | jq --raw-output '.text')
+
+        # One jq call extracts both line numbers; a second writes the block
+        # text straight to the temp file. (Down from three jq forks.)
+        local meta start_line end_line td tf
+        meta=$(jq -r '"\(.start_line)\t\(.end_line)"' <<< "${block}")
+        IFS=$'\t' read -r start_line end_line <<< "${meta}"
 
         td=$(mktemp -d)
         tf="${td}/main.tf"
+        jq -r '.text' <<< "${block}" > "${tf}"
 
-        echo "${text}" > "${tf}"
+        local tflint_output tflint_exitcode
 
-        # We need to capture the output and error code here. We don't want to exit on the first error
+        # Standard rules pass.
         set +e
-        tflint_output=$(${TFLINT_CMD} --config "${TFLINT_CONFIG}" --chdir="${td}" "${rules[@]}" 2>&1)
+        tflint_output=$(${TFLINT_CMD} --config "${TFLINT_CONFIG}" --chdir="${td}" "${RULES[@]}" 2>&1)
         tflint_exitcode=$?
         set -e
-
         if [[ ${tflint_exitcode} -ne 0 ]]; then
-            echo "ERROR: File \"${filename}\", block #${block_number} (lines ${start_line}-${end_line}):"
-            echo "${tflint_output}"
-            echo
+            printf 'ERROR: File "%s", block #%d (lines %s-%s):\n%s\n\n' \
+                "${filename}" "${block_number}" "${start_line}" "${end_line}" "${tflint_output}"
             exit_code=1
         fi
 
-        # Run OPA rules separately (--only is incompatible with OPA rules)
+        # OPA rules pass.
         set +e
         tflint_output=$(${TFLINT_CMD} --config "${TFLINT_OPA_CONFIG}" --chdir="${td}" 2>&1)
         tflint_exitcode=$?
         set -e
-
         if [[ ${tflint_exitcode} -ne 0 ]] && [[ "${tflint_output}" != *"eval_builtin_error"* ]]; then
-            echo "ERROR: File \"${filename}\", block #${block_number} (lines ${start_line}-${end_line}):"
-            echo "${tflint_output}"
-            echo
+            printf 'ERROR: File "%s", block #%d (lines %s-%s):\n%s\n\n' \
+                "${filename}" "${block_number}" "${start_line}" "${end_line}" "${tflint_output}"
             exit_code=1
         fi
-    done < <( ${TERRAFMT_CMD} blocks --fmtcompat --json "${filename}" | jq --compact-output '.blocks[]?' )
-done
 
-exit "${exit_code}"
+        rm -rf "${td}"
+    done < <( ${TERRAFMT_CMD} blocks --fmtcompat --json "${filename}" | jq --compact-output '.blocks[]?' )
+
+    return "${exit_code}"
+}
+
+# Single-file mode.
+if [[ "${1:-}" == "--process-file" ]]; then
+    process_one_file "$2"
+    exit $?
+fi
+
+# Default (orchestrator) mode: read filenames from stdin and fan out.
+JOBS="${JOBS:-$(nproc 2>/dev/null || echo 4)}"
+
+# xargs -P exits 123 if any worker exits non-zero (1-125), so the workflow
+# step still fails when any file has lint errors.
+xargs -P "${JOBS}" -n 1 -I {} "$0" --process-file "{}"

--- a/.ci/scripts/validate-terraform.sh
+++ b/.ci/scripts/validate-terraform.sh
@@ -53,6 +53,18 @@ process_one_file() {
     local filename=$1
     local exit_code=0
     local block_number=0
+    local blocks
+
+    # Materialize the block stream first. Process substitution (done < <(...))
+    # would run terrafmt|jq in a separate process whose exit status is invisible
+    # to the outer shell, so a terrafmt or jq failure would be silently treated
+    # as "zero blocks". Capturing the pipe output here ensures pipefail + set -e
+    # propagate the failure to xargs and on to the workflow step.
+    blocks=$(${TERRAFMT_CMD} blocks --fmtcompat --json "${filename}" | jq --compact-output '.blocks[]?')
+
+    # Files with no embedded HCL produce an empty stream; skip them so we don't
+    # feed jq an empty block below.
+    [[ -z "${blocks}" ]] && return 0
 
     while IFS= read -r block ; do
         ((block_number+=1))
@@ -92,7 +104,7 @@ process_one_file() {
         fi
 
         rm -rf "${td}"
-    done < <( ${TERRAFMT_CMD} blocks --fmtcompat --json "${filename}" | jq --compact-output '.blocks[]?' )
+    done <<< "${blocks}"
 
     return "${exit_code}"
 }

--- a/.ci/scripts/validate-terraform.sh
+++ b/.ci/scripts/validate-terraform.sh
@@ -111,6 +111,10 @@ process_one_file() {
 
 # Single-file mode.
 if [[ "${1:-}" == "--process-file" ]]; then
+    if [[ -z "${2:-}" ]]; then
+        echo "Usage: ${BASH_SOURCE[0]} --process-file <path>" >&2
+        exit 64
+    fi
     process_one_file "$2"
     exit $?
 fi

--- a/.github/workflows/semgrep-ci.yml
+++ b/.github/workflows/semgrep-ci.yml
@@ -60,7 +60,7 @@ jobs:
   semgrep:
     name: Code Quality Scan (make semgrep-code-quality)
     needs: [semgrep-test]
-    runs-on: ubuntu-latest
+    runs-on: custom-ubuntu-22.04-large
     container:
       image: "semgrep/semgrep:1.154.0"
     steps:

--- a/.github/workflows/semgrep-ci.yml
+++ b/.github/workflows/semgrep-ci.yml
@@ -13,6 +13,7 @@ on:
       - internal/**
       - .semgrep*yml
       - .ci/semgrep*
+      - .ci/semgrep/**
       - .ci/.semgrep*
       - .github/workflows/semgrep-ci.yml
 

--- a/.github/workflows/semgrep-ci.yml
+++ b/.github/workflows/semgrep-ci.yml
@@ -57,8 +57,21 @@ jobs:
           semgrep --quiet --test .ci/semgrep/
           semgrep --quiet --test --config .ci/semgrep-caps-aws-ec2.yml .ci/semgrep-caps-aws-ec2.go
 
-  semgrep:
-    name: Code Quality Scan (make semgrep-code-quality)
+  semgrep_constants:
+    name: Code Quality Scan (Constants)
+    needs: [semgrep-test]
+    runs-on: custom-ubuntu-22.04-large
+    container:
+      image: "semgrep/semgrep:1.168.0"
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - run: |
+          semgrep $SEMGREP_ARGS \
+          --config .ci/.semgrep-constants.yml \
+          --config .ci/.semgrep-test-constants.yml
+
+  semgrep_rules:
+    name: Code Quality Scan (Rules)
     needs: [semgrep-test]
     runs-on: custom-ubuntu-22.04-large
     container:
@@ -68,8 +81,6 @@ jobs:
       - run: |
           semgrep $SEMGREP_ARGS \
           --config .ci/.semgrep.yml \
-          --config .ci/.semgrep-constants.yml \
-          --config .ci/.semgrep-test-constants.yml \
           --config .ci/semgrep/ \
           --config 'r/dgryski.semgrep-go.anon-struct-args' \
           --config 'r/dgryski.semgrep-go.badnilguard' \

--- a/.github/workflows/semgrep-ci.yml
+++ b/.github/workflows/semgrep-ci.yml
@@ -13,6 +13,7 @@ on:
       - internal/**
       - .semgrep*yml
       - .ci/semgrep*
+      - .ci/.semgrep*
       - .github/workflows/semgrep-ci.yml
 
 ## NOTE: !!!

--- a/.github/workflows/semgrep-ci.yml
+++ b/.github/workflows/semgrep-ci.yml
@@ -62,7 +62,7 @@ jobs:
     needs: [semgrep-test]
     runs-on: custom-ubuntu-22.04-large
     container:
-      image: "semgrep/semgrep:1.154.0"
+      image: "semgrep/semgrep:1.168.0"
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - run: |

--- a/.github/workflows/semgrep-ci.yml
+++ b/.github/workflows/semgrep-ci.yml
@@ -57,8 +57,8 @@ jobs:
           semgrep --quiet --test .ci/semgrep/
           semgrep --quiet --test --config .ci/semgrep-caps-aws-ec2.yml .ci/semgrep-caps-aws-ec2.go
 
-  semgrep_constants:
-    name: Code Quality Scan (Constants)
+  constants:
+    name: Constants Check (make semgrep-constants)
     needs: [semgrep-test]
     runs-on: custom-ubuntu-22.04-large
     container:
@@ -70,8 +70,8 @@ jobs:
           --config .ci/.semgrep-constants.yml \
           --config .ci/.semgrep-test-constants.yml
 
-  semgrep_rules:
-    name: Code Quality Scan (Rules)
+  semgrep:
+    name: Code Quality Scan (make semgrep-code-quality)
     needs: [semgrep-test]
     runs-on: custom-ubuntu-22.04-large
     container:

--- a/.github/workflows/semgrep-ci.yml
+++ b/.github/workflows/semgrep-ci.yml
@@ -35,7 +35,7 @@ jobs:
     name: Validate Code Quality Rules
     runs-on: ubuntu-latest
     container:
-      image: "semgrep/semgrep:1.154.0"
+      image: &semgrep_image "semgrep/semgrep:1.168.0"
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - run: |
@@ -50,7 +50,7 @@ jobs:
     needs: [semgrep-validate]
     runs-on: ubuntu-latest
     container:
-      image: "semgrep/semgrep:1.154.0"
+      image: *semgrep_image
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - run: |
@@ -62,7 +62,7 @@ jobs:
     needs: [semgrep-test]
     runs-on: custom-ubuntu-22.04-large
     container:
-      image: "semgrep/semgrep:1.168.0"
+      image: *semgrep_image
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - run: |
@@ -75,7 +75,7 @@ jobs:
     needs: [semgrep-test]
     runs-on: custom-ubuntu-22.04-large
     container:
-      image: "semgrep/semgrep:1.168.0"
+      image: *semgrep_image
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - run: |
@@ -106,7 +106,7 @@ jobs:
     name: Naming Scan Caps/AWS/EC2 (make semgrep-naming-cae)
     runs-on: ubuntu-latest
     container:
-      image: "semgrep/semgrep:1.154.0"
+      image: *semgrep_image
     if: (github.action != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -117,7 +117,7 @@ jobs:
     name: Test Configs Scan (make semgrep-naming)
     runs-on: ubuntu-latest
     container:
-      image: "semgrep/semgrep:1.154.0"
+      image: *semgrep_image
     if: (github.action != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -128,7 +128,7 @@ jobs:
     name: Service Name Scan A-C (make semgrep-service-naming)
     runs-on: ubuntu-latest
     container:
-      image: "semgrep/semgrep:1.154.0"
+      image: *semgrep_image
     if: (github.action != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -139,7 +139,7 @@ jobs:
     name: Service Name Scan C-I (make semgrep-service-naming)
     runs-on: ubuntu-latest
     container:
-      image: "semgrep/semgrep:1.154.0"
+      image: *semgrep_image
     if: (github.action != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -150,7 +150,7 @@ jobs:
     name: Service Name Scan I-Q (make semgrep-service-naming)
     runs-on: ubuntu-latest
     container:
-      image: "semgrep/semgrep:1.154.0"
+      image: *semgrep_image
     if: (github.action != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -161,7 +161,7 @@ jobs:
     name: Service Name Scan Q-Z (make semgrep-service-naming)
     runs-on: ubuntu-latest
     container:
-      image: "semgrep/semgrep:1.154.0"
+      image: *semgrep_image
     if: (github.action != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -140,7 +140,7 @@ changelog-misspell: ## [CI] CHANGELOG Misspell / misspell
 
 ci: tools go-build gen-check acctest-lint copyright deps-check docs examples-tflint gh-workflow-lint golangci-lint import-lint makefile-lint provider-lint provider-markdown-lint semgrep skaff-check-compile sweeper-check swissshepherd test website yamllint ## [CI] Run all CI checks (requires docker)
 
-ci-quick: tools go-build testacc-lint copyright deps-check docs-misspell examples-tflint gh-workflow-lint golangci-lint1 import-lint makefile-lint provider-lint semgrep-code-quality semgrep-naming semgrep-naming-cae website-misspell website-terrafmt yamllint ## [CI] Run quicker CI checks (no docker)
+ci-quick: tools go-build testacc-lint copyright deps-check docs-misspell examples-tflint gh-workflow-lint golangci-lint1 import-lint makefile-lint provider-lint semgrep-code-quality semgrep-constants semgrep-naming semgrep-naming-cae website-misspell website-terrafmt yamllint ## [CI] Run quicker CI checks (no docker)
 
 clean: clean-make-tests clean-go clean-tidy build tools ## Clean up Go cache, tidy and re-install tools
 	@echo "make: Clean complete"
@@ -318,7 +318,7 @@ examples-tflint: tflint-init tflint-opa-tests ## [CI] Examples Checks / tflint
 	tflint --config="$$TFLINT_CONFIG" --chdir=./examples --recursive \
 		--disable-rule=terraform_typed_variables
 
-fix-constants: semgrep-constants fmt ## Use Semgrep to fix constants
+fix-constants: semgrep-fix-constants fmt ## Use Semgrep to fix constants
 
 fix-imports: ## Fixing source code imports with goimports
 	@echo "make: Fixing source code imports with goimports..."
@@ -607,7 +607,7 @@ schema-validate: ## Validate schemas
 	@$(GO_VER) test -vet=off -buildvcs=false \
 		./internal/provider/framework -run=TestProviderInit
 
-semgrep: semgrep-code-quality semgrep-naming semgrep-naming-cae semgrep-service-naming ## [CI] Run all CI Semgrep checks
+semgrep: semgrep-code-quality semgrep-constants semgrep-naming semgrep-naming-cae semgrep-service-naming ## [CI] Run all CI Semgrep checks
 
 semgrep-all: semgrep-test semgrep-validate ## Run semgrep on all files
 	@echo "make: Running Semgrep checks locally (must have semgrep installed)..."
@@ -649,8 +649,6 @@ semgrep-code-quality: semgrep-test semgrep-validate ## [CI] Semgrep Checks / Cod
 	@semgrep $(SEMGREP_ARGS) \
 		$(if $(filter-out $(origin PKG), undefined),--include $(PKG_NAME),) \
 		--config .ci/.semgrep.yml \
-		--config .ci/.semgrep-constants.yml \
-		--config .ci/.semgrep-test-constants.yml \
 		--config .ci/semgrep/ \
 		--config 'r/dgryski.semgrep-go.anon-struct-args' \
 		--config 'r/dgryski.semgrep-go.badnilguard' \
@@ -672,7 +670,15 @@ semgrep-code-quality: semgrep-test semgrep-validate ## [CI] Semgrep Checks / Cod
 		--config 'r/dgryski.semgrep-go.writestring' \
 		--config 'r/dgryski.semgrep-go.wrongerrcall'
 
-semgrep-constants: semgrep-validate ## Fix constants with Semgrep --autofix
+semgrep-constants: semgrep-test semgrep-validate ## [CI] Semgrep Checks / Constants Check
+	@echo "make: Semgrep Checks / Constants Check..."
+	@echo "make: Running Semgrep checks locally (must have semgrep installed)"
+	@semgrep $(SEMGREP_ARGS) \
+		$(if $(filter-out $(origin PKG), undefined),--include $(PKG_NAME),) \
+		--config .ci/.semgrep-constants.yml \
+		--config .ci/.semgrep-test-constants.yml
+
+semgrep-fix-constants: semgrep-validate ## Fix constants with Semgrep --autofix
 	@echo "make: Fix constants with Semgrep --autofix"
 	@semgrep $(SEMGREP_ARGS) --autofix \
 		$(if $(filter-out $(origin PKG), undefined),--include $(PKG_NAME),) \
@@ -1241,6 +1247,7 @@ yamllint: ## [CI] YAML Linting / yamllint
 	semgrep-constants \
 	semgrep-docker \
 	semgrep-fix \
+	semgrep-fix-constants \
 	semgrep-fix-core \
 	semgrep-naming \
 	semgrep-naming-cae \

--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -537,6 +537,28 @@ You can limit the scan to a service package by using the `PKG` environment varia
 PKG=rds make semgrep-code-quality
 ```
 
+#### Constants Check
+
+This scan flags string literals in service code that should use a constant from the `names` package (for example, `"arn"` should be `names.AttrARN`). The rules are generated from `names/data/names_data.hcl` and similar sources, so they grow as the codebase evolves.
+
+Use the `semgrep-constants` target to run the same check CI runs:
+
+```console
+make semgrep-constants
+```
+
+You can limit the scan to a service package by using the `PKG` environment variable:
+
+```console
+PKG=rds make semgrep-constants
+```
+
+To apply the recommended fixes automatically, use `semgrep-fix-constants`:
+
+```console
+make semgrep-fix-constants
+```
+
 #### Naming Scan Caps/AWS/EC2
 
 Idiomatic Go uses [_mixed caps_](naming.md#mixed-caps) for multiword names, not camel case. In camel case, a name with the words "SMTP thing" would be `SmtpThing`. This is wrong in Go. In mixed caps, and therefore idiomatic Go, `SMTPThing` is correct. This scan ensures that many acronyms and initialisms are capitalized correctly in code.

--- a/docs/makefile-cheat-sheet.md
+++ b/docs/makefile-cheat-sheet.md
@@ -157,9 +157,10 @@ Variables are often defined before the `make` call on the same line, such as `MY
 | `semgrep`<sup>M</sup> | Run all CI Semgrep checks | ✔️ |  | `K`, `PKG`, `PKG_NAME`, `SEMGREP_ARGS` |
 | `semgrep-all`<sup>D</sup> | Run semgrep on all files |  |  | `K`, `PKG`, `PKG_NAME`, `SEMGREP_ARGS` |
 | `semgrep-code-quality`<sup>D</sup> | Semgrep Checks / Code Quality Scan | ✔️ |  | `K`, `PKG`, `PKG_NAME`, `SEMGREP_ARGS` |
-| `semgrep-constants`<sup>D</sup> | Fix constants with Semgrep --autofix |  |  | `K`, `PKG`, `PKG_NAME`, `SEMGREP_ARGS` |
+| `semgrep-constants`<sup>D</sup> | Semgrep Checks / Constants Check | ✔️ |  | `K`, `PKG`, `PKG_NAME`, `SEMGREP_ARGS` |
 | `semgrep-docker`<sup>D</sup> | Run Semgrep |  | ✔️ |  |
 | `semgrep-fix`<sup>D</sup> | Fix Semgrep issues that have fixes |  |  | `K`, `PKG`, `PKG_NAME`, `SEMGREP_ARGS` |
+| `semgrep-fix-constants`<sup>D</sup> | Fix constants with Semgrep --autofix |  |  | `K`, `PKG`, `PKG_NAME`, `SEMGREP_ARGS` |
 | `semgrep-fix-core` | Fix Semgrep issues in core directories |  |  | `SEMGREP_ARGS` |
 | `semgrep-naming`<sup>D</sup> | Semgrep Checks / Test Configs Scan | ✔️ |  | `K`, `PKG`, `PKG_NAME`, `SEMGREP_ARGS` |
 | `semgrep-naming-cae`<sup>D</sup> | Semgrep Checks / Naming Scan Caps/`AWS`/EC2 | ✔️ |  | `K`, `PKG`, `PKG_NAME`, `SEMGREP_ARGS` |


### PR DESCRIPTION
## Wins

| Job | Before | After |
|---|---|---|
| Embedded lint `[a-f]` | ~25m | **~2m** |
| Embedded lint `[g-z]` | ~25m | **~2m** |
| Semgrep Code Quality Scan | ~13m | **~3m** |
| Semgrep Constants Check (new shard) | (in the 13m above) | **~5m** |

Semgrep workflow wall-clock: ~13m → ~5m. Embedded lint workflow wall-clock: ~25m → ~2m.

## How

- **Embedded lint** — `validate-terraform.sh` was a serial bash loop forking `tflint` twice per HCL block on a single core of an xl runner. Refactored to fan out across cores via `xargs -P $JOBS` (default `nproc`); folded 3 `jq` forks per block down to 2; clean up per-block temp dirs.
- **Semgrep Code Quality Scan** — moved off `ubuntu-latest` to `custom-ubuntu-22.04-large`, bumped to `semgrep/semgrep:1.168.0`, and split into two parallel jobs: **Code Quality Scan** (rules) and **Constants Check** (the bulk of generated literal-string rules).
- **Makefile** — `semgrep-constants` is now the constants check target; the existing autofix target is renamed to `semgrep-fix-constants` (matching the `semgrep-fix-*` family). `semgrep-code-quality` no longer pulls the constants configs. Both targets are wired into `ci-quick` and the parent `semgrep` target.
- **Docs** — `docs/continuous-integration.md` adds a Constants Check subsection; `docs/makefile-cheat-sheet.md` reflects the renamed/added targets.

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

None.

## Relations

Relates #48553
