### PR TITLE
resource/aws_sagemaker_endpoint_configuration: Add vpc_config and explainer_config

### DIFF
--- a/.changelog/48884.txt
+++ b/.changelog/48884.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_sagemaker_endpoint_configuration: Add `vpc_config` argument
+```
+
+```release-note:enhancement
+resource/aws_sagemaker_endpoint_configuration: Add `explainer_config` argument
+```

--- a/internal/service/sagemaker/endpoint_configuration.go
+++ b/internal/service/sagemaker/endpoint_configuration.go
@@ -233,6 +233,178 @@ func resourceEndpointConfiguration() *schema.Resource {
 						},
 					},
 				},
+				"explainer_config": {
+					Type:     schema.TypeList,
+					MaxItems: 1,
+					Optional: true,
+					ForceNew: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"clarify_explainer_config": {
+								Type:     schema.TypeList,
+								Required: true,
+								MaxItems: 1,
+								ForceNew: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"enable_explanations": {
+											Type:     schema.TypeString,
+											Optional: true,
+											ForceNew: true,
+										},
+										"inference_config": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											ForceNew: true,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"content_template": {
+														Type:     schema.TypeString,
+														Optional: true,
+														ForceNew: true,
+													},
+													"feature_headers": {
+														Type:     schema.TypeList,
+														Optional: true,
+														ForceNew: true,
+														Elem: &schema.Schema{
+															Type: schema.TypeString,
+														},
+													},
+													"feature_types": {
+														Type:     schema.TypeList,
+														Optional: true,
+														ForceNew: true,
+														Elem: &schema.Schema{
+															Type:             schema.TypeString,
+															ValidateDiagFunc: enum.Validate[awstypes.ClarifyFeatureType](),
+														},
+													},
+													"features_attribute": {
+														Type:     schema.TypeString,
+														Optional: true,
+														ForceNew: true,
+													},
+													"label_attribute": {
+														Type:     schema.TypeString,
+														Optional: true,
+														ForceNew: true,
+													},
+													"label_headers": {
+														Type:     schema.TypeList,
+														Optional: true,
+														ForceNew: true,
+														Elem: &schema.Schema{
+															Type: schema.TypeString,
+														},
+													},
+													"label_index": {
+														Type:     schema.TypeInt,
+														Optional: true,
+														ForceNew: true,
+													},
+													"max_payload_in_mb": {
+														Type:     schema.TypeInt,
+														Optional: true,
+														ForceNew: true,
+													},
+													"max_record_count": {
+														Type:     schema.TypeInt,
+														Optional: true,
+														ForceNew: true,
+													},
+													"probability_attribute": {
+														Type:     schema.TypeString,
+														Optional: true,
+														ForceNew: true,
+													},
+													"probability_index": {
+														Type:     schema.TypeInt,
+														Optional: true,
+														ForceNew: true,
+													},
+												},
+											},
+										},
+										"shap_config": {
+											Type:     schema.TypeList,
+											Required: true,
+											MaxItems: 1,
+											ForceNew: true,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"number_of_samples": {
+														Type:     schema.TypeInt,
+														Optional: true,
+														ForceNew: true,
+													},
+													"seed": {
+														Type:     schema.TypeInt,
+														Optional: true,
+														ForceNew: true,
+													},
+													"shap_baseline_config": {
+														Type:     schema.TypeList,
+														Required: true,
+														MaxItems: 1,
+														ForceNew: true,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																"mime_type": {
+																	Type:     schema.TypeString,
+																	Optional: true,
+																	ForceNew: true,
+																},
+																"shap_baseline": {
+																	Type:     schema.TypeString,
+																	Optional: true,
+																	ForceNew: true,
+																},
+																"shap_baseline_uri": {
+																	Type:     schema.TypeString,
+																	Optional: true,
+																	ForceNew: true,
+																},
+															},
+														},
+													},
+													"text_config": {
+														Type:     schema.TypeList,
+														Optional: true,
+														MaxItems: 1,
+														ForceNew: true,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																"granularity": {
+																	Type:             schema.TypeString,
+																	Required:         true,
+																	ForceNew:         true,
+																	ValidateDiagFunc: enum.Validate[awstypes.ClarifyTextGranularity](),
+																},
+																"language": {
+																	Type:             schema.TypeString,
+																	Required:         true,
+																	ForceNew:         true,
+																	ValidateDiagFunc: enum.Validate[awstypes.ClarifyTextLanguage](),
+																},
+															},
+														},
+													},
+													"use_logit": {
+														Type:     schema.TypeBool,
+														Optional: true,
+														ForceNew: true,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
 				names.AttrKMSKeyARN: {
 					Type:         schema.TypeString,
 					Optional:     true,
@@ -676,6 +848,32 @@ func resourceEndpointConfiguration() *schema.Resource {
 				},
 				names.AttrTags:    tftags.TagsSchema(),
 				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				"vpc_config": {
+					Type:     schema.TypeList,
+					MaxItems: 1,
+					Optional: true,
+					ForceNew: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrSecurityGroupIDs: {
+								Type:     schema.TypeSet,
+								Required: true,
+								ForceNew: true,
+								Elem: &schema.Schema{
+									Type: schema.TypeString,
+								},
+							},
+							names.AttrSubnetIDs: {
+								Type:     schema.TypeSet,
+								Required: true,
+								ForceNew: true,
+								Elem: &schema.Schema{
+									Type: schema.TypeString,
+								},
+							},
+						},
+					},
+				},
 			}
 		},
 
@@ -771,12 +969,20 @@ func resourceEndpointConfigurationCreate(ctx context.Context, d *schema.Resource
 		input.ExecutionRoleArn = aws.String(v.(string))
 	}
 
+	if v, ok := d.GetOk("explainer_config"); ok {
+		input.ExplainerConfig = expandEndpointConfigExplainerConfig(v.([]any))
+	}
+
 	if v, ok := d.GetOk(names.AttrKMSKeyARN); ok {
 		input.KmsKeyId = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("shadow_production_variants"); ok && len(v.([]any)) > 0 {
 		input.ShadowProductionVariants = expandProductionVariants(v.([]any))
+	}
+
+	if v, ok := d.GetOk("vpc_config"); ok {
+		input.VpcConfig = expandEndpointConfigVpcConfig(v.([]any))
 	}
 
 	_, err := conn.CreateEndpointConfig(ctx, &input)
@@ -821,6 +1027,14 @@ func resourceEndpointConfigurationRead(ctx context.Context, d *schema.ResourceDa
 	}
 	if err := d.Set("shadow_production_variants", flattenProductionVariants(endpointConfig.ShadowProductionVariants)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting shadow_production_variants: %s", err)
+	}
+
+	if err := d.Set("vpc_config", flattenEndpointConfigVpcConfig(endpointConfig.VpcConfig)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting vpc_config for SageMaker AI Endpoint Configuration (%s): %s", d.Id(), err)
+	}
+
+	if err := d.Set("explainer_config", flattenEndpointConfigExplainerConfig(endpointConfig.ExplainerConfig)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting explainer_config for SageMaker AI Endpoint Configuration (%s): %s", d.Id(), err)
 	}
 
 	return diags
@@ -1510,4 +1724,377 @@ func flattenCapacityReservationConfig(apiObject *awstypes.ProductionVariantCapac
 	}
 
 	return []any{tfMap}
+}
+
+func expandEndpointConfigVpcConfig(configured []any) *awstypes.VpcConfig {
+	if len(configured) == 0 {
+		return nil
+	}
+
+	m := configured[0].(map[string]any)
+
+	c := &awstypes.VpcConfig{}
+
+	if v, ok := m[names.AttrSecurityGroupIDs].(*schema.Set); ok && v.Len() > 0 {
+		c.SecurityGroupIds = flex.ExpandStringValueSet(v)
+	}
+
+	if v, ok := m[names.AttrSubnetIDs].(*schema.Set); ok && v.Len() > 0 {
+		c.Subnets = flex.ExpandStringValueSet(v)
+	}
+
+	return c
+}
+
+func flattenEndpointConfigVpcConfig(config *awstypes.VpcConfig) []map[string]any {
+	if config == nil {
+		return []map[string]any{}
+	}
+
+	cfg := map[string]any{}
+
+	if config.SecurityGroupIds != nil {
+		cfg[names.AttrSecurityGroupIDs] = flex.FlattenStringValueSet(config.SecurityGroupIds)
+	}
+
+	if config.Subnets != nil {
+		cfg[names.AttrSubnetIDs] = flex.FlattenStringValueSet(config.Subnets)
+	}
+
+	return []map[string]any{cfg}
+}
+
+func expandEndpointConfigExplainerConfig(configured []any) *awstypes.ExplainerConfig {
+	if len(configured) == 0 {
+		return nil
+	}
+
+	m := configured[0].(map[string]any)
+
+	c := &awstypes.ExplainerConfig{}
+
+	if v, ok := m["clarify_explainer_config"].([]any); ok && len(v) > 0 {
+		c.ClarifyExplainerConfig = expandClarifyExplainerConfig(v)
+	}
+
+	return c
+}
+
+func expandClarifyExplainerConfig(configured []any) *awstypes.ClarifyExplainerConfig {
+	if len(configured) == 0 {
+		return nil
+	}
+
+	m := configured[0].(map[string]any)
+
+	c := &awstypes.ClarifyExplainerConfig{}
+
+	if v, ok := m["enable_explanations"].(string); ok && v != "" {
+		c.EnableExplanations = aws.String(v)
+	}
+
+	if v, ok := m["shap_config"].([]any); ok && len(v) > 0 {
+		c.ShapConfig = expandClarifyShapConfig(v)
+	}
+
+	if v, ok := m["inference_config"].([]any); ok && len(v) > 0 {
+		c.InferenceConfig = expandClarifyInferenceConfig(v)
+	}
+
+	return c
+}
+
+func expandClarifyShapConfig(configured []any) *awstypes.ClarifyShapConfig {
+	if len(configured) == 0 {
+		return nil
+	}
+
+	m := configured[0].(map[string]any)
+
+	c := &awstypes.ClarifyShapConfig{}
+
+	if v, ok := m["number_of_samples"].(int); ok && v > 0 {
+		c.NumberOfSamples = aws.Int32(int32(v))
+	}
+
+	if v, ok := m["seed"].(int); ok && v > 0 {
+		c.Seed = aws.Int32(int32(v))
+	}
+
+	if v, ok := m["use_logit"].(bool); ok && v {
+		c.UseLogit = aws.Bool(v)
+	}
+
+	if v, ok := m["shap_baseline_config"].([]any); ok && len(v) > 0 {
+		c.ShapBaselineConfig = expandClarifyShapBaselineConfig(v)
+	}
+
+	if v, ok := m["text_config"].([]any); ok && len(v) > 0 {
+		c.TextConfig = expandClarifyTextConfig(v)
+	}
+
+	return c
+}
+
+func expandClarifyShapBaselineConfig(configured []any) *awstypes.ClarifyShapBaselineConfig {
+	if len(configured) == 0 {
+		return nil
+	}
+
+	m := configured[0].(map[string]any)
+
+	c := &awstypes.ClarifyShapBaselineConfig{}
+
+	if v, ok := m["mime_type"].(string); ok && v != "" {
+		c.MimeType = aws.String(v)
+	}
+
+	if v, ok := m["shap_baseline"].(string); ok && v != "" {
+		c.ShapBaseline = aws.String(v)
+	}
+
+	if v, ok := m["shap_baseline_uri"].(string); ok && v != "" {
+		c.ShapBaselineUri = aws.String(v)
+	}
+
+	return c
+}
+
+func expandClarifyTextConfig(configured []any) *awstypes.ClarifyTextConfig {
+	if len(configured) == 0 {
+		return nil
+	}
+
+	m := configured[0].(map[string]any)
+
+	c := &awstypes.ClarifyTextConfig{}
+
+	if v, ok := m["granularity"].(string); ok && v != "" {
+		c.Granularity = awstypes.ClarifyTextGranularity(v)
+	}
+
+	if v, ok := m["language"].(string); ok && v != "" {
+		c.Language = awstypes.ClarifyTextLanguage(v)
+	}
+
+	return c
+}
+
+func expandClarifyInferenceConfig(configured []any) *awstypes.ClarifyInferenceConfig {
+	if len(configured) == 0 {
+		return nil
+	}
+
+	m := configured[0].(map[string]any)
+
+	c := &awstypes.ClarifyInferenceConfig{}
+
+	if v, ok := m["content_template"].(string); ok && v != "" {
+		c.ContentTemplate = aws.String(v)
+	}
+
+	if v, ok := m["feature_headers"].([]any); ok && len(v) > 0 {
+		c.FeatureHeaders = flex.ExpandStringValueList(v)
+	}
+
+	if v, ok := m["feature_types"].([]any); ok && len(v) > 0 {
+		featureTypes := make([]awstypes.ClarifyFeatureType, 0, len(v))
+		for _, val := range v {
+			featureTypes = append(featureTypes, awstypes.ClarifyFeatureType(val.(string)))
+		}
+		c.FeatureTypes = featureTypes
+	}
+
+	if v, ok := m["features_attribute"].(string); ok && v != "" {
+		c.FeaturesAttribute = aws.String(v)
+	}
+
+	if v, ok := m["label_attribute"].(string); ok && v != "" {
+		c.LabelAttribute = aws.String(v)
+	}
+
+	if v, ok := m["label_headers"].([]any); ok && len(v) > 0 {
+		c.LabelHeaders = flex.ExpandStringValueList(v)
+	}
+
+	if v, ok := m["label_index"].(int); ok && v > 0 {
+		c.LabelIndex = aws.Int32(int32(v))
+	}
+
+	if v, ok := m["max_payload_in_mb"].(int); ok && v > 0 {
+		c.MaxPayloadInMB = aws.Int32(int32(v))
+	}
+
+	if v, ok := m["max_record_count"].(int); ok && v > 0 {
+		c.MaxRecordCount = aws.Int32(int32(v))
+	}
+
+	if v, ok := m["probability_attribute"].(string); ok && v != "" {
+		c.ProbabilityAttribute = aws.String(v)
+	}
+
+	if v, ok := m["probability_index"].(int); ok && v > 0 {
+		c.ProbabilityIndex = aws.Int32(int32(v))
+	}
+
+	return c
+}
+
+func flattenEndpointConfigExplainerConfig(config *awstypes.ExplainerConfig) []map[string]any {
+	if config == nil {
+		return []map[string]any{}
+	}
+
+	cfg := map[string]any{}
+
+	if config.ClarifyExplainerConfig != nil {
+		cfg["clarify_explainer_config"] = flattenClarifyExplainerConfig(config.ClarifyExplainerConfig)
+	}
+
+	return []map[string]any{cfg}
+}
+
+func flattenClarifyExplainerConfig(config *awstypes.ClarifyExplainerConfig) []map[string]any {
+	if config == nil {
+		return []map[string]any{}
+	}
+
+	cfg := map[string]any{}
+
+	if config.EnableExplanations != nil {
+		cfg["enable_explanations"] = aws.ToString(config.EnableExplanations)
+	}
+
+	if config.ShapConfig != nil {
+		cfg["shap_config"] = flattenClarifyShapConfig(config.ShapConfig)
+	}
+
+	if config.InferenceConfig != nil {
+		cfg["inference_config"] = flattenClarifyInferenceConfig(config.InferenceConfig)
+	}
+
+	return []map[string]any{cfg}
+}
+
+func flattenClarifyShapConfig(config *awstypes.ClarifyShapConfig) []map[string]any {
+	if config == nil {
+		return []map[string]any{}
+	}
+
+	cfg := map[string]any{}
+
+	if config.NumberOfSamples != nil {
+		cfg["number_of_samples"] = aws.ToInt32(config.NumberOfSamples)
+	}
+
+	if config.Seed != nil {
+		cfg["seed"] = aws.ToInt32(config.Seed)
+	}
+
+	if config.UseLogit != nil {
+		cfg["use_logit"] = aws.ToBool(config.UseLogit)
+	}
+
+	if config.ShapBaselineConfig != nil {
+		cfg["shap_baseline_config"] = flattenClarifyShapBaselineConfig(config.ShapBaselineConfig)
+	}
+
+	if config.TextConfig != nil {
+		cfg["text_config"] = flattenClarifyTextConfig(config.TextConfig)
+	}
+
+	return []map[string]any{cfg}
+}
+
+func flattenClarifyShapBaselineConfig(config *awstypes.ClarifyShapBaselineConfig) []map[string]any {
+	if config == nil {
+		return []map[string]any{}
+	}
+
+	cfg := map[string]any{}
+
+	if config.MimeType != nil {
+		cfg["mime_type"] = aws.ToString(config.MimeType)
+	}
+
+	if config.ShapBaseline != nil {
+		cfg["shap_baseline"] = aws.ToString(config.ShapBaseline)
+	}
+
+	if config.ShapBaselineUri != nil {
+		cfg["shap_baseline_uri"] = aws.ToString(config.ShapBaselineUri)
+	}
+
+	return []map[string]any{cfg}
+}
+
+func flattenClarifyTextConfig(config *awstypes.ClarifyTextConfig) []map[string]any {
+	if config == nil {
+		return []map[string]any{}
+	}
+
+	cfg := map[string]any{
+		"granularity": string(config.Granularity),
+		"language":    string(config.Language),
+	}
+
+	return []map[string]any{cfg}
+}
+
+func flattenClarifyInferenceConfig(config *awstypes.ClarifyInferenceConfig) []map[string]any {
+	if config == nil {
+		return []map[string]any{}
+	}
+
+	cfg := map[string]any{}
+
+	if config.ContentTemplate != nil {
+		cfg["content_template"] = aws.ToString(config.ContentTemplate)
+	}
+
+	if config.FeatureHeaders != nil {
+		cfg["feature_headers"] = flex.FlattenStringValueList(config.FeatureHeaders)
+	}
+
+	if config.FeatureTypes != nil {
+		featureTypes := make([]string, 0, len(config.FeatureTypes))
+		for _, v := range config.FeatureTypes {
+			featureTypes = append(featureTypes, string(v))
+		}
+		cfg["feature_types"] = featureTypes
+	}
+
+	if config.FeaturesAttribute != nil {
+		cfg["features_attribute"] = aws.ToString(config.FeaturesAttribute)
+	}
+
+	if config.LabelAttribute != nil {
+		cfg["label_attribute"] = aws.ToString(config.LabelAttribute)
+	}
+
+	if config.LabelHeaders != nil {
+		cfg["label_headers"] = flex.FlattenStringValueList(config.LabelHeaders)
+	}
+
+	if config.LabelIndex != nil {
+		cfg["label_index"] = aws.ToInt32(config.LabelIndex)
+	}
+
+	if config.MaxPayloadInMB != nil {
+		cfg["max_payload_in_mb"] = aws.ToInt32(config.MaxPayloadInMB)
+	}
+
+	if config.MaxRecordCount != nil {
+		cfg["max_record_count"] = aws.ToInt32(config.MaxRecordCount)
+	}
+
+	if config.ProbabilityAttribute != nil {
+		cfg["probability_attribute"] = aws.ToString(config.ProbabilityAttribute)
+	}
+
+	if config.ProbabilityIndex != nil {
+		cfg["probability_index"] = aws.ToInt32(config.ProbabilityIndex)
+	}
+
+	return []map[string]any{cfg}
 }

--- a/internal/service/sagemaker/endpoint_configuration_test.go
+++ b/internal/service/sagemaker/endpoint_configuration_test.go
@@ -1981,3 +1981,165 @@ resource "aws_sagemaker_endpoint_configuration" "test" {
 }
 `, rName)
 }
