### PR TITLE
resource/aws_memorydb_multi_region_cluster: allow in-place node_type …

### DIFF
--- a/.changelog/48832.txt
+++ b/.changelog/48832.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_memorydb_multi_region_cluster: Allow in-place `node_type` updates for online vertical scaling instead of forcing cluster replacement
+```

--- a/internal/service/memorydb/multi_region_cluster.go
+++ b/internal/service/memorydb/multi_region_cluster.go
@@ -106,9 +106,6 @@ func (r *multiRegionClusterResource) Schema(ctx context.Context, request resourc
 			},
 			"node_type": schema.StringAttribute{
 				Required: true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
-				},
 			},
 			"num_shards": schema.Int64Attribute{
 				Computed: true,

--- a/internal/service/memorydb/multi_region_cluster_test.go
+++ b/internal/service/memorydb/multi_region_cluster_test.go
@@ -322,6 +322,11 @@ func TestAccMemoryDBMultiRegionCluster_nodeType(t *testing.T) {
 			},
 			{
 				Config: testAccMultiRegionClusterConfig_nodeType(rName, "db.r7g.2xlarge"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMultiRegionClusterExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "node_type", "db.r7g.2xlarge"),


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

### Description

The `node_type` attribute on `aws_memorydb_multi_region_cluster` previously had a `RequiresReplace` plan modifier, causing Terraform to destroy and recreate the entire multi-region cluster (and all regional clusters) when the node type was changed. 

AWS MemoryDB supports online vertical scaling via the `UpdateMultiRegionCluster` API, which scales the cluster in-place with minimal downtime. The resource's `Update` function already handled this correctly — the only issue was the schema forcing replacement.

This PR removes the `RequiresReplace()` modifier and adds a `plancheck.ExpectResourceAction(..., ResourceActionUpdate)` to the existing acceptance test to prevent regression.

### References

- [AWS Documentation: Online vertical scaling with MemoryDB](https://docs.aws.amazon.com/memorydb/latest/devguide/vertical-scaling.html)

### Output from Acceptance Testing

```console
% make testacc TESTS=TestAccMemoryDBMultiRegionCluster_nodeType PKG=memorydb
