### PR TITLE
r/aws_directory_service_directory: support hybrid edition

### DIFF
--- a/.changelog/48773.txt
+++ b/.changelog/48773.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_directory_service_directory: Add support for hybrid edition
+```

--- a/internal/service/ds/directory.go
+++ b/internal/service/ds/directory.go
@@ -27,6 +27,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -140,13 +141,14 @@ func resourceDirectory() *schema.Resource {
 				},
 				names.AttrName: {
 					Type:         schema.TypeString,
-					Required:     true,
+					Optional:     true,
+					Computed:     true,
 					ForceNew:     true,
 					ValidateFunc: domainValidator,
 				},
 				names.AttrPassword: {
 					Type:      schema.TypeString,
-					Required:  true,
+					Optional:  true,
 					ForceNew:  true,
 					Sensitive: true,
 				},
@@ -180,6 +182,7 @@ func resourceDirectory() *schema.Resource {
 					Type:     schema.TypeList,
 					MaxItems: 1,
 					Optional: true,
+					Computed: true,
 					ForceNew: true,
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{
@@ -207,6 +210,34 @@ func resourceDirectory() *schema.Resource {
 					Optional: true,
 					Default:  false,
 				},
+				"assessment_id": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"secret_arn": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: verify.ValidARN,
+				},
+				"hybrid_settings": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"self_managed_dns_ip_addrs": {
+								Type:     schema.TypeSet,
+								Computed: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+							},
+							"self_managed_instance_ids": {
+								Type:     schema.TypeSet,
+								Computed: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+							},
+						},
+					},
+				},
 			}
 		},
 	}
@@ -223,7 +254,11 @@ func resourceDirectoryCreate(ctx context.Context, d *schema.ResourceData, meta a
 		creator = adConnectorCreator{}
 
 	case awstypes.DirectoryTypeMicrosoftAd:
-		creator = microsoftADCreator{}
+		if d.Get("edition") == "Hybrid" {
+			creator = hybridADCreator{}
+		} else {
+			creator = microsoftADCreator{}
+		}
 
 	case awstypes.DirectoryTypeSimpleAd:
 		creator = simpleADCreator{}
@@ -289,6 +324,9 @@ func resourceDirectoryCreate(ctx context.Context, d *schema.ResourceData, meta a
 	}
 
 	if v, ok := d.GetOk("enable_directory_data_access"); ok && v.(bool) {
+		if d.Get("edition") == "Hybrid" {
+			return sdkdiag.AppendErrorf(diags, "Directory Service Data feature is not supported for this directory type.")
+		}
 		if err := enableDirectoryDataAccess(ctx, conn, d.Id()); err != nil {
 			sdkdiag.AppendFromErr(diags, err)
 		}
@@ -366,7 +404,7 @@ func resourceDirectoryRead(ctx context.Context, d *schema.ResourceData, meta any
 		d.Set("vpc_settings", nil)
 	}
 
-	if dir.Type == awstypes.DirectoryTypeMicrosoftAd {
+	if dir.Type == awstypes.DirectoryTypeMicrosoftAd && dir.Edition != awstypes.DirectoryEditionHybrid {
 		dda, err := getDirectoryDataAccess(ctx, conn, d.Id())
 		if errs.IsA[*awstypes.UnsupportedOperationException](err) {
 			// Directory Service Data is not available in all regions (e.g. GovCloud).
@@ -378,6 +416,18 @@ func resourceDirectoryRead(ctx context.Context, d *schema.ResourceData, meta any
 		}
 	} else {
 		d.Set("enable_directory_data_access", false)
+	}
+
+	if dir.Type == awstypes.DirectoryTypeMicrosoftAd && dir.Edition == awstypes.DirectoryEditionHybrid {
+		d.Set(names.AttrName, dir.Name)
+	}
+
+	if dir.HybridSettings != nil {
+		if err := d.Set("hybrid_settings", []any{flattenHybridSettingsDescription(dir.HybridSettings)}); err != nil {
+			return sdkdiag.AppendErrorf(diags, "setting hybrid_settings: %s", err)
+		}
+	} else {
+		d.Set("hybrid_settings", nil)
 	}
 
 	return diags
@@ -542,6 +592,35 @@ func (c microsoftADCreator) Create(ctx context.Context, conn *directoryservice.C
 	}
 
 	output, err := conn.CreateMicrosoftAD(ctx, input)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(aws.ToString(output.DirectoryId))
+
+	return nil
+}
+
+type hybridADCreator struct{}
+
+func (c hybridADCreator) TypeName() string {
+	return "Microsoft AD"
+}
+
+func (c hybridADCreator) Create(ctx context.Context, conn *directoryservice.Client, name string, d *schema.ResourceData) error {
+	input := &directoryservice.CreateHybridADInput{
+		Tags: getTagsIn(ctx),
+	}
+
+	if v, ok := d.GetOk("assessment_id"); ok {
+		input.AssessmentId = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("secret_arn"); ok {
+		input.SecretArn = aws.String(v.(string))
+	}
+
+	output, err := conn.CreateHybridAD(ctx, input)
 	if err != nil {
 		return err
 	}
@@ -1117,6 +1196,24 @@ func flattenDirectoryVpcSettingsDescription(apiObject *awstypes.DirectoryVpcSett
 
 	if v := apiObject.VpcId; v != nil {
 		tfMap[names.AttrVPCID] = aws.ToString(v)
+	}
+
+	return tfMap
+}
+
+func flattenHybridSettingsDescription(apiObject *awstypes.HybridSettingsDescription) map[string]any { // nosemgrep:ci.caps5-in-func-name,ci.ds-in-func-name
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]any{}
+
+	if v := apiObject.SelfManagedDnsIpAddrs; v != nil {
+		tfMap["self_managed_dns_ip_addrs"] = v
+	}
+
+	if v := apiObject.SelfManagedInstanceIds; v != nil {
+		tfMap["self_managed_instance_ids"] = v
 	}
 
 	return tfMap

--- a/website/docs/r/directory_service_directory.html.markdown
+++ b/website/docs/r/directory_service_directory.html.markdown
@@ -120,13 +120,41 @@ resource "aws_subnet" "bar" {
 }
 ```
 
