### PR TITLE
r/aws_bedrockagentcore_online_evaluation_config: add insight and clustering_config

### DIFF
--- a/.changelog/48799.txt
+++ b/.changelog/48799.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_bedrockagentcore_online_evaluation_config: Add `insight` and `clustering_config` configuration blocks
+```

--- a/internal/service/bedrockagentcore/online_evaluation_config.go
+++ b/internal/service/bedrockagentcore/online_evaluation_config.go
@@ -79,6 +79,32 @@ func (r *onlineEvaluationConfigResource) Schema(ctx context.Context, request res
 	)
 	response.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
+			// clustering_config is an object-typed Optional+Computed ListAttribute (not a
+			// block): the Update API PATCH-merges and cannot clear it once set (omitting it
+			// retains the server value, and the SDK requires Frequencies so an empty value is
+			// not a clear signal). Computed lets state absorb the retained server value so a
+			// set->unset transition converges instead of a perpetual diff, mirroring
+			// description. A block cannot be Computed, and protocol v5 does not support nested
+			// attributes, so the frequencies size/uniqueness validators are enforced in
+			// ValidateConfig instead of on a nested attribute.
+			"clustering_config": schema.ListAttribute{
+				CustomType: fwtypes.NewListNestedObjectTypeOf[clusteringConfigModel](ctx),
+				Optional:   true,
+				Computed:   true,
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+					// The service rejects clustering_config unless insight is also set. The
+					// reverse does NOT hold (insight without clustering_config is valid), so
+					// this requirement is one-directional (clustering => insight only).
+					listvalidator.AlsoRequires(path.MatchRoot("insight")),
+				},
+				PlanModifiers: []planmodifier.List{
+					listplanmodifier.UseStateForUnknown(),
+				},
+				ElementType: types.ObjectType{
+					AttrTypes: fwtypes.AttributeTypesMust[clusteringConfigModel](ctx),
+				},
+			},
 			names.AttrDescription: schema.StringAttribute{
 				Optional: true,
 				// The Update API retains description when omitted and rejects an empty
@@ -131,30 +157,6 @@ func (r *onlineEvaluationConfigResource) Schema(ctx context.Context, request res
 			names.AttrTagsAll: tftags.TagsAttributeComputedOnly(),
 		},
 		Blocks: map[string]schema.Block{
-			"clustering_config": schema.ListNestedBlock{
-				CustomType: fwtypes.NewListNestedObjectTypeOf[clusteringConfigModel](ctx),
-				Validators: []validator.List{
-					listvalidator.SizeAtMost(1),
-					// The service rejects clustering_config unless insight is also set
-					// ("clusteringConfig can only be set when insights are provided").
-					// The reverse does NOT hold: insight without clustering_config is a
-					// valid, service-accepted configuration, so this requirement is
-					// one-directional (clustering => insight only).
-					listvalidator.AlsoRequires(path.MatchRoot("insight")),
-				},
-				NestedObject: schema.NestedBlockObject{
-					Attributes: map[string]schema.Attribute{
-						"frequencies": schema.ListAttribute{
-							ElementType: fwtypes.StringEnumType[awstypes.ClusteringFrequency](),
-							Required:    true,
-							Validators: []validator.List{
-								listvalidator.SizeBetween(1, 3),
-								listvalidator.UniqueValues(),
-							},
-						},
-					},
-				},
-			},
 			"data_source_config": schema.ListNestedBlock{
 				CustomType: fwtypes.NewListNestedObjectTypeOf[dataSourceConfigModel](ctx),
 				Validators: []validator.List{
@@ -346,6 +348,50 @@ func (r *onlineEvaluationConfigResource) ConfigValidators(context.Context) []res
 			path.MatchRoot("evaluator"),
 			path.MatchRoot("insight"),
 		),
+	}
+}
+
+// ValidateConfig enforces the clustering_config.frequencies size and uniqueness
+// constraints offline. clustering_config is an object-typed Optional+Computed
+// ListAttribute (so set->unset converges), which cannot carry per-nested-attribute
+// validators, so those checks live here instead.
+func (r *onlineEvaluationConfigResource) ValidateConfig(ctx context.Context, request resource.ValidateConfigRequest, response *resource.ValidateConfigResponse) {
+	var data onlineEvaluationConfigResourceModel
+	smerr.AddEnrich(ctx, &response.Diagnostics, request.Config.Get(ctx, &data))
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	if data.ClusteringConfig.IsNull() || data.ClusteringConfig.IsUnknown() {
+		return
+	}
+
+	clusteringConfigs, d := data.ClusteringConfig.ToSlice(ctx)
+	smerr.AddEnrich(ctx, &response.Diagnostics, d)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	for _, cc := range clusteringConfigs {
+		if cc.Frequencies.IsNull() || cc.Frequencies.IsUnknown() {
+			continue
+		}
+		elements := cc.Frequencies.Elements()
+		if len(elements) < 1 || len(elements) > 3 {
+			smerr.AddError(ctx, &response.Diagnostics, fmt.Errorf("clustering_config.frequencies must contain between 1 and 3 values, got %d", len(elements)))
+		}
+		seen := make(map[string]struct{}, len(elements))
+		for _, e := range elements {
+			se, ok := e.(fwtypes.StringEnum[awstypes.ClusteringFrequency])
+			if !ok || se.IsNull() || se.IsUnknown() {
+				continue
+			}
+			v := se.ValueString()
+			if _, dup := seen[v]; dup {
+				smerr.AddError(ctx, &response.Diagnostics, fmt.Errorf("clustering_config.frequencies must not contain duplicate values: %q appears more than once", v))
+			}
+			seen[v] = struct{}{}
+		}
 	}
 }
 

--- a/internal/service/bedrockagentcore/online_evaluation_config.go
+++ b/internal/service/bedrockagentcore/online_evaluation_config.go
@@ -137,8 +137,9 @@ func (r *onlineEvaluationConfigResource) Schema(ctx context.Context, request res
 					listvalidator.SizeAtMost(1),
 					// The service rejects clustering_config unless insight is also set
 					// ("clusteringConfig can only be set when insights are provided").
-					// insight already AlsoRequires clustering_config, so the two are
-					// mutually required.
+					// The reverse does NOT hold: insight without clustering_config is a
+					// valid, service-accepted configuration, so this requirement is
+					// one-directional (clustering => insight only).
 					listvalidator.AlsoRequires(path.MatchRoot("insight")),
 				},
 				NestedObject: schema.NestedBlockObject{
@@ -219,7 +220,6 @@ func (r *onlineEvaluationConfigResource) Schema(ctx context.Context, request res
 				CustomType: fwtypes.NewListNestedObjectTypeOf[insightModel](ctx),
 				Validators: []validator.List{
 					listvalidator.SizeAtMost(10),
-					listvalidator.AlsoRequires(path.MatchRoot("clustering_config")),
 				},
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{

--- a/internal/service/bedrockagentcore/online_evaluation_config.go
+++ b/internal/service/bedrockagentcore/online_evaluation_config.go
@@ -29,6 +29,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -80,14 +81,26 @@ func (r *onlineEvaluationConfigResource) Schema(ctx context.Context, request res
 		Attributes: map[string]schema.Attribute{
 			names.AttrDescription: schema.StringAttribute{
 				Optional: true,
+				// The Update API retains description when omitted and rejects an empty
+				// string (pattern .+, min length 1), so it cannot be cleared once set.
+				// Computed lets state absorb the retained server value instead of
+				// showing a perpetual "-> null" diff.
+				Computed: true,
 				Validators: []validator.String{
 					stringvalidator.LengthBetween(1, 200),
+				},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"enable_on_create": schema.BoolAttribute{
 				Required: true,
 				PlanModifiers: []planmodifier.Bool{
 					boolplanmodifier.UseStateForUnknown(),
+					// enable_on_create only takes effect at creation (absent from the
+					// Update input and the Get output), so a change must force replacement
+					// rather than plan an in-place update that never reaches the API.
+					boolplanmodifier.RequiresReplace(),
 				},
 			},
 			"evaluation_execution_role_arn": schema.StringAttribute{
@@ -122,6 +135,11 @@ func (r *onlineEvaluationConfigResource) Schema(ctx context.Context, request res
 				CustomType: fwtypes.NewListNestedObjectTypeOf[clusteringConfigModel](ctx),
 				Validators: []validator.List{
 					listvalidator.SizeAtMost(1),
+					// The service rejects clustering_config unless insight is also set
+					// ("clusteringConfig can only be set when insights are provided").
+					// insight already AlsoRequires clustering_config, so the two are
+					// mutually required.
+					listvalidator.AlsoRequires(path.MatchRoot("insight")),
 				},
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
@@ -130,6 +148,7 @@ func (r *onlineEvaluationConfigResource) Schema(ctx context.Context, request res
 							Required:    true,
 							Validators: []validator.List{
 								listvalidator.SizeBetween(1, 3),
+								listvalidator.UniqueValues(),
 							},
 						},
 					},
@@ -168,6 +187,22 @@ func (r *onlineEvaluationConfigResource) Schema(ctx context.Context, request res
 				CustomType: fwtypes.NewSetNestedObjectTypeOf[evaluatorReferenceModel](ctx),
 				Validators: []validator.Set{
 					setvalidator.SizeBetween(1, 10),
+				},
+				PlanModifiers: []planmodifier.Set{
+					// The service cannot switch between evaluators and insights via
+					// update ("Cannot switch between evaluators and insights via update.
+					// Delete and recreate the config."). evaluator is ExactlyOneOf with
+					// insight, so toggling this block on or off IS the mode switch and
+					// must force replacement.
+					setplanmodifier.RequiresReplaceIf(
+						func(ctx context.Context, request planmodifier.SetRequest, response *setplanmodifier.RequiresReplaceIfFuncResponse) {
+							stateHas := !request.StateValue.IsNull() && len(request.StateValue.Elements()) > 0
+							planHas := !request.PlanValue.IsNull() && len(request.PlanValue.Elements()) > 0
+							response.RequiresReplace = stateHas != planHas
+						},
+						"Switching between evaluator and insight requires replacement.",
+						"Switching between evaluator and insight requires replacement.",
+					),
 				},
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
@@ -259,6 +294,16 @@ func (r *onlineEvaluationConfigResource) Schema(ctx context.Context, request res
 													Optional: true,
 													Validators: []validator.String{
 														stringvalidator.LengthBetween(1, 1024),
+														// Exactly one filter value member must be set. Attaching to
+														// a single attribute is sufficient: the validator runs even
+														// when it is null and tallies every sibling, catching both
+														// multiple members (silent-drop -> inconsistent result after
+														// apply) and an empty value {} (nil Expand -> internal error).
+														stringvalidator.ExactlyOneOf(
+															path.MatchRelative().AtParent().AtName("boolean_value"),
+															path.MatchRelative().AtParent().AtName("double_value"),
+															path.MatchRelative().AtParent().AtName("string_value"),
+														),
 													},
 												},
 											},

--- a/internal/service/bedrockagentcore/online_evaluation_config.go
+++ b/internal/service/bedrockagentcore/online_evaluation_config.go
@@ -184,6 +184,7 @@ func (r *onlineEvaluationConfigResource) Schema(ctx context.Context, request res
 				CustomType: fwtypes.NewListNestedObjectTypeOf[insightModel](ctx),
 				Validators: []validator.List{
 					listvalidator.SizeAtMost(10),
+					listvalidator.AlsoRequires(path.MatchRoot("clustering_config")),
 				},
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{

--- a/internal/service/bedrockagentcore/online_evaluation_config.go
+++ b/internal/service/bedrockagentcore/online_evaluation_config.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/float64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/resourcevalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -117,6 +118,23 @@ func (r *onlineEvaluationConfigResource) Schema(ctx context.Context, request res
 			names.AttrTagsAll: tftags.TagsAttributeComputedOnly(),
 		},
 		Blocks: map[string]schema.Block{
+			"clustering_config": schema.ListNestedBlock{
+				CustomType: fwtypes.NewListNestedObjectTypeOf[clusteringConfigModel](ctx),
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"frequencies": schema.ListAttribute{
+							ElementType: fwtypes.StringEnumType[awstypes.ClusteringFrequency](),
+							Required:    true,
+							Validators: []validator.List{
+								listvalidator.SizeBetween(1, 3),
+							},
+						},
+					},
+				},
+			},
 			"data_source_config": schema.ListNestedBlock{
 				CustomType: fwtypes.NewListNestedObjectTypeOf[dataSourceConfigModel](ctx),
 				Validators: []validator.List{
@@ -150,7 +168,6 @@ func (r *onlineEvaluationConfigResource) Schema(ctx context.Context, request res
 				CustomType: fwtypes.NewSetNestedObjectTypeOf[evaluatorReferenceModel](ctx),
 				Validators: []validator.Set{
 					setvalidator.SizeBetween(1, 10),
-					setvalidator.IsRequired(),
 				},
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
@@ -158,6 +175,22 @@ func (r *onlineEvaluationConfigResource) Schema(ctx context.Context, request res
 							Required: true,
 							Validators: []validator.String{
 								stringvalidator.RegexMatches(regexache.MustCompile(`^(Builtin\.[a-zA-Z0-9_-]+|[a-zA-Z][a-zA-Z0-9-_]{0,99}-[a-zA-Z0-9]{10})$`), "must be a builtin evaluator (e.g. Builtin.Helpfulness) or a custom evaluator ID"),
+							},
+						},
+					},
+				},
+			},
+			"insight": schema.ListNestedBlock{
+				CustomType: fwtypes.NewListNestedObjectTypeOf[insightModel](ctx),
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(10),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"insight_id": schema.StringAttribute{
+							Required: true,
+							Validators: []validator.String{
+								stringvalidator.RegexMatches(regexache.MustCompile(`^(Builtin\.[a-zA-Z0-9._-]+|[a-zA-Z][a-zA-Z0-9-_]{0,99}-[a-zA-Z0-9]{10})$`), "must be a builtin insight (e.g. Builtin.Insight.*) or a custom insight ID"),
 							},
 						},
 					},
@@ -258,6 +291,15 @@ func (r *onlineEvaluationConfigResource) Schema(ctx context.Context, request res
 				Delete: true,
 			}),
 		},
+	}
+}
+
+func (r *onlineEvaluationConfigResource) ConfigValidators(context.Context) []resource.ConfigValidator {
+	return []resource.ConfigValidator{
+		resourcevalidator.ExactlyOneOf(
+			path.MatchRoot("evaluator"),
+			path.MatchRoot("insight"),
+		),
 	}
 }
 
@@ -521,12 +563,14 @@ func findOnlineEvaluationConfig(ctx context.Context, conn *bedrockagentcorecontr
 
 type onlineEvaluationConfigResourceModel struct {
 	framework.WithRegionModel
+	ClusteringConfig           fwtypes.ListNestedObjectValueOf[clusteringConfigModel]       `tfsdk:"clustering_config"`
 	DataSourceConfig           fwtypes.ListNestedObjectValueOf[dataSourceConfigModel]       `tfsdk:"data_source_config"`
 	Description                types.String                                                 `tfsdk:"description"`
 	EnableOnCreate             types.Bool                                                   `tfsdk:"enable_on_create"`
 	EvaluationExecutionRoleARN fwtypes.ARN                                                  `tfsdk:"evaluation_execution_role_arn"`
 	Evaluators                 fwtypes.SetNestedObjectValueOf[evaluatorReferenceModel]      `tfsdk:"evaluator"`
 	ExecutionStatus            fwtypes.StringEnum[awstypes.OnlineEvaluationExecutionStatus] `tfsdk:"execution_status"`
+	Insights                   fwtypes.ListNestedObjectValueOf[insightModel]                `tfsdk:"insight"`
 	OnlineEvaluationConfigARN  types.String                                                 `tfsdk:"online_evaluation_config_arn"`
 	OnlineEvaluationConfigID   types.String                                                 `tfsdk:"online_evaluation_config_id"`
 	OnlineEvaluationConfigName types.String                                                 `tfsdk:"online_evaluation_config_name"`
@@ -615,6 +659,14 @@ func (m *evaluatorReferenceModel) Flatten(ctx context.Context, v any) diag.Diagn
 		diags.AddError("Unsupported Type", fmt.Sprintf("evaluator flatten: %T", v))
 	}
 	return diags
+}
+
+type insightModel struct {
+	InsightID types.String `tfsdk:"insight_id"`
+}
+
+type clusteringConfigModel struct {
+	Frequencies fwtypes.ListValueOf[fwtypes.StringEnum[awstypes.ClusteringFrequency]] `tfsdk:"frequencies"`
 }
 
 type outputConfigModel struct {

--- a/internal/service/bedrockagentcore/online_evaluation_config_test.go
+++ b/internal/service/bedrockagentcore/online_evaluation_config_test.go
@@ -386,6 +386,28 @@ func TestAccBedrockAgentCoreOnlineEvaluationConfig_insightsAndClustering(t *test
 	})
 }
 
+func TestAccBedrockAgentCoreOnlineEvaluationConfig_insightRequiresClusteringConfig(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := testAccRandomOnlineEvaluationConfigName(t)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID)
+			testAccPreCheckOnlineEvaluationConfig(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockAgentCoreServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckOnlineEvaluationConfigDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccOnlineEvaluationConfigConfig_insightsWithoutClustering(rName),
+				ExpectError: regexache.MustCompile("Invalid Attribute Combination"),
+			},
+		},
+	})
+}
+
 // Test helper functions.
 
 func testAccCheckOnlineEvaluationConfigDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
@@ -685,6 +707,33 @@ resource "aws_bedrockagentcore_online_evaluation_config" "test" {
 
   clustering_config {
     frequencies = ["DAILY", "WEEKLY"]
+  }
+
+  rule {
+    sampling_config {
+      sampling_percentage = 10.0
+    }
+  }
+}
+`, rName))
+}
+
+func testAccOnlineEvaluationConfigConfig_insightsWithoutClustering(rName string) string {
+	return acctest.ConfigCompose(testAccOnlineEvaluationConfigConfig_base(rName), fmt.Sprintf(`
+resource "aws_bedrockagentcore_online_evaluation_config" "test" {
+  online_evaluation_config_name = %[1]q
+  enable_on_create              = false
+  evaluation_execution_role_arn = aws_iam_role.test.arn
+
+  data_source_config {
+    cloudwatch_logs {
+      log_group_names = [aws_cloudwatch_log_group.test.name]
+      service_names   = ["strands_healthcare_single_agent.DEFAULT"]
+    }
+  }
+
+  insight {
+    insight_id = "Builtin.Insight.FailureAnalysis"
   }
 
   rule {

--- a/internal/service/bedrockagentcore/online_evaluation_config_test.go
+++ b/internal/service/bedrockagentcore/online_evaluation_config_test.go
@@ -386,9 +386,11 @@ func TestAccBedrockAgentCoreOnlineEvaluationConfig_insightsAndClustering(t *test
 	})
 }
 
-func TestAccBedrockAgentCoreOnlineEvaluationConfig_insightRequiresClusteringConfig(t *testing.T) {
+func TestAccBedrockAgentCoreOnlineEvaluationConfig_insightOnly(t *testing.T) {
 	ctx := acctest.Context(t)
+	var v bedrockagentcorecontrol.GetOnlineEvaluationConfigOutput
 	rName := testAccRandomOnlineEvaluationConfigName(t)
+	resourceName := "aws_bedrockagentcore_online_evaluation_config.test"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -401,8 +403,25 @@ func TestAccBedrockAgentCoreOnlineEvaluationConfig_insightRequiresClusteringConf
 		CheckDestroy:             testAccCheckOnlineEvaluationConfigDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccOnlineEvaluationConfigConfig_insightsWithoutClustering(rName),
-				ExpectError: regexache.MustCompile("Invalid Attribute Combination"),
+				// insight without clustering_config is a valid, service-accepted configuration.
+				Config: testAccOnlineEvaluationConfigConfig_insightsWithoutClustering(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckOnlineEvaluationConfigExists(ctx, t, resourceName, &v),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("insight").AtSliceIndex(0).AtMapKey("insight_id"), knownvalue.StringExact("Builtin.Insight.FailureAnalysis")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("clustering_config"), knownvalue.ListSizeExact(0)),
+				},
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, "online_evaluation_config_id"),
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "online_evaluation_config_id",
+				ImportStateVerifyIgnore: []string{
+					"enable_on_create",
+				},
 			},
 		},
 	})

--- a/internal/service/bedrockagentcore/online_evaluation_config_test.go
+++ b/internal/service/bedrockagentcore/online_evaluation_config_test.go
@@ -744,3 +744,411 @@ resource "aws_bedrockagentcore_online_evaluation_config" "test" {
 }
 `, rName))
 }
