### PR TITLE
Normalize commitment values for Savings Plans

### DIFF
--- a/.changelog/48393.txt
+++ b/.changelog/48393.txt
@@ -1,0 +1,1 @@
+* fixed a bug in `aws_savingsplans_savings_plan` where commitment values with different decimal precision could cause inconsistent apply results after creation. ([#48393](https://github.com/hashicorp/terraform-provider-aws/issues/48393))

--- a/internal/service/savingsplans/commitment.go
+++ b/internal/service/savingsplans/commitment.go
@@ -3,17 +3,141 @@
 
 package savingsplans
 
-import "strconv"
+import (
+	"context"
+	"fmt"
 
-func normalizeCommitmentValue(v string) string {
-	if v == "" {
-		return ""
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/shopspring/decimal"
+)
+
+var (
+	_ basetypes.StringTypable = (*commitmentStringType)(nil)
+)
+
+type commitmentStringType struct {
+	basetypes.StringType
+}
+
+var (
+	CommitmentStringType = commitmentStringType{}
+)
+
+func (t commitmentStringType) Equal(o attr.Type) bool {
+	other, ok := o.(commitmentStringType)
+	if !ok {
+		return false
 	}
 
-	f, err := strconv.ParseFloat(v, 64)
+	return t.StringType.Equal(other.StringType)
+}
+
+func (commitmentStringType) String() string {
+	return "CommitmentStringType"
+}
+
+func (t commitmentStringType) ValueFromString(_ context.Context, in types.String) (basetypes.StringValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return CommitmentStringNull(), diags
+	}
+	if in.IsUnknown() {
+		return CommitmentStringUnknown(), diags
+	}
+
+	return CommitmentStringValue(in.ValueString()), diags
+}
+
+func (t commitmentStringType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	attrValue, err := t.StringType.ValueFromTerraform(ctx, in)
 	if err != nil {
-		return v
+		return nil, err
 	}
 
-	return strconv.FormatFloat(f, 'f', -1, 64)
+	stringValue, ok := attrValue.(basetypes.StringValue)
+	if !ok {
+		return nil, fmt.Errorf("unexpected value type of %T", attrValue)
+	}
+
+	stringValuable, diags := t.ValueFromString(ctx, stringValue)
+	if diags.HasError() {
+		return nil, fmt.Errorf("unexpected error converting StringValue to StringValuable: %v", diags)
+	}
+
+	return stringValuable, nil
+}
+
+func (commitmentStringType) ValueType(context.Context) attr.Value {
+	return CommitmentString{}
+}
+
+var (
+	_ basetypes.StringValuable                   = (*CommitmentString)(nil)
+	_ basetypes.StringValuableWithSemanticEquals = (*CommitmentString)(nil)
+)
+
+type CommitmentString struct {
+	basetypes.StringValue
+}
+
+func CommitmentStringNull() CommitmentString {
+	return CommitmentString{StringValue: basetypes.NewStringNull()}
+}
+
+func CommitmentStringUnknown() CommitmentString {
+	return CommitmentString{StringValue: basetypes.NewStringUnknown()}
+}
+
+func CommitmentStringValue(value string) CommitmentString {
+	return CommitmentString{StringValue: basetypes.NewStringValue(value)}
+}
+
+func (v CommitmentString) Equal(o attr.Value) bool {
+	other, ok := o.(CommitmentString)
+	if !ok {
+		return false
+	}
+
+	return v.StringValue.Equal(other.StringValue)
+}
+
+func (CommitmentString) Type(context.Context) attr.Type {
+	return CommitmentStringType
+}
+
+func (v CommitmentString) StringSemanticEquals(ctx context.Context, newValuable basetypes.StringValuable) (bool, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	oldValue, d := v.ToStringValue(ctx)
+	diags.Append(d...)
+	if diags.HasError() {
+		return false, diags
+	}
+
+	newValue, d := newValuable.ToStringValue(ctx)
+	diags.Append(d...)
+	if diags.HasError() {
+		return false, diags
+	}
+
+	return commitmentStringSemanticEquals(oldValue.ValueString(), newValue.ValueString()), diags
+}
+
+func commitmentStringSemanticEquals(oldValue, newValue string) bool {
+	if oldValue == newValue {
+		return true
+	}
+
+	oldDecimal, oldErr := decimal.NewFromString(oldValue)
+	newDecimal, newErr := decimal.NewFromString(newValue)
+	if oldErr != nil || newErr != nil {
+		return false
+	}
+
+	return oldDecimal.Equal(newDecimal)
 }

--- a/internal/service/savingsplans/commitment.go
+++ b/internal/service/savingsplans/commitment.go
@@ -1,0 +1,19 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package savingsplans
+
+import "strconv"
+
+func normalizeCommitmentValue(v string) string {
+	if v == "" {
+		return ""
+	}
+
+	f, err := strconv.ParseFloat(v, 64)
+	if err != nil {
+		return v
+	}
+
+	return strconv.FormatFloat(f, 'f', -1, 64)
+}

--- a/internal/service/savingsplans/savings_plan.go
+++ b/internal/service/savingsplans/savings_plan.go
@@ -237,6 +237,8 @@ func (r *savingsPlanResource) Create(ctx context.Context, req resource.CreateReq
 		return
 	}
 
+	plan.Commitment = types.StringValue(normalizeCommitmentValue(plan.Commitment.ValueString()))
+
 	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, plan))
 }
 
