### PR TITLE
route53recoverycontrolconfig: retry on ConflictException

### DIFF
--- a/.changelog/48576.txt
+++ b/.changelog/48576.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_route53recoverycontrolconfig_routing_control: Retry on `ConflictException` errors raised by concurrent requests
+```

--- a/internal/service/route53recoverycontrolconfig/service_package.go
+++ b/internal/service/route53recoverycontrolconfig/service_package.go
@@ -1,0 +1,40 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package route53recoverycontrolconfig
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/retry"
+	"github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/vcr"
+)
+
+func (p *servicePackage) withExtraOptions(ctx context.Context, config map[string]any) []func(*route53recoverycontrolconfig.Options) {
+	cfg := *(config["aws_sdkv2_config"].(*aws.Config))
+
+	return []func(*route53recoverycontrolconfig.Options){
+		func(o *route53recoverycontrolconfig.Options) {
+			retryables := []retry.IsErrorRetryable{
+				retry.IsErrorRetryableFunc(func(err error) aws.Ternary {
+					if errs.IsA[*awstypes.ConflictException](err) {
+						return aws.TrueTernary
+					}
+					return aws.UnknownTernary
+				}),
+			}
+			if inContext, ok := conns.FromContext(ctx); ok && inContext.VCREnabled() {
+				tflog.Info(ctx, "overriding retry behavior to immediately return VCR errors")
+				retryables = append(retryables, vcr.InteractionNotFoundRetryableFunc)
+			}
+
+			o.Retryer = conns.AddIsErrorRetryables(cfg.Retryer().(aws.RetryerV2), retryables...)
+		},
+	}
+}


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
The aws route53 recovery control config API returns _ConflictException_ / http 409 when resources on the same control panel are mutated concurrently, e.g. creating multiple routing controls in parallel.

This PR adds a service-level client retryer that marks ConflictException as retryable. Because it's applied at the client layer, it covers all resources in the service, e.g., _cluster_, _control_panel_, _routing_control_.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #48311 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

- route53 arc api:
https://docs.aws.amazon.com/recovery-cluster/latest/api/routingcontrol.html
- Customizing a service client:  
https://hashicorp.github.io/terraform-provider-aws/add-a-new-service/#customizing-a-new-service-client
- [`internal/service/appsync/service_package.go`](https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/appsync/service_package.go)
- [`internal/service/apigatewayv2/service_package.go`](https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/apigatewayv2/service_package.go) 

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

_Route53 ARC acceptance tests require a live recovery cluster_ 🙏🏻 
