### PR TITLE
New data sources: `aws_elasticache_clusters`, `aws_elasticache_replication_groups`

### DIFF
--- a/.changelog/48779.txt
+++ b/.changelog/48779.txt
@@ -1,0 +1,7 @@
+```release-note:new-data-source
+aws_elasticache_clusters
+```
+
+```release-note:new-data-source
+aws_elasticache_replication_groups
+```

--- a/internal/service/elasticache/clusters_data_source.go
+++ b/internal/service/elasticache/clusters_data_source.go
@@ -65,7 +65,7 @@ func (d *clustersDataSource) Read(ctx context.Context, request datasource.ReadRe
 	})
 
 	data.ID = types.StringValue(d.Meta().Region(ctx))
-	data.ClusterIDs = fwflex.FlattenFrameworkStringValueListOfString(ctx, clusterIDs)
+	data.ClusterIDs = fwflex.FlattenFrameworkStringValueListOfStringLegacy(ctx, clusterIDs)
 
 	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
 }

--- a/internal/service/elasticache/clusters_data_source.go
+++ b/internal/service/elasticache/clusters_data_source.go
@@ -1,0 +1,77 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package elasticache
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/elasticache"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkDataSource("aws_elasticache_clusters", name="Clusters")
+func newClustersDataSource(context.Context) (datasource.DataSourceWithConfigure, error) {
+	return &clustersDataSource{}, nil
+}
+
+type clustersDataSource struct {
+	framework.DataSourceWithModel[clustersDataSourceModel]
+}
+
+func (d *clustersDataSource) Schema(ctx context.Context, request datasource.SchemaRequest, response *datasource.SchemaResponse) {
+	response.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			names.AttrID: framework.IDAttribute(),
+			"cluster_ids": schema.ListAttribute{
+				CustomType:  fwtypes.ListOfStringType,
+				ElementType: types.StringType,
+				Computed:    true,
+			},
+		},
+	}
+}
+
+// Read is called when the provider must read data source values in order to update state.
+// Config values should be read from the ReadRequest and new state values set on the ReadResponse.
+func (d *clustersDataSource) Read(ctx context.Context, request datasource.ReadRequest, response *datasource.ReadResponse) {
+	var data clustersDataSourceModel
+
+	response.Diagnostics.Append(request.Config.Get(ctx, &data)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	conn := d.Meta().ElastiCacheClient(ctx)
+
+	input := elasticache.DescribeCacheClustersInput{}
+	output, err := findCacheClusters(ctx, conn, &input, tfslices.PredicateTrue[*awstypes.CacheCluster]())
+	if err != nil {
+		response.Diagnostics.AddError("reading ElastiCache Cache Clusters", err.Error())
+		return
+	}
+
+	clusterIDs := tfslices.ApplyToAll(output, func(v awstypes.CacheCluster) string {
+		return aws.ToString(v.CacheClusterId)
+	})
+
+	data.ID = types.StringValue(d.Meta().Region(ctx))
+	data.ClusterIDs = fwflex.FlattenFrameworkStringValueListOfString(ctx, clusterIDs)
+
+	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
+}
+
+type clustersDataSourceModel struct {
+	framework.WithRegionModel
+	ID         types.String         `tfsdk:"id"`
+	ClusterIDs fwtypes.ListOfString `tfsdk:"cluster_ids"`
+}

--- a/internal/service/elasticache/clusters_data_source_test.go
+++ b/internal/service/elasticache/clusters_data_source_test.go
@@ -29,8 +29,6 @@ func TestAccElastiCacheClustersDataSource_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClustersDataSourceConfig_basic(rName),
-				// The data source is account/region-wide, so assert membership
-				// (the created ID is present) rather than exact list equality.
 				Check: resource.ComposeAggregateTestCheckFunc(
 					acctest.CheckResourceAttrGreaterThanOrEqualValue(dataSourceName, "cluster_ids.#", 1),
 					resource.TestCheckTypeSetElemAttrPair(dataSourceName, "cluster_ids.*", resourceName, "cluster_id"),
@@ -58,7 +56,6 @@ func TestAccElastiCacheClustersDataSource_multiple(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClustersDataSourceConfig_multiple(rName),
-				// Each created identifier must appear in the aggregated list.
 				Check: resource.ComposeAggregateTestCheckFunc(
 					acctest.CheckResourceAttrGreaterThanOrEqualValue(dataSourceName, "cluster_ids.#", 2),
 					resource.TestCheckTypeSetElemAttrPair(dataSourceName, "cluster_ids.*", resourceName1, "cluster_id"),
@@ -84,9 +81,6 @@ func TestAccElastiCacheClustersDataSource_empty(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClustersDataSourceConfig_empty(),
-				// The read succeeds and cluster_ids is a valid list (possibly
-				// empty). In a shared account other clusters may exist, so we
-				// only assert the attribute is present and a valid list.
 				Check: resource.ComposeAggregateTestCheckFunc(
 					acctest.CheckResourceAttrGreaterThanOrEqualValue(dataSourceName, "cluster_ids.#", 0),
 					resource.TestCheckResourceAttrSet(dataSourceName, names.AttrID),
@@ -100,10 +94,10 @@ func testAccClustersDataSourceConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_elasticache_cluster" "test" {
   cluster_id      = %[1]q
-  engine          = "memcached"
+  engine          = "redis"
   node_type       = "cache.t3.small"
   num_cache_nodes = 1
-  port            = 11211
+  port            = 6379
 }
 
 data "aws_elasticache_clusters" "test" {
@@ -116,18 +110,18 @@ func testAccClustersDataSourceConfig_multiple(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_elasticache_cluster" "test1" {
   cluster_id      = "%[1]s-1"
-  engine          = "memcached"
+  engine          = "redis"
   node_type       = "cache.t3.small"
   num_cache_nodes = 1
-  port            = 11211
+  port            = 6379
 }
 
 resource "aws_elasticache_cluster" "test2" {
   cluster_id      = "%[1]s-2"
-  engine          = "memcached"
+  engine          = "redis"
   node_type       = "cache.t3.small"
   num_cache_nodes = 1
-  port            = 11211
+  port            = 6379
 }
 
 data "aws_elasticache_clusters" "test" {

--- a/internal/service/elasticache/clusters_data_source_test.go
+++ b/internal/service/elasticache/clusters_data_source_test.go
@@ -1,0 +1,143 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package elasticache_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccElastiCacheClustersDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_elasticache_cluster.test"
+	dataSourceName := "data.aws_elasticache_clusters.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClustersDataSourceConfig_basic(rName),
+				// The data source is account/region-wide, so assert membership
+				// (the created ID is present) rather than exact list equality.
+				Check: resource.ComposeAggregateTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanOrEqualValue(dataSourceName, "cluster_ids.#", 1),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, "cluster_ids.*", resourceName, "cluster_id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccElastiCacheClustersDataSource_multiple(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName1 := "aws_elasticache_cluster.test1"
+	resourceName2 := "aws_elasticache_cluster.test2"
+	dataSourceName := "data.aws_elasticache_clusters.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClustersDataSourceConfig_multiple(rName),
+				// Each created identifier must appear in the aggregated list.
+				Check: resource.ComposeAggregateTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanOrEqualValue(dataSourceName, "cluster_ids.#", 2),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, "cluster_ids.*", resourceName1, "cluster_id"),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, "cluster_ids.*", resourceName2, "cluster_id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccElastiCacheClustersDataSource_empty(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	dataSourceName := "data.aws_elasticache_clusters.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClustersDataSourceConfig_empty(),
+				// The read succeeds and cluster_ids is a valid list (possibly
+				// empty). In a shared account other clusters may exist, so we
+				// only assert the attribute is present and a valid list.
+				Check: resource.ComposeAggregateTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanOrEqualValue(dataSourceName, "cluster_ids.#", 0),
+					resource.TestCheckResourceAttrSet(dataSourceName, names.AttrID),
+				),
+			},
+		},
+	})
+}
+
+func testAccClustersDataSourceConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_elasticache_cluster" "test" {
+  cluster_id      = %[1]q
+  engine          = "memcached"
+  node_type       = "cache.t3.small"
+  num_cache_nodes = 1
+  port            = 11211
+}
+
+data "aws_elasticache_clusters" "test" {
+  depends_on = [aws_elasticache_cluster.test]
+}
+`, rName)
+}
+
+func testAccClustersDataSourceConfig_multiple(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_elasticache_cluster" "test1" {
+  cluster_id      = "%[1]s-1"
+  engine          = "memcached"
+  node_type       = "cache.t3.small"
+  num_cache_nodes = 1
+  port            = 11211
+}
+
+resource "aws_elasticache_cluster" "test2" {
+  cluster_id      = "%[1]s-2"
+  engine          = "memcached"
+  node_type       = "cache.t3.small"
+  num_cache_nodes = 1
+  port            = 11211
+}
+
+data "aws_elasticache_clusters" "test" {
+  depends_on = [aws_elasticache_cluster.test1, aws_elasticache_cluster.test2]
+}
+`, rName)
+}
+
+func testAccClustersDataSourceConfig_empty() string {
+	return `
+data "aws_elasticache_clusters" "test" {}
+`
+}

