### PR TITLE
feat: Add database_installation_files arg + SQL Server Developer support for r/aws_rds_custom_db_engine_version

### DIFF
--- a/.changelog/48667.txt
+++ b/.changelog/48667.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_rds_custom_db_engine_version: Add `database_installation_files` argument and support for RDS for SQL Server Developer Edition
+```

--- a/internal/service/rds/custom_db_engine_version.go
+++ b/internal/service/rds/custom_db_engine_version.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/rds"
 	"github.com/aws/aws-sdk-go-v2/service/rds/types"
@@ -24,6 +23,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	tfio "github.com/hashicorp/terraform-provider-aws/internal/io"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
@@ -75,6 +75,14 @@ func resourceCustomDBEngineVersion() *schema.Resource {
 					ForceNew:     true,
 					ValidateFunc: validation.StringLenBetween(1, 255),
 				},
+				"database_installation_files": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					ForceNew: true,
+					Elem: &schema.Schema{
+						Type: schema.TypeString,
+					},
+				},
 				"db_parameter_group_family": {
 					Type:     schema.TypeString,
 					Computed: true,
@@ -82,16 +90,14 @@ func resourceCustomDBEngineVersion() *schema.Resource {
 				names.AttrDescription: {
 					Type:         schema.TypeString,
 					Optional:     true,
+					Computed:     true,
 					ValidateFunc: validation.StringLenBetween(1, 1000),
 				},
 				names.AttrEngine: {
-					Type:     schema.TypeString,
-					Required: true,
-					ForceNew: true,
-					ValidateFunc: validation.All(
-						validation.StringMatch(regexache.MustCompile(fmt.Sprintf(`^%s.*$`, instanceEngineCustomPrefix)), fmt.Sprintf("must begin with %s", instanceEngineCustomPrefix)),
-						validation.StringLenBetween(1, 35),
-					),
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringLenBetween(1, 35),
 				},
 				names.AttrEngineVersion: {
 					Type:         schema.TypeString,
@@ -187,6 +193,10 @@ func resourceCustomDBEngineVersionCreate(ctx context.Context, d *schema.Resource
 		input.DatabaseInstallationFilesS3Prefix = aws.String(v.(string))
 	}
 
+	if v, ok := d.GetOk("database_installation_files"); ok && v.(*schema.Set).Len() > 0 {
+		input.DatabaseInstallationFiles = flex.ExpandStringValueSet(v.(*schema.Set))
+	}
+
 	if v, ok := d.GetOk(names.AttrDescription); ok {
 		input.Description = aws.String(v.(string))
 	}
@@ -277,11 +287,14 @@ func resourceCustomDBEngineVersionRead(ctx context.Context, d *schema.ResourceDa
 	}
 	d.Set("database_installation_files_s3_bucket_name", out.DatabaseInstallationFilesS3BucketName)
 	d.Set("database_installation_files_s3_prefix", out.DatabaseInstallationFilesS3Prefix)
+	d.Set("database_installation_files", flex.FlattenStringValueSet(out.DatabaseInstallationFiles))
 	d.Set("db_parameter_group_family", out.DBParameterGroupFamily)
 	d.Set(names.AttrDescription, out.DBEngineVersionDescription)
 	d.Set(names.AttrEngine, out.Engine)
 	d.Set(names.AttrEngineVersion, out.EngineVersion)
-	d.Set("image_id", out.Image.ImageId)
+	if out.Image != nil {
+		d.Set("image_id", out.Image.ImageId)
+	}
 	d.Set(names.AttrKMSKeyID, out.KMSKeyId)
 	d.Set("major_engine_version", out.MajorEngineVersion)
 	d.Set("manifest_computed", out.CustomDBEngineVersionManifest)
@@ -432,6 +445,7 @@ const (
 	statusDeprecated        = "deprecated"
 	statusFailed            = "failed"
 	statusPendingValidation = "pending-validation" // Custom for SQL Server, ready for validation by an instance
+	statusValidating        = "validating"         // SQL Server Developer Edition only
 )
 
 func statusDBEngineVersion(conn *rds.Client, engine, engineVersion string) retry.StateRefreshFunc {
@@ -451,9 +465,17 @@ func statusDBEngineVersion(conn *rds.Client, engine, engineVersion string) retry
 }
 
 func waitCustomDBEngineVersionCreated(ctx context.Context, conn *rds.Client, engine, engineVersion string, timeout time.Duration) (*types.DBEngineVersion, error) {
+	// Engine sqlserver-dev-ee has different statuses, so a condition is needed here
+	pending := []string{statusCreating}
+	target := []string{statusAvailable, statusPendingValidation}
+	if engine == "sqlserver-dev-ee" {
+		pending = []string{statusPendingValidation, statusValidating}
+		target = []string{statusAvailable}
+	}
+
 	stateConf := &retry.StateChangeConf{
-		Pending:                   []string{statusCreating},
-		Target:                    []string{statusAvailable, statusPendingValidation},
+		Pending:                   pending,
+		Target:                    target,
 		Refresh:                   statusDBEngineVersion(conn, engine, engineVersion),
 		Timeout:                   timeout,
 		NotFoundChecks:            20,

--- a/internal/service/rds/custom_db_engine_version_test.go
+++ b/internal/service/rds/custom_db_engine_version_test.go
@@ -61,7 +61,7 @@ func TestAccRDSCustomDBEngineVersion_sqlServer(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"filename", "manifest_hash", "manifest", "source_image_id"},
+				ImportStateVerifyIgnore: []string{"filename", "manifest_hash", "manifest", "source_image_id", "database_installation_files"},
 			},
 		},
 	})
@@ -107,7 +107,7 @@ func TestAccRDSCustomDBEngineVersion_sqlServerUpdate(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"filename", "manifest_hash", "manifest", "source_image_id"},
+				ImportStateVerifyIgnore: []string{"filename", "manifest_hash", "manifest", "source_image_id", "database_installation_files"},
 			},
 			{
 				Config: testAccCustomDBEngineVersionConfig_sqlServerUpdate(rName, ami, description2),
@@ -160,7 +160,7 @@ func TestAccRDSCustomDBEngineVersion_oracle(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"filename", "manifest_hash", "manifest"},
+				ImportStateVerifyIgnore: []string{"filename", "manifest_hash", "manifest", "database_installation_files"},
 			},
 		},
 	})
@@ -206,7 +206,77 @@ func TestAccRDSCustomDBEngineVersion_manifestFile(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"filename", "manifest_hash", "manifest"},
+				ImportStateVerifyIgnore: []string{"filename", "manifest_hash", "manifest", "database_installation_files"},
+			},
+		},
+	})
+}
+
+func TestAccRDSCustomDBEngineVersion_databaseInstallationFiles(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	// Requires SQL Server Developer Edition installation media and Cumulative Update executable in S3 bucket owned
+	// (bucket must be in operating region) by operating account set as environmental variable
+	// Pre-requisite: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/sqlserver-dev-edition.preparing.html
+	s3BucketNameKey := "RDS_SQL_DEV_S3_BUCKET_NAME"
+	s3BucketName := os.Getenv(s3BucketNameKey)
+	if s3BucketName == "" {
+		t.Skipf("Environment variable %s is not set", s3BucketNameKey)
+	}
+
+	s3PrefixKey := "RDS_SQL_DEV_S3_PREFIX"
+	s3Prefix := os.Getenv(s3PrefixKey)
+	if s3Prefix == "" {
+		t.Skipf("Environment variable %s is not set", s3PrefixKey)
+	}
+
+	isoFileNameKey := "RDS_SQL_DEV_ISO_FILE_NAME"
+	isoFileName := os.Getenv(isoFileNameKey)
+	if isoFileName == "" {
+		t.Skipf("Environment variable %s is not set", isoFileNameKey)
+	}
+
+	cuExeFileNameKey := "RDS_SQL_DEV_CU_EXE_FILE_NAME"
+	cuExeFileName := os.Getenv(cuExeFileNameKey)
+	if cuExeFileName == "" {
+		t.Skipf("Environment variable %s is not set", cuExeFileNameKey)
+	}
+
+	var customdbengineversion types.DBEngineVersion
+	rName := fmt.Sprintf("%s%s%d", "16.00.4215.2.", acctest.ResourcePrefix, acctest.RandIntRange(t, 100, 999))
+	resourceName := "aws_rds_custom_db_engine_version.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckCustomDBEngineVersionDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCustomDBEngineVersionConfig_databaseInstallationFiles(rName, s3BucketName, s3Prefix, isoFileName, cuExeFileName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCustomDBEngineVersionExists(ctx, t, resourceName, &customdbengineversion),
+					resource.TestCheckResourceAttr(resourceName, names.AttrEngineVersion, rName),
+					resource.TestCheckResourceAttr(resourceName, "database_installation_files_s3_bucket_name", s3BucketName),
+					resource.TestCheckResourceAttr(resourceName, "database_installation_files_s3_prefix", s3Prefix),
+					resource.TestCheckResourceAttr(resourceName, "database_installation_files.#", "2"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "database_installation_files.*", isoFileName),
+					resource.TestCheckTypeSetElemAttr(resourceName, "database_installation_files.*", cuExeFileName),
+					resource.TestCheckResourceAttrSet(resourceName, names.AttrCreateTime),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "rds", regexache.MustCompile(fmt.Sprintf(`cev:sqlserver-dev-ee.+%s.+`, rName))),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"filename", "manifest_hash", "manifest", "database_installation_files"},
 			},
 		},
 	})
@@ -456,4 +526,19 @@ resource "aws_rds_custom_db_engine_version" "test" {
   }
 }
 `, rName, ami, key, value)
