### PR TITLE
resource/aws_sagemaker_endpoint_configuration: Add managed_instance_scaling.scale_in_policy

### DIFF
--- a/.changelog/48767.txt
+++ b/.changelog/48767.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_sagemaker_endpoint_configuration: Add `production_variants.managed_instance_scaling.scale_in_policy` and `shadow_production_variants.managed_instance_scaling.scale_in_policy` arguments
+```

--- a/internal/service/sagemaker/endpoint_configuration.go
+++ b/internal/service/sagemaker/endpoint_configuration.go
@@ -443,6 +443,34 @@ func resourceEndpointConfiguration() *schema.Resource {
 											ForceNew:     true,
 											ValidateFunc: validation.IntAtLeast(0),
 										},
+										"scale_in_policy": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											ForceNew: true,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"cooldown_in_minutes": {
+														Type:         schema.TypeInt,
+														Optional:     true,
+														ForceNew:     true,
+														ValidateFunc: validation.IntAtLeast(1),
+													},
+													"maximum_step_size": {
+														Type:         schema.TypeInt,
+														Optional:     true,
+														ForceNew:     true,
+														ValidateFunc: validation.IntAtLeast(1),
+													},
+													"strategy": {
+														Type:             schema.TypeString,
+														Required:         true,
+														ForceNew:         true,
+														ValidateDiagFunc: enum.Validate[awstypes.ManagedInstanceScalingScaleInStrategy](),
+													},
+												},
+											},
+										},
 										names.AttrStatus: {
 											Type:             schema.TypeString,
 											Optional:         true,
@@ -649,6 +677,34 @@ func resourceEndpointConfiguration() *schema.Resource {
 											Optional:     true,
 											ForceNew:     true,
 											ValidateFunc: validation.IntAtLeast(0),
+										},
+										"scale_in_policy": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											ForceNew: true,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"cooldown_in_minutes": {
+														Type:         schema.TypeInt,
+														Optional:     true,
+														ForceNew:     true,
+														ValidateFunc: validation.IntAtLeast(1),
+													},
+													"maximum_step_size": {
+														Type:         schema.TypeInt,
+														Optional:     true,
+														ForceNew:     true,
+														ValidateFunc: validation.IntAtLeast(1),
+													},
+													"strategy": {
+														Type:             schema.TypeString,
+														Required:         true,
+														ForceNew:         true,
+														ValidateDiagFunc: enum.Validate[awstypes.ManagedInstanceScalingScaleInStrategy](),
+													},
+												},
+											},
 										},
 										names.AttrStatus: {
 											Type:             schema.TypeString,
@@ -1320,7 +1376,34 @@ func expandManagedInstanceScaling(configured []any) *awstypes.ProductionVariantM
 		c.MaxInstanceCount = aws.Int32(int32(v))
 	}
 
+	if v, ok := m["scale_in_policy"].([]any); ok && len(v) > 0 {
+		c.ScaleInPolicy = expandScaleInPolicy(v)
+	}
+
 	return c
+}
+
+func expandScaleInPolicy(tfList []any) *awstypes.ProductionVariantManagedInstanceScalingScaleInPolicy {
+	if len(tfList) == 0 {
+		return nil
+	}
+
+	tfMap := tfList[0].(map[string]any)
+	apiObject := &awstypes.ProductionVariantManagedInstanceScalingScaleInPolicy{}
+
+	if v, ok := tfMap["strategy"].(string); ok && v != "" {
+		apiObject.Strategy = awstypes.ManagedInstanceScalingScaleInStrategy(v)
+	}
+
+	if v, ok := tfMap["cooldown_in_minutes"].(int); ok && v > 0 {
+		apiObject.CooldownInMinutes = aws.Int32(int32(v))
+	}
+
+	if v, ok := tfMap["maximum_step_size"].(int); ok && v > 0 {
+		apiObject.MaximumStepSize = aws.Int32(int32(v))
+	}
+
+	return apiObject
 }
 
 func expandCapacityReservationConfig(tfList []any) *awstypes.ProductionVariantCapacityReservationConfig {
@@ -1489,6 +1572,30 @@ func flattenManagedInstanceScaling(apiObject *awstypes.ProductionVariantManagedI
 
 	if apiObject.MaxInstanceCount != nil {
 		tfMap["max_instance_count"] = aws.ToInt32(apiObject.MaxInstanceCount)
+	}
+
+	if apiObject.ScaleInPolicy != nil {
+		tfMap["scale_in_policy"] = flattenScaleInPolicy(apiObject.ScaleInPolicy)
+	}
+
+	return []any{tfMap}
+}
+
+func flattenScaleInPolicy(apiObject *awstypes.ProductionVariantManagedInstanceScalingScaleInPolicy) []any {
+	if apiObject == nil {
+		return []any{}
+	}
+
+	tfMap := map[string]any{
+		"strategy": apiObject.Strategy,
+	}
+
+	if apiObject.CooldownInMinutes != nil {
+		tfMap["cooldown_in_minutes"] = aws.ToInt32(apiObject.CooldownInMinutes)
+	}
+
+	if apiObject.MaximumStepSize != nil {
+		tfMap["maximum_step_size"] = aws.ToInt32(apiObject.MaximumStepSize)
 	}
 
 	return []any{tfMap}

--- a/internal/service/sagemaker/endpoint_configuration_test.go
+++ b/internal/service/sagemaker/endpoint_configuration_test.go
@@ -968,7 +968,6 @@ func TestAccSageMakerEndpointConfiguration_ProductionVariants_managedInstanceSca
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, "production_variants.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "production_variants.0.variant_name", "variant-1"),
-					resource.TestCheckResourceAttr(resourceName, "production_variants.0.model_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "production_variants.0.initial_instance_count", "1"),
 					resource.TestCheckResourceAttr(resourceName, "production_variants.0.instance_type", "ml.g5.4xlarge"),
 					resource.TestCheckResourceAttr(resourceName, "production_variants.0.managed_instance_scaling.0.status", "ENABLED"),
@@ -1003,12 +1002,48 @@ func TestAccSageMakerEndpointConfiguration_ProductionVariants_managedInstanceSca
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, "production_variants.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "production_variants.0.variant_name", "variant-1"),
-					resource.TestCheckResourceAttr(resourceName, "production_variants.0.model_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "production_variants.0.initial_instance_count", "1"),
 					resource.TestCheckResourceAttr(resourceName, "production_variants.0.instance_type", "ml.g5.4xlarge"),
 					resource.TestCheckResourceAttr(resourceName, "production_variants.0.managed_instance_scaling.0.status", "ENABLED"),
 					resource.TestCheckResourceAttr(resourceName, "production_variants.0.managed_instance_scaling.0.min_instance_count", "0"),
 					resource.TestCheckResourceAttr(resourceName, "production_variants.0.managed_instance_scaling.0.max_instance_count", "2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccSageMakerEndpointConfiguration_ProductionVariants_scaleInPolicy(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_sagemaker_endpoint_configuration.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SageMakerServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEndpointConfigurationDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEndpointConfigurationConfig_productionVariantsScaleInPolicy(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckEndpointConfigurationExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					resource.TestCheckResourceAttr(resourceName, "production_variants.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "production_variants.0.variant_name", "variant-1"),
+					resource.TestCheckResourceAttr(resourceName, "production_variants.0.instance_type", "ml.g5.xlarge"),
+					resource.TestCheckResourceAttr(resourceName, "production_variants.0.managed_instance_scaling.0.status", "ENABLED"),
+					resource.TestCheckResourceAttr(resourceName, "production_variants.0.managed_instance_scaling.0.min_instance_count", "1"),
+					resource.TestCheckResourceAttr(resourceName, "production_variants.0.managed_instance_scaling.0.max_instance_count", "3"),
+					resource.TestCheckResourceAttr(resourceName, "production_variants.0.managed_instance_scaling.0.scale_in_policy.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "production_variants.0.managed_instance_scaling.0.scale_in_policy.0.strategy", "CONSOLIDATION"),
+					resource.TestCheckResourceAttr(resourceName, "production_variants.0.managed_instance_scaling.0.scale_in_policy.0.cooldown_in_minutes", "30"),
+					resource.TestCheckResourceAttr(resourceName, "production_variants.0.managed_instance_scaling.0.scale_in_policy.0.maximum_step_size", "2"),
 				),
 			},
 			{
@@ -1815,113 +1850,36 @@ resource "aws_sagemaker_endpoint_configuration" "test" {
 }
 
 func testAccEndpointConfigurationConfig_productionVariantsManagedInstanceScaling(rName string, min int) string {
-	return acctest.ConfigCompose(fmt.Sprintf(`
-data "aws_region" "current" {}
+	return fmt.Sprintf(`
 data "aws_partition" "current" {}
-data "aws_sagemaker_prebuilt_ecr_image" "managed_instance_scaling_test" {
-  repository_name = "djl-inference"
-  image_tag       = "0.27.0-deepspeed0.12.6-cu121"
-}
 
-data "aws_iam_policy_document" "managed_instance_scaling_test_policy" {
-  statement {
-    effect = "Allow"
-
-    actions = [
-      "cloudwatch:PutMetricData",
-      "logs:CreateLogStream",
-      "logs:PutLogEvents",
-      "logs:CreateLogGroup",
-      "logs:DescribeLogStreams",
-      "ecr:GetAuthorizationToken",
-      "ecr:BatchCheckLayerAvailability",
-      "ecr:GetDownloadUrlForLayer",
-      "ecr:BatchGetImage",
+resource "aws_iam_role" "test" {
+  name = %[1]q
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "sagemaker.amazonaws.com"
+        }
+      },
     ]
-
-    resources = [
-      "*",
-    ]
-  }
-
-  statement {
-    effect = "Allow"
-
-    actions = [
-      "s3:GetObject",
-      "s3:ListBucket",
-    ]
-
-    resources = [
-      aws_s3_bucket.managed_instance_scaling_test.arn,
-      "${aws_s3_bucket.managed_instance_scaling_test.arn}/*",
-    ]
-  }
+  })
 }
 
-resource "aws_iam_policy" "managed_instance_scaling_test" {
-  name        = %[1]q
-  description = "Allow SageMaker AI to create model"
-  policy      = data.aws_iam_policy_document.managed_instance_scaling_test_policy.json
-}
-
-resource "aws_iam_role" "managed_instance_scaling_test" {
-  name               = %[1]q
-  path               = "/"
-  assume_role_policy = data.aws_iam_policy_document.assume_role.json
-}
-
-data "aws_iam_policy_document" "assume_role" {
-  statement {
-    actions = ["sts:AssumeRole"]
-
-    principals {
-      type        = "Service"
-      identifiers = ["sagemaker.amazonaws.com"]
-    }
-  }
-}
-
-resource "aws_iam_role_policy_attachment" "managed_instance_scaling_test" {
-  role       = aws_iam_role.managed_instance_scaling_test.name
-  policy_arn = aws_iam_policy.managed_instance_scaling_test.arn
-}
-
-resource "aws_s3_bucket" "managed_instance_scaling_test" {
-  bucket        = %[1]q
-  force_destroy = true
-}
-
-resource "aws_s3_object" "managed_instance_scaling_test" {
-  bucket  = aws_s3_bucket.managed_instance_scaling_test.bucket
-  key     = "model/inference.py"
-  content = "some-data"
-}
-
-resource "aws_sagemaker_model" "managed_instance_scaling_test" {
-  name               = %[1]q
-  execution_role_arn = aws_iam_role.managed_instance_scaling_test.arn
-  primary_container {
-    image = data.aws_sagemaker_prebuilt_ecr_image.managed_instance_scaling_test.registry_path
-    model_data_source {
-      s3_data_source {
-        s3_data_type     = "S3Prefix"
-        s3_uri           = "s3://${aws_s3_object.managed_instance_scaling_test.bucket}/model/"
-        compression_type = "None"
-      }
-    }
-  }
-  depends_on = [
-    aws_iam_role_policy_attachment.managed_instance_scaling_test
-  ]
+resource "aws_iam_role_policy_attachment" "test" {
+  role       = aws_iam_role.test.name
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonSageMakerFullAccess"
 }
 
 resource "aws_sagemaker_endpoint_configuration" "test" {
-  name = %[1]q
+  name               = %[1]q
+  execution_role_arn = aws_iam_role.test.arn
 
   production_variants {
     variant_name           = "variant-1"
-    model_name             = aws_sagemaker_model.managed_instance_scaling_test.name
     initial_instance_count = 1
     instance_type          = "ml.g5.4xlarge"
 
@@ -1930,16 +1888,67 @@ resource "aws_sagemaker_endpoint_configuration" "test" {
       min_instance_count = %[2]d
       max_instance_count = 2
     }
+  }
+
+  depends_on = [aws_iam_role_policy_attachment.test]
+}
+`, rName, min)
+}
+
+func testAccEndpointConfigurationConfig_productionVariantsScaleInPolicy(rName string) string {
+	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+resource "aws_iam_role" "test" {
+  name = %[1]q
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "sagemaker.amazonaws.com"
+        }
+      },
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "test" {
+  role       = aws_iam_role.test.name
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonSageMakerFullAccess"
+}
+
+resource "aws_sagemaker_endpoint_configuration" "test" {
+  name               = %[1]q
+  execution_role_arn = aws_iam_role.test.arn
+
+  production_variants {
+    variant_name           = "variant-1"
+    initial_instance_count = 1
+    instance_type          = "ml.g5.xlarge"
+
+    managed_instance_scaling {
+      status             = "ENABLED"
+      min_instance_count = 1
+      max_instance_count = 3
+
+      scale_in_policy {
+        strategy            = "CONSOLIDATION"
+        cooldown_in_minutes = 30
+        maximum_step_size   = 2
+      }
+    }
 
     routing_config {
       routing_strategy = "LEAST_OUTSTANDING_REQUESTS"
     }
-
-    model_data_download_timeout_in_seconds            = 60
-    container_startup_health_check_timeout_in_seconds = 60
   }
+
+  depends_on = [aws_iam_role_policy_attachment.test]
 }
