### PR TITLE
storagegateway: allow cache_stale_timeout_in_seconds = 0

### DIFF
--- a/.changelog/48885.txt
+++ b/.changelog/48885.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_storagegateway_smb_file_share: Fix `cache_attributes.cache_stale_timeout_in_seconds` to allow `0`
+```
+
+```release-note:bug
+resource/aws_storagegateway_nfs_file_share: Fix `cache_attributes.cache_stale_timeout_in_seconds` to allow `0`
+```

--- a/internal/service/storagegateway/nfs_file_share.go
+++ b/internal/service/storagegateway/nfs_file_share.go
@@ -73,9 +73,13 @@ func resourceNFSFileShare() *schema.Resource {
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{
 							"cache_stale_timeout_in_seconds": {
-								Type:         schema.TypeInt,
-								Optional:     true,
-								ValidateFunc: validation.IntBetween(300, 2592000),
+								Type:     schema.TypeInt,
+								Optional: true,
+								Default:  0,
+								ValidateFunc: validation.Any(
+									validation.IntInSlice([]int{0}),
+									validation.IntBetween(300, 2592000),
+								),
 							},
 						},
 					},

--- a/internal/service/storagegateway/smb_file_share.go
+++ b/internal/service/storagegateway/smb_file_share.go
@@ -89,9 +89,13 @@ func resourceSMBFileShare() *schema.Resource {
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{
 							"cache_stale_timeout_in_seconds": {
-								Type:         schema.TypeInt,
-								Optional:     true,
-								ValidateFunc: validation.IntBetween(300, 2592000),
+								Type:     schema.TypeInt,
+								Optional: true,
+								Default:  0,
+								ValidateFunc: validation.Any(
+									validation.IntInSlice([]int{0}),
+									validation.IntBetween(300, 2592000),
+								),
 							},
 						},
 					},
@@ -585,7 +589,7 @@ func expandCacheAttributes(tfMap map[string]any) *awstypes.CacheAttributes {
 
 	apiObject := &awstypes.CacheAttributes{}
 
-	if v, ok := tfMap["cache_stale_timeout_in_seconds"].(int); ok && v != 0 {
+	if v, ok := tfMap["cache_stale_timeout_in_seconds"].(int); ok {
 		apiObject.CacheStaleTimeoutInSeconds = aws.Int32(int32(v))
 	}
 

--- a/internal/service/storagegateway/smb_file_share_test.go
+++ b/internal/service/storagegateway/smb_file_share_test.go
@@ -831,6 +831,17 @@ func TestAccStorageGatewaySMBFileShare_cacheAttributes(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "cache_attributes.0.cache_stale_timeout_in_seconds", "300"),
 				),
 			},
+			{
+				// 0 is a valid API value meaning "cache refresh disabled" -- regression test
+				// for a bug where 0 was rejected by ValidateFunc and, separately, silently
+				// dropped by expandCacheAttributes so it never reached the API.
+				Config: testAccSMBFileShareConfig_cacheAttributes(rName, 0),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSMBFileShareExists(ctx, t, resourceName, &smbFileShare),
+					resource.TestCheckResourceAttr(resourceName, "cache_attributes.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "cache_attributes.0.cache_stale_timeout_in_seconds", "0"),
+				),
+			},
 		},
 	})
 }

--- a/website/docs/r/storagegateway_nfs_file_share.html.markdown
+++ b/website/docs/r/storagegateway_nfs_file_share.html.markdown
@@ -60,7 +60,7 @@ Files and folders stored as Amazon S3 objects in S3 buckets don't, by default, h
 
 * `cache_stale_timeout_in_seconds` - (Optional) Refreshes a file share's cache by using Time To Live (TTL).
  TTL is the length of time since the last refresh after which access to the directory would cause the file gateway
-  to first refresh that directory's contents from the Amazon S3 bucket. Valid Values: 300 to 2,592,000 seconds (5 minutes to 30 days)
+  to first refresh that directory's contents from the Amazon S3 bucket. Valid Values: `0` or `300` to `2592000` seconds (5 minutes to 30 days). Defaults to `0`
 
 ## Attribute Reference
 

--- a/website/docs/r/storagegateway_smb_file_share.html.markdown
+++ b/website/docs/r/storagegateway_smb_file_share.html.markdown
@@ -77,7 +77,7 @@ The `cache_attributes` configuration block supports the following arguments:
 
 * `cache_stale_timeout_in_seconds` - (Optional) Refreshes a file share's cache by using Time To Live (TTL).
  TTL is the length of time since the last refresh after which access to the directory would cause the file gateway
-  to first refresh that directory's contents from the Amazon S3 bucket. Valid Values: 300 to 2,592,000 seconds (5 minutes to 30 days)
+  to first refresh that directory's contents from the Amazon S3 bucket. Valid Values: `0` or `300` to `2592000` seconds (5 minutes to 30 days). Defaults to `0`
 
 ## Attribute Reference
 


### PR DESCRIPTION
## Description

The AWS Storage Gateway API documents `cache_stale_timeout_in_seconds` as accepting `0` (meaning "cache refresh disabled") or `300`-`2592000`, but `aws_storagegateway_smb_file_share` validated it as `IntBetween(300, 2592000)`, rejecting `0` at plan time. Separately, `expandCacheAttributes` explicitly skipped forwarding the value when it was `0`, so even past validation the API would never actually receive it.

- Widen `ValidateFunc` to accept `0` via `validation.Any(...)`, matching the pattern already used for this exact field on `aws_storagegateway_file_system_association`.
- Remove the `v != 0` guard in `expandCacheAttributes` so an explicit `0` reaches the API instead of being silently dropped.
- Apply the same validation fix to `aws_storagegateway_nfs_file_share`, which has the identical bug (its expand function already forwarded `0` unconditionally, so only the validation needed fixing there).
- Add an acceptance test step setting the value to `0` and update both resources' docs to state the valid range includes `0`.

Fixes #48876

## Relations

Closes #48876

## References

- AWS Storage Gateway API docs: cache_stale_timeout_in_seconds accepts `0` or `300`-`2,592,000`

## Output from Acceptance Testing

Acceptance tests require live AWS credentials which I don't have configured in this environment; `go build`, `gofmt`, and `go vet` all pass clean on the changed packages. The new test step (`TestAccStorageGatewaySMBFileShare_cacheAttributes`) follows the existing test's exact structure and should be run by CI/maintainers with AWS credentials.