### PR TITLE
r/rds, r/elasticache: Add aws_rds_instance_type and aws_elasticache_node_type data sources

### DIFF
--- a/.changelog/48811.txt
+++ b/.changelog/48811.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_rds_instance_type
+```

--- a/.changelog/48811.txt
+++ b/.changelog/48811.txt
@@ -1,3 +1,7 @@
 ```release-note:new-data-source
 aws_rds_instance_type
 ```
+
+```release-note:new-data-source
+aws_elasticache_node_type
+```

--- a/internal/service/elasticache/node_type_data_source.go
+++ b/internal/service/elasticache/node_type_data_source.go
@@ -1,0 +1,163 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package elasticache
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkDataSource("aws_elasticache_node_type", name="Node Type")
+func newNodeTypeDataSource(context.Context) (datasource.DataSourceWithConfigure, error) {
+	return &nodeTypeDataSource{}, nil
+}
+
+const (
+	DSNameNodeType = "Node Type Data Source"
+)
+
+type nodeTypeDataSource struct {
+	framework.DataSourceWithModel[nodeTypeDataSourceModel]
+}
+
+func (d *nodeTypeDataSource) Schema(ctx context.Context, _ datasource.SchemaRequest, response *datasource.SchemaResponse) {
+	response.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"burstable_performance_supported": schema.BoolAttribute{
+				Computed: true,
+			},
+			"cache_node_type": schema.StringAttribute{
+				Required: true,
+			},
+			"current_generation": schema.BoolAttribute{
+				Computed: true,
+			},
+			"default_cores": schema.Int64Attribute{
+				Computed: true,
+			},
+			"default_threads_per_core": schema.Int64Attribute{
+				Computed: true,
+			},
+			"default_vcpus": schema.Int64Attribute{
+				Computed: true,
+			},
+			"ec2_instance_type": schema.StringAttribute{
+				Computed: true,
+			},
+			"free_tier_eligible": schema.BoolAttribute{
+				Computed: true,
+			},
+			names.AttrID: framework.IDAttribute(),
+			"memory_size": schema.Int64Attribute{
+				Computed: true,
+			},
+			"supported_architectures": schema.ListAttribute{
+				CustomType:  fwtypes.ListOfStringType,
+				Computed:    true,
+				ElementType: types.StringType,
+			},
+		},
+	}
+}
+
+func (d *nodeTypeDataSource) Read(ctx context.Context, request datasource.ReadRequest, response *datasource.ReadResponse) {
+	var data nodeTypeDataSourceModel
+	response.Diagnostics.Append(request.Config.Get(ctx, &data)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	cacheNodeType := data.CacheNodeType.ValueString()
+	ec2InstanceType, ok := strings.CutPrefix(cacheNodeType, "cache.")
+	if !ok || ec2InstanceType == "" {
+		response.Diagnostics.AddAttributeError(
+			path.Root("cache_node_type"),
+			"Invalid Attribute Value",
+			fmt.Sprintf(`cache_node_type must be an ElastiCache node type of the form "cache.<type>" (e.g. "cache.t3.medium"), got: %q`, cacheNodeType),
+		)
+		return
+	}
+
+	conn := d.Meta().EC2Client(ctx)
+
+	v, err := findInstanceTypeByElastiCacheNodeType(ctx, conn, ec2InstanceType)
+	if err != nil {
+		err = fmt.Errorf("this ElastiCache node type may not have a directly corresponding EC2 instance type (%s): %w", ec2InstanceType, err)
+		response.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.ElastiCache, create.ErrActionReading, DSNameNodeType, cacheNodeType, err),
+			err.Error(),
+		)
+		return
+	}
+
+	archs := make([]string, len(v.ProcessorInfo.SupportedArchitectures))
+	for i, a := range v.ProcessorInfo.SupportedArchitectures {
+		archs[i] = string(a)
+	}
+
+	data.ID = types.StringValue(cacheNodeType)
+	data.BurstablePerformanceSupported = types.BoolValue(aws.ToBool(v.BurstablePerformanceSupported))
+	data.CurrentGeneration = types.BoolValue(aws.ToBool(v.CurrentGeneration))
+	data.DefaultCores = types.Int64Value(int64(aws.ToInt32(v.VCpuInfo.DefaultCores)))
+	data.DefaultThreadsPerCore = types.Int64Value(int64(aws.ToInt32(v.VCpuInfo.DefaultThreadsPerCore)))
+	data.DefaultVCPUs = types.Int64Value(int64(aws.ToInt32(v.VCpuInfo.DefaultVCpus)))
+	data.EC2InstanceType = types.StringValue(string(v.InstanceType))
+	data.FreeTierEligible = types.BoolValue(aws.ToBool(v.FreeTierEligible))
+	data.MemorySize = types.Int64Value(aws.ToInt64(v.MemoryInfo.SizeInMiB))
+	data.SupportedArchitectures = flex.FlattenFrameworkStringValueListOfString(ctx, archs)
+
+	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
+}
+
+type nodeTypeDataSourceModel struct {
+	framework.WithRegionModel
+	BurstablePerformanceSupported types.Bool           `tfsdk:"burstable_performance_supported"`
+	CacheNodeType                 types.String         `tfsdk:"cache_node_type"`
+	CurrentGeneration             types.Bool           `tfsdk:"current_generation"`
+	DefaultCores                  types.Int64          `tfsdk:"default_cores"`
+	DefaultThreadsPerCore         types.Int64          `tfsdk:"default_threads_per_core"`
+	DefaultVCPUs                  types.Int64          `tfsdk:"default_vcpus"`
+	EC2InstanceType               types.String         `tfsdk:"ec2_instance_type"`
+	FreeTierEligible              types.Bool           `tfsdk:"free_tier_eligible"`
+	ID                            types.String         `tfsdk:"id"`
+	MemorySize                    types.Int64          `tfsdk:"memory_size"`
+	SupportedArchitectures        fwtypes.ListOfString `tfsdk:"supported_architectures"`
+}
+
+func findInstanceTypeByElastiCacheNodeType(ctx context.Context, conn *ec2.Client, ec2InstanceType string) (*awstypes.InstanceTypeInfo, error) {
+	input := ec2.DescribeInstanceTypesInput{
+		InstanceTypes: []awstypes.InstanceType{awstypes.InstanceType(ec2InstanceType)},
+	}
+
+	output, err := conn.DescribeInstanceTypes(ctx, &input)
+	if err != nil {
+		return nil, err
+	}
+
+	v, err := tfresource.AssertSingleValueResult(output.InstanceTypes)
+	if err != nil {
+		return nil, err
+	}
+
+	if v.MemoryInfo == nil || v.VCpuInfo == nil || v.ProcessorInfo == nil {
+		return nil, fmt.Errorf("incomplete instance type information returned for %q", ec2InstanceType)
+	}
+
+	return v, nil
+}

--- a/internal/service/elasticache/node_type_data_source_test.go
+++ b/internal/service/elasticache/node_type_data_source_test.go
@@ -1,0 +1,62 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package elasticache_test
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccElastiCacheNodeTypeDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_elasticache_node_type.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNodeTypeDataSourceConfig_basic("cache.t3.medium"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "cache_node_type", "cache.t3.medium"),
+					resource.TestCheckResourceAttr(dataSourceName, "ec2_instance_type", "t3.medium"),
+					resource.TestCheckResourceAttr(dataSourceName, "memory_size", "4096"),
+					resource.TestCheckResourceAttr(dataSourceName, "default_vcpus", "2"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "burstable_performance_supported"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "current_generation"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccElastiCacheNodeTypeDataSource_invalidType(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccNodeTypeDataSourceConfig_basic("cache.unknown.type"),
+				ExpectError: regexp.MustCompile(`No EC2 instance type found|corresponding EC2 instance type`),
+			},
+		},
+	})
+}
+
+func testAccNodeTypeDataSourceConfig_basic(cacheNodeType string) string {
+	return fmt.Sprintf(`
+data "aws_elasticache_node_type" "test" {
+  cache_node_type = %[1]q
+}
+`, cacheNodeType)
+}

--- a/internal/service/elasticache/service_package_gen.go
+++ b/internal/service/elasticache/service_package_gen.go
@@ -34,6 +34,12 @@ func (p *servicePackage) Actions(ctx context.Context) []*inttypes.ServicePackage
 func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*inttypes.ServicePackageFrameworkDataSource {
 	return []*inttypes.ServicePackageFrameworkDataSource{
 		{
+			Factory:  newNodeTypeDataSource,
+			TypeName: "aws_elasticache_node_type",
+			Name:     "Node Type",
+			Region:   inttypes.ResourceRegionDefault(),
+		},
+		{
 			Factory:  newReservedCacheNodeOfferingDataSource,
 			TypeName: "aws_elasticache_reserved_cache_node_offering",
 			Name:     "Reserved Cache Node Offering",

--- a/internal/service/rds/instance_type_data_source.go
+++ b/internal/service/rds/instance_type_data_source.go
@@ -1,0 +1,163 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package rds
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkDataSource("aws_rds_instance_type", name="Instance Type")
+func newInstanceTypeDataSource(context.Context) (datasource.DataSourceWithConfigure, error) {
+	return &instanceTypeDataSource{}, nil
+}
+
+const (
+	DSNameInstanceType = "Instance Type Data Source"
+)
+
+type instanceTypeDataSource struct {
+	framework.DataSourceWithModel[instanceTypeDataSourceModel]
+}
+
+func (d *instanceTypeDataSource) Schema(ctx context.Context, _ datasource.SchemaRequest, response *datasource.SchemaResponse) {
+	response.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"burstable_performance_supported": schema.BoolAttribute{
+				Computed: true,
+			},
+			"current_generation": schema.BoolAttribute{
+				Computed: true,
+			},
+			"default_cores": schema.Int64Attribute{
+				Computed: true,
+			},
+			"default_threads_per_core": schema.Int64Attribute{
+				Computed: true,
+			},
+			"default_vcpus": schema.Int64Attribute{
+				Computed: true,
+			},
+			"ec2_instance_type": schema.StringAttribute{
+				Computed: true,
+			},
+			"free_tier_eligible": schema.BoolAttribute{
+				Computed: true,
+			},
+			names.AttrID: framework.IDAttribute(),
+			"instance_class": schema.StringAttribute{
+				Required: true,
+			},
+			"memory_size": schema.Int64Attribute{
+				Computed: true,
+			},
+			"supported_architectures": schema.ListAttribute{
+				CustomType:  fwtypes.ListOfStringType,
+				Computed:    true,
+				ElementType: types.StringType,
+			},
+		},
+	}
+}
+
+func (d *instanceTypeDataSource) Read(ctx context.Context, request datasource.ReadRequest, response *datasource.ReadResponse) {
+	var data instanceTypeDataSourceModel
+	response.Diagnostics.Append(request.Config.Get(ctx, &data)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	instanceClass := data.InstanceClass.ValueString()
+	ec2InstanceType, ok := strings.CutPrefix(instanceClass, "db.")
+	if !ok || ec2InstanceType == "" {
+		response.Diagnostics.AddAttributeError(
+			path.Root("instance_class"),
+			"Invalid Attribute Value",
+			fmt.Sprintf(`instance_class must be an RDS DB instance class of the form "db.<type>" (e.g. "db.t3.medium"), got: %q`, instanceClass),
+		)
+		return
+	}
+
+	conn := d.Meta().EC2Client(ctx)
+
+	v, err := findInstanceTypeByRDSInstanceClass(ctx, conn, ec2InstanceType)
+	if err != nil {
+		err = fmt.Errorf("this RDS instance class may not have a directly corresponding EC2 instance type (%s): %w", ec2InstanceType, err)
+		response.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.RDS, create.ErrActionReading, DSNameInstanceType, instanceClass, err),
+			err.Error(),
+		)
+		return
+	}
+
+	archs := make([]string, len(v.ProcessorInfo.SupportedArchitectures))
+	for i, a := range v.ProcessorInfo.SupportedArchitectures {
+		archs[i] = string(a)
+	}
+
+	data.ID = types.StringValue(instanceClass)
+	data.BurstablePerformanceSupported = types.BoolValue(aws.ToBool(v.BurstablePerformanceSupported))
+	data.CurrentGeneration = types.BoolValue(aws.ToBool(v.CurrentGeneration))
+	data.DefaultCores = types.Int64Value(int64(aws.ToInt32(v.VCpuInfo.DefaultCores)))
+	data.DefaultThreadsPerCore = types.Int64Value(int64(aws.ToInt32(v.VCpuInfo.DefaultThreadsPerCore)))
+	data.DefaultVCPUs = types.Int64Value(int64(aws.ToInt32(v.VCpuInfo.DefaultVCpus)))
+	data.EC2InstanceType = types.StringValue(string(v.InstanceType))
+	data.FreeTierEligible = types.BoolValue(aws.ToBool(v.FreeTierEligible))
+	data.MemorySize = types.Int64Value(aws.ToInt64(v.MemoryInfo.SizeInMiB))
+	data.SupportedArchitectures = flex.FlattenFrameworkStringValueListOfString(ctx, archs)
+
+	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
+}
+
+type instanceTypeDataSourceModel struct {
+	framework.WithRegionModel
+	BurstablePerformanceSupported types.Bool           `tfsdk:"burstable_performance_supported"`
+	CurrentGeneration             types.Bool           `tfsdk:"current_generation"`
+	DefaultCores                  types.Int64          `tfsdk:"default_cores"`
+	DefaultThreadsPerCore         types.Int64          `tfsdk:"default_threads_per_core"`
+	DefaultVCPUs                  types.Int64          `tfsdk:"default_vcpus"`
+	EC2InstanceType               types.String         `tfsdk:"ec2_instance_type"`
+	FreeTierEligible              types.Bool           `tfsdk:"free_tier_eligible"`
+	ID                            types.String         `tfsdk:"id"`
+	InstanceClass                 types.String         `tfsdk:"instance_class"`
+	MemorySize                    types.Int64          `tfsdk:"memory_size"`
+	SupportedArchitectures        fwtypes.ListOfString `tfsdk:"supported_architectures"`
+}
+
+func findInstanceTypeByRDSInstanceClass(ctx context.Context, conn *ec2.Client, ec2InstanceType string) (*awstypes.InstanceTypeInfo, error) {
+	input := ec2.DescribeInstanceTypesInput{
+		InstanceTypes: []awstypes.InstanceType{awstypes.InstanceType(ec2InstanceType)},
+	}
+
+	output, err := conn.DescribeInstanceTypes(ctx, &input)
+	if err != nil {
+		return nil, err
+	}
+
+	v, err := tfresource.AssertSingleValueResult(output.InstanceTypes)
+	if err != nil {
+		return nil, err
+	}
+
+	if v.MemoryInfo == nil || v.VCpuInfo == nil || v.ProcessorInfo == nil {
+		return nil, fmt.Errorf("incomplete instance type information returned for %q", ec2InstanceType)
+	}
+
+	return v, nil
+}

--- a/internal/service/rds/instance_type_data_source_test.go
+++ b/internal/service/rds/instance_type_data_source_test.go
@@ -1,0 +1,62 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package rds_test
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccRDSInstanceTypeDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_rds_instance_type.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceTypeDataSourceConfig_basic("db.t3.medium"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "instance_class", "db.t3.medium"),
+					resource.TestCheckResourceAttr(dataSourceName, "ec2_instance_type", "t3.medium"),
+					resource.TestCheckResourceAttr(dataSourceName, "memory_size", "4096"),
+					resource.TestCheckResourceAttr(dataSourceName, "default_vcpus", "2"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "burstable_performance_supported"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "current_generation"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRDSInstanceTypeDataSource_invalidClass(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccInstanceTypeDataSourceConfig_basic("db.serverless"),
+				ExpectError: regexp.MustCompile(`No EC2 instance type found|corresponding EC2 instance type`),
+			},
+		},
+	})
+}
+
+func testAccInstanceTypeDataSourceConfig_basic(instanceClass string) string {
+	return fmt.Sprintf(`
+data "aws_rds_instance_type" "test" {
+  instance_class = %[1]q
+}
+`, instanceClass)
+}

--- a/internal/service/rds/service_package_gen.go
+++ b/internal/service/rds/service_package_gen.go
@@ -39,6 +39,12 @@ func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*inttypes.S
 			}),
 			Region: inttypes.ResourceRegionDefault(),
 		},
+		{
+			Factory:  newInstanceTypeDataSource,
+			TypeName: "aws_rds_instance_type",
+			Name:     "Instance Type",
+			Region:   inttypes.ResourceRegionDefault(),
+		},
 	}
 }
 

--- a/internal/service/rds/service_package_gen.go
+++ b/internal/service/rds/service_package_gen.go
@@ -40,6 +40,12 @@ func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*inttypes.S
 			Region: inttypes.ResourceRegionDefault(),
 		},
 		{
+			Factory:  newInstanceTypeDataSource,
+			TypeName: "aws_rds_instance_type",
+			Name:     "Instance Type",
+			Region:   inttypes.ResourceRegionDefault(),
+		},
+		{
 			Factory:  newSnapshotsDataSource,
 			TypeName: "aws_rds_snapshots",
 			Name:     "Snapshots",

--- a/website/docs/d/elasticache_node_type.html.markdown
+++ b/website/docs/d/elasticache_node_type.html.markdown
@@ -1,0 +1,43 @@
+---
+subcategory: "ElastiCache"
+layout: "aws"
+page_title: "AWS: aws_elasticache_node_type"
+description: |-
+  Information about hardware specifications for an ElastiCache node type.
+---
+
+# Data Source: aws_elasticache_node_type
+
+Information about hardware specifications (memory, vCPUs) for an ElastiCache node type.
+
+The ElastiCache API does not expose memory or vCPU information for node types. This data source derives the underlying EC2 instance type from the node type (for example, `cache.t3.medium` corresponds to EC2 instance type `t3.medium`) and looks up its hardware specifications. As a result, node types with no directly corresponding EC2 instance type are not supported.
+
+## Example Usage
+
+```terraform
+data "aws_elasticache_node_type" "example" {
+  cache_node_type = "cache.t3.medium"
+}
+```
+
+## Argument Reference
+
+This data source supports the following arguments:
+
+* `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
+* `cache_node_type` - (Required) ElastiCache node type, for example `cache.t3.medium`.
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `burstable_performance_supported` - Whether the node type is a burstable performance instance type.
+* `current_generation` - Whether the node type is a current generation instance type.
+* `default_cores` - Default number of cores.
+* `default_threads_per_core` - Default number of threads per core.
+* `default_vcpus` - Default number of vCPUs.
+* `ec2_instance_type` - EC2 instance type derived from `cache_node_type` and used to look up hardware specifications.
+* `free_tier_eligible` - Whether the node type is eligible for the free tier.
+* `id` - ElastiCache node type (same value as `cache_node_type`).
+* `memory_size` - Size of memory for the node type, in MiB.
+* `supported_architectures` - Supported processor architectures.

