### PR TITLE
r/aws_bedrockagentcore_gateway: add custom_transform_configuration argument

### DIFF
--- a/.changelog/48875.txt
+++ b/.changelog/48875.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_bedrockagentcore_gateway: Add `custom_transform_configuration` argument
+```

--- a/internal/service/bedrockagentcore/gateway.go
+++ b/internal/service/bedrockagentcore/gateway.go
@@ -139,6 +139,7 @@ func (r *gatewayResource) Schema(ctx context.Context, request resource.SchemaReq
 						"lambda": schema.ListNestedBlock{
 							CustomType: fwtypes.NewListNestedObjectTypeOf[lambdaTransformConfigurationModel](ctx),
 							Validators: []validator.List{
+								listvalidator.IsRequired(),
 								listvalidator.SizeAtMost(1),
 							},
 							NestedObject: schema.NestedBlockObject{

--- a/internal/service/bedrockagentcore/gateway.go
+++ b/internal/service/bedrockagentcore/gateway.go
@@ -129,6 +129,30 @@ func (r *gatewayResource) Schema(ctx context.Context, request resource.SchemaReq
 		},
 		Blocks: map[string]schema.Block{
 			"authorizer_configuration": authorizerConfigurationSchema(ctx),
+			"custom_transform_configuration": schema.ListNestedBlock{
+				CustomType: fwtypes.NewListNestedObjectTypeOf[customTransformConfigurationModel](ctx),
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Blocks: map[string]schema.Block{
+						"lambda": schema.ListNestedBlock{
+							CustomType: fwtypes.NewListNestedObjectTypeOf[lambdaTransformConfigurationModel](ctx),
+							Validators: []validator.List{
+								listvalidator.SizeAtMost(1),
+							},
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									names.AttrARN: schema.StringAttribute{
+										CustomType: fwtypes.ARNType,
+										Required:   true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 			"interceptor_configuration": schema.ListNestedBlock{
 				CustomType: fwtypes.NewListNestedObjectTypeOf[gatewayInterceptorConfigurationModel](ctx),
 				Validators: []validator.List{
@@ -332,6 +356,31 @@ func (r *gatewayResource) Create(ctx context.Context, request resource.CreateReq
 	// Set values for unknowns. Capture the configured authorizer first so the API-omitted
 	// private_endpoint_overrides can be restored after Flatten.
 	plannedAuthorizerConfiguration := data.AuthorizerConfiguration
+
+	// custom_transform_configuration is only accepted by UpdateGateway, not CreateGateway,
+	// so apply it with a follow-up update when set at create time.
+	customTransformConfiguration := data.CustomTransformConfiguration
+	if !customTransformConfiguration.IsNull() && !customTransformConfiguration.IsUnknown() {
+		var updateInput bedrockagentcorecontrol.UpdateGatewayInput
+		smerr.AddEnrich(ctx, &response.Diagnostics, fwflex.Expand(ctx, data, &updateInput))
+		if response.Diagnostics.HasError() {
+			return
+		}
+
+		updateInput.GatewayIdentifier = aws.String(gatewayID)
+
+		if _, err := conn.UpdateGateway(ctx, &updateInput); err != nil {
+			smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, gatewayID)
+			return
+		}
+
+		gateway, err = waitGatewayUpdated(ctx, conn, gatewayID, r.CreateTimeout(ctx, data.Timeouts))
+		if err != nil {
+			smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, gatewayID)
+			return
+		}
+	}
+
 	smerr.AddEnrich(ctx, &response.Diagnostics, fwflex.Flatten(ctx, gateway, &data))
 	if response.Diagnostics.HasError() {
 		return
@@ -343,6 +392,9 @@ func (r *gatewayResource) Create(ctx context.Context, request resource.CreateReq
 		return
 	}
 	data.AuthorizerConfiguration = authorizerConfiguration
+
+	// custom_transform_configuration is not returned by GetGateway, so preserve the configured value.
+	data.CustomTransformConfiguration = customTransformConfiguration
 
 	smerr.AddEnrich(ctx, &response.Diagnostics, response.State.Set(ctx, data))
 }
@@ -369,6 +421,8 @@ func (r *gatewayResource) Read(ctx context.Context, request resource.ReadRequest
 	}
 
 	priorAuthorizerConfiguration := data.AuthorizerConfiguration
+	// custom_transform_configuration is not returned by GetGateway, so preserve the value already in state.
+	customTransformConfiguration := data.CustomTransformConfiguration
 	smerr.AddEnrich(ctx, &response.Diagnostics, fwflex.Flatten(ctx, out, &data))
 	if response.Diagnostics.HasError() {
 		return
@@ -380,6 +434,7 @@ func (r *gatewayResource) Read(ctx context.Context, request resource.ReadRequest
 		return
 	}
 	data.AuthorizerConfiguration = authorizerConfiguration
+	data.CustomTransformConfiguration = customTransformConfiguration
 
 	smerr.AddEnrich(ctx, &response.Diagnostics, response.State.Set(ctx, &data))
 }
@@ -593,24 +648,25 @@ func findGateway(ctx context.Context, conn *bedrockagentcorecontrol.Client, inpu
 
 type gatewayResourceModel struct {
 	framework.WithRegionModel
-	AuthorizerConfiguration   fwtypes.ListNestedObjectValueOf[authorizerConfigurationModel]          `tfsdk:"authorizer_configuration"`
-	AuthorizerType            fwtypes.StringEnum[awstypes.AuthorizerType]                            `tfsdk:"authorizer_type"`
-	Description               types.String                                                           `tfsdk:"description"`
-	ExceptionLevel            fwtypes.StringEnum[awstypes.ExceptionLevel]                            `tfsdk:"exception_level"`
-	GatewayARN                types.String                                                           `tfsdk:"gateway_arn"`
-	GatewayID                 types.String                                                           `tfsdk:"gateway_id"`
-	GatewayURL                types.String                                                           `tfsdk:"gateway_url"`
-	InterceptorConfigurations fwtypes.ListNestedObjectValueOf[gatewayInterceptorConfigurationModel]  `tfsdk:"interceptor_configuration"`
-	KMSKeyARN                 fwtypes.ARN                                                            `tfsdk:"kms_key_arn"`
-	Name                      types.String                                                           `tfsdk:"name"`
-	PolicyEngineConfiguration fwtypes.ListNestedObjectValueOf[gatewayPolicyEngineConfigurationModel] `tfsdk:"policy_engine_configuration"`
-	ProtocolConfiguration     fwtypes.ListNestedObjectValueOf[gatewayProtocolConfigurationModel]     `tfsdk:"protocol_configuration"`
-	ProtocolType              fwtypes.StringEnum[awstypes.GatewayProtocolType]                       `tfsdk:"protocol_type"`
-	RoleARN                   fwtypes.ARN                                                            `tfsdk:"role_arn"`
-	Tags                      tftags.Map                                                             `tfsdk:"tags"`
-	TagsAll                   tftags.Map                                                             `tfsdk:"tags_all"`
-	Timeouts                  timeouts.Value                                                         `tfsdk:"timeouts"`
-	WorkloadIdentityDetails   fwtypes.ListNestedObjectValueOf[workloadIdentityDetailsModel]          `tfsdk:"workload_identity_details"`
+	AuthorizerConfiguration      fwtypes.ListNestedObjectValueOf[authorizerConfigurationModel]          `tfsdk:"authorizer_configuration"`
+	AuthorizerType               fwtypes.StringEnum[awstypes.AuthorizerType]                            `tfsdk:"authorizer_type"`
+	CustomTransformConfiguration fwtypes.ListNestedObjectValueOf[customTransformConfigurationModel]     `tfsdk:"custom_transform_configuration"`
+	Description                  types.String                                                           `tfsdk:"description"`
+	ExceptionLevel               fwtypes.StringEnum[awstypes.ExceptionLevel]                            `tfsdk:"exception_level"`
+	GatewayARN                   types.String                                                           `tfsdk:"gateway_arn"`
+	GatewayID                    types.String                                                           `tfsdk:"gateway_id"`
+	GatewayURL                   types.String                                                           `tfsdk:"gateway_url"`
+	InterceptorConfigurations    fwtypes.ListNestedObjectValueOf[gatewayInterceptorConfigurationModel]  `tfsdk:"interceptor_configuration"`
+	KMSKeyARN                    fwtypes.ARN                                                            `tfsdk:"kms_key_arn"`
+	Name                         types.String                                                           `tfsdk:"name"`
+	PolicyEngineConfiguration    fwtypes.ListNestedObjectValueOf[gatewayPolicyEngineConfigurationModel] `tfsdk:"policy_engine_configuration"`
+	ProtocolConfiguration        fwtypes.ListNestedObjectValueOf[gatewayProtocolConfigurationModel]     `tfsdk:"protocol_configuration"`
+	ProtocolType                 fwtypes.StringEnum[awstypes.GatewayProtocolType]                       `tfsdk:"protocol_type"`
+	RoleARN                      fwtypes.ARN                                                            `tfsdk:"role_arn"`
+	Tags                         tftags.Map                                                             `tfsdk:"tags"`
+	TagsAll                      tftags.Map                                                             `tfsdk:"tags_all"`
+	Timeouts                     timeouts.Value                                                         `tfsdk:"timeouts"`
+	WorkloadIdentityDetails      fwtypes.ListNestedObjectValueOf[workloadIdentityDetailsModel]          `tfsdk:"workload_identity_details"`
 }
 
 type gatewayPolicyEngineConfigurationModel struct {
@@ -741,5 +797,13 @@ func (m interceptorConfigurationModel) Expand(ctx context.Context) (any, diag.Di
 }
 
 type lambdaInterceptorConfigurationModel struct {
+	ARN fwtypes.ARN `tfsdk:"arn"`
+}
+
+type customTransformConfigurationModel struct {
+	Lambda fwtypes.ListNestedObjectValueOf[lambdaTransformConfigurationModel] `tfsdk:"lambda"`
+}
+
+type lambdaTransformConfigurationModel struct {
 	ARN fwtypes.ARN `tfsdk:"arn"`
 }

--- a/internal/service/bedrockagentcore/gateway.go
+++ b/internal/service/bedrockagentcore/gateway.go
@@ -371,12 +371,16 @@ func (r *gatewayResource) Create(ctx context.Context, request resource.CreateReq
 		updateInput.GatewayIdentifier = aws.String(gatewayID)
 
 		if _, err := conn.UpdateGateway(ctx, &updateInput); err != nil {
+			// The gateway was created but the follow-up update failed; taint so it is tracked and can be cleaned up.
+			response.State.SetAttribute(ctx, path.Root("gateway_id"), gatewayID)
 			smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, gatewayID)
 			return
 		}
 
 		gateway, err = waitGatewayUpdated(ctx, conn, gatewayID, r.CreateTimeout(ctx, data.Timeouts))
 		if err != nil {
+			// The gateway was created but the follow-up update failed; taint so it is tracked and can be cleaned up.
+			response.State.SetAttribute(ctx, path.Root("gateway_id"), gatewayID)
 			smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, gatewayID)
 			return
 		}

--- a/internal/service/bedrockagentcore/gateway_test.go
+++ b/internal/service/bedrockagentcore/gateway_test.go
@@ -1029,6 +1029,64 @@ func testAccPreCheckGateways(ctx context.Context, t *testing.T) {
 	}
 }
 
+func TestAccBedrockAgentCoreGateway_customTransformConfiguration(t *testing.T) {
+	ctx := acctest.Context(t)
+	var gateway bedrockagentcorecontrol.GetGatewayOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_bedrockagentcore_gateway.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockAgentCoreServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckGatewayDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				// custom_transform_configuration is only accepted by UpdateGateway, so a create with it set
+				// exercises the create-then-update path.
+				Config: testAccGatewayConfig_customTransformConfiguration(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckGatewayExists(ctx, t, resourceName, &gateway),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("custom_transform_configuration"), knownvalue.ListSizeExact(1)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("custom_transform_configuration").AtSliceIndex(0).AtMapKey("lambda").AtSliceIndex(0).AtMapKey(names.AttrARN), knownvalue.NotNull()),
+				},
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, "gateway_id"),
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "gateway_id",
+				// custom_transform_configuration is not returned by GetGateway, so it cannot be recovered on import.
+				ImportStateVerifyIgnore: []string{"custom_transform_configuration"},
+			},
+			{
+				// Removing custom_transform_configuration clears it: the gateway Update is a full replacement,
+				// so an omitted block sends nil and the value is cleared with no perpetual diff.
+				Config: testAccGatewayConfig_customTransformConfigurationCleared(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckGatewayExists(ctx, t, resourceName, &gateway),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("custom_transform_configuration"), knownvalue.ListSizeExact(0)),
+				},
+			},
+		},
+	})
+}
+
 func testAccGatewayConfig_iamRole(rName string) string {
 	return fmt.Sprintf(`
 data "aws_partition" "current" {}
