### PR TITLE
[Enhancement] aws_neptune_cluster_snapshot, aws_docdb_cluster_snapshot: Add `shared_accounts` argument

### DIFF
--- a/.changelog/48562.txt
+++ b/.changelog/48562.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_neptune_cluster_snapshot: Add `shared_accounts` argument
+```
+
+```release-note:enhancement
+resource/aws_docdb_cluster_snapshot: Add `shared_accounts` argument
+```

--- a/internal/service/docdb/cluster_snapshot.go
+++ b/internal/service/docdb/cluster_snapshot.go
@@ -18,7 +18,9 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
+	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	inttypes "github.com/hashicorp/terraform-provider-aws/internal/types"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -29,6 +31,7 @@ func resourceClusterSnapshot() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceClusterSnapshotCreate,
 		ReadWithoutTimeout:   resourceClusterSnapshotRead,
+		UpdateWithoutTimeout: resourceClusterSnapshotUpdate,
 		DeleteWithoutTimeout: resourceClusterSnapshotDelete,
 
 		Importer: &schema.ResourceImporter{
@@ -78,6 +81,11 @@ func resourceClusterSnapshot() *schema.Resource {
 					Type:     schema.TypeInt,
 					Computed: true,
 				},
+				"shared_accounts": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
 				"snapshot_type": {
 					Type:     schema.TypeString,
 					Computed: true,
@@ -125,6 +133,20 @@ func resourceClusterSnapshotCreate(ctx context.Context, d *schema.ResourceData, 
 		return sdkdiag.AppendErrorf(diags, "waiting for DocumentDB Cluster Snapshot (%s) create: %s", d.Id(), err)
 	}
 
+	if v, ok := d.GetOk("shared_accounts"); ok && v.(*schema.Set).Len() > 0 {
+		input := &docdb.ModifyDBClusterSnapshotAttributeInput{
+			AttributeName:               aws.String(clusterSnapshotAttributeNameRestore),
+			DBClusterSnapshotIdentifier: aws.String(d.Id()),
+			ValuesToAdd:                 flex.ExpandStringValueSet(v.(*schema.Set)),
+		}
+
+		_, err := conn.ModifyDBClusterSnapshotAttribute(ctx, input)
+
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "modifying DocumentDB Cluster Snapshot (%s) attribute: %s", d.Id(), err)
+		}
+	}
+
 	return append(diags, resourceClusterSnapshotRead(ctx, d, meta)...)
 }
 
@@ -158,7 +180,41 @@ func resourceClusterSnapshotRead(ctx context.Context, d *schema.ResourceData, me
 	d.Set(names.AttrStorageEncrypted, snapshot.StorageEncrypted)
 	d.Set(names.AttrVPCID, snapshot.VpcId)
 
+	attribute, err := findClusterSnapshotAttributeByTwoPartKey(ctx, conn, d.Id(), clusterSnapshotAttributeNameRestore)
+	switch {
+	case err == nil:
+		d.Set("shared_accounts", attribute.AttributeValues)
+	case retry.NotFound(err):
+	default:
+		return sdkdiag.AppendErrorf(diags, "reading DocumentDB Cluster Snapshot (%s) attribute: %s", d.Id(), err)
+	}
+
 	return diags
+}
+
+func resourceClusterSnapshotUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).DocDBClient(ctx)
+
+	if d.HasChange("shared_accounts") {
+		o, n := d.GetChange("shared_accounts")
+		os, ns := o.(*schema.Set), n.(*schema.Set)
+		add, del := ns.Difference(os), os.Difference(ns)
+		input := &docdb.ModifyDBClusterSnapshotAttributeInput{
+			AttributeName:               aws.String(clusterSnapshotAttributeNameRestore),
+			DBClusterSnapshotIdentifier: aws.String(d.Id()),
+			ValuesToAdd:                 flex.ExpandStringValueSet(add),
+			ValuesToRemove:              flex.ExpandStringValueSet(del),
+		}
+
+		_, err := conn.ModifyDBClusterSnapshotAttribute(ctx, input)
+
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "modifying DocumentDB Cluster Snapshot (%s) attribute: %s", d.Id(), err)
+		}
+	}
+
+	return append(diags, resourceClusterSnapshotRead(ctx, d, meta)...)
 }
 
 func resourceClusterSnapshotDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
@@ -270,4 +326,44 @@ func waitClusterSnapshotCreated(ctx context.Context, conn *docdb.Client, id stri
 	}
 
 	return nil, err
+}
+
+func findClusterSnapshotAttributeByTwoPartKey(ctx context.Context, conn *docdb.Client, id, attributeName string) (*awstypes.DBClusterSnapshotAttribute, error) {
+	input := &docdb.DescribeDBClusterSnapshotAttributesInput{
+		DBClusterSnapshotIdentifier: aws.String(id),
+	}
+
+	return findClusterSnapshotAttribute(ctx, conn, input, func(v *awstypes.DBClusterSnapshotAttribute) bool {
+		return aws.ToString(v.AttributeName) == attributeName
+	})
+}
+
+func findClusterSnapshotAttribute(ctx context.Context, conn *docdb.Client, input *docdb.DescribeDBClusterSnapshotAttributesInput, filter tfslices.Predicate[*awstypes.DBClusterSnapshotAttribute]) (*awstypes.DBClusterSnapshotAttribute, error) {
+	output, err := findClusterSnapshotAttributes(ctx, conn, input, filter)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return tfresource.AssertSingleValueResult(output)
+}
+
+func findClusterSnapshotAttributes(ctx context.Context, conn *docdb.Client, input *docdb.DescribeDBClusterSnapshotAttributesInput, filter tfslices.Predicate[*awstypes.DBClusterSnapshotAttribute]) ([]awstypes.DBClusterSnapshotAttribute, error) {
+	output, err := conn.DescribeDBClusterSnapshotAttributes(ctx, input)
+
+	if errs.IsA[*awstypes.DBClusterSnapshotNotFoundFault](err) {
+		return nil, &retry.NotFoundError{
+			LastError: err,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || output.DBClusterSnapshotAttributesResult == nil {
+		return nil, tfresource.NewEmptyResultError()
+	}
+
+	return tfslices.Filter(output.DBClusterSnapshotAttributesResult.DBClusterSnapshotAttributes, tfslices.PredicateValue(filter)), nil
 }

--- a/internal/service/docdb/cluster_snapshot_test.go
+++ b/internal/service/docdb/cluster_snapshot_test.go
@@ -157,3 +157,110 @@ resource "aws_docdb_cluster_snapshot" "test" {
 }
 `, rName))
 }
