### PR TITLE
resource/aws_opensearch_package_association: Fix import

### DIFF
--- a/.changelog/48803.txt
+++ b/.changelog/48803.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_opensearch_package_association: Fix `terraform import`
+```

--- a/internal/service/opensearch/package_association.go
+++ b/internal/service/opensearch/package_association.go
@@ -20,11 +20,14 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
+
+const packageAssociationResourceIDPartCount = 2
 
 // @SDKResource("aws_opensearch_package_association", name="Package Association")
 func resourcePackageAssociation() *schema.Resource {
@@ -34,7 +37,19 @@ func resourcePackageAssociation() *schema.Resource {
 		DeleteWithoutTimeout: resourcePackageAssociationDelete,
 
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: func(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
+				parts, err := flex.ExpandResourceId(d.Id(), packageAssociationResourceIDPartCount, false)
+				if err != nil {
+					return nil, err
+				}
+
+				domainName, packageID := parts[0], parts[1]
+				d.Set(names.AttrDomainName, domainName)
+				d.Set("package_id", packageID)
+				d.SetId(fmt.Sprintf("%s-%s", domainName, packageID))
+
+				return []*schema.ResourceData{d}, nil
+			},
 		},
 
 		Timeouts: &schema.ResourceTimeout{

--- a/internal/service/opensearch/package_association_test.go
+++ b/internal/service/opensearch/package_association_test.go
@@ -39,6 +39,12 @@ func TestAccOpenSearchPackageAssociation_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "package_id", packageResourceName, names.AttrID),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccPackageAssociationImportStateIDFunc(resourceName),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -73,6 +79,17 @@ func TestAccOpenSearchPackageAssociation_disappears(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testAccPackageAssociationImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		return fmt.Sprintf("%s,%s", rs.Primary.Attributes[names.AttrDomainName], rs.Primary.Attributes["package_id"]), nil
+	}
 }
 
 func testAccCheckPackageAssociationExists(ctx context.Context, t *testing.T, n string) resource.TestCheckFunc {

--- a/website/docs/r/opensearch_package_association.html.markdown
+++ b/website/docs/r/opensearch_package_association.html.markdown
@@ -59,3 +59,20 @@ This resource exports the following attributes in addition to the arguments abov
 
 * `create` - (Default `10m`)
 * `delete` - (Default `10m`)
+
+## Import
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import OpenSearch Package Associations using the `domain_name` and `package_id` separated by a comma (`,`). For example:
+
+```terraform
+import {
+  to = aws_opensearch_package_association.example
+  id = "my-opensearch-domain,F1234567890"
+}
+```
+
+Using `terraform import`, import OpenSearch Package Associations using the `domain_name` and `package_id` separated by a comma (`,`). For example:
+
+```console
+% terraform import aws_opensearch_package_association.example my-opensearch-domain,F1234567890
+```


### PR DESCRIPTION
### Description

The `aws_opensearch_package_association` importer used `schema.ImportStatePassthroughContext`, which only sets the resource ID and never populates the required `domain_name` and `package_id` attributes. Because `Read` derives the lookup from `d.Get("domain_name")`/`d.Get("package_id")` (not from the ID), import always looked up an empty domain and failed. No import format worked, and there was no import documentation.

This PR replaces the passthrough importer with one that parses a `domain_name,package_id` import ID (comma is the standard `flex.ResourceIdSeparator`, unambiguous unlike the `-` used to build the resource ID), sets both attributes, and normalizes the stored ID to the same `domain_name-package_id` form `Create` produces — so imported and created resources are identical in state. Adds an import test step and an Import section to the docs.

### Relations

Closes #0000

### References

n/a

### Output from Acceptance Testing

```
$ make testacc TESTS=TestAccOpenSearchPackageAssociation_basic PKG=opensearch
... (pending maintainer run)
```