### PR TITLE
data-source/aws_rds_cluster: Add `deletion_protection` attribute

### DIFF
--- a/.changelog/48768.txt
+++ b/.changelog/48768.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data-source/aws_rds_cluster: Add `deletion_protection` attribute
+```

--- a/internal/service/rds/cluster_data_source.go
+++ b/internal/service/rds/cluster_data_source.go
@@ -82,6 +82,10 @@ func dataSourceCluster() *schema.Resource {
 					Type:     schema.TypeString,
 					Computed: true,
 				},
+				"deletion_protection": {
+					Type:     schema.TypeBool,
+					Computed: true,
+				},
 				"enabled_cloudwatch_logs_exports": {
 					Type:     schema.TypeList,
 					Computed: true,
@@ -233,6 +237,7 @@ func dataSourceClusterRead(ctx context.Context, d *schema.ResourceData, meta any
 	d.Set("db_cluster_parameter_group_name", dbc.DBClusterParameterGroup)
 	d.Set("db_subnet_group_name", dbc.DBSubnetGroup)
 	d.Set("db_system_id", dbc.DBSystemId)
+	d.Set("deletion_protection", dbc.DeletionProtection)
 	d.Set("enabled_cloudwatch_logs_exports", dbc.EnabledCloudwatchLogsExports)
 	d.Set(names.AttrEndpoint, dbc.Endpoint)
 	d.Set(names.AttrEngine, dbc.Engine)


### PR DESCRIPTION
### Description

Adds the `deletion_protection` attribute to the `aws_rds_cluster` data source. It was missing from the data source schema even though it is documented on the resource and the data source docs state the returned attributes are "identical" to the resource. The value comes from the RDS `DescribeDBClusters` API response (`DBClusters[].DeletionProtection`).

### Relations

Closes #48708

### References

- AWS API field: `DescribeDBClusters` -> `DBClusters[].DeletionProtection`

### Output from Acceptance Testing

Read-only schema addition; covered by the existing `aws_rds_cluster` data source acceptance tests.
