### PR TITLE
docs: Update product manager in maintainers list

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -9,7 +9,7 @@
 
 The HashiCorp Terraform AWS provider team is :
 
-* Marc Cosentino, Product Manager - GitHub [@marcosentino](https://github.com/marcosentino)
+* Tiberiu Radu, Product Manager - GitHub [@hashTB](https://github.com/hashTB)
 * Simon Davis, Engineering Manager - GitHub [@breathingdust](https://github.com/breathingdust)
 * Justin Retzolk, Ecosystem Engineer - GitHub [@justinretzolk](https://github.com/justinretzolk)
 * Adrian Johnson, Engineer - GitHub [@johnsonaj](https://github.com/johnsonaj)


### PR DESCRIPTION
### Description

Updates the maintainers list in `docs/faq.md` to replace the previous Product Manager (Marc Cosentino) with Tiberiu Radu ([@hashTB](https://github.com/hashTB)).

### Relations

Closes #0

### References

n/a

