### PR TITLE
feat: add updated_at attribute to Bedrock guardrail

### DIFF
--- a/.changelog/48881.txt
+++ b/.changelog/48881.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_bedrock_guardrail: Add `updated_at` attribute
+```

--- a/internal/service/bedrock/guardrail.go
+++ b/internal/service/bedrock/guardrail.go
@@ -644,21 +644,21 @@ func (r *guardrailResource) Update(ctx context.Context, req resource.UpdateReque
 			)
 			return
 		}
+	}
 
-		guardrail, err := findGuardrailByTwoPartKey(ctx, conn, plan.GuardrailID.ValueString(), plan.Version.ValueString())
-		if err != nil {
-			resp.Diagnostics.AddError(
-				create.ProblemStandardMessage(names.Bedrock, create.ErrActionSetting, ResNameGuardrail, plan.GuardrailID.String(), err),
-				err.Error(),
-			)
-			return
-		}
+	findOut, err := findGuardrailByTwoPartKey(ctx, conn, plan.GuardrailID.ValueString(), plan.Version.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.Bedrock, create.ErrActionUpdating, ResNameGuardrail, plan.GuardrailID.String(), err),
+			err.Error(),
+		)
+		return
+	}
 
-		// Set values for unknowns.
-		resp.Diagnostics.Append(fwflex.Flatten(ctx, guardrail, &plan, r.flexOpt)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
+	// Set values for unknowns.
+	resp.Diagnostics.Append(fwflex.Flatten(ctx, findOut, &plan, r.flexOpt)...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)

--- a/internal/service/bedrock/guardrail.go
+++ b/internal/service/bedrock/guardrail.go
@@ -133,6 +133,10 @@ func (r *guardrailResource) Schema(ctx context.Context, req resource.SchemaReque
 			},
 			names.AttrTags:    tftags.TagsAttribute(),
 			names.AttrTagsAll: tftags.TagsAttributeComputedOnly(),
+			"updated_at": schema.StringAttribute{
+				CustomType: timetypes.RFC3339Type{},
+				Computed:   true,
+			},
 			names.AttrVersion: schema.StringAttribute{
 				Computed: true,
 				PlanModifiers: []planmodifier.String{
@@ -821,6 +825,7 @@ type guardrailResourceModel struct {
 	TagsAll                    tftags.Map                                                         `tfsdk:"tags_all"`
 	Timeouts                   timeouts.Value                                                     `tfsdk:"timeouts"`
 	TopicPolicy                fwtypes.ListNestedObjectValueOf[guardrailTopicPolicyConfigModel]   `tfsdk:"topic_policy_config"`
+	UpdatedAt                  timetypes.RFC3339                                                  `tfsdk:"updated_at"`
 	Version                    types.String                                                       `tfsdk:"version"`
 	WordPolicy                 fwtypes.ListNestedObjectValueOf[wordPolicyConfig]                  `tfsdk:"word_policy_config"`
 }

--- a/internal/service/bedrock/guardrail_test.go
+++ b/internal/service/bedrock/guardrail_test.go
@@ -53,6 +53,7 @@ func TestAccBedrockGuardrail_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "contextual_grounding_policy_config.0.filters_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "cross_region_config.#", "0"),
 					acctest.CheckResourceAttrRFC3339(resourceName, names.AttrCreatedAt),
+					acctest.CheckResourceAttrRFC3339(resourceName, "updated_at"),
 					resource.TestCheckNoResourceAttr(resourceName, names.AttrDescription),
 					resource.TestCheckNoResourceAttr(resourceName, names.AttrKMSKeyARN),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),

--- a/website/docs/r/bedrock_guardrail.html.markdown
+++ b/website/docs/r/bedrock_guardrail.html.markdown
@@ -216,6 +216,7 @@ This resource exports the following attributes in addition to the arguments abov
 * `guardrail_arn` - ARN of the Guardrail.
 * `guardrail_id` - ID of the Guardrail.
 * `status` - Status of the Bedrock Guardrail. One of `READY`, `FAILED`.
+* `updated_at` - Date and time that the Guardrail list was last updated.
 * `version` - Version of the Guardrail.
 
 ## Timeouts


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls implemented.

### Description

Add the attribute `updated_at´ to resource `aws_bedrock_guardrail`

### Relations

Closes #48762

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing

```console
make testacc T=TestAccBedrockGuardrail_basic K=bedrock
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     0.218s
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework 0.223s
make: Running acceptance tests on branch: 🌿 main 🌿...
TF_ACC=1 go1.26.4 test ./internal/service/bedrock/... -v -count 1 -parallel 20 -run='TestAccBedrockGuardrail_basic'  -timeout 360m -vet=off -buildvcs=false
2026/07/09 18:37:34 Creating Terraform AWS Provider (SDKv2-style)...
2026/07/09 18:37:34 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccBedrockGuardrail_basic
=== PAUSE TestAccBedrockGuardrail_basic
=== CONT  TestAccBedrockGuardrail_basic
--- PASS: TestAccBedrockGuardrail_basic (34.20s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/bedrock    34.364s```
