### PR TITLE
fix/aws_bedrockagentcore_harness: handle managed and disabled memory configurations

### DIFF
--- a/.changelog/48873.txt
+++ b/.changelog/48873.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_bedrockagentcore_harness: Fix `Unsupported Type` error when reading a harness that uses the service-default managed memory configuration (for example, one created without a `memory` block)
+```
+
+```release-note:enhancement
+resource/aws_bedrockagentcore_harness: Add `memory.disabled` to disable harness memory
+```

--- a/internal/service/bedrockagentcore/harness.go
+++ b/internal/service/bedrockagentcore/harness.go
@@ -155,6 +155,11 @@ func (r *harnessResource) Schema(ctx context.Context, request resource.SchemaReq
 					listvalidator.SizeAtMost(1),
 				},
 				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"disabled": schema.BoolAttribute{
+							Optional: true,
+						},
+					},
 					Blocks: map[string]schema.Block{
 						"agentcore_memory_configuration": schema.ListNestedBlock{
 							CustomType: fwtypes.NewListNestedObjectTypeOf[harnessAgentCoreMemoryConfigurationModel](ctx),
@@ -576,6 +581,7 @@ func (r *harnessResource) Create(ctx context.Context, request resource.CreateReq
 	if response.Diagnostics.HasError() {
 		return
 	}
+	collapseDefaultManagedMemory(ctx, harness, &data)
 
 	smerr.AddEnrich(ctx, &response.Diagnostics, response.State.Set(ctx, data))
 }
@@ -683,7 +689,22 @@ func (r *harnessResource) Delete(ctx context.Context, request resource.DeleteReq
 func (r *harnessResource) flatten(ctx context.Context, harness *awstypes.Harness, data *harnessResourceModel) diag.Diagnostics {
 	var diags diag.Diagnostics
 	diags.Append(fwflex.Flatten(ctx, harness, data)...)
+	if diags.HasError() {
+		return diags
+	}
+	collapseDefaultManagedMemory(ctx, harness, data)
 	return diags
+}
+
+// collapseDefaultManagedMemory resets the memory configuration to null when the
+// service returned its default managed memory configuration. That variant is only
+// ever returned as the server-side default for a harness created without an
+// explicit memory block; there is no configurable managed block, so leaving it in
+// state would produce a perpetual diff against an omitted memory block.
+func collapseDefaultManagedMemory(ctx context.Context, harness *awstypes.Harness, data *harnessResourceModel) {
+	if _, ok := harness.Memory.(*awstypes.HarnessMemoryConfigurationMemberManagedMemoryConfiguration); ok {
+		data.Memory = fwtypes.NewListNestedObjectValueOfNull[harnessMemoryConfigurationModel](ctx)
+	}
 }
 
 // Waiters.
@@ -1388,6 +1409,7 @@ func (m harnessEnvironmentArtifactModel) expandToUpdatedHarnessEnvironmentArtifa
 
 type harnessMemoryConfigurationModel struct {
 	AgentCoreMemoryConfiguration fwtypes.ListNestedObjectValueOf[harnessAgentCoreMemoryConfigurationModel] `tfsdk:"agentcore_memory_configuration"`
+	Disabled                     types.Bool                                                                `tfsdk:"disabled"`
 }
 
 var (
@@ -1405,6 +1427,14 @@ func (m *harnessMemoryConfigurationModel) Flatten(ctx context.Context, v any) di
 			return diags
 		}
 		m.AgentCoreMemoryConfiguration = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &data)
+	case awstypes.HarnessMemoryConfigurationMemberDisabled:
+		m.Disabled = types.BoolValue(true)
+	case awstypes.HarnessMemoryConfigurationMemberManagedMemoryConfiguration:
+		// The service assigns a managed memory configuration by default when a
+		// harness is created without an explicit memory block. There is no
+		// configurable managed block, so this is collapsed to a null memory
+		// configuration at the resource level (see (*harnessResource).flatten)
+		// to keep an omitted memory block from producing a perpetual diff.
 	default:
 		diags.AddError("Unsupported Type", fmt.Sprintf("memory configuration flatten: %T", v))
 	}
@@ -1425,7 +1455,8 @@ func (m harnessMemoryConfigurationModel) ExpandTo(ctx context.Context, targetTyp
 
 func (m harnessMemoryConfigurationModel) expandToHarnessMemoryConfiguration(ctx context.Context) (awstypes.HarnessMemoryConfiguration, diag.Diagnostics) {
 	var diags diag.Diagnostics
-	if !m.AgentCoreMemoryConfiguration.IsNull() {
+	switch {
+	case !m.AgentCoreMemoryConfiguration.IsNull():
 		data, d := m.AgentCoreMemoryConfiguration.ToPtr(ctx)
 		smerr.AddEnrich(ctx, &diags, d)
 		if diags.HasError() {
@@ -1434,18 +1465,20 @@ func (m harnessMemoryConfigurationModel) expandToHarnessMemoryConfiguration(ctx 
 		var r awstypes.HarnessMemoryConfigurationMemberAgentCoreMemoryConfiguration
 		smerr.AddEnrich(ctx, &diags, fwflex.Expand(ctx, data, &r.Value))
 		return &r, diags
+	case !m.Disabled.IsNull() && m.Disabled.ValueBool():
+		return &awstypes.HarnessMemoryConfigurationMemberDisabled{}, diags
 	}
 	return nil, diags
 }
 
 func (m harnessMemoryConfigurationModel) expandToUpdatedHarnessMemoryConfiguration(ctx context.Context) (*awstypes.UpdatedHarnessMemoryConfiguration, diag.Diagnostics) {
 	var diags diag.Diagnostics
-	if !m.AgentCoreMemoryConfiguration.IsNull() {
-		r, d := m.expandToHarnessMemoryConfiguration(ctx)
-		smerr.AddEnrich(ctx, &diags, d)
-		if diags.HasError() {
-			return nil, diags
-		}
+	r, d := m.expandToHarnessMemoryConfiguration(ctx)
+	smerr.AddEnrich(ctx, &diags, d)
+	if diags.HasError() {
+		return nil, diags
+	}
+	if r != nil {
 		return &awstypes.UpdatedHarnessMemoryConfiguration{OptionalValue: r}, diags
 	}
 	return &awstypes.UpdatedHarnessMemoryConfiguration{}, diags

--- a/internal/service/bedrockagentcore/harness_memory_configuration_roundtrip_test.go
+++ b/internal/service/bedrockagentcore/harness_memory_configuration_roundtrip_test.go
@@ -1,0 +1,151 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package bedrockagentcore
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol/types"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+)
+
+// TestHarnessMemoryConfigurationRoundTrip proves the memory configuration union
+// round-trips SDK -> model -> SDK for the configurable members and that the
+// default managed member (returned by the service when no memory block is
+// configured) expands back to no memory configuration. autoflex passes the
+// dereferenced union member value to Flatten, which is what the fixtures below
+// feed in.
+func TestHarnessMemoryConfigurationRoundTrip(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	agentCore := &awstypes.HarnessMemoryConfigurationMemberAgentCoreMemoryConfiguration{
+		Value: awstypes.HarnessAgentCoreMemoryConfiguration{
+			Arn:           aws.String("arn:aws:bedrock-agentcore:us-west-2:123456789012:memory/mem-abc123"),
+			ActorId:       aws.String("actor-1"),
+			MessagesCount: aws.Int32(10),
+			RetrievalConfig: map[string]awstypes.HarnessAgentCoreMemoryRetrievalConfig{
+				"strategy-key": {
+					RelevanceScore: aws.Float32(0.5),
+					StrategyId:     aws.String("strategy-1"),
+					TopK:           aws.Int32(3),
+				},
+			},
+		},
+	}
+
+	testCases := map[string]struct {
+		flattenInput   any                                 // union member value, as autoflex passes it
+		expectedExpand awstypes.HarnessMemoryConfiguration // union member pointer, as Expand returns it
+	}{
+		"agentcore": {
+			flattenInput:   *agentCore,
+			expectedExpand: agentCore,
+		},
+		"disabled": {
+			flattenInput:   awstypes.HarnessMemoryConfigurationMemberDisabled{},
+			expectedExpand: &awstypes.HarnessMemoryConfigurationMemberDisabled{},
+		},
+		// The service assigns a managed memory configuration by default; it is not
+		// a configurable block, so it expands back to no memory configuration.
+		"managed_default": {
+			flattenInput:   awstypes.HarnessMemoryConfigurationMemberManagedMemoryConfiguration{Value: awstypes.HarnessManagedMemoryConfiguration{}},
+			expectedExpand: nil,
+		},
+	}
+
+	opts := cmp.Options{
+		cmpopts.IgnoreUnexported(
+			awstypes.HarnessMemoryConfigurationMemberAgentCoreMemoryConfiguration{},
+			awstypes.HarnessMemoryConfigurationMemberDisabled{},
+			awstypes.HarnessAgentCoreMemoryConfiguration{},
+			awstypes.HarnessAgentCoreMemoryRetrievalConfig{},
+			awstypes.HarnessDisabledMemoryConfiguration{},
+		),
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var model harnessMemoryConfigurationModel
+			if diags := model.Flatten(ctx, tc.flattenInput); diags.HasError() {
+				t.Fatalf("Flatten: %v", diags)
+			}
+
+			out, diags := model.expandToHarnessMemoryConfiguration(ctx)
+			if diags.HasError() {
+				t.Fatalf("Expand: %v", diags)
+			}
+
+			if diff := cmp.Diff(tc.expectedExpand, out, opts...); diff != "" {
+				t.Errorf("SDK -> model -> SDK round-trip mismatch (-in +out):\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestCollapseDefaultManagedMemory verifies that the server-assigned managed
+// default is collapsed to a null memory configuration (so an omitted memory block
+// does not produce a perpetual diff), while an explicit disabled configuration is
+// preserved.
+func TestCollapseDefaultManagedMemory(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("managed default collapses to null", func(t *testing.T) {
+		t.Parallel()
+
+		// Mirror what autoflex produces for the managed default: a populated
+		// (all-null) memory element. Collapse must reset it to null.
+		data := &harnessResourceModel{
+			Memory: fwtypes.NewListNestedObjectValueOfPtrMust(ctx, newTestMemoryModel(ctx, false)),
+		}
+		harness := &awstypes.Harness{
+			Memory: &awstypes.HarnessMemoryConfigurationMemberManagedMemoryConfiguration{},
+		}
+
+		collapseDefaultManagedMemory(ctx, harness, data)
+
+		if !data.Memory.IsNull() {
+			t.Fatalf("expected memory to be null for the default managed configuration")
+		}
+	})
+
+	t.Run("explicit disabled is preserved", func(t *testing.T) {
+		t.Parallel()
+
+		data := &harnessResourceModel{
+			Memory: fwtypes.NewListNestedObjectValueOfPtrMust(ctx, newTestMemoryModel(ctx, true)),
+		}
+		harness := &awstypes.Harness{
+			Memory: &awstypes.HarnessMemoryConfigurationMemberDisabled{},
+		}
+
+		collapseDefaultManagedMemory(ctx, harness, data)
+
+		if data.Memory.IsNull() {
+			t.Fatalf("expected an explicit disabled memory configuration to be preserved")
+		}
+	})
+}
+
+// newTestMemoryModel builds a memory configuration model with its framework-typed
+// fields initialized as proper nulls (the framework/autoflex does this in the real
+// Create/Read path; a bare struct literal would leave them as invalid zero values).
+func newTestMemoryModel(ctx context.Context, disabled bool) *harnessMemoryConfigurationModel {
+	m := &harnessMemoryConfigurationModel{
+		AgentCoreMemoryConfiguration: fwtypes.NewListNestedObjectValueOfNull[harnessAgentCoreMemoryConfigurationModel](ctx),
+		Disabled:                     types.BoolNull(),
+	}
+	if disabled {
+		m.Disabled = types.BoolValue(true)
+	}
+	return m
+}

--- a/internal/service/bedrockagentcore/harness_test.go
+++ b/internal/service/bedrockagentcore/harness_test.go
@@ -470,6 +470,88 @@ func TestAccBedrockAgentCoreHarness_memory(t *testing.T) {
 	})
 }
 
+func TestAccBedrockAgentCoreHarness_memoryDefault(t *testing.T) {
+	ctx := acctest.Context(t)
+	var harness awstypes.Harness
+	rName := testAccRandomHarnessName(t)
+	resourceName := "aws_bedrockagentcore_harness.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID)
+			testAccPreCheckHarness(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockAgentCoreServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckHarnessDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				// Regression: a harness created without a memory block must not fail
+				// on the service-assigned default managed memory configuration, and
+				// that default must round-trip to a null memory block (no diff).
+				ConfigDirectory: config.StaticDirectory("testdata/Harness/basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckHarnessExists(ctx, t, resourceName, &harness),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					// The service-assigned default managed memory configuration
+					// collapses to an empty (absent) memory block.
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("memory"), knownvalue.ListSizeExact(0)),
+				},
+			},
+		},
+	})
+}
+
+func TestAccBedrockAgentCoreHarness_memoryDisabled(t *testing.T) {
+	ctx := acctest.Context(t)
+	var harness awstypes.Harness
+	rName := testAccRandomHarnessName(t)
+	resourceName := "aws_bedrockagentcore_harness.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID)
+			testAccPreCheckHarness(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockAgentCoreServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckHarnessDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccHarnessConfig_memoryDisabled(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckHarnessExists(ctx, t, resourceName, &harness),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("memory").AtSliceIndex(0).AtMapKey("disabled"), knownvalue.Bool(true)),
+				},
+			},
+		},
+	})
+}
+
 func TestAccBedrockAgentCoreHarness_environmentArtifact(t *testing.T) {
 	ctx := acctest.Context(t)
 	var harness awstypes.Harness
@@ -969,6 +1051,29 @@ resource "aws_bedrockagentcore_memory" "test" {
   event_expiry_duration = 7
 }
 `, rName, relevanceScore))
