### PR TITLE
[Enhancement] `aws_elasticache_cluster` populate `cluster_address` for single-node Redis

### DIFF
--- a/.changelog/48784.txt
+++ b/.changelog/48784.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_elasticache_cluster: Populate `cluster_address` for Redis clusters
+```
+
+```release-note:enhancement
+data-source/aws_elasticache_cluster: Populate `cluster_address` for Redis clusters
+```

--- a/internal/service/elasticache/cluster.go
+++ b/internal/service/elasticache/cluster.go
@@ -536,6 +536,7 @@ func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta any) 
 		d.Set("cluster_address", c.ConfigurationEndpoint.Address)
 	} else if len(c.CacheNodes) > 0 {
 		d.Set(names.AttrPort, c.CacheNodes[0].Endpoint.Port)
+		d.Set("cluster_address", aws.ToString(c.CacheNodes[0].Endpoint.Address))
 	}
 
 	d.Set("replication_group_id", c.ReplicationGroupId)

--- a/internal/service/elasticache/cluster.go
+++ b/internal/service/elasticache/cluster.go
@@ -536,7 +536,7 @@ func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta any) 
 		d.Set("cluster_address", c.ConfigurationEndpoint.Address)
 	} else if len(c.CacheNodes) > 0 {
 		d.Set(names.AttrPort, c.CacheNodes[0].Endpoint.Port)
-		d.Set("cluster_address", aws.ToString(c.CacheNodes[0].Endpoint.Address))
+		d.Set("cluster_address", c.CacheNodes[0].Endpoint.Address)
 	}
 
 	d.Set("replication_group_id", c.ReplicationGroupId)

--- a/internal/service/elasticache/cluster_data_source.go
+++ b/internal/service/elasticache/cluster_data_source.go
@@ -198,7 +198,7 @@ func dataSourceClusterRead(ctx context.Context, d *schema.ResourceData, meta any
 		d.Set("configuration_endpoint", fmt.Sprintf("%s:%d", clusterAddress, port))
 		d.Set(names.AttrPort, port)
 	} else if len(cluster.CacheNodes) > 0 {
-		d.Set("cluster_address", aws.ToString(cluster.CacheNodes[0].Endpoint.Address))
+		d.Set("cluster_address", cluster.CacheNodes[0].Endpoint.Address)
 	}
 	d.Set("cluster_id", cluster.CacheClusterId)
 	d.Set(names.AttrEngine, cluster.Engine)

--- a/internal/service/elasticache/cluster_data_source.go
+++ b/internal/service/elasticache/cluster_data_source.go
@@ -197,6 +197,8 @@ func dataSourceClusterRead(ctx context.Context, d *schema.ResourceData, meta any
 		d.Set("cluster_address", clusterAddress)
 		d.Set("configuration_endpoint", fmt.Sprintf("%s:%d", clusterAddress, port))
 		d.Set(names.AttrPort, port)
+	} else if len(cluster.CacheNodes) > 0 {
+		d.Set("cluster_address", aws.ToString(cluster.CacheNodes[0].Endpoint.Address))
 	}
 	d.Set("cluster_id", cluster.CacheClusterId)
 	d.Set(names.AttrEngine, cluster.Engine)

--- a/internal/service/elasticache/cluster_data_source_test.go
+++ b/internal/service/elasticache/cluster_data_source_test.go
@@ -95,3 +95,45 @@ data "aws_elasticache_cluster" "test" {
 }
 `, rName)
 }
