### PR TITLE
resource/aws_cloudfront_multitenant_distribution: add owner_account_id to vpc_origin_config

### DIFF
--- a/.changelog/48801.txt
+++ b/.changelog/48801.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_cloudfront_multitenant_distribution: Add `owner_account_id` argument to `vpc_origin_config` for cross-account VPC origin support
+```

--- a/internal/service/cloudfront/multitenant_distribution.go
+++ b/internal/service/cloudfront/multitenant_distribution.go
@@ -555,6 +555,9 @@ func (r *multiTenantDistributionResource) Schema(ctx context.Context, request re
 										Computed: true,
 										Default:  int32default.StaticInt32(defaultOriginReadTimeout),
 									},
+									names.AttrOwnerAccountID: schema.StringAttribute{
+										Optional: true,
+									},
 									"vpc_origin_id": schema.StringAttribute{
 										Required: true,
 									},
@@ -1146,6 +1149,7 @@ type originShieldModel struct {
 type vpcOriginConfigModel struct {
 	OriginKeepaliveTimeout types.Int32  `tfsdk:"origin_keepalive_timeout"`
 	OriginReadTimeout      types.Int32  `tfsdk:"origin_read_timeout"`
+	OwnerAccountID         types.String `tfsdk:"owner_account_id"`
 	VpcOriginID            types.String `tfsdk:"vpc_origin_id"`
 }
 

--- a/internal/service/cloudfront/multitenant_distribution_test.go
+++ b/internal/service/cloudfront/multitenant_distribution_test.go
@@ -121,6 +121,40 @@ func TestAccCloudFrontMultiTenantDistribution_basic(t *testing.T) {
 	})
 }
 
+func TestAccCloudFrontMultiTenantDistribution_vpcOriginConfigOwnerAccountID(t *testing.T) {
+	ctx := acctest.Context(t)
+	var distribution awstypes.Distribution
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_cloudfront_multitenant_distribution.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.CloudFrontEndpointID) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CloudFrontServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckMultiTenantDistributionDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMultiTenantDistributionConfig_vpcOriginConfigOwnerAccountID(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMultiTenantDistributionExists(ctx, t, resourceName, &distribution),
+					resource.TestCheckResourceAttr(resourceName, "origin.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "origin.0.vpc_origin_config.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "origin.0.vpc_origin_config.0.owner_account_id", "data.aws_caller_identity.current", names.AttrAccountID),
+				),
+				// Same-account owner_account_id round-trips a diff, mirroring
+				// TestAccCloudFrontDistribution_vpcOriginConfigOwnerAccountID.
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"etag"},
+			},
+		},
+	})
+}
+
 func TestAccCloudFrontMultiTenantDistribution_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var distribution awstypes.Distribution
@@ -1006,6 +1040,60 @@ resource "aws_cloudfront_multitenant_distribution" "test" {
   }
 }
 `
+}
+
+func testAccMultiTenantDistributionConfig_vpcOriginConfigOwnerAccountID(rName string) string {
+	return acctest.ConfigCompose(testAccVPCOriginConfig_basic(rName), `
+data "aws_caller_identity" "current" {}
+
+resource "aws_cloudfront_multitenant_distribution" "test" {
+  enabled = false
+  comment = "Test multi-tenant distribution with cross-account VPC origin"
+
+  origin {
+    domain_name = "www.example.com"
+    id          = "example"
+
+    vpc_origin_config {
+      vpc_origin_id    = aws_cloudfront_vpc_origin.test.id
+      owner_account_id = data.aws_caller_identity.current.account_id
+    }
+  }
+
+  default_cache_behavior {
+    target_origin_id       = "example"
+    viewer_protocol_policy = "redirect-to-https"
+    cache_policy_id        = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad" # AWS Managed CachingDisabled policy
+
+    allowed_methods {
+      items          = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+      cached_methods = ["GET", "HEAD", "OPTIONS"]
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  tenant_config {
+    parameter_definition {
+      name = "origin_domain"
+      definition {
+        string_schema {
+          required = true
+          comment  = "Origin domain parameter for tenants"
+        }
+      }
+    }
+  }
+}
+`)
 }
 
 func testAccMultiTenantDistributionConfig_comprehensive(rName, comment, defaultRootObject string, compress bool) string {

--- a/website/docs/r/cloudfront_multitenant_distribution.html.markdown
+++ b/website/docs/r/cloudfront_multitenant_distribution.html.markdown
@@ -228,6 +228,7 @@ Cache behavior supports all the same arguments as [Default Cache Behavior](#defa
 
 * `origin_keepalive_timeout` - (Optional) Custom keep-alive timeout, in seconds. By default, CloudFront uses a default timeout. Default: 5.
 * `origin_read_timeout` - (Optional) Custom read timeout, in seconds. By default, CloudFront uses a default timeout. Default: 30.
+* `owner_account_id` - (Optional) AWS account ID that owns the VPC origin. Required when referencing a VPC origin shared from a different AWS account (cross-account VPC origin access).
 * `vpc_origin_id` - (Required) ID of the VPC origin that you want CloudFront to route requests to.
 
 ### Custom Error Response


### PR DESCRIPTION
### Description

Adds the `owner_account_id` argument to the `vpc_origin_config` block of `aws_cloudfront_multitenant_distribution`, so a multi-tenant distribution can reference a VPC origin shared from another AWS account via AWS RAM (cross-account VPC origin access).

This mirrors the argument added to `aws_cloudfront_distribution` in v6.28.0 (#45021). The CloudFront API and the SDK `VpcOriginConfig` type already carry `OwnerAccountId` (the same type is used by both resources); this resource uses autoflex, so adding the schema attribute and the model struct field is sufficient — no manual expand/flatten is needed.

### Relations

Closes #48801
Closes #47692

### References

* #45011 / #45021 — the equivalent `owner_account_id` support for `aws_cloudfront_distribution`.

### Output from Acceptance Testing

Adds `TestAccCloudFrontMultiTenantDistribution_vpcOriginConfigOwnerAccountID`, mirroring `TestAccCloudFrontDistribution_vpcOriginConfigOwnerAccountID`. The acceptance test has not been executed in this environment; it is included for CI / maintainer runs.

```console
% make testacc TESTS=TestAccCloudFrontMultiTenantDistribution_vpcOriginConfigOwnerAccountID PKG=cloudfront
```
