### PR TITLE
odb: remove exception for `sdkretry` use

### DIFF
--- a/.ci/semgrep/acctest/vcr/random.yml
+++ b/.ci/semgrep/acctest/vcr/random.yml
@@ -15,7 +15,6 @@ rules:
         - "**/*_test.go"
       exclude:
         - "/internal/provider/sdkv2"
-        - "/internal/service/odb"
 
   - id: use-acctest-randint
     languages: [go]
@@ -30,7 +29,6 @@ rules:
         - "**/*_test.go"
       exclude:
         - "/internal/provider/sdkv2"
-        - "/internal/service/odb"
 
   - id: use-acctest-randintrange
     languages: [go]
@@ -45,7 +43,6 @@ rules:
         - "**/*_test.go"
       exclude:
         - "/internal/provider/sdkv2"
-        - "/internal/service/odb"
 
   - id: use-acctest-randstring
     languages: [go]
@@ -60,7 +57,6 @@ rules:
         - "**/*_test.go"
       exclude:
         - "/internal/provider/sdkv2"
-        - "/internal/service/odb"
 
   - id: use-acctest-randstringfromcharset
     languages: [go]
@@ -75,7 +71,6 @@ rules:
         - "**/*_test.go"
       exclude:
         - "/internal/provider/sdkv2"
-        - "/internal/service/odb"
 
   - id: use-acctest-charsetalpha
     languages: [go]
@@ -90,7 +85,6 @@ rules:
         - "**/*_test.go"
       exclude:
         - "/internal/provider/sdkv2"
-        - "/internal/service/odb"
 
   - id: use-acctest-charsetalphanum
     languages: [go]
@@ -105,4 +99,3 @@ rules:
         - "**/*_test.go"
       exclude:
         - "/internal/provider/sdkv2"
-        - "/internal/service/odb"

--- a/.ci/semgrep/acctest/vcr/test.yml
+++ b/.ci/semgrep/acctest/vcr/test.yml
@@ -15,7 +15,6 @@ rules:
         - "**/*_test.go"
       exclude:
         - "/internal/provider/sdkv2"
-        - "/internal/service/odb"
 
   - id: use-acctest-paralleltest
     languages: [go]
@@ -30,7 +29,6 @@ rules:
         - "**/*_test.go"
       exclude:
         - "/internal/provider/sdkv2"
-        - "/internal/service/odb"
 
   - id: use-acctest-providermeta
     languages: [go]
@@ -45,4 +43,3 @@ rules:
         - "**/*_test.go"
       exclude:
         - "/internal/provider/sdkv2"
-        - "/internal/service/odb"

--- a/.ci/semgrep/acctest/vcr/uniqueid.yml
+++ b/.ci/semgrep/acctest/vcr/uniqueid.yml
@@ -19,4 +19,3 @@ rules:
         - "**/*.go"
       exclude:
         - "/internal/provider/sdkv2"
-        - "/internal/service/odb"

--- a/.ci/semgrep/pluginsdk/retry.yml
+++ b/.ci/semgrep/pluginsdk/retry.yml
@@ -37,8 +37,6 @@ rules:
         # packages wrap SDK error types for compatibility
         - "internal/retry"
         - "internal/tfresource"
-        # out of scope for go-vcr support
-        - "internal/service/odb"
 
   - id: internal-retry-staterefreshfunc-pass-context
     languages: [go]
@@ -60,7 +58,6 @@ rules:
       exclude:
         - "internal/retry"
         - "internal/tfresource"
-        - "internal/service/odb"
 
   - id: internal-retry-staterefreshfunc-remove-parent-context
     languages: [go]
@@ -80,7 +77,6 @@ rules:
       exclude:
         - "internal/retry"
         - "internal/tfresource"
-        - "internal/service/odb"
 
   - id: internal-retry-statechangeconf-refresh-remove-context
     languages: [go]
@@ -98,7 +94,6 @@ rules:
       exclude:
         - "internal/retry"
         - "internal/tfresource"
-        - "internal/service/odb"
 
   - id: internal-retry-notfounderror-drop-lastrequest
     languages: [go]
@@ -119,4 +114,3 @@ rules:
       exclude:
         - "internal/retry"
         - "internal/tfresource"
-        - "internal/service/odb"

--- a/internal/service/odb/cloud_autonomous_vm_cluster.go
+++ b/internal/service/odb/cloud_autonomous_vm_cluster.go
@@ -30,7 +30,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
@@ -681,10 +680,10 @@ func (r *resourceCloudAutonomousVmCluster) Delete(ctx context.Context, req resou
 }
 
 func waitCloudAutonomousVmClusterCreated(ctx context.Context, conn *odb.Client, id string, timeout time.Duration) (*odbtypes.CloudAutonomousVmCluster, error) {
-	stateConf := &sdkretry.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending: enum.Slice(odbtypes.ResourceStatusProvisioning),
 		Target:  enum.Slice(odbtypes.ResourceStatusAvailable, odbtypes.ResourceStatusFailed),
-		Refresh: statusCloudAutonomousVmCluster(ctx, conn, id),
+		Refresh: statusCloudAutonomousVmCluster(conn, id),
 		Timeout: timeout,
 	}
 
@@ -697,10 +696,10 @@ func waitCloudAutonomousVmClusterCreated(ctx context.Context, conn *odb.Client, 
 }
 
 func waitCloudAutonomousVmClusterDeleted(ctx context.Context, conn *odb.Client, id string, timeout time.Duration) (*odbtypes.CloudAutonomousVmCluster, error) {
-	stateConf := &sdkretry.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending: enum.Slice(odbtypes.ResourceStatusTerminating),
 		Target:  []string{},
-		Refresh: statusCloudAutonomousVmCluster(ctx, conn, id),
+		Refresh: statusCloudAutonomousVmCluster(conn, id),
 		Timeout: timeout,
 	}
 
@@ -712,8 +711,8 @@ func waitCloudAutonomousVmClusterDeleted(ctx context.Context, conn *odb.Client, 
 	return nil, err
 }
 