+
+// TestAccBedrockAgentCoreOnlineEvaluationConfig_filterValueExactlyOneOf confirms
+// the filter value union rejects multiple members (which silently dropped all but
+// the first -> inconsistent result after apply) and an empty value {} (which
+// surfaced an internal "always an error in the provider" message) at plan time.
+func TestAccBedrockAgentCoreOnlineEvaluationConfig_filterValueExactlyOneOf(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := testAccRandomOnlineEvaluationConfigName(t)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID)
+			testAccPreCheckOnlineEvaluationConfig(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockAgentCoreServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckOnlineEvaluationConfigDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccOnlineEvaluationConfigConfig_filterValueMultiMember(rName),
+				ExpectError: regexache.MustCompile("Invalid Attribute Combination"),
+			},
+			{
+				Config:      testAccOnlineEvaluationConfigConfig_filterValueEmpty(rName),
+				ExpectError: regexache.MustCompile("Invalid Attribute Combination"),
+			},
+		},
+	})
+}
+
+// TestAccBedrockAgentCoreOnlineEvaluationConfig_frequenciesUnique confirms duplicate
+// clustering frequencies are rejected at plan time instead of only by the API.
+func TestAccBedrockAgentCoreOnlineEvaluationConfig_frequenciesUnique(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := testAccRandomOnlineEvaluationConfigName(t)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID)
+			testAccPreCheckOnlineEvaluationConfig(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockAgentCoreServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckOnlineEvaluationConfigDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccOnlineEvaluationConfigConfig_frequenciesDuplicate(rName),
+				ExpectError: regexache.MustCompile("Duplicate List Value"),
+			},
+		},
+	})
+}
+
+// TestAccBedrockAgentCoreOnlineEvaluationConfig_clusteringRequiresInsight confirms
+// clustering_config is rejected without insight at plan time (the service only
+// accepts clusteringConfig when insights are provided).
+func TestAccBedrockAgentCoreOnlineEvaluationConfig_clusteringRequiresInsight(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := testAccRandomOnlineEvaluationConfigName(t)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID)
+			testAccPreCheckOnlineEvaluationConfig(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockAgentCoreServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckOnlineEvaluationConfigDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccOnlineEvaluationConfigConfig_evaluatorClustering(rName),
+				ExpectError: regexache.MustCompile("Invalid Attribute Combination"),
+			},
+		},
+	})
+}
+
+// TestAccBedrockAgentCoreOnlineEvaluationConfig_evaluatorInsightSwitch confirms that
+// switching between evaluators and insights forces replacement. The service cannot
+// switch via update ("Cannot switch between evaluators and insights via update.
+// Delete and recreate the config."), which previously failed at apply.
+func TestAccBedrockAgentCoreOnlineEvaluationConfig_evaluatorInsightSwitch(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v bedrockagentcorecontrol.GetOnlineEvaluationConfigOutput
+	rName := testAccRandomOnlineEvaluationConfigName(t)
+	resourceName := "aws_bedrockagentcore_online_evaluation_config.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID)
+			testAccPreCheckOnlineEvaluationConfig(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockAgentCoreServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckOnlineEvaluationConfigDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOnlineEvaluationConfigConfig_evaluator(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckOnlineEvaluationConfigExists(ctx, t, resourceName, &v),
+				),
+			},
+			{
+				Config: testAccOnlineEvaluationConfigConfig_insightsAndClustering(rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionReplace),
+					},
+				},
+			},
+		},
+	})
+}
+
+// TestAccBedrockAgentCoreOnlineEvaluationConfig_descriptionClear confirms the
+// set->unset transition for description. The Update API retains description when
+// omitted and rejects an empty string, so description is Optional+Computed;
+// removing it from configuration must not produce a perpetual diff.
+func TestAccBedrockAgentCoreOnlineEvaluationConfig_descriptionClear(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v bedrockagentcorecontrol.GetOnlineEvaluationConfigOutput
+	rName := testAccRandomOnlineEvaluationConfigName(t)
+	resourceName := "aws_bedrockagentcore_online_evaluation_config.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID)
+			testAccPreCheckOnlineEvaluationConfig(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockAgentCoreServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckOnlineEvaluationConfigDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOnlineEvaluationConfigConfig_evaluatorDescription(rName, "initial description"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckOnlineEvaluationConfigExists(ctx, t, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "initial description"),
+				),
+			},
+			{
+				Config: testAccOnlineEvaluationConfigConfig_evaluator(rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+// TestAccBedrockAgentCoreOnlineEvaluationConfig_enableOnCreateForcesNew confirms that
+// changing enable_on_create forces replacement. It is a create-only field (absent
+// from the Update input and Get output), so an in-place change never reached the API.
+func TestAccBedrockAgentCoreOnlineEvaluationConfig_enableOnCreateForcesNew(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v bedrockagentcorecontrol.GetOnlineEvaluationConfigOutput
+	rName := testAccRandomOnlineEvaluationConfigName(t)
+	resourceName := "aws_bedrockagentcore_online_evaluation_config.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID)
+			testAccPreCheckOnlineEvaluationConfig(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockAgentCoreServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckOnlineEvaluationConfigDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOnlineEvaluationConfigConfig_enableOnCreate(rName, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckOnlineEvaluationConfigExists(ctx, t, resourceName, &v),
+				),
+			},
+			{
+				Config: testAccOnlineEvaluationConfigConfig_enableOnCreate(rName, true),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionReplace),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccOnlineEvaluationConfigConfig_evaluator(rName string) string {
+	return acctest.ConfigCompose(testAccOnlineEvaluationConfigConfig_base(rName), fmt.Sprintf(`
+resource "aws_bedrockagentcore_online_evaluation_config" "test" {
+  online_evaluation_config_name = %[1]q
+  enable_on_create              = false
+  evaluation_execution_role_arn = aws_iam_role.test.arn
+
+  data_source_config {
+    cloudwatch_logs {
+      log_group_names = [aws_cloudwatch_log_group.test.name]
+      service_names   = ["strands_healthcare_single_agent.DEFAULT"]
+    }
+  }
+
+  evaluator {
+    evaluator_id = "Builtin.Helpfulness"
+  }
+
+  rule {
+    sampling_config {
+      sampling_percentage = 10.0
+    }
+  }
+}
+`, rName))
+}
+
+func testAccOnlineEvaluationConfigConfig_evaluatorDescription(rName, description string) string {
+	return acctest.ConfigCompose(testAccOnlineEvaluationConfigConfig_base(rName), fmt.Sprintf(`
+resource "aws_bedrockagentcore_online_evaluation_config" "test" {
+  online_evaluation_config_name = %[1]q
+  enable_on_create              = false
+  description                   = %[2]q
+  evaluation_execution_role_arn = aws_iam_role.test.arn
+
+  data_source_config {
+    cloudwatch_logs {
+      log_group_names = [aws_cloudwatch_log_group.test.name]
+      service_names   = ["strands_healthcare_single_agent.DEFAULT"]
+    }
+  }
+
+  evaluator {
+    evaluator_id = "Builtin.Helpfulness"
+  }
+
+  rule {
+    sampling_config {
+      sampling_percentage = 10.0
+    }
+  }
+}
+`, rName, description))
+}
+
+func testAccOnlineEvaluationConfigConfig_enableOnCreate(rName string, enable bool) string {
+	return acctest.ConfigCompose(testAccOnlineEvaluationConfigConfig_base(rName), fmt.Sprintf(`
+resource "aws_bedrockagentcore_online_evaluation_config" "test" {
+  online_evaluation_config_name = %[1]q
+  enable_on_create              = %[2]t
+  evaluation_execution_role_arn = aws_iam_role.test.arn
+
+  data_source_config {
+    cloudwatch_logs {
+      log_group_names = [aws_cloudwatch_log_group.test.name]
+      service_names   = ["strands_healthcare_single_agent.DEFAULT"]
+    }
+  }
+
+  evaluator {
+    evaluator_id = "Builtin.Helpfulness"
+  }
+
+  rule {
+    sampling_config {
+      sampling_percentage = 10.0
+    }
+  }
+}
+`, rName, enable))
+}
+
+func testAccOnlineEvaluationConfigConfig_filterValueMultiMember(rName string) string {
+	return acctest.ConfigCompose(testAccOnlineEvaluationConfigConfig_base(rName), fmt.Sprintf(`
+resource "aws_bedrockagentcore_online_evaluation_config" "test" {
+  online_evaluation_config_name = %[1]q
+  enable_on_create              = false
+  evaluation_execution_role_arn = aws_iam_role.test.arn
+
+  data_source_config {
+    cloudwatch_logs {
+      log_group_names = [aws_cloudwatch_log_group.test.name]
+      service_names   = ["strands_healthcare_single_agent.DEFAULT"]
+    }
+  }
+
+  evaluator {
+    evaluator_id = "Builtin.Helpfulness"
+  }
+
+  rule {
+    sampling_config {
+      sampling_percentage = 10.0
+    }
+
+    filter {
+      key      = "environment"
+      operator = "Equals"
+
+      value {
+        string_value  = "production"
+        boolean_value = true
+      }
+    }
+  }
+}
+`, rName))
+}
+
+func testAccOnlineEvaluationConfigConfig_filterValueEmpty(rName string) string {
+	return acctest.ConfigCompose(testAccOnlineEvaluationConfigConfig_base(rName), fmt.Sprintf(`
+resource "aws_bedrockagentcore_online_evaluation_config" "test" {
+  online_evaluation_config_name = %[1]q
+  enable_on_create              = false
+  evaluation_execution_role_arn = aws_iam_role.test.arn
+
+  data_source_config {
+    cloudwatch_logs {
+      log_group_names = [aws_cloudwatch_log_group.test.name]
+      service_names   = ["strands_healthcare_single_agent.DEFAULT"]
+    }
+  }
+
+  evaluator {
+    evaluator_id = "Builtin.Helpfulness"
+  }
+
+  rule {
+    sampling_config {
+      sampling_percentage = 10.0
+    }
+
+    filter {
+      key      = "environment"
+      operator = "Equals"
+
+      value {}
+    }
+  }
+}
+`, rName))
+}
+
+func testAccOnlineEvaluationConfigConfig_frequenciesDuplicate(rName string) string {
+	return acctest.ConfigCompose(testAccOnlineEvaluationConfigConfig_base(rName), fmt.Sprintf(`
+resource "aws_bedrockagentcore_online_evaluation_config" "test" {
+  online_evaluation_config_name = %[1]q
+  enable_on_create              = false
+  evaluation_execution_role_arn = aws_iam_role.test.arn
+
+  data_source_config {
+    cloudwatch_logs {
+      log_group_names = [aws_cloudwatch_log_group.test.name]
+      service_names   = ["strands_healthcare_single_agent.DEFAULT"]
+    }
+  }
+
+  insight {
+    insight_id = "Builtin.Insight.FailureAnalysis"
+  }
+
+  clustering_config {
+    frequencies = ["MONTHLY", "MONTHLY"]
+  }
+
+  rule {
+    sampling_config {
+      sampling_percentage = 10.0
+    }
+  }
+}
+`, rName))
+}
+
+func testAccOnlineEvaluationConfigConfig_evaluatorClustering(rName string) string {
+	return acctest.ConfigCompose(testAccOnlineEvaluationConfigConfig_base(rName), fmt.Sprintf(`
+resource "aws_bedrockagentcore_online_evaluation_config" "test" {
+  online_evaluation_config_name = %[1]q
+  enable_on_create              = false
+  evaluation_execution_role_arn = aws_iam_role.test.arn
+
+  data_source_config {
+    cloudwatch_logs {
+      log_group_names = [aws_cloudwatch_log_group.test.name]
+      service_names   = ["strands_healthcare_single_agent.DEFAULT"]
+    }
+  }
+
+  evaluator {
+    evaluator_id = "Builtin.Helpfulness"
+  }
+
+  clustering_config {
+    frequencies = ["DAILY"]
+  }
+
+  rule {
+    sampling_config {
+      sampling_percentage = 10.0
+    }
+  }
+}
+`, rName))
+}

--- a/internal/service/bedrockagentcore/online_evaluation_config_test.go
+++ b/internal/service/bedrockagentcore/online_evaluation_config_test.go
@@ -999,6 +999,92 @@ func TestAccBedrockAgentCoreOnlineEvaluationConfig_enableOnCreateForcesNew(t *te
 	})
 }
 
+// TestAccBedrockAgentCoreOnlineEvaluationConfig_filterClearing confirms the
+// set->unset transition for the optional rule.filter block. Update re-sends the
+// full rule, so removing the filter block must converge to an empty plan rather
+// than a perpetual diff or an inconsistent result after apply.
+func TestAccBedrockAgentCoreOnlineEvaluationConfig_filterClearing(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v bedrockagentcorecontrol.GetOnlineEvaluationConfigOutput
+	rName := testAccRandomOnlineEvaluationConfigName(t)
+	resourceName := "aws_bedrockagentcore_online_evaluation_config.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID)
+			testAccPreCheckOnlineEvaluationConfig(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockAgentCoreServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckOnlineEvaluationConfigDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOnlineEvaluationConfigConfig_evaluatorFilter(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckOnlineEvaluationConfigExists(ctx, t, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "rule.0.filter.#", "1"),
+				),
+			},
+			{
+				Config: testAccOnlineEvaluationConfigConfig_evaluator(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckOnlineEvaluationConfigExists(ctx, t, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "rule.0.filter.#", "0"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+// TestAccBedrockAgentCoreOnlineEvaluationConfig_sessionConfigClearing confirms the
+// set->unset transition for the optional rule.session_config block. Update re-sends
+// the full rule, so removing the session_config block must converge to an empty plan
+// rather than a perpetual diff or an inconsistent result after apply.
+func TestAccBedrockAgentCoreOnlineEvaluationConfig_sessionConfigClearing(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v bedrockagentcorecontrol.GetOnlineEvaluationConfigOutput
+	rName := testAccRandomOnlineEvaluationConfigName(t)
+	resourceName := "aws_bedrockagentcore_online_evaluation_config.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID)
+			testAccPreCheckOnlineEvaluationConfig(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockAgentCoreServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckOnlineEvaluationConfigDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOnlineEvaluationConfigConfig_evaluatorSessionConfig(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckOnlineEvaluationConfigExists(ctx, t, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "rule.0.session_config.#", "1"),
+				),
+			},
+			{
+				Config: testAccOnlineEvaluationConfigConfig_evaluator(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckOnlineEvaluationConfigExists(ctx, t, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "rule.0.session_config.#", "0"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
 func testAccOnlineEvaluationConfigConfig_evaluator(rName string) string {
 	return acctest.ConfigCompose(testAccOnlineEvaluationConfigConfig_base(rName), fmt.Sprintf(`
 resource "aws_bedrockagentcore_online_evaluation_config" "test" {
@@ -1020,6 +1106,73 @@ resource "aws_bedrockagentcore_online_evaluation_config" "test" {
   rule {
     sampling_config {
       sampling_percentage = 10.0
+    }
+  }
+}
+`, rName))
+}
+
+func testAccOnlineEvaluationConfigConfig_evaluatorFilter(rName string) string {
+	return acctest.ConfigCompose(testAccOnlineEvaluationConfigConfig_base(rName), fmt.Sprintf(`
+resource "aws_bedrockagentcore_online_evaluation_config" "test" {
+  online_evaluation_config_name = %[1]q
+  enable_on_create              = false
+  evaluation_execution_role_arn = aws_iam_role.test.arn
+
+  data_source_config {
+    cloudwatch_logs {
+      log_group_names = [aws_cloudwatch_log_group.test.name]
+      service_names   = ["strands_healthcare_single_agent.DEFAULT"]
+    }
+  }
+
+  evaluator {
+    evaluator_id = "Builtin.Helpfulness"
+  }
+
+  rule {
+    sampling_config {
+      sampling_percentage = 10.0
+    }
+
+    filter {
+      key      = "environment"
+      operator = "Equals"
+
+      value {
+        string_value = "production"
+      }
+    }
+  }
+}
+`, rName))
+}
+
+func testAccOnlineEvaluationConfigConfig_evaluatorSessionConfig(rName string) string {
+	return acctest.ConfigCompose(testAccOnlineEvaluationConfigConfig_base(rName), fmt.Sprintf(`
+resource "aws_bedrockagentcore_online_evaluation_config" "test" {
+  online_evaluation_config_name = %[1]q
+  enable_on_create              = false
+  evaluation_execution_role_arn = aws_iam_role.test.arn
+
+  data_source_config {
+    cloudwatch_logs {
+      log_group_names = [aws_cloudwatch_log_group.test.name]
+      service_names   = ["strands_healthcare_single_agent.DEFAULT"]
+    }
+  }
+
+  evaluator {
+    evaluator_id = "Builtin.Helpfulness"
+  }
+
+  rule {
+    sampling_config {
+      sampling_percentage = 10.0
+    }
+
+    session_config {
+      session_timeout_minutes = 20
     }
   }
 }

--- a/internal/service/bedrockagentcore/online_evaluation_config_test.go
+++ b/internal/service/bedrockagentcore/online_evaluation_config_test.go
@@ -812,7 +812,7 @@ func TestAccBedrockAgentCoreOnlineEvaluationConfig_frequenciesUnique(t *testing.
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccOnlineEvaluationConfigConfig_frequenciesDuplicate(rName),
-				ExpectError: regexache.MustCompile("Duplicate List Value"),
+				ExpectError: regexache.MustCompile("must not contain duplicate values"),
 			},
 		},
 	})
@@ -910,6 +910,48 @@ func TestAccBedrockAgentCoreOnlineEvaluationConfig_descriptionClear(t *testing.T
 			},
 			{
 				Config: testAccOnlineEvaluationConfigConfig_evaluator(rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+// TestAccBedrockAgentCoreOnlineEvaluationConfig_clusteringConfigClear confirms the
+// set->unset transition for clustering_config converges. The Update API PATCH-merges and
+// retains clustering_config when omitted (the SDK requires Frequencies, so an empty value
+// is not a clear signal), so clustering_config is Optional+Computed and removing it must
+// produce an empty re-plan instead of a perpetual diff.
+func TestAccBedrockAgentCoreOnlineEvaluationConfig_clusteringConfigClear(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v bedrockagentcorecontrol.GetOnlineEvaluationConfigOutput
+	rName := testAccRandomOnlineEvaluationConfigName(t)
+	resourceName := "aws_bedrockagentcore_online_evaluation_config.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID)
+			testAccPreCheckOnlineEvaluationConfig(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockAgentCoreServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckOnlineEvaluationConfigDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOnlineEvaluationConfigConfig_insightsAndClustering(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckOnlineEvaluationConfigExists(ctx, t, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "clustering_config.#", "1"),
+				),
+			},
+			{
+				// Remove clustering_config (keep insight). Optional+Computed absorbs the
+				// server-retained value, so the post-apply refresh plan is empty.
+				Config: testAccOnlineEvaluationConfigConfig_insightsWithoutClustering(rName),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PostApplyPostRefresh: []plancheck.PlanCheck{
 						plancheck.ExpectEmptyPlan(),

--- a/internal/service/bedrockagentcore/online_evaluation_config_test.go
+++ b/internal/service/bedrockagentcore/online_evaluation_config_test.go
@@ -343,6 +343,49 @@ func TestAccBedrockAgentCoreOnlineEvaluationConfig_filters(t *testing.T) {
 	})
 }
 
+func TestAccBedrockAgentCoreOnlineEvaluationConfig_insightsAndClustering(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v bedrockagentcorecontrol.GetOnlineEvaluationConfigOutput
+	rName := testAccRandomOnlineEvaluationConfigName(t)
+	resourceName := "aws_bedrockagentcore_online_evaluation_config.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID)
+			testAccPreCheckOnlineEvaluationConfig(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockAgentCoreServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckOnlineEvaluationConfigDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOnlineEvaluationConfigConfig_insightsAndClustering(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckOnlineEvaluationConfigExists(ctx, t, resourceName, &v),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("insight").AtSliceIndex(0).AtMapKey("insight_id"), knownvalue.StringExact("Builtin.Insight.FailureAnalysis")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("clustering_config").AtSliceIndex(0).AtMapKey("frequencies"), knownvalue.ListExact([]knownvalue.Check{
+						knownvalue.StringExact("DAILY"),
+						knownvalue.StringExact("WEEKLY"),
+					})),
+				},
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, "online_evaluation_config_id"),
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "online_evaluation_config_id",
+				ImportStateVerifyIgnore: []string{
+					"enable_on_create",
+				},
+			},
+		},
+	})
+}
+
 // Test helper functions.
 
 func testAccCheckOnlineEvaluationConfigDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
@@ -616,6 +659,37 @@ resource "aws_bedrockagentcore_online_evaluation_config" "test" {
 
     session_config {
       session_timeout_minutes = 20
+    }
+  }
+}
+`, rName))
+}
+
+func testAccOnlineEvaluationConfigConfig_insightsAndClustering(rName string) string {
+	return acctest.ConfigCompose(testAccOnlineEvaluationConfigConfig_base(rName), fmt.Sprintf(`
+resource "aws_bedrockagentcore_online_evaluation_config" "test" {
+  online_evaluation_config_name = %[1]q
+  enable_on_create              = false
+  evaluation_execution_role_arn = aws_iam_role.test.arn
+
+  data_source_config {
+    cloudwatch_logs {
+      log_group_names = [aws_cloudwatch_log_group.test.name]
+      service_names   = ["strands_healthcare_single_agent.DEFAULT"]
+    }
+  }
+
+  insight {
+    insight_id = "Builtin.Insight.FailureAnalysis"
+  }
+
+  clustering_config {
+    frequencies = ["DAILY", "WEEKLY"]
+  }
+
+  rule {
+    sampling_config {
+      sampling_percentage = 10.0
     }
   }
 }

--- a/website/docs/r/bedrockagentcore_online_evaluation_config.html.markdown
+++ b/website/docs/r/bedrockagentcore_online_evaluation_config.html.markdown
@@ -122,11 +122,11 @@ The following arguments are required:
 Exactly one of the following arguments is required:
 
 * `evaluator` - (Optional) List of evaluators to apply during online evaluation. Minimum 1, maximum 10. Exactly one of `evaluator` or `insight` must be specified. See [`evaluator` Block](#evaluator-block) below.
-* `insight` - (Optional) List of insight analyses to run against sessions during evaluation. Maximum 10. Exactly one of `evaluator` or `insight` must be specified. See [`insight` Block](#insight-block) below.
+* `insight` - (Optional) List of insight analyses to run against sessions during evaluation. Maximum 10. Exactly one of `evaluator` or `insight` must be specified. When `insight` is specified, `clustering_config` is required. See [`insight` Block](#insight-block) below.
 
 The following arguments are optional:
 
-* `clustering_config` - (Optional) Configuration for periodic batch evaluation clustering, specifying how often clustering batch evaluations are triggered. See [`clustering_config` Block](#clustering_config-block) below.
+* `clustering_config` - (Optional) Configuration for periodic batch evaluation clustering, specifying how often clustering batch evaluations are triggered. Required when `insight` is specified. See [`clustering_config` Block](#clustering_config-block) below.
 * `description` - (Optional) Description of the online evaluation configuration.
 * `execution_status` - (Optional) Execution status to enable or disable the online evaluation. Valid values: `ENABLED`, `DISABLED`. Computed on create based on `enable_on_create`.
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).

--- a/website/docs/r/bedrockagentcore_online_evaluation_config.html.markdown
+++ b/website/docs/r/bedrockagentcore_online_evaluation_config.html.markdown
@@ -122,11 +122,11 @@ The following arguments are required:
 Exactly one of the following arguments is required:
 
 * `evaluator` - (Optional) List of evaluators to apply during online evaluation. Minimum 1, maximum 10. Exactly one of `evaluator` or `insight` must be specified. See [`evaluator` Block](#evaluator-block) below.
-* `insight` - (Optional) List of insight analyses to run against sessions during evaluation. Maximum 10. Exactly one of `evaluator` or `insight` must be specified. When `insight` is specified, `clustering_config` is required. See [`insight` Block](#insight-block) below.
+* `insight` - (Optional) List of insight analyses to run against sessions during evaluation. Maximum 10. Exactly one of `evaluator` or `insight` must be specified. See [`insight` Block](#insight-block) below.
 
 The following arguments are optional:
 
-* `clustering_config` - (Optional) Configuration for periodic batch evaluation clustering, specifying how often clustering batch evaluations are triggered. Required when `insight` is specified. See [`clustering_config` Block](#clustering_config-block) below.
+* `clustering_config` - (Optional) Configuration for periodic batch evaluation clustering, specifying how often clustering batch evaluations are triggered. Can only be set when `insight` is specified. Cannot be removed once set (the service retains it on update); recreate the resource to remove it. See [`clustering_config` Block](#clustering_config-block) below.
 * `description` - (Optional) Description of the online evaluation configuration.
 * `execution_status` - (Optional) Execution status to enable or disable the online evaluation. Valid values: `ENABLED`, `DISABLED`. Computed on create based on `enable_on_create`.
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).

--- a/website/docs/r/bedrockagentcore_online_evaluation_config.html.markdown
+++ b/website/docs/r/bedrockagentcore_online_evaluation_config.html.markdown
@@ -57,6 +57,10 @@ resource "aws_bedrockagentcore_online_evaluation_config" "example" {
     evaluator_id = "Builtin.GoalSuccessRate"
   }
 
+  clustering_config {
+    frequencies = ["DAILY", "WEEKLY"]
+  }
+
   rule {
     sampling_config {
       sampling_percentage = 10.0
@@ -112,12 +116,17 @@ The following arguments are required:
 * `data_source_config` - (Required) Data source configuration specifying where to read agent traces. See [`data_source_config` Block](#data_source_config-block) below.
 * `enable_on_create` - (Required) Whether to enable the online evaluation configuration immediately upon creation.
 * `evaluation_execution_role_arn` - (Required) ARN of the IAM role that grants permissions to read from CloudWatch logs, write evaluation results, and invoke Amazon Bedrock models for evaluation.
-* `evaluator` - (Required) List of evaluators to apply during online evaluation. Minimum 1, maximum 10. See [`evaluator` Block](#evaluator-block) below.
 * `online_evaluation_config_name` - (Required, Forces new resource) Name of the online evaluation configuration. Must start with a letter and contain only alphanumeric characters and underscores, up to 48 characters.
 * `rule` - (Required) Evaluation rule defining sampling configuration, filters, and session detection settings. See [`rule` Block](#rule-block) below.
 
+Exactly one of the following arguments is required:
+
+* `evaluator` - (Optional) List of evaluators to apply during online evaluation. Minimum 1, maximum 10. Exactly one of `evaluator` or `insight` must be specified. See [`evaluator` Block](#evaluator-block) below.
+* `insight` - (Optional) List of insight analyses to run against sessions during evaluation. Maximum 10. Exactly one of `evaluator` or `insight` must be specified. See [`insight` Block](#insight-block) below.
+
 The following arguments are optional:
 
+* `clustering_config` - (Optional) Configuration for periodic batch evaluation clustering, specifying how often clustering batch evaluations are triggered. See [`clustering_config` Block](#clustering_config-block) below.
 * `description` - (Optional) Description of the online evaluation configuration.
 * `execution_status` - (Optional) Execution status to enable or disable the online evaluation. Valid values: `ENABLED`, `DISABLED`. Computed on create based on `enable_on_create`.
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
@@ -141,6 +150,18 @@ The `cloudwatch_logs` block supports the following:
 The `evaluator` block supports the following:
 
 * `evaluator_id` - (Required) Unique identifier of the evaluator. Can reference builtin evaluators (e.g., `Builtin.Helpfulness`, `Builtin.GoalSuccessRate`) or custom evaluator IDs.
+
+### `insight` Block
+
+The `insight` block supports the following:
+
+* `insight_id` - (Required) Unique identifier of the insight to run. Can reference builtin insights using the `Builtin.Insight.*` naming convention or custom insight IDs.
+
+### `clustering_config` Block
+
+The `clustering_config` block supports the following:
+
+* `frequencies` - (Required) List of frequencies at which clustering batch evaluations are triggered. Maximum 3. Valid values: `DAILY`, `WEEKLY`, `MONTHLY`.
 
 ### `rule` Block
 


### PR DESCRIPTION
## Description

Adds two missing `Create`-input members to `aws_bedrockagentcore_online_evaluation_config`:

- **`insight`** (list block, max 10) — references to insight analyses to run against agent sessions during evaluation. Each block has a required `insight_id` (builtin `Builtin.Insight.*` or custom insight ID).
- **`clustering_config`** (single block) — periodic batch-evaluation clustering. Has a required `frequencies` list (`DAILY` / `WEEKLY` / `MONTHLY`, max 3).

These correspond to the `insights` and `clusteringConfig` members of `CreateOnlineEvaluationConfig`, which previously had no representation in the Terraform schema.

### `evaluator` is no longer unconditionally required

The API requires **exactly one of `evaluators` or `insights`** on create (server-side `ValidationException: "Exactly one of evaluators or insights must be provided"`). The resource previously marked the `evaluator` block as `IsRequired()`, which — now that `insight` is supported — would wrongly reject a valid insights-only configuration at plan time. This PR:

- Removes `setvalidator.IsRequired()` from the `evaluator` block (still validated as 1–10 items when present).
- Adds a resource-level `ConfigValidators` with `resourcevalidator.ExactlyOneOf(evaluator, insight)` so users get a plan-time error instead of an API error.

No `Create`/`Update` method changes were needed — the existing generic `fwflex.Expand` / `fwflex.Diff` handles both new fields (plain structs, no unions).

## Source

- Go SDK: `aws/aws-sdk-go-v2` @ `a4cd1c9dc` (`service/bedrockagentcorecontrol/api_op_CreateOnlineEvaluationConfig.go`)
- Both `insights` and `clusteringConfig` also appear in `GetOnlineEvaluationConfigResponse` (round-trip on read) and `UpdateOnlineEvaluationConfigRequest` (updatable).

## Testing

Full `aws_bedrockagentcore_online_evaluation_config` acceptance suite, single real run against the committed code (`us-west-2`). The 5 `SKIP`s are the generated `_Identity_*` / `_List_*` tests, skipped because the local Terraform CLI (1.9.8) is below their required minimum (1.12 / 1.14) — unrelated to this change:

```
$ TF_ACC=1 go test -v -timeout 60m ./internal/service/bedrockagentcore/ \
  -run 'TestAccBedrockAgentCoreOnlineEvaluationConfig_'
=== RUN   TestAccBedrockAgentCoreOnlineEvaluationConfig_Identity_basic
=== PAUSE TestAccBedrockAgentCoreOnlineEvaluationConfig_Identity_basic
=== RUN   TestAccBedrockAgentCoreOnlineEvaluationConfig_Identity_regionOverride
=== PAUSE TestAccBedrockAgentCoreOnlineEvaluationConfig_Identity_regionOverride
=== RUN   TestAccBedrockAgentCoreOnlineEvaluationConfig_List_basic
=== PAUSE TestAccBedrockAgentCoreOnlineEvaluationConfig_List_basic
=== RUN   TestAccBedrockAgentCoreOnlineEvaluationConfig_List_includeResource
=== PAUSE TestAccBedrockAgentCoreOnlineEvaluationConfig_List_includeResource
=== RUN   TestAccBedrockAgentCoreOnlineEvaluationConfig_List_regionOverride
=== PAUSE TestAccBedrockAgentCoreOnlineEvaluationConfig_List_regionOverride
=== RUN   TestAccBedrockAgentCoreOnlineEvaluationConfig_basic
=== PAUSE TestAccBedrockAgentCoreOnlineEvaluationConfig_basic
=== RUN   TestAccBedrockAgentCoreOnlineEvaluationConfig_disappears
=== PAUSE TestAccBedrockAgentCoreOnlineEvaluationConfig_disappears
=== RUN   TestAccBedrockAgentCoreOnlineEvaluationConfig_tags
=== PAUSE TestAccBedrockAgentCoreOnlineEvaluationConfig_tags
=== RUN   TestAccBedrockAgentCoreOnlineEvaluationConfig_update
=== PAUSE TestAccBedrockAgentCoreOnlineEvaluationConfig_update
=== RUN   TestAccBedrockAgentCoreOnlineEvaluationConfig_executionStatus
=== PAUSE TestAccBedrockAgentCoreOnlineEvaluationConfig_executionStatus
=== RUN   TestAccBedrockAgentCoreOnlineEvaluationConfig_filters
=== PAUSE TestAccBedrockAgentCoreOnlineEvaluationConfig_filters
=== RUN   TestAccBedrockAgentCoreOnlineEvaluationConfig_insightsAndClustering
=== PAUSE TestAccBedrockAgentCoreOnlineEvaluationConfig_insightsAndClustering
=== CONT  TestAccBedrockAgentCoreOnlineEvaluationConfig_Identity_basic
=== CONT  TestAccBedrockAgentCoreOnlineEvaluationConfig_disappears
=== CONT  TestAccBedrockAgentCoreOnlineEvaluationConfig_filters
=== CONT  TestAccBedrockAgentCoreOnlineEvaluationConfig_insightsAndClustering
=== CONT  TestAccBedrockAgentCoreOnlineEvaluationConfig_Identity_regionOverride
=== CONT  TestAccBedrockAgentCoreOnlineEvaluationConfig_executionStatus
=== CONT  TestAccBedrockAgentCoreOnlineEvaluationConfig_update
=== CONT  TestAccBedrockAgentCoreOnlineEvaluationConfig_tags
=== CONT  TestAccBedrockAgentCoreOnlineEvaluationConfig_List_includeResource
=== CONT  TestAccBedrockAgentCoreOnlineEvaluationConfig_basic
=== CONT  TestAccBedrockAgentCoreOnlineEvaluationConfig_List_basic
=== CONT  TestAccBedrockAgentCoreOnlineEvaluationConfig_List_regionOverride
    online_evaluation_config_list_test.go:149: Terraform CLI version 1.9.8 is below minimum version 1.14.0: skipping test
--- SKIP: TestAccBedrockAgentCoreOnlineEvaluationConfig_List_regionOverride (0.28s)
=== NAME  TestAccBedrockAgentCoreOnlineEvaluationConfig_List_basic
    online_evaluation_config_list_test.go:31: Terraform CLI version 1.9.8 is below minimum version 1.14.0: skipping test
--- SKIP: TestAccBedrockAgentCoreOnlineEvaluationConfig_List_basic (0.28s)
=== NAME  TestAccBedrockAgentCoreOnlineEvaluationConfig_Identity_regionOverride
    online_evaluation_config_identity_gen_test.go:125: Terraform CLI version 1.9.8 is below minimum version 1.12.0: skipping test
--- SKIP: TestAccBedrockAgentCoreOnlineEvaluationConfig_Identity_regionOverride (0.28s)
=== NAME  TestAccBedrockAgentCoreOnlineEvaluationConfig_List_includeResource
    online_evaluation_config_list_test.go:84: Terraform CLI version 1.9.8 is below minimum version 1.14.0: skipping test
=== NAME  TestAccBedrockAgentCoreOnlineEvaluationConfig_Identity_basic
    online_evaluation_config_identity_gen_test.go:31: Terraform CLI version 1.9.8 is below minimum version 1.12.0: skipping test
--- SKIP: TestAccBedrockAgentCoreOnlineEvaluationConfig_List_includeResource (0.28s)
--- SKIP: TestAccBedrockAgentCoreOnlineEvaluationConfig_Identity_basic (0.28s)
--- PASS: TestAccBedrockAgentCoreOnlineEvaluationConfig_filters (32.20s)
--- PASS: TestAccBedrockAgentCoreOnlineEvaluationConfig_disappears (35.15s)
--- PASS: TestAccBedrockAgentCoreOnlineEvaluationConfig_basic (38.64s)
--- PASS: TestAccBedrockAgentCoreOnlineEvaluationConfig_insightsAndClustering (46.27s)
--- PASS: TestAccBedrockAgentCoreOnlineEvaluationConfig_update (50.42s)
--- PASS: TestAccBedrockAgentCoreOnlineEvaluationConfig_executionStatus (70.99s)
--- PASS: TestAccBedrockAgentCoreOnlineEvaluationConfig_tags (71.72s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/bedrockagentcore	71.888s
```

## Honest caveats

- **`insight` modeled as a List, not a Set.** The Smithy `InsightList` has no `@uniqueItems`, so a list is the faithful representation. The sibling `evaluator` block is a Set, so a reviewer may prefer a Set here for in-resource consistency — flagging for review.
- **`insight_id` validation is pattern-only.** The SDK model documents the `Builtin.Insight.*` convention with a free-form regex but does not enumerate valid builtin IDs. The acctest uses `Builtin.Insight.FailureAnalysis` (a confirmed valid builtin; others: `Builtin.Insight.UserIntent`, `Builtin.Insight.ExecutionSummary`).
- **`evaluator` requiredness relaxed** — see the note above. Existing configs that specify `evaluator` are unaffected; the change only permits an insights-only alternative and enforces the mutual exclusivity at plan time.
