### PR TITLE
security-scan: suppress unreachable GO-2026-5932 (x/crypto/openpgp)

### DIFF
--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -11,4 +11,18 @@ binary {
   osv          = true
   oss_index    = false
   nvd          = false
+
+  triage {
+    suppress {
+      vulnerabilities = [
+        // golang.org/x/crypto/openpgp is deprecated/unmaintained with no fixed
+        // version. The provider does not use this package (confirmed via
+        // `go mod why golang.org/x/crypto/openpgp`); it imports the maintained
+        // fork github.com/ProtonMail/go-crypto/openpgp instead. x/crypto is
+        // only pulled in for the unaffected golang.org/x/crypto/cryptobyte
+        // package. Not reachable in the built binary.
+        "GO-2026-5932",
+      ]
+    }
+  }
 }


### PR DESCRIPTION
## Summary
Suppresses OSV advisory GO-2026-5932 in the CRT security scanner. The advisory deprecates `golang.org/x/crypto/openpgp`; it has no fixed version, so bumping x/crypto cannot clear it.

The provider does not use the flagged package:
- `go mod why golang.org/x/crypto/openpgp` → "main module does not need package"
- x/crypto is pulled in only via `internal/service/acmpca` → `golang.org/x/crypto/cryptobyte` (unaffected)
- The provider's PGP code (`internal/vault/helper/pgpkeys`) already uses the maintained fork `github.com/ProtonMail/go-crypto/openpgp`

The scanner flags it at the module-graph level, not by reachability, so this is a false positive for the built binary. Follows the same pattern as hashicorp/terraform (GO-2026-4762) and hashicorp/vault (GO-2022-0635).

## Testing
Release security scan should no longer fail on GO-2026-5932.