### PR TITLE
list resource/aws_lambda_layer_version: Removes resource Read function from List

### DIFF
--- a/.ci/semgrep/list/no-resource-read.yml
+++ b/.ci/semgrep/list/no-resource-read.yml
@@ -9,7 +9,6 @@ rules:
       include:
         - "/internal/service"
       exclude:
-        - "/internal/service/lambda/layer_version_list.go"
         - "/internal/service/route53/record_list.go"
         - "/internal/service/route53resolver/rule_association_list.go"
         - "/internal/service/s3/bucket_acl_list.go"

--- a/internal/service/lambda/layer_version_list.go
+++ b/internal/service/lambda/layer_version_list.go
@@ -71,15 +71,19 @@ func (l *layerVersionListResource) List(ctx context.Context, request list.ListRe
 			rd.Set(names.AttrVersion, strconv.FormatInt(item.layerVersion.Version, 10))
 
 			if request.IncludeResource {
-				tflog.Info(ctx, "Reading Lambda Layer Version")
-				diags := resourceLayerVersionRead(ctx, rd, awsClient)
-				if diags.HasError() {
-					tflog.Error(ctx, "Reading Lambda Layer Version", map[string]any{"error": fmt.Sprintf("reading Lambda Layer Version (%s)", id)})
+				layerName, versionNumber, err := layerVersionParseResourceID(id)
+				if err != nil {
+					tflog.Error(ctx, "Reading Lambda Layer Version", map[string]any{"error": err.Error()})
 					continue
 				}
-				if rd.Id() == "" {
+
+				output, err := findLayerVersionByTwoPartKey(ctx, conn, layerName, versionNumber)
+				if err != nil {
+					tflog.Error(ctx, "Reading Lambda Layer Version", map[string]any{"error": fmt.Sprintf("reading Lambda Layer Version (%s): %s", id, err)})
 					continue
 				}
+
+				flattenLayerVersion(rd, layerName, output)
 			}
 
 			result.DisplayName = id

--- a/internal/service/lambda/layer_version_list.go
+++ b/internal/service/lambda/layer_version_list.go
@@ -73,13 +73,13 @@ func (l *layerVersionListResource) List(ctx context.Context, request list.ListRe
 			if request.IncludeResource {
 				layerName, versionNumber, err := layerVersionParseResourceID(id)
 				if err != nil {
-					tflog.Error(ctx, "Reading Lambda Layer Version", map[string]any{"error": err.Error()})
+					tflog.Error(ctx, "Reading Lambda Layer Version", map[string]any{"error": err})
 					continue
 				}
 
 				output, err := findLayerVersionByTwoPartKey(ctx, conn, layerName, versionNumber)
 				if err != nil {
-					tflog.Error(ctx, "Reading Lambda Layer Version", map[string]any{"error": fmt.Sprintf("reading Lambda Layer Version (%s): %s", id, err)})
+					tflog.Error(ctx, "Reading Lambda Layer Version", map[string]any{"error": err})
 					continue
 				}
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description


Removes resource Read function from `aws_lambda_layer_version ` List

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=lambda TESTS=TestAccLambdaLayerVersion_List_

--- PASS: TestAccLambdaLayerVersion_List_includeResource (20.88s)
--- PASS: TestAccLambdaLayerVersion_List_regionOverride (30.53s)
--- PASS: TestAccLambdaLayerVersion_List_basic (39.52s)
```
