### PR TITLE
resource/aws_bedrock_guardrail_resource_policy: new resource

### DIFF
--- a/.changelog/48697.txt
+++ b/.changelog/48697.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_bedrock_guardrail_resource_policy
+```

--- a/examples/bedrock-guardrail-resource-policy/README.md
+++ b/examples/bedrock-guardrail-resource-policy/README.md
@@ -1,0 +1,97 @@
+<!-- Copyright IBM Corp. 2014, 2026 -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
+# Bedrock Guardrail Resource Policy example
+
+This example demonstrates how to use `aws_bedrock_guardrail_resource_policy` to
+attach resource-based policies (RBPs) to an Amazon Bedrock guardrail and,
+optionally, to a system-defined guardrail profile used for Cross-Region Inference
+(CRIS).
+
+RBPs are required for organisation-level enforced guardrails
+(`BEDROCK_POLICY` in AWS Organizations Service Control Policies): member accounts
+must be granted `bedrock:ApplyGuardrail` on a guardrail that lives in the
+management account before the SCP can enforce it.
+
+## What this example creates
+
+| Resource | Purpose |
+|---|---|
+| `aws_bedrock_guardrail.this` | Guardrail with content and PII filters, living in the management account |
+| `aws_bedrock_guardrail_resource_policy.guardrail` | RBP on the guardrail, scoped to all principals in the AWS Organisation |
+| `aws_bedrock_guardrail_resource_policy.profile` | *(optional)* RBP on a system-defined guardrail profile for CRIS |
+
+## Prerequisites
+
+- Terraform ≥ 1.5
+- Go toolchain (to build the provider locally)
+- AWS credentials for the **management account** of an AWS Organization
+- The caller must have permissions to call `bedrock:CreateGuardrail`,
+  `bedrock:PutResourcePolicy`, and `organizations:DescribeOrganization`
+
+## Building the provider locally
+
+This example uses `aws_bedrock_guardrail_resource_policy`, which is not yet in a
+published release of the provider.  You must build and install the provider from
+this repository before running the example.
+
+From the **repository root**:
+
+```bash
+make build
+```
+
+This compiles the provider and installs the binary to `$GOPATH/bin/terraform-provider-aws`.
+
+## Running the example
+
+Because the provider is not published to the registry, Terraform must be told to
+use the local binary.  The `dev.tfrc` file in this directory contains the
+necessary `dev_overrides` block.  Update the path inside it to match your
+`$GOPATH/bin` directory if it differs, then prefix every Terraform command with
+`TF_CLI_CONFIG_FILE=dev.tfrc`.
+
+> **Note:** `dev_overrides` skips `terraform init` — go straight to `plan`.
+
+### Basic (guardrail RBP only)
+
+```bash
+# from this directory, after running `make build` in the repo root
+TF_CLI_CONFIG_FILE=dev.tfrc terraform plan
+TF_CLI_CONFIG_FILE=dev.tfrc terraform apply
+```
+
+After applying, reference the `guardrail_arn` output in your
+`BEDROCK_POLICY` service control policy.
+
+### With Cross-Region Inference profile
+
+If your organisation policy also enforces guardrails on Cross-Region Inference
+calls, supply the system-defined profile ARN:
+
+```bash
+TF_CLI_CONFIG_FILE=dev.tfrc terraform apply \
+  -var 'guardrail_profile_arn=arn:aws:bedrock:us-east-1::guardrail-profile/<id>'
+```
+
+### Override defaults
+
+```bash
+TF_CLI_CONFIG_FILE=dev.tfrc terraform apply \
+  -var 'region=eu-west-1' \
+  -var 'guardrail_name=my-org-guardrail'
+```
+
+## Outputs
+
+| Name | Description |
+|---|---|
+| `guardrail_arn` | Use this in the `BEDROCK_POLICY` SCP |
+| `guardrail_id` | Guardrail identifier |
+| `organization_id` | AWS Organizations ID used to scope the RBPs |
+
+## Clean up
+
+```bash
+TF_CLI_CONFIG_FILE=dev.tfrc terraform destroy
+```

--- a/examples/bedrock-guardrail-resource-policy/main.tf
+++ b/examples/bedrock-guardrail-resource-policy/main.tf
@@ -1,0 +1,134 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+# ---------------------------------------------------------------------------
+# Guardrail
+# ---------------------------------------------------------------------------
+
+resource "aws_bedrock_guardrail" "this" {
+  name                      = var.guardrail_name
+  blocked_input_messaging   = "This request has been blocked by your organisation's content policy."
+  blocked_outputs_messaging = "This response has been blocked by your organisation's content policy."
+  description               = "Organisation-level guardrail managed centrally and enforced via AWS Organizations."
+
+  content_policy_config {
+    filters_config {
+      type            = "HATE"
+      input_strength  = "HIGH"
+      output_strength = "HIGH"
+    }
+    filters_config {
+      type            = "VIOLENCE"
+      input_strength  = "HIGH"
+      output_strength = "HIGH"
+    }
+    filters_config {
+      type            = "SEXUAL"
+      input_strength  = "HIGH"
+      output_strength = "HIGH"
+    }
+    filters_config {
+      type            = "MISCONDUCT"
+      input_strength  = "HIGH"
+      output_strength = "HIGH"
+    }
+    filters_config {
+      type            = "PROMPT_ATTACK"
+      input_strength  = "HIGH"
+      output_strength = "NONE"
+    }
+  }
+
+  sensitive_information_policy_config {
+    pii_entities_config {
+      type   = "EMAIL"
+      action = "ANONYMIZE"
+    }
+    pii_entities_config {
+      type   = "PHONE"
+      action = "ANONYMIZE"
+    }
+    pii_entities_config {
+      type   = "AWS_ACCESS_KEY"
+      action = "BLOCK"
+    }
+    pii_entities_config {
+      type   = "AWS_SECRET_KEY"
+      action = "BLOCK"
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------
+# AWS Organizations — used to scope the resource-based policy to the org
+# ---------------------------------------------------------------------------
+
+data "aws_organizations_organization" "org" {}
+
+# ---------------------------------------------------------------------------
+# Resource-based policy on the guardrail
+#
+# Grants every principal in the organisation permission to call
+# bedrock:GetGuardrail and bedrock:ApplyGuardrail on this guardrail.
+# This is a prerequisite for the BEDROCK_POLICY service control policy
+# in AWS Organizations to take effect in member accounts.
+# ---------------------------------------------------------------------------
+
+resource "aws_bedrock_guardrail_resource_policy" "guardrail" {
+  resource_arn = aws_bedrock_guardrail.this.guardrail_arn
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = "*"
+      Action    = ["bedrock:GetGuardrail", "bedrock:ApplyGuardrail"]
+      Resource  = aws_bedrock_guardrail.this.guardrail_arn
+      Condition = {
+        StringEquals = { "aws:PrincipalOrgID" = data.aws_organizations_organization.org.id }
+      }
+    }]
+  })
+}
+
+# ---------------------------------------------------------------------------
+# Resource-based policy on a system-defined guardrail profile
+#
+# Required when Cross-Region Inference (CRIS) is enabled.  The guardrail
+# profile ARN is system-defined by AWS and must be supplied as a variable.
+# Set var.guardrail_profile_arn to enable this block.
+# ---------------------------------------------------------------------------
+
+resource "aws_bedrock_guardrail_resource_policy" "profile" {
+  count = var.guardrail_profile_arn != "" ? 1 : 0
+
+  resource_arn = var.guardrail_profile_arn
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = "*"
+      Action    = ["bedrock:ApplyGuardrail"]
+      Resource  = var.guardrail_profile_arn
+      Condition = {
+        StringEquals = { "aws:PrincipalOrgID" = data.aws_organizations_organization.org.id }
+      }
+    }]
+  })
+}

--- a/examples/bedrock-guardrail-resource-policy/outputs.tf
+++ b/examples/bedrock-guardrail-resource-policy/outputs.tf
@@ -1,0 +1,17 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+output "guardrail_arn" {
+  description = "ARN of the Bedrock guardrail. Reference this in the BEDROCK_POLICY service control policy."
+  value       = aws_bedrock_guardrail.this.guardrail_arn
+}
+
+output "guardrail_id" {
+  description = "ID of the Bedrock guardrail."
+  value       = aws_bedrock_guardrail.this.guardrail_id
+}
+
+output "organization_id" {
+  description = "AWS Organizations ID used to scope the resource-based policies."
+  value       = data.aws_organizations_organization.org.id
+}

--- a/examples/bedrock-guardrail-resource-policy/variables.tf
+++ b/examples/bedrock-guardrail-resource-policy/variables.tf
@@ -1,0 +1,32 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+variable "region" {
+  description = "AWS region in which to create the guardrail. This should be the management account's home region."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "guardrail_name" {
+  description = "Name for the Bedrock guardrail."
+  type        = string
+  default     = "org-guardrail"
+}
+
+variable "guardrail_profile_arn" {
+  description = <<-EOT
+    ARN of the system-defined Bedrock guardrail profile to attach a resource-based
+    policy to. Only required when Cross-Region Inference (CRIS) is enabled for the
+    organisation-level guardrail enforcement policy (BEDROCK_POLICY).
+
+    AWS defines these ARNs; they are not created by Terraform. Leave empty to skip
+    creating the profile policy.
+
+    Retrieve available profile ARNs with:
+    aws bedrock list-foundation-model-availability --query 'guardrailProfiles[*].guardrailProfileArn'
+
+    Example: arn:aws:bedrock:us-east-1::guardrail-profile/system-defined-profile-id
+  EOT
+  type    = string
+  default = "arn:aws:bedrock:us-east-1:271376211545:guardrail-profile/us.guardrail.v1:0"
+}

--- a/internal/service/bedrock/exports_test.go
+++ b/internal/service/bedrock/exports_test.go
@@ -7,12 +7,14 @@ package bedrock
 var (
 	ResourceCustomModel                         = newCustomModelResource
 	ResourceGuardrail                           = newGuardrailResource
+	ResourceGuardrailResourcePolicy             = newGuardrailResourcePolicyResource
 	ResourceGuardrailVersion                    = newGuardrailVersionResource
 	ResourceModelInvocationLoggingConfiguration = newModelInvocationLoggingConfigurationResource
 	ResourceInferenceProfile                    = newInferenceProfileResource
 
 	FindCustomModelByID                     = findCustomModelByID
 	FindGuardrailByTwoPartKey               = findGuardrailByTwoPartKey
+	FindGuardrailResourcePolicyByARN        = findGuardrailResourcePolicyByARN
 	FindModelCustomizationJobByID           = findModelCustomizationJobByID
 	FindModelInvocationLoggingConfiguration = findModelInvocationLoggingConfiguration
 	FindProvisionedModelThroughputByID      = findProvisionedModelThroughputByID

--- a/internal/service/bedrock/guardrail_resource_policy.go
+++ b/internal/service/bedrock/guardrail_resource_policy.go
@@ -1,0 +1,191 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package bedrock
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/bedrock"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/bedrock/types"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+)
+
+// @FrameworkResource("aws_bedrock_guardrail_resource_policy", name="Guardrail Resource Policy")
+// @Testing(tagsTest=false)
+func newGuardrailResourcePolicyResource(_ context.Context) (resource.ResourceWithConfigure, error) {
+	return &guardrailResourcePolicyResource{}, nil
+}
+
+const (
+	ResNameGuardrailResourcePolicy = "Guardrail Resource Policy"
+)
+
+type guardrailResourcePolicyResource struct {
+	framework.ResourceWithModel[guardrailResourcePolicyResourceModel]
+}
+
+func (r *guardrailResourcePolicyResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"policy": schema.StringAttribute{
+				CustomType: fwtypes.IAMPolicyType,
+				Required:   true,
+			},
+			"resource_arn": schema.StringAttribute{
+				CustomType: fwtypes.ARNType,
+				Required:   true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+		},
+	}
+}
+
+func (r *guardrailResourcePolicyResource) Create(ctx context.Context, request resource.CreateRequest, response *resource.CreateResponse) {
+	var data guardrailResourcePolicyResourceModel
+	response.Diagnostics.Append(request.Plan.Get(ctx, &data)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	conn := r.Meta().BedrockClient(ctx)
+
+	resourceARN := data.ResourceARN.ValueString()
+	input := &bedrock.PutResourcePolicyInput{
+		ResourceArn:    aws.String(resourceARN),
+		ResourcePolicy: aws.String(data.Policy.ValueString()),
+	}
+
+	_, err := conn.PutResourcePolicy(ctx, input)
+	if err != nil {
+		response.Diagnostics.AddError(fmt.Sprintf("creating Bedrock Guardrail Resource Policy (%s)", resourceARN), err.Error())
+		return
+	}
+
+	response.Diagnostics.Append(response.State.Set(ctx, data)...)
+}
+
+func (r *guardrailResourcePolicyResource) Read(ctx context.Context, request resource.ReadRequest, response *resource.ReadResponse) {
+	var data guardrailResourcePolicyResourceModel
+	response.Diagnostics.Append(request.State.Get(ctx, &data)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	conn := r.Meta().BedrockClient(ctx)
+
+	resourceARN := data.ResourceARN.ValueString()
+	policy, err := findGuardrailResourcePolicyByARN(ctx, conn, resourceARN)
+	if retry.NotFound(err) {
+		response.Diagnostics.Append(fwdiag.NewResourceNotFoundWarningDiagnostic(err))
+		response.State.RemoveResource(ctx)
+		return
+	}
+	if err != nil {
+		response.Diagnostics.AddError(fmt.Sprintf("reading Bedrock Guardrail Resource Policy (%s)", resourceARN), err.Error())
+		return
+	}
+
+	policyToSet, err := verify.PolicyToSet(data.Policy.ValueString(), aws.ToString(policy))
+	if err != nil {
+		response.Diagnostics.AddError(fmt.Sprintf("reading Bedrock Guardrail Resource Policy (%s)", resourceARN), err.Error())
+		return
+	}
+	data.Policy = fwtypes.IAMPolicyValue(policyToSet)
+
+	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
+}
+
+func (r *guardrailResourcePolicyResource) Update(ctx context.Context, request resource.UpdateRequest, response *resource.UpdateResponse) {
+	var data guardrailResourcePolicyResourceModel
+	response.Diagnostics.Append(request.Plan.Get(ctx, &data)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	conn := r.Meta().BedrockClient(ctx)
+
+	resourceARN := data.ResourceARN.ValueString()
+	input := &bedrock.PutResourcePolicyInput{
+		ResourceArn:    aws.String(resourceARN),
+		ResourcePolicy: aws.String(data.Policy.ValueString()),
+	}
+
+	_, err := conn.PutResourcePolicy(ctx, input)
+	if err != nil {
+		response.Diagnostics.AddError(fmt.Sprintf("updating Bedrock Guardrail Resource Policy (%s)", resourceARN), err.Error())
+		return
+	}
+
+	response.Diagnostics.Append(response.State.Set(ctx, data)...)
+}
+
+func (r *guardrailResourcePolicyResource) Delete(ctx context.Context, request resource.DeleteRequest, response *resource.DeleteResponse) {
+	var data guardrailResourcePolicyResourceModel
+	response.Diagnostics.Append(request.State.Get(ctx, &data)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	conn := r.Meta().BedrockClient(ctx)
+
+	_, err := conn.DeleteResourcePolicy(ctx, &bedrock.DeleteResourcePolicyInput{
+		ResourceArn: data.ResourceARN.ValueStringPointer(),
+	})
+
+	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+		return
+	}
+
+	if err != nil {
+		response.Diagnostics.AddError(fmt.Sprintf("deleting Bedrock Guardrail Resource Policy (%s)", data.ResourceARN.ValueString()), err.Error())
+		return
+	}
+}
+
+func (r *guardrailResourcePolicyResource) ImportState(ctx context.Context, request resource.ImportStateRequest, response *resource.ImportStateResponse) {
+	response.Diagnostics.Append(response.State.SetAttribute(ctx, path.Root("resource_arn"), request.ID)...)
+}
+
+type guardrailResourcePolicyResourceModel struct {
+	framework.WithRegionModel
+	Policy      fwtypes.IAMPolicy `tfsdk:"policy"`
+	ResourceARN fwtypes.ARN       `tfsdk:"resource_arn"`
+}
+
+func findGuardrailResourcePolicyByARN(ctx context.Context, conn *bedrock.Client, arn string) (*string, error) {
+	input := &bedrock.GetResourcePolicyInput{
+		ResourceArn: aws.String(arn),
+	}
+
+	output, err := conn.GetResourcePolicy(ctx, input)
+
+	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+		return nil, &retry.NotFoundError{LastError: err}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || output.ResourcePolicy == nil {
+		return nil, tfresource.NewEmptyResultError()
+	}
+
+	return output.ResourcePolicy, nil
+}

--- a/internal/service/bedrock/guardrail_resource_policy_test.go
+++ b/internal/service/bedrock/guardrail_resource_policy_test.go
@@ -1,0 +1,245 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package bedrock_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/bedrock/types"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	tfbedrock "github.com/hashicorp/terraform-provider-aws/internal/service/bedrock"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccBedrockGuardrailResourcePolicy_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_bedrock_guardrail_resource_policy.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID)
+			acctest.PreCheckOrganizationsEnabled(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckGuardrailResourcePolicyDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGuardrailResourcePolicyConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGuardrailResourcePolicyExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "resource_arn", "aws_bedrock_guardrail.test", "guardrail_arn"),
+					resource.TestCheckResourceAttrSet(resourceName, "policy"),
+				),
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateIdFunc:                    testAccGuardrailResourcePolicyImportStateIDFunc(resourceName),
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: names.AttrResourceARN,
+			},
+		},
+	})
+}
+
+func TestAccBedrockGuardrailResourcePolicy_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_bedrock_guardrail_resource_policy.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID)
+			acctest.PreCheckOrganizationsEnabled(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckGuardrailResourcePolicyDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGuardrailResourcePolicyConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGuardrailResourcePolicyExists(ctx, t, resourceName),
+					acctest.CheckFrameworkResourceDisappears(ctx, t, tfbedrock.ResourceGuardrailResourcePolicy, resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccBedrockGuardrailResourcePolicy_update(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_bedrock_guardrail_resource_policy.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID)
+			acctest.PreCheckOrganizationsEnabled(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckGuardrailResourcePolicyDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGuardrailResourcePolicyConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGuardrailResourcePolicyExists(ctx, t, resourceName),
+				),
+			},
+			{
+				Config: testAccGuardrailResourcePolicyConfig_updated(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGuardrailResourcePolicyExists(ctx, t, resourceName),
+				),
+			},
+		},
+	})
+}
+
+func testAccGuardrailResourcePolicyImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		return rs.Primary.Attributes["resource_arn"], nil
+	}
+}
+
+func testAccCheckGuardrailResourcePolicyDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.ProviderMeta(ctx, t).BedrockClient(ctx)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_bedrock_guardrail_resource_policy" {
+				continue
+			}
+
+			arn := rs.Primary.Attributes["resource_arn"]
+
+			_, err := tfbedrock.FindGuardrailResourcePolicyByARN(ctx, conn, arn)
+			if errs.IsA[*types.ResourceNotFoundException](err) {
+				return nil
+			}
+			if err != nil {
+				return create.Error(names.Bedrock, create.ErrActionCheckingDestroyed, tfbedrock.ResNameGuardrailResourcePolicy, arn, err)
+			}
+
+			return create.Error(names.Bedrock, create.ErrActionCheckingDestroyed, tfbedrock.ResNameGuardrailResourcePolicy, arn, errors.New("not destroyed"))
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckGuardrailResourcePolicyExists(ctx context.Context, t *testing.T, name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return create.Error(names.Bedrock, create.ErrActionCheckingExistence, tfbedrock.ResNameGuardrailResourcePolicy, name, errors.New("not found"))
+		}
+
+		arn := rs.Primary.Attributes["resource_arn"]
+		if arn == "" {
+			return create.Error(names.Bedrock, create.ErrActionCheckingExistence, tfbedrock.ResNameGuardrailResourcePolicy, name, errors.New("resource_arn not set"))
+		}
+
+		conn := acctest.ProviderMeta(ctx, t).BedrockClient(ctx)
+
+		_, err := tfbedrock.FindGuardrailResourcePolicyByARN(ctx, conn, arn)
+		if err != nil {
+			return create.Error(names.Bedrock, create.ErrActionCheckingExistence, tfbedrock.ResNameGuardrailResourcePolicy, arn, err)
+		}
+
+		return nil
+	}
+}
+
+func testAccGuardrailResourcePolicyConfig_base(rName string) string {
+	return fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+
+resource "aws_bedrock_guardrail" "test" {
+  name                      = %[1]q
+  blocked_input_messaging   = "test"
+  blocked_outputs_messaging = "test"
+  description               = "test"
+
+  content_policy_config {
+    filters_config {
+      input_strength  = "MEDIUM"
+      output_strength = "MEDIUM"
+      type            = "HATE"
+    }
+  }
+}
+`, rName)
+}
+
+func testAccGuardrailResourcePolicyConfig_basic(rName string) string {
+	return acctest.ConfigCompose(testAccGuardrailResourcePolicyConfig_base(rName), `
+data "aws_organizations_organization" "current" {}
+
+resource "aws_bedrock_guardrail_resource_policy" "test" {
+  resource_arn = aws_bedrock_guardrail.test.guardrail_arn
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = "*"
+      Action    = ["bedrock:GetGuardrail", "bedrock:ApplyGuardrail"]
+      Resource  = aws_bedrock_guardrail.test.guardrail_arn
+      Condition = {
+        StringEquals = { "aws:PrincipalOrgID" = data.aws_organizations_organization.current.id }
+      }
+    }]
+  })
+}
+`)
+}
+
+func testAccGuardrailResourcePolicyConfig_updated(rName string) string {
+	return acctest.ConfigCompose(testAccGuardrailResourcePolicyConfig_base(rName), `
+data "aws_organizations_organization" "current" {}
+
+resource "aws_bedrock_guardrail_resource_policy" "test" {
+  resource_arn = aws_bedrock_guardrail.test.guardrail_arn
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = "*"
+      Action    = ["bedrock:ApplyGuardrail"]
+      Resource  = aws_bedrock_guardrail.test.guardrail_arn
+      Condition = {
+        StringEquals = { "aws:PrincipalOrgID" = data.aws_organizations_organization.current.id }
+      }
+    }]
+  })
+}
+`)
+}