@@ -1455,4 +1513,61 @@ resource "aws_bedrockagentcore_policy_engine" "test" {
   name = %[2]q
 }
 `, rName, rNamePolicyEngine, mode))
+}
+
+func testAccGatewayConfig_customTransformBase(rName string) string {
+	return acctest.ConfigCompose(testAccGatewayConfig_iamRole(rName), fmt.Sprintf(`
+resource "aws_iam_role" "lambda" {
+  name = "%[1]s-lambda"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "lambda.amazonaws.com"
+      }
+    }]
+  })
+}
+
+resource "aws_lambda_function" "test" {
+  filename      = "test-fixtures/lambdatest.zip"
+  function_name = %[1]q
+  role          = aws_iam_role.lambda.arn
+  handler       = "index.handler"
+  runtime       = "python3.12"
+}
+`, rName))
+}
+
+func testAccGatewayConfig_customTransformConfiguration(rName string) string {
+	return acctest.ConfigCompose(testAccGatewayConfig_customTransformBase(rName), fmt.Sprintf(`
+resource "aws_bedrockagentcore_gateway" "test" {
+  name     = %[1]q
+  role_arn = aws_iam_role.test.arn
+
+  authorizer_type = "AWS_IAM"
+  protocol_type   = "MCP"
+
+  custom_transform_configuration {
+    lambda {
+      arn = aws_lambda_function.test.arn
+    }
+  }
+}
+`, rName))
+}
+
+func testAccGatewayConfig_customTransformConfigurationCleared(rName string) string {
+	return acctest.ConfigCompose(testAccGatewayConfig_customTransformBase(rName), fmt.Sprintf(`
+resource "aws_bedrockagentcore_gateway" "test" {
+  name     = %[1]q
+  role_arn = aws_iam_role.test.arn
+
+  authorizer_type = "AWS_IAM"
+  protocol_type   = "MCP"
+}
+`, rName))
 }

--- a/internal/service/bedrockagentcore/gateway_test.go
+++ b/internal/service/bedrockagentcore/gateway_test.go
@@ -1087,6 +1087,73 @@ func TestAccBedrockAgentCoreGateway_customTransformConfiguration(t *testing.T) {
 	})
 }
 
+func TestAccBedrockAgentCoreGateway_customTransformConfigurationAddOnUpdate(t *testing.T) {
+	ctx := acctest.Context(t)
+	var gateway bedrockagentcorecontrol.GetGatewayOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_bedrockagentcore_gateway.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID)
+			testAccPreCheckGateways(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockAgentCoreServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckGatewayDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				// Create the gateway WITHOUT custom_transform_configuration so the follow-up step
+				// exercises the pure Update add path (not the create-then-update path in Create).
+				Config: testAccGatewayConfig_customTransformConfigurationCleared(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckGatewayExists(ctx, t, resourceName, &gateway),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("custom_transform_configuration"), knownvalue.ListSizeExact(0)),
+				},
+			},
+			{
+				// Adding custom_transform_configuration drives Update: fwflex.Diff -> Expand -> UpdateGateway
+				// -> waitGatewayUpdated -> State.Set(new). The PostApplyPostRefresh empty-plan assertion
+				// proves the planned value survives the next Read (which does not flatten this write-only
+				// field) with no perpetual diff.
+				Config: testAccGatewayConfig_customTransformConfiguration(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckGatewayExists(ctx, t, resourceName, &gateway),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("custom_transform_configuration"), knownvalue.ListSizeExact(1)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("custom_transform_configuration").AtSliceIndex(0).AtMapKey("lambda").AtSliceIndex(0).AtMapKey(names.AttrARN), knownvalue.NotNull()),
+				},
+			},
+			{
+				// Re-apply the same WITH-block config to lock idempotency.
+				Config: testAccGatewayConfig_customTransformConfiguration(rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
 func testAccGatewayConfig_iamRole(rName string) string {
 	return fmt.Sprintf(`
 data "aws_partition" "current" {}