--- a/internal/service/elasticache/replication_groups_data_source.go
+++ b/internal/service/elasticache/replication_groups_data_source.go
@@ -1,0 +1,77 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package elasticache
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/elasticache"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkDataSource("aws_elasticache_replication_groups", name="Replication Groups")
+func newReplicationGroupsDataSource(context.Context) (datasource.DataSourceWithConfigure, error) {
+	return &replicationGroupsDataSource{}, nil
+}
+
+type replicationGroupsDataSource struct {
+	framework.DataSourceWithModel[replicationGroupsDataSourceModel]
+}
+
+func (d *replicationGroupsDataSource) Schema(ctx context.Context, request datasource.SchemaRequest, response *datasource.SchemaResponse) {
+	response.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			names.AttrID: framework.IDAttribute(),
+			"replication_group_ids": schema.ListAttribute{
+				CustomType:  fwtypes.ListOfStringType,
+				ElementType: types.StringType,
+				Computed:    true,
+			},
+		},
+	}
+}
+
+// Read is called when the provider must read data source values in order to update state.
+// Config values should be read from the ReadRequest and new state values set on the ReadResponse.
+func (d *replicationGroupsDataSource) Read(ctx context.Context, request datasource.ReadRequest, response *datasource.ReadResponse) {
+	var data replicationGroupsDataSourceModel
+
+	response.Diagnostics.Append(request.Config.Get(ctx, &data)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	conn := d.Meta().ElastiCacheClient(ctx)
+
+	input := elasticache.DescribeReplicationGroupsInput{}
+	output, err := findReplicationGroups(ctx, conn, &input, tfslices.PredicateTrue[*awstypes.ReplicationGroup]())
+	if err != nil {
+		response.Diagnostics.AddError("reading ElastiCache Replication Groups", err.Error())
+		return
+	}
+
+	replicationGroupIDs := tfslices.ApplyToAll(output, func(v awstypes.ReplicationGroup) string {
+		return aws.ToString(v.ReplicationGroupId)
+	})
+
+	data.ID = types.StringValue(d.Meta().Region(ctx))
+	data.ReplicationGroupIDs = fwflex.FlattenFrameworkStringValueListOfString(ctx, replicationGroupIDs)
+
+	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
+}
+
+type replicationGroupsDataSourceModel struct {
+	framework.WithRegionModel
+	ID                  types.String         `tfsdk:"id"`
+	ReplicationGroupIDs fwtypes.ListOfString `tfsdk:"replication_group_ids"`
+}

--- a/internal/service/elasticache/replication_groups_data_source.go
+++ b/internal/service/elasticache/replication_groups_data_source.go
@@ -65,7 +65,7 @@ func (d *replicationGroupsDataSource) Read(ctx context.Context, request datasour
 	})
 
 	data.ID = types.StringValue(d.Meta().Region(ctx))
