### PR TITLE
list resource/aws_secretsmanager_secret: Removes resource Read function from List

### DIFF
--- a/.ci/semgrep/list/no-resource-read.yml
+++ b/.ci/semgrep/list/no-resource-read.yml
@@ -9,7 +9,6 @@ rules:
       include:
         - "/internal/service"
       exclude:
-        - "/internal/service/secretsmanager/secret_list.go"
         - "/internal/service/secretsmanager/secret_version_list.go"
         - "/internal/service/sqs/queue_list.go"
         - "/internal/service/ssm/parameter_list.go"

--- a/internal/service/secretsmanager/secret.go
+++ b/internal/service/secretsmanager/secret.go
@@ -241,6 +241,12 @@ func resourceSecretRead(ctx context.Context, d *schema.ResourceData, meta any) d
 		return sdkdiag.AppendErrorf(diags, "reading Secrets Manager Secret (%s): %s", d.Id(), err)
 	}
 
+	return resourceSecretFlatten(ctx, conn, d, output)
+}
+
+func resourceSecretFlatten(ctx context.Context, conn *secretsmanager.Client, d *schema.ResourceData, output *secretsmanager.DescribeSecretOutput) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	d.Set(names.AttrARN, output.ARN)
 	d.Set(names.AttrDescription, output.Description)
 	d.Set(names.AttrKMSKeyID, output.KmsKeyId)
@@ -251,7 +257,7 @@ func resourceSecretRead(ctx context.Context, d *schema.ResourceData, meta any) d
 	}
 
 	var policy *secretsmanager.GetResourcePolicyOutput
-	err = tfresource.Retry(ctx, propagationTimeout, func(ctx context.Context) *tfresource.RetryError {
+	err := tfresource.Retry(ctx, propagationTimeout, func(ctx context.Context) *tfresource.RetryError {
 		output, err := findSecretPolicyByID(ctx, conn, d.Id())
 
 		if err != nil {

--- a/internal/service/secretsmanager/secret_list.go
+++ b/internal/service/secretsmanager/secret_list.go
@@ -61,19 +61,24 @@ func (l *listResourceSecret) List(ctx context.Context, request list.ListRequest,
 			result := request.NewListResult(ctx)
 			rd := l.ResourceData()
 			rd.SetId(arn)
+			rd.Set(names.AttrARN, arn)
 
-			tflog.Info(ctx, "Reading Secrets Manager Secret")
-			diags := resourceSecretRead(ctx, rd, l.Meta())
-			if diags.HasError() {
-				tflog.Error(ctx, "Reading Secrets Manager Secret", map[string]any{
-					names.AttrID: arn,
-					"diags":      sdkdiag.DiagnosticsString(diags),
-				})
-				continue
-			}
-			if rd.Id() == "" {
-				// Resource is logically deleted
-				continue
+			if request.IncludeResource {
+				output, err := findSecretByID(ctx, conn, arn)
+				if err != nil {
+					tflog.Error(ctx, "Reading Secrets Manager Secret", map[string]any{
+						"error": err,
+					})
+					continue
+				}
+
+				diags := resourceSecretFlatten(ctx, conn, rd, output)
+				if diags.HasError() {
+					tflog.Error(ctx, "Reading Secrets Manager Secret", map[string]any{
+						"error": sdkdiag.DiagnosticsString(diags),
+					})
+					continue
+				}
 			}
 
 			result.DisplayName = aws.ToString(item.Name)

--- a/internal/service/secretsmanager/secret_list_test.go
+++ b/internal/service/secretsmanager/secret_list_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	tfknownvalue "github.com/hashicorp/terraform-provider-aws/internal/acctest/knownvalue"
+	tfquerycheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/querycheck"
+	tfqueryfilter "github.com/hashicorp/terraform-provider-aws/internal/acctest/queryfilter"
 	tfstatecheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/statecheck"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -73,6 +75,115 @@ func TestAccSecretsManagerSecret_List_basic(t *testing.T) {
 					querycheck.ExpectIdentity("aws_secretsmanager_secret.test", map[string]knownvalue.Check{
 						names.AttrARN: arn2.ValueCheck(),
 					}),
+				},
+			},
+		},
+	})
+}
+
+func TestAccSecretsManagerSecret_List_includeResource(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	resourceName1 := "aws_secretsmanager_secret.test[0]"
+
+	identity1 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SecretsManagerServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckSecretDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Secret/list_include_resource"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(1),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+				},
+			},
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/Secret/list_include_resource"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(1),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_secretsmanager_secret.test", identity1.Checks()),
+					querycheck.ExpectResourceKnownValues("aws_secretsmanager_secret.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), []querycheck.KnownValueCheck{
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrARN), tfknownvalue.RegionalARNRegexp("secretsmanager", regexache.MustCompile(`secret:.+`))),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrDescription), knownvalue.StringExact("")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrKMSKeyID), knownvalue.StringExact("")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrName), knownvalue.StringExact(rName+"-0")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrNamePrefix), knownvalue.StringExact("")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrPolicy), knownvalue.StringExact("")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("replica"), knownvalue.SetExact([]knownvalue.Check{})),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
+							"Name": knownvalue.StringExact(rName + "-0"),
+						})),
+					}),
+				},
+			},
+		},
+	})
+}
+
+func TestAccSecretsManagerSecret_List_regionOverride(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	resourceName1 := "aws_secretsmanager_secret.test[0]"
+	resourceName2 := "aws_secretsmanager_secret.test[1]"
+
+	identity1 := tfstatecheck.Identity()
+	identity2 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.SecretsManagerServiceID),
+		CheckDestroy:             acctest.CheckDestroyNoop,
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Secret/list_region_override"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+					"region":         config.StringVariable(acctest.AlternateRegion()),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+					identity2.GetIdentity(resourceName2),
+				},
+			},
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/Secret/list_region_override"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+					"region":         config.StringVariable(acctest.AlternateRegion()),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_secretsmanager_secret.test", identity1.Checks()),
+					tfquerycheck.ExpectIdentityFunc("aws_secretsmanager_secret.test", identity2.Checks()),
 				},
 			},
 		},