+
+func TestAccDocDBClusterSnapshot_sharedAccounts(t *testing.T) {
+	ctx := acctest.Context(t)
+	var dbClusterSnapshot awstypes.DBClusterSnapshot
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_docdb_cluster_snapshot.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.DocDBServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckClusterSnapshotDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterSnapshotConfig_sharedAccounts(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClusterSnapshotExists(ctx, t, resourceName, &dbClusterSnapshot),
+					resource.TestCheckResourceAttr(resourceName, "shared_accounts.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "shared_accounts.*", "all"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDocDBClusterSnapshot_sharedAccountsUpdate(t *testing.T) {
+	ctx := acctest.Context(t)
+	var dbClusterSnapshot awstypes.DBClusterSnapshot
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_docdb_cluster_snapshot.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.DocDBServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckClusterSnapshotDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterSnapshotConfig_sharedAccounts(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClusterSnapshotExists(ctx, t, resourceName, &dbClusterSnapshot),
+					resource.TestCheckResourceAttr(resourceName, "shared_accounts.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "shared_accounts.*", "all"),
+				),
+			},
+			{
+				Config: testAccClusterSnapshotConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClusterSnapshotExists(ctx, t, resourceName, &dbClusterSnapshot),
+					resource.TestCheckResourceAttr(resourceName, "shared_accounts.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDocDBClusterSnapshot_sharedAccountsImport(t *testing.T) {
+	ctx := acctest.Context(t)
+	var dbClusterSnapshot awstypes.DBClusterSnapshot
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_docdb_cluster_snapshot.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.DocDBServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckClusterSnapshotDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterSnapshotConfig_sharedAccounts(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClusterSnapshotExists(ctx, t, resourceName, &dbClusterSnapshot),
+					resource.TestCheckResourceAttr(resourceName, "shared_accounts.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "shared_accounts.*", "all"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccClusterSnapshotConfig_sharedAccounts(rName string) string {
+	return acctest.ConfigCompose(acctest.ConfigVPCWithSubnets(rName, 2), fmt.Sprintf(`
+resource "aws_docdb_subnet_group" "test" {
+  name       = %[1]q
+  subnet_ids = aws_subnet.test[*].id
+}
+
+resource "aws_docdb_cluster" "test" {
+  cluster_identifier   = %[1]q
+  db_subnet_group_name = aws_docdb_subnet_group.test.name
+  master_password      = "avoid-plaintext-passwords"
+  master_username      = "tfacctest"
+  skip_final_snapshot  = true
+}
+
+resource "aws_docdb_cluster_snapshot" "test" {
+  db_cluster_identifier          = aws_docdb_cluster.test.id
+  db_cluster_snapshot_identifier = %[1]q
+  shared_accounts                = ["all"]
+}
+`, rName))
+}

--- a/internal/service/docdb/consts.go
+++ b/internal/service/docdb/consts.go
@@ -43,6 +43,10 @@ const (
 )
 
 const (
+	clusterSnapshotAttributeNameRestore = "restore"
+)
+
+const (
 	eventSubscriptionStatusActive    = "active"
 	eventSubscriptionStatusCreating  = "creating"
 	eventSubscriptionStatusDeleting  = "deleting"

--- a/internal/service/neptune/cluster_snapshot.go
+++ b/internal/service/neptune/cluster_snapshot.go
@@ -18,7 +18,9 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
+	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -28,6 +30,7 @@ func resourceClusterSnapshot() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceClusterSnapshotCreate,
 		ReadWithoutTimeout:   resourceClusterSnapshotRead,
+		UpdateWithoutTimeout: resourceClusterSnapshotUpdate,
 		DeleteWithoutTimeout: resourceClusterSnapshotDelete,
 
 		Importer: &schema.ResourceImporter{
@@ -91,6 +94,11 @@ func resourceClusterSnapshot() *schema.Resource {
 					Type:     schema.TypeString,
 					Computed: true,
 				},
+				"shared_accounts": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
 				names.AttrStatus: {
 					Type:     schema.TypeString,
 					Computed: true,
@@ -130,6 +138,20 @@ func resourceClusterSnapshotCreate(ctx context.Context, d *schema.ResourceData, 
 		return sdkdiag.AppendErrorf(diags, "waiting for Neptune Cluster Snapshot (%s) create: %s", d.Id(), err)
 	}
 
+	if v, ok := d.GetOk("shared_accounts"); ok && v.(*schema.Set).Len() > 0 {
+		input := &neptune.ModifyDBClusterSnapshotAttributeInput{
+			AttributeName:               aws.String(clusterSnapshotAttributeNameRestore),
+			DBClusterSnapshotIdentifier: aws.String(d.Id()),
+			ValuesToAdd:                 flex.ExpandStringValueSet(v.(*schema.Set)),
+		}
+
+		_, err := conn.ModifyDBClusterSnapshotAttribute(ctx, input)
+
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "modifying Neptune Cluster Snapshot (%s) attribute: %s", d.Id(), err)
+		}
+	}
+
 	return append(diags, resourceClusterSnapshotRead(ctx, d, meta)...)
 }
 
@@ -165,7 +187,41 @@ func resourceClusterSnapshotRead(ctx context.Context, d *schema.ResourceData, me
 	d.Set(names.AttrStorageEncrypted, snapshot.StorageEncrypted)
 	d.Set(names.AttrVPCID, snapshot.VpcId)
 
+	attribute, err := findClusterSnapshotAttributeByTwoPartKey(ctx, conn, d.Id(), clusterSnapshotAttributeNameRestore)
+	switch {
+	case err == nil:
+		d.Set("shared_accounts", attribute.AttributeValues)
+	case retry.NotFound(err):
+	default:
+		return sdkdiag.AppendErrorf(diags, "reading Neptune Cluster Snapshot (%s) attribute: %s", d.Id(), err)
+	}
+
 	return diags
+}
+
+func resourceClusterSnapshotUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).NeptuneClient(ctx)
+
+	if d.HasChange("shared_accounts") {
+		o, n := d.GetChange("shared_accounts")
+		os, ns := o.(*schema.Set), n.(*schema.Set)
+		add, del := ns.Difference(os), os.Difference(ns)
+		input := &neptune.ModifyDBClusterSnapshotAttributeInput{
+			AttributeName:               aws.String(clusterSnapshotAttributeNameRestore),
+			DBClusterSnapshotIdentifier: aws.String(d.Id()),
+			ValuesToAdd:                 flex.ExpandStringValueSet(add),
+			ValuesToRemove:              flex.ExpandStringValueSet(del),
+		}
+
+		_, err := conn.ModifyDBClusterSnapshotAttribute(ctx, input)
+
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "modifying Neptune Cluster Snapshot (%s) attribute: %s", d.Id(), err)
+		}
+	}
+
+	return append(diags, resourceClusterSnapshotRead(ctx, d, meta)...)
 }
 
 func resourceClusterSnapshotDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
@@ -272,4 +328,44 @@ func waitClusterSnapshotCreated(ctx context.Context, conn *neptune.Client, id st
 	}
 
 	return nil, err
+}
+
+func findClusterSnapshotAttributeByTwoPartKey(ctx context.Context, conn *neptune.Client, id, attributeName string) (*awstypes.DBClusterSnapshotAttribute, error) {
+	input := &neptune.DescribeDBClusterSnapshotAttributesInput{
+		DBClusterSnapshotIdentifier: aws.String(id),
+	}
+
+	return findClusterSnapshotAttribute(ctx, conn, input, func(v *awstypes.DBClusterSnapshotAttribute) bool {
+		return aws.ToString(v.AttributeName) == attributeName
+	})
+}
+
+func findClusterSnapshotAttribute(ctx context.Context, conn *neptune.Client, input *neptune.DescribeDBClusterSnapshotAttributesInput, filter tfslices.Predicate[*awstypes.DBClusterSnapshotAttribute]) (*awstypes.DBClusterSnapshotAttribute, error) {
+	output, err := findClusterSnapshotAttributes(ctx, conn, input, filter)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return tfresource.AssertSingleValueResult(output)
+}
+
+func findClusterSnapshotAttributes(ctx context.Context, conn *neptune.Client, input *neptune.DescribeDBClusterSnapshotAttributesInput, filter tfslices.Predicate[*awstypes.DBClusterSnapshotAttribute]) ([]awstypes.DBClusterSnapshotAttribute, error) {
+	output, err := conn.DescribeDBClusterSnapshotAttributes(ctx, input)
+
+	if errs.IsA[*awstypes.DBClusterSnapshotNotFoundFault](err) {
+		return nil, &retry.NotFoundError{
+			LastError: err,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || output.DBClusterSnapshotAttributesResult == nil {
+		return nil, tfresource.NewEmptyResultError()
+	}
+
+	return tfslices.Filter(output.DBClusterSnapshotAttributesResult.DBClusterSnapshotAttributes, tfslices.PredicateValue(filter)), nil
 }

--- a/internal/service/neptune/cluster_snapshot_test.go
+++ b/internal/service/neptune/cluster_snapshot_test.go
@@ -157,3 +157,120 @@ resource "aws_neptune_cluster_snapshot" "test" {
 }
 `, rName)
 }
+
+func TestAccNeptuneClusterSnapshot_sharedAccounts(t *testing.T) {
+	ctx := acctest.Context(t)
+	var dbClusterSnapshot awstypes.DBClusterSnapshot
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_neptune_cluster_snapshot.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.NeptuneServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckClusterSnapshotDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterSnapshotConfig_sharedAccounts(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClusterSnapshotExists(ctx, t, resourceName, &dbClusterSnapshot),
+					resource.TestCheckResourceAttr(resourceName, "shared_accounts.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "shared_accounts.*", "all"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNeptuneClusterSnapshot_sharedAccountsUpdate(t *testing.T) {
+	ctx := acctest.Context(t)
+	var dbClusterSnapshot awstypes.DBClusterSnapshot
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_neptune_cluster_snapshot.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.NeptuneServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckClusterSnapshotDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterSnapshotConfig_sharedAccounts(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClusterSnapshotExists(ctx, t, resourceName, &dbClusterSnapshot),
+					resource.TestCheckResourceAttr(resourceName, "shared_accounts.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "shared_accounts.*", "all"),
+				),
+			},
+			{
+				Config: testAccClusterSnapshotConfig_sharedAccountsRemoved(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClusterSnapshotExists(ctx, t, resourceName, &dbClusterSnapshot),
+					resource.TestCheckResourceAttr(resourceName, "shared_accounts.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNeptuneClusterSnapshot_sharedAccountsImport(t *testing.T) {
+	ctx := acctest.Context(t)
+	var dbClusterSnapshot awstypes.DBClusterSnapshot
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_neptune_cluster_snapshot.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.NeptuneServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckClusterSnapshotDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterSnapshotConfig_sharedAccounts(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClusterSnapshotExists(ctx, t, resourceName, &dbClusterSnapshot),
+					resource.TestCheckResourceAttr(resourceName, "shared_accounts.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "shared_accounts.*", "all"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccClusterSnapshotConfig_sharedAccounts(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_neptune_cluster" "test" {
+  cluster_identifier  = %[1]q
+  skip_final_snapshot = true
+
+  neptune_cluster_parameter_group_name = "default.neptune1.4"
+}
+
+resource "aws_neptune_cluster_snapshot" "test" {
+  db_cluster_identifier          = aws_neptune_cluster.test.id
+  db_cluster_snapshot_identifier = %[1]q
+  shared_accounts                = ["all"]
+}
+`, rName)
+}
+
+func testAccClusterSnapshotConfig_sharedAccountsRemoved(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_neptune_cluster" "test" {
+  cluster_identifier  = %[1]q
+  skip_final_snapshot = true
+
+  neptune_cluster_parameter_group_name = "default.neptune1.4"
+}
+
+resource "aws_neptune_cluster_snapshot" "test" {
+  db_cluster_identifier          = aws_neptune_cluster.test.id
+  db_cluster_snapshot_identifier = %[1]q
+}
+`, rName)
+}

--- a/internal/service/neptune/consts.go
+++ b/internal/service/neptune/consts.go
@@ -41,6 +41,10 @@ const (
 )
 
 const (
+	clusterSnapshotAttributeNameRestore = "restore"
+)
+
+const (
 	clusterSnapshotStatusAvailable = "available"
 	clusterSnapshotStatusCreating  = "creating"
 )

--- a/website/docs/r/docdb_cluster_snapshot.html.markdown
+++ b/website/docs/r/docdb_cluster_snapshot.html.markdown
@@ -12,10 +12,22 @@ Manages a DocumentDB database cluster snapshot for DocumentDB clusters.
 
 ## Example Usage
 
+### Basic Usage
+
 ```terraform
 resource "aws_docdb_cluster_snapshot" "example" {
   db_cluster_identifier          = aws_docdb_cluster.example.id
   db_cluster_snapshot_identifier = "resourcetestsnapshot1234"
+}
+```
+
+### Sharing With Specific Accounts
+
+```terraform
+resource "aws_docdb_cluster_snapshot" "example" {
+  db_cluster_identifier          = aws_docdb_cluster.example.id
+  db_cluster_snapshot_identifier = "resourcetestsnapshot1234"
+  shared_accounts                = ["123456789012", "234567890123"]
 }
 ```
 
@@ -26,6 +38,7 @@ This resource supports the following arguments:
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `db_cluster_identifier` - (Required) The DocumentDB Cluster Identifier from which to take the snapshot.
 * `db_cluster_snapshot_identifier` - (Required) The Identifier for the snapshot.
+* `shared_accounts` - (Optional) List of AWS Account IDs to share the snapshot with. Use `all` to make the snapshot public.
 
 ## Attribute Reference
 

--- a/website/docs/r/neptune_cluster_snapshot.html.markdown
+++ b/website/docs/r/neptune_cluster_snapshot.html.markdown
@@ -12,10 +12,22 @@ Manages a Neptune database cluster snapshot.
 
 ## Example Usage
 
+### Basic Usage
+
 ```terraform
 resource "aws_neptune_cluster_snapshot" "example" {
   db_cluster_identifier          = aws_neptune_cluster.example.id
   db_cluster_snapshot_identifier = "resourcetestsnapshot1234"
+}
+```
+
+### Sharing With Specific Accounts
+
+```terraform
+resource "aws_neptune_cluster_snapshot" "example" {
+  db_cluster_identifier          = aws_neptune_cluster.example.id
+  db_cluster_snapshot_identifier = "resourcetestsnapshot1234"
+  shared_accounts                = ["123456789012", "234567890123"]
 }
 ```
 
@@ -26,6 +38,7 @@ This resource supports the following arguments:
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `db_cluster_identifier` - (Required) The DB Cluster Identifier from which to take the snapshot.
 * `db_cluster_snapshot_identifier` - (Required) The Identifier for the snapshot.
+* `shared_accounts` - (Optional) List of AWS Account IDs to share the snapshot with. Use `all` to make the snapshot public.
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Adds `shared_accounts` argument to `aws_neptune_cluster_snapshot` and `aws_docdb_cluster_snapshot` resources, following the same approach used for RDS snapshots.

As noted in [this comment](https://github.com/hashicorp/terraform-provider-aws/issues/44056#issuecomment-3258398011), both Neptune and DocDB support `modify-db-cluster-snapshot-attribute` with attribute name "restore". This wires up that API in the provider. Implementation mirrors the existing RDS pattern in `internal/service/rds/cluster_snapshot.go`.

Also adds an Update handler to both resources since they previously only had Create, Read, and Delete.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #44056

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
**Neptune Tests:**
```console
% make testacc TESTS="TestAccNeptuneClusterSnapshot_sharedAccounts" PKG=neptune ACCTEST_PARALLELISM=1 ACCTEST_TIMEOUT=4880m
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework (cached)
make: Running acceptance tests on branch: 🌿 f-shared-account-neptune-docdb 🌿...
TF_ACC=1 go1.26.4 test ./internal/service/neptune/... -v -count 1 -parallel 1 -run='TestAccNeptuneClusterSnapshot_sharedAccounts'  -timeout 4880m -vet=off -buildvcs=false
2026/06/24 20:13:16 Creating Terraform AWS Provider (SDKv2-style)...
2026/06/24 20:13:16 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccNeptuneClusterSnapshot_sharedAccounts
=== PAUSE TestAccNeptuneClusterSnapshot_sharedAccounts
=== RUN   TestAccNeptuneClusterSnapshot_sharedAccountsUpdate
=== PAUSE TestAccNeptuneClusterSnapshot_sharedAccountsUpdate
=== RUN   TestAccNeptuneClusterSnapshot_sharedAccountsImport
=== PAUSE TestAccNeptuneClusterSnapshot_sharedAccountsImport
=== CONT  TestAccNeptuneClusterSnapshot_sharedAccounts
--- PASS: TestAccNeptuneClusterSnapshot_sharedAccounts (231.43s)
=== CONT  TestAccNeptuneClusterSnapshot_sharedAccountsImport
--- PASS: TestAccNeptuneClusterSnapshot_sharedAccountsImport (233.57s)
=== CONT  TestAccNeptuneClusterSnapshot_sharedAccountsUpdate
--- PASS: TestAccNeptuneClusterSnapshot_sharedAccountsUpdate (230.14s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/neptune    701.810s
```
**DocDb Tests:**
```console
% make testacc TESTS="TestAccDocDBClusterSnapshot_sharedAccounts" PKG=docdb ACCTEST_PARALLELISM=1 ACCTEST_TIMEOUT=4880m
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework (cached)
make: Running acceptance tests on branch: 🌿 f-shared-account-neptune-docdb 🌿...
TF_ACC=1 go1.26.4 test ./internal/service/docdb/... -v -count 1 -parallel 1 -run='TestAccDocDBClusterSnapshot_sharedAccounts'  -timeout 4880m -vet=off -buildvcs=false
2026/06/24 20:13:21 Creating Terraform AWS Provider (SDKv2-style)...
2026/06/24 20:13:21 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccDocDBClusterSnapshot_sharedAccounts
=== PAUSE TestAccDocDBClusterSnapshot_sharedAccounts
=== RUN   TestAccDocDBClusterSnapshot_sharedAccountsUpdate
=== PAUSE TestAccDocDBClusterSnapshot_sharedAccountsUpdate
=== RUN   TestAccDocDBClusterSnapshot_sharedAccountsImport
=== PAUSE TestAccDocDBClusterSnapshot_sharedAccountsImport
=== CONT  TestAccDocDBClusterSnapshot_sharedAccounts
--- PASS: TestAccDocDBClusterSnapshot_sharedAccounts (239.10s)
=== CONT  TestAccDocDBClusterSnapshot_sharedAccountsImport
--- PASS: TestAccDocDBClusterSnapshot_sharedAccountsImport (231.66s)
=== CONT  TestAccDocDBClusterSnapshot_sharedAccountsUpdate
--- PASS: TestAccDocDBClusterSnapshot_sharedAccountsUpdate (241.82s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/docdb      723.918s
```
