### PR TITLE
list resource/aws_route53_resolver_rule_association: Removes resource Read function from List

### DIFF
--- a/.ci/semgrep/list/no-resource-read.yml
+++ b/.ci/semgrep/list/no-resource-read.yml
@@ -9,7 +9,6 @@ rules:
       include:
         - "/internal/service"
       exclude:
-        - "/internal/service/route53resolver/rule_association_list.go"
         - "/internal/service/s3/bucket_acl_list.go"
         - "/internal/service/s3/bucket_public_access_block_list.go"
         - "/internal/service/s3/object_list.go"

--- a/internal/service/route53resolver/rule_association.go
+++ b/internal/service/route53resolver/rule_association.go
@@ -111,6 +111,12 @@ func resourceRuleAssociationRead(ctx context.Context, d *schema.ResourceData, me
 		return sdkdiag.AppendErrorf(diags, "reading Route53 Resolver Rule Association (%s): %s", d.Id(), err)
 	}
 
+	return resourceRuleAssociationFlatten(d, ruleAssociation)
+}
+
+func resourceRuleAssociationFlatten(d *schema.ResourceData, ruleAssociation *awstypes.ResolverRuleAssociation) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	d.Set(names.AttrName, ruleAssociation.Name)
 	d.Set("resolver_rule_id", ruleAssociation.ResolverRuleId)
 	d.Set(names.AttrVPCID, ruleAssociation.VPCId)

--- a/internal/service/route53resolver/rule_association_list.go
+++ b/internal/service/route53resolver/rule_association_list.go
@@ -62,17 +62,11 @@ func (l *listResourceRuleAssociation) List(ctx context.Context, request list.Lis
 			rd := l.ResourceData()
 			rd.SetId(id)
 
-			tflog.Info(ctx, "Reading Route 53 Resolver Rule Association")
-			diags := resourceRuleAssociationRead(ctx, rd, l.Meta())
+			diags := resourceRuleAssociationFlatten(rd, &item)
 			if diags.HasError() {
 				tflog.Error(ctx, "Reading Route 53 Resolver Rule Association", map[string]any{
-					names.AttrID: id,
-					"diags":      sdkdiag.DiagnosticsString(diags),
+					"error": sdkdiag.DiagnosticsString(diags),
 				})
-				continue
-			}
-			if rd.Id() == "" {
-				// Resource is logically deleted
 				continue
 			}
 

--- a/internal/service/route53resolver/rule_association_list_test.go
+++ b/internal/service/route53resolver/rule_association_list_test.go
@@ -6,6 +6,7 @@ package route53resolver_test
 import (
 	"testing"
 
+	"github.com/YakDriver/regexache"
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
@@ -15,6 +16,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	tfknownvalue "github.com/hashicorp/terraform-provider-aws/internal/acctest/knownvalue"
+	tfquerycheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/querycheck"
+	tfqueryfilter "github.com/hashicorp/terraform-provider-aws/internal/acctest/queryfilter"
 	tfstatecheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/statecheck"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -74,6 +77,62 @@ func TestAccRoute53ResolverRuleAssociation_List_basic(t *testing.T) {
 						names.AttrID:        id2.ValueCheck(),
 						names.AttrAccountID: tfknownvalue.AccountID(),
 						names.AttrRegion:    knownvalue.StringExact(acctest.Region()),
+					}),
+				},
+			},
+		},
+	})
+}
+
+func TestAccRoute53ResolverRuleAssociation_List_includeResource(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	domain := acctest.RandomDomainName(t)
+
+	resourceName1 := "aws_route53_resolver_rule_association.test[0]"
+
+	identity1 := tfstatecheck.Identity()
+	resolverRuleID := tfstatecheck.StateValue()
+	vpcID := tfstatecheck.StateValue()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.Route53ResolverServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckRuleAssociationDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/RuleAssociation/list_include_resource"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(1),
+					"domain":         config.StringVariable(domain),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+					resolverRuleID.GetStateValue("aws_route53_resolver_rule.test[0]", tfjsonpath.New(names.AttrID)),
+					vpcID.GetStateValue("aws_vpc.test", tfjsonpath.New(names.AttrID)),
+				},
+			},
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/RuleAssociation/list_include_resource"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(1),
+					"domain":         config.StringVariable(domain),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_route53_resolver_rule_association.test", identity1.Checks()),
+					querycheck.ExpectResourceKnownValues("aws_route53_resolver_rule_association.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), []querycheck.KnownValueCheck{
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrName), knownvalue.StringExact(rName+"-0")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("resolver_rule_id"), knownvalue.StringRegexp(regexache.MustCompile(`^rslvr-rr-.+$`))),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrVPCID), vpcID.ValueCheck()),
 					}),
 				},
 			},

