### PR TITLE
r/aws_mq_broker: Support RabbitMQ private networking via resource_share_arns

### DIFF
--- a/.changelog/48729.txt
+++ b/.changelog/48729.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_mq_broker: Add `resource_share_arns` argument and `shared_resources` attribute
+```
+
+```release-note:enhancement
+data-source/aws_mq_broker: Add `resource_share_arns` and `shared_resources` attributes
+```

--- a/internal/service/mq/broker.go
+++ b/internal/service/mq/broker.go
@@ -307,11 +307,44 @@ func resourceBroker() *schema.Resource {
 					ForceNew: true,
 					Default:  false,
 				},
+				"resource_share_arns": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem: &schema.Schema{
+						Type:         schema.TypeString,
+						ValidateFunc: verify.ValidARN,
+					},
+				},
 				names.AttrSecurityGroups: {
 					Type:     schema.TypeSet,
 					Optional: true,
 					MaxItems: 5,
 					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"shared_resources": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"dns_names": {
+								Type:     schema.TypeList,
+								Computed: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+							},
+							names.AttrResourceARN: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							names.AttrStatus: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							names.AttrType: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+						},
+					},
 				},
 				names.AttrStorageType: {
 					Type:             schema.TypeString,
@@ -377,6 +410,12 @@ func resourceBroker() *schema.Resource {
 						if v, _, _ := nullable.Bool(v.(string)).ValueBool(); v {
 							return errors.New("logs.audit: Can not be configured when engine is RabbitMQ")
 						}
+					}
+				}
+
+				if !strings.EqualFold(diff.Get("engine_type").(string), string(types.EngineTypeRabbitmq)) {
+					if v, ok := diff.GetOk("resource_share_arns"); ok && v.(*schema.Set).Len() > 0 {
+						return errors.New("resource_share_arns: Can only be configured when engine is RabbitMQ")
 					}
 				}
 
@@ -455,6 +494,33 @@ func resourceBrokerCreate(ctx context.Context, d *schema.ResourceData, meta any)
 		return sdkdiag.AppendErrorf(diags, "waiting for MQ Broker (%s) create: %s", d.Id(), err)
 	}
 
+	// Resource shares can only be set via UpdateBroker, so they are applied
+	// after the broker reaches a running state.
+	if v, ok := d.GetOk("resource_share_arns"); ok && v.(*schema.Set).Len() > 0 {
+		_, err := conn.UpdateBroker(ctx, &mq.UpdateBrokerInput{
+			BrokerId:          aws.String(d.Id()),
+			ResourceShareArns: flex.ExpandStringValueSet(v.(*schema.Set)),
+		})
+
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "updating MQ Broker (%s) resource shares: %s", d.Id(), err)
+		}
+
+		if d.Get(names.AttrApplyImmediately).(bool) {
+			_, err := conn.RebootBroker(ctx, &mq.RebootBrokerInput{
+				BrokerId: aws.String(d.Id()),
+			})
+
+			if err != nil {
+				return sdkdiag.AppendErrorf(diags, "rebooting MQ Broker (%s): %s", d.Id(), err)
+			}
+
+			if _, err := waitBrokerRebooted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
+				return sdkdiag.AppendErrorf(diags, "waiting for MQ Broker (%s) reboot: %s", d.Id(), err)
+			}
+		}
+	}
+
 	return append(diags, resourceBrokerRead(ctx, d, meta)...)
 }
 
@@ -490,6 +556,22 @@ func resourceBrokerRead(ctx context.Context, d *schema.ResourceData, meta any) d
 	d.Set(names.AttrSecurityGroups, output.SecurityGroups)
 	d.Set(names.AttrStorageType, output.StorageType)
 	d.Set(names.AttrSubnetIDs, output.SubnetIds)
+
+	// Shared resources are only supported for RabbitMQ brokers and are read
+	// via a separate API not exposed by DescribeBroker.
+	if strings.EqualFold(string(output.EngineType), string(types.EngineTypeRabbitmq)) {
+		sharedResources, err := findSharedResourcesByBrokerID(ctx, conn, d.Id())
+
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "reading MQ Broker (%s) shared resources: %s", d.Id(), err)
+		}
+
+		d.Set("resource_share_arns", flattenResourceShareARNs(sharedResources))
+
+		if err := d.Set("shared_resources", flattenSharedResources(sharedResources)); err != nil {
+			return sdkdiag.AppendErrorf(diags, "setting shared_resources: %s", err)
+		}
+	}
 
 	if err := d.Set(names.AttrConfiguration, flattenConfiguration(output.Configurations)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting configuration: %s", err)
@@ -649,6 +731,21 @@ func resourceBrokerUpdate(ctx context.Context, d *schema.ResourceData, meta any)
 		requiresReboot = true
 	}
 
+	if d.HasChange("resource_share_arns") {
+		input := &mq.UpdateBrokerInput{
+			BrokerId:          aws.String(d.Id()),
+			ResourceShareArns: flex.ExpandStringValueSet(d.Get("resource_share_arns").(*schema.Set)),
+		}
+
+		_, err := conn.UpdateBroker(ctx, input)
+
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "updating MQ Broker (%s) resource shares: %s", d.Id(), err)
+		}
+
+		requiresReboot = true
+	}
+
 	if d.Get(names.AttrApplyImmediately).(bool) && requiresReboot {
 		_, err := conn.RebootBroker(ctx, &mq.RebootBrokerInput{
 			BrokerId: aws.String(d.Id()),
@@ -710,6 +807,27 @@ func findBrokerByID(ctx context.Context, conn *mq.Client, id string) (*mq.Descri
 
 	if output == nil {
 		return nil, tfresource.NewEmptyResultError()
+	}
+
+	return output, nil
+}
+
+func findSharedResourcesByBrokerID(ctx context.Context, conn *mq.Client, id string) ([]types.SharedResource, error) {
+	input := &mq.DescribeSharedResourcesInput{
+		BrokerId: aws.String(id),
+	}
+
+	var output []types.SharedResource
+
+	pages := mq.NewDescribeSharedResourcesPaginator(conn, input)
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
+
+		if err != nil {
+			return nil, err
+		}
+
+		output = append(output, page.SharedResources...)
 	}
 
 	return output, nil
@@ -1144,6 +1262,42 @@ func flattenConfiguration(config *types.Configurations) []any {
 	}
 
 	return []any{m}
+}
+
+// flattenResourceShareARNs returns the RAM resource share ARNs associated with a
+// broker. DescribeSharedResources represents each share as a RESOURCE_SHARE entry
+// whose resource ARN is the share ARN.
+func flattenResourceShareARNs(sharedResources []types.SharedResource) []string {
+	var arns []string
+
+	for _, sharedResource := range sharedResources {
+		if sharedResource.Type == types.SharedResourceTypeResourceShare {
+			arns = append(arns, aws.ToString(sharedResource.ResourceArn))
+		}
+	}
+
+	return arns
+}
+
+func flattenSharedResources(sharedResources []types.SharedResource) []any {
+	if len(sharedResources) == 0 {
+		return []any{}
+	}
+
+	l := make([]any, len(sharedResources))
+	for i, sharedResource := range sharedResources {
+		m := map[string]any{
+			names.AttrResourceARN: aws.ToString(sharedResource.ResourceArn),
+			names.AttrStatus:      string(sharedResource.Status),
+			names.AttrType:        string(sharedResource.Type),
+		}
+		if len(sharedResource.DnsNames) > 0 {
+			m["dns_names"] = sharedResource.DnsNames
+		}
+		l[i] = m
+	}
+
+	return l
 }
 
 // brokerEndpointOrder defines the canonical sort priority for known MQ broker endpoints,

--- a/internal/service/mq/broker.go
+++ b/internal/service/mq/broker.go
@@ -497,10 +497,7 @@ func resourceBrokerCreate(ctx context.Context, d *schema.ResourceData, meta any)
 	// Resource shares can only be set via UpdateBroker, so they are applied
 	// after the broker reaches a running state.
 	if v, ok := d.GetOk("resource_share_arns"); ok && v.(*schema.Set).Len() > 0 {
-		_, err := conn.UpdateBroker(ctx, &mq.UpdateBrokerInput{
-			BrokerId:          aws.String(d.Id()),
-			ResourceShareArns: flex.ExpandStringValueSet(v.(*schema.Set)),
-		})
+		err := updateBrokerResourceShares(ctx, conn, d.Id(), flex.ExpandStringValueSet(v.(*schema.Set)), d.Timeout(schema.TimeoutCreate))
 
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating MQ Broker (%s) resource shares: %s", d.Id(), err)
@@ -732,12 +729,7 @@ func resourceBrokerUpdate(ctx context.Context, d *schema.ResourceData, meta any)
 	}
 
 	if d.HasChange("resource_share_arns") {
-		input := &mq.UpdateBrokerInput{
-			BrokerId:          aws.String(d.Id()),
-			ResourceShareArns: flex.ExpandStringValueSet(d.Get("resource_share_arns").(*schema.Set)),
-		}
-
-		_, err := conn.UpdateBroker(ctx, input)
+		err := updateBrokerResourceShares(ctx, conn, d.Id(), flex.ExpandStringValueSet(d.Get("resource_share_arns").(*schema.Set)), d.Timeout(schema.TimeoutUpdate))
 
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating MQ Broker (%s) resource shares: %s", d.Id(), err)
@@ -831,6 +823,68 @@ func findSharedResourcesByBrokerID(ctx context.Context, conn *mq.Client, id stri
 	}
 
 	return output, nil
+}
+
+// updateBrokerResourceShares sets the broker's resource shares and waits for them
+// to register. A broker can briefly reject the update with a ConflictException
+// immediately after reaching a running state, so the update is retried, and the
+// subsequent wait ensures the shares are attached before the broker is rebooted
+// to apply them.
+func updateBrokerResourceShares(ctx context.Context, conn *mq.Client, id string, resourceShareARNs []string, timeout time.Duration) error {
+	_, err := tfresource.RetryWhenIsA[*mq.UpdateBrokerOutput, *types.ConflictException](ctx, timeout, func(ctx context.Context) (*mq.UpdateBrokerOutput, error) {
+		return conn.UpdateBroker(ctx, &mq.UpdateBrokerInput{
+			BrokerId:          aws.String(id),
+			ResourceShareArns: resourceShareARNs,
+		})
+	})
+
+	if err != nil {
+		return err
+	}
+
+	return waitBrokerResourceSharesAttached(ctx, conn, id, resourceShareARNs, timeout)
+}
+
+func waitBrokerResourceSharesAttached(ctx context.Context, conn *mq.Client, id string, resourceShareARNs []string, timeout time.Duration) error {
+	const (
+		attachPending  = "pending"
+		attachComplete = "attached"
+	)
+
+	stateConf := retry.StateChangeConf{
+		Pending: []string{attachPending},
+		Target:  []string{attachComplete},
+		Timeout: timeout,
+		Refresh: func(ctx context.Context) (any, string, error) {
+			sharedResources, err := findSharedResourcesByBrokerID(ctx, conn, id)
+
+			if err != nil {
+				return nil, "", err
+			}
+
+			// A resource share is fully attached only once its RESOURCE_SHARE
+			// entry is AVAILABLE. This is reached without a reboot; the shared
+			// resources themselves become AVAILABLE only after the reboot.
+			available := make(map[string]struct{})
+			for _, sharedResource := range sharedResources {
+				if sharedResource.Type == types.SharedResourceTypeResourceShare && sharedResource.Status == types.SharedResourceStatusAvailable {
+					available[aws.ToString(sharedResource.ResourceArn)] = struct{}{}
+				}
+			}
+
+			for _, arn := range resourceShareARNs {
+				if _, ok := available[arn]; !ok {
+					return sharedResources, attachPending, nil
+				}
+			}
+
+			return sharedResources, attachComplete, nil
+		},
+	}
+
+	_, err := stateConf.WaitForStateContext(ctx)
+
+	return err
 }
 
 func statusBrokerState(conn *mq.Client, id string) retry.StateRefreshFunc {

--- a/internal/service/mq/broker_data_source.go
+++ b/internal/service/mq/broker_data_source.go
@@ -7,6 +7,7 @@ package mq
 
 import (
 	"context"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/mq"
@@ -215,10 +216,40 @@ func dataSourceBroker() *schema.Resource {
 					Type:     schema.TypeBool,
 					Computed: true,
 				},
+				"resource_share_arns": {
+					Type:     schema.TypeSet,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
 				names.AttrSecurityGroups: {
 					Type:     schema.TypeSet,
 					Elem:     &schema.Schema{Type: schema.TypeString},
 					Computed: true,
+				},
+				"shared_resources": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"dns_names": {
+								Type:     schema.TypeList,
+								Computed: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+							},
+							names.AttrResourceARN: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							names.AttrStatus: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							names.AttrType: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+						},
+					},
 				},
 				names.AttrStorageType: {
 					Type:     schema.TypeString,
@@ -305,6 +336,20 @@ func dataSourceBrokerRead(ctx context.Context, d *schema.ResourceData, meta any)
 	d.Set(names.AttrSecurityGroups, output.SecurityGroups)
 	d.Set(names.AttrStorageType, output.StorageType)
 	d.Set(names.AttrSubnetIDs, output.SubnetIds)
+
+	if strings.EqualFold(string(output.EngineType), string(types.EngineTypeRabbitmq)) {
+		sharedResources, err := findSharedResourcesByBrokerID(ctx, conn, brokerID)
+
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "reading MQ Broker (%s) shared resources: %s", brokerID, err)
+		}
+
+		d.Set("resource_share_arns", flattenResourceShareARNs(sharedResources))
+
+		if err := d.Set("shared_resources", flattenSharedResources(sharedResources)); err != nil {
+			return sdkdiag.AppendErrorf(diags, "setting shared_resources: %s", err)
+		}
+	}
 
 	if err := d.Set(names.AttrConfiguration, flattenConfiguration(output.Configurations)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting configuration: %s", err)

--- a/internal/service/mq/broker_data_source_test.go
+++ b/internal/service/mq/broker_data_source_test.go
@@ -79,9 +79,15 @@ func TestAccMQBrokerDataSource_resourceShareArns(t *testing.T) {
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.MQEndpointID) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.MQServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {
+				Source:            "hashicorp/time",
+				VersionConstraint: "0.12.1",
+			},
+		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBrokerDataSourceConfig_resourceShareARNs(rName, testAccRabbitVersionNormalized3_13),
+				Config: testAccBrokerDataSourceConfig_resourceShareARNs(rName, testAccRabbitVersionNormalized4_2),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "resource_share_arns.#", "1"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "resource_share_arns.#", resourceName, "resource_share_arns.#"),

--- a/internal/service/mq/broker_data_source_test.go
+++ b/internal/service/mq/broker_data_source_test.go
@@ -65,6 +65,41 @@ func TestAccMQBrokerDataSource_basic(t *testing.T) {
 	})
 }
 
+func TestAccMQBrokerDataSource_resourceShareArns(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_mq_broker.test"
+	dataSourceName := "data.aws_mq_broker.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.MQEndpointID) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.MQServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBrokerDataSourceConfig_resourceShareARNs(rName, testAccRabbitVersionNormalized3_13),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "resource_share_arns.#", "1"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "resource_share_arns.#", resourceName, "resource_share_arns.#"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "shared_resources.#", resourceName, "shared_resources.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAccBrokerDataSourceConfig_resourceShareARNs(rName, version string) string {
+	return acctest.ConfigCompose(testAccBrokerConfig_rabbitResourceShareARNs(rName, version), `
+data "aws_mq_broker" "test" {
+  broker_id = aws_mq_broker.test.id
+}
+`)
+}
+
 func testAccBrokerDataSourceConfig_base(rName string) string {
 	return acctest.ConfigCompose(testAccBrokerConfig_baseCustomVPC(rName), fmt.Sprintf(`
 resource "aws_mq_configuration" "test" {

--- a/internal/service/mq/broker_data_source_test.go
+++ b/internal/service/mq/broker_data_source_test.go
@@ -65,7 +65,7 @@ func TestAccMQBrokerDataSource_basic(t *testing.T) {
 	})
 }
 
