### PR TITLE
r/aws_ecs_task_definition: Add trusted_execution_configuration argument

### DIFF
--- a/.changelog/48702.txt
+++ b/.changelog/48702.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_ecs_task_definition: Add `trusted_execution_configuration` argument
+```
+
+```release-note:enhancement
+data-source/aws_ecs_task_definition: Add `trusted_execution_configuration` attribute
+```

--- a/internal/service/ecs/task_definition.go
+++ b/internal/service/ecs/task_definition.go
@@ -298,6 +298,29 @@ func resourceTaskDefinition() *schema.Resource {
 					Default:  false,
 					Optional: true,
 				},
+				"trusted_execution_configuration": {
+					Type:     schema.TypeList,
+					Optional: true,
+					ForceNew: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"isolation_mode": {
+								Type:             schema.TypeString,
+								Required:         true,
+								ForceNew:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.IsolationMode](),
+							},
+							"instance_reuse_mode": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								Computed:         true,
+								ForceNew:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.InstanceReuseMode](),
+							},
+						},
+					},
+				},
 				"volume": resourceTaskDefinitionVolumeSchema(),
 			}
 		},
@@ -674,6 +697,10 @@ func resourceTaskDefinitionCreate(ctx context.Context, d *schema.ResourceData, m
 
 	if v, ok := d.GetOk("task_role_arn"); ok {
 		input.TaskRoleArn = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("trusted_execution_configuration"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.TrustedExecutionConfiguration = expandTrustedExecutionConfiguration(v.([]any))
 	}
 
 	if v, ok := d.GetOk("volume"); ok {
@@ -1266,6 +1293,41 @@ func flattenEphemeralStorage(apiObject *awstypes.EphemeralStorage) []any {
 	return []any{tfMap}
 }
 
+func expandTrustedExecutionConfiguration(tfList []any) *awstypes.TrustedExecutionConfiguration {
+	if len(tfList) == 0 || tfList[0] == nil {
+		return nil
+	}
+
+	tfMap := tfList[0].(map[string]any)
+	apiObject := &awstypes.TrustedExecutionConfiguration{}
+
+	if v, ok := tfMap["isolation_mode"].(string); ok && v != "" {
+		apiObject.IsolationMode = awstypes.IsolationMode(v)
+	}
+
+	if v, ok := tfMap["instance_reuse_mode"].(string); ok && v != "" {
+		apiObject.InstanceReuseMode = awstypes.InstanceReuseMode(v)
+	}
+
+	return apiObject
+}
+
+func flattenTrustedExecutionConfiguration(apiObject *awstypes.TrustedExecutionConfiguration) []any {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]any{
+		"isolation_mode": string(apiObject.IsolationMode),
+	}
+
+	if apiObject.InstanceReuseMode != "" {
+		tfMap["instance_reuse_mode"] = string(apiObject.InstanceReuseMode)
+	}
+
+	return []any{tfMap}
+}
+
 func expandS3FilesVolumeConfiguration(tfList []any) *awstypes.S3FilesVolumeConfiguration {
 	tfMap := tfList[0].(map[string]any)
 	apiObject := &awstypes.S3FilesVolumeConfiguration{}
@@ -1339,6 +1401,7 @@ func resourceTaskDefinitionFlatten(ctx context.Context, d *schema.ResourceData, 
 	d.Set("runtime_platform", flattenRuntimePlatform(taskDefinition.RuntimePlatform))
 	d.Set("task_role_arn", taskDefinition.TaskRoleArn)
 	d.Set("track_latest", d.Get("track_latest"))
+	d.Set("trusted_execution_configuration", flattenTrustedExecutionConfiguration(taskDefinition.TrustedExecutionConfiguration))
 	d.Set("volume", flattenVolumes(taskDefinition.Volumes))
 
 	// Sort the lists of environment variables as they come in, so we won't get spurious reorderings in plans

--- a/internal/service/ecs/task_definition_data_source.go
+++ b/internal/service/ecs/task_definition_data_source.go
@@ -157,6 +157,22 @@ func dataSourceTaskDefinition() *schema.Resource {
 					Type:     schema.TypeString,
 					Computed: true,
 				},
+				"trusted_execution_configuration": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"isolation_mode": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"instance_reuse_mode": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+						},
+					},
+				},
 				"volume": sdkv2.ComputedOnlyFromSchema(resourceTaskDefinitionVolumeSchema()),
 			}
 		},
@@ -220,6 +236,7 @@ func dataSourceTaskDefinitionRead(ctx context.Context, d *schema.ResourceData, m
 	}
 	d.Set(names.AttrStatus, taskDefinition.Status)
 	d.Set("task_role_arn", taskDefinition.TaskRoleArn)
+	d.Set("trusted_execution_configuration", flattenTrustedExecutionConfiguration(taskDefinition.TrustedExecutionConfiguration))
 	if err := d.Set("volume", flattenVolumes(taskDefinition.Volumes)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting volume: %s", err)
 	}

--- a/internal/service/ecs/task_definition_test.go
+++ b/internal/service/ecs/task_definition_test.go
@@ -4279,3 +4279,209 @@ TASK_DEFINITION
 }
 `, rName, enableFaultInjection)
 }