+
+func TestAccSageMakerEndpointConfiguration_vpcConfig(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_sagemaker_endpoint_configuration.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SageMakerServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEndpointConfigurationDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEndpointConfigurationConfig_vpcConfig(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckEndpointConfigurationExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "vpc_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "vpc_config.0.security_group_ids.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "vpc_config.0.subnet_ids.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccSageMakerEndpointConfiguration_explainerConfig(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_sagemaker_endpoint_configuration.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SageMakerServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEndpointConfigurationDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEndpointConfigurationConfig_explainerConfig(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckEndpointConfigurationExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "explainer_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "explainer_config.0.clarify_explainer_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "explainer_config.0.clarify_explainer_config.0.shap_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "explainer_config.0.clarify_explainer_config.0.shap_config.0.shap_baseline_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "explainer_config.0.clarify_explainer_config.0.shap_config.0.shap_baseline_config.0.shap_baseline", `"1","2","3","4","5"`),
+					resource.TestCheckResourceAttr(resourceName, "explainer_config.0.clarify_explainer_config.0.shap_config.0.shap_baseline_config.0.mime_type", "text/csv"),
+					resource.TestCheckResourceAttr(resourceName, "explainer_config.0.clarify_explainer_config.0.shap_config.0.number_of_samples", "100"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccEndpointConfigurationConfig_vpcConfig(rName string) string {
+	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_subnet" "test" {
+  vpc_id     = aws_vpc.test.id
+  cidr_block = "10.0.1.0/24"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_security_group" "test" {
+  name   = %[1]q
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_iam_role" "test" {
+  name = %[1]q
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "sagemaker.amazonaws.com"
+        }
+      },
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "test" {
+  role       = aws_iam_role.test.name
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonSageMakerFullAccess"
+}
+
+resource "aws_sagemaker_endpoint_configuration" "test" {
+  name               = %[1]q
+  execution_role_arn = aws_iam_role.test.arn
+
+  production_variants {
+    variant_name           = "variant-1"
+    initial_instance_count = 1
+    instance_type          = "ml.g5.xlarge"
+  }
+
+  vpc_config {
+    security_group_ids = [aws_security_group.test.id]
+    subnet_ids         = [aws_subnet.test.id]
+  }
+
+  depends_on = [aws_iam_role_policy_attachment.test]
+}
+`, rName)
+}
+
+func testAccEndpointConfigurationConfig_explainerConfig(rName string) string {
+	return acctest.ConfigCompose(testAccEndpointConfigurationConfig_base(rName), fmt.Sprintf(`
+resource "aws_sagemaker_endpoint_configuration" "test" {
+  name = %[1]q
+
+  production_variants {
+    variant_name           = "variant-1"
+    model_name             = aws_sagemaker_model.test.name
+    initial_instance_count = 1
+    instance_type          = "ml.t2.medium"
+    initial_variant_weight = 1
+  }
+
+  explainer_config {
+    clarify_explainer_config {
+      shap_config {
+        shap_baseline_config {
+          shap_baseline = "\"1\",\"2\",\"3\",\"4\",\"5\""
+          mime_type     = "text/csv"
+        }
+
+        number_of_samples = 100
+      }
+    }
+  }
+}
+`, rName))
+}

--- a/website/docs/r/sagemaker_endpoint_configuration.html.markdown
+++ b/website/docs/r/sagemaker_endpoint_configuration.html.markdown
@@ -38,6 +38,7 @@ This resource supports the following arguments:
 * `async_inference_config` - (Optional) How an endpoint performs asynchronous inference.
 * `data_capture_config` - (Optional) Parameters to capture input/output of SageMaker AI models endpoints. Fields are documented below.
 * `execution_role_arn` - (Optional) ARN of an IAM role that SageMaker AI can assume to perform actions on your behalf. Required when `model_name` is not specified in `production_variants` to support Inference Components.
+* `explainer_config` - (Optional) Configuration for Clarify real-time explainability. [See below](#explainer_config).
 * `kms_key_arn` - (Optional) ARN of a AWS KMS key that SageMaker AI uses to encrypt data on the storage volume attached to the ML compute instance that hosts the endpoint.
 * `name_prefix` - (Optional) Unique endpoint configuration name beginning with the specified prefix. Conflicts with `name`.
 * `name` - (Optional) Name of the endpoint configuration. If omitted, Terraform will assign a random, unique name. Conflicts with `name_prefix`.
@@ -45,6 +46,7 @@ This resource supports the following arguments:
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `shadow_production_variants` - (Optional) Models that you want to host at this endpoint in shadow mode with production traffic replicated from the model specified on `production_variants`. If you use this field, you can only specify one variant for `production_variants` and one variant for `shadow_production_variants`. [See below](#production_variants) (same arguments as `production_variants`).
 * `tags` - (Optional) Mapping of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+* `vpc_config` - (Optional) VPC configuration for the endpoint. Cannot be used when `model_name` is specified in `production_variants`. [See below](#vpc_config).
 
 ### production_variants
 
@@ -130,6 +132,54 @@ This resource supports the following arguments:
 * `error_topic` - (Optional) SNS topic to post a notification to when inference fails. If no topic is provided, no notification is sent on failure.
 * `include_inference_response_in` - (Optional) SNS topics where you want the inference response to be included. Valid values are `SUCCESS_NOTIFICATION_TOPIC` and `ERROR_NOTIFICATION_TOPIC`.
 * `success_topic` - (Optional) SNS topic to post a notification to when inference completes successfully. If no topic is provided, no notification is sent on success.
+
+### explainer_config
+
+* `clarify_explainer_config` - (Required) Configuration for Clarify explainer. [See below](#clarify_explainer_config).
+
+#### clarify_explainer_config
+
+* `enable_explanations` - (Optional) A JMESPath boolean expression used to filter which records to explain. Refer to the [SageMaker AI documentation](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-online-explainability-create-endpoint.html#clarify-online-explainability-create-endpoint-enable) for more information.
+* `inference_config` - (Optional) The inference configuration parameter for the model container. [See below](#inference_config).
+* `shap_config` - (Required) The SHAP baseline configuration. [See below](#shap_config).
+
+#### shap_config
+
+* `number_of_samples` - (Optional) The number of samples to be used for analysis by the Kernal SHAP algorithm.
+* `seed` - (Optional) The starting value used to initialize the random number generator in the explainer.
+* `shap_baseline_config` - (Required) The configuration for the SHAP baseline. [See below](#shap_baseline_config).
+* `text_config` - (Optional) Configuration for text explainability. [See below](#text_config).
+* `use_logit` - (Optional) A Boolean toggle to indicate if you want to use the logit function (true) or log-odds units (false).
+
+##### shap_baseline_config
+
+* `mime_type` - (Optional) The MIME type of the baseline data. Choose from `text/csv` or `application/jsonlines`.
+* `shap_baseline` - (Optional) The inline SHAP baseline data in string format.
+* `shap_baseline_uri` - (Optional) The S3 URI where the SHAP baseline file is stored.
+
+##### text_config
+
+* `granularity` - (Required) The unit of granularity for the analysis of text features. Valid values are `token`, `sentence`, and `paragraph`.
+* `language` - (Required) The language of the text features. Valid values include language codes such as `en`, `fr`, `de`, `es`, etc.
+
+#### inference_config
+
+* `content_template` - (Optional) A template string used to format a JSON record into an acceptable model container input.
+* `feature_headers` - (Optional) The names of the features.
+* `feature_types` - (Optional) A list of data types of the features. Valid values are `numerical`, `categorical`, and `text`.
+* `features_attribute` - (Optional) Provides the JMESPath expression to extract the features from a model container input in JSON Lines format.
+* `label_attribute` - (Optional) Provides the JMESPath expression to extract the label from a model container output in JSON Lines format.
+* `label_headers` - (Optional) The names of the label classes.
+* `label_index` - (Optional) Zero-based index used to extract a label header from the model container output in CSV format.
+* `max_payload_in_mb` - (Optional) The maximum payload size (MB) allowed of a request from the explainer to the model container.
+* `max_record_count` - (Optional) The maximum number of records in a request that the model container can process when querying the model container for the predictions of a synthetic dataset.
+* `probability_attribute` - (Optional) Provides the JMESPath expression to extract the probability (or score) from the model container output if the model container is in JSON Lines format.
+* `probability_index` - (Optional) Zero-based index used to extract a probability value (score) from the model container output in CSV format.
+
+### vpc_config
+
+* `security_group_ids` - (Required) Set of security group IDs.
+* `subnet_ids` - (Required) Set of subnet IDs.
 
 ## Attribute Reference
 


### PR DESCRIPTION
Community Note

- Please vote on this PR by adding a 👍 reaction to the original PR to help the community and maintainers prioritize this request.
- Please do not leave "+1" or "me too" comments, they generate extra noise for PR reviewers.

### Description

Adds two new top-level arguments to `aws_sagemaker_endpoint_configuration`:

- **`vpc_config`**: Specifies an Amazon VPC that SageMaker AI hosted models and compute resources have access to. Contains `security_group_ids` and `subnet_ids`. Can only be used with Inference Components endpoints (no `model_name`).

- **`explainer_config`**: Enables SageMaker Clarify real-time explainability on the endpoint. Supports:
  - `clarify_explainer_config` with `shap_config` (baseline config, text config, `number_of_samples`, `seed`, `use_logit`)
  - `inference_config` (feature headers/types, label attributes, content template, probability attributes)
  - `enable_explanations`

Both fields are supported by the AWS API ([CreateEndpointConfig](https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_CreateEndpointConfig.html)) but were not yet exposed in the Terraform provider.

Closes #48740

### PR Checklist

- [x] Acceptance test coverage for new behavior
- [x] Documentation update in `website/docs/r/`
- [x] Changelog entry in `.changelog/`
- [x] No dependency updates

### New/Affected Resource(s)

- `aws_sagemaker_endpoint_configuration`

### Acceptance test output

```
--- PASS: TestAccSageMakerEndpointConfiguration_vpcConfig (40.82s)
--- PASS: TestAccSageMakerEndpointConfiguration_explainerConfig (35.24s)
```

Full test suite for `TestAccSageMakerEndpointConfiguration_*`: 29/31 pass. The 2 failures (`managedInstanceScaling` tests) are pre-existing on `main` — caused by an undocumented API constraint (`ManagedInstanceScaling is only supported for inference component endpoints`) added after those tests were merged. They are fixed separately in #48767.