### PR TITLE
New action: aws_athena_execute_query

### DIFF
--- a/.changelog/48678.txt
+++ b/.changelog/48678.txt
@@ -1,0 +1,3 @@
+```release-note:new-action
+aws_athena_execute_query
+```

--- a/internal/service/athena/execute_query_action.go
+++ b/internal/service/athena/execute_query_action.go
@@ -1,0 +1,274 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package athena
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/athena"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/athena/types"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/action"
+	"github.com/hashicorp/terraform-plugin-framework/action/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-provider-aws/internal/actionwait"
+	"github.com/hashicorp/terraform-provider-aws/internal/backoff"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	fwactions "github.com/hashicorp/terraform-provider-aws/internal/framework/actions"
+	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	fwvalidators "github.com/hashicorp/terraform-provider-aws/internal/framework/validators"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @Action(aws_athena_execute_query, name="Execute query")
+func newStartQueryExecutionAction(_ context.Context) (action.ActionWithConfigure, error) {
+	return &startQueryExecutionAction{}, nil
+}
+
+type startQueryExecutionAction struct {
+	framework.ActionWithModel[startQueryExecutionActionModel]
+}
+
+type startQueryExecutionActionModel struct {
+	framework.WithRegionModel
+	ExecutionParameters   fwtypes.ListValueOf[types.String]                           `tfsdk:"execution_parameters"`
+	QueryExecutionContext fwtypes.ListNestedObjectValueOf[QueryExecutionContextModel] `tfsdk:"query_execution_context"`
+	QueryString           types.String                                                `tfsdk:"query_string"`
+	ResultConfiguration   fwtypes.ListNestedObjectValueOf[ResultConfigurationModel]   `tfsdk:"result_configuration"`
+	Workgroup             types.String                                                `tfsdk:"workgroup"`
+	Timeout               types.Int64                                                 `tfsdk:"timeout"`
+}
+
+type QueryExecutionContextModel struct {
+	Catalog  types.String `tfsdk:"catalog"`
+	Database types.String `tfsdk:"database"`
+}
+
+type ResultConfigurationModel struct {
+	AclConfiguration        fwtypes.ListNestedObjectValueOf[AclConfigurationModel]        `tfsdk:"acl_configuration"`
+	EncryptionConfiguration fwtypes.ListNestedObjectValueOf[EncryptionConfigurationModel] `tfsdk:"encryption_configuration"`
+	ExpectedBucketOwner     types.String                                                  `tfsdk:"expected_bucket_owner"`
+	OutputLocation          types.String                                                  `tfsdk:"output_location"`
+}
+
+type EncryptionConfigurationModel struct {
+	EncryptionOption types.String `tfsdk:"encryption_option"`
+	KmsKey           types.String `tfsdk:"kms_key"`
+}
+
+type AclConfigurationModel struct {
+	S3AclOption types.String `tfsdk:"s3_acl_option"`
+}
+
+func (a *startQueryExecutionAction) Schema(ctx context.Context, req action.SchemaRequest, resp *action.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "This action runs the SQL query statements contained in the query_string.",
+		Attributes: map[string]schema.Attribute{
+			"execution_parameters": schema.ListAttribute{
+				Description: "A list of values for the parameters in a query. The values are applied sequentially to the parameters in the query in the order in which the parameters occur.",
+				Optional:    true,
+				CustomType:  fwtypes.ListOfStringType,
+				ElementType: types.StringType,
+				Validators: []validator.List{
+					listvalidator.SizeBetween(1, 1024),
+				},
+			},
+			"query_string": schema.StringAttribute{
+				Description: "The SQL query statements to be executed.",
+				Required:    true,
+				Validators: []validator.String{
+					stringvalidator.LengthBetween(1, 262144),
+				},
+			},
+			names.AttrTimeout: schema.Int64Attribute{
+				Description: "Timeout in seconds for query execution. Defaults to 300 seconds",
+				Optional:    true,
+			},
+			"workgroup": schema.StringAttribute{
+				Description: "The name of the workgroup in which the query is being started.",
+				Optional:    true,
+			},
+		},
+
+		Blocks: map[string]schema.Block{
+			"query_execution_context": schema.ListNestedBlock{
+				Description: "The database and data catalog context in which the query execution occurs.",
+				CustomType:  fwtypes.NewListNestedObjectTypeOf[QueryExecutionContextModel](ctx),
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"catalog": schema.StringAttribute{
+							Description: "The name of the data catalog used in the query execution.",
+							Optional:    true,
+							Validators: []validator.String{
+								stringvalidator.LengthBetween(1, 256),
+							},
+						},
+						names.AttrDatabase: schema.StringAttribute{
+							Description: "The name of the database used in the query execution. The database must exist in the catalog.",
+							Optional:    true,
+							Validators: []validator.String{
+								stringvalidator.LengthBetween(1, 255),
+							},
+						},
+					},
+				},
+			},
+			"result_configuration": schema.ListNestedBlock{
+				Description: "Specifies information about where and how to save the results of the query execution",
+				CustomType:  fwtypes.NewListNestedObjectTypeOf[ResultConfigurationModel](ctx),
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						names.AttrExpectedBucketOwner: schema.StringAttribute{
+							Description: "The AWS account ID that you expect to be the owner of the Amazon S3 bucket",
+							Optional:    true,
+							Validators: []validator.String{
+								fwvalidators.AWSAccountID(),
+							},
+						},
+						"output_location": schema.StringAttribute{
+							Description: "The location in Amazon S3 where your query and calculation results are stored, such as s3://path/to/query/bucket/",
+							Optional:    true,
+							Validators: []validator.String{
+								fwvalidators.S3URI(),
+							},
+						},
+					},
+					Blocks: map[string]schema.Block{
+						"acl_configuration": schema.ListNestedBlock{
+							Description: "Indicates that an Amazon S3 canned ACL should be set to control ownership of stored query results.",
+							Validators: []validator.List{
+								listvalidator.SizeAtMost(1),
+							},
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									"s3_acl_option": schema.StringAttribute{
+										Description: "The Amazon S3 canned ACL that Athena should specify when storing query results",
+										Required:    true,
+										Validators: []validator.String{
+											stringvalidator.OneOf("BUCKET_OWNER_FULL_CONTROL"),
+										},
+									},
+								},
+							},
+						},
+						names.AttrEncryptionConfiguration: schema.ListNestedBlock{
+							Description: "If query and calculation results are encrypted in Amazon S3, indicates the encryption option used.",
+							Validators: []validator.List{
+								listvalidator.SizeAtMost(1),
+							},
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									"encryption_option": schema.StringAttribute{
+										Description: "Indicates whether Amazon S3 server-side encryption with Amazon S3-managed keys (SSE_S3), server-side encryption with KMS-managed keys (SSE_KMS), or client-side encryption with KMS-managed keys (CSE_KMS) is used.",
+										Required:    true,
+										Validators: []validator.String{
+											stringvalidator.OneOf("SSE_S3", "SSE_KMS", "CSE_KMS"),
+										},
+									},
+									names.AttrKMSKey: schema.StringAttribute{
+										Description: "For SSE_KMS and CSE_KMS, this is the KMS key ARN or ID.",
+										Optional:    true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (a *startQueryExecutionAction) Invoke(ctx context.Context, req action.InvokeRequest, resp *action.InvokeResponse) {
+	var config startQueryExecutionActionModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	conn := a.Meta().AthenaClient(ctx)
+
+	// Set default timeout if undefined
+	timeout := fwactions.TimeoutOr(config.Timeout, 10*time.Minute)
+
+	cb := fwactions.NewSendProgressFunc(resp)
+	cb(ctx, "Executing Athena query...")
+
+	input := &athena.StartQueryExecutionInput{}
+	resp.Diagnostics.Append(fwflex.Expand(ctx, config, input)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tflog.Debug(ctx, "Executing Athena query", map[string]any{
+		"input": *input,
+	})
+
+	output, err := conn.StartQueryExecution(ctx, input)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Failed to start Athena Query execution",
+			fmt.Sprintf("Could not execute query: %s", err),
+		)
+		return
+	}
+
+	cb(ctx, "Query execution started, waiting for completion...")
+	execId := output.QueryExecutionId
+
+	_, err = actionwait.WaitForStatus(ctx, func(ctx context.Context) (actionwait.FetchResult[*awstypes.QueryExecution], error) {
+		input := &athena.GetQueryExecutionInput{QueryExecutionId: execId}
+		output, err := conn.GetQueryExecution(ctx, input)
+		if err != nil {
+			return actionwait.FetchResult[*awstypes.QueryExecution]{}, err
+		}
+
+		res := output.QueryExecution
+		return actionwait.FetchResult[*awstypes.QueryExecution]{Status: actionwait.Status(res.Status.State), Value: res}, nil
+	}, actionwait.Options[*awstypes.QueryExecution]{
+		Timeout:       timeout,
+		Interval:      actionwait.WithBackoffDelay(backoff.DefaultSDKv2HelperRetryCompatibleDelay()),
+		SuccessStates: []actionwait.Status{actionwait.Status(awstypes.QueryExecutionStateSucceeded)},
+		TransitionalStates: []actionwait.Status{
+			actionwait.Status(awstypes.QueryExecutionStateRunning),
+			actionwait.Status(awstypes.QueryExecutionStateQueued),
+		},
+		FailureStates: []actionwait.Status{
+			actionwait.Status(awstypes.QueryExecutionStateFailed),
+			actionwait.Status(awstypes.QueryExecutionStateCancelled),
+		},
+		ProgressSink: func(fr actionwait.FetchResult[any], meta actionwait.ProgressMeta) {
+			cb(ctx, "Athena query currently in state: %s", fr.Status)
+		},
+	})
+
+	if err != nil {
+		var timeoutErr *actionwait.TimeoutError
+		var failureErr *actionwait.FailureStateError
+		if errors.As(err, &timeoutErr) {
+			resp.Diagnostics.AddError("Query execution timed out", "Query did not complete within the specified timeout")
+		} else if errors.As(err, &failureErr) {
+			resp.Diagnostics.AddError("Query execution failed", "Query execution failed with status: "+failureErr.Error())
+		} else {
+			resp.Diagnostics.AddError("Error while waiting to query to complete", err.Error())
+		}
+		return
+	}
+
+	cb(ctx, "Athena query completed successfully. Execution ID: %s", *execId)
+	tflog.Info(ctx, "Athena query completed successfully", map[string]any{
+		"athena_execution_id": *execId,
+	})
+}

--- a/internal/service/athena/execute_query_action_test.go
+++ b/internal/service/athena/execute_query_action_test.go
@@ -1,0 +1,146 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package athena_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/YakDriver/regexache"
+	glue "github.com/aws/aws-sdk-go-v2/service/glue"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccAthenaExecuteQueryAction_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	tableName := "test_table"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.AthenaServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccExecuteQueryConfig_basic(rName, tableName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTableExists(ctx, t, tableName, rName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAthenaExecuteQueryAction_withInvalidQuery(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.AthenaServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccExecuteQueryConfig_withInvalidQuery(rName),
+				ExpectError: regexache.MustCompile("Query execution failed"),
+			},
+		},
+	})
+}
+
+func testAccCheckTableExists(ctx context.Context, t *testing.T, tableName string, dbName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.ProviderMeta(ctx, t).GlueClient(ctx)
+		input := &glue.GetTableInput{
+			Name:         &tableName,
+			DatabaseName: &dbName,
+		}
+
+		_, err := conn.GetTable(ctx, input)
+
+		if err != nil {
+			return fmt.Errorf("Error while getting %s table: %w", tableName, err)
+		}
+
+		return nil
+	}
+}
+
+func testAccExecuteQueryConfig_basic(rName string, tableName string) string {
+	return acctest.ConfigCompose(
+		testAccExecuteActionConfig_base(rName),
+		fmt.Sprintf(`
+action "aws_athena_execute_query" "test" {
+  config {
+    query_string = <<EOT
+CREATE EXTERNAL TABLE %[1]s (
+    test INT
+    )
+LOCATION 's3://${aws_s3_bucket.test.id}/%[1]s/'
+EOT
+    workgroup = "primary"
+    query_execution_context {
+	  database = aws_glue_catalog_database.test.name
+	}
+	result_configuration {
+  	  output_location = "s3://${aws_s3_bucket.test.id}/query-results/"
+    }
+  }
+}
+`, tableName))
+}
+
+func testAccExecuteQueryConfig_withInvalidQuery(rName string) string {
+	return acctest.ConfigCompose(
+		testAccExecuteActionConfig_base(rName),
+		`
+action "aws_athena_execute_query" "test" {
+  config {
+    query_string = "SELECT COUNT(*) FROM non_existent_table"
+    workgroup    = "primary"
+    query_execution_context {
+	  database = aws_glue_catalog_database.test.name
+	}
+	result_configuration {
+  	  output_location = "s3://${aws_s3_bucket.test.id}/query-results/"
+    }
+  }
+}
+`)
+}
+
+func testAccExecuteActionConfig_base(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_glue_catalog_database" "test" {
+  name = %[1]q
+}
+
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+
+  force_destroy = true
+}
+
+resource "terraform_data" "trigger" {
+  input = "trigger"
+  lifecycle {
+    action_trigger {
+      events  = [before_create, before_update]
+      actions = [action.aws_athena_execute_query.test]
+    }
+  }
+}
+`, rName)
+}

--- a/internal/service/athena/service_package_gen.go
+++ b/internal/service/athena/service_package_gen.go
@@ -20,6 +20,17 @@ import (
 
 type servicePackage struct{}
 
+func (p *servicePackage) Actions(ctx context.Context) []*inttypes.ServicePackageAction {
+	return []*inttypes.ServicePackageAction{
+		{
+			Factory:  newStartQueryExecutionAction,
+			TypeName: "aws_athena_execute_query",
+			Name:     "Execute query",
+			Region:   inttypes.ResourceRegionDefault(),
+		},
+	}
+}
+
 func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*inttypes.ServicePackageFrameworkDataSource {
 	return []*inttypes.ServicePackageFrameworkDataSource{}
 }

--- a/website/docs/actions/aws_athena_execute_query.html.markdown
+++ b/website/docs/actions/aws_athena_execute_query.html.markdown
@@ -1,0 +1,98 @@
+---
+subcategory: "Athena"
+layout: "aws"
+page_title: "AWS: aws_athena_execute_query"
+description: Executes an Athena query on-demand.
+---
+
+# Action aws_athena_execute_query
+
+Executes an Athena query on-demand. This action will initiate an Athena query and wait for it to complete, providing progress updates during execution.
+
+For information about Athena queries, see the [Use Athena SQL guide](https://docs.aws.amazon.com/athena/latest/ug/using-athena-sql.html). For specific information about running Athena queries, see the [StartQueryExecution](https://docs.aws.amazon.com/athena/latest/APIReference/API_StartQueryExecution.html) page in the Athena API Reference.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+action "aws_athena_execute_query" "query" {
+  config {
+    query_string = <<EOT
+CREATE EXTERNAL TABLE test (
+    test INT
+    )
+LOCATION 's3://${aws_s3_bucket.test.id}/test/'
+EOT
+    workgroup    = "primary"
+    query_execution_context {
+      database = aws_glue_catalog_database.database.name
+    }
+    result_configuration {
+      output_location = "s3://${aws_s3_bucket.test.id}/query-results/"
+    }
+  }
+}
+
+resource "aws_glue_catalog_database" "database" {
+  name = "test"
+}
+
+resource "aws_s3_bucket" "bucket" {
+  bucket = "bucket"
+}
+
+resource "terraform_data" "trigger" {
+  input = "trigger-query"
+
+  lifecycle {
+    action_trigger {
+      events  = [after_create]
+      actions = [action.aws_athena_execute_query.query]
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `query_string` - (Required) The SQL query statements to be executed.
+
+The following arguments are optional:
+
+* `execution_parameters` - (Optional) A list of values for the parameters in a query. The values are applied sequentially to the parameters in the query in the order in which the parameters occur.
+* `query_execution_context` - (Optional) The database and data catalog context in which the query execution occurs. See [query_execution_context](#query-execution-context) below.
+* `result_configuration` - (Optional) Specifies information about where and how to save the results of the query execution. See [result_configuration](#result-configuration) below.
+* `timeout` - (Optional) Timeout in seconds for the backup operation. Defaults to 300 seconds.
+* `workgroup` - (Optional) The name of the workgroup in which the query is being started
+
+### Query Execution Context
+
+The `query_execution_context` block supports the following:
+
+* `catalog` - (Optional) The name of the data catalog used in the query execution.
+* `database` - (Optional) The name of the database used in the query execution. The database must exist in the catalog.
+
+### Result Configuration
+
+The `result_configuration` block supports the following:
+
+* `expected_bucket_owner` - (Optional) The AWS account ID that you expect to be the owner of the Amazon S3 bucket.
+* `output_location` - (Optional) The location in Amazon S3 where your query and calculation results are stored, such as `s3://path/to/query/bucket/`.
+* `acl_configuration` - (Optional) Indicates that an Amazon S3 canned ACL should be set to control ownership of stored query results. See [acl_configuration](#acl-configuration) below.
+* `encryption_configuration` - (Optional) If query and calculation results are encrypted in Amazon S3, indicates the encryption option used. See [encryption_configuration](#encryption-configuration) below.
+
+### ACL Configuration
+
+The `acl_configuration` block supports the following:
+
+* `s3_acl_option` - (Optional) The Amazon S3 canned ACL that Athena should specify when storing query results.
+
+### Encryption Configuration
+
+The `encryption_configuration` block supports the following:
+
+* `encryption_option` - (Optional) Indicates whether Amazon S3 server-side encryption with Amazon S3-managed keys (SSE_S3), server-side encryption with KMS-managed keys (SSE_KMS), or client-side encryption with KMS-managed keys (CSE_KMS) is used.
+* `kms_key` - (Optional) For SSE_KMS and CSE_KMS, this is the KMS key ARN or ID.


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No.

### Description
This PR introduces a new action `aws_athena_execute_query` which allows execution of Athena queries on demand.


### Relations

Closes #47059

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing

```console
% make testacc TESTS=TestAccAthenaExecuteQueryAction_ PKG=athena
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2	(cached)
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider/framework	(cached)
make: Running acceptance tests on branch: 🌿 f-aws_athena_execute_named_query-new-action 🌿...
TF_ACC=1 go1.26.4 test ./internal/service/athena/... -v -count 1 -parallel 20 -run='TestAccAthenaExecuteQueryAction_'  -timeout 360m -vet=off -buildvcs=false
2026/06/29 22:31:57 Creating Terraform AWS Provider (SDKv2-style)...
2026/06/29 22:31:57 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccAthenaExecuteQueryAction_basic
=== PAUSE TestAccAthenaExecuteQueryAction_basic
=== RUN   TestAccAthenaExecuteQueryAction_withInvalidQuery
=== PAUSE TestAccAthenaExecuteQueryAction_withInvalidQuery
=== CONT  TestAccAthenaExecuteQueryAction_basic
=== CONT  TestAccAthenaExecuteQueryAction_withInvalidQuery
--- PASS: TestAccAthenaExecuteQueryAction_withInvalidQuery (23.00s)
--- PASS: TestAccAthenaExecuteQueryAction_basic (37.65s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/athena	37.893s
```