-func TestAccMQBrokerDataSource_resourceShareArns(t *testing.T) {
+func TestAccMQBrokerDataSource_resourceShareARNs(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")

--- a/internal/service/mq/broker_test.go
+++ b/internal/service/mq/broker_test.go
@@ -454,6 +454,73 @@ func TestSortBrokerInstanceEndpoints(t *testing.T) {
 	}
 }
 
+func TestFlattenResourceShareARNs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		resources []types.SharedResource
+		want      []string
+	}{
+		{
+			name:      "nil",
+			resources: nil,
+			want:      nil,
+		},
+		{
+			name: "resource share and resource entries",
+			resources: []types.SharedResource{
+				{
+					Type:        types.SharedResourceTypeResourceShare,
+					ResourceArn: aws.String("arn:aws:ram:eu-west-1:123456789012:resource-share/share-1"),
+					Status:      types.SharedResourceStatusAvailable,
+				},
+				{
+					Type:        types.SharedResourceTypeResource,
+					ResourceArn: aws.String("arn:aws:vpc-lattice:eu-west-1:123456789012:resourceconfiguration/rcfg-1"),
+					DnsNames:    []string{"example.vpc-lattice-rsc.eu-west-1.on.aws"},
+					Status:      types.SharedResourceStatusAvailable,
+				},
+			},
+			want: []string{"arn:aws:ram:eu-west-1:123456789012:resource-share/share-1"},
+		},
+		{
+			name: "resource entry only",
+			resources: []types.SharedResource{
+				{
+					Type:        types.SharedResourceTypeResource,
+					ResourceArn: aws.String("arn:aws:vpc-lattice:eu-west-1:123456789012:resourceconfiguration/rcfg-1"),
+					Status:      types.SharedResourceStatusAvailable,
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "pending share still surfaced",
+			resources: []types.SharedResource{
+				{
+					Type:        types.SharedResourceTypeResourceShare,
+					ResourceArn: aws.String("arn:aws:ram:eu-west-1:123456789012:resource-share/share-1"),
+					Status:      types.SharedResourceStatusPendingCreate,
+				},
+			},
+			want: []string{"arn:aws:ram:eu-west-1:123456789012:resource-share/share-1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfmq.FlattenResourceShareARNs(tt.resources)
+
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("FlattenResourceShareARNs() =\n  %v\nwant\n  %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestNormalizeEngineVersion(t *testing.T) {
 	t.Parallel()
 
@@ -1959,6 +2026,46 @@ func TestAccMQBroker_dataReplicationMode(t *testing.T) {
 	})
 }
 
+func TestAccMQBroker_RabbitMQ_resourceShareArns(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var broker mq.DescribeBrokerOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_mq_broker.test"
+	shareResourceName := "aws_ram_resource_share.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.MQEndpointID)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.MQServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckBrokerDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBrokerConfig_rabbitResourceShareARNs(rName, testAccRabbitVersionNormalized3_13),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBrokerExists(ctx, t, resourceName, &broker),
+					resource.TestCheckResourceAttr(resourceName, "engine_type", "RabbitMQ"),
+					resource.TestCheckResourceAttr(resourceName, "resource_share_arns.#", "1"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "resource_share_arns.*", shareResourceName, names.AttrARN),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{names.AttrApplyImmediately, "user"},
+			},
+		},
+	})
+}
+
 func testAccCheckBrokerDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.ProviderMeta(ctx, t).MQClient(ctx)
