### PR TITLE
feat: add monitoring (high-resolution metrics) support in aws_ecs_service

### DIFF
--- a/.changelog/48792.txt
+++ b/.changelog/48792.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_ecs_service: Add `monitoring` configuration block
+```
+
+```release-note:enhancement
+data-source/aws_ecs_service: Add `monitoring` attribute
+```

--- a/internal/service/ecs/service.go
+++ b/internal/service/ecs/service.go
@@ -865,6 +865,35 @@ func resourceService() *schema.Resource {
 						},
 					},
 				},
+				"monitoring": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"metric_configuration": {
+								Type:     schema.TypeList,
+								Required: true,
+								MinItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"metric_names": {
+											Type:     schema.TypeSet,
+											Required: true,
+											MinItems: 1,
+											Elem:     &schema.Schema{Type: schema.TypeString},
+										},
+										"resolution_seconds": {
+											Type:         schema.TypeInt,
+											Required:     true,
+											ValidateFunc: validation.IntInSlice([]int{20, 60}),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
 				names.AttrName: {
 					Type:     schema.TypeString,
 					Required: true,
@@ -1493,6 +1522,10 @@ func resourceServiceCreate(ctx context.Context, d *schema.ResourceData, meta any
 		input.LoadBalancers = v
 	}
 
+	if v, ok := d.GetOk("monitoring"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.Monitoring = expandMonitoringConfiguration(v.([]any)[0].(map[string]any))
+	}
+
 	if v, ok := d.GetOk("ordered_placement_strategy"); ok {
 		apiObject, err := expandPlacementStrategy(v.([]any))
 		if err != nil {
@@ -1592,6 +1625,36 @@ func resourceServiceRead(ctx context.Context, d *schema.ResourceData, meta any) 
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "reading ECS Service (%s): %s", d.Id(), err)
+	}
+
+	// The monitoring configuration is only returned on service revisions (DescribeServiceRevisions),
+	// not on the Service object itself.
+	var revisionARNs []string
+	for _, v := range service.CurrentServiceRevisions {
+		if arn := aws.ToString(v.Arn); arn != "" {
+			revisionARNs = append(revisionARNs, arn)
+		}
+	}
+	if len(revisionARNs) > 0 {
+		input := ecs.DescribeServiceRevisionsInput{
+			ServiceRevisionArns: revisionARNs,
+		}
+		revisions, err := findServiceRevisions(ctx, conn, &input)
+
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "reading ECS Service (%s) revisions: %s", d.Id(), err)
+		}
+
+		if len(revisions) > 0 {
+			// During a deployment there can be multiple current revisions.
+			// The newest one reflects the service's target configuration.
+			revision := slices.MaxFunc(revisions, func(a, b awstypes.ServiceRevision) int {
+				return aws.ToTime(a.CreatedAt).Compare(aws.ToTime(b.CreatedAt))
+			})
+			if err := d.Set("monitoring", flattenMonitoringConfiguration(revision.Monitoring)); err != nil {
+				return sdkdiag.AppendErrorf(diags, "setting monitoring: %s", err)
+			}
+		}
 	}
 
 	return append(diags, resourceServiceFlatten(ctx, d, service, cluster)...)
@@ -1746,6 +1809,18 @@ func resourceServiceUpdate(ctx context.Context, d *schema.ResourceData, meta any
 		if d.HasChange("load_balancer") {
 			if v, ok := d.Get("load_balancer").(*schema.Set); ok && v != nil {
 				input.LoadBalancers = expandServiceLoadBalancers(v.List())
+			}
+		}
+
+		if d.HasChange("monitoring") {
+			// To remove the existing monitoring configuration, specify an explicitly
+			// empty metricConfigurations list.
+			input.Monitoring = &awstypes.MonitoringConfiguration{
+				MetricConfigurations: []awstypes.MetricConfiguration{},
+			}
+
+			if v, ok := d.GetOk("monitoring"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+				input.Monitoring = expandMonitoringConfiguration(v.([]any)[0].(map[string]any))
 			}
 		}
 
@@ -2308,6 +2383,26 @@ func findServiceDeployments(ctx context.Context, conn *ecs.Client, input *ecs.De
 	return output.ServiceDeployments, nil
 }
 
+func findServiceRevisions(ctx context.Context, conn *ecs.Client, input *ecs.DescribeServiceRevisionsInput) ([]awstypes.ServiceRevision, error) {
+	output, err := conn.DescribeServiceRevisions(ctx, input)
+
+	if errs.IsA[*awstypes.ClusterNotFoundException](err) || errs.IsA[*awstypes.ServiceNotFoundException](err) {
+		return nil, &retry.NotFoundError{
+			LastError: err,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil {
+		return nil, tfresource.NewEmptyResultError()
+	}
+
+	return output.ServiceRevisions, nil
+}
+
 func findServiceDeploymentBriefs(ctx context.Context, conn *ecs.Client, input *ecs.ListServiceDeploymentsInput) ([]awstypes.ServiceDeploymentBrief, error) {
 	var output []awstypes.ServiceDeploymentBrief
 
@@ -2568,6 +2663,72 @@ func flattenAlarms(apiObject *awstypes.DeploymentAlarms) map[string]any {
 	tfMap["rollback"] = apiObject.Rollback
 
 	return tfMap
+}
+
+func expandMonitoringConfiguration(tfMap map[string]any) *awstypes.MonitoringConfiguration {
+	if tfMap == nil {
+		return nil
+	}
+
+	apiObject := &awstypes.MonitoringConfiguration{}
+
+	if v, ok := tfMap["metric_configuration"].([]any); ok && len(v) > 0 {
+		apiObject.MetricConfigurations = expandMetricConfigurations(v)
+	}
+
+	return apiObject
+}
+
+func expandMetricConfigurations(tfList []any) []awstypes.MetricConfiguration {
+	apiObjects := make([]awstypes.MetricConfiguration, 0, len(tfList))
+
+	for _, tfMapRaw := range tfList {
+		tfMap, ok := tfMapRaw.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		apiObject := awstypes.MetricConfiguration{}
+
+		if v, ok := tfMap["metric_names"].(*schema.Set); ok && v.Len() > 0 {
+			apiObject.MetricNames = flex.ExpandStringValueSet(v)
+		}
+
+		if v, ok := tfMap["resolution_seconds"].(int); ok {
+			apiObject.ResolutionSeconds = aws.Int32(int32(v))
+		}
+
+		apiObjects = append(apiObjects, apiObject)
+	}
+
+	return apiObjects
+}
+
+func flattenMonitoringConfiguration(apiObject *awstypes.MonitoringConfiguration) []any {
+	if apiObject == nil || len(apiObject.MetricConfigurations) == 0 {
+		return nil
+	}
+
+	tfMap := map[string]any{
+		"metric_configuration": flattenMetricConfigurations(apiObject.MetricConfigurations),
+	}
+
+	return []any{tfMap}
+}
+
+func flattenMetricConfigurations(apiObjects []awstypes.MetricConfiguration) []any {
+	tfList := make([]any, 0, len(apiObjects))
+
+	for _, apiObject := range apiObjects {
+		tfMap := map[string]any{
+			"metric_names":       flex.FlattenStringValueSet(apiObject.MetricNames),
+			"resolution_seconds": aws.ToInt32(apiObject.ResolutionSeconds),
+		}
+
+		tfList = append(tfList, tfMap)
+	}
+
+	return tfList
 }
 
 func expandDeploymentController(l []any) *awstypes.DeploymentController {

--- a/internal/service/ecs/service_data_source.go
+++ b/internal/service/ecs/service_data_source.go
@@ -7,9 +7,11 @@ package ecs
 
 import (
 	"context"
+	"slices"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ecs"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -283,6 +285,31 @@ func dataSourceService() *schema.Resource {
 					Type:     schema.TypeString,
 					Computed: true,
 				},
+				"monitoring": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"metric_configuration": {
+								Type:     schema.TypeList,
+								Computed: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"metric_names": {
+											Type:     schema.TypeSet,
+											Computed: true,
+											Elem:     &schema.Schema{Type: schema.TypeString},
+										},
+										"resolution_seconds": {
+											Type:     schema.TypeInt,
+											Computed: true,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
 				names.AttrNetworkConfiguration: {
 					Type:     schema.TypeList,
 					Computed: true,
@@ -540,6 +567,35 @@ func dataSourceServiceRead(ctx context.Context, d *schema.ResourceData, meta any
 	if service.LoadBalancers != nil {
 		if err := d.Set("load_balancer", flattenServiceLoadBalancers(service.LoadBalancers)); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting load_balancer: %s", err)
+		}
+	}
+	// The monitoring configuration is only returned on service revisions (DescribeServiceRevisions),
+	// not on the Service object itself.
+	var revisionARNs []string
+	for _, v := range service.CurrentServiceRevisions {
+		if arn := aws.ToString(v.Arn); arn != "" {
+			revisionARNs = append(revisionARNs, arn)
+		}
+	}
+	if len(revisionARNs) > 0 {
+		input := ecs.DescribeServiceRevisionsInput{
+			ServiceRevisionArns: revisionARNs,
+		}
+		revisions, err := findServiceRevisions(ctx, conn, &input)
+
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "reading ECS Service (%s) revisions: %s", arn, err)
+		}
+
+		if len(revisions) > 0 {
+			// During a deployment there can be multiple current revisions.
+			// The newest one reflects the service's target configuration.
+			revision := slices.MaxFunc(revisions, func(a, b awstypes.ServiceRevision) int {
+				return aws.ToTime(a.CreatedAt).Compare(aws.ToTime(b.CreatedAt))
+			})
+			if err := d.Set("monitoring", flattenMonitoringConfiguration(revision.Monitoring)); err != nil {
+				return sdkdiag.AppendErrorf(diags, "setting monitoring: %s", err)
+			}
 		}
 	}
 	if err := d.Set(names.AttrNetworkConfiguration, flattenNetworkConfiguration(service.NetworkConfiguration)); err != nil {

--- a/internal/service/ecs/service_data_source_test.go
+++ b/internal/service/ecs/service_data_source_test.go
@@ -166,6 +166,35 @@ func TestAccECSServiceDataSource_fullConfiguration(t *testing.T) {
 	})
 }
 
+func TestAccECSServiceDataSource_monitoring(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_ecs_service.test"
+	resourceName := "aws_ecs_service.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ECSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceDataSourceConfig_monitoring(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrID, dataSourceName, names.AttrARN),
+					resource.TestCheckResourceAttrPair(resourceName, "monitoring.#", dataSourceName, "monitoring.#"),
+					resource.TestCheckResourceAttrPair(resourceName, "monitoring.0.metric_configuration.#", dataSourceName, "monitoring.0.metric_configuration.#"),
+					resource.TestCheckResourceAttr(dataSourceName, "monitoring.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "monitoring.0.metric_configuration.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "monitoring.0.metric_configuration.0.resolution_seconds", "20"),
+					resource.TestCheckResourceAttr(dataSourceName, "monitoring.0.metric_configuration.0.metric_names.#", "2"),
+					resource.TestCheckTypeSetElemAttr(dataSourceName, "monitoring.0.metric_configuration.0.metric_names.*", "CPUUtilization"),
+					resource.TestCheckTypeSetElemAttr(dataSourceName, "monitoring.0.metric_configuration.0.metric_names.*", "MemoryUtilization"),
+				),
+			},
+		},
+	})
+}
+
 func testAccServiceDataSourceConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ecs_cluster" "test" {
@@ -235,6 +264,17 @@ func testAccServiceDataSourceConfig_canaryDeployment(rName string) string {
 data "aws_ecs_service" "test" {
   service_name = aws_ecs_service.test.name
   cluster_arn  = aws_ecs_cluster.main.arn
+}
+`)
+}
+
+func testAccServiceDataSourceConfig_monitoring(rName string) string {
+	return acctest.ConfigCompose(
+		testAccServiceConfig_monitoring(rName, 20),
+		`
+data "aws_ecs_service" "test" {
+  service_name = aws_ecs_service.test.name
+  cluster_arn  = aws_ecs_cluster.test.arn
 }
 `)
 }

