### PR TITLE
cognitoidp: fix InvalidParameterException when removing token_validity_units with non-default validity values

### DIFF
--- a/.changelog/48630.txt
+++ b/.changelog/48630.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cognito_user_pool_client: Fix `InvalidParameterException: Invalid range for token validity` when removing `token_validity_units` block from a resource that was configured with non-default units (e.g. `minutes`) and explicit validity integers
+```

--- a/internal/service/cognitoidp/user_pool_client.go
+++ b/internal/service/cognitoidp/user_pool_client.go
@@ -462,13 +462,19 @@ func (r *userPoolClientResource) Update(ctx context.Context, request resource.Up
 		return
 	}
 
-	// If removing `token_validity_units`, reset to defaults
+	// If removing `token_validity_units`, reset units and validity integers to
+	// Cognito defaults. Without resetting the integers, an existing value (e.g.
+	// AccessTokenValidity=60 set in minutes) is sent as-is with the new hours
+	// unit, yielding 60 hours which exceeds Cognito's 24-hour maximum and causes
+	// InvalidParameterException: Invalid range for token validity.
 	if !state.TokenValidityUnits.IsNull() && plan.TokenValidityUnits.IsNull() {
 		input.TokenValidityUnits = &awstypes.TokenValidityUnitsType{
 			AccessToken:  awstypes.TimeUnitsTypeHours,
 			IdToken:      awstypes.TimeUnitsTypeHours,
 			RefreshToken: awstypes.TimeUnitsTypeDays,
 		}
+		input.AccessTokenValidity = aws.Int32(1)
+		input.IdTokenValidity = aws.Int32(1)
 	}
 
 	const (

--- a/internal/service/cognitoidp/user_pool_client.go
+++ b/internal/service/cognitoidp/user_pool_client.go
@@ -474,9 +474,9 @@ func (r *userPoolClientResource) Update(ctx context.Context, request resource.Up
 			IdToken:      awstypes.TimeUnitsTypeHours,
 			RefreshToken: awstypes.TimeUnitsTypeDays,
 		}
-		input.AccessTokenValidity = aws.Int32(1)  // 1 hour — Cognito default
-		input.IdTokenValidity = aws.Int32(1)       // 1 hour — Cognito default
-		input.RefreshTokenValidity = 30            // 30 days — Cognito default
+		input.AccessTokenValidity = aws.Int32(1) // 1 hour — Cognito default
+		input.IdTokenValidity = aws.Int32(1)     // 1 hour — Cognito default
+		input.RefreshTokenValidity = 30          // 30 days — Cognito default
 	}
 
 	const (

--- a/internal/service/cognitoidp/user_pool_client.go
+++ b/internal/service/cognitoidp/user_pool_client.go
@@ -462,19 +462,21 @@ func (r *userPoolClientResource) Update(ctx context.Context, request resource.Up
 		return
 	}
 
-	// If removing `token_validity_units`, reset units and validity integers to
-	// Cognito defaults. Without resetting the integers, an existing value (e.g.
-	// AccessTokenValidity=60 set in minutes) is sent as-is with the new hours
-	// unit, yielding 60 hours which exceeds Cognito's 24-hour maximum and causes
-	// InvalidParameterException: Invalid range for token validity.
+	// If removing `token_validity_units`, reset all units and validity integers
+	// to Cognito factory defaults. Without resetting the integers, an existing
+	// value sized for the old unit is sent as-is under the new unit, e.g.:
+	//   AccessTokenValidity=60 (minutes) + hours unit → 60 hours > 24h max
+	//   RefreshTokenValidity=43200 (minutes) + days unit → 43200 days > 3650d max
+	// Both produce InvalidParameterException: Invalid range for token validity.
 	if !state.TokenValidityUnits.IsNull() && plan.TokenValidityUnits.IsNull() {
 		input.TokenValidityUnits = &awstypes.TokenValidityUnitsType{
 			AccessToken:  awstypes.TimeUnitsTypeHours,
 			IdToken:      awstypes.TimeUnitsTypeHours,
 			RefreshToken: awstypes.TimeUnitsTypeDays,
 		}
-		input.AccessTokenValidity = aws.Int32(1)
-		input.IdTokenValidity = aws.Int32(1)
+		input.AccessTokenValidity = aws.Int32(1)  // 1 hour — Cognito default
+		input.IdTokenValidity = aws.Int32(1)       // 1 hour — Cognito default
+		input.RefreshTokenValidity = 30            // 30 days — Cognito default
 	}
 
 	const (

--- a/internal/service/cognitoidp/user_pool_client_test.go
+++ b/internal/service/cognitoidp/user_pool_client_test.go
@@ -555,6 +555,64 @@ func TestAccCognitoIDPUserPoolClient_tokenValidityUnitsWTokenValidity(t *testing
 	})
 }
 
+// TestAccCognitoIDPUserPoolClient_tokenValidityUnits_removeBlockWithExplicitValues
+// reproduces the scenario where token_validity_units is set with non-default units
+// (e.g. minutes) and a matching validity integer (e.g. 60), then the block is
+// removed from config. Previously the update sent AccessTokenValidity=60 with
+// units reset to hours, yielding 60 hours which exceeds Cognito's 24h maximum:
+//
+//	InvalidParameterException: Invalid range for token validity.
+func TestAccCognitoIDPUserPoolClient_tokenValidityUnits_removeBlockWithExplicitValues(t *testing.T) {
+	ctx := acctest.Context(t)
+	var client awstypes.UserPoolClientType
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_cognito_user_pool_client.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckIdentityProvider(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CognitoIDPServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckUserPoolClientDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				// Step 1: create with explicit minutes units and a 60-minute validity.
+				Config: testAccUserPoolClientConfig_tokenValidityUnitsExplicitMinutes(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckUserPoolClientExists(ctx, t, resourceName, &client),
+					resource.TestCheckResourceAttr(resourceName, "access_token_validity", "60"),
+					resource.TestCheckResourceAttr(resourceName, "id_token_validity", "60"),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("token_validity_units"), knownvalue.ListExact([]knownvalue.Check{
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"access_token":  knownvalue.StringExact("minutes"),
+							"id_token":      knownvalue.StringExact("minutes"),
+							"refresh_token": knownvalue.StringExact("days"),
+						}),
+					})),
+				},
+			},
+			{
+				// Step 2: remove the token_validity_units block entirely.
+				// Must not produce InvalidParameterException: Invalid range for token validity.
+				Config: testAccUserPoolClientConfig_basic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckUserPoolClientExists(ctx, t, resourceName, &client),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("token_validity_units"), knownvalue.ListExact([]knownvalue.Check{})),
+				},
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccUserPoolClientImportStateIDFunc(ctx, t, resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccCognitoIDPUserPoolClient_name(t *testing.T) {
 	ctx := acctest.Context(t)
 	var client awstypes.UserPoolClientType
@@ -1729,6 +1787,26 @@ resource "aws_cognito_user_pool_client" "test" {
   }
 }
 `, rName, units))