-	data.ReplicationGroupIDs = fwflex.FlattenFrameworkStringValueListOfString(ctx, replicationGroupIDs)
+	data.ReplicationGroupIDs = fwflex.FlattenFrameworkStringValueListOfStringLegacy(ctx, replicationGroupIDs)
 
 	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
 }

--- a/internal/service/elasticache/replication_groups_data_source_test.go
+++ b/internal/service/elasticache/replication_groups_data_source_test.go
@@ -29,8 +29,6 @@ func TestAccElastiCacheReplicationGroupsDataSource_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReplicationGroupsDataSourceConfig_basic(rName),
-				// The data source is account/region-wide, so assert membership
-				// (the created ID is present) rather than exact list equality.
 				Check: resource.ComposeAggregateTestCheckFunc(
 					acctest.CheckResourceAttrGreaterThanOrEqualValue(dataSourceName, "replication_group_ids.#", 1),
 					resource.TestCheckTypeSetElemAttrPair(dataSourceName, "replication_group_ids.*", resourceName, "replication_group_id"),
@@ -58,7 +56,6 @@ func TestAccElastiCacheReplicationGroupsDataSource_multiple(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReplicationGroupsDataSourceConfig_multiple(rName),
-				// Each created identifier must appear in the aggregated list.
 				Check: resource.ComposeAggregateTestCheckFunc(
 					acctest.CheckResourceAttrGreaterThanOrEqualValue(dataSourceName, "replication_group_ids.#", 2),
 					resource.TestCheckTypeSetElemAttrPair(dataSourceName, "replication_group_ids.*", resourceName1, "replication_group_id"),
@@ -84,13 +81,63 @@ func TestAccElastiCacheReplicationGroupsDataSource_empty(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReplicationGroupsDataSourceConfig_empty(),
-				// The read succeeds and replication_group_ids is a valid list
-				// (possibly empty). In a shared account other replication groups
-				// may exist, so we only assert the attribute is present and a
-				// valid list.
 				Check: resource.ComposeAggregateTestCheckFunc(
 					acctest.CheckResourceAttrGreaterThanOrEqualValue(dataSourceName, "replication_group_ids.#", 0),
 					resource.TestCheckResourceAttrSet(dataSourceName, names.AttrID),
+				),
+			},
+		},
+	})
+}
+
+func TestAccElastiCacheReplicationGroupsDataSource_valkey(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_elasticache_replication_group.test"
+	dataSourceName := "data.aws_elasticache_replication_groups.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccReplicationGroupsDataSourceConfig_valkey(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanOrEqualValue(dataSourceName, "replication_group_ids.#", 1),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, "replication_group_ids.*", resourceName, "replication_group_id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccElastiCacheReplicationGroupsDataSource_valkeyMultiple(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName1 := "aws_elasticache_replication_group.test1"
+	resourceName2 := "aws_elasticache_replication_group.test2"
+	dataSourceName := "data.aws_elasticache_replication_groups.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccReplicationGroupsDataSourceConfig_valkeyMultiple(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanOrEqualValue(dataSourceName, "replication_group_ids.#", 2),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, "replication_group_ids.*", resourceName1, "replication_group_id"),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, "replication_group_ids.*", resourceName2, "replication_group_id"),
 				),
 			},
 		},
