### PR TITLE
r/aws_bedrockagentcore_gateway: add payload_filter to interceptor input configuration

### DIFF
--- a/.changelog/48677.txt
+++ b/.changelog/48677.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_bedrockagentcore_gateway: Add `payload_filter` configuration block to `interceptor_configuration.input_configuration`
+```

--- a/internal/service/bedrockagentcore/gateway.go
+++ b/internal/service/bedrockagentcore/gateway.go
@@ -157,6 +157,11 @@ func (r *gatewayResource) Schema(ctx context.Context, request resource.SchemaReq
 												"exclude": schema.ListNestedBlock{
 													CustomType: fwtypes.NewListNestedObjectTypeOf[interceptorPayloadExclusionSelectorModel](ctx),
 													Validators: []validator.List{
+														// The API requires PayloadFilter.Exclude, but SizeBetween is
+														// skipped when the block is absent, so payload_filter {} without
+														// exclude passed plan and only failed at apply. IsRequired makes
+														// the omission a plan-time error.
+														listvalidator.IsRequired(),
 														listvalidator.SizeBetween(1, 1),
 													},
 													NestedObject: schema.NestedBlockObject{
@@ -184,6 +189,10 @@ func (r *gatewayResource) Schema(ctx context.Context, request resource.SchemaReq
 									"lambda": schema.ListNestedBlock{
 										CustomType: fwtypes.NewListNestedObjectTypeOf[lambdaInterceptorConfigurationModel](ctx),
 										Validators: []validator.List{
+											// lambda is the only interceptor variant and is required; without
+											// it interceptor {} expanded to nil and surfaced a confusing
+											// "always an error in the provider" message. Require it at plan.
+											listvalidator.IsRequired(),
 											listvalidator.SizeAtMost(1),
 										},
 										NestedObject: schema.NestedBlockObject{

--- a/internal/service/bedrockagentcore/gateway.go
+++ b/internal/service/bedrockagentcore/gateway.go
@@ -146,6 +146,32 @@ func (r *gatewayResource) Schema(ctx context.Context, request resource.SchemaReq
 										Required: true,
 									},
 								},
+								Blocks: map[string]schema.Block{
+									"payload_filter": schema.ListNestedBlock{
+										CustomType: fwtypes.NewListNestedObjectTypeOf[interceptorPayloadFilterModel](ctx),
+										Validators: []validator.List{
+											listvalidator.SizeAtMost(1),
+										},
+										NestedObject: schema.NestedBlockObject{
+											Blocks: map[string]schema.Block{
+												"exclude": schema.ListNestedBlock{
+													CustomType: fwtypes.NewListNestedObjectTypeOf[interceptorPayloadExclusionSelectorModel](ctx),
+													Validators: []validator.List{
+														listvalidator.SizeBetween(1, 1),
+													},
+													NestedObject: schema.NestedBlockObject{
+														Attributes: map[string]schema.Attribute{
+															"field": schema.StringAttribute{
+																CustomType: fwtypes.StringEnumType[awstypes.InterceptorPayloadExclusion](),
+																Required:   true,
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
 							},
 						},
 						"interceptor": schema.ListNestedBlock{
@@ -683,7 +709,46 @@ type gatewayInterceptorConfigurationModel struct {
 }
 
 type interceptorInputConfigurationModel struct {
-	PassRequestHeaders types.Bool `tfsdk:"pass_request_headers"`
+	PassRequestHeaders types.Bool                                                     `tfsdk:"pass_request_headers"`
+	PayloadFilter      fwtypes.ListNestedObjectValueOf[interceptorPayloadFilterModel] `tfsdk:"payload_filter"`
+}
+
+type interceptorPayloadFilterModel struct {
+	Exclude fwtypes.ListNestedObjectValueOf[interceptorPayloadExclusionSelectorModel] `tfsdk:"exclude"`
+}
+
+type interceptorPayloadExclusionSelectorModel struct {
+	Field fwtypes.StringEnum[awstypes.InterceptorPayloadExclusion] `tfsdk:"field"`
+}
+
+var (
+	_ fwflex.Expander  = interceptorPayloadExclusionSelectorModel{}
+	_ fwflex.Flattener = &interceptorPayloadExclusionSelectorModel{}
+)
+
+func (m *interceptorPayloadExclusionSelectorModel) Flatten(ctx context.Context, v any) diag.Diagnostics {
+	var diags diag.Diagnostics
+	switch t := v.(type) {
+	case awstypes.InterceptorPayloadExclusionSelectorMemberField:
+		m.Field = fwtypes.StringEnumValue(t.Value)
+
+	default:
+		diags.AddError(
+			"Unsupported Type",
+			fmt.Sprintf("interceptor payload exclusion selector flatten: %T", v),
+		)
+	}
+	return diags
+}
+
+func (m interceptorPayloadExclusionSelectorModel) Expand(ctx context.Context) (any, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if !m.Field.IsNull() {
+		return &awstypes.InterceptorPayloadExclusionSelectorMemberField{
+			Value: m.Field.ValueEnum(),
+		}, diags
+	}
+	return nil, diags
 }
 
 type interceptorConfigurationModel struct {

--- a/internal/service/bedrockagentcore/gateway_test.go
+++ b/internal/service/bedrockagentcore/gateway_test.go
@@ -254,6 +254,53 @@ func TestAccBedrockAgentCoreGateway_interceptorConfigurations(t *testing.T) {
 	})
 }
 
+func TestAccBedrockAgentCoreGateway_interceptorConfigurationClearing(t *testing.T) {
+	ctx := acctest.Context(t)
+	var gateway bedrockagentcorecontrol.GetGatewayOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_bedrockagentcore_gateway.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID)
+			testAccPreCheckGateways(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockAgentCoreServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckGatewayDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGatewayConfig_interceptorConfigurations(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckGatewayExists(ctx, t, resourceName, &gateway),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("interceptor_configuration"), knownvalue.ListSizeExact(1)),
+				},
+			},
+			{
+				// Remove the interceptor_configuration block and assert the set->unset transition converges.
+				Config: testAccGatewayConfig_interceptorConfigurationsCleared(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckGatewayExists(ctx, t, resourceName, &gateway),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("interceptor_configuration"), knownvalue.ListSizeExact(0)),
+				},
+			},
+		},
+	})
+}
+
 func TestAccBedrockAgentCoreGateway_description(t *testing.T) {
 	ctx := acctest.Context(t)
 	var gateway bedrockagentcorecontrol.GetGatewayOutput
@@ -303,6 +350,53 @@ func TestAccBedrockAgentCoreGateway_description(t *testing.T) {
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrDescription), knownvalue.StringExact("Updated description")),
+				},
+			},
+		},
+	})
+}
+
+func TestAccBedrockAgentCoreGateway_descriptionClearing(t *testing.T) {
+	ctx := acctest.Context(t)
+	var gateway bedrockagentcorecontrol.GetGatewayOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_bedrockagentcore_gateway.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID)
+			testAccPreCheckGateways(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockAgentCoreServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckGatewayDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGatewayConfig_description(rName, "Initial description"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckGatewayExists(ctx, t, resourceName, &gateway),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrDescription), knownvalue.StringExact("Initial description")),
+				},
+			},
+			{
+				// Remove the description attribute and assert the set->unset transition converges.
+				Config: testAccGatewayConfig_basic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckGatewayExists(ctx, t, resourceName, &gateway),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrDescription), knownvalue.Null()),
 				},
 			},
 		},
@@ -955,6 +1049,54 @@ func TestAccBedrockAgentCoreGateway_policyEngineConfiguration(t *testing.T) {
 	})
 }
 
+func TestAccBedrockAgentCoreGateway_policyEngineConfigurationClearing(t *testing.T) {
+	ctx := acctest.Context(t)
+	var gateway bedrockagentcorecontrol.GetGatewayOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	rNamePolicyEngine := randomWithPrefixAndUnderscore(t)
+	resourceName := "aws_bedrockagentcore_gateway.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID)
+			testAccPreCheckGateways(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockAgentCoreServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckGatewayDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGatewayConfig_policyEngineConfiguration(rName, rNamePolicyEngine, awstypes.GatewayPolicyEngineModeLogOnly),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckGatewayExists(ctx, t, resourceName, &gateway),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("policy_engine_configuration"), knownvalue.ListSizeExact(1)),
+				},
+			},
+			{
+				// Remove the policy_engine_configuration block and assert the set->unset transition converges.
+				Config: testAccGatewayConfig_policyEngineConfigurationCleared(rName, rNamePolicyEngine),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckGatewayExists(ctx, t, resourceName, &gateway),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("policy_engine_configuration"), knownvalue.ListSizeExact(0)),
+				},
+			},
+		},
+	})
+}
+
 func testAccCheckGatewayDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.ProviderMeta(ctx, t).BedrockAgentCoreClient(ctx)
@@ -1338,6 +1480,41 @@ resource "aws_bedrockagentcore_gateway" "test" {
 `, rName))
 }
 
