### PR TITLE
Un-Listable resource type: `aws_lakeformation_permissions`

### DIFF
--- a/docs/design-decisions/resource-types-without-list.md
+++ b/docs/design-decisions/resource-types-without-list.md
@@ -9,9 +9,23 @@ One of the primary use cases for List Resources is to allow practitioners to enu
 This means that, in general, there should be a List Resource corresponding to a Resource type.
 This includes Singleton cases where there is a single remote resource in a given AWS region or account, so that the remote resource can be identified and imported.
 
-There are some rare cases where a corresponding List Resource should not be created.
+There are specific cases where a corresponding List Resource cannot be implemented in a way that is correct, useful, and consistent with practitioner expectations.
+These cases are described below.
+Exclusions reflect the current resource type and the AWS API it wraps; a redesigned successor resource may become a viable List candidate in the future.
 
 ## Excluded Resource Patterns
+
+### Composite Grant Resources
+
+A **composite grant resource** is a resource type that models a single permission-grant request, but the AWS API stores and returns the resulting grants in normalized form.
+As a consequence:
+
+1. The AWS API does not assign a stable per-grant identifier; the only way to identify the grants associated with a Terraform resource is to filter `ListPermissions`-style output against the original Terraform input configuration.
+2. AWS may normalize the resource selector (for example, returning a `Table` grant as `TableWithColumns` and vice versa), so reconstructing the Terraform-shaped state from API output without the input configuration is ambiguous.
+3. AWS-returned grants mix implicit (administrator-derived) and explicit (user-created) records indistinguishably, so an enumeration cannot reliably identify Terraform-managed resources.
+
+For these reasons, composite grant resources are not importable, do not have a Resource Identity schema, and cannot support List.
+A future resource that models a single AWS-side grant with a stable composite identity may become a viable candidate.
 
 ### Exclusive Resources
 
@@ -32,6 +46,10 @@ As there is no corresponding remote resource, there is nothing to List or Import
 ## Excluded Resource Types
 
 As new excluded resource types are identified, they should be added to this list.
+
+### Composite Grant Resources
+
+* `aws_lakeformation_permissions`
 
 ### Exclusive Resources
 

--- a/internal/service/lakeformation/permissions_list.go
+++ b/internal/service/lakeformation/permissions_list.go
@@ -1,0 +1,11 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package lakeformation
+
+// The List Resource `aws_lakeformation_permissions` will not be implemented: This is a "Composite Grant Resource".
+// The AWS Lake Formation API does not provide stable per-grant identifiers, and returned grants are normalized in
+// shapes that depend on the original Terraform input configuration. As a consequence, this resource is not
+// importable and does not have a Resource Identity schema.
+//
+// See docs/design-decisions/resource-types-without-list.md


### PR DESCRIPTION
### Description

Documents `aws_lakeformation_permissions` as a resource type that will not receive a corresponding List Resource, following the pattern established in #48537.

Adds a new **Composite Grant Resources** category to the "When Not to Support `List` on a Resource Type" design decision. This category covers resource types that model a single permission-grant request where the AWS API stores and returns the resulting grants in normalized form. For these resources:

* The AWS API does not assign a stable per-grant identifier.
* AWS may normalize the resource selector (e.g. returning a `Table` grant as `TableWithColumns`), making the Terraform-shaped state ambiguous to reconstruct without the input configuration.
* AWS-returned grants mix implicit (administrator-derived) and explicit (user-created) records indistinguishably.

As a result, `aws_lakeformation_permissions` is not importable, has no Resource Identity schema, and cannot support List. A marker file records this decision alongside the existing `aws_acm_certificate_validation` and `aws_iam_policy_attachment` exclusions.

### Relations

Closes #47238
Relates #47234
Relates #47005

### Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

### Changes to Security Controls

None.

