### PR TITLE
resource/backup_region_settings: Add `EKS` to test configs

### DIFF
--- a/internal/service/backup/region_settings_test.go
+++ b/internal/service/backup/region_settings_test.go
@@ -45,13 +45,14 @@ func testAccRegionSettings_basic(t *testing.T) {
 				Config: testAccRegionSettingsConfig_1(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckRegionSettingsExists(ctx, t, resourceName, &settings),
-					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.%", "18"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.%", "19"),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.Aurora", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.DocumentDB", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.DynamoDB", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.EBS", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.EC2", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.EFS", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.EKS", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.FSx", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.Neptune", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.RDS", acctest.CtTrue),
@@ -73,13 +74,14 @@ func testAccRegionSettings_basic(t *testing.T) {
 				Config: testAccRegionSettingsConfig_2(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckRegionSettingsExists(ctx, t, resourceName, &settings),
-					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.%", "18"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.%", "19"),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.Aurora", acctest.CtFalse),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.DocumentDB", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.DynamoDB", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.EBS", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.EC2", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.EFS", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.EKS", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.FSx", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.Neptune", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.RDS", acctest.CtTrue),
@@ -95,13 +97,14 @@ func testAccRegionSettings_basic(t *testing.T) {
 				Config: testAccRegionSettingsConfig_3(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckRegionSettingsExists(ctx, t, resourceName, &settings),
-					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.%", "18"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.%", "19"),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.Aurora", acctest.CtFalse),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.DocumentDB", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.DynamoDB", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.EBS", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.EC2", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.EFS", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.EKS", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.FSx", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.Neptune", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.RDS", acctest.CtTrue),
@@ -145,6 +148,7 @@ resource "aws_backup_region_settings" "test" {
     "EBS"                    = true
     "EC2"                    = true
     "EFS"                    = true
+    "EKS"                    = true
     "FSx"                    = true
     "Neptune"                = true
     "RDS"                    = true
@@ -172,6 +176,7 @@ resource "aws_backup_region_settings" "test" {
     "EBS"                    = true
     "EC2"                    = true
     "EFS"                    = true
+    "EKS"                    = true
     "FSx"                    = true
     "Neptune"                = true
     "RDS"                    = true
@@ -204,6 +209,7 @@ resource "aws_backup_region_settings" "test" {
     "EBS"                    = true
     "EC2"                    = true
     "EFS"                    = true
+    "EKS"                    = true
     "FSx"                    = true
     "Neptune"                = true
     "RDS"                    = true

--- a/internal/service/backup/testdata/RegionSettings/basic/main_gen.tf
+++ b/internal/service/backup/testdata/RegionSettings/basic/main_gen.tf
@@ -11,6 +11,7 @@ resource "aws_backup_region_settings" "test" {
     "EBS"                    = true
     "EC2"                    = true
     "EFS"                    = true
+    "EKS"                    = true
     "FSx"                    = true
     "Neptune"                = true
     "RDS"                    = true

--- a/internal/service/backup/testdata/RegionSettings/basic_v5.100.0/main_gen.tf
+++ b/internal/service/backup/testdata/RegionSettings/basic_v5.100.0/main_gen.tf
@@ -11,6 +11,7 @@ resource "aws_backup_region_settings" "test" {
     "EBS"                    = true
     "EC2"                    = true
     "EFS"                    = true
+    "EKS"                    = true
     "FSx"                    = true
     "Neptune"                = true
     "RDS"                    = true

--- a/internal/service/backup/testdata/RegionSettings/basic_v6.0.0/main_gen.tf
+++ b/internal/service/backup/testdata/RegionSettings/basic_v6.0.0/main_gen.tf
@@ -11,6 +11,7 @@ resource "aws_backup_region_settings" "test" {
     "EBS"                    = true
     "EC2"                    = true
     "EFS"                    = true
+    "EKS"                    = true
     "FSx"                    = true
     "Neptune"                = true
     "RDS"                    = true

--- a/internal/service/backup/testdata/RegionSettings/region_override/main_gen.tf
+++ b/internal/service/backup/testdata/RegionSettings/region_override/main_gen.tf
@@ -13,6 +13,7 @@ resource "aws_backup_region_settings" "test" {
     "EBS"                    = true
     "EC2"                    = true
     "EFS"                    = true
+    "EKS"                    = true
     "FSx"                    = true
     "Neptune"                = true
     "RDS"                    = true

--- a/internal/service/backup/testdata/tmpl/region_settings_basic.gtpl
+++ b/internal/service/backup/testdata/tmpl/region_settings_basic.gtpl
@@ -9,6 +9,7 @@ resource "aws_backup_region_settings" "test" {
     "EBS"                    = true
     "EC2"                    = true
     "EFS"                    = true
+    "EKS"                    = true
     "FSx"                    = true
     "Neptune"                = true
     "RDS"                    = true


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Adds `EKS` to opt-in configs in acceptance tests

### Output from Acceptance Testing

```console
% make testacc PKG=backup TESTS='TestAccBackupRegionSettings_serial'

 --- PASS: TestAccBackupRegionSettings_serial (250.79s)
        --- PASS: TestAccBackupRegionSettings_serial/basic (41.23s)
        --- PASS: TestAccBackupRegionSettings_serial/Identity (209.56s)
            --- PASS: TestAccBackupRegionSettings_serial/Identity/ExistingResourceNoRefresh (50.72s)
            --- PASS: TestAccBackupRegionSettings_serial/Identity/RegionOverride (38.78s)
            --- PASS: TestAccBackupRegionSettings_serial/Identity/basic (29.52s)
            --- PASS: TestAccBackupRegionSettings_serial/Identity/ExistingResource (90.54s)
 ```
