### PR TITLE
enhance(bedrockagentcore_memory_strategy): add reflection_configuration for EPISODIC type

### DIFF
--- a/.changelog/48758.txt
+++ b/.changelog/48758.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_bedrockagentcore_memory_strategy: Add `reflection_configuration` configuration block for `EPISODIC` strategy type
+```

--- a/internal/service/bedrockagentcore/memory_strategy.go
+++ b/internal/service/bedrockagentcore/memory_strategy.go
@@ -88,6 +88,15 @@ func (r *resourceMemoryStrategy) Schema(ctx context.Context, request resource.Sc
 				CustomType: fwtypes.SetOfStringType,
 				Required:   true,
 			},
+			names.AttrType: schema.StringAttribute{
+				Required:   true,
+				CustomType: fwtypes.StringEnumType[awstypes.MemoryStrategyType](),
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+		},
+		Blocks: map[string]schema.Block{
 			"reflection_configuration": schema.ListNestedBlock{
 				CustomType: fwtypes.NewListNestedObjectTypeOf[reflectionConfigurationModel](ctx),
 				Validators: []validator.List{
@@ -102,15 +111,6 @@ func (r *resourceMemoryStrategy) Schema(ctx context.Context, request resource.Sc
 					},
 				},
 			},
-			names.AttrType: schema.StringAttribute{
-				Required:   true,
-				CustomType: fwtypes.StringEnumType[awstypes.MemoryStrategyType](),
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
-				},
-			},
-		},
-		Blocks: map[string]schema.Block{
 			names.AttrConfiguration: schema.ListNestedBlock{
 				CustomType: fwtypes.NewListNestedObjectTypeOf[customConfigurationModel](ctx),
 				Validators: []validator.List{
@@ -163,29 +163,29 @@ func (r *resourceMemoryStrategy) Schema(ctx context.Context, request resource.Sc
 								},
 							},
 						},
-							"reflection": schema.ListNestedBlock{
-								CustomType: fwtypes.NewListNestedObjectTypeOf[reflectionOverrideModel](ctx),
-								Validators: []validator.List{
-									listvalidator.SizeAtMost(1),
-								},
-								PlanModifiers: []planmodifier.List{
-									errorIfSingleBlockRemoved("reflection"),
-								},
-								NestedObject: schema.NestedBlockObject{
-									Attributes: map[string]schema.Attribute{
-										"append_to_prompt": schema.StringAttribute{
-											Required: true,
-										},
-										"model_id": schema.StringAttribute{
-											Required: true,
-										},
-										"namespace_templates": schema.ListAttribute{
-											CustomType: fwtypes.ListOfStringType,
-											Optional:   true,
-										},
+						"reflection": schema.ListNestedBlock{
+							CustomType: fwtypes.NewListNestedObjectTypeOf[reflectionOverrideModel](ctx),
+							Validators: []validator.List{
+								listvalidator.SizeAtMost(1),
+							},
+							PlanModifiers: []planmodifier.List{
+								errorIfSingleBlockRemoved("reflection"),
+							},
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									"append_to_prompt": schema.StringAttribute{
+										Required: true,
+									},
+									"model_id": schema.StringAttribute{
+										Required: true,
+									},
+									"namespace_templates": schema.ListAttribute{
+										CustomType: fwtypes.ListOfStringType,
+										Optional:   true,
 									},
 								},
 							},
+						},
 					},
 				},
 			},
@@ -297,7 +297,6 @@ func (r *resourceMemoryStrategy) ValidateConfig(ctx context.Context, request res
 			}
 		}
 	}
-	}
 }
 
 func (r *resourceMemoryStrategy) Create(ctx context.Context, request resource.CreateRequest, response *resource.CreateResponse) {
@@ -363,7 +362,7 @@ func (r *resourceMemoryStrategy) Create(ctx context.Context, request resource.Cr
 			if episodicReflection, ok := found.Configuration.Reflection.(*awstypes.ReflectionConfigurationMemberEpisodicReflectionConfiguration); ok {
 				var rc reflectionConfigurationModel
 				if episodicReflection.Value.NamespaceTemplates != nil {
-					rc.NamespaceTemplates, _ = fwtypes.ListOfStringValueFrom(ctx, episodicReflection.Value.NamespaceTemplates)
+					rc.NamespaceTemplates = fwflex.FlattenFrameworkStringValueListOfString(ctx, episodicReflection.Value.NamespaceTemplates)
 				}
 				plan.ReflectionConfiguration, _ = fwtypes.NewListNestedObjectValueOfPtr(ctx, &rc)
 			}
@@ -425,7 +424,7 @@ func (r *resourceMemoryStrategy) Read(ctx context.Context, request resource.Read
 		if episodicReflection, ok := out.Configuration.Reflection.(*awstypes.ReflectionConfigurationMemberEpisodicReflectionConfiguration); ok {
 			var rc reflectionConfigurationModel
 			if episodicReflection.Value.NamespaceTemplates != nil {
-				rc.NamespaceTemplates, _ = fwtypes.ListOfStringValueFrom(ctx, episodicReflection.Value.NamespaceTemplates)
+				rc.NamespaceTemplates = fwflex.FlattenFrameworkStringValueListOfString(ctx, episodicReflection.Value.NamespaceTemplates)
 			}
 			state.ReflectionConfiguration, _ = fwtypes.NewListNestedObjectValueOfPtr(ctx, &rc)
 		}
@@ -681,16 +680,16 @@ func findMemoryStrategyByTwoPartKey(ctx context.Context, conn *bedrockagentcorec
 
 type memoryStrategyResourceModel struct {
 	framework.WithRegionModel
-	Configuration          fwtypes.ListNestedObjectValueOf[customConfigurationModel] `tfsdk:"configuration"`
-	Description            types.String                                              `tfsdk:"description"`
-	MemoryExecutionRoleARN fwtypes.ARN                                               `tfsdk:"memory_execution_role_arn"`
-	MemoryStrategyID       types.String                                              `tfsdk:"memory_strategy_id"`
-	MemoryID               types.String                                              `tfsdk:"memory_id"`
-	Name                   types.String                                              `tfsdk:"name"`
-	Namespaces             fwtypes.SetOfString                                       `tfsdk:"namespaces"`
-	ReflectionConfiguration  fwtypes.ListNestedObjectValueOf[reflectionConfigurationModel] `tfsdk:"reflection_configuration"`
-	Type                   fwtypes.StringEnum[awstypes.MemoryStrategyType]           `tfsdk:"type"`
-	Timeouts               timeouts.Value                                            `tfsdk:"timeouts"`
+	Configuration           fwtypes.ListNestedObjectValueOf[customConfigurationModel]     `tfsdk:"configuration"`
+	Description             types.String                                                  `tfsdk:"description"`
+	MemoryExecutionRoleARN  fwtypes.ARN                                                   `tfsdk:"memory_execution_role_arn"`
+	MemoryStrategyID        types.String                                                  `tfsdk:"memory_strategy_id"`
+	MemoryID                types.String                                                  `tfsdk:"memory_id"`
+	Name                    types.String                                                  `tfsdk:"name"`
+	Namespaces              fwtypes.SetOfString                                           `tfsdk:"namespaces"`
+	ReflectionConfiguration fwtypes.ListNestedObjectValueOf[reflectionConfigurationModel] `tfsdk:"reflection_configuration"`
+	Type                    fwtypes.StringEnum[awstypes.MemoryStrategyType]               `tfsdk:"type"`
+	Timeouts                timeouts.Value                                                `tfsdk:"timeouts"`
 }
 
 func (m *memoryStrategyResourceModel) GetIdentifier() string {
@@ -815,10 +814,10 @@ func (m memoryStrategyResourceModel) expandToModifyMemoryStrategyInput(ctx conte
 }
 
 type customConfigurationModel struct {
-	Type          fwtypes.StringEnum[awstypes.OverrideType]             `tfsdk:"type"`
-	Consolidation fwtypes.ListNestedObjectValueOf[overrideDetailsModel] `tfsdk:"consolidation"`
-	Extraction    fwtypes.ListNestedObjectValueOf[overrideDetailsModel] `tfsdk:"extraction"`
-	Reflection    fwtypes.ListNestedObjectValueOf[reflectionOverrideModel]   `tfsdk:"reflection"`
+	Type          fwtypes.StringEnum[awstypes.OverrideType]                `tfsdk:"type"`
+	Consolidation fwtypes.ListNestedObjectValueOf[overrideDetailsModel]    `tfsdk:"consolidation"`
+	Extraction    fwtypes.ListNestedObjectValueOf[overrideDetailsModel]    `tfsdk:"extraction"`
+	Reflection    fwtypes.ListNestedObjectValueOf[reflectionOverrideModel] `tfsdk:"reflection"`
 }
 
 var (
@@ -860,6 +859,7 @@ func (m *customConfigurationModel) Flatten(ctx context.Context, v any) (diags di
 					return diags
 				}
 			}
+		}
 
 		if t.Reflection != nil {
 			switch rt := t.Reflection.(type) {
@@ -879,8 +879,6 @@ func (m *customConfigurationModel) Flatten(ctx context.Context, v any) (diags di
 					}
 				}
 			}
-		}
-		}
 		}
 	default:
 		diags.AddError(
@@ -972,7 +970,6 @@ func (m customConfigurationModel) expandToModifyStrategyConfiguration(ctx contex
 			return nil, diags
 		}
 	}
-
 
 	var reflection *reflectionOverrideModel
 	if !m.Reflection.IsNull() {

--- a/internal/service/bedrockagentcore/memory_strategy.go
+++ b/internal/service/bedrockagentcore/memory_strategy.go
@@ -88,6 +88,20 @@ func (r *resourceMemoryStrategy) Schema(ctx context.Context, request resource.Sc
 				CustomType: fwtypes.SetOfStringType,
 				Required:   true,
 			},
+			"reflection_configuration": schema.ListNestedBlock{
+				CustomType: fwtypes.NewListNestedObjectTypeOf[reflectionConfigurationModel](ctx),
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"namespace_templates": schema.ListAttribute{
+							CustomType: fwtypes.ListOfStringType,
+							Optional:   true,
+						},
+					},
+				},
+			},
 			names.AttrType: schema.StringAttribute{
 				Required:   true,
 				CustomType: fwtypes.StringEnumType[awstypes.MemoryStrategyType](),
@@ -149,6 +163,29 @@ func (r *resourceMemoryStrategy) Schema(ctx context.Context, request resource.Sc
 								},
 							},
 						},
+							"reflection": schema.ListNestedBlock{
+								CustomType: fwtypes.NewListNestedObjectTypeOf[reflectionOverrideModel](ctx),
+								Validators: []validator.List{
+									listvalidator.SizeAtMost(1),
+								},
+								PlanModifiers: []planmodifier.List{
+									errorIfSingleBlockRemoved("reflection"),
+								},
+								NestedObject: schema.NestedBlockObject{
+									Attributes: map[string]schema.Attribute{
+										"append_to_prompt": schema.StringAttribute{
+											Required: true,
+										},
+										"model_id": schema.StringAttribute{
+											Required: true,
+										},
+										"namespace_templates": schema.ListAttribute{
+											CustomType: fwtypes.ListOfStringType,
+											Optional:   true,
+										},
+									},
+								},
+							},
 					},
 				},
 			},
@@ -246,11 +283,20 @@ func (r *resourceMemoryStrategy) ValidateConfig(ctx context.Context, request res
 			if c.Type.ValueEnum() == awstypes.OverrideTypeSummaryOverride && !(c.Extraction.IsNull() || c.Extraction.IsUnknown()) {
 				smerr.AddError(ctx, &response.Diagnostics, fmt.Errorf("When configuration type is `SUMMARY_OVERRIDE`, the extraction block cannot be defined."))
 			}
+			if !(data.ReflectionConfiguration.IsNull() || data.ReflectionConfiguration.IsUnknown()) {
+				smerr.AddError(ctx, &response.Diagnostics, fmt.Errorf("When type is `CUSTOM`, the reflection_configuration block must be omitted."))
+			}
 		}
 	} else {
 		if !(data.Configuration.IsNull() || data.Configuration.IsUnknown()) {
 			smerr.AddError(ctx, &response.Diagnostics, fmt.Errorf("When type is not `CUSTOM`, the configuration block must be omitted."))
 		}
+		if data.Type.ValueEnum() != awstypes.MemoryStrategyTypeEpisodic {
+			if !(data.ReflectionConfiguration.IsNull() || data.ReflectionConfiguration.IsUnknown()) {
+				smerr.AddError(ctx, &response.Diagnostics, fmt.Errorf("When type is not `EPISODIC`, the reflection_configuration block must be omitted."))
+			}
+		}
+	}
 	}
 }
 
@@ -311,6 +357,17 @@ func (r *resourceMemoryStrategy) Create(ctx context.Context, request resource.Cr
 			found.Configuration = nil
 		}
 		smerr.AddEnrich(ctx, &response.Diagnostics, fwflex.Flatten(ctx, found, &plan, fwflex.WithFieldNamePrefix("Memory")))
+
+		// Flatten reflection configuration for built-in EPISODIC type
+		if plan.Type.ValueEnum() == awstypes.MemoryStrategyTypeEpisodic && found.Configuration != nil && found.Configuration.Reflection != nil {
+			if episodicReflection, ok := found.Configuration.Reflection.(*awstypes.ReflectionConfigurationMemberEpisodicReflectionConfiguration); ok {
+				var rc reflectionConfigurationModel
+				if episodicReflection.Value.NamespaceTemplates != nil {
+					rc.NamespaceTemplates, _ = fwtypes.ListOfStringValueFrom(ctx, episodicReflection.Value.NamespaceTemplates)
+				}
+				plan.ReflectionConfiguration, _ = fwtypes.NewListNestedObjectValueOfPtr(ctx, &rc)
+			}
+		}
 		if response.Diagnostics.HasError() {
 			return
 		}
@@ -360,6 +417,19 @@ func (r *resourceMemoryStrategy) Read(ctx context.Context, request resource.Read
 	}
 
 	smerr.AddEnrich(ctx, &response.Diagnostics, fwflex.Flatten(ctx, out, &state, fwflex.WithFieldNamePrefix("Memory")))
+
+	// Flatten reflection configuration for built-in EPISODIC type.
+	// The API returns reflection config inside StrategyConfiguration, which is
+	// cleared for non-CUSTOM types before flattening. We handle it separately.
+	if state.Type.ValueEnum() == awstypes.MemoryStrategyTypeEpisodic && out.Configuration != nil && out.Configuration.Reflection != nil {
+		if episodicReflection, ok := out.Configuration.Reflection.(*awstypes.ReflectionConfigurationMemberEpisodicReflectionConfiguration); ok {
+			var rc reflectionConfigurationModel
+			if episodicReflection.Value.NamespaceTemplates != nil {
+				rc.NamespaceTemplates, _ = fwtypes.ListOfStringValueFrom(ctx, episodicReflection.Value.NamespaceTemplates)
+			}
+			state.ReflectionConfiguration, _ = fwtypes.NewListNestedObjectValueOfPtr(ctx, &rc)
+		}
+	}
 	if response.Diagnostics.HasError() {
 		return
 	}
@@ -618,6 +688,7 @@ type memoryStrategyResourceModel struct {
 	MemoryID               types.String                                              `tfsdk:"memory_id"`
 	Name                   types.String                                              `tfsdk:"name"`
 	Namespaces             fwtypes.SetOfString                                       `tfsdk:"namespaces"`
+	ReflectionConfiguration  fwtypes.ListNestedObjectValueOf[reflectionConfigurationModel] `tfsdk:"reflection_configuration"`
 	Type                   fwtypes.StringEnum[awstypes.MemoryStrategyType]           `tfsdk:"type"`
 	Timeouts               timeouts.Value                                            `tfsdk:"timeouts"`
 }
@@ -695,11 +766,27 @@ func (m memoryStrategyResourceModel) expandToMemoryStrategyInput(ctx context.Con
 		if diags.HasError() {
 			return nil, diags
 		}
-		// The API requires the reflection namespace to be the same as or a prefix
-		// of the episodic namespace. Set it to match the episodic namespaces.
-		r.Value.ReflectionConfiguration = &awstypes.EpisodicReflectionConfigurationInput{
-			Namespaces: r.Value.Namespaces,
+		// Build reflection configuration from user-provided values or defaults.
+		// If no reflection_configuration block is provided, set namespaceTemplates
+		// to match the episodic namespaces (matching the legacy default behavior).
+		reflectionConfig := &awstypes.EpisodicReflectionConfigurationInput{}
+		if !m.ReflectionConfiguration.IsNull() && !m.ReflectionConfiguration.IsUnknown() {
+			rc, rcDiags := m.ReflectionConfiguration.ToPtr(ctx)
+			smerr.AddEnrich(ctx, &diags, rcDiags)
+			if diags.HasError() {
+				return nil, diags
+			}
+			if !rc.NamespaceTemplates.IsNull() && !rc.NamespaceTemplates.IsUnknown() {
+				smerr.AddEnrich(ctx, &diags, rc.NamespaceTemplates.ElementsAs(ctx, &reflectionConfig.NamespaceTemplates, false))
+				if diags.HasError() {
+					return nil, diags
+				}
+			}
+		} else {
+			// Default: use episodic namespaces as reflection namespaces
+			reflectionConfig.Namespaces = r.Value.Namespaces
 		}
+		r.Value.ReflectionConfiguration = reflectionConfig
 		return &r, diags
 	default:
 		diags.AddError(
@@ -731,6 +818,7 @@ type customConfigurationModel struct {
 	Type          fwtypes.StringEnum[awstypes.OverrideType]             `tfsdk:"type"`
 	Consolidation fwtypes.ListNestedObjectValueOf[overrideDetailsModel] `tfsdk:"consolidation"`
 	Extraction    fwtypes.ListNestedObjectValueOf[overrideDetailsModel] `tfsdk:"extraction"`
+	Reflection    fwtypes.ListNestedObjectValueOf[reflectionOverrideModel]   `tfsdk:"reflection"`
 }
 
 var (
@@ -772,6 +860,27 @@ func (m *customConfigurationModel) Flatten(ctx context.Context, v any) (diags di
 					return diags
 				}
 			}
+
+		if t.Reflection != nil {
+			switch rt := t.Reflection.(type) {
+			case *awstypes.ReflectionConfigurationMemberCustomReflectionConfiguration:
+				if customReflection, ok := rt.Value.(*awstypes.CustomReflectionConfigurationMemberEpisodicReflectionOverride); ok {
+					var reflection reflectionOverrideModel
+					smerr.AddEnrich(ctx, &diags, fwflex.Flatten(ctx, customReflection.Value, &reflection))
+					if diags.HasError() {
+						return diags
+					}
+					if !reflection.AppendToPrompt.IsNull() && !reflection.ModelID.IsNull() {
+						m.Reflection, d = fwtypes.NewListNestedObjectValueOfPtr(ctx, &reflection)
+						smerr.AddEnrich(ctx, &diags, d)
+						if diags.HasError() {
+							return diags
+						}
+					}
+				}
+			}
+		}
+		}
 		}
 	default:
 		diags.AddError(
@@ -864,6 +973,15 @@ func (m customConfigurationModel) expandToModifyStrategyConfiguration(ctx contex
 		}
 	}
 
+
+	var reflection *reflectionOverrideModel
+	if !m.Reflection.IsNull() {
+		reflection, d = m.Reflection.ToPtr(ctx)
+		smerr.AddEnrich(ctx, &diags, d)
+		if diags.HasError() {
+			return nil, diags
+		}
+	}
 	switch m.Type.ValueEnum() {
 	case awstypes.OverrideTypeSemanticOverride:
 		if consolidation != nil {
@@ -949,6 +1067,17 @@ func (m customConfigurationModel) expandToModifyStrategyConfiguration(ctx contex
 				Value: &extractionInput,
 			}
 		}
+
+		if reflection != nil {
+			var reflectionInput awstypes.CustomReflectionConfigurationInputMemberEpisodicReflectionOverride
+			smerr.AddEnrich(ctx, &diags, fwflex.Expand(ctx, reflection, &reflectionInput.Value))
+			if diags.HasError() {
+				return nil, diags
+			}
+			result.Reflection = &awstypes.ModifyReflectionConfigurationMemberCustomReflectionConfiguration{
+				Value: &reflectionInput,
+			}
+		}
 	default:
 		diags.AddError(
 			"Unsupported Type",
@@ -962,6 +1091,18 @@ func (m customConfigurationModel) expandToModifyStrategyConfiguration(ctx contex
 type overrideDetailsModel struct {
 	AppendToPrompt types.String `tfsdk:"append_to_prompt"`
 	ModelID        types.String `tfsdk:"model_id"`
+}
+
+// reflectionConfigurationModel is the model for the built-in EPISODIC reflection_configuration block.
+type reflectionConfigurationModel struct {
+	NamespaceTemplates fwtypes.ListOfString `tfsdk:"namespace_templates"`
+}
+
+// reflectionOverrideModel is the model for the reflection block inside configuration (CUSTOM EPISODIC_OVERRIDE).
+type reflectionOverrideModel struct {
+	AppendToPrompt     types.String         `tfsdk:"append_to_prompt"`
+	ModelID            types.String         `tfsdk:"model_id"`
+	NamespaceTemplates fwtypes.ListOfString `tfsdk:"namespace_templates"`
 }
 
 var (

--- a/website/docs/r/bedrockagentcore_memory_strategy.html.markdown
+++ b/website/docs/r/bedrockagentcore_memory_strategy.html.markdown
@@ -66,6 +66,23 @@ resource "aws_bedrockagentcore_memory_strategy" "episodic" {
 }
 ```
 
