### PR TITLE
.github: group `actions/cache/*` dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,11 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      actions-cache:
+        patterns:
+          - "actions/cache"
+          - "actions/cache/*"
     ignore:
       - dependency-name: "github/gh-aw-actions/*" # Managed by "gh aw compile".
   - package-ecosystem: "gomod"


### PR DESCRIPTION

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This will allow updates to `actions/cache`, `actions/cache/save`, and `actions/cache/restore` to be grouped together in a single PR.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->
Relates https://github.com/hashicorp/terraform-provider-aws/pull/48664
Relates https://github.com/hashicorp/terraform-provider-aws/pull/48663
Relates https://github.com/hashicorp/terraform-provider-aws/pull/48666