+}
+
+func testAccUserPoolClientConfig_tokenValidityUnitsExplicitMinutes(rName string) string {
+	return acctest.ConfigCompose(
+		testAccUserPoolClientConfig_base(rName),
+		fmt.Sprintf(`
+resource "aws_cognito_user_pool_client" "test" {
+  name         = %[1]q
+  user_pool_id = aws_cognito_user_pool.test.id
+
+  access_token_validity = 60
+  id_token_validity     = 60
+
+  token_validity_units {
+    access_token  = "minutes"
+    id_token      = "minutes"
+    refresh_token = "days"
+  }
+}
+`, rName))
 }
 
 func testAccUserPoolClientConfig_name(rName, name string) string {


### PR DESCRIPTION
## Community Note

- Please vote on this PR by adding a 👍 reaction to help maintainers prioritize it.

## Description

Fixes #32504

When `token_validity_units` is removed from config on an existing `aws_cognito_user_pool_client` that was configured with non-default units (e.g. `minutes`) and explicit validity integers (e.g. `access_token_validity = 60`), the update handler resets units to `hours/hours/days` but leaves `AccessTokenValidity`, `IdTokenValidity`, and `RefreshTokenValidity` unchanged.

This causes Cognito to receive integers sized for the old unit interpreted under the new unit:

- `AccessTokenValidity=60` (minutes) + `hours` unit → 60 hours → exceeds Cognito's 24-hour maximum
- `RefreshTokenValidity=43200` (minutes) + `days` unit → 43,200 days → exceeds Cognito's 3,650-day maximum

Both produce:

```
InvalidParameterException: Invalid range for token validity.
```

### Root cause

In `Update()`, the existing reset block only sets `TokenValidityUnits`:

```go
if !state.TokenValidityUnits.IsNull() && plan.TokenValidityUnits.IsNull() {
    input.TokenValidityUnits = &awstypes.TokenValidityUnitsType{
        AccessToken:  awstypes.TimeUnitsTypeHours,
        IdToken:      awstypes.TimeUnitsTypeHours,
        RefreshToken: awstypes.TimeUnitsTypeDays,
    }
}
```

The validity integers flow through from the plan via `fwflex.Expand` unchanged. If those integers were sized for `minutes`, they are out of range when reinterpreted under `hours` or `days`.

### Fix

Reset all three validity integers to Cognito factory defaults alongside the units reset:

```go
input.AccessTokenValidity = aws.Int32(1)  // 1 hour  — Cognito default
input.IdTokenValidity = aws.Int32(1)       // 1 hour  — Cognito default
input.RefreshTokenValidity = 30            // 30 days — Cognito default
```

### Reproduction scenario

Triggered by out-of-band drift: a client is created without `token_validity_units` in Terraform, units are set manually in the console or via another tool, then a subsequent `for_each` re-evaluation causes Terraform to refresh state, detect the non-default units, and plan their removal. Apply then fails with `InvalidParameterException`.

## Testing

Added `TestAccCognitoIDPUserPoolClient_tokenValidityUnits_removeBlockWithExplicitValues`:
1. Create client with `access_token_validity = 60`, `token_validity_units { access_token = "minutes", id_token = "minutes", refresh_token = "days" }`
2. Remove the `token_validity_units` block entirely — must not produce `InvalidParameterException`
3. Import state verify

```
make testacc PKG=cognitoidp TESTS=TestAccCognitoIDPUserPoolClient_tokenValidityUnits_removeBlockWithExplicitValues
```

## References

- Fixes #32504
- Related: #34285 (same underlying mechanism, different trigger)