### PR TITLE
d/aws_route53profiles_profile : New Data Source

### DIFF
--- a/.changelog/48780.txt
+++ b/.changelog/48780.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_route53profiles_profile
+```

--- a/internal/service/route53profiles/profile_data_source.go
+++ b/internal/service/route53profiles/profile_data_source.go
@@ -42,15 +42,15 @@ func (d *profileDataSource) Schema(ctx context.Context, req datasource.SchemaReq
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			names.AttrARN: framework.ARNAttributeComputedOnly(),
+			names.AttrID: schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+			},
 			names.AttrName: schema.StringAttribute{
 				Optional: true,
 				Computed: true,
 			},
 			names.AttrOwnerID: schema.StringAttribute{
-				Computed: true,
-			},
-			"profile_id": schema.StringAttribute{
-				Optional: true,
 				Computed: true,
 			},
 			"share_status": schema.StringAttribute{
@@ -73,7 +73,7 @@ func (d *profileDataSource) ConfigValidators(context.Context) []datasource.Confi
 	return []datasource.ConfigValidator{
 		datasourcevalidator.ExactlyOneOf(
 			path.MatchRoot(names.AttrName),
-			path.MatchRoot("profile_id"),
+			path.MatchRoot(names.AttrID),
 		),
 	}
 }
@@ -88,7 +88,7 @@ func (d *profileDataSource) Read(ctx context.Context, req datasource.ReadRequest
 		return
 	}
 
-	id := data.ProfileID.ValueString()
+	id := data.ID.ValueString()
 	if id == "" {
 		name := data.Name.ValueString()
 		summary, err := findProfileByName(ctx, conn, name)
@@ -110,8 +110,6 @@ func (d *profileDataSource) Read(ctx context.Context, req datasource.ReadRequest
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	data.ProfileID = fwflex.StringToFramework(ctx, out.Id)
 
 	tags, err := listTags(ctx, conn, aws.ToString(out.Arn))
 	if err != nil {
@@ -148,9 +146,9 @@ func findProfileByName(ctx context.Context, conn *route53profiles.Client, name s
 type profileDataSourceModel struct {
 	framework.WithRegionModel
 	ARN           types.String                               `tfsdk:"arn"`
+	ID            types.String                               `tfsdk:"id"`
 	Name          types.String                               `tfsdk:"name"`
 	OwnerId       types.String                               `tfsdk:"owner_id"`
-	ProfileID     types.String                               `tfsdk:"profile_id"`
 	ShareStatus   fwtypes.StringEnum[awstypes.ShareStatus]   `tfsdk:"share_status"`
 	Status        fwtypes.StringEnum[awstypes.ProfileStatus] `tfsdk:"status"`
 	StatusMessage types.String                               `tfsdk:"status_message"`

--- a/internal/service/route53profiles/profile_data_source.go
+++ b/internal/service/route53profiles/profile_data_source.go
@@ -123,10 +123,10 @@ func (d *profileDataSource) Read(ctx context.Context, req datasource.ReadRequest
 }
 
 func findProfileByName(ctx context.Context, conn *route53profiles.Client, name string) (*awstypes.ProfileSummary, error) {
-	input := &route53profiles.ListProfilesInput{}
+	var input route53profiles.ListProfilesInput
 
 	var results []awstypes.ProfileSummary
-	pages := route53profiles.NewListProfilesPaginator(conn, input)
+	pages := route53profiles.NewListProfilesPaginator(conn, &input)
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
 		if err != nil {

--- a/internal/service/route53profiles/profile_data_source.go
+++ b/internal/service/route53profiles/profile_data_source.go
@@ -1,0 +1,159 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package route53profiles
+
+import (
+	"context"
+
+	"github.com/YakDriver/smarterr"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/route53profiles"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/route53profiles/types"
+	"github.com/hashicorp/terraform-plugin-framework-validators/datasourcevalidator"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/smerr"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkDataSource("aws_route53profiles_profile", name="Profile")
+// @Tags(identifierAttribute="arn")
+func newProfileDataSource(context.Context) (datasource.DataSourceWithConfigure, error) {
+	return &profileDataSource{}, nil
+}
+
+const (
+	DSNameProfile = "Profile Data Source"
+)
+
+type profileDataSource struct {
+	framework.DataSourceWithModel[profileDataSourceModel]
+}
+
+func (d *profileDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			names.AttrARN: framework.ARNAttributeComputedOnly(),
+			names.AttrName: schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+			},
+			names.AttrOwnerID: schema.StringAttribute{
+				Computed: true,
+			},
+			"profile_id": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+			},
+			"share_status": schema.StringAttribute{
+				CustomType: fwtypes.StringEnumType[awstypes.ShareStatus](),
+				Computed:   true,
+			},
+			names.AttrStatus: schema.StringAttribute{
+				CustomType: fwtypes.StringEnumType[awstypes.ProfileStatus](),
+				Computed:   true,
+			},
+			names.AttrStatusMessage: schema.StringAttribute{
+				Computed: true,
+			},
+			names.AttrTags: tftags.TagsAttributeComputedOnly(),
+		},
+	}
+}
+
+func (d *profileDataSource) ConfigValidators(context.Context) []datasource.ConfigValidator {
+	return []datasource.ConfigValidator{
+		datasourcevalidator.ExactlyOneOf(
+			path.MatchRoot(names.AttrName),
+			path.MatchRoot("profile_id"),
+		),
+	}
+}
+
+func (d *profileDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	conn := d.Meta().Route53ProfilesClient(ctx)
+	ignoreTagsConfig := d.Meta().IgnoreTagsConfig(ctx)
+
+	var data profileDataSourceModel
+	smerr.AddEnrich(ctx, &resp.Diagnostics, req.Config.Get(ctx, &data))
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	id := data.ProfileID.ValueString()
+	if id == "" {
+		name := data.Name.ValueString()
+		summary, err := findProfileByName(ctx, conn, name)
+		if err != nil {
+			smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, name)
+			return
+		}
+
+		id = aws.ToString(summary.Id)
+	}
+
+	out, err := findProfileByID(ctx, conn, id)
+	if err != nil {
+		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, id)
+		return
+	}
+
+	smerr.AddEnrich(ctx, &resp.Diagnostics, fwflex.Flatten(ctx, out, &data))
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data.ProfileID = fwflex.StringToFramework(ctx, out.Id)
+
+	// Transparent tagging doesn't work for DataSource yet.
+	tags, err := listTags(ctx, conn, aws.ToString(out.Arn))
+	if err != nil {
+		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, id)
+		return
+	}
+
+	data.Tags = tftags.NewMapFromMapValue(fwflex.FlattenFrameworkStringValueMapLegacy(ctx, tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()))
+
+	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, &data))
+}
+
+func findProfileByName(ctx context.Context, conn *route53profiles.Client, name string) (*awstypes.ProfileSummary, error) {
+	input := &route53profiles.ListProfilesInput{}
+
+	var results []awstypes.ProfileSummary
+	pages := route53profiles.NewListProfilesPaginator(conn, input)
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
+		if err != nil {
+			return nil, smarterr.NewError(err)
+		}
+
+		for _, summary := range page.ProfileSummaries {
+			if aws.ToString(summary.Name) == name {
+				results = append(results, summary)
+			}
+		}
+	}
+
+	return smarterr.Assert(tfresource.AssertSingleValueResult(results))
+}
+
+type profileDataSourceModel struct {
+	framework.WithRegionModel
+	ARN           types.String                               `tfsdk:"arn"`
+	Name          types.String                               `tfsdk:"name"`
+	OwnerId       types.String                               `tfsdk:"owner_id"`
+	ProfileID     types.String                               `tfsdk:"profile_id"`
+	ShareStatus   fwtypes.StringEnum[awstypes.ShareStatus]   `tfsdk:"share_status"`
+	Status        fwtypes.StringEnum[awstypes.ProfileStatus] `tfsdk:"status"`
+	StatusMessage types.String                               `tfsdk:"status_message"`
+	Tags          tftags.Map                                 `tfsdk:"tags"`
+}

--- a/internal/service/route53profiles/profile_data_source.go
+++ b/internal/service/route53profiles/profile_data_source.go
@@ -117,7 +117,7 @@ func (d *profileDataSource) Read(ctx context.Context, req datasource.ReadRequest
 		return
 	}
 
-	data.Tags = tftags.NewMapFromMapValue(fwflex.FlattenFrameworkStringValueMapLegacy(ctx, tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()))
+	data.Tags = tftags.FlattenStringValueMap(ctx, tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map())
 
 	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, &data))
 }

--- a/internal/service/route53profiles/profile_data_source.go
+++ b/internal/service/route53profiles/profile_data_source.go
@@ -113,7 +113,6 @@ func (d *profileDataSource) Read(ctx context.Context, req datasource.ReadRequest
 
 	data.ProfileID = fwflex.StringToFramework(ctx, out.Id)
 
-	// Transparent tagging doesn't work for DataSource yet.
 	tags, err := listTags(ctx, conn, aws.ToString(out.Arn))
 	if err != nil {
 		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, id)

--- a/internal/service/route53profiles/profile_data_source_test.go
+++ b/internal/service/route53profiles/profile_data_source_test.go
@@ -1,0 +1,105 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package route53profiles_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccRoute53ProfilesProfileDataSource_byName(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	dataSourceName := "data.aws_route53profiles_profile.test"
+	resourceName := "aws_route53profiles_profile.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.Route53ProfilesServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckProfileDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProfileDataSourceConfig_byName(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrName, resourceName, names.AttrName),
+					resource.TestCheckResourceAttrPair(dataSourceName, "profile_id", resourceName, names.AttrID),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrARN, resourceName, names.AttrARN),
+					resource.TestCheckResourceAttrSet(dataSourceName, names.AttrStatus),
+					resource.TestCheckResourceAttrSet(dataSourceName, names.AttrOwnerID),
+					resource.TestCheckResourceAttrSet(dataSourceName, "share_status"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRoute53ProfilesProfileDataSource_byID(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	dataSourceName := "data.aws_route53profiles_profile.test"
+	resourceName := "aws_route53profiles_profile.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.Route53ProfilesServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckProfileDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProfileDataSourceConfig_byID(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "profile_id", resourceName, names.AttrID),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrName, resourceName, names.AttrName),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrARN, resourceName, names.AttrARN),
+					resource.TestCheckResourceAttrSet(dataSourceName, names.AttrStatus),
+					resource.TestCheckResourceAttrSet(dataSourceName, names.AttrOwnerID),
+					resource.TestCheckResourceAttrSet(dataSourceName, "share_status"),
+				),
+			},
+		},
+	})
+}
+
+func testAccProfileDataSourceConfig_byName(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_route53profiles_profile" "test" {
+  name = %[1]q
+}
+
+data "aws_route53profiles_profile" "test" {
+  name = aws_route53profiles_profile.test.name
+}
+`, rName)
+}
+
+func testAccProfileDataSourceConfig_byID(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_route53profiles_profile" "test" {
+  name = %[1]q
+}
+
+data "aws_route53profiles_profile" "test" {
+  profile_id = aws_route53profiles_profile.test.id
+}
+`, rName)
+}

--- a/internal/service/route53profiles/profile_data_source_test.go
+++ b/internal/service/route53profiles/profile_data_source_test.go
@@ -35,7 +35,7 @@ func TestAccRoute53ProfilesProfileDataSource_byName(t *testing.T) {
 				Config: testAccProfileDataSourceConfig_byName(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrName, resourceName, names.AttrName),
-					resource.TestCheckResourceAttrPair(dataSourceName, "profile_id", resourceName, names.AttrID),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrID, resourceName, names.AttrID),
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrARN, resourceName, names.AttrARN),
 					resource.TestCheckResourceAttrSet(dataSourceName, names.AttrStatus),
 					resource.TestCheckResourceAttrSet(dataSourceName, names.AttrOwnerID),
@@ -68,7 +68,7 @@ func TestAccRoute53ProfilesProfileDataSource_byID(t *testing.T) {
 			{
 				Config: testAccProfileDataSourceConfig_byID(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrPair(dataSourceName, "profile_id", resourceName, names.AttrID),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrID, resourceName, names.AttrID),
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrName, resourceName, names.AttrName),
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrARN, resourceName, names.AttrARN),
 					resource.TestCheckResourceAttrSet(dataSourceName, names.AttrStatus),
@@ -99,7 +99,7 @@ resource "aws_route53profiles_profile" "test" {
 }
 
 data "aws_route53profiles_profile" "test" {
-  profile_id = aws_route53profiles_profile.test.id
+  id = aws_route53profiles_profile.test.id
 }
 `, rName)
 }

