### PR TITLE
resource/aws_sagemaker_endpoint_configuration: Add enable_network_isolation argument

### DIFF
--- a/.changelog/48738.txt
+++ b/.changelog/48738.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_sagemaker_endpoint_configuration: Add `enable_network_isolation` argument
+```

--- a/internal/service/sagemaker/endpoint_configuration.go
+++ b/internal/service/sagemaker/endpoint_configuration.go
@@ -255,6 +255,11 @@ func resourceEndpointConfiguration() *schema.Resource {
 					ConflictsWith: []string{names.AttrName},
 					ValidateFunc:  validPrefix,
 				},
+				"enable_network_isolation": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					ForceNew: true,
+				},
 				names.AttrExecutionRoleARN: {
 					Type:         schema.TypeString,
 					Optional:     true,
@@ -691,6 +696,30 @@ func validateDataCaptureConfigCustomDiff(ctx context.Context, d *schema.Resource
 		return nil
 	}
 
+	enableNetworkIsolation := configRaw.GetAttr("enable_network_isolation")
+	if enableNetworkIsolation.IsKnown() && !enableNetworkIsolation.IsNull() && enableNetworkIsolation.True() {
+		productionVariants := configRaw.GetAttr("production_variants")
+		if productionVariants.IsKnown() && !productionVariants.IsNull() {
+			it := productionVariants.ElementIterator()
+			for it.Next() {
+				_, variant := it.Element()
+				if !variant.IsKnown() || variant.IsNull() {
+					continue
+				}
+				modelName := variant.GetAttr("model_name")
+				if modelName.IsKnown() && !modelName.IsNull() && modelName.AsString() != "" {
+					diags = append(diags, diag.Diagnostic{
+						Severity:      diag.Error,
+						Summary:       "Conflicting configuration",
+						Detail:        "\"enable_network_isolation\" cannot be set when \"model_name\" is specified in \"production_variants\". Remove \"model_name\" and set \"execution_role_arn\" to use an Inference Components endpoint.",
+						AttributePath: cty.GetAttrPath("enable_network_isolation"),
+					})
+					break
+				}
+			}
+		}
+	}
+
 	dataCapturesPath := cty.GetAttrPath("data_capture_config")
 	dataCaptures := configRaw.GetAttr("data_capture_config")
 	if dataCaptures.IsKnown() && !dataCaptures.IsNull() {
@@ -767,6 +796,10 @@ func resourceEndpointConfigurationCreate(ctx context.Context, d *schema.Resource
 		input.DataCaptureConfig = expandDataCaptureConfig(v.([]any))
 	}
 
+	if v, ok := d.GetOk("enable_network_isolation"); ok {
+		input.EnableNetworkIsolation = aws.Bool(v.(bool))
+	}
+
 	if v, ok := d.GetOk(names.AttrExecutionRoleARN); ok {
 		input.ExecutionRoleArn = aws.String(v.(string))
 	}
@@ -812,6 +845,7 @@ func resourceEndpointConfigurationRead(ctx context.Context, d *schema.ResourceDa
 	if err := d.Set("data_capture_config", flattenDataCaptureConfig(endpointConfig.DataCaptureConfig)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting data_capture_config: %s", err)
 	}
+	d.Set("enable_network_isolation", endpointConfig.EnableNetworkIsolation)
 	d.Set(names.AttrExecutionRoleARN, endpointConfig.ExecutionRoleArn)
 	d.Set(names.AttrKMSKeyARN, endpointConfig.KmsKeyId)
 	d.Set(names.AttrName, endpointConfig.EndpointConfigName)

--- a/internal/service/sagemaker/endpoint_configuration_test.go
+++ b/internal/service/sagemaker/endpoint_configuration_test.go
@@ -1981,3 +1981,113 @@ resource "aws_sagemaker_endpoint_configuration" "test" {
 }
 `, rName)
 }
