### PR TITLE
🚀 Add optional `policy_name` argument to `aws_verifiedpermissions_policy` resource

### DIFF
--- a/.changelog/48786.txt
+++ b/.changelog/48786.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_verifiedpermissions_policy: Add optional computed `policy_name` argument and support updating policy name in place.
+```

--- a/internal/service/verifiedpermissions/policy.go
+++ b/internal/service/verifiedpermissions/policy.go
@@ -8,12 +8,14 @@ package verifiedpermissions
 import (
 	"context"
 
+	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/verifiedpermissions"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/verifiedpermissions/types"
 	"github.com/cedar-policy/cedar-go"
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -61,6 +63,18 @@ func (r *policyResource) Schema(ctx context.Context, req resource.SchemaRequest,
 			},
 			names.AttrID: framework.IDAttribute(),
 			"policy_id":  framework.IDAttribute(),
+			"policy_name": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+				Validators: []validator.String{
+					stringvalidator.LengthBetween(0, 150),
+					stringvalidator.RegexMatches(regexache.MustCompile(`^[a-zA-Z0-9-/_]*$`), "must match [a-zA-Z0-9-/_]*"),
+					stringvalidator.RegexMatches(regexache.MustCompile(`^$|^name/`), "must be empty or begin with 'name/'"),
+				},
+			},
 			"policy_store_id": schema.StringAttribute{
 				Required: true,
 				PlanModifiers: []planmodifier.String{
@@ -228,6 +242,9 @@ func (r *policyResource) Create(ctx context.Context, req resource.CreateRequest,
 	in := &verifiedpermissions.CreatePolicyInput{}
 
 	in.ClientToken = aws.String(create.UniqueId(ctx))
+	if !plan.PolicyName.IsNull() && !plan.PolicyName.IsUnknown() && plan.PolicyName.ValueString() != "" {
+		in.Name = fwflex.StringFromFramework(ctx, plan.PolicyName)
+	}
 	in.PolicyStoreId = plan.PolicyStoreID.ValueStringPointer()
 
 	def, diags := plan.Definition.ToPtr(ctx)
@@ -320,6 +337,17 @@ func (r *policyResource) Create(ctx context.Context, req resource.CreateRequest,
 	plan.CreatedDate = timetypes.NewRFC3339TimePointerValue(out.CreatedDate)
 	plan.PolicyID = fwflex.StringToFramework(ctx, out.PolicyId)
 
+	// CreatePolicy output currently does not include Name, so read it back.
+	policy, err := findPolicyByID(ctx, conn, aws.ToString(out.PolicyId), aws.ToString(out.PolicyStoreId))
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.VerifiedPermissions, create.ErrActionReading, ResNamePolicy, plan.PolicyStoreID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+	plan.PolicyName = fwflex.StringToFramework(ctx, policy.Name)
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 }
 
@@ -356,6 +384,7 @@ func (r *policyResource) Read(ctx context.Context, req resource.ReadRequest, res
 	}
 
 	state.PolicyID = fwflex.StringToFramework(ctx, out.PolicyId)
+	state.PolicyName = fwflex.StringToFramework(ctx, out.Name)
 	state.PolicyStoreID = fwflex.StringToFramework(ctx, out.PolicyStoreId)
 	state.CreatedDate = timetypes.NewRFC3339TimePointerValue(out.CreatedDate)
 
@@ -415,8 +444,9 @@ func (r *policyResource) Update(ctx context.Context, req resource.UpdateRequest,
 		return
 	}
 
-	if !plan.Definition.Equal(state.Definition) {
+	if !plan.Definition.Equal(state.Definition) || !plan.PolicyName.Equal(state.PolicyName) {
 		in := &verifiedpermissions.UpdatePolicyInput{}
+		in.Name = fwflex.StringFromFramework(ctx, plan.PolicyName)
 		in.PolicyId = fwflex.StringFromFramework(ctx, state.PolicyID)
 		in.PolicyStoreId = fwflex.StringFromFramework(ctx, state.PolicyStoreID)
 
@@ -550,6 +580,7 @@ type policyResourceModel struct {
 	Definition    fwtypes.ListNestedObjectValueOf[policyDefinition] `tfsdk:"definition"`
 	ID            types.String                                      `tfsdk:"id"`
 	PolicyID      types.String                                      `tfsdk:"policy_id"`
+	PolicyName    types.String                                      `tfsdk:"policy_name"`
 	PolicyStoreID types.String                                      `tfsdk:"policy_store_id"`
 }
 

--- a/internal/service/verifiedpermissions/policy_test.go
+++ b/internal/service/verifiedpermissions/policy_test.go
@@ -50,6 +50,7 @@ func TestAccVerifiedPermissionsPolicy_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "definition.0.static.0.description", rName),
 					resource.TestCheckResourceAttr(resourceName, "definition.0.static.0.statement", policyStatement),
 					resource.TestCheckResourceAttrSet(resourceName, "policy_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "policy_name"),
 				),
 			},
 			{
@@ -174,6 +175,93 @@ func TestAccVerifiedPermissionsPolicy_update(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "definition.0.static.0.description", rName),
 					resource.TestCheckResourceAttr(resourceName, "definition.0.static.0.statement", policyStatementResourceUpdated),
 					resource.TestCheckResourceAttrSet(resourceName, "policy_id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccVerifiedPermissionsPolicy_policyName(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var policy verifiedpermissions.GetPolicyOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_verifiedpermissions_policy.test"
+
+	policyStatement := "permit (principal, action == Action::\"view\", resource in Album:: \"test_album\");"
+	policyName1 := fmt.Sprintf("name/%s-1", rName)
+	policyName2 := fmt.Sprintf("name/%s-2", rName)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.VerifiedPermissionsEndpointID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.VerifiedPermissionsServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckPolicyDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPolicyConfig_policyName(rName, policyStatement, policyName1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPolicyExists(ctx, t, resourceName, &policy),
+					resource.TestCheckResourceAttr(resourceName, "policy_name", policyName1),
+					resource.TestCheckResourceAttrSet(resourceName, "policy_id"),
+				),
+			},
+			{
+				Config:            testAccPolicyConfig_policyName(rName, policyStatement, policyName1),
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccPolicyConfig_policyName(rName, policyStatement, policyName2),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPolicyExists(ctx, t, resourceName, &policy),
+					resource.TestCheckResourceAttr(resourceName, "policy_name", policyName2),
+					resource.TestCheckResourceAttrSet(resourceName, "policy_id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccVerifiedPermissionsPolicy_policyNameComputed(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var policy verifiedpermissions.GetPolicyOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_verifiedpermissions_policy.test"
+
+	policyStatement := "permit (principal, action == Action::\"view\", resource in Album:: \"test_album\");"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.VerifiedPermissionsEndpointID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.VerifiedPermissionsServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckPolicyDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPolicyConfig_basic(rName, policyStatement),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPolicyExists(ctx, t, resourceName, &policy),
+					resource.TestCheckResourceAttrSet(resourceName, "policy_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "policy_name"),
 				),
 			},
 		},
@@ -316,6 +404,24 @@ resource "aws_verifiedpermissions_policy" "test" {
   }
 }
 `, rName, policyStatement))
