### PR TITLE
fix/aws_bedrockagentcore: enforce exactly-one-of in JWT authorizer claim_match_value

### DIFF
--- a/.changelog/48889.txt
+++ b/.changelog/48889.txt
@@ -1,0 +1,15 @@
+```release-note:bug
+resource/aws_bedrockagentcore_agent_runtime: Enforce that exactly one of `match_value_string` or `match_value_string_list` is set in the `authorizer_configuration.custom_jwt_authorizer.custom_claim.authorizing_claim_match_value.claim_match_value` block at plan time
+```
+
+```release-note:bug
+resource/aws_bedrockagentcore_gateway: Enforce that exactly one of `match_value_string` or `match_value_string_list` is set in the `authorizer_configuration.custom_jwt_authorizer.custom_claim.authorizing_claim_match_value.claim_match_value` block at plan time
+```
+
+```release-note:bug
+resource/aws_bedrockagentcore_harness: Enforce that exactly one of `match_value_string` or `match_value_string_list` is set in the `authorizer_configuration.custom_jwt_authorizer.custom_claim.authorizing_claim_match_value.claim_match_value` block at plan time
+```
+
+```release-note:bug
+resource/aws_bedrockagentcore_registry: Enforce that exactly one of `match_value_string` or `match_value_string_list` is set in the `authorizer_configuration.custom_jwt_authorizer.custom_claim.authorizing_claim_match_value.claim_match_value` block at plan time
+```

