### PR TITLE
list resource/aws_s3_object: Removes resource Read function from List

### DIFF
--- a/.ci/semgrep/list/no-resource-read.yml
+++ b/.ci/semgrep/list/no-resource-read.yml
@@ -9,7 +9,6 @@ rules:
       include:
         - "/internal/service"
       exclude:
-        - "/internal/service/s3/object_list.go"
         - "/internal/service/secretsmanager/secret_list.go"
         - "/internal/service/secretsmanager/secret_version_list.go"
         - "/internal/service/sqs/queue_list.go"

--- a/internal/service/s3/object.go
+++ b/internal/service/s3/object.go
@@ -295,6 +295,12 @@ func resourceObjectRead(ctx context.Context, d *schema.ResourceData, meta any) d
 	}
 	d.Set(names.AttrARN, arn.String())
 
+	return resourceObjectFlatten(d, output)
+}
+
+func resourceObjectFlatten(d *schema.ResourceData, output *s3.HeadObjectOutput) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	d.Set("bucket_key_enabled", output.BucketKeyEnabled)
 	d.Set("cache_control", output.CacheControl)
 	d.Set("checksum_crc32", output.ChecksumCRC32)

--- a/internal/service/s3/object_list.go
+++ b/internal/service/s3/object_list.go
@@ -96,18 +96,31 @@ func (l *listResourceObject) List(ctx context.Context, request list.ListRequest,
 			rd.Set(names.AttrBucket, bucket)
 			rd.Set(names.AttrKey, key)
 
-			tflog.Info(ctx, "Reading S3 Object")
-			diags := resourceObjectRead(ctx, rd, l.Meta())
-			if diags.HasError() {
-				tflog.Error(ctx, "Reading S3 Object", map[string]any{
-					names.AttrID: id,
-					"diags":      sdkdiag.DiagnosticsString(diags),
-				})
-				continue
-			}
-			if rd.Id() == "" || rd.Id() == "/" {
-				// Resource is logically deleted
-				continue
+			if request.IncludeResource {
+				output, err := findObjectByBucketAndKey(ctx, conn, bucket, key, "", "")
+				if err != nil {
+					tflog.Error(ctx, "Reading S3 Object", map[string]any{
+						"error": err,
+					})
+					continue
+				}
+
+				objectARN, err := newObjectARN(l.Meta().Partition(ctx), bucket, key)
+				if err != nil {
+					tflog.Error(ctx, "Reading S3 Object", map[string]any{
+						"error": err,
+					})
+					continue
+				}
+				rd.Set(names.AttrARN, objectARN.String())
+
+				diags := resourceObjectFlatten(rd, output)
+				if diags.HasError() {
+					tflog.Error(ctx, "Reading S3 Object", map[string]any{
+						"error": sdkdiag.DiagnosticsString(diags),
+					})
+					continue
+				}
 			}
 
 			result.DisplayName = fmt.Sprintf("%s/%s", bucket, key)


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Removes resource Read function from `aws_s3_object` List

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=s3 TESTS=TestAccS3Object_

--- FAIL: TestAccS3Object_DirectoryBucket_kmsSSE (42.72s)
--- PASS: TestAccS3Object_crossRegion (62.74s)
--- PASS: TestAccS3Object_withContentCharacteristics (67.12s)
--- PASS: TestAccS3Object_contentBase64 (67.46s)
--- PASS: TestAccS3Object_DirectoryBucket_DefaultTags_providerOnly (67.60s)
--- PASS: TestAccS3Object_Disappears_bucket (72.41s)
--- PASS: TestAccS3Object_source (78.60s)
--- PASS: TestAccS3Object_defaultKMS (79.00s)
--- PASS: TestAccS3Object_DirectoryBucket_disappears (79.27s)
--- PASS: TestAccS3Object_prefix (84.34s)
--- PASS: TestAccS3Object_content (84.54s)
--- PASS: TestAccS3Object_etagEncryption (84.87s)
--- PASS: TestAccS3Object_directoryBucket (84.90s)
--- PASS: TestAccS3Object_upgradeFromV4 (105.48s)
--- PASS: TestAccS3Object_defaultKMSUpgrade (115.46s)
--- PASS: TestAccS3Object_basicUpgrade (121.23s)
--- PASS: TestAccS3Object_disappears (78.56s)
--- PASS: TestAccS3Object_Identity_ExistingResource_NoRefresh_WithChange (127.89s)
--- PASS: TestAccS3Object_sourceHashTrigger (149.05s)
--- PASS: TestAccS3Object_Identity_basic (149.08s)
--- PASS: TestAccS3Object_basic (102.36s)
--- PASS: TestAccS3Object_Tags_DefaultTags_updateToResourceOnly (165.62s)
--- PASS: TestAccS3Object_Tags_ComputedTag_onCreate (98.89s)
--- PASS: TestAccS3Object_Tags_DefaultTags_nullNonOverlappingResourceTag (98.85s)
--- PASS: TestAccS3Object_Tags_DefaultTags_nullOverlappingResourceTag (98.65s)
--- PASS: TestAccS3Object_Tags_DefaultTags_emptyProviderOnlyTag (98.57s)
--- PASS: TestAccS3Object_Tags_DefaultTags_emptyResourceTag (98.51s)
--- PASS: TestAccS3Object_Tags_null (147.47s)
--- PASS: TestAccS3Object_Tags_ComputedTag_OnUpdate_add (163.65s)
--- PASS: TestAccS3Object_Tags_ComputedTag_OnUpdate_replace (169.98s)
--- PASS: TestAccS3Object_bucketBucketKeyEnabled (69.19s)
--- PASS: TestAccS3Object_Tags_DefaultTags_updateToProviderOnly (167.38s)
--- PASS: TestAccS3Object_defaultBucketSSE (69.96s)
--- PASS: TestAccS3Object_keyWithSlashesMigrated (95.87s)
--- PASS: TestAccS3Object_Tags_EmptyTag_OnUpdate_replace (172.58s)
--- PASS: TestAccS3Object_Tags_IgnoreTags_Overlap_defaultTag (226.86s)
--- PASS: TestAccS3Object_tagsViaAccessPointAlias (134.18s)
--- PASS: TestAccS3Object_ignoreTags (127.62s)
--- PASS: TestAccS3Object_objectBucketKeyEnabled (77.56s)
--- PASS: TestAccS3Object_Tags_emptyMap (151.77s)
--- PASS: TestAccS3Object_Tags_addOnUpdate (172.98s)
--- PASS: TestAccS3Object_Tags_IgnoreTags_Overlap_resourceTag (255.64s)
--- PASS: TestAccS3Object_Tags_EmptyTag_onCreate (182.67s)
--- PASS: TestAccS3Object_viaDirectoryBucketAccessPointAlias (75.27s)
--- PASS: TestAccS3Object_List_includeResource (74.82s)
--- PASS: TestAccS3Object_checksumAlgorithm (191.69s)
--- PASS: TestAccS3Object_objectLockLegalHoldStartWithOn (128.49s)
--- PASS: TestAccS3Object_List_prefix (75.25s)
--- PASS: TestAccS3Object_Tags_EmptyTag_OnUpdate_add (253.09s)
--- PASS: TestAccS3Object_Tags_DefaultTags_overlapping (276.18s)
--- PASS: TestAccS3Object_List_directoryBucket (76.94s)
--- PASS: TestAccS3Object_List_regionOverride (80.83s)
--- PASS: TestAccS3Object_Tags_DefaultTags_nonOverlapping (283.05s)
--- PASS: TestAccS3Object_objectLockRetentionStartWithNone (180.50s)
--- PASS: TestAccS3Object_List_basic (74.21s)
--- PASS: TestAccS3Object_objectLockLegalHoldStartWithNone (180.32s)
--- PASS: TestAccS3Object_Identity_ExistingResource_noRefreshNoChange (109.97s)
--- PASS: TestAccS3Object_tagsViaAccessPointARN (125.81s)
--- PASS: TestAccS3Object_sse (81.43s)
--- PASS: TestAccS3Object_objectLockRetentionStartWithSet (235.06s)
--- PASS: TestAccS3Object_kms (78.16s)
--- PASS: TestAccS3Object_Tags_DefaultTags_providerOnly (358.20s)
--- PASS: TestAccS3Object_Identity_ExistingResource_basic (115.66s)
--- PASS: TestAccS3Object_updatesWithVersioningViaAccessPoint (111.86s)
--- PASS: TestAccS3Object_acl (178.44s)
--- PASS: TestAccS3Object_updateSameFile (103.83s)
--- PASS: TestAccS3Object_updates (103.91s)
--- PASS: TestAccS3Object_updatesWithVersioning (99.23s)
--- PASS: TestAccS3Object_metadata (134.72s)
--- PASS: TestAccS3Object_Identity_regionOverride (103.15s)
--- PASS: TestAccS3Object_tagsMultipleSlashes (171.95s)
--- PASS: TestAccS3Object_tagsLeadingMultipleSlashes (164.51s)
--- PASS: TestAccS3Object_tagsLeadingSingleSlash (168.73s)
--- PASS: TestAccS3Object_tags (251.09s)
--- PASS: TestAccS3Object_storageClass (170.66s)
--- PASS: TestAccS3Object_tagsViaMultiRegionAccessPointARN (301.01s)
--- PASS: TestAccS3Object_tagsViaFSxAccessPointARN (1330.80s)
```

`TestAccS3Object_DirectoryBucket_kmsSSE` is a pre-existing failure