+}
+
+func testAccPolicyConfig_policyName(rName, policyStatement, policyName string) string {
+	return acctest.ConfigCompose(
+		testAccPolicyConfig_base(rName),
+		fmt.Sprintf(`
+resource "aws_verifiedpermissions_policy" "test" {
+	policy_name     = %[3]q
+	policy_store_id = aws_verifiedpermissions_policy_store.test.id
+
+	definition {
+		static {
+			description = %[1]q
+			statement   = %[2]q
+		}
+	}
+}
+`, rName, policyStatement, policyName))
 }
 
 func testAccPolicyConfig_templateLinked(rName string) string {

--- a/internal/service/verifiedpermissions/policy_test.go
+++ b/internal/service/verifiedpermissions/policy_test.go
@@ -411,15 +411,15 @@ func testAccPolicyConfig_policyName(rName, policyStatement, policyName string) s
 		testAccPolicyConfig_base(rName),
 		fmt.Sprintf(`
 resource "aws_verifiedpermissions_policy" "test" {
-	policy_name     = %[3]q
-	policy_store_id = aws_verifiedpermissions_policy_store.test.id
+  policy_name     = %[3]q
+  policy_store_id = aws_verifiedpermissions_policy_store.test.id
 
-	definition {
-		static {
-			description = %[1]q
-			statement   = %[2]q
-		}
-	}
+  definition {
+    static {
+      description = %[1]q
+      statement   = %[2]q
+    }
+  }
 }
 `, rName, policyStatement, policyName))
 }

--- a/website/docs/r/verifiedpermissions_policy.html.markdown
+++ b/website/docs/r/verifiedpermissions_policy.html.markdown
@@ -28,11 +28,15 @@ resource "aws_verifiedpermissions_policy" "test" {
 
 ## Argument Reference
 
-This resource supports the following arguments:
+The following arguments are required:
 
+* `definition` - (Required) Definition of the policy. See [Definition](#definition) below.
+* `policy_store_id` - (Required) Policy store ID of the policy store.
+
+The following arguments are optional:
+
+* `policy_name` - (Optional) Name of the policy that must begin with `name/`. If omitted, AWS Verified Permissions can generate and return a name.
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
-* `policy_store_id` - (Required) The Policy Store ID of the policy store.
-* `definition`- (Required) The definition of the policy. See [Definition](#definition) below.
 
 ### Definition
 
@@ -60,6 +64,7 @@ This resource exports the following attributes in addition to the arguments abov
 
 * `created_date` - The date the policy was created.
 * `policy_id` - The Policy ID of the policy.
+* `policy_name` - The policy name.
 
 ## Import
 


### PR DESCRIPTION
### Description
- Introduced `policy_name` as an optional argument in the resource schema.
- Updated Create and Update methods to handle the new `policy_name` field.
- Enhanced tests to validate the functionality of `policy_name`.
- Updated documentation to reflect the new argument.

### Relations
Closes  #48786

### Output from Acceptance Testing
```console
$ make testacc TESTS=TestAccVerifiedPermissionsPolicy_policyName PKG=verifiedpermissions
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework (cached)
make: Running acceptance tests on branch: feature/issue-48786 ...
=== RUN   TestAccVerifiedPermissionsPolicy_policyName
=== PAUSE TestAccVerifiedPermissionsPolicy_policyName
=== RUN   TestAccVerifiedPermissionsPolicy_policyNameComputed
=== PAUSE TestAccVerifiedPermissionsPolicy_policyNameComputed
=== CONT  TestAccVerifiedPermissionsPolicy_policyName
=== CONT  TestAccVerifiedPermissionsPolicy_policyNameComputed
=== NAME  TestAccVerifiedPermissionsPolicy_policyName
```