### PR TITLE
r/aws_bedrockagentcore_gateway: add waf_configuration and web_acl_arn

### DIFF
--- a/.changelog/48903.txt
+++ b/.changelog/48903.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_bedrockagentcore_gateway: Add `waf_configuration` argument and `web_acl_arn` attribute
+```

--- a/internal/service/bedrockagentcore/gateway.go
+++ b/internal/service/bedrockagentcore/gateway.go
@@ -27,6 +27,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -116,8 +117,26 @@ func (r *gatewayResource) Schema(ctx context.Context, request resource.SchemaReq
 				CustomType: fwtypes.ARNType,
 				Required:   true,
 			},
-			names.AttrTags:              tftags.TagsAttribute(),
-			names.AttrTagsAll:           tftags.TagsAttributeComputedOnly(),
+			names.AttrTags:    tftags.TagsAttribute(),
+			names.AttrTagsAll: tftags.TagsAttributeComputedOnly(),
+			// waf_configuration is server-managed: the AgentCore API synthesizes it
+			// (defaulting failure_mode to FAIL_CLOSE) once a WebACL is associated with
+			// the gateway, so it must be Optional+Computed to absorb that default when
+			// the practitioner does not manage it. It cannot be a block (blocks have no
+			// Computed concept and would perpetually diff against the default), nor a
+			// SingleNestedAttribute (schema-level nesting requires protocol v6, but this
+			// provider is served over v5). ObjectAttribute is the v5-compatible idiom;
+			// failure_mode's enum is enforced by the model's StringEnum custom type.
+			// TODO: Once Protocol v6 is supported, convert this to a schema.SingleNestedAttribute.
+			"waf_configuration": schema.ObjectAttribute{
+				CustomType: fwtypes.NewObjectTypeOf[gatewayWafConfigurationModel](ctx),
+				Optional:   true,
+				Computed:   true,
+				PlanModifiers: []planmodifier.Object{
+					objectplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"web_acl_arn":               framework.ARNAttributeComputedOnly(),
 			"workload_identity_details": framework.ResourceComputedListOfObjectsAttribute[workloadIdentityDetailsModel](ctx, listplanmodifier.UseStateForUnknown()),
 		},
 		Blocks: map[string]schema.Block{
@@ -289,6 +308,25 @@ func (r *gatewayResource) Create(ctx context.Context, request resource.CreateReq
 	var data gatewayResourceModel
 	smerr.AddEnrich(ctx, &response.Diagnostics, request.Plan.Get(ctx, &data))
 	if response.Diagnostics.HasError() {
+		return
+	}
+
+	// waf_configuration is only accepted by UpdateGateway once a WebACL is
+	// associated with the gateway, which cannot happen during creation. Reject it
+	// here with a clear message instead of surfacing a raw service error. Read from
+	// the config rather than the plan because waf_configuration is Optional+Computed,
+	// so its planned value is unknown (not null) whenever the practitioner omits it.
+	var config gatewayResourceModel
+	smerr.AddEnrich(ctx, &response.Diagnostics, request.Config.Get(ctx, &config))
+	if response.Diagnostics.HasError() {
+		return
+	}
+	if !config.WafConfiguration.IsNull() {
+		response.Diagnostics.AddAttributeError(
+			path.Root("waf_configuration"),
+			"Invalid Attribute Combination",
+			"waf_configuration cannot be set when creating a gateway because it requires an associated WebACL. Create the gateway, associate a WebACL (for example with aws_wafv2_web_acl_association), then set waf_configuration in a subsequent apply.",
+		)
 		return
 	}
 
@@ -604,7 +642,13 @@ type gatewayResourceModel struct {
 	Tags                      tftags.Map                                                             `tfsdk:"tags"`
 	TagsAll                   tftags.Map                                                             `tfsdk:"tags_all"`
 	Timeouts                  timeouts.Value                                                         `tfsdk:"timeouts"`
+	WafConfiguration          fwtypes.ObjectValueOf[gatewayWafConfigurationModel]                    `tfsdk:"waf_configuration"`
+	WebACLARN                 types.String                                                           `tfsdk:"web_acl_arn"`
 	WorkloadIdentityDetails   fwtypes.ListNestedObjectValueOf[workloadIdentityDetailsModel]          `tfsdk:"workload_identity_details"`
+}
+
+type gatewayWafConfigurationModel struct {
+	FailureMode fwtypes.StringEnum[awstypes.WafFailureMode] `tfsdk:"failure_mode"`
 }
 
 type gatewayPolicyEngineConfigurationModel struct {

--- a/internal/service/bedrockagentcore/gateway_test.go
+++ b/internal/service/bedrockagentcore/gateway_test.go
@@ -954,6 +954,168 @@ func TestAccBedrockAgentCoreGateway_policyEngineConfiguration(t *testing.T) {
 	})
 }
 
+func TestAccBedrockAgentCoreGateway_wafConfiguration(t *testing.T) {
+	ctx := acctest.Context(t)
+	var gateway bedrockagentcorecontrol.GetGatewayOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_bedrockagentcore_gateway.test"
+	failureModePath := tfjsonpath.New("waf_configuration").AtMapKey("failure_mode")
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID)
+			testAccPreCheckGateways(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockAgentCoreServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckGatewayDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				// waf_configuration requires an associated WebACL, so first create the
+				// gateway and the association without it.
+				Config: testAccGatewayConfig_wafConfiguration(rName, ""),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckGatewayExists(ctx, t, resourceName, &gateway),
+				),
+			},
+			{
+				// With a WebACL associated, waf_configuration can be applied via update.
+				Config: testAccGatewayConfig_wafConfiguration(rName, "FAIL_OPEN"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckGatewayExists(ctx, t, resourceName, &gateway),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, failureModePath, knownvalue.StringExact("FAIL_OPEN")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("web_acl_arn"), knownvalue.NotNull()),
+				},
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, "gateway_id"),
+				ImportStateVerifyIdentifierAttribute: "gateway_id",
+			},
+			{
+				// The failure mode is updatable in place.
+				Config: testAccGatewayConfig_wafConfiguration(rName, "FAIL_CLOSE"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckGatewayExists(ctx, t, resourceName, &gateway),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, failureModePath, knownvalue.StringExact("FAIL_CLOSE")),
+				},
+			},
+		},
+	})
+}
+
+func TestAccBedrockAgentCoreGateway_wafConfigurationAtCreate(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID)
+			testAccPreCheckGateways(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockAgentCoreServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckGatewayDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				// waf_configuration cannot be set at create (it requires an associated
+				// WebACL, which cannot exist before the gateway does).
+				Config:      testAccGatewayConfig_wafConfigurationAtCreate(rName),
+				ExpectError: regexache.MustCompile(`waf_configuration cannot be set when creating`),
+			},
+		},
+	})
+}
+
+func testAccGatewayConfig_wafConfiguration(rName, failureMode string) string {
+	waf := ""
+	if failureMode != "" {
+		waf = fmt.Sprintf(`
+  waf_configuration = {
+    failure_mode = %q
+  }
+`, failureMode)
+	}
+
+	return acctest.ConfigCompose(testAccGatewayConfig_iamRole(rName), fmt.Sprintf(`
+resource "aws_bedrockagentcore_gateway" "test" {
+  name     = %[1]q
+  role_arn = aws_iam_role.test.arn
+
+  authorizer_type = "CUSTOM_JWT"
+  authorizer_configuration {
+    custom_jwt_authorizer {
+      discovery_url    = "https://accounts.google.com/.well-known/openid-configuration"
+      allowed_audience = ["test1", "test2"]
+    }
+  }
+
+  protocol_type = "MCP"
+%[2]s}
+
+resource "aws_wafv2_web_acl" "test" {
+  name  = %[1]q
+  scope = "REGIONAL"
+
+  default_action {
+    allow {}
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = false
+    metric_name                = %[1]q
+    sampled_requests_enabled   = false
+  }
+}
+
+resource "aws_wafv2_web_acl_association" "test" {
+  resource_arn = aws_bedrockagentcore_gateway.test.gateway_arn
+  web_acl_arn  = aws_wafv2_web_acl.test.arn
+}
+`, rName, waf))
+}
+
+func testAccGatewayConfig_wafConfigurationAtCreate(rName string) string {
+	return acctest.ConfigCompose(testAccGatewayConfig_iamRole(rName), fmt.Sprintf(`
+resource "aws_bedrockagentcore_gateway" "test" {
+  name     = %[1]q
+  role_arn = aws_iam_role.test.arn
+
+  authorizer_type = "CUSTOM_JWT"
+  authorizer_configuration {
+    custom_jwt_authorizer {
+      discovery_url    = "https://accounts.google.com/.well-known/openid-configuration"
+      allowed_audience = ["test1", "test2"]
+    }
+  }
+
+  protocol_type = "MCP"
+
+  waf_configuration = {
+    failure_mode = "FAIL_OPEN"
+  }
+}
+`, rName))
+}
+
 func testAccCheckGatewayDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.ProviderMeta(ctx, t).BedrockAgentCoreClient(ctx)

--- a/website/docs/r/bedrockagentcore_gateway.html.markdown
+++ b/website/docs/r/bedrockagentcore_gateway.html.markdown
@@ -110,6 +110,29 @@ resource "aws_bedrockagentcore_gateway" "example" {
 }
 ```
 
