### PR TITLE
🤖🤖🤖 resource/aws_dynamodb_table: Allow warm_throughput units below 12000/4000 (API minimum is 1)

### DIFF
--- a/.changelog/48785.txt
+++ b/.changelog/48785.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_dynamodb_table: Allow `warm_throughput` `read_units_per_second` and `write_units_per_second` values below the previous `12000`/`4000` minimums (the AWS API minimum is `1`), and fix a perpetual diff when such values are configured
+```

--- a/internal/service/dynamodb/table.go
+++ b/internal/service/dynamodb/table.go
@@ -628,13 +628,13 @@ func warmThroughputSchema() *schema.Schema {
 					Type:         schema.TypeInt,
 					Optional:     true,
 					Computed:     true,
-					ValidateFunc: validation.IntAtLeast(12000),
+					ValidateFunc: validation.IntAtLeast(1),
 				},
 				"write_units_per_second": {
 					Type:         schema.TypeInt,
 					Optional:     true,
 					Computed:     true,
-					ValidateFunc: validation.IntAtLeast(4000),
+					ValidateFunc: validation.IntAtLeast(1),
 				},
 			},
 		},
@@ -2883,16 +2883,9 @@ func flattenTableWarmThroughput(apiObject *awstypes.TableWarmThroughputDescripti
 		return []any{}
 	}
 
-	// AWS may return values below the minimum when warm throughput is not actually configured
-	// Also treat exact minimum values as defaults since AWS sets these automatically
-	readUnits := aws.ToInt64(apiObject.ReadUnitsPerSecond)
-	writeUnits := aws.ToInt64(apiObject.WriteUnitsPerSecond)
-
-	// Return empty if values are below minimums OR exactly at minimums (AWS defaults)
-	if (readUnits < 12000 && writeUnits < 4000) || (readUnits == 12000 && writeUnits == 4000) {
-		return []any{}
-	}
-
+	// Return the API values faithfully. Hiding AWS's auto-applied defaults when
+	// warm_throughput is not configured is handled by suppressTableWarmThroughputDefaults,
+	// which (unlike this function) has access to the configuration.
 	m := map[string]any{}
 
 	if v := apiObject.ReadUnitsPerSecond; v != nil {
@@ -2911,16 +2904,8 @@ func flattenGSIWarmThroughput(apiObject *awstypes.GlobalSecondaryIndexWarmThroug
 		return []any{}
 	}
 
-	// AWS may return values below the minimum when warm throughput is not actually configured
-	// Also treat exact minimum values as defaults since AWS sets these automatically
-	readUnits := aws.ToInt64(apiObject.ReadUnitsPerSecond)
-	writeUnits := aws.ToInt64(apiObject.WriteUnitsPerSecond)
-
-	// Return empty if values are below minimums OR exactly at minimums (AWS defaults)
-	if (readUnits < 12000 && writeUnits < 4000) || (readUnits == 12000 && writeUnits == 4000) {
-		return []any{}
-	}
-
+	// Return the API values faithfully; see flattenTableWarmThroughput for the
+	// rationale on why defaults are suppressed elsewhere (config-aware CustomizeDiff).
 	m := map[string]any{}
 
 	if v := apiObject.ReadUnitsPerSecond; v != nil {

--- a/internal/service/dynamodb/table_test.go
+++ b/internal/service/dynamodb/table_test.go
@@ -8628,6 +8628,56 @@ func TestAccDynamoDBTable_warmThroughputDefault(t *testing.T) {
 	})
 }
 
+// Regression test for #47673: warm_throughput read/write units below the on-demand
+// default (12000/4000) were rejected by schema validation, even though the AWS API
+// minimum is 1 and a PROVISIONED table accepts such values. Beyond validation, the
+// read path also dropped sub-default values, causing a perpetual diff. This verifies
+// a below-default value is accepted, round-trips into state, and re-applies as a no-op.
+//
+// Note: this uses a PROVISIONED table on purpose. An on-demand (PAY_PER_REQUEST) table
+// rejects warm_throughput below 12000/4000 at the API ("lower than initial throughput
+// for OnDemand"), so it cannot exercise the sub-default round-trip.
+func TestAccDynamoDBTable_warmThroughputBelowDefault(t *testing.T) {
+	ctx := acctest.Context(t)
+	var conf awstypes.TableDescription
+	resourceName := "aws_dynamodb_table.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.DynamoDBServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTableDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTableConfig_warmThroughputProvisioned(rName, 1, 1, 100, 100),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckInitialTableExists(ctx, t, resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "billing_mode", string(awstypes.BillingModeProvisioned)),
+					resource.TestCheckResourceAttr(resourceName, "warm_throughput.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "warm_throughput.0.read_units_per_second", "100"),
+					resource.TestCheckResourceAttr(resourceName, "warm_throughput.0.write_units_per_second", "100"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				// Re-applying the same config must be a no-op: the sub-default warm
+				// throughput must round-trip cleanly with no perpetual diff.
+				Config: testAccTableConfig_warmThroughputProvisioned(rName, 1, 1, 100, 100),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
 func TestAccDynamoDBTable_gsiWarmThroughput_billingProvisioned(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf awstypes.TableDescription
@@ -13232,6 +13282,26 @@ resource "aws_dynamodb_table" "test" {
   }
 }
 `, rName, maxRead, maxWrite, warmRead, warmWrite)
