### PR TITLE
r/aws_bedrockagentcore_harness: fix Unsupported Type on managed/disabled memory

### DIFF
--- a/.changelog/48655.txt
+++ b/.changelog/48655.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_bedrockagentcore_harness: Add `managed_memory_configuration` configuration block and `disabled` argument to `memory`
+```
+
+```release-note:bug
+resource/aws_bedrockagentcore_harness: Fix `Unsupported Type` error on create when the service returns a managed or disabled memory configuration
+```

--- a/internal/service/bedrockagentcore/harness.go
+++ b/internal/service/bedrockagentcore/harness.go
@@ -84,6 +84,7 @@ func (r *harnessResource) Schema(ctx context.Context, request resource.SchemaReq
 			},
 			names.AttrARN:         framework.ARNAttributeComputedOnly(),
 			names.AttrEnvironment: framework.ResourceOptionalComputedListOfObjectsAttribute[harnessEnvironmentProviderModel](ctx, 1, nil, listplanmodifier.UseStateForUnknown()),
+			"memory":              framework.ResourceOptionalComputedListOfObjectsAttribute[harnessMemoryConfigurationModel](ctx, 1, nil, listplanmodifier.UseStateForUnknown()),
 			"environment_variables": schema.MapAttribute{
 				CustomType: fwtypes.MapOfStringType,
 				Optional:   true,
@@ -142,63 +143,6 @@ func (r *harnessResource) Schema(ctx context.Context, request resource.SchemaReq
 								Attributes: map[string]schema.Attribute{
 									"container_uri": schema.StringAttribute{
 										Required: true,
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			"memory": schema.ListNestedBlock{
-				CustomType: fwtypes.NewListNestedObjectTypeOf[harnessMemoryConfigurationModel](ctx),
-				Validators: []validator.List{
-					listvalidator.SizeAtMost(1),
-				},
-				NestedObject: schema.NestedBlockObject{
-					Blocks: map[string]schema.Block{
-						"agentcore_memory_configuration": schema.ListNestedBlock{
-							CustomType: fwtypes.NewListNestedObjectTypeOf[harnessAgentCoreMemoryConfigurationModel](ctx),
-							Validators: []validator.List{
-								listvalidator.SizeAtMost(1),
-							},
-							NestedObject: schema.NestedBlockObject{
-								Attributes: map[string]schema.Attribute{
-									names.AttrARN: schema.StringAttribute{
-										CustomType: fwtypes.ARNType,
-										Required:   true,
-									},
-									"actor_id": schema.StringAttribute{
-										Optional: true,
-									},
-									"messages_count": schema.Int32Attribute{
-										Optional: true,
-									},
-								},
-								Blocks: map[string]schema.Block{
-									"retrieval_config": schema.ListNestedBlock{
-										CustomType: fwtypes.NewListNestedObjectTypeOf[harnessAgentCoreMemoryRetrievalConfigModel](ctx),
-										Validators: []validator.List{
-											listvalidator.SizeAtMost(1),
-										},
-										NestedObject: schema.NestedBlockObject{
-											Attributes: map[string]schema.Attribute{ // nosemgrep:ci.semgrep.framework.map_block_key-meaningful-names
-												"map_block_key": schema.StringAttribute{
-													Required: true,
-												},
-												"relevance_score": schema.Float32Attribute{
-													Optional: true,
-													Validators: []validator.Float32{
-														float32validator.Between(0, 1),
-													},
-												},
-												"strategy_id": schema.StringAttribute{
-													Optional: true,
-												},
-												"top_k": schema.Int32Attribute{
-													Optional: true,
-												},
-											},
-										},
 									},
 								},
 							},
@@ -1388,6 +1332,8 @@ func (m harnessEnvironmentArtifactModel) expandToUpdatedHarnessEnvironmentArtifa
 
 type harnessMemoryConfigurationModel struct {
 	AgentCoreMemoryConfiguration fwtypes.ListNestedObjectValueOf[harnessAgentCoreMemoryConfigurationModel] `tfsdk:"agentcore_memory_configuration"`
+	Disabled                     types.Bool                                                                `tfsdk:"disabled"`
+	ManagedMemoryConfiguration   fwtypes.ListNestedObjectValueOf[harnessManagedMemoryConfigurationModel]   `tfsdk:"managed_memory_configuration"`
 }
 
 var (
@@ -1405,6 +1351,15 @@ func (m *harnessMemoryConfigurationModel) Flatten(ctx context.Context, v any) di
 			return diags
 		}
 		m.AgentCoreMemoryConfiguration = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &data)
+	case awstypes.HarnessMemoryConfigurationMemberManagedMemoryConfiguration:
+		var data harnessManagedMemoryConfigurationModel
+		smerr.AddEnrich(ctx, &diags, fwflex.Flatten(ctx, t.Value, &data))
+		if diags.HasError() {
+			return diags
+		}
+		m.ManagedMemoryConfiguration = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &data)
+	case awstypes.HarnessMemoryConfigurationMemberDisabled:
+		m.Disabled = types.BoolValue(true)
 	default:
 		diags.AddError("Unsupported Type", fmt.Sprintf("memory configuration flatten: %T", v))
 	}
@@ -1425,7 +1380,8 @@ func (m harnessMemoryConfigurationModel) ExpandTo(ctx context.Context, targetTyp
 
 func (m harnessMemoryConfigurationModel) expandToHarnessMemoryConfiguration(ctx context.Context) (awstypes.HarnessMemoryConfiguration, diag.Diagnostics) {
 	var diags diag.Diagnostics
-	if !m.AgentCoreMemoryConfiguration.IsNull() {
+	switch {
+	case !m.AgentCoreMemoryConfiguration.IsNull():
 		data, d := m.AgentCoreMemoryConfiguration.ToPtr(ctx)
 		smerr.AddEnrich(ctx, &diags, d)
 		if diags.HasError() {
@@ -1434,13 +1390,24 @@ func (m harnessMemoryConfigurationModel) expandToHarnessMemoryConfiguration(ctx 
 		var r awstypes.HarnessMemoryConfigurationMemberAgentCoreMemoryConfiguration
 		smerr.AddEnrich(ctx, &diags, fwflex.Expand(ctx, data, &r.Value))
 		return &r, diags
+	case !m.ManagedMemoryConfiguration.IsNull():
+		data, d := m.ManagedMemoryConfiguration.ToPtr(ctx)
+		smerr.AddEnrich(ctx, &diags, d)
+		if diags.HasError() {
+			return nil, diags
+		}
+		var r awstypes.HarnessMemoryConfigurationMemberManagedMemoryConfiguration
+		smerr.AddEnrich(ctx, &diags, fwflex.Expand(ctx, data, &r.Value))
+		return &r, diags
+	case !m.Disabled.IsNull() && m.Disabled.ValueBool():
+		return &awstypes.HarnessMemoryConfigurationMemberDisabled{}, diags
 	}
 	return nil, diags
 }
 
 func (m harnessMemoryConfigurationModel) expandToUpdatedHarnessMemoryConfiguration(ctx context.Context) (*awstypes.UpdatedHarnessMemoryConfiguration, diag.Diagnostics) {
 	var diags diag.Diagnostics
-	if !m.AgentCoreMemoryConfiguration.IsNull() {
+	if !m.AgentCoreMemoryConfiguration.IsNull() || !m.ManagedMemoryConfiguration.IsNull() || (!m.Disabled.IsNull() && m.Disabled.ValueBool()) {
 		r, d := m.expandToHarnessMemoryConfiguration(ctx)
 		smerr.AddEnrich(ctx, &diags, d)
 		if diags.HasError() {
@@ -1463,4 +1430,10 @@ type harnessAgentCoreMemoryRetrievalConfigModel struct {
 	RelevanceScore types.Float32 `tfsdk:"relevance_score"`
 	StrategyID     types.String  `tfsdk:"strategy_id"`
 	TopK           types.Int32   `tfsdk:"top_k"`
+}
+
+type harnessManagedMemoryConfigurationModel struct {
+	EncryptionKeyARN    fwtypes.ARN                                                         `tfsdk:"encryption_key_arn"`
+	EventExpiryDuration types.Int32                                                         `tfsdk:"event_expiry_duration"`
+	Strategies          fwtypes.ListOfStringEnum[awstypes.HarnessManagedMemoryStrategyType] `tfsdk:"strategies"`
 }

--- a/internal/service/bedrockagentcore/harness.go
+++ b/internal/service/bedrockagentcore/harness.go
@@ -8,6 +8,8 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"slices"
+	"strings"
 	"time"
 
 	"github.com/YakDriver/smarterr"
@@ -84,7 +86,12 @@ func (r *harnessResource) Schema(ctx context.Context, request resource.SchemaReq
 			},
 			names.AttrARN:         framework.ARNAttributeComputedOnly(),
 			names.AttrEnvironment: framework.ResourceOptionalComputedListOfObjectsAttribute[harnessEnvironmentProviderModel](ctx, 1, nil, listplanmodifier.UseStateForUnknown()),
-			"memory":              framework.ResourceOptionalComputedListOfObjectsAttribute[harnessMemoryConfigurationModel](ctx, 1, nil, listplanmodifier.UseStateForUnknown()),
+			"memory": framework.ResourceOptionalComputedListOfObjectsAttribute[harnessMemoryConfigurationModel](ctx, 1, nil,
+				// encryption_key_arn cannot be updated after memory creation, so a change to it forces
+				// replacement. A nested attribute of an object-typed Optional+Computed list cannot carry
+				// its own RequiresReplace plan modifier, so this is enforced at the list level.
+				listplanmodifier.RequiresReplaceIf(memoryEncryptionKeyRequiresReplace, "Changing memory.managed_memory_configuration.encryption_key_arn forces replacement", ""),
+				listplanmodifier.UseStateForUnknown()),
 			"environment_variables": schema.MapAttribute{
 				CustomType: fwtypes.MapOfStringType,
 				Optional:   true,
@@ -454,6 +461,145 @@ func (r *harnessResource) Schema(ctx context.Context, request resource.SchemaReq
 			}),
 		},
 	}
+}
+
+// ValidateConfig enforces constraints on the memory union that the object-typed
+// Optional+Computed `memory` ListAttribute cannot express through per-attribute
+// validators. It runs offline during `terraform validate`/plan.
+func (r *harnessResource) ValidateConfig(ctx context.Context, request resource.ValidateConfigRequest, response *resource.ValidateConfigResponse) {
+	var data harnessResourceModel
+	smerr.AddEnrich(ctx, &response.Diagnostics, request.Config.Get(ctx, &data))
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	if data.Memory.IsNull() || data.Memory.IsUnknown() {
+		return
+	}
+
+	memoryConfigs, d := data.Memory.ToSlice(ctx)
+	smerr.AddEnrich(ctx, &response.Diagnostics, d)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	for _, mc := range memoryConfigs {
+		// Exactly one memory union member must be active. `disabled` counts only when true,
+		// so this rejects an empty `memory {}` block and the `disabled = false` degenerate
+		// case (which a plain ExactlyOneOf validator would let through) as well as the
+		// two-members-set case.
+		if !mc.AgentCoreMemoryConfiguration.IsUnknown() && !mc.ManagedMemoryConfiguration.IsUnknown() && !mc.Disabled.IsUnknown() {
+			active := 0
+			if !mc.AgentCoreMemoryConfiguration.IsNull() {
+				active++
+			}
+			if !mc.ManagedMemoryConfiguration.IsNull() {
+				active++
+			}
+			if !mc.Disabled.IsNull() && mc.Disabled.ValueBool() {
+				active++
+			}
+			if active != 1 {
+				smerr.AddError(ctx, &response.Diagnostics, errors.New("memory must specify exactly one of agentcore_memory_configuration, managed_memory_configuration, or disabled = true"))
+			}
+		}
+
+		// Validate managed_memory_configuration.strategies enum values. The object-typed
+		// ListAttribute does not run the enum custom type's ValidateAttribute.
+		if !mc.ManagedMemoryConfiguration.IsNull() && !mc.ManagedMemoryConfiguration.IsUnknown() {
+			managed, d := mc.ManagedMemoryConfiguration.ToPtr(ctx)
+			smerr.AddEnrich(ctx, &response.Diagnostics, d)
+			if response.Diagnostics.HasError() {
+				return
+			}
+			if !managed.Strategies.IsNull() && !managed.Strategies.IsUnknown() {
+				valid := enum.Values[awstypes.HarnessManagedMemoryStrategyType]()
+				for _, e := range managed.Strategies.Elements() {
+					se, ok := e.(fwtypes.StringEnum[awstypes.HarnessManagedMemoryStrategyType])
+					if !ok || se.IsNull() || se.IsUnknown() {
+						continue
+					}
+					if !slices.Contains(valid, se.ValueString()) {
+						smerr.AddError(ctx, &response.Diagnostics, fmt.Errorf("invalid memory strategy %q; valid values are: %s", se.ValueString(), strings.Join(valid, ", ")))
+					}
+				}
+			}
+		}
+
+		// Validate agentcore_memory_configuration.retrieval_config.relevance_score range
+		// [0, 1]. The float32validator.Between(0, 1) was dropped when the memory block became
+		// an object-typed ListAttribute.
+		if !mc.AgentCoreMemoryConfiguration.IsNull() && !mc.AgentCoreMemoryConfiguration.IsUnknown() {
+			agentcore, d := mc.AgentCoreMemoryConfiguration.ToPtr(ctx)
+			smerr.AddEnrich(ctx, &response.Diagnostics, d)
+			if response.Diagnostics.HasError() {
+				return
+			}
+			if !agentcore.RetrievalConfig.IsNull() && !agentcore.RetrievalConfig.IsUnknown() {
+				retrievalConfigs, d := agentcore.RetrievalConfig.ToSlice(ctx)
+				smerr.AddEnrich(ctx, &response.Diagnostics, d)
+				if response.Diagnostics.HasError() {
+					return
+				}
+				for _, rc := range retrievalConfigs {
+					if rc.RelevanceScore.IsNull() || rc.RelevanceScore.IsUnknown() {
+						continue
+					}
+					if v := rc.RelevanceScore.ValueFloat32(); v < 0 || v > 1 {
+						smerr.AddError(ctx, &response.Diagnostics, fmt.Errorf("relevance_score must be between 0.0 and 1.0, got: %f", v))
+					}
+				}
+			}
+		}
+	}
+}
+
+// memoryEncryptionKeyRequiresReplace forces resource replacement when
+// memory.managed_memory_configuration.encryption_key_arn changes to a new, known value,
+// because the API rejects updating it after memory creation.
+func memoryEncryptionKeyRequiresReplace(ctx context.Context, request planmodifier.ListRequest, response *listplanmodifier.RequiresReplaceIfFuncResponse) {
+	if request.StateValue.IsNull() || request.PlanValue.IsNull() || request.PlanValue.IsUnknown() {
+		return
+	}
+
+	var prev, plan harnessMemoryConfigurationModel
+	smerr.AddEnrich(ctx, &response.Diagnostics, request.State.GetAttribute(ctx, path.Root("memory").AtListIndex(0), &prev))
+	smerr.AddEnrich(ctx, &response.Diagnostics, request.Plan.GetAttribute(ctx, path.Root("memory").AtListIndex(0), &plan))
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	prevKey, d := managedEncryptionKeyARN(ctx, prev)
+	smerr.AddEnrich(ctx, &response.Diagnostics, d)
+	planKey, d := managedEncryptionKeyARN(ctx, plan)
+	smerr.AddEnrich(ctx, &response.Diagnostics, d)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	// encryption_key_arn cannot be updated after memory creation. Setting it (unset->set) or
+	// changing it (set->different) forces replacement. A planned value that is unknown (e.g. a KMS
+	// key created in the same apply) is treated as a change, since it cannot be compared and an
+	// in-place update would be rejected by the API.
+	if planKey.IsNull() {
+		return
+	}
+	if prevKey.IsNull() || planKey.IsUnknown() || !planKey.Equal(prevKey) {
+		response.RequiresReplace = true
+	}
+}
+
+func managedEncryptionKeyARN(ctx context.Context, m harnessMemoryConfigurationModel) (fwtypes.ARN, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if m.ManagedMemoryConfiguration.IsNull() || m.ManagedMemoryConfiguration.IsUnknown() {
+		return fwtypes.ARN{}, diags
+	}
+	managed, d := m.ManagedMemoryConfiguration.ToPtr(ctx)
+	smerr.AddEnrich(ctx, &diags, d)
+	if diags.HasError() || managed == nil {
+		return fwtypes.ARN{}, diags
+	}
+	return managed.EncryptionKeyARN, diags
 }
 
 func (r *harnessResource) Create(ctx context.Context, request resource.CreateRequest, response *resource.CreateResponse) {
@@ -1402,6 +1548,10 @@ func (m harnessMemoryConfigurationModel) expandToHarnessMemoryConfiguration(ctx 
 	case !m.Disabled.IsNull() && m.Disabled.ValueBool():
 		return &awstypes.HarnessMemoryConfigurationMemberDisabled{}, diags
 	}
+	// A memory block that resolves to no active member (all null, or disabled = false) has no
+	// valid API representation. ValidateConfig rejects this at plan time; guard here so it can
+	// never silently produce an empty union.
+	smerr.AddError(ctx, &diags, errors.New("memory must specify exactly one of agentcore_memory_configuration, managed_memory_configuration, or disabled = true"))
 	return nil, diags
 }
 
@@ -1415,7 +1565,11 @@ func (m harnessMemoryConfigurationModel) expandToUpdatedHarnessMemoryConfigurati
 		}
 		return &awstypes.UpdatedHarnessMemoryConfiguration{OptionalValue: r}, diags
 	}
-	return &awstypes.UpdatedHarnessMemoryConfiguration{}, diags
+	// An empty/degenerate memory block would send an empty UpdatedHarnessMemoryConfiguration{},
+	// which the API treats as a no-op, producing a perpetual diff. ValidateConfig rejects this at
+	// plan time; guard here as defense-in-depth.
+	smerr.AddError(ctx, &diags, errors.New("memory must specify exactly one of agentcore_memory_configuration, managed_memory_configuration, or disabled = true"))
+	return nil, diags
 }
 
 type harnessAgentCoreMemoryConfigurationModel struct {

--- a/internal/service/bedrockagentcore/harness_test.go
+++ b/internal/service/bedrockagentcore/harness_test.go
@@ -534,6 +534,146 @@ func TestAccBedrockAgentCoreHarness_memory_disabled(t *testing.T) {
 	})
 }
 
+func TestAccBedrockAgentCoreHarness_memory_managed_encryptionKeyRequiresReplace(t *testing.T) {
+	ctx := acctest.Context(t)
+	var harness awstypes.Harness
+	rName := testAccRandomHarnessName(t)
+	resourceName := "aws_bedrockagentcore_harness.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID)
+			testAccPreCheckHarness(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockAgentCoreServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckHarnessDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccHarnessConfig_memoryManagedEncryptionKey(rName, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckHarnessExists(ctx, t, resourceName, &harness),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+			},
+			{
+				// encryption_key_arn is not updatable after memory creation, so setting it must
+				// plan a replacement instead of an in-place update that the API would reject.
+				Config: testAccHarnessConfig_memoryManagedEncryptionKey(rName, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckHarnessExists(ctx, t, resourceName, &harness),
+					resource.TestCheckResourceAttrPair(resourceName, "memory.0.managed_memory_configuration.0.encryption_key_arn", "aws_kms_key.test", names.AttrARN),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionReplace),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccBedrockAgentCoreHarness_memory_invalidUnion(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := testAccRandomHarnessName(t)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID)
+			testAccPreCheckHarness(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockAgentCoreServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckHarnessDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				// Two members set.
+				Config: testAccHarnessConfig_memoryRaw(rName, `
+  memory {
+    disabled = true
+    managed_memory_configuration {}
+  }`),
+				PlanOnly:    true,
+				ExpectError: regexache.MustCompile(`exactly one of`),
+			},
+			{
+				// Empty memory block (no member).
+				Config: testAccHarnessConfig_memoryRaw(rName, `
+  memory {}`),
+				PlanOnly:    true,
+				ExpectError: regexache.MustCompile(`exactly one of`),
+			},
+			{
+				// disabled = false is not a valid "disabled" selection.
+				Config: testAccHarnessConfig_memoryRaw(rName, `
+  memory {
+    disabled = false
+  }`),
+				PlanOnly:    true,
+				ExpectError: regexache.MustCompile(`exactly one of`),
+			},
+		},
+	})
+}
+
+func TestAccBedrockAgentCoreHarness_memory_invalidStrategy(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := testAccRandomHarnessName(t)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID)
+			testAccPreCheckHarness(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockAgentCoreServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckHarnessDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccHarnessConfig_memoryRaw(rName, `
+  memory {
+    managed_memory_configuration {
+      strategies = ["BOGUS_STRATEGY"]
+    }
+  }`),
+				PlanOnly:    true,
+				ExpectError: regexache.MustCompile(`(?i)invalid memory strategy`),
+			},
+		},
+	})
+}
+
+func TestAccBedrockAgentCoreHarness_memory_invalidRelevanceScore(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := testAccRandomHarnessName(t)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID)
+			testAccPreCheckHarness(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockAgentCoreServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckHarnessDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccHarnessConfig_memory(rName, 5.0),
+				PlanOnly:    true,
+				ExpectError: regexache.MustCompile(`relevance_score must be between`),
+			},
+		},
+	})
+}
+
 func TestAccBedrockAgentCoreHarness_environmentArtifact(t *testing.T) {
 	ctx := acctest.Context(t)
 	var harness awstypes.Harness
@@ -1082,6 +1222,65 @@ resource "aws_bedrockagentcore_harness" "test" {
   }
 }
 `, rName))