--- a/website/docs/r/bedrockagentcore_gateway.html.markdown
+++ b/website/docs/r/bedrockagentcore_gateway.html.markdown
@@ -121,6 +121,7 @@ The following arguments are required:
 The following arguments are optional:
 
 * `authorizer_configuration` - (Optional) Configuration for request authorization. Required when `authorizer_type` is set to `CUSTOM_JWT`. See [`authorizer_configuration`](#authorizer_configuration) below.
+* `custom_transform_configuration` - (Optional) Custom transformation configuration that defines how the gateway transforms requests and responses. This configuration is applied via a follow-up update immediately after the gateway is created, because the create operation does not accept it. The AgentCore API does not return this value, so it cannot be detected as drift on refresh and is not populated on import. See [`custom_transform_configuration`](#custom_transform_configuration) below.
 * `description` - (Optional) Description of the gateway.
 * `exception_level` - (Optional) Exception level for the gateway. Valid values: `DEBUG`.
 * `interceptor_configuration` - (Optional) List of interceptor configurations for the gateway. Minimum of 1, maximum of 2. See [`interceptor_configuration`](#interceptor_configuration) below.
@@ -130,6 +131,13 @@ The following arguments are optional:
 * `protocol_type` - (Optional) Protocol type for the gateway. Valid values: `MCP`. Omit this argument to create a gateway that routes traffic directly to HTTP targets such as AgentCore Runtime agents (see [`aws_bedrockagentcore_gateway_target`](bedrockagentcore_gateway_target.html.markdown) `target_configuration.http`).
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+### `custom_transform_configuration` Block
+
+The `custom_transform_configuration` block supports the following:
+
+* `lambda` - (Required) Lambda transformation configuration. The `lambda` block supports:
+    * `arn` - (Required) ARN of the Lambda function that the gateway invokes to transform requests and responses.
 
 ### `authorizer_configuration` Block
 


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

None.

### Description

Adds the `custom_transform_configuration` argument to `aws_bedrockagentcore_gateway`, exposing the Lambda-based request/response transformation configuration (`lambda.arn`) for the gateway.

`custom_transform_configuration` is accepted only by `UpdateGateway` — it is **not** a member of `CreateGateway` — so when set at create time it is applied with a follow-up `UpdateGateway` immediately after the gateway is created.

The AgentCore API does **not** return `customTransformConfiguration` in `GetGateway`. It is therefore treated as a write-only input: the configured value is preserved across `Create`, `Read`, and `Update` (which already trusts the plan). As a consequence, out-of-band changes are not detected as drift and the value is not populated on import; this is documented on the argument and the import step ignores it.

Behavior confirmed during acceptance testing against a live account:

- Create with `custom_transform_configuration` performs the create-then-update and round-trips cleanly (`terraform plan` reports no changes after apply).
- Removing the block clears the configuration via `UpdateGateway` (full replacement) with no perpetual diff.

### Relations

Relates to ongoing AgentCore update-only attribute coverage.

### References

- https://docs.aws.amazon.com/bedrock-agentcore-control/latest/APIReference/API_UpdateGateway.html
- https://docs.aws.amazon.com/bedrock-agentcore-control/latest/APIReference/API_CustomTransformConfiguration.html

### Output from Acceptance Testing

```console
% make testacc TESTS=TestAccBedrockAgentCoreGateway_customTransformConfiguration PKG=bedrockagentcore

--- PASS: TestAccBedrockAgentCoreGateway_customTransformConfiguration (66.21s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/bedrockagentcore	66.367s
```
