### PR TITLE
🤖🤖🤖 resource/aws_cognito_user_pool_domain: Add security_policy argument

### DIFF
--- a/.changelog/PENDING.txt
+++ b/.changelog/PENDING.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_cognito_user_pool_domain: Add `security_policy` argument
+```

--- a/internal/service/cognitoidp/user_pool_domain.go
+++ b/internal/service/cognitoidp/user_pool_domain.go
@@ -78,6 +78,12 @@ func resourceUserPoolDomain() *schema.Resource {
 					Type:     schema.TypeString,
 					Computed: true,
 				},
+				"security_policy": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					Computed:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.SecurityPolicyType](),
+				},
 				names.AttrUserPoolID: {
 					Type:     schema.TypeString,
 					Required: true,
@@ -111,6 +117,9 @@ func resourceUserPoolDomainCreate(ctx context.Context, d *schema.ResourceData, m
 	if v, ok := d.GetOk(names.AttrCertificateARN); ok {
 		input.CustomDomainConfig = &awstypes.CustomDomainConfigType{
 			CertificateArn: aws.String(v.(string)),
+		}
+		if v, ok := d.GetOk("security_policy"); ok {
+			input.CustomDomainConfig.SecurityPolicy = awstypes.SecurityPolicyType(v.(string))
 		}
 		timeout = 60 * time.Minute // Custom domains take more time to become active.
 	}
@@ -152,8 +161,10 @@ func resourceUserPoolDomainRead(ctx context.Context, d *schema.ResourceData, met
 
 	d.Set(names.AttrAWSAccountID, desc.AWSAccountId)
 	d.Set(names.AttrCertificateARN, "")
+	d.Set("security_policy", "")
 	if desc.CustomDomainConfig != nil {
 		d.Set(names.AttrCertificateARN, desc.CustomDomainConfig.CertificateArn)
+		d.Set("security_policy", string(desc.CustomDomainConfig.SecurityPolicy))
 	}
 	d.Set("cloudfront_distribution", desc.CloudFrontDistribution)
 	d.Set("cloudfront_distribution_arn", desc.CloudFrontDistribution)
@@ -177,21 +188,28 @@ func resourceUserPoolDomainUpdate(ctx context.Context, d *schema.ResourceData, m
 		UserPoolId: aws.String(d.Get(names.AttrUserPoolID).(string)),
 	}
 
-	if d.HasChange(names.AttrCertificateARN) {
-		timeout = 60 * time.Minute // Certificate ARN updates on custom domains take more time to become active.
+	if d.HasChanges(names.AttrCertificateARN, "security_policy") {
+		timeout = 60 * time.Minute // Updates on custom domains take more time to become active.
 		input.CustomDomainConfig = &awstypes.CustomDomainConfigType{
 			CertificateArn: aws.String(d.Get(names.AttrCertificateARN).(string)),
+		}
+		if v, ok := d.GetOk("security_policy"); ok {
+			input.CustomDomainConfig.SecurityPolicy = awstypes.SecurityPolicyType(v.(string))
 		}
 	}
 
 	if d.HasChange("managed_login_version") {
 		input.ManagedLoginVersion = aws.Int32(int32(d.Get("managed_login_version").(int)))
 
-		if v, ok := d.GetOk(names.AttrCertificateARN); ok {
+		if v, ok := d.GetOk(names.AttrCertificateARN); ok && input.CustomDomainConfig == nil {
 			// If there is a certificate use it as part of the request, this is how AWS distinguishes between custom and prefix domains.
 			timeout = 60 * time.Minute // Custom domains take more time to become active.
 			input.CustomDomainConfig = &awstypes.CustomDomainConfigType{
 				CertificateArn: aws.String(v.(string)),
+			}
+			if sv, ok := d.GetOk("security_policy"); ok {
+				// Include the current security_policy so a managed_login_version-only update doesn't clear it.
+				input.CustomDomainConfig.SecurityPolicy = awstypes.SecurityPolicyType(sv.(string))
 			}
 		}
 	}

--- a/internal/service/cognitoidp/user_pool_domain_test.go
+++ b/internal/service/cognitoidp/user_pool_domain_test.go
@@ -224,6 +224,40 @@ func TestAccCognitoIDPUserPoolDomain_customCustomDomainManagedLoginVersionUpdate
 	})
 }
 
+func TestAccCognitoIDPUserPoolDomain_customCustomDomainSecurityPolicy(t *testing.T) {
+	ctx := acctest.Context(t)
+	rootDomain := acctest.ACMCertificateDomainFromEnv(t)
+	domain := acctest.ACMCertificateRandomSubDomain(rootDomain)
+	poolName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	acmCertResourceName := "aws_acm_certificate.test"
+	cognitoPoolResourceName := "aws_cognito_user_pool_domain.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckRegion(t, endpoints.UsEast1RegionID) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CognitoIDPServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckUserPoolDomainDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserPoolDomainConfig_customCustomDomainSecurityPolicy(rootDomain, domain, poolName, "TLS_V1_2_2021"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckUserPoolDomainExists(ctx, t, cognitoPoolResourceName),
+					resource.TestCheckResourceAttr(cognitoPoolResourceName, "security_policy", "TLS_V1_2_2021"),
+					resource.TestCheckResourceAttrPair(cognitoPoolResourceName, names.AttrCertificateARN, acmCertResourceName, names.AttrARN),
+				),
+			},
+			{
+				Config: testAccUserPoolDomainConfig_customCustomDomainSecurityPolicy(rootDomain, domain, poolName, "TLS_V1_3_2025"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckUserPoolDomainCertMatches(ctx, t, cognitoPoolResourceName, acmCertResourceName),
+					resource.TestCheckResourceAttr(cognitoPoolResourceName, "security_policy", "TLS_V1_3_2025"),
+					resource.TestCheckResourceAttrPair(cognitoPoolResourceName, names.AttrCertificateARN, acmCertResourceName, names.AttrARN),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckUserPoolDomainExists(ctx context.Context, t *testing.T, n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -457,4 +491,44 @@ resource "aws_cognito_user_pool_domain" "test" {
   managed_login_version = %[4]d
 }
 `, rootDomain, domain, poolName, version)
