### PR TITLE
Correct argument names in `aws_ec2_transit_gateway_metering_policy_entry` docs

### DIFF
--- a/website/docs/r/ec2_transit_gateway_metering_policy_entry.html.markdown
+++ b/website/docs/r/ec2_transit_gateway_metering_policy_entry.html.markdown
@@ -45,11 +45,11 @@ The following arguments are required:
 
 The following arguments are optional:
 
-* `destination_attachment_resource_type` - (Optional, Forces new resource) Destination attachment resource type to match. Valid values are `vpc`, `vpn`, `direct-connect-gateway`, `connect`, `peering`, `tgw-peering`.
+* `destination_transit_gateway_attachment_type` - (Optional, Forces new resource) Destination attachment resource type to match. Valid values are `vpc`, `vpn`, `direct-connect-gateway`, `connect`, `peering`, `tgw-peering`.
 * `destination_cidr_block` - (Optional, Forces new resource) Destination CIDR block to match. If not specified, all destination CIDR blocks are matched.
 * `protocol` - (Optional, Forces new resource) Protocol number to match (e.g., `6` for TCP, `17` for UDP). If not specified, all protocols are matched.
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
-* `source_attachment_resource_type` - (Optional, Forces new resource) Source attachment resource type to match. Valid values are `vpc`, `vpn`, `direct-connect-gateway`, `connect`, `peering`, `tgw-peering`.
+* `source_transit_gateway_attachment_type` - (Optional, Forces new resource) Source attachment resource type to match. Valid values are `vpc`, `vpn`, `direct-connect-gateway`, `connect`, `peering`, `tgw-peering`.
 * `source_cidr_block` - (Optional, Forces new resource) Source CIDR block to match. If not specified, all source CIDR blocks are matched.
 
 ## Attribute Reference


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Corrects the names of two arguments in the `aws_ec2_transit_gateway_metering_policy_entry` documentation

### Relations

Closes #48829

### References

Schema references:

- [`destination_transit_gateway_attachment_type`](https://github.com/hashicorp/terraform-provider-aws/blob/c5850b3e0086e64ca3b29696c92ed081c943e7b1/internal/service/ec2/transitgateway_metering_policy_entry.go#L69)
- [`source_transit_gateway_attachment_type`](https://github.com/hashicorp/terraform-provider-aws/blob/c5850b3e0086e64ca3b29696c92ed081c943e7b1/internal/service/ec2/transitgateway_metering_policy_entry.go#L113)

### Output from Acceptance Testing

N/a, docs
