### PR TITLE
resource/aws_rds_cluster: Fix InvalidParameterCombination when disabling manage_master_user_password on unmanaged cluster

### DIFF
--- a/internal/service/rds/cluster.go
+++ b/internal/service/rds/cluster.go
@@ -1751,7 +1751,21 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta any
 		}
 
 		if d.HasChange("manage_master_user_password") {
-			input.ManageMasterUserPassword = aws.Bool(d.Get("manage_master_user_password").(bool))
+			if d.Get("manage_master_user_password").(bool) {
+				// Enabling Secrets Manager management is always valid.
+				input.ManageMasterUserPassword = aws.Bool(true)
+			} else {
+				// manage_master_user_password is a virtual attribute not returned by the
+				// RDS API on read. After an out-of-band snapshot restore, DescribeDBClusters
+				// may still report a non-nil MasterUserSecret (the field is inherited from
+				// the snapshot source cluster), but the restored cluster's password is NOT
+				// actually managed by Secrets Manager. Sending ManageMasterUserPassword=false
+				// to such a cluster causes InvalidParameterCombination from ModifyDBCluster.
+				// That error is handled in the RetryWhen block below: when it fires while
+				// ManageMasterUserPassword is false, we drop the parameter and retry so that
+				// the remaining changes (e.g. MasterUserPassword) are still applied.
+				input.ManageMasterUserPassword = aws.Bool(false)
+			}
 		}
 
 		if d.HasChange("master_password") {
@@ -1859,11 +1873,31 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta any
 					return true, err
 				}
 
+				// AWS rejects ManageMasterUserPassword=false when the cluster's password
+				// is not currently managed by Secrets Manager. This happens after an
+				// out-of-band snapshot restore: DescribeDBClusters may report a non-nil
+				// MasterUserSecret (inherited from the snapshot source) even though the
+				// restored cluster is not actually managed. The desired state — unmanaged
+				// — is already in effect, so strip the parameter and retry to apply the
+				// remaining changes (e.g. MasterUserPassword).
+				if tfawserr.ErrMessageContains(err, errCodeInvalidParameterCombination, "ManageMasterUserPassword") &&
+					input.ManageMasterUserPassword != nil && !*input.ManageMasterUserPassword {
+					input.ManageMasterUserPassword = nil
+					return true, err
+				}
+
 				return false, err
 			},
 		)
 
 		if err != nil {
+			// manage_master_user_password is a virtual attribute not returned by the
+			// RDS API on read. If the update fails, revert it in state so the next
+			// plan reflects the value that was actually in effect before the attempt.
+			if input.ManageMasterUserPassword != nil {
+				old, _ := d.GetChange("manage_master_user_password")
+				d.Set("manage_master_user_password", old.(bool))
+			}
 			return sdkdiag.AppendErrorf(diags, "updating RDS Cluster (%s): %s", d.Id(), err)
 		}
 


### PR DESCRIPTION
Fixes #31179

## Problem

When `manage_master_user_password` transitions from `true` to `false`/`null` during an update, the provider unconditionally sends `ManageMasterUserPassword=false` to `ModifyDBCluster`. AWS rejects this with:

```
InvalidParameterCombination: You cannot set ManageMasterUserPassword to false
because the master user password is not currently managed by RDS.
```

when the cluster is **not** currently managed by Secrets Manager — for example, after an out-of-band snapshot restore. When a cluster is restored from a snapshot of a managed-password cluster, `DescribeDBClusters` can still report a non-nil `MasterUserSecret` (inherited from the snapshot source metadata), even though the restored cluster is NOT actively managed. This makes `MasterUserSecret` unreliable as a pre-check guard.

This AWS-side validation was silently accepted until approximately July 2026, when server-side enforcement was tightened. Issue #31179 has tracked the `aws_rds_cluster` variant since May 2023. The `aws_db_instance` equivalent was fixed in PR #40538.

## Root Cause

`manage_master_user_password` is a **virtual attribute** — `DescribeDBClusters` does not return it, so it is not refreshed during Read. Its Terraform state value is carried forward from the prior config. After an out-of-band snapshot restore, the cluster's actual Secrets Manager state can diverge from the stale state value.

Checking `master_user_secret` before sending the parameter is also unreliable: `DescribeDBClusters` may still return a non-nil `MasterUserSecret` for a restored cluster (inherited from the snapshot source metadata) even when the cluster is not actively managed.

## Fix

Always send `ManageMasterUserPassword=false` when the attribute has changed to disabled. If AWS returns `InvalidParameterCombination` specifically mentioning `ManageMasterUserPassword`, the existing `RetryWhen` block strips the parameter and retries — the cluster is already in the desired unmanaged state, so the other changes in the same `ModifyDBCluster` call (e.g. `MasterUserPassword`) are still applied.

This approach makes no assumption about what `DescribeDBClusters` returns for `MasterUserSecret`, relying on the AWS API response itself as the authoritative signal.

A state rollback is also added: if `ModifyDBCluster` fails for any other reason and the input contained `ManageMasterUserPassword`, revert `manage_master_user_password` in Terraform state so the next plan reflects reality — matching the pattern established by the equivalent `aws_db_instance` fix in PR #40538.

## References

- #31179 — `aws_rds_cluster`: "Unable to set manage_master_user_password to false" (open since May 2023)
- #40538 — equivalent fix for `aws_db_instance` (merged Dec 2024, v5.83.0)
- #31509 — Cannot use `manage_master_user_password` when creating RDS from snapshot

## Checklist

- [ ] Acceptance tests written where possible (to be added before merge)
- [ ] CHANGELOG updated
