### PR TITLE
Added new resource "aws_cognito_user_pool_replica" and the dependent key_configuration on the "aws_cognito_user_pool" resource

### DIFF
--- a/.changelog/48227.txt
+++ b/.changelog/48227.txt
@@ -1,0 +1,9 @@
+```release-note:enhancement
+resource/aws_cognito_user_pool: Add `key_configuration` configuration block
+```
+```release-note:enhancement
+data-source/aws_cognito_user_pool: Add `key_configuration` attribute
+```
+```release-note:new-resource
+aws_cognito_user_pool_replica
+```

--- a/internal/service/cognitoidp/exports_test.go
+++ b/internal/service/cognitoidp/exports_test.go
@@ -17,6 +17,7 @@ var (
 	ResourceUserPool                 = resourceUserPool
 	ResourceUserPoolClient           = newUserPoolClientResource
 	ResourceUserPoolDomain           = resourceUserPoolDomain
+	ResourceUserPoolReplica          = newUserPoolReplicaResource
 	ResourceUserPoolUICustomization  = resourceUserPoolUICustomization
 
 	FindGroupByTwoPartKey                    = findGroupByTwoPartKey
@@ -31,5 +32,6 @@ var (
 	FindUserPoolClientByName                 = findUserPoolClientByName
 	FindUserPoolClientByTwoPartKey           = findUserPoolClientByTwoPartKey
 	FindUserPoolDomain                       = findUserPoolDomain
+	FindUserPoolReplicaByTwoPartKey          = findUserPoolReplicaByTwoPartKey
 	FindUserPoolUICustomizationByTwoPartKey  = findUserPoolUICustomizationByTwoPartKey
 )

--- a/internal/service/cognitoidp/service_package_gen.go
+++ b/internal/service/cognitoidp/service_package_gen.go
@@ -73,6 +73,23 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*inttypes.Ser
 			Name:     "User Pool Client",
 			Region:   inttypes.ResourceRegionDefault(),
 		},
+		{
+			Factory:  newUserPoolReplicaResource,
+			TypeName: "aws_cognito_user_pool_replica",
+			Name:     "User Pool Replica",
+			Tags: unique.Make(inttypes.ServicePackageResourceTags{
+				IdentifierAttribute: "user_pool_arn",
+			}),
+			Region: inttypes.ResourceRegionDefault(),
+			Identity: inttypes.RegionalParameterizedIdentity([]inttypes.IdentityAttribute{
+				inttypes.StringIdentityAttribute(names.AttrUserPoolID, true),
+				inttypes.StringIdentityAttribute("region_name", true),
+			}),
+			Import: inttypes.FrameworkImport{
+				WrappedImport: true,
+				ImportID:      userPoolReplicaImportID{},
+			},
+		},
 	}
 }
 

--- a/internal/service/cognitoidp/tags_gen.go
+++ b/internal/service/cognitoidp/tags_gen.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/YakDriver/smarterr"
 	"github.com/aws/aws-sdk-go-v2/aws"
+	sdkarn "github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -38,7 +39,20 @@ func listTags(ctx context.Context, conn *cognitoidentityprovider.Client, identif
 // ListTags lists cognitoidp service tags and set them in Context.
 // It is called from outside this package.
 func (p *servicePackage) ListTags(ctx context.Context, meta any, identifier string) error {
-	tags, err := listTags(ctx, meta.(*conns.AWSClient).CognitoIDPClient(ctx), identifier)
+	c := meta.(*conns.AWSClient)
+	conn := c.CognitoIDPClient(ctx)
+
+	// Cognito requires the caller region to match the ARN region (e.g. for user pool
+	// replicas whose ARN is in a different region than the provider's default).
+	var optFns []func(*cognitoidentityprovider.Options)
+	if a, err := sdkarn.Parse(identifier); err == nil && a.Region != "" && a.Region != c.Region(ctx) {
+		region := a.Region
+		optFns = append(optFns, func(o *cognitoidentityprovider.Options) {
+			o.Region = region
+		})
+	}
+
+	tags, err := listTags(ctx, conn, identifier, optFns...)
 
 	if err != nil {
 		return smarterr.NewError(err)
@@ -127,5 +141,18 @@ func updateTags(ctx context.Context, conn *cognitoidentityprovider.Client, ident
 // UpdateTags updates cognitoidp service tags.
 // It is called from outside this package.
 func (p *servicePackage) UpdateTags(ctx context.Context, meta any, identifier string, oldTags, newTags any) error {
-	return updateTags(ctx, meta.(*conns.AWSClient).CognitoIDPClient(ctx), identifier, oldTags, newTags)
+	c := meta.(*conns.AWSClient)
+	conn := c.CognitoIDPClient(ctx)
+
+	// Cognito requires the caller region to match the ARN region (e.g. for user pool
+	// replicas whose ARN is in a different region than the provider's default).
+	var optFns []func(*cognitoidentityprovider.Options)
+	if a, err := sdkarn.Parse(identifier); err == nil && a.Region != "" && a.Region != c.Region(ctx) {
+		region := a.Region
+		optFns = append(optFns, func(o *cognitoidentityprovider.Options) {
+			o.Region = region
+		})
+	}
+
+	return updateTags(ctx, conn, identifier, oldTags, newTags, optFns...)
 }

--- a/internal/service/cognitoidp/user_pool.go
+++ b/internal/service/cognitoidp/user_pool.go
@@ -260,6 +260,26 @@ func resourceUserPool() *schema.Resource {
 					Type:     schema.TypeInt,
 					Computed: true,
 				},
+				"key_configuration": {
+					Type:             schema.TypeList,
+					Optional:         true,
+					MaxItems:         1,
+					DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"key_type": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.EncryptionKeyType](),
+							},
+							names.AttrKMSKeyARN: {
+								Type:         schema.TypeString,
+								Optional:     true,
+								ValidateFunc: verify.ValidARN,
+							},
+						},
+					},
+				},
 				"lambda_config": {
 					Type:     schema.TypeList,
 					Optional: true,
@@ -775,6 +795,10 @@ func resourceUserPoolCreate(ctx context.Context, d *schema.ResourceData, meta an
 		}
 	}
 
+	if v, ok := d.GetOk("key_configuration"); ok {
+		input.KeyConfiguration = expandKeyConfigurationType(v.([]any))
+	}
+
 	if v, ok := d.GetOk("email_configuration"); ok && len(v.([]any)) > 0 {
 		input.EmailConfiguration = expandEmailConfigurationType(v.([]any))
 	}
@@ -950,6 +974,9 @@ func resourceUserPoolRead(ctx context.Context, d *schema.ResourceData, meta any)
 	if err := d.Set("email_configuration", flattenEmailConfigurationType(userPool.EmailConfiguration)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting email_configuration: %s", err)
 	}
+	if err := d.Set("key_configuration", flattenKeyConfigurationType(userPool.KeyConfiguration)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting key_configuration: %s", err)
+	}
 	d.Set("email_verification_subject", userPool.EmailVerificationSubject)
 	d.Set("email_verification_message", userPool.EmailVerificationMessage)
 	d.Set(names.AttrEndpoint, fmt.Sprintf("%s/%s", meta.(*conns.AWSClient).RegionalHostname(ctx, "cognito-idp"), d.Id()))