+### Gateway with WAF Configuration
+
+`waf_configuration` requires an AWS WAF WebACL to already be associated with the gateway, so associate one with [`aws_wafv2_web_acl_association`](wafv2_web_acl_association.html.markdown) first. Because the association cannot exist until the gateway does, `waf_configuration` cannot be set in the same apply that creates the gateway; set it in a subsequent apply.
+
+```terraform
+resource "aws_bedrockagentcore_gateway" "example" {
+  name     = "gateway-with-waf"
+  role_arn = aws_iam_role.example.arn
+
+  authorizer_type = "AWS_IAM"
+  protocol_type   = "MCP"
+
+  waf_configuration = {
+    failure_mode = "FAIL_OPEN"
+  }
+}
+
+resource "aws_wafv2_web_acl_association" "example" {
+  resource_arn = aws_bedrockagentcore_gateway.example.gateway_arn
+  web_acl_arn  = aws_wafv2_web_acl.example.arn
+}
+```
+
 ## Argument Reference
 
 The following arguments are required:
@@ -130,6 +153,7 @@ The following arguments are optional:
 * `protocol_type` - (Optional) Protocol type for the gateway. Valid values: `MCP`. Omit this argument to create a gateway that routes traffic directly to HTTP targets such as AgentCore Runtime agents (see [`aws_bedrockagentcore_gateway_target`](bedrockagentcore_gateway_target.html.markdown) `target_configuration.http`).
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+* `waf_configuration` - (Optional) WAF configuration for the gateway. This can only be set on a gateway that already has a WebACL associated (for example with [`aws_wafv2_web_acl_association`](wafv2_web_acl_association.html.markdown)); it cannot be set in the same apply that creates the gateway. Once a WebACL is associated, the service manages this value (defaulting `failure_mode` to `FAIL_CLOSE`), so it is also Computed. See [`waf_configuration`](#waf_configuration) below.
 
 ### `authorizer_configuration`
 
@@ -230,6 +254,12 @@ The `streaming_configuration` block supports the following:
 
 * `enable_response_streaming` - (Optional) Boolean indicating whether response streaming is enabled for the gateway.
 
+### `waf_configuration`
+
+The `waf_configuration` block supports the following:
+
+* `failure_mode` - (Required) How the gateway handles requests when AWS WAF is unavailable or returns an error. Valid values: `FAIL_OPEN`, `FAIL_CLOSE`. Defaults to `FAIL_CLOSE` when a WebACL is associated and `waf_configuration` is not set.
+
 ## Attribute Reference
 
 This resource exports the following attributes in addition to the arguments above:
@@ -238,6 +268,7 @@ This resource exports the following attributes in addition to the arguments abov
 * `gateway_id` - Unique identifier of the Gateway.
 * `gateway_url` - URL endpoint for the gateway.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
+* `web_acl_arn` - ARN of the AWS WAF WebACL associated with the gateway, if any. Associate a WebACL with [`aws_wafv2_web_acl_association`](wafv2_web_acl_association.html.markdown).
 * `workload_identity_details` - Workload identity details for the gateway. See [`workload_identity_details`](#workload_identity_details) below.
 
 ### `workload_identity_details`


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

This PR surfaces an existing AWS WAF control on the gateway: `waf_configuration.failure_mode` selects the gateway's fail-open/fail-close behavior when AWS WAF is unavailable, and the new computed `web_acl_arn` reports the associated WebACL. No new access-control, encryption, or logging behavior is introduced by the provider itself; it exposes service-side WAF settings that are configured through `UpdateGateway`.

### Description

Adds AWS WAF support to `aws_bedrockagentcore_gateway`:

* New `waf_configuration` argument with a required `failure_mode` (`FAIL_OPEN` / `FAIL_CLOSE`).
* New computed `web_acl_arn` attribute reporting the WebACL associated with the gateway.

The AgentCore API only accepts `WafConfiguration` through `UpdateGateway`, and only once a WebACL is associated with the gateway (a WebACL is associated via the separate `aws_wafv2_web_acl_association` resource, which now supports `AGENTCORE_GATEWAY`). Two implementation details follow from the API's shape:

* **Update-only + create guard.** `CreateGateway` has no WAF field, and `UpdateGateway` rejects WAF until an association exists — which cannot happen before the gateway does. Setting `waf_configuration` in the same apply that creates the gateway is therefore rejected with a clear, actionable error instead of a raw service exception. It must be applied in a subsequent apply.
* **`Optional+Computed` to absorb the server default.** Once a WebACL is associated, the service synthesizes a `WafConfiguration` (defaulting `failure_mode` to `FAIL_CLOSE`) even when the practitioner never set one. Modeling the field as `Optional+Computed` prevents a perpetual `FAIL_CLOSE -> null` diff. Because the provider is served over Terraform plugin protocol v5, the nested value is expressed as a `schema.ObjectAttribute` (the v5-compatible idiom; a `SingleNestedAttribute` would require protocol v6).

Also bumps `aws-sdk-go-v2/service/bedrockagentcorecontrol` to `v1.47.0` for the WAF types.

### Relations

Closes #48661

### References

* AWS WAF association for AgentCore gateways is handled by `aws_wafv2_web_acl_association` (resource type `AGENTCORE_GATEWAY`).

### Output from Acceptance Testing

Verified against real AWS (us-west-2). The lifecycle test exercises: create gateway + WebACL + `aws_wafv2_web_acl_association` with no `waf_configuration` (no perpetual diff), add `waf_configuration` with `FAIL_OPEN` via update, import round-trip, then flip to `FAIL_CLOSE`. The second test asserts the create-time guard.

```console
% make testacc TESTS='TestAccBedrockAgentCoreGateway_wafConfiguration$$|TestAccBedrockAgentCoreGateway_wafConfigurationAtCreate$$' PKG=bedrockagentcore

--- PASS: TestAccBedrockAgentCoreGateway_wafConfigurationAtCreate (9.79s)
--- PASS: TestAccBedrockAgentCoreGateway_wafConfiguration (156.38s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/bedrockagentcore	156.535s
```

