### PR TITLE
r/aws_bedrockagentcore_agent_runtime: add metadata_configuration argument

### DIFF
--- a/.changelog/48874.txt
+++ b/.changelog/48874.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_bedrockagentcore_agent_runtime: Add `metadata_configuration` argument
+```

--- a/internal/service/bedrockagentcore/agent_runtime.go
+++ b/internal/service/bedrockagentcore/agent_runtime.go
@@ -95,6 +95,7 @@ func (r *agentRuntimeResource) Schema(ctx context.Context, request resource.Sche
 				Optional:   true,
 			},
 			"lifecycle_configuration": framework.ResourceOptionalComputedListOfObjectsAttribute[lifecycleConfigurationModel](ctx, 1, nil, listplanmodifier.UseStateForUnknown()),
+			"metadata_configuration":  framework.ResourceOptionalComputedListOfObjectsAttribute[runtimeMetadataConfigurationModel](ctx, 1, nil, listplanmodifier.UseStateForUnknown()),
 			names.AttrRoleARN: schema.StringAttribute{
 				CustomType: fwtypes.ARNType,
 				Required:   true,
@@ -681,6 +682,29 @@ func (r *agentRuntimeResource) Create(ctx context.Context, request resource.Crea
 		return
 	}
 
+	// metadata_configuration is only accepted by UpdateAgentRuntime, not
+	// CreateAgentRuntime, so apply it with a follow-up update when set at create time.
+	if !data.MetadataConfiguration.IsNull() && !data.MetadataConfiguration.IsUnknown() {
+		var updateInput bedrockagentcorecontrol.UpdateAgentRuntimeInput
+		smerr.AddEnrich(ctx, &response.Diagnostics, fwflex.Expand(ctx, data, &updateInput, fwflex.WithFieldNamePrefix("AgentRuntime")))
+		if response.Diagnostics.HasError() {
+			return
+		}
+
+		updateInput.AgentRuntimeId = aws.String(agentRuntimeID)
+		updateInput.ClientToken = aws.String(create.UniqueId(ctx))
+
+		if _, err := conn.UpdateAgentRuntime(ctx, &updateInput); err != nil {
+			smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, agentRuntimeID)
+			return
+		}
+
+		if _, err := waitAgentRuntimeUpdated(ctx, conn, agentRuntimeID, r.CreateTimeout(ctx, data.Timeouts)); err != nil {
+			smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, agentRuntimeID)
+			return
+		}
+	}
+
 	runtime, err := findAgentRuntimeByID(ctx, conn, agentRuntimeID)
 	if err != nil {
 		smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, agentRuntimeID)
@@ -938,24 +962,25 @@ func findAgentRuntime(ctx context.Context, conn *bedrockagentcorecontrol.Client,
 
 type agentRuntimeResourceModel struct {
 	framework.WithRegionModel
-	AgentRuntimeARN            types.String                                                     `tfsdk:"agent_runtime_arn"`
-	AgentRuntimeArtifact       fwtypes.ListNestedObjectValueOf[agentRuntimeArtifactModel]       `tfsdk:"agent_runtime_artifact"`
-	AgentRuntimeID             types.String                                                     `tfsdk:"agent_runtime_id"`
-	AgentRuntimeName           types.String                                                     `tfsdk:"agent_runtime_name"`
-	AgentRuntimeVersion        types.String                                                     `tfsdk:"agent_runtime_version"`
-	AuthorizerConfiguration    fwtypes.ListNestedObjectValueOf[authorizerConfigurationModel]    `tfsdk:"authorizer_configuration"`
-	Description                types.String                                                     `tfsdk:"description"`
-	EnvironmentVariables       fwtypes.MapOfString                                              `tfsdk:"environment_variables"`
-	FilesystemConfigurations   fwtypes.ListNestedObjectValueOf[filesystemConfigurationModel]    `tfsdk:"filesystem_configuration"`
-	LifecycleConfiguration     fwtypes.ListNestedObjectValueOf[lifecycleConfigurationModel]     `tfsdk:"lifecycle_configuration"`
-	NetworkConfiguration       fwtypes.ListNestedObjectValueOf[networkConfigurationModel]       `tfsdk:"network_configuration"`
-	ProtocolConfiguration      fwtypes.ListNestedObjectValueOf[protocolConfigurationModel]      `tfsdk:"protocol_configuration"`
-	RequestHeaderConfiguration fwtypes.ListNestedObjectValueOf[requestHeaderConfigurationModel] `tfsdk:"request_header_configuration"`
-	RoleARN                    fwtypes.ARN                                                      `tfsdk:"role_arn"`
-	Tags                       tftags.Map                                                       `tfsdk:"tags"`
-	TagsAll                    tftags.Map                                                       `tfsdk:"tags_all"`
-	Timeouts                   timeouts.Value                                                   `tfsdk:"timeouts"`
-	WorkloadIdentityDetails    fwtypes.ListNestedObjectValueOf[workloadIdentityDetailsModel]    `tfsdk:"workload_identity_details"`
+	AgentRuntimeARN            types.String                                                       `tfsdk:"agent_runtime_arn"`
+	AgentRuntimeArtifact       fwtypes.ListNestedObjectValueOf[agentRuntimeArtifactModel]         `tfsdk:"agent_runtime_artifact"`
+	AgentRuntimeID             types.String                                                       `tfsdk:"agent_runtime_id"`
+	AgentRuntimeName           types.String                                                       `tfsdk:"agent_runtime_name"`
+	AgentRuntimeVersion        types.String                                                       `tfsdk:"agent_runtime_version"`
+	AuthorizerConfiguration    fwtypes.ListNestedObjectValueOf[authorizerConfigurationModel]      `tfsdk:"authorizer_configuration"`
+	Description                types.String                                                       `tfsdk:"description"`
+	EnvironmentVariables       fwtypes.MapOfString                                                `tfsdk:"environment_variables"`
+	FilesystemConfigurations   fwtypes.ListNestedObjectValueOf[filesystemConfigurationModel]      `tfsdk:"filesystem_configuration"`
+	LifecycleConfiguration     fwtypes.ListNestedObjectValueOf[lifecycleConfigurationModel]       `tfsdk:"lifecycle_configuration"`
+	MetadataConfiguration      fwtypes.ListNestedObjectValueOf[runtimeMetadataConfigurationModel] `tfsdk:"metadata_configuration"`
+	NetworkConfiguration       fwtypes.ListNestedObjectValueOf[networkConfigurationModel]         `tfsdk:"network_configuration"`
+	ProtocolConfiguration      fwtypes.ListNestedObjectValueOf[protocolConfigurationModel]        `tfsdk:"protocol_configuration"`
+	RequestHeaderConfiguration fwtypes.ListNestedObjectValueOf[requestHeaderConfigurationModel]   `tfsdk:"request_header_configuration"`
+	RoleARN                    fwtypes.ARN                                                        `tfsdk:"role_arn"`
+	Tags                       tftags.Map                                                         `tfsdk:"tags"`
+	TagsAll                    tftags.Map                                                         `tfsdk:"tags_all"`
+	Timeouts                   timeouts.Value                                                     `tfsdk:"timeouts"`
+	WorkloadIdentityDetails    fwtypes.ListNestedObjectValueOf[workloadIdentityDetailsModel]      `tfsdk:"workload_identity_details"`
 }
 
 type agentRuntimeArtifactModel struct {
@@ -1390,6 +1415,10 @@ func (m customJWTAuthorizerClaimMatchValueModel) Expand(ctx context.Context) (an
 type lifecycleConfigurationModel struct {
 	IdleRuntimeSessionTimeout types.Int32 `tfsdk:"idle_runtime_session_timeout"`
 	MaxLifetime               types.Int32 `tfsdk:"max_lifetime"`
+}
+
+type runtimeMetadataConfigurationModel struct {
+	RequireMMDSV2 types.Bool `tfsdk:"require_mmds_v2"`
 }
 
 type networkConfigurationModel struct {

--- a/internal/service/bedrockagentcore/agent_runtime.go
+++ b/internal/service/bedrockagentcore/agent_runtime.go
@@ -701,7 +701,7 @@ func (r *agentRuntimeResource) Create(ctx context.Context, request resource.Crea
 			return
 		}
 
-		if _, err := waitAgentRuntimeUpdated(ctx, conn, agentRuntimeID, r.CreateTimeout(ctx, data.Timeouts)); err != nil {
+		if err := waitAgentRuntimeUpdated(ctx, conn, agentRuntimeID, r.CreateTimeout(ctx, data.Timeouts)); err != nil {
 			// The runtime was created but the metadata update failed; taint so it is tracked and can be cleaned up.
 			response.State.SetAttribute(ctx, path.Root("agent_runtime_id"), agentRuntimeID)
 			smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, agentRuntimeID)
@@ -822,7 +822,7 @@ func (r *agentRuntimeResource) Update(ctx context.Context, request resource.Upda
 		}
 		new.AuthorizerConfiguration = authorizerConfiguration
 
-		if _, err := waitAgentRuntimeUpdated(ctx, conn, agentRuntimeID, r.UpdateTimeout(ctx, new.Timeouts)); err != nil {
+		if err := waitAgentRuntimeUpdated(ctx, conn, agentRuntimeID, r.UpdateTimeout(ctx, new.Timeouts)); err != nil {
 			smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, agentRuntimeID)
 			return
 		}
@@ -888,7 +888,7 @@ func waitAgentRuntimeCreated(ctx context.Context, conn *bedrockagentcorecontrol.
 	return nil, smarterr.NewError(err)
 }
 
-func waitAgentRuntimeUpdated(ctx context.Context, conn *bedrockagentcorecontrol.Client, id string, timeout time.Duration) (*bedrockagentcorecontrol.GetAgentRuntimeOutput, error) {
+func waitAgentRuntimeUpdated(ctx context.Context, conn *bedrockagentcorecontrol.Client, id string, timeout time.Duration) error {
 	stateConf := &retry.StateChangeConf{
 		Pending:                   enum.Slice(awstypes.AgentRuntimeStatusUpdating),
 		Target:                    enum.Slice(awstypes.AgentRuntimeStatusReady),
@@ -897,12 +897,8 @@ func waitAgentRuntimeUpdated(ctx context.Context, conn *bedrockagentcorecontrol.
 		ContinuousTargetOccurence: 2,
 	}
 
-	outputRaw, err := stateConf.WaitForStateContext(ctx)
-	if out, ok := outputRaw.(*bedrockagentcorecontrol.GetAgentRuntimeOutput); ok {
-		return out, smarterr.NewError(err)
-	}
-
-	return nil, smarterr.NewError(err)
+	_, err := stateConf.WaitForStateContext(ctx)
+	return smarterr.NewError(err)
 }
 
 func waitAgentRuntimeDeleted(ctx context.Context, conn *bedrockagentcorecontrol.Client, id string, timeout time.Duration) (*bedrockagentcorecontrol.GetAgentRuntimeOutput, error) {

--- a/internal/service/bedrockagentcore/agent_runtime.go
+++ b/internal/service/bedrockagentcore/agent_runtime.go
@@ -695,11 +695,15 @@ func (r *agentRuntimeResource) Create(ctx context.Context, request resource.Crea
 		updateInput.ClientToken = aws.String(create.UniqueId(ctx))
 
 		if _, err := conn.UpdateAgentRuntime(ctx, &updateInput); err != nil {
+			// The runtime was created but the metadata update failed; taint so it is tracked and can be cleaned up.
+			response.State.SetAttribute(ctx, path.Root("agent_runtime_id"), agentRuntimeID)
 			smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, agentRuntimeID)
 			return
 		}
 
 		if _, err := waitAgentRuntimeUpdated(ctx, conn, agentRuntimeID, r.CreateTimeout(ctx, data.Timeouts)); err != nil {
+			// The runtime was created but the metadata update failed; taint so it is tracked and can be cleaned up.
+			response.State.SetAttribute(ctx, path.Root("agent_runtime_id"), agentRuntimeID)
 			smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, agentRuntimeID)
 			return
 		}

--- a/internal/service/bedrockagentcore/agent_runtime_test.go
+++ b/internal/service/bedrockagentcore/agent_runtime_test.go
@@ -1274,6 +1274,64 @@ func testAccPreCheckAgentRuntimes(ctx context.Context, t *testing.T) {
 	}
 }
 
+func TestAccBedrockAgentCoreAgentRuntime_metadataConfiguration(t *testing.T) {
+	ctx := acctest.Context(t)
+	var agentRuntime bedrockagentcorecontrol.GetAgentRuntimeOutput
+	rName := strings.ReplaceAll(acctest.RandomWithPrefix(t, acctest.ResourcePrefix), "-", "_")
+	resourceName := "aws_bedrockagentcore_agent_runtime.test"
+	rImageUri := acctest.SkipIfEnvVarNotSet(t, "AWS_BEDROCK_AGENTCORE_RUNTIME_IMAGE_V1_URI")
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID)
+			testAccPreCheckAgentRuntimes(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockAgentCoreServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckAgentRuntimeDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				// metadata_configuration is only accepted by UpdateAgentRuntime, so a create with it set
+				// exercises the create-then-update path.
+				Config: testAccAgentRuntimeConfig_metadataConfiguration(rName, rImageUri),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAgentRuntimeExists(ctx, t, resourceName, &agentRuntime),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("metadata_configuration").AtSliceIndex(0).AtMapKey("require_mmds_v2"), knownvalue.Bool(true)),
+				},
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, "agent_runtime_id"),
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "agent_runtime_id",
+			},
+			{
+				// Removing metadata_configuration is a no-op: the API preserves the value and
+				// Optional+Computed retains it, so there is no perpetual diff. The API rejects
+				// require_mmds_v2 = false for agents created after 2026-02-15, so it is not toggled here.
+				Config: testAccAgentRuntimeConfig_basic(rName, rImageUri),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("metadata_configuration").AtSliceIndex(0).AtMapKey("require_mmds_v2"), knownvalue.Bool(true)),
+				},
+			},
+		},
+	})
+}
+
 func TestAccBedrockAgentCoreAgentRuntime_authorizer_privateEndpointOverrides(t *testing.T) {
 	ctx := acctest.Context(t)
 	var agentRuntime bedrockagentcorecontrol.GetAgentRuntimeOutput
@@ -1385,6 +1443,29 @@ resource "aws_bedrockagentcore_agent_runtime" "test" {
       }
     }
   }
+}
+`, rName, rImageUri))
+}
+
+func testAccAgentRuntimeConfig_metadataConfiguration(rName, rImageUri string) string {
+	return acctest.ConfigCompose(testAccAgentRuntimeConfig_baseIAMRole(rName), fmt.Sprintf(`
+resource "aws_bedrockagentcore_agent_runtime" "test" {
+  agent_runtime_name = %[1]q
+  role_arn           = aws_iam_role.test.arn
+
+  agent_runtime_artifact {
+    container_configuration {
+      container_uri = %[2]q
+    }
+  }
+
+  network_configuration {
+    network_mode = "PUBLIC"
+  }
+
+  metadata_configuration = [{
+    require_mmds_v2 = true
+  }]
 }
 `, rName, rImageUri))
 }