@@ -141,4 +188,47 @@ func testAccReplicationGroupsDataSourceConfig_empty() string {
 	return `
 data "aws_elasticache_replication_groups" "test" {}
 `
+}
+
+func testAccReplicationGroupsDataSourceConfig_valkey(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_elasticache_replication_group" "test" {
+  replication_group_id = %[1]q
+  description          = "test description"
+  engine               = "valkey"
+  node_type            = "cache.t3.small"
+  num_cache_clusters   = 1
+  port                 = 6379
+}
+
+data "aws_elasticache_replication_groups" "test" {
+  depends_on = [aws_elasticache_replication_group.test]
+}
+`, rName)
+}
+
+func testAccReplicationGroupsDataSourceConfig_valkeyMultiple(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_elasticache_replication_group" "test1" {
+  replication_group_id = "%[1]s-1"
+  description          = "test description"
+  engine               = "valkey"
+  node_type            = "cache.t3.small"
+  num_cache_clusters   = 1
+  port                 = 6379
+}
+
+resource "aws_elasticache_replication_group" "test2" {
+  replication_group_id = "%[1]s-2"
+  description          = "test description"
+  engine               = "valkey"
+  node_type            = "cache.t3.small"
+  num_cache_clusters   = 1
+  port                 = 6379
+}
+
+data "aws_elasticache_replication_groups" "test" {
+  depends_on = [aws_elasticache_replication_group.test1, aws_elasticache_replication_group.test2]
+}
+`, rName)
 }