-func statusCloudAutonomousVmCluster(ctx context.Context, conn *odb.Client, id string) sdkretry.StateRefreshFunc {
-	return func() (any, string, error) {
+func statusCloudAutonomousVmCluster(conn *odb.Client, id string) retry.StateRefreshFunc {
+	return func(ctx context.Context) (any, string, error) {
 		out, err := findCloudAutonomousVmClusterByID(ctx, conn, id)
 		if retry.NotFound(err) {
 			return nil, "", nil
@@ -734,9 +733,8 @@ func findCloudAutonomousVmClusterByID(ctx context.Context, conn *odb.Client, id 
 	out, err := conn.GetCloudAutonomousVmCluster(ctx, &input)
 	if err != nil {
 		if errs.IsA[*odbtypes.ResourceNotFoundException](err) {
-			return nil, &sdkretry.NotFoundError{
-				LastError:   err,
-				LastRequest: &input,
+			return nil, &retry.NotFoundError{
+				LastError: err,
 			}
 		}
 		return nil, err

--- a/internal/service/odb/cloud_autonomous_vm_cluster_data_source_test.go
+++ b/internal/service/odb/cloud_autonomous_vm_cluster_data_source_test.go
@@ -10,11 +10,9 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/odb"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfodb "github.com/hashicorp/terraform-provider-aws/internal/service/odb"
@@ -42,14 +40,14 @@ func TestAccODBCloudAutonomousVmClusterDataSource_basic(t *testing.T) {
 	avmcResource := "aws_odb_cloud_autonomous_vm_cluster.test"
 	avmcDataSource := "data.aws_odb_cloud_autonomous_vm_cluster.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			autonomousVMClusterDSTestEntity.testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ODBServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             autonomousVMClusterDSTestEntity.testAccCheckCloudAutonomousVmClusterDestroy(ctx),
+		CheckDestroy:             autonomousVMClusterDSTestEntity.testAccCheckCloudAutonomousVmClusterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: autonomousVMClusterDSTestEntity.avmcBasic(t),
@@ -61,9 +59,9 @@ func TestAccODBCloudAutonomousVmClusterDataSource_basic(t *testing.T) {
 	})
 }
 
-func (autonomousVMClusterDSTest) testAccCheckCloudAutonomousVmClusterDestroy(ctx context.Context) resource.TestCheckFunc {
+func (autonomousVMClusterDSTest) testAccCheckCloudAutonomousVmClusterDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ODBClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).ODBClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_odb_cloud_autonomous_vm_cluster" {
@@ -85,7 +83,7 @@ func (autonomousVMClusterDSTest) testAccCheckCloudAutonomousVmClusterDestroy(ctx
 	}
 }
 func (autonomousVMClusterDSTest) testAccPreCheck(ctx context.Context, t *testing.T) {
-	conn := acctest.Provider.Meta().(*conns.AWSClient).ODBClient(ctx)
+	conn := acctest.ProviderMeta(ctx, t).ODBClient(ctx)
 	input := odb.ListCloudAutonomousVmClustersInput{}
 	_, err := conn.ListCloudAutonomousVmClusters(ctx, &input)
 	if acctest.PreCheckSkipError(err) {
@@ -97,9 +95,9 @@ func (autonomousVMClusterDSTest) testAccPreCheck(ctx context.Context, t *testing
 }
 
 func (autonomousVMClusterDSTest) avmcBasic(t *testing.T) string {
-	exaInfraDisplayName := sdkacctest.RandomWithPrefix(autonomousVMClusterDSTestEntity.exaInfraDisplayNamePrefix)
-	odbNetworkDisplayName := sdkacctest.RandomWithPrefix(autonomousVMClusterDSTestEntity.odbNetDisplayNamePrefix)
-	avmcDisplayName := sdkacctest.RandomWithPrefix(autonomousVMClusterDSTestEntity.autonomousVmClusterDisplayNamePrefix)
+	exaInfraDisplayName := acctest.RandomWithPrefix(t, autonomousVMClusterDSTestEntity.exaInfraDisplayNamePrefix)
+	odbNetworkDisplayName := acctest.RandomWithPrefix(t, autonomousVMClusterDSTestEntity.odbNetDisplayNamePrefix)
+	avmcDisplayName := acctest.RandomWithPrefix(t, autonomousVMClusterDSTestEntity.autonomousVmClusterDisplayNamePrefix)
 	domain := acctest.RandomDomainName(t)
 	emailAddress := acctest.RandomEmailAddress(domain)
 	exaInfraRes := autonomousVMClusterDSTestEntity.exaInfra(exaInfraDisplayName, emailAddress)

--- a/internal/service/odb/cloud_autonomous_vm_cluster_test.go
+++ b/internal/service/odb/cloud_autonomous_vm_cluster_test.go
@@ -13,15 +13,12 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/odb"
 	odbtypes "github.com/aws/aws-sdk-go-v2/service/odb/types"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
@@ -52,19 +49,19 @@ func TestAccODBCloudAutonomousVmCluster_basic(t *testing.T) {
 
 	resourceName := "aws_odb_cloud_autonomous_vm_cluster.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			autonomousVMClusterResourceTestEntity.testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ODBServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             autonomousVMClusterResourceTestEntity.testAccCheckCloudAutonomousVmClusterDestroy(ctx),
+		CheckDestroy:             autonomousVMClusterResourceTestEntity.testAccCheckCloudAutonomousVmClusterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: autonomousVMClusterResourceTestEntity.avmcBasic(t),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					autonomousVMClusterResourceTestEntity.checkCloudAutonomousVmClusterExists(ctx, resourceName, &cloudAVMC),
+					autonomousVMClusterResourceTestEntity.checkCloudAutonomousVmClusterExists(ctx, t, resourceName, &cloudAVMC),
 				),
 			},
 			{
@@ -82,16 +79,16 @@ func TestAccODBCloudAutonomousVmCluster_variables(t *testing.T) {
 		t.Skip("skipping long-running test in short mode")
 	}
 
-	avmcDisplayName := sdkacctest.RandomWithPrefix(autonomousVMClusterResourceTestEntity.autonomousVmClusterDisplayNamePrefix)
+	avmcDisplayName := acctest.RandomWithPrefix(t, autonomousVMClusterResourceTestEntity.autonomousVmClusterDisplayNamePrefix)
 	resourceName := "oci_database_cloud_autonomous_vm_cluster.test"
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			autonomousVMClusterResourceTestEntity.testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ODBServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             autonomousVMClusterResourceTestEntity.testAccCheckCloudAutonomousVmClusterDestroy(ctx),
+		CheckDestroy:             autonomousVMClusterResourceTestEntity.testAccCheckCloudAutonomousVmClusterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: autonomousVmClusterConfig_useVariables(avmcDisplayName),
@@ -116,14 +113,14 @@ func TestAccODBCloudAutonomousVmCluster_usingARN(t *testing.T) {
 	resourceName := "aws_odb_cloud_autonomous_vm_cluster.test"
 
 	avmcWithoutTag, avmcWithTag := autonomousVMClusterResourceTestEntity.autonomousVmClusterByARN(t)
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			autonomousVMClusterResourceTestEntity.testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ODBServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             autonomousVMClusterResourceTestEntity.testAccCheckCloudAutonomousVmClusterDestroy(ctx),
+		CheckDestroy:             autonomousVMClusterResourceTestEntity.testAccCheckCloudAutonomousVmClusterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: avmcWithoutTag,
@@ -131,7 +128,7 @@ func TestAccODBCloudAutonomousVmCluster_usingARN(t *testing.T) {
 					resource.ComposeTestCheckFunc(func(state *terraform.State) error {
 						return nil
 					}),
-					autonomousVMClusterResourceTestEntity.checkCloudAutonomousVmClusterExists(ctx, resourceName, &avmc1),
+					autonomousVMClusterResourceTestEntity.checkCloudAutonomousVmClusterExists(ctx, t, resourceName, &avmc1),
 				),
 			},
 			{
@@ -142,7 +139,7 @@ func TestAccODBCloudAutonomousVmCluster_usingARN(t *testing.T) {
 			{
 				Config: avmcWithTag,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					autonomousVMClusterResourceTestEntity.checkCloudAutonomousVmClusterExists(ctx, resourceName, &avmc2),
+					autonomousVMClusterResourceTestEntity.checkCloudAutonomousVmClusterExists(ctx, t, resourceName, &avmc2),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.env", "dev"),
 					resource.ComposeTestCheckFunc(func(state *terraform.State) error {
@@ -167,7 +164,7 @@ func TestAccODBCloudAutonomousVmCluster_withAllParams(t *testing.T) {
 
 	resourceName := "aws_odb_cloud_autonomous_vm_cluster.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			//acctest.PreCheckPartitionHasService(t, names.ODBServiceID)
@@ -175,12 +172,12 @@ func TestAccODBCloudAutonomousVmCluster_withAllParams(t *testing.T) {
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ODBServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             autonomousVMClusterResourceTestEntity.testAccCheckCloudAutonomousVmClusterDestroy(ctx),
+		CheckDestroy:             autonomousVMClusterResourceTestEntity.testAccCheckCloudAutonomousVmClusterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: autonomousVMClusterResourceTestEntity.avmcAllParamsConfig(t),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					autonomousVMClusterResourceTestEntity.checkCloudAutonomousVmClusterExists(ctx, resourceName, &cloudAVMC),
+					autonomousVMClusterResourceTestEntity.checkCloudAutonomousVmClusterExists(ctx, t, resourceName, &cloudAVMC),
 				),
 			},
 			{
@@ -201,21 +198,21 @@ func TestAccODBCloudAutonomousVmCluster_tagging(t *testing.T) {
 	var avmc1, avmc2 odbtypes.CloudAutonomousVmCluster
 	resourceName := "aws_odb_cloud_autonomous_vm_cluster.test"
 	withoutTag, withTag := autonomousVMClusterResourceTestEntity.avmcNoTagWithTag(t)
-	resource.Test(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			autonomousVMClusterResourceTestEntity.testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ODBServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             autonomousVMClusterResourceTestEntity.testAccCheckCloudAutonomousVmClusterDestroy(ctx),
+		CheckDestroy:             autonomousVMClusterResourceTestEntity.testAccCheckCloudAutonomousVmClusterDestroy(ctx, t),
 
 		Steps: []resource.TestStep{
 			{
 				Config: withoutTag,
 
 				Check: resource.ComposeAggregateTestCheckFunc(
-					autonomousVMClusterResourceTestEntity.checkCloudAutonomousVmClusterExists(ctx, resourceName, &avmc1),
+					autonomousVMClusterResourceTestEntity.checkCloudAutonomousVmClusterExists(ctx, t, resourceName, &avmc1),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "0"),
 				),
 			},
@@ -227,7 +224,7 @@ func TestAccODBCloudAutonomousVmCluster_tagging(t *testing.T) {
 			{
 				Config: withTag,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					autonomousVMClusterResourceTestEntity.checkCloudAutonomousVmClusterExists(ctx, resourceName, &avmc2),
+					autonomousVMClusterResourceTestEntity.checkCloudAutonomousVmClusterExists(ctx, t, resourceName, &avmc2),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.env", "dev"),
 					resource.ComposeTestCheckFunc(func(state *terraform.State) error {
@@ -250,19 +247,19 @@ func TestAccODBCloudAutonomousVmCluster_disappears(t *testing.T) {
 	var cloudautonomousvmcluster odbtypes.CloudAutonomousVmCluster
 	resourceName := "aws_odb_cloud_autonomous_vm_cluster.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			autonomousVMClusterResourceTestEntity.testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ODBServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             autonomousVMClusterResourceTestEntity.testAccCheckCloudAutonomousVmClusterDestroy(ctx),
+		CheckDestroy:             autonomousVMClusterResourceTestEntity.testAccCheckCloudAutonomousVmClusterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: autonomousVMClusterResourceTestEntity.avmcBasic(t),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					autonomousVMClusterResourceTestEntity.checkCloudAutonomousVmClusterExists(ctx, resourceName, &cloudautonomousvmcluster),
+					autonomousVMClusterResourceTestEntity.checkCloudAutonomousVmClusterExists(ctx, t, resourceName, &cloudautonomousvmcluster),
 					acctest.CheckFrameworkResourceDisappears(ctx, t, tfodb.ResourceCloudAutonomousVMCluster, resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -280,7 +277,7 @@ func TestAccODBCloudAutonomousVmCluster_disappears(t *testing.T) {
 }
 
 func (autonomousVMClusterResourceTest) testAccPreCheck(ctx context.Context, t *testing.T) {
-	conn := acctest.Provider.Meta().(*conns.AWSClient).ODBClient(ctx)
+	conn := acctest.ProviderMeta(ctx, t).ODBClient(ctx)
 	input := odb.ListCloudAutonomousVmClustersInput{}
 	_, err := conn.ListCloudAutonomousVmClusters(ctx, &input)
 	if acctest.PreCheckSkipError(err) {
@@ -290,9 +287,9 @@ func (autonomousVMClusterResourceTest) testAccPreCheck(ctx context.Context, t *t
 		t.Fatalf("unexpected PreCheck error: %s", err)
 	}
 }
-func (autonomousVMClusterResourceTest) testAccCheckCloudAutonomousVmClusterDestroy(ctx context.Context) resource.TestCheckFunc {
+func (autonomousVMClusterResourceTest) testAccCheckCloudAutonomousVmClusterDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ODBClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).ODBClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_odb_cloud_autonomous_vm_cluster" {
@@ -314,7 +311,7 @@ func (autonomousVMClusterResourceTest) testAccCheckCloudAutonomousVmClusterDestr
 	}
 }
 
-func (autonomousVMClusterResourceTest) checkCloudAutonomousVmClusterExists(ctx context.Context, name string, cloudAutonomousVMCluster *odbtypes.CloudAutonomousVmCluster) resource.TestCheckFunc {
+func (autonomousVMClusterResourceTest) checkCloudAutonomousVmClusterExists(ctx context.Context, t *testing.T, name string, cloudAutonomousVMCluster *odbtypes.CloudAutonomousVmCluster) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {
@@ -325,7 +322,7 @@ func (autonomousVMClusterResourceTest) checkCloudAutonomousVmClusterExists(ctx c
 			return create.Error(names.ODB, create.ErrActionCheckingExistence, tfodb.ResNameCloudAutonomousVmCluster, name, errors.New("not set"))
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ODBClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).ODBClient(ctx)
 		resp, err := autonomousVMClusterResourceTestEntity.findAVMC(ctx, conn, rs.Primary.ID)
 		if err != nil {
 			return create.Error(names.ODB, create.ErrActionCheckingExistence, tfodb.ResNameCloudAutonomousVmCluster, rs.Primary.ID, err)
@@ -344,9 +341,8 @@ func (autonomousVMClusterResourceTest) findAVMC(ctx context.Context, conn *odb.C
 	out, err := conn.GetCloudAutonomousVmCluster(ctx, &input)
 	if err != nil {
 		if errs.IsA[*odbtypes.ResourceNotFoundException](err) {
-			return nil, &sdkretry.NotFoundError{
-				LastError:   err,
-				LastRequest: &input,
+			return nil, &retry.NotFoundError{
+				LastError: err,
 			}
 		}
 		return nil, err
@@ -360,9 +356,9 @@ func (autonomousVMClusterResourceTest) findAVMC(ctx context.Context, conn *odb.C
 }
 
 func (autonomousVMClusterResourceTest) avmcBasic(t *testing.T) string {
-	exaInfraDisplayName := sdkacctest.RandomWithPrefix(autonomousVMClusterDSTestEntity.exaInfraDisplayNamePrefix)
-	odbNetworkDisplayName := sdkacctest.RandomWithPrefix(autonomousVMClusterDSTestEntity.odbNetDisplayNamePrefix)
-	avmcDisplayName := sdkacctest.RandomWithPrefix(autonomousVMClusterDSTestEntity.autonomousVmClusterDisplayNamePrefix)
+	exaInfraDisplayName := acctest.RandomWithPrefix(t, autonomousVMClusterDSTestEntity.exaInfraDisplayNamePrefix)
+	odbNetworkDisplayName := acctest.RandomWithPrefix(t, autonomousVMClusterDSTestEntity.odbNetDisplayNamePrefix)
+	avmcDisplayName := acctest.RandomWithPrefix(t, autonomousVMClusterDSTestEntity.autonomousVmClusterDisplayNamePrefix)
 	domain := acctest.RandomDomainName(t)
 	emailAddress := acctest.RandomEmailAddress(domain)
 	exaInfraRes := autonomousVMClusterResourceTestEntity.exaInfra(exaInfraDisplayName, emailAddress)
@@ -403,9 +399,9 @@ resource "aws_odb_cloud_autonomous_vm_cluster" "test" {
 }
 
 func (autonomousVMClusterResourceTest) avmcNoTagWithTag(t *testing.T) (string, string) {
-	exaInfraDisplayName := sdkacctest.RandomWithPrefix(autonomousVMClusterDSTestEntity.exaInfraDisplayNamePrefix)
-	odbNetworkDisplayName := sdkacctest.RandomWithPrefix(autonomousVMClusterDSTestEntity.odbNetDisplayNamePrefix)
-	avmcDisplayName := sdkacctest.RandomWithPrefix(autonomousVMClusterDSTestEntity.autonomousVmClusterDisplayNamePrefix)
+	exaInfraDisplayName := acctest.RandomWithPrefix(t, autonomousVMClusterDSTestEntity.exaInfraDisplayNamePrefix)
+	odbNetworkDisplayName := acctest.RandomWithPrefix(t, autonomousVMClusterDSTestEntity.odbNetDisplayNamePrefix)
+	avmcDisplayName := acctest.RandomWithPrefix(t, autonomousVMClusterDSTestEntity.autonomousVmClusterDisplayNamePrefix)
 	domain := acctest.RandomDomainName(t)
 	emailAddress := acctest.RandomEmailAddress(domain)
 	exaInfraRes := autonomousVMClusterResourceTestEntity.exaInfra(exaInfraDisplayName, emailAddress)
@@ -480,9 +476,9 @@ resource "aws_odb_cloud_autonomous_vm_cluster" "test" {
 }
 
 func (autonomousVMClusterResourceTest) avmcAllParamsConfig(t *testing.T) string {
-	exaInfraDisplayName := sdkacctest.RandomWithPrefix(autonomousVMClusterDSTestEntity.exaInfraDisplayNamePrefix)
-	odbNetworkDisplayName := sdkacctest.RandomWithPrefix(autonomousVMClusterDSTestEntity.odbNetDisplayNamePrefix)
-	avmcDisplayName := sdkacctest.RandomWithPrefix(autonomousVMClusterDSTestEntity.autonomousVmClusterDisplayNamePrefix)
+	exaInfraDisplayName := acctest.RandomWithPrefix(t, autonomousVMClusterDSTestEntity.exaInfraDisplayNamePrefix)
+	odbNetworkDisplayName := acctest.RandomWithPrefix(t, autonomousVMClusterDSTestEntity.odbNetDisplayNamePrefix)
+	avmcDisplayName := acctest.RandomWithPrefix(t, autonomousVMClusterDSTestEntity.autonomousVmClusterDisplayNamePrefix)
 	domain := acctest.RandomDomainName(t)
 	emailAddress := acctest.RandomEmailAddress(domain)
 	exaInfraRes := autonomousVMClusterResourceTestEntity.exaInfra(exaInfraDisplayName, emailAddress)
@@ -608,9 +604,9 @@ resource "aws_odb_cloud_autonomous_vm_cluster" "test" {
 }
 
 func (autonomousVMClusterResourceTest) autonomousVmClusterByARN(t *testing.T) (string, string) {
-	exaInfraDisplayName := sdkacctest.RandomWithPrefix(autonomousVMClusterDSTestEntity.exaInfraDisplayNamePrefix)
-	odbNetworkDisplayName := sdkacctest.RandomWithPrefix(autonomousVMClusterDSTestEntity.odbNetDisplayNamePrefix)
-	avmcDisplayName := sdkacctest.RandomWithPrefix(autonomousVMClusterDSTestEntity.autonomousVmClusterDisplayNamePrefix)
+	exaInfraDisplayName := acctest.RandomWithPrefix(t, autonomousVMClusterDSTestEntity.exaInfraDisplayNamePrefix)
+	odbNetworkDisplayName := acctest.RandomWithPrefix(t, autonomousVMClusterDSTestEntity.odbNetDisplayNamePrefix)
+	avmcDisplayName := acctest.RandomWithPrefix(t, autonomousVMClusterDSTestEntity.autonomousVmClusterDisplayNamePrefix)
 	domain := acctest.RandomDomainName(t)
 	emailAddress := acctest.RandomEmailAddress(domain)
 	exaInfraRes := autonomousVMClusterResourceTestEntity.exaInfra(exaInfraDisplayName, emailAddress)

--- a/internal/service/odb/cloud_autonomous_vm_clusters_data_source_test.go
+++ b/internal/service/odb/cloud_autonomous_vm_clusters_data_source_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	tfodb "github.com/hashicorp/terraform-provider-aws/internal/service/odb"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -28,7 +27,7 @@ func TestAccODBListAutonomousVmClustersDataSource_basic(t *testing.T) {
 	var output odb.ListCloudAutonomousVmClustersOutput
 
 	dataSourceName := "data.aws_odb_cloud_autonomous_vm_clusters.test"
-	resource.Test(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			avmcListTest.testAccPreCheck(ctx, t)
@@ -40,7 +39,7 @@ func TestAccODBListAutonomousVmClustersDataSource_basic(t *testing.T) {
 				Config: avmcListTest.basic(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.ComposeTestCheckFunc(func(s *terraform.State) error {
-						avmcListTest.count(ctx, dataSourceName, &output)
+						avmcListTest.count(ctx, t, dataSourceName, &output)
 						resource.TestCheckResourceAttr(dataSourceName, "cloud_autonomous_vm_clusters.#", strconv.Itoa(len(output.CloudAutonomousVmClusters)))
 						return nil
 					},
@@ -55,13 +54,13 @@ func (listAVMCListDSTest) basic() string {
 	return `data "aws_odb_cloud_autonomous_vm_clusters" "test" {}`
 }
 
-func (listAVMCListDSTest) count(ctx context.Context, name string, list *odb.ListCloudAutonomousVmClustersOutput) resource.TestCheckFunc {
+func (listAVMCListDSTest) count(ctx context.Context, t *testing.T, name string, list *odb.ListCloudAutonomousVmClustersOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {
 			return create.Error(names.ODB, create.ErrActionCheckingExistence, tfodb.DSNameCloudAutonomousVmClustersList, name, errors.New("not found"))
 		}
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ODBClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).ODBClient(ctx)
 		resp, err := tfodb.ListCloudAutonomousVmClusters(ctx, conn)
 		if err != nil {
 			return create.Error(names.ODB, create.ErrActionCheckingExistence, tfodb.DSNameCloudAutonomousVmClustersList, rs.Primary.ID, err)
@@ -71,7 +70,7 @@ func (listAVMCListDSTest) count(ctx context.Context, name string, list *odb.List
 	}
 }
 func (listAVMCListDSTest) testAccPreCheck(ctx context.Context, t *testing.T) {
-	conn := acctest.Provider.Meta().(*conns.AWSClient).ODBClient(ctx)
+	conn := acctest.ProviderMeta(ctx, t).ODBClient(ctx)
 	input := odb.ListCloudAutonomousVmClustersInput{}
 	_, err := conn.ListCloudAutonomousVmClusters(ctx, &input)
 	if acctest.PreCheckSkipError(err) {

--- a/internal/service/odb/cloud_exadata_infrastructure.go
+++ b/internal/service/odb/cloud_exadata_infrastructure.go
@@ -25,7 +25,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
@@ -487,10 +486,10 @@ func (r *resourceCloudExadataInfrastructure) Delete(ctx context.Context, req res
 }
 
 func waitCloudExadataInfrastructureCreated(ctx context.Context, conn *odb.Client, id string, timeout time.Duration) (*odbtypes.CloudExadataInfrastructure, error) {
-	stateConf := &sdkretry.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending:      enum.Slice(odbtypes.ResourceStatusProvisioning),
 		Target:       enum.Slice(odbtypes.ResourceStatusAvailable, odbtypes.ResourceStatusFailed),
-		Refresh:      statusCloudExadataInfrastructure(ctx, conn, id),
+		Refresh:      statusCloudExadataInfrastructure(conn, id),
 		PollInterval: 1 * time.Minute,
 		Timeout:      timeout,
 	}
@@ -503,10 +502,10 @@ func waitCloudExadataInfrastructureCreated(ctx context.Context, conn *odb.Client
 }
 
 func waitCloudExadataInfrastructureUpdated(ctx context.Context, conn *odb.Client, id string, timeout time.Duration) (*odbtypes.CloudExadataInfrastructure, error) {
-	stateConf := &sdkretry.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending:      enum.Slice(odbtypes.ResourceStatusUpdating),
 		Target:       enum.Slice(odbtypes.ResourceStatusAvailable, odbtypes.ResourceStatusFailed),
-		Refresh:      statusCloudExadataInfrastructure(ctx, conn, id),
+		Refresh:      statusCloudExadataInfrastructure(conn, id),
 		PollInterval: 1 * time.Minute,
 		Timeout:      timeout,
 	}
@@ -520,10 +519,10 @@ func waitCloudExadataInfrastructureUpdated(ctx context.Context, conn *odb.Client
 }
 
 func waitCloudExadataInfrastructureDeleted(ctx context.Context, conn *odb.Client, id string, timeout time.Duration) (*odbtypes.CloudExadataInfrastructure, error) {
-	stateConf := &sdkretry.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending: enum.Slice(odbtypes.ResourceStatusTerminating),
 		Target:  []string{},
-		Refresh: statusCloudExadataInfrastructure(ctx, conn, id),
+		Refresh: statusCloudExadataInfrastructure(conn, id),
 		Timeout: timeout,
 	}
 
@@ -535,8 +534,8 @@ func waitCloudExadataInfrastructureDeleted(ctx context.Context, conn *odb.Client
 	return nil, err
 }
 
-func statusCloudExadataInfrastructure(ctx context.Context, conn *odb.Client, id string) sdkretry.StateRefreshFunc {
-	return func() (any, string, error) {
+func statusCloudExadataInfrastructure(conn *odb.Client, id string) retry.StateRefreshFunc {
+	return func(ctx context.Context) (any, string, error) {
 		out, err := findExadataInfraResourceByID(ctx, conn, id)
 		if retry.NotFound(err) {
 			return nil, "", nil
@@ -558,9 +557,8 @@ func findExadataInfraResourceByID(ctx context.Context, conn *odb.Client, id stri
 	out, err := conn.GetCloudExadataInfrastructure(ctx, &input)
 	if err != nil {
 		if errs.IsA[*odbtypes.ResourceNotFoundException](err) {
-			return nil, &sdkretry.NotFoundError{
-				LastError:   err,
-				LastRequest: &input,
+			return nil, &retry.NotFoundError{
+				LastError: err,
 			}
 		}
 

--- a/internal/service/odb/cloud_exadata_infrastructure_data_source.go
+++ b/internal/service/odb/cloud_exadata_infrastructure_data_source.go
@@ -15,12 +15,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
 	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -246,9 +246,8 @@ func FindExaDataInfraForDataSourceByID(ctx context.Context, conn *odb.Client, id
 	out, err := conn.GetCloudExadataInfrastructure(ctx, &input)
 	if err != nil {
 		if errs.IsA[*odbtypes.ResourceNotFoundException](err) {
-			return nil, &sdkretry.NotFoundError{
-				LastError:   err,
-				LastRequest: &input,
+			return nil, &retry.NotFoundError{
+				LastError: err,
 			}
 		}
 

--- a/internal/service/odb/cloud_exadata_infrastructure_data_source_test.go
+++ b/internal/service/odb/cloud_exadata_infrastructure_data_source_test.go
@@ -9,11 +9,9 @@ import (
 	"fmt"
 	"testing"
 
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfodb "github.com/hashicorp/terraform-provider-aws/internal/service/odb"
@@ -36,18 +34,18 @@ func TestAccODBCloudExadataInfrastructureDataSource_basic(t *testing.T) {
 	}
 	exaInfraResource := "aws_odb_cloud_exadata_infrastructure.test"
 	exaInfraDataSource := "data.aws_odb_cloud_exadata_infrastructure.test"
-	displayNameSuffix := sdkacctest.RandomWithPrefix(exaInfraDataSourceTestEntity.displayNamePrefix)
+	displayNameSuffix := acctest.RandomWithPrefix(t, exaInfraDataSourceTestEntity.displayNamePrefix)
 	domain := acctest.RandomDomainName(t)
 	emailAddress1 := acctest.RandomEmailAddress(domain)
 	emailAddress2 := acctest.RandomEmailAddress(domain)
 
-	resource.Test(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ODBServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             exaInfraDataSourceTestEntity.testAccCheckCloudExadataInfrastructureDestroy(ctx),
+		CheckDestroy:             exaInfraDataSourceTestEntity.testAccCheckCloudExadataInfrastructureDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: exaInfraDataSourceTestEntity.basicExaInfraDataSource(displayNameSuffix, emailAddress1, emailAddress2),
@@ -63,9 +61,9 @@ func TestAccODBCloudExadataInfrastructureDataSource_basic(t *testing.T) {
 	})
 }
 
-func (cloudExaDataInfraDataSourceTest) testAccCheckCloudExadataInfrastructureDestroy(ctx context.Context) resource.TestCheckFunc {
+func (cloudExaDataInfraDataSourceTest) testAccCheckCloudExadataInfrastructureDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ODBClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).ODBClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_odb_cloud_exadata_infrastructure" {

--- a/internal/service/odb/cloud_exadata_infrastructure_test.go
+++ b/internal/service/odb/cloud_exadata_infrastructure_test.go
@@ -12,12 +12,10 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/odb"
 	odbtypes "github.com/aws/aws-sdk-go-v2/service/odb/types"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfodb "github.com/hashicorp/terraform-provider-aws/internal/service/odb"
@@ -43,20 +41,20 @@ func TestAccODBCloudExadataInfrastructureResource_basic(t *testing.T) {
 
 	var cloudExaDataInfrastructure odbtypes.CloudExadataInfrastructure
 	resourceName := "aws_odb_cloud_exadata_infrastructure.test"
-	rName := sdkacctest.RandomWithPrefix(exaInfraTestResource.displayNamePrefix)
-	resource.ParallelTest(t, resource.TestCase{
+	rName := acctest.RandomWithPrefix(t, exaInfraTestResource.displayNamePrefix)
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			exaInfraTestResource.testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ODBServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             exaInfraTestResource.testAccCheckCloudExaDataInfraDestroyed(ctx),
+		CheckDestroy:             exaInfraTestResource.testAccCheckCloudExaDataInfraDestroyed(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: exaInfraTestResource.exaDataInfraResourceBasicConfig(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					exaInfraTestResource.testAccCheckCloudExadataInfrastructureExists(ctx, resourceName, &cloudExaDataInfrastructure),
+					exaInfraTestResource.testAccCheckCloudExadataInfrastructureExists(ctx, t, resourceName, &cloudExaDataInfrastructure),
 				),
 			},
 			{
@@ -76,23 +74,23 @@ func TestAccODBCloudExadataInfrastructureResource_withAllParameters(t *testing.T
 
 	var cloudExaDataInfrastructure odbtypes.CloudExadataInfrastructure
 	resourceName := "aws_odb_cloud_exadata_infrastructure.test"
-	rName := sdkacctest.RandomWithPrefix(exaInfraTestResource.displayNamePrefix)
+	rName := acctest.RandomWithPrefix(t, exaInfraTestResource.displayNamePrefix)
 	domain := acctest.RandomDomainName(t)
 	emailAddress1 := acctest.RandomEmailAddress(domain)
 	emailAddress2 := acctest.RandomEmailAddress(domain)
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			exaInfraTestResource.testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ODBServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             exaInfraTestResource.testAccCheckCloudExaDataInfraDestroyed(ctx),
+		CheckDestroy:             exaInfraTestResource.testAccCheckCloudExaDataInfraDestroyed(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: exaInfraTestResource.exaDataInfraResourceWithAllConfig(rName, emailAddress1, emailAddress2),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					exaInfraTestResource.testAccCheckCloudExadataInfrastructureExists(ctx, resourceName, &cloudExaDataInfrastructure),
+					exaInfraTestResource.testAccCheckCloudExadataInfrastructureExists(ctx, t, resourceName, &cloudExaDataInfrastructure),
 				),
 			},
 			{
@@ -113,20 +111,20 @@ func TestAccODBCloudExadataInfrastructureResource_tagging(t *testing.T) {
 	var cloudExaDataInfrastructure1 odbtypes.CloudExadataInfrastructure
 	var cloudExaDataInfrastructure2 odbtypes.CloudExadataInfrastructure
 	resourceName := "aws_odb_cloud_exadata_infrastructure.test"
-	rName := sdkacctest.RandomWithPrefix(exaInfraTestResource.displayNamePrefix)
-	resource.Test(t, resource.TestCase{
+	rName := acctest.RandomWithPrefix(t, exaInfraTestResource.displayNamePrefix)
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			exaInfraTestResource.testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ODBServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             exaInfraTestResource.testAccCheckCloudExaDataInfraDestroyed(ctx),
+		CheckDestroy:             exaInfraTestResource.testAccCheckCloudExaDataInfraDestroyed(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: exaInfraTestResource.exaDataInfraResourceBasicConfigWithTags(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					exaInfraTestResource.testAccCheckCloudExadataInfrastructureExists(ctx, resourceName, &cloudExaDataInfrastructure1),
+					exaInfraTestResource.testAccCheckCloudExadataInfrastructureExists(ctx, t, resourceName, &cloudExaDataInfrastructure1),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.env", "dev"),
 				),
@@ -139,7 +137,7 @@ func TestAccODBCloudExadataInfrastructureResource_tagging(t *testing.T) {
 			{
 				Config: exaInfraTestResource.exaDataInfraResourceBasicConfig(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					exaInfraTestResource.testAccCheckCloudExadataInfrastructureExists(ctx, resourceName, &cloudExaDataInfrastructure2),
+					exaInfraTestResource.testAccCheckCloudExadataInfrastructureExists(ctx, t, resourceName, &cloudExaDataInfrastructure2),
 					resource.ComposeTestCheckFunc(func(state *terraform.State) error {
 						if strings.Compare(*(cloudExaDataInfrastructure1.CloudExadataInfrastructureId), *(cloudExaDataInfrastructure2.CloudExadataInfrastructureId)) != 0 {
 							return errors.New("Should not  create a new cloud exa basicExaInfraDataSource after  update")
@@ -167,20 +165,20 @@ func TestAccODBCloudExadataInfrastructureResource_updateDisplayName(t *testing.T
 	var cloudExaDataInfrastructure1 odbtypes.CloudExadataInfrastructure
 	var cloudExaDataInfrastructure2 odbtypes.CloudExadataInfrastructure
 	resourceName := "aws_odb_cloud_exadata_infrastructure.test"
-	rName := sdkacctest.RandomWithPrefix(exaInfraTestResource.displayNamePrefix)
-	resource.Test(t, resource.TestCase{
+	rName := acctest.RandomWithPrefix(t, exaInfraTestResource.displayNamePrefix)
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			exaInfraTestResource.testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ODBServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             exaInfraTestResource.testAccCheckCloudExaDataInfraDestroyed(ctx),
+		CheckDestroy:             exaInfraTestResource.testAccCheckCloudExaDataInfraDestroyed(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: exaInfraTestResource.exaDataInfraResourceBasicConfig(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					exaInfraTestResource.testAccCheckCloudExadataInfrastructureExists(ctx, resourceName, &cloudExaDataInfrastructure1),
+					exaInfraTestResource.testAccCheckCloudExadataInfrastructureExists(ctx, t, resourceName, &cloudExaDataInfrastructure1),
 				),
 			},
 			{
@@ -191,7 +189,7 @@ func TestAccODBCloudExadataInfrastructureResource_updateDisplayName(t *testing.T
 			{
 				Config: exaInfraTestResource.exaDataInfraResourceBasicConfig(rName + "-u"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					exaInfraTestResource.testAccCheckCloudExadataInfrastructureExists(ctx, resourceName, &cloudExaDataInfrastructure2),
+					exaInfraTestResource.testAccCheckCloudExadataInfrastructureExists(ctx, t, resourceName, &cloudExaDataInfrastructure2),
 					resource.ComposeTestCheckFunc(func(state *terraform.State) error {
 						if strings.Compare(*(cloudExaDataInfrastructure1.CloudExadataInfrastructureId), *(cloudExaDataInfrastructure2.CloudExadataInfrastructureId)) == 0 {
 							return errors.New("Should   create a new cloud exa basicExaInfraDataSource after update")
@@ -218,20 +216,20 @@ func TestAccODBCloudExadataInfrastructureResource_updateMaintenanceWindow(t *tes
 	var cloudExaDataInfrastructure1 odbtypes.CloudExadataInfrastructure
 	var cloudExaDataInfrastructure2 odbtypes.CloudExadataInfrastructure
 	resourceName := "aws_odb_cloud_exadata_infrastructure.test"
-	rName := sdkacctest.RandomWithPrefix(exaInfraTestResource.displayNamePrefix)
-	resource.ParallelTest(t, resource.TestCase{
+	rName := acctest.RandomWithPrefix(t, exaInfraTestResource.displayNamePrefix)
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			exaInfraTestResource.testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ODBServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             exaInfraTestResource.testAccCheckCloudExaDataInfraDestroyed(ctx),
+		CheckDestroy:             exaInfraTestResource.testAccCheckCloudExaDataInfraDestroyed(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: exaInfraTestResource.exaDataInfraResourceBasicConfig(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					exaInfraTestResource.testAccCheckCloudExadataInfrastructureExists(ctx, resourceName, &cloudExaDataInfrastructure1),
+					exaInfraTestResource.testAccCheckCloudExadataInfrastructureExists(ctx, t, resourceName, &cloudExaDataInfrastructure1),
 				),
 			},
 			{
@@ -242,7 +240,7 @@ func TestAccODBCloudExadataInfrastructureResource_updateMaintenanceWindow(t *tes
 			{
 				Config: exaInfraTestResource.basicWithCustomMaintenanceWindow(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					exaInfraTestResource.testAccCheckCloudExadataInfrastructureExists(ctx, resourceName, &cloudExaDataInfrastructure2),
+					exaInfraTestResource.testAccCheckCloudExadataInfrastructureExists(ctx, t, resourceName, &cloudExaDataInfrastructure2),
 					resource.ComposeTestCheckFunc(func(state *terraform.State) error {
 						if strings.Compare(*(cloudExaDataInfrastructure1.CloudExadataInfrastructureId), *(cloudExaDataInfrastructure2.CloudExadataInfrastructureId)) != 0 {
 							return errors.New("Should not  create a new cloud exa basicExaInfraDataSource after  update")
@@ -268,22 +266,22 @@ func TestAccODBCloudExadataInfrastructureResource_disappears(t *testing.T) {
 
 	var cloudExaDataInfrastructure odbtypes.CloudExadataInfrastructure
 
-	rName := sdkacctest.RandomWithPrefix(exaInfraTestResource.displayNamePrefix)
+	rName := acctest.RandomWithPrefix(t, exaInfraTestResource.displayNamePrefix)
 	resourceName := "aws_odb_cloud_exadata_infrastructure.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			exaInfraTestResource.testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ODBServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             exaInfraTestResource.testAccCheckCloudExaDataInfraDestroyed(ctx),
+		CheckDestroy:             exaInfraTestResource.testAccCheckCloudExaDataInfraDestroyed(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: exaInfraTestResource.exaDataInfraResourceBasicConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					exaInfraTestResource.testAccCheckCloudExadataInfrastructureExists(ctx, resourceName, &cloudExaDataInfrastructure),
+					exaInfraTestResource.testAccCheckCloudExadataInfrastructureExists(ctx, t, resourceName, &cloudExaDataInfrastructure),
 					acctest.CheckFrameworkResourceDisappears(ctx, t, tfodb.ResourceCloudExadataInfrastructure, resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -300,9 +298,9 @@ func TestAccODBCloudExadataInfrastructureResource_disappears(t *testing.T) {
 	})
 }
 
-func (cloudExaDataInfraResourceTest) testAccCheckCloudExaDataInfraDestroyed(ctx context.Context) resource.TestCheckFunc {
+func (cloudExaDataInfraResourceTest) testAccCheckCloudExaDataInfraDestroyed(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ODBClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).ODBClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_odb_cloud_exadata_infrastructure" {
@@ -323,7 +321,7 @@ func (cloudExaDataInfraResourceTest) testAccCheckCloudExaDataInfraDestroyed(ctx 
 	}
 }
 
-func (cloudExaDataInfraResourceTest) testAccCheckCloudExadataInfrastructureExists(ctx context.Context, name string, cloudExadataInfrastructure *odbtypes.CloudExadataInfrastructure) resource.TestCheckFunc {
+func (cloudExaDataInfraResourceTest) testAccCheckCloudExadataInfrastructureExists(ctx context.Context, t *testing.T, name string, cloudExadataInfrastructure *odbtypes.CloudExadataInfrastructure) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {
@@ -334,7 +332,7 @@ func (cloudExaDataInfraResourceTest) testAccCheckCloudExadataInfrastructureExist
 			return create.Error(names.ODB, create.ErrActionCheckingExistence, tfodb.ResNameCloudExadataInfrastructure, name, errors.New("not set"))
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ODBClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).ODBClient(ctx)
 
 		resp, err := tfodb.FindExadataInfraResourceByID(ctx, conn, rs.Primary.ID)
 		if err != nil {
@@ -348,7 +346,7 @@ func (cloudExaDataInfraResourceTest) testAccCheckCloudExadataInfrastructureExist
 }
 
 func (cloudExaDataInfraResourceTest) testAccPreCheck(ctx context.Context, t *testing.T) {
-	conn := acctest.Provider.Meta().(*conns.AWSClient).ODBClient(ctx)
+	conn := acctest.ProviderMeta(ctx, t).ODBClient(ctx)
 
 	input := odb.ListCloudExadataInfrastructuresInput{}
 

--- a/internal/service/odb/cloud_exadata_infrastructures_data_source_test.go
+++ b/internal/service/odb/cloud_exadata_infrastructures_data_source_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	tfodb "github.com/hashicorp/terraform-provider-aws/internal/service/odb"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -27,7 +26,7 @@ func TestAccODBListCloudExadataInfrastructuresDataSource_basic(t *testing.T) {
 	var listExaInfraDSTest = listExaInfraTest{}
 	var infraList odb.ListCloudExadataInfrastructuresOutput
 	dataSourceName := "data.aws_odb_cloud_exadata_infrastructures.test"
-	resource.Test(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			listExaInfraDSTest.testAccPreCheck(ctx, t)
@@ -39,7 +38,7 @@ func TestAccODBListCloudExadataInfrastructuresDataSource_basic(t *testing.T) {
 				Config: listExaInfraDSTest.basic(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.ComposeTestCheckFunc(func(s *terraform.State) error {
-						listExaInfraDSTest.countExaInfrastructures(ctx, dataSourceName, &infraList)
+						listExaInfraDSTest.countExaInfrastructures(ctx, t, dataSourceName, &infraList)
 						resource.TestCheckResourceAttr(dataSourceName, "cloud_exadata_infrastructures.#", strconv.Itoa(len(infraList.CloudExadataInfrastructures)))
 						return nil
 					},
@@ -54,13 +53,13 @@ func (listExaInfraTest) basic() string {
 	return `data "aws_odb_cloud_exadata_infrastructures" "test" {}`
 }
 
-func (listExaInfraTest) countExaInfrastructures(ctx context.Context, name string, listOfInfra *odb.ListCloudExadataInfrastructuresOutput) resource.TestCheckFunc {
+func (listExaInfraTest) countExaInfrastructures(ctx context.Context, t *testing.T, name string, listOfInfra *odb.ListCloudExadataInfrastructuresOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {
 			return create.Error(names.ODB, create.ErrActionCheckingExistence, tfodb.DSNameCloudExadataInfrastructuresList, name, errors.New("not found"))
 		}
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ODBClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).ODBClient(ctx)
 		resp, err := tfodb.ListCloudExadataInfrastructures(ctx, conn)
 		if err != nil {
 			return create.Error(names.ODB, create.ErrActionCheckingExistence, tfodb.DSNameCloudExadataInfrastructuresList, rs.Primary.ID, err)
@@ -70,7 +69,7 @@ func (listExaInfraTest) countExaInfrastructures(ctx context.Context, name string
 	}
 }
 func (listExaInfraTest) testAccPreCheck(ctx context.Context, t *testing.T) {
-	conn := acctest.Provider.Meta().(*conns.AWSClient).ODBClient(ctx)
+	conn := acctest.ProviderMeta(ctx, t).ODBClient(ctx)
 	input := odb.ListCloudExadataInfrastructuresInput{}
 	_, err := conn.ListCloudExadataInfrastructures(ctx, &input)
 	if acctest.PreCheckSkipError(err) {

--- a/internal/service/odb/cloud_vm_cluster.go
+++ b/internal/service/odb/cloud_vm_cluster.go
@@ -32,7 +32,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
@@ -693,10 +692,10 @@ func computeHostnamePrefix(hostnamePrefixComputed *string) *string {
 	}
 }
 func waitCloudVmClusterCreated(ctx context.Context, conn *odb.Client, id string, timeout time.Duration) (*odbtypes.CloudVmCluster, error) {
-	stateConf := &sdkretry.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending:                   enum.Slice(odbtypes.ResourceStatusProvisioning),
 		Target:                    enum.Slice(odbtypes.ResourceStatusAvailable, odbtypes.ResourceStatusFailed),
-		Refresh:                   statusCloudVmCluster(ctx, conn, id),
+		Refresh:                   statusCloudVmCluster(conn, id),
 		Timeout:                   timeout,
 		NotFoundChecks:            20,
 		ContinuousTargetOccurence: 2,
@@ -711,10 +710,10 @@ func waitCloudVmClusterCreated(ctx context.Context, conn *odb.Client, id string,
 }
 
 func waitCloudVmClusterDeleted(ctx context.Context, conn *odb.Client, id string, timeout time.Duration) (*odbtypes.CloudVmCluster, error) {
-	stateConf := &sdkretry.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending: enum.Slice(odbtypes.ResourceStatusTerminating),
 		Target:  []string{},
-		Refresh: statusCloudVmCluster(ctx, conn, id),
+		Refresh: statusCloudVmCluster(conn, id),
 		Timeout: timeout,
 	}
 
@@ -726,8 +725,8 @@ func waitCloudVmClusterDeleted(ctx context.Context, conn *odb.Client, id string,
 	return nil, err
 }
 
-func statusCloudVmCluster(ctx context.Context, conn *odb.Client, id string) sdkretry.StateRefreshFunc {
-	return func() (any, string, error) {
+func statusCloudVmCluster(conn *odb.Client, id string) retry.StateRefreshFunc {
+	return func(ctx context.Context) (any, string, error) {
 		out, err := findCloudVmClusterForResourceByID(ctx, conn, id)
 		if retry.NotFound(err) {
 			return nil, "", nil
@@ -748,9 +747,8 @@ func findCloudVmClusterForResourceByID(ctx context.Context, conn *odb.Client, id
 	out, err := conn.GetCloudVmCluster(ctx, &input)
 	if err != nil {
 		if errs.IsA[*odbtypes.ResourceNotFoundException](err) {
-			return nil, &sdkretry.NotFoundError{
-				LastError:   err,
-				LastRequest: &input,
+			return nil, &retry.NotFoundError{
+				LastError: err,
 			}
 		}
 		return nil, err

--- a/internal/service/odb/cloud_vm_cluster_data_source_test.go
+++ b/internal/service/odb/cloud_vm_cluster_data_source_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfodb "github.com/hashicorp/terraform-provider-aws/internal/service/odb"
@@ -42,28 +41,28 @@ func TestAccODBCloudVmClusterDataSource_basic(t *testing.T) {
 	}
 
 	var cloudvmcluster odbtypes.CloudVmCluster
-	odbNetRName := sdkacctest.RandomWithPrefix(vmClusterTestDS.odbNetDisplayNamePrefix)
-	exaInfraRName := sdkacctest.RandomWithPrefix(vmClusterTestDS.exaInfraDisplayNamePrefix)
-	vmcDisplayName := sdkacctest.RandomWithPrefix(vmClusterTestDS.vmClusterDisplayNamePrefix)
+	odbNetRName := acctest.RandomWithPrefix(t, vmClusterTestDS.odbNetDisplayNamePrefix)
+	exaInfraRName := acctest.RandomWithPrefix(t, vmClusterTestDS.exaInfraDisplayNamePrefix)
+	vmcDisplayName := acctest.RandomWithPrefix(t, vmClusterTestDS.vmClusterDisplayNamePrefix)
 	dataSourceName := "data.aws_odb_cloud_vm_cluster.test"
 	publicKey, _, err := sdkacctest.RandSSHKeyPair(acctest.DefaultEmailAddress)
 	if err != nil {
 		t.Fatal(err)
 		return
 	}
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			vmClusterTestDS.testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ODBServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             vmClusterTestDS.testAccCheckCloudVmClusterDestroy(ctx),
+		CheckDestroy:             vmClusterTestDS.testAccCheckCloudVmClusterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: vmClusterTestDS.cloudVMClusterConfig(odbNetRName, exaInfraRName, vmcDisplayName, publicKey),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					vmClusterTestDS.testAccCheckCloudVmClusterExists(ctx, dataSourceName, &cloudvmcluster),
+					vmClusterTestDS.testAccCheckCloudVmClusterExists(ctx, t, dataSourceName, &cloudvmcluster),
 					resource.TestCheckResourceAttr(dataSourceName, names.AttrDisplayName, vmcDisplayName),
 				),
 			},
@@ -71,9 +70,9 @@ func TestAccODBCloudVmClusterDataSource_basic(t *testing.T) {
 	})
 }
 
-func (cloudVmClusterDSTest) testAccCheckCloudVmClusterDestroy(ctx context.Context) resource.TestCheckFunc {
+func (cloudVmClusterDSTest) testAccCheckCloudVmClusterDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ODBClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).ODBClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_odb_cloud_vm_cluster" {
@@ -92,7 +91,7 @@ func (cloudVmClusterDSTest) testAccCheckCloudVmClusterDestroy(ctx context.Contex
 	}
 }
 
-func (cloudVmClusterDSTest) testAccCheckCloudVmClusterExists(ctx context.Context, name string, cloudvmcluster *odbtypes.CloudVmCluster) resource.TestCheckFunc {
+func (cloudVmClusterDSTest) testAccCheckCloudVmClusterExists(ctx context.Context, t *testing.T, name string, cloudvmcluster *odbtypes.CloudVmCluster) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {
@@ -101,7 +100,7 @@ func (cloudVmClusterDSTest) testAccCheckCloudVmClusterExists(ctx context.Context
 		if rs.Primary.ID == "" {
 			return create.Error(names.ODB, create.ErrActionCheckingExistence, tfodb.ResNameCloudVmCluster, name, errors.New("not set"))
 		}
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ODBClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).ODBClient(ctx)
 		resp, err := tfodb.FindCloudVmClusterForResourceByID(ctx, conn, rs.Primary.ID)
 		if err != nil {
 			return create.Error(names.ODB, create.ErrActionCheckingExistence, tfodb.ResNameCloudVmCluster, rs.Primary.ID, err)
@@ -112,7 +111,7 @@ func (cloudVmClusterDSTest) testAccCheckCloudVmClusterExists(ctx context.Context
 }
 
 func (cloudVmClusterDSTest) testAccPreCheck(ctx context.Context, t *testing.T) {
-	conn := acctest.Provider.Meta().(*conns.AWSClient).ODBClient(ctx)
+	conn := acctest.ProviderMeta(ctx, t).ODBClient(ctx)
 	input := odb.ListCloudVmClustersInput{}
 	_, err := conn.ListCloudVmClusters(ctx, &input)
 	if acctest.PreCheckSkipError(err) {

--- a/internal/service/odb/cloud_vm_cluster_test.go
+++ b/internal/service/odb/cloud_vm_cluster_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfodb "github.com/hashicorp/terraform-provider-aws/internal/service/odb"
@@ -42,27 +41,27 @@ func TestAccODBCloudVmCluster_basic(t *testing.T) {
 		t.Skip("skipping long-running test in short mode")
 	}
 	var cloudvmcluster odbtypes.CloudVmCluster
-	vmcDisplayName := sdkacctest.RandomWithPrefix(vmClusterTestEntity.vmClusterDisplayNamePrefix)
+	vmcDisplayName := acctest.RandomWithPrefix(t, vmClusterTestEntity.vmClusterDisplayNamePrefix)
 	publicKey, _, err := sdkacctest.RandSSHKeyPair(acctest.DefaultEmailAddress)
 	if err != nil {
 		t.Fatal(err)
 		return
 	}
 	resourceName := "aws_odb_cloud_vm_cluster.test"
-	basicConfig, _ := vmClusterTestEntity.testAccCloudVmClusterConfigBasic(vmcDisplayName, publicKey)
-	resource.ParallelTest(t, resource.TestCase{
+	basicConfig, _ := vmClusterTestEntity.testAccCloudVmClusterConfigBasic(t, vmcDisplayName, publicKey)
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			vmClusterTestEntity.testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ODBServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             vmClusterTestEntity.testAccCheckCloudVmClusterDestroy(ctx),
+		CheckDestroy:             vmClusterTestEntity.testAccCheckCloudVmClusterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: basicConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					vmClusterTestEntity.testAccCheckCloudVmClusterExists(ctx, resourceName, &cloudvmcluster),
+					vmClusterTestEntity.testAccCheckCloudVmClusterExists(ctx, t, resourceName, &cloudvmcluster),
 				),
 			},
 			{
@@ -80,26 +79,26 @@ func TestAccODBCloudVmCluster_allParams(t *testing.T) {
 		t.Skip("skipping long-running test in short mode")
 	}
 	var cloudvmcluster odbtypes.CloudVmCluster
-	vmcClusterDisplayName := sdkacctest.RandomWithPrefix(vmClusterTestEntity.vmClusterDisplayNamePrefix)
+	vmcClusterDisplayName := acctest.RandomWithPrefix(t, vmClusterTestEntity.vmClusterDisplayNamePrefix)
 	publicKey, _, err := sdkacctest.RandSSHKeyPair(acctest.DefaultEmailAddress)
 	if err != nil {
 		t.Fatal(err)
 		return
 	}
 	resourceName := "aws_odb_cloud_vm_cluster.test"
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			vmClusterTestEntity.testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ODBServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             vmClusterTestEntity.testAccCheckCloudVmClusterDestroy(ctx),
+		CheckDestroy:             vmClusterTestEntity.testAccCheckCloudVmClusterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: vmClusterTestEntity.cloudVmClusterWithAllParameters(vmcClusterDisplayName, publicKey),
+				Config: vmClusterTestEntity.cloudVmClusterWithAllParameters(t, vmcClusterDisplayName, publicKey),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					vmClusterTestEntity.testAccCheckCloudVmClusterExists(ctx, resourceName, &cloudvmcluster),
+					vmClusterTestEntity.testAccCheckCloudVmClusterExists(ctx, t, resourceName, &cloudvmcluster),
 				),
 			},
 			{
@@ -118,7 +117,7 @@ func TestAccODBCloudVmCluster_taggingTest(t *testing.T) {
 	}
 	var cloudvmcluster1 odbtypes.CloudVmCluster
 	var cloudvmcluster2 odbtypes.CloudVmCluster
-	vmcDisplayName := sdkacctest.RandomWithPrefix(vmClusterTestEntity.vmClusterDisplayNamePrefix)
+	vmcDisplayName := acctest.RandomWithPrefix(t, vmClusterTestEntity.vmClusterDisplayNamePrefix)
 	resourceName := "aws_odb_cloud_vm_cluster.test"
 
 	publicKey, _, err := sdkacctest.RandSSHKeyPair(acctest.DefaultEmailAddress)
@@ -126,15 +125,15 @@ func TestAccODBCloudVmCluster_taggingTest(t *testing.T) {
 		t.Fatal(err)
 		return
 	}
-	vmcNoTag, vmcWithTag := vmClusterTestEntity.testAccCloudVmClusterConfigBasic(vmcDisplayName, publicKey)
-	resource.ParallelTest(t, resource.TestCase{
+	vmcNoTag, vmcWithTag := vmClusterTestEntity.testAccCloudVmClusterConfigBasic(t, vmcDisplayName, publicKey)
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			vmClusterTestEntity.testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ODBServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             vmClusterTestEntity.testAccCheckCloudVmClusterDestroy(ctx),
+		CheckDestroy:             vmClusterTestEntity.testAccCheckCloudVmClusterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: vmcNoTag,
@@ -142,7 +141,7 @@ func TestAccODBCloudVmCluster_taggingTest(t *testing.T) {
 					resource.ComposeTestCheckFunc(func(state *terraform.State) error {
 						return nil
 					}),
-					vmClusterTestEntity.testAccCheckCloudVmClusterExists(ctx, resourceName, &cloudvmcluster1),
+					vmClusterTestEntity.testAccCheckCloudVmClusterExists(ctx, t, resourceName, &cloudvmcluster1),
 				),
 			},
 			{
@@ -156,7 +155,7 @@ func TestAccODBCloudVmCluster_taggingTest(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.env", "dev"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
-					vmClusterTestEntity.testAccCheckCloudVmClusterExists(ctx, resourceName, &cloudvmcluster2),
+					vmClusterTestEntity.testAccCheckCloudVmClusterExists(ctx, t, resourceName, &cloudvmcluster2),
 					resource.ComposeTestCheckFunc(func(state *terraform.State) error {
 						if strings.Compare(*(cloudvmcluster1.CloudVmClusterId), *(cloudvmcluster2.CloudVmClusterId)) != 0 {
 							return errors.New("Should  not create a new cloud vm cluster for tag update")
@@ -180,7 +179,7 @@ func TestAccODBCloudVmCluster_giVersionTag(t *testing.T) {
 		t.Skip("skipping long-running test in short mode")
 	}
 	var cloudvmcluster1 odbtypes.CloudVmCluster
-	vmcDisplayName := sdkacctest.RandomWithPrefix(vmClusterTestEntity.vmClusterDisplayNamePrefix)
+	vmcDisplayName := acctest.RandomWithPrefix(t, vmClusterTestEntity.vmClusterDisplayNamePrefix)
 	resourceName := "aws_odb_cloud_vm_cluster.test"
 
 	publicKey, _, err := sdkacctest.RandSSHKeyPair(acctest.DefaultEmailAddress)
@@ -188,15 +187,15 @@ func TestAccODBCloudVmCluster_giVersionTag(t *testing.T) {
 		t.Fatal(err)
 		return
 	}
-	vmcWithGiVersionTag := vmClusterTestEntity.cloudVmClusterConfigWithGiVersionTag(vmcDisplayName, publicKey)
-	resource.ParallelTest(t, resource.TestCase{
+	vmcWithGiVersionTag := vmClusterTestEntity.cloudVmClusterConfigWithGiVersionTag(t, vmcDisplayName, publicKey)
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			vmClusterTestEntity.testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ODBServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             vmClusterTestEntity.testAccCheckCloudVmClusterDestroy(ctx),
+		CheckDestroy:             vmClusterTestEntity.testAccCheckCloudVmClusterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: vmcWithGiVersionTag,
@@ -205,7 +204,7 @@ func TestAccODBCloudVmCluster_giVersionTag(t *testing.T) {
 						return nil
 					}),
 					resource.TestCheckResourceAttr(resourceName, "gi_version_computed", "26.0.0.0"),
-					vmClusterTestEntity.testAccCheckCloudVmClusterExists(ctx, resourceName, &cloudvmcluster1),
+					vmClusterTestEntity.testAccCheckCloudVmClusterExists(ctx, t, resourceName, &cloudvmcluster1),
 				),
 			},
 			{
@@ -224,7 +223,7 @@ func TestAccODBCloudVmCluster_real(t *testing.T) {
 	}
 	var cloudvmcluster1 odbtypes.CloudVmCluster
 	var cloudvmcluster2 odbtypes.CloudVmCluster
-	vmcDisplayName := sdkacctest.RandomWithPrefix("tf-real")
+	vmcDisplayName := acctest.RandomWithPrefix(t, "tf-real")
 	resourceName := "aws_odb_cloud_vm_cluster.test"
 
 	publicKey, _, err := sdkacctest.RandSSHKeyPair(acctest.DefaultEmailAddress)
@@ -232,15 +231,15 @@ func TestAccODBCloudVmCluster_real(t *testing.T) {
 		t.Fatal(err)
 		return
 	}
-	vmcWithoutTag, vmcWithTag := vmClusterTestEntity.cloudVmClusterReal(vmcDisplayName, publicKey)
-	resource.ParallelTest(t, resource.TestCase{
+	vmcWithoutTag, vmcWithTag := vmClusterTestEntity.cloudVmClusterReal(t, vmcDisplayName, publicKey)
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			vmClusterTestEntity.testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ODBServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             vmClusterTestEntity.testAccCheckCloudVmClusterDestroy(ctx),
+		CheckDestroy:             vmClusterTestEntity.testAccCheckCloudVmClusterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: vmcWithoutTag,
@@ -248,7 +247,7 @@ func TestAccODBCloudVmCluster_real(t *testing.T) {
 					resource.ComposeTestCheckFunc(func(state *terraform.State) error {
 						return nil
 					}),
-					vmClusterTestEntity.testAccCheckCloudVmClusterExists(ctx, resourceName, &cloudvmcluster1),
+					vmClusterTestEntity.testAccCheckCloudVmClusterExists(ctx, t, resourceName, &cloudvmcluster1),
 				),
 			},
 			{
@@ -261,7 +260,7 @@ func TestAccODBCloudVmCluster_real(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.env", "dev"),
-					vmClusterTestEntity.testAccCheckCloudVmClusterExists(ctx, resourceName, &cloudvmcluster2),
+					vmClusterTestEntity.testAccCheckCloudVmClusterExists(ctx, t, resourceName, &cloudvmcluster2),
 					resource.ComposeTestCheckFunc(func(state *terraform.State) error {
 						if strings.Compare(*(cloudvmcluster1.CloudVmClusterId), *(cloudvmcluster2.CloudVmClusterId)) != 0 {
 							return errors.New("Should  not create a new cloud vm cluster for tag update")
@@ -285,27 +284,27 @@ func TestAccODBCloudVmCluster_disappears(t *testing.T) {
 		t.Skip("skipping long-running test in short mode")
 	}
 	var cloudvmcluster odbtypes.CloudVmCluster
-	vmClusterDisplayName := sdkacctest.RandomWithPrefix(vmClusterTestEntity.vmClusterDisplayNamePrefix)
+	vmClusterDisplayName := acctest.RandomWithPrefix(t, vmClusterTestEntity.vmClusterDisplayNamePrefix)
 	resourceName := "aws_odb_cloud_vm_cluster.test"
 	publicKey, _, err := sdkacctest.RandSSHKeyPair(acctest.DefaultEmailAddress)
 	if err != nil {
 		t.Fatal(err)
 		return
 	}
-	vmcBasicConfig, _ := vmClusterTestEntity.testAccCloudVmClusterConfigBasic(vmClusterDisplayName, publicKey)
-	resource.ParallelTest(t, resource.TestCase{
+	vmcBasicConfig, _ := vmClusterTestEntity.testAccCloudVmClusterConfigBasic(t, vmClusterDisplayName, publicKey)
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			vmClusterTestEntity.testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ODBServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             vmClusterTestEntity.testAccCheckCloudVmClusterDestroy(ctx),
+		CheckDestroy:             vmClusterTestEntity.testAccCheckCloudVmClusterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: vmcBasicConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					vmClusterTestEntity.testAccCheckCloudVmClusterExists(ctx, resourceName, &cloudvmcluster),
+					vmClusterTestEntity.testAccCheckCloudVmClusterExists(ctx, t, resourceName, &cloudvmcluster),
 					acctest.CheckFrameworkResourceDisappears(ctx, t, tfodb.ResourceCloudVmCluster, resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -329,7 +328,7 @@ func TestAccODBCloudVmCluster_usingARN(t *testing.T) {
 	}
 	var cloudvmcluster1 odbtypes.CloudVmCluster
 	var cloudvmcluster2 odbtypes.CloudVmCluster
-	vmcDisplayName := sdkacctest.RandomWithPrefix("Ofake")
+	vmcDisplayName := acctest.RandomWithPrefix(t, "Ofake")
 	resourceName := "aws_odb_cloud_vm_cluster.test"
 
 	publicKey, _, err := sdkacctest.RandSSHKeyPair(acctest.DefaultEmailAddress)
@@ -337,15 +336,15 @@ func TestAccODBCloudVmCluster_usingARN(t *testing.T) {
 		t.Fatal(err)
 		return
 	}
-	vmcWithoutTag, vmcWithTag := vmClusterTestEntity.cloudVmClusterByARN(vmcDisplayName, publicKey)
-	resource.ParallelTest(t, resource.TestCase{
+	vmcWithoutTag, vmcWithTag := vmClusterTestEntity.cloudVmClusterByARN(t, vmcDisplayName, publicKey)
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			vmClusterTestEntity.testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ODBServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             vmClusterTestEntity.testAccCheckCloudVmClusterDestroy(ctx),
+		CheckDestroy:             vmClusterTestEntity.testAccCheckCloudVmClusterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: vmcWithoutTag,
@@ -353,7 +352,7 @@ func TestAccODBCloudVmCluster_usingARN(t *testing.T) {
 					resource.ComposeTestCheckFunc(func(state *terraform.State) error {
 						return nil
 					}),
-					vmClusterTestEntity.testAccCheckCloudVmClusterExists(ctx, resourceName, &cloudvmcluster1),
+					vmClusterTestEntity.testAccCheckCloudVmClusterExists(ctx, t, resourceName, &cloudvmcluster1),
 				),
 			},
 			{
@@ -366,7 +365,7 @@ func TestAccODBCloudVmCluster_usingARN(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.env", "dev"),
-					vmClusterTestEntity.testAccCheckCloudVmClusterExists(ctx, resourceName, &cloudvmcluster2),
+					vmClusterTestEntity.testAccCheckCloudVmClusterExists(ctx, t, resourceName, &cloudvmcluster2),
 					resource.ComposeTestCheckFunc(func(state *terraform.State) error {
 						if strings.Compare(*(cloudvmcluster1.CloudVmClusterId), *(cloudvmcluster2.CloudVmClusterId)) != 0 {
 							return errors.New("Should  not create a new cloud vm cluster for tag update")
@@ -390,15 +389,15 @@ func TestAccODBCloudVmCluster_variables(t *testing.T) {
 		t.Skip("skipping long-running test in short mode")
 	}
 
-	vmcDisplayName := sdkacctest.RandomWithPrefix(vmClusterTestEntity.vmClusterDisplayNamePrefix)
-	resource.ParallelTest(t, resource.TestCase{
+	vmcDisplayName := acctest.RandomWithPrefix(t, vmClusterTestEntity.vmClusterDisplayNamePrefix)
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			vmClusterTestEntity.testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ODBServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             vmClusterTestEntity.testAccCheckCloudVmClusterDestroy(ctx),
+		CheckDestroy:             vmClusterTestEntity.testAccCheckCloudVmClusterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// nosemgrep:ci.semgrep.acctest.checks.replace-planonly-checks
 			{
@@ -410,9 +409,9 @@ func TestAccODBCloudVmCluster_variables(t *testing.T) {
 	})
 }
 
-func (cloudVmClusterResourceTest) testAccCheckCloudVmClusterDestroy(ctx context.Context) resource.TestCheckFunc {
+func (cloudVmClusterResourceTest) testAccCheckCloudVmClusterDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ODBClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).ODBClient(ctx)
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_odb_cloud_vm_cluster" {
 				continue
@@ -430,7 +429,7 @@ func (cloudVmClusterResourceTest) testAccCheckCloudVmClusterDestroy(ctx context.
 	}
 }
 
-func (cloudVmClusterResourceTest) testAccCheckCloudVmClusterExists(ctx context.Context, name string, cloudvmcluster *odbtypes.CloudVmCluster) resource.TestCheckFunc {
+func (cloudVmClusterResourceTest) testAccCheckCloudVmClusterExists(ctx context.Context, t *testing.T, name string, cloudvmcluster *odbtypes.CloudVmCluster) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {
@@ -439,7 +438,7 @@ func (cloudVmClusterResourceTest) testAccCheckCloudVmClusterExists(ctx context.C
 		if rs.Primary.ID == "" {
 			return create.Error(names.ODB, create.ErrActionCheckingExistence, tfodb.ResNameCloudVmCluster, name, errors.New("not set"))
 		}
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ODBClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).ODBClient(ctx)
 		resp, err := tfodb.FindCloudVmClusterForResourceByID(ctx, conn, rs.Primary.ID)
 		if err != nil {
 			return create.Error(names.ODB, create.ErrActionCheckingExistence, tfodb.ResNameCloudVmCluster, rs.Primary.ID, err)
@@ -450,7 +449,7 @@ func (cloudVmClusterResourceTest) testAccCheckCloudVmClusterExists(ctx context.C
 }
 
 func (cloudVmClusterResourceTest) testAccPreCheck(ctx context.Context, t *testing.T) {
-	conn := acctest.Provider.Meta().(*conns.AWSClient).ODBClient(ctx)
+	conn := acctest.ProviderMeta(ctx, t).ODBClient(ctx)
 	input := odb.ListCloudVmClustersInput{}
 	_, err := conn.ListCloudVmClusters(ctx, &input)
 	if acctest.PreCheckSkipError(err) {
@@ -498,9 +497,9 @@ resource "aws_odb_cloud_vm_cluster" "test" {
 }
 `, rName)
 }
-func (cloudVmClusterResourceTest) testAccCloudVmClusterConfigBasic(vmClusterDisplayName, sshKey string) (string, string) {
-	exaInfraDisplayName := sdkacctest.RandomWithPrefix(vmClusterTestEntity.exaInfraDisplayNamePrefix)
-	odbNetDisplayName := sdkacctest.RandomWithPrefix(vmClusterTestEntity.odbNetDisplayNamePrefix)
+func (cloudVmClusterResourceTest) testAccCloudVmClusterConfigBasic(t *testing.T, vmClusterDisplayName, sshKey string) (string, string) {
+	exaInfraDisplayName := acctest.RandomWithPrefix(t, vmClusterTestEntity.exaInfraDisplayNamePrefix)
+	odbNetDisplayName := acctest.RandomWithPrefix(t, vmClusterTestEntity.odbNetDisplayNamePrefix)
 	exaInfra := vmClusterTestEntity.exaInfra(exaInfraDisplayName)
 	odbNet := vmClusterTestEntity.oracleDBNetwork(odbNetDisplayName)
 	vmcNoTag := fmt.Sprintf(`
@@ -577,9 +576,9 @@ resource "aws_odb_cloud_vm_cluster" "test" {
 	return vmcNoTag, vmcWithTag
 }
 
-func (cloudVmClusterResourceTest) cloudVmClusterWithAllParameters(vmClusterDisplayName, sshKey string) string {
-	exaInfraDisplayName := sdkacctest.RandomWithPrefix(vmClusterTestEntity.exaInfraDisplayNamePrefix)
-	odbNetDisplayName := sdkacctest.RandomWithPrefix(vmClusterTestEntity.odbNetDisplayNamePrefix)
+func (cloudVmClusterResourceTest) cloudVmClusterWithAllParameters(t *testing.T, vmClusterDisplayName, sshKey string) string {
+	exaInfraDisplayName := acctest.RandomWithPrefix(t, vmClusterTestEntity.exaInfraDisplayNamePrefix)
+	odbNetDisplayName := acctest.RandomWithPrefix(t, vmClusterTestEntity.odbNetDisplayNamePrefix)
 	exaInfra := vmClusterTestEntity.exaInfra(exaInfraDisplayName)
 	odbNet := vmClusterTestEntity.oracleDBNetwork(odbNetDisplayName)
 
@@ -658,9 +657,9 @@ resource "aws_odb_network" "test" {
 	return resource
 }
 
-func (cloudVmClusterResourceTest) cloudVmClusterReal(vmClusterDisplayName, sshKey string) (string, string) {
-	exaInfraDisplayName := sdkacctest.RandomWithPrefix("tf-real")
-	odbNetDisplayName := sdkacctest.RandomWithPrefix(vmClusterTestEntity.odbNetDisplayNamePrefix)
+func (cloudVmClusterResourceTest) cloudVmClusterReal(t *testing.T, vmClusterDisplayName, sshKey string) (string, string) {
+	exaInfraDisplayName := acctest.RandomWithPrefix(t, "tf-real")
+	odbNetDisplayName := acctest.RandomWithPrefix(t, vmClusterTestEntity.odbNetDisplayNamePrefix)
 	exaInfra := vmClusterTestEntity.exaInfra(exaInfraDisplayName)
 	odbNet := vmClusterTestEntity.oracleDBNetwork(odbNetDisplayName)
 	vmClusterResourceNoTag := fmt.Sprintf(`
@@ -737,9 +736,9 @@ resource "aws_odb_cloud_vm_cluster" "test" {
 	return vmClusterResourceNoTag, vmClusterResourceWithTag
 }
 
-func (cloudVmClusterResourceTest) cloudVmClusterByARN(vmClusterDisplayName, sshKey string) (string, string) {
-	exaInfraDisplayName := sdkacctest.RandomWithPrefix("Ofake-exa")
-	odbNetDisplayName := sdkacctest.RandomWithPrefix(vmClusterTestEntity.odbNetDisplayNamePrefix)
+func (cloudVmClusterResourceTest) cloudVmClusterByARN(t *testing.T, vmClusterDisplayName, sshKey string) (string, string) {
+	exaInfraDisplayName := acctest.RandomWithPrefix(t, "Ofake-exa")
+	odbNetDisplayName := acctest.RandomWithPrefix(t, vmClusterTestEntity.odbNetDisplayNamePrefix)
 	exaInfra := vmClusterTestEntity.exaInfra(exaInfraDisplayName)
 	odbNet := vmClusterTestEntity.oracleDBNetwork(odbNetDisplayName)
 	vmClusterResourceNoTag := fmt.Sprintf(`
@@ -825,9 +824,9 @@ resource "aws_odb_cloud_vm_cluster" "test" {
 	return vmClusterResourceNoTag, vmClusterResourceWithTag
 }
 
-func (cloudVmClusterResourceTest) cloudVmClusterConfigWithGiVersionTag(vmClusterDisplayName, sshKey string) string {
-	exaInfraDisplayName := sdkacctest.RandomWithPrefix(vmClusterTestEntity.exaInfraDisplayNamePrefix)
-	odbNetDisplayName := sdkacctest.RandomWithPrefix(vmClusterTestEntity.odbNetDisplayNamePrefix)
+func (cloudVmClusterResourceTest) cloudVmClusterConfigWithGiVersionTag(t *testing.T, vmClusterDisplayName, sshKey string) string {
+	exaInfraDisplayName := acctest.RandomWithPrefix(t, vmClusterTestEntity.exaInfraDisplayNamePrefix)
+	odbNetDisplayName := acctest.RandomWithPrefix(t, vmClusterTestEntity.odbNetDisplayNamePrefix)
 	exaInfra := vmClusterTestEntity.exaInfra(exaInfraDisplayName)
 	odbNet := vmClusterTestEntity.oracleDBNetwork(odbNetDisplayName)
 	vmcWithGiVersionTag := fmt.Sprintf(`
@@ -887,7 +886,7 @@ func TestAccODBCloudVmCluster_previousProviderVersion(t *testing.T) {
 	var cloudvmcluster1 odbtypes.CloudVmCluster
 	var cloudvmcluster2 odbtypes.CloudVmCluster
 	var cloudvmcluster3 odbtypes.CloudVmCluster
-	vmcDisplayName := sdkacctest.RandomWithPrefix(vmClusterTestEntity.vmClusterDisplayNamePrefix)
+	vmcDisplayName := acctest.RandomWithPrefix(t, vmClusterTestEntity.vmClusterDisplayNamePrefix)
 	resourceName := "aws_odb_cloud_vm_cluster.test"
 
 	publicKey, _, err := sdkacctest.RandSSHKeyPair(acctest.DefaultEmailAddress)
@@ -896,14 +895,14 @@ func TestAccODBCloudVmCluster_previousProviderVersion(t *testing.T) {
 		return
 	}
 
-	vmcWithoutGiVersionTag, vmcWithGiVersionTag := vmClusterTestEntity.cloudVmClusterConfigWithOlderTfProviderAndUpgradeToLatest(vmcDisplayName, publicKey)
-	resource.ParallelTest(t, resource.TestCase{
+	vmcWithoutGiVersionTag, vmcWithGiVersionTag := vmClusterTestEntity.cloudVmClusterConfigWithOlderTfProviderAndUpgradeToLatest(t, vmcDisplayName, publicKey)
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			vmClusterTestEntity.testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.ODBServiceID),
-		CheckDestroy: vmClusterTestEntity.testAccCheckCloudVmClusterDestroy(ctx),
+		CheckDestroy: vmClusterTestEntity.testAccCheckCloudVmClusterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ExternalProviders: map[string]resource.ExternalProvider{
@@ -914,7 +913,7 @@ func TestAccODBCloudVmCluster_previousProviderVersion(t *testing.T) {
 				},
 				Config: vmcWithoutGiVersionTag,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					vmClusterTestEntity.testAccCheckCloudVmClusterExists(ctx, resourceName, &cloudvmcluster1),
+					vmClusterTestEntity.testAccCheckCloudVmClusterExists(ctx, t, resourceName, &cloudvmcluster1),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrID),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
 				),
@@ -923,7 +922,7 @@ func TestAccODBCloudVmCluster_previousProviderVersion(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				Config:                   vmcWithoutGiVersionTag,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					vmClusterTestEntity.testAccCheckCloudVmClusterExists(ctx, resourceName, &cloudvmcluster2),
+					vmClusterTestEntity.testAccCheckCloudVmClusterExists(ctx, t, resourceName, &cloudvmcluster2),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrID),
 					resource.ComposeTestCheckFunc(func(state *terraform.State) error {
 						if strings.Compare(*(cloudvmcluster1.CloudVmClusterId), *(cloudvmcluster2.CloudVmClusterId)) != 0 {
@@ -937,7 +936,7 @@ func TestAccODBCloudVmCluster_previousProviderVersion(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				Config:                   vmcWithGiVersionTag,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					vmClusterTestEntity.testAccCheckCloudVmClusterExists(ctx, resourceName, &cloudvmcluster3),
+					vmClusterTestEntity.testAccCheckCloudVmClusterExists(ctx, t, resourceName, &cloudvmcluster3),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrID),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(resourceName, "tags.odb:input_gi_version", "26.0.0.0"),
@@ -953,9 +952,9 @@ func TestAccODBCloudVmCluster_previousProviderVersion(t *testing.T) {
 	})
 }
 
-func (cloudVmClusterResourceTest) cloudVmClusterConfigWithOlderTfProviderAndUpgradeToLatest(vmClusterDisplayName, sshKey string) (string, string) {
-	exaInfraDisplayName := sdkacctest.RandomWithPrefix(vmClusterTestEntity.exaInfraDisplayNamePrefix)
-	odbNetDisplayName := sdkacctest.RandomWithPrefix(vmClusterTestEntity.odbNetDisplayNamePrefix)
+func (cloudVmClusterResourceTest) cloudVmClusterConfigWithOlderTfProviderAndUpgradeToLatest(t *testing.T, vmClusterDisplayName, sshKey string) (string, string) {
+	exaInfraDisplayName := acctest.RandomWithPrefix(t, vmClusterTestEntity.exaInfraDisplayNamePrefix)
+	odbNetDisplayName := acctest.RandomWithPrefix(t, vmClusterTestEntity.odbNetDisplayNamePrefix)
 	exaInfra := vmClusterTestEntity.exaInfra(exaInfraDisplayName)
 	odbNet := vmClusterTestEntity.oracleDBNetwork(odbNetDisplayName)
 	vmcWithoutGiVersionTag := fmt.Sprintf(`

--- a/internal/service/odb/cloud_vm_clusters_data_source_test.go
+++ b/internal/service/odb/cloud_vm_clusters_data_source_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	tfodb "github.com/hashicorp/terraform-provider-aws/internal/service/odb"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -29,7 +28,7 @@ func TestAccODBListVmClustersDataSource_basic(t *testing.T) {
 	var vmcListTest = listVMCListDSTest{}
 	var output odb.ListCloudVmClustersOutput
 	dataSourceName := "data.aws_odb_cloud_vm_clusters.test"
-	resource.Test(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			vmcListTest.testAccPreCheck(ctx, t)
@@ -42,7 +41,7 @@ func TestAccODBListVmClustersDataSource_basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 
 					resource.ComposeTestCheckFunc(func(s *terraform.State) error {
-						vmcListTest.count(ctx, dataSourceName, &output)
+						vmcListTest.count(ctx, t, dataSourceName, &output)
 						resource.TestCheckResourceAttr(dataSourceName, "cloud_autonomous_vm_clusters.#", strconv.Itoa(len(output.CloudVmClusters)))
 						return nil
 					},
@@ -57,13 +56,13 @@ func (listVMCListDSTest) basic() string {
 	return `data "aws_odb_cloud_vm_clusters" "test" {}`
 }
 
-func (listVMCListDSTest) count(ctx context.Context, name string, list *odb.ListCloudVmClustersOutput) resource.TestCheckFunc {
+func (listVMCListDSTest) count(ctx context.Context, t *testing.T, name string, list *odb.ListCloudVmClustersOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {
 			return create.Error(names.ODB, create.ErrActionCheckingExistence, tfodb.DSNameCloudVmClustersList, name, errors.New("not found"))
 		}
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ODBClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).ODBClient(ctx)
 		resp, err := tfodb.ListCloudVmClusters(ctx, conn)
 		if err != nil {
 			return create.Error(names.ODB, create.ErrActionCheckingExistence, tfodb.DSNameCloudVmClustersList, rs.Primary.ID, err)
@@ -73,7 +72,7 @@ func (listVMCListDSTest) count(ctx context.Context, name string, list *odb.ListC
 	}
 }
 func (listVMCListDSTest) testAccPreCheck(ctx context.Context, t *testing.T) {
-	conn := acctest.Provider.Meta().(*conns.AWSClient).ODBClient(ctx)
+	conn := acctest.ProviderMeta(ctx, t).ODBClient(ctx)
 	_, err := tfodb.ListCloudVmClusters(ctx, conn)
 	if acctest.PreCheckSkipError(err) {
 		t.Skipf("skipping acceptance testing: %s", err)

--- a/internal/service/odb/db_node_data_source_test.go
+++ b/internal/service/odb/db_node_data_source_test.go
@@ -12,12 +12,10 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/odb"
 	odbtypes "github.com/aws/aws-sdk-go-v2/service/odb/types"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
@@ -51,31 +49,31 @@ func TestAccODBDBNodeDataSource_basic(t *testing.T) {
 	}
 	var dbNode odb.GetDbNodeOutput
 	dataSourceName := "data.aws_odb_db_node.test"
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ODBServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             dbNodeDataSourceTestEntity.testAccCheckDBNodeDestroyed(ctx),
+		CheckDestroy:             dbNodeDataSourceTestEntity.testAccCheckDBNodeDestroyed(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: dbNodeDataSourceTestEntity.dbNodeDataSourceBasicConfig(publicKey),
+				Config: dbNodeDataSourceTestEntity.dbNodeDataSourceBasicConfig(t, publicKey),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					dbNodeDataSourceTestEntity.testAccCheckDBNodeExists(ctx, dataSourceName, &dbNode),
+					dbNodeDataSourceTestEntity.testAccCheckDBNodeExists(ctx, t, dataSourceName, &dbNode),
 				),
 			},
 		},
 	})
 }
 
-func (testDbNodeDataSourceTest) testAccCheckDBNodeExists(ctx context.Context, name string, output *odb.GetDbNodeOutput) resource.TestCheckFunc {
+func (testDbNodeDataSourceTest) testAccCheckDBNodeExists(ctx context.Context, t *testing.T, name string, output *odb.GetDbNodeOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {
 			return create.Error(names.ODB, create.ErrActionCheckingExistence, tfodb.DSNameDBServer, name, errors.New("not found"))
 		}
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ODBClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).ODBClient(ctx)
 		var dbNodeId = rs.Primary.ID
 		var attributes = rs.Primary.Attributes
 		cloudVmClusterId := attributes["cloud_vm_cluster_id"]
@@ -92,9 +90,9 @@ func (testDbNodeDataSourceTest) testAccCheckDBNodeExists(ctx context.Context, na
 	}
 }
 
-func (testDbNodeDataSourceTest) testAccCheckDBNodeDestroyed(ctx context.Context) resource.TestCheckFunc {
+func (testDbNodeDataSourceTest) testAccCheckDBNodeDestroyed(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ODBClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).ODBClient(ctx)
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_odb_cloud_vm_cluster" {
 				continue
@@ -119,9 +117,8 @@ func (testDbNodeDataSourceTest) findVmCluster(ctx context.Context, conn *odb.Cli
 	output, err := conn.GetCloudVmCluster(ctx, &input)
 	if err != nil {
 		if errs.IsA[*odbtypes.ResourceNotFoundException](err) {
-			return &sdkretry.NotFoundError{
-				LastError:   err,
-				LastRequest: &input,
+			return &retry.NotFoundError{
+				LastError: err,
 			}
 		}
 		return err
@@ -132,8 +129,8 @@ func (testDbNodeDataSourceTest) findVmCluster(ctx context.Context, conn *odb.Cli
 	return nil
 }
 
-func (testDbNodeDataSourceTest) dbNodeDataSourceBasicConfig(publicKey string) string {
-	vmClusterConfig := dbNodeDataSourceTestEntity.vmClusterBasicConfig(publicKey)
+func (testDbNodeDataSourceTest) dbNodeDataSourceBasicConfig(t *testing.T, publicKey string) string {
+	vmClusterConfig := dbNodeDataSourceTestEntity.vmClusterBasicConfig(t, publicKey)
 
 	return fmt.Sprintf(`
 %s
@@ -150,10 +147,10 @@ data "aws_odb_db_node" "test" {
 `, vmClusterConfig)
 }
 
-func (testDbNodeDataSourceTest) vmClusterBasicConfig(publicKey string) string {
-	exaInfraDisplayName := sdkacctest.RandomWithPrefix(dbNodeDataSourceTestEntity.exaDisplayNamePrefix)
-	oracleDBNetDisplayName := sdkacctest.RandomWithPrefix(dbNodeDataSourceTestEntity.oracleDBNetworkDisplayNamePrefix)
-	vmcDisplayName := sdkacctest.RandomWithPrefix(dbNodeDataSourceTestEntity.vmClusterDisplayNamePrefix)
+func (testDbNodeDataSourceTest) vmClusterBasicConfig(t *testing.T, publicKey string) string {
+	exaInfraDisplayName := acctest.RandomWithPrefix(t, dbNodeDataSourceTestEntity.exaDisplayNamePrefix)
+	oracleDBNetDisplayName := acctest.RandomWithPrefix(t, dbNodeDataSourceTestEntity.oracleDBNetworkDisplayNamePrefix)
+	vmcDisplayName := acctest.RandomWithPrefix(t, dbNodeDataSourceTestEntity.vmClusterDisplayNamePrefix)
 	dsTfCodeVmCluster := fmt.Sprintf(`
 
 

--- a/internal/service/odb/db_nodes_data_source_test.go
+++ b/internal/service/odb/db_nodes_data_source_test.go
@@ -13,12 +13,10 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/odb"
 	odbtypes "github.com/aws/aws-sdk-go-v2/service/odb/types"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
@@ -54,18 +52,18 @@ func TestAccODBDBNodesListDataSource_basic(t *testing.T) {
 	dbNodesListsDataSourceName := "data.aws_odb_db_nodes.test"
 	vmClusterListsResourceName := "aws_odb_cloud_vm_cluster.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ODBServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             dbNodesListDataSourceTestEntity.testAccCheckDBNodesDestroyed(ctx),
+		CheckDestroy:             dbNodesListDataSourceTestEntity.testAccCheckDBNodesDestroyed(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: dbNodesListDataSourceTestEntity.basicDBNodesListDataSource(publicKey),
+				Config: dbNodesListDataSourceTestEntity.basicDBNodesListDataSource(t, publicKey),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					dbNodesListDataSourceTestEntity.testAccCheckDBNodesListExists(ctx, vmClusterListsResourceName, &dbNodesList),
+					dbNodesListDataSourceTestEntity.testAccCheckDBNodesListExists(ctx, t, vmClusterListsResourceName, &dbNodesList),
 					resource.TestCheckResourceAttr(dbNodesListsDataSourceName, "aws_odb_db_nodes.db_nodes.#", strconv.Itoa(len(dbNodesList.DbNodes))),
 				),
 			},
@@ -73,13 +71,13 @@ func TestAccODBDBNodesListDataSource_basic(t *testing.T) {
 	})
 }
 
-func (dbNodesListDataSourceTest) testAccCheckDBNodesListExists(ctx context.Context, name string, output *odb.ListDbNodesOutput) resource.TestCheckFunc {
+func (dbNodesListDataSourceTest) testAccCheckDBNodesListExists(ctx context.Context, t *testing.T, name string, output *odb.ListDbNodesOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {
 			return create.Error(names.ODB, create.ErrActionCheckingExistence, tfodb.DSNameDBNodesList, name, errors.New("not found"))
 		}
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ODBClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).ODBClient(ctx)
 		var vmClusterId = &rs.Primary.ID
 		input := odb.ListDbNodesInput{
 			CloudVmClusterId: vmClusterId,
@@ -98,9 +96,9 @@ func (dbNodesListDataSourceTest) testAccCheckDBNodesListExists(ctx context.Conte
 	}
 }
 
-func (dbNodesListDataSourceTest) testAccCheckDBNodesDestroyed(ctx context.Context) resource.TestCheckFunc {
+func (dbNodesListDataSourceTest) testAccCheckDBNodesDestroyed(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ODBClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).ODBClient(ctx)
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_odb_cloud_vm_cluster" {
 				continue
@@ -125,9 +123,8 @@ func (dbNodesListDataSourceTest) findVmCluster(ctx context.Context, conn *odb.Cl
 	output, err := conn.GetCloudVmCluster(ctx, &input)
 	if err != nil {
 		if errs.IsA[*odbtypes.ResourceNotFoundException](err) {
-			return nil, &sdkretry.NotFoundError{
-				LastError:   err,
-				LastRequest: &input,
+			return nil, &retry.NotFoundError{
+				LastError: err,
 			}
 		}
 		return nil, err
@@ -138,8 +135,8 @@ func (dbNodesListDataSourceTest) findVmCluster(ctx context.Context, conn *odb.Cl
 	return output.CloudVmCluster, nil
 }
 
-func (dbNodesListDataSourceTest) basicDBNodesListDataSource(publicKey string) string {
-	vmCluster := dbNodesListDataSourceTestEntity.vmClusterBasic(publicKey)
+func (dbNodesListDataSourceTest) basicDBNodesListDataSource(t *testing.T, publicKey string) string {
+	vmCluster := dbNodesListDataSourceTestEntity.vmClusterBasic(t, publicKey)
 	return fmt.Sprintf(`
 
 	%s
@@ -150,10 +147,10 @@ data "aws_odb_db_nodes" "test" {
 `, vmCluster)
 }
 
-func (dbNodesListDataSourceTest) vmClusterBasic(publicKey string) string {
-	odbNetRName := sdkacctest.RandomWithPrefix(dbNodesListDataSourceTestEntity.oracleDBNetworkDisplayNamePrefix)
-	exaInfraRName := sdkacctest.RandomWithPrefix(dbNodesListDataSourceTestEntity.exadataInfraDisplayNamePrefix)
-	vmcDisplayName := sdkacctest.RandomWithPrefix(dbNodesListDataSourceTestEntity.vmClusterDisplayNamePrefix)
+func (dbNodesListDataSourceTest) vmClusterBasic(t *testing.T, publicKey string) string {
+	odbNetRName := acctest.RandomWithPrefix(t, dbNodesListDataSourceTestEntity.oracleDBNetworkDisplayNamePrefix)
+	exaInfraRName := acctest.RandomWithPrefix(t, dbNodesListDataSourceTestEntity.exadataInfraDisplayNamePrefix)
+	vmcDisplayName := acctest.RandomWithPrefix(t, dbNodesListDataSourceTestEntity.vmClusterDisplayNamePrefix)
 	return fmt.Sprintf(`
 
 resource "aws_odb_network" "test" {

--- a/internal/service/odb/db_server_data_source_test.go
+++ b/internal/service/odb/db_server_data_source_test.go
@@ -12,12 +12,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/odb"
 	odbtypes "github.com/aws/aws-sdk-go-v2/service/odb/types"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
@@ -43,31 +40,31 @@ func TestAccODBDBServerDataSource_basic(t *testing.T) {
 	var dbServer odb.GetDbServerOutput
 
 	dataSourceName := "data.aws_odb_db_server.test"
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ODBServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             dbServerDataSourceTestEntity.testAccCheckDBServersDestroyed(ctx),
+		CheckDestroy:             dbServerDataSourceTestEntity.testAccCheckDBServersDestroyed(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: dbServerDataSourceTestEntity.basicDBServerDataSourceConfig(),
+				Config: dbServerDataSourceTestEntity.basicDBServerDataSourceConfig(t),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					dbServerDataSourceTestEntity.testAccCheckDBServerExists(ctx, dataSourceName, &dbServer),
+					dbServerDataSourceTestEntity.testAccCheckDBServerExists(ctx, t, dataSourceName, &dbServer),
 				),
 			},
 		},
 	})
 }
 
-func (testDbServerDataSourceTest) testAccCheckDBServerExists(ctx context.Context, name string, output *odb.GetDbServerOutput) resource.TestCheckFunc {
+func (testDbServerDataSourceTest) testAccCheckDBServerExists(ctx context.Context, t *testing.T, name string, output *odb.GetDbServerOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {
 			return create.Error(names.ODB, create.ErrActionCheckingExistence, tfodb.DSNameDBServer, name, errors.New("not found"))
 		}
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ODBClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).ODBClient(ctx)
 		var dbServerId = rs.Primary.ID
 		var attributes = rs.Primary.Attributes
 		exaId := attributes["exadata_infrastructure_id"]
@@ -80,9 +77,9 @@ func (testDbServerDataSourceTest) testAccCheckDBServerExists(ctx context.Context
 	}
 }
 
-func (testDbServerDataSourceTest) testAccCheckDBServersDestroyed(ctx context.Context) resource.TestCheckFunc {
+func (testDbServerDataSourceTest) testAccCheckDBServersDestroyed(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ODBClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).ODBClient(ctx)
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_odb_cloud_exadata_infrastructure" {
 				continue
@@ -107,9 +104,8 @@ func (testDbServerDataSourceTest) findExaInfra(ctx context.Context, conn *odb.Cl
 	out, err := conn.GetCloudExadataInfrastructure(ctx, &input)
 	if err != nil {
 		if errs.IsA[*odbtypes.ResourceNotFoundException](err) {
-			return &sdkretry.NotFoundError{
-				LastError:   err,
-				LastRequest: &input,
+			return &retry.NotFoundError{
+				LastError: err,
 			}
 		}
 		return err
@@ -132,8 +128,8 @@ func (testDbServerDataSourceTest) findDBServer(ctx context.Context, conn *odb.Cl
 	return output, nil
 }
 
-func (testDbServerDataSourceTest) basicDBServerDataSourceConfig() string {
-	exaInfraDisplayName := sdkacctest.RandomWithPrefix(dbServersListDataSourceTestEntity.displayNamePrefix)
+func (testDbServerDataSourceTest) basicDBServerDataSourceConfig(t *testing.T) string {
+	exaInfraDisplayName := acctest.RandomWithPrefix(t, dbServersListDataSourceTestEntity.displayNamePrefix)
 	exaInfra := dbServerDataSourceTestEntity.exaInfra(exaInfraDisplayName)
 
 	return fmt.Sprintf(`

--- a/internal/service/odb/db_servers_data_source_test.go
+++ b/internal/service/odb/db_servers_data_source_test.go
@@ -13,12 +13,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/odb"
 	odbtypes "github.com/aws/aws-sdk-go-v2/service/odb/types"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
@@ -44,18 +41,18 @@ func TestAccODBDBServersListDataSource_basic(t *testing.T) {
 	var dbServersList odb.ListDbServersOutput
 	dataSourceName := "data.aws_odb_db_servers.test"
 	exaInfraResourceName := "aws_odb_cloud_exadata_infrastructure.test"
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ODBServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             dbServersListDataSourceTestEntity.testAccCheckDBServersDestroyed(ctx),
+		CheckDestroy:             dbServersListDataSourceTestEntity.testAccCheckDBServersDestroyed(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: dbServersListDataSourceTestEntity.testAccDBServersListDataSourceConfigBasic(),
+				Config: dbServersListDataSourceTestEntity.testAccDBServersListDataSourceConfigBasic(t),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					dbServersListDataSourceTestEntity.testAccCheckDBServersListExists(ctx, exaInfraResourceName, &dbServersList),
+					dbServersListDataSourceTestEntity.testAccCheckDBServersListExists(ctx, t, exaInfraResourceName, &dbServersList),
 					resource.TestCheckResourceAttr(dataSourceName, "aws_odb_db_servers.db_servers.#", strconv.Itoa(len(dbServersList.DbServers))),
 				),
 			},
@@ -63,13 +60,13 @@ func TestAccODBDBServersListDataSource_basic(t *testing.T) {
 	})
 }
 
-func (testDbServersListDataSource) testAccCheckDBServersListExists(ctx context.Context, name string, output *odb.ListDbServersOutput) resource.TestCheckFunc {
+func (testDbServersListDataSource) testAccCheckDBServersListExists(ctx context.Context, t *testing.T, name string, output *odb.ListDbServersOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {
 			return create.Error(names.ODB, create.ErrActionCheckingExistence, tfodb.DSNameDBServersList, name, errors.New("not found"))
 		}
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ODBClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).ODBClient(ctx)
 		var exaInfraId = &rs.Primary.ID
 
 		resp, err := dbServersListDataSourceTestEntity.findDBServersList(ctx, conn, exaInfraId)
@@ -81,9 +78,9 @@ func (testDbServersListDataSource) testAccCheckDBServersListExists(ctx context.C
 	}
 }
 
-func (testDbServersListDataSource) testAccCheckDBServersDestroyed(ctx context.Context) resource.TestCheckFunc {
+func (testDbServersListDataSource) testAccCheckDBServersDestroyed(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ODBClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).ODBClient(ctx)
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_odb_cloud_exadata_infrastructure" {
 				continue
@@ -108,9 +105,8 @@ func (testDbServersListDataSource) findExaInfra(ctx context.Context, conn *odb.C
 	out, err := conn.GetCloudExadataInfrastructure(ctx, &input)
 	if err != nil {
 		if errs.IsA[*odbtypes.ResourceNotFoundException](err) {
-			return nil, &sdkretry.NotFoundError{
-				LastError:   err,
-				LastRequest: &input,
+			return nil, &retry.NotFoundError{
+				LastError: err,
 			}
 		}
 		return nil, err
@@ -132,8 +128,8 @@ func (testDbServersListDataSource) findDBServersList(ctx context.Context, conn *
 	return output, nil
 }
 
-func (testDbServersListDataSource) testAccDBServersListDataSourceConfigBasic() string {
-	exaInfraDisplayName := sdkacctest.RandomWithPrefix(dbServersListDataSourceTestEntity.displayNamePrefix)
+func (testDbServersListDataSource) testAccDBServersListDataSourceConfigBasic(t *testing.T) string {
+	exaInfraDisplayName := acctest.RandomWithPrefix(t, dbServersListDataSourceTestEntity.displayNamePrefix)
 	exaInfra := dbServersListDataSourceTestEntity.exaInfra(exaInfraDisplayName)
 	return fmt.Sprintf(`
 %s

--- a/internal/service/odb/db_system_shapes_data_source_test.go
+++ b/internal/service/odb/db_system_shapes_data_source_test.go
@@ -18,7 +18,7 @@ func TestAccODBDBSystemShapesListDataSource_basic(t *testing.T) {
 		t.Skip("skipping long-running test in short mode")
 	}
 	dataSourceName := "data.aws_odb_db_system_shapes.test"
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 		},

--- a/internal/service/odb/gi_versions_data_source_test.go
+++ b/internal/service/odb/gi_versions_data_source_test.go
@@ -20,7 +20,7 @@ func TestAccODBGiVersionsListDataSource_basicX9M(t *testing.T) {
 	}
 	dataSourceName := "data.aws_odb_gi_versions.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 		},
@@ -43,7 +43,7 @@ func TestAccODBGiVersionsListDataSource_basicX11M(t *testing.T) {
 		t.Skip("skipping long-running test in short mode")
 	}
 	dataSourceName := "data.aws_odb_gi_versions.test"
-	resource.Test(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 		},

--- a/internal/service/odb/network.go
+++ b/internal/service/odb/network.go
@@ -29,7 +29,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
@@ -748,10 +747,10 @@ func (r *resourceNetwork) Delete(ctx context.Context, req resource.DeleteRequest
 }
 
 func waitNetworkCreated(ctx context.Context, conn *odb.Client, id string, timeout time.Duration) (*odbtypes.OdbNetwork, error) {
-	stateConf := &sdkretry.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending: enum.Slice(odbtypes.ResourceStatusProvisioning),
 		Target:  enum.Slice(odbtypes.ResourceStatusAvailable, odbtypes.ResourceStatusFailed),
-		Refresh: statusNetwork(ctx, conn, id),
+		Refresh: statusNetwork(conn, id),
 		Timeout: timeout,
 	}
 
@@ -766,10 +765,10 @@ func waitNetworkCreated(ctx context.Context, conn *odb.Client, id string, timeou
 func waitForManagedService(ctx context.Context, targetStatus odbtypes.Access, conn *odb.Client, id string, timeout time.Duration, managedResourceStatus func(managedService *odbtypes.ManagedServices) odbtypes.ManagedResourceStatus) (*odbtypes.OdbNetwork, error) {
 	switch targetStatus {
 	case odbtypes.AccessEnabled:
-		stateConf := &sdkretry.StateChangeConf{
+		stateConf := &retry.StateChangeConf{
 			Pending: enum.Slice(odbtypes.ManagedResourceStatusEnabling),
 			Target:  enum.Slice(odbtypes.ManagedResourceStatusEnabled),
-			Refresh: statusManagedService(ctx, conn, id, managedResourceStatus),
+			Refresh: statusManagedService(conn, id, managedResourceStatus),
 			Timeout: timeout,
 		}
 		outputRaw, err := stateConf.WaitForStateContext(ctx)
@@ -778,10 +777,10 @@ func waitForManagedService(ctx context.Context, targetStatus odbtypes.Access, co
 		}
 		return nil, err
 	case odbtypes.AccessDisabled:
-		stateConf := &sdkretry.StateChangeConf{
+		stateConf := &retry.StateChangeConf{
 			Pending: enum.Slice(odbtypes.ManagedResourceStatusDisabling),
 			Target:  enum.Slice(odbtypes.ManagedResourceStatusDisabled),
-			Refresh: statusManagedService(ctx, conn, id, managedResourceStatus),
+			Refresh: statusManagedService(conn, id, managedResourceStatus),
 			Timeout: timeout,
 		}
 		outputRaw, err := stateConf.WaitForStateContext(ctx)
@@ -820,8 +819,8 @@ func waitForCrossRegionRestoreSourcesStatus(ctx context.Context, conn *odb.Clien
 	return nil
 }
 
-func statusManagedService(ctx context.Context, conn *odb.Client, id string, managedResourceStatus func(managedService *odbtypes.ManagedServices) odbtypes.ManagedResourceStatus) sdkretry.StateRefreshFunc {
-	return func() (any, string, error) {
+func statusManagedService(conn *odb.Client, id string, managedResourceStatus func(managedService *odbtypes.ManagedServices) odbtypes.ManagedResourceStatus) retry.StateRefreshFunc {
+	return func(ctx context.Context) (any, string, error) {
 		out, err := FindOracleDBNetworkResourceByID(ctx, conn, id)
 
 		if err != nil {
@@ -837,10 +836,10 @@ func statusManagedService(ctx context.Context, conn *odb.Client, id string, mana
 }
 
 func waitNetworkUpdated(ctx context.Context, conn *odb.Client, id string, timeout time.Duration) (*odbtypes.OdbNetwork, error) {
-	stateConf := &sdkretry.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending: enum.Slice(odbtypes.ResourceStatusUpdating),
 		Target:  enum.Slice(odbtypes.ResourceStatusAvailable, odbtypes.ResourceStatusFailed),
-		Refresh: statusNetwork(ctx, conn, id),
+		Refresh: statusNetwork(conn, id),
 		Timeout: timeout,
 	}
 
@@ -853,10 +852,10 @@ func waitNetworkUpdated(ctx context.Context, conn *odb.Client, id string, timeou
 }
 
 func waitNetworkDeleted(ctx context.Context, conn *odb.Client, id string, timeout time.Duration) (*odbtypes.OdbNetwork, error) {
-	stateConf := &sdkretry.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending: enum.Slice(odbtypes.ResourceStatusTerminating),
 		Target:  []string{},
-		Refresh: statusNetwork(ctx, conn, id),
+		Refresh: statusNetwork(conn, id),
 		Timeout: timeout,
 	}
 
@@ -868,8 +867,8 @@ func waitNetworkDeleted(ctx context.Context, conn *odb.Client, id string, timeou
 	return nil, err
 }
 
-func statusNetwork(ctx context.Context, conn *odb.Client, id string) sdkretry.StateRefreshFunc {
-	return func() (any, string, error) {
+func statusNetwork(conn *odb.Client, id string) retry.StateRefreshFunc {
+	return func(ctx context.Context) (any, string, error) {
 		out, err := FindOracleDBNetworkResourceByID(ctx, conn, id)
 		if retry.NotFound(err) {
 			return nil, "", nil
@@ -905,9 +904,8 @@ func FindOracleDBNetworkResourceByID(ctx context.Context, conn *odb.Client, id s
 	out, err := conn.GetOdbNetwork(ctx, &input)
 	if err != nil {
 		if errs.IsA[*odbtypes.ResourceNotFoundException](err) {
-			return nil, &sdkretry.NotFoundError{
-				LastError:   err,
-				LastRequest: &input,
+			return nil, &retry.NotFoundError{
+				LastError: err,
 			}
 		}
 

--- a/internal/service/odb/network_data_source_test.go
+++ b/internal/service/odb/network_data_source_test.go
@@ -14,12 +14,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/odb"
 	odbtypes "github.com/aws/aws-sdk-go-v2/service/odb/types"
 	"github.com/hashicorp/aws-sdk-go-base/v2/endpoints"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
@@ -40,16 +37,16 @@ func TestAccODBNetworkDataSource_basic(t *testing.T) {
 	}
 	networkResource := "aws_odb_network.test_resource"
 	networkDataSource := "data.aws_odb_network.test"
-	rName := sdkacctest.RandomWithPrefix("tf-ora-net")
+	rName := acctest.RandomWithPrefix(t, "tf-ora-net")
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			oracleDBNetworkDataSourceTestEntity.testAccNetworkDataSourcePreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ODBServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             oracleDBNetworkDataSourceTestEntity.testAccCheckNetworkDataSourceDestroyed(ctx),
+		CheckDestroy:             oracleDBNetworkDataSourceTestEntity.testAccCheckNetworkDataSourceDestroyed(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: oracleDBNetworkDataSourceTestEntity.basicNetworkDataSource(rName, endpoints.UsWest2RegionID),
@@ -68,16 +65,16 @@ func TestAccODBNetworkDataSource_ec2PlacementGroupIDs(t *testing.T) {
 	}
 	networkResource := "aws_odb_network.test_resource"
 	networkDataSource := "data.aws_odb_network.test"
-	rName := sdkacctest.RandomWithPrefix("tf-ora-net")
+	rName := acctest.RandomWithPrefix(t, "tf-ora-net")
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			oracleDBNetworkDataSourceTestEntity.testAccNetworkDataSourcePreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ODBServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             oracleDBNetworkDataSourceTestEntity.testAccCheckNetworkDataSourceDestroyed(ctx),
+		CheckDestroy:             oracleDBNetworkDataSourceTestEntity.testAccCheckNetworkDataSourceDestroyed(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: oracleDBNetworkDataSourceTestEntity.basicNetworkDataSourceForEC2PlacementGroup(rName),
@@ -99,9 +96,9 @@ func TestAccODBNetworkDataSource_ec2PlacementGroupIDs(t *testing.T) {
 	})
 }
 
-func (oracleDBNetworkDataSourceTest) testAccCheckNetworkDataSourceDestroyed(ctx context.Context) resource.TestCheckFunc {
+func (oracleDBNetworkDataSourceTest) testAccCheckNetworkDataSourceDestroyed(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ODBClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).ODBClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_odb_network" {
@@ -130,9 +127,8 @@ func (oracleDBNetworkDataSourceTest) findNetwork(ctx context.Context, conn *odb.
 	out, err := conn.GetOdbNetwork(ctx, &input)
 	if err != nil {
 		if errs.IsA[*odbtypes.ResourceNotFoundException](err) {
-			return nil, &sdkretry.NotFoundError{
-				LastError:   err,
-				LastRequest: &input,
+			return nil, &retry.NotFoundError{
+				LastError: err,
 			}
 		}
 
@@ -178,7 +174,7 @@ data "aws_odb_network" "test" {
 }
 
 func (oracleDBNetworkDataSourceTest) testAccNetworkDataSourcePreCheck(ctx context.Context, t *testing.T) {
-	conn := acctest.Provider.Meta().(*conns.AWSClient).ODBClient(ctx)
+	conn := acctest.ProviderMeta(ctx, t).ODBClient(ctx)
 	input := odb.ListOdbNetworksInput{}
 	_, err := conn.ListOdbNetworks(ctx, &input)
 	if acctest.PreCheckSkipError(err) {

--- a/internal/service/odb/network_peering_connection.go
+++ b/internal/service/odb/network_peering_connection.go
@@ -25,7 +25,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
@@ -459,10 +458,10 @@ func (r *resourceNetworkPeeringConnection) FindAddRemovePeeredNetworkCIDR(planCI
 }
 
 func waitNetworkPeeringConnectionCreated(ctx context.Context, conn *odb.Client, id string, timeout time.Duration) (*odbtypes.OdbPeeringConnection, error) {
-	stateConf := &sdkretry.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending:                   enum.Slice(odbtypes.ResourceStatusProvisioning),
 		Target:                    enum.Slice(odbtypes.ResourceStatusAvailable, odbtypes.ResourceStatusFailed),
-		Refresh:                   statusNetworkPeeringConnection(ctx, conn, id),
+		Refresh:                   statusNetworkPeeringConnection(conn, id),
 		Timeout:                   timeout,
 		NotFoundChecks:            20,
 		ContinuousTargetOccurence: 2,
@@ -477,10 +476,10 @@ func waitNetworkPeeringConnectionCreated(ctx context.Context, conn *odb.Client, 
 }
 
 func waitNetworkPeeringConnectionUpdated(ctx context.Context, conn *odb.Client, id string, timeout time.Duration) (*odbtypes.OdbPeeringConnection, error) {
-	stateConf := &sdkretry.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending:                   enum.Slice(odbtypes.ResourceStatusUpdating),
 		Target:                    enum.Slice(odbtypes.ResourceStatusAvailable, odbtypes.ResourceStatusFailed),
-		Refresh:                   statusNetworkPeeringConnection(ctx, conn, id),
+		Refresh:                   statusNetworkPeeringConnection(conn, id),
 		Timeout:                   timeout,
 		NotFoundChecks:            20,
 		ContinuousTargetOccurence: 2,
@@ -495,10 +494,10 @@ func waitNetworkPeeringConnectionUpdated(ctx context.Context, conn *odb.Client, 
 }
 
 func waitNetworkPeeringConnectionDeleted(ctx context.Context, conn *odb.Client, id string, timeout time.Duration) (*odbtypes.OdbPeeringConnection, error) {
-	stateConf := &sdkretry.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending: enum.Slice(odbtypes.ResourceStatusTerminating),
 		Target:  []string{},
-		Refresh: statusNetworkPeeringConnection(ctx, conn, id),
+		Refresh: statusNetworkPeeringConnection(conn, id),
 		Timeout: timeout,
 	}
 
@@ -509,8 +508,8 @@ func waitNetworkPeeringConnectionDeleted(ctx context.Context, conn *odb.Client, 
 	return nil, err
 }
 
-func statusNetworkPeeringConnection(ctx context.Context, conn *odb.Client, id string) sdkretry.StateRefreshFunc {
-	return func() (any, string, error) {
+func statusNetworkPeeringConnection(conn *odb.Client, id string) retry.StateRefreshFunc {
+	return func(ctx context.Context) (any, string, error) {
 		out, err := findNetworkPeeringConnectionByID(ctx, conn, id)
 		if retry.NotFound(err) {
 			return nil, "", nil
@@ -530,9 +529,8 @@ func findNetworkPeeringConnectionByID(ctx context.Context, conn *odb.Client, id 
 	out, err := conn.GetOdbPeeringConnection(ctx, &input)
 	if err != nil {
 		if errs.IsA[*odbtypes.ResourceNotFoundException](err) {
-			return nil, &sdkretry.NotFoundError{
-				LastError:   err,
-				LastRequest: &input,
+			return nil, &retry.NotFoundError{
+				LastError: err,
 			}
 		}
 

--- a/internal/service/odb/network_peering_connection_data_source_test.go
+++ b/internal/service/odb/network_peering_connection_data_source_test.go
@@ -11,12 +11,9 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/odb"
 	odbtypes "github.com/aws/aws-sdk-go-v2/service/odb/types"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
@@ -44,16 +41,16 @@ func TestAccODBNetworkPeeringConnectionDataSource_basic(t *testing.T) {
 	}
 	networkPeeringResource := "aws_odb_network_peering_connection.test"
 	networkPerringDataSource := "data.aws_odb_network_peering_connection.test"
-	odbNetPeeringDisplayName := sdkacctest.RandomWithPrefix(oracleDBNetPeeringDSTestEntity.odbNetworkPeeringDisplayNamePrefix)
-	odbNetDispName := sdkacctest.RandomWithPrefix(oracleDBNetPeeringDSTestEntity.odbNetDisplayNamePrefix)
-	vpcName := sdkacctest.RandomWithPrefix(oracleDBNetPeeringDSTestEntity.vpcNamePrefix)
-	resource.Test(t, resource.TestCase{
+	odbNetPeeringDisplayName := acctest.RandomWithPrefix(t, oracleDBNetPeeringDSTestEntity.odbNetworkPeeringDisplayNamePrefix)
+	odbNetDispName := acctest.RandomWithPrefix(t, oracleDBNetPeeringDSTestEntity.odbNetDisplayNamePrefix)
+	vpcName := acctest.RandomWithPrefix(t, oracleDBNetPeeringDSTestEntity.vpcNamePrefix)
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ODBServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             oracleDBNetPeeringDSTestEntity.testAccCheckCloudOracleDBNetworkPeeringDestroy(ctx),
+		CheckDestroy:             oracleDBNetPeeringDSTestEntity.testAccCheckCloudOracleDBNetworkPeeringDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: oracleDBNetPeeringDSTestEntity.basicPeeringConfig(vpcName, odbNetDispName, odbNetPeeringDisplayName),
@@ -65,9 +62,9 @@ func TestAccODBNetworkPeeringConnectionDataSource_basic(t *testing.T) {
 	})
 }
 
-func (oracleDBNetPeeringDataSourceTest) testAccCheckCloudOracleDBNetworkPeeringDestroy(ctx context.Context) resource.TestCheckFunc {
+func (oracleDBNetPeeringDataSourceTest) testAccCheckCloudOracleDBNetworkPeeringDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ODBClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).ODBClient(ctx)
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_odb_network_peering_connection" {
 				continue
@@ -93,9 +90,8 @@ func (oracleDBNetPeeringDataSourceTest) findOracleDBNetworkPeering(ctx context.C
 	out, err := conn.GetOdbPeeringConnection(ctx, &input)
 	if err != nil {
 		if errs.IsA[*odbtypes.ResourceNotFoundException](err) {
-			return nil, &sdkretry.NotFoundError{
-				LastError:   err,
-				LastRequest: &input,
+			return nil, &retry.NotFoundError{
+				LastError: err,
 			}
 		}
 

--- a/internal/service/odb/network_peering_connection_test.go
+++ b/internal/service/odb/network_peering_connection_test.go
@@ -13,13 +13,10 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/odb"
 	odbtypes "github.com/aws/aws-sdk-go-v2/service/odb/types"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
@@ -99,24 +96,24 @@ func TestAccODBNetworkPeeringConnection_basic(t *testing.T) {
 	}
 
 	var odbPeeringResource odb.GetOdbPeeringConnectionOutput
-	odbPeeringDisplayName := sdkacctest.RandomWithPrefix(oracleDBNwkPeeringTestResource.odbPeeringDisplayNamePrefix)
-	vpcName := sdkacctest.RandomWithPrefix(oracleDBNwkPeeringTestResource.vpcNamePrefix)
-	odbNetName := sdkacctest.RandomWithPrefix(oracleDBNwkPeeringTestResource.odbNwkDisplayNamePrefix)
+	odbPeeringDisplayName := acctest.RandomWithPrefix(t, oracleDBNwkPeeringTestResource.odbPeeringDisplayNamePrefix)
+	vpcName := acctest.RandomWithPrefix(t, oracleDBNwkPeeringTestResource.vpcNamePrefix)
+	odbNetName := acctest.RandomWithPrefix(t, oracleDBNwkPeeringTestResource.odbNwkDisplayNamePrefix)
 	resourceName := "aws_odb_network_peering_connection.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			oracleDBNwkPeeringTestResource.testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ODBServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             oracleDBNwkPeeringTestResource.testAccCheckNetworkPeeringConnectionDestroy(ctx),
+		CheckDestroy:             oracleDBNwkPeeringTestResource.testAccCheckNetworkPeeringConnectionDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: oracleDBNwkPeeringTestResource.basicConfig(vpcName, odbNetName, odbPeeringDisplayName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckNetworkPeeringConnectionExists(ctx, resourceName, &odbPeeringResource),
+					testAccCheckNetworkPeeringConnectionExists(ctx, t, resourceName, &odbPeeringResource),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.env", "dev"),
 				),
@@ -138,24 +135,24 @@ func TestAccODBNetworkPeeringConnection_withARN(t *testing.T) {
 	}
 
 	var odbPeeringResource odb.GetOdbPeeringConnectionOutput
-	odbPeeringDisplayName := sdkacctest.RandomWithPrefix(oracleDBNwkPeeringTestResource.odbPeeringDisplayNamePrefix)
-	vpcName := sdkacctest.RandomWithPrefix(oracleDBNwkPeeringTestResource.vpcNamePrefix)
-	odbNetName := sdkacctest.RandomWithPrefix(oracleDBNwkPeeringTestResource.odbNwkDisplayNamePrefix)
+	odbPeeringDisplayName := acctest.RandomWithPrefix(t, oracleDBNwkPeeringTestResource.odbPeeringDisplayNamePrefix)
+	vpcName := acctest.RandomWithPrefix(t, oracleDBNwkPeeringTestResource.vpcNamePrefix)
+	odbNetName := acctest.RandomWithPrefix(t, oracleDBNwkPeeringTestResource.odbNwkDisplayNamePrefix)
 	resourceName := "aws_odb_network_peering_connection.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			oracleDBNwkPeeringTestResource.testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ODBServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             oracleDBNwkPeeringTestResource.testAccCheckNetworkPeeringConnectionDestroy(ctx),
+		CheckDestroy:             oracleDBNwkPeeringTestResource.testAccCheckNetworkPeeringConnectionDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: oracleDBNwkPeeringTestResource.basicConfigWithARN(vpcName, odbNetName, odbPeeringDisplayName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckNetworkPeeringConnectionExists(ctx, resourceName, &odbPeeringResource),
+					testAccCheckNetworkPeeringConnectionExists(ctx, t, resourceName, &odbPeeringResource),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.env", "dev"),
 				),
@@ -175,18 +172,18 @@ func TestAccODBNetworkPeeringConnection_variables(t *testing.T) {
 		t.Skip("skipping long-running test in short mode")
 	}
 
-	odbPeeringDisplayName := sdkacctest.RandomWithPrefix(oracleDBNwkPeeringTestResource.odbPeeringDisplayNamePrefix)
-	vpcName := sdkacctest.RandomWithPrefix(oracleDBNwkPeeringTestResource.vpcNamePrefix)
-	odbNetName := sdkacctest.RandomWithPrefix(oracleDBNwkPeeringTestResource.odbNwkDisplayNamePrefix)
+	odbPeeringDisplayName := acctest.RandomWithPrefix(t, oracleDBNwkPeeringTestResource.odbPeeringDisplayNamePrefix)
+	vpcName := acctest.RandomWithPrefix(t, oracleDBNwkPeeringTestResource.vpcNamePrefix)
+	odbNetName := acctest.RandomWithPrefix(t, oracleDBNwkPeeringTestResource.odbNwkDisplayNamePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			vmClusterTestEntity.testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ODBServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             oracleDBNwkPeeringTestResource.testAccCheckNetworkPeeringConnectionDestroy(ctx),
+		CheckDestroy:             oracleDBNwkPeeringTestResource.testAccCheckNetworkPeeringConnectionDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// nosemgrep:ci.semgrep.acctest.checks.replace-planonly-checks
 			{
@@ -206,24 +203,24 @@ func TestAccODBNetworkPeeringConnection_tagging(t *testing.T) {
 	}
 
 	var odbPeeringResource odb.GetOdbPeeringConnectionOutput
-	odbPeeringDisplayName := sdkacctest.RandomWithPrefix(oracleDBNwkPeeringTestResource.odbPeeringDisplayNamePrefix)
-	vpcName := sdkacctest.RandomWithPrefix(oracleDBNwkPeeringTestResource.vpcNamePrefix)
-	odbNetName := sdkacctest.RandomWithPrefix(oracleDBNwkPeeringTestResource.odbNwkDisplayNamePrefix)
+	odbPeeringDisplayName := acctest.RandomWithPrefix(t, oracleDBNwkPeeringTestResource.odbPeeringDisplayNamePrefix)
+	vpcName := acctest.RandomWithPrefix(t, oracleDBNwkPeeringTestResource.vpcNamePrefix)
+	odbNetName := acctest.RandomWithPrefix(t, oracleDBNwkPeeringTestResource.odbNwkDisplayNamePrefix)
 	resourceName := "aws_odb_network_peering_connection.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			oracleDBNwkPeeringTestResource.testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ODBServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             oracleDBNwkPeeringTestResource.testAccCheckNetworkPeeringConnectionDestroy(ctx),
+		CheckDestroy:             oracleDBNwkPeeringTestResource.testAccCheckNetworkPeeringConnectionDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: oracleDBNwkPeeringTestResource.basicConfig(vpcName, odbNetName, odbPeeringDisplayName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckNetworkPeeringConnectionExists(ctx, resourceName, &odbPeeringResource),
+					testAccCheckNetworkPeeringConnectionExists(ctx, t, resourceName, &odbPeeringResource),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.env", "dev"),
 				),
@@ -236,7 +233,7 @@ func TestAccODBNetworkPeeringConnection_tagging(t *testing.T) {
 			{
 				Config: oracleDBNwkPeeringTestResource.basicConfigNoTag(vpcName, odbNetName, odbPeeringDisplayName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckNetworkPeeringConnectionExists(ctx, resourceName, &odbPeeringResource),
+					testAccCheckNetworkPeeringConnectionExists(ctx, t, resourceName, &odbPeeringResource),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "0"),
 				),
 			},
@@ -257,25 +254,25 @@ func TestAccODBNetworkPeeringConnection_addRemovePeeredCIDR(t *testing.T) {
 	}
 
 	var peering1, peering2, peering3 odb.GetOdbPeeringConnectionOutput
-	odbPeeringDisplayName := sdkacctest.RandomWithPrefix(oracleDBNwkPeeringTestResource.odbPeeringDisplayNamePrefix)
-	vpcName := sdkacctest.RandomWithPrefix(oracleDBNwkPeeringTestResource.vpcNamePrefix)
-	odbNetName := sdkacctest.RandomWithPrefix(oracleDBNwkPeeringTestResource.odbNwkDisplayNamePrefix)
+	odbPeeringDisplayName := acctest.RandomWithPrefix(t, oracleDBNwkPeeringTestResource.odbPeeringDisplayNamePrefix)
+	vpcName := acctest.RandomWithPrefix(t, oracleDBNwkPeeringTestResource.vpcNamePrefix)
+	odbNetName := acctest.RandomWithPrefix(t, oracleDBNwkPeeringTestResource.odbNwkDisplayNamePrefix)
 	resourceName := "aws_odb_network_peering_connection.test"
 	basicConfig, removedCidr, addedCidr := oracleDBNwkPeeringTestResource.addRemovePeeredNetworkCIDRConfig(vpcName, odbNetName, odbPeeringDisplayName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			oracleDBNwkPeeringTestResource.testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ODBServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             oracleDBNwkPeeringTestResource.testAccCheckNetworkPeeringConnectionDestroy(ctx),
+		CheckDestroy:             oracleDBNwkPeeringTestResource.testAccCheckNetworkPeeringConnectionDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: basicConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckNetworkPeeringConnectionExists(ctx, resourceName, &peering1),
+					testAccCheckNetworkPeeringConnectionExists(ctx, t, resourceName, &peering1),
 				),
 			},
 			{
@@ -286,7 +283,7 @@ func TestAccODBNetworkPeeringConnection_addRemovePeeredCIDR(t *testing.T) {
 			{
 				Config: removedCidr,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckNetworkPeeringConnectionExists(ctx, resourceName, &peering2),
+					testAccCheckNetworkPeeringConnectionExists(ctx, t, resourceName, &peering2),
 					resource.ComposeTestCheckFunc(func(state *terraform.State) error {
 						if strings.Compare(*(peering1.OdbPeeringConnection.OdbPeeringConnectionId), *(peering2.OdbPeeringConnection.OdbPeeringConnectionId)) != 0 {
 							return errors.New("should not  create a new odb network peering connection")
@@ -303,7 +300,7 @@ func TestAccODBNetworkPeeringConnection_addRemovePeeredCIDR(t *testing.T) {
 			{
 				Config: addedCidr,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckNetworkPeeringConnectionExists(ctx, resourceName, &peering3),
+					testAccCheckNetworkPeeringConnectionExists(ctx, t, resourceName, &peering3),
 					resource.ComposeTestCheckFunc(func(state *terraform.State) error {
 						if strings.Compare(*(peering1.OdbPeeringConnection.OdbPeeringConnectionId), *(peering3.OdbPeeringConnection.OdbPeeringConnectionId)) != 0 {
 							return errors.New("should not  create a new odb network peering connection")
@@ -327,25 +324,25 @@ func TestAccODBNetworkPeeringConnection_updateTagAndRemovePeeredCIDR(t *testing.
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}
-	vpcName := sdkacctest.RandomWithPrefix(oracleDBNwkPeeringTestResource.vpcNamePrefix)
-	odbNetName := sdkacctest.RandomWithPrefix(oracleDBNwkPeeringTestResource.odbNwkDisplayNamePrefix)
+	vpcName := acctest.RandomWithPrefix(t, oracleDBNwkPeeringTestResource.vpcNamePrefix)
+	odbNetName := acctest.RandomWithPrefix(t, oracleDBNwkPeeringTestResource.odbNwkDisplayNamePrefix)
 	resourceName := "aws_odb_network_peering_connection.test"
 	var peering1, peering2 odb.GetOdbPeeringConnectionOutput
 	basicConfig, removedCidr := oracleDBNwkPeeringTestResource.basicConfigWithMultiplePeerCIDR(vpcName, odbNetName, resourceName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			oracleDBNwkPeeringTestResource.testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ODBServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             oracleDBNwkPeeringTestResource.testAccCheckNetworkPeeringConnectionDestroy(ctx),
+		CheckDestroy:             oracleDBNwkPeeringTestResource.testAccCheckNetworkPeeringConnectionDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: basicConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckNetworkPeeringConnectionExists(ctx, resourceName, &peering1),
+					testAccCheckNetworkPeeringConnectionExists(ctx, t, resourceName, &peering1),
 				),
 			},
 			{
@@ -356,7 +353,7 @@ func TestAccODBNetworkPeeringConnection_updateTagAndRemovePeeredCIDR(t *testing.
 			{
 				Config: removedCidr,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckNetworkPeeringConnectionExists(ctx, resourceName, &peering2),
+					testAccCheckNetworkPeeringConnectionExists(ctx, t, resourceName, &peering2),
 					resource.ComposeTestCheckFunc(func(state *terraform.State) error {
 						if strings.Compare(*(peering1.OdbPeeringConnection.OdbPeeringConnectionId), *(peering2.OdbPeeringConnection.OdbPeeringConnectionId)) != 0 {
 							return errors.New("should not  create a new odb network peering connection")
@@ -381,24 +378,24 @@ func TestAccODBNetworkPeeringConnection_disappears(t *testing.T) {
 	}
 
 	var odbPeering odb.GetOdbPeeringConnectionOutput
-	odbPeeringDisplayName := sdkacctest.RandomWithPrefix(oracleDBNwkPeeringTestResource.odbPeeringDisplayNamePrefix)
-	vpcName := sdkacctest.RandomWithPrefix(oracleDBNwkPeeringTestResource.vpcNamePrefix)
-	odbNetDisplayName := sdkacctest.RandomWithPrefix(oracleDBNwkPeeringTestResource.odbPeeringDisplayNamePrefix)
+	odbPeeringDisplayName := acctest.RandomWithPrefix(t, oracleDBNwkPeeringTestResource.odbPeeringDisplayNamePrefix)
+	vpcName := acctest.RandomWithPrefix(t, oracleDBNwkPeeringTestResource.vpcNamePrefix)
+	odbNetDisplayName := acctest.RandomWithPrefix(t, oracleDBNwkPeeringTestResource.odbPeeringDisplayNamePrefix)
 	resourceName := "aws_odb_network_peering_connection.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			oracleDBNwkPeeringTestResource.testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ODBServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             oracleDBNwkPeeringTestResource.testAccCheckNetworkPeeringConnectionDestroy(ctx),
+		CheckDestroy:             oracleDBNwkPeeringTestResource.testAccCheckNetworkPeeringConnectionDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: oracleDBNwkPeeringTestResource.basicConfig(vpcName, odbNetDisplayName, odbPeeringDisplayName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckNetworkPeeringConnectionExists(ctx, resourceName, &odbPeering),
+					testAccCheckNetworkPeeringConnectionExists(ctx, t, resourceName, &odbPeering),
 					acctest.CheckFrameworkResourceDisappears(ctx, t, tfodb.OracleDBNetworkPeeringConnection, resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -415,9 +412,9 @@ func TestAccODBNetworkPeeringConnection_disappears(t *testing.T) {
 	})
 }
 
-func (oracleDBNwkPeeringResourceTest) testAccCheckNetworkPeeringConnectionDestroy(ctx context.Context) resource.TestCheckFunc {
+func (oracleDBNwkPeeringResourceTest) testAccCheckNetworkPeeringConnectionDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ODBClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).ODBClient(ctx)
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_odb_network_peering_connection" {
 				continue
@@ -435,7 +432,7 @@ func (oracleDBNwkPeeringResourceTest) testAccCheckNetworkPeeringConnectionDestro
 	}
 }
 
-func testAccCheckNetworkPeeringConnectionExists(ctx context.Context, name string, odbPeeringConnection *odb.GetOdbPeeringConnectionOutput) resource.TestCheckFunc {
+func testAccCheckNetworkPeeringConnectionExists(ctx context.Context, t *testing.T, name string, odbPeeringConnection *odb.GetOdbPeeringConnectionOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {
@@ -444,7 +441,7 @@ func testAccCheckNetworkPeeringConnectionExists(ctx context.Context, name string
 		if rs.Primary.ID == "" {
 			return create.Error(names.ODB, create.ErrActionCheckingExistence, tfodb.ResNameNetworkPeeringConnection, name, errors.New("not set"))
 		}
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ODBClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).ODBClient(ctx)
 
 		resp, err := oracleDBNwkPeeringTestResource.findOracleDBNetworkPeering(ctx, conn, rs.Primary.ID)
 		if err != nil {
@@ -456,7 +453,7 @@ func testAccCheckNetworkPeeringConnectionExists(ctx context.Context, name string
 }
 
 func (oracleDBNwkPeeringResourceTest) testAccPreCheck(ctx context.Context, t *testing.T) {
-	conn := acctest.Provider.Meta().(*conns.AWSClient).ODBClient(ctx)
+	conn := acctest.ProviderMeta(ctx, t).ODBClient(ctx)
 	input := odb.ListOdbPeeringConnectionsInput{}
 	_, err := conn.ListOdbPeeringConnections(ctx, &input)
 	if acctest.PreCheckSkipError(err) {
@@ -474,9 +471,8 @@ func (oracleDBNwkPeeringResourceTest) findOracleDBNetworkPeering(ctx context.Con
 	out, err := conn.GetOdbPeeringConnection(ctx, &input)
 	if err != nil {
 		if errs.IsA[*odbtypes.ResourceNotFoundException](err) {
-			return nil, &sdkretry.NotFoundError{
-				LastError:   err,
-				LastRequest: &input,
+			return nil, &retry.NotFoundError{
+				LastError: err,
 			}
 		}
 		return nil, err

--- a/internal/service/odb/network_peering_connections_data_source_test.go
+++ b/internal/service/odb/network_peering_connections_data_source_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	tfodb "github.com/hashicorp/terraform-provider-aws/internal/service/odb"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -29,7 +28,7 @@ func TestAccODBListNetworkPeeringConnections_basic(t *testing.T) {
 	var output odb.ListOdbPeeringConnectionsOutput
 
 	dataSourceName := "data.aws_odb_network_peering_connections.test"
-	resource.Test(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			listOfPeeredNwks.testAccPreCheck(ctx, t)
@@ -42,7 +41,7 @@ func TestAccODBListNetworkPeeringConnections_basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 
 					resource.ComposeTestCheckFunc(func(s *terraform.State) error {
-						listOfPeeredNwks.count(ctx, dataSourceName, &output)
+						listOfPeeredNwks.count(ctx, t, dataSourceName, &output)
 						resource.TestCheckResourceAttr(dataSourceName, "odb_peering_connections.#", strconv.Itoa(len(output.OdbPeeringConnections)))
 						return nil
 					},
@@ -56,7 +55,7 @@ func TestAccODBListNetworkPeeringConnections_basic(t *testing.T) {
 func TestAccODBListNetworkPeeringConnections_planCheck(t *testing.T) {
 	ctx := acctest.Context(t)
 	var listOfPeeredNwks = listOdbNetworkPeering{}
-	resource.Test(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			listOfPeeredNwks.testAccPreCheck(ctx, t)
@@ -81,13 +80,13 @@ func (listOdbNetworkPeering) basic() string {
 	return `data "aws_odb_network_peering_connections" "test" {}`
 }
 
-func (listOdbNetworkPeering) count(ctx context.Context, name string, list *odb.ListOdbPeeringConnectionsOutput) resource.TestCheckFunc {
+func (listOdbNetworkPeering) count(ctx context.Context, t *testing.T, name string, list *odb.ListOdbPeeringConnectionsOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {
 			return create.Error(names.ODB, create.ErrActionCheckingExistence, tfodb.DSNameNetworkPeeringConnectionsList, name, errors.New("not found"))
 		}
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ODBClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).ODBClient(ctx)
 		resp, err := tfodb.ListOracleDBPeeringConnections(ctx, conn)
 		if err != nil {
 			return create.Error(names.ODB, create.ErrActionCheckingExistence, tfodb.DSNameNetworkPeeringConnectionsList, rs.Primary.ID, err)
@@ -97,7 +96,7 @@ func (listOdbNetworkPeering) count(ctx context.Context, name string, list *odb.L
 	}
 }
 func (listOdbNetworkPeering) testAccPreCheck(ctx context.Context, t *testing.T) {
-	conn := acctest.Provider.Meta().(*conns.AWSClient).ODBClient(ctx)
+	conn := acctest.ProviderMeta(ctx, t).ODBClient(ctx)
 	input := odb.ListOdbPeeringConnectionsInput{}
 	_, err := conn.ListOdbPeeringConnections(ctx, &input)
 	if acctest.PreCheckSkipError(err) {

--- a/internal/service/odb/network_status_test.go
+++ b/internal/service/odb/network_status_test.go
@@ -47,9 +47,9 @@ func TestStatusNetwork_NilOutput(t *testing.T) {
 
 	// API returns 200 with no odbNetwork field → Find returns nil + EmptyResultError.
 	conn := newTestClient(t, jsonHandler(http.StatusOK, map[string]any{}))
-	refreshFunc := statusNetwork(ctx, conn, "odn-doesnotexist")
+	refreshFunc := statusNetwork(conn, "odn-doesnotexist")
 
-	result, state, err := refreshFunc()
+	result, state, err := refreshFunc(ctx)
 
 	// The Find function returns a NotFoundError‐style empty result error,
 	// and statusNetwork swallows NotFound errors.  The key assertion is that
@@ -77,9 +77,9 @@ func TestStatusNetwork_ValidOutput(t *testing.T) {
 			names.AttrStatus: "AVAILABLE",
 		},
 	}))
-	refreshFunc := statusNetwork(ctx, conn, "odn-12345")
+	refreshFunc := statusNetwork(conn, "odn-12345")
 
-	result, state, err := refreshFunc()
+	result, state, err := refreshFunc(ctx)
 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -102,9 +102,9 @@ func TestStatusNetwork_NotFound(t *testing.T) {
 		"__type":          "ResourceNotFoundException",
 		names.AttrMessage: "ODB network not found",
 	}))
-	refreshFunc := statusNetwork(ctx, conn, "odn-doesnotexist")
+	refreshFunc := statusNetwork(conn, "odn-doesnotexist")
 
-	result, state, err := refreshFunc()
+	result, state, err := refreshFunc(ctx)
 
 	if err != nil {
 		t.Fatalf("expected no error for NotFound, got: %v", err)
@@ -140,9 +140,9 @@ func TestStatusManagedService_NilManagedServices(t *testing.T) {
 			names.AttrStatus: "AVAILABLE",
 		},
 	}))
-	refreshFunc := statusManagedService(ctx, conn, "odn-12345", s3ManagedResourceStatus)
+	refreshFunc := statusManagedService(conn, "odn-12345", s3ManagedResourceStatus)
 
-	result, state, err := refreshFunc()
+	result, state, err := refreshFunc(ctx)
 
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
@@ -166,9 +166,9 @@ func TestStatusManagedService_NilOutput(t *testing.T) {
 
 	// API returns 200 with no odbNetwork field → Find returns nil + EmptyResultError.
 	conn := newTestClient(t, jsonHandler(http.StatusOK, map[string]any{}))
-	refreshFunc := statusManagedService(ctx, conn, "odn-doesnotexist", s3ManagedResourceStatus)
+	refreshFunc := statusManagedService(conn, "odn-doesnotexist", s3ManagedResourceStatus)
 
-	result, state, err := refreshFunc()
+	result, state, err := refreshFunc(ctx)
 
 	// Find returns EmptyResultError (which is a NotFoundError), but
 	// statusManagedService treats any error as propagated.  The critical
@@ -197,9 +197,9 @@ func TestStatusManagedService_WithManagedServices(t *testing.T) {
 			},
 		},
 	}))
-	refreshFunc := statusManagedService(ctx, conn, "odn-12345", s3ManagedResourceStatus)
+	refreshFunc := statusManagedService(conn, "odn-12345", s3ManagedResourceStatus)
 
-	result, state, err := refreshFunc()
+	result, state, err := refreshFunc(ctx)
 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -222,9 +222,9 @@ func TestStatusManagedService_NotFound(t *testing.T) {
 		"__type":          "ResourceNotFoundException",
 		names.AttrMessage: "ODB network not found",
 	}))
-	refreshFunc := statusManagedService(ctx, conn, "odn-doesnotexist", s3ManagedResourceStatus)
+	refreshFunc := statusManagedService(conn, "odn-doesnotexist", s3ManagedResourceStatus)
 
-	_, _, err := refreshFunc()
+	_, _, err := refreshFunc(ctx)
 
 	// statusManagedService does NOT have a NotFound guard (unlike statusNetwork),
 	// so it propagates the error.

--- a/internal/service/odb/network_test.go
+++ b/internal/service/odb/network_test.go
@@ -14,12 +14,10 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/odb"
 	odbtypes "github.com/aws/aws-sdk-go-v2/service/odb/types"
 	"github.com/hashicorp/aws-sdk-go-base/v2/endpoints"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfodb "github.com/hashicorp/terraform-provider-aws/internal/service/odb"
@@ -44,21 +42,21 @@ func TestAccODBNetworkResource_basic(t *testing.T) {
 		"delete_associated_resources",
 	}
 	var network odbtypes.OdbNetwork
-	rName := sdkacctest.RandomWithPrefix(oracleDBNetworkResourceTestEntity.displayNamePrefix)
+	rName := acctest.RandomWithPrefix(t, oracleDBNetworkResourceTestEntity.displayNamePrefix)
 	resourceName := "aws_odb_network.test"
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			oracleDBNetworkResourceTestEntity.testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ODBServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             oracleDBNetworkResourceTestEntity.testAccCheckNetworkDestroy(ctx),
+		CheckDestroy:             oracleDBNetworkResourceTestEntity.testAccCheckNetworkDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: oracleDBNetworkResourceTestEntity.basicNetwork(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					oracleDBNetworkResourceTestEntity.testAccCheckNetworkExists(ctx, resourceName, &network),
+					oracleDBNetworkResourceTestEntity.testAccCheckNetworkExists(ctx, t, resourceName, &network),
 				),
 			},
 			{
@@ -80,22 +78,22 @@ func TestAccODBNetworkResource_withAllParams(t *testing.T) {
 		"delete_associated_resources",
 	}
 	var network1 odbtypes.OdbNetwork
-	rName := sdkacctest.RandomWithPrefix(oracleDBNetworkResourceTestEntity.displayNamePrefix)
+	rName := acctest.RandomWithPrefix(t, oracleDBNetworkResourceTestEntity.displayNamePrefix)
 	resourceName := "aws_odb_network.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			oracleDBNetworkResourceTestEntity.testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ODBServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             oracleDBNetworkResourceTestEntity.testAccCheckNetworkDestroy(ctx),
+		CheckDestroy:             oracleDBNetworkResourceTestEntity.testAccCheckNetworkDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: oracleDBNetworkResourceTestEntity.networkWithAllParams(rName, "julia.com", endpoints.UsWest2RegionID),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					oracleDBNetworkResourceTestEntity.testAccCheckNetworkExists(ctx, resourceName, &network1),
+					oracleDBNetworkResourceTestEntity.testAccCheckNetworkExists(ctx, t, resourceName, &network1),
 					resource.TestCheckResourceAttr(
 						resourceName,
 						"cross_region_s3_restore_sources_access.#",
@@ -127,22 +125,22 @@ func TestAccODBNetworkResource_ec2PlacementGroupIDs(t *testing.T) {
 		"delete_associated_resources",
 	}
 	var network odbtypes.OdbNetwork
-	rName := sdkacctest.RandomWithPrefix(oracleDBNetworkResourceTestEntity.displayNamePrefix)
+	rName := acctest.RandomWithPrefix(t, oracleDBNetworkResourceTestEntity.displayNamePrefix)
 	resourceName := "aws_odb_network.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			oracleDBNetworkResourceTestEntity.testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ODBServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             oracleDBNetworkResourceTestEntity.testAccCheckNetworkDestroy(ctx),
+		CheckDestroy:             oracleDBNetworkResourceTestEntity.testAccCheckNetworkDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: oracleDBNetworkResourceTestEntity.basicNetworkFroEC2PlacementGroup(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					oracleDBNetworkResourceTestEntity.testAccCheckNetworkExists(ctx, resourceName, &network),
+					oracleDBNetworkResourceTestEntity.testAccCheckNetworkExists(ctx, t, resourceName, &network),
 					resource.TestCheckResourceAttrWith(resourceName, "ec2_placement_group_ids.#", func(value string) error {
 						count, err := strconv.Atoi(value)
 						if err != nil {
@@ -174,22 +172,22 @@ func TestAccODBNetworkResource_updateManagedService(t *testing.T) {
 		"delete_associated_resources",
 	}
 	var network1, network2 odbtypes.OdbNetwork
-	rName := sdkacctest.RandomWithPrefix(oracleDBNetworkResourceTestEntity.displayNamePrefix)
+	rName := acctest.RandomWithPrefix(t, oracleDBNetworkResourceTestEntity.displayNamePrefix)
 	resourceName := "aws_odb_network.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			oracleDBNetworkResourceTestEntity.testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ODBServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             oracleDBNetworkResourceTestEntity.testAccCheckNetworkDestroy(ctx),
+		CheckDestroy:             oracleDBNetworkResourceTestEntity.testAccCheckNetworkDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: oracleDBNetworkResourceTestEntity.basicNetwork(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					oracleDBNetworkResourceTestEntity.testAccCheckNetworkExists(ctx, resourceName, &network1),
+					oracleDBNetworkResourceTestEntity.testAccCheckNetworkExists(ctx, t, resourceName, &network1),
 				),
 			},
 			{
@@ -201,7 +199,7 @@ func TestAccODBNetworkResource_updateManagedService(t *testing.T) {
 			{
 				Config: oracleDBNetworkResourceTestEntity.basicNetworkWithActiveManagedService(rName, endpoints.UsWest2RegionID),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					oracleDBNetworkResourceTestEntity.testAccCheckNetworkExists(ctx, resourceName, &network2),
+					oracleDBNetworkResourceTestEntity.testAccCheckNetworkExists(ctx, t, resourceName, &network2),
 					resource.ComposeTestCheckFunc(func(state *terraform.State) error {
 						if strings.Compare(*(network1.OdbNetworkId), *(network2.OdbNetworkId)) != 0 {
 							return errors.New("should not  create a new cloud odb network")
@@ -229,22 +227,22 @@ func TestAccODBNetworkResource_disableManagedService(t *testing.T) {
 		"delete_associated_resources",
 	}
 	var network1, network2 odbtypes.OdbNetwork
-	rName := sdkacctest.RandomWithPrefix(oracleDBNetworkResourceTestEntity.displayNamePrefix)
+	rName := acctest.RandomWithPrefix(t, oracleDBNetworkResourceTestEntity.displayNamePrefix)
 	resourceName := "aws_odb_network.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			oracleDBNetworkResourceTestEntity.testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ODBServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             oracleDBNetworkResourceTestEntity.testAccCheckNetworkDestroy(ctx),
+		CheckDestroy:             oracleDBNetworkResourceTestEntity.testAccCheckNetworkDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: oracleDBNetworkResourceTestEntity.basicNetworkWithActiveManagedService(rName, endpoints.UsWest2RegionID),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					oracleDBNetworkResourceTestEntity.testAccCheckNetworkExists(ctx, resourceName, &network1),
+					oracleDBNetworkResourceTestEntity.testAccCheckNetworkExists(ctx, t, resourceName, &network1),
 				),
 			},
 			{
@@ -256,7 +254,7 @@ func TestAccODBNetworkResource_disableManagedService(t *testing.T) {
 			{
 				Config: oracleDBNetworkResourceTestEntity.basicNetwork(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					oracleDBNetworkResourceTestEntity.testAccCheckNetworkExists(ctx, resourceName, &network2),
+					oracleDBNetworkResourceTestEntity.testAccCheckNetworkExists(ctx, t, resourceName, &network2),
 					resource.ComposeTestCheckFunc(func(state *terraform.State) error {
 						if strings.Compare(*(network1.OdbNetworkId), *(network2.OdbNetworkId)) != 0 {
 							return errors.New("should not  create a new cloud odb network")
@@ -289,29 +287,29 @@ func TestAccODBNetworkResource_updateTags(t *testing.T) {
 		"delete_associated_resources",
 	}
 	var network1, network2 odbtypes.OdbNetwork
-	rName := sdkacctest.RandomWithPrefix(oracleDBNetworkResourceTestEntity.displayNamePrefix)
+	rName := acctest.RandomWithPrefix(t, oracleDBNetworkResourceTestEntity.displayNamePrefix)
 	resourceName := "aws_odb_network.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			oracleDBNetworkResourceTestEntity.testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ODBServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             oracleDBNetworkResourceTestEntity.testAccCheckNetworkDestroy(ctx),
+		CheckDestroy:             oracleDBNetworkResourceTestEntity.testAccCheckNetworkDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: oracleDBNetworkResourceTestEntity.basicNetwork(rName),
 
 				Check: resource.ComposeAggregateTestCheckFunc(
-					oracleDBNetworkResourceTestEntity.testAccCheckNetworkExists(ctx, resourceName, &network1),
+					oracleDBNetworkResourceTestEntity.testAccCheckNetworkExists(ctx, t, resourceName, &network1),
 				),
 			},
 			{
 				Config: oracleDBNetworkResourceTestEntity.updateNetworkTags(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					oracleDBNetworkResourceTestEntity.testAccCheckNetworkExists(ctx, resourceName, &network2),
+					oracleDBNetworkResourceTestEntity.testAccCheckNetworkExists(ctx, t, resourceName, &network2),
 					resource.ComposeTestCheckFunc(func(state *terraform.State) error {
 						if strings.Compare(*(network1.OdbNetworkId), *(network2.OdbNetworkId)) != 0 {
 							return errors.New("should not  create a new cloud odb network")
@@ -339,22 +337,22 @@ func TestAccODBNetworkResource_disappears(t *testing.T) {
 	}
 
 	var network odbtypes.OdbNetwork
-	rName := sdkacctest.RandomWithPrefix(oracleDBNetworkResourceTestEntity.displayNamePrefix)
+	rName := acctest.RandomWithPrefix(t, oracleDBNetworkResourceTestEntity.displayNamePrefix)
 	resourceName := "aws_odb_network.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			oracleDBNetworkResourceTestEntity.testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ODBServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             oracleDBNetworkResourceTestEntity.testAccCheckNetworkDestroy(ctx),
+		CheckDestroy:             oracleDBNetworkResourceTestEntity.testAccCheckNetworkDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: oracleDBNetworkResourceTestEntity.basicNetwork(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					oracleDBNetworkResourceTestEntity.testAccCheckNetworkExists(ctx, resourceName, &network),
+					oracleDBNetworkResourceTestEntity.testAccCheckNetworkExists(ctx, t, resourceName, &network),
 					acctest.CheckFrameworkResourceDisappears(ctx, t, tfodb.OracleDBNetwork, resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -380,22 +378,22 @@ func TestAccODBNetworkResource_updateDeleteAssociatedResource(t *testing.T) {
 		"delete_associated_resources",
 	}
 	var network1, network2 odbtypes.OdbNetwork
-	rName := sdkacctest.RandomWithPrefix(oracleDBNetworkResourceTestEntity.displayNamePrefix)
+	rName := acctest.RandomWithPrefix(t, oracleDBNetworkResourceTestEntity.displayNamePrefix)
 	resourceName := "aws_odb_network.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			oracleDBNetworkResourceTestEntity.testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ODBServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             oracleDBNetworkResourceTestEntity.testAccCheckNetworkDestroy(ctx),
+		CheckDestroy:             oracleDBNetworkResourceTestEntity.testAccCheckNetworkDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: oracleDBNetworkResourceTestEntity.basicNetworkWithWithDeleteAssociatedResourceFalse(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					oracleDBNetworkResourceTestEntity.testAccCheckNetworkExists(ctx, resourceName, &network1),
+					oracleDBNetworkResourceTestEntity.testAccCheckNetworkExists(ctx, t, resourceName, &network1),
 				),
 			},
 			{
@@ -407,7 +405,7 @@ func TestAccODBNetworkResource_updateDeleteAssociatedResource(t *testing.T) {
 			{
 				Config: oracleDBNetworkResourceTestEntity.basicNetwork(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					oracleDBNetworkResourceTestEntity.testAccCheckNetworkExists(ctx, resourceName, &network2),
+					oracleDBNetworkResourceTestEntity.testAccCheckNetworkExists(ctx, t, resourceName, &network2),
 					resource.ComposeTestCheckFunc(func(state *terraform.State) error {
 						if strings.Compare(*(network1.OdbNetworkId), *(network2.OdbNetworkId)) != 0 {
 							return errors.New("should not  create a new cloud odb network")
@@ -435,22 +433,22 @@ func TestAccODBNetworkResource_updateCrossRegionRestore(t *testing.T) {
 		"delete_associated_resources",
 	}
 	var network1, network2 odbtypes.OdbNetwork
-	rName := sdkacctest.RandomWithPrefix(oracleDBNetworkResourceTestEntity.displayNamePrefix)
+	rName := acctest.RandomWithPrefix(t, oracleDBNetworkResourceTestEntity.displayNamePrefix)
 	resourceName := "aws_odb_network.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			oracleDBNetworkResourceTestEntity.testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ODBServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             oracleDBNetworkResourceTestEntity.testAccCheckNetworkDestroy(ctx),
+		CheckDestroy:             oracleDBNetworkResourceTestEntity.testAccCheckNetworkDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: oracleDBNetworkResourceTestEntity.basicNetworkWithActiveManagedService(rName, endpoints.UsWest2RegionID),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					oracleDBNetworkResourceTestEntity.testAccCheckNetworkExists(ctx, resourceName, &network1),
+					oracleDBNetworkResourceTestEntity.testAccCheckNetworkExists(ctx, t, resourceName, &network1),
 					resource.TestCheckResourceAttr(
 						resourceName,
 						"cross_region_s3_restore_sources_access.#",
@@ -472,7 +470,7 @@ func TestAccODBNetworkResource_updateCrossRegionRestore(t *testing.T) {
 			{
 				Config: oracleDBNetworkResourceTestEntity.updateNetworkCrossRegionRestore(rName, endpoints.UsEast2RegionID),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					oracleDBNetworkResourceTestEntity.testAccCheckNetworkExists(ctx, resourceName, &network2),
+					oracleDBNetworkResourceTestEntity.testAccCheckNetworkExists(ctx, t, resourceName, &network2),
 					resource.ComposeTestCheckFunc(func(state *terraform.State) error {
 						if *(network1.OdbNetworkId) != *(network2.OdbNetworkId) {
 							return errors.New("should not create a new cloud odb network")
@@ -501,9 +499,9 @@ func TestAccODBNetworkResource_updateCrossRegionRestore(t *testing.T) {
 	})
 }
 
-func (oracleDBNetworkResourceTest) testAccCheckNetworkDestroy(ctx context.Context) resource.TestCheckFunc {
+func (oracleDBNetworkResourceTest) testAccCheckNetworkDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ODBClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).ODBClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_odb_network" {
@@ -524,7 +522,7 @@ func (oracleDBNetworkResourceTest) testAccCheckNetworkDestroy(ctx context.Contex
 	}
 }
 
-func (oracleDBNetworkResourceTest) testAccCheckNetworkExists(ctx context.Context, name string, network *odbtypes.OdbNetwork) resource.TestCheckFunc {
+func (oracleDBNetworkResourceTest) testAccCheckNetworkExists(ctx context.Context, t *testing.T, name string, network *odbtypes.OdbNetwork) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {
@@ -535,7 +533,7 @@ func (oracleDBNetworkResourceTest) testAccCheckNetworkExists(ctx context.Context
 			return create.Error(names.ODB, create.ErrActionCheckingExistence, tfodb.ResNameNetwork, name, errors.New("not set"))
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ODBClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).ODBClient(ctx)
 
 		resp, err := tfodb.FindOracleDBNetworkResourceByID(ctx, conn, rs.Primary.ID)
 		if err != nil {
@@ -549,7 +547,7 @@ func (oracleDBNetworkResourceTest) testAccCheckNetworkExists(ctx context.Context
 }
 
 func (oracleDBNetworkResourceTest) testAccPreCheck(ctx context.Context, t *testing.T) {
-	conn := acctest.Provider.Meta().(*conns.AWSClient).ODBClient(ctx)
+	conn := acctest.ProviderMeta(ctx, t).ODBClient(ctx)
 	input := odb.ListOdbNetworksInput{}
 	_, err := conn.ListOdbNetworks(ctx, &input)
 	if acctest.PreCheckSkipError(err) {

--- a/internal/service/odb/networks_data_source_test.go
+++ b/internal/service/odb/networks_data_source_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	tfodb "github.com/hashicorp/terraform-provider-aws/internal/service/odb"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -30,7 +29,7 @@ func TestAccODBListNetworksDataSource_basic(t *testing.T) {
 	var output odb.ListOdbNetworksOutput
 
 	dataSourceName := "data.aws_odb_networks.test"
-	resource.Test(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			networkListTest.testAccPreCheck(ctx, t)
@@ -44,7 +43,7 @@ func TestAccODBListNetworksDataSource_basic(t *testing.T) {
 
 					resource.ComposeTestCheckFunc(func(s *terraform.State) error {
 						pattern := `^odbnet_`
-						networkListTest.count(ctx, dataSourceName, &output)
+						networkListTest.count(ctx, t, dataSourceName, &output)
 						resource.TestCheckResourceAttr(dataSourceName, "aws_odb_networks.#", strconv.Itoa(len(output.OdbNetworks)))
 						i := 0
 						for i < len(output.OdbNetworks) {
@@ -64,13 +63,13 @@ func (odbNetworksListTestDS) basic() string {
 	return `data "aws_odb_networks" "test" {}`
 }
 
-func (odbNetworksListTestDS) count(ctx context.Context, name string, list *odb.ListOdbNetworksOutput) resource.TestCheckFunc {
+func (odbNetworksListTestDS) count(ctx context.Context, t *testing.T, name string, list *odb.ListOdbNetworksOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {
 			return create.Error(names.ODB, create.ErrActionCheckingExistence, tfodb.DSNameNetworksList, name, errors.New("not found"))
 		}
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ODBClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).ODBClient(ctx)
 		resp, err := tfodb.ListOracleDBNetworks(ctx, conn)
 		if err != nil {
 			return create.Error(names.ODB, create.ErrActionCheckingExistence, tfodb.DSNameNetworksList, rs.Primary.ID, err)
@@ -81,7 +80,7 @@ func (odbNetworksListTestDS) count(ctx context.Context, name string, list *odb.L
 	}
 }
 func (odbNetworksListTestDS) testAccPreCheck(ctx context.Context, t *testing.T) {
-	conn := acctest.Provider.Meta().(*conns.AWSClient).ODBClient(ctx)
+	conn := acctest.ProviderMeta(ctx, t).ODBClient(ctx)
 	input := odb.ListOdbNetworksInput{}
 	_, err := conn.ListOdbNetworks(ctx, &input)
 	if acctest.PreCheckSkipError(err) {


### PR DESCRIPTION

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This brings the `odb` service into parity with the rest of the provider, requiring use of the `internal/retry` package for state change waiters, and VCR-compatible ID generation functions and service clients in acceptance tests.

**AI Disclosure:** An agent (OpenCode, Sonnet 4.6 (high)) was used to perform the semgrep fixes and manual edits required to make the changes compile. I have manually reviewed all changes to ensure they align with best practices in all other services.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #48555


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

Unable to run acceptance tests due to license constraints, but unit tests for the service are passing.

```console
% go test ./internal/service/odb
ok      github.com/hashicorp/terraform-provider-aws/internal/service/odb        9.495s
```