+
+func TestAccSageMakerEndpointConfiguration_enableNetworkIsolation(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_sagemaker_endpoint_configuration.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SageMakerServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEndpointConfigurationDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEndpointConfigurationConfig_enableNetworkIsolation(rName, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckEndpointConfigurationExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "enable_network_isolation", acctest.CtTrue),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccEndpointConfigurationConfig_enableNetworkIsolation(rName, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckEndpointConfigurationExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "enable_network_isolation", acctest.CtFalse),
+				),
+			},
+		},
+	})
+}
+
+func testAccEndpointConfigurationConfig_enableNetworkIsolation(rName string, enableNetworkIsolation bool) string {
+	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+resource "aws_iam_role" "test" {
+  name = %[1]q
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "sagemaker.amazonaws.com"
+        }
+      },
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "test" {
+  role       = aws_iam_role.test.name
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonSageMakerFullAccess"
+}
+
+resource "aws_sagemaker_endpoint_configuration" "test" {
+  name                     = %[1]q
+  execution_role_arn       = aws_iam_role.test.arn
+  enable_network_isolation = %[2]t
+
+  production_variants {
+    variant_name           = "variant-1"
+    initial_instance_count = 1
+    instance_type          = "ml.g5.xlarge"
+  }
+
+  depends_on = [aws_iam_role_policy_attachment.test]
+}
+`, rName, enableNetworkIsolation)
+}
+
+func TestAccSageMakerEndpointConfiguration_enableNetworkIsolationWithModelName(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SageMakerServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEndpointConfigurationDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccEndpointConfigurationConfig_enableNetworkIsolationWithModelName(rName),
+				ExpectError: regexache.MustCompile(`"enable_network_isolation" cannot be set when "model_name" is specified`),
+			},
+		},
+	})
+}
+
+func testAccEndpointConfigurationConfig_enableNetworkIsolationWithModelName(rName string) string {
+	return acctest.ConfigCompose(testAccEndpointConfigurationConfig_base(rName), fmt.Sprintf(`
+resource "aws_sagemaker_endpoint_configuration" "test" {
+  name                     = %[1]q
+  enable_network_isolation = true
+
+  production_variants {
+    variant_name           = "variant-1"
+    model_name             = aws_sagemaker_model.test.name
+    initial_instance_count = 2
+    instance_type          = "ml.t2.medium"
+    initial_variant_weight = 1
+  }
+}
+`, rName))
+}

--- a/website/docs/r/sagemaker_endpoint_configuration.html.markdown
+++ b/website/docs/r/sagemaker_endpoint_configuration.html.markdown
@@ -37,6 +37,7 @@ This resource supports the following arguments:
 
 * `async_inference_config` - (Optional) How an endpoint performs asynchronous inference.
 * `data_capture_config` - (Optional) Parameters to capture input/output of SageMaker AI models endpoints. Fields are documented below.
+* `enable_network_isolation` - (Optional) Sets whether all model containers deployed to the endpoint are isolated. If they are, no inbound or outbound network calls can be made to or from the model containers. Can only be set when `model_name` is not specified in `production_variants` (Inference Components endpoint).
 * `execution_role_arn` - (Optional) ARN of an IAM role that SageMaker AI can assume to perform actions on your behalf. Required when `model_name` is not specified in `production_variants` to support Inference Components.
 * `kms_key_arn` - (Optional) ARN of a AWS KMS key that SageMaker AI uses to encrypt data on the storage volume attached to the ML compute instance that hosts the endpoint.
 * `name_prefix` - (Optional) Unique endpoint configuration name beginning with the specified prefix. Conflicts with `name`.


### PR DESCRIPTION
Community Note

- Please vote on this PR by adding a 👍 reaction to the original PR to help the community and maintainers prioritize this request.
- Please do not leave "+1" or "me too" comments, they generate extra noise for PR reviewers.

### Description

Adds support for the `enable_network_isolation` argument on `aws_sagemaker_endpoint_configuration`. When enabled, all model containers deployed to the endpoint are isolated — no inbound or outbound network calls can be made to or from the model containers.

This field is supported by the AWS API ([CreateEndpointConfig](https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_CreateEndpointConfig.html)) but was not yet exposed in the Terraform provider.

A `CustomizeDiff` validation emits a plan-time error when `enable_network_isolation` is set alongside `model_name` in `production_variants`, since the API only supports this for Inference Components endpoints.

Closes #48713

### PR Checklist

- [x] Acceptance test coverage (create, import, ForceNew, validation error)
- [x] Documentation update in `website/docs/r/`
- [x] Changelog entry in `.changelog/`
- [x] No dependency updates

### New/Affected Resource(s)

- `aws_sagemaker_endpoint_configuration`

### Acceptance test output

```
--- PASS: TestAccSageMakerEndpointConfiguration_enableNetworkIsolation (53.99s)
--- PASS: TestAccSageMakerEndpointConfiguration_enableNetworkIsolationWithModelName (3.85s)
```

Full test suite for `TestAccSageMakerEndpointConfiguration_*`: 27/29 pass. 2 pre-existing failures (`managedInstanceScaling` tests) confirmed failing on `main` with the same API error.