### PR TITLE
fix(bcmdataexports): preserve planned table_configurations after create

### DIFF
--- a/.changelog/48809.txt
+++ b/.changelog/48809.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_bcmdataexports_export: Fix `Provider produced inconsistent result after apply` error when API returns extra keys (e.g., `BILLING_VIEW_ARN`) in `table_configurations`
+```

--- a/internal/service/bcmdataexports/export.go
+++ b/internal/service/bcmdataexports/export.go
@@ -280,10 +280,33 @@ func (r *exportResource) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 
+	// Save the planned table_configurations before flattening the API response.
+	// The API may return additional keys (e.g., BILLING_VIEW_ARN) that were not
+	// in the user's configuration, which causes a "Provider produced inconsistent
+	// result" error.
+	var plannedTableConfigurations fwtypes.MapOfMapOfString
+	if exports, diags := plan.Export.ToSlice(ctx); !diags.HasError() && len(exports) > 0 {
+		if dataQueries, diags := exports[0].DataQuery.ToSlice(ctx); !diags.HasError() && len(dataQueries) > 0 {
+			plannedTableConfigurations = dataQueries[0].TableConfigurations
+		}
+	}
+
 	resp.Diagnostics.Append(flex.Flatten(ctx, outputRaw, &plan)...)
 
 	if resp.Diagnostics.HasError() {
 		return
+	}
+
+	// Restore the planned table_configurations to avoid inconsistency with
+	// extra API-returned keys.
+	if !plannedTableConfigurations.IsNull() && !plannedTableConfigurations.IsUnknown() {
+		if exports, diags := plan.Export.ToSlice(ctx); !diags.HasError() && len(exports) > 0 {
+			if dataQueries, diags := exports[0].DataQuery.ToSlice(ctx); !diags.HasError() && len(dataQueries) > 0 {
+				dataQueries[0].TableConfigurations = plannedTableConfigurations
+				exports[0].DataQuery, _ = fwtypes.NewListNestedObjectValueOfSlice(ctx, dataQueries, nil)
+				plan.Export, _ = fwtypes.NewListNestedObjectValueOfSlice(ctx, exports, nil)
+			}
+		}
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)


### PR DESCRIPTION
### Description

Fixes #48807. Relates to #42761, #46402.

The BCM Data Exports API returns additional keys in `table_configurations` (e.g., `BILLING_VIEW_ARN`, `INCLUDE_MANUAL_DISCOUNT_COMPATIBILITY`) that were not specified in the user's configuration. This causes a "Provider produced inconsistent result after apply" error because the state after create doesn't match the plan.

### Fix

Save the planned `table_configurations` value before flattening the API response and restore it afterward. This follows the same pattern used in `ecs/express_gateway_service.go` (`preservePlanContainerOrdering` / `restorePlanContainerOrdering`).

### Acceptance Tests

The existing test `TestAccBCMDataExportsExport_CUR_tableConfigurations` covers this scenario. To reproduce the bug, a `COST_AND_USAGE_REPORT` export must be created without specifying `BILLING_VIEW_ARN` in `table_configurations`.

```
$ go test ./internal/service/bcmdataexports/... -run TestAccBCMDataExportsExport_CUR_tableConfigurations -count=1
```

### Checklist

- [x] `go build` passes
- [x] Follows existing patterns in the provider (ECS express_gateway_service)
- [x] Targets the root cause (API returns extra keys not in config)
