### PR TITLE
docs: add FEDERATED type example and documentation for aws_athena_data_catalog

### DIFF
--- a/website/docs/r/athena_data_catalog.html.markdown
+++ b/website/docs/r/athena_data_catalog.html.markdown
@@ -75,13 +75,36 @@ resource "aws_athena_data_catalog" "example" {
 }
 ```
 
+### Federated Data Catalog
+
+```terraform
+resource "aws_athena_data_catalog" "example" {
+  name        = "federated-data-catalog"
+  description = "Federated Data Catalog"
+  type        = "FEDERATED"
+
+  parameters = {
+    "connection-type" = "POSTGRESQL"
+    "connection-properties" = jsonencode({
+      HOST                = aws_db_instance.example.address
+      PORT                = tostring(aws_db_instance.example.port)
+      DATABASE            = aws_db_instance.example.db_name
+      SecretArn           = aws_secretsmanager_secret.example.arn
+      spill_bucket        = aws_s3_bucket.example.bucket
+      SubnetId            = aws_subnet.example.id
+      SecurityGroupIdList = [aws_security_group.example.id]
+    })
+  }
+}
+```
+
 ## Argument Reference
 
 This resource supports the following arguments:
 
 - `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 - `name` - (Required) Name of the data catalog. The catalog name must be unique for the AWS account and can use a maximum of 128 alphanumeric, underscore, at sign, or hyphen characters.
-- `type` - (Required) Type of data catalog: `LAMBDA` for a federated catalog, `GLUE` for AWS Glue Catalog, or `HIVE` for an external hive metastore.
+- `type` - (Required) Type of data catalog: `LAMBDA` for a federated catalog, `GLUE` for AWS Glue Catalog, `HIVE` for an external hive metastore, or `FEDERATED` for a federated catalog for which Athena creates the connection and the Lambda function based on the parameters that you pass.
 - `parameters` - (Required) Key value pairs that specifies the Lambda function or functions to use for the data catalog. The mapping used depends on the catalog type.
 - `description` - (Required) Description of the data catalog.
 - `tags` - (Optional) Map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.


### PR DESCRIPTION
### Description

Documented `type = "FEDERATED"` for aws_athena_data_catalog.

### Relations

N/A

### References

https://docs.aws.amazon.com/athena/latest/APIReference/API_DataCatalog.html#API_DataCatalog_Contents