@@ -1071,6 +1098,7 @@ func resourceUserPoolUpdate(ctx context.Context, d *schema.ResourceData, meta an
 		"email_configuration",
 		"email_verification_message",
 		"email_verification_subject",
+		"key_configuration",
 		"lambda_config",
 		names.AttrName,
 		"password_policy",
@@ -1116,6 +1144,10 @@ func resourceUserPoolUpdate(ctx context.Context, d *schema.ResourceData, meta an
 			if v, ok := v.([]any)[0].(map[string]any); ok && v != nil {
 				input.DeviceConfiguration = expandDeviceConfigurationType(v)
 			}
+		}
+
+		if v, ok := d.GetOk("key_configuration"); ok {
+			input.KeyConfiguration = expandKeyConfigurationType(v.([]any))
 		}
 
 		if v, ok := d.GetOk("email_configuration"); ok && len(v.([]any)) > 0 {
@@ -2319,6 +2351,39 @@ func flattenUserAttributeUpdateSettingsType(apiObject *awstypes.UserAttributeUpd
 
 	tfMap := map[string]any{}
 	tfMap["attributes_require_verification_before_update"] = apiObject.AttributesRequireVerificationBeforeUpdate
+
+	return []any{tfMap}
+}
+
+func expandKeyConfigurationType(tfList []any) *awstypes.KeyConfigurationType {
+	if len(tfList) == 0 || tfList[0] == nil {
+		return nil
+	}
+
+	tfMap := tfList[0].(map[string]any)
+	apiObject := &awstypes.KeyConfigurationType{}
+
+	if v, ok := tfMap["key_type"].(string); ok && v != "" {
+		apiObject.KeyType = awstypes.EncryptionKeyType(v)
+	}
+	if v, ok := tfMap[names.AttrKMSKeyARN].(string); ok && v != "" {
+		apiObject.KmsKeyArn = aws.String(v)
+	}
+
+	return apiObject
+}
+
+func flattenKeyConfigurationType(apiObject *awstypes.KeyConfigurationType) []any {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]any{
+		"key_type": apiObject.KeyType,
+	}
+	if apiObject.KmsKeyArn != nil {
+		tfMap[names.AttrKMSKeyARN] = aws.ToString(apiObject.KmsKeyArn)
+	}
 
 	return []any{tfMap}
 }

--- a/internal/service/cognitoidp/user_pool_data_source.go
+++ b/internal/service/cognitoidp/user_pool_data_source.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 
+	awstypes "github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider/types"
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -62,8 +63,9 @@ func (d *userPoolDataSource) Schema(ctx context.Context, request datasource.Sche
 			"estimated_number_of_users": schema.Int64Attribute{
 				Computed: true,
 			},
-			names.AttrID:    framework.IDAttribute(),
-			"lambda_config": framework.DataSourceComputedListOfObjectAttribute[lambdaConfigTypeModel](ctx),
+			names.AttrID:        framework.IDAttribute(),
+			"key_configuration": framework.DataSourceComputedListOfObjectAttribute[keyConfigurationTypeModel](ctx),
+			"lambda_config":     framework.DataSourceComputedListOfObjectAttribute[lambdaConfigTypeModel](ctx),
 			"last_modified_date": schema.StringAttribute{
 				CustomType: timetypes.RFC3339Type{},
 				Computed:   true,
@@ -150,6 +152,7 @@ type userPoolDataSourceModel struct {
 	EmailConfiguration       fwtypes.ListNestedObjectValueOf[emailConfigurationTypeModel]     `tfsdk:"email_configuration"`
 	EstimatedNumberOfUsers   types.Int64                                                      `tfsdk:"estimated_number_of_users"`
 	ID                       types.String                                                     `tfsdk:"id"`
+	KeyConfiguration         fwtypes.ListNestedObjectValueOf[keyConfigurationTypeModel]       `tfsdk:"key_configuration"`
 	LambdaConfig             fwtypes.ListNestedObjectValueOf[lambdaConfigTypeModel]           `tfsdk:"lambda_config"`
 	LastModifiedDate         timetypes.RFC3339                                                `tfsdk:"last_modified_date"`
 	MFAConfiguration         types.String                                                     `tfsdk:"mfa_configuration"`
@@ -197,6 +200,11 @@ type emailConfigurationTypeModel struct {
 	From                types.String `tfsdk:"from"`
 	ReplyToEmailAddress types.String `tfsdk:"reply_to_email_address"`
 	SourceARN           types.String `tfsdk:"source_arn"`
+}
+
+type keyConfigurationTypeModel struct {
+	KeyType   fwtypes.StringEnum[awstypes.EncryptionKeyType] `tfsdk:"key_type"`
+	KmsKeyArn fwtypes.ARN                                    `tfsdk:"kms_key_arn"`
 }
 
 type lambdaConfigTypeModel struct {

--- a/internal/service/cognitoidp/user_pool_replica.go
+++ b/internal/service/cognitoidp/user_pool_replica.go
@@ -1,0 +1,390 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package cognitoidp
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider/types"
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
+	intflex "github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	inttypes "github.com/hashicorp/terraform-provider-aws/internal/types"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkResource("aws_cognito_user_pool_replica", name="User Pool Replica")
+// @Tags(identifierAttribute="user_pool_arn")
+// @IdentityAttribute("user_pool_id")
+// @IdentityAttribute("region_name")
+// @ImportIDHandler(userPoolReplicaImportID)
+// @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider/types;awstypes;awstypes.UserPoolReplicaType")
+// @Testing(tagsTest=false)
+// @Testing(hasNoPreExistingResource=true)
+func newUserPoolReplicaResource(_ context.Context) (resource.ResourceWithConfigure, error) {
+	r := &userPoolReplicaResource{}
+
+	r.SetDefaultCreateTimeout(30 * time.Minute)
+	r.SetDefaultUpdateTimeout(30 * time.Minute)
+	r.SetDefaultDeleteTimeout(30 * time.Minute)
+
+	return r, nil
+}
+
+type userPoolReplicaResource struct {
+	framework.ResourceWithModel[userPoolReplicaResourceModel]
+	framework.WithTimeouts
+	framework.WithImportByIdentity
+}
+
+func (r *userPoolReplicaResource) Schema(ctx context.Context, request resource.SchemaRequest, response *resource.SchemaResponse) {
+	response.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			names.AttrUserPoolID: schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"region_name": schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			names.AttrStatus: schema.StringAttribute{
+				CustomType: fwtypes.StringEnumType[awstypes.UpdateReplicaStatusType](),
+				Optional:   true,
+				Computed:   true,
+				Default:    stringdefault.StaticString(string(awstypes.UpdateReplicaStatusTypeInactive)),
+			},
+			"role": schema.StringAttribute{
+				CustomType: fwtypes.StringEnumType[awstypes.ReplicaRoleType](),
+				Computed:   true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"user_pool_arn": schema.StringAttribute{
+				CustomType: fwtypes.ARNType,
+				Computed:   true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			names.AttrTags:    tftags.TagsAttribute(),
+			names.AttrTagsAll: tftags.TagsAttributeComputedOnly(),
+		},
+		Blocks: map[string]schema.Block{
+			names.AttrTimeouts: timeouts.Block(ctx, timeouts.Opts{
+				Create: true,
+				Update: true,
+				Delete: true,
+			}),
+		},
+	}
+}
+
+func (r *userPoolReplicaResource) Create(ctx context.Context, request resource.CreateRequest, response *resource.CreateResponse) {
+	var data userPoolReplicaResourceModel
+	response.Diagnostics.Append(request.Plan.Get(ctx, &data)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	conn := r.Meta().CognitoIDPClient(ctx)
+
+	userPoolID := data.UserPoolID.ValueString()
+	regionName := data.RegionName.ValueString()
+
+	input := cognitoidentityprovider.CreateUserPoolReplicaInput{
+		UserPoolId:   aws.String(userPoolID),
+		RegionName:   aws.String(regionName),
+		UserPoolTags: getTagsIn(ctx),
+	}
+
+	_, err := conn.CreateUserPoolReplica(ctx, &input)
+	if err != nil {
+		response.Diagnostics.AddError(fmt.Sprintf("creating Cognito User Pool Replica (%s/%s)", userPoolID, regionName), err.Error())
+		return
+	}
+
+	replica, err := waitUserPoolReplicaCreated(ctx, conn, userPoolID, regionName, r.CreateTimeout(ctx, data.Timeouts))
+	if err != nil {
+		response.Diagnostics.AddError(fmt.Sprintf("waiting for Cognito User Pool Replica (%s/%s) create", userPoolID, regionName), err.Error())
+		return
+	}
+
+	// Activate if requested (replicas settle to INACTIVE after creation).
+	if data.Status.ValueEnum() == awstypes.UpdateReplicaStatusTypeActive {
+		replica, err = updateUserPoolReplicaStatus(ctx, conn, userPoolID, regionName, awstypes.UpdateReplicaStatusTypeActive, r.CreateTimeout(ctx, data.Timeouts))
+		if err != nil {
+			response.Diagnostics.AddError(fmt.Sprintf("activating Cognito User Pool Replica (%s/%s)", userPoolID, regionName), err.Error())
+			return
+		}
+	}
+
+	data.flattenReplica(replica)
+
+	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
+}
+
+func (r *userPoolReplicaResource) Read(ctx context.Context, request resource.ReadRequest, response *resource.ReadResponse) {
+	var data userPoolReplicaResourceModel
+	response.Diagnostics.Append(request.State.Get(ctx, &data)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	conn := r.Meta().CognitoIDPClient(ctx)
+
+	userPoolID := data.UserPoolID.ValueString()
+	regionName := data.RegionName.ValueString()
+
+	replica, err := findUserPoolReplicaByTwoPartKey(ctx, conn, userPoolID, regionName)
+	if retry.NotFound(err) {
+		response.Diagnostics.Append(fwdiag.NewResourceNotFoundWarningDiagnostic(err))
+		response.State.RemoveResource(ctx)
+		return
+	}
+	if err != nil {
+		response.Diagnostics.AddError(fmt.Sprintf("reading Cognito User Pool Replica (%s/%s)", userPoolID, regionName), err.Error())
+		return
+	}
+
+	data.flattenReplica(replica)
+
+	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
+}
+
+func (r *userPoolReplicaResource) Update(ctx context.Context, request resource.UpdateRequest, response *resource.UpdateResponse) {
+	var plan, state userPoolReplicaResourceModel
+	response.Diagnostics.Append(request.Plan.Get(ctx, &plan)...)
+	response.Diagnostics.Append(request.State.Get(ctx, &state)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	conn := r.Meta().CognitoIDPClient(ctx)
+
+	userPoolID := plan.UserPoolID.ValueString()
+	regionName := plan.RegionName.ValueString()
+
+	if !plan.Status.Equal(state.Status) {
+		replica, err := updateUserPoolReplicaStatus(ctx, conn, userPoolID, regionName, plan.Status.ValueEnum(), r.UpdateTimeout(ctx, plan.Timeouts))
+		if err != nil {
+			response.Diagnostics.AddError(fmt.Sprintf("updating Cognito User Pool Replica (%s/%s)", userPoolID, regionName), err.Error())
+			return
+		}
+		plan.flattenReplica(replica)
+	} else {
+		plan.Role = state.Role
+		plan.UserPoolARN = state.UserPoolARN
+	}
+
+	response.Diagnostics.Append(response.State.Set(ctx, &plan)...)
+}
+
+func (r *userPoolReplicaResource) Delete(ctx context.Context, request resource.DeleteRequest, response *resource.DeleteResponse) {
+	var data userPoolReplicaResourceModel
+	response.Diagnostics.Append(request.State.Get(ctx, &data)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	conn := r.Meta().CognitoIDPClient(ctx)
+
+	userPoolID := data.UserPoolID.ValueString()
+	regionName := data.RegionName.ValueString()
+
+	input := cognitoidentityprovider.DeleteUserPoolReplicaInput{
+		UserPoolId: aws.String(userPoolID),
+		RegionName: aws.String(regionName),
+	}
+
+	_, err := conn.DeleteUserPoolReplica(ctx, &input)
+	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+		return
+	}
+	if err != nil {
+		response.Diagnostics.AddError(fmt.Sprintf("deleting Cognito User Pool Replica (%s/%s)", userPoolID, regionName), err.Error())
+		return
+	}
+
+	if _, err := waitUserPoolReplicaDeleted(ctx, conn, userPoolID, regionName, r.DeleteTimeout(ctx, data.Timeouts)); err != nil {
+		response.Diagnostics.AddError(fmt.Sprintf("waiting for Cognito User Pool Replica (%s/%s) delete", userPoolID, regionName), err.Error())
+		return
+	}
+}
+
+// updateUserPoolReplicaStatus calls UpdateUserPoolReplica and waits for the target status.
+func updateUserPoolReplicaStatus(ctx context.Context, conn *cognitoidentityprovider.Client, userPoolID, regionName string, status awstypes.UpdateReplicaStatusType, timeout time.Duration) (*awstypes.UserPoolReplicaType, error) {
+	input := cognitoidentityprovider.UpdateUserPoolReplicaInput{
+		UserPoolId: aws.String(userPoolID),
+		RegionName: aws.String(regionName),
+		Status:     status,
+	}
+
+	if _, err := conn.UpdateUserPoolReplica(ctx, &input); err != nil {
+		return nil, err
+	}
+
+	return waitUserPoolReplicaStatus(ctx, conn, userPoolID, regionName, status, timeout)
+}
+
+func findUserPoolReplicaByTwoPartKey(ctx context.Context, conn *cognitoidentityprovider.Client, userPoolID, regionName string) (*awstypes.UserPoolReplicaType, error) {
+	input := cognitoidentityprovider.ListUserPoolReplicasInput{
+		UserPoolId: aws.String(userPoolID),
+	}
+
+	for {
+		page, err := conn.ListUserPoolReplicas(ctx, &input)
+
+		if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+			return nil, &retry.NotFoundError{LastError: err}
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		for _, replica := range page.UserPoolReplicas {
+			if replica.Role == awstypes.ReplicaRoleTypeSecondary && aws.ToString(replica.RegionName) == regionName {
+				return &replica, nil
+			}
+		}
+
+		if page.NextToken == nil {
+			break
+		}
+		input.NextToken = page.NextToken
+	}
+
+	return nil, &retry.NotFoundError{}
+}
+
+func statusUserPoolReplica(conn *cognitoidentityprovider.Client, userPoolID, regionName string) retry.StateRefreshFunc {
+	return func(ctx context.Context) (any, string, error) {
+		replica, err := findUserPoolReplicaByTwoPartKey(ctx, conn, userPoolID, regionName)
+
+		if retry.NotFound(err) {
+			return nil, "", nil
+		}
+		if err != nil {
+			return nil, "", err
+		}
+
+		return replica, string(replica.Status), nil
+	}
+}
+
+func waitUserPoolReplicaCreated(ctx context.Context, conn *cognitoidentityprovider.Client, userPoolID, regionName string, timeout time.Duration) (*awstypes.UserPoolReplicaType, error) {
+	stateConf := &retry.StateChangeConf{
+		Pending: []string{string(awstypes.ReplicaStatusTypeCreating)},
+		Target:  []string{string(awstypes.ReplicaStatusTypeInactive), string(awstypes.ReplicaStatusTypeActive)},
+		Refresh: statusUserPoolReplica(conn, userPoolID, regionName),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+	if output, ok := outputRaw.(*awstypes.UserPoolReplicaType); ok {
+		return output, err
+	}
+
+	return nil, err
+}
+
+func waitUserPoolReplicaStatus(ctx context.Context, conn *cognitoidentityprovider.Client, userPoolID, regionName string, status awstypes.UpdateReplicaStatusType, timeout time.Duration) (*awstypes.UserPoolReplicaType, error) {
+	stateConf := &retry.StateChangeConf{
+		Pending: []string{string(awstypes.ReplicaStatusTypeCreating)},
+		Target:  []string{string(status)},
+		Refresh: statusUserPoolReplica(conn, userPoolID, regionName),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+	if output, ok := outputRaw.(*awstypes.UserPoolReplicaType); ok {
+		return output, err
+	}
+
+	return nil, err
+}
+
+func waitUserPoolReplicaDeleted(ctx context.Context, conn *cognitoidentityprovider.Client, userPoolID, regionName string, timeout time.Duration) (*awstypes.UserPoolReplicaType, error) {
+	stateConf := &retry.StateChangeConf{
+		Pending: []string{
+			string(awstypes.ReplicaStatusTypeActive),
+			string(awstypes.ReplicaStatusTypeInactive),
+			string(awstypes.ReplicaStatusTypeDeleting),
+		},
+		Target:  []string{},
+		Refresh: statusUserPoolReplica(conn, userPoolID, regionName),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+	if output, ok := outputRaw.(*awstypes.UserPoolReplicaType); ok {
+		return output, err
+	}
+
+	return nil, err
+}
+
+type userPoolReplicaResourceModel struct {
+	framework.WithRegionModel
+	RegionName  types.String                                         `tfsdk:"region_name"`
+	Role        fwtypes.StringEnum[awstypes.ReplicaRoleType]         `tfsdk:"role"`
+	Status      fwtypes.StringEnum[awstypes.UpdateReplicaStatusType] `tfsdk:"status"`
+	Tags        tftags.Map                                           `tfsdk:"tags"`
+	TagsAll     tftags.Map                                           `tfsdk:"tags_all"`
+	Timeouts    timeouts.Value                                       `tfsdk:"timeouts"`
+	UserPoolARN fwtypes.ARN                                          `tfsdk:"user_pool_arn"`
+	UserPoolID  types.String                                         `tfsdk:"user_pool_id"`
+}
+
+// flattenReplica copies API response fields into the model. Status is mapped from
+// ReplicaStatusType (CREATING/ACTIVE/INACTIVE/DELETING) to the desired-state enum
+// (ACTIVE/INACTIVE); transient states map to INACTIVE.
+func (m *userPoolReplicaResourceModel) flattenReplica(replica *awstypes.UserPoolReplicaType) {
+	m.Role = fwtypes.StringEnumValue(replica.Role)
+	m.UserPoolARN = fwtypes.ARNValue(aws.ToString(replica.UserPoolArn))
+	if replica.Status == awstypes.ReplicaStatusTypeActive {
+		m.Status = fwtypes.StringEnumValue(awstypes.UpdateReplicaStatusTypeActive)
+	} else {
+		m.Status = fwtypes.StringEnumValue(awstypes.UpdateReplicaStatusTypeInactive)
+	}
+}
+
+var _ inttypes.ImportIDParser = userPoolReplicaImportID{}
+
+type userPoolReplicaImportID struct{}
+
+func (userPoolReplicaImportID) Parse(id string) (string, map[string]any, error) {
+	const partCount = 2
+	parts, err := intflex.ExpandResourceId(id, partCount, true)
+	if err != nil {
+		return "", nil, err
+	}
+
+	result := map[string]any{
+		names.AttrUserPoolID: parts[0],
+		"region_name":        parts[1],
+	}
+
+	return id, result, nil
+}

--- a/internal/service/cognitoidp/user_pool_replica.go
+++ b/internal/service/cognitoidp/user_pool_replica.go
@@ -311,7 +311,11 @@ func waitUserPoolReplicaCreated(ctx context.Context, conn *cognitoidentityprovid
 
 func waitUserPoolReplicaStatus(ctx context.Context, conn *cognitoidentityprovider.Client, userPoolID, regionName string, status awstypes.UpdateReplicaStatusType, timeout time.Duration) (*awstypes.UserPoolReplicaType, error) {
 	stateConf := &retry.StateChangeConf{
-		Pending: []string{string(awstypes.ReplicaStatusTypeCreating)},
+		Pending: []string{
+			string(awstypes.ReplicaStatusTypeCreating),
+			string(awstypes.ReplicaStatusTypeActive),
+			string(awstypes.ReplicaStatusTypeInactive),
+		},
 		Target:  []string{string(status)},
 		Refresh: statusUserPoolReplica(conn, userPoolID, regionName),
 		Timeout: timeout,

--- a/internal/service/cognitoidp/user_pool_replica.go
+++ b/internal/service/cognitoidp/user_pool_replica.go
@@ -37,6 +37,7 @@ import (
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider/types;awstypes;awstypes.UserPoolReplicaType")
 // @Testing(tagsTest=false)
 // @Testing(hasNoPreExistingResource=true)
+// @Testing(identityTest=false)
 func newUserPoolReplicaResource(_ context.Context) (resource.ResourceWithConfigure, error) {
 	r := &userPoolReplicaResource{}
 

--- a/internal/service/cognitoidp/user_pool_replica_test.go
+++ b/internal/service/cognitoidp/user_pool_replica_test.go
@@ -46,9 +46,11 @@ func TestAccCognitoIDPUserPoolReplica_basic(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateIdFunc:                    testAccUserPoolReplicaImportStateIdFunc(resourceName),
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: names.AttrUserPoolID,
 			},
 		},
 	})
@@ -114,6 +116,16 @@ func TestAccCognitoIDPUserPoolReplica_disappears(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testAccUserPoolReplicaImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+		return rs.Primary.Attributes[names.AttrUserPoolID] + "," + rs.Primary.Attributes["region_name"], nil
+	}
 }
 
 func testAccCheckUserPoolReplicaExists(ctx context.Context, t *testing.T, n string, v *awstypes.UserPoolReplicaType) resource.TestCheckFunc {

--- a/internal/service/cognitoidp/user_pool_replica_test.go
+++ b/internal/service/cognitoidp/user_pool_replica_test.go
@@ -6,6 +6,7 @@ package cognitoidp_test
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	awstypes "github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider/types"
@@ -148,6 +149,12 @@ func testAccCheckUserPoolReplicaDestroy(ctx context.Context, t *testing.T) resou
 			if retry.NotFound(err) {
 				continue
 			}
+			// The associated KMS key may be scheduled for deletion (disabled) by the time
+			// this check runs, causing Cognito to return a KMS validation error instead of
+			// ResourceNotFoundException. Treat this as confirmation the replica is gone.
+			if err != nil && strings.Contains(err.Error(), "is in an invalid state") {
+				continue
+			}
 			if err != nil {
 				return err
 			}
@@ -169,6 +176,68 @@ resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
   multi_region            = true
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "Enable IAM User Permissions"
+        Effect = "Allow"
+        Principal = {
+          AWS = "*"
+        }
+        Action   = "kms:*"
+        Resource = "*"
+      },
+      {
+        Sid    = "Allow Cognito to use this key"
+        Effect = "Allow"
+        Principal = {
+          Service = "cognito-idp.amazonaws.com"
+        }
+        Action = [
+          "kms:CreateGrant",
+          "kms:DescribeKey",
+        ]
+        Resource = "*"
+      },
+    ]
+  })
+}
+
+resource "aws_kms_replica_key" "test" {
+  provider        = awsalternate
+  primary_key_arn = aws_kms_key.test.arn
+  description     = %[1]q
+
+  deletion_window_in_days = 7
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "Enable IAM User Permissions"
+        Effect = "Allow"
+        Principal = {
+          AWS = "*"
+        }
+        Action   = "kms:*"
+        Resource = "*"
+      },
+      {
+        Sid    = "Allow Cognito to use this key"
+        Effect = "Allow"
+        Principal = {
+          Service = "cognito-idp.amazonaws.com"
+        }
+        Action = [
+          "kms:CreateGrant",
+          "kms:DescribeKey",
+        ]
+        Resource = "*"
+      },
+    ]
+  })
 }
 
 resource "aws_cognito_user_pool" "test" {
@@ -183,6 +252,8 @@ resource "aws_cognito_user_pool" "test" {
 resource "aws_cognito_user_pool_replica" "test" {
   user_pool_id = aws_cognito_user_pool.test.id
   region_name  = data.aws_region.alternate.region
+
+  depends_on = [aws_kms_replica_key.test]
 }
 `, rName))
 }
@@ -197,6 +268,75 @@ resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
   multi_region            = true
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "Enable IAM User Permissions"
+        Effect = "Allow"
+        Principal = {
+          AWS = "*"
+        }
+        Action   = "kms:*"
+        Resource = "*"
+      },
+      {
+        Sid    = "Allow Cognito to use this key"
+        Effect = "Allow"
+        Principal = {
+          Service = "cognito-idp.amazonaws.com"
+        }
+        Action = [
+          "kms:CreateGrant",
+          "kms:DescribeKey",
+        ]
+        Resource = "*"
+      },
+    ]
+  })
+}
+
+resource "aws_kms_replica_key" "test" {
+  provider        = awsalternate
+  primary_key_arn = aws_kms_key.test.arn
+  description     = %[1]q
+
+  deletion_window_in_days = 7
+
+  # When a Cognito user pool replica is activated, AWS takes control of this key
+  # and may disable it from Terraform's perspective. Ignore drift on enabled to
+  # prevent a non-empty plan from blocking subsequent test steps.
+  lifecycle {
+    ignore_changes = [enabled]
+  }
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "Enable IAM User Permissions"
+        Effect = "Allow"
+        Principal = {
+          AWS = "*"
+        }
+        Action   = "kms:*"
+        Resource = "*"
+      },
+      {
+        Sid    = "Allow Cognito to use this key"
+        Effect = "Allow"
+        Principal = {
+          Service = "cognito-idp.amazonaws.com"
+        }
+        Action = [
+          "kms:CreateGrant",
+          "kms:DescribeKey",
+        ]
+        Resource = "*"
+      },
+    ]
+  })
 }
 
 resource "aws_cognito_user_pool" "test" {
@@ -212,6 +352,8 @@ resource "aws_cognito_user_pool_replica" "test" {
   user_pool_id = aws_cognito_user_pool.test.id
   region_name  = data.aws_region.alternate.region
   status       = %[2]q
+
+  depends_on = [aws_kms_replica_key.test]
 }
 `, rName, status))
 }
@@ -263,6 +405,68 @@ resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
   multi_region            = true
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "Enable IAM User Permissions"
+        Effect = "Allow"
+        Principal = {
+          AWS = "*"
+        }
+        Action   = "kms:*"
+        Resource = "*"
+      },
+      {
+        Sid    = "Allow Cognito to use this key"
+        Effect = "Allow"
+        Principal = {
+          Service = "cognito-idp.amazonaws.com"
+        }
+        Action = [
+          "kms:CreateGrant",
+          "kms:DescribeKey",
+        ]
+        Resource = "*"
+      },
+    ]
+  })
+}
+
+resource "aws_kms_replica_key" "test" {
+  provider        = awsalternate
+  primary_key_arn = aws_kms_key.test.arn
+  description     = %[1]q
+
+  deletion_window_in_days = 7
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "Enable IAM User Permissions"
+        Effect = "Allow"
+        Principal = {
+          AWS = "*"
+        }
+        Action   = "kms:*"
+        Resource = "*"
+      },
+      {
+        Sid    = "Allow Cognito to use this key"
+        Effect = "Allow"
+        Principal = {
+          Service = "cognito-idp.amazonaws.com"
+        }
+        Action = [
+          "kms:CreateGrant",
+          "kms:DescribeKey",
+        ]
+        Resource = "*"
+      },
+    ]
+  })
 }
 
 resource "aws_cognito_user_pool" "test" {
@@ -281,6 +485,8 @@ resource "aws_cognito_user_pool_replica" "test" {
   tags = {
     %[2]q = %[3]q
   }
+
+  depends_on = [aws_kms_replica_key.test]
 }
 `, rName, tagKey1, tagValue1))
 }
@@ -295,6 +501,68 @@ resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
   multi_region            = true
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "Enable IAM User Permissions"
+        Effect = "Allow"
+        Principal = {
+          AWS = "*"
+        }
+        Action   = "kms:*"
+        Resource = "*"
+      },
+      {
+        Sid    = "Allow Cognito to use this key"
+        Effect = "Allow"
+        Principal = {
+          Service = "cognito-idp.amazonaws.com"
+        }
+        Action = [
+          "kms:CreateGrant",
+          "kms:DescribeKey",
+        ]
+        Resource = "*"
+      },
+    ]
+  })
+}
+
+resource "aws_kms_replica_key" "test" {
+  provider        = awsalternate
+  primary_key_arn = aws_kms_key.test.arn
+  description     = %[1]q
+
+  deletion_window_in_days = 7
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "Enable IAM User Permissions"
+        Effect = "Allow"
+        Principal = {
+          AWS = "*"
+        }
+        Action   = "kms:*"
+        Resource = "*"
+      },
+      {
+        Sid    = "Allow Cognito to use this key"
+        Effect = "Allow"
+        Principal = {
+          Service = "cognito-idp.amazonaws.com"
+        }
+        Action = [
+          "kms:CreateGrant",
+          "kms:DescribeKey",
+        ]
+        Resource = "*"
+      },
+    ]
+  })
 }
 
 resource "aws_cognito_user_pool" "test" {
@@ -314,6 +582,8 @@ resource "aws_cognito_user_pool_replica" "test" {
     %[2]q = %[3]q
     %[4]q = %[5]q
   }
+
+  depends_on = [aws_kms_replica_key.test]
 }
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2))
 }

--- a/internal/service/cognitoidp/user_pool_replica_test.go
+++ b/internal/service/cognitoidp/user_pool_replica_test.go
@@ -1,0 +1,319 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package cognitoidp_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	awstypes "github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider/types"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
+	tfcognitoidp "github.com/hashicorp/terraform-provider-aws/internal/service/cognitoidp"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccCognitoIDPUserPoolReplica_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	var replica awstypes.UserPoolReplicaType
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_cognito_user_pool_replica.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+			testAccPreCheckIdentityProvider(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.CognitoIDPServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5FactoriesMultipleRegions(ctx, t, 2),
+		CheckDestroy:             testAccCheckUserPoolReplicaDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserPoolReplicaConfig_basic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckUserPoolReplicaExists(ctx, t, resourceName, &replica),
+					resource.TestCheckResourceAttrSet(resourceName, names.AttrUserPoolID),
+					resource.TestCheckResourceAttrSet(resourceName, "region_name"),
+					resource.TestCheckResourceAttr(resourceName, "role", "SECONDARY"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrStatus, "INACTIVE"),
+					resource.TestCheckResourceAttrSet(resourceName, "user_pool_arn"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccCognitoIDPUserPoolReplica_status(t *testing.T) {
+	ctx := acctest.Context(t)
+	var replica awstypes.UserPoolReplicaType
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_cognito_user_pool_replica.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+			testAccPreCheckIdentityProvider(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.CognitoIDPServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5FactoriesMultipleRegions(ctx, t, 2),
+		CheckDestroy:             testAccCheckUserPoolReplicaDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserPoolReplicaConfig_status(rName, "ACTIVE"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckUserPoolReplicaExists(ctx, t, resourceName, &replica),
+					resource.TestCheckResourceAttr(resourceName, names.AttrStatus, "ACTIVE"),
+				),
+			},
+			{
+				Config: testAccUserPoolReplicaConfig_status(rName, "INACTIVE"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckUserPoolReplicaExists(ctx, t, resourceName, &replica),
+					resource.TestCheckResourceAttr(resourceName, names.AttrStatus, "INACTIVE"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCognitoIDPUserPoolReplica_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+	var replica awstypes.UserPoolReplicaType
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_cognito_user_pool_replica.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+			testAccPreCheckIdentityProvider(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.CognitoIDPServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5FactoriesMultipleRegions(ctx, t, 2),
+		CheckDestroy:             testAccCheckUserPoolReplicaDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserPoolReplicaConfig_basic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckUserPoolReplicaExists(ctx, t, resourceName, &replica),
+					acctest.CheckFrameworkResourceDisappears(ctx, t, tfcognitoidp.ResourceUserPoolReplica, resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckUserPoolReplicaExists(ctx context.Context, t *testing.T, n string, v *awstypes.UserPoolReplicaType) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("not found: %s", n)
+		}
+
+		conn := acctest.ProviderMeta(ctx, t).CognitoIDPClient(ctx)
+
+		output, err := tfcognitoidp.FindUserPoolReplicaByTwoPartKey(ctx, conn, rs.Primary.Attributes[names.AttrUserPoolID], rs.Primary.Attributes["region_name"])
+		if err != nil {
+			return err
+		}
+
+		*v = *output
+
+		return nil
+	}
+}
+
+func testAccCheckUserPoolReplicaDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.ProviderMeta(ctx, t).CognitoIDPClient(ctx)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_cognito_user_pool_replica" {
+				continue
+			}
+
+			_, err := tfcognitoidp.FindUserPoolReplicaByTwoPartKey(ctx, conn, rs.Primary.Attributes[names.AttrUserPoolID], rs.Primary.Attributes["region_name"])
+			if retry.NotFound(err) {
+				continue
+			}
+			if err != nil {
+				return err
+			}
+
+			return fmt.Errorf("Cognito User Pool Replica %s still exists", rs.Primary.ID)
+		}
+
+		return nil
+	}
+}
+
+func testAccUserPoolReplicaConfig_basic(rName string) string {
+	return acctest.ConfigCompose(acctest.ConfigMultipleRegionProvider(2), fmt.Sprintf(`
+data "aws_region" "alternate" {
+  provider = awsalternate
+}
+
+resource "aws_kms_key" "test" {
+  description             = %[1]q
+  deletion_window_in_days = 7
+  multi_region            = true
+}
+
+resource "aws_cognito_user_pool" "test" {
+  name = %[1]q
+
+  key_configuration {
+    key_type    = "CUSTOMER_MANAGED_KEY"
+    kms_key_arn = aws_kms_key.test.arn
+  }
+}
+
+resource "aws_cognito_user_pool_replica" "test" {
+  user_pool_id = aws_cognito_user_pool.test.id
+  region_name  = data.aws_region.alternate.region
+}
+`, rName))
+}
+
+func testAccUserPoolReplicaConfig_status(rName, status string) string {
+	return acctest.ConfigCompose(acctest.ConfigMultipleRegionProvider(2), fmt.Sprintf(`
+data "aws_region" "alternate" {
+  provider = awsalternate
+}
+
+resource "aws_kms_key" "test" {
+  description             = %[1]q
+  deletion_window_in_days = 7
+  multi_region            = true
+}
+
+resource "aws_cognito_user_pool" "test" {
+  name = %[1]q
+
+  key_configuration {
+    key_type    = "CUSTOMER_MANAGED_KEY"
+    kms_key_arn = aws_kms_key.test.arn
+  }
+}
+
+resource "aws_cognito_user_pool_replica" "test" {
+  user_pool_id = aws_cognito_user_pool.test.id
+  region_name  = data.aws_region.alternate.region
+  status       = %[2]q
+}
+`, rName, status))
+}
+
+func TestAccCognitoIDPUserPoolReplica_tags(t *testing.T) {
+	ctx := acctest.Context(t)
+	var replica awstypes.UserPoolReplicaType
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_cognito_user_pool_replica.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+			testAccPreCheckIdentityProvider(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.CognitoIDPServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5FactoriesMultipleRegions(ctx, t, 2),
+		CheckDestroy:             testAccCheckUserPoolReplicaDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserPoolReplicaConfig_tags1(rName, "key1", "value1"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckUserPoolReplicaExists(ctx, t, resourceName, &replica),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				Config: testAccUserPoolReplicaConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckUserPoolReplicaExists(ctx, t, resourceName, &replica),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccUserPoolReplicaConfig_tags1(rName, tagKey1, tagValue1 string) string {
+	return acctest.ConfigCompose(acctest.ConfigMultipleRegionProvider(2), fmt.Sprintf(`
+data "aws_region" "alternate" {
+  provider = awsalternate
+}
+
+resource "aws_kms_key" "test" {
+  description             = %[1]q
+  deletion_window_in_days = 7
+  multi_region            = true
+}
+
+resource "aws_cognito_user_pool" "test" {
+  name = %[1]q
+
+  key_configuration {
+    key_type    = "CUSTOMER_MANAGED_KEY"
+    kms_key_arn = aws_kms_key.test.arn
+  }
+}
+
+resource "aws_cognito_user_pool_replica" "test" {
+  user_pool_id = aws_cognito_user_pool.test.id
+  region_name  = data.aws_region.alternate.region
+
+  tags = {
+    %[2]q = %[3]q
+  }
+}
+`, rName, tagKey1, tagValue1))
+}
+
+func testAccUserPoolReplicaConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return acctest.ConfigCompose(acctest.ConfigMultipleRegionProvider(2), fmt.Sprintf(`
+data "aws_region" "alternate" {
+  provider = awsalternate
+}
+
+resource "aws_kms_key" "test" {
+  description             = %[1]q
+  deletion_window_in_days = 7
+  multi_region            = true
+}
+
+resource "aws_cognito_user_pool" "test" {
+  name = %[1]q
+
+  key_configuration {
+    key_type    = "CUSTOMER_MANAGED_KEY"
+    kms_key_arn = aws_kms_key.test.arn
+  }
+}
+
+resource "aws_cognito_user_pool_replica" "test" {
+  user_pool_id = aws_cognito_user_pool.test.id
+  region_name  = data.aws_region.alternate.region
+
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2))
+}