--- a/website/docs/d/rds_instance_type.html.markdown
+++ b/website/docs/d/rds_instance_type.html.markdown
@@ -1,0 +1,43 @@
+---
+subcategory: "RDS (Relational Database)"
+layout: "aws"
+page_title: "AWS: aws_rds_instance_type"
+description: |-
+  Information about hardware specifications for an RDS DB instance class.
+---
+
+# Data Source: aws_rds_instance_type
+
+Information about hardware specifications (memory, vCPUs) for an RDS DB instance class.
+
+The RDS API does not expose memory or vCPU information for DB instance classes. This data source derives the underlying EC2 instance type from the DB instance class (for example, `db.t3.medium` corresponds to EC2 instance type `t3.medium`) and looks up its hardware specifications. As a result, DB instance classes with no directly corresponding EC2 instance type (for example, `db.serverless`) are not supported.
+
+## Example Usage
+
+```terraform
+data "aws_rds_instance_type" "example" {
+  instance_class = "db.t3.medium"
+}
+```
+
+## Argument Reference
+
+This data source supports the following arguments:
+
+* `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
+* `instance_class` - (Required) RDS DB instance class, for example `db.t3.medium`.
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `burstable_performance_supported` - Whether the instance class is a burstable performance instance class.
+* `current_generation` - Whether the instance class is a current generation instance class.
+* `default_cores` - Default number of cores.
+* `default_threads_per_core` - Default number of threads per core.
+* `default_vcpus` - Default number of vCPUs.
+* `ec2_instance_type` - EC2 instance type derived from `instance_class` and used to look up hardware specifications.
+* `free_tier_eligible` - Whether the instance class is eligible for the free tier.
+* `id` - RDS DB instance class (same value as `instance_class`).
+* `memory_size` - Size of memory for the instance class, in MiB.
+* `supported_architectures` - Supported processor architectures.


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

None. This adds two new read-only data sources that call `ec2:DescribeInstanceTypes`; no new write permissions or controls are introduced.

### Description

Adds two new data sources that return hardware specifications (memory size, vCPUs, supported architectures, etc.) derived from an EC2 instance type:

* `aws_rds_instance_type` - for an RDS DB instance class (e.g. `db.t3.medium` -> `t3.medium`)
* `aws_elasticache_node_type` - for an ElastiCache node type (e.g. `cache.t3.medium` -> `t3.medium`)

Neither the RDS nor the ElastiCache API exposes this hardware information directly. Both data sources derive the underlying EC2 instance type from the DB instance class / cache node type and look up its specs via `ec2:DescribeInstanceTypes`. Classes/types with no directly corresponding EC2 instance type (e.g. `db.serverless`) are not supported and return a descriptive error.

Note this differs from the config shape originally sketched in the issue (which used `db_instance_identifier` / `cluster_id` to look up an existing resource) — deriving from the instance class/node type works without a live instance and needs no extra IAM permissions beyond `ec2:DescribeInstanceTypes`.

### Relations

Closes #40477

### References

### Output from Acceptance Testing

```console
% make testacc TESTS=TestAccRDSInstanceTypeDataSource_ PKG=rds

