### PR TITLE
resource/aws_prometheus_workspace_configuration: add support for out of order samples

### DIFF
--- a/.changelog/48652.txt
+++ b/.changelog/48652.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_prometheus_workspace_configuration: Add `out_of_order_time_window_in_seconds` and `rule_query_offset_in_seconds` arguments
+```

--- a/.changelog/48652.txt
+++ b/.changelog/48652.txt
@@ -1,3 +1,0 @@
-```release-note:enhancement
-resource/aws_prometheus_workspace_configuration: Add `out_of_order_time_window_in_seconds` and `rule_query_offset_in_seconds` arguments
-```

--- a/.changelog/48659.txt
+++ b/.changelog/48659.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_prometheus_workspace_configuration: Add `out_of_order_time_window_in_seconds` and `rule_query_offset_in_seconds` arguments
+```

--- a/internal/service/amp/workspace_configuration.go
+++ b/internal/service/amp/workspace_configuration.go
@@ -58,11 +58,31 @@ type workspaceConfigurationResource struct {
 func (r *workspaceConfigurationResource) Schema(ctx context.Context, request resource.SchemaRequest, response *resource.SchemaResponse) {
 	response.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
+			"out_of_order_time_window_in_seconds": schema.Int32Attribute{
+				Optional: true,
+				Computed: true,
+				Validators: []validator.Int32{
+					int32validator.Between(0, 600),
+				},
+				PlanModifiers: []planmodifier.Int32{
+					int32planmodifier.UseStateForUnknown(),
+				},
+			},
 			"retention_period_in_days": schema.Int32Attribute{
 				Optional: true,
 				Computed: true,
 				Validators: []validator.Int32{
 					int32validator.AtLeast(1),
+				},
+				PlanModifiers: []planmodifier.Int32{
+					int32planmodifier.UseStateForUnknown(),
+				},
+			},
+			"rule_query_offset_in_seconds": schema.Int32Attribute{
+				Optional: true,
+				Computed: true,
+				Validators: []validator.Int32{
+					int32validator.Between(0, 86400),
 				},
 				PlanModifiers: []planmodifier.Int32{
 					int32planmodifier.UseStateForUnknown(),
@@ -155,7 +175,9 @@ func (r *workspaceConfigurationResource) Create(ctx context.Context, request res
 	}
 
 	// Set values for unknowns after creation is complete.
+	data.OutOfOrderTimeWindowInSeconds = fwflex.Int32ToFramework(ctx, output.OutOfOrderTimeWindowInSeconds)
 	data.RetentionPeriodInDays = fwflex.Int32ToFramework(ctx, output.RetentionPeriodInDays)
+	data.RuleQueryOffsetInSeconds = fwflex.Int32ToFramework(ctx, output.RuleQueryOffsetInSeconds)
 
 	response.Diagnostics.Append(response.State.Set(ctx, data)...)
 }
@@ -219,9 +241,16 @@ func (r *workspaceConfigurationResource) Update(ctx context.Context, request res
 		return
 	}
 
-	if _, err := waitWorkspaceConfigurationUpdated(ctx, conn, workspaceID, r.UpdateTimeout(ctx, new.Timeouts)); err != nil {
+	output, err := waitWorkspaceConfigurationUpdated(ctx, conn, workspaceID, r.UpdateTimeout(ctx, new.Timeouts))
+	if err != nil {
 		response.Diagnostics.AddError(fmt.Sprintf("waiting for AMP Workspace (%s) Configuration update", workspaceID), err.Error())
 
+		return
+	}
+
+	// Re-read to get updated computed values
+	response.Diagnostics.Append(fwflex.Flatten(ctx, output, &new)...)
+	if response.Diagnostics.HasError() {
 		return
 	}
 
@@ -292,10 +321,12 @@ func waitWorkspaceConfigurationUpdated(ctx context.Context, conn *amp.Client, id
 
 type workspaceConfigurationResourceModel struct {
 	framework.WithRegionModel
-	LimitsPerLabelSet     fwtypes.ListNestedObjectValueOf[limitsPerLabelSetModel] `tfsdk:"limits_per_label_set"`
-	RetentionPeriodInDays types.Int32                                             `tfsdk:"retention_period_in_days"`
-	Timeouts              timeouts.Value                                          `tfsdk:"timeouts"`
-	WorkspaceID           types.String                                            `tfsdk:"workspace_id"`
+	LimitsPerLabelSet             fwtypes.ListNestedObjectValueOf[limitsPerLabelSetModel] `tfsdk:"limits_per_label_set"`
+	OutOfOrderTimeWindowInSeconds types.Int32                                             `tfsdk:"out_of_order_time_window_in_seconds"`
+	RetentionPeriodInDays         types.Int32                                             `tfsdk:"retention_period_in_days"`
+	RuleQueryOffsetInSeconds      types.Int32                                             `tfsdk:"rule_query_offset_in_seconds"`
+	Timeouts                      timeouts.Value                                          `tfsdk:"timeouts"`
+	WorkspaceID                   types.String                                            `tfsdk:"workspace_id"`
 }
 
 type limitsPerLabelSetModel struct {

--- a/internal/service/amp/workspace_configuration_test.go
+++ b/internal/service/amp/workspace_configuration_test.go
@@ -264,9 +264,9 @@ func testAccWorkspaceConfigurationConfig_timeWindowAndQueryOffset(timeWindow, qu
 resource "aws_prometheus_workspace" "test" {}
 
 resource "aws_prometheus_workspace_configuration" "test" {
-  workspace_id                          = aws_prometheus_workspace.test.id
-  out_of_order_time_window_in_seconds   = %[1]d
-  rule_query_offset_in_seconds          = %[2]d
+  workspace_id                        = aws_prometheus_workspace.test.id
+  out_of_order_time_window_in_seconds = %[1]d
+  rule_query_offset_in_seconds        = %[2]d
 }
 `, timeWindow, queryOffset)
 }

--- a/internal/service/amp/workspace_configuration_test.go
+++ b/internal/service/amp/workspace_configuration_test.go
@@ -126,6 +126,51 @@ func TestAccAMPWorkspaceConfiguration_limitPerLabelSet(t *testing.T) {
 	})
 }
 
+func TestAccAMPWorkspaceConfiguration_timeWindowAndQueryOffset(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v awstypes.WorkspaceConfigurationDescription
+	resourceName := "aws_prometheus_workspace_configuration.test"
+	workspaceResourceName := "aws_prometheus_workspace.test"
+	timeWindow := 120
+	queryOffset := 300
+	timeWindowUpdated := 300
+	queryOffsetUpdated := 600
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.AMPServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             acctest.CheckDestroyNoop,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWorkspaceConfigurationConfig_timeWindowAndQueryOffset(timeWindow, queryOffset),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWorkspaceConfigurationExists(ctx, t, resourceName, &v),
+					resource.TestCheckResourceAttrPair(resourceName, "workspace_id", workspaceResourceName, names.AttrID),
+					resource.TestCheckResourceAttr(resourceName, "out_of_order_time_window_in_seconds", strconv.Itoa(timeWindow)),
+					resource.TestCheckResourceAttr(resourceName, "rule_query_offset_in_seconds", strconv.Itoa(queryOffset)),
+				),
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, "workspace_id"),
+				ImportStateVerifyIdentifierAttribute: "workspace_id",
+			},
+			{
+				Config: testAccWorkspaceConfigurationConfig_timeWindowAndQueryOffset(timeWindowUpdated, queryOffsetUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWorkspaceConfigurationExists(ctx, t, resourceName, &v),
+					resource.TestCheckResourceAttrPair(resourceName, "workspace_id", workspaceResourceName, names.AttrID),
+					resource.TestCheckResourceAttr(resourceName, "out_of_order_time_window_in_seconds", strconv.Itoa(timeWindowUpdated)),
+					resource.TestCheckResourceAttr(resourceName, "rule_query_offset_in_seconds", strconv.Itoa(queryOffsetUpdated)),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckWorkspaceConfigurationExists(ctx context.Context, t *testing.T, n string, v *awstypes.WorkspaceConfigurationDescription) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -212,4 +257,16 @@ resource "aws_prometheus_workspace_configuration" "test" {
   }
 }
 `
+}
+
+func testAccWorkspaceConfigurationConfig_timeWindowAndQueryOffset(timeWindow, queryOffset int) string {
+	return fmt.Sprintf(`
+resource "aws_prometheus_workspace" "test" {}
+
+resource "aws_prometheus_workspace_configuration" "test" {
+  workspace_id                          = aws_prometheus_workspace.test.id
+  out_of_order_time_window_in_seconds   = %[1]d
+  rule_query_offset_in_seconds          = %[2]d
+}
+`, timeWindow, queryOffset)
 }

--- a/website/docs/r/prometheus_workspace_configuration.html.markdown
+++ b/website/docs/r/prometheus_workspace_configuration.html.markdown
@@ -61,6 +61,19 @@ resource "aws_prometheus_workspace_configuration" "example" {
 }
 ```
 
+### With out-of-order and rule query configuration
+
+```terraform
+resource "aws_prometheus_workspace" "example" {}
+
+resource "aws_prometheus_workspace_configuration" "example" {
+  workspace_id                          = aws_prometheus_workspace.example.id
+  retention_period_in_days              = 30
+  out_of_order_time_window_in_seconds   = 120
+  rule_query_offset_in_seconds          = 300
+}
+```
+
 ## Argument Reference
 
 The following arguments are required:
@@ -70,8 +83,10 @@ The following arguments are required:
 The following arguments are optional:
 
 * `limits_per_label_set` - (Optional) Configuration block for setting limits on metrics with specific label sets. Detailed below.
+* `out_of_order_time_window_in_seconds` - (Optional) Time window in seconds for accepting out-of-order samples. Must be between 0 and 600 seconds.
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `retention_period_in_days` - (Optional) Number of days to retain metric data in the workspace.
+* `rule_query_offset_in_seconds` - (Optional) Query offset in seconds for rule evaluation. Must be between 0 and 86400 seconds.
 
 ### `limits_per_label_set`
 

--- a/website/docs/r/prometheus_workspace_configuration.html.markdown
+++ b/website/docs/r/prometheus_workspace_configuration.html.markdown
@@ -67,10 +67,10 @@ resource "aws_prometheus_workspace_configuration" "example" {
 resource "aws_prometheus_workspace" "example" {}
 
 resource "aws_prometheus_workspace_configuration" "example" {
-  workspace_id                          = aws_prometheus_workspace.example.id
-  retention_period_in_days              = 30
-  out_of_order_time_window_in_seconds   = 120
-  rule_query_offset_in_seconds          = 300
+  workspace_id                        = aws_prometheus_workspace.example.id
+  retention_period_in_days            = 30
+  out_of_order_time_window_in_seconds = 120
+  rule_query_offset_in_seconds        = 300
 }
 ```
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
No

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR provides support for the newly announced out of order sample handling in Amazon Managed Prometheus: https://aws.amazon.com/about-aws/whats-new/2026/06/amazon-managed-service-prometheus-outoforder-ingestion/

Add out_of_order_time_window_in_seconds field with 0-600 second validation
Add rule_query_offset_in_seconds field with 0-86400 second validation
Both fields are optional and computed

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->



### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/amp#UpdateWorkspaceConfigurationInput

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccAMPWorkspaceConfiguration PKG=amp

=== RUN TestAccAMPWorkspaceConfiguration_basic
=== PAUSE TestAccAMPWorkspaceConfiguration_basic
=== RUN TestAccAMPWorkspaceConfiguration_defaultBucket
=== PAUSE TestAccAMPWorkspaceConfiguration_defaultBucket
=== RUN TestAccAMPWorkspaceConfiguration_limitPerLabelSet
=== PAUSE TestAccAMPWorkspaceConfiguration_limitPerLabelSet
=== RUN TestAccAMPWorkspaceConfiguration_timeWindowAndQueryOffset
=== PAUSE TestAccAMPWorkspaceConfiguration_timeWindowAndQueryOffset
=== CONT TestAccAMPWorkspaceConfiguration_basic
--- PASS: TestAccAMPWorkspaceConfiguration_basic (162.45s)
=== CONT TestAccAMPWorkspaceConfiguration_limitPerLabelSet
--- PASS: TestAccAMPWorkspaceConfiguration_limitPerLabelSet (81.87s)
=== CONT TestAccAMPWorkspaceConfiguration_timeWindowAndQueryOffset
--- PASS: TestAccAMPWorkspaceConfiguration_timeWindowAndQueryOffset (153.76s)
=== CONT TestAccAMPWorkspaceConfiguration_defaultBucket
--- PASS: TestAccAMPWorkspaceConfiguration_defaultBucket (74.30s)
PASS
ok github.com/hashicorp/terraform-provider-aws/internal/service/amp 472.559s

```

TestAccAMPWorkspaceConfiguration_timeWindowAndQueryOffset validates the two new fields:
- out_of_order_time_window_in_seconds

rule_query_offset_in_seconds