+}
+
+func testAccTableConfig_warmThroughputProvisioned(rName string, readCapacity, writeCapacity, warmRead, warmWrite int) string {
+	return fmt.Sprintf(`
+resource "aws_dynamodb_table" "test" {
+  name           = %[1]q
+  billing_mode   = "PROVISIONED"
+  hash_key       = "TestTableHashKey"
+  read_capacity  = %[2]d
+  write_capacity = %[3]d
+  warm_throughput {
+    read_units_per_second  = %[4]d
+    write_units_per_second = %[5]d
+  }
+  attribute {
+    name = "TestTableHashKey"
+    type = "S"
+  }
+}
+`, rName, readCapacity, writeCapacity, warmRead, warmWrite)
 }
 
 func testAccTableConfig_gsiWarmThroughput_billingProvisioned(rName string, readCapacity, writeCapacity, warmRead, warmWrite int) string {

--- a/website/docs/r/dynamodb_table.html.markdown
+++ b/website/docs/r/dynamodb_table.html.markdown
@@ -473,8 +473,8 @@ The following arguments are optional:
 
 ~> **Note:** Explicitly configuring both `read_units_per_second` and `write_units_per_second` to the default/minimum values will cause Terraform to report differences.
 
-* `read_units_per_second` - (Optional) Number of read operations a table or index can instantaneously support. For the base table, this value cannot be decreased. For a global secondary index, this value can be increased or decreased. Minimum value of `12000` (default).
-* `write_units_per_second` - (Optional) Number of write operations a table or index can instantaneously support. For the base table, this value cannot be decreased. For a global secondary index, this value can be increased or decreased. Minimum value of `4000` (default).
+* `read_units_per_second` - (Optional) Number of read operations a table or index can instantaneously support. For the base table, decreasing this value will force a new resource. For a global secondary index, this value can be increased or decreased without recreation. Minimum value of `1`. On-demand (`PAY_PER_REQUEST`) tables require a value of at least `12000`, which AWS also applies as the default starting capacity when not configured.
+* `write_units_per_second` - (Optional) Number of write operations a table or index can instantaneously support. For the base table, decreasing this value will force a new resource. For a global secondary index, this value can be increased or decreased without recreation. Minimum value of `1`. On-demand (`PAY_PER_REQUEST`) tables require a value of at least `4000`, which AWS also applies as the default starting capacity when not configured.
 
 ## Attribute Reference
 


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No. This change only affects `warm_throughput` value validation and read-path serialization for `aws_dynamodb_table`; there are no changes to access controls, encryption, or logging.

### Description

The base-table `warm_throughput` block validated `read_units_per_second`/`write_units_per_second` with `validation.IntAtLeast(12000)` / `validation.IntAtLeast(4000)`. Those numbers are the **on-demand default starting capacity**, not the API field minimum — the actual minimum is `1`, and `PROVISIONED` tables accept values as low as `1`. The GSI `warm_throughput` block already delegates this to the API (no `ValidateFunc`); this makes the base table consistent.

Relaxing the validation alone was **not sufficient**, and would have traded a validation error for a permanent diff:

* `flattenTableWarmThroughput` / `flattenGSIWarmThroughput` dropped any value where `read < 12000 && write < 4000` (or exactly `12000/4000`) on read, returning an empty list. A legitimately-configured low value (e.g. `100/100` on a provisioned table) therefore applied once and then never round-tripped into state → **perpetual diff**. The `&&` also made it inconsistent: `100/5000` round-tripped fine while `100/100` diffed forever.

This PR:

1. Lowers both `ValidateFunc`s to `validation.IntAtLeast(1)` (the true API minimum; `0`/negative remain rejected as a cheap static floor). Anything AWS rejects for a given billing mode — e.g. on-demand tables require `≥ 12000/4000` — is surfaced as the API error, consistent with how the GSI block already behaves.
2. Makes both `flatten` functions return the API values **faithfully** (removes the magnitude-based drop). Hiding AWS's auto-applied defaults when the block is *unconfigured* is already handled by the config-aware `suppressTableWarmThroughputDefaults` `CustomizeDiff`, which — unlike `flatten` — can see the configuration. This also removes the previously-documented wart where explicitly configuring the default values reported differences.
3. Updates the docs and adds a regression test.

Verified AWS behavior (live, us-east-1):

| Billing mode | Unconfigured default | Minimum accepted |
|---|---|---|
| `PROVISIONED` | `1 / 1` | `1 / 1` |
| `PAY_PER_REQUEST` | `12000 / 4000` | `12000 / 4000` (AWS rejects lower) |

#### AI usage disclosure

Per [`docs/ai-usage.md`](https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/ai-usage.md). An LLM agent (Claude Code) assisted with drafting the regression test, docs wording, and this description, and helped run the empirical AWS characterization. I directed the investigation and every decision, verified the root cause and the fix by running acceptance tests against a personal throwaway AWS account (including the perpetual-diff reproduction and the no-regression check on the existing suite), and can explain every line without the AI. The final scope — relax validation + make `flatten` faithful, leaving billing-mode-dependent limits to the API — is a deliberate choice matching this resource's existing GSI behavior and the maintainer's guidance in the issue.

### Relations

Closes #47673

### References

* [`TableWarmThroughputDescription`](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_TableWarmThroughputDescription.html) — API field minimum is `1`
* [On-demand capacity mode initial throughput](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/on-demand-capacity-mode.html#on-demand-capacity-mode-initial) — source of the `12000/4000` on-demand defaults
* Detailed analysis + full behavior matrix: https://github.com/hashicorp/terraform-provider-aws/issues/47673#issuecomment-4884097102

### Output from Acceptance Testing

Run against a personal throwaway AWS account (us-east-1). The new regression test covers acceptance of a sub-default value, round-trip into state, import, and an empty re-apply plan (no perpetual diff). The existing `warm_throughput` suite was re-run to confirm the `flatten` change causes no regression.

```console
% make testacc PKG=dynamodb TESTS=TestAccDynamoDBTable_warmThroughputBelowDefault
--- PASS: TestAccDynamoDBTable_warmThroughputBelowDefault (64.73s)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb    77.964s

% make testacc PKG=dynamodb TESTS='TestAccDynamoDBTable_warmThroughput|TestAccDynamoDBTable_warmThroughputDefault|TestAccDynamoDBTable_gsiWarmThroughput_'
--- PASS: TestAccDynamoDBTable_warmThroughput (250.95s)
--- PASS: TestAccDynamoDBTable_warmThroughputDefault (61.07s)
--- PASS: TestAccDynamoDBTable_gsiWarmThroughput_billingProvisioned (804.32s)
--- PASS: TestAccDynamoDBTable_gsiWarmThroughput_billingPayPerRequest (685.03s)
--- PASS: TestAccDynamoDBTable_gsiWarmThroughput_switchBilling (321.15s)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb
```