-`, rName, min))
+`, rName)
 }
 
 func testAccEndpointConfigurationConfig_ProductionVariants_optionalModelName(rName string) string {

--- a/website/docs/r/sagemaker_endpoint_configuration.html.markdown
+++ b/website/docs/r/sagemaker_endpoint_configuration.html.markdown
@@ -89,7 +89,14 @@ This resource supports the following arguments:
 
 * `max_instance_count` - (Optional) Maximum number of instances that the endpoint can provision when it scales up to accommodate an increase in traffic.
 * `min_instance_count` - (Optional) Minimum number of instances that the endpoint must retain when it scales down to accommodate a decrease in traffic.
+* `scale_in_policy` - (Optional) Configures the scale-in behavior for managed instance scaling. See [scale_in_policy](#scale_in_policy) below.
 * `status` - (Optional) Whether managed instance scaling is enabled. Valid values are `ENABLED` and `DISABLED`.
+
+##### scale_in_policy
+
+* `strategy` - (Required) The strategy for scaling in instances. Valid values are `IDLE_RELEASE` and `CONSOLIDATION`. `IDLE_RELEASE` releases instances that have no hosted inference component copies. `CONSOLIDATION` consolidates inference component copies onto fewer instances to release more instances.
+* `cooldown_in_minutes` - (Optional) The cooldown period, in minutes, after the last endpoint operation before the endpoint evaluates consolidation scale-in opportunities. Default: `20`.
+* `maximum_step_size` - (Optional) The maximum number of instances that the endpoint can terminate at a time during a consolidation scale-in operation. Default: `1`.
 
 ### data_capture_config
 


### PR DESCRIPTION
Community Note

- Please vote on this PR by adding a 👍 reaction to the original PR to help the community and maintainers prioritize this request.
- Please do not leave "+1" or "me too" comments, they generate extra noise for PR reviewers.

### Description

Adds support for `scale_in_policy` on the `managed_instance_scaling` block of production variants (both `production_variants` and `shadow_production_variants`) on `aws_sagemaker_endpoint_configuration`. Configures scale-in behavior for managed instance scaling with:

- `strategy` (Required) — `IDLE_RELEASE` or `CONSOLIDATION`
- `cooldown_in_minutes` (Optional) — Cooldown period before evaluating consolidation scale-in. Valid values >= 1.
- `maximum_step_size` (Optional) — Max instances to terminate per consolidation scale-in. Valid values >= 1.

> **Note:** This PR originally also included `capacity_reservation_config`, which has since been added to `main` via #45926. That portion has been dropped and this PR rebased onto the latest `main`.

Additionally, this PR fixes pre-existing test failures in `TestAccSageMakerEndpointConfiguration_ProductionVariants_managedInstanceScaling` and `TestAccSageMakerEndpointConfiguration_ProductionVariants_managedInstanceScalingZero`. These tests were using `model_name` with `managed_instance_scaling`, which the API now rejects with: `ManagedInstanceScaling is only supported for inference component endpoints`. This is an undocumented API constraint added after the original tests were merged (PR #35479). Fixed by converting the tests to the Inference Components endpoint pattern (no `model_name`, with `execution_role_arn`).

Closes #48739

### PR Checklist

- [x] Acceptance test coverage for new behavior
- [x] Documentation update in `website/docs/r/`
- [x] Changelog entry in `.changelog/`
- [x] No dependency updates
- [x] Pre-existing test failures fixed

### New/Affected Resource(s)

- `aws_sagemaker_endpoint_configuration`

### Acceptance test output

```
--- PASS: TestAccSageMakerEndpointConfiguration_ProductionVariants_scaleInPolicy (33.73s)
--- PASS: TestAccSageMakerEndpointConfiguration_ProductionVariants_managedInstanceScaling (35.34s)
--- PASS: TestAccSageMakerEndpointConfiguration_ProductionVariants_managedInstanceScalingZero (33.62s)
```