--- a/internal/service/bedrockagentcore/agent_runtime.go
+++ b/internal/service/bedrockagentcore/agent_runtime.go
@@ -18,8 +18,8 @@ import (
 	awstypes "github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol/types"
 	"github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
-	"github.com/hashicorp/terraform-plugin-framework-validators/objectvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -31,6 +31,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
@@ -366,10 +367,7 @@ func authorizerConfigurationSchema(ctx context.Context) schema.ListNestedBlock {
 														},
 														NestedObject: schema.NestedBlockObject{
 															Validators: []validator.Object{
-																objectvalidator.ExactlyOneOf(
-																	path.MatchRelative().AtName("match_value_string"),
-																	path.MatchRelative().AtName("match_value_string_list"),
-																),
+																claimMatchValueExactlyOneOf(),
 															},
 															Attributes: map[string]schema.Attribute{
 																"match_value_string": schema.StringAttribute{
@@ -1113,6 +1111,51 @@ var (
 	_ fwflex.Expander  = customJWTAuthorizerClaimMatchValueModel{}
 	_ fwflex.Flattener = &customJWTAuthorizerClaimMatchValueModel{}
 )
+
+var _ validator.Object = claimMatchValueExactlyOneOfValidator{}
+
+// claimMatchValueExactlyOneOf enforces that exactly one of match_value_string or
+// match_value_string_list is set within a claim_match_value block. That block is
+// nested inside a set of custom_claim blocks, where a path-expression validator
+// (objectvalidator/stringvalidator ExactlyOneOf) cannot resolve sibling attributes
+// across the set-element boundary, so the constraint is checked on the object
+// value directly.
+func claimMatchValueExactlyOneOf() validator.Object {
+	return claimMatchValueExactlyOneOfValidator{}
+}
+
+type claimMatchValueExactlyOneOfValidator struct{}
+
+func (v claimMatchValueExactlyOneOfValidator) Description(_ context.Context) string {
+	return "exactly one of match_value_string or match_value_string_list must be set"
+}
+
+func (v claimMatchValueExactlyOneOfValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (v claimMatchValueExactlyOneOfValidator) ValidateObject(ctx context.Context, req validator.ObjectRequest, resp *validator.ObjectResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	var config customJWTAuthorizerClaimMatchValueModel
+	resp.Diagnostics.Append(req.ConfigValue.As(ctx, &config, basetypes.ObjectAsOptions{})...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if config.MatchValueString.IsUnknown() || config.MatchValueStringList.IsUnknown() {
+		return
+	}
+
+	if config.MatchValueString.IsNull() == config.MatchValueStringList.IsNull() {
+		resp.Diagnostics.Append(validatordiag.InvalidAttributeCombinationDiagnostic(
+			req.Path,
+			"exactly one of `match_value_string` or `match_value_string_list` must be set",
+		))
+	}
+}
 
 func (m *customJWTAuthorizerClaimMatchValueModel) Flatten(ctx context.Context, v any) diag.Diagnostics {
 	var diags diag.Diagnostics

--- a/internal/service/bedrockagentcore/gateway_test.go
+++ b/internal/service/bedrockagentcore/gateway_test.go
@@ -904,6 +904,38 @@ func TestAccBedrockAgentCoreGateway_customJWTAuthorizerCustomClaim(t *testing.T)
 	})
 }
 
+func TestAccBedrockAgentCoreGateway_customJWTAuthorizerClaimMatchValueExactlyOneOf(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID)
+			testAccPreCheckGateways(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockAgentCoreServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckGatewayDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				// Regression: claim_match_value requires exactly one of
+				// match_value_string / match_value_string_list. The block is nested
+				// inside a set of custom_claim blocks, where a path-expression
+				// validator silently no-ops, so both-set must still be rejected at
+				// plan time.
+				Config:      testAccGatewayConfig_customJWTAuthorizerClaimMatchValueBoth(rName),
+				ExpectError: regexache.MustCompile(`Exactly one of`),
+			},
+			{
+				// Neither set must also be rejected at plan time.
+				Config:      testAccGatewayConfig_customJWTAuthorizerClaimMatchValueNeither(rName),
+				ExpectError: regexache.MustCompile(`Exactly one of`),
+			},
+		},
+	})
+}
+
 func TestAccBedrockAgentCoreGateway_policyEngineConfiguration(t *testing.T) {
 	ctx := acctest.Context(t)
 	var gateway bedrockagentcorecontrol.GetGatewayOutput
@@ -1381,6 +1413,62 @@ resource "aws_bedrockagentcore_gateway" "test" {
   protocol_type = "MCP"
 }
 `, rName, discoveryUrl, audience1, audience2, client1, client2, scope1, scope2, inboundTokenClaimValueType, claimMatchOperator))
+}
+
+func testAccGatewayConfig_customJWTAuthorizerClaimMatchValueBoth(rName string) string {
+	return acctest.ConfigCompose(testAccGatewayConfig_iamRole(rName), fmt.Sprintf(`
+resource "aws_bedrockagentcore_gateway" "test" {
+  name     = %[1]q
+  role_arn = aws_iam_role.test.arn
+
+  authorizer_type = "CUSTOM_JWT"
+  authorizer_configuration {
+    custom_jwt_authorizer {
+      discovery_url = "https://accounts.google.com/.well-known/openid-configuration"
+      custom_claim {
+        inbound_token_claim_name       = "cognito:groups"
+        inbound_token_claim_value_type = "STRING"
+        authorizing_claim_match_value {
+          claim_match_operator = "EQUALS"
+          claim_match_value {
+            match_value_string      = "admin"
+            match_value_string_list = ["admin"]
+          }
+        }
+      }
+    }
+  }
+
+  protocol_type = "MCP"
+}
+`, rName))
+}
+
+func testAccGatewayConfig_customJWTAuthorizerClaimMatchValueNeither(rName string) string {
+	return acctest.ConfigCompose(testAccGatewayConfig_iamRole(rName), fmt.Sprintf(`
+resource "aws_bedrockagentcore_gateway" "test" {
+  name     = %[1]q
+  role_arn = aws_iam_role.test.arn
+
+  authorizer_type = "CUSTOM_JWT"
+  authorizer_configuration {
+    custom_jwt_authorizer {
+      discovery_url = "https://accounts.google.com/.well-known/openid-configuration"
+      custom_claim {
+        inbound_token_claim_name       = "cognito:groups"
+        inbound_token_claim_value_type = "STRING"
+        authorizing_claim_match_value {
+          claim_match_operator = "EQUALS"
+          claim_match_value {
+          }
+        }
+      }
+    }
+  }
+
+  protocol_type = "MCP"
+}
+`, rName))
 }
 
 func testAccGatewayConfig_customJWTAuthorizerCustomClaimStringList(rName, discoveryUrl, audience1, audience2, client1, client2, scope1, scope2 string) string {


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

### Description

The shared `custom_jwt_authorizer` `claim_match_value` block requires exactly one of `match_value_string` or `match_value_string_list`, enforced by an `objectvalidator.ExactlyOneOf` on the `NestedBlockObject`. That validator is a **no-op**: the block is nested inside a *set* of `custom_claim` blocks, and framework path-expression validators cannot resolve sibling attributes across the set-element boundary — the set-element path step (`ExpressionStepElementKeyValueExact`) captures a concrete `attr.Value` that never compares `Equal` to the value reconstructed during `PathMatches`'s walk, so the sibling is never counted. The count reduces to "is the attribute the validator is attached to set?", which means **both-set and neither-set both pass `terraform validate`**, and the constraint is only enforced by the service at apply time.

This replaces the path-expression validator with a bespoke `validator.Object` that reads the block value directly (`req.ConfigValue.As(...)`) and checks the two fields — the same approach `internal/service/s3/bucket_lifecycle_configuration.go` uses for an identical set-nested constraint. The fix lives on the shared authorizer schema, so it applies to all four resources that use it: `aws_bedrockagentcore_agent_runtime`, `aws_bedrockagentcore_gateway`, `aws_bedrockagentcore_harness`, and `aws_bedrockagentcore_registry`.

### Relations

Relates #47602

### References

N/A

### Output from Acceptance Testing

Verified offline with `terraform validate` via dev_overrides (both-set → reject, neither-set → reject, string-only → pass, list-only → pass) and with an acceptance test:

```console
% make testacc TESTS=TestAccBedrockAgentCoreGateway_customJWTAuthorizerClaimMatchValueExactlyOneOf PKG=bedrockagentcore

--- PASS: TestAccBedrockAgentCoreGateway_customJWTAuthorizerClaimMatchValueExactlyOneOf (3.41s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/bedrockagentcore
```
