### PR TITLE
r/aws_lightsail_key_pair , r/aws_lightsail_bucket_access_key , d/aws_codeartifact_authorization_token : Mark sensitive attributes

### DIFF
--- a/.changelog/48577.txt
+++ b/.changelog/48577.txt
@@ -2,11 +2,9 @@
 resource/aws_lightsail_key_pair: Mark `private_key` as sensitive
 ```
 
-
 ```release-note:bug
 resource/aws_lightsail_bucket_access_key: Mark `secret_access_key` as sensitive
 ```
-
 
 ```release-note:bug
 data-source/aws_codeartifact_authorization_token: Mark `authorization_token` as sensitive

--- a/.changelog/48577.txt
+++ b/.changelog/48577.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_lightsail_key_pair: Mark `private_key` as sensitive
+```

--- a/.changelog/48577.txt
+++ b/.changelog/48577.txt
@@ -6,3 +6,8 @@ resource/aws_lightsail_key_pair: Mark `private_key` as sensitive
 ```release-note:bug
 resource/aws_lightsail_bucket_access_key: Mark `secret_access_key` as sensitive
 ```
+
+
+```release-note:bug
+data-source/aws_codeartifact_authorization_token: Mark `authorization_token` as sensitive
+```

--- a/.changelog/48577.txt
+++ b/.changelog/48577.txt
@@ -1,3 +1,8 @@
 ```release-note:bug
 resource/aws_lightsail_key_pair: Mark `private_key` as sensitive
 ```
+
+
+```release-note:bug
+resource/aws_lightsail_bucket_access_key: Mark `secret_access_key` as sensitive
+```

--- a/internal/service/codeartifact/authorization_token_data_source.go
+++ b/internal/service/codeartifact/authorization_token_data_source.go
@@ -29,8 +29,9 @@ func dataSourceAuthorizationToken() *schema.Resource {
 		SchemaFunc: func() map[string]*schema.Schema {
 			return map[string]*schema.Schema{
 				"authorization_token": {
-					Type:     schema.TypeString,
-					Computed: true,
+					Type:      schema.TypeString,
+					Computed:  true,
+					Sensitive: true,
 				},
 				names.AttrDomain: {
 					Type:     schema.TypeString,

--- a/internal/service/lightsail/bucket_access_key.go
+++ b/internal/service/lightsail/bucket_access_key.go
@@ -56,8 +56,9 @@ func ResourceBucketAccessKey() *schema.Resource {
 					Computed: true,
 				},
 				"secret_access_key": {
-					Type:     schema.TypeString,
-					Computed: true,
+					Type:      schema.TypeString,
+					Computed:  true,
+					Sensitive: true,
 				},
 				names.AttrStatus: {
 					Type:     schema.TypeString,

--- a/internal/service/lightsail/key_pair.go
+++ b/internal/service/lightsail/key_pair.go
@@ -79,8 +79,9 @@ func ResourceKeyPair() *schema.Resource {
 					ForceNew: true,
 				},
 				names.AttrPrivateKey: {
-					Type:     schema.TypeString,
-					Computed: true,
+					Type:      schema.TypeString,
+					Computed:  true,
+					Sensitive: true,
 				},
 				names.AttrPublicKey: {
 					Type:     schema.TypeString,


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

### Description

The following attributes under resources/datasource are missing `Sensitive: true` in the resource schema, causing them to be displayed in TF’s output under certain circumstances.

`aws_lightsail_key_pair.private_key`

`aws_lightsail_bucket_access_key.secret_access_key`

`aws_codeartifact_authorization_token.authorization_token`

This PR fixes that.

### Acc test output 

```console
make t K=lightsail T=TestAccLightsailKeyPair_     
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 td-sensitive-attributes 🌿...
TF_ACC=1 go1.26.4 test ./internal/service/lightsail/... -v -count 1 -parallel 20 -run='TestAccLightsailKeyPair_'  -timeout 360m -vet=off
2026/06/25 22:51:36 Creating Terraform AWS Provider (SDKv2-style)...
2026/06/25 22:51:36 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccLightsailKeyPair_basic
=== PAUSE TestAccLightsailKeyPair_basic
=== RUN   TestAccLightsailKeyPair_publicKey
=== PAUSE TestAccLightsailKeyPair_publicKey
=== RUN   TestAccLightsailKeyPair_encrypted
=== PAUSE TestAccLightsailKeyPair_encrypted
=== RUN   TestAccLightsailKeyPair_namePrefix
=== PAUSE TestAccLightsailKeyPair_namePrefix
=== RUN   TestAccLightsailKeyPair_tags
=== PAUSE TestAccLightsailKeyPair_tags
=== RUN   TestAccLightsailKeyPair_keyOnlyTags
=== PAUSE TestAccLightsailKeyPair_keyOnlyTags
=== RUN   TestAccLightsailKeyPair_disappears
=== PAUSE TestAccLightsailKeyPair_disappears
=== CONT  TestAccLightsailKeyPair_basic
=== CONT  TestAccLightsailKeyPair_tags
=== CONT  TestAccLightsailKeyPair_encrypted
=== CONT  TestAccLightsailKeyPair_publicKey
=== CONT  TestAccLightsailKeyPair_keyOnlyTags
=== CONT  TestAccLightsailKeyPair_disappears
=== CONT  TestAccLightsailKeyPair_namePrefix
--- PASS: TestAccLightsailKeyPair_basic (63.56s)
--- PASS: TestAccLightsailKeyPair_publicKey (70.65s)
--- PASS: TestAccLightsailKeyPair_encrypted (75.45s)
--- PASS: TestAccLightsailKeyPair_namePrefix (80.52s)
--- PASS: TestAccLightsailKeyPair_disappears (87.41s)
--- PASS: TestAccLightsailKeyPair_keyOnlyTags (144.44s)
--- PASS: TestAccLightsailKeyPair_tags (198.94s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lightsail  207.635s
```

```console
make t K=lightsail T=TestAccLightsailBucketAccessKey_     
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 td-sensitive-attributes 🌿...
TF_ACC=1 go1.26.4 test ./internal/service/lightsail/... -v -count 1 -parallel 20 -run='TestAccLightsailBucketAccessKey_'  -timeout 360m -vet=off
2026/06/25 22:58:14 Creating Terraform AWS Provider (SDKv2-style)...
2026/06/25 22:58:14 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccLightsailBucketAccessKey_basic
=== PAUSE TestAccLightsailBucketAccessKey_basic
=== RUN   TestAccLightsailBucketAccessKey_disappears
=== PAUSE TestAccLightsailBucketAccessKey_disappears
=== CONT  TestAccLightsailBucketAccessKey_basic
=== CONT  TestAccLightsailBucketAccessKey_disappears
--- PASS: TestAccLightsailBucketAccessKey_disappears (96.96s)
--- PASS: TestAccLightsailBucketAccessKey_basic (126.56s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lightsail  134.675s
```

```console
make t K=codeartifact T='TestAccCodeArtifact_serial/AuthorizationTokenDataSource'
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 td-sensitive-attributes 🌿...
TF_ACC=1 go1.26.4 test ./internal/service/codeartifact/... -v -count 1 -parallel 20 -run='TestAccCodeArtifact_serial/AuthorizationTokenDataSource'  -timeout 360m -vet=off
2026/06/25 23:16:36 Creating Terraform AWS Provider (SDKv2-style)...
2026/06/25 23:16:36 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccCodeArtifact_serial
=== PAUSE TestAccCodeArtifact_serial
=== CONT  TestAccCodeArtifact_serial
=== RUN   TestAccCodeArtifact_serial/AuthorizationTokenDataSource
=== RUN   TestAccCodeArtifact_serial/AuthorizationTokenDataSource/basic
=== RUN   TestAccCodeArtifact_serial/AuthorizationTokenDataSource/duration
=== RUN   TestAccCodeArtifact_serial/AuthorizationTokenDataSource/owner
--- PASS: TestAccCodeArtifact_serial (270.31s)
    --- PASS: TestAccCodeArtifact_serial/AuthorizationTokenDataSource (270.31s)
        --- PASS: TestAccCodeArtifact_serial/AuthorizationTokenDataSource/basic (97.06s)
        --- PASS: TestAccCodeArtifact_serial/AuthorizationTokenDataSource/duration (93.27s)
        --- PASS: TestAccCodeArtifact_serial/AuthorizationTokenDataSource/owner (79.98s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/codeartifact       278.390s
```