+}
+
+func testAccUserPoolDomainConfig_customCustomDomainSecurityPolicy(rootDomain, domain, poolName, securityPolicy string) string {
+	return fmt.Sprintf(`
+data "aws_route53_zone" "test" {
+  name         = %[1]q
+  private_zone = false
+}
+
+resource "aws_acm_certificate" "test" {
+  domain_name       = %[2]q
+  validation_method = "DNS"
+}
+
+resource "aws_route53_record" "test" {
+  allow_overwrite = true
+  name            = tolist(aws_acm_certificate.test.domain_validation_options)[0].resource_record_name
+  records         = [tolist(aws_acm_certificate.test.domain_validation_options)[0].resource_record_value]
+  ttl             = 60
+  type            = tolist(aws_acm_certificate.test.domain_validation_options)[0].resource_record_type
+  zone_id         = data.aws_route53_zone.test.zone_id
+}
+
+resource "aws_acm_certificate_validation" "test" {
+  certificate_arn         = aws_acm_certificate.test.arn
+  validation_record_fqdns = [aws_route53_record.test.fqdn]
+}
+
+resource "aws_cognito_user_pool" "test" {
+  name = %[3]q
+}
+
+resource "aws_cognito_user_pool_domain" "test" {
+  certificate_arn = aws_acm_certificate_validation.test.certificate_arn
+  domain          = aws_acm_certificate.test.domain_name
+  user_pool_id    = aws_cognito_user_pool.test.id
+
+  security_policy = %[4]q
+}
+`, rootDomain, domain, poolName, securityPolicy)
 }

--- a/website/docs/r/cognito_user_pool_domain.html.markdown
+++ b/website/docs/r/cognito_user_pool_domain.html.markdown
@@ -64,6 +64,7 @@ This resource supports the following arguments:
 * `user_pool_id` - (Required) The user pool ID.
 * `certificate_arn` - (Optional) The ARN of an ISSUED ACM certificate in us-east-1 for a custom domain.
 * `managed_login_version` - (Optional) A version number that indicates the state of managed login for your domain. Valid values: `1` for hosted UI (classic), `2` for the newer managed login with the branding designer.
+* `security_policy` - (Optional) Minimum TLS version served by the custom domain's CloudFront distribution. Only applies to custom domains (`certificate_arn` set). Valid values: `TLS_V1` (TLS 1.0+, broadest compatibility), `TLS_V1_2_2021` (TLS 1.2+, recommended), `TLS_V1_3_2025` (TLS 1.3+, strongest posture). Defaults to `TLS_V1` server-side when not set.
 
 ## Attribute Reference
 


### PR DESCRIPTION
### Description

Adds `security_policy` argument to `aws_cognito_user_pool_domain`, exposing `SecurityPolicy` on `CustomDomainConfig` shipped in `aws-sdk-go-v2` [`cognitoidentityprovider` v1.62.0 (2026-06-18)](https://github.com/aws/aws-sdk-go-v2/blob/main/service/cognitoidentityprovider/CHANGELOG.md#v1620-2026-06-18). Valid values: `TLS_V1`, `TLS_V1_2_2021`, `TLS_V1_3_2025`. Applies to custom domains only (no-op for prefix domains).

Closes #48731.

### Output from Acceptance Testing

New acceptance test `TestAccCognitoIDPUserPoolDomain_customCustomDomainSecurityPolicy` was not run locally (requires `ACM_CERTIFICATE_ROOT_DOMAIN` + a Route 53 hosted zone, ~60m custom-domain propagation). Behavior was validated out-of-band against a live Cognito custom domain via `aws cognito-idp update-user-pool-domain --custom-domain-config CertificateArn=<arn>,SecurityPolicy=TLS_V1_2_2021`; post-update `sslscan` confirmed TLS 1.0/1.1 removed. Deferring the acctest itself to maintainer CI.

Local:

```
$ make lint
...
0 issues across all 5 golangci configs + providerlint + import-lint.

$ make test-unit
...
PASS
```

### AI Usage

Claude Code drafted the schema attribute, CRUD wiring, acceptance test scaffold (mirrored from `_customCustomDomainManagedLoginVersionUpdate`), docs, and changelog entry. Each diff was reviewed before commit. Providerlint `R005` flagged the initial `HasChange || HasChange` idiom; corrected to `HasChanges(...)` in the version submitted here.