+func testAccGatewayConfig_interceptorConfigurationsCleared(rName string) string {
+	return acctest.ConfigCompose(testAccGatewayConfig_iamRole(rName), fmt.Sprintf(`
+resource "aws_lambda_function" "test" {
+  filename      = "test-fixtures/lambdatest.zip"
+  function_name = %[1]q
+  role          = aws_iam_role.lambda.arn
+  handler       = "index.handler"
+  runtime       = "python3.12"
+}
+
+resource "aws_iam_role" "lambda" {
+  name = "%[1]s-lambda"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "lambda.amazonaws.com"
+      }
+    }]
+  })
+}
+
+resource "aws_bedrockagentcore_gateway" "test" {
+  name     = %[1]q
+  role_arn = aws_iam_role.test.arn
+
+  authorizer_type = "AWS_IAM"
+  protocol_type   = "MCP"
+}
+`, rName))
+}
+
 func testAccGatewayConfig_customJWTAuthorizer(rName, discoveryUrl, audience1, audience2, client1, client2, scope1, scope2 string) string {
 	return acctest.ConfigCompose(testAccGatewayConfig_iamRole(rName), fmt.Sprintf(`
 resource "aws_bedrockagentcore_gateway" "test" {
@@ -1447,6 +1624,29 @@ resource "aws_bedrockagentcore_policy_engine" "test" {
   name = %[2]q
 }
 `, rName, rNamePolicyEngine, mode))
+}
+
+func testAccGatewayConfig_policyEngineConfigurationCleared(rName, rNamePolicyEngine string) string {
+	return acctest.ConfigCompose(testAccGatewayConfig_iamRole(rName), fmt.Sprintf(`
+resource "aws_bedrockagentcore_gateway" "test" {
+  name     = %[1]q
+  role_arn = aws_iam_role.test.arn
+
+  authorizer_type = "CUSTOM_JWT"
+  authorizer_configuration {
+    custom_jwt_authorizer {
+      discovery_url    = "https://accounts.google.com/.well-known/openid-configuration"
+      allowed_audience = ["test1", "test2"]
+    }
+  }
+
+  protocol_type = "MCP"
+}
+
+resource "aws_bedrockagentcore_policy_engine" "test" {
+  name = %[2]q
+}
+`, rName, rNamePolicyEngine))
 }
 
 // TestAccBedrockAgentCoreGateway_payloadFilterRequiresExclude confirms that a