--- a/internal/service/secretsmanager/testdata/Secret/list_include_resource/main.tf
+++ b/internal/service/secretsmanager/testdata/Secret/list_include_resource/main.tf
@@ -1,0 +1,24 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_secretsmanager_secret" "test" {
+  count = var.resource_count
+
+  name = "${var.rName}-${count.index}"
+
+  tags = {
+    Name = "${var.rName}-${count.index}"
+  }
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}

--- a/internal/service/secretsmanager/testdata/Secret/list_include_resource/query.tfquery.hcl
+++ b/internal/service/secretsmanager/testdata/Secret/list_include_resource/query.tfquery.hcl
@@ -1,0 +1,8 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_secretsmanager_secret" "test" {
+  provider = aws
+
+  include_resource = true
+}

--- a/internal/service/secretsmanager/testdata/Secret/list_region_override/main.tf
+++ b/internal/service/secretsmanager/testdata/Secret/list_region_override/main.tf
@@ -1,0 +1,27 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_secretsmanager_secret" "test" {
+  count = var.resource_count
+
+  region = var.region
+  name   = "${var.rName}-${count.index}"
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}
+
+variable "region" {
+  description = "Region to deploy resource in"
+  type        = string
+  nullable    = false
+}

--- a/internal/service/secretsmanager/testdata/Secret/list_region_override/query.tfquery.hcl
+++ b/internal/service/secretsmanager/testdata/Secret/list_region_override/query.tfquery.hcl
@@ -1,0 +1,10 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_secretsmanager_secret" "test" {
+  provider = aws
+
+  config {
+    region = var.region
+  }
+}


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Removes resource Read function from `aws_secretsmanager_secret ` List

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=secretsmanager TESTS=TestAccSecretsManagerSecret_

