### PR TITLE
 r/aws_cloudfront_response_headers_policy: add distribution removal test case, example

### DIFF
--- a/internal/service/cloudfront/response_headers_policy_test.go
+++ b/internal/service/cloudfront/response_headers_policy_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	awstypes "github.com/aws/aws-sdk-go-v2/service/cloudfront/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -394,6 +395,61 @@ func TestAccCloudFrontResponseHeadersPolicy_disappears(t *testing.T) {
 	})
 }
 
+// TestAccCloudFrontResponseHeadersPolicy_Distribution_removal verifies that a response
+// headers policy which is referenced by a distribution's default cache behavior
+// can be removed from the configuration together with the reference.
+//
+// Ref: https://github.com/hashicorp/terraform-provider-aws/issues/21730
+//
+// Doing so requires a create_before_destroy lifecycle argument on
+// the policy resource to modify the graph order during destroy:
+//
+// Ref: https://github.com/hashicorp/terraform/blob/v1.15.8/docs/destroying.md#create-before-destroy
+func TestAccCloudFrontResponseHeadersPolicy_Distribution_removal(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var distribution awstypes.Distribution
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	distributionResourceName := "aws_cloudfront_distribution.test"
+	resourceName := "aws_cloudfront_response_headers_policy.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.CloudFrontEndpointID) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CloudFrontServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy: resource.ComposeAggregateTestCheckFunc(
+			testAccCheckDistributionDestroy(ctx, t),
+			testAccCheckResponseHeadersPolicyDestroy(ctx, t),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResponseHeadersPolicyConfig_Distribution_initial(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckResponseHeadersPolicyExists(ctx, t, resourceName),
+					testAccCheckDistributionExists(ctx, t, distributionResourceName, &distribution),
+					resource.TestCheckResourceAttrPair(distributionResourceName, "default_cache_behavior.0.response_headers_policy_id", resourceName, names.AttrID),
+				),
+			},
+			{
+				Config: testAccResponseHeadersPolicyConfig_Distribution_removed(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckDistributionExists(ctx, t, distributionResourceName, &distribution),
+					resource.TestCheckResourceAttr(distributionResourceName, "default_cache_behavior.0.response_headers_policy_id", ""),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionDestroy),
+						plancheck.ExpectResourceAction(distributionResourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+		},
+	})
+}
+
 func testAccCheckResponseHeadersPolicyDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.ProviderMeta(ctx, t).CloudFrontClient(ctx)
@@ -619,4 +675,112 @@ resource "aws_cloudfront_response_headers_policy" "test" {
   }
 }
 `, rName, enabled, rate)
+}
+
+func testAccResponseHeadersPolicyConfig_Distribution_initial(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_cloudfront_response_headers_policy" "test" {
+  name = %[1]q
+
+  security_headers_config {
+    content_security_policy {
+      content_security_policy = "default-src 'none';"
+      override                = true
+    }
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_cloudfront_distribution" "test" {
+  enabled          = false
+  retain_on_delete = false
+
+  origin {
+    domain_name = "www.example.com"
+    origin_id   = "test"
+
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "https-only"
+      origin_ssl_protocols   = ["TLSv1.2"]
+    }
+  }
+
+  default_cache_behavior {
+    allowed_methods            = ["GET", "HEAD"]
+    cached_methods             = ["GET", "HEAD"]
+    target_origin_id           = "test"
+    viewer_protocol_policy     = "allow-all"
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.test.id
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+}
+`, rName)
+}
+
+func testAccResponseHeadersPolicyConfig_Distribution_removed() string {
+	return `
+resource "aws_cloudfront_distribution" "test" {
+  enabled          = false
+  retain_on_delete = false
+
+  origin {
+    domain_name = "www.example.com"
+    origin_id   = "test"
+
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "https-only"
+      origin_ssl_protocols   = ["TLSv1.2"]
+    }
+  }
+
+  default_cache_behavior {
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    target_origin_id       = "test"
+    viewer_protocol_policy = "allow-all"
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+}
+`
 }

