### PR TITLE
sweepers: Allow skip of stuck VPC/subnets

### DIFF
--- a/internal/service/ec2/sweep.go
+++ b/internal/service/ec2/sweep.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv2"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep/framework"
@@ -1830,7 +1831,7 @@ func sweepSubnets(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepab
 
 			d := r.Data(nil)
 			d.SetId(subnetID)
-			d.Set(names.AttrVPCID, aws.ToString(v.VpcId))
+			d.Set(names.AttrVPCID, v.VpcId)
 
 			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
 		}
@@ -1845,15 +1846,15 @@ func sweepSubnets(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepab
 // aws_vpc Delete paths cannot remove these endpoints, so any subnet or VPC they
 // reference cannot be deleted by the sweeper and must be skipped.
 func findResourcesBlockedByRequesterManagedVPCEndpoints(ctx context.Context, conn *ec2.Client) (subnetIDs, vpcIDs map[string][]string, err error) {
-	input := &ec2.DescribeVpcEndpointsInput{
+	input := ec2.DescribeVpcEndpointsInput{
 		Filters: newAttributeFilterList(map[string]string{
 			"vpc-endpoint-state": vpcEndpointStateAvailable,
 		}),
 	}
 
-	endpoints, err := findVPCEndpoints(ctx, conn, input)
+	endpoints, err := findVPCEndpoints(ctx, conn, &input)
 	if err != nil {
-		if tfresource.NotFound(err) {
+		if retry.NotFound(err) {
 			return nil, nil, nil
 		}
 		return nil, nil, err

--- a/internal/service/ec2/sweep.go
+++ b/internal/service/ec2/sweep.go
@@ -1785,19 +1785,8 @@ func sweepSpotInstanceRequests(region string) error {
 func sweepSubnets(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepable, error) {
 	conn := client.EC2Client(ctx)
 
-	// Pre-compute the set of subnets that contain a requester-managed VPC endpoint. The
-	// aws_subnet Delete path cannot remove these: DeleteVpcEndpoints and ModifyVpcEndpoint
-	// both refuse requester-managed endpoints, so an unattended sweep would spin on
-	// DependencyViolation for the full schema.TimeoutDelete (~20 min per subnet). The most
-	// common source is orphan GuardDuty Runtime Monitoring endpoints whose underlying
-	// endpoint service has been decommissioned; clearing those requires AWS Support.
-	// The companion aws_vpc_endpoint sweeper already skips RequesterManaged=true endpoints
-	// for the same reason; this is the symmetric guard on the consumer side.
-	//
-	// To inspect what this would skip in a region:
-	//   aws ec2 describe-vpc-endpoints --region <region> \
-	//     --filters Name=vpc-endpoint-state,Values=available \
-	//     --query 'VpcEndpoints[?RequesterManaged==`true`].{Endpoint:VpcEndpointId,Subnets:SubnetIds,Service:ServiceName}'
+	// Skip subnets anchored by a VPC endpoint we cannot remove;
+	// see findResourcesBlockedByRequesterManagedVPCEndpoints for rationale.
 	blockedSubnets, _, err := findResourcesBlockedByRequesterManagedVPCEndpoints(ctx, conn)
 	if err != nil {
 		return nil, fmt.Errorf("listing requester-managed VPC endpoints: %w", err)
@@ -1840,11 +1829,22 @@ func sweepSubnets(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepab
 	return sweepResources, nil
 }
 
-// findResourcesBlockedByRequesterManagedVPCEndpoints returns two maps keyed by
-// subnet ID and VPC ID respectively, each mapping to the IDs of available,
-// requester-managed VPC endpoints anchoring that resource. The aws_subnet and
-// aws_vpc Delete paths cannot remove these endpoints, so any subnet or VPC they
-// reference cannot be deleted by the sweeper and must be skipped.
+// findResourcesBlockedByRequesterManagedVPCEndpoints returns subnet→endpoints
+// and VPC→endpoints maps of every available, requester-managed VPC endpoint in
+// the region. The customer role cannot delete these endpoints (DeleteVpcEndpoints
+// and ModifyVpcEndpoint both refuse them), and the in-resource GuardDuty cleanup
+// matches only a narrow service-name/tag heuristic, so subnets and VPCs anchored
+// by anything else would hang their sweeper on DependencyViolation for the full
+// schema.TimeoutDelete. The most common producer is an orphan GuardDuty Runtime
+// Monitoring endpoint whose underlying service AWS has since retired; clearing
+// those requires AWS Support. Consumer-side counterpart to the RequesterManaged
+// skip in sweepVPCEndpoints.
+//
+// To inspect what this would skip in a region:
+//
+//	aws ec2 describe-vpc-endpoints --region <region> \
+//	  --filters Name=vpc-endpoint-state,Values=available \
+//	  --query 'VpcEndpoints[?RequesterManaged==`true`].{Endpoint:VpcEndpointId,Subnets:SubnetIds,VPC:VpcId,Service:ServiceName}'
 func findResourcesBlockedByRequesterManagedVPCEndpoints(ctx context.Context, conn *ec2.Client) (subnetIDs, vpcIDs map[string][]string, err error) {
 	input := ec2.DescribeVpcEndpointsInput{
 		Filters: newAttributeFilterList(map[string]string{
@@ -1877,12 +1877,9 @@ func findResourcesBlockedByRequesterManagedVPCEndpoints(ctx context.Context, con
 	return subnetIDs, vpcIDs, nil
 }
 
-// logSweepBlockedByRequesterManagedVPCEndpoint emits an operator-facing [WARN]
-// when a sweeper skips a resource because of a requester-managed VPC endpoint
-// it cannot delete. The message identifies the blocker, explains why the
-// sweeper cannot recover, and suggests opening an AWS Support case as the
-// unblock path. Wording is centralized so both the subnet and VPC sweepers
-// emit the same guidance, and so it stays easy to refine in one place.
+// logSweepBlockedByRequesterManagedVPCEndpoint emits the standard [WARN] used by
+// sweepers when they skip a resource anchored by a requester-managed VPC endpoint;
+// the log body points at the AWS Support routing needed to clear the orphan.
 func logSweepBlockedByRequesterManagedVPCEndpoint(resourceKind, resourceID string, endpointIDs []string) {
 	log.Printf("[WARN] Skipping %s %s: blocked by requester-managed VPC endpoint(s) %v\n"+
 		"  Why: Requester-managed VPC endpoints cannot be removed by the customer role; "+
@@ -2562,12 +2559,8 @@ func sweepVPCs(region string) error {
 	conn := client.EC2Client(ctx)
 	var sweepResources []sweep.Sweepable
 
-	// Pre-compute the set of VPCs that contain a requester-managed VPC endpoint. The
-	// aws_vpc Delete path cannot remove these endpoints (DeleteVpcEndpoints refuses
-	// requester-managed endpoints, and the in-resource GuardDuty cleanup only matches
-	// endpoints whose service name and tags fit a narrow heuristic), so DeleteVpc keeps
-	// returning DependencyViolation. See sweepSubnets for the symmetric guard on the
-	// subnet side and the debug one-liner that lists currently-blocking endpoints.
+	// Skip VPCs anchored by a VPC endpoint we cannot remove;
+	// see findResourcesBlockedByRequesterManagedVPCEndpoints for rationale.
 	_, blockedVPCs, err := findResourcesBlockedByRequesterManagedVPCEndpoints(ctx, conn)
 	if err != nil {
 		return fmt.Errorf("listing requester-managed VPC endpoints (%s): %w", region, err)

--- a/internal/service/ec2/sweep.go
+++ b/internal/service/ec2/sweep.go
@@ -1824,7 +1824,7 @@ func sweepSubnets(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepab
 			subnetID := aws.ToString(v.SubnetId)
 
 			if endpointIDs, blocked := blockedSubnets[subnetID]; blocked {
-				log.Printf("[INFO] Skipping EC2 Subnet %s: blocked by requester-managed VPC endpoint(s) %v", subnetID, endpointIDs)
+				logSweepBlockedByRequesterManagedVPCEndpoint("EC2 Subnet", subnetID, endpointIDs)
 				continue
 			}
 
@@ -1874,6 +1874,24 @@ func findResourcesBlockedByRequesterManagedVPCEndpoints(ctx context.Context, con
 		}
 	}
 	return subnetIDs, vpcIDs, nil
+}
+
+// logSweepBlockedByRequesterManagedVPCEndpoint emits an operator-facing [WARN]
+// when a sweeper skips a resource because of a requester-managed VPC endpoint
+// it cannot delete. The message identifies the blocker, explains why the
+// sweeper cannot recover, and suggests opening an AWS Support case as the
+// unblock path. Wording is centralized so both the subnet and VPC sweepers
+// emit the same guidance, and so it stays easy to refine in one place.
+func logSweepBlockedByRequesterManagedVPCEndpoint(resourceKind, resourceID string, endpointIDs []string) {
+	log.Printf("[WARN] Skipping %s %s: blocked by requester-managed VPC endpoint(s) %v\n"+
+		"  Why: Requester-managed VPC endpoints cannot be removed by the customer role; "+
+		"DeleteVpcEndpoints and ModifyVpcEndpoint both refuse them. The most common cause is "+
+		"an orphan AWS-managed endpoint (e.g., left behind by GuardDuty Runtime Monitoring "+
+		"after the feature was disabled, sometimes against an endpoint service AWS has since retired).\n"+
+		"  Next: If not already addressed, open an AWS Support case (service: "+
+		"amazon-virtual-private-cloud, category: vpc-endpoints) requesting force-delete of "+
+		"the listed endpoint(s). A subsequent sweep will then clear this resource automatically.",
+		resourceKind, resourceID, endpointIDs)
 }
 
 func sweepTrafficMirrorFilters(region string) error {
@@ -2579,7 +2597,7 @@ func sweepVPCs(region string) error {
 			vpcID := aws.ToString(v.VpcId)
 
 			if endpointIDs, blocked := blockedVPCs[vpcID]; blocked {
-				log.Printf("[INFO] Skipping EC2 VPC %s: blocked by requester-managed VPC endpoint(s) %v", vpcID, endpointIDs)
+				logSweepBlockedByRequesterManagedVPCEndpoint("EC2 VPC", vpcID, endpointIDs)
 				continue
 			}
 

--- a/internal/service/ec2/sweep.go
+++ b/internal/service/ec2/sweep.go
@@ -1805,6 +1805,7 @@ func sweepSubnets(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepab
 		for _, v := range page.Subnets {
 			d := r.Data(nil)
 			d.SetId(aws.ToString(v.SubnetId))
+			d.Set(names.AttrVPCID, aws.ToString(v.VpcId))
 
 			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
 		}

--- a/internal/service/ec2/sweep.go
+++ b/internal/service/ec2/sweep.go
@@ -1797,7 +1797,7 @@ func sweepSubnets(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepab
 	//   aws ec2 describe-vpc-endpoints --region <region> \
 	//     --filters Name=vpc-endpoint-state,Values=available \
 	//     --query 'VpcEndpoints[?RequesterManaged==`true`].{Endpoint:VpcEndpointId,Subnets:SubnetIds,Service:ServiceName}'
-	blockedSubnets, err := findSubnetsBlockedByRequesterManagedVPCEndpoints(ctx, conn)
+	blockedSubnets, _, err := findResourcesBlockedByRequesterManagedVPCEndpoints(ctx, conn)
 	if err != nil {
 		return nil, fmt.Errorf("listing requester-managed VPC endpoints: %w", err)
 	}
@@ -1839,11 +1839,12 @@ func sweepSubnets(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepab
 	return sweepResources, nil
 }
 
-// findSubnetsBlockedByRequesterManagedVPCEndpoints returns a map of subnet ID to the IDs
-// of available, requester-managed VPC endpoints associated with that subnet. Such endpoints
-// cannot be removed by the user role, so any subnet they reference cannot be deleted by the
-// sweeper and must be skipped.
-func findSubnetsBlockedByRequesterManagedVPCEndpoints(ctx context.Context, conn *ec2.Client) (map[string][]string, error) {
+// findResourcesBlockedByRequesterManagedVPCEndpoints returns two maps keyed by
+// subnet ID and VPC ID respectively, each mapping to the IDs of available,
+// requester-managed VPC endpoints anchoring that resource. The aws_subnet and
+// aws_vpc Delete paths cannot remove these endpoints, so any subnet or VPC they
+// reference cannot be deleted by the sweeper and must be skipped.
+func findResourcesBlockedByRequesterManagedVPCEndpoints(ctx context.Context, conn *ec2.Client) (subnetIDs, vpcIDs map[string][]string, err error) {
 	input := &ec2.DescribeVpcEndpointsInput{
 		Filters: newAttributeFilterList(map[string]string{
 			"vpc-endpoint-state": vpcEndpointStateAvailable,
@@ -1853,22 +1854,26 @@ func findSubnetsBlockedByRequesterManagedVPCEndpoints(ctx context.Context, conn 
 	endpoints, err := findVPCEndpoints(ctx, conn, input)
 	if err != nil {
 		if tfresource.NotFound(err) {
-			return nil, nil
+			return nil, nil, nil
 		}
-		return nil, err
+		return nil, nil, err
 	}
 
-	blocked := make(map[string][]string)
+	subnetIDs = make(map[string][]string)
+	vpcIDs = make(map[string][]string)
 	for _, ep := range endpoints {
 		if !aws.ToBool(ep.RequesterManaged) {
 			continue
 		}
 		endpointID := aws.ToString(ep.VpcEndpointId)
 		for _, subnetID := range ep.SubnetIds {
-			blocked[subnetID] = append(blocked[subnetID], endpointID)
+			subnetIDs[subnetID] = append(subnetIDs[subnetID], endpointID)
+		}
+		if vpcID := aws.ToString(ep.VpcId); vpcID != "" {
+			vpcIDs[vpcID] = append(vpcIDs[vpcID], endpointID)
 		}
 	}
-	return blocked, nil
+	return subnetIDs, vpcIDs, nil
 }
 
 func sweepTrafficMirrorFilters(region string) error {
@@ -2538,6 +2543,17 @@ func sweepVPCs(region string) error {
 	conn := client.EC2Client(ctx)
 	var sweepResources []sweep.Sweepable
 
+	// Pre-compute the set of VPCs that contain a requester-managed VPC endpoint. The
+	// aws_vpc Delete path cannot remove these endpoints (DeleteVpcEndpoints refuses
+	// requester-managed endpoints, and the in-resource GuardDuty cleanup only matches
+	// endpoints whose service name and tags fit a narrow heuristic), so DeleteVpc keeps
+	// returning DependencyViolation. See sweepSubnets for the symmetric guard on the
+	// subnet side and the debug one-liner that lists currently-blocking endpoints.
+	_, blockedVPCs, err := findResourcesBlockedByRequesterManagedVPCEndpoints(ctx, conn)
+	if err != nil {
+		return fmt.Errorf("listing requester-managed VPC endpoints (%s): %w", region, err)
+	}
+
 	input := ec2.DescribeVpcsInput{
 		Filters: []awstypes.Filter{
 			{
@@ -2560,9 +2576,16 @@ func sweepVPCs(region string) error {
 		}
 
 		for _, v := range page.Vpcs {
+			vpcID := aws.ToString(v.VpcId)
+
+			if endpointIDs, blocked := blockedVPCs[vpcID]; blocked {
+				log.Printf("[INFO] Skipping EC2 VPC %s: blocked by requester-managed VPC endpoint(s) %v", vpcID, endpointIDs)
+				continue
+			}
+
 			r := resourceVPC()
 			d := r.Data(nil)
-			d.SetId(aws.ToString(v.VpcId))
+			d.SetId(vpcID)
 
 			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
 		}

--- a/internal/service/ec2/sweep.go
+++ b/internal/service/ec2/sweep.go
@@ -1784,6 +1784,24 @@ func sweepSpotInstanceRequests(region string) error {
 func sweepSubnets(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepable, error) {
 	conn := client.EC2Client(ctx)
 
+	// Pre-compute the set of subnets that contain a requester-managed VPC endpoint. The
+	// aws_subnet Delete path cannot remove these: DeleteVpcEndpoints and ModifyVpcEndpoint
+	// both refuse requester-managed endpoints, so an unattended sweep would spin on
+	// DependencyViolation for the full schema.TimeoutDelete (~20 min per subnet). The most
+	// common source is orphan GuardDuty Runtime Monitoring endpoints whose underlying
+	// endpoint service has been decommissioned; clearing those requires AWS Support.
+	// The companion aws_vpc_endpoint sweeper already skips RequesterManaged=true endpoints
+	// for the same reason; this is the symmetric guard on the consumer side.
+	//
+	// To inspect what this would skip in a region:
+	//   aws ec2 describe-vpc-endpoints --region <region> \
+	//     --filters Name=vpc-endpoint-state,Values=available \
+	//     --query 'VpcEndpoints[?RequesterManaged==`true`].{Endpoint:VpcEndpointId,Subnets:SubnetIds,Service:ServiceName}'
+	blockedSubnets, err := findSubnetsBlockedByRequesterManagedVPCEndpoints(ctx, conn)
+	if err != nil {
+		return nil, fmt.Errorf("listing requester-managed VPC endpoints: %w", err)
+	}
+
 	var sweepResources []sweep.Sweepable
 
 	r := resourceSubnet()
@@ -1803,8 +1821,15 @@ func sweepSubnets(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepab
 		}
 
 		for _, v := range page.Subnets {
+			subnetID := aws.ToString(v.SubnetId)
+
+			if endpointIDs, blocked := blockedSubnets[subnetID]; blocked {
+				log.Printf("[INFO] Skipping EC2 Subnet %s: blocked by requester-managed VPC endpoint(s) %v", subnetID, endpointIDs)
+				continue
+			}
+
 			d := r.Data(nil)
-			d.SetId(aws.ToString(v.SubnetId))
+			d.SetId(subnetID)
 			d.Set(names.AttrVPCID, aws.ToString(v.VpcId))
 
 			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
@@ -1812,6 +1837,38 @@ func sweepSubnets(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepab
 	}
 
 	return sweepResources, nil
+}
+
+// findSubnetsBlockedByRequesterManagedVPCEndpoints returns a map of subnet ID to the IDs
+// of available, requester-managed VPC endpoints associated with that subnet. Such endpoints
+// cannot be removed by the user role, so any subnet they reference cannot be deleted by the
+// sweeper and must be skipped.
+func findSubnetsBlockedByRequesterManagedVPCEndpoints(ctx context.Context, conn *ec2.Client) (map[string][]string, error) {
+	input := &ec2.DescribeVpcEndpointsInput{
+		Filters: newAttributeFilterList(map[string]string{
+			"vpc-endpoint-state": vpcEndpointStateAvailable,
+		}),
+	}
+
+	endpoints, err := findVPCEndpoints(ctx, conn, input)
+	if err != nil {
+		if tfresource.NotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	blocked := make(map[string][]string)
+	for _, ep := range endpoints {
+		if !aws.ToBool(ep.RequesterManaged) {
+			continue
+		}
+		endpointID := aws.ToString(ep.VpcEndpointId)
+		for _, subnetID := range ep.SubnetIds {
+			blocked[subnetID] = append(blocked[subnetID], endpointID)
+		}
+	}
+	return blocked, nil
 }
 
 func sweepTrafficMirrorFilters(region string) error {

--- a/internal/service/ec2/vpc_subnet.go
+++ b/internal/service/ec2/vpc_subnet.go
@@ -854,6 +854,13 @@ func isVPCOwnedByAccount(ctx context.Context, conn *ec2.Client, vpcID, accountID
 func dissociateGuardDutyVPCEndpoints(ctx context.Context, conn *ec2.Client, subnetID, vpcID, accountID string) error {
 	ctx = tflog.SetField(ctx, logging.ResourceAttributeKey(names.AttrVPCID), vpcID)
 
+	// Without a VPC ID we cannot perform the ownership check or list endpoints.
+	// Bail early rather than failing the lookup and falsely reporting "no work to do."
+	if vpcID == "" {
+		tflog.Debug(ctx, "Skipping GuardDuty cleanup: empty VPC ID")
+		return nil
+	}
+
 	ownedByAccount, err := isVPCOwnedByAccount(ctx, conn, vpcID, accountID)
 	if err != nil {
 		tflog.Warn(ctx, "Error checking VPC ownership for GuardDuty cleanup", map[string]any{


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Stops the aws_subnet and aws_vpc sweepers from stalling ~20 minutes per resource on requester-managed VPC endpoints they have no API path to remove. The trigger here was a GuardDuty Runtime Monitoring orphan whose underlying endpoint service AWS has since retired — sitting outside the in-resource GuardDuty cleanup heuristic, so DeleteSubnet/DeleteVpc just retried DependencyViolation until schema.TimeoutDelete. Fix is two layers: tighten the existing cleanup path (populate vpc_id on the sweeper's synthetic ResourceData; bail the GuardDuty fallback early on empty vpc_id instead of silently succeeding), and add a sweep-time pre-check — one DescribeVpcEndpoints per region builds subnet→endpoint and VPC→endpoint blocker maps, matched resources are skipped with a [WARN] that names the blocker, explains the API impasse, and points at the exact AWS Support routing (service amazon-virtual-private-cloud, category vpc-endpoints) for force-delete. Once the endpoint is gone the maps are empty and the resources sweep normally — no code to remove.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

Before this, 187' account (afflicted with a GuardDuty orphan) would hang on sweeping and never complete. Now, it completes in reasonable time (~1100s).

```console
% make sweeper
...
2026/06/29 17:56:36 	- aws_quicksight_data_source
2026/06/29 17:56:36 	- aws_s3_object_directory_bucket
2026/06/29 17:56:36 	- aws_appstream_image_builder
2026/06/29 17:56:36 	- aws_ram_resource_share
2026/06/29 17:56:36 	- aws_devicefarm_project
2026/06/29 17:56:36 	- aws_iam_service_linked_role
2026/06/29 17:56:36 	- aws_workmail_group
2026/06/29 17:56:36 	- aws_datazone_domain
2026/06/29 17:56:36 	- aws_storagegateway_file_system_association
2026/06/29 17:56:36 	- aws_redshift_cluster_snapshot
2026/06/29 17:56:36 	- aws_sagemaker_hyper_parameter_tuning_job
2026/06/29 17:56:36 	- aws_memorydb_cluster
2026/06/29 17:56:36 	- aws_sagemaker_workforce
2026/06/29 17:56:36 	- aws_cloudfront_realtime_log_config
2026/06/29 17:56:36 	- aws_ssmincidents_replication_set
2026/06/29 17:56:36 	- aws_bedrockagentcore_harness
2026/06/29 17:56:36 	- aws_glue_workflow
2026/06/29 17:56:36 	- aws_route53_zone
2026/06/29 17:56:36 	- aws_dlm_lifecycle_policy
2026/06/29 17:56:36 	- aws_vpc
2026/06/29 17:56:36 	- aws_acmpca_certificate_authority
2026/06/29 17:56:36 	- aws_rds_cluster_parameter_group
2026/06/29 17:56:36 	- aws_sagemaker_mlflow_app
2026/06/29 17:56:36 	- aws_networkmanager_transit_gateway_route_table_attachment
2026/06/29 17:56:36 	- aws_guardduty_publishing_destination
2026/06/29 17:56:36 	- aws_budgets_budget_action
2026/06/29 17:56:36 	- aws_location_place_index
2026/06/29 17:56:36 	- aws_db_parameter_group
2026/06/29 17:56:36 	- aws_redshift_hsm_client_certificate
2026/06/29 17:56:36 	- aws_rds_blue_green_deployment
2026/06/29 17:56:36 	- aws_servicecatalog_constraint
2026/06/29 17:56:36 	- aws_xray_group
2026/06/29 17:56:36 	- aws_gamelift_game_server_group
2026/06/29 17:56:36 	- aws_fsx_ontap_file_system
2026/06/29 17:56:36 	- aws_servicecatalog_tag_option_resource_association
2026/06/29 17:56:36 	- aws_ec2_transit_gateway_vpc_attachment
2026/06/29 17:56:36 	- aws_elasticache_cluster
2026/06/29 17:56:36 	- aws_ecs_service
FAIL	github.com/hashicorp/terraform-provider-aws/internal/sweep	1142.418s
FAIL
make: *** [sweeper] Error 1
```
