### PR TITLE
rolesanywhere: support in-place update of trust anchor notification_settings 🤖🤖🤖

### DIFF
--- a/.changelog/48753.txt
+++ b/.changelog/48753.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_rolesanywhere_trust_anchor: Fix `notification_settings` so that changes to an already-configured event are actually applied via `PutNotificationSettings` instead of being silently dropped
+```

--- a/internal/service/rolesanywhere/trust_anchor.go
+++ b/internal/service/rolesanywhere/trust_anchor.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"reflect"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/rolesanywhere"
@@ -26,8 +25,6 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
-
-const configuredByDefault string = "rolesanywhere.amazonaws.com"
 
 // @SDKResource("aws_rolesanywhere_trust_anchor", name="Trust Anchor")
 // @Tags(identifierAttribute="arn")
@@ -60,7 +57,6 @@ func resourceTrustAnchor() *schema.Resource {
 				"notification_settings": {
 					Type:     schema.TypeSet,
 					Computed: true,
-					ForceNew: true,
 					Optional: true,
 					MaxItems: 50,
 					Elem: &schema.Resource{
@@ -68,7 +64,6 @@ func resourceTrustAnchor() *schema.Resource {
 							"channel": {
 								Type:             schema.TypeString,
 								Computed:         true,
-								ForceNew:         true,
 								Optional:         true,
 								ValidateDiagFunc: enum.Validate[awstypes.NotificationChannel](),
 							},
@@ -79,20 +74,17 @@ func resourceTrustAnchor() *schema.Resource {
 							names.AttrEnabled: {
 								Type:     schema.TypeBool,
 								Computed: true,
-								ForceNew: true,
 								Optional: true,
 							},
 							"event": {
 								Type:             schema.TypeString,
 								Computed:         true,
-								ForceNew:         true,
 								Optional:         true,
 								ValidateDiagFunc: enum.Validate[awstypes.NotificationEvent](),
 							},
 							"threshold": {
 								Type:     schema.TypeInt,
 								Computed: true,
-								ForceNew: true,
 								Optional: true,
 							},
 						},
@@ -141,42 +133,64 @@ func resourceTrustAnchor() *schema.Resource {
 	}
 }
 
-// The AWS API returns two default entries for notification_settings. These entries are overwritten based on if a user defines a notification setting with the same event type.
-// Since notification settings cannot be updated, we need to force a resource recreation when they change, while at the same time allowing computed values.
-// Because both computed and user-defined arguments need to be supported, a custom diff function is required to handle this.
-// The function checks the diff, and if the difference is due to computed value change, the diff is suppressed based on the configuredBy attribute.
+// The AWS API always returns a default entry for every notification event, even one the
+// user never configured. Those default entries must not produce a perpetual diff on an
+// event the user simply didn't reference. A value change on an event the user did
+// reference, however, is a real, user-driven change and must not be suppressed.
+//
+// This diff is matched by "event" rather than by full object equality: comparing whole
+// objects can't tell "AWS filled in a default the user never mentioned" apart from "the
+// user changed a value on an event they did configure", since both show up as the old
+// object having no identical match in the new set.
 func customizeDiffNotificationSettings(_ context.Context, diff *schema.ResourceDiff, meta any) error {
 	oldSet, newSet := diff.GetChange("notification_settings")
 
-	oldSetTyped, okOld := oldSet.(*schema.Set)
-	newSetTyped, okNew := newSet.(*schema.Set)
-
-	if !okOld || !okNew {
-		return fmt.Errorf("unexpected type for notification_settings: oldSet: %T, newSet: %T", oldSet, newSet)
+	oldSetTyped, ok := oldSet.(*schema.Set)
+	if !ok {
+		return fmt.Errorf("unexpected type for notification_settings (old): %T", oldSet)
+	}
+	newSetTyped, ok := newSet.(*schema.Set)
+	if !ok {
+		return fmt.Errorf("unexpected type for notification_settings (new): %T", newSet)
 	}
 
-	oldList := oldSetTyped.List()
-	newList := newSetTyped.List()
+	// Nothing to reconcile: a brand-new resource has no prior state to compare against,
+	// and clearing here would strip the Computed "pending" marker, locking the plan to an
+	// empty set and preventing AWS's real default entries from ever landing in state.
+	if oldSetTyped.Len() == 0 {
+		return nil
+	}
 
-	for _, obj1 := range oldList {
-		found := false
-		for _, obj2 := range newList {
-			if reflect.DeepEqual(obj1, obj2) {
-				found = true
-				break
-			}
-		}
-		if !found {
-			if object, okNew := obj1.(map[string]any); okNew && object["configured_by"] == configuredByDefault {
-				if err := diff.Clear("notification_settings"); err != nil {
-					return err
-				}
-				break
-			}
+	oldByEvent := make(map[string]map[string]any, oldSetTyped.Len())
+	for _, raw := range oldSetTyped.List() {
+		if m, ok := raw.(map[string]any); ok {
+			oldByEvent[fmt.Sprint(m["event"])] = m
 		}
 	}
 
-	return nil
+	for _, raw := range newSetTyped.List() {
+		newMap, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		oldMap, existed := oldByEvent[fmt.Sprint(newMap["event"])]
+		if !existed {
+			// A new event block the prior state never had is always a real change.
+			return nil
+		}
+
+		if oldMap["enabled"] != newMap["enabled"] ||
+			oldMap["threshold"] != newMap["threshold"] ||
+			oldMap["channel"] != newMap["channel"] {
+			// The user changed a value on an event that already existed: keep the diff.
+			return nil
+		}
+	}
+
+	// Every entry the user configured already matches the refreshed state; any remaining
+	// difference is solely AWS-computed defaults for events the user never referenced.
+	return diff.Clear("notification_settings")
 }
 
 func resourceTrustAnchorCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
@@ -242,7 +256,7 @@ func resourceTrustAnchorUpdate(ctx context.Context, d *schema.ResourceData, meta
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RolesAnywhereClient(ctx)
 
-	if d.HasChangesExcept(names.AttrTags, names.AttrTagsAll) {
+	if d.HasChangesExcept(names.AttrTags, names.AttrTagsAll, "notification_settings") {
 		input := &rolesanywhere.UpdateTrustAnchorInput{
 			TrustAnchorId: aws.String(d.Id()),
 			Name:          aws.String(d.Get(names.AttrName).(string)),
@@ -266,6 +280,22 @@ func resourceTrustAnchorUpdate(ctx context.Context, d *schema.ResourceData, meta
 				if err := disableTrustAnchor(ctx, d.Id(), meta); err != nil {
 					return sdkdiag.AppendErrorf(diags, "disabling RolesAnywhere Trust Anchor (%s): %s", d.Id(), err)
 				}
+			}
+		}
+	}
+
+	if d.HasChange("notification_settings") {
+		if v, ok := d.GetOk("notification_settings"); ok && v.(*schema.Set).Len() > 0 {
+			input := &rolesanywhere.PutNotificationSettingsInput{
+				TrustAnchorId:        aws.String(d.Id()),
+				NotificationSettings: expandNotificationSettings(v.(*schema.Set).List()),
+			}
+
+			log.Printf("[DEBUG] Updating RolesAnywhere Trust Anchor (%s) notification settings: %#v", d.Id(), input)
+			_, err := conn.PutNotificationSettings(ctx, input)
+
+			if err != nil {
+				return sdkdiag.AppendErrorf(diags, "updating RolesAnywhere Trust Anchor (%s) notification settings: %s", d.Id(), err)
 			}
 		}
 	}

--- a/internal/service/rolesanywhere/trust_anchor_test.go
+++ b/internal/service/rolesanywhere/trust_anchor_test.go
@@ -206,6 +206,62 @@ func TestAccRolesAnywhereTrustAnchor_certificateBundle(t *testing.T) {
 	})
 }
 
+// TestAccRolesAnywhereTrustAnchor_notificationSettingsUpdate exercises an in-place
+// update of an already-configured notification_settings event (as opposed to
+// TestAccRolesAnywhereTrustAnchor_notificationSettings, which only covers setting and
+// fully removing the block). notification_settings previously required ForceNew for any
+// change, and the resource's CustomizeDiff unconditionally suppressed diffs whenever the
+// prior state's entries were AWS-computed defaults -- which is true for every event the
+// user hasn't already customized via Terraform. That meant a value change to an event the
+// user *did* configure was silently dropped: no error, no plan diff, no API call, and the
+// live setting never changed. See https://github.com/hashicorp/terraform-provider-aws/issues/41668.
+func TestAccRolesAnywhereTrustAnchor_notificationSettingsUpdate(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_rolesanywhere_trust_anchor.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.RolesAnywhereServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTrustAnchorDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTrustAnchorConfig_notificationSettingsUpdate(t, rName, true, 45),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTrustAnchorExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "notification_settings.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "notification_settings.*", map[string]string{
+						"event":     string(awstypes.NotificationEventEndEntityCertificateExpiry),
+						"enabled":   acctest.CtTrue,
+						"threshold": "45",
+					}),
+				),
+			},
+			{
+				// The exact production bug: the user changes a value (threshold) on an
+				// event that was already explicitly configured. Before the fix this was
+				// silently dropped -- no diff, no API call, no error, no plan change.
+				Config: testAccTrustAnchorConfig_notificationSettingsUpdate(t, rName, true, 60),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTrustAnchorExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "notification_settings.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "notification_settings.*", map[string]string{
+						"event":     string(awstypes.NotificationEventEndEntityCertificateExpiry),
+						"enabled":   acctest.CtTrue,
+						"threshold": "60",
+					}),
+				),
+			},
+		},
+	})
+}
+
 func TestAccRolesAnywhereTrustAnchor_enabled(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
@@ -427,6 +483,30 @@ resource "aws_rolesanywhere_trust_anchor" "test" {
   }
 }
 `, rName, acctest.TLSPEMEscapeNewlines(caCertificate))
