### PR TITLE
feat: add deletion_protection attribute to data source aws_rds_cluster

### DIFF
--- a/.changelog/48759.txt
+++ b/.changelog/48759.txt
@@ -1,0 +1,3 @@
+``release-note:bug
+data-source/aws_rds_cluster: Add `deletion_protection` attribute
+```

--- a/internal/service/rds/cluster_data_source.go
+++ b/internal/service/rds/cluster_data_source.go
@@ -70,6 +70,10 @@ func dataSourceCluster() *schema.Resource {
 					Type:     schema.TypeString,
 					Computed: true,
 				},
+				names.AttrDeletionProtection: {
+					Type:     schema.TypeBool,
+					Computed: true,
+				},
 				"db_cluster_parameter_group_name": {
 					Type:     schema.TypeString,
 					Computed: true,
@@ -223,6 +227,7 @@ func dataSourceClusterRead(ctx context.Context, d *schema.ResourceData, meta any
 	d.Set("cluster_resource_id", dbc.DbClusterResourceId)
 	d.Set("cluster_scalability_type", dbc.ClusterScalabilityType)
 	d.Set("database_insights_mode", dbc.DatabaseInsightsMode)
+	d.Set(names.AttrDeletionProtection, aws.ToBool(dbc.DeletionProtection))
 	// Only set the DatabaseName if it is not nil. There is a known API bug where
 	// RDS accepts a DatabaseName but does not return it, causing a perpetual
 	// diff.

--- a/internal/service/rds/cluster_data_source.go
+++ b/internal/service/rds/cluster_data_source.go
@@ -227,7 +227,7 @@ func dataSourceClusterRead(ctx context.Context, d *schema.ResourceData, meta any
 	d.Set("cluster_resource_id", dbc.DbClusterResourceId)
 	d.Set("cluster_scalability_type", dbc.ClusterScalabilityType)
 	d.Set("database_insights_mode", dbc.DatabaseInsightsMode)
-	d.Set(names.AttrDeletionProtection, aws.ToBool(dbc.DeletionProtection))
+	d.Set(names.AttrDeletionProtection, dbc.DeletionProtection)
 	// Only set the DatabaseName if it is not nil. There is a known API bug where
 	// RDS accepts a DatabaseName but does not return it, causing a perpetual
 	// diff.

--- a/internal/service/rds/cluster_data_source_test.go
+++ b/internal/service/rds/cluster_data_source_test.go
@@ -30,6 +30,7 @@ func TestAccRDSClusterDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName, "backtrack_window", resourceName, "backtrack_window"),
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrClusterIdentifier, resourceName, names.AttrClusterIdentifier),
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrDatabaseName, resourceName, names.AttrDatabaseName),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrDeletionProtection, resourceName, names.AttrDeletionProtection),
 					resource.TestCheckResourceAttrPair(dataSourceName, "db_cluster_parameter_group_name", resourceName, "db_cluster_parameter_group_name"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "db_subnet_group_name", resourceName, "db_subnet_group_name"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "db_system_id", resourceName, "db_system_id"),
@@ -66,6 +67,7 @@ func TestAccRDSClusterDataSource_ManagedMasterPassword_managed(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName, "backtrack_window", resourceName, "backtrack_window"),
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrClusterIdentifier, resourceName, names.AttrClusterIdentifier),
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrDatabaseName, resourceName, names.AttrDatabaseName),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrDeletionProtection, resourceName, names.AttrDeletionProtection),
 					resource.TestCheckResourceAttrPair(dataSourceName, "db_cluster_parameter_group_name", resourceName, "db_cluster_parameter_group_name"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "db_subnet_group_name", resourceName, "db_subnet_group_name"),
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrEngine, resourceName, names.AttrEngine),
@@ -79,6 +81,35 @@ func TestAccRDSClusterDataSource_ManagedMasterPassword_managed(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName, "network_type", resourceName, "network_type"),
 					resource.TestCheckResourceAttrPair(dataSourceName, acctest.CtTagsPercent, resourceName, acctest.CtTagsPercent),
 					resource.TestCheckResourceAttrPair(dataSourceName, "tags.Name", resourceName, "tags.Name"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRDSClusterDataSource_deletionProtection(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	dataSourceName := "data.aws_rds_cluster.test"
+	resourceName := "aws_rds_cluster.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterDataSourceConfig_deletionProtection(rName, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrDeletionProtection, resourceName, names.AttrDeletionProtection),
+					resource.TestCheckResourceAttr(dataSourceName, names.AttrDeletionProtection, acctest.CtTrue),
+				),
+			},
+			{
+				Config: testAccClusterDataSourceConfig_deletionProtection(rName, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrDeletionProtection, resourceName, names.AttrDeletionProtection),
+					resource.TestCheckResourceAttr(dataSourceName, names.AttrDeletionProtection, acctest.CtFalse),
 				),
 			},
 		},
@@ -118,7 +149,6 @@ resource "aws_db_subnet_group" "test" {
   name       = %[1]q
   subnet_ids = aws_subnet.test[*].id
 }
-
 resource "aws_rds_cluster" "test" {
   cluster_identifier          = %[1]q
   database_name               = "test"
@@ -137,4 +167,28 @@ data "aws_rds_cluster" "test" {
   cluster_identifier = aws_rds_cluster.test.cluster_identifier
 }
 `, rName))
