### PR TITLE
resource/aws_computeoptimizer_enrollment_status: send include_member_accounts on update

### DIFF
--- a/.changelog/48745.txt
+++ b/.changelog/48745.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_computeoptimizer_enrollment_status: Fix `include_member_accounts` being ignored on update
+```

--- a/internal/service/computeoptimizer/enrollment_status.go
+++ b/internal/service/computeoptimizer/enrollment_status.go
@@ -160,7 +160,8 @@ func (r *enrollmentStatusResource) Update(ctx context.Context, request resource.
 	conn := r.Meta().ComputeOptimizerClient(ctx)
 
 	input := &computeoptimizer.UpdateEnrollmentStatusInput{
-		Status: awstypes.Status(fwflex.StringValueFromFramework(ctx, new.Status)),
+		IncludeMemberAccounts: fwflex.BoolValueFromFramework(ctx, new.MemberAccountsEnrolled),
+		Status:                awstypes.Status(fwflex.StringValueFromFramework(ctx, new.Status)),
 	}
 
 	_, err := conn.UpdateEnrollmentStatus(ctx, input)


### PR DESCRIPTION
### Description

The `Update` method of `aws_computeoptimizer_enrollment_status` builds its `UpdateEnrollmentStatus` input from the `Status` field only. `Create` sends both `Status` and `IncludeMemberAccounts`. Because of that gap, changing `include_member_accounts` on an existing resource issues the API call without the flag, so Compute Optimizer keeps the previous scope. Terraform reports the update as applied while the enrollment scope never changes, and every following plan shows drift on `include_member_accounts`.

This change adds `IncludeMemberAccounts` to the `Update` input so it matches `Create`.

### Relations

Closes #48720

### Output from Acceptance Testing

I was not able to run the acceptance tests for this resource. They require an organization management account, which I do not have access to. The fix mirrors the existing `Create` path one to one, and the reproduction is described in #48720 (flipping `include_member_accounts` from `false` to `true` on an already-enrolled account is a silent no-op). Happy to add or adjust a test if a maintainer can point me at the expected pattern for this org-scoped resource.
