### PR TITLE
r/aws_db_instance: Wait for green instance to leave storage-optimization before Blue/Green switchover

### DIFF
--- a/.changelog/48830.txt
+++ b/.changelog/48830.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_db_instance: Wait for the green instance to finish `storage-optimization` and reach `available` before switching over a Blue/Green Deployment
+```

--- a/internal/service/rds/instance.go
+++ b/internal/service/rds/instance.go
@@ -2228,6 +2228,10 @@ func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta an
 				return sdkdiag.AppendErrorf(diags, "updating RDS DB Instance (%s): %s", d.Get(names.AttrIdentifier).(string), err)
 			}
 
+			if _, err := waitDBInstanceAvailableForBlueGreenSwitchover(ctx, conn, targetARN.Identifier, deadline.Remaining()); err != nil {
+				return sdkdiag.AppendErrorf(diags, "updating RDS DB Instance (%s): creating Blue/Green Deployment: waiting for Green environment: %s", d.Get(names.AttrIdentifier).(string), err)
+			}
+
 			log.Printf("[DEBUG] Updating RDS DB Instance (%s): Switching over Blue/Green Deployment", d.Get(names.AttrIdentifier).(string))
 
 			dep, err = orchestrator.Switchover(ctx, aws.ToString(dep.BlueGreenDeploymentIdentifier), deadline.Remaining())
@@ -2926,6 +2930,58 @@ func waitDBInstanceAvailable(ctx context.Context, conn *rds.Client, id string, t
 			instanceStatusUpgrading,
 		},
 		Target:  []string{instanceStatusAvailable, instanceStatusStorageOptimization},
+		Refresh: statusDBInstance(conn, id),
+		Timeout: timeout,
+	}
+	options.Apply(stateConf)
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+
+	if output, ok := outputRaw.(*types.DBInstance); ok {
+		return output, err
+	}
+
+	return nil, err
+}
+
+// waitDBInstanceAvailableForBlueGreenSwitchover waits for a DB instance to reach
+// "available" before a Blue/Green Deployment switchover. Unlike
+// waitDBInstanceAvailable, it treats "storage-optimization" as pending rather
+// than a target state: the SwitchoverBlueGreenDeployment API requires the green
+// instance to be truly available, and storage optimization can cause replication
+// lag that trips the switchover guardrails.
+func waitDBInstanceAvailableForBlueGreenSwitchover(ctx context.Context, conn *rds.Client, id string, timeout time.Duration, optFns ...tfresource.OptionsFunc) (*types.DBInstance, error) {
+	options := tfresource.Options{
+		PollInterval:              10 * time.Second,
+		Delay:                     1 * time.Minute,
+		ContinuousTargetOccurence: 3,
+	}
+	for _, fn := range optFns {
+		fn(&options)
+	}
+
+	stateConf := &retry.StateChangeConf{
+		Pending: []string{
+			instanceStatusBackingUp,
+			instanceStatusConfiguringEnhancedMonitoring,
+			instanceStatusConfiguringIAMDatabaseAuth,
+			instanceStatusConfiguringLogExports,
+			instanceStatusCreating,
+			instanceStatusMaintenance,
+			instanceStatusModifying,
+			instanceStatusMovingToVPC,
+			instanceStatusRebooting,
+			instanceStatusRenaming,
+			instanceStatusResettingMasterCredentials,
+			instanceStatusStarting,
+			instanceStatusStopping,
+			instanceStatusStorageConfigUpgrade,
+			instanceStatusStorageFull,
+			instanceStatusStorageInitialization,
+			instanceStatusStorageOptimization,
+			instanceStatusUpgrading,
+		},
+		Target:  []string{instanceStatusAvailable},
 		Refresh: statusDBInstance(conn, id),
 		Timeout: timeout,
 	}

--- a/internal/service/rds/instance_test.go
+++ b/internal/service/rds/instance_test.go
@@ -6830,6 +6830,68 @@ func TestAccRDSInstance_BlueGreenDeployment_updateInstanceClass(t *testing.T) {
 	})
 }
 
+func TestAccRDSInstance_BlueGreenDeployment_updateStorageTypeAndInstanceClass(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	// All RDS Instance tests should skip for testing.Short() except the 20 shortest running tests.
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var v1, v2 types.DBInstance
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_db_instance.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_11_0),
+		},
+		CheckDestroy: testAccCheckDBInstanceDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceConfig_BlueGreenDeployment_storageTypeAndInstanceClass(rName, false, "gp2"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckDBInstanceExists(ctx, t, resourceName, &v1),
+					resource.TestCheckResourceAttrPair(resourceName, "instance_class", "data.aws_rds_orderable_db_instance.test", "instance_class"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrStorageType, "gp2"),
+					resource.TestCheckResourceAttr(resourceName, "backup_retention_period", "1"),
+				),
+			},
+			{
+				// Changing both the instance class and the storage type (gp2 -> gp3) in
+				// the same Blue/Green update leaves the green instance in
+				// "storage-optimization" for an extended period. The switchover must wait
+				// for it to reach "available" first. See GitHub issue #47493.
+				Config: testAccInstanceConfig_BlueGreenDeployment_storageTypeAndInstanceClass(rName, true, "gp3"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckDBInstanceExists(ctx, t, resourceName, &v2),
+					testAccCheckDBInstanceRecreated(&v1, &v2),
+					resource.TestCheckResourceAttrPair(resourceName, "instance_class", "data.aws_rds_orderable_db_instance.test", "instance_class"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrStorageType, "gp3"),
+					resource.TestCheckResourceAttr(resourceName, "blue_green_update.0.enabled", acctest.CtTrue),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					names.AttrApplyImmediately,
+					names.AttrFinalSnapshotIdentifier,
+					names.AttrPassword,
+					"skip_final_snapshot",
+					"delete_automated_backups",
+					"blue_green_update",
+					"latest_restorable_time",
+				},
+			},
+		},
+	})
+}
+
 func TestAccRDSInstance_BlueGreenDeployment_updateAndPromoteReplica(t *testing.T) {
 	ctx := acctest.Context(t)
 
@@ -14351,6 +14413,59 @@ resource "aws_db_instance" "test" {
   }
 }
 `, rName))
