### PR TITLE
resource/aws_sagemaker_inference_component: new resource

### DIFF
--- a/.changelog/48894.txt
+++ b/.changelog/48894.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_sagemaker_inference_component
+```

--- a/internal/service/sagemaker/exports_test.go
+++ b/internal/service/sagemaker/exports_test.go
@@ -71,6 +71,7 @@ var (
 	ResourceImage                                  = resourceImage
 	ResourceLabelingJob                            = newLabelingJobResource
 	ResourceImageVersion                           = resourceImageVersion
+	ResourceInferenceComponent                     = resourceInferenceComponent
 	ResourceMlflowApp                              = newMlflowAppResource
 	ResourceMlflowTrackingServer                   = resourceMlflowTrackingServer
 	ResourceModel                                  = resourceModel
@@ -107,6 +108,7 @@ var (
 	FindHumanTaskUIByName                     = findHumanTaskUIByName
 	FindImageByName                           = findImageByName
 	FindImageVersionByTwoPartKey              = findImageVersionByTwoPartKey
+	FindInferenceComponentByName              = findInferenceComponentByName
 	FindLabelingJobByName                     = findLabelingJobByName
 	FindMlflowAppByARN                        = findMlflowAppByARN
 	FindMlflowTrackingServerByName            = findMlflowTrackingServerByName

--- a/internal/service/sagemaker/inference_component.go
+++ b/internal/service/sagemaker/inference_component.go
@@ -1,0 +1,1187 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package sagemaker
+
+import (
+	"context"
+	"errors"
+	"log"
+	"time"
+
+	"github.com/YakDriver/regexache"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sagemaker"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/sagemaker/types"
+	"github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+const (
+	// Default create/update/delete timeouts. These are only the fallback values for the
+	// resource's user-overridable timeouts block, not fixed limits.
+	inferenceComponentInServiceDefaultTimeout = 30 * time.Minute
+	inferenceComponentDeletedDefaultTimeout   = 30 * time.Minute
+)
+
+// @SDKResource("aws_sagemaker_inference_component", name="Inference Component")
+// @Tags(identifierAttribute="arn")
+func resourceInferenceComponent() *schema.Resource {
+	return &schema.Resource{
+		CreateWithoutTimeout: resourceInferenceComponentCreate,
+		ReadWithoutTimeout:   resourceInferenceComponentRead,
+		UpdateWithoutTimeout: resourceInferenceComponentUpdate,
+		DeleteWithoutTimeout: resourceInferenceComponentDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(inferenceComponentInServiceDefaultTimeout),
+			Update: schema.DefaultTimeout(inferenceComponentInServiceDefaultTimeout),
+			Delete: schema.DefaultTimeout(inferenceComponentDeletedDefaultTimeout),
+		},
+
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrCreationTime: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"endpoint_arn": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"failure_reason": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"last_modified_time": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"deployment_config": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"auto_rollback_configuration": {
+								Type:     schema.TypeList,
+								Optional: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"alarms": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 10,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"alarm_name": {
+														Type:     schema.TypeString,
+														Required: true,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							"rolling_update_policy": {
+								Type:     schema.TypeList,
+								Required: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"maximum_batch_size": {
+											Type:     schema.TypeList,
+											Required: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													names.AttrType: {
+														Type:             schema.TypeString,
+														Required:         true,
+														ValidateDiagFunc: enum.Validate[awstypes.InferenceComponentCapacitySizeType](),
+													},
+													names.AttrValue: {
+														Type:         schema.TypeInt,
+														Required:     true,
+														ValidateFunc: validation.IntAtLeast(1),
+													},
+												},
+											},
+										},
+										"maximum_execution_timeout_in_seconds": {
+											Type:         schema.TypeInt,
+											Optional:     true,
+											ValidateFunc: validation.IntBetween(600, 28800),
+										},
+										"rollback_maximum_batch_size": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													names.AttrType: {
+														Type:             schema.TypeString,
+														Required:         true,
+														ValidateDiagFunc: enum.Validate[awstypes.InferenceComponentCapacitySizeType](),
+													},
+													names.AttrValue: {
+														Type:         schema.TypeInt,
+														Required:     true,
+														ValidateFunc: validation.IntAtLeast(1),
+													},
+												},
+											},
+										},
+										"wait_interval_in_seconds": {
+											Type:         schema.TypeInt,
+											Required:     true,
+											ValidateFunc: validation.IntBetween(0, 3600),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				"endpoint_name": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validName,
+				},
+				names.AttrName: {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validName,
+				},
+				"runtime_config": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Computed: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"copy_count": {
+								Type:         schema.TypeInt,
+								Required:     true,
+								ValidateFunc: validation.IntAtLeast(0),
+							},
+							"current_copy_count": {
+								Type:     schema.TypeInt,
+								Computed: true,
+							},
+							"desired_copy_count": {
+								Type:     schema.TypeInt,
+								Computed: true,
+							},
+							"placement_status": {
+								Type:     schema.TypeList,
+								Computed: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"current_copy_count": {
+											Type:     schema.TypeInt,
+											Computed: true,
+										},
+										names.AttrInstanceType: {
+											Type:     schema.TypeString,
+											Computed: true,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				"specification": {
+					Type:         schema.TypeList,
+					Optional:     true,
+					MaxItems:     1,
+					ExactlyOneOf: []string{"specification", "specifications"},
+					Elem: &schema.Resource{
+						Schema: inferenceComponentSpecificationSchema(),
+					},
+				},
+				"specifications": {
+					Type:         schema.TypeList,
+					Optional:     true,
+					MinItems:     2,
+					ExactlyOneOf: []string{"specification", "specifications"},
+					Elem: &schema.Resource{
+						Schema: inferenceComponentSpecificationSchema(),
+					},
+				},
+				names.AttrStatus: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				names.AttrTags:    tftags.TagsSchema(),
+				names.AttrTagsAll: tftags.TagsSchemaComputed(),
+				// variant_name is conditionally required: the CreateInferenceComponent API
+				// rejects a null value for a standard inference component but forbids it for
+				// an adapter component (one that sets base_inference_component_name), which
+				// instead inherits — and echoes back on read — the base component's variant.
+				// It is therefore Optional (requirement enforced server-side) and Computed
+				// (absorbs the inherited value so the adapter case does not force replacement).
+				"variant_name": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Computed:     true,
+					ForceNew:     true,
+					ValidateFunc: validName,
+				},
+			}
+		},
+	}
+}
+
+func inferenceComponentSpecificationSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"base_inference_component_name": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		// An adapter inference component (one that sets base_inference_component_name)
+		// omits this block and inherits the base component's compute resources, which the
+		// API then echoes back on read. Computed absorbs those inherited values so the
+		// adapter case does not produce a perpetual diff.
+		"compute_resource_requirements": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Computed: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"max_memory_required_in_mb": {
+						Type:         schema.TypeInt,
+						Optional:     true,
+						ValidateFunc: validation.IntAtLeast(128),
+					},
+					"min_memory_required_in_mb": {
+						Type:         schema.TypeInt,
+						Required:     true,
+						ValidateFunc: validation.IntAtLeast(128),
+					},
+					"number_of_accelerator_devices_required": {
+						Type:         schema.TypeFloat,
+						Optional:     true,
+						ValidateFunc: validation.FloatAtLeast(1),
+					},
+					"number_of_cpu_cores_required": {
+						Type:         schema.TypeFloat,
+						Optional:     true,
+						ValidateFunc: validation.FloatAtLeast(0.25),
+					},
+				},
+			},
+		},
+		"container": {
+			Type:     schema.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"artifact_url": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+					"container_metrics_config": {
+						Type:     schema.TypeList,
+						Optional: true,
+						MaxItems: 1,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"metrics_endpoint": {
+									Type:     schema.TypeList,
+									Optional: true,
+									MaxItems: 1,
+									Elem: &schema.Resource{
+										Schema: map[string]*schema.Schema{
+											"metric_publish_frequency_in_seconds": {
+												Type:         schema.TypeInt,
+												Optional:     true,
+												Default:      60,
+												ValidateFunc: validation.IntInSlice([]int{10, 30, 60, 120, 180, 240, 300}),
+											},
+											"metrics_endpoint_path": {
+												Type:     schema.TypeString,
+												Required: true,
+												ValidateFunc: validation.All(
+													validation.StringLenBetween(1, 256),
+													validation.StringMatch(regexache.MustCompile(`^/`), "must start with '/'"),
+												),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					names.AttrEnvironment: {
+						Type:     schema.TypeMap,
+						Optional: true,
+						Elem:     &schema.Schema{Type: schema.TypeString},
+					},
+					"image": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+					"resolved_image": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+				},
+			},
+		},
+		// The service may return a data_cache_config (e.g. caching enabled by default on
+		// accelerator instances) even when the block is omitted, so it is Computed to
+		// absorb that server-populated value without producing a perpetual diff.
+		"data_cache_config": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Computed: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"enable_caching": {
+						Type:     schema.TypeBool,
+						Required: true,
+					},
+				},
+			},
+		},
+		names.AttrInstanceType: {
+			Type:             schema.TypeString,
+			Optional:         true,
+			ValidateDiagFunc: enum.Validate[awstypes.ProductionVariantInstanceType](),
+		},
+		"model_name": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"scheduling_config": {
+			Type:     schema.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"availability_zone_balance": {
+						Type:     schema.TypeList,
+						Optional: true,
+						MaxItems: 1,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"enforcement_mode": {
+									Type:             schema.TypeString,
+									Required:         true,
+									ValidateDiagFunc: enum.Validate[awstypes.AvailabilityZoneBalanceEnforcementMode](),
+								},
+								"max_imbalance": {
+									Type:     schema.TypeInt,
+									Optional: true,
+								},
+							},
+						},
+					},
+					"placement_strategy": {
+						Type:             schema.TypeString,
+						Required:         true,
+						ValidateDiagFunc: enum.Validate[awstypes.InferenceComponentPlacementStrategy](),
+					},
+				},
+			},
+		},
+		"startup_parameters": {
+			Type:     schema.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"container_startup_health_check_timeout_in_seconds": {
+						Type:         schema.TypeInt,
+						Optional:     true,
+						ValidateFunc: validation.IntBetween(60, 3600),
+					},
+					"model_data_download_timeout_in_seconds": {
+						Type:         schema.TypeInt,
+						Optional:     true,
+						ValidateFunc: validation.IntBetween(60, 3600),
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceInferenceComponentCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).SageMakerClient(ctx)
+
+	name := d.Get(names.AttrName).(string)
+	input := &sagemaker.CreateInferenceComponentInput{
+		InferenceComponentName: aws.String(name),
+		EndpointName:           aws.String(d.Get("endpoint_name").(string)),
+		Tags:                   getTagsIn(ctx),
+	}
+
+	if v, ok := d.GetOk("variant_name"); ok {
+		input.VariantName = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("runtime_config"); ok && len(v.([]any)) > 0 {
+		input.RuntimeConfig = expandInferenceComponentRuntimeConfig(v.([]any))
+	}
+
+	if v, ok := d.GetOk("specification"); ok && len(v.([]any)) > 0 {
+		input.Specification = expandInferenceComponentSpecification(v.([]any)[0].(map[string]any))
+	}
+
+	if v, ok := d.GetOk("specifications"); ok && len(v.([]any)) > 0 {
+		input.Specifications = expandInferenceComponentSpecifications(v.([]any))
+	}
+
+	_, err := conn.CreateInferenceComponent(ctx, input)
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "creating SageMaker Inference Component (%s): %s", name, err)
+	}
+
+	d.SetId(name)
+
+	if err := waitInferenceComponentInService(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "waiting for SageMaker Inference Component (%s) to be in service: %s", d.Id(), err)
+	}
+
+	return append(diags, resourceInferenceComponentRead(ctx, d, meta)...)
+}
+
+func resourceInferenceComponentRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).SageMakerClient(ctx)
+
+	output, err := findInferenceComponentByName(ctx, conn, d.Id())
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] SageMaker Inference Component (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return diags
+	}
+
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "reading SageMaker Inference Component (%s): %s", d.Id(), err)
+	}
+
+	d.Set(names.AttrARN, output.InferenceComponentArn)
+	d.Set(names.AttrName, output.InferenceComponentName)
+	d.Set("endpoint_arn", output.EndpointArn)
+	d.Set("endpoint_name", output.EndpointName)
+	d.Set("variant_name", output.VariantName)
+	d.Set(names.AttrStatus, string(output.InferenceComponentStatus))
+	d.Set("failure_reason", output.FailureReason)
+
+	if output.CreationTime != nil {
+		d.Set(names.AttrCreationTime, aws.ToTime(output.CreationTime).Format(time.RFC3339))
+	}
+
+	if output.LastModifiedTime != nil {
+		d.Set("last_modified_time", aws.ToTime(output.LastModifiedTime).Format(time.RFC3339))
+	}
+
+	if err := d.Set("runtime_config", flattenInferenceComponentRuntimeConfigSummary(output.RuntimeConfig)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting runtime_config: %s", err)
+	}
+
+	if output.Specification != nil {
+		if err := d.Set("specification", []any{flattenInferenceComponentSpecificationSummary(output.Specification)}); err != nil {
+			return sdkdiag.AppendErrorf(diags, "setting specification: %s", err)
+		}
+		d.Set("specifications", nil)
+	} else if output.Specifications != nil {
+		d.Set("specification", nil)
+		if err := d.Set("specifications", flattenInferenceComponentSpecificationSummaries(output.Specifications)); err != nil {
+			return sdkdiag.AppendErrorf(diags, "setting specifications: %s", err)
+		}
+	} else {
+		d.Set("specification", nil)
+		d.Set("specifications", nil)
+	}
+
+	// deployment_config is an update-only rollout directive: the CreateInferenceComponent
+	// API does not accept it, and DescribeInferenceComponent only reports it via
+	// LastDeploymentConfig after an update has occurred. To avoid perpetual diffs on
+	// resources that were never updated, we preserve the configured value in state rather
+	// than refreshing it from the API.
+
+	return diags
+}
+
+func resourceInferenceComponentUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).SageMakerClient(ctx)
+
+	if d.HasChangesExcept(names.AttrTags, names.AttrTagsAll) {
+		input := &sagemaker.UpdateInferenceComponentInput{
+			InferenceComponentName: aws.String(d.Id()),
+		}
+
+		// UpdateInferenceComponent requires RuntimeConfig or a Specification; it rejects a
+		// request carrying only the name or only a DeploymentConfig. Track whether one of
+		// the required fields is populated so we skip a no-op/invalid API call (e.g. when
+		// the sole change is clearing an optional block).
+		var hasSpecOrRuntime bool
+
+		if d.HasChange("runtime_config") {
+			if v, ok := d.GetOk("runtime_config"); ok && len(v.([]any)) > 0 {
+				input.RuntimeConfig = expandInferenceComponentRuntimeConfig(v.([]any))
+				hasSpecOrRuntime = true
+			}
+		}
+
+		if d.HasChange("specification") {
+			if v, ok := d.GetOk("specification"); ok && len(v.([]any)) > 0 {
+				input.Specification = expandInferenceComponentSpecification(v.([]any)[0].(map[string]any))
+				hasSpecOrRuntime = true
+			}
+		}
+
+		if d.HasChange("specifications") {
+			if v, ok := d.GetOk("specifications"); ok && len(v.([]any)) > 0 {
+				input.Specifications = expandInferenceComponentSpecifications(v.([]any))
+				hasSpecOrRuntime = true
+			}
+		}
+
+		// deployment_config only governs how a spec/runtime change rolls out, so it is
+		// attached to the request but never triggers one on its own.
+		if d.HasChange("deployment_config") {
+			if v, ok := d.GetOk("deployment_config"); ok && len(v.([]any)) > 0 {
+				input.DeploymentConfig = expandInferenceComponentDeploymentConfig(v.([]any))
+			}
+		}
+
+		if hasSpecOrRuntime {
+			_, err := conn.UpdateInferenceComponent(ctx, input)
+			if err != nil {
+				return sdkdiag.AppendErrorf(diags, "updating SageMaker Inference Component (%s): %s", d.Id(), err)
+			}
+
+			if err := waitInferenceComponentInService(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
+				return sdkdiag.AppendErrorf(diags, "waiting for SageMaker Inference Component (%s) to be in service: %s", d.Id(), err)
+			}
+		}
+	}
+
+	return append(diags, resourceInferenceComponentRead(ctx, d, meta)...)
+}
+
+func resourceInferenceComponentDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).SageMakerClient(ctx)
+
+	log.Printf("[INFO] Deleting SageMaker Inference Component: %s", d.Id())
+	// A delete may be rejected with a transient conflict: the component still has an
+	// adapter component attached and being torn down ("is a base inference component
+	// for one or more associated"), or it is mid-transition (Creating/Updating). Retry
+	// only those cases. A component already in DELETE_IN_PROGRESS is treated as success
+	// below rather than retried, since the delete has effectively been accepted.
+	_, err := tfresource.RetryWhen(ctx, d.Timeout(schema.TimeoutDelete),
+		func(ctx context.Context) (any, error) {
+			return conn.DeleteInferenceComponent(ctx, &sagemaker.DeleteInferenceComponentInput{
+				InferenceComponentName: aws.String(d.Id()),
+			})
+		},
+		func(err error) (bool, error) {
+			if tfawserr.ErrMessageContains(err, ErrCodeValidationException, "is a base inference component") {
+				return true, err
+			}
+			return false, err
+		})
+
+	// Already gone, or a concurrent/prior delete is already in progress. In both cases
+	// the component will be (or already is being) removed, so fall through to the wait.
+	if tfawserr.ErrMessageContains(err, ErrCodeValidationException, "Could not find inference component") ||
+		tfawserr.ErrMessageContains(err, ErrCodeValidationException, "DELETE_IN_PROGRESS") {
+		err = nil
+	}
+
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "deleting SageMaker Inference Component (%s): %s", d.Id(), err)
+	}
+
+	if err := waitInferenceComponentDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "waiting for SageMaker Inference Component (%s) to be deleted: %s", d.Id(), err)
+	}
+
+	return diags
+}
+
+func findInferenceComponentByName(ctx context.Context, conn *sagemaker.Client, name string) (*sagemaker.DescribeInferenceComponentOutput, error) {
+	input := &sagemaker.DescribeInferenceComponentInput{
+		InferenceComponentName: aws.String(name),
+	}
+
+	output, err := conn.DescribeInferenceComponent(ctx, input)
+
+	if tfawserr.ErrMessageContains(err, ErrCodeValidationException, "Could not find inference component") {
+		return nil, &retry.NotFoundError{
+			LastError: err,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil {
+		return nil, tfresource.NewEmptyResultError()
+	}
+
+	if output.InferenceComponentStatus == awstypes.InferenceComponentStatusDeleting {
+		return nil, &retry.NotFoundError{
+			Message: string(output.InferenceComponentStatus),
+		}
+	}
+
+	return output, nil
+}
+
+func statusInferenceComponent(conn *sagemaker.Client, name string) retry.StateRefreshFunc {
+	return func(ctx context.Context) (any, string, error) {
+		output, err := findInferenceComponentByName(ctx, conn, name)
+
+		if retry.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return output, string(output.InferenceComponentStatus), nil
+	}
+}
+
+// statusInferenceComponentForDeletion reports the real status, including Deleting,
+// rather than collapsing Deleting to not-found the way findInferenceComponentByName
+// does for drift detection. This lets the delete waiter block until the component is
+// genuinely gone (a bare "Could not find" from Describe), which matters when a base
+// component's deletion must wait for its adapter component to be fully removed first.
+func statusInferenceComponentForDeletion(conn *sagemaker.Client, name string) retry.StateRefreshFunc {
+	return func(ctx context.Context) (any, string, error) {
+		input := &sagemaker.DescribeInferenceComponentInput{
+			InferenceComponentName: aws.String(name),
+		}
+
+		output, err := conn.DescribeInferenceComponent(ctx, input)
+
+		if tfawserr.ErrMessageContains(err, ErrCodeValidationException, "Could not find inference component") {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return output, string(output.InferenceComponentStatus), nil
+	}
+}
+
+func waitInferenceComponentInService(ctx context.Context, conn *sagemaker.Client, name string, timeout time.Duration) error {
+	stateConf := &retry.StateChangeConf{
+		Pending: enum.Slice(awstypes.InferenceComponentStatusCreating, awstypes.InferenceComponentStatusUpdating),
+		Target:  enum.Slice(awstypes.InferenceComponentStatusInService),
+		Refresh: statusInferenceComponent(conn, name),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+
+	if output, ok := outputRaw.(*sagemaker.DescribeInferenceComponentOutput); ok {
+		if status, reason := output.InferenceComponentStatus, aws.ToString(output.FailureReason); status == awstypes.InferenceComponentStatusFailed && reason != "" {
+			retry.SetLastError(err, errors.New(reason))
+		}
+		return err
+	}
+
+	return err
+}
+
+func waitInferenceComponentDeleted(ctx context.Context, conn *sagemaker.Client, name string, timeout time.Duration) error {
+	// Use the deletion-aware status refresh so the wait blocks through the Deleting
+	// state until the component is actually gone, rather than returning as soon as
+	// deletion begins.
+	stateConf := &retry.StateChangeConf{
+		Pending: enum.Slice(awstypes.InferenceComponentStatusInService, awstypes.InferenceComponentStatusCreating, awstypes.InferenceComponentStatusUpdating, awstypes.InferenceComponentStatusFailed, awstypes.InferenceComponentStatusDeleting),
+		Target:  []string{},
+		Refresh: statusInferenceComponentForDeletion(conn, name),
+		Timeout: timeout,
+	}
+
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
+}
+
+// Expand functions
+
+func expandInferenceComponentRuntimeConfig(tfList []any) *awstypes.InferenceComponentRuntimeConfig {
+	if len(tfList) == 0 || tfList[0] == nil {
+		return nil
+	}
+
+	tfMap := tfList[0].(map[string]any)
+	return &awstypes.InferenceComponentRuntimeConfig{
+		CopyCount: aws.Int32(int32(tfMap["copy_count"].(int))),
+	}
+}
+
+func expandInferenceComponentSpecification(tfMap map[string]any) *awstypes.InferenceComponentSpecification {
+	if tfMap == nil {
+		return nil
+	}
+
+	apiObject := &awstypes.InferenceComponentSpecification{}
+
+	if v, ok := tfMap["base_inference_component_name"].(string); ok && v != "" {
+		apiObject.BaseInferenceComponentName = aws.String(v)
+	}
+
+	if v, ok := tfMap["model_name"].(string); ok && v != "" {
+		apiObject.ModelName = aws.String(v)
+	}
+
+	if v, ok := tfMap[names.AttrInstanceType].(string); ok && v != "" {
+		apiObject.InstanceType = awstypes.ProductionVariantInstanceType(v)
+	}
+
+	if v, ok := tfMap["compute_resource_requirements"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.ComputeResourceRequirements = expandInferenceComponentComputeResourceRequirements(v[0].(map[string]any))
+	}
+
+	if v, ok := tfMap["container"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.Container = expandInferenceComponentContainerSpecification(v[0].(map[string]any))
+	}
+
+	if v, ok := tfMap["data_cache_config"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.DataCacheConfig = expandInferenceComponentDataCacheConfig(v[0].(map[string]any))
+	}
+
+	if v, ok := tfMap["scheduling_config"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.SchedulingConfig = expandInferenceComponentSchedulingConfig(v[0].(map[string]any))
+	}
+
+	if v, ok := tfMap["startup_parameters"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.StartupParameters = expandInferenceComponentStartupParameters(v[0].(map[string]any))
+	}
+
+	return apiObject
+}
+
+func expandInferenceComponentSpecifications(tfList []any) []awstypes.InferenceComponentSpecification {
+	if len(tfList) == 0 {
+		return nil
+	}
+
+	apiObjects := make([]awstypes.InferenceComponentSpecification, 0, len(tfList))
+	for _, tfMapRaw := range tfList {
+		if tfMapRaw == nil {
+			continue
+		}
+		tfMap := tfMapRaw.(map[string]any)
+		apiObject := expandInferenceComponentSpecification(tfMap)
+		if apiObject != nil {
+			apiObjects = append(apiObjects, *apiObject)
+		}
+	}
+
+	return apiObjects
+}
+
+func expandInferenceComponentComputeResourceRequirements(tfMap map[string]any) *awstypes.InferenceComponentComputeResourceRequirements {
+	apiObject := &awstypes.InferenceComponentComputeResourceRequirements{
+		MinMemoryRequiredInMb: aws.Int32(int32(tfMap["min_memory_required_in_mb"].(int))),
+	}
+
+	if v, ok := tfMap["max_memory_required_in_mb"].(int); ok && v > 0 {
+		apiObject.MaxMemoryRequiredInMb = aws.Int32(int32(v))
+	}
+
+	if v, ok := tfMap["number_of_accelerator_devices_required"].(float64); ok && v > 0 {
+		apiObject.NumberOfAcceleratorDevicesRequired = aws.Float32(float32(v))
+	}
+
+	if v, ok := tfMap["number_of_cpu_cores_required"].(float64); ok && v > 0 {
+		apiObject.NumberOfCpuCoresRequired = aws.Float32(float32(v))
+	}
+
+	return apiObject
+}
+
+func expandInferenceComponentContainerSpecification(tfMap map[string]any) *awstypes.InferenceComponentContainerSpecification {
+	apiObject := &awstypes.InferenceComponentContainerSpecification{}
+
+	if v, ok := tfMap["artifact_url"].(string); ok && v != "" {
+		apiObject.ArtifactUrl = aws.String(v)
+	}
+
+	if v, ok := tfMap["image"].(string); ok && v != "" {
+		apiObject.Image = aws.String(v)
+	}
+
+	if v, ok := tfMap[names.AttrEnvironment].(map[string]any); ok && len(v) > 0 {
+		apiObject.Environment = flex.ExpandStringValueMap(v)
+	}
+
+	if v, ok := tfMap["container_metrics_config"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.ContainerMetricsConfig = expandInferenceComponentContainerMetricsConfig(v[0].(map[string]any))
+	}
+
+	return apiObject
+}
+
+func expandInferenceComponentContainerMetricsConfig(tfMap map[string]any) *awstypes.ContainerMetricsConfig {
+	apiObject := &awstypes.ContainerMetricsConfig{}
+
+	if v, ok := tfMap["metrics_endpoint"].([]any); ok && len(v) > 0 && v[0] != nil {
+		endpointMap := v[0].(map[string]any)
+		metricsEndpoint := awstypes.MetricsEndpoint{
+			MetricsEndpointPath: aws.String(endpointMap["metrics_endpoint_path"].(string)),
+		}
+		if freq, ok := endpointMap["metric_publish_frequency_in_seconds"].(int); ok && freq > 0 {
+			metricsEndpoint.MetricPublishFrequencyInSeconds = int32(freq)
+		}
+		apiObject.MetricsEndpoints = []awstypes.MetricsEndpoint{metricsEndpoint}
+	}
+
+	return apiObject
+}
+
+func expandInferenceComponentDataCacheConfig(tfMap map[string]any) *awstypes.InferenceComponentDataCacheConfig {
+	return &awstypes.InferenceComponentDataCacheConfig{
+		EnableCaching: aws.Bool(tfMap["enable_caching"].(bool)),
+	}
+}
+
+func expandInferenceComponentSchedulingConfig(tfMap map[string]any) *awstypes.InferenceComponentSchedulingConfig {
+	apiObject := &awstypes.InferenceComponentSchedulingConfig{
+		PlacementStrategy: awstypes.InferenceComponentPlacementStrategy(tfMap["placement_strategy"].(string)),
+	}
+
+	if v, ok := tfMap["availability_zone_balance"].([]any); ok && len(v) > 0 && v[0] != nil {
+		azMap := v[0].(map[string]any)
+		azBalance := &awstypes.InferenceComponentAvailabilityZoneBalance{
+			EnforcementMode: awstypes.AvailabilityZoneBalanceEnforcementMode(azMap["enforcement_mode"].(string)),
+		}
+		if maxImbalance, ok := azMap["max_imbalance"].(int); ok && maxImbalance > 0 {
+			azBalance.MaxImbalance = aws.Int32(int32(maxImbalance))
+		}
+		apiObject.AvailabilityZoneBalance = azBalance
+	}
+
+	return apiObject
+}
+
+func expandInferenceComponentStartupParameters(tfMap map[string]any) *awstypes.InferenceComponentStartupParameters {
+	apiObject := &awstypes.InferenceComponentStartupParameters{}
+
+	if v, ok := tfMap["container_startup_health_check_timeout_in_seconds"].(int); ok && v > 0 {
+		apiObject.ContainerStartupHealthCheckTimeoutInSeconds = aws.Int32(int32(v))
+	}
+
+	if v, ok := tfMap["model_data_download_timeout_in_seconds"].(int); ok && v > 0 {
+		apiObject.ModelDataDownloadTimeoutInSeconds = aws.Int32(int32(v))
+	}
+
+	return apiObject
+}
+
+func expandInferenceComponentDeploymentConfig(tfList []any) *awstypes.InferenceComponentDeploymentConfig {
+	if len(tfList) == 0 || tfList[0] == nil {
+		return nil
+	}
+
+	tfMap := tfList[0].(map[string]any)
+	apiObject := &awstypes.InferenceComponentDeploymentConfig{}
+
+	if v, ok := tfMap["rolling_update_policy"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.RollingUpdatePolicy = expandInferenceComponentRollingUpdatePolicy(v[0].(map[string]any))
+	}
+
+	if v, ok := tfMap["auto_rollback_configuration"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.AutoRollbackConfiguration = expandInferenceComponentAutoRollbackConfig(v[0].(map[string]any))
+	}
+
+	return apiObject
+}
+
+func expandInferenceComponentRollingUpdatePolicy(tfMap map[string]any) *awstypes.InferenceComponentRollingUpdatePolicy {
+	apiObject := &awstypes.InferenceComponentRollingUpdatePolicy{
+		WaitIntervalInSeconds: aws.Int32(int32(tfMap["wait_interval_in_seconds"].(int))),
+	}
+
+	if v, ok := tfMap["maximum_batch_size"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.MaximumBatchSize = expandInferenceComponentCapacitySize(v[0].(map[string]any))
+	}
+
+	if v, ok := tfMap["maximum_execution_timeout_in_seconds"].(int); ok && v > 0 {
+		apiObject.MaximumExecutionTimeoutInSeconds = aws.Int32(int32(v))
+	}
+
+	if v, ok := tfMap["rollback_maximum_batch_size"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.RollbackMaximumBatchSize = expandInferenceComponentCapacitySize(v[0].(map[string]any))
+	}
+
+	return apiObject
+}
+
+func expandInferenceComponentCapacitySize(tfMap map[string]any) *awstypes.InferenceComponentCapacitySize {
+	return &awstypes.InferenceComponentCapacitySize{
+		Type:  awstypes.InferenceComponentCapacitySizeType(tfMap[names.AttrType].(string)),
+		Value: aws.Int32(int32(tfMap[names.AttrValue].(int))),
+	}
+}
+
+func expandInferenceComponentAutoRollbackConfig(tfMap map[string]any) *awstypes.AutoRollbackConfig {
+	apiObject := &awstypes.AutoRollbackConfig{}
+
+	if v, ok := tfMap["alarms"].([]any); ok && len(v) > 0 {
+		apiObject.Alarms = expandAlarms(v)
+	}
+
+	return apiObject
+}
+
+// Flatten functions
+
+func flattenInferenceComponentRuntimeConfigSummary(apiObject *awstypes.InferenceComponentRuntimeConfigSummary) []any {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]any{
+		"current_copy_count": aws.ToInt32(apiObject.CurrentCopyCount),
+		"desired_copy_count": aws.ToInt32(apiObject.DesiredCopyCount),
+		"placement_status":   flattenInferenceComponentPlacementStatus(apiObject.PlacementStatus),
+	}
+
+	if apiObject.DesiredCopyCount != nil {
+		tfMap["copy_count"] = aws.ToInt32(apiObject.DesiredCopyCount)
+	} else if apiObject.CurrentCopyCount != nil {
+		tfMap["copy_count"] = aws.ToInt32(apiObject.CurrentCopyCount)
+	}
+
+	return []any{tfMap}
+}
+
+func flattenInferenceComponentPlacementStatus(apiObjects []awstypes.InferenceComponentPlacementStatus) []any {
+	if len(apiObjects) == 0 {
+		return nil
+	}
+
+	tfList := make([]any, 0, len(apiObjects))
+	for _, apiObject := range apiObjects {
+		tfList = append(tfList, map[string]any{
+			"current_copy_count":   aws.ToInt32(apiObject.CurrentCopyCount),
+			names.AttrInstanceType: string(apiObject.InstanceType),
+		})
+	}
+
+	return tfList
+}
+
+func flattenInferenceComponentSpecificationSummary(apiObject *awstypes.InferenceComponentSpecificationSummary) map[string]any {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]any{}
+
+	if apiObject.BaseInferenceComponentName != nil {
+		tfMap["base_inference_component_name"] = aws.ToString(apiObject.BaseInferenceComponentName)
+	}
+
+	if apiObject.ModelName != nil {
+		tfMap["model_name"] = aws.ToString(apiObject.ModelName)
+	}
+
+	if apiObject.InstanceType != "" {
+		tfMap[names.AttrInstanceType] = string(apiObject.InstanceType)
+	}
+
+	if apiObject.ComputeResourceRequirements != nil {
+		tfMap["compute_resource_requirements"] = flattenInferenceComponentComputeResourceRequirements(apiObject.ComputeResourceRequirements)
+	}
+
+	if apiObject.Container != nil {
+		tfMap["container"] = flattenInferenceComponentContainerSummary(apiObject.Container)
+	}
+
+	if apiObject.DataCacheConfig != nil {
+		tfMap["data_cache_config"] = flattenInferenceComponentDataCacheConfigSummary(apiObject.DataCacheConfig)
+	}
+
+	if apiObject.SchedulingConfig != nil {
+		tfMap["scheduling_config"] = flattenInferenceComponentSchedulingConfig(apiObject.SchedulingConfig)
+	}
+
+	if apiObject.StartupParameters != nil {
+		tfMap["startup_parameters"] = flattenInferenceComponentStartupParameters(apiObject.StartupParameters)
+	}
+
+	return tfMap
+}
+
+func flattenInferenceComponentSpecificationSummaries(apiObjects []awstypes.InferenceComponentSpecificationSummary) []any {
+	if len(apiObjects) == 0 {
+		return nil
+	}
+
+	tfList := make([]any, 0, len(apiObjects))
+	for _, apiObject := range apiObjects {
+		tfList = append(tfList, flattenInferenceComponentSpecificationSummary(&apiObject))
+	}
+
+	return tfList
+}
+
+func flattenInferenceComponentComputeResourceRequirements(apiObject *awstypes.InferenceComponentComputeResourceRequirements) []any {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]any{
+		"min_memory_required_in_mb": aws.ToInt32(apiObject.MinMemoryRequiredInMb),
+	}
+
+	if apiObject.MaxMemoryRequiredInMb != nil {
+		tfMap["max_memory_required_in_mb"] = aws.ToInt32(apiObject.MaxMemoryRequiredInMb)
+	}
+
+	if apiObject.NumberOfAcceleratorDevicesRequired != nil {
+		tfMap["number_of_accelerator_devices_required"] = aws.ToFloat32(apiObject.NumberOfAcceleratorDevicesRequired)
+	}
+
+	if apiObject.NumberOfCpuCoresRequired != nil {
+		tfMap["number_of_cpu_cores_required"] = aws.ToFloat32(apiObject.NumberOfCpuCoresRequired)
+	}
+
+	return []any{tfMap}
+}
+
+func flattenInferenceComponentContainerSummary(apiObject *awstypes.InferenceComponentContainerSpecificationSummary) []any {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]any{}
+
+	if apiObject.DeployedImage != nil {
+		if apiObject.DeployedImage.SpecifiedImage != nil {
+			tfMap["image"] = aws.ToString(apiObject.DeployedImage.SpecifiedImage)
+		}
+		if apiObject.DeployedImage.ResolvedImage != nil {
+			tfMap["resolved_image"] = aws.ToString(apiObject.DeployedImage.ResolvedImage)
+		}
+	}
+
+	if apiObject.ArtifactUrl != nil {
+		tfMap["artifact_url"] = aws.ToString(apiObject.ArtifactUrl)
+	}
+
+	if len(apiObject.Environment) > 0 {
+		tfMap[names.AttrEnvironment] = apiObject.Environment
+	}
+
+	if apiObject.ContainerMetricsConfig != nil {
+		tfMap["container_metrics_config"] = flattenInferenceComponentContainerMetricsConfig(apiObject.ContainerMetricsConfig)
+	}
+
+	return []any{tfMap}
+}
+
+func flattenInferenceComponentContainerMetricsConfig(apiObject *awstypes.ContainerMetricsConfig) []any {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]any{}
+
+	if len(apiObject.MetricsEndpoints) > 0 {
+		endpoint := apiObject.MetricsEndpoints[0]
+		endpointMap := map[string]any{
+			"metrics_endpoint_path":               aws.ToString(endpoint.MetricsEndpointPath),
+			"metric_publish_frequency_in_seconds": int(endpoint.MetricPublishFrequencyInSeconds),
+		}
+		tfMap["metrics_endpoint"] = []any{endpointMap}
+	}
+
+	return []any{tfMap}
+}
+
+func flattenInferenceComponentDataCacheConfigSummary(apiObject *awstypes.InferenceComponentDataCacheConfigSummary) []any {
+	if apiObject == nil {
+		return nil
+	}
+
+	return []any{map[string]any{
+		"enable_caching": aws.ToBool(apiObject.EnableCaching),
+	}}
+}
+
+func flattenInferenceComponentSchedulingConfig(apiObject *awstypes.InferenceComponentSchedulingConfig) []any {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]any{
+		"placement_strategy": string(apiObject.PlacementStrategy),
+	}
+
+	if apiObject.AvailabilityZoneBalance != nil {
+		azMap := map[string]any{
+			"enforcement_mode": string(apiObject.AvailabilityZoneBalance.EnforcementMode),
+		}
+		if apiObject.AvailabilityZoneBalance.MaxImbalance != nil {
+			azMap["max_imbalance"] = aws.ToInt32(apiObject.AvailabilityZoneBalance.MaxImbalance)
+		}
+		tfMap["availability_zone_balance"] = []any{azMap}
+	}
+
+	return []any{tfMap}
+}
+
+func flattenInferenceComponentStartupParameters(apiObject *awstypes.InferenceComponentStartupParameters) []any {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]any{}
+
+	if apiObject.ContainerStartupHealthCheckTimeoutInSeconds != nil {
+		tfMap["container_startup_health_check_timeout_in_seconds"] = aws.ToInt32(apiObject.ContainerStartupHealthCheckTimeoutInSeconds)
+	}
+
+	if apiObject.ModelDataDownloadTimeoutInSeconds != nil {
+		tfMap["model_data_download_timeout_in_seconds"] = aws.ToInt32(apiObject.ModelDataDownloadTimeoutInSeconds)
+	}
+
+	return []any{tfMap}
+}

--- a/internal/service/sagemaker/inference_component_test.go
+++ b/internal/service/sagemaker/inference_component_test.go
@@ -1,0 +1,1293 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package sagemaker_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
+	tfsagemaker "github.com/hashicorp/terraform-provider-aws/internal/service/sagemaker"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccSageMakerInferenceComponent_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_sagemaker_inference_component.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SageMakerServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckInferenceComponentDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInferenceComponentConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInferenceComponentExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.CheckResourceAttrRegionalARN(ctx, resourceName, "endpoint_arn", "sagemaker", fmt.Sprintf("endpoint/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "endpoint_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "variant_name", "variant-1"),
+					resource.TestCheckResourceAttrSet(resourceName, names.AttrCreationTime),
+					resource.TestCheckResourceAttrSet(resourceName, "last_modified_time"),
+					resource.TestCheckResourceAttr(resourceName, "runtime_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "runtime_config.0.copy_count", "1"),
+					resource.TestCheckResourceAttr(resourceName, "runtime_config.0.current_copy_count", "1"),
+					resource.TestCheckResourceAttr(resourceName, "runtime_config.0.desired_copy_count", "1"),
+					resource.TestCheckResourceAttr(resourceName, "specification.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "specification.0.compute_resource_requirements.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "specification.0.compute_resource_requirements.0.min_memory_required_in_mb", "1024"),
+					resource.TestCheckResourceAttr(resourceName, "specification.0.compute_resource_requirements.0.number_of_cpu_cores_required", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "specification.0.container.0.resolved_image"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrStatus, "InService"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccSageMakerInferenceComponent_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_sagemaker_inference_component.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SageMakerServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckInferenceComponentDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInferenceComponentConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInferenceComponentExists(ctx, t, resourceName),
+					acctest.CheckSDKResourceDisappears(ctx, t, tfsagemaker.ResourceInferenceComponent(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccSageMakerInferenceComponent_tags(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_sagemaker_inference_component.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SageMakerServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckInferenceComponentDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInferenceComponentConfig_tags1(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInferenceComponentExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccInferenceComponentConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInferenceComponentExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccInferenceComponentConfig_tags1(rName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInferenceComponentExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccSageMakerInferenceComponent_runtimeConfigUpdate(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_sagemaker_inference_component.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SageMakerServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckInferenceComponentDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInferenceComponentConfig_runtimeConfig(rName, 1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInferenceComponentExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "runtime_config.0.copy_count", "1"),
+				),
+			},
+			{
+				Config: testAccInferenceComponentConfig_runtimeConfig(rName, 2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInferenceComponentExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "runtime_config.0.copy_count", "2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccSageMakerInferenceComponent_container(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_sagemaker_inference_component.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SageMakerServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckInferenceComponentDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInferenceComponentConfig_container(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInferenceComponentExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "specification.0.container.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "specification.0.container.0.image"),
+					resource.TestCheckResourceAttr(resourceName, "specification.0.container.0.environment.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "specification.0.container.0.environment.MY_ENV", "my_value"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccSageMakerInferenceComponent_startupParameters(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_sagemaker_inference_component.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SageMakerServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckInferenceComponentDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInferenceComponentConfig_startupParameters(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInferenceComponentExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "specification.0.startup_parameters.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "specification.0.startup_parameters.0.container_startup_health_check_timeout_in_seconds", "120"),
+					resource.TestCheckResourceAttr(resourceName, "specification.0.startup_parameters.0.model_data_download_timeout_in_seconds", "120"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccSageMakerInferenceComponent_dataCacheConfig(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_sagemaker_inference_component.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SageMakerServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckInferenceComponentDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInferenceComponentConfig_dataCacheConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInferenceComponentExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "specification.0.data_cache_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "specification.0.data_cache_config.0.enable_caching", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccSageMakerInferenceComponent_schedulingConfig(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_sagemaker_inference_component.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SageMakerServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckInferenceComponentDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInferenceComponentConfig_schedulingConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInferenceComponentExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "specification.0.scheduling_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "specification.0.scheduling_config.0.placement_strategy", "SPREAD"),
+					resource.TestCheckResourceAttr(resourceName, "specification.0.scheduling_config.0.availability_zone_balance.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "specification.0.scheduling_config.0.availability_zone_balance.0.enforcement_mode", "PERMISSIVE"),
+					resource.TestCheckResourceAttr(resourceName, "specification.0.scheduling_config.0.availability_zone_balance.0.max_imbalance", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccSageMakerInferenceComponent_containerImage(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_sagemaker_inference_component.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SageMakerServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckInferenceComponentDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInferenceComponentConfig_containerImage(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInferenceComponentExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "specification.0.container.0.image"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccSageMakerInferenceComponent_deploymentConfig(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_sagemaker_inference_component.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SageMakerServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckInferenceComponentDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				// deployment_config is an update-only rollout directive that the API rejects
+				// unless it accompanies a spec or runtime change. Create with copy_count 2
+				// and no deployment_config, then in the next step bump copy_count to 3 and
+				// attach deployment_config to govern that rollout. maximum_batch_size uses
+				// CAPACITY_PERCENT so it is independent of the copy count (the API validates
+				// a COPY_COUNT batch against the current count, which is fragile in a test).
+				Config: testAccInferenceComponentConfig_runtimeConfig(rName, 2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInferenceComponentExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "deployment_config.#", "0"),
+				),
+			},
+			{
+				Config: testAccInferenceComponentConfig_deploymentConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInferenceComponentExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "deployment_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "deployment_config.0.rolling_update_policy.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "deployment_config.0.rolling_update_policy.0.wait_interval_in_seconds", "60"),
+					resource.TestCheckResourceAttr(resourceName, "deployment_config.0.rolling_update_policy.0.maximum_execution_timeout_in_seconds", "1800"),
+					resource.TestCheckResourceAttr(resourceName, "deployment_config.0.rolling_update_policy.0.maximum_batch_size.0.type", "CAPACITY_PERCENT"),
+					resource.TestCheckResourceAttr(resourceName, "deployment_config.0.rolling_update_policy.0.maximum_batch_size.0.value", "50"),
+					resource.TestCheckResourceAttr(resourceName, "deployment_config.0.rolling_update_policy.0.rollback_maximum_batch_size.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "deployment_config.0.rolling_update_policy.0.rollback_maximum_batch_size.0.type", "COPY_COUNT"),
+					resource.TestCheckResourceAttr(resourceName, "deployment_config.0.rolling_update_policy.0.rollback_maximum_batch_size.0.value", "1"),
+					resource.TestCheckResourceAttr(resourceName, "deployment_config.0.auto_rollback_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "deployment_config.0.auto_rollback_configuration.0.alarms.#", "1"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deployment_config"},
+			},
+		},
+	})
+}
+
+func TestAccSageMakerInferenceComponent_computeResourceRequirements(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_sagemaker_inference_component.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SageMakerServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckInferenceComponentDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInferenceComponentConfig_computeResourceFull(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInferenceComponentExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "specification.0.compute_resource_requirements.0.min_memory_required_in_mb", "1024"),
+					resource.TestCheckResourceAttr(resourceName, "specification.0.compute_resource_requirements.0.max_memory_required_in_mb", "2048"),
+					resource.TestCheckResourceAttr(resourceName, "specification.0.compute_resource_requirements.0.number_of_cpu_cores_required", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccSageMakerInferenceComponent_acceleratorDevices(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_sagemaker_inference_component.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SageMakerServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckInferenceComponentDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInferenceComponentConfig_acceleratorDevices(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInferenceComponentExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "specification.0.compute_resource_requirements.0.number_of_accelerator_devices_required", "1"),
+					resource.TestCheckResourceAttr(resourceName, "specification.0.scheduling_config.0.placement_strategy", "BINPACK"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccSageMakerInferenceComponent_modelName(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_sagemaker_inference_component.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SageMakerServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckInferenceComponentDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInferenceComponentConfig_modelName(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInferenceComponentExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "specification.0.model_name", rName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccSageMakerInferenceComponent_specifications(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_sagemaker_inference_component.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SageMakerServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckInferenceComponentDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInferenceComponentConfig_specifications(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInferenceComponentExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "specification.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "specifications.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "specifications.0.instance_type", "ml.c5.xlarge"),
+					resource.TestCheckResourceAttr(resourceName, "specifications.1.instance_type", "ml.c5.2xlarge"),
+					resource.TestCheckResourceAttr(resourceName, "specifications.0.model_name", rName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccSageMakerInferenceComponent_adapter(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_sagemaker_inference_component.adapter"
+	baseResourceName := "aws_sagemaker_inference_component.base"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SageMakerServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckInferenceComponentDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInferenceComponentConfig_adapter(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInferenceComponentExists(ctx, t, baseResourceName),
+					testAccCheckInferenceComponentExists(ctx, t, resourceName),
+					// An adapter inference component references a base component and inherits
+					// its compute resources; the API echoes those inherited resources back on
+					// read, so the block is populated even though the config omits it.
+					resource.TestCheckResourceAttrPair(resourceName, "specification.0.base_inference_component_name", baseResourceName, names.AttrName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccSageMakerInferenceComponent_containerMetricsConfig(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_sagemaker_inference_component.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SageMakerServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckInferenceComponentDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInferenceComponentConfig_containerMetricsConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInferenceComponentExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "specification.0.container.0.container_metrics_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "specification.0.container.0.container_metrics_config.0.metrics_endpoint.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "specification.0.container.0.container_metrics_config.0.metrics_endpoint.0.metrics_endpoint_path", "/metrics"),
+					resource.TestCheckResourceAttr(resourceName, "specification.0.container.0.container_metrics_config.0.metrics_endpoint.0.metric_publish_frequency_in_seconds", "30"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccSageMakerInferenceComponent_specificationUpdate(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_sagemaker_inference_component.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SageMakerServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckInferenceComponentDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInferenceComponentConfig_specificationMemory(rName, 1024),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInferenceComponentExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "specification.0.compute_resource_requirements.0.min_memory_required_in_mb", "1024"),
+				),
+			},
+			{
+				Config: testAccInferenceComponentConfig_specificationMemory(rName, 2048),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInferenceComponentExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "specification.0.compute_resource_requirements.0.min_memory_required_in_mb", "2048"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckInferenceComponentDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.ProviderMeta(ctx, t).SageMakerClient(ctx)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_sagemaker_inference_component" {
+				continue
+			}
+
+			_, err := tfsagemaker.FindInferenceComponentByName(ctx, conn, rs.Primary.ID)
+
+			if retry.NotFound(err) {
+				continue
+			}
+
+			if err != nil {
+				return err
+			}
+
+			return fmt.Errorf("SageMaker Inference Component (%s) still exists", rs.Primary.ID)
+		}
+		return nil
+	}
+}
+
+func testAccCheckInferenceComponentExists(ctx context.Context, t *testing.T, n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		conn := acctest.ProviderMeta(ctx, t).SageMakerClient(ctx)
+
+		_, err := tfsagemaker.FindInferenceComponentByName(ctx, conn, rs.Primary.ID)
+
+		return err
+	}
+}
+
+func testAccInferenceComponentConfig_base(rName string) string {
+	return testAccInferenceComponentConfig_baseInstanceType(rName, "ml.c5.xlarge")
+}
+
+func testAccInferenceComponentConfig_baseInstanceType(rName, instanceType string) string {
+	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+data "aws_iam_policy_document" "assume_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["sagemaker.${data.aws_partition.current.dns_suffix}"]
+    }
+  }
+}
+
+resource "aws_iam_role" "test" {
+  name               = %[1]q
+  path               = "/"
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
+}
+
+resource "aws_iam_role_policy_attachment" "test" {
+  role       = aws_iam_role.test.name
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonSageMakerFullAccess"
+}
+
+resource "aws_iam_role_policy" "s3_access" {
+  role = aws_iam_role.test.name
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:ListBucket",
+        ]
+        Resource = [
+          "arn:${data.aws_partition.current.partition}:s3:::%[1]s",
+          "arn:${data.aws_partition.current.partition}:s3:::%[1]s/*",
+        ]
+      }
+    ]
+  })
+}
+
+data "aws_sagemaker_prebuilt_ecr_image" "test" {
+  repository_name = "sagemaker-tensorflow-serving"
+  image_tag       = "1.12-cpu"
+}
+
+resource "aws_s3_bucket" "test" {
+  bucket        = %[1]q
+  force_destroy = true
+}
+
+resource "aws_s3_object" "test" {
+  bucket       = aws_s3_bucket.test.bucket
+  key          = "model/model.tar.gz"
+  content_type = "application/gzip"
+  source       = "test-fixtures/sagemaker-tensorflow-serving-test-model.tar.gz"
+}
+
+resource "aws_sagemaker_endpoint_configuration" "test" {
+  name               = %[1]q
+  execution_role_arn = aws_iam_role.test.arn
+
+  production_variants {
+    variant_name           = "variant-1"
+    instance_type          = %[2]q
+    initial_instance_count = 1
+
+    managed_instance_scaling {
+      status             = "ENABLED"
+      min_instance_count = 1
+      max_instance_count = 1
+    }
+
+    routing_config {
+      routing_strategy = "LEAST_OUTSTANDING_REQUESTS"
+    }
+  }
+
+  depends_on = [aws_iam_role_policy_attachment.test, aws_iam_role_policy.s3_access]
+}
+
+resource "aws_sagemaker_endpoint" "test" {
+  endpoint_config_name = aws_sagemaker_endpoint_configuration.test.name
+  name                 = %[1]q
+
+  depends_on = [aws_iam_role_policy_attachment.test, aws_iam_role_policy.s3_access]
+}
+`, rName, instanceType)
+}
+
+func testAccInferenceComponentConfig_basic(rName string) string {
+	return acctest.ConfigCompose(testAccInferenceComponentConfig_base(rName), fmt.Sprintf(`
+resource "aws_sagemaker_inference_component" "test" {
+  name          = %[1]q
+  endpoint_name = aws_sagemaker_endpoint.test.name
+  variant_name  = "variant-1"
+
+  specification {
+    container {
+      image        = data.aws_sagemaker_prebuilt_ecr_image.test.registry_path
+      artifact_url = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.test.key}"
+    }
+
+    compute_resource_requirements {
+      min_memory_required_in_mb    = 1024
+      number_of_cpu_cores_required = 1
+    }
+
+    startup_parameters {
+      container_startup_health_check_timeout_in_seconds = 300
+      model_data_download_timeout_in_seconds            = 300
+    }
+  }
+
+  runtime_config {
+    copy_count = 1
+  }
+}
+`, rName))
+}
+
+func testAccInferenceComponentConfig_tags1(rName, tagKey1, tagValue1 string) string {
+	return acctest.ConfigCompose(testAccInferenceComponentConfig_base(rName), fmt.Sprintf(`
+resource "aws_sagemaker_inference_component" "test" {
+  name          = %[1]q
+  endpoint_name = aws_sagemaker_endpoint.test.name
+  variant_name  = "variant-1"
+
+  specification {
+    container {
+      image        = data.aws_sagemaker_prebuilt_ecr_image.test.registry_path
+      artifact_url = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.test.key}"
+    }
+
+    compute_resource_requirements {
+      min_memory_required_in_mb    = 1024
+      number_of_cpu_cores_required = 1
+    }
+  }
+
+  runtime_config {
+    copy_count = 1
+  }
+
+  tags = {
+    %[2]q = %[3]q
+  }
+}
+`, rName, tagKey1, tagValue1))
+}
+
+func testAccInferenceComponentConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return acctest.ConfigCompose(testAccInferenceComponentConfig_base(rName), fmt.Sprintf(`
+resource "aws_sagemaker_inference_component" "test" {
+  name          = %[1]q
+  endpoint_name = aws_sagemaker_endpoint.test.name
+  variant_name  = "variant-1"
+
+  specification {
+    container {
+      image        = data.aws_sagemaker_prebuilt_ecr_image.test.registry_path
+      artifact_url = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.test.key}"
+    }
+
+    compute_resource_requirements {
+      min_memory_required_in_mb    = 1024
+      number_of_cpu_cores_required = 1
+    }
+  }
+
+  runtime_config {
+    copy_count = 1
+  }
+
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2))
+}
+
+func testAccInferenceComponentConfig_runtimeConfig(rName string, copyCount int) string {
+	return acctest.ConfigCompose(testAccInferenceComponentConfig_base(rName), fmt.Sprintf(`
+resource "aws_sagemaker_inference_component" "test" {
+  name          = %[1]q
+  endpoint_name = aws_sagemaker_endpoint.test.name
+  variant_name  = "variant-1"
+
+  specification {
+    container {
+      image        = data.aws_sagemaker_prebuilt_ecr_image.test.registry_path
+      artifact_url = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.test.key}"
+    }
+
+    compute_resource_requirements {
+      min_memory_required_in_mb    = 1024
+      number_of_cpu_cores_required = 1
+    }
+  }
+
+  runtime_config {
+    copy_count = %[2]d
+  }
+}
+`, rName, copyCount))
+}
+
+func testAccInferenceComponentConfig_container(rName string) string {
+	return acctest.ConfigCompose(testAccInferenceComponentConfig_base(rName), fmt.Sprintf(`
+resource "aws_sagemaker_inference_component" "test" {
+  name          = %[1]q
+  endpoint_name = aws_sagemaker_endpoint.test.name
+  variant_name  = "variant-1"
+
+  specification {
+    container {
+      image        = data.aws_sagemaker_prebuilt_ecr_image.test.registry_path
+      artifact_url = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.test.key}"
+
+      environment = {
+        MY_ENV = "my_value"
+      }
+    }
+
+    compute_resource_requirements {
+      min_memory_required_in_mb    = 1024
+      number_of_cpu_cores_required = 1
+    }
+  }
+
+  runtime_config {
+    copy_count = 1
+  }
+}
+`, rName))
+}
+
+func testAccInferenceComponentConfig_startupParameters(rName string) string {
+	return acctest.ConfigCompose(testAccInferenceComponentConfig_base(rName), fmt.Sprintf(`
+resource "aws_sagemaker_inference_component" "test" {
+  name          = %[1]q
+  endpoint_name = aws_sagemaker_endpoint.test.name
+  variant_name  = "variant-1"
+
+  specification {
+    container {
+      image        = data.aws_sagemaker_prebuilt_ecr_image.test.registry_path
+      artifact_url = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.test.key}"
+    }
+
+    compute_resource_requirements {
+      min_memory_required_in_mb    = 1024
+      number_of_cpu_cores_required = 1
+    }
+
+    startup_parameters {
+      container_startup_health_check_timeout_in_seconds = 120
+      model_data_download_timeout_in_seconds            = 120
+    }
+  }
+
+  runtime_config {
+    copy_count = 1
+  }
+}
+`, rName))
+}
+
+func testAccInferenceComponentConfig_dataCacheConfig(rName string) string {
+	return acctest.ConfigCompose(testAccInferenceComponentConfig_base(rName), fmt.Sprintf(`
+resource "aws_sagemaker_inference_component" "test" {
+  name          = %[1]q
+  endpoint_name = aws_sagemaker_endpoint.test.name
+  variant_name  = "variant-1"
+
+  specification {
+    container {
+      image        = data.aws_sagemaker_prebuilt_ecr_image.test.registry_path
+      artifact_url = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.test.key}"
+    }
+
+    compute_resource_requirements {
+      min_memory_required_in_mb    = 1024
+      number_of_cpu_cores_required = 1
+    }
+
+    data_cache_config {
+      enable_caching = true
+    }
+  }
+
+  runtime_config {
+    copy_count = 1
+  }
+}
+`, rName))
+}
+
+func testAccInferenceComponentConfig_schedulingConfig(rName string) string {
+	return acctest.ConfigCompose(testAccInferenceComponentConfig_base(rName), fmt.Sprintf(`
+resource "aws_sagemaker_inference_component" "test" {
+  name          = %[1]q
+  endpoint_name = aws_sagemaker_endpoint.test.name
+  variant_name  = "variant-1"
+
+  specification {
+    container {
+      image        = data.aws_sagemaker_prebuilt_ecr_image.test.registry_path
+      artifact_url = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.test.key}"
+    }
+
+    compute_resource_requirements {
+      min_memory_required_in_mb    = 1024
+      number_of_cpu_cores_required = 1
+    }
+
+    scheduling_config {
+      placement_strategy = "SPREAD"
+
+      availability_zone_balance {
+        enforcement_mode = "PERMISSIVE"
+        max_imbalance    = 1
+      }
+    }
+  }
+
+  runtime_config {
+    copy_count = 1
+  }
+}
+`, rName))
+}
+
+func testAccInferenceComponentConfig_containerImage(rName string) string {
+	return acctest.ConfigCompose(testAccInferenceComponentConfig_base(rName), fmt.Sprintf(`
+resource "aws_sagemaker_inference_component" "test" {
+  name          = %[1]q
+  endpoint_name = aws_sagemaker_endpoint.test.name
+  variant_name  = "variant-1"
+
+  specification {
+    container {
+      image        = data.aws_sagemaker_prebuilt_ecr_image.test.registry_path
+      artifact_url = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.test.key}"
+    }
+
+    compute_resource_requirements {
+      min_memory_required_in_mb    = 1024
+      number_of_cpu_cores_required = 1
+    }
+  }
+
+  runtime_config {
+    copy_count = 1
+  }
+}
+`, rName))
+}
+
+func testAccInferenceComponentConfig_deploymentConfig(rName string) string {
+	return acctest.ConfigCompose(testAccInferenceComponentConfig_base(rName), fmt.Sprintf(`
+resource "aws_cloudwatch_metric_alarm" "test" {
+  alarm_name                = %[1]q
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = "2"
+  metric_name               = "CPUUtilization"
+  namespace                 = "AWS/EC2"
+  period                    = "120"
+  statistic                 = "Average"
+  threshold                 = "80"
+  alarm_description         = "This metric monitors ec2 cpu utilization"
+  insufficient_data_actions = []
+
+  dimensions = {
+    InstanceId = "i-abc123"
+  }
+}
+
+resource "aws_sagemaker_inference_component" "test" {
+  name          = %[1]q
+  endpoint_name = aws_sagemaker_endpoint.test.name
+  variant_name  = "variant-1"
+
+  specification {
+    container {
+      image        = data.aws_sagemaker_prebuilt_ecr_image.test.registry_path
+      artifact_url = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.test.key}"
+    }
+
+    compute_resource_requirements {
+      min_memory_required_in_mb    = 1024
+      number_of_cpu_cores_required = 1
+    }
+  }
+
+  runtime_config {
+    copy_count = 3
+  }
+
+  deployment_config {
+    rolling_update_policy {
+      maximum_batch_size {
+        type  = "CAPACITY_PERCENT"
+        value = 50
+      }
+
+      wait_interval_in_seconds             = 60
+      maximum_execution_timeout_in_seconds = 1800
+
+      rollback_maximum_batch_size {
+        type  = "COPY_COUNT"
+        value = 1
+      }
+    }
+
+    auto_rollback_configuration {
+      alarms {
+        alarm_name = aws_cloudwatch_metric_alarm.test.alarm_name
+      }
+    }
+  }
+}
+`, rName))
+}
+
+func testAccInferenceComponentConfig_computeResourceFull(rName string) string {
+	return acctest.ConfigCompose(testAccInferenceComponentConfig_base(rName), fmt.Sprintf(`
+resource "aws_sagemaker_inference_component" "test" {
+  name          = %[1]q
+  endpoint_name = aws_sagemaker_endpoint.test.name
+  variant_name  = "variant-1"
+
+  specification {
+    container {
+      image        = data.aws_sagemaker_prebuilt_ecr_image.test.registry_path
+      artifact_url = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.test.key}"
+    }
+
+    compute_resource_requirements {
+      min_memory_required_in_mb    = 1024
+      max_memory_required_in_mb    = 2048
+      number_of_cpu_cores_required = 1
+    }
+  }
+
+  runtime_config {
+    copy_count = 1
+  }
+}
+`, rName))
+}
+
+func testAccInferenceComponentConfig_modelName(rName string) string {
+	return acctest.ConfigCompose(testAccInferenceComponentConfig_base(rName), fmt.Sprintf(`
+resource "aws_sagemaker_model" "test" {
+  name               = %[1]q
+  execution_role_arn = aws_iam_role.test.arn
+
+  primary_container {
+    image          = data.aws_sagemaker_prebuilt_ecr_image.test.registry_path
+    model_data_url = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.test.key}"
+  }
+
+  depends_on = [aws_iam_role_policy_attachment.test, aws_iam_role_policy.s3_access]
+}
+
+resource "aws_sagemaker_inference_component" "test" {
+  name          = %[1]q
+  endpoint_name = aws_sagemaker_endpoint.test.name
+  variant_name  = "variant-1"
+
+  specification {
+    model_name = aws_sagemaker_model.test.name
+
+    compute_resource_requirements {
+      min_memory_required_in_mb    = 1024
+      number_of_cpu_cores_required = 1
+    }
+  }
+
+  runtime_config {
+    copy_count = 1
+  }
+}
+`, rName))
+}
+
+func testAccInferenceComponentConfig_specifications(rName string) string {
+	return acctest.ConfigCompose(testAccInferenceComponentConfig_base(rName), fmt.Sprintf(`
+resource "aws_sagemaker_model" "test" {
+  name               = %[1]q
+  execution_role_arn = aws_iam_role.test.arn
+
+  primary_container {
+    image          = data.aws_sagemaker_prebuilt_ecr_image.test.registry_path
+    model_data_url = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.test.key}"
+  }
+
+  depends_on = [aws_iam_role_policy_attachment.test, aws_iam_role_policy.s3_access]
+}
+
+resource "aws_sagemaker_inference_component" "test" {
+  name          = %[1]q
+  endpoint_name = aws_sagemaker_endpoint.test.name
+  variant_name  = "variant-1"
+
+  specifications {
+    instance_type = "ml.c5.xlarge"
+    model_name    = aws_sagemaker_model.test.name
+
+    compute_resource_requirements {
+      min_memory_required_in_mb    = 1024
+      number_of_cpu_cores_required = 1
+    }
+  }
+
+  specifications {
+    instance_type = "ml.c5.2xlarge"
+    model_name    = aws_sagemaker_model.test.name
+
+    compute_resource_requirements {
+      min_memory_required_in_mb    = 1024
+      number_of_cpu_cores_required = 1
+    }
+  }
+
+  runtime_config {
+    copy_count = 1
+  }
+}
+`, rName))
+}
+
+func testAccInferenceComponentConfig_containerMetricsConfig(rName string) string {
+	return acctest.ConfigCompose(testAccInferenceComponentConfig_base(rName), fmt.Sprintf(`
+resource "aws_sagemaker_inference_component" "test" {
+  name          = %[1]q
+  endpoint_name = aws_sagemaker_endpoint.test.name
+  variant_name  = "variant-1"
+
+  specification {
+    container {
+      image        = data.aws_sagemaker_prebuilt_ecr_image.test.registry_path
+      artifact_url = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.test.key}"
+
+      container_metrics_config {
+        metrics_endpoint {
+          metrics_endpoint_path               = "/metrics"
+          metric_publish_frequency_in_seconds = 30
+        }
+      }
+    }
+
+    compute_resource_requirements {
+      min_memory_required_in_mb    = 1024
+      number_of_cpu_cores_required = 1
+    }
+  }
+
+  runtime_config {
+    copy_count = 1
+  }
+}
+`, rName))
+}
+
+func testAccInferenceComponentConfig_specificationMemory(rName string, minMemory int) string {
+	return acctest.ConfigCompose(testAccInferenceComponentConfig_base(rName), fmt.Sprintf(`
+resource "aws_sagemaker_inference_component" "test" {
+  name          = %[1]q
+  endpoint_name = aws_sagemaker_endpoint.test.name
+  variant_name  = "variant-1"
+
+  specification {
+    container {
+      image        = data.aws_sagemaker_prebuilt_ecr_image.test.registry_path
+      artifact_url = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.test.key}"
+    }
+
+    compute_resource_requirements {
+      min_memory_required_in_mb    = %[2]d
+      number_of_cpu_cores_required = 1
+    }
+  }
+
+  runtime_config {
+    copy_count = 1
+  }
+}
+`, rName, minMemory))
+}
+
+func testAccInferenceComponentConfig_acceleratorDevices(rName string) string {
+	return acctest.ConfigCompose(testAccInferenceComponentConfig_baseInstanceType(rName, "ml.g5.xlarge"), fmt.Sprintf(`
+resource "aws_sagemaker_inference_component" "test" {
+  name          = %[1]q
+  endpoint_name = aws_sagemaker_endpoint.test.name
+  variant_name  = "variant-1"
+
+  specification {
+    container {
+      image        = data.aws_sagemaker_prebuilt_ecr_image.test.registry_path
+      artifact_url = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.test.key}"
+    }
+
+    compute_resource_requirements {
+      min_memory_required_in_mb              = 1024
+      number_of_accelerator_devices_required = 1
+    }
+
+    scheduling_config {
+      placement_strategy = "BINPACK"
+
+      availability_zone_balance {
+        enforcement_mode = "PERMISSIVE"
+      }
+    }
+  }
+
+  runtime_config {
+    copy_count = 1
+  }
+}
+`, rName))
+}
+
+func testAccInferenceComponentConfig_adapter(rName string) string {
+	return acctest.ConfigCompose(testAccInferenceComponentConfig_base(rName), fmt.Sprintf(`
+resource "aws_sagemaker_inference_component" "base" {
+  name          = "%[1]s-base"
+  endpoint_name = aws_sagemaker_endpoint.test.name
+  variant_name  = "variant-1"
+
+  specification {
+    container {
+      image        = data.aws_sagemaker_prebuilt_ecr_image.test.registry_path
+      artifact_url = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.test.key}"
+    }
+
+    compute_resource_requirements {
+      min_memory_required_in_mb    = 1024
+      number_of_cpu_cores_required = 1
+    }
+  }
+
+  runtime_config {
+    copy_count = 1
+  }
+}
+
+resource "aws_sagemaker_inference_component" "adapter" {
+  name          = "%[1]s-adapter"
+  endpoint_name = aws_sagemaker_endpoint.test.name
+
+  specification {
+    base_inference_component_name = aws_sagemaker_inference_component.base.name
+
+    container {
+      artifact_url = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.test.key}"
+    }
+  }
+}
+`, rName))
+}

--- a/internal/service/sagemaker/service_package_gen.go
+++ b/internal/service/sagemaker/service_package_gen.go
@@ -315,6 +315,15 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*inttypes.ServicePa
 			Region:   inttypes.ResourceRegionDefault(),
 		},
 		{
+			Factory:  resourceInferenceComponent,
+			TypeName: "aws_sagemaker_inference_component",
+			Name:     "Inference Component",
+			Tags: unique.Make(inttypes.ServicePackageResourceTags{
+				IdentifierAttribute: names.AttrARN,
+			}),
+			Region: inttypes.ResourceRegionDefault(),
+		},
+		{
 			Factory:  resourceMlflowTrackingServer,
 			TypeName: "aws_sagemaker_mlflow_tracking_server",
 			Name:     "Mlflow Tracking Server",

--- a/website/docs/r/sagemaker_inference_component.html.markdown
+++ b/website/docs/r/sagemaker_inference_component.html.markdown
@@ -1,0 +1,239 @@
+---
+subcategory: "SageMaker AI"
+layout: "aws"
+page_title: "AWS: aws_sagemaker_inference_component"
+description: |-
+  Provides a SageMaker AI Inference Component resource.
+---
+
+# Resource: aws_sagemaker_inference_component
+
+Provides a SageMaker AI Inference Component resource. An inference component is a SageMaker AI hosting object that you can use to deploy a model to an endpoint. You can optimize resource utilization by tailoring how the required CPU cores, accelerators, and memory are allocated. You can deploy multiple inference components to an endpoint, where each inference component contains one model and the resource utilization needs for that individual model.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_sagemaker_inference_component" "example" {
+  name          = "my-inference-component"
+  endpoint_name = aws_sagemaker_endpoint.example.name
+  variant_name  = "variant-1"
+
+  specification {
+    model_name = aws_sagemaker_model.example.name
+
+    compute_resource_requirements {
+      min_memory_required_in_mb = 1024
+    }
+  }
+
+  runtime_config {
+    copy_count = 1
+  }
+}
+```
+
+### With Container Specification
+
+```terraform
+resource "aws_sagemaker_inference_component" "example" {
+  name          = "my-inference-component"
+  endpoint_name = aws_sagemaker_endpoint.example.name
+  variant_name  = "variant-1"
+
+  specification {
+    container {
+      image        = "123456789012.dkr.ecr.us-east-1.amazonaws.com/my-model:latest"
+      artifact_url = "s3://my-bucket/model.tar.gz"
+
+      environment = {
+        MODEL_NAME = "my-model"
+      }
+    }
+
+    compute_resource_requirements {
+      min_memory_required_in_mb              = 2048
+      max_memory_required_in_mb              = 4096
+      number_of_cpu_cores_required           = 2
+      number_of_accelerator_devices_required = 1
+    }
+
+    startup_parameters {
+      container_startup_health_check_timeout_in_seconds = 300
+      model_data_download_timeout_in_seconds            = 300
+    }
+  }
+
+  runtime_config {
+    copy_count = 2
+  }
+}
+```
+
+### With Deployment Config
+
+`deployment_config` controls how *updates* to an existing inference component are rolled out; it has no effect on the initial create. Add it (or change it) on a subsequent apply to govern the rollout of a `specification` or `runtime_config` change.
+
+```terraform
+resource "aws_sagemaker_inference_component" "example" {
+  name          = "my-inference-component"
+  endpoint_name = aws_sagemaker_endpoint.example.name
+  variant_name  = "variant-1"
+
+  specification {
+    model_name = aws_sagemaker_model.example.name
+
+    compute_resource_requirements {
+      min_memory_required_in_mb = 1024
+    }
+  }
+
+  runtime_config {
+    copy_count = 4
+  }
+
+  deployment_config {
+    rolling_update_policy {
+      maximum_batch_size {
+        type  = "COPY_COUNT"
+        value = 1
+      }
+
+      wait_interval_in_seconds = 60
+    }
+
+    auto_rollback_configuration {
+      alarms {
+        alarm_name = aws_cloudwatch_metric_alarm.example.alarm_name
+      }
+    }
+  }
+}
+```
+
+## Argument Reference
+
+This resource supports the following arguments:
+
+* `name` - (Required) A unique name to assign to the inference component.
+* `endpoint_name` - (Required) The name of an existing endpoint where you host the inference component.
+* `variant_name` - (Optional) The name of an existing production variant where you host the inference component. Required for a standard inference component; must be omitted for an adapter inference component (one that sets `base_inference_component_name`).
+* `specification` - (Optional, conflicts with `specifications`) Details about the resources to deploy with this inference component. See [Specification](#specification).
+* `specifications` - (Optional, conflicts with `specification`) A list of specification objects for the inference component, one per instance type. See [Specification](#specification).
+* `runtime_config` - (Optional) Runtime settings for a model that is deployed with an inference component. See [Runtime Config](#runtime-config).
+* `deployment_config` - (Optional) The deployment configuration for the inference component, which controls the rollout strategy and rollback behavior. This directive applies only when the inference component is **updated** — the `CreateInferenceComponent` API does not accept it, so it has no effect on initial creation. It is not returned by the API and is therefore not refreshed into state or verified on import. See [Deployment Config](#deployment-config).
+* `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+### Specification
+
+* `model_name` - (Optional) The name of an existing SageMaker AI model object in your account that you want to deploy with the inference component.
+* `base_inference_component_name` - (Optional) The name of an existing inference component that is to contain the inference component that you're creating. Used for adapter inference components.
+* `instance_type` - (Optional) The ML compute instance type for this specification. Required when using the `specifications` parameter with multiple entries.
+* `compute_resource_requirements` - (Optional) The compute resources allocated to run a model. See [Compute Resource Requirements](#compute-resource-requirements).
+* `container` - (Optional) Defines a container that provides the runtime environment for a model. See [Container](#container).
+* `data_cache_config` - (Optional) Settings that affect how the inference component caches data. See [Data Cache Config](#data-cache-config).
+* `scheduling_config` - (Optional) The scheduling configuration for placing inference component copies. See [Scheduling Config](#scheduling-config).
+* `startup_parameters` - (Optional) Settings that take effect while the model container starts up. See [Startup Parameters](#startup-parameters).
+
+### Compute Resource Requirements
+
+* `min_memory_required_in_mb` - (Required) The minimum MB of memory to allocate to run a model. Minimum value of `128`.
+* `max_memory_required_in_mb` - (Optional) The maximum MB of memory to allocate to run a model. Minimum value of `128`.
+* `number_of_accelerator_devices_required` - (Optional) The number of accelerators (GPUs or AWS Inferentia) to allocate. Minimum value of `1`.
+* `number_of_cpu_cores_required` - (Optional) The number of CPU cores to allocate. Minimum value of `0.25`.
+
+### Container
+
+* `image` - (Optional) The Amazon ECR path where the Docker image for the model is stored.
+* `artifact_url` - (Optional) The Amazon S3 path where the model artifacts are stored (.tar.gz).
+* `environment` - (Optional) The environment variables to set in the Docker container.
+* `container_metrics_config` - (Optional) Configuration for container metrics scraping. See [Container Metrics Config](#container-metrics-config).
+
+### Container Metrics Config
+
+* `metrics_endpoint` - (Optional) The metrics endpoint configuration. See [Metrics Endpoint](#metrics-endpoint).
+
+### Metrics Endpoint
+
+* `metrics_endpoint_path` - (Required) The path to the metrics endpoint. Must start with `/`. Maximum 256 characters.
+* `metric_publish_frequency_in_seconds` - (Optional) The interval in seconds at which metrics are published. Valid values: `10`, `30`, `60`, `120`, `180`, `240`, `300`. Defaults to `60`.
+
+### Data Cache Config
+
+* `enable_caching` - (Required) Whether the endpoint caches model artifacts and container images.
+
+### Scheduling Config
+
+* `placement_strategy` - (Required) The strategy for placing inference component copies. Valid values: `SPREAD`, `BINPACK`.
+* `availability_zone_balance` - (Optional) Configuration for balancing copies across Availability Zones. See [Availability Zone Balance](#availability-zone-balance).
+
+### Availability Zone Balance
+
+* `enforcement_mode` - (Required) How strictly the AZ balance constraint is enforced. Valid values: `PERMISSIVE`.
+* `max_imbalance` - (Optional) The maximum allowed difference in copy count between any two Availability Zones. Default: `0`.
+
+### Startup Parameters
+
+* `container_startup_health_check_timeout_in_seconds` - (Optional) The timeout in seconds for the inference container to pass health check. Valid values: `60`-`3600`.
+* `model_data_download_timeout_in_seconds` - (Optional) The timeout in seconds to download and extract the model. Valid values: `60`-`3600`.
+
+### Runtime Config
+
+* `copy_count` - (Required) The number of runtime copies of the model container to deploy.
+
+### Deployment Config
+
+* `rolling_update_policy` - (Required) Specifies a rolling deployment strategy. See [Rolling Update Policy](#rolling-update-policy).
+* `auto_rollback_configuration` - (Optional) Automatic rollback configuration. See [Auto Rollback Configuration](#auto-rollback-configuration).
+
+### Rolling Update Policy
+
+* `maximum_batch_size` - (Required) The batch size for each rolling step. See [Capacity Size](#capacity-size).
+* `wait_interval_in_seconds` - (Required) The length of the baking period in seconds. Valid values: `0`-`3600`.
+* `maximum_execution_timeout_in_seconds` - (Optional) The time limit for the total deployment. Valid values are between `600` and `28800`.
+* `rollback_maximum_batch_size` - (Optional) The batch size for a rollback. See [Capacity Size](#capacity-size).
+
+### Capacity Size
+
+* `type` - (Required) The capacity size type. Valid values: `COPY_COUNT`, `CAPACITY_PERCENT`.
+* `value` - (Required) The capacity size value.
+
+### Auto Rollback Configuration
+
+* `alarms` - (Optional) List of CloudWatch alarms that trigger rollback. See [Alarms](#alarms).
+
+### Alarms
+
+* `alarm_name` - (Required) The name of a CloudWatch alarm.
+
+## Attribute Reference
+
+This resource exports the following attributes in addition to the arguments above:
+
+* `arn` - The Amazon Resource Name (ARN) of the inference component.
+* `endpoint_arn` - The Amazon Resource Name (ARN) of the endpoint that hosts the inference component.
+* `status` - The status of the inference component (e.g., `InService`, `Creating`, `Updating`, `Failed`, `Deleting`).
+* `failure_reason` - If the inference component status is `Failed`, the reason for the failure.
+* `creation_time` - The time when the inference component was created.
+* `last_modified_time` - The time when the inference component was last updated.
+* `runtime_config.0.current_copy_count` - The number of runtime copies currently deployed.
+* `runtime_config.0.desired_copy_count` - The number of runtime copies requested.
+* `runtime_config.0.placement_status` - The placement status of the inference component copies across instance types. Each block contains `current_copy_count` (the number of copies placed on this instance type) and `instance_type`.
+* `specification.0.container.0.resolved_image` - The specific digest path of the container image that was resolved and deployed.
+
+## Timeouts
+
+[Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
+
+* `create` - (Default `30m`)
+* `update` - (Default `30m`)
+* `delete` - (Default `30m`)
+
+## Import
+
+SageMaker AI Inference Components can be imported using the `name`, e.g.,
+
+```
+$ terraform import aws_sagemaker_inference_component.example my-inference-component
+```


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

None. This adds a new resource that manages SageMaker AI inference components via the standard SageMaker API; it introduces no new access-control, encryption, or logging behavior. IAM permissions for `sagemaker:CreateInferenceComponent`, `UpdateInferenceComponent`, `DescribeInferenceComponent`, and `DeleteInferenceComponent` are the caller's responsibility, consistent with other SageMaker resources.

### Description

> **Note:** This resource was developed with AI assistance. The code has been human-reviewed, the full acceptance-test suite was run against AWS (17/17 passing, output below), and the resource's create/update/delete lifecycle was additionally verified independently against CloudTrail logs — confirming balanced create/delete counts (18 creates / 18 deletes, no leaked resources), the 3 expected in-place updates, and zero unexpected API errors.

Adds a new resource, `aws_sagemaker_inference_component`, which deploys a model to a SageMaker AI endpoint as an inference component — letting you tailor the CPU cores, accelerators, and memory allocated to an individual model and run multiple models on one endpoint.

The resource covers the full `CreateInferenceComponent` / `UpdateInferenceComponent` SDK surface:

- **Specifications** — both the singular `specification` and the plural `specifications` (per-instance-type, minimum 2 entries), enforced mutually exclusive via `ExactlyOneOf`.
- **Container** — `image`, `artifact_url`, `environment`, and `container_metrics_config` (Prometheus metrics endpoint).
- **Compute** — `compute_resource_requirements` (memory, CPU cores, accelerator devices) with the API's documented minimums validated at plan time.
- **Scheduling** — `scheduling_config` (placement strategy, Availability Zone balance).
- **Runtime & rollout** — `runtime_config` (copy count) and update-only `deployment_config` (rolling update policy, auto-rollback alarms).
- **Adapter components** — `base_inference_component_name` for adapter inference components, which inherit the base component's compute and variant.

Server-populated fields (`variant_name`, `runtime_config`, `compute_resource_requirements`, `data_cache_config`) are marked `Computed` to avoid perpetual diffs, and computed outputs (`arn`, `endpoint_arn`, `status`, `failure_reason`, `creation_time`, `last_modified_time`, runtime copy counts and per-AZ `placement_status`, resolved container image) are surfaced. Create/update/delete use asynchronous status waiters; the delete path waits for full removal so a base component is not deleted before its adapter, and tolerates in-progress/concurrent deletions.

### Relations

Closes #35226

### References

- [CreateInferenceComponent API reference](https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_CreateInferenceComponent.html)

### Output from Acceptance Testing

```console
% make testacc TESTS='TestAccSageMakerInferenceComponent_' PKG=sagemaker

--- PASS: TestAccSageMakerInferenceComponent_acceleratorDevices (375.48s)
--- PASS: TestAccSageMakerInferenceComponent_adapter (528.05s)
--- PASS: TestAccSageMakerInferenceComponent_basic (386.36s)
--- PASS: TestAccSageMakerInferenceComponent_computeResourceRequirements (372.50s)
--- PASS: TestAccSageMakerInferenceComponent_container (384.08s)
--- PASS: TestAccSageMakerInferenceComponent_containerImage (372.62s)
--- PASS: TestAccSageMakerInferenceComponent_containerMetricsConfig (361.79s)
--- PASS: TestAccSageMakerInferenceComponent_dataCacheConfig (378.10s)
--- PASS: TestAccSageMakerInferenceComponent_deploymentConfig (449.33s)
--- PASS: TestAccSageMakerInferenceComponent_disappears (390.71s)
--- PASS: TestAccSageMakerInferenceComponent_modelName (382.31s)
--- PASS: TestAccSageMakerInferenceComponent_runtimeConfigUpdate (459.83s)
--- PASS: TestAccSageMakerInferenceComponent_schedulingConfig (484.06s)
--- PASS: TestAccSageMakerInferenceComponent_specifications (408.73s)
--- PASS: TestAccSageMakerInferenceComponent_specificationUpdate (756.39s)
--- PASS: TestAccSageMakerInferenceComponent_startupParameters (403.12s)
--- PASS: TestAccSageMakerInferenceComponent_tags (439.43s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sagemaker	1934.431s
```