--- a/internal/service/route53resolver/rule_association_list_test.go
+++ b/internal/service/route53resolver/rule_association_list_test.go
@@ -139,3 +139,59 @@ func TestAccRoute53ResolverRuleAssociation_List_includeResource(t *testing.T) {
 		},
 	})
 }
+
+func TestAccRoute53ResolverRuleAssociation_List_regionOverride(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	domain := acctest.RandomDomainName(t)
+
+	resourceName1 := "aws_route53_resolver_rule_association.test[0]"
+	resourceName2 := "aws_route53_resolver_rule_association.test[1]"
+
+	identity1 := tfstatecheck.Identity()
+	identity2 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.Route53ResolverServiceID),
+		CheckDestroy:             acctest.CheckDestroyNoop,
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/RuleAssociation/list_region_override"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+					"domain":         config.StringVariable(domain),
+					"region":         config.StringVariable(acctest.AlternateRegion()),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+					identity2.GetIdentity(resourceName2),
+				},
+			},
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/RuleAssociation/list_region_override"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+					"domain":         config.StringVariable(domain),
+					"region":         config.StringVariable(acctest.AlternateRegion()),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_route53_resolver_rule_association.test", identity1.Checks()),
+					tfquerycheck.ExpectIdentityFunc("aws_route53_resolver_rule_association.test", identity2.Checks()),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/route53resolver/testdata/RuleAssociation/list_basic/main.tf
+++ b/internal/service/route53resolver/testdata/RuleAssociation/list_basic/main.tf
@@ -1,10 +1,12 @@
 # Copyright IBM Corp. 2014, 2026
 # SPDX-License-Identifier: MPL-2.0
 