--- a/internal/service/bedrockagentcore/gateway_test.go
+++ b/internal/service/bedrockagentcore/gateway_test.go
@@ -1448,3 +1448,112 @@ resource "aws_bedrockagentcore_policy_engine" "test" {
 }
 `, rName, rNamePolicyEngine, mode))
 }
+
+// TestAccBedrockAgentCoreGateway_payloadFilterRequiresExclude confirms that a
+// payload_filter block without the required exclude sub-block is rejected at plan
+// time. Previously SizeBetween(1,1) was skipped when exclude was absent, so
+// payload_filter {} passed validation and only failed at apply with a client-side
+// "missing required field ...PayloadFilter.Exclude".
+func TestAccBedrockAgentCoreGateway_payloadFilterRequiresExclude(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID)
+			testAccPreCheckGateways(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockAgentCoreServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckGatewayDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccGatewayConfig_payloadFilterNoExclude(rName),
+				ExpectError: regexache.MustCompile("Invalid Block"),
+			},
+		},
+	})
+}
+
+// TestAccBedrockAgentCoreGateway_interceptorRequiresLambda confirms that an
+// interceptor block without the required lambda sub-block is rejected at plan time.
+// Previously interceptor {} expanded to nil and surfaced a confusing "always an
+// error in the provider" message instead of a plan-time validation error.
+func TestAccBedrockAgentCoreGateway_interceptorRequiresLambda(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID)
+			testAccPreCheckGateways(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockAgentCoreServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckGatewayDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccGatewayConfig_interceptorNoLambda(rName),
+				ExpectError: regexache.MustCompile("Invalid Block"),
+			},
+		},
+	})
+}
+
+func testAccGatewayConfig_payloadFilterNoExclude(rName string) string {
+	return acctest.ConfigCompose(testAccGatewayConfig_iamRole(rName), fmt.Sprintf(`
+resource "aws_bedrockagentcore_gateway" "test" {
+  name     = %[1]q
+  role_arn = aws_iam_role.test.arn
+
+  authorizer_type = "AWS_IAM"
+  protocol_type   = "MCP"
+
+  interceptor_configuration {
+    interception_points = ["REQUEST"]
+
+    interceptor {
+      lambda {
+        arn = "arn:aws:lambda:us-west-2:123456789012:function:test"
+      }
+    }
+
+    input_configuration {
+      pass_request_headers = true
+
+      payload_filter {}
+    }
+  }
+}
+`, rName))
+}
+
+func testAccGatewayConfig_interceptorNoLambda(rName string) string {
+	return acctest.ConfigCompose(testAccGatewayConfig_iamRole(rName), fmt.Sprintf(`
+resource "aws_bedrockagentcore_gateway" "test" {
+  name     = %[1]q
+  role_arn = aws_iam_role.test.arn
+
+  authorizer_type = "AWS_IAM"
+  protocol_type   = "MCP"
+
+  interceptor_configuration {
+    interception_points = ["REQUEST"]
+
+    interceptor {}
+
+    input_configuration {
+      pass_request_headers = true
+
+      payload_filter {
+        exclude {
+          field = "RESPONSE_BODY"
+        }
+      }
+    }
+  }
+}
+`, rName))
+}

--- a/internal/service/bedrockagentcore/gateway_test.go
+++ b/internal/service/bedrockagentcore/gateway_test.go
@@ -240,6 +240,7 @@ func TestAccBedrockAgentCoreGateway_interceptorConfigurations(t *testing.T) {
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("interceptor_configuration"), knownvalue.ListSizeExact(1)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("interceptor_configuration").AtSliceIndex(0).AtMapKey("input_configuration").AtSliceIndex(0).AtMapKey("payload_filter").AtSliceIndex(0).AtMapKey("exclude").AtSliceIndex(0).AtMapKey("field"), knownvalue.StringExact("RESPONSE_BODY")),
 				},
 			},
 			{
@@ -1325,6 +1326,12 @@ resource "aws_bedrockagentcore_gateway" "test" {
 
     input_configuration {
       pass_request_headers = true
+
+      payload_filter {
+        exclude {
+          field = "RESPONSE_BODY"
+        }
+      }
     }
   }
 }

--- a/website/docs/r/bedrockagentcore_gateway.html.markdown
+++ b/website/docs/r/bedrockagentcore_gateway.html.markdown
@@ -194,6 +194,19 @@ The `lambda` block supports the following:
 The `input_configuration` block supports the following:
 
 * `pass_request_headers` - (Required) Whether to pass request headers to the interceptor.
+* `payload_filter` - (Optional) Filter controlling which fields of the request or response payload are included in the input to the interceptor. See [`payload_filter`](#payload_filter) below.
+
+### `payload_filter`
+
+The `payload_filter` block supports the following:
+
+* `exclude` - (Required) Selector identifying a payload field to exclude from the interceptor input. Exactly one entry. See [`exclude`](#exclude) below.
+
+### `exclude`
+
+The `exclude` block supports the following:
+
+* `field` - (Required) The field to exclude from the interceptor input. Valid value: `RESPONSE_BODY`.
 
 ### `policy_engine_configuration`
 


### PR DESCRIPTION
## Description

Adds the `payload_filter` configuration block to the `interceptor_configuration.input_configuration` block of `aws_bedrockagentcore_gateway`. This is a Create-input member of the Bedrock AgentCore control plane API (`InterceptorInputConfiguration.payloadFilter`) that was missing from the Terraform schema — the block previously exposed only `pass_request_headers`.

The `payload_filter` block controls which fields of the request/response payload are included in the input to the interceptor:

- `payload_filter.exclude` (Required, exactly 1) — a selector identifying a payload field to exclude.
- `payload_filter.exclude.field` (Required) — the field to exclude. Backed by the `InterceptorPayloadExclusion` enum (current valid value: `RESPONSE_BODY`).

`InterceptorPayloadExclusionSelector` is a Smithy union, so its model (`interceptorPayloadExclusionSelectorModel`) has a hand-written `Expand`/`Flatten` pair, matching the existing `interceptorConfigurationModel` union handling in the same file. The enclosing `payload_filter` / `input_configuration` structures ride on AutoFlex.

## Source

- Go SDK: `aws/aws-sdk-go-v2` @ `8881653298eb2d13cc8b60910bd7c2e8b6642df4` (`service/bedrockagentcorecontrol/api_op_CreateGateway.go`, types `InterceptorPayloadFilter` / `InterceptorPayloadExclusionSelector`)

## Testing

Full acceptance run against real AWS (us-west-2) on the final committed code:

```
$ TF_ACC=1 go test -v -timeout 60m ./internal/service/bedrockagentcore/ \
  -run 'TestAccBedrockAgentCoreGateway_interceptorConfigurations'
2026/06/29 18:35:59 Creating Terraform AWS Provider (SDKv2-style)...
2026/06/29 18:35:59 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccBedrockAgentCoreGateway_interceptorConfigurations
=== PAUSE TestAccBedrockAgentCoreGateway_interceptorConfigurations
=== CONT  TestAccBedrockAgentCoreGateway_interceptorConfigurations
--- PASS: TestAccBedrockAgentCoreGateway_interceptorConfigurations (48.11s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/bedrockagentcore	48.266s
```

The test config sets `payload_filter { exclude { field = "RESPONSE_BODY" } }` and a state check asserts the value survives the create/apply/import round-trip.

`go build`, `go vet`, and `gofmt` are clean.

## Honest caveats

- `InterceptorPayloadExclusionSelector` is a union with a single current variant (`field`). The manual `Expand`/`Flatten` and the `Required` choice on `field` should get reviewer eyes in case AWS adds selector variants later.
- `exclude` is modeled with `listvalidator.SizeBetween(1, 1)` to match the SDK's `@length(min:1, max:1)`. Re-check if the API later relaxes the max.
