### PR TITLE
list resource/aws_s3_bucket_public_access_block: Removes resource Read function from List

### DIFF
--- a/.ci/semgrep/list/no-resource-read.yml
+++ b/.ci/semgrep/list/no-resource-read.yml
@@ -9,7 +9,6 @@ rules:
       include:
         - "/internal/service"
       exclude:
-        - "/internal/service/s3/bucket_public_access_block_list.go"
         - "/internal/service/s3/object_list.go"
         - "/internal/service/secretsmanager/secret_list.go"
         - "/internal/service/secretsmanager/secret_version_list.go"

--- a/internal/service/s3/bucket_public_access_block.go
+++ b/internal/service/s3/bucket_public_access_block.go
@@ -133,6 +133,12 @@ func resourceBucketPublicAccessBlockRead(ctx context.Context, d *schema.Resource
 		return sdkdiag.AppendErrorf(diags, "reading S3 Bucket Public Access Block (%s): %s", d.Id(), err)
 	}
 
+	return resourceBucketPublicAccessBlockFlatten(d, bucket, pabc)
+}
+
+func resourceBucketPublicAccessBlockFlatten(d *schema.ResourceData, bucket string, pabc *types.PublicAccessBlockConfiguration) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	d.Set(names.AttrBucket, bucket)
 	d.Set("block_public_acls", pabc.BlockPublicAcls)
 	d.Set("block_public_policy", pabc.BlockPublicPolicy)

--- a/internal/service/s3/bucket_public_access_block_list.go
+++ b/internal/service/s3/bucket_public_access_block_list.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
 	"github.com/hashicorp/terraform-provider-aws/internal/logging"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	inttypes "github.com/hashicorp/terraform-provider-aws/internal/types"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -66,16 +67,22 @@ func (l *listResourceBucketPublicAccessBlock) List(ctx context.Context, request 
 
 			// A Bucket Policy is optionally associated with a Bucket (1:0..1)
 			// So always try to read it to see if it is present.
-			tflog.Info(ctx, "Reading S3 Bucket Public Access Block")
-			diags := resourceBucketPublicAccessBlockRead(ctx, rd, l.Meta())
-			if diags.HasError() {
+			pabc, err := findPublicAccessBlockConfiguration(ctx, conn, bucketName)
+			if err != nil {
+				if retry.NotFound(err) {
+					continue
+				}
 				tflog.Error(ctx, "Reading S3 Bucket Public Access Block", map[string]any{
-					"diags": sdkdiag.DiagnosticsString(diags),
+					"error": err,
 				})
 				continue
 			}
-			if rd.Id() == "" {
-				tflog.Warn(ctx, "Resource disappeared during listing, skipping")
+
+			diags := resourceBucketPublicAccessBlockFlatten(rd, bucketName, pabc)
+			if diags.HasError() {
+				tflog.Error(ctx, "Reading S3 Bucket Public Access Block", map[string]any{
+					"error": sdkdiag.DiagnosticsString(diags),
+				})
 				continue
 			}
 

--- a/internal/service/s3/bucket_public_access_block_list_test.go
+++ b/internal/service/s3/bucket_public_access_block_list_test.go
@@ -143,3 +143,54 @@ func TestAccS3BucketPublicAccessBlock_List_regionOverride(t *testing.T) {
 		},
 	})
 }
+
+func TestAccS3BucketPublicAccessBlock_List_includeResource(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	resourceName1 := "aws_s3_bucket_public_access_block.test[0]"
+
+	identity1 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             acctest.CheckDestroyNoop,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/BucketPublicAccessBlock/list_include_resource"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(1),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+				},
+			},
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/BucketPublicAccessBlock/list_include_resource"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(1),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_s3_bucket_public_access_block.test", identity1.Checks()),
+					querycheck.ExpectResourceKnownValues("aws_s3_bucket_public_access_block.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), []querycheck.KnownValueCheck{
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrBucket), knownvalue.StringExact(rName+"-0")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("block_public_acls"), knownvalue.Bool(true)),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("block_public_policy"), knownvalue.Bool(true)),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("ignore_public_acls"), knownvalue.Bool(true)),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("restrict_public_buckets"), knownvalue.Bool(true)),
+					}),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/s3/testdata/BucketPublicAccessBlock/list_include_resource/main.tf
+++ b/internal/service/s3/testdata/BucketPublicAccessBlock/list_include_resource/main.tf
@@ -1,0 +1,31 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_s3_bucket_public_access_block" "test" {
+  count = var.resource_count
+
+  bucket = aws_s3_bucket.test[count.index].bucket
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket" "test" {
+  count = var.resource_count
+
+  bucket = "${var.rName}-${count.index}"
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}

--- a/internal/service/s3/testdata/BucketPublicAccessBlock/list_include_resource/query.tfquery.hcl
+++ b/internal/service/s3/testdata/BucketPublicAccessBlock/list_include_resource/query.tfquery.hcl
@@ -1,0 +1,8 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_s3_bucket_public_access_block" "test" {
+  provider = aws
+
+  include_resource = true
+}


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Removes resource Read function from `aws_s3_bucket_public_access_block ` List

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=s3 TESTS=TestAccS3BucketPublicAccessBlock_

--- PASS: TestAccS3BucketPublicAccessBlock_directoryBucket (27.67s)
--- PASS: TestAccS3BucketPublicAccessBlock_Disappears_bucket (58.29s)
--- PASS: TestAccS3BucketPublicAccessBlock_disappears (58.90s)
--- PASS: TestAccS3BucketPublicAccessBlock_basic (63.26s)
--- PASS: TestAccS3BucketPublicAccessBlock_List_includeResource (63.62s)
--- PASS: TestAccS3BucketPublicAccessBlock_List_basic (64.02s)
--- PASS: TestAccS3BucketPublicAccessBlock_List_regionOverride (64.48s)
--- PASS: TestAccS3BucketPublicAccessBlock_Identity_ExistingResource_noRefreshNoChange (82.65s)
--- PASS: TestAccS3BucketPublicAccessBlock_Identity_basic (85.84s)
--- PASS: TestAccS3BucketPublicAccessBlock_Identity_ExistingResource_basic (86.95s)
--- PASS: TestAccS3BucketPublicAccessBlock_Identity_regionOverride (88.93s)
--- PASS: TestAccS3BucketPublicAccessBlock_skipDestroy (94.61s)
--- PASS: TestAccS3BucketPublicAccessBlock_blockPublicPolicy (100.53s)
--- PASS: TestAccS3BucketPublicAccessBlock_ignorePublicACLs (100.55s)
--- PASS: TestAccS3BucketPublicAccessBlock_blockPublicACLs (100.64s)
--- PASS: TestAccS3BucketPublicAccessBlock_restrictPublicBuckets (101.70s)
```