--- PASS: TestAccSecretsManagerSecret_List_basic (73.78s)
--- PASS: TestAccSecretsManagerSecret_List_regionOverride (74.54s)
--- PASS: TestAccSecretsManagerSecret_List_includeResource (79.69s)
--- PASS: TestAccSecretsManagerSecret_basic (91.67s)
--- PASS: TestAccSecretsManagerSecret_Tags_DefaultTags_emptyResourceTag (98.59s)
--- PASS: TestAccSecretsManagerSecret_Identity_ExistingResource_basic (117.80s)
--- PASS: TestAccSecretsManagerSecret_Identity_ExistingResource_noRefreshNoChange (123.58s)
--- PASS: TestAccSecretsManagerSecret_Tags_null (144.30s)
--- PASS: TestAccSecretsManagerSecret_Identity_basic (145.78s)
--- PASS: TestAccSecretsManagerSecret_Tags_DefaultTags_updateToResourceOnly (160.05s)
--- PASS: TestAccSecretsManagerSecret_Tags_ComputedTag_OnUpdate_replace (166.56s)
--- PASS: TestAccSecretsManagerSecret_Tags_addOnUpdate (166.87s)
--- PASS: TestAccSecretsManagerSecret_Tags_DefaultTags_updateToProviderOnly (167.78s)
--- PASS: TestAccSecretsManagerSecret_Tags_ComputedTag_OnUpdate_add (168.19s)
--- PASS: TestAccSecretsManagerSecret_disappears (84.29s)
--- PASS: TestAccSecretsManagerSecret_Tags_emptyMap (185.14s)
--- PASS: TestAccSecretsManagerSecret_Tags_IgnoreTags_Overlap_defaultTag (216.61s)
--- PASS: TestAccSecretsManagerSecret_Tags_EmptyTag_OnUpdate_replace (241.90s)
--- PASS: TestAccSecretsManagerSecret_Tags_IgnoreTags_Overlap_resourceTag (330.98s)
--- PASS: TestAccSecretsManagerSecret_RecoveryWindowInDays_recreate (221.17s)
--- PASS: TestAccSecretsManagerSecret_Tags_ComputedTag_onCreate (178.51s)
--- PASS: TestAccSecretsManagerSecret_Tags_DefaultTags_nullNonOverlappingResourceTag (178.23s)
--- PASS: TestAccSecretsManagerSecret_Identity_regionOverride (266.50s)
--- PASS: TestAccSecretsManagerSecret_Tags_DefaultTags_nullOverlappingResourceTag (178.44s)
--- PASS: TestAccSecretsManagerSecret_Tags_DefaultTags_nonOverlapping (350.30s)
--- PASS: TestAccSecretsManagerSecret_Tags_DefaultTags_emptyProviderOnlyTag (174.60s)
--- PASS: TestAccSecretsManagerSecret_Tags_DefaultTags_overlapping (350.60s)
--- PASS: TestAccSecretsManagerSecret_kmsKeyID (227.04s)
--- PASS: TestAccSecretsManagerSecret_basicReplica (210.27s)
--- PASS: TestAccSecretsManagerSecret_policy (258.00s)
--- PASS: TestAccSecretsManagerSecret_withNamePrefix (144.11s)
--- PASS: TestAccSecretsManagerSecret_description (200.70s)
--- PASS: TestAccSecretsManagerSecret_Tags_EmptyTag_onCreate (193.02s)
--- PASS: TestAccSecretsManagerSecret_tags (384.55s)
--- PASS: TestAccSecretsManagerSecret_Tags_EmptyTag_OnUpdate_add (223.83s)
--- PASS: TestAccSecretsManagerSecret_Tags_DefaultTags_providerOnly (318.75s)
--- PASS: TestAccSecretsManagerSecret_overwriteReplica (289.97s)
```