-resource "aws_vpc" "test" {
-  cidr_block           = "10.6.0.0/16"
-  enable_dns_hostnames = true
-  enable_dns_support   = true
+resource "aws_route53_resolver_rule_association" "test" {
+  count = var.resource_count
+
+  name             = "${var.rName}-${count.index}"
+  resolver_rule_id = aws_route53_resolver_rule.test[count.index].id
+  vpc_id           = aws_vpc.test.id
 }
 
 resource "aws_route53_resolver_rule" "test" {
@@ -15,12 +17,10 @@ resource "aws_route53_resolver_rule" "test" {
   rule_type   = "SYSTEM"
 }
 
-resource "aws_route53_resolver_rule_association" "test" {
-  count = var.resource_count
-
-  name             = "${var.rName}-${count.index}"
-  resolver_rule_id = aws_route53_resolver_rule.test[count.index].id
-  vpc_id           = aws_vpc.test.id
+resource "aws_vpc" "test" {
+  cidr_block           = "10.6.0.0/16"
+  enable_dns_hostnames = true
+  enable_dns_support   = true
 }
 
 variable "rName" {

--- a/internal/service/route53resolver/testdata/RuleAssociation/list_include_resource/main.tf
+++ b/internal/service/route53resolver/testdata/RuleAssociation/list_include_resource/main.tf
@@ -1,0 +1,42 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_route53_resolver_rule_association" "test" {
+  count = var.resource_count
+
+  name             = "${var.rName}-${count.index}"
+  resolver_rule_id = aws_route53_resolver_rule.test[count.index].id
+  vpc_id           = aws_vpc.test.id
+}
+
+resource "aws_route53_resolver_rule" "test" {
+  count = var.resource_count
+
+  domain_name = "${count.index}.${var.domain}"
+  name        = "${var.rName}-rule-${count.index}"
+  rule_type   = "SYSTEM"
+}
+
+resource "aws_vpc" "test" {
+  cidr_block           = "10.6.0.0/16"
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}
+
+variable "domain" {
+  description = "Domain name for resolver rule"
+  type        = string
+  nullable    = false
+}

--- a/internal/service/route53resolver/testdata/RuleAssociation/list_include_resource/query.tfquery.hcl
+++ b/internal/service/route53resolver/testdata/RuleAssociation/list_include_resource/query.tfquery.hcl
@@ -1,0 +1,8 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_route53_resolver_rule_association" "test" {
+  provider = aws
+
+  include_resource = true
+}

--- a/internal/service/route53resolver/testdata/RuleAssociation/list_region_override/main.tf
+++ b/internal/service/route53resolver/testdata/RuleAssociation/list_region_override/main.tf
@@ -1,0 +1,51 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_route53_resolver_rule_association" "test" {
+  count = var.resource_count
+
+  region           = var.region
+  name             = "${var.rName}-${count.index}"
+  resolver_rule_id = aws_route53_resolver_rule.test[count.index].id
+  vpc_id           = aws_vpc.test.id
+}
+
+resource "aws_route53_resolver_rule" "test" {
+  count = var.resource_count
+
+  region      = var.region
+  domain_name = "${count.index}.${var.domain}"
+  name        = "${var.rName}-rule-${count.index}"
+  rule_type   = "SYSTEM"
+}
+
+resource "aws_vpc" "test" {
+  region               = var.region
+  cidr_block           = "10.6.0.0/16"
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}
+
+variable "domain" {
+  description = "Domain name for resolver rule"
+  type        = string
+  nullable    = false
+}
+
+variable "region" {
+  description = "Region to deploy resource in"
+  type        = string
+  nullable    = false
+}

--- a/internal/service/route53resolver/testdata/RuleAssociation/list_region_override/query.tfquery.hcl
+++ b/internal/service/route53resolver/testdata/RuleAssociation/list_region_override/query.tfquery.hcl
@@ -1,0 +1,10 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_route53_resolver_rule_association" "test" {
+  provider = aws
+
+  config {
+    region = var.region
+  }
+}


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Removes resource Read function from `aws_route53_resolver_rule_association ` List

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=route53resolver TESTS=TestAccRoute53ResolverRuleAssociation_

--- PASS: TestAccRoute53ResolverRuleAssociation_disappears (154.40s)
--- PASS: TestAccRoute53ResolverRuleAssociation_Disappears_vpc (156.97s)
--- PASS: TestAccRoute53ResolverRuleAssociation_List_includeResource (157.32s)
--- PASS: TestAccRoute53ResolverRuleAssociation_List_basic (157.36s)
--- PASS: TestAccRoute53ResolverRuleAssociation_basic (159.58s)
--- PASS: TestAccRoute53ResolverRuleAssociation_Identity_basic (181.75s)
--- PASS: TestAccRoute53ResolverRuleAssociation_Identity_ExistingResource_noRefreshNoChange (210.29s)
--- PASS: TestAccRoute53ResolverRuleAssociation_Identity_ExistingResource_basic (218.55s)
--- PASS: TestAccRoute53ResolverRuleAssociation_List_regionOverride (228.69s)
--- PASS: TestAccRoute53ResolverRuleAssociation_Identity_regionOverride (264.31s)
```
