### PR TITLE
Removes `@V60SDKv2Fix` annotation from resource types with new RI versions

### DIFF
--- a/internal/generate/servicepackage/main.go
+++ b/internal/generate/servicepackage/main.go
@@ -493,6 +493,9 @@ func (v *visitor) processFuncDecl(funcDecl *ast.FuncDecl) {
 		if !d.HasNoPreExistingResource && d.PreIdentityVersion == nil {
 			v.errs = append(v.errs, fmt.Errorf("%s.%s: one of \"preIdentityVersion\" or \"hasNoPreExistingResource\" is required", v.packageName, v.functionName))
 		}
+		if d.HasV6_0NullValuesError && d.IdentityVersion != 0 {
+			v.errs = append(v.errs, fmt.Errorf("%s.%s: \"V60SDKv2Fix\" should no longer be specified when a new Resource Identity version is created", v.packageName, v.functionName))
+		}
 	} else {
 		if d.HasNoPreExistingResource {
 			v.errs = append(v.errs, fmt.Errorf("hasNoPreExistingResource specified without Resource Identity: %s", fmt.Sprintf("%s.%s", v.packageName, v.functionName)))

--- a/internal/service/ec2/ec2_image_block_public_access.go
+++ b/internal/service/ec2/ec2_image_block_public_access.go
@@ -119,6 +119,7 @@ func resourceImageBlockPublicAccessRead(ctx context.Context, d *schema.ResourceD
 var imageBlockPublicAccessIdentityUpgradeV0 = schema.IdentityUpgrader{
 	Version: 0,
 	Upgrade: func(ctx context.Context, rawState map[string]any, meta any) (map[string]any, error) {
+		rawState[names.AttrAccountID] = meta.(*conns.AWSClient).AccountID(ctx)
 		rawState[names.AttrRegion] = meta.(*conns.AWSClient).Region(ctx)
 		return rawState, nil
 	},

--- a/internal/service/ec2/ec2_image_block_public_access.go
+++ b/internal/service/ec2/ec2_image_block_public_access.go
@@ -26,13 +26,13 @@ import (
 // @SDKResource("aws_ec2_image_block_public_access", name="Image Block Public Access")
 // @SingletonIdentity
 // @IdentityVersion(1, sdkV2IdentityUpgraders="imageBlockPublicAccessIdentityUpgradeV0")
-// @V60SDKv2Fix
 // @NoImport
 // @Testing(checkDestroyNoop=true)
 // @Testing(hasExistsFunction=false)
 // @Testing(generator=false)
 // Generated tests have several issues: (todo: list them)
 // @Testing(identityTest=false)
+// @Testing(preIdentityVersion="v5.100.0")
 // @Testing(identityVersion="0;v6.0.0")
 // @Testing(identityVersion="1;v6.21.0")
 func resourceImageBlockPublicAccess() *schema.Resource {

--- a/internal/service/ec2/ec2_serial_console_access.go
+++ b/internal/service/ec2/ec2_serial_console_access.go
@@ -123,6 +123,7 @@ func setSerialConsoleAccess(ctx context.Context, conn *ec2.Client, enabled bool)
 var serialConsoleAccessIdentityUpgradeV0 = schema.IdentityUpgrader{
 	Version: 0,
 	Upgrade: func(ctx context.Context, rawState map[string]any, meta any) (map[string]any, error) {
+		rawState[names.AttrAccountID] = meta.(*conns.AWSClient).AccountID(ctx)
 		rawState[names.AttrRegion] = meta.(*conns.AWSClient).Region(ctx)
 		return rawState, nil
 	},

--- a/internal/service/ec2/ec2_serial_console_access.go
+++ b/internal/service/ec2/ec2_serial_console_access.go
@@ -21,11 +21,11 @@ import (
 // @SDKResource("aws_ec2_serial_console_access", name="Serial Console Access")
 // @SingletonIdentity
 // @IdentityVersion(1, sdkV2IdentityUpgraders="serialConsoleAccessIdentityUpgradeV0")
-// @V60SDKv2Fix
 // @Testing(hasExistsFunction=false)
 // @Testing(generator=false)
 // Generated tests have several issues: (todo: list them)
 // @Testing(identityTest=false)
+// @Testing(preIdentityVersion="v5.100.0")
 // @Testing(identityVersion="0;v6.0.0")
 // @Testing(identityVersion="1;v6.21.0")
 func resourceSerialConsoleAccess() *schema.Resource {

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -1311,7 +1311,6 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*inttypes.ServicePa
 			Name:     "Serial Console Access",
 			Region:   inttypes.ResourceRegionDefault(),
 			Identity: inttypes.RegionalSingletonIdentity(
-				inttypes.WithV6_0SDKv2Fix(),
 				inttypes.WithVersion(1),
 				inttypes.WithSDKv2IdentityUpgraders(serialConsoleAccessIdentityUpgradeV0),
 			),

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -1247,7 +1247,6 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*inttypes.ServicePa
 			Name:     "Image Block Public Access",
 			Region:   inttypes.ResourceRegionDefault(),
 			Identity: inttypes.RegionalSingletonIdentity(
-				inttypes.WithV6_0SDKv2Fix(),
 				inttypes.WithVersion(1),
 				inttypes.WithSDKv2IdentityUpgraders(imageBlockPublicAccessIdentityUpgradeV0),
 			),


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

The annotation `@V60SDKv2Fix` makes a Resource Identity mutable to work around errors in the initial v6.0 implementation of RI. For resource types with a newer Resource Identity, this can be removed as it is no longer relevant.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=ec2 TESTS='TestAccEC2ImageBlockPublicAccess_serial/Identity'

--- PASS: TestAccEC2ImageBlockPublicAccess_serial (341.63s)
    --- PASS: TestAccEC2ImageBlockPublicAccess_serial/Identity (341.63s)
        --- PASS: TestAccEC2ImageBlockPublicAccess_serial/Identity/RegionOverride (24.95s)
        --- PASS: TestAccEC2ImageBlockPublicAccess_serial/Identity/Upgrade (60.25s)
        --- PASS: TestAccEC2ImageBlockPublicAccess_serial/Identity/UpgradeNoRefresh (70.85s)
        --- PASS: TestAccEC2ImageBlockPublicAccess_serial/Identity/basic (24.56s)
        --- PASS: TestAccEC2ImageBlockPublicAccess_serial/Identity/ExistingResource (91.32s)
        --- PASS: TestAccEC2ImageBlockPublicAccess_serial/Identity/ExistingResourceNoRefresh (69.69s)
```

```console
% make testacc PKG=ec2 TESTS='TestAccEC2SerialConsoleAccess_serial/Resource/Identity'

--- PASS: TestAccEC2SerialConsoleAccess_serial (272.41s)
    --- PASS: TestAccEC2SerialConsoleAccess_serial/Resource (272.41s)
        --- PASS: TestAccEC2SerialConsoleAccess_serial/Resource/Identity (272.41s)
            --- PASS: TestAccEC2SerialConsoleAccess_serial/Resource/Identity/basic (27.79s)
            --- PASS: TestAccEC2SerialConsoleAccess_serial/Resource/Identity/ExistingResource (74.45s)
            --- PASS: TestAccEC2SerialConsoleAccess_serial/Resource/Identity/ExistingResourceNoRefresh (40.22s)
            --- PASS: TestAccEC2SerialConsoleAccess_serial/Resource/Identity/RegionOverride (36.69s)
            --- PASS: TestAccEC2SerialConsoleAccess_serial/Resource/Identity/Upgrade (46.77s)
            --- PASS: TestAccEC2SerialConsoleAccess_serial/Resource/Identity/UpgradeNoRefresh (46.50s)
```