+
+func TestAccECSTaskDefinition_TrustedExecution_exclusiveReuse(t *testing.T) {
+	ctx := acctest.Context(t)
+	var def awstypes.TaskDefinition
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_ecs_task_definition.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ECSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTaskDefinitionDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTaskDefinitionConfig_trustedExecution(rName, "EXCLUSIVE", "REUSE"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckTaskDefinitionExists(ctx, t, resourceName, &def),
+					resource.TestCheckResourceAttr(resourceName, "trusted_execution_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "trusted_execution_configuration.0.isolation_mode", "EXCLUSIVE"),
+					resource.TestCheckResourceAttr(resourceName, "trusted_execution_configuration.0.instance_reuse_mode", "REUSE"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateIdFunc:       acctest.AttrImportStateIdFunc(resourceName, names.AttrARN),
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{names.AttrSkipDestroy, "track_latest"},
+			},
+		},
+	})
+}
+
+func TestAccECSTaskDefinition_TrustedExecution_exclusiveTerminate(t *testing.T) {
+	ctx := acctest.Context(t)
+	var def awstypes.TaskDefinition
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_ecs_task_definition.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ECSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTaskDefinitionDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTaskDefinitionConfig_trustedExecution(rName, "EXCLUSIVE", "TERMINATE"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckTaskDefinitionExists(ctx, t, resourceName, &def),
+					resource.TestCheckResourceAttr(resourceName, "trusted_execution_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "trusted_execution_configuration.0.isolation_mode", "EXCLUSIVE"),
+					resource.TestCheckResourceAttr(resourceName, "trusted_execution_configuration.0.instance_reuse_mode", "TERMINATE"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateIdFunc:       acctest.AttrImportStateIdFunc(resourceName, names.AttrARN),
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{names.AttrSkipDestroy, "track_latest"},
+			},
+		},
+	})
+}
+
+func testAccTaskDefinitionConfig_trustedExecution(rName, isolationMode, instanceReuseMode string) string {
+	return fmt.Sprintf(`
+resource "aws_ecs_task_definition" "test" {
+  family                   = %[1]q
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["MANAGED_INSTANCES"]
+
+  trusted_execution_configuration {
+    isolation_mode      = %[2]q
+    instance_reuse_mode = %[3]q
+  }
+
+  container_definitions = <<TASK_DEFINITION
+[
+  {
+    "name": "app",
+    "image": "busybox",
+    "cpu": 256,
+    "memory": 512,
+    "essential": true
+  }
+]
+TASK_DEFINITION
+}
+`, rName, isolationMode, instanceReuseMode)
+}
+
+func TestAccECSTaskDefinition_TrustedExecution_shared(t *testing.T) {
+	ctx := acctest.Context(t)
+	var def awstypes.TaskDefinition
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_ecs_task_definition.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ECSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTaskDefinitionDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTaskDefinitionConfig_trustedExecutionShared(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckTaskDefinitionExists(ctx, t, resourceName, &def),
+					resource.TestCheckResourceAttr(resourceName, "trusted_execution_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "trusted_execution_configuration.0.isolation_mode", "SHARED"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateIdFunc:       acctest.AttrImportStateIdFunc(resourceName, names.AttrARN),
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{names.AttrSkipDestroy, "track_latest"},
+			},
+		},
+	})
+}
+
+func testAccTaskDefinitionConfig_trustedExecutionShared(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_ecs_task_definition" "test" {
+  family                   = %[1]q
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["MANAGED_INSTANCES"]
+
+  trusted_execution_configuration {
+    isolation_mode = "SHARED"
+  }
+
+  container_definitions = <<TASK_DEFINITION
+[
+  {
+    "name": "app",
+    "image": "busybox",
+    "cpu": 256,
+    "memory": 512,
+    "essential": true
+  }
+]
+TASK_DEFINITION
+}
+`, rName)
+}
+
+func TestAccECSTaskDefinition_TrustedExecution_exclusiveDefaultReuse(t *testing.T) {
+	ctx := acctest.Context(t)
+	var def awstypes.TaskDefinition
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_ecs_task_definition.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ECSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTaskDefinitionDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTaskDefinitionConfig_trustedExecutionExclusiveOnly(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckTaskDefinitionExists(ctx, t, resourceName, &def),
+					resource.TestCheckResourceAttr(resourceName, "trusted_execution_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "trusted_execution_configuration.0.isolation_mode", "EXCLUSIVE"),
+					resource.TestCheckResourceAttr(resourceName, "trusted_execution_configuration.0.instance_reuse_mode", ""),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateIdFunc:       acctest.AttrImportStateIdFunc(resourceName, names.AttrARN),
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{names.AttrSkipDestroy, "track_latest"},
+			},
+		},
+	})
+}
+
+func testAccTaskDefinitionConfig_trustedExecutionExclusiveOnly(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_ecs_task_definition" "test" {
+  family                   = %[1]q
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["MANAGED_INSTANCES"]
+
+  trusted_execution_configuration {
+    isolation_mode = "EXCLUSIVE"
+  }
+
+  container_definitions = <<TASK_DEFINITION
+[
+  {
+    "name": "app",
+    "image": "busybox",
+    "cpu": 256,
+    "memory": 512,
+    "essential": true
+  }
+]
+TASK_DEFINITION
+}
+`, rName)
+}

