### PR TITLE
resource/aws_emrserverless_application: Add application_level_digest_resolution to image_configuration 🤖🤖🤖

### DIFF
--- a/.changelog/48673.txt
+++ b/.changelog/48673.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_emrserverless_application: Add `image_configuration.application_level_digest_resolution` argument
+```

--- a/internal/service/emrserverless/application.go
+++ b/internal/service/emrserverless/application.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
@@ -103,6 +104,11 @@ func resourceApplication() *schema.Resource {
 					MaxItems: 1,
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{
+							"application_level_digest_resolution": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Computed: true,
+							},
 							"image_uri": {
 								Type:     schema.TypeString,
 								Required: true,
@@ -448,6 +454,7 @@ func resourceApplicationCreate(ctx context.Context, d *schema.ResourceData, meta
 
 	if v, ok := d.GetOk("image_configuration"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
 		input.ImageConfiguration = expandImageConfiguration(v.([]any)[0].(map[string]any))
+		input.ImageConfiguration.ApplicationLevelDigestResolution = imageConfigDigestResolutionFromRawConfig(d)
 	}
 
 	if v, ok := d.GetOk("initial_capacity"); ok && v.(*schema.Set).Len() > 0 {
@@ -592,6 +599,7 @@ func resourceApplicationUpdate(ctx context.Context, d *schema.ResourceData, meta
 
 		if v, ok := d.GetOk("image_configuration"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
 			input.ImageConfiguration = expandImageConfiguration(v.([]any)[0].(map[string]any))
+			input.ImageConfiguration.ApplicationLevelDigestResolution = imageConfigDigestResolutionFromRawConfig(d)
 		}
 
 		if v, ok := d.GetOk("initial_capacity"); ok && v.(*schema.Set).Len() > 0 {
@@ -978,6 +986,28 @@ func flattenNetworkConfiguration(apiObject *types.NetworkConfiguration) map[stri
 	return tfMap
 }
 
+// imageConfigDigestResolutionFromRawConfig returns the user-configured value of
+// application_level_digest_resolution, or nil if the user omitted the field.
+// TypeBool zero-value (false) is indistinguishable from "unset" in d.Get(), so
+// we consult the raw HCL config to determine whether the user explicitly wrote
+// the attribute. Passing nil to the API causes it to use its version-specific
+// default (true for EMR ≤7.13, false for EMR ≥7.14).
+func imageConfigDigestResolutionFromRawConfig(d *schema.ResourceData) *bool {
+	rawImgCfg := d.GetRawConfig().GetAttr("image_configuration")
+	if !rawImgCfg.IsKnown() || rawImgCfg.IsNull() || rawImgCfg.LengthInt() == 0 {
+		return nil
+	}
+	firstItem := rawImgCfg.Index(cty.NumberIntVal(0))
+	if !firstItem.IsKnown() || firstItem.IsNull() {
+		return nil
+	}
+	v := firstItem.GetAttr("application_level_digest_resolution")
+	if v.IsNull() || !v.IsKnown() {
+		return nil
+	}
+	return aws.Bool(v.True())
+}
+
 func expandImageConfiguration(tfMap map[string]any) *types.ImageConfigurationInput {
 	if tfMap == nil {
 		return nil
@@ -997,15 +1027,15 @@ func flattenImageConfiguration(apiObject *types.ImageConfiguration) []any {
 		return nil
 	}
 
-	var tfList []any
-
-	if v := apiObject.ImageUri; v != nil {
-		tfList = append(tfList, map[string]any{
-			"image_uri": aws.ToString(v),
-		})
+	tfMap := map[string]any{
+		"image_uri": aws.ToString(apiObject.ImageUri),
 	}
 
-	return tfList
+	if v := apiObject.ApplicationLevelDigestResolution; v != nil {
+		tfMap["application_level_digest_resolution"] = aws.ToBool(v)
+	}
+
+	return []any{tfMap}
 }
 
 func expandInitialCapacity(tfMap *schema.Set) map[string]types.InitialCapacityConfig {

--- a/internal/service/emrserverless/application_test.go
+++ b/internal/service/emrserverless/application_test.go
@@ -264,6 +264,46 @@ func TestAccEMRServerlessApplication_imageConfiguration(t *testing.T) {
 	})
 }
 
+func TestAccEMRServerlessApplication_imageConfigurationApplicationLevelDigestResolution(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+	var application types.Application
+	resourceName := "aws_emrserverless_application.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EMRServerlessServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckApplicationDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApplicationConfig_imageConfigurationDigestResolution(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApplicationExists(ctx, t, resourceName, &application),
+					resource.TestCheckResourceAttr(resourceName, "image_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "image_configuration.0.application_level_digest_resolution", acctest.CtFalse),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccApplicationConfig_imageConfigurationDigestResolution(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApplicationExists(ctx, t, resourceName, &application),
+					resource.TestCheckResourceAttr(resourceName, "image_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "image_configuration.0.application_level_digest_resolution", acctest.CtTrue),
+				),
+			},
+		},
+	})
+}
+
 func TestAccEMRServerlessApplication_interactiveConfiguration(t *testing.T) {
 	ctx := acctest.Context(t)
 	var application types.Application
@@ -853,6 +893,158 @@ resource "aws_emrserverless_application" "test" {
   architecture  = %[2]q
 }
 `, rName, arch)
