### PR TITLE
r/aws_ecs_capacity_provider: Wait until capacity provider is `ACTIVE` on Create

### DIFF
--- a/.changelog/48741.txt
+++ b/.changelog/48741.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_ecs_capacity_provider: Wait until capacity provider is `ACTIVE` on resource Create
+```

--- a/internal/service/ecs/capacity_provider.go
+++ b/internal/service/ecs/capacity_provider.go
@@ -577,6 +577,13 @@ func resourceCapacityProviderCreate(ctx context.Context, d *schema.ResourceData,
 
 	d.SetId(aws.ToString(output.CapacityProvider.CapacityProviderArn))
 
+	const (
+		timeout = 10 * time.Minute
+	)
+	if _, err := waitCapacityProviderActive(ctx, conn, d.Id(), timeout); err != nil {
+		return sdkdiag.AppendErrorf(diags, "waiting for ECS Capacity Provider (%s) create: %s", d.Id(), err)
+	}
+
 	// For partitions not supporting tag-on-create, attempt tag after create.
 	if tags := getTagsIn(ctx); input.Tags == nil && len(tags) > 0 {
 		err := createTags(ctx, conn, d.Id(), tags)
@@ -750,6 +757,22 @@ func findCapacityProviderByARN(ctx context.Context, conn *ecs.Client, arn string
 	return output, nil
 }
 
+func statusCapacityProvider(conn *ecs.Client, arn string) retry.StateRefreshFunc {
+	return func(ctx context.Context) (any, string, error) {
+		output, err := findCapacityProviderByARN(ctx, conn, arn)
+
+		if retry.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return output, string(output.Status), nil
+	}
+}
+
 func statusCapacityProviderDelete(conn *ecs.Client, arn string) retry.StateRefreshFunc {
 	return func(ctx context.Context) (any, string, error) {
 		output, err := findCapacityProviderByARN(ctx, conn, arn)
@@ -788,6 +811,23 @@ func statusCapacityProviderUpdate(conn *ecs.Client, arn string) retry.StateRefre
 
 		return output, string(output.UpdateStatus), nil
 	}
+}
+
+func waitCapacityProviderActive(ctx context.Context, conn *ecs.Client, arn string, timeout time.Duration) (*awstypes.CapacityProvider, error) {
+	stateConf := &retry.StateChangeConf{
+		Pending: []string{},
+		Target:  enum.Slice(awstypes.CapacityProviderStatusActive),
+		Refresh: statusCapacityProvider(conn, arn),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+
+	if output, ok := outputRaw.(*awstypes.CapacityProvider); ok {
+		return output, err
+	}
+
+	return nil, err
 }
 
 func waitCapacityProviderUpdated(ctx context.Context, conn *ecs.Client, arn string, timeout time.Duration) (*awstypes.CapacityProvider, error) {


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

No.

### Description

Waits until an ECS capacity provider has status `ACTIVE` on resource Create before returning. This avoids race conditions where a freshly created capacity provider is attached to a cluster (e.g. via `aws_ecs_cluster_capacity_providers`) before it is ready to be used.

The linked issue suggests a `wait_for_active` argument analogous to `aws_ecs_service`'s `wait_for_steady_state`. Instead, this PR makes the wait unconditional, following the approach of #38332 (`aws_lb_trust_store`): unlike an ECS service reaching steady state, a capacity provider becomes `ACTIVE` quickly, so there is no reason to make waiting opt-in. The new `statusCapacityProvider`/`waitCapacityProviderActive` functions mirror the existing `waitCapacityProviderUpdated`/`waitCapacityProviderDeleted` waiters in the same file.

### Relations

Closes #42943

### References

Same pattern as #38332 (`aws_lb_trust_store: wait for status ACTIVE`).

### Output from Acceptance Testing

There is no schema change; the Create path is covered by the existing `TestAccECSCapacityProvider_*` tests. I was unable to run the acceptance tests locally (no AWS account available for testing):

```console
% make testacc TESTS=TestAccECSCapacityProvider_ PKG=ecs
```