+}
+
+func testAccInstanceConfig_BlueGreenDeployment_storageTypeAndInstanceClass(rName string, oddClasses bool, storageType string) string {
+	var halfClasses []string
+	start := 0
+	if oddClasses {
+		start = 1
+	}
+	for i := start; i < len(instanceClassesSlice); i += 2 {
+		halfClasses = append(halfClasses, instanceClassesSlice[i])
+	}
+	halfMainInstClass := strings.Join(halfClasses, ", ")
+
+	return acctest.ConfigCompose(
+		acctest.ConfigRandomPassword(),
+		fmt.Sprintf(`
+data "aws_rds_engine_version" "default" {
+  engine = %[1]q
+}
+
+data "aws_rds_orderable_db_instance" "test" {
+  engine         = data.aws_rds_engine_version.default.engine
+  engine_version = data.aws_rds_engine_version.default.version
+  license_model  = %[2]q
+  storage_type   = %[3]q
+
+  preferred_instance_classes = [%[4]s]
+}
+
+data "aws_db_parameter_group" "test" {
+  name = "default.${data.aws_rds_engine_version.default.parameter_group_family}"
+}
+
+resource "aws_db_instance" "test" {
+  identifier              = %[5]q
+  allocated_storage       = 20
+  storage_type            = %[6]q
+  backup_retention_period = 1
+  engine                  = data.aws_rds_orderable_db_instance.test.engine
+  engine_version          = data.aws_rds_orderable_db_instance.test.engine_version
+  instance_class          = data.aws_rds_orderable_db_instance.test.instance_class
+  db_name                 = "test"
+  parameter_group_name    = data.aws_db_parameter_group.test.name
+  skip_final_snapshot     = true
+  password_wo             = ephemeral.aws_secretsmanager_random_password.test.random_password
+  password_wo_version     = 1
+  username                = "tfacctest"
+
+  blue_green_update {
+    enabled = true
+  }
+}
+`, tfrds.InstanceEngineMySQL, "general-public-license", "gp3", halfMainInstClass, rName, storageType))
 }
 
 func testAccInstanceConfig_BlueGreenDeployment_updateableInstanceClass(rName string, oddClasses bool) string {


### PR DESCRIPTION
### Description

When an `aws_db_instance` update triggers a Blue/Green Deployment that includes a storage type change (e.g. `gp2` → `gp3`), the provider applies that change to the green instance via `modifyTarget`, which puts the green into `storage-optimization` and `SwitchoverBlueGreenDeployment` requires the instance to be truly `available` — storage optimization can cause replication lag that trips the switchover guardrails.

Previously the switchover was attempted immediately after `modifyTarget`, while the green was still optimizing, guarded only by the 10-minute `RetryWhen` in `Switchover`. Storage optimization can take far longer than 10 minutes, so the retry window was exhausted and the operation failed with:

```
InvalidBlueGreenDeploymentStateFault: DB instance ... is not in available state
```

This PR adds `waitDBInstanceAvailableForBlueGreenSwitchover` and calls it **after `modifyTarget` and before the switchover**. Unlike the general-purpose `waitDBInstanceAvailable`, it treats `storage-optimization` as a **pending** state and targets only `available`, so the switchover is attempted only once the green is truly ready — rather than relying on the switchover retry as a readiness proxy. `waitDBInstanceAvailable` is left unchanged, preserving the intentional behavior from #2437 where `storage-optimization` is a valid target for normal RDS operations.

The waiter honors the resource's configured update timeout (`deadline.Remaining()`), so a storage-type change whose optimization exceeds the default 80-minute `Update` timeout may require raising `timeouts { update = ... }`.

### Note on testing

The added acceptance test exercises the previously-uncovered combined storage-type + instance-class Blue/Green path. It cannot deterministically reproduce a multi-hour optimization in CI (a 20 GB volume optimizes within minutes), so it validates the happy path rather than acting as a strict timing regression guard.

### Relations

Closes #47493

### References

- #2437 — original reason `storage-optimization` was added as a target state for general waits
- #35802, #41275 — prior related reports / partial fixes

### Output from Acceptance Testing

```console
% make testacc PKG=rds TESTS=TestAccRDSInstance_BlueGreenDeployment_updateStorageTypeAndInstanceClass

--- PASS: TestAccRDSInstance_BlueGreenDeployment_updateStorageTypeAndInstanceClass (1969.40s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/rds	1978.165s
```
