### PR TITLE
r/aws_cognito_user_pool_domain: add security_policy support

### DIFF
--- a/.changelog/48870.txt
+++ b/.changelog/48870.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_cognito_user_pool_domain: Add `security_policy` argument
+```

--- a/internal/service/cognitoidp/user_pool_domain.go
+++ b/internal/service/cognitoidp/user_pool_domain.go
@@ -78,6 +78,13 @@ func resourceUserPoolDomain() *schema.Resource {
 					Type:     schema.TypeString,
 					Computed: true,
 				},
+				"security_policy": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					Computed:         true,
+					RequiredWith:     []string{names.AttrCertificateARN},
+					ValidateDiagFunc: enum.Validate[awstypes.SecurityPolicyType](),
+				},
 				names.AttrUserPoolID: {
 					Type:     schema.TypeString,
 					Required: true,
@@ -111,6 +118,9 @@ func resourceUserPoolDomainCreate(ctx context.Context, d *schema.ResourceData, m
 	if v, ok := d.GetOk(names.AttrCertificateARN); ok {
 		input.CustomDomainConfig = &awstypes.CustomDomainConfigType{
 			CertificateArn: aws.String(v.(string)),
+		}
+		if v, ok := d.GetOk("security_policy"); ok {
+			input.CustomDomainConfig.SecurityPolicy = awstypes.SecurityPolicyType(v.(string))
 		}
 		timeout = 60 * time.Minute // Custom domains take more time to become active.
 	}
@@ -152,8 +162,10 @@ func resourceUserPoolDomainRead(ctx context.Context, d *schema.ResourceData, met
 
 	d.Set(names.AttrAWSAccountID, desc.AWSAccountId)
 	d.Set(names.AttrCertificateARN, "")
+	d.Set("security_policy", "")
 	if desc.CustomDomainConfig != nil {
 		d.Set(names.AttrCertificateARN, desc.CustomDomainConfig.CertificateArn)
+		d.Set("security_policy", desc.CustomDomainConfig.SecurityPolicy)
 	}
 	d.Set("cloudfront_distribution", desc.CloudFrontDistribution)
 	d.Set("cloudfront_distribution_arn", desc.CloudFrontDistribution)
@@ -177,22 +189,18 @@ func resourceUserPoolDomainUpdate(ctx context.Context, d *schema.ResourceData, m
 		UserPoolId: aws.String(d.Get(names.AttrUserPoolID).(string)),
 	}
 
-	if d.HasChange(names.AttrCertificateARN) {
-		timeout = 60 * time.Minute // Certificate ARN updates on custom domains take more time to become active.
-		input.CustomDomainConfig = &awstypes.CustomDomainConfigType{
-			CertificateArn: aws.String(d.Get(names.AttrCertificateARN).(string)),
-		}
-	}
-
 	if d.HasChange("managed_login_version") {
 		input.ManagedLoginVersion = aws.Int32(int32(d.Get("managed_login_version").(int)))
+	}
 
-		if v, ok := d.GetOk(names.AttrCertificateARN); ok {
-			// If there is a certificate use it as part of the request, this is how AWS distinguishes between custom and prefix domains.
-			timeout = 60 * time.Minute // Custom domains take more time to become active.
-			input.CustomDomainConfig = &awstypes.CustomDomainConfigType{
-				CertificateArn: aws.String(v.(string)),
-			}
+	if v, ok := d.GetOk(names.AttrCertificateARN); ok && d.HasChanges(names.AttrCertificateARN, "security_policy", "managed_login_version") {
+		// If there is a certificate use it as part of the request, this is how AWS distinguishes between custom and prefix domains.
+		timeout = 60 * time.Minute // Custom domains take more time to become active.
+
+		// Send the certificate ARN and security policy together since UpdateUserPoolDomain replaces the whole CustomDomainConfig.
+		input.CustomDomainConfig = &awstypes.CustomDomainConfigType{
+			CertificateArn: aws.String(v.(string)),
+			SecurityPolicy: awstypes.SecurityPolicyType(d.Get("security_policy").(string)),
 		}
 	}
 

--- a/internal/service/cognitoidp/user_pool_domain_test.go
+++ b/internal/service/cognitoidp/user_pool_domain_test.go
@@ -224,6 +224,50 @@ func TestAccCognitoIDPUserPoolDomain_customCustomDomainManagedLoginVersionUpdate
 	})
 }
 
+func TestAccCognitoIDPUserPoolDomain_securityPolicy(t *testing.T) {
+	ctx := acctest.Context(t)
+	rootDomain := acctest.ACMCertificateDomainFromEnv(t)
+	domain := acctest.ACMCertificateRandomSubDomain(rootDomain)
+	poolName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_cognito_user_pool_domain.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckRegion(t, endpoints.UsEast1RegionID) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CognitoIDPServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckUserPoolDomainDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserPoolDomainConfig_securityPolicy(rootDomain, domain, poolName, "TLS_V1", 1),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckUserPoolDomainExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "security_policy", "TLS_V1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccUserPoolDomainConfig_securityPolicy(rootDomain, domain, poolName, "TLS_V1_2_2021", 1),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckUserPoolDomainExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "security_policy", "TLS_V1_2_2021"),
+				),
+			},
+			{
+				Config: testAccUserPoolDomainConfig_securityPolicy(rootDomain, domain, poolName, "TLS_V1_2_2021", 2),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckUserPoolDomainExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "managed_login_version", "2"),
+					resource.TestCheckResourceAttr(resourceName, "security_policy", "TLS_V1_2_2021"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckUserPoolDomainExists(ctx context.Context, t *testing.T, n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -457,4 +501,45 @@ resource "aws_cognito_user_pool_domain" "test" {
   managed_login_version = %[4]d
 }
 `, rootDomain, domain, poolName, version)
