### PR TITLE
l/aws_sfn_state_machine: new list resource

### DIFF
--- a/.changelog/48840.txt
+++ b/.changelog/48840.txt
@@ -1,0 +1,3 @@
+```release-note:new-list-resource
+aws_sfn_state_machine
+```

--- a/internal/service/sfn/service_package_gen.go
+++ b/internal/service/sfn/service_package_gen.go
@@ -7,6 +7,8 @@ package sfn
 
 import (
 	"context"
+	"iter"
+	"slices"
 	"unique"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -113,6 +115,21 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*inttypes.ServicePa
 			},
 		},
 	}
+}
+
+func (p *servicePackage) SDKListResources(ctx context.Context) iter.Seq[*inttypes.ServicePackageSDKListResource] {
+	return slices.Values([]*inttypes.ServicePackageSDKListResource{
+		{
+			Factory:  newStateMachineResourceAsListResource,
+			TypeName: "aws_sfn_state_machine",
+			Name:     "State Machine",
+			Region:   inttypes.ResourceRegionDefault(),
+			Tags: unique.Make(inttypes.ServicePackageResourceTags{
+				IdentifierAttribute: names.AttrID,
+			}),
+			Identity: inttypes.RegionalARNIdentity(),
+		},
+	})
 }
 
 func (p *servicePackage) ServicePackageName() string {

--- a/internal/service/sfn/state_machine.go
+++ b/internal/service/sfn/state_machine.go
@@ -266,61 +266,7 @@ func resourceStateMachineRead(ctx context.Context, d *schema.ResourceData, meta 
 		return sdkdiag.AppendErrorf(diags, "reading Step Functions State Machine (%s): %s", d.Id(), err)
 	}
 
-	d.Set(names.AttrARN, output.StateMachineArn)
-	if output.CreationDate != nil {
-		d.Set(names.AttrCreationDate, aws.ToTime(output.CreationDate).Format(time.RFC3339))
-	} else {
-		d.Set(names.AttrCreationDate, nil)
-	}
-	d.Set("definition", output.Definition)
-	d.Set(names.AttrDescription, output.Description)
-	if output.EncryptionConfiguration != nil {
-		if err := d.Set(names.AttrEncryptionConfiguration, []any{flattenEncryptionConfiguration(output.EncryptionConfiguration)}); err != nil {
-			return sdkdiag.AppendErrorf(diags, "setting encryption_configuration: %s", err)
-		}
-	} else {
-		d.Set(names.AttrEncryptionConfiguration, nil)
-	}
-	if output.LoggingConfiguration != nil {
-		if err := d.Set(names.AttrLoggingConfiguration, []any{flattenLoggingConfiguration(output.LoggingConfiguration)}); err != nil {
-			return sdkdiag.AppendErrorf(diags, "setting logging_configuration: %s", err)
-		}
-	} else {
-		d.Set(names.AttrLoggingConfiguration, nil)
-	}
-	d.Set(names.AttrName, output.Name)
-	d.Set(names.AttrNamePrefix, create.NamePrefixFromName(aws.ToString(output.Name)))
-	d.Set("publish", d.Get("publish").(bool))
-	d.Set("revision_id", output.RevisionId)
-	d.Set(names.AttrRoleARN, output.RoleArn)
-	d.Set(names.AttrStatus, output.Status)
-	if output.TracingConfiguration != nil {
-		if err := d.Set("tracing_configuration", []any{flattenTracingConfiguration(output.TracingConfiguration)}); err != nil {
-			return sdkdiag.AppendErrorf(diags, "setting tracing_configuration: %s", err)
-		}
-	} else {
-		d.Set("tracing_configuration", nil)
-	}
-	d.Set(names.AttrType, output.Type)
-
-	input := &sfn.ListStateMachineVersionsInput{
-		StateMachineArn: aws.String(d.Id()),
-	}
-	listVersionsOutput, err := conn.ListStateMachineVersions(ctx, input)
-
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "listing Step Functions State Machine (%s) Versions: %s", d.Id(), err)
-	}
-
-	// The results are sorted in descending order of the version creation time.
-	// https://docs.aws.amazon.com/step-functions/latest/apireference/API_ListStateMachineVersions.html
-	if len(listVersionsOutput.StateMachineVersions) > 0 {
-		d.Set("state_machine_version_arn", listVersionsOutput.StateMachineVersions[0].StateMachineVersionArn)
-	} else {
-		d.Set("state_machine_version_arn", nil)
-	}
-
-	return diags
+	return append(diags, resourceStateMachineFlatten(ctx, conn, output, d)...)
 }
 
 func resourceStateMachineUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
