### PR TITLE
r/aws_vpclattice_resource_configuration: add support for group_domain attribute

### DIFF
--- a/.changelog/48843.txt
+++ b/.changelog/48843.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_vpclattice_resource_configuration: Add `group_domain` argument
+```

--- a/internal/service/vpclattice/resource_configuration.go
+++ b/internal/service/vpclattice/resource_configuration.go
@@ -103,6 +103,12 @@ func (r *resourceConfigurationResource) Schema(ctx context.Context, request reso
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
+			"group_domain": schema.StringAttribute{
+				Optional: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
 			names.AttrID: framework.IDAttribute(),
 			names.AttrName: schema.StringAttribute{
 				Required: true,
@@ -529,6 +535,7 @@ type resourceConfigurationResourceModel struct {
 	DomainVerificationARN                     fwtypes.ARN                                                           `tfsdk:"domain_verification_arn"`
 	DomainVerificationID                      types.String                                                          `tfsdk:"domain_verification_id"`
 	DomainVerificationStatus                  fwtypes.StringEnum[awstypes.VerificationStatus]                       `tfsdk:"domain_verification_status"`
+	GroupDomain                               types.String                                                          `tfsdk:"group_domain"`
 	ID                                        types.String                                                          `tfsdk:"id"`
 	Name                                      types.String                                                          `tfsdk:"name"`
 	PortRanges                                fwtypes.SetOfString                                                   `tfsdk:"port_ranges"`

--- a/internal/service/vpclattice/resource_configuration_test.go
+++ b/internal/service/vpclattice/resource_configuration_test.go
@@ -223,6 +223,8 @@ func TestAccVPCLatticeResourceConfiguration_parentChild(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "resource_configuration_group_id", resourceParentName, names.AttrID),
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, string(types.ResourceConfigurationTypeChild)),
 					resource.TestCheckResourceAttr(resourceParentName, names.AttrType, string(types.ResourceConfigurationTypeGroup)),
+					resource.TestCheckResourceAttr(resourceParentName, "group_domain", "example.com"),
+					resource.TestCheckResourceAttr(resourceName, "custom_domain_name", fmt.Sprintf("%s.example.com", rName)),
 					resource.TestCheckResourceAttr(resourceName, "port_ranges.0", "80"),
 					resource.TestCheckResourceAttr(resourceName, "resource_configuration_definition.0.ip_resource.0.ip_address", "10.0.0.1"),
 					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "vpc-lattice", regexache.MustCompile(`resourceconfiguration/+.`)),
@@ -481,7 +483,8 @@ func testAccResourceConfigurationConfig_parentChild(rName, ip string) string {
 resource "aws_vpclattice_resource_configuration" "parent" {
   name = "%[1]s-parent"
 
-  protocol = "TCP"
+  protocol     = "TCP"
+  group_domain = "example.com"
 
   resource_gateway_identifier = aws_vpclattice_resource_gateway.test.id
   type                        = "GROUP"
@@ -494,6 +497,8 @@ resource "aws_vpclattice_resource_configuration" "test" {
 
   resource_configuration_group_id = aws_vpclattice_resource_configuration.parent.id
   type                            = "CHILD"
+
+  custom_domain_name = "%[1]s.example.com"
 
   resource_configuration_definition {
     ip_resource {

--- a/website/docs/r/vpclattice_resource_configuration.html.markdown
+++ b/website/docs/r/vpclattice_resource_configuration.html.markdown
@@ -120,6 +120,7 @@ The following arguments are optional:
 * `allow_association_to_shareable_service_network` (Optional) Allow or Deny the association of this resource to a shareable service network.
 * `custom_domain_name` - (Optional) Custom domain name for your resource configuration. Additionally, provide a `domain_verification_id` to prove your ownership of a domain.
 * `domain_verification_id` - (Optional) The domain verification ID of your verified custom domain name. If you don't provide an ID, you must configure the DNS settings yourself.
+* `group_domain` - (Optional) Group domain for a group resource configuration. Only applicable when `type` is `GROUP`. Domains created for child resources are subdomains of this group domain, and child resources inherit the verification status of the domain. Changing this value forces a new resource.
 * `protocol` - (Optional) Protocol for the Resource `TCP` is currently the only supported value.  MUST be specified if `resource_configuration_group_id` is not.
 * `resource_configuration_group_id` (Optional) ID of Resource Configuration where `type` is `CHILD`.
 * `resource_gateway_identifier` - (Optional) ID of the Resource Gateway used to access the resource. MUST be specified if `resource_configuration_group_id` is not.


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

None

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Adds support for `group_domain` on `aws_vpclattice_resource_configuration` when `type = "GROUP"`

This is very similar to #46024 but with less magic and is more in line with the existing AWS API. #46024 takes an approach that treats `custom_domain_name` differently depending on the `type`. This PR instead expects the user to provide the `group_domain` for `GROUP`s and otherwise use `custom_domain_name` where appropriate.

While I prefer less magic, I'm happy with either PR so long as we get group domain support 🙏!

AI disclosure: I used an AI to review the changes.

### Relations
Closes https://github.com/hashicorp/terraform-provider-aws/issues/46023
Closes #46024

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
https://docs.aws.amazon.com/vpc-lattice/latest/ug/resource-configuration.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2	7.316s
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider/framework	7.111s
make: Running acceptance tests on branch: 🌿 lattice-group-domains 🌿...
TF_ACC=1 go test ./internal/service/vpclattice/... -v -count 1 -parallel 20 -run='TestAccVPCLatticeResourceConfiguration_parentChild'  -timeout 360m -vet=off -buildvcs=false
2026/07/08 16:49:56 Creating Terraform AWS Provider (SDKv2-style)...
2026/07/08 16:49:56 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccVPCLatticeResourceConfiguration_parentChild
=== PAUSE TestAccVPCLatticeResourceConfiguration_parentChild
=== CONT  TestAccVPCLatticeResourceConfiguration_parentChild
--- PASS: TestAccVPCLatticeResourceConfiguration_parentChild (48.55s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/vpclattice	55.736s

...
```