@@ -265,6 +267,8 @@ func (r *savingsPlanResource) Read(ctx context.Context, req resource.ReadRequest
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	state.Commitment = types.StringValue(normalizeCommitmentValue(state.Commitment.ValueString()))
 	state.SavingsPlanOfferingID = fwflex.StringToFramework(ctx, out.OfferingId)
 
 	setTagsOut(ctx, out.Tags)

--- a/internal/service/savingsplans/savings_plan.go
+++ b/internal/service/savingsplans/savings_plan.go
@@ -54,6 +54,7 @@ func (r *savingsPlanResource) Schema(ctx context.Context, req resource.SchemaReq
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"commitment": schema.StringAttribute{
+				CustomType:  CommitmentStringType,
 				Required:    true,
 				Description: "The hourly commitment, in USD.",
 				PlanModifiers: []planmodifier.String{
@@ -237,8 +238,6 @@ func (r *savingsPlanResource) Create(ctx context.Context, req resource.CreateReq
 		return
 	}
 
-	plan.Commitment = types.StringValue(normalizeCommitmentValue(plan.Commitment.ValueString()))
-
 	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, plan))
 }
 
@@ -268,7 +267,6 @@ func (r *savingsPlanResource) Read(ctx context.Context, req resource.ReadRequest
 		return
 	}
 
-	state.Commitment = types.StringValue(normalizeCommitmentValue(state.Commitment.ValueString()))
 	state.SavingsPlanOfferingID = fwflex.StringToFramework(ctx, out.OfferingId)
 
 	setTagsOut(ctx, out.Tags)
@@ -406,7 +404,7 @@ func findSavingsPlans(ctx context.Context, conn *savingsplans.Client, input *sav
 }
 
 type savingsPlanResourceModel struct {
-	Commitment             types.String                                  `tfsdk:"commitment"`
+	Commitment             CommitmentString                              `tfsdk:"commitment"`
 	Currency               types.String                                  `tfsdk:"currency"`
 	Description            types.String                                  `tfsdk:"description"`
 	EC2InstanceFamily      types.String                                  `tfsdk:"ec2_instance_family"`

--- a/internal/service/savingsplans/savings_plan_data_source.go
+++ b/internal/service/savingsplans/savings_plan_data_source.go
@@ -138,7 +138,6 @@ func (d *savingsPlanDataSource) Read(ctx context.Context, req datasource.ReadReq
 		return
 	}
 
-	data.Commitment = types.StringValue(normalizeCommitmentValue(data.Commitment.ValueString()))
 	data.SavingsPlanOfferingID = fwflex.StringToFramework(ctx, out.OfferingId)
 
 	setTagsOut(ctx, out.Tags)
@@ -147,7 +146,7 @@ func (d *savingsPlanDataSource) Read(ctx context.Context, req datasource.ReadReq
 }
 
 type savingsPlanDataSourceModel struct {
-	Commitment             types.String         `tfsdk:"commitment"`
+	Commitment             CommitmentString     `tfsdk:"commitment"`
 	Currency               types.String         `tfsdk:"currency"`
 	Description            types.String         `tfsdk:"description"`
 	EC2InstanceFamily      types.String         `tfsdk:"ec2_instance_family"`

--- a/internal/service/savingsplans/savings_plan_data_source.go
+++ b/internal/service/savingsplans/savings_plan_data_source.go
@@ -137,6 +137,8 @@ func (d *savingsPlanDataSource) Read(ctx context.Context, req datasource.ReadReq
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	data.Commitment = types.StringValue(normalizeCommitmentValue(data.Commitment.ValueString()))
 	data.SavingsPlanOfferingID = fwflex.StringToFramework(ctx, out.OfferingId)
 
 	setTagsOut(ctx, out.Tags)

--- a/internal/service/savingsplans/savings_plan_internal_test.go
+++ b/internal/service/savingsplans/savings_plan_internal_test.go
@@ -1,0 +1,57 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package savingsplans
+
+import "testing"
+
+func TestNormalizeCommitmentValue(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "preserves concise decimal",
+			input:    "1.158",
+			expected: "1.158",
+		},
+		{
+			name:     "trims trailing zeros",
+			input:    "1.15800000",
+			expected: "1.158",
+		},
+		{
+			name:     "removes redundant decimal part",
+			input:    "1.00000000",
+			expected: "1",
+		},
+		{
+			name:     "handles leading zeros",
+			input:    "0001.2300",
+			expected: "1.23",
+		},
+		{
+			name:     "handles zero values",
+			input:    "0.00000000",
+			expected: "0",
+		},
+		{
+			name:     "leaves non-decimal input unchanged",
+			input:    "abc",
+			expected: "abc",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := normalizeCommitmentValue(tt.input); got != tt.expected {
+				t.Errorf("normalizeCommitmentValue(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/service/savingsplans/savings_plan_internal_test.go
+++ b/internal/service/savingsplans/savings_plan_internal_test.go
@@ -3,45 +3,43 @@
 
 package savingsplans
 
-import "testing"
+import (
+	"context"
+	"testing"
+)
 
-func TestNormalizeCommitmentValue(t *testing.T) {
+func TestCommitmentStringSemanticEquals(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
 		name     string
-		input    string
-		expected string
+		oldValue string
+		newValue string
+		want     bool
 	}{
 		{
-			name:     "preserves concise decimal",
-			input:    "1.158",
-			expected: "1.158",
+			name:     "treats equivalent decimals as equal",
+			oldValue: "1.158",
+			newValue: "1.15800000",
+			want:     true,
 		},
 		{
-			name:     "trims trailing zeros",
-			input:    "1.15800000",
-			expected: "1.158",
+			name:     "treats different decimals as unequal",
+			oldValue: "1.158",
+			newValue: "1.159",
+			want:     false,
 		},
 		{
-			name:     "removes redundant decimal part",
-			input:    "1.00000000",
-			expected: "1",
+			name:     "treats values with different representation as equal",
+			oldValue: "0001.2300",
+			newValue: "1.23",
+			want:     true,
 		},
 		{
-			name:     "handles leading zeros",
-			input:    "0001.2300",
-			expected: "1.23",
-		},
-		{
-			name:     "handles zero values",
-			input:    "0.00000000",
-			expected: "0",
-		},
-		{
-			name:     "leaves non-decimal input unchanged",
-			input:    "abc",
-			expected: "abc",
+			name:     "falls back to exact string equality for non-decimal values",
+			oldValue: "abc",
+			newValue: "abc",
+			want:     true,
 		},
 	}
 
@@ -49,8 +47,13 @@ func TestNormalizeCommitmentValue(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			if got := normalizeCommitmentValue(tt.input); got != tt.expected {
-				t.Errorf("normalizeCommitmentValue(%q) = %q, want %q", tt.input, got, tt.expected)
+			oldValue := CommitmentStringValue(tt.oldValue)
+			got, diags := oldValue.StringSemanticEquals(context.Background(), CommitmentStringValue(tt.newValue))
+			if diags.HasError() {
+				t.Fatalf("unexpected diagnostics: %v", diags)
+			}
+			if got != tt.want {
+				t.Errorf("StringSemanticEquals(%q, %q) = %t, want %t", tt.oldValue, tt.newValue, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No

### Description
Normalize commitment values so inputs like 1.158 and 1.15800000 are treated as equivalent



### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #48393

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

None