--- a/internal/service/elasticache/replication_groups_data_source_test.go
+++ b/internal/service/elasticache/replication_groups_data_source_test.go
@@ -1,0 +1,144 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package elasticache_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccElastiCacheReplicationGroupsDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_elasticache_replication_group.test"
+	dataSourceName := "data.aws_elasticache_replication_groups.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccReplicationGroupsDataSourceConfig_basic(rName),
+				// The data source is account/region-wide, so assert membership
+				// (the created ID is present) rather than exact list equality.
+				Check: resource.ComposeAggregateTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanOrEqualValue(dataSourceName, "replication_group_ids.#", 1),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, "replication_group_ids.*", resourceName, "replication_group_id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccElastiCacheReplicationGroupsDataSource_multiple(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName1 := "aws_elasticache_replication_group.test1"
+	resourceName2 := "aws_elasticache_replication_group.test2"
+	dataSourceName := "data.aws_elasticache_replication_groups.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccReplicationGroupsDataSourceConfig_multiple(rName),
+				// Each created identifier must appear in the aggregated list.
+				Check: resource.ComposeAggregateTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanOrEqualValue(dataSourceName, "replication_group_ids.#", 2),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, "replication_group_ids.*", resourceName1, "replication_group_id"),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, "replication_group_ids.*", resourceName2, "replication_group_id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccElastiCacheReplicationGroupsDataSource_empty(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	dataSourceName := "data.aws_elasticache_replication_groups.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccReplicationGroupsDataSourceConfig_empty(),
+				// The read succeeds and replication_group_ids is a valid list
+				// (possibly empty). In a shared account other replication groups
+				// may exist, so we only assert the attribute is present and a
+				// valid list.
+				Check: resource.ComposeAggregateTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanOrEqualValue(dataSourceName, "replication_group_ids.#", 0),
+					resource.TestCheckResourceAttrSet(dataSourceName, names.AttrID),
+				),
+			},
+		},
+	})
+}
+
+func testAccReplicationGroupsDataSourceConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_elasticache_replication_group" "test" {
+  replication_group_id = %[1]q
+  description          = "test description"
+  node_type            = "cache.t3.small"
+  num_cache_clusters   = 1
+  port                 = 6379
+}
+
+data "aws_elasticache_replication_groups" "test" {
+  depends_on = [aws_elasticache_replication_group.test]
+}
+`, rName)
+}
+
+func testAccReplicationGroupsDataSourceConfig_multiple(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_elasticache_replication_group" "test1" {
+  replication_group_id = "%[1]s-1"
+  description          = "test description"
+  node_type            = "cache.t3.small"
+  num_cache_clusters   = 1
+  port                 = 6379
+}
+
+resource "aws_elasticache_replication_group" "test2" {
+  replication_group_id = "%[1]s-2"
+  description          = "test description"
+  node_type            = "cache.t3.small"
+  num_cache_clusters   = 1
+  port                 = 6379
+}
+
+data "aws_elasticache_replication_groups" "test" {
+  depends_on = [aws_elasticache_replication_group.test1, aws_elasticache_replication_group.test2]
+}
+`, rName)
+}
+
+func testAccReplicationGroupsDataSourceConfig_empty() string {
+	return `
+data "aws_elasticache_replication_groups" "test" {}
+`
+}

