### PR TITLE
resource/aws_bedrockagentcore_gateway_waf_configuration: new resource

### DIFF
--- a/.changelog/48710.txt
+++ b/.changelog/48710.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_bedrockagentcore_gateway_waf_configuration
+```

--- a/internal/service/bedrockagentcore/exports_test.go
+++ b/internal/service/bedrockagentcore/exports_test.go
@@ -13,6 +13,7 @@ var (
 	ResourceEvaluator                = newEvaluatorResource
 	ResourceGateway                  = newGatewayResource
 	ResourceGatewayTarget            = newGatewayTargetResource
+	ResourceGatewayWAFConfiguration  = newGatewayWAFConfigurationResource
 	ResourceMemory                   = newMemoryResource
 	ResourceResourcePolicy           = newResourcePolicyResource
 	ResourceMemoryStrategy           = newResourceMemoryStrategy

--- a/internal/service/bedrockagentcore/exports_test.go
+++ b/internal/service/bedrockagentcore/exports_test.go
@@ -15,6 +15,7 @@ var (
 	ResourceGateway                  = newGatewayResource
 	ResourceGatewayRule              = newGatewayRuleResource
 	ResourceGatewayTarget            = newGatewayTargetResource
+	ResourceGatewayWAFConfiguration  = newGatewayWAFConfigurationResource
 	ResourceMemory                   = newMemoryResource
 	ResourceResourcePolicy           = newResourcePolicyResource
 	ResourceMemoryStrategy           = newResourceMemoryStrategy

--- a/internal/service/bedrockagentcore/gateway.go
+++ b/internal/service/bedrockagentcore/gateway.go
@@ -411,7 +411,7 @@ func (r *gatewayResource) Update(ctx context.Context, request resource.UpdateReq
 			return
 		}
 
-		if _, err := waitGatewayUpdated(ctx, conn, gatewayID, r.UpdateTimeout(ctx, new.Timeouts)); err != nil {
+		if err := waitGatewayUpdated(ctx, conn, gatewayID, r.UpdateTimeout(ctx, new.Timeouts)); err != nil {
 			smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, gatewayID)
 			return
 		}
@@ -507,7 +507,7 @@ func waitGatewayCreated(ctx context.Context, conn *bedrockagentcorecontrol.Clien
 	return nil, smarterr.NewError(err)
 }
 
-func waitGatewayUpdated(ctx context.Context, conn *bedrockagentcorecontrol.Client, id string, timeout time.Duration) (*bedrockagentcorecontrol.GetGatewayOutput, error) {
+func waitGatewayUpdated(ctx context.Context, conn *bedrockagentcorecontrol.Client, id string, timeout time.Duration) error {
 	stateConf := &retry.StateChangeConf{
 		Pending:                   enum.Slice(awstypes.GatewayStatusUpdating),
 		Target:                    enum.Slice(awstypes.GatewayStatusReady),
@@ -519,10 +519,10 @@ func waitGatewayUpdated(ctx context.Context, conn *bedrockagentcorecontrol.Clien
 	outputRaw, err := stateConf.WaitForStateContext(ctx)
 	if out, ok := outputRaw.(*bedrockagentcorecontrol.GetGatewayOutput); ok {
 		retry.SetLastError(err, errors.New(strings.Join(out.StatusReasons, "; ")))
-		return out, smarterr.NewError(err)
+		return smarterr.NewError(err)
 	}
 
-	return nil, smarterr.NewError(err)
+	return smarterr.NewError(err)
 }
 
 func waitGatewayDeleted(ctx context.Context, conn *bedrockagentcorecontrol.Client, id string, timeout time.Duration) (*bedrockagentcorecontrol.GetGatewayOutput, error) {

--- a/internal/service/bedrockagentcore/gateway.go
+++ b/internal/service/bedrockagentcore/gateway.go
@@ -419,7 +419,7 @@ func (r *gatewayResource) Update(ctx context.Context, request resource.UpdateReq
 			return
 		}
 
-		if _, err := waitGatewayUpdated(ctx, conn, gatewayID, r.UpdateTimeout(ctx, new.Timeouts)); err != nil {
+		if err := waitGatewayUpdated(ctx, conn, gatewayID, r.UpdateTimeout(ctx, new.Timeouts)); err != nil {
 			smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, gatewayID)
 			return
 		}
@@ -515,7 +515,7 @@ func waitGatewayCreated(ctx context.Context, conn *bedrockagentcorecontrol.Clien
 	return nil, smarterr.NewError(err)
 }
 
-func waitGatewayUpdated(ctx context.Context, conn *bedrockagentcorecontrol.Client, id string, timeout time.Duration) (*bedrockagentcorecontrol.GetGatewayOutput, error) {
+func waitGatewayUpdated(ctx context.Context, conn *bedrockagentcorecontrol.Client, id string, timeout time.Duration) error {
 	stateConf := &retry.StateChangeConf{
 		Pending:                   enum.Slice(awstypes.GatewayStatusUpdating),
 		Target:                    enum.Slice(awstypes.GatewayStatusReady),
@@ -527,10 +527,10 @@ func waitGatewayUpdated(ctx context.Context, conn *bedrockagentcorecontrol.Clien
 	outputRaw, err := stateConf.WaitForStateContext(ctx)
 	if out, ok := outputRaw.(*bedrockagentcorecontrol.GetGatewayOutput); ok {
 		retry.SetLastError(err, errors.New(strings.Join(out.StatusReasons, "; ")))
-		return out, smarterr.NewError(err)
+		return smarterr.NewError(err)
 	}
 
-	return nil, smarterr.NewError(err)
+	return smarterr.NewError(err)
 }
 
 func waitGatewayDeleted(ctx context.Context, conn *bedrockagentcorecontrol.Client, id string, timeout time.Duration) (*bedrockagentcorecontrol.GetGatewayOutput, error) {

--- a/internal/service/bedrockagentcore/gateway_waf_configuration.go
+++ b/internal/service/bedrockagentcore/gateway_waf_configuration.go
@@ -1,0 +1,250 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package bedrockagentcore
+
+import (
+	"context"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol/types"
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
+	"github.com/hashicorp/terraform-provider-aws/internal/smerr"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkResource("aws_bedrockagentcore_gateway_waf_configuration", name="Gateway WAF Configuration")
+func newGatewayWAFConfigurationResource(_ context.Context) (resource.ResourceWithConfigure, error) {
+	r := &gatewayWAFConfigurationResource{}
+
+	r.SetDefaultCreateTimeout(30 * time.Minute)
+	r.SetDefaultUpdateTimeout(30 * time.Minute)
+	r.SetDefaultDeleteTimeout(30 * time.Minute)
+
+	return r, nil
+}
+
+type gatewayWAFConfigurationResource struct {
+	framework.ResourceWithModel[gatewayWAFConfigurationResourceModel]
+	framework.WithTimeouts
+}
+
+func (r *gatewayWAFConfigurationResource) Schema(ctx context.Context, request resource.SchemaRequest, response *resource.SchemaResponse) {
+	response.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"failure_mode": schema.StringAttribute{
+				CustomType: fwtypes.StringEnumType[awstypes.WafFailureMode](),
+				Required:   true,
+			},
+			"gateway_identifier": schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"web_acl_arn": schema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+		},
+		Blocks: map[string]schema.Block{
+			names.AttrTimeouts: timeouts.Block(ctx, timeouts.Opts{
+				Create: true,
+				Update: true,
+				Delete: true,
+			}),
+		},
+	}
+}
+
+func (r *gatewayWAFConfigurationResource) Create(ctx context.Context, request resource.CreateRequest, response *resource.CreateResponse) {
+	var data gatewayWAFConfigurationResourceModel
+	smerr.AddEnrich(ctx, &response.Diagnostics, request.Plan.Get(ctx, &data))
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	conn := r.Meta().BedrockAgentCoreClient(ctx)
+
+	gatewayID := fwflex.StringValueFromFramework(ctx, data.GatewayIdentifier)
+	wafConfiguration := &awstypes.WafConfiguration{
+		FailureMode: data.FailureMode.ValueEnum(),
+	}
+
+	if err := r.putWAFConfiguration(ctx, conn, gatewayID, wafConfiguration, r.CreateTimeout(ctx, data.Timeouts)); err != nil {
+		smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, gatewayID)
+		return
+	}
+
+	gateway, err := findGatewayByID(ctx, conn, gatewayID)
+	if err != nil {
+		smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, gatewayID)
+		return
+	}
+
+	data.WebACLARN = fwflex.StringToFramework(ctx, gateway.WebAclArn)
+
+	smerr.AddEnrich(ctx, &response.Diagnostics, response.State.Set(ctx, &data))
+}
+
+func (r *gatewayWAFConfigurationResource) Read(ctx context.Context, request resource.ReadRequest, response *resource.ReadResponse) {
+	var data gatewayWAFConfigurationResourceModel
+	smerr.AddEnrich(ctx, &response.Diagnostics, request.State.Get(ctx, &data))
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	conn := r.Meta().BedrockAgentCoreClient(ctx)
+
+	gatewayID := fwflex.StringValueFromFramework(ctx, data.GatewayIdentifier)
+	gateway, err := findGatewayByID(ctx, conn, gatewayID)
+	if retry.NotFound(err) {
+		smerr.AddOne(ctx, &response.Diagnostics, fwdiag.NewResourceNotFoundWarningDiagnostic(err))
+		response.State.RemoveResource(ctx)
+		return
+	}
+	if err != nil {
+		smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, gatewayID)
+		return
+	}
+
+	// The WAF configuration was cleared out-of-band (e.g. the WebACL association was
+	// removed). Treat the resource as gone so Terraform plans to recreate it.
+	if gateway.WafConfiguration == nil {
+		response.State.RemoveResource(ctx)
+		return
+	}
+
+	data.FailureMode = fwtypes.StringEnumValue(gateway.WafConfiguration.FailureMode)
+	data.WebACLARN = fwflex.StringToFramework(ctx, gateway.WebAclArn)
+
+	smerr.AddEnrich(ctx, &response.Diagnostics, response.State.Set(ctx, &data))
+}
+
+func (r *gatewayWAFConfigurationResource) Update(ctx context.Context, request resource.UpdateRequest, response *resource.UpdateResponse) {
+	var data gatewayWAFConfigurationResourceModel
+	smerr.AddEnrich(ctx, &response.Diagnostics, request.Plan.Get(ctx, &data))
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	conn := r.Meta().BedrockAgentCoreClient(ctx)
+
+	gatewayID := fwflex.StringValueFromFramework(ctx, data.GatewayIdentifier)
+	wafConfiguration := &awstypes.WafConfiguration{
+		FailureMode: data.FailureMode.ValueEnum(),
+	}
+
+	if err := r.putWAFConfiguration(ctx, conn, gatewayID, wafConfiguration, r.UpdateTimeout(ctx, data.Timeouts)); err != nil {
+		smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, gatewayID)
+		return
+	}
+
+	gateway, err := findGatewayByID(ctx, conn, gatewayID)
+	if err != nil {
+		smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, gatewayID)
+		return
+	}
+
+	data.WebACLARN = fwflex.StringToFramework(ctx, gateway.WebAclArn)
+
+	smerr.AddEnrich(ctx, &response.Diagnostics, response.State.Set(ctx, &data))
+}
+
+func (r *gatewayWAFConfigurationResource) Delete(ctx context.Context, request resource.DeleteRequest, response *resource.DeleteResponse) {
+	var data gatewayWAFConfigurationResourceModel
+	smerr.AddEnrich(ctx, &response.Diagnostics, request.State.Get(ctx, &data))
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	conn := r.Meta().BedrockAgentCoreClient(ctx)
+
+	gatewayID := fwflex.StringValueFromFramework(ctx, data.GatewayIdentifier)
+
+	// Clearing the WAF configuration requires a WebACL to still be associated with the
+	// gateway. During destroy the aws_wafv2_web_acl_association is often torn down at the
+	// same time; once it is gone the gateway no longer has WAF behavior, so a failure to
+	// clear is benign (the configuration is effectively already removed).
+	err := r.putWAFConfiguration(ctx, conn, gatewayID, nil, r.DeleteTimeout(ctx, data.Timeouts))
+	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+		return
+	}
+	if errs.IsAErrorMessageContains[*awstypes.ValidationException](err, "WebACL") {
+		return
+	}
+	if err != nil {
+		smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, gatewayID)
+		return
+	}
+}
+
+func (r *gatewayWAFConfigurationResource) ImportState(ctx context.Context, request resource.ImportStateRequest, response *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("gateway_identifier"), request, response)
+}
+
+// putWAFConfiguration performs a read-modify-write against the gateway: it reads the
+// current gateway, preserves all of its fields, sets the WAF configuration (nil clears
+// it), calls UpdateGateway, and waits for the gateway to become ready. UpdateGateway is a
+// full replacement, so every field must be carried over to avoid clobbering attributes
+// managed by the aws_bedrockagentcore_gateway resource.
+func (r *gatewayWAFConfigurationResource) putWAFConfiguration(ctx context.Context, conn *bedrockagentcorecontrol.Client, gatewayID string, wafConfiguration *awstypes.WafConfiguration, timeout time.Duration) error {
+	gateway, err := findGatewayByID(ctx, conn, gatewayID)
+	if err != nil {
+		return err
+	}
+
+	input := expandUpdateGatewayFromGateway(gatewayID, gateway, wafConfiguration)
+	if _, err := conn.UpdateGateway(ctx, input); err != nil {
+		return err
+	}
+
+	if _, err := waitGatewayUpdated(ctx, conn, gatewayID, timeout); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func expandUpdateGatewayFromGateway(gatewayID string, gateway *bedrockagentcorecontrol.GetGatewayOutput, wafConfiguration *awstypes.WafConfiguration) *bedrockagentcorecontrol.UpdateGatewayInput {
+	return &bedrockagentcorecontrol.UpdateGatewayInput{
+		GatewayIdentifier:            aws.String(gatewayID),
+		Name:                         gateway.Name,
+		RoleArn:                      gateway.RoleArn,
+		AuthorizerType:               gateway.AuthorizerType,
+		AuthorizerConfiguration:      gateway.AuthorizerConfiguration,
+		CustomTransformConfiguration: gateway.CustomTransformConfiguration,
+		Description:                  gateway.Description,
+		ExceptionLevel:               gateway.ExceptionLevel,
+		InterceptorConfigurations:    gateway.InterceptorConfigurations,
+		KmsKeyArn:                    gateway.KmsKeyArn,
+		PolicyEngineConfiguration:    gateway.PolicyEngineConfiguration,
+		ProtocolConfiguration:        gateway.ProtocolConfiguration,
+		ProtocolType:                 gateway.ProtocolType,
+		WafConfiguration:             wafConfiguration,
+	}
+}
+
+type gatewayWAFConfigurationResourceModel struct {
+	framework.WithRegionModel
+	FailureMode       fwtypes.StringEnum[awstypes.WafFailureMode] `tfsdk:"failure_mode"`
+	GatewayIdentifier types.String                                `tfsdk:"gateway_identifier"`
+	Timeouts          timeouts.Value                              `tfsdk:"timeouts"`
+	WebACLARN         types.String                                `tfsdk:"web_acl_arn"`
+}

--- a/internal/service/bedrockagentcore/gateway_waf_configuration.go
+++ b/internal/service/bedrockagentcore/gateway_waf_configuration.go
@@ -138,33 +138,46 @@ func (r *gatewayWAFConfigurationResource) Read(ctx context.Context, request reso
 }
 
 func (r *gatewayWAFConfigurationResource) Update(ctx context.Context, request resource.UpdateRequest, response *resource.UpdateResponse) {
-	var data gatewayWAFConfigurationResourceModel
-	smerr.AddEnrich(ctx, &response.Diagnostics, request.Plan.Get(ctx, &data))
+	var plan, state gatewayWAFConfigurationResourceModel
+	smerr.AddEnrich(ctx, &response.Diagnostics, request.Plan.Get(ctx, &plan))
+	if response.Diagnostics.HasError() {
+		return
+	}
+	smerr.AddEnrich(ctx, &response.Diagnostics, request.State.Get(ctx, &state))
 	if response.Diagnostics.HasError() {
 		return
 	}
 
 	conn := r.Meta().BedrockAgentCoreClient(ctx)
 
-	gatewayID := fwflex.StringValueFromFramework(ctx, data.GatewayIdentifier)
-	wafConfiguration := &awstypes.WafConfiguration{
-		FailureMode: data.FailureMode.ValueEnum(),
+	gatewayID := fwflex.StringValueFromFramework(ctx, plan.GatewayIdentifier)
+
+	// failure_mode is the only server-relevant mutable attribute (gateway_identifier is
+	// RequiresReplace, web_acl_arn is Computed, and timeouts is client-side only). Skip the
+	// read-modify-write UpdateGateway round trip when it is unchanged so a plan that only
+	// edits the timeouts block does not needlessly drive the gateway through UPDATING.
+	if !plan.FailureMode.Equal(state.FailureMode) {
+		wafConfiguration := &awstypes.WafConfiguration{
+			FailureMode: plan.FailureMode.ValueEnum(),
+		}
+
+		if err := r.putWAFConfiguration(ctx, conn, gatewayID, wafConfiguration, r.UpdateTimeout(ctx, plan.Timeouts)); err != nil {
+			smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, gatewayID)
+			return
+		}
+
+		gateway, err := findGatewayByID(ctx, conn, gatewayID)
+		if err != nil {
+			smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, gatewayID)
+			return
+		}
+
+		plan.WebACLARN = fwflex.StringToFramework(ctx, gateway.WebAclArn)
+	} else {
+		plan.WebACLARN = state.WebACLARN
 	}
 
-	if err := r.putWAFConfiguration(ctx, conn, gatewayID, wafConfiguration, r.UpdateTimeout(ctx, data.Timeouts)); err != nil {
-		smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, gatewayID)
-		return
-	}
-
-	gateway, err := findGatewayByID(ctx, conn, gatewayID)
-	if err != nil {
-		smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, gatewayID)
-		return
-	}
-
-	data.WebACLARN = fwflex.StringToFramework(ctx, gateway.WebAclArn)
-
-	smerr.AddEnrich(ctx, &response.Diagnostics, response.State.Set(ctx, &data))
+	smerr.AddEnrich(ctx, &response.Diagnostics, response.State.Set(ctx, &plan))
 }
 
 func (r *gatewayWAFConfigurationResource) Delete(ctx context.Context, request resource.DeleteRequest, response *resource.DeleteResponse) {

--- a/internal/service/bedrockagentcore/gateway_waf_configuration.go
+++ b/internal/service/bedrockagentcore/gateway_waf_configuration.go
@@ -215,7 +215,7 @@ func (r *gatewayWAFConfigurationResource) putWAFConfiguration(ctx context.Contex
 		return err
 	}
 
-	if _, err := waitGatewayUpdated(ctx, conn, gatewayID, timeout); err != nil {
+	if err := waitGatewayUpdated(ctx, conn, gatewayID, timeout); err != nil {
 		return err
 	}
 

--- a/internal/service/bedrockagentcore/gateway_waf_configuration_test.go
+++ b/internal/service/bedrockagentcore/gateway_waf_configuration_test.go
@@ -1,0 +1,179 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package bedrockagentcore_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol/types"
+	"github.com/hashicorp/terraform-plugin-testing/compare"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
+	tfbedrockagentcore "github.com/hashicorp/terraform-provider-aws/internal/service/bedrockagentcore"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccBedrockAgentCoreGatewayWAFConfiguration_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	var gateway bedrockagentcorecontrol.GetGatewayOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_bedrockagentcore_gateway_waf_configuration.test"
+	gatewayResourceName := "aws_bedrockagentcore_gateway.test"
+	webACLResourceName := "aws_wafv2_web_acl.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID)
+			testAccPreCheckGateways(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockAgentCoreServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckGatewayWAFConfigurationDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGatewayWAFConfigurationConfig_basic(rName, string(awstypes.WafFailureModeFailOpen)),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckGatewayWAFConfigurationExists(ctx, t, gatewayResourceName, &gateway, awstypes.WafFailureModeFailOpen),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("failure_mode"), knownvalue.StringExact(string(awstypes.WafFailureModeFailOpen))),
+					statecheck.CompareValuePairs(resourceName, tfjsonpath.New("web_acl_arn"), webACLResourceName, tfjsonpath.New(names.AttrARN), compare.ValuesSame()),
+				},
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, "gateway_identifier"),
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "gateway_identifier",
+			},
+			{
+				Config: testAccGatewayWAFConfigurationConfig_basic(rName, string(awstypes.WafFailureModeFailClose)),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckGatewayWAFConfigurationExists(ctx, t, gatewayResourceName, &gateway, awstypes.WafFailureModeFailClose),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("failure_mode"), knownvalue.StringExact(string(awstypes.WafFailureModeFailClose))),
+				},
+			},
+		},
+	})
+}
+
+// testAccCheckGatewayWAFConfigurationExists verifies the gateway exists and carries the
+// expected WAF failure mode.
+func testAccCheckGatewayWAFConfigurationExists(ctx context.Context, t *testing.T, n string, v *bedrockagentcorecontrol.GetGatewayOutput, expected awstypes.WafFailureMode) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		conn := acctest.ProviderMeta(ctx, t).BedrockAgentCoreClient(ctx)
+
+		resp, err := tfbedrockagentcore.FindGatewayByID(ctx, conn, rs.Primary.Attributes["gateway_id"])
+		if err != nil {
+			return err
+		}
+
+		if resp.WafConfiguration == nil {
+			return fmt.Errorf("Bedrock Agent Core Gateway %s has no WAF configuration", rs.Primary.Attributes["gateway_id"])
+		}
+		if resp.WafConfiguration.FailureMode != expected {
+			return fmt.Errorf("expected WAF failure mode %s, got %s", expected, resp.WafConfiguration.FailureMode)
+		}
+
+		*v = *resp
+
+		return nil
+	}
+}
+
+// testAccCheckGatewayWAFConfigurationDestroy confirms the WAF configuration was cleared
+// from the gateway. The gateway itself is owned by the aws_bedrockagentcore_gateway
+// resource, so its own CheckDestroy validates the gateway is gone.
+func testAccCheckGatewayWAFConfigurationDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.ProviderMeta(ctx, t).BedrockAgentCoreClient(ctx)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_bedrockagentcore_gateway_waf_configuration" {
+				continue
+			}
+
+			out, err := tfbedrockagentcore.FindGatewayByID(ctx, conn, rs.Primary.Attributes["gateway_identifier"])
+			if retry.NotFound(err) {
+				continue
+			}
+			if err != nil {
+				return err
+			}
+
+			if out.WafConfiguration != nil {
+				return fmt.Errorf("Bedrock Agent Core Gateway %s still has WAF configuration", rs.Primary.Attributes["gateway_identifier"])
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccGatewayWAFConfigurationConfig_basic(rName, failureMode string) string {
+	return acctest.ConfigCompose(testAccGatewayConfig_iamRole(rName), fmt.Sprintf(`
+resource "aws_bedrockagentcore_gateway" "test" {
+  name     = %[1]q
+  role_arn = aws_iam_role.test.arn
+
+  authorizer_type = "AWS_IAM"
+  protocol_type   = "MCP"
+}
+
+resource "aws_wafv2_web_acl" "test" {
+  name  = %[1]q
+  scope = "REGIONAL"
+
+  default_action {
+    allow {}
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = false
+    metric_name                = %[1]q
+    sampled_requests_enabled   = false
+  }
+}
+
+resource "aws_wafv2_web_acl_association" "test" {
+  resource_arn = aws_bedrockagentcore_gateway.test.gateway_arn
+  web_acl_arn  = aws_wafv2_web_acl.test.arn
+}
+
+resource "aws_bedrockagentcore_gateway_waf_configuration" "test" {
+  gateway_identifier = aws_bedrockagentcore_gateway.test.gateway_id
+  failure_mode       = %[2]q
+
+  depends_on = [aws_wafv2_web_acl_association.test]
+}
+`, rName, failureMode))
+}

--- a/internal/service/bedrockagentcore/service_package_gen.go
+++ b/internal/service/bedrockagentcore/service_package_gen.go
@@ -104,6 +104,12 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*inttypes.Ser
 			Region:   inttypes.ResourceRegionDefault(),
 		},
 		{
+			Factory:  newGatewayWAFConfigurationResource,
+			TypeName: "aws_bedrockagentcore_gateway_waf_configuration",
+			Name:     "Gateway WAF Configuration",
+			Region:   inttypes.ResourceRegionDefault(),
+		},
+		{
 			Factory:  newHarnessResource,
 			TypeName: "aws_bedrockagentcore_harness",
 			Name:     "Harness",

--- a/internal/service/bedrockagentcore/service_package_gen.go
+++ b/internal/service/bedrockagentcore/service_package_gen.go
@@ -139,6 +139,12 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*inttypes.Ser
 			},
 		},
 		{
+			Factory:  newGatewayWAFConfigurationResource,
+			TypeName: "aws_bedrockagentcore_gateway_waf_configuration",
+			Name:     "Gateway WAF Configuration",
+			Region:   inttypes.ResourceRegionDefault(),
+		},
+		{
 			Factory:  newHarnessResource,
 			TypeName: "aws_bedrockagentcore_harness",
 			Name:     "Harness",

--- a/website/docs/r/bedrockagentcore_gateway_waf_configuration.html.markdown
+++ b/website/docs/r/bedrockagentcore_gateway_waf_configuration.html.markdown
@@ -1,0 +1,96 @@
+---
+subcategory: "Bedrock AgentCore"
+layout: "aws"
+page_title: "AWS: aws_bedrockagentcore_gateway_waf_configuration"
+description: |-
+  Manages the AWS WAF configuration for an Amazon Bedrock AgentCore Gateway.
+---
+
+# Resource: aws_bedrockagentcore_gateway_waf_configuration
+
+Manages the AWS WAF configuration for an Amazon Bedrock AgentCore Gateway.
+
+AWS WAF protection for a gateway is enabled by associating an AWS WAF web ACL with the gateway ARN using [`aws_wafv2_web_acl_association`](wafv2_web_acl_association.html.markdown). This resource then sets the gateway's `failure_mode`, which controls how the gateway behaves when AWS WAF is unreachable.
+
+~> **NOTE:** The gateway's WAF configuration can only be set once an AWS WAF web ACL is associated with the gateway. Use `depends_on` to ensure the [`aws_wafv2_web_acl_association`](wafv2_web_acl_association.html.markdown) is created before this resource. Removing this resource resets the gateway's failure mode.
+
+## Example Usage
+
+```terraform
+resource "aws_bedrockagentcore_gateway" "example" {
+  name     = "example"
+  role_arn = aws_iam_role.example.arn
+
+  authorizer_type = "AWS_IAM"
+  protocol_type   = "MCP"
+}
+
+resource "aws_wafv2_web_acl" "example" {
+  name  = "example"
+  scope = "REGIONAL"
+
+  default_action {
+    allow {}
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = false
+    metric_name                = "example"
+    sampled_requests_enabled   = false
+  }
+}
+
+resource "aws_wafv2_web_acl_association" "example" {
+  resource_arn = aws_bedrockagentcore_gateway.example.gateway_arn
+  web_acl_arn  = aws_wafv2_web_acl.example.arn
+}
+
+resource "aws_bedrockagentcore_gateway_waf_configuration" "example" {
+  gateway_identifier = aws_bedrockagentcore_gateway.example.gateway_id
+  failure_mode       = "FAIL_OPEN"
+
+  depends_on = [aws_wafv2_web_acl_association.example]
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `failure_mode` - (Required) Behavior when AWS WAF is unreachable or times out. Valid values: `FAIL_OPEN` (allow requests), `FAIL_CLOSE` (block requests).
+* `gateway_identifier` - (Required) Identifier of the gateway to configure. Forces replacement if changed.
+
+The following arguments are optional:
+
+* `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
+
+## Attribute Reference
+
+This resource exports the following attributes in addition to the arguments above:
+
+* `web_acl_arn` - ARN of the AWS WAF web ACL associated with the gateway.
+
+## Timeouts
+
+[Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
+
+* `create` - (Default `30m`)
+* `update` - (Default `30m`)
+* `delete` - (Default `30m`)
+
+## Import
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import an Amazon Bedrock AgentCore Gateway WAF Configuration using the `gateway_identifier`. For example:
+
+```terraform
+import {
+  to = aws_bedrockagentcore_gateway_waf_configuration.example
+  id = "gateway-abc123"
+}
+```
+
+Using `terraform import`, import an Amazon Bedrock AgentCore Gateway WAF Configuration using the `gateway_identifier`. For example:
+
+```console
+% terraform import aws_bedrockagentcore_gateway_waf_configuration.example gateway-abc123
+```


### PR DESCRIPTION
### Description

Adds a new resource `aws_bedrockagentcore_gateway_waf_configuration` to manage the AWS WAF configuration (`failure_mode`) for an Amazon Bedrock AgentCore Gateway.

This is modeled as a separate resource rather than an attribute on `aws_bedrockagentcore_gateway` because of how the AgentCore API works:

- `CreateGateway` does not accept `wafConfiguration` — only `UpdateGateway` does.
- `UpdateGateway` with `wafConfiguration` fails (`ValidationException: wafConfiguration can only be set when a WebACL is associated with the gateway`) unless a WAF web ACL is already associated with the gateway.
- WAF association is performed with `aws_wafv2_web_acl_association` using the gateway ARN as `resource_arn`.

Putting `waf_configuration` on the gateway resource itself would create a circular dependency (the gateway can't accept the config until the association — a separate resource pointing at the gateway — exists). A separate resource that `depends_on` the association breaks the cycle: `gateway → web_acl_association → gateway_waf_configuration`. This mirrors the satellite-resource pattern used by `aws_s3_bucket_versioning` and similar.

The resource performs a read-modify-write against `UpdateGateway` (which is a full replacement): it reads the current gateway, preserves all existing fields, and sets only `wafConfiguration`, so it does not clobber attributes managed by `aws_bedrockagentcore_gateway`. Delete clears `wafConfiguration`, tolerating the case where the web ACL association has already been torn down.

### Changes

- New resource `aws_bedrockagentcore_gateway_waf_configuration` with `gateway_identifier` (required, forces replacement), `failure_mode` (required, `FAIL_OPEN` / `FAIL_CLOSE`), and computed `web_acl_arn`.
- Acceptance test covering create (`FAIL_OPEN`), update (`FAIL_CLOSE`), import, and destroy.
- Website documentation.

### Relations

Closes #48661

### References

- https://docs.aws.amazon.com/bedrock-agentcore-control/latest/APIReference/API_UpdateGateway.html
- https://docs.aws.amazon.com/bedrock-agentcore-control/latest/APIReference/API_WafConfiguration.html
- https://docs.aws.amazon.com/waf/latest/APIReference/API_AssociateWebACL.html

### Output from Acceptance Testing

```
$ TF_ACC=1 go test ./internal/service/bedrockagentcore/ -run '^TestAccBedrockAgentCoreGatewayWAFConfiguration_basic$' -v -timeout 60m

--- PASS: TestAccBedrockAgentCoreGatewayWAFConfiguration_basic (108.83s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/bedrockagentcore	117.497s
```
