### PR TITLE
Bugfix: aws bedrock agent guardrails fall off

### DIFF
--- a/.changelog/48681.txt
+++ b/.changelog/48681.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+resource/aws_bedrockagent_agent: Fix `Provider produced inconsistent result after apply` error when making non-guardrail changes to an existing agent with guardrail configuration
+```
+

--- a/internal/service/bedrockagent/agent.go
+++ b/internal/service/bedrockagent/agent.go
@@ -302,7 +302,8 @@ func (r *agentResource) Update(ctx context.Context, request resource.UpdateReque
 			input.CustomerEncryptionKeyArn = fwflex.StringFromFramework(ctx, new.CustomerEncryptionKeyARN)
 		}
 
-		if !new.GuardrailConfiguration.Equal(old.GuardrailConfiguration) && !new.GuardrailConfiguration.IsNull() {
+		if (!new.GuardrailConfiguration.Equal(old.GuardrailConfiguration) && !new.GuardrailConfiguration.IsNull()) ||
+			(new.GuardrailConfiguration.Equal(old.GuardrailConfiguration) && !old.GuardrailConfiguration.IsNull()) {
 			guardrailConfiguration := &awstypes.GuardrailConfiguration{}
 			response.Diagnostics.Append(fwflex.Expand(ctx, new.GuardrailConfiguration, guardrailConfiguration)...)
 			if response.Diagnostics.HasError() {

--- a/internal/service/bedrockagent/agent_test.go
+++ b/internal/service/bedrockagent/agent_test.go
@@ -261,6 +261,15 @@ func TestAccBedrockAgentAgent_guardrail(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccAgentConfig_guardrail_withConfig(rName+"NameChange", "anthropic.claude-v2", "DRAFT"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAgentExists(ctx, t, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "guardrail_configuration.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "guardrail_configuration.0.guardrail_identifier", guardrailResourceName, "guardrail_id"),
+					resource.TestCheckResourceAttr(resourceName, "guardrail_configuration.0.guardrail_version", "DRAFT"),
+				),
+			},
+			{
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

### Description

If a bedrock agent with a guardrail configuration exists, making a non-guardrail update to the agent (such as the instruction, name, or description) results in the DRAFT version of the agent with a null guardrail configuration.  This change ensures that the guardrail configuration is explicitly in the `updateAgent` API call even when the guardrail configuration does not change, ensuring that the expected state of the agent is consistent.


### Relations

Relates #40015
Relates #47967


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccBedrockAgentAgent_guardrail PKG=bedrockagent
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2	0.336s
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider/framework	0.255s
make: Running acceptance tests on branch: 🌿 b-fix_aws_bedrock_agent_guardrails_fall_off 🌿...
TF_ACC=1 go1.26.4 test ./internal/service/bedrockagent/... -v -count 1 -parallel 20 -run='TestAccBedrockAgentAgent_guardrail'  -timeout 360m -vet=off -buildvcs=false
2026/06/29 16:19:33 Creating Terraform AWS Provider (SDKv2-style)...
2026/06/29 16:19:33 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccBedrockAgentAgent_guardrail
=== PAUSE TestAccBedrockAgentAgent_guardrail
=== CONT  TestAccBedrockAgentAgent_guardrail
--- PASS: TestAccBedrockAgentAgent_guardrail (141.76s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/bedrockagent	141.931s

...
```