+}
+
+func testAccUserPoolDomainConfig_securityPolicy(rootDomain, domain, poolName, securityPolicy string, version int) string {
+	return fmt.Sprintf(`
+data "aws_route53_zone" "test" {
+  name         = %[1]q
+  private_zone = false
+}
+
+resource "aws_acm_certificate" "test" {
+  domain_name       = %[2]q
+  validation_method = "DNS"
+}
+
+resource "aws_route53_record" "test" {
+  allow_overwrite = true
+  name            = tolist(aws_acm_certificate.test.domain_validation_options)[0].resource_record_name
+  records         = [tolist(aws_acm_certificate.test.domain_validation_options)[0].resource_record_value]
+  ttl             = 60
+  type            = tolist(aws_acm_certificate.test.domain_validation_options)[0].resource_record_type
+  zone_id         = data.aws_route53_zone.test.zone_id
+}
+
+resource "aws_acm_certificate_validation" "test" {
+  certificate_arn         = aws_acm_certificate.test.arn
+  validation_record_fqdns = [aws_route53_record.test.fqdn]
+}
+
+resource "aws_cognito_user_pool" "test" {
+  name = %[3]q
+}
+
+resource "aws_cognito_user_pool_domain" "test" {
+  certificate_arn = aws_acm_certificate_validation.test.certificate_arn
+  domain          = aws_acm_certificate.test.domain_name
+  user_pool_id    = aws_cognito_user_pool.test.id
+
+  security_policy       = %[4]q
+  managed_login_version = %[5]d
+}
+`, rootDomain, domain, poolName, securityPolicy, version)
 }

--- a/website/docs/r/cognito_user_pool_domain.html.markdown
+++ b/website/docs/r/cognito_user_pool_domain.html.markdown
@@ -63,6 +63,7 @@ This resource supports the following arguments:
 * `domain` - (Required) For custom domains, this is the fully-qualified domain name, such as auth.example.com. For Amazon Cognito prefix domains, this is the prefix alone, such as auth.
 * `user_pool_id` - (Required) The user pool ID.
 * `certificate_arn` - (Optional) The ARN of an ISSUED ACM certificate in us-east-1 for a custom domain.
+* `security_policy` - (Optional) The security policy for the custom domain. Defines the minimum TLS version and cipher suites that CloudFront uses when communicating with viewers (clients). Valid values: `TLS_V1`, `TLS_V1_2_2021`, `TLS_V1_3_2025`.
 * `managed_login_version` - (Optional) A version number that indicates the state of managed login for your domain. Valid values: `1` for hosted UI (classic), `2` for the newer managed login with the branding designer.
 
 ## Attribute Reference


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

N/A

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Adds `security_policy` argument to `aws_cognito_user_pool_domain`.
Previously the user could not manage this field, now configurable through aws console/api/sdk.
This argument applies only to custom domains.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #48731 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccCognitoIDPUserPoolDomain_securityPolicy PKG=cognitoidp

TF_ACC=1 go test ./internal/service/cognitoidp/... -v -count 1 -parallel 20 -run='TestAccCognitoIDPUserPoolDomain_securityPolicy'  -timeout 360m -vet=off -buildvcs=false
...
=== RUN   TestAccCognitoIDPUserPoolDomain_securityPolicy
=== PAUSE TestAccCognitoIDPUserPoolDomain_securityPolicy
=== CONT  TestAccCognitoIDPUserPoolDomain_securityPolicy
--- PASS: TestAccCognitoIDPUserPoolDomain_securityPolicy (555.52s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cognitoidp 563.912s
```