+}
+
+func testAccCustomDBEngineVersionConfig_databaseInstallationFiles(rName, s3BucketName, s3Prefix, isoFileName, cuExeFileName string) string {
+	return fmt.Sprintf(`
+resource "aws_rds_custom_db_engine_version" "test" {
+  engine                                     = "sqlserver-dev-ee"
+  engine_version                             = %[1]q
+  database_installation_files_s3_bucket_name = %[2]q
+  database_installation_files_s3_prefix      = %[3]q
+  database_installation_files = [
+    %[4]q,
+    %[5]q
+  ]
+}
+`, rName, s3BucketName, s3Prefix, isoFileName, cuExeFileName)
 }

--- a/website/docs/r/rds_custom_db_engine_version.html.markdown
+++ b/website/docs/r/rds_custom_db_engine_version.html.markdown
@@ -3,12 +3,12 @@ subcategory: "RDS (Relational Database)"
 layout: "aws"
 page_title: "AWS: aws_rds_custom_db_engine_version"
 description: |-
-  Provides an custom engine version (CEV) resource for Amazon RDS Custom.
+  Provides an custom engine version (CEV) resource for Amazon RDS Custom and RDS for SQL Server Developer Edition.
 ---
 
 # Resource: aws_rds_custom_db_engine_version
 