@@ -2684,6 +2791,68 @@ resource "aws_mq_broker" "test" {
   }
 }
 `, rName, version, autoMinorVersionUpgrade)
+}
+
+func testAccBrokerConfig_rabbitResourceShareARNs(rName, version string) string {
+	return acctest.ConfigCompose(acctest.ConfigVPCWithSubnets(rName, 1), fmt.Sprintf(`
+resource "aws_security_group" "test" {
+  name = %[1]q
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_vpclattice_resource_gateway" "test" {
+  name       = %[1]q
+  vpc_id     = aws_vpc.test.id
+  subnet_ids = [aws_subnet.test[0].id]
+}
+
+resource "aws_vpclattice_resource_configuration" "test" {
+  name = %[1]q
+
+  resource_gateway_identifier = aws_vpclattice_resource_gateway.test.id
+
+  port_ranges = ["443"]
+  protocol    = "TCP"
+
+  resource_configuration_definition {
+    dns_resource {
+      domain_name     = "example.com"
+      ip_address_type = "IPV4"
+    }
+  }
+}
+
+resource "aws_ram_resource_share" "test" {
+  name                      = %[1]q
+  allow_external_principals = false
+}
+
+resource "aws_ram_resource_association" "test" {
+  resource_arn       = aws_vpclattice_resource_configuration.test.arn
+  resource_share_arn = aws_ram_resource_share.test.arn
+}
+
+resource "aws_mq_broker" "test" {
+  broker_name        = %[1]q
+  engine_type        = "RabbitMQ"
+  engine_version     = %[2]q
+  host_instance_type = "mq.t3.micro"
+  security_groups    = [aws_security_group.test.id]
+  apply_immediately  = true
+
+  resource_share_arns = [aws_ram_resource_share.test.arn]
+
+  user {
+    username = "Test"
+    password = "TestTest1234"
+  }
+
+  depends_on = [aws_ram_resource_association.test]
+}
+`, rName, version))
 }
 
 func testAccBrokerConfig_updateUsersSecurityGroups(rName, version, autoMinorVersionUpgrade string) string {

--- a/internal/service/mq/broker_test.go
+++ b/internal/service/mq/broker_test.go
@@ -472,24 +472,24 @@ func TestFlattenResourceShareARNs(t *testing.T) {
 			resources: []types.SharedResource{
 				{
 					Type:        types.SharedResourceTypeResourceShare,
-					ResourceArn: aws.String("arn:aws:ram:eu-west-1:123456789012:resource-share/share-1"),
+					ResourceArn: aws.String("resource-share-1"),
 					Status:      types.SharedResourceStatusAvailable,
 				},
 				{
 					Type:        types.SharedResourceTypeResource,
-					ResourceArn: aws.String("arn:aws:vpc-lattice:eu-west-1:123456789012:resourceconfiguration/rcfg-1"),
-					DnsNames:    []string{"example.vpc-lattice-rsc.eu-west-1.on.aws"},
+					ResourceArn: aws.String("resource-configuration-1"),
+					DnsNames:    []string{"example.internal"},
 					Status:      types.SharedResourceStatusAvailable,
 				},
 			},
-			want: []string{"arn:aws:ram:eu-west-1:123456789012:resource-share/share-1"},
+			want: []string{"resource-share-1"},
 		},
 		{
 			name: "resource entry only",
 			resources: []types.SharedResource{
 				{
 					Type:        types.SharedResourceTypeResource,
-					ResourceArn: aws.String("arn:aws:vpc-lattice:eu-west-1:123456789012:resourceconfiguration/rcfg-1"),
+					ResourceArn: aws.String("resource-configuration-1"),
 					Status:      types.SharedResourceStatusAvailable,
 				},
 			},
@@ -500,11 +500,11 @@ func TestFlattenResourceShareARNs(t *testing.T) {
 			resources: []types.SharedResource{
 				{
 					Type:        types.SharedResourceTypeResourceShare,
-					ResourceArn: aws.String("arn:aws:ram:eu-west-1:123456789012:resource-share/share-1"),
+					ResourceArn: aws.String("resource-share-1"),
 					Status:      types.SharedResourceStatusPendingCreate,
 				},
 			},
-			want: []string{"arn:aws:ram:eu-west-1:123456789012:resource-share/share-1"},
+			want: []string{"resource-share-1"},
 		},
 	}
 
@@ -2027,7 +2027,7 @@ func TestAccMQBroker_dataReplicationMode(t *testing.T) {
 	})
 }
 
-func TestAccMQBroker_RabbitMQ_resourceShareArns(t *testing.T) {
+func TestAccMQBroker_RabbitMQ_resourceShareARNs(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")

--- a/internal/service/mq/broker_test.go
+++ b/internal/service/mq/broker_test.go
@@ -629,6 +629,7 @@ func TestNormalizeEngineVersion(t *testing.T) {
 const (
 	testAccActiveVersionNormalized5_18 = "5.18"
 	testAccRabbitVersionNormalized3_13 = "3.13"
+	testAccRabbitVersionNormalized4_2  = "4.2"
 	// testAccNoAutoMinorVersionUpgrade   = acctest.CtFalse
 	testAccAutoMinorVersionUpgrade = acctest.CtTrue
 )
@@ -2045,10 +2046,16 @@ func TestAccMQBroker_RabbitMQ_resourceShareArns(t *testing.T) {
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.MQServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckBrokerDestroy(ctx, t),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {
+				Source:            "hashicorp/time",
+				VersionConstraint: "0.12.1",
+			},
+		},
+		CheckDestroy: testAccCheckBrokerDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBrokerConfig_rabbitResourceShareARNs(rName, testAccRabbitVersionNormalized3_13),
+				Config: testAccBrokerConfig_rabbitResourceShareARNs(rName, testAccRabbitVersionNormalized4_2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBrokerExists(ctx, t, resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, "engine_type", "RabbitMQ"),
@@ -2057,10 +2064,12 @@ func TestAccMQBroker_RabbitMQ_resourceShareArns(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{names.AttrApplyImmediately, "user"},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				// shared_resources reflects live infrastructure (e.g. rotating
+				// VPC endpoint DNS names) and is not guaranteed to round-trip.
+				ImportStateVerifyIgnore: []string{names.AttrApplyImmediately, "user", "shared_resources"},
 			},
 		},
 	})
@@ -2796,17 +2805,39 @@ resource "aws_mq_broker" "test" {
 func testAccBrokerConfig_rabbitResourceShareARNs(rName, version string) string {
 	return acctest.ConfigCompose(acctest.ConfigVPCWithSubnets(rName, 1), fmt.Sprintf(`
 resource "aws_security_group" "test" {
-  name = %[1]q
+  name   = %[1]q
+  vpc_id = aws_vpc.test.id
 
   tags = {
     Name = %[1]q
   }
 }
 