+}
+
+func testAccHarnessConfig_memoryManagedEncryptionKey(rName string, withKey bool) string {
+	encryptionKey := ""
+	kmsResource := ""
+	if withKey {
+		encryptionKey = "encryption_key_arn = aws_kms_key.test.arn"
+		kmsResource = `
+resource "aws_kms_key" "test" {
+  description             = "tf-acc-test harness managed memory"
+  deletion_window_in_days = 7
+}
+`
+	}
+	return acctest.ConfigCompose(testAccHarnessConfig_iamRole(rName), fmt.Sprintf(`
+resource "aws_bedrockagentcore_harness" "test" {
+  harness_name       = %[1]q
+  execution_role_arn = aws_iam_role.test.arn
+
+  memory {
+    managed_memory_configuration {
+      event_expiry_duration = 30
+      strategies            = ["SEMANTIC", "SUMMARIZATION"]
+      %[2]s
+    }
+  }
+
+  model {
+    bedrock_model_config {
+      model_id = "anthropic.claude-sonnet-4-20250514"
+    }
+  }
+
+  system_prompt {
+    text = "You are a helpful assistant."
+  }
+}
+%[3]s
+`, rName, encryptionKey, kmsResource))
+}
+
+func testAccHarnessConfig_memoryRaw(rName, memoryBlock string) string {
+	return acctest.ConfigCompose(testAccHarnessConfig_iamRole(rName), fmt.Sprintf(`
+resource "aws_bedrockagentcore_harness" "test" {
+  harness_name       = %[1]q
+  execution_role_arn = aws_iam_role.test.arn
+%[2]s
+
+  model {
+    bedrock_model_config {
+      model_id = "anthropic.claude-sonnet-4-20250514"
+    }
+  }
+
+  system_prompt {
+    text = "You are a helpful assistant."
+  }
+}
+`, rName, memoryBlock))
 }
 
 func testAccHarnessConfig_environmentArtifact(rName, imageTag string) string {

--- a/internal/service/bedrockagentcore/harness_test.go
+++ b/internal/service/bedrockagentcore/harness_test.go
@@ -470,6 +470,70 @@ func TestAccBedrockAgentCoreHarness_memory(t *testing.T) {
 	})
 }
 