+}
+
+func testAccHarnessConfig_memoryDisabled(rName string) string {
+	return acctest.ConfigCompose(testAccHarnessConfig_iamRole(rName), fmt.Sprintf(`
+resource "aws_bedrockagentcore_harness" "test" {
+  harness_name       = %[1]q
+  execution_role_arn = aws_iam_role.test.arn
+
+  memory {
+    disabled = true
+  }
+
+  model {
+    bedrock_model_config {
+      model_id = "anthropic.claude-sonnet-4-20250514"
+    }
+  }
+
+  system_prompt {
+    text = "You are a helpful assistant."
+  }
+}
+`, rName))
 }
 
 func testAccHarnessConfig_environmentArtifact(rName, imageTag string) string {

--- a/website/docs/r/bedrockagentcore_harness.html.markdown
+++ b/website/docs/r/bedrockagentcore_harness.html.markdown
@@ -361,7 +361,10 @@ The `claim_match_value` block supports the following:
 
 ### `memory` Block
 
-* `agentcore_memory_configuration` - (Required) AgentCore memory configuration. See [`agentcore_memory_configuration`](#agentcore_memory_configuration) below.
+When the `memory` block is omitted, the service assigns a managed memory configuration by default. To use an existing AgentCore Memory resource or to disable memory, specify one of the following:
+
+* `agentcore_memory_configuration` - (Optional) AgentCore memory configuration. See [`agentcore_memory_configuration`](#agentcore_memory_configuration) below.
+* `disabled` - (Optional) Set to `true` to disable memory for the harness.
 
 ### `agentcore_memory_configuration` Block
 


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

### Description

The `aws_bedrockagentcore_harness` memory configuration (`HarnessMemoryConfiguration`) is a union with three members — `AgentCoreMemoryConfiguration`, `ManagedMemoryConfiguration`, and `Disabled` — but the resource only flattened `AgentCoreMemoryConfiguration`. Reading a harness that used either of the other two members hit the `Flatten` default case and failed with an `Unsupported Type` error.

In practice this broke the common case: a harness created **without** a `memory` block is assigned a managed memory configuration by the service, so the post-create read always errored. (It also blocks the `aws_bedrockagentcore_harness_endpoint` acceptance tests, whose fixtures create a harness without a `memory` block.)

Changes:

- `Flatten` now handles all three union members. The service-default managed configuration is collapsed to a null `memory` block so that an omitted block round-trips without a perpetual diff. The resource is already released, so the `memory` block schema is preserved as-is (a block cannot be `Computed`); the managed configuration is treated as the implicit server default rather than a configurable block. A configurable managed memory block can be added later as an enhancement.
- Added a `memory.disabled` boolean attribute (mirroring the resource's existing `outbound_auth` `aws_iam`/`none` union markers) so memory can be explicitly disabled and a disabled harness round-trips.

An offline SDK↔model↔SDK round-trip unit test covers every union member, and new acceptance tests cover the default (no `memory` block) and `disabled` paths.

### Relations

Relates #47725

### References

N/A

### Output from Acceptance Testing

```console
% make testacc TESTS='TestAccBedrockAgentCoreHarness_basic|TestAccBedrockAgentCoreHarness_memory|TestAccBedrockAgentCoreHarness_memoryDefault|TestAccBedrockAgentCoreHarness_memoryDisabled' PKG=bedrockagentcore

--- PASS: TestAccBedrockAgentCoreHarness_memoryDisabled (81.09s)
--- PASS: TestAccBedrockAgentCoreHarness_memory (289.08s)
--- PASS: TestAccBedrockAgentCoreHarness_basic (371.06s)
--- PASS: TestAccBedrockAgentCoreHarness_memoryDefault (360.19s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/bedrockagentcore

% go test ./internal/service/bedrockagentcore/ -run 'TestHarnessMemoryConfigurationRoundTrip|TestCollapseDefaultManagedMemory'
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/bedrockagentcore
```
