### PR TITLE
list resource/aws_s3_bucket_acl: Removes resource Read function from List

### DIFF
--- a/.ci/semgrep/list/no-resource-read.yml
+++ b/.ci/semgrep/list/no-resource-read.yml
@@ -9,7 +9,6 @@ rules:
       include:
         - "/internal/service"
       exclude:
-        - "/internal/service/s3/bucket_acl_list.go"
         - "/internal/service/s3/bucket_public_access_block_list.go"
         - "/internal/service/s3/object_list.go"
         - "/internal/service/secretsmanager/secret_list.go"

--- a/internal/service/s3/bucket_acl.go
+++ b/internal/service/s3/bucket_acl.go
@@ -251,6 +251,12 @@ func resourceBucketACLRead(ctx context.Context, d *schema.ResourceData, meta any
 		return sdkdiag.AppendErrorf(diags, "reading S3 Bucket ACL (%s): %s", d.Id(), err)
 	}
 
+	return resourceBucketACLFlatten(d, bucketACL, bucket, expectedBucketOwner, acl)
+}
+
+func resourceBucketACLFlatten(d *schema.ResourceData, bucketACL *s3.GetBucketAclOutput, bucket, expectedBucketOwner, acl string) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	if err := d.Set("access_control_policy", flattenBucketACL(bucketACL)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting access_control_policy: %s", err)
 	}

--- a/internal/service/s3/bucket_acl_list.go
+++ b/internal/service/s3/bucket_acl_list.go
@@ -67,16 +67,19 @@ func (l *listResourceBucketACL) List(ctx context.Context, request list.ListReque
 			// There is always a Bucket ACL associated with a Bucket (1:1)
 			// So only read it if resource data is requested.
 			if request.IncludeResource {
-				tflog.Info(ctx, "Reading S3 Bucket ACL")
-				diags := resourceBucketACLRead(ctx, rd, l.Meta())
-				if diags.HasError() {
+				bucketACL, err := findBucketACL(ctx, conn, bucketName, "")
+				if err != nil {
 					tflog.Error(ctx, "Reading S3 Bucket ACL", map[string]any{
-						"diags": sdkdiag.DiagnosticsString(diags),
+						"error": err,
 					})
 					continue
 				}
-				if rd.Id() == "" {
-					tflog.Warn(ctx, "Resource disappeared during listing, skipping")
+
+				diags := resourceBucketACLFlatten(rd, bucketACL, bucketName, "", "")
+				if diags.HasError() {
+					tflog.Error(ctx, "Reading S3 Bucket ACL", map[string]any{
+						"error": sdkdiag.DiagnosticsString(diags),
+					})
 					continue
 				}
 			}


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Removes resource Read function from `aws_s3_bucket_acl ` List

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=s3 TESTS=TestAccS3BucketACL_

--- PASS: TestAccS3BucketACL_directoryBucket (32.47s)
--- PASS: TestAccS3BucketACL_List_basic (76.32s)
--- PASS: TestAccS3BucketACL_List_regionOverride (77.26s)
--- PASS: TestAccS3BucketACL_List_includeResource (83.97s)
--- PASS: TestAccS3BucketACL_grant_expectedBucketOwner (92.41s)
--- PASS: TestAccS3BucketACL_migrate_grantsWithChange (127.42s)
--- PASS: TestAccS3BucketACL_migrate_aclWithChange (132.77s)
--- PASS: TestAccS3BucketACL_grantToACL (145.49s)
--- PASS: TestAccS3BucketACL_Identity_ExistingResource_grant_expectedBucketOwner (145.84s)
--- PASS: TestAccS3BucketACL_updateACL (146.19s)
--- PASS: TestAccS3BucketACL_Identity_upgrade (153.19s)
--- PASS: TestAccS3BucketACL_Identity_basic (153.31s)
--- PASS: TestAccS3BucketACL_ACLToGrant (153.54s)
--- PASS: TestAccS3BucketACL_Identity_grant_expectedBucketOwner (157.85s)
--- PASS: TestAccS3BucketACL_Identity_Upgrade_grant_expectedBucketOwner (157.90s)
--- PASS: TestAccS3BucketACL_Identity_cannedACL_expectedBucketOwner (157.90s)
--- PASS: TestAccS3BucketACL_Identity_Upgrade_cannedACL_expectedBucketOwner (157.94s)
--- PASS: TestAccS3BucketACL_Identity_Upgrade_noRefresh (125.50s)
--- PASS: TestAccS3BucketACL_Identity_CannedACL (158.15s)
--- PASS: TestAccS3BucketACL_Identity_ExistingResource_cannedACL_expectedBucketOwner (158.37s)
--- PASS: TestAccS3BucketACL_disappears (84.33s)
--- PASS: TestAccS3BucketACL_updateGrant (163.88s)
--- PASS: TestAccS3BucketACL_basic (82.26s)
--- PASS: TestAccS3BucketACL_migrate_aclNoChange (103.46s)
--- PASS: TestAccS3BucketACL_Identity_Upgrade_CannedACL (91.79s)
--- PASS: TestAccS3BucketACL_cannedACL_expectedBucketOwner (58.40s)
--- PASS: TestAccS3BucketACL_Identity_ExistingResource_CannedACL (70.74s)
--- PASS: TestAccS3BucketACL_Identity_regionOverride (61.17s)
--- PASS: TestAccS3BucketACL_Identity_ExistingResource_noRefreshNoChange (65.56s)
--- PASS: TestAccS3BucketACL_Identity_ExistingResource_basic (69.98s)
```