+func TestAccBedrockAgentCoreHarness_memory_managed(t *testing.T) {
+	ctx := acctest.Context(t)
+	var harness awstypes.Harness
+	rName := testAccRandomHarnessName(t)
+	resourceName := "aws_bedrockagentcore_harness.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID)
+			testAccPreCheckHarness(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockAgentCoreServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckHarnessDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccHarnessConfig_memoryManaged(rName, 45),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckHarnessExists(ctx, t, resourceName, &harness),
+					resource.TestCheckResourceAttr(resourceName, "memory.0.managed_memory_configuration.0.event_expiry_duration", "45"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccBedrockAgentCoreHarness_memory_disabled(t *testing.T) {
+	ctx := acctest.Context(t)
+	var harness awstypes.Harness
+	rName := testAccRandomHarnessName(t)
+	resourceName := "aws_bedrockagentcore_harness.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID)
+			testAccPreCheckHarness(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockAgentCoreServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckHarnessDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccHarnessConfig_memoryDisabled(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckHarnessExists(ctx, t, resourceName, &harness),
+					resource.TestCheckResourceAttr(resourceName, "memory.0.disabled", acctest.CtTrue),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+			},
+		},
+	})
+}
+
 func TestAccBedrockAgentCoreHarness_environmentArtifact(t *testing.T) {
 	ctx := acctest.Context(t)
 	var harness awstypes.Harness
@@ -969,6 +1033,55 @@ resource "aws_bedrockagentcore_memory" "test" {
   event_expiry_duration = 7
 }
 `, rName, relevanceScore))
+}
+
+func testAccHarnessConfig_memoryManaged(rName string, eventExpiryDuration int) string {
+	return acctest.ConfigCompose(testAccHarnessConfig_iamRole(rName), fmt.Sprintf(`
+resource "aws_bedrockagentcore_harness" "test" {
+  harness_name       = %[1]q
+  execution_role_arn = aws_iam_role.test.arn
+
+  memory {
+    managed_memory_configuration {
+      event_expiry_duration = %[2]d
+      strategies            = ["SEMANTIC", "SUMMARIZATION"]
+    }
+  }
+
+  model {
+    bedrock_model_config {
+      model_id = "anthropic.claude-sonnet-4-20250514"
+    }
+  }
+
+  system_prompt {
+    text = "You are a helpful assistant."
+  }
+}
+`, rName, eventExpiryDuration))
+}
+
+func testAccHarnessConfig_memoryDisabled(rName string) string {
+	return acctest.ConfigCompose(testAccHarnessConfig_iamRole(rName), fmt.Sprintf(`
+resource "aws_bedrockagentcore_harness" "test" {
+  harness_name       = %[1]q
+  execution_role_arn = aws_iam_role.test.arn
+
+  memory {
+    disabled = true
+  }
+
+  model {
+    bedrock_model_config {
+      model_id = "anthropic.claude-sonnet-4-20250514"
+    }
+  }
+
+  system_prompt {
+    text = "You are a helpful assistant."
+  }
+}
+`, rName))
 }
 
 func testAccHarnessConfig_environmentArtifact(rName, imageTag string) string {

--- a/internal/service/bedrockagentcore/harness_test.go
+++ b/internal/service/bedrockagentcore/harness_test.go
@@ -600,14 +600,12 @@ func TestAccBedrockAgentCoreHarness_memory_invalidUnion(t *testing.T) {
     disabled = true
     managed_memory_configuration {}
   }`),
-				PlanOnly:    true,
 				ExpectError: regexache.MustCompile(`exactly one of`),
 			},
 			{
 				// Empty memory block (no member).
 				Config: testAccHarnessConfig_memoryRaw(rName, `
   memory {}`),
-				PlanOnly:    true,
 				ExpectError: regexache.MustCompile(`exactly one of`),
 			},
 			{
@@ -616,7 +614,6 @@ func TestAccBedrockAgentCoreHarness_memory_invalidUnion(t *testing.T) {
   memory {
     disabled = false
   }`),
-				PlanOnly:    true,
 				ExpectError: regexache.MustCompile(`exactly one of`),
 			},
 		},
@@ -644,7 +641,6 @@ func TestAccBedrockAgentCoreHarness_memory_invalidStrategy(t *testing.T) {
       strategies = ["BOGUS_STRATEGY"]
     }
   }`),
-				PlanOnly:    true,
 				ExpectError: regexache.MustCompile(`(?i)invalid memory strategy`),
 			},
 		},
