### PR TITLE
iot: Retry post-create read of attachment resources to tolerate eventual consistency 🤖🤖🤖

### DIFF
--- a/.changelog/48566.txt
+++ b/.changelog/48566.txt
@@ -1,0 +1,11 @@
+```release-note:bug
+resource/aws_iot_policy_attachment: Retry the post-create read to tolerate IoT eventual consistency, preventing intermittent `empty result` errors that incorrectly tainted the resource
+```
+
+```release-note:bug
+resource/aws_iot_thing_principal_attachment: Retry the post-create read to tolerate IoT eventual consistency, preventing intermittent `empty result` errors that incorrectly tainted the resource
+```
+
+```release-note:bug
+resource/aws_iot_thing_group_membership: Retry the post-create read to tolerate IoT eventual consistency, preventing intermittent `empty result` errors that incorrectly tainted the resource
+```

--- a/internal/service/iot/policy_attachment.go
+++ b/internal/service/iot/policy_attachment.go
@@ -80,7 +80,9 @@ func resourcePolicyAttachmentRead(ctx context.Context, d *schema.ResourceData, m
 		return sdkdiag.AppendFromErr(diags, err)
 	}
 
-	_, err = findAttachedPolicyByTwoPartKey(ctx, conn, policyName, target)
+	_, err = tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func(ctx context.Context) (*awstypes.Policy, error) {
+		return findAttachedPolicyByTwoPartKey(ctx, conn, policyName, target)
+	}, d.IsNewResource())
 
 	if !d.IsNewResource() && retry.NotFound(err) {
 		log.Printf("[WARN] IoT Policy Attachment (%s) not found, removing from state", d.Id())

--- a/internal/service/iot/thing_group_membership.go
+++ b/internal/service/iot/thing_group_membership.go
@@ -92,7 +92,9 @@ func resourceThingGroupMembershipRead(ctx context.Context, d *schema.ResourceDat
 		return sdkdiag.AppendFromErr(diags, err)
 	}
 
-	_, err = findThingGroupMembershipByTwoPartKey(ctx, conn, thingGroupName, thingName)
+	_, err = tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func(ctx context.Context) (*awstypes.GroupNameAndArn, error) {
+		return findThingGroupMembershipByTwoPartKey(ctx, conn, thingGroupName, thingName)
+	}, d.IsNewResource())
 
 	if !d.IsNewResource() && retry.NotFound(err) {
 		log.Printf("[WARN] IoT Thing Group Membership (%s) not found, removing from state", d.Id())

--- a/internal/service/iot/thing_principal_attachment.go
+++ b/internal/service/iot/thing_principal_attachment.go
@@ -100,7 +100,9 @@ func resourceThingPrincipalAttachmentRead(ctx context.Context, d *schema.Resourc
 	thing := parts[0]
 	principal := parts[1]
 
-	out, err := findThingPrincipalAttachmentByTwoPartKey(ctx, conn, thing, principal)
+	out, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func(ctx context.Context) (*awstypes.ThingPrincipalObject, error) {
+		return findThingPrincipalAttachmentByTwoPartKey(ctx, conn, thing, principal)
+	}, d.IsNewResource())
 
 	if !d.IsNewResource() && retry.NotFound(err) {
 		log.Printf("[WARN] IoT Thing Principal Attachment (%s) not found, removing from state", d.Id())


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

There are no changes to security controls (access controls, encryption, logging) in this pull request.

### Description

The IoT attachment resources perform a read immediately after create. That read lists the attachment from the IoT control plane and asserts a result is present (`findAttachedPolicyByTwoPartKey` → `tfresource.AssertFirstValueResult`, and the equivalent `AssertSingleValueResult` calls in the sibling resources). IoT attachments are eventually consistent, so a freshly-created attachment may not yet appear in `ListAttachedPolicies` / `ListThingPrincipalsV2` / `ListThingGroupsForThing`. When that happens the list call succeeds but returns an empty set, which surfaces as `empty result` and incorrectly taints the resource, failing the apply. A re-apply succeeds.

This is the same class of issue already handled for IAM attachments (e.g. `internal/service/iam/role_policy_attachment.go`), which wrap the post-create find in `tfresource.RetryWhenNewResourceNotFound(..., d.IsNewResource())`. This PR applies the same pattern to the three affected IoT resources:

* `aws_iot_policy_attachment`
* `aws_iot_thing_principal_attachment`
* `aws_iot_thing_group_membership`

The empty-result error already converts to `*retry.NotFoundError` via its `As` method, so the existing helper retries it during the propagation window and returns the not-found handling unchanged for non-new resources. No new constant is required — `propagationTimeout = 2 * time.Minute` already exists in the package's `consts.go`. This matches the eventual-consistency guidance for SDKv2 `Read` functions in `docs/retries-and-waiters.md`.

### Relations

Closes #48563

### References

* `internal/service/iam/role_policy_attachment.go` — the IAM pattern this change mirrors
* #34329 — same eventual-consistency class previously fixed for `aws_iot_policy` deletes
* #45351 — IAM attachment, same `empty result` symptom

### AI Usage

Claude Code (Claude Opus) was used to assist this contribution: diagnosing the root cause from the linked issue, locating the IAM reference pattern, applying the retry wrapper across the three resources, and running the build, `go vet`, unit, and acceptance tests locally. The submitter reviewed all changes and retains full ownership and accountability. Acceptance tests were run against a personal sandbox AWS account and all passed (output below).

### Output from Acceptance Testing

```console
% make testacc PKG=iot TESTS='TestAccIoTPolicyAttachment_basic|TestAccIoTThingPrincipalAttachment_|TestAccIoTThingGroupMembership_'

--- PASS: TestAccIoTThingGroupMembership_disappears_ThingGroup (43.79s)
--- PASS: TestAccIoTThingGroupMembership_overrideDynamicGroup (39.85s)
--- PASS: TestAccIoTThingPrincipalAttachment_thingPrincipalType (96.26s)
--- PASS: TestAccIoTPolicyAttachment_basic (112.26s)
--- PASS: TestAccIoTThingGroupMembership_disappears (35.62s)
--- PASS: TestAccIoTThingGroupMembership_disappears_Thing (34.12s)
--- PASS: TestAccIoTThingPrincipalAttachment_basic (141.18s)
--- PASS: TestAccIoTThingGroupMembership_basic (31.70s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/iot        157.040s
```