+
+func TestAccElastiCacheClusterDataSource_Engine_redis(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_elasticache_cluster.test"
+	dataSourceName := "data.aws_elasticache_cluster.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterDataSourceConfig_engineRedis(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "cluster_address", resourceName, "cluster_address"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "cluster_address"),
+					resource.TestCheckResourceAttr(dataSourceName, "configuration_endpoint", ""),
+				),
+			},
+		},
+	})
+}
+
+func testAccClusterDataSourceConfig_engineRedis(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_elasticache_cluster" "test" {
+  cluster_id      = %[1]q
+  engine          = "redis"
+  node_type       = "cache.t3.small"
+  num_cache_nodes = 1
+}
+
+data "aws_elasticache_cluster" "test" {
+  cluster_id = aws_elasticache_cluster.test.cluster_id
+}
+`, rName)
+}

--- a/internal/service/elasticache/cluster_data_source_test.go
+++ b/internal/service/elasticache/cluster_data_source_test.go
@@ -116,7 +116,7 @@ func TestAccElastiCacheClusterDataSource_Engine_redis(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "cluster_address", resourceName, "cluster_address"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "cluster_address"),
-					resource.TestCheckResourceAttr(dataSourceName, "configuration_endpoint", ""),
+					resource.TestCheckNoResourceAttr(dataSourceName, "configuration_endpoint"),
 				),
 			},
 		},

--- a/internal/service/elasticache/cluster_test.go
+++ b/internal/service/elasticache/cluster_test.go
@@ -103,7 +103,7 @@ func TestAccElastiCacheCluster_Engine_redis(t *testing.T) {
 					resource.TestCheckNoResourceAttr(resourceName, "outpost_mode"),
 					resource.TestCheckResourceAttr(resourceName, "preferred_outpost_arn", ""),
 					resource.TestCheckResourceAttrSet(resourceName, "cluster_address"),
-					resource.TestCheckResourceAttr(resourceName, "configuration_endpoint", ""),
+					resource.TestCheckNoResourceAttr(resourceName, "configuration_endpoint"),
 				),
 			},
 			{
@@ -199,7 +199,7 @@ func TestAccElastiCacheCluster_Engine_redis_v5(t *testing.T) {
 					// Even though it is ignored, the API returns `true` in this case
 					resource.TestCheckResourceAttr(resourceName, names.AttrAutoMinorVersionUpgrade, acctest.CtTrue),
 					resource.TestCheckResourceAttrSet(resourceName, "cluster_address"),
-					resource.TestCheckResourceAttr(resourceName, "configuration_endpoint", ""),
+					resource.TestCheckNoResourceAttr(resourceName, "configuration_endpoint"),
 				),
 			},
 			{

--- a/internal/service/elasticache/cluster_test.go
+++ b/internal/service/elasticache/cluster_test.go
@@ -102,6 +102,8 @@ func TestAccElastiCacheCluster_Engine_redis(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "network_type", "ipv4"),
 					resource.TestCheckNoResourceAttr(resourceName, "outpost_mode"),
 					resource.TestCheckResourceAttr(resourceName, "preferred_outpost_arn", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "cluster_address"),
+					resource.TestCheckResourceAttr(resourceName, "configuration_endpoint", ""),
 				),
 			},
 			{
@@ -196,6 +198,8 @@ func TestAccElastiCacheCluster_Engine_redis_v5(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "engine_version_actual", "5.0.6"),
 					// Even though it is ignored, the API returns `true` in this case
 					resource.TestCheckResourceAttr(resourceName, names.AttrAutoMinorVersionUpgrade, acctest.CtTrue),
+					resource.TestCheckResourceAttrSet(resourceName, "cluster_address"),
+					resource.TestCheckResourceAttr(resourceName, "configuration_endpoint", ""),
 				),
 			},
 			{

--- a/website/docs/d/elasticache_cluster.html.markdown
+++ b/website/docs/d/elasticache_cluster.html.markdown
@@ -52,7 +52,7 @@ SNS topic that ElastiCache notifications get sent to.
 * `port` - The port number on which each of the cache nodes will
 accept connections.
 * `configuration_endpoint` - (Memcached only) Configuration endpoint to allow host discovery.
-* `cluster_address` - (Memcached only) DNS name of the cache cluster without the port appended.
+* `cluster_address` - (Memcached and Redis) DNS name of the cache cluster without the port appended.
 * `preferred_outpost_arn` - The outpost ARN in which the cache cluster was created if created in outpost.
 * `cache_nodes` - List of node objects including `id`, `address`, `port`, `availability_zone` and `outpost_arn`.
    Referenceable e.g., as `${data.aws_elasticache_cluster.bar.cache_nodes.0.address}`

--- a/website/docs/r/elasticache_cluster.html.markdown
+++ b/website/docs/r/elasticache_cluster.html.markdown
@@ -199,7 +199,7 @@ This resource exports the following attributes in addition to the arguments abov
 * `arn` - The ARN of the created ElastiCache Cluster.
 * `engine_version_actual` - Because ElastiCache pulls the latest minor or patch for a version, this attribute returns the running version of the cache engine.
 * `cache_nodes` - List of node objects including `id`, `address`, `port` and `availability_zone`.
-* `cluster_address` - (Memcached only) DNS name of the cache cluster without the port appended.
+* `cluster_address` - (Memcached and Redis) DNS name of the cache cluster without the port appended.
 * `configuration_endpoint` - (Memcached only) Configuration endpoint to allow host discovery.
 * `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This behavior was observed on a single-node Redis cluster, where `cluster_address` is returned