@@ -540,6 +486,66 @@ func flattenTracingConfiguration(apiObject *awstypes.TracingConfiguration) map[s
 	}
 
 	return tfMap
+}
+
+func resourceStateMachineFlatten(ctx context.Context, conn *sfn.Client, output *sfn.DescribeStateMachineOutput, d *schema.ResourceData) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	d.Set(names.AttrARN, output.StateMachineArn)
+	if output.CreationDate != nil {
+		d.Set(names.AttrCreationDate, aws.ToTime(output.CreationDate).Format(time.RFC3339))
+	} else {
+		d.Set(names.AttrCreationDate, nil)
+	}
+	d.Set("definition", output.Definition)
+	d.Set(names.AttrDescription, output.Description)
+	if output.EncryptionConfiguration != nil {
+		if err := d.Set(names.AttrEncryptionConfiguration, []any{flattenEncryptionConfiguration(output.EncryptionConfiguration)}); err != nil {
+			return sdkdiag.AppendErrorf(diags, "setting encryption_configuration: %s", err)
+		}
+	} else {
+		d.Set(names.AttrEncryptionConfiguration, nil)
+	}
+	if output.LoggingConfiguration != nil {
+		if err := d.Set(names.AttrLoggingConfiguration, []any{flattenLoggingConfiguration(output.LoggingConfiguration)}); err != nil {
+			return sdkdiag.AppendErrorf(diags, "setting logging_configuration: %s", err)
+		}
+	} else {
+		d.Set(names.AttrLoggingConfiguration, nil)
+	}
+	d.Set(names.AttrName, output.Name)
+	d.Set(names.AttrNamePrefix, create.NamePrefixFromName(aws.ToString(output.Name)))
+	d.Set("publish", d.Get("publish").(bool))
+	d.Set("revision_id", output.RevisionId)
+	d.Set(names.AttrRoleARN, output.RoleArn)
+	d.Set(names.AttrStatus, output.Status)
+	if output.TracingConfiguration != nil {
+		if err := d.Set("tracing_configuration", []any{flattenTracingConfiguration(output.TracingConfiguration)}); err != nil {
+			return sdkdiag.AppendErrorf(diags, "setting tracing_configuration: %s", err)
+		}
+	} else {
+		d.Set("tracing_configuration", nil)
+	}
+	d.Set(names.AttrType, output.Type)
+
+	input := &sfn.ListStateMachineVersionsInput{
+		StateMachineArn: aws.String(d.Id()),
+	}
+	listVersionsOutput, err := conn.ListStateMachineVersions(ctx, input)
+
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "listing Step Functions State Machine (%s) Versions: %s", d.Id(), err)
+	}
+
+	// The results are sorted in descending order of the version creation time.
+	// https://docs.aws.amazon.com/step-functions/latest/apireference/API_ListStateMachineVersions.html
+	if len(listVersionsOutput.StateMachineVersions) > 0 {
+		d.Set("state_machine_version_arn", listVersionsOutput.StateMachineVersions[0].StateMachineVersionArn)
+	} else {
+		d.Set("state_machine_version_arn", nil)
+	}
+
+	return diags
 }
 
 func stateMachineUpdateComputedAttributesOnPublish(_ context.Context, d *schema.ResourceDiff, meta any) error {

--- a/internal/service/sfn/state_machine_list.go
+++ b/internal/service/sfn/state_machine_list.go
@@ -1,0 +1,112 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package sfn
+
+import (
+	"context"
+	"fmt"
+	"iter"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sfn"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/sfn/types"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/logging"
+	inttypes "github.com/hashicorp/terraform-provider-aws/internal/types"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @SDKListResource("aws_sfn_state_machine")
+func newStateMachineResourceAsListResource() inttypes.ListResourceForSDK {
+	l := stateMachineListResource{}
+	l.SetResourceSchema(resourceStateMachine())
+	return &l
+}
+
+var _ list.ListResource = &stateMachineListResource{}
+
+type stateMachineListResource struct {
+	framework.ListResourceWithSDKv2Resource
+}
+
+func (l *stateMachineListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
+	awsClient := l.Meta()
+	conn := awsClient.SFNClient(ctx)
+
+	tflog.Info(ctx, "Listing Step Functions State Machines")
+
+	stream.Results = func(yield func(list.ListResult) bool) {
+		var input sfn.ListStateMachinesInput
+		for item, err := range listStateMachines(ctx, conn, &input) {
+			if err != nil {
+				result := fwdiag.NewListResultErrorDiagnostic(err)
+				yield(result)
+				return
+			}
+
+			arn := aws.ToString(item.StateMachineArn)
+			ctx := tflog.SetField(ctx, logging.ResourceAttributeKey(names.AttrARN), arn)
+
+			result := request.NewListResult(ctx)
+
+			rd := l.ResourceData()
+			rd.SetId(arn)
+			rd.Set(names.AttrARN, arn)
+
+			if request.IncludeResource {
+				tflog.Info(ctx, "Reading Step Functions State Machine")
+				output, err := findStateMachineByARN(ctx, conn, arn)
+				if err != nil {
+					tflog.Error(ctx, "Reading Step Functions State Machine", map[string]any{
+						"error": err.Error(),
+					})
+					continue
+				}
+
+				diags := resourceStateMachineFlatten(ctx, conn, output, rd)
+				if diags.HasError() {
+					tflog.Error(ctx, "Flattening Step Functions State Machine", map[string]any{
+						"diags": sdkdiag.DiagnosticsString(diags),
+					})
+					continue
+				}
+			}
+
+			result.DisplayName = aws.ToString(item.Name)
+
+			l.SetResult(ctx, awsClient, request.IncludeResource, rd, &result)
+			if result.Diagnostics.HasError() {
+				yield(result)
+				return
+			}
+
+			if !yield(result) {
+				return
+			}
+		}
+	}
+}
+
+func listStateMachines(ctx context.Context, conn *sfn.Client, input *sfn.ListStateMachinesInput) iter.Seq2[awstypes.StateMachineListItem, error] {
+	return func(yield func(awstypes.StateMachineListItem, error) bool) {
+		pages := sfn.NewListStateMachinesPaginator(conn, input)
+		for pages.HasMorePages() {
+			page, err := pages.NextPage(ctx)
+			if err != nil {
+				yield(awstypes.StateMachineListItem{}, fmt.Errorf("listing Step Functions State Machines: %w", err))
+				return
+			}
+
+			for _, item := range page.StateMachines {
+				if !yield(item, nil) {
+					return
+				}
+			}
+		}
+	}
+}

--- a/internal/service/sfn/state_machine_list_test.go
+++ b/internal/service/sfn/state_machine_list_test.go
@@ -1,0 +1,215 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package sfn_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	tfknownvalue "github.com/hashicorp/terraform-provider-aws/internal/acctest/knownvalue"
+	tfquerycheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/querycheck"
+	tfqueryfilter "github.com/hashicorp/terraform-provider-aws/internal/acctest/queryfilter"
+	tfstatecheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/statecheck"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccSFNStateMachine_List_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_sfn_state_machine.test[0]"
+	resourceName2 := "aws_sfn_state_machine.test[1]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity1 := tfstatecheck.Identity()
+	identity2 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SFNServiceID),
+		CheckDestroy:             testAccCheckStateMachineDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/StateMachine/list_basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+					statecheck.ExpectKnownValue(resourceName1, tfjsonpath.New(names.AttrARN), tfknownvalue.RegionalARNExact("states", "stateMachine:"+rName+"-0")),
+
+					identity2.GetIdentity(resourceName2),
+					statecheck.ExpectKnownValue(resourceName2, tfjsonpath.New(names.AttrARN), tfknownvalue.RegionalARNExact("states", "stateMachine:"+rName+"-1")),
+				},
+			},
+
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/StateMachine/list_basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_sfn_state_machine.test", identity1.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_sfn_state_machine.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), knownvalue.StringExact(rName+"-0")),
+					tfquerycheck.ExpectNoResourceObject("aws_sfn_state_machine.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks())),
+
+					tfquerycheck.ExpectIdentityFunc("aws_sfn_state_machine.test", identity2.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_sfn_state_machine.test", tfqueryfilter.ByResourceIdentityFunc(identity2.Checks()), knownvalue.StringExact(rName+"-1")),
+					tfquerycheck.ExpectNoResourceObject("aws_sfn_state_machine.test", tfqueryfilter.ByResourceIdentityFunc(identity2.Checks())),
+				},
+			},
+		},
+	})
+}
+
+func TestAccSFNStateMachine_List_includeResource(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_sfn_state_machine.test[0]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity1 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SFNServiceID),
+		CheckDestroy:             testAccCheckStateMachineDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/StateMachine/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(1),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
+						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
+					}),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+					statecheck.ExpectKnownValue(resourceName1, tfjsonpath.New(names.AttrARN), tfknownvalue.RegionalARNExact("states", "stateMachine:"+rName+"-0")),
+				},
+			},
+
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/StateMachine/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(1),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
+						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
+					}),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_sfn_state_machine.test", identity1.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_sfn_state_machine.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), knownvalue.StringExact(rName+"-0")),
+					querycheck.ExpectResourceKnownValues("aws_sfn_state_machine.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), []querycheck.KnownValueCheck{
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrARN), tfknownvalue.RegionalARNExact("states", "stateMachine:"+rName+"-0")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.Region())),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrID), knownvalue.NotNull()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrCreationDate), knownvalue.NotNull()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("definition"), knownvalue.NotNull()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrDescription), knownvalue.StringExact("")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrEncryptionConfiguration), knownvalue.ListSizeExact(1)),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrLoggingConfiguration), knownvalue.ListSizeExact(1)),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrName), knownvalue.StringExact(rName+"-0")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrNamePrefix), knownvalue.StringExact("")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("publish"), knownvalue.Bool(false)),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("revision_id"), knownvalue.NotNull()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrRoleARN), knownvalue.NotNull()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("state_machine_version_arn"), knownvalue.StringExact("")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrStatus), knownvalue.StringExact("ACTIVE")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("tracing_configuration"), knownvalue.ListSizeExact(1)),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrType), knownvalue.StringExact("STANDARD")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
+							acctest.CtKey1: knownvalue.StringExact(acctest.CtValue1),
+						})),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrTagsAll), knownvalue.MapExact(map[string]knownvalue.Check{
+							acctest.CtKey1: knownvalue.StringExact(acctest.CtValue1),
+						})),
+					}),
+				},
+			},
+		},
+	})
+}
+
+func TestAccSFNStateMachine_List_regionOverride(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_sfn_state_machine.test[0]"
+	resourceName2 := "aws_sfn_state_machine.test[1]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity1 := tfstatecheck.Identity()
+	identity2 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.SFNServiceID),
+		CheckDestroy:             acctest.CheckDestroyNoop,
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/StateMachine/list_region_override/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+					"region":         config.StringVariable(acctest.AlternateRegion()),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+					statecheck.ExpectKnownValue(resourceName1, tfjsonpath.New(names.AttrARN), tfknownvalue.RegionalARNAlternateRegionExact("states", "stateMachine:"+rName+"-0")),
+
+					identity2.GetIdentity(resourceName2),
+					statecheck.ExpectKnownValue(resourceName2, tfjsonpath.New(names.AttrARN), tfknownvalue.RegionalARNAlternateRegionExact("states", "stateMachine:"+rName+"-1")),
+				},
+			},
+
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/StateMachine/list_region_override/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+					"region":         config.StringVariable(acctest.AlternateRegion()),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_sfn_state_machine.test", identity1.Checks()),
+
+					tfquerycheck.ExpectIdentityFunc("aws_sfn_state_machine.test", identity2.Checks()),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/sfn/testdata/StateMachine/list_basic/main.tf
+++ b/internal/service/sfn/testdata/StateMachine/list_basic/main.tf
@@ -1,0 +1,53 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_sfn_state_machine" "test" {
+  count = var.resource_count
+
+  name     = "${var.rName}-${count.index}"
+  role_arn = aws_iam_role.test.arn
+
+  definition = <<EOF
+{
+  "Comment": "A Hello World example using a Pass state",
+  "StartAt": "HelloWorld",
+  "States": {
+    "HelloWorld": {
+      "Type": "Pass",
+      "End": true
+    }
+  }
+}
+EOF
+}
+
+resource "aws_iam_role" "test" {
+  name = var.rName
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": {
+      "Service": "states.${data.aws_region.current.region}.amazonaws.com"
+    },
+    "Action": "sts:AssumeRole"
+  }]
+}
+EOF
+}
+
+data "aws_region" "current" {}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}