+}
+
+func testAccTrustAnchorConfig_notificationSettingsUpdate(t *testing.T, rName string, enabled bool, threshold int) string {
+	caKey := acctest.TLSRSAPrivateKeyPEM(t, 2048)
+	caCertificate := acctest.TLSRSAX509SelfSignedCACertificateForRolesAnywhereTrustAnchorPEM(t, caKey)
+
+	return fmt.Sprintf(`
+resource "aws_rolesanywhere_trust_anchor" "test" {
+  name = %[1]q
+  source {
+    source_data {
+      x509_certificate_data = "%[2]s"
+    }
+    source_type = "CERTIFICATE_BUNDLE"
+  }
+
+  notification_settings {
+    channel   = "ALL"
+    enabled   = %[3]t
+    event     = "END_ENTITY_CERTIFICATE_EXPIRY"
+    threshold = %[4]d
+  }
+}
+`, rName, acctest.TLSPEMEscapeNewlines(caCertificate), enabled, threshold)
 }
 
 func testAccTrustAnchorConfig_enabled(t *testing.T, rName string, enabled bool) string {

--- a/website/docs/r/rolesanywhere_trust_anchor.html.markdown
+++ b/website/docs/r/rolesanywhere_trust_anchor.html.markdown
@@ -65,8 +65,17 @@ This resource supports the following arguments:
 
 * `enabled` - (Optional) Whether or not the Trust Anchor should be enabled.
 * `name` - (Required) The name of the Trust Anchor.
+* `notification_settings` - (Optional) A list of notification settings to be associated with the trust anchor, documented below.
 * `source` - (Required) The source of trust, documented below
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+#### `notification_settings`
+
+* `channel` - (Optional) Channel to notify. Valid value is `ALL`.
+* `enabled` - (Optional) Whether to enable the notification setting.
+* `event` - (Optional) Event to notify for. Valid values are `CA_CERTIFICATE_EXPIRY` and `END_ENTITY_CERTIFICATE_EXPIRY`.
+* `threshold` - (Optional) Number of days before certificate expiry to send the notification. Required when `enabled` is `true`. Valid value is between `1` and `360`.
+* `configured_by` - (Computed) Account that configured the notification setting.
 
 #### `source`
 


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

None.

### Description

`notification_settings` on `aws_rolesanywhere_trust_anchor` was `ForceNew`, and its `CustomizeDiff` unconditionally suppressed any diff whenever the prior state's entries were AWS-computed defaults (`configured_by == "rolesanywhere.amazonaws.com"`) -- which is true for every event a user hasn't already customized via Terraform. In practice this meant a value change to an event the user *did* configure was silently dropped: no plan diff, no API call, no error, and the live setting on the trust anchor never changed. First apply worked; every subsequent change to an existing event was a silent no-op.

`PutNotificationSettings`/`ResetNotificationSettings` have existed in the RolesAnywhere API since `aws-sdk-go-v2` [v1.2.0](https://github.com/aws/aws-sdk-go-v2/blob/main/service/rolesanywhere/CHANGELOG.md) (2023-05-15) -- over a year before `notification_settings` was added to this resource in #39108 (Sept 2024). The `ForceNew`/no-update premise documented in that PR was incorrect from the start; a dedicated update API existed the whole time.

Changes:
- Drop `ForceNew` from `notification_settings` and its sub-fields.
- Call `PutNotificationSettings` from `Update` when the block changes, instead of relying on recreation.
- Rework `CustomizeDiff` to match old/new entries by `event` instead of clearing the whole diff whenever *any* old entry carries the AWS-default `configured_by`. A genuine value change on an event the user already configured is no longer swallowed; an event the user never referenced still doesn't produce a perpetual diff.
- Document `notification_settings`, which has existed since #39108 but was never in the website docs (flagged by a commenter on #41668).

### Relations

Closes #41668

### References

- #39108 (original PR that added `notification_settings`, with the now-outdated "cannot be updated" rationale)
- https://github.com/aws/aws-sdk-go-v2/blob/main/service/rolesanywhere/CHANGELOG.md (v1.2.0 entry adding `PutNotificationSettings`/`ResetNotificationSettings`)

### Output from Acceptance Testing

```console
% make testacc TESTS=TestAccRolesAnywhere PKG=rolesanywhere
=== RUN   TestAccRolesAnywhereProfile_basic
=== PAUSE TestAccRolesAnywhereProfile_basic
=== RUN   TestAccRolesAnywhereProfile_noRoleARNs
=== PAUSE TestAccRolesAnywhereProfile_noRoleARNs
=== RUN   TestAccRolesAnywhereProfile_tags
=== PAUSE TestAccRolesAnywhereProfile_tags
=== RUN   TestAccRolesAnywhereProfile_disappears
=== PAUSE TestAccRolesAnywhereProfile_disappears
=== RUN   TestAccRolesAnywhereProfile_enabled
=== PAUSE TestAccRolesAnywhereProfile_enabled
=== RUN   TestAccRolesAnywhereProfile_acceptRoleSessionName
=== PAUSE TestAccRolesAnywhereProfile_acceptRoleSessionName
=== RUN   TestAccRolesAnywhereTrustAnchor_basic
=== PAUSE TestAccRolesAnywhereTrustAnchor_basic
=== RUN   TestAccRolesAnywhereTrustAnchor_notificationSettings
=== PAUSE TestAccRolesAnywhereTrustAnchor_notificationSettings
=== RUN   TestAccRolesAnywhereTrustAnchor_tags
=== PAUSE TestAccRolesAnywhereTrustAnchor_tags
=== RUN   TestAccRolesAnywhereTrustAnchor_disappears
=== PAUSE TestAccRolesAnywhereTrustAnchor_disappears
=== RUN   TestAccRolesAnywhereTrustAnchor_certificateBundle
=== PAUSE TestAccRolesAnywhereTrustAnchor_certificateBundle
=== RUN   TestAccRolesAnywhereTrustAnchor_notificationSettingsUpdate
=== PAUSE TestAccRolesAnywhereTrustAnchor_notificationSettingsUpdate
=== RUN   TestAccRolesAnywhereTrustAnchor_enabled
=== PAUSE TestAccRolesAnywhereTrustAnchor_enabled
--- PASS: TestAccRolesAnywhereProfile_disappears (21.92s)
--- PASS: TestAccRolesAnywhereTrustAnchor_certificateBundle (21.96s)
--- PASS: TestAccRolesAnywhereProfile_basic (25.07s)
--- PASS: TestAccRolesAnywhereTrustAnchor_basic (28.16s)
--- PASS: TestAccRolesAnywhereTrustAnchor_notificationSettingsUpdate (32.31s)
--- PASS: TestAccRolesAnywhereTrustAnchor_notificationSettings (38.18s)
--- PASS: TestAccRolesAnywhereTrustAnchor_disappears (21.58s)
--- PASS: TestAccRolesAnywhereTrustAnchor_enabled (44.87s)
--- PASS: TestAccRolesAnywhereProfile_tags (50.32s)
--- PASS: TestAccRolesAnywhereProfile_enabled (50.33s)
--- PASS: TestAccRolesAnywhereProfile_acceptRoleSessionName (50.34s)
--- PASS: TestAccRolesAnywhereProfile_noRoleARNs (29.94s)
--- PASS: TestAccRolesAnywhereTrustAnchor_tags (40.20s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/rolesanywhere	72.015s
```

`TestAccRolesAnywhereTrustAnchor_notificationSettingsUpdate` is a new test added by this PR, reproducing the exact bug: changing `threshold` on an already-configured, still-enabled event. It fails against the pre-fix code (plan shows no changes, value never updates) and passes against the fix.

### AI Disclosure

This PR was diagnosed, written, and tested with the assistance of an AI coding agent (Claude), working under my direction and review. Specifically:
- Root cause analysis (reading the provider source, the AWS SDK changelog, and reproducing the bug) was AI-assisted.
- The code changes and the new acceptance test were AI-generated, then reviewed by me.
- All acceptance tests in this PR's "Output from Acceptance Testing" section were actually run against a real AWS account by the agent under my supervision, including catching and fixing a regression the first version of the `CustomizeDiff` rewrite introduced (it broke default `notification_settings` population on resource creation) before this PR was opened.

I have reviewed the diff and understand the change: `notification_settings` no longer needs `ForceNew` because a dedicated `PutNotificationSettings` API exists and is now called from `Update`; the `CustomizeDiff` now compares by `event` so it only suppresses noise from AWS-computed defaults, not genuine user-driven changes.