+}
+
+func testAccClusterDataSourceConfig_deletionProtection(rName string, deletionProtection bool) string {
+	return acctest.ConfigCompose(acctest.ConfigVPCWithSubnets(rName, 2), fmt.Sprintf(`
+resource "aws_db_subnet_group" "test" {
+  name       = %[1]q
+  subnet_ids = aws_subnet.test[*].id
+}
+
+resource "aws_rds_cluster" "test" {
+  cluster_identifier   = %[1]q
+  database_name        = "test"
+  engine               = "aurora-mysql"
+  master_username      = "tfacctest"
+  master_password      = "avoid-plaintext-passwords"
+  skip_final_snapshot  = true
+  db_subnet_group_name = aws_db_subnet_group.test.name
+  deletion_protection  = %[2]t
+}
+
+data "aws_rds_cluster" "test" {
+  cluster_identifier = aws_rds_cluster.test.cluster_identifier
+}
+`, rName, deletionProtection))
 }


### PR DESCRIPTION

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls are implemeted.

### Description

Add missing `deletion_protection` attribute to the data source [`aws_rds_cluster`](https://registry.terraform.io/providers/hashicorp/awS/latest/docs/data-sources/rds_cluster).

Updating the data source documentation is intentionally skipped as we have there

> See the [RDS Cluster Resource](https://registry.terraform.io/providers/hashicorp/awS/latest/docs/resources/rds_cluster) for details on the returned attributes - they are identical for all attributes, except the tags_all. If you need to get the tags for this resource, use the attribute tags as described below.

### Relations

Closes #48708

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing

```console
make testacc T=TestAccRDSClusterDataSource_ K=rds                  
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     0.308s
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework 0.191s
make: Running acceptance tests on branch: 🌿 f-rds-cluster-datasource-deletion-protection 🌿...
TF_ACC=1 go1.26.4 test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccRDSClusterDataSource_'  -timeout 360m -vet=off -buildvcs=false
2026/07/02 19:51:38 Creating Terraform AWS Provider (SDKv2-style)...
2026/07/02 19:51:38 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccRDSClusterDataSource_basic
=== PAUSE TestAccRDSClusterDataSource_basic
=== RUN   TestAccRDSClusterDataSource_ManagedMasterPassword_managed
=== PAUSE TestAccRDSClusterDataSource_ManagedMasterPassword_managed
=== RUN   TestAccRDSClusterDataSource_deletionProtection
=== PAUSE TestAccRDSClusterDataSource_deletionProtection
=== CONT  TestAccRDSClusterDataSource_basic
=== CONT  TestAccRDSClusterDataSource_deletionProtection
=== CONT  TestAccRDSClusterDataSource_ManagedMasterPassword_managed
--- PASS: TestAccRDSClusterDataSource_ManagedMasterPassword_managed (124.36s)
--- PASS: TestAccRDSClusterDataSource_basic (132.13s)
--- PASS: TestAccRDSClusterDataSource_deletionProtection (215.60s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/rds        215.755s
```