--- a/internal/service/sfn/testdata/StateMachine/list_basic/query.tfquery.hcl
+++ b/internal/service/sfn/testdata/StateMachine/list_basic/query.tfquery.hcl
@@ -1,0 +1,6 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_sfn_state_machine" "test" {
+  provider = aws
+}

--- a/internal/service/sfn/testdata/StateMachine/list_include_resource/main.tf
+++ b/internal/service/sfn/testdata/StateMachine/list_include_resource/main.tf
@@ -1,0 +1,61 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_sfn_state_machine" "test" {
+  count = var.resource_count
+
+  name     = "${var.rName}-${count.index}"
+  role_arn = aws_iam_role.test.arn
+
+  definition = <<EOF
+{
+  "Comment": "A Hello World example using a Pass state",
+  "StartAt": "HelloWorld",
+  "States": {
+    "HelloWorld": {
+      "Type": "Pass",
+      "End": true
+    }
+  }
+}
+EOF
+
+  tags = var.resource_tags
+}
+
+resource "aws_iam_role" "test" {
+  name = var.rName
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": {
+      "Service": "states.${data.aws_region.current.region}.amazonaws.com"
+    },
+    "Action": "sts:AssumeRole"
+  }]
+}
+EOF
+}
+
+data "aws_region" "current" {}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}
+
+variable "resource_tags" {
+  description = "Tags to set on resource"
+  type        = map(string)
+  nullable    = false
+}

