### PR TITLE
r/aws_batch_compute_environment: update job_execution_timeout_minutes

### DIFF
--- a/.changelog/48633.txt
+++ b/.changelog/48633.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_batch_compute_environment: Raise maximum `update_policy.job_execution_timeout_minutes` to 7200
+```

--- a/internal/service/batch/compute_environment.go
+++ b/internal/service/batch/compute_environment.go
@@ -281,7 +281,7 @@ func resourceComputeEnvironment() *schema.Resource {
 								Type:         schema.TypeInt,
 								Optional:     true,
 								Computed:     true,
-								ValidateFunc: validation.IntBetween(1, 360),
+								ValidateFunc: validation.IntBetween(1, 7200),
 							},
 							"terminate_jobs_on_update": {
 								Type:     schema.TypeBool,


### PR DESCRIPTION
Raise update_policy.job_execution_timeout_minutes from 360 to 7200, to reflect AWS's current limit[^1].

[^1]: https://docs.aws.amazon.com/batch/latest/APIReference/API_UpdatePolicy.html

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
No

### Description
Raise update_policy.job_execution_timeout_minutes from 360 to 7200, to reflect AWS's current limit[^1].

[^1]: https://docs.aws.amazon.com/batch/latest/APIReference/API_UpdatePolicy.html

I didn't modify the acceptance tests, because they didn't previously test the old maximum of 360, which makes sense to me.

### Relations
Closes https://github.com/hashicorp/terraform-provider-aws/issues/48709

### Acceptance Testing

I didn't run the acceptance tests, but I did use this version to create a batch compute environment, and verified the actual jobExecutionTimeoutMinutes was set to 7200.