-Provides an custom engine version (CEV) resource for Amazon RDS Custom. For additional information, see [Working with CEVs for RDS Custom for Oracle](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/custom-cev.html) and [Working with CEVs for RDS Custom for SQL Server](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/custom-cev-sqlserver.html) in the the [RDS User Guide](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Welcome.html).
+Provides an custom engine version (CEV) resource for Amazon RDS Custom. For additional information, see [Working with CEVs for RDS Custom for Oracle](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/custom-cev.html), [Working with CEVs for RDS Custom for SQL Server](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/custom-cev-sqlserver.html), and [Preparing a CEV for RDS for SQL Server](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/sqlserver-dev-edition.preparing.html) in the the [RDS User Guide](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Welcome.html).
 
 ## Example Usage
 
@@ -20,7 +20,7 @@ resource "aws_kms_key" "example" {
 }
 
 resource "aws_rds_custom_db_engine_version" "example" {
-  database_installation_files_s3_bucket_name = "DOC-EXAMPLE-BUCKET"
+  database_installation_files_s3_bucket_name = "EXAMPLE-BUCKET"
   database_installation_files_s3_prefix      = "1915_GI/"
   engine                                     = "custom-oracle-ee-cdb"
   engine_version                             = "19.cdb_cev1"
@@ -46,7 +46,7 @@ resource "aws_kms_key" "example" {
 }
 
 resource "aws_rds_custom_db_engine_version" "example" {
-  database_installation_files_s3_bucket_name = "DOC-EXAMPLE-BUCKET"
+  database_installation_files_s3_bucket_name = "EXAMPLE-BUCKET"
   database_installation_files_s3_prefix      = "1915_GI/"
   engine                                     = "custom-oracle-ee-cdb"
   engine_version                             = "19.cdb_cev1"
@@ -81,11 +81,27 @@ resource "aws_ami_copy" "example" {
   source_ami_id     = "ami-xxxxxxxx"
   source_ami_region = "us-east-1"
 }
+
 # CEV creation requires an AMI owned by the operator
 resource "aws_rds_custom_db_engine_version" "test" {
   engine          = "custom-sqlserver-se"
   engine_version  = "15.00.4249.2.cev-1"
   source_image_id = aws_ami_copy.example.id
+}
+```
+
+### SQL Server Developer Edition on RDS for SQL Server Usage
+
+```terraform
+resource "aws_rds_custom_db_engine_version" "example" {
+  engine                                     = "sqlserver-dev-ee"
+  engine_version                             = "16.00.4215.2.sql-server-dev-ed-cev"
+  database_installation_files_s3_bucket_name = "EXAMPLE-BUCKET"
+  database_installation_files_s3_prefix      = "sqlserver-dev-media"
+  database_installation_files = [
+    "SQLServer2022-x64-ENU-Dev.iso",
+    "SQLServer2022-KB5065865-x64.exe"
+  ]
 }
 ```
 
@@ -96,9 +112,10 @@ This resource supports the following arguments:
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `database_installation_files_s3_bucket_name` - (Required) The name of the Amazon S3 bucket that contains the database installation files.
 * `database_installation_files_s3_prefix` - (Required) The prefix for the Amazon S3 bucket that contains the database installation files.
+* `database_installation_files` - (Optional) A list of database installation files (ISO and EXE) uploaded to Amazon S3 for your database engine version to import to Amazon RDS. This field is an alternative to specifying the files in the `manifest` JSON.
 * `description` - (Optional) The description of the CEV.
-* `engine` - (Required) The name of the database engine. Valid values are `custom-oracle*`, `custom-sqlserver*`.
-* `engine_version` - (Required) The version of the database engine.
+* `engine` - (Required) The name of the database engine. For a list of valid values, see [CreateCustomDBEngineVersion](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateCustomDBEngineVersion.html) in the Amazon Relational Database Service API Reference.
+* `engine_version` - (Required) The version of the database engine. For the CEV name format, see [CreateCustomDBEngineVersion](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateCustomDBEngineVersion.html) in the Amazon Relational Database Service API Reference.
 * `filename` - (Optional) The name of the manifest file within the local filesystem. Conflicts with `manifest`.
 * `kms_key_id` - (Optional) The ARN of the AWS KMS key that is used to encrypt the database installation files. Required for RDS Custom for Oracle.
 * `manifest` - (Optional) The manifest file, in JSON format, that contains the list of database installation files. Conflicts with `filename`.


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

n/a

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to add support for RDS for SQL Server Developer Edition to the `aws_rds_custom_db_engine_version` resource.

To run the acceptance test case `TestAccRDSCustomDBEngineVersion_databaseInstallationFiles`, you need to follow the instructions at [Preparing a CEV for RDS for SQL Server](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/sqlserver-dev-edition.preparing.html) to download the SQL Server 2022 Developer Edition media and store the files in a S3 bucket. Then set the following environment variables to reference the media in S3:

- `RDS_SQL_DEV_S3_BUCKET_NAME` - The name of the S3 bucket that contains the SQL Server Developer ISO and CU exe files.
- `RDS_SQL_DEV_S3_PREFIX` - The prefix ("folder") where the files are stored in the S3 bucket (e.g. `media`).
- `RDS_SQL_DEV_ISO_FILE_NAME` - The name of the SQL Server Developer Edition ISO file (e.g. `SQLServer2022-x64-ENU-Dev.iso`).
- `RDS_SQL_DEV_CU_EXE_FILE_NAME` - The name of the currently supported 2022 CU i.e. CU 21 (e.g. `sqlserver2022-kb5065865-x64.exe`, which is renamed with the hash removed from the original file name for brevity)

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #45549

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Referred to [Working with SQL Server Developer Edition on RDS for SQL Server](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/sqlserver-dev-edition.html), [CreateCustomDBEngineVersion](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateCustomDBEngineVersion.html), and [DeleteCustomDBEngineVersion](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_DeleteCustomDBEngineVersion.html) for specs and wordings.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTS=TestAccRDSCustomDBEngineVersion_databaseInstallationFiles PKG=rds
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework (cached)
make: Running acceptance tests on branch: ðŸŒ¿ f-aws_rds_custom_db_engine_version-support_rds_sql_server_dev ðŸŒ¿...
TF_ACC=1 go1.26.4 test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccRDSCustomDBEngineVersion_databaseInstallationFiles'  -timeout 360m -vet=off -buildvcs=false
2026/06/29 03:37:58 Creating Terraform AWS Provider (SDKv2-style)...
2026/06/29 03:37:58 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccRDSCustomDBEngineVersion_databaseInstallationFiles
=== PAUSE TestAccRDSCustomDBEngineVersion_databaseInstallationFiles
=== CONT  TestAccRDSCustomDBEngineVersion_databaseInstallationFiles
--- PASS: TestAccRDSCustomDBEngineVersion_databaseInstallationFiles (1113.04s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/rds        1114.255s

$ 
```