--- a/internal/service/sfn/testdata/StateMachine/list_include_resource/query.tfquery.hcl
+++ b/internal/service/sfn/testdata/StateMachine/list_include_resource/query.tfquery.hcl
@@ -1,0 +1,8 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_sfn_state_machine" "test" {
+  provider = aws
+
+  include_resource = true
+}

--- a/internal/service/sfn/testdata/StateMachine/list_region_override/main.tf
+++ b/internal/service/sfn/testdata/StateMachine/list_region_override/main.tf
@@ -1,0 +1,62 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_sfn_state_machine" "test" {
+  count  = var.resource_count
+  region = var.region
+
+  name     = "${var.rName}-${count.index}"
+  role_arn = aws_iam_role.test.arn
+
+  definition = <<EOF
+{
+  "Comment": "A Hello World example using a Pass state",
+  "StartAt": "HelloWorld",
+  "States": {
+    "HelloWorld": {
+      "Type": "Pass",
+      "End": true
+    }
+  }
+}
+EOF
+}
+
+resource "aws_iam_role" "test" {
+  name = var.rName
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": {
+      "Service": "states.${data.aws_region.current.region}.amazonaws.com"
+    },
+    "Action": "sts:AssumeRole"
+  }]
+}
+EOF
+}
+
+data "aws_region" "current" {
+  region = var.region
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}
+
+variable "region" {
+  description = "Region to deploy resource in"
+  type        = string
+  nullable    = false
+}

