### PR TITLE
docs/wafv2_web_acl_association: document Amplify and AgentCore Gateway as associable resources

### DIFF
--- a/website/docs/d/wafv2_web_acl.html.markdown
+++ b/website/docs/d/wafv2_web_acl.html.markdown
@@ -41,7 +41,7 @@ This data source supports the following arguments:
 
 * `name` - (Optional) Name of the WAFv2 Web ACL. Exactly one of `name` or `resource_arn` must be specified.
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
-* `resource_arn` - (Optional) ARN of the AWS resource associated with the Web ACL. This can be an ARN of an Application Load Balancer, Amazon API Gateway REST API, AWS AppSync GraphQL API, Amazon Cognito user pool, AWS App Runner service, AWS Verified Access instance, or AWS Amplify application. Exactly one of `name` or `resource_arn` must be specified.
+* `resource_arn` - (Optional) ARN of the AWS resource associated with the Web ACL. This can be an ARN of an Application Load Balancer, Amazon API Gateway REST API, AWS AppSync GraphQL API, Amazon Cognito user pool, AWS App Runner service, AWS Verified Access instance, AWS Amplify application, or Amazon Bedrock AgentCore Gateway. Exactly one of `name` or `resource_arn` must be specified.
 * `scope` - (Required) Specifies whether this is for an AWS CloudFront distribution or for a regional application. Valid values are `CLOUDFRONT` or `REGIONAL`. To work with CloudFront, you must also specify the region `us-east-1` (N. Virginia) on the AWS provider.
 
 ## Attribute Reference

--- a/website/docs/r/wafv2_web_acl_association.html.markdown
+++ b/website/docs/r/wafv2_web_acl_association.html.markdown
@@ -83,7 +83,7 @@ resource "aws_wafv2_web_acl_association" "example" {
 This resource supports the following arguments:
 
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
-* `resource_arn` - (Required) The Amazon Resource Name (ARN) of the resource to associate with the web ACL. This must be an ARN of an Application Load Balancer, an Amazon API Gateway stage (REST only, HTTP is unsupported), an Amazon Cognito User Pool, an Amazon AppSync GraphQL API, an Amazon App Runner service, or an Amazon Verified Access instance.
+* `resource_arn` - (Required) The Amazon Resource Name (ARN) of the resource to associate with the web ACL. This must be an ARN of an Application Load Balancer, an Amazon API Gateway stage (REST only, HTTP is unsupported), an Amazon Cognito User Pool, an Amazon AppSync GraphQL API, an Amazon App Runner service, an AWS Amplify application, an Amazon Bedrock AgentCore Gateway, or an Amazon Verified Access instance.
 * `web_acl_arn` - (Required) The Amazon Resource Name (ARN) of the Web ACL that you want to associate with the resource.
 
 ## Attribute Reference


### PR DESCRIPTION
### Description

The `resource_arn` documentation for `aws_wafv2_web_acl_association` lists the resource types that can be associated with a Web ACL, but the list has fallen behind the WAF API. The `wafv2` `AssociatedResourceType` enum currently includes `AMPLIFY` and `AGENTCORE_GATEWAY`, neither of which is mentioned in the docs:

```
CLOUDFRONT | API_GATEWAY | COGNITO_USER_POOL | APP_RUNNER_SERVICE |
VERIFIED_ACCESS_INSTANCE | AMPLIFY | AGENTCORE_GATEWAY
```

AWS announced general availability of AWS WAF support for Amazon Bedrock AgentCore Gateway on 2026-06-29. The resource itself already supports associating these targets — it passes any ARN through to the `AssociateWebACL` API and does not enumerate resource types in the schema — so this is a documentation-only accuracy fix.

This updates both:

- `aws_wafv2_web_acl_association` (`resource_arn`) — adds AWS Amplify application and Amazon Bedrock AgentCore Gateway.
- `aws_wafv2_web_acl` data source (`resource_arn`) — adds Amazon Bedrock AgentCore Gateway (it already listed Amplify).

### Affected Resource(s) or Data Source(s)

* `aws_wafv2_web_acl_association`
* `aws_wafv2_web_acl` (data source)

### References

- AWS WAF now supports Amazon Bedrock AgentCore Gateway: https://aws.amazon.com/about-aws/whats-new/2026/06/aws-waf-amazon-bedrock-agentcore/
- AssociateWebACL API reference: https://docs.aws.amazon.com/waf/latest/APIReference/API_AssociateWebACL.html
- Related schema enhancement (bedrockagentcore side): #48661

### Would you like to implement the enhancement?

Already implemented in this PR (documentation only).