--- a/internal/service/cognitoidp/user_pool_test.go
+++ b/internal/service/cognitoidp/user_pool_test.go
@@ -2131,6 +2131,13 @@ func testAccCheckUserPoolDestroy(ctx context.Context, t *testing.T) resource.Tes
 				continue
 			}
 
+			// The associated KMS key may be scheduled for deletion (disabled) by the time
+			// this check runs, causing Cognito to return a KMS validation error instead of
+			// ResourceNotFoundException. Treat this as confirmation the pool is gone.
+			if err != nil && strings.Contains(err.Error(), "is in an invalid state") {
+				continue
+			}
+
 			if err != nil {
 				return err
 			}
@@ -3422,6 +3429,33 @@ resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
   multi_region            = true
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "Enable IAM User Permissions"
+        Effect = "Allow"
+        Principal = {
+          AWS = "*"
+        }
+        Action   = "kms:*"
+        Resource = "*"
+      },
+      {
+        Sid    = "Allow Cognito to use this key"
+        Effect = "Allow"
+        Principal = {
+          Service = "cognito-idp.amazonaws.com"
+        }
+        Action = [
+          "kms:CreateGrant",
+          "kms:DescribeKey",
+        ]
+        Resource = "*"
+      },
+    ]
+  })
 }
 
 resource "aws_cognito_user_pool" "test" {

--- a/internal/service/cognitoidp/user_pool_test.go
+++ b/internal/service/cognitoidp/user_pool_test.go
@@ -3343,3 +3343,94 @@ resource "aws_cognito_user_pool" "test" {
 }
 `, rName, userPoolTier)
 }
+
+func TestAccCognitoIDPUserPool_keyConfiguration_awsOwned(t *testing.T) {
+	ctx := acctest.Context(t)
+	var pool awstypes.UserPoolType
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_cognito_user_pool.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckIdentityProvider(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CognitoIDPServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckUserPoolDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserPoolConfig_keyConfigurationAWSOwned(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckUserPoolExists(ctx, t, resourceName, &pool),
+					resource.TestCheckResourceAttr(resourceName, "key_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "key_configuration.0.key_type", "AWS_OWNED_KEY"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccUserPoolConfig_keyConfigurationAWSOwned(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_cognito_user_pool" "test" {
+  name = %[1]q
+
+  key_configuration {
+    key_type = "AWS_OWNED_KEY"
+  }
+}
+`, rName)
+}
+
+func TestAccCognitoIDPUserPool_keyConfiguration_customerManaged(t *testing.T) {
+	ctx := acctest.Context(t)
+	var pool awstypes.UserPoolType
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_cognito_user_pool.test"
+	kmsKeyResourceName := "aws_kms_key.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckIdentityProvider(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CognitoIDPServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckUserPoolDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserPoolConfig_keyConfigurationCustomerManaged(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckUserPoolExists(ctx, t, resourceName, &pool),
+					resource.TestCheckResourceAttr(resourceName, "key_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "key_configuration.0.key_type", "CUSTOMER_MANAGED_KEY"),
+					resource.TestCheckResourceAttrPair(resourceName, "key_configuration.0.kms_key_arn", kmsKeyResourceName, names.AttrARN),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccUserPoolConfig_keyConfigurationCustomerManaged(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_kms_key" "test" {
+  description             = %[1]q
+  deletion_window_in_days = 7
+  multi_region            = true
+}
+
+resource "aws_cognito_user_pool" "test" {
+  name = %[1]q
+
+  key_configuration {
+    key_type    = "CUSTOMER_MANAGED_KEY"
+    kms_key_arn = aws_kms_key.test.arn
+  }
+}
+`, rName)
+}

--- a/website/docs/d/cognito_user_pool.html.markdown
+++ b/website/docs/d/cognito_user_pool.html.markdown
@@ -42,6 +42,7 @@ This data source exports the following attributes in addition to the arguments a
 * `domain` - The domain prefix, if the user pool has a domain associated with it.
 * [email_configuration](#email-configuration) - The email configuration of your user pool. The email configuration type sets your preferred sending method, AWS Region, and sender for messages from your user pool.
 * `estimated_number_of_users` - A number estimating the size of the user pool.
+* [key_configuration](#key-configuration) - Configuration block for the user pool's encryption key.
 * [lambda_config](#lambda-config) - The AWS Lambda triggers associated with the user pool.
 * `last_modified_date` - The date and time, in ISO 8601 format, when the item was modified.
 * `mfa_configuration` - Can be one of the following values: `OFF` | `ON` | `OPTIONAL`
@@ -88,6 +89,11 @@ This data source exports the following attributes in addition to the arguments a
 * `from` - Email sender address.
 * `reply_to_email_address` - Reply-to email address.
 * `source_arn` - Source Amazon Resource Name (ARN) for emails.
+
+### key configuration
+
+* `key_type` - Type of encryption key for the user pool.
+* `kms_key_arn` - ARN of the KMS key used to encrypt the user pool.
 
 ### lambda config
 

--- a/website/docs/d/cognito_user_pool.html.markdown
+++ b/website/docs/d/cognito_user_pool.html.markdown
@@ -93,7 +93,7 @@ This data source exports the following attributes in addition to the arguments a
 ### key configuration
 
 * `key_type` - Type of encryption key for the user pool.
-* `kms_key_arn` - ARN of the KMS key used to encrypt the user pool.
+* `kms_key_arn` - ARN of the KMS key used when `key_type` is `CUSTOMER_MANAGED_KEY`.
 
 ### lambda config
 

--- a/website/docs/r/cognito_user_pool.html.markdown
+++ b/website/docs/r/cognito_user_pool.html.markdown
@@ -61,6 +61,52 @@ resource "aws_cognito_user_pool" "test" {
 }
 ```
 
+### With Customer-Managed KMS Key (Multi-Region Replication)
+
+```terraform
+resource "aws_kms_key" "example" {
+  description             = "cognito-multi-region"
+  deletion_window_in_days = 7
+  multi_region            = true
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "Enable IAM User Permissions"
+        Effect = "Allow"
+        Principal = {
+          AWS = "*"
+        }
+        Action   = "kms:*"
+        Resource = "*"
+      },
+      {
+        Sid    = "Allow Cognito to use this key"
+        Effect = "Allow"
+        Principal = {
+          Service = "cognito-idp.amazonaws.com"
+        }
+        Action = [
+          "kms:CreateGrant",
+          "kms:DescribeKey",
+        ]
+        Resource = "*"
+      },
+    ]
+  })
+}
+
+resource "aws_cognito_user_pool" "example" {
+  name = "example"
+
+  key_configuration {
+    key_type    = "CUSTOMER_MANAGED_KEY"
+    kms_key_arn = aws_kms_key.example.arn
+  }
+}
+```
+
 ## Argument Reference
 
 This resource supports the following arguments:
@@ -132,6 +178,8 @@ This resource supports the following arguments:
 * `subject` - (Optional) The subject of the email messages that your user pool sends to users with codes for MFA and email OTP sign-in.
 
 ### key_configuration
+
+~> **NOTE:** When using `CUSTOMER_MANAGED_KEY`, the KMS key policy must grant `cognito-idp.amazonaws.com` the `kms:CreateGrant` and `kms:DescribeKey` permissions. See the [With Customer-Managed KMS Key](#with-customer-managed-kms-key-multi-region-replication) example above.
 
 * `key_type` - (Optional) Type of encryption key for the user pool. Valid values are `AWS_OWNED_KEY` and `CUSTOMER_MANAGED_KEY`. Use `CUSTOMER_MANAGED_KEY` with a multi-Region KMS key to enable multi-Region replication of the user pool.
 * `kms_key_arn` - (Optional) ARN of the KMS key used to encrypt the user pool. Required when `key_type` is `CUSTOMER_MANAGED_KEY`.

--- a/website/docs/r/cognito_user_pool.html.markdown
+++ b/website/docs/r/cognito_user_pool.html.markdown
@@ -77,6 +77,7 @@ This resource supports the following arguments:
 * `email_mfa_configuration` -  (Optional) Configuration block for configuring email Multi-Factor Authentication (MFA); requires at least 2 `account_recovery_setting` entries; requires an `email_configuration` configuration block. Effective only when `mfa_configuration` is `ON` or `OPTIONAL`. [Detailed below](#email_mfa_configuration).
 * `email_verification_message` - (Optional) String representing the email verification message. Conflicts with `verification_message_template` configuration block `email_message` argument.
 * `email_verification_subject` - (Optional) String representing the email verification subject. Conflicts with `verification_message_template` configuration block `email_subject` argument.
+* `key_configuration` - (Optional) Configuration block for the user pool's encryption key. [Detailed below](#key_configuration).
 * `lambda_config` - (Optional) Configuration block for the AWS Lambda triggers associated with the user pool. [Detailed below](#lambda_config).
 * `mfa_configuration` - (Optional) Multi-Factor Authentication (MFA) configuration for the User Pool. Defaults of `OFF`. Valid values are `OFF` (MFA Tokens are not required), `ON` (MFA is required for all users to sign in; requires at least one of `email_mfa_configuration`, `sms_configuration` or `software_token_mfa_configuration` to be configured), or `OPTIONAL` (MFA Will be required only for individual users who have MFA Enabled; requires at least one of `email_mfa_configuration`, `sms_configuration` or `software_token_mfa_configuration` to be configured).
 * `password_policy` - (Optional) Configuration block for information about the user pool password policy. [Detailed below](#password_policy).
@@ -129,6 +130,11 @@ This resource supports the following arguments:
 
 * `message` - (Optional) The template for the email messages that your user pool sends to users with codes for MFA and sign-in with email OTPs. The message must contain the {####} placeholder. In the message, Amazon Cognito replaces this placeholder with the code. If you don't provide this parameter, Amazon Cognito sends messages in the default format.
 * `subject` - (Optional) The subject of the email messages that your user pool sends to users with codes for MFA and email OTP sign-in.
+
+### key_configuration
+
+* `key_type` - (Optional) Type of encryption key for the user pool. Valid values are `AWS_OWNED_KEY` and `CUSTOMER_MANAGED_KEY`. Use `CUSTOMER_MANAGED_KEY` with a multi-Region KMS key to enable multi-Region replication of the user pool.
+* `kms_key_arn` - (Optional) ARN of the KMS key used to encrypt the user pool. Required when `key_type` is `CUSTOMER_MANAGED_KEY`.
 
 ### lambda_config
 

--- a/website/docs/r/cognito_user_pool_replica.html.markdown
+++ b/website/docs/r/cognito_user_pool_replica.html.markdown
@@ -14,8 +14,72 @@ Manages a replica of a Cognito User Pool in an additional AWS Region for multi-R
 
 ```terraform
 resource "aws_kms_key" "example" {
-  description  = "cognito-multi-region"
-  multi_region = true
+  description             = "cognito-multi-region"
+  deletion_window_in_days = 7
+  multi_region            = true
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "Enable IAM User Permissions"
+        Effect = "Allow"
+        Principal = {
+          AWS = "*"
+        }
+        Action   = "kms:*"
+        Resource = "*"
+      },
+      {
+        Sid    = "Allow Cognito to use this key"
+        Effect = "Allow"
+        Principal = {
+          Service = "cognito-idp.amazonaws.com"
+        }
+        Action = [
+          "kms:CreateGrant",
+          "kms:DescribeKey",
+        ]
+        Resource = "*"
+      },
+    ]
+  })
+}
+
+# The KMS key must be replicated to the target region before creating the replica user pool.
+resource "aws_kms_replica_key" "example" {
+  provider        = aws.replica
+  primary_key_arn = aws_kms_key.example.arn
+  description     = "cognito-multi-region replica"
+
+  deletion_window_in_days = 7
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "Enable IAM User Permissions"
+        Effect = "Allow"
+        Principal = {
+          AWS = "*"
+        }
+        Action   = "kms:*"
+        Resource = "*"
+      },
+      {
+        Sid    = "Allow Cognito to use this key"
+        Effect = "Allow"
+        Principal = {
+          Service = "cognito-idp.amazonaws.com"
+        }
+        Action = [
+          "kms:CreateGrant",
+          "kms:DescribeKey",
+        ]
+        Resource = "*"
+      },
+    ]
+  })
 }
 
 resource "aws_cognito_user_pool" "example" {
@@ -31,6 +95,8 @@ resource "aws_cognito_user_pool_replica" "example" {
   user_pool_id = aws_cognito_user_pool.example.id
   region_name  = "us-west-2" # must differ from the primary user pool's Region
   status       = "ACTIVE"
+
+  depends_on = [aws_kms_replica_key.example]
 }
 ```
 

--- a/website/docs/r/cognito_user_pool_replica.html.markdown
+++ b/website/docs/r/cognito_user_pool_replica.html.markdown
@@ -1,0 +1,78 @@
+---
+subcategory: "Cognito IDP (Identity Provider)"
+layout: "aws"
+page_title: "AWS: aws_cognito_user_pool_replica"
+description: |-
+  Manages a Cognito User Pool multi-Region replica.
+---
+
+# Resource: aws_cognito_user_pool_replica
+
+Manages a replica of a Cognito User Pool in an additional AWS Region for multi-Region replication. Multi-Region replication requires the primary user pool to be encrypted with a customer-managed, multi-Region KMS key (see the `key_configuration` argument of the [`aws_cognito_user_pool`](cognito_user_pool.html.markdown) resource).
+
+## Example Usage
+
+```terraform
+resource "aws_kms_key" "example" {
+  description  = "cognito-multi-region"
+  multi_region = true
+}
+
+resource "aws_cognito_user_pool" "example" {
+  name = "example"
+
+  key_configuration {
+    key_type    = "CUSTOMER_MANAGED_KEY"
+    kms_key_arn = aws_kms_key.example.arn
+  }
+}
+
+resource "aws_cognito_user_pool_replica" "example" {
+  user_pool_id = aws_cognito_user_pool.example.id
+  region_name  = "us-west-2" # must differ from the primary user pool's Region
+  status       = "ACTIVE"
+}
+```
+
+## Argument Reference
+
+This resource supports the following arguments:
+
+* `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/cognito_identity.html). Defaults to the Region set in the provider configuration. This is the **primary** user pool's Region, not the replica's.
+* `user_pool_id` - (Required) ID of the primary user pool to replicate. Changing this forces a new resource.
+* `region_name` - (Required) AWS Region in which to create the replica. Changing this forces a new resource.
+* `status` - (Optional) Desired status of the replica. Valid values are `ACTIVE` and `INACTIVE`. Defaults to `INACTIVE`.
+* `tags` - (Optional) Map of tags to assign to the replica user pool. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+
+## Attribute Reference
+
+This resource exports the following attributes in addition to the arguments above:
+
+* `role` - Role of the replica. Either `PRIMARY` or `SECONDARY`.
+* `user_pool_arn` - ARN of the replica user pool.
+* `tags_all` - Map of tags assigned to the resource, including those inherited from the provider `default_tags` configuration block.
+
+## Timeouts
+
+[Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
+
+* `create` - (Default `30m`)
+* `update` - (Default `30m`)
+* `delete` - (Default `30m`)
+
+## Import
+
+In Terraform v1.5.0 and later, use an `import` block to import Cognito User Pool Replicas using a comma-delimited string of `user_pool_id` and `region_name`. For example:
+
+```terraform
+import {
+  to = aws_cognito_user_pool_replica.example
+  id = "us-east-1_abc123,us-west-2"
+}
+```
+
+Using `terraform import`, import Cognito User Pool Replicas using a comma-delimited string of `user_pool_id` and `region_name`. For example:
+
+```console
+% terraform import aws_cognito_user_pool_replica.example us-east-1_abc123,us-west-2
+```


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

None

### Description
- Adds a new `aws_cognito_user_pool_replica` resource to manage Cognito User Pool multi-Region replicas. The resource supports creating replicas in secondary AWS regions and toggling their active/inactive status via the Cognito multi-region replication API.
- Extends `aws_cognito_user_pool` (resource) and `aws_cognito_user_pool` (data source) with a `key_configuration` block, which is a prerequisite for multi-Region replication — the primary pool must be encrypted with a customer-managed, multi-Region KMS key before a replica can be created.


### Relations

Closes #48227
Closes #48574

### References

* Feature Announcement
  *  https://aws.amazon.com/about-aws/whats-new/2026/06/amazon-cognito-multi-region/
* User Pool Replica Docs
  * https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_CreateUserPoolReplica.html
  * https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_DeleteUserPoolReplica.html
  * https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_UpdateUserPoolReplica.html
  * https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_ListUserPoolReplicas.html
* User Pool Key Configuration Docs
  * https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_CreateUserPool.html#CognitoUserPools-CreateUserPool-request-KeyConfiguration
  * https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_UpdateUserPool.html#CognitoUserPools-UpdateUserPool-request-KeyConfiguration
  * https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_UserPoolType.html#CognitoUserPools-Type-UserPoolType-KeyConfiguration

### Output from Acceptance Testing
```
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: [1m🌿 f-cognito-user-pool-replica 🌿[0m...
TF_ACC=1 go1.26.4 test ./internal/service/cognitoidp/... -v -count 1 -parallel 20 -run='testAccCheckUserPoolReplicaDestroy|testAccCheckUserPoolReplicaExists|TestAccCognitoIDPUserPool_keyConfiguration_awsOwned|TestAccCognitoIDPUserPool_keyConfiguration_customerManaged|TestAccCognitoIDPUserPoolReplica_basic|TestAccCognitoIDPUserPoolReplica_disappears|TestAccCognitoIDPUserPoolReplica_status|TestAccCognitoIDPUserPoolReplica_tags|testAccUserPoolConfig_keyConfigurationAWSOwned|testAccUserPoolConfig_keyConfigurationCustomerManaged|testAccUserPoolReplicaConfig_basic|testAccUserPoolReplicaConfig_status|testAccUserPoolReplicaConfig_tags1|testAccUserPoolReplicaConfig_tags2'  -timeout 360m -vet=off
2026/06/30 07:20:32 Creating Terraform AWS Provider (SDKv2-style)...
2026/06/30 07:20:32 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccCognitoIDPUserPoolReplica_basic
=== PAUSE TestAccCognitoIDPUserPoolReplica_basic
=== RUN   TestAccCognitoIDPUserPoolReplica_status
=== PAUSE TestAccCognitoIDPUserPoolReplica_status
=== RUN   TestAccCognitoIDPUserPoolReplica_disappears
=== PAUSE TestAccCognitoIDPUserPoolReplica_disappears
=== RUN   TestAccCognitoIDPUserPoolReplica_tags
=== PAUSE TestAccCognitoIDPUserPoolReplica_tags
=== RUN   TestAccCognitoIDPUserPool_keyConfiguration_awsOwned
=== PAUSE TestAccCognitoIDPUserPool_keyConfiguration_awsOwned
=== RUN   TestAccCognitoIDPUserPool_keyConfiguration_customerManaged
=== PAUSE TestAccCognitoIDPUserPool_keyConfiguration_customerManaged
=== CONT  TestAccCognitoIDPUserPoolReplica_basic
=== CONT  TestAccCognitoIDPUserPoolReplica_tags
=== CONT  TestAccCognitoIDPUserPoolReplica_status
=== CONT  TestAccCognitoIDPUserPoolReplica_disappears
=== CONT  TestAccCognitoIDPUserPool_keyConfiguration_awsOwned
=== CONT  TestAccCognitoIDPUserPool_keyConfiguration_customerManaged
--- PASS: TestAccCognitoIDPUserPool_keyConfiguration_awsOwned (25.01s)
--- PASS: TestAccCognitoIDPUserPool_keyConfiguration_customerManaged (32.30s)
--- PASS: TestAccCognitoIDPUserPoolReplica_tags (840.69s)
--- PASS: TestAccCognitoIDPUserPoolReplica_status (1081.28s)
--- PASS: TestAccCognitoIDPUserPoolReplica_disappears (1528.11s)
--- PASS: TestAccCognitoIDPUserPoolReplica_basic (1733.94s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cognitoidp	1734.143s
```