+resource "aws_security_group" "gateway" {
+  name   = "%[1]s-gateway"
+  vpc_id = aws_vpc.test.id
+
+  ingress {
+    from_port       = 5671
+    to_port         = 5671
+    protocol        = "tcp"
+    security_groups = [aws_security_group.test.id]
+  }
+
+  tags = {
+    Name = "%[1]s-gateway"
+  }
+}
+
+# The resource gateway shares the broker's subnet so a single-instance broker
+# overlaps an Availability Zone with the gateway.
 resource "aws_vpclattice_resource_gateway" "test" {
-  name       = %[1]q
-  vpc_id     = aws_vpc.test.id
-  subnet_ids = [aws_subnet.test[0].id]
+  name                           = %[1]q
+  vpc_id                         = aws_vpc.test.id
+  subnet_ids                     = [aws_subnet.test[0].id]
+  ip_address_type                = "IPV4"
+  resource_config_dns_resolution = "IN_VPC"
+  security_group_ids             = [aws_security_group.gateway.id]
 }
 
 resource "aws_vpclattice_resource_configuration" "test" {
@@ -2814,7 +2845,7 @@ resource "aws_vpclattice_resource_configuration" "test" {
 
   resource_gateway_identifier = aws_vpclattice_resource_gateway.test.id
 
-  port_ranges = ["443"]
+  port_ranges = ["5671"]
   protocol    = "TCP"
 
   resource_configuration_definition {
@@ -2827,21 +2858,34 @@ resource "aws_vpclattice_resource_configuration" "test" {
 
 resource "aws_ram_resource_share" "test" {
   name                      = %[1]q
-  allow_external_principals = false
+  allow_external_principals = true
+}
+
+# Deleting the broker asynchronously removes the VPC endpoints it created for the
+# shared resource. Delay destroying the resource configuration until those
+# endpoints are gone, otherwise its deletion fails as still associated.
+resource "time_sleep" "wait_for_endpoint_cleanup" {
+  depends_on       = [aws_vpclattice_resource_configuration.test]
+  destroy_duration = "5m"
 }
 
 resource "aws_ram_resource_association" "test" {
   resource_arn       = aws_vpclattice_resource_configuration.test.arn
   resource_share_arn = aws_ram_resource_share.test.arn
+
+  depends_on = [time_sleep.wait_for_endpoint_cleanup]
 }
 
 resource "aws_mq_broker" "test" {
-  broker_name        = %[1]q
-  engine_type        = "RabbitMQ"
-  engine_version     = %[2]q
-  host_instance_type = "mq.t3.micro"
-  security_groups    = [aws_security_group.test.id]
-  apply_immediately  = true
+  broker_name                = %[1]q
+  engine_type                = "RabbitMQ"
+  engine_version             = %[2]q
+  host_instance_type         = "mq.m7g.medium"
+  publicly_accessible        = false
+  security_groups            = [aws_security_group.test.id]
+  subnet_ids                 = [aws_subnet.test[0].id]
+  apply_immediately          = true
+  auto_minor_version_upgrade = true
 
   resource_share_arns = [aws_ram_resource_share.test.arn]
 

--- a/internal/service/mq/exports_test.go
+++ b/internal/service/mq/exports_test.go
@@ -13,6 +13,8 @@ var (
 
 	NormalizeEngineVersion = normalizeEngineVersion
 
+	FlattenResourceShareARNs = flattenResourceShareARNs
+
 	SortBrokerInstanceEndpoints = sortBrokerInstanceEndpoints
 
 	WaitBrokerRebooted = waitBrokerRebooted

--- a/website/docs/d/mq_broker.html.markdown
+++ b/website/docs/d/mq_broker.html.markdown
@@ -51,7 +51,9 @@ This data source exports the following attributes in addition to the arguments a
 * `logs` - Configuration block for the logging configuration of the broker. See [Logs](#logs) below.
 * `maintenance_window_start_time` - Configuration block for the maintenance window start time. See [Maintenance Window Start Time](#maintenance-window-start-time) below.
 * `publicly_accessible` - Whether to enable connections from applications outside of the VPC that hosts the broker's subnets.
+* `resource_share_arns` - Set of AWS RAM resource share ARNs that grant the broker access to shared resources for private networking. Only populated for `engine_type` of `RabbitMQ`.
 * `security_groups` - List of security group IDs assigned to the broker.
+* `shared_resources` - List of resources shared with the broker. See [Shared Resources](#shared-resources) below. Only populated for `engine_type` of `RabbitMQ`.
 * `storage_type` - Storage type of the broker.
 * `subnet_ids` - List of subnet IDs in which to launch the broker.
 * `tags` - Map of tags assigned to the broker.
@@ -97,6 +99,13 @@ This data source exports the following attributes in addition to the arguments a
 * `day_of_week` - Day of the week.
 * `time_of_day` - Time, in 24-hour format.
 * `time_zone` - Time zone in either the Country/City format or the UTC offset format.
+
+### Shared Resources
+
+* `dns_names` - DNS names through which the broker reaches the shared resource.
+* `resource_arn` - ARN of the shared resource.
+* `status` - Status of the shared resource.
+* `type` - Type of the shared resource, either `RESOURCE_SHARE` or `RESOURCE`.
 
 ### User
 

--- a/website/docs/r/mq_broker.html.markdown
+++ b/website/docs/r/mq_broker.html.markdown
@@ -145,6 +145,7 @@ The following arguments are optional:
 * `maintenance_window_start_time` - (Optional) Configuration block for the maintenance window start time. Detailed below.
 * `publicly_accessible` - (Optional) Whether to enable connections from applications outside of the VPC that hosts the broker's subnets.
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
+* `resource_share_arns` - (Optional) Set of [AWS RAM](https://docs.aws.amazon.com/ram/latest/userguide/what-is.html) resource share ARNs that grant the broker access to shared resources for [private networking](https://aws.amazon.com/blogs/big-data/introducing-private-networking-for-amazon-mq-for-rabbitmq/). Applies to `engine_type` of `RabbitMQ` only. Because Amazon MQ applies resource shares during a reboot, set `apply_immediately` to `true` for changes to take effect without waiting for the next maintenance window.
 * `security_groups` - (Optional) List of security group IDs assigned to the broker.
 * `storage_type` - (Optional) Storage type of the broker. For `engine_type` `ActiveMQ`, valid values are `efs` and `ebs` (AWS-default is `efs`). For `engine_type` `RabbitMQ`, only `ebs` is supported. When using `ebs`, only the `mq.m5` broker instance type family is supported.
 * `subnet_ids` - (Optional) List of subnet IDs in which to launch the broker. A `SINGLE_INSTANCE` deployment requires one subnet. An `ACTIVE_STANDBY_MULTI_AZ` deployment requires multiple subnets.
@@ -231,6 +232,11 @@ This resource exports the following attributes in addition to the arguments abov
             * `instances.0.endpoints.0` - `amqps://broker-id.mq.us-west-2.amazonaws.com:5671`
             * `instances.0.endpoints.1` - `https://broker-id.mq.us-west-2.amazonaws.com:16001`
 * `pending_data_replication_mode` - Data replication mode that will be applied after reboot.
+* `shared_resources` - List of resources shared with the broker via `resource_share_arns`. Only populated for `engine_type` of `RabbitMQ`.
+    * `shared_resources.0.dns_names` - DNS names through which the broker reaches the shared resource.
+    * `shared_resources.0.resource_arn` - ARN of the shared resource.
+    * `shared_resources.0.status` - Status of the shared resource.
+    * `shared_resources.0.type` - Type of the shared resource, either `RESOURCE_SHARE` or `RESOURCE`.
 * `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 
 ## Timeouts


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to the provider's security controls. This feature exposes AWS's existing RAM resource-share association for Amazon MQ for RabbitMQ private networking; it adds no new credential handling, encryption, or logging behavior. The shared-resource information is read from the AWS API and surfaced as computed attributes only.

### Description

Adds support for [Amazon MQ for RabbitMQ private networking](https://aws.amazon.com/blogs/big-data/introducing-private-networking-for-amazon-mq-for-rabbitmq/), announced by AWS, by allowing a broker to be associated with AWS RAM resource shares (e.g. VPC Lattice resource configurations).

`aws_mq_broker` gains:

- `resource_share_arns` (Optional, `TypeSet` of ARNs) — RAM resource share ARNs to associate with the broker. RabbitMQ only.
- `shared_resources` (Computed) — the resources currently shared with the broker (`resource_arn`, `dns_names`, `status`, `type`), read via `DescribeSharedResources`.
`data.aws_mq_broker` gains the same two attributes (Computed).

Implementation notes / design decisions:

- **Update-only API:** `ResourceShareArns` exists only on `UpdateBroker`, not `CreateBroker`. On create, shares     are applied with a follow-up `UpdateBroker` after the broker reaches `RUNNING`.
- **Reboot semantics:** AWS applies resource shares on reboot. Both create and update reboot+wait only when `apply_immediately = true`, consistent with the existing `data_replication_mode` / configuration update behavior. Documented.
- **Eventual consistency (found during acceptance testing):** immediately after reaching `RUNNING` the broker can reject the share update with a `ConflictException` ("concurrent update ... retry the request"), so the `UpdateBroker` call is retried. The provider then waits for each requested share's `RESOURCE_SHARE` entry to become `AVAILABLE` before rebooting, so the reboot does not collide with in-progress share setup.
- **RabbitMQ-only:** ActiveMQ doesn't support the feature, so a `CustomizeDiff` rejects `resource_share_arns` on ActiveMQ, and the `DescribeSharedResources` read is gated on `engine_type = RabbitMQ` (it would otherwise error for every ActiveMQ broker read).
- **Drift-stable read-back:** `DescribeBroker` does not return the share list, so `resource_share_arns` is reconstructed from the `RESOURCE_SHARE`-typed entries of `DescribeSharedResources` (whose `resourceArn` is the share ARN). Verified against a real API response. `resource_share_arns` is a Set, so it round-trips order-independently.

Testing notes:

- The acceptance test provisions a self-contained stack (VPC, subnets, security groups, a VPC Lattice resource gateway + resource configuration, a RAM resource share, and a RabbitMQ broker) since the feature requires a live shared resource.
- Deleting the broker asynchronously removes the VPC endpoints it created for the shared resource, so a `time_sleep` delays destroying the resource configuration until those endpoints are gone; otherwise its deletion fails as still associated.
- `shared_resources` is excluded from `ImportStateVerify` because its `dns_names` reflect live infrastructure (rotating VPC endpoint DNS names) and do not round-trip byte-for-byte.

### Relations

Closes #48487

### References

- https://github.com/hashicorp/terraform-provider-aws/issues/48487
- https://aws.amazon.com/blogs/big-data/introducing-private-networking-for-amazon-mq-for-rabbitmq/
- https://docs.aws.amazon.com/amazon-mq/latest/api-reference/brokers-broker-id.html#brokers-broker-id-prop-updatebrokerinput-resourcesharearns

### Output from Acceptance Testing

Acceptance tests were run manually against a live AWS account (they are not run in CI). Both the resource and data source tests pass, including the full create → attach → reboot → import → destroy lifecycle:

```console
% make testacc PKG=mq TESTS=TestAccMQBroker_RabbitMQ_resourceShareArns
--- PASS: TestAccMQBroker_RabbitMQ_resourceShareArns (1528.42s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/mq 1530.553s

% make testacc PKG=mq TESTS=TestAccMQBrokerDataSource_resourceShareArns
--- PASS: TestAccMQBrokerDataSource_resourceShareArns (1424.52s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/mq 1426.525s
```

Unit tests and linting also pass locally:

```console
% make test PKG=mq
ok      github.com/hashicorp/terraform-provider-aws/internal/service/mq 2.339s

% make golangci-lint PKG=mq
make: golangci-lint Checks / 1..5 of 5...
0 issues.
```

### AI Usage Disclosure

This change was developed with AI assistance (Claude). AI helped draft the resource/data-source code, tests, and documentation following existing provider patterns and ran the unit tests and linters locally. All design decisions were human-reviewed and directed, including:

- the update-only / reboot handling;
- the `ConflictException` retry and the wait for `RESOURCE_SHARE` to reach `AVAILABLE`, both diagnosed from real acceptance-test runs;
- the RabbitMQ-only gating; and
- the drift-stable read-back, modeled from a real `describe-shared-resources` response.

Acceptance tests were run and iterated on a real AWS account. I have reviewed every line and can explain the implementation.