--- a/internal/service/sfn/testdata/StateMachine/list_region_override/query.tfquery.hcl
+++ b/internal/service/sfn/testdata/StateMachine/list_region_override/query.tfquery.hcl
@@ -1,0 +1,10 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_sfn_state_machine" "test" {
+  provider = aws
+
+  config {
+    region = var.region
+  }
+}

--- a/website/docs/list-resources/sfn_state_machine.html.markdown
+++ b/website/docs/list-resources/sfn_state_machine.html.markdown
@@ -1,0 +1,25 @@
+---
+subcategory: "SFN (Step Functions)"
+layout: "aws"
+page_title: "AWS: aws_sfn_state_machine"
+description: |-
+  Lists SFN (Step Functions) State Machine resources.
+---
+
+# List Resource: aws_sfn_state_machine
+
+Lists SFN (Step Functions) State Machine resources.
+
+## Example Usage
+
+```terraform
+list "aws_sfn_state_machine" "example" {
+  provider = aws
+}
+```
+
+## Argument Reference
+
+This list resource supports the following arguments:
+
+* `region` - (Optional) Region to query. Defaults to provider region.


### PR DESCRIPTION



<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Adds a new list resource, `aws_sfn_state_machine`.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->
Closes #48603
Relates https://github.com/hashicorp/terraform-provider-aws/issues/47005



### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t K=sfn T=TestAccSFNStateMachine_List
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 tmp5 🌿...
TF_ACC=1 go1.26.4 test ./internal/service/sfn/... -v -count 1 -parallel 20 -run='TestAccSFNStateMachine_List'  -timeout 360m -vet=off
2026/07/08 14:11:09 Creating Terraform AWS Provider (SDKv2-style)...
2026/07/08 14:11:09 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccSFNStateMachine_List_regionOverride (60.75s)
--- PASS: TestAccSFNStateMachine_List_includeResource (145.48s)
--- PASS: TestAccSFNStateMachine_List_basic (194.96s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/sfn        203.078s
```

```console
% make t K=sfn T=TestAccSFNStateMachine_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-sfn_state_machine-list 🌿...
TF_ACC=1 go1.26.4 test ./internal/service/sfn/... -v -count 1 -parallel 20 -run='TestAccSFNStateMachine_'  -timeout 360m -vet=off
2026/07/08 14:17:30 Creating Terraform AWS Provider (SDKv2-style)...
2026/07/08 14:17:30 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccSFNStateMachine_definitionValidation (49.28s)
--- PASS: TestAccSFNStateMachine_List_regionOverride (104.91s)
--- PASS: TestAccSFNStateMachine_tracing (149.27s)
--- PASS: TestAccSFNStateMachine_expressUpdate (168.49s)
--- PASS: TestAccSFNStateMachine_Identity_regionOverride (170.40s)
--- PASS: TestAccSFNStateMachine_namePrefix (207.70s)
--- PASS: TestAccSFNStateMachine_List_basic (208.92s)
--- PASS: TestAccSFNStateMachine_createUpdate (215.15s)
--- PASS: TestAccSFNStateMachine_List_includeResource (221.96s)
--- PASS: TestAccSFNStateMachine_Identity_ExistingResource_noRefreshNoChange (232.22s)
--- PASS: TestAccSFNStateMachine_nameGenerated (236.54s)
--- PASS: TestAccSFNStateMachine_expressLogging (239.76s)
--- PASS: TestAccSFNStateMachine_standardUpdate (240.04s)
--- PASS: TestAccSFNStateMachine_disappears (264.72s)
--- PASS: TestAccSFNStateMachine_publish (266.47s)
--- PASS: TestAccSFNStateMachine_tags (267.96s)
--- PASS: TestAccSFNStateMachine_encryptionConfigurationServiceOwnedKey (270.37s)
--- PASS: TestAccSFNStateMachine_Identity_ExistingResource_basic (329.09s)
--- PASS: TestAccSFNStateMachine_Identity_basic (363.49s)
--- PASS: TestAccSFNStateMachine_encryptionConfigurationCustomerManagedKMSKey (414.16s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/sfn        422.334s
```