+}
+
+func testAccApplicationConfig_imageConfigurationDigestResolution(rName string, digestResolution bool) string {
+	return fmt.Sprintf(`
+data "aws_region" "current" {}
+
+data "aws_partition" "current" {}
+
+resource "aws_ecr_repository" "test" {
+  name         = %[1]q
+  force_delete = true
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_default_route_table" "test" {
+  default_route_table_id = aws_vpc.test.default_route_table_id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.test.id
+  }
+}
+
+resource "aws_internet_gateway" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_subnet" "test" {
+  cidr_block              = cidrsubnet(aws_vpc.test.cidr_block, 8, 0)
+  map_public_ip_on_launch = true
+  vpc_id                  = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_default_security_group" "test" {
+  vpc_id = aws_vpc.test.id
+
+  egress {
+    cidr_blocks = ["0.0.0.0/0"]
+    from_port   = 0
+    protocol    = "-1"
+    to_port     = 0
+  }
+
+  ingress {
+    from_port = 0
+    protocol  = -1
+    self      = true
+    to_port   = 0
+  }
+}
+
+resource "aws_iam_role" "test" {
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "ec2.${data.aws_partition.current.dns_suffix}"
+      }
+      Sid = ""
+    }]
+  })
+  name = %[1]q
+}
+
+resource "aws_iam_role_policy_attachment" "AmazonSSMManagedInstanceCore" {
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonSSMManagedInstanceCore"
+  role       = aws_iam_role.test.name
+}
+
+resource "aws_iam_role_policy_attachment" "EC2InstanceProfileForImageBuilder" {
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/EC2InstanceProfileForImageBuilder"
+  role       = aws_iam_role.test.name
+}
+
+resource "aws_iam_role_policy_attachment" "EC2InstanceProfileForImageBuilderECRContainerBuilds" {
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/EC2InstanceProfileForImageBuilderECRContainerBuilds"
+  role       = aws_iam_role.test.name
+}
+
+resource "aws_iam_instance_profile" "test" {
+  name = aws_iam_role.test.name
+  role = aws_iam_role.test.name
+
+  depends_on = [
+    aws_iam_role_policy_attachment.AmazonSSMManagedInstanceCore,
+    aws_iam_role_policy_attachment.EC2InstanceProfileForImageBuilderECRContainerBuilds
+  ]
+}
+
+resource "aws_imagebuilder_container_recipe" "test" {
+  name              = %[1]q
+  container_type    = "DOCKER"
+  parent_image      = "public.ecr.aws/emr-serverless/hive/emr-6.9.0"
+  version           = "1.0.0"
+  platform_override = "Linux"
+
+  component {
+    component_arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:component/hello-world-linux/x.x.x"
+  }
+
+  dockerfile_template_data = <<EOF
+FROM {{{ imagebuilder:parentImage }}}
+EOF
+
+  target_repository {
+    repository_name = aws_ecr_repository.test.name
+    service         = "ECR"
+  }
+}
+
+resource "aws_imagebuilder_infrastructure_configuration" "test" {
+  instance_profile_name = aws_iam_instance_profile.test.name
+  name                  = %[1]q
+  security_group_ids    = [aws_default_security_group.test.id]
+  subnet_id             = aws_subnet.test.id
+
+  depends_on = [aws_default_route_table.test]
+}
+
+resource "aws_imagebuilder_image" "test" {
+  container_recipe_arn             = aws_imagebuilder_container_recipe.test.arn
+  infrastructure_configuration_arn = aws_imagebuilder_infrastructure_configuration.test.arn
+}
+
+resource "aws_emrserverless_application" "test" {
+  name          = %[1]q
+  release_label = "emr-6.9.0"
+  type          = "hive"
+
+  image_configuration {
+    image_uri                           = "${aws_ecr_repository.test.repository_url}:${replace(aws_imagebuilder_image.test.version, "/", "-")}"
+    application_level_digest_resolution = %[2]t
+  }
+}
+`, rName, digestResolution)
 }
 
 // At the time of writing, the AWS EMR Serverless API returns a 500 error if you try to create an EMR Serverless