TF_ACC=1 go test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccRDSInstanceTypeDataSource_' -timeout 360m -vet=off
=== RUN   TestAccRDSInstanceTypeDataSource_basic
=== PAUSE TestAccRDSInstanceTypeDataSource_basic
=== RUN   TestAccRDSInstanceTypeDataSource_invalidClass
=== PAUSE TestAccRDSInstanceTypeDataSource_invalidClass
=== CONT  TestAccRDSInstanceTypeDataSource_basic
=== CONT  TestAccRDSInstanceTypeDataSource_invalidClass
--- PASS: TestAccRDSInstanceTypeDataSource_invalidClass (5.26s)
--- PASS: TestAccRDSInstanceTypeDataSource_basic (17.83s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/rds       24.716s
```

```console
% make testacc TESTS=TestAccElastiCacheNodeTypeDataSource_ PKG=elasticache

TF_ACC=1 go test ./internal/service/elasticache/... -v -count 1 -parallel 20 -run='TestAccElastiCacheNodeTypeDataSource_' -timeout 360m -vet=off
=== RUN   TestAccElastiCacheNodeTypeDataSource_basic
=== PAUSE TestAccElastiCacheNodeTypeDataSource_basic
=== RUN   TestAccElastiCacheNodeTypeDataSource_invalidType
=== PAUSE TestAccElastiCacheNodeTypeDataSource_invalidType
=== CONT  TestAccElastiCacheNodeTypeDataSource_basic
=== CONT  TestAccElastiCacheNodeTypeDataSource_invalidType
--- PASS: TestAccElastiCacheNodeTypeDataSource_invalidType (4.40s)
--- PASS: TestAccElastiCacheNodeTypeDataSource_basic (17.22s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elasticache	24.024s
```

```release-note:new-data-source
aws_rds_instance_type
```

```release-note:new-data-source
aws_elasticache_node_type
```