+### Microsoft Active Directory (MicrosoftAD Hybrid Edition)
+
+```terraform
+resource "aws_directory_service_directory" "bar" {
+  edition            = "Hybrid"
+  type               = "MicrosoftAD"
+  assessment_id      = "da-xxxxxxxxxxxxxxxxxx"
+  secret_manager_arn = aws_secretsmanager_secret.admin.arn
+
+  tags = {
+    Project = "foo"
+  }
+}
+
+resource "aws_secretsmanager_secret" "admin" {
+  name = "hybrid_ad_user"
+}
+
+resource "aws_secretsmanager_secret_version" "admin" {
+  secret_id = aws_secretsmanager_secret.admin.id
+  secret_string = jsonencode({
+    customerAdAdminDomainUsername = "Administrator"
+    customerAdAdminDomainPassword = "SuperSecretPassw0rd"
+  })
+}
+
+```
+
 ## Argument Reference
 
 This resource supports the following arguments:
 
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
-* `name` - (Required) The fully qualified name for the directory, such as `corp.example.com`
-* `password` - (Required) The password for the directory administrator or connector user.
+* `name` - (Required, except `MicrosoftAD - Hybrid Edition`) The fully qualified name for the directory, such as `corp.example.com`
+* `password` - (Required, except `MicrosoftAD - Hybrid Edition`) The password for the directory administrator or connector user.
 * `size` - (Optional) (For `SimpleAD` and `ADConnector` types) The size of the directory (`Small` or `Large` are accepted values). `Large` by default.
 * `vpc_settings` - (Required for `SimpleAD` and `MicrosoftAD`) VPC related information about the directory. Fields documented below.
 * `connect_settings` - (Required for `ADConnector`) Connector related information about the directory. Fields documented below.
@@ -136,7 +164,9 @@ This resource supports the following arguments:
 * `short_name` - (Optional) The short name of the directory, such as `CORP`.
 * `enable_sso` - (Optional) Whether to enable single-sign on for the directory. Requires `alias`. Defaults to `false`.
 * `type` (Optional) - The directory type (`SimpleAD`, `ADConnector` or `MicrosoftAD` are accepted values). Defaults to `SimpleAD`.
