### PR TITLE
data-source/aws_quicksight_data_set: Use transparent tagging

### DIFF
--- a/internal/service/quicksight/data_set_data_source.go
+++ b/internal/service/quicksight/data_set_data_source.go
@@ -18,8 +18,7 @@ import (
 )
 
 // @SDKDataSource("aws_quicksight_data_set", name="Data Set")
-// @Testing(tagsTest=true)
-// @Testing(tagsIdentifierAttribute="arn")
+// @Tags(identifierAttribute="arn")
 func dataSourceDataSet() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceDataSetRead,
@@ -104,21 +103,6 @@ func dataSourceDataSetRead(ctx context.Context, d *schema.ResourceData, meta any
 	}
 	if err := d.Set("row_level_permission_tag_configuration", quicksightschema.FlattenRowLevelPermissionTagConfiguration(dataSet.RowLevelPermissionTagConfiguration)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting row_level_permission_tag_configuration: %s", err)
-	}
-
-	// Cannot use transparent tagging because it has to handle `tags_all` as well
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig(ctx)
-
-	tags, err := listTags(ctx, conn, d.Get(names.AttrARN).(string))
-
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "listing tags for QuickSight Data Set (%s): %s", d.Id(), err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	if err := d.Set(names.AttrTags, tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
 	}
 
 	permissions, err := findDataSetPermissionsByTwoPartKey(ctx, conn, awsAccountID, dataSetID)

--- a/internal/service/quicksight/data_set_data_source_tags_gen_test.go
+++ b/internal/service/quicksight/data_set_data_source_tags_gen_test.go
@@ -6,9 +6,7 @@
 package quicksight_test
 
 import (
-	"context"
 	"testing"
-	"unique"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -17,9 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	tfstatecheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/statecheck"
-	tfquicksight "github.com/hashicorp/terraform-provider-aws/internal/service/quicksight"
-	inttypes "github.com/hashicorp/terraform-provider-aws/internal/types"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -179,7 +174,7 @@ func TestAccQuickSightDataSetDataSource_Tags_IgnoreTags_Overlap_defaultTag(t *te
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
 						acctest.CtResourceKey1: knownvalue.StringExact(acctest.CtResourceValue1),
 					})),
-					expectFullDataSetDataSourceTags(ctx, dataSourceName, knownvalue.MapExact(map[string]knownvalue.Check{
+					expectFullDataSourceTags(ctx, dataSourceName, knownvalue.MapExact(map[string]knownvalue.Check{
 						acctest.CtProviderKey1: knownvalue.StringExact(acctest.CtProviderValue1),
 						acctest.CtResourceKey1: knownvalue.StringExact(acctest.CtResourceValue1),
 					})),
@@ -216,7 +211,7 @@ func TestAccQuickSightDataSetDataSource_Tags_IgnoreTags_Overlap_resourceTag(t *t
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
-					expectFullDataSetDataSourceTags(ctx, dataSourceName, knownvalue.MapExact(map[string]knownvalue.Check{
+					expectFullDataSourceTags(ctx, dataSourceName, knownvalue.MapExact(map[string]knownvalue.Check{
 						acctest.CtResourceKey1: knownvalue.StringExact(acctest.CtResourceValue1),
 					})),
 				},
@@ -224,10 +219,4 @@ func TestAccQuickSightDataSetDataSource_Tags_IgnoreTags_Overlap_resourceTag(t *t
 			},
 		},
 	})
-}
-
-func expectFullDataSetDataSourceTags(ctx context.Context, resourceAddress string, knownValue knownvalue.Check) statecheck.StateCheck {
-	return tfstatecheck.ExpectFullDataSourceTagsSpecTags(tfquicksight.ServicePackage(ctx), resourceAddress, unique.Make(inttypes.ServicePackageResourceTags{
-		IdentifierAttribute: names.AttrARN,
-	}), knownValue)
 }

--- a/internal/service/quicksight/service_package_gen.go
+++ b/internal/service/quicksight/service_package_gen.go
@@ -137,7 +137,10 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*inttypes.Service
 			Factory:  dataSourceDataSet,
 			TypeName: "aws_quicksight_data_set",
 			Name:     "Data Set",
-			Region:   inttypes.ResourceRegionDefault(),
+			Tags: unique.Make(inttypes.ServicePackageResourceTags{
+				IdentifierAttribute: names.AttrARN,
+			}),
+			Region: inttypes.ResourceRegionDefault(),
 		},
 		{
 			Factory:  dataSourceGroup,


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

`data.aws_quicksight_data_set` could not use transparent tagging because it incorrectly had the attribute `tags_all`. `tags_all` was removed in v6.0, but transparent tagging was not implemented

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=quicksight TESTS=TestAccQuickSightDataSetDataSource_

--- PASS: TestAccQuickSightDataSetDataSource_Tags_DefaultTags_nonOverlapping (45.88s)
--- PASS: TestAccQuickSightDataSetDataSource_basic (47.87s)
--- PASS: TestAccQuickSightDataSetDataSource_Tags_emptyMap (47.88s)
--- PASS: TestAccQuickSightDataSetDataSource_Tags_nullMap (47.88s)
--- PASS: TestAccQuickSightDataSetDataSource_tags (47.89s)
--- PASS: TestAccQuickSightDataSetDataSource_Tags_IgnoreTags_Overlap_defaultTag (48.45s)
--- PASS: TestAccQuickSightDataSetDataSource_Tags_IgnoreTags_Overlap_resourceTag (49.72s)
```
