### PR TITLE
resource/aws_prometheus_workspace_configuration: add support for out of order samples

### DIFF
--- a/.changelog/48652.txt
+++ b/.changelog/48652.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_amp_workspace_configuration: Add `out_of_order_time_window_in_seconds` and `rule_query_offset_in_seconds` arguments
+```

--- a/.changelog/XXXXX.txt
+++ b/.changelog/XXXXX.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_prometheus_workspace_configuration: Add `out_of_order_time_window_in_seconds` and `rule_query_offset_in_seconds` arguments
+```

--- a/.changelog/XXXXX.txt
+++ b/.changelog/XXXXX.txt
@@ -1,3 +1,0 @@
-```release-note:enhancement
-resource/aws_prometheus_workspace_configuration: Add `out_of_order_time_window_in_seconds` and `rule_query_offset_in_seconds` arguments
-```

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/YakDriver/go-version v0.1.0
 	github.com/YakDriver/regexache v0.25.0
 	github.com/YakDriver/smarterr v0.8.0
-	github.com/aws/aws-sdk-go-v2 v1.41.7
+	github.com/aws/aws-sdk-go-v2 v1.42.0
 	github.com/aws/aws-sdk-go-v2/config v1.32.17
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.16
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.23
@@ -20,7 +20,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/account v1.31.0
 	github.com/aws/aws-sdk-go-v2/service/acm v1.39.0
 	github.com/aws/aws-sdk-go-v2/service/acmpca v1.47.0
-	github.com/aws/aws-sdk-go-v2/service/amp v1.42.11
+	github.com/aws/aws-sdk-go-v2/service/amp v1.44.0
 	github.com/aws/aws-sdk-go-v2/service/amplify v1.38.16
 	github.com/aws/aws-sdk-go-v2/service/apigateway v1.40.0
 	github.com/aws/aws-sdk-go-v2/service/apigatewayv2 v1.35.0
@@ -280,7 +280,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/workspaces v1.68.1
 	github.com/aws/aws-sdk-go-v2/service/workspacesweb v1.39.0
 	github.com/aws/aws-sdk-go-v2/service/xray v1.36.23