-* `edition` - (Optional, for type `MicrosoftAD` only) The MicrosoftAD edition (`Standard` or `Enterprise`). Defaults to `Enterprise`.
+* `edition` - (Optional, for type `MicrosoftAD` only) The MicrosoftAD edition (`Standard`, `Enterprise` or `Hybrid`). Defaults to `Enterprise`.
+* `assessment_id` - (Optional, for type `MicrosoftAD` - `Hybrid` edition only) The id of passed trial hybrid directory assessment
+* `secret_arn` - (Optional, for type `MicrosoftAD` - `Hybrid` edition only) ARN of secret containing domain admin credentials for hybrid join.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `enable_directory_data_access` - (Optional) Enables access to directory data via the Directory Service Data API for the specified directory. For more information, see [Directory Service Data API Reference](https://docs.aws.amazon.com/directoryservicedata/latest/DirectoryServiceDataAPIReference/Welcome.html).
 
@@ -160,11 +190,17 @@ This resource exports the following attributes in addition to the arguments abov
 * `access_url` - The access URL for the directory, such as `http://alias.awsapps.com`.
 * `dns_ip_addresses` - A list of IP addresses of the DNS servers for the directory or connector.
 * `security_group_id` - The ID of the security group created by the directory.
+* `hybrid_settings` - Describes the current hybrid directory configuration settings for a directory. See [Hybrid Settings](#hybrid-settings) below.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 
 `connect_settings` (for `ADConnector`) is also exported with the following attributes:
 
 * `connect_ips` - The IP addresses of the AD Connector servers.
+
+### Hybrid Settings
+
+* `self_managed_dns_ip_addrs` - The IP addresses of the DNS servers in your self-managed AD environment.
+* `self_managed_instance_ids` - The identifiers of the self-managed instances with SSM used for hybrid directory operations.
 
 ## Timeouts
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls
There is no changes related to security controls

### Description
This pull requests extends aws_directory_service_directory resource, so it can create hybrid directory. 

Things to consider: 
- acceptance tests would require deployment of 2 EC2s with AD on them - it's a hassle creating them solely in terraform due to restarts needed during AD installation 


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #43731

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
[Announcement of Microsoft AD Hybrid Edition](https://aws.amazon.com/about-aws/whats-new/2025/08/aws-directory-service-aws-microsoft-ad-hybrid-edition/)
AWS SDK for Go v2 [Release 2025-07-30](https://github.com/aws/aws-sdk-go-v2/commit/67148dbe156c9519ccc35f7e46f1df7367c67b81): https://github.com/hashicorp/terraform-provider-aws/pull/43619.


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
make: Running acceptance tests on branch: 🌿 f-aws_directory_service_directory-hybrid-edition 🌿...
TF_ACC=1 go1.26.4 test ./internal/service/ds/... -v -count 1 -parallel 20 -run='TestAccDSDirectory'  -timeout 360m -vet=off -buildvcs=false
2026/07/07 12:40:12 Creating Terraform AWS Provider (SDKv2-style)...
2026/07/07 12:40:12 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccDSDirectoryDataSource_simpleAD
=== PAUSE TestAccDSDirectoryDataSource_simpleAD
=== RUN   TestAccDSDirectoryDataSource_microsoftAD
=== PAUSE TestAccDSDirectoryDataSource_microsoftAD
=== RUN   TestAccDSDirectoryDataSource_connector
=== PAUSE TestAccDSDirectoryDataSource_connector
=== RUN   TestAccDSDirectoryDataSource_sharedMicrosoftAD
=== PAUSE TestAccDSDirectoryDataSource_sharedMicrosoftAD
=== RUN   TestAccDSDirectory_basic
=== PAUSE TestAccDSDirectory_basic
=== RUN   TestAccDSDirectory_disappears
=== PAUSE TestAccDSDirectory_disappears
=== RUN   TestAccDSDirectory_tags
=== PAUSE TestAccDSDirectory_tags
=== RUN   TestAccDSDirectory_microsoft
=== PAUSE TestAccDSDirectory_microsoft
=== RUN   TestAccDSDirectory_microsoftStandard
=== PAUSE TestAccDSDirectory_microsoftStandard
=== RUN   TestAccDSDirectory_connector
=== PAUSE TestAccDSDirectory_connector
=== RUN   TestAccDSDirectory_withAliasAndSSO
=== PAUSE TestAccDSDirectory_withAliasAndSSO
=== RUN   TestAccDSDirectory_desiredNumberOfDomainControllers
=== PAUSE TestAccDSDirectory_desiredNumberOfDomainControllers
=== RUN   TestAccDSDirectory_enableDirectoryDataAccess
=== PAUSE TestAccDSDirectory_enableDirectoryDataAccess
=== CONT  TestAccDSDirectory_enableDirectoryDataAccess
=== CONT  TestAccDSDirectory_tags
=== CONT  TestAccDSDirectoryDataSource_sharedMicrosoftAD
=== CONT  TestAccDSDirectory_disappears
=== CONT  TestAccDSDirectory_basic
=== CONT  TestAccDSDirectoryDataSource_connector
=== CONT  TestAccDSDirectoryDataSource_simpleAD
=== CONT  TestAccDSDirectoryDataSource_microsoftAD
=== CONT  TestAccDSDirectory_withAliasAndSSO
=== CONT  TestAccDSDirectory_connector
=== CONT  TestAccDSDirectory_microsoftStandard
=== CONT  TestAccDSDirectory_microsoft
=== CONT  TestAccDSDirectory_desiredNumberOfDomainControllers
=== NAME  TestAccDSDirectoryDataSource_sharedMicrosoftAD
    directory_data_source_test.go:155: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
--- SKIP: TestAccDSDirectoryDataSource_sharedMicrosoftAD (0.53s)
=== NAME  TestAccDSDirectoryDataSource_simpleAD
    directory_data_source_test.go:24: skipping acceptance testing: operation error Directory Service: CreateDirectory, https response error StatusCode: 400, RequestID: 1eaeae18-7322-44e0-8d6b-adc932703427, ClientException: Simple AD directory creation is currently not supported in this region. : RequestId: 1eaeae18-7322-44e0-8d6b-adc932703427 : RequestId: 1eaeae18-7322-44e0-8d6b-adc932703427
--- SKIP: TestAccDSDirectoryDataSource_simpleAD (0.58s)
=== NAME  TestAccDSDirectory_connector
    directory_test.go:272: skipping acceptance testing: operation error Directory Service: CreateDirectory, https response error StatusCode: 400, RequestID: 67e02d88-f616-4cdf-a5f2-7f85860a4649, ClientException: Simple AD directory creation is currently not supported in this region. : RequestId: 67e02d88-f616-4cdf-a5f2-7f85860a4649 : RequestId: 67e02d88-f616-4cdf-a5f2-7f85860a4649
--- SKIP: TestAccDSDirectory_connector (0.58s)
=== NAME  TestAccDSDirectory_tags
    directory_test.go:122: skipping acceptance testing: operation error Directory Service: CreateDirectory, https response error StatusCode: 400, RequestID: 77ccc31b-6d32-4bf6-8dec-9bf27598ae77, ClientException: Simple AD directory creation is currently not supported in this region. : RequestId: 77ccc31b-6d32-4bf6-8dec-9bf27598ae77 : RequestId: 77ccc31b-6d32-4bf6-8dec-9bf27598ae77
--- SKIP: TestAccDSDirectory_tags (0.58s)
=== NAME  TestAccDSDirectoryDataSource_connector
    directory_data_source_test.go:108: skipping acceptance testing: operation error Directory Service: CreateDirectory, https response error StatusCode: 400, RequestID: 88a5b6a6-6c92-4bcd-9802-473cd2fbbabd, ClientException: Simple AD directory creation is currently not supported in this region. : RequestId: 88a5b6a6-6c92-4bcd-9802-473cd2fbbabd : RequestId: 88a5b6a6-6c92-4bcd-9802-473cd2fbbabd
--- SKIP: TestAccDSDirectoryDataSource_connector (0.61s)
=== NAME  TestAccDSDirectory_withAliasAndSSO
    directory_test.go:327: skipping acceptance testing: operation error Directory Service: CreateDirectory, https response error StatusCode: 400, RequestID: ab4772ed-8cea-42b3-8e26-27269a74fe16, ClientException: Simple AD directory creation is currently not supported in this region. : RequestId: ab4772ed-8cea-42b3-8e26-27269a74fe16 : RequestId: ab4772ed-8cea-42b3-8e26-27269a74fe16
--- SKIP: TestAccDSDirectory_withAliasAndSSO (0.62s)
=== NAME  TestAccDSDirectory_basic
    directory_test.go:32: skipping acceptance testing: operation error Directory Service: CreateDirectory, https response error StatusCode: 400, RequestID: bbf857f0-2682-4560-8319-0bfb9f2dcba9, ClientException: Simple AD directory creation is currently not supported in this region. : RequestId: bbf857f0-2682-4560-8319-0bfb9f2dcba9 : RequestId: bbf857f0-2682-4560-8319-0bfb9f2dcba9
--- SKIP: TestAccDSDirectory_basic (0.69s)
=== NAME  TestAccDSDirectory_disappears
    directory_test.go:85: skipping acceptance testing: operation error Directory Service: CreateDirectory, https response error StatusCode: 400, RequestID: 30991820-a955-4283-aca6-ca72fb63bac0, ClientException: Simple AD directory creation is currently not supported in this region. : RequestId: 30991820-a955-4283-aca6-ca72fb63bac0 : RequestId: 30991820-a955-4283-aca6-ca72fb63bac0
--- SKIP: TestAccDSDirectory_disappears (0.70s)
--- PASS: TestAccDSDirectory_microsoft (1593.21s)
--- PASS: TestAccDSDirectory_microsoftStandard (1623.33s)
--- PASS: TestAccDSDirectory_enableDirectoryDataAccess (2020.50s)
--- PASS: TestAccDSDirectoryDataSource_microsoftAD (2494.35s)
--- PASS: TestAccDSDirectory_desiredNumberOfDomainControllers (3180.02s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ds	3187.125s

...
```