+
+### Episodic Strategy with Custom Reflection Configuration
+
+```terraform
+resource "aws_bedrockagentcore_memory_strategy" "episodic_reflection" {
+  name        = "episodic-reflection-strategy"
+  memory_id   = aws_bedrockagentcore_memory.example.id
+  type        = "EPISODIC"
+  description = "Episodic strategy with custom reflection namespaces"
+  namespaces  = ["/strategies/{memoryStrategyId}/actors/{actorId}/sessions/{sessionId}"]
+
+  reflection_configuration {
+    namespace_templates = ["/strategies/{memoryStrategyId}/actors/{actorId}/reflections"]
+  }
+}
+```
+
 ### Custom Strategy with Semantic Override
 
 ```terraform
@@ -167,6 +184,40 @@ resource "aws_bedrockagentcore_memory_strategy" "custom_episodic" {
 }
 ```
 
+
+### Custom Strategy with Episodic Override and Reflection
+
+```terraform
+resource "aws_bedrockagentcore_memory_strategy" "custom_episodic_reflection" {
+  name                      = "custom-episodic-reflection-strategy"
+  memory_id                 = aws_bedrockagentcore_memory.example.id
+  memory_execution_role_arn = aws_bedrockagentcore_memory.example.memory_execution_role_arn
+  type                      = "CUSTOM"
+  description               = "Custom episodic strategy with reflection override"
+  namespaces                = ["/strategies/{memoryStrategyId}/actors/{actorId}/sessions/{sessionId}"]
+
+  configuration {
+    type = "EPISODIC_OVERRIDE"
+
+    consolidation {
+      append_to_prompt = "Consolidate episodic memories into coherent narratives"
+      model_id         = "anthropic.claude-3-sonnet-20240229-v1:0"
+    }
+
+    extraction {
+      append_to_prompt = "Extract key events and episodes from interactions"
+      model_id         = "anthropic.claude-3-haiku-20240307-v1:0"
+    }
+
+    reflection {
+      append_to_prompt    = "Identify successful patterns and recurring failure modes across episodes"
+      model_id            = "anthropic.claude-3-sonnet-20240229-v1:0"
+      namespace_templates = ["/strategies/{memoryStrategyId}/actors/{actorId}/reflections"]
+    }
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are required:
@@ -180,6 +231,7 @@ The following arguments are optional:
 
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `description` - (Optional) Description of the memory strategy.
+* `reflection_configuration` - (Optional) Reflection configuration block for built-in `EPISODIC` strategies. Controls where reflections (cross-episode insights) are stored. Must be omitted when `type` is not `EPISODIC`. See [`reflection_configuration`](#reflection_configuration) below.
 * `configuration` - (Optional) Custom configuration block. Required when `type` is `CUSTOM`, must be omitted for other types. See [`configuration`](#configuration) below.
 
 ### `configuration`
@@ -189,6 +241,7 @@ The `configuration` block supports the following:
 * `type` - (Required) Type of custom override. Valid values: `SEMANTIC_OVERRIDE`, `SUMMARY_OVERRIDE`, `USER_PREFERENCE_OVERRIDE`, `EPISODIC_OVERRIDE`. Changing this forces a new resource.
 * `consolidation` - (Optional) Consolidation configuration for processing and organizing memory content. See [`consolidation`](#consolidation) below. Once added, this block cannot be removed without recreating the resource.
 * `extraction` - (Optional) Extraction configuration for identifying and extracting relevant information. See [`extraction`](#extraction) below. Cannot be used with `type` set to `SUMMARY_OVERRIDE`. Once added, this block cannot be removed without recreating the resource.
+* `reflection` - (Optional) Reflection configuration for customizing the reflection step. Only valid when `type` is `EPISODIC_OVERRIDE`. See [`reflection`](#reflection) below. Once added, this block cannot be removed without recreating the resource.
 
 ### `consolidation`
 
@@ -203,6 +256,21 @@ The `extraction` block supports the following:
 
 * `append_to_prompt` - (Required) Additional text to append to the model prompt for extraction processing.
 * `model_id` - (Required) ID of the foundation model to use for extraction processing.
+
+### `reflection`
+
+The `reflection` block supports the following (only valid when `configuration.type` is `EPISODIC_OVERRIDE`):
+
+* `append_to_prompt` - (Required) Additional text to append to the model prompt for reflection processing.
+* `model_id` - (Required) ID of the foundation model to use for reflection processing.
+* `namespace_templates` - (Optional) Set of namespace templates where reflection records are stored. Can be less nested than episode namespaces.
+
+### `reflection_configuration`
+
+The `reflection_configuration` block supports the following (only valid when `type` is `EPISODIC`):
+
+* `namespace_templates` - (Optional) Set of namespace templates where reflection records are stored. Can be less nested than episode namespaces. If omitted, defaults to the episodic namespaces.
+
 
 ## Attribute Reference
 


### PR DESCRIPTION
## Description

Adds support for configuring reflection behavior in both built-in EPISODIC and CUSTOM EPISODIC_OVERRIDE memory strategies.

### What this PR does

The `aws_bedrockagentcore_memory_strategy` resource previously only exposed the `type = "EPISODIC"` option without allowing users to configure the reflection step — the cross-episode insight generation that produces "patterns, successful strategies, failure modes, and lessons learned."

This PR adds two new optional blocks:

**1. `reflection_configuration` block (built-in EPISODIC)**

Allows users to customize where reflection records are stored via `namespace_templates`. When omitted, defaults to using the episodic namespaces (preserving existing behavior).

```hcl
resource "aws_bedrockagentcore_memory_strategy" "episodic" {
  name       = "episodic-strategy"
  memory_id  = aws_bedrockagentcore_memory.example.id
  type       = "EPISODIC"
  namespaces = ["/strategies/{memoryStrategyId}/actors/{actorId}/sessions/{sessionId}"]

  reflection_configuration {
    namespace_templates = ["/strategies/{memoryStrategyId}/actors/{actorId}/reflections"]
  }
}
```

**2. `reflection` block inside `configuration` (CUSTOM EPISODIC_OVERRIDE)**

Allows full customization of the reflection step including `append_to_prompt`, `model_id`, and `namespace_templates`.

```hcl
resource "aws_bedrockagentcore_memory_strategy" "custom_episodic" {
  name       = "custom-episodic-strategy"
  memory_id  = aws_bedrockagentcore_memory.example.id
  type       = "CUSTOM"
  namespaces = ["/strategies/{memoryStrategyId}/actors/{actorId}/sessions/{sessionId}"]

  configuration {
    type = "EPISODIC_OVERRIDE"

    consolidation {
      append_to_prompt = "Consolidate episodic memories into coherent narratives"
      model_id         = "anthropic.claude-3-sonnet-20240229-v1:0"
    }

    extraction {
      append_to_prompt = "Extract key events and episodes from interactions"
      model_id         = "anthropic.claude-3-haiku-20240307-v1:0"
    }

    reflection {
      append_to_prompt    = "Identify successful patterns and recurring failure modes across episodes"
      model_id            = "anthropic.claude-3-sonnet-20240229-v1:0"
      namespace_templates = ["/strategies/{memoryStrategyId}/actors/{actorId}/reflections"]
    }
  }
}
```

### Changes

- **Schema**: Added `reflection_configuration` ListNestedBlock (EPISODIC only), `reflection` ListNestedBlock inside `configuration` (EPISODIC_OVERRIDE only)
- **Model**: Added `reflectionConfigurationModel` and `reflectionOverrideModel` types
- **Expand**: Updated `expandToMemoryStrategyInput` to use user-provided reflection config; updated `expandToModifyStrategyConfiguration` to handle reflection in EPISODIC_OVERRIDE
- **Flatten**: Added reflection flattening in `customConfigurationModel.Flatten` for CUSTOM types; added manual reflection flattening in Read/Create for built-in EPISODIC
- **Validation**: `reflection_configuration` only allowed with EPISODIC; `reflection` only allowed inside CUSTOM EPISODIC_OVERRIDE
- **Documentation**: Added examples for both use cases, documented all new arguments

### Affected Resource(s)

- `aws_bedrockagentcore_memory_strategy`

### References

- Closes #47938
- [AWS API: EpisodicMemoryStrategyInput](https://docs.aws.amazon.com/bedrock-agentcore-control/latest/APIReference/API_EpisodicMemoryStrategyInput.html)
- [AWS API: EpisodicReflectionConfigurationInput](https://docs.aws.amazon.com/bedrock-agentcore-control/latest/APIReference/API_EpisodicReflectionConfigurationInput.html)
- [AWS API: EpisodicOverrideReflectionConfigurationInput](https://docs.aws.amazon.com/bedrock-agentcore-control/latest/APIReference/API_EpisodicOverrideReflectionConfigurationInput.html)