--- a/website/docs/r/emrserverless_application.html.markdown
+++ b/website/docs/r/emrserverless_application.html.markdown
@@ -207,6 +207,7 @@ This resource supports the following arguments:
 
 #### image_configuration Arguments
 
+* `application_level_digest_resolution` - (Optional) Whether the custom image URI is resolved to a digest at application start time (`true`) or at workload submission time (`false`). When `true`, all workloads use the same image digest until the application restarts. Defaults to `true` for EMR releases 7.13 and earlier; defaults to `false` for EMR releases 7.14 and later.
 * `image_uri` - (Required) The image URI.
 
 #### initial_capacity_config Arguments


### PR DESCRIPTION
## Description

Adds support for `application_level_digest_resolution` within the `image_configuration` block of the `aws_emrserverless_application` resource.

### Why

The EMR Serverless API added `ApplicationLevelDigestResolution` to `ImageConfigurationInput` and `ImageConfiguration` in SDK v1.42.2. Without this field exposed in Terraform, users on EMR ≤7.13 cannot opt into live image updates — every `terraform apply` that updates `image_uri` silently resets the flag to `true` (the 7.13 default), re-pinning the digest at application start time.

### Behavior

| `application_level_digest_resolution` | Effect |
|--|--|
| `true` (default for EMR ≤7.13) | Image URI resolved to digest at application start; all workloads use that digest until the app restarts |
| `false` (default for EMR ≥7.14) | Image URI resolved at workload submission time; new workloads pick up a new image without restarting the app |

## Changes

- `internal/service/emrserverless/application.go`: Added `application_level_digest_resolution` (`TypeBool`, Optional, Computed) to the `image_configuration` schema; updated `expandImageConfiguration` and `flattenImageConfiguration`. Uses `GetRawConfig()`/`cty` to distinguish "user set false" from "omitted", so the API applies its own version-specific default when the field is absent.
- `internal/service/emrserverless/application_test.go`: Added `TestAccEMRServerlessApplication_imageConfigurationApplicationLevelDigestResolution` (false → true + ImportState)
- `website/docs/r/emrserverless_application.html.markdown`: Documented the new argument under `image_configuration Arguments`
- `.changelog/48673.txt`: Changelog entry

## Testing

Added `TestAccEMRServerlessApplication_imageConfigurationApplicationLevelDigestResolution` covering create with `false`, ImportState, and update to `true`. The test follows the same ImageBuilder/ECR infrastructure pattern as the existing `TestAccEMRServerlessApplication_imageConfiguration`. Acceptance tests have not been run locally as they require live AWS resources, per the contribution guide.

## References

- [AWS docs: Updating custom image configurations](https://docs.aws.amazon.com/emr/latest/EMR-Serverless-UserGuide/updating-running-applications.html)
- SDK change: `aws-sdk-go-v2/service/emrserverless` v1.42.2

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)