--- a/internal/service/bedrock/service_package_gen.go
+++ b/internal/service/bedrock/service_package_gen.go
@@ -86,6 +86,12 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*inttypes.Ser
 			Region: inttypes.ResourceRegionDefault(),
 		},
 		{
+			Factory:  newGuardrailResourcePolicyResource,
+			TypeName: "aws_bedrock_guardrail_resource_policy",
+			Name:     "Guardrail Resource Policy",
+			Region:   inttypes.ResourceRegionDefault(),
+		},
+		{
 			Factory:  newGuardrailVersionResource,
 			TypeName: "aws_bedrock_guardrail_version",
 			Name:     "Guardrail Version",

--- a/website/docs/r/bedrock_guardrail_resource_policy.html.markdown
+++ b/website/docs/r/bedrock_guardrail_resource_policy.html.markdown
@@ -1,0 +1,104 @@
+---
+subcategory: "Bedrock"
+layout: "aws"
+page_title: "AWS: aws_bedrock_guardrail_resource_policy"
+description: |-
+  Terraform resource for managing an AWS Bedrock Guardrail Resource Policy.
+---
+# Resource: aws_bedrock_guardrail_resource_policy
+
+Manages a resource-based policy (RBP) on an Amazon Bedrock guardrail or system-defined guardrail profile.
+
+Resource-based policies are required for organization-level enforced guardrails (`BEDROCK_POLICY` in AWS Organizations Service Control Policies). Member accounts must be granted `bedrock:ApplyGuardrail` on the guardrail (and, when Cross-Region Inference is enabled, on the associated guardrail profile) that lives in the management account.
+
+## Example Usage
+
+### Guardrail RBP for Organization Enforcement
+
+```terraform
+resource "aws_bedrock_guardrail" "example" {
+  name                      = "org-guardrail"
+  blocked_input_messaging   = "Blocked."
+  blocked_outputs_messaging = "Blocked."
+
+  content_policy_config {
+    filters_config {
+      type            = "VIOLENCE"
+      input_strength  = "HIGH"
+      output_strength = "HIGH"
+    }
+  }
+}
+
+data "aws_organizations_organization" "current" {}
+
+resource "aws_bedrock_guardrail_resource_policy" "example" {
+  resource_arn = aws_bedrock_guardrail.example.guardrail_arn
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = "*"
+      Action    = ["bedrock:GetGuardrail", "bedrock:ApplyGuardrail"]
+      Resource  = aws_bedrock_guardrail.example.guardrail_arn
+      Condition = {
+        StringEquals = { "aws:PrincipalOrgID" = data.aws_organizations_organization.current.id }
+      }
+    }]
+  })
+}
+```
+
+### Guardrail Profile RBP for Cross-Region Inference
+
+```terraform
+resource "aws_bedrock_guardrail_resource_policy" "profile" {
+  resource_arn = var.guardrail_profile_arn
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = "*"
+      Action    = ["bedrock:ApplyGuardrail"]
+      Resource  = var.guardrail_profile_arn
+      Condition = {
+        StringEquals = { "aws:PrincipalOrgID" = data.aws_organizations_organization.current.id }
+      }
+    }]
+  })
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `resource_arn` - (Required, Forces new resource) ARN of the Bedrock resource to attach the policy to. This can be a guardrail ARN or a system-defined guardrail profile ARN.
+* `policy` - (Required) JSON policy document. This is a resource-based policy granting other principals (e.g., all principals in an AWS Organization) permission to call Bedrock APIs on this resource.
+
+The following arguments are optional:
+
+* `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
+
+## Attribute Reference
+
+This resource exports no additional attributes beyond the arguments above.
+
+## Import
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Bedrock Guardrail Resource Policy using the `resource_arn`. For example:
+
+```terraform
+import {
+  to = aws_bedrock_guardrail_resource_policy.example
+  id = "arn:aws:bedrock:us-east-1:123456789012:guardrail/abc123"
+}
+```
+
+Using `terraform import`, import Bedrock Guardrail Resource Policy using the `resource_arn`. For example:
+
+```console
+% terraform import aws_bedrock_guardrail_resource_policy.example arn:aws:bedrock:us-east-1:123456789012:guardrail/abc123
+```


### PR DESCRIPTION
Adds support for AWS Bedrock guardrail resource-based policies via PutResourcePolicy/GetResourcePolicy/DeleteResourcePolicy APIs, including acceptance tests, example configuration, and documentation.

<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #48674 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
badams@U-2Z3HIOMNBMWOG:~/development/hashicorp/terraform-provider-aws$ TF_ACC=1 go test ./internal/service/bedrock/... -v -run TestAccBedrockGuardrailResourcePolicy -timeout 30m
2026/06/30 15:23:42 Creating Terraform AWS Provider (SDKv2-style)...
2026/06/30 15:23:42 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccBedrockGuardrailResourcePolicy_basic
=== PAUSE TestAccBedrockGuardrailResourcePolicy_basic
=== RUN   TestAccBedrockGuardrailResourcePolicy_disappears
=== PAUSE TestAccBedrockGuardrailResourcePolicy_disappears
=== RUN   TestAccBedrockGuardrailResourcePolicy_update
=== PAUSE TestAccBedrockGuardrailResourcePolicy_update
=== CONT  TestAccBedrockGuardrailResourcePolicy_basic
=== CONT  TestAccBedrockGuardrailResourcePolicy_update
=== CONT  TestAccBedrockGuardrailResourcePolicy_disappears
--- PASS: TestAccBedrockGuardrailResourcePolicy_disappears (27.61s)
--- PASS: TestAccBedrockGuardrailResourcePolicy_basic (30.36s)
--- PASS: TestAccBedrockGuardrailResourcePolicy_update (40.22s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/bedrock    40.363s
...
```