-	github.com/aws/smithy-go v1.25.1
+	github.com/aws/smithy-go v1.27.3
 	github.com/beevik/etree v1.6.0
 	github.com/cedar-policy/cedar-go v1.6.2
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
@@ -336,8 +336,8 @@ require (
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/armon/go-radix v1.0.0 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.29 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.29 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.24 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.15 // indirect

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
 github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
-github.com/aws/aws-sdk-go-v2 v1.41.7 h1:DWpAJt66FmnnaRIOT/8ASTucrvuDPZASqhhLey6tLY8=
-github.com/aws/aws-sdk-go-v2 v1.41.7/go.mod h1:4LAfZOPHNVNQEckOACQx60Y8pSRjIkNZQz1w92xpMJc=
+github.com/aws/aws-sdk-go-v2 v1.42.0 h1:XvXMJTkFQtpBKIWZnmr9ZEOc2InWM2yldjXEJ/bymhA=
+github.com/aws/aws-sdk-go-v2 v1.42.0/go.mod h1:27+ACypSLljLAEKsCYOmrjKh83vuTRkuAe9Uv/3A4bg=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10 h1:gx1AwW1Iyk9Z9dD9F4akX5gnN3QZwUB20GGKH/I+Rho=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10/go.mod h1:qqY157uZoqm5OXq/amuaBJyC9hgBCBQnsaWnPe905GY=
 github.com/aws/aws-sdk-go-v2/config v1.32.17 h1:FpL4/758/diKwqbytU0prpuiu60fgXKUWCpDJtApclU=
@@ -35,10 +35,10 @@ github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.23 h1:UuSfcORqNSz/ey3VPRS8Tc
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.23/go.mod h1:+G/OSGiOFnSOkYloKj/9M35s74LgVAdJBSD5lsFfqKg=
 github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.22.18 h1:9XFUd2lkr7VrbE4Qtrhm7AtNhGgZeGFI5QLZtQIflj8=
 github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.22.18/go.mod h1:trImuKdWelQIJALvyGj6sKolJ1W8t628JOoTdDGVL9Q=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23 h1:GpT/TrnBYuE5gan2cZbTtvP+JlHsutdmlV2YfEyNde0=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23/go.mod h1:xYWD6BS9ywC5bS3sz9Xh04whO/hzK2plt2Zkyrp4JuA=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23 h1:bpd8vxhlQi2r1hiueOw02f/duEPTMK59Q4QMAoTTtTo=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23/go.mod h1:15DfR2nw+CRHIk0tqNyifu3G1YdAOy68RftkhMDDwYk=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.29 h1:f3vKqSo13fhTYb+JEcXwXefZQE26I1FB5eTSniU67ko=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.29/go.mod h1:MzoLFUArKGpGD+ukmPiTPG1X5x4o6M2kq4v2dr1FiEc=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.29 h1:RdwIf/CuUsvJX3RgJagbOyotl/cxoLY4xviKuE7p2GY=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.29/go.mod h1:71wt8W2EgswdZy9Mf9KNnzxZ3TiZlv4caKghPktDOkA=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.24 h1:OQqn11BtaYv1WLUowvcA30MpzIu8Ti4pcLPIIyoKZrA=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.24/go.mod h1:X5ZJyfwVrWA96GzPmUCWFQaEARPR7gCrpq2E92PJwAE=
 github.com/aws/aws-sdk-go-v2/service/accessanalyzer v1.48.0 h1:SG+cxHh/AWWo4TWg/UzjZPEBbDuVEC1i4lfrK+bdMwE=
@@ -49,8 +49,8 @@ github.com/aws/aws-sdk-go-v2/service/acm v1.39.0 h1:XMmPIioQg/yHkpzllEX/AmNeLL9X
 github.com/aws/aws-sdk-go-v2/service/acm v1.39.0/go.mod h1:yCteizCNPaHt0SnNusoGGHvy0JDB0tvGDTVhEt5anZM=
 github.com/aws/aws-sdk-go-v2/service/acmpca v1.47.0 h1:NS9lpox+4E9bJdsHDKFoRQqEmplD2wlcZR0rryn2z1s=
 github.com/aws/aws-sdk-go-v2/service/acmpca v1.47.0/go.mod h1:qFP+Zv26pVlLajTm293Ga9I82NRjnrTpXtMtkFFn5xc=
-github.com/aws/aws-sdk-go-v2/service/amp v1.42.11 h1:HI9LlMarNX1Eg0ImXP4+360daUKPBahG58ux/GQGobI=
-github.com/aws/aws-sdk-go-v2/service/amp v1.42.11/go.mod h1:ttMqUqrgELhbdkEGgstJ3ofCbXtLDrLml47v8jJdH8Y=
+github.com/aws/aws-sdk-go-v2/service/amp v1.44.0 h1:rGc0jAqUYdqilmmsyYVvCnCL+3StF/y589j6+LDKe4w=
+github.com/aws/aws-sdk-go-v2/service/amp v1.44.0/go.mod h1:f8J/SOLYzsCEKbZaDoq1SKWvsZBjeMtNY4UXZqF6NZc=
 github.com/aws/aws-sdk-go-v2/service/amplify v1.38.16 h1:gzzIbyyvOBH5LroqCzPbeVXvYATG1E6giLukqFrTAR8=
 github.com/aws/aws-sdk-go-v2/service/amplify v1.38.16/go.mod h1:Cpr737zpOuoLZ137MQ5iImlVxP5A3pdKkVwgOBATy04=
 github.com/aws/aws-sdk-go-v2/service/apigateway v1.40.0 h1:+s2yzvSERu63KCzhRQopwqfKcOYKMbP1LAw0RgR2PRM=
@@ -583,8 +583,8 @@ github.com/aws/aws-sdk-go-v2/service/workspacesweb v1.39.0 h1:oieTfrV3d0D/00Q7T8
 github.com/aws/aws-sdk-go-v2/service/workspacesweb v1.39.0/go.mod h1:5d3WGmJnZy7o8uLL4hAGEcj1aDM1UkP1+rVPOhSe6cw=
 github.com/aws/aws-sdk-go-v2/service/xray v1.36.23 h1:23UXC4h6nNZqOmk+xaXcfyTH/IIvqWycQk154GaSiE8=
 github.com/aws/aws-sdk-go-v2/service/xray v1.36.23/go.mod h1:XEYnz2YYwBDEDHrfBWjv31kK8vCTrvCcnS7K7vyrDA0=
-github.com/aws/smithy-go v1.25.1 h1:J8ERsGSU7d+aCmdQur5Txg6bVoYelvQJgtZehD12GkI=
-github.com/aws/smithy-go v1.25.1/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
+github.com/aws/smithy-go v1.27.3 h1:F3Zb497UhhskkfpJmfkXswyo+t0sh9OTBnIHjogWbVY=
+github.com/aws/smithy-go v1.27.3/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/beevik/etree v1.6.0 h1:u8Kwy8pp9D9XeITj2Z0XtA5qqZEmtJtuXZRQi+j03eE=
 github.com/beevik/etree v1.6.0/go.mod h1:bh4zJxiIr62SOf9pRzN7UUYaEDa9HEKafK25+sLc0Gc=
 github.com/bgentry/speakeasy v0.1.0 h1:ByYyxL9InA1OWqxJqqp2A5pYHUrCiAL6K3J+LKSsQkY=

--- a/internal/service/amp/workspace_configuration.go
+++ b/internal/service/amp/workspace_configuration.go
@@ -58,11 +58,31 @@ type workspaceConfigurationResource struct {
 func (r *workspaceConfigurationResource) Schema(ctx context.Context, request resource.SchemaRequest, response *resource.SchemaResponse) {
 	response.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
+			"out_of_order_time_window_in_seconds": schema.Int32Attribute{
+				Optional: true,
+				Computed: true,
+				Validators: []validator.Int32{
+					int32validator.Between(0, 600),
+				},
+				PlanModifiers: []planmodifier.Int32{
+					int32planmodifier.UseStateForUnknown(),
+				},
+			},
 			"retention_period_in_days": schema.Int32Attribute{
 				Optional: true,
 				Computed: true,
 				Validators: []validator.Int32{
 					int32validator.AtLeast(1),
+				},
+				PlanModifiers: []planmodifier.Int32{
+					int32planmodifier.UseStateForUnknown(),
+				},
+			},
+			"rule_query_offset_in_seconds": schema.Int32Attribute{
+				Optional: true,
+				Computed: true,
+				Validators: []validator.Int32{
+					int32validator.Between(0, 86400),
 				},
 				PlanModifiers: []planmodifier.Int32{
 					int32planmodifier.UseStateForUnknown(),
@@ -155,7 +175,9 @@ func (r *workspaceConfigurationResource) Create(ctx context.Context, request res
 	}
 
 	// Set values for unknowns after creation is complete.
+	data.OutOfOrderTimeWindowInSeconds = fwflex.Int32ToFramework(ctx, output.OutOfOrderTimeWindowInSeconds)
 	data.RetentionPeriodInDays = fwflex.Int32ToFramework(ctx, output.RetentionPeriodInDays)
+	data.RuleQueryOffsetInSeconds = fwflex.Int32ToFramework(ctx, output.RuleQueryOffsetInSeconds)
 
 	response.Diagnostics.Append(response.State.Set(ctx, data)...)
 }
@@ -219,9 +241,16 @@ func (r *workspaceConfigurationResource) Update(ctx context.Context, request res
 		return
 	}
 
-	if _, err := waitWorkspaceConfigurationUpdated(ctx, conn, workspaceID, r.UpdateTimeout(ctx, new.Timeouts)); err != nil {
+	output, err := waitWorkspaceConfigurationUpdated(ctx, conn, workspaceID, r.UpdateTimeout(ctx, new.Timeouts))
+	if err != nil {
 		response.Diagnostics.AddError(fmt.Sprintf("waiting for AMP Workspace (%s) Configuration update", workspaceID), err.Error())
 
+		return
+	}
+
+	// Re-read to get updated computed values
+	response.Diagnostics.Append(fwflex.Flatten(ctx, output, &new)...)
+	if response.Diagnostics.HasError() {
 		return
 	}
 
@@ -292,10 +321,12 @@ func waitWorkspaceConfigurationUpdated(ctx context.Context, conn *amp.Client, id
 
 type workspaceConfigurationResourceModel struct {
 	framework.WithRegionModel
-	LimitsPerLabelSet     fwtypes.ListNestedObjectValueOf[limitsPerLabelSetModel] `tfsdk:"limits_per_label_set"`
-	RetentionPeriodInDays types.Int32                                             `tfsdk:"retention_period_in_days"`
-	Timeouts              timeouts.Value                                          `tfsdk:"timeouts"`
-	WorkspaceID           types.String                                            `tfsdk:"workspace_id"`
+	LimitsPerLabelSet             fwtypes.ListNestedObjectValueOf[limitsPerLabelSetModel] `tfsdk:"limits_per_label_set"`
+	OutOfOrderTimeWindowInSeconds types.Int32                                             `tfsdk:"out_of_order_time_window_in_seconds"`
+	RetentionPeriodInDays         types.Int32                                             `tfsdk:"retention_period_in_days"`
+	RuleQueryOffsetInSeconds      types.Int32                                             `tfsdk:"rule_query_offset_in_seconds"`
+	Timeouts                      timeouts.Value                                          `tfsdk:"timeouts"`
+	WorkspaceID                   types.String                                            `tfsdk:"workspace_id"`
 }
 
 type limitsPerLabelSetModel struct {

--- a/internal/service/amp/workspace_configuration_test.go
+++ b/internal/service/amp/workspace_configuration_test.go
@@ -126,6 +126,51 @@ func TestAccAMPWorkspaceConfiguration_limitPerLabelSet(t *testing.T) {
 	})
 }
 
+func TestAccAMPWorkspaceConfiguration_timeWindowAndQueryOffset(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v awstypes.WorkspaceConfigurationDescription
+	resourceName := "aws_prometheus_workspace_configuration.test"
+	workspaceResourceName := "aws_prometheus_workspace.test"
+	timeWindow := 120
+	queryOffset := 300
+	timeWindowUpdated := 300
+	queryOffsetUpdated := 600
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.AMPServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             acctest.CheckDestroyNoop,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWorkspaceConfigurationConfig_timeWindowAndQueryOffset(timeWindow, queryOffset),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWorkspaceConfigurationExists(ctx, t, resourceName, &v),
+					resource.TestCheckResourceAttrPair(resourceName, "workspace_id", workspaceResourceName, names.AttrID),
+					resource.TestCheckResourceAttr(resourceName, "out_of_order_time_window_in_seconds", strconv.Itoa(timeWindow)),
+					resource.TestCheckResourceAttr(resourceName, "rule_query_offset_in_seconds", strconv.Itoa(queryOffset)),
+				),
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, "workspace_id"),
+				ImportStateVerifyIdentifierAttribute: "workspace_id",
+			},
+			{
+				Config: testAccWorkspaceConfigurationConfig_timeWindowAndQueryOffset(timeWindowUpdated, queryOffsetUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWorkspaceConfigurationExists(ctx, t, resourceName, &v),
+					resource.TestCheckResourceAttrPair(resourceName, "workspace_id", workspaceResourceName, names.AttrID),
+					resource.TestCheckResourceAttr(resourceName, "out_of_order_time_window_in_seconds", strconv.Itoa(timeWindowUpdated)),
+					resource.TestCheckResourceAttr(resourceName, "rule_query_offset_in_seconds", strconv.Itoa(queryOffsetUpdated)),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckWorkspaceConfigurationExists(ctx context.Context, t *testing.T, n string, v *awstypes.WorkspaceConfigurationDescription) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -212,4 +257,16 @@ resource "aws_prometheus_workspace_configuration" "test" {
   }
 }
 `
+}
+
+func testAccWorkspaceConfigurationConfig_timeWindowAndQueryOffset(timeWindow, queryOffset int) string {
+	return fmt.Sprintf(`
+resource "aws_prometheus_workspace" "test" {}
+
+resource "aws_prometheus_workspace_configuration" "test" {
+  workspace_id                          = aws_prometheus_workspace.test.id
+  out_of_order_time_window_in_seconds   = %[1]d
+  rule_query_offset_in_seconds          = %[2]d
+}
+`, timeWindow, queryOffset)
 }

--- a/website/docs/r/prometheus_workspace_configuration.html.markdown
+++ b/website/docs/r/prometheus_workspace_configuration.html.markdown
@@ -61,6 +61,19 @@ resource "aws_prometheus_workspace_configuration" "example" {
 }
 ```
 
+### With out-of-order and rule query configuration
+
+```terraform
+resource "aws_prometheus_workspace" "example" {}
+
+resource "aws_prometheus_workspace_configuration" "example" {
+  workspace_id                          = aws_prometheus_workspace.example.id
+  retention_period_in_days              = 30
+  out_of_order_time_window_in_seconds   = 120
+  rule_query_offset_in_seconds          = 300
+}
+```
+
 ## Argument Reference
 
 The following arguments are required:
@@ -70,8 +83,10 @@ The following arguments are required:
 The following arguments are optional:
 
 * `limits_per_label_set` - (Optional) Configuration block for setting limits on metrics with specific label sets. Detailed below.
+* `out_of_order_time_window_in_seconds` - (Optional) Time window in seconds for accepting out-of-order samples. Must be between 0 and 600 seconds.
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `retention_period_in_days` - (Optional) Number of days to retain metric data in the workspace.
+* `rule_query_offset_in_seconds` - (Optional) Query offset in seconds for rule evaluation. Must be between 0 and 86400 seconds.
 
 ### `limits_per_label_set`
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
No

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR provides support for the newly announced out of order sample handling in Amazon Managed Prometheus: https://aws.amazon.com/about-aws/whats-new/2026/06/amazon-managed-service-prometheus-outoforder-ingestion/
* Add out_of_order_time_window_in_seconds field with 0-600 second validation
* Add rule_query_offset_in_seconds field with 0-86400 second validation
* Both fields are optional and computed

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/amp#UpdateWorkspaceConfigurationInput

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

  % make testacc TESTS=TestAccAMPWorkspaceConfiguration PKG=amp
  
  === RUN   TestAccAMPWorkspaceConfiguration_basic
  === PAUSE TestAccAMPWorkspaceConfiguration_basic
  === RUN   TestAccAMPWorkspaceConfiguration_defaultBucket
  === PAUSE TestAccAMPWorkspaceConfiguration_defaultBucket
  === RUN   TestAccAMPWorkspaceConfiguration_limitPerLabelSet
  === PAUSE TestAccAMPWorkspaceConfiguration_limitPerLabelSet
  === RUN   TestAccAMPWorkspaceConfiguration_timeWindowAndQueryOffset
  === PAUSE TestAccAMPWorkspaceConfiguration_timeWindowAndQueryOffset
  === CONT  TestAccAMPWorkspaceConfiguration_basic
  --- PASS: TestAccAMPWorkspaceConfiguration_basic (162.45s)
  === CONT  TestAccAMPWorkspaceConfiguration_limitPerLabelSet
  --- PASS: TestAccAMPWorkspaceConfiguration_limitPerLabelSet (81.87s)
  === CONT  TestAccAMPWorkspaceConfiguration_timeWindowAndQueryOffset
  --- PASS: TestAccAMPWorkspaceConfiguration_timeWindowAndQueryOffset (153.76s)
  === CONT  TestAccAMPWorkspaceConfiguration_defaultBucket
  --- PASS: TestAccAMPWorkspaceConfiguration_defaultBucket (74.30s)
  PASS
  ok    github.com/hashicorp/terraform-provider-aws/internal/service/amp 472.559s

TestAccAMPWorkspaceConfiguration_timeWindowAndQueryOffset validates the two new fields:
    - out_of_order_time_window_in_seconds
  - rule_query_offset_in_seconds