--- a/internal/service/route53profiles/profile_data_source_test.go
+++ b/internal/service/route53profiles/profile_data_source_test.go
@@ -26,6 +26,7 @@ func TestAccRoute53ProfilesProfileDataSource_byName(t *testing.T) {
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.Route53Profiles)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.Route53ProfilesServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -60,6 +61,7 @@ func TestAccRoute53ProfilesProfileDataSource_byID(t *testing.T) {
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.Route53Profiles)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.Route53ProfilesServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,

--- a/internal/service/route53profiles/service_package_gen.go
+++ b/internal/service/route53profiles/service_package_gen.go
@@ -23,6 +23,15 @@ type servicePackage struct{}
 func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*inttypes.ServicePackageFrameworkDataSource {
 	return []*inttypes.ServicePackageFrameworkDataSource{
 		{
+			Factory:  newProfileDataSource,
+			TypeName: "aws_route53profiles_profile",
+			Name:     "Profile",
+			Tags: unique.Make(inttypes.ServicePackageResourceTags{
+				IdentifierAttribute: names.AttrARN,
+			}),
+			Region: inttypes.ResourceRegionDefault(),
+		},
+		{
 			Factory:  newProfilesDataSource,
 			TypeName: "aws_route53profiles_profiles",
 			Name:     "Profiles",

--- a/website/docs/d/route53profiles_profile.html.markdown
+++ b/website/docs/d/route53profiles_profile.html.markdown
@@ -3,12 +3,12 @@ subcategory: "Route 53 Profiles"
 layout: "aws"
 page_title: "AWS: aws_route53profiles_profile"
 description: |-
-  Terraform data source for managing an AWS Route 53 Profile.
+  Provides details about an AWS Route 53 Profile.
 ---
 
 # Data Source: aws_route53profiles_profile
 
-Terraform data source for managing an AWS Route 53 Profile.
+Provides details about an AWS Route 53 Profile.
 
 ## Example Usage
 

--- a/website/docs/d/route53profiles_profile.html.markdown
+++ b/website/docs/d/route53profiles_profile.html.markdown
@@ -32,9 +32,9 @@ data "aws_route53profiles_profile" "example" {
 
 This data source supports the following arguments:
 
-* `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `name` - (Optional) Name of the Profile. One of `name` or `profile_id` must be specified.
 * `profile_id` - (Optional) ID of the Profile. One of `name` or `profile_id` must be specified.
+* `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 
 ## Attribute Reference
 

--- a/website/docs/d/route53profiles_profile.html.markdown
+++ b/website/docs/d/route53profiles_profile.html.markdown
@@ -24,7 +24,7 @@ data "aws_route53profiles_profile" "example" {
 
 ```terraform
 data "aws_route53profiles_profile" "example" {
-  profile_id = "rp-12345678"
+  id = "rp-12345678"
 }
 ```
 
@@ -32,8 +32,8 @@ data "aws_route53profiles_profile" "example" {
 
 This data source supports the following arguments:
 
-* `name` - (Optional) Name of the Profile. One of `name` or `profile_id` must be specified.
-* `profile_id` - (Optional) ID of the Profile. One of `name` or `profile_id` must be specified.
+* `id` - (Optional) ID of the Profile. One of `name` or `id` must be specified.
+* `name` - (Optional) Name of the Profile. One of `name` or `id` must be specified.
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 
 ## Attribute Reference
@@ -41,9 +41,9 @@ This data source supports the following arguments:
 This data source exports the following attributes in addition to the arguments above:
 
 * `arn` - ARN of the Profile.
+* `id` - ID of the Profile.
 * `name` - Name of the Profile.
 * `owner_id` - ID of the AWS account that owns the Profile.
-* `profile_id` - ID of the Profile.
 * `share_status` - Share status of the Profile.
 * `status` - Status of the Profile.
 * `status_message` - Status message of the Profile.

--- a/website/docs/d/route53profiles_profile.html.markdown
+++ b/website/docs/d/route53profiles_profile.html.markdown
@@ -1,0 +1,50 @@
+---
+subcategory: "Route 53 Profiles"
+layout: "aws"
+page_title: "AWS: aws_route53profiles_profile"
+description: |-
+  Terraform data source for managing an AWS Route 53 Profile.
+---
+
+# Data Source: aws_route53profiles_profile
+
+Terraform data source for managing an AWS Route 53 Profile.
+
+## Example Usage
+
+### By Name
+
+```terraform
+data "aws_route53profiles_profile" "example" {
+  name = "example"
+}
+```
+
+### By ID
+
+```terraform
+data "aws_route53profiles_profile" "example" {
+  profile_id = "rp-12345678"
+}
+```
+
+## Argument Reference
+
+This data source supports the following arguments:
+
+* `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
+* `name` - (Optional) Name of the Profile. One of `name` or `profile_id` must be specified.
+* `profile_id` - (Optional) ID of the Profile. One of `name` or `profile_id` must be specified.
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `arn` - ARN of the Profile.
+* `name` - Name of the Profile.
+* `owner_id` - ID of the AWS account that owns the Profile.
+* `profile_id` - ID of the Profile.
+* `share_status` - Share status of the Profile.
+* `status` - Status of the Profile.
+* `status_message` - Status message of the Profile.
+* `tags` - Map of tags assigned to the Profile.


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

### Description

Adds New Data Source :  `aws_route53profiles_profile`


### Relations

Closes https://github.com/hashicorp/terraform-provider-aws/issues/40242

### References

https://docs.aws.amazon.com/Route53/latest/APIReference/API_route53profiles_ListProfiles.html
https://docs.aws.amazon.com/Route53/latest/APIReference/API_route53profiles_GetProfile.html


### Output from Acceptance Testing

```console
make t K=route53profile
s T=TestAccRoute53ProfilesProfileDataSource_      
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-data-source-aws_route53profiles_profile 🌿...
TF_ACC=1 go1.26.4 test ./internal/service/route53profiles/... -v -count 1 -parallel 20 -run='TestAccRoute53ProfilesProfileDataSource_'  -timeout 360m -vet=off
2026/07/03 20:53:04 Creating Terraform AWS Provider (SDKv2-style)...
2026/07/03 20:53:04 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccRoute53ProfilesProfileDataSource_byName
=== PAUSE TestAccRoute53ProfilesProfileDataSource_byName
=== RUN   TestAccRoute53ProfilesProfileDataSource_byID
=== PAUSE TestAccRoute53ProfilesProfileDataSource_byID
=== CONT  TestAccRoute53ProfilesProfileDataSource_byName
=== CONT  TestAccRoute53ProfilesProfileDataSource_byID
--- PASS: TestAccRoute53ProfilesProfileDataSource_byName (43.05s)
--- PASS: TestAccRoute53ProfilesProfileDataSource_byID (43.06s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/route53profiles    51.635s
```