empty. It was found that `cluster_address` had only ever been set from the Memcached configuration
endpoint; Redis clusters are not given one, and the address is exposed on the cache node instead.
That gap is addressed here.

During Read, the configuration endpoint is checked first (Memcached, unchanged), and otherwise the
first cache node's endpoint address is used, which is where a single-node Redis cluster's address
is exposed. The same fix is applied to the data source. No schema changes are required -
`cluster_address` already exists and simply was not being populated for Redis.

Some decisions were made deliberately:

- `cluster_address` is reused rather than a new `primary_endpoint` attribute being added, as the
  issue suggested. For a single-node cluster the same value would be returned, and "primary
  endpoint" is more accurately used to describe a replication group (where `primary_endpoint_address`
  is already provided), not a standalone cluster; a redundant attribute was therefore avoided.
- The value is left as a bare hostname with no port appended, so that what `cluster_address` already
  returns for Memcached and what CloudFormation's `RedisEndpoint.Address` provides are matched. The
  port is still exposed on the `port` attribute.
- It is kept as an `else if`, so that Memcached is left completely untouched; only the Redis path is
  changed.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #20394

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS='TestAccElastiCacheCluster_Engine_redis|TestAccElastiCacheCluster_Engine_memcached|TestAccElastiCacheClusterDataSource_Engine_redis|TestAccElastiCacheClusterDataSource_basic' PKG=elasticache ACCTEST_PARALLELISM=1 ACCTEST_TIMEOUT=4880m 
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
xargs: gofmt: No such file or directory
make: Validating schemas
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2	(cached)
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider/framework	(cached)
make: Running acceptance tests on branch: 🌿 f-elasticache-cluster-address 🌿...
TF_ACC=1 go1.26.4 test ./internal/service/elasticache/... -v -count 1 -parallel 1 -run='TestAccElastiCacheCluster_Engine_redis|TestAccElastiCacheCluster_Engine_memcached|TestAccElastiCacheClusterDataSource_Engine_redis|TestAccElastiCacheClusterDataSource_basic'  -timeout 4880m -vet=off -buildvcs=false
2026/07/07 03:17:54 Creating Terraform AWS Provider (SDKv2-style)...
2026/07/07 03:17:54 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccElastiCacheClusterDataSource_basic
=== PAUSE TestAccElastiCacheClusterDataSource_basic
=== RUN   TestAccElastiCacheClusterDataSource_Engine_redis
=== PAUSE TestAccElastiCacheClusterDataSource_Engine_redis
=== RUN   TestAccElastiCacheCluster_Engine_memcached
=== PAUSE TestAccElastiCacheCluster_Engine_memcached
=== RUN   TestAccElastiCacheCluster_Engine_redis
=== PAUSE TestAccElastiCacheCluster_Engine_redis
=== RUN   TestAccElastiCacheCluster_Engine_redis_v5
=== PAUSE TestAccElastiCacheCluster_Engine_redis_v5
=== CONT  TestAccElastiCacheClusterDataSource_basic
--- PASS: TestAccElastiCacheClusterDataSource_basic (420.60s)
=== CONT  TestAccElastiCacheCluster_Engine_redis
--- PASS: TestAccElastiCacheCluster_Engine_redis (434.38s)
=== CONT  TestAccElastiCacheCluster_Engine_redis_v5
--- PASS: TestAccElastiCacheCluster_Engine_redis_v5 (434.56s)
=== CONT  TestAccElastiCacheCluster_Engine_memcached
--- PASS: TestAccElastiCacheCluster_Engine_memcached (414.15s)
=== CONT  TestAccElastiCacheClusterDataSource_Engine_redis
--- PASS: TestAccElastiCacheClusterDataSource_Engine_redis (440.94s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elasticache	2144.778s
```
