### PR TITLE
Fix import documentation for `aws_eip_domain_name`

### DIFF
--- a/website/docs/r/eip_domain_name.html.markdown
+++ b/website/docs/r/eip_domain_name.html.markdown
@@ -60,12 +60,12 @@ In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashico
 ```terraform
 import {
   to = aws_eip_domain_name.test
-  id = "eipassoc-ab12c345"
+  id = "eipalloc-ab12c345"
 }
 ```
 
 Using `terraform import`, import a static reverse DNS record to an Elastic IP addresses using their association IDs. For example:
 
 ```console
-% terraform import aws_eip_domain_name.test eipassoc-ab12c345
+% terraform import aws_eip_domain_name.test eipalloc-ab12c345
 ```


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Corrects the import documentation for `aws_eip_domain_name` so that it uses `eipalloc-` rather than `eipassoc-`

### Relations

Closes #48746

### References

[Dosu's take on the matter](https://github.com/hashicorp/terraform-provider-aws/issues/48746#issuecomment-4867840608)

### Output from Acceptance Testing

N/a, docs