--- a/internal/service/ecs/service_test.go
+++ b/internal/service/ecs/service_test.go
@@ -1062,6 +1062,90 @@ func TestAccECSService_alarmsUpdate(t *testing.T) {
 	})
 }
 
+func TestAccECSService_monitoring(t *testing.T) {
+	ctx := acctest.Context(t)
+	var service awstypes.Service
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_ecs_service.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ECSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckServiceDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceConfig_monitoring(rName, 20),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceExists(ctx, t, resourceName, &service),
+					resource.TestCheckResourceAttr(resourceName, "monitoring.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "monitoring.0.metric_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "monitoring.0.metric_configuration.0.resolution_seconds", "20"),
+					resource.TestCheckResourceAttr(resourceName, "monitoring.0.metric_configuration.0.metric_names.#", "2"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "monitoring.0.metric_configuration.0.metric_names.*", "CPUUtilization"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "monitoring.0.metric_configuration.0.metric_names.*", "MemoryUtilization"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateId:     fmt.Sprintf("%s/%s", rName, rName),
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"wait_for_steady_state",
+					"task_definition", // https://github.com/hashicorp/terraform-provider-aws/issues/42731
+				},
+			},
+			{
+				Config: testAccServiceConfig_monitoring(rName, 60),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceExists(ctx, t, resourceName, &service),
+					resource.TestCheckResourceAttr(resourceName, "monitoring.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "monitoring.0.metric_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "monitoring.0.metric_configuration.0.resolution_seconds", "60"),
+				),
+			},
+			{
+				Config: testAccServiceConfig_monitoringRemoved(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceExists(ctx, t, resourceName, &service),
+					resource.TestCheckResourceAttr(resourceName, "monitoring.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccECSService_monitoringMultipleMetricConfigurations(t *testing.T) {
+	ctx := acctest.Context(t)
+	var service awstypes.Service
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_ecs_service.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ECSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckServiceDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceConfig_monitoringMultiple(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceExists(ctx, t, resourceName, &service),
+					resource.TestCheckResourceAttr(resourceName, "monitoring.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "monitoring.0.metric_configuration.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "monitoring.0.metric_configuration.0.resolution_seconds", "20"),
+					resource.TestCheckResourceAttr(resourceName, "monitoring.0.metric_configuration.0.metric_names.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "monitoring.0.metric_configuration.0.metric_names.*", "CPUUtilization"),
+					resource.TestCheckResourceAttr(resourceName, "monitoring.0.metric_configuration.1.resolution_seconds", "60"),
+					resource.TestCheckResourceAttr(resourceName, "monitoring.0.metric_configuration.1.metric_names.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "monitoring.0.metric_configuration.1.metric_names.*", "MemoryUtilization"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccECSService_BlueGreenDeployment_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var service awstypes.Service
@@ -6191,6 +6275,82 @@ resource "aws_cloudwatch_metric_alarm" "test" {
   insufficient_data_actions = []
 }
 `, rName)
+}
+
+func testAccServiceConfig_monitoringBase(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_ecs_cluster" "test" {
+  name = %[1]q
+}
+
+resource "aws_ecs_task_definition" "test" {
+  family = %[1]q
+
+  container_definitions = <<DEFINITION
+[
+  {
+    "cpu": 128,
+    "essential": true,
+    "image": "mongo:latest",
+    "memory": 128,
+    "name": "mongodb"
+  }
+]
+DEFINITION
+}
+`, rName)
+}
+
+func testAccServiceConfig_monitoring(rName string, resolutionSeconds int) string {
+	return acctest.ConfigCompose(testAccServiceConfig_monitoringBase(rName), fmt.Sprintf(`
+resource "aws_ecs_service" "test" {
+  name            = %[1]q
+  cluster         = aws_ecs_cluster.test.id
+  task_definition = aws_ecs_task_definition.test.arn
+  desired_count   = 1
+
+  monitoring {
+    metric_configuration {
+      metric_names       = ["CPUUtilization", "MemoryUtilization"]
+      resolution_seconds = %[2]d
+    }
+  }
+}
+`, rName, resolutionSeconds))
+}
+
+func testAccServiceConfig_monitoringMultiple(rName string) string {
+	return acctest.ConfigCompose(testAccServiceConfig_monitoringBase(rName), fmt.Sprintf(`
+resource "aws_ecs_service" "test" {
+  name            = %[1]q
+  cluster         = aws_ecs_cluster.test.id
+  task_definition = aws_ecs_task_definition.test.arn
+  desired_count   = 1
+
+  monitoring {
+    metric_configuration {
+      metric_names       = ["CPUUtilization"]
+      resolution_seconds = 20
+    }
+
+    metric_configuration {
+      metric_names       = ["MemoryUtilization"]
+      resolution_seconds = 60
+    }
+  }
+}
+`, rName))
+}
+
+func testAccServiceConfig_monitoringRemoved(rName string) string {
+	return acctest.ConfigCompose(testAccServiceConfig_monitoringBase(rName), fmt.Sprintf(`
+resource "aws_ecs_service" "test" {
+  name            = %[1]q
+  cluster         = aws_ecs_cluster.test.id
+  task_definition = aws_ecs_task_definition.test.arn
+  desired_count   = 1
+}
+`, rName))
 }
 
 func testAccServiceConfig_deploymentValues(rName string) string {

--- a/website/docs/d/ecs_service.html.markdown
+++ b/website/docs/d/ecs_service.html.markdown
@@ -48,6 +48,7 @@ This data source exports the following attributes in addition to the arguments a
 * `iam_role` - ARN of the IAM role associated with the service
 * `launch_type` - Launch type for the ECS Service
 * `load_balancer` - Load balancers for the ECS Service. See [`load_balancer` Block](#load_balancer-block) for details.
+* `monitoring` - Monitoring configuration for the service. See [`monitoring` Block](#monitoring-block) for details.
 * `network_configuration` - Network configuration for the service. See [`network_configuration` Block](#network_configuration-block) for details.
 * `ordered_placement_strategy` - Placement strategy for tasks. See [`ordered_placement_strategy` Block](#ordered_placement_strategy-block) for details.
 * `pending_count` - Number of tasks in PENDING state
@@ -149,6 +150,21 @@ The `events` block exports the following attributes:
 * `created_at` - Time when event occurred (RFC3339 format)
 * `id` - Event ID
 * `message` - Event message
+
+### `monitoring` Block
+
+The `monitoring` block exports the following attributes:
+
+* `metric_configuration` - List of metric configurations for the service monitoring. See [`metric_configuration` Block](#metric_configuration-block) for details.
+
+-> **Note:** The monitoring configuration is returned by the [`DescribeServiceRevisions` API](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_DescribeServiceRevisions.html) rather than `DescribeServices`, so reading this attribute requires the `ecs:DescribeServiceRevisions` IAM permission.
+
+### `metric_configuration` Block
+
+The `metric_configuration` block exports the following attributes:
+
+* `metric_names` - Set of configured metric names.
+* `resolution_seconds` - Resolution, in seconds, at which the metrics are collected.
 
 ### `network_configuration` Block
 

--- a/website/docs/r/ecs_service.html.markdown
+++ b/website/docs/r/ecs_service.html.markdown
@@ -250,6 +250,7 @@ The following arguments are optional:
 * `iam_role` - (Optional) ARN of the IAM role that allows Amazon ECS to make calls to your load balancer on your behalf. This parameter is required if you are using a load balancer with your service, but only if your task definition does not use the `awsvpc` network mode. If using `awsvpc` network mode, do not specify this role. If your account has already created the Amazon ECS service-linked role, that role is used by default for your service unless you specify a role here.
 * `launch_type` - (Optional) Launch type on which to run your service. The valid values are `EC2`, `FARGATE`, and `EXTERNAL`. Defaults to `EC2`. Conflicts with `capacity_provider_strategy`.
 * `load_balancer` - (Optional) Configuration block for load balancers. [See below](#load_balancer-block).
+* `monitoring` - (Optional) Configuration block for the resolution of the service-level `CPUUtilization` and `MemoryUtilization` CloudWatch metrics. When not specified, Amazon ECS uses the default resolution of `60` seconds. [See below](#monitoring).
 * `network_configuration` - (Optional) Network configuration for the service. This parameter is required for task definitions that use the `awsvpc` network mode to receive their own Elastic Network Interface, and it is not supported for other network modes. [See below](#network_configuration-block).
 * `ordered_placement_strategy` - (Optional) Service level strategy rules that are taken into consideration during task placement. List from top to bottom in order of precedence. Updates to this configuration will take effect next task deployment unless `force_new_deployment` is enabled. The maximum number of `ordered_placement_strategy` blocks is `5`. [See below](#ordered_placement_strategy-block).
 * `placement_constraints` - (Optional) Rules that are taken into consideration during task placement. Updates to this configuration will take effect next task deployment unless `force_new_deployment` is enabled. Maximum number of `placement_constraints` is `10`. [See below](#placement_constraints-block).
@@ -380,6 +381,21 @@ The `advanced_configuration` configuration block supports the following:
 * `production_listener_rule` - (Required) ARN of the listener rule that routes production traffic.
 * `role_arn` - (Required) ARN of the IAM role that allows ECS to manage the target groups.
 * `test_listener_rule` - (Optional) ARN of the listener rule that routes test traffic.
+
+### monitoring
+
+`monitoring` supports the following:
+
+* `metric_configuration` - (Required) List of metric configurations for the service monitoring. [See below](#metric_configuration).
+
+-> **Note:** The monitoring configuration is returned by the [`DescribeServiceRevisions` API](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_DescribeServiceRevisions.html) rather than `DescribeServices`, so reading this attribute requires the `ecs:DescribeServiceRevisions` IAM permission.
+
+### metric_configuration
+
+The `metric_configuration` configuration block supports the following:
+
+* `metric_names` - (Required) Set of metric names to configure. The currently supported metric names are `CPUUtilization` and `MemoryUtilization`.
+* `resolution_seconds` - (Required) Resolution, in seconds, at which to collect the metrics. The valid values are `20` and `60`. Publishing metrics at 20-second resolution allows [faster service auto scaling](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/target-tracking-faster-auto-scaling.html) using the `ECSServiceAverageCPUUtilizationHighResolution` and `ECSServiceAverageMemoryUtilizationHighResolution` predefined metric types.
 
 ### `network_configuration` Block
 


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

### Description

Add support for the `monitoring` configuration block (`Monitoring.MetricConfigurations` in the `CreateService`/`UpdateService` APIs) in [`aws_ecs_service`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service), enabling high-resolution (20-second) `CPUUtilization` and `MemoryUtilization` CloudWatch metrics for faster service auto scaling. The same attribute is also exposed (computed) on the `aws_ecs_service` data source.

```hcl
resource "aws_ecs_service" "example" {
  # ...

  monitoring {
    metric_configuration {
      metric_names       = ["CPUUtilization", "MemoryUtilization"]
      resolution_seconds = 20
    }
  }
}
```

Implementation notes:

- **Read-back**: `DescribeServices` does not return the monitoring configuration; it is only available on service revisions. Read therefore makes a secondary `DescribeServiceRevisions` call (new `findServiceRevisions` finder) against `Service.CurrentServiceRevisions` and uses the flattened `Monitoring` block from the newest revision, so drift detection and `terraform import` work correctly. Reading the attribute requires the `ecs:DescribeServiceRevisions` IAM permission (noted in the resource and data source docs). When a service has no revisions (e.g. `CODE_DEPLOY`/`EXTERNAL` deployment controllers), the lookup is skipped.
- **Clearing on update**: removing the block sends `Monitoring` with an explicitly empty `MetricConfigurations` list. Sending an empty `MonitoringConfiguration{}` object (i.e. with `metricConfigurations` omitted) consistently causes the API to return a 500 error (`ServerException: Service Unavailable`); the empty-list form is accepted and clears the configuration. This appears to be a bug on the AWS side. See the removal step in `TestAccECSService_monitoring`).

### Relations

Closes #48669

### References

- [AWS Blog: Amazon ECS introduces new high-resolution metrics for faster service auto scaling](https://aws.amazon.com/blogs/aws/amazon-ecs-introduces-new-high-resolution-metrics-for-faster-service-auto-scaling/)
- [AWS Docs: Faster auto scaling with high-resolution metrics](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/target-tracking-faster-auto-scaling.html)
- [`CreateService` API — `monitoring`](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_CreateService.html)
- [`MetricConfiguration` type](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_MetricConfiguration.html)
- [`DescribeServiceRevisions` API](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_DescribeServiceRevisions.html)

### Output from Acceptance Testing

```console
make testacc TESTS='TestAccECSService_monitoring|TestAccECSServiceDataSource_monitoring' PKG=ecs
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2	5.405s
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider/framework	5.412s
make: Running acceptance tests on branch: 🌿 ecs-high-res-metrics 🌿...
TF_ACC=1 go1.26.4 test ./internal/service/ecs/... -v -count 1 -parallel 20 -run='TestAccECSService_monitoring|TestAccECSServiceDataSource_monitoring'  -timeout 360m -vet=off -buildvcs=false
2026/07/06 16:54:00 Creating Terraform AWS Provider (SDKv2-style)...
2026/07/06 16:54:00 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccECSServiceDataSource_monitoring
=== PAUSE TestAccECSServiceDataSource_monitoring
=== RUN   TestAccECSService_monitoring
=== PAUSE TestAccECSService_monitoring
=== RUN   TestAccECSService_monitoringMultipleMetricConfigurations
=== PAUSE TestAccECSService_monitoringMultipleMetricConfigurations
=== CONT  TestAccECSServiceDataSource_monitoring
=== CONT  TestAccECSService_monitoringMultipleMetricConfigurations
=== CONT  TestAccECSService_monitoring
--- PASS: TestAccECSServiceDataSource_monitoring (66.46s)
--- PASS: TestAccECSService_monitoringMultipleMetricConfigurations (76.81s)
--- PASS: TestAccECSService_monitoring (81.58s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecs	86.927s
```