--- a/internal/service/elasticache/service_package_gen.go
+++ b/internal/service/elasticache/service_package_gen.go
@@ -23,6 +23,18 @@ type servicePackage struct{}
 func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*inttypes.ServicePackageFrameworkDataSource {
 	return []*inttypes.ServicePackageFrameworkDataSource{
 		{
+			Factory:  newClustersDataSource,
+			TypeName: "aws_elasticache_clusters",
+			Name:     "Clusters",
+			Region:   inttypes.ResourceRegionDefault(),
+		},
+		{
+			Factory:  newReplicationGroupsDataSource,
+			TypeName: "aws_elasticache_replication_groups",
+			Name:     "Replication Groups",
+			Region:   inttypes.ResourceRegionDefault(),
+		},
+		{
 			Factory:  newReservedCacheNodeOfferingDataSource,
 			TypeName: "aws_elasticache_reserved_cache_node_offering",
 			Name:     "Reserved Cache Node Offering",

--- a/website/docs/d/elasticache_clusters.html.markdown
+++ b/website/docs/d/elasticache_clusters.html.markdown
@@ -24,11 +24,13 @@ output "example" {
 
 ## Argument Reference
 
-This data source does not support any arguments.
+This data source supports the following arguments:
+
+* `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 
 ## Attribute Reference
 
 This data source exports the following attributes in addition to the arguments above:
 
-* `cluster_ids` - A list of all the ElastiCache Cache Cluster IDs found.
+* `cluster_ids` - List of all the ElastiCache Cache Cluster IDs found.
 * `id` - AWS Region.

--- a/website/docs/d/elasticache_clusters.html.markdown
+++ b/website/docs/d/elasticache_clusters.html.markdown
@@ -1,0 +1,34 @@
+---
+subcategory: "ElastiCache"
+layout: "aws"
+page_title: "AWS: aws_elasticache_clusters"
+description: |-
+    Provides a list of ElastiCache Cache Cluster IDs in a Region
+---
+
+# Data Source: aws_elasticache_clusters
+
+This resource can be useful for getting back a list of ElastiCache Cache Cluster IDs for a Region.
+
+## Example Usage
+
+The following example retrieves a list of all ElastiCache Cache Cluster IDs.
+
+```terraform
+data "aws_elasticache_clusters" "example" {}
+
+output "example" {
+  value = data.aws_elasticache_clusters.example.cluster_ids
+}
+```
+
+## Argument Reference
+
+This data source does not support any arguments.
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `cluster_ids` - A list of all the ElastiCache Cache Cluster IDs found.
+* `id` - AWS Region.

--- a/website/docs/d/elasticache_replication_groups.html.markdown
+++ b/website/docs/d/elasticache_replication_groups.html.markdown
@@ -24,11 +24,13 @@ output "example" {
 
 ## Argument Reference
 
-This data source does not support any arguments.
+This data source supports the following arguments:
+
+* `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 
 ## Attribute Reference
 
 This data source exports the following attributes in addition to the arguments above:
 
 * `id` - AWS Region.
-* `replication_group_ids` - A list of all the ElastiCache Replication Group IDs found.
+* `replication_group_ids` - List of all the ElastiCache Replication Group IDs found.

--- a/website/docs/d/elasticache_replication_groups.html.markdown
+++ b/website/docs/d/elasticache_replication_groups.html.markdown
@@ -1,0 +1,34 @@
+---
+subcategory: "ElastiCache"
+layout: "aws"
+page_title: "AWS: aws_elasticache_replication_groups"
+description: |-
+    Provides a list of ElastiCache Replication Group IDs in a Region
+---
+
+# Data Source: aws_elasticache_replication_groups
+
+This resource can be useful for getting back a list of ElastiCache Replication Group IDs for a Region.
+
+## Example Usage
+
+The following example retrieves a list of all ElastiCache Replication Group IDs.
+
+```terraform
+data "aws_elasticache_replication_groups" "example" {}
+
+output "example" {
+  value = data.aws_elasticache_replication_groups.example.replication_group_ids
+}
+```
+
+## Argument Reference
+
+This data source does not support any arguments.
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `id` - AWS Region.
+* `replication_group_ids` - A list of all the ElastiCache Replication Group IDs found.


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Adds two new plural data sources to the ElastiCache service package that list resource identifiers in the configured account and region:

- `aws_elasticache_clusters` - returns `cluster_ids`
- `aws_elasticache_replication_groups` - returns `replication_group_ids`

Both are region-scoped, take no arguments, and return identifiers only, following the `aws_db_instances` pattern. 

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #34343
Relates #33942

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=elasticache TESTS="TestAccElastiCacheClustersDataSource_|TestAccElastiCacheReplicationGroupsDataSource_" ACCTEST_PARALLELISM=1 ACCTEST_TIMEOUT=4880m
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
xargs: gofmt: No such file or directory
make: Validating schemas
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2	(cached)
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider/framework	(cached)
make: Running acceptance tests on branch: 🌿 f-elastiacache-plural-ds 🌿...
TF_ACC=1 go1.26.4 test ./internal/service/elasticache/... -v -count 1 -parallel 1 -run='TestAccElastiCacheClustersDataSource_|TestAccElastiCacheReplicationGroupsDataSource_'  -timeout 4880m -vet=off -buildvcs=false
2026/07/03 15:36:41 Creating Terraform AWS Provider (SDKv2-style)...
2026/07/03 15:36:41 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccElastiCacheClustersDataSource_basic
=== PAUSE TestAccElastiCacheClustersDataSource_basic
=== RUN   TestAccElastiCacheClustersDataSource_multiple
=== PAUSE TestAccElastiCacheClustersDataSource_multiple
=== RUN   TestAccElastiCacheClustersDataSource_empty
=== PAUSE TestAccElastiCacheClustersDataSource_empty
=== RUN   TestAccElastiCacheReplicationGroupsDataSource_basic
=== PAUSE TestAccElastiCacheReplicationGroupsDataSource_basic
=== RUN   TestAccElastiCacheReplicationGroupsDataSource_multiple
=== PAUSE TestAccElastiCacheReplicationGroupsDataSource_multiple
=== RUN   TestAccElastiCacheReplicationGroupsDataSource_empty
=== PAUSE TestAccElastiCacheReplicationGroupsDataSource_empty
=== RUN   TestAccElastiCacheReplicationGroupsDataSource_valkey
=== PAUSE TestAccElastiCacheReplicationGroupsDataSource_valkey
=== RUN   TestAccElastiCacheReplicationGroupsDataSource_valkeyMultiple
=== PAUSE TestAccElastiCacheReplicationGroupsDataSource_valkeyMultiple
=== CONT  TestAccElastiCacheClustersDataSource_basic
--- PASS: TestAccElastiCacheClustersDataSource_basic (430.08s)
=== CONT  TestAccElastiCacheReplicationGroupsDataSource_multiple
--- PASS: TestAccElastiCacheReplicationGroupsDataSource_multiple (472.86s)
=== CONT  TestAccElastiCacheReplicationGroupsDataSource_valkeyMultiple
--- PASS: TestAccElastiCacheReplicationGroupsDataSource_valkeyMultiple (683.84s)
=== CONT  TestAccElastiCacheReplicationGroupsDataSource_valkey
--- PASS: TestAccElastiCacheReplicationGroupsDataSource_valkey (593.97s)
=== CONT  TestAccElastiCacheReplicationGroupsDataSource_empty
--- PASS: TestAccElastiCacheReplicationGroupsDataSource_empty (14.79s)
=== CONT  TestAccElastiCacheClustersDataSource_multiple
--- PASS: TestAccElastiCacheClustersDataSource_multiple (430.45s)
=== CONT  TestAccElastiCacheClustersDataSource_empty
--- PASS: TestAccElastiCacheClustersDataSource_empty (14.76s)
=== CONT  TestAccElastiCacheReplicationGroupsDataSource_basic
--- PASS: TestAccElastiCacheReplicationGroupsDataSource_basic (553.23s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elasticache	3194.131s
```