--- a/website/docs/r/bedrockagentcore_agent_runtime.html.markdown
+++ b/website/docs/r/bedrockagentcore_agent_runtime.html.markdown
@@ -174,6 +174,7 @@ The following arguments are optional:
 * `authorizer_configuration` - (Optional) Authorization configuration for authenticating incoming requests. See [`authorizer_configuration`](#authorizer_configuration) below.
 * `filesystem_configuration` - (Optional) List of filesystems to mount into the agent runtime. Up to 5 entries are supported. Each entry is one of session storage, Amazon S3 Files access point, or Amazon EFS access point. See [`filesystem_configuration`](#filesystem_configuration) below.
 * `lifecycle_configuration` - (Optional) Runtime session and resource lifecycle configuration for the agent runtime. See [`lifecycle_configuration`](#lifecycle_configuration) below.
+* `metadata_configuration` - (Optional) microVM Metadata Service (MMDS) configuration for the agent runtime. This configuration is applied via a follow-up update immediately after the runtime is created, because the create operation does not accept it. See [`metadata_configuration`](#metadata_configuration) below.
 * `protocol_configuration` - (Optional) Protocol configuration for the agent runtime. See [`protocol_configuration`](#protocol_configuration) below.
 * `request_header_configuration` - (Optional) Configuration for HTTP request headers that will be passed through to the runtime. See [`request_header_configuration`](#request_header_configuration) below.
 * `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
@@ -322,6 +323,12 @@ The `lifecycle_configuration` block supports the following:
 
 * `idle_runtime_session_timeout` - (Optional) Timeout in seconds for idle runtime sessions.
 * `max_lifetime` - (Optional) Maximum lifetime for the instance in seconds.
+
+### `metadata_configuration`
+
+The `metadata_configuration` block supports the following:
+
+* `require_mmds_v2` - (Required) Whether the runtime microVM requires MMDSv2 (microVM Metadata Service Version 2). When `true`, the runtime microVM only accepts MMDSv2 requests. Agents created after February 15, 2026 must have this enabled.
 
 ### `network_configuration`
 


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

None.

### Description

Adds the `metadata_configuration` argument to `aws_bedrockagentcore_agent_runtime`, exposing the microVM Metadata Service (MMDS) configuration (`require_mmds_v2`) for the runtime.

`metadata_configuration` is accepted only by `UpdateAgentRuntime` — it is **not** a member of `CreateAgentRuntime` — and it is returned by `GetAgentRuntime`. It is therefore modeled as an `Optional`+`Computed` attribute, and when set at create time it is applied with a follow-up `UpdateAgentRuntime` immediately after the runtime reaches a ready state.

Behavior confirmed during acceptance testing against a live account:

- Create with `require_mmds_v2 = true` performs the create-then-update (the runtime advances to version `2`) and round-trips cleanly.
- Create without `metadata_configuration` leaves the value to the service, which auto-enables `require_mmds_v2` for agents created after February 15, 2026; the computed value is read back with no perpetual diff.
- The API rejects `require_mmds_v2 = false` for agents created after February 15, 2026. The attribute is intentionally **not** schema-restricted to `true`, so pre-existing agents that have the value `false` continue to import and round-trip.

### Relations

Relates to ongoing AgentCore update-only attribute coverage.

### References

- https://docs.aws.amazon.com/bedrock-agentcore-control/latest/APIReference/API_UpdateAgentRuntime.html

### Output from Acceptance Testing

```console
% make testacc TESTS=TestAccBedrockAgentCoreAgentRuntime_metadataConfiguration PKG=bedrockagentcore

--- PASS: TestAccBedrockAgentCoreAgentRuntime_metadataConfiguration (53.17s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/bedrockagentcore	53.342s
```