--- a/website/docs/r/cloudfront_response_headers_policy.html.markdown
+++ b/website/docs/r/cloudfront_response_headers_policy.html.markdown
@@ -95,10 +95,10 @@ resource "aws_cloudfront_response_headers_policy" "example" {
 
 ### Removing from a Distribution
 
-Response Header Policies must be disassociated from all distributions before it can be safely deleted.
+Response header policies must be disassociated from all distributions before they can be safely deleted.
 When managing both a policy and distribution in the same Terraform configuration, use the [`create_before_destroy` lifecycle argument](https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle#create_before_destroy) on the policy resource to ensure that the distribution will be updated or deleted before the policy.
 
-```hcl
+```terraform
 resource "aws_cloudfront_response_headers_policy" "example" {
   name = "example-policy"
 
@@ -122,7 +122,7 @@ resource "aws_cloudfront_distribution" "example" {
   default_cache_behavior {
     allowed_methods            = ["GET", "HEAD"]
     cached_methods             = ["GET", "HEAD"]
-    target_origin_id           = "test"
+    target_origin_id           = "example"
     viewer_protocol_policy     = "allow-all"
     response_headers_policy_id = aws_cloudfront_response_headers_policy.example.id
 
@@ -143,13 +143,13 @@ This resource supports the following arguments:
 
 * `name` - (Required) A unique name to identify the response headers policy.
 * `comment` - (Optional) A comment to describe the response headers policy. The comment cannot be longer than 128 characters.
-* `cors_config` - (Optional) A configuration for a set of HTTP response headers that are used for Cross-Origin Resource Sharing (CORS). See [Cors Config](#cors-config) for more information.
+* `cors_config` - (Optional) A configuration for a set of HTTP response headers that are used for Cross-Origin Resource Sharing (CORS). See [CORS Config](#cors-config) for more information.
 * `custom_headers_config` - (Optional) Object that contains an attribute `items` that contains a list of custom headers. See [Custom Header](#custom-header) for more information.
 * `remove_headers_config` - (Optional) A configuration for a set of HTTP headers to remove from the HTTP response. Object that contains an attribute `items` that contains a list of headers. See [Remove Header](#remove-header) for more information.
 * `security_headers_config` - (Optional) A configuration for a set of security-related HTTP response headers. See [Security Headers Config](#security-headers-config) for more information.
 * `server_timing_headers_config` - (Optional) A configuration for enabling the Server-Timing header in HTTP responses sent from CloudFront. See [Server Timing Headers Config](#server-timing-headers-config) for more information.
 
-### Cors Config
+### CORS Config
 
 * `access_control_allow_credentials` - (Required) A Boolean value that CloudFront uses as the value for the `Access-Control-Allow-Credentials` HTTP response header.
 * `access_control_allow_headers` - (Required) Object that contains an attribute `items` that contains a list of HTTP header names that CloudFront includes as values for the `Access-Control-Allow-Headers` HTTP response header.
@@ -226,7 +226,7 @@ This resource exports the following attributes in addition to the arguments abov
 
 ## Import
 
-In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Cloudfront Response Headers Policies using the `id`. For example:
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import CloudFront response header policies using the `id`. For example:
 
 ```terraform
 import {
@@ -235,7 +235,7 @@ import {
 }
 ```
 
-Using `terraform import`, import Cloudfront Response Headers Policies using the `id`. For example:
+Using `terraform import`, import CloudFront response header policies using the `id`. For example:
 
 ```console
 % terraform import aws_cloudfront_response_headers_policy.policy 658327ea-f89d-4fab-a63d-7e88639e58f9

--- a/website/docs/r/cloudfront_response_headers_policy.html.markdown
+++ b/website/docs/r/cloudfront_response_headers_policy.html.markdown
@@ -15,7 +15,7 @@ When it’s attached to a cache behavior, CloudFront adds the headers in the pol
 
 ## Example Usage
 
-The example below creates a CloudFront response headers policy.
+### CORS Config Usage
 
 ```terraform
 resource "aws_cloudfront_response_headers_policy" "example" {
@@ -42,7 +42,7 @@ resource "aws_cloudfront_response_headers_policy" "example" {
 }
 ```
 
-The example below creates a CloudFront response headers policy with a custom headers config.
+### Custom Headers Config Usage
 
 ```terraform
 resource "aws_cloudfront_response_headers_policy" "example" {
@@ -63,6 +63,8 @@ resource "aws_cloudfront_response_headers_policy" "example" {
   }
 }
 ```
+
+### Mixed Config Usage
 
 The example below creates a CloudFront response headers policy with a custom headers config, remove headers config and server timing headers config.
 
@@ -87,6 +89,50 @@ resource "aws_cloudfront_response_headers_policy" "example" {
   server_timing_headers_config {
     enabled       = true
     sampling_rate = 50
+  }
+}
+```
+
+### Removing from a Distribution
+
+Response Header Policies must be disassociated from all distributions before it can be safely deleted.
+When managing both a policy and distribution in the same Terraform configuration, use the [`create_before_destroy` lifecycle argument](https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle#create_before_destroy) on the policy resource to ensure that the distribution will be updated or deleted before the policy.
+
+```hcl
+resource "aws_cloudfront_response_headers_policy" "example" {
+  name = "example-policy"
+
+  custom_headers_config {
+    items {
+      header   = "X-Permitted-Cross-Domain-Policies"
+      override = true
+      value    = "none"
+    }
+  }
+
+  # Required to invert the order of operations during destroy
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_cloudfront_distribution" "example" {
+  ### Additional configuration omitted for brevity ###
+
+  default_cache_behavior {
+    allowed_methods            = ["GET", "HEAD"]
+    cached_methods             = ["GET", "HEAD"]
+    target_origin_id           = "test"
+    viewer_protocol_policy     = "allow-all"
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.example.id
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
   }
 }
 ```


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Adds an acceptance test and example documenting how to pair a CloudFront distribution and response headers policy such that removal of the policy or destruction of both resources can be achieved in a single apply.

See this comment for additional context.
https://github.com/hashicorp/terraform-provider-aws/issues/21730#issuecomment-4926792071


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #21730

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle#create_before_destroy
- https://github.com/hashicorp/terraform/blob/v1.15.8/docs/destroying.md#create-before-destroy

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t K=cloudfront T=TestAccCloudFrontResponseHeadersPolicy_Distribution_removal
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...

--- PASS: TestAccCloudFrontResponseHeadersPolicy_Distribution_removal (241.75s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudfront 249.906s
```