--- a/website/docs/d/ecs_task_definition.html.markdown
+++ b/website/docs/d/ecs_task_definition.html.markdown
@@ -85,7 +85,13 @@ The following arguments are optional:
 * `runtime_platform` - Configuration block for [runtime_platform](#runtime_platform) that containers in your task may use.
 * `status` - Status of the task definition.
 * `task_role_arn` - ARN of IAM role that allows your Amazon ECS container task to make calls to other AWS services.
+* `trusted_execution_configuration` - The trusted execution configuration for the task. See [Trusted Execution Configuration](#trusted_execution_configuration) below.
 * `volume` - Attributes corresponding to the `volume` argument of the [`aws_ecs_task_definition`](/docs/providers/aws/r/ecs_task_definition.html) resource.
+
+### trusted_execution_configuration
+
+* `isolation_mode` - The isolation mode for the task. `EXCLUSIVE` guarantees the task is the only primary task running on the instance. `SHARED` uses standard shared placement.
+* `instance_reuse_mode` - Controls what happens to the instance after the exclusive task stops. `REUSE` retains the instance for the next exclusive task. `TERMINATE` always provisions a fresh instance and terminates it after the task stops.
 
 ### ephemeral_storage
 

--- a/website/docs/r/ecs_task_definition.html.markdown
+++ b/website/docs/r/ecs_task_definition.html.markdown
@@ -214,6 +214,31 @@ TASK_DEFINITION
 }
 ```
 
+### Exclusive Execution (Managed Instances)
+
+```terraform
+resource "aws_ecs_task_definition" "exclusive" {
+  family                   = "exclusive-task"
+  requires_compatibilities = ["MANAGED_INSTANCES"]
+  network_mode             = "awsvpc"
+
+  trusted_execution_configuration {
+    isolation_mode      = "EXCLUSIVE"
+    instance_reuse_mode = "REUSE"
+  }
+
+  container_definitions = jsonencode([
+    {
+      name      = "app"
+      image     = "123456789012.dkr.ecr.us-west-2.amazonaws.com/my-app:latest"
+      cpu       = 256
+      memory    = 512
+      essential = true
+    }
+  ])
+}
+```
+
 ## Argument Reference
 
 The following arguments are required:
@@ -240,6 +265,7 @@ The following arguments are optional:
 * `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `task_role_arn` - (Optional) ARN of IAM role that allows your Amazon ECS container task to make calls to other AWS services.
 * `track_latest` - (Optional) Whether should track latest `ACTIVE` task definition on AWS or the one created with the resource stored in state. Default is `false`. Useful in the event the task definition is modified outside of this resource.
+* `trusted_execution_configuration` - (Optional) Configuration block for exclusive execution mode on ECS Managed Instances. Forces new resource. See [Trusted Execution Configuration](#trusted_execution_configuration) below.
 * `volume` - (Optional) Repeatable configuration block for [volumes](#volume) that containers in your task may use. Detailed below.
 
 ~> **NOTE:** Proper escaping is required for JSON field values containing quotes (`"`) such as `environment` values. If directly setting the JSON, they should be escaped as `\"` in the JSON,  e.g., `"value": "I \"love\" escaped quotes"`. If using a Terraform variable value, they should be escaped as `\\\"` in the variable, e.g., `value = "I \\\"love\\\" escaped quotes"` in the variable and `"value": "${var.myvariable}"` in the JSON.
@@ -319,6 +345,11 @@ For more information, see [Mounting S3 file systems on Amazon ECS](https://docs.
 * `container_name` - (Required) Name of the container that will serve as the App Mesh proxy.
 * `properties` - (Required) Set of network configuration parameters to provide the Container Network Interface (CNI) plugin, specified a key-value mapping.
 * `type` - (Optional) Proxy type. The default value is `APPMESH`. The only supported value is `APPMESH`.
+
+### trusted_execution_configuration
+
+* `isolation_mode` - (Required) The isolation mode for the task. `EXCLUSIVE` guarantees the task is the only primary task running on the instance. `SHARED` uses standard shared placement. Valid values: `EXCLUSIVE`, `SHARED`.
+* `instance_reuse_mode` - (Optional) Controls what happens to the instance after the exclusive task stops. `REUSE` retains the instance for the next exclusive task. `TERMINATE` always provisions a fresh instance and terminates it after the task stops. Only valid when `isolation_mode` is `EXCLUSIVE`. Valid values: `REUSE`, `TERMINATE`. Default: `REUSE`.
 
 ### ephemeral_storage
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No security control changes. This adds support for a new ECS task isolation feature that is configured entirely through the existing `RegisterTaskDefinition` API.

### Description
Adds the `trusted_execution_configuration` argument to `aws_ecs_task_definition` and the corresponding attribute to `data.aws_ecs_task_definition`.

`trusted_execution_configuration` enables exclusive execution mode for tasks running on ECS Managed Instances. When `isolation_mode` is set to `EXCLUSIVE`, ECS guarantees the task is the only primary task running on the instance. The `instance_reuse_mode` controls post-task instance lifecycle (`REUSE` retains the instance; `TERMINATE` provisions fresh and terminates after).

> **Note:** This PR depends on a forthcoming `aws-sdk-go-v2/service/ecs` release that adds `TrustedExecutionConfiguration`, `IsolationMode`, and `InstanceReuseMode` types (expected July 6, 2026). CI will fail until the SDK update is available. Acceptance tests have been verified locally against a pre-release endpoint (output below).


### Relations
N/A — new feature, no existing GitHub issues.

### References
- [ECS Managed Instances documentation](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/managed-instances.html)

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
% make testacc TESTARGS='-run=TestAccECSTaskDefinition_TrustedExecution' PKG=ecs ACCTEST_PARALLELISM=4
make: Verifying source code with gofmt.
==> Checking that code complies with gofmt requirements.
make: Running acceptance tests on branch: 🌿 f-aws_ecs_task_definition.trusted_execution_configuration 🌿.
TF_ACC=1 go1.26.4 test ./internal/service/ecs/. -v -count 1 -parallel 4 -run=TestAccECSTaskDefinition_TrustedExecution -timeout 360m -vet=off
2026/06/30 23:26:12 Creating Terraform AWS Provider (SDKv2-style)...
2026/06/30 23:26:12 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccECSTaskDefinition_TrustedExecution_exclusiveReuse
=== PAUSE TestAccECSTaskDefinition_TrustedExecution_exclusiveReuse
=== RUN   TestAccECSTaskDefinition_TrustedExecution_exclusiveTerminate
=== PAUSE TestAccECSTaskDefinition_TrustedExecution_exclusiveTerminate
=== RUN   TestAccECSTaskDefinition_TrustedExecution_shared
=== PAUSE TestAccECSTaskDefinition_TrustedExecution_shared
=== RUN   TestAccECSTaskDefinition_TrustedExecution_exclusiveDefaultReuse
=== PAUSE TestAccECSTaskDefinition_TrustedExecution_exclusiveDefaultReuse
=== CONT  TestAccECSTaskDefinition_TrustedExecution_exclusiveReuse
=== CONT  TestAccECSTaskDefinition_TrustedExecution_shared
=== CONT  TestAccECSTaskDefinition_TrustedExecution_exclusiveDefaultReuse
=== CONT  TestAccECSTaskDefinition_TrustedExecution_exclusiveTerminate
--- PASS: TestAccECSTaskDefinition_TrustedExecution_exclusiveTerminate (40.96s)
--- PASS: TestAccECSTaskDefinition_TrustedExecution_exclusiveReuse (41.06s)
--- PASS: TestAccECSTaskDefinition_TrustedExecution_exclusiveDefaultReuse (41.23s)
--- PASS: TestAccECSTaskDefinition_TrustedExecution_shared (41.33s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecs	41.522s
```

### Changes

- **`internal/service/ecs/task_definition.go`**: Added `trusted_execution_configuration` schema block (TypeList, MaxItems 1, ForceNew), `expandTrustedExecutionConfiguration` and `flattenTrustedExecutionConfiguration` functions, and wired into create/read handlers.
- **`internal/service/ecs/task_definition_data_source.go`**: Added `trusted_execution_configuration` as a computed attribute with flatten in the read handler.
- **`internal/service/ecs/task_definition_test.go`**: Four acceptance tests covering EXCLUSIVE+REUSE, EXCLUSIVE+TERMINATE, EXCLUSIVE with default reuse mode, and SHARED.
- **`website/docs/r/ecs_task_definition.html.markdown`**: Added example, argument reference, and section documentation.
- **`website/docs/d/ecs_task_definition.html.markdown`**: Added attribute reference and section documentation.
- **`.changelog/48702.txt`**: Release notes for resource and data source.