@@ -667,7 +663,6 @@ func TestAccBedrockAgentCoreHarness_memory_invalidRelevanceScore(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccHarnessConfig_memory(rName, 5.0),
-				PlanOnly:    true,
 				ExpectError: regexache.MustCompile(`relevance_score must be between`),
 			},
 		},

--- a/website/docs/r/bedrockagentcore_harness.html.markdown
+++ b/website/docs/r/bedrockagentcore_harness.html.markdown
@@ -361,7 +361,11 @@ The `claim_match_value` block supports the following:
 
 ### `memory` Block
 
-* `agentcore_memory_configuration` - (Required) AgentCore memory configuration. See [`agentcore_memory_configuration`](#agentcore_memory_configuration) below.
+The `memory` block is optional and computed. If omitted, AgentCore provisions a managed memory configuration by default. When specified, it supports exactly one of the following:
+
+* `agentcore_memory_configuration` - (Optional) AgentCore memory configuration referencing an existing memory resource. See [`agentcore_memory_configuration`](#agentcore_memory_configuration) below.
+* `managed_memory_configuration` - (Optional) Configuration for a memory resource that the harness creates and manages in your account. See [`managed_memory_configuration`](#managed_memory_configuration) below.
+* `disabled` - (Optional) Set to `true` to explicitly opt out of memory.
 
 ### `agentcore_memory_configuration` Block
 
@@ -369,6 +373,12 @@ The `claim_match_value` block supports the following:
 * `actor_id` - (Optional) Actor ID for memory sessions.
 * `messages_count` - (Optional) Number of messages to retrieve from memory.
 * `retrieval_config` - (Optional) Retrieval configuration parameters. See [`retrieval_config`](#retrieval_config) below.
+
+### `managed_memory_configuration` Block
+
+* `encryption_key_arn` - (Optional) ARN of a customer-managed KMS key. Defaults to an AWS-owned key. Not updatable after creation.
+* `event_expiry_duration` - (Optional) Event retention in days. Defaults to 30.
+* `strategies` - (Optional) Strategy types to enable. Valid values: `SEMANTIC`, `SUMMARIZATION`, `USER_PREFERENCE`, `EPISODIC`. Defaults to `["SEMANTIC", "SUMMARIZATION"]`.
 
 ### `retrieval_config` Block
 

--- a/website/docs/r/bedrockagentcore_harness.html.markdown
+++ b/website/docs/r/bedrockagentcore_harness.html.markdown
@@ -376,7 +376,7 @@ The `memory` block is optional and computed. If omitted, AgentCore provisions a 
 
 ### `managed_memory_configuration` Block
 
-* `encryption_key_arn` - (Optional) ARN of a customer-managed KMS key. Defaults to an AWS-owned key. Not updatable after creation.
+* `encryption_key_arn` - (Optional) ARN of a customer-managed KMS key. Defaults to an AWS-owned key. Not updatable after creation; changing this forces a new resource to be created.
 * `event_expiry_duration` - (Optional) Event retention in days. Defaults to 30.
 * `strategies` - (Optional) Strategy types to enable. Valid values: `SEMANTIC`, `SUMMARIZATION`, `USER_PREFERENCE`, `EPISODIC`. Defaults to `["SEMANTIC", "SUMMARIZATION"]`.
 


### PR DESCRIPTION
## Description

Fixes a create-time `Unsupported Type` error and adds the remaining memory union variants to `aws_bedrockagentcore_harness`.

**Bug fix:** Creating a harness without an explicit `memory` block previously failed with:

```
Error: creating Bedrock AgentCore Harness: Unsupported Type
Cause: memory configuration flatten: ...HarnessMemoryConfigurationMemberManagedMemoryConfiguration
```

The Bedrock AgentCore service **provisions a managed memory configuration by default** when none is specified, and the provider could not flatten the `Managed` or `Disabled` union members the service returned. The memory union now flattens all three SDK members, and `memory` is `Optional` + `Computed` so the service-chosen default round-trips cleanly.

**Enhancement:** Adds the `managed_memory_configuration` configuration block and the `disabled` argument to `memory`.

## Split from #48556

Part of breaking up #48556 (size/XL). This is the standalone bug fix + its memory enhancements, separated so the fix can be reviewed and merged on its own.

> **Note for reviewers:** Because the service always returns a managed memory configuration by default, this fix is effectively a prerequisite for any other harness-create acceptance test. The companion harness-feature PR is stacked on this branch.

## Testing

```
TF_ACC=1 go test -v -timeout 60m ./internal/service/bedrockagentcore/ \
  -run "TestAccBedrockAgentCoreHarness_memory_(managed|disabled)$"

--- PASS: TestAccBedrockAgentCoreHarness_memory_disabled (58.23s)
--- PASS: TestAccBedrockAgentCoreHarness_memory_managed (404.91s)
PASS
ok  github.com/hashicorp/terraform-provider-aws/internal/service/bedrockagentcore  405.060s
```

`go build`, `go vet`, `gofmt` clean.

## Relations

Part of splitting #48556. Closes #48310.
