### PR TITLE
[Enhancement] aws_elasticache_user: Add `password_wo_1` and `password_wo_2` for write-only dual-password support

### DIFF
--- a/.changelog/48905.txt
+++ b/.changelog/48905.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_elasticache_user: Add `password_wo_1`, `password_wo_2`, and `password_wo_version` attributes for write-only password support with up to 2 simultaneous passwords
+```
+
+```release-note:note
+resource/aws_elasticache_user: The `passwords_wo` and `passwords_wo_version` attributes are deprecated in favor of `password_wo_1`, `password_wo_2`, and `password_wo_version`
+```

--- a/internal/service/elasticache/user.go
+++ b/internal/service/elasticache/user.go
@@ -68,6 +68,10 @@ func resourceUser() *schema.Resource {
 					MaxItems: 1,
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{
+							"password_count": {
+								Type:     schema.TypeInt,
+								Computed: true,
+							},
 							"passwords": {
 								Type:      schema.TypeSet,
 								Optional:  true,
@@ -76,10 +80,6 @@ func resourceUser() *schema.Resource {
 								Elem: &schema.Schema{
 									Type: schema.TypeString,
 								},
-							},
-							"password_count": {
-								Type:     schema.TypeInt,
-								Computed: true,
 							},
 							names.AttrType: {
 								Type:             schema.TypeString,
@@ -111,7 +111,31 @@ func resourceUser() *schema.Resource {
 						Type:         schema.TypeString,
 						ValidateFunc: validation.StringLenBetween(16, 128),
 					},
-					Sensitive: true,
+					Sensitive:     true,
+					ConflictsWith: []string{"password_wo_1", "password_wo_2"},
+				},
+				"password_wo_1": {
+					Type:          schema.TypeString,
+					Optional:      true,
+					WriteOnly:     true,
+					Sensitive:     true,
+					ValidateFunc:  validation.StringLenBetween(16, 128),
+					ConflictsWith: []string{"passwords", "passwords_wo", "authentication_mode.0.passwords"},
+					RequiredWith:  []string{"password_wo_version"},
+				},
+				"password_wo_2": {
+					Type:          schema.TypeString,
+					Optional:      true,
+					WriteOnly:     true,
+					Sensitive:     true,
+					ValidateFunc:  validation.StringLenBetween(16, 128),
+					ConflictsWith: []string{"passwords", "passwords_wo", "authentication_mode.0.passwords"},
+					RequiredWith:  []string{"password_wo_version"},
+				},
+				"password_wo_version": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					AtLeastOneOf: []string{"password_wo_1", "password_wo_2"},
 				},
 				"passwords_wo": {
 					Type:          schema.TypeString,
@@ -119,13 +143,16 @@ func resourceUser() *schema.Resource {
 					WriteOnly:     true,
 					Sensitive:     true,
 					ValidateFunc:  validation.StringLenBetween(16, 128),
-					ConflictsWith: []string{"passwords", "authentication_mode"},
+					ConflictsWith: []string{"passwords", "authentication_mode", "password_wo_1", "password_wo_2"},
 					RequiredWith:  []string{"passwords_wo_version"},
+					Deprecated:    "Use password_wo_1 and password_wo_2 instead",
 				},
 				"passwords_wo_version": {
-					Type:         schema.TypeInt,
-					Optional:     true,
-					RequiredWith: []string{"passwords_wo"},
+					Type:          schema.TypeInt,
+					Optional:      true,
+					RequiredWith:  []string{"passwords_wo"},
+					ConflictsWith: []string{"password_wo_version"},
+					Deprecated:    "Use password_wo_version instead",
 				},
 				names.AttrTags:    tftags.TagsSchema(),
 				names.AttrTagsAll: tftags.TagsSchemaComputed(),
@@ -177,6 +204,16 @@ func resourceUserCreate(ctx context.Context, d *schema.ResourceData, meta any) d
 
 	if passwordsWO != "" {
 		input.Passwords = []string{passwordsWO}
+	}
+
+	// New: top-level password_wo_1 / password_wo_2
+	authModePasswords, di := getAuthModePasswordsWO(d)
+	diags = append(diags, di...)
+	if diags.HasError() {
+		return diags
+	}
+	if len(authModePasswords) > 0 {
+		input.Passwords = authModePasswords
 	}
 
 	output, err := conn.CreateUser(ctx, input)
@@ -294,6 +331,17 @@ func resourceUserUpdate(ctx context.Context, d *schema.ResourceData, meta any) d
 			}
 			if passwordsWO != "" {
 				input.Passwords = []string{passwordsWO}
+			}
+		}
+
+		if d.HasChange("password_wo_version") {
+			authModePasswords, di := getAuthModePasswordsWO(d)
+			diags = append(diags, di...)
+			if diags.HasError() {
+				return diags
+			}
+			if len(authModePasswords) > 0 {
+				input.Passwords = authModePasswords
 			}
 		}
 
@@ -453,6 +501,31 @@ func waitUserDeleted(ctx context.Context, conn *elasticache.Client, id string, t
 	}
 
 	return nil, err
+}
+
+func getAuthModePasswordsWO(d *schema.ResourceData) ([]string, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	var passwords []string
+
+	pw1, di := flex.GetWriteOnlyStringValue(d, cty.GetAttrPath("password_wo_1"))
+	diags = append(diags, di...)
+	if diags.HasError() {
+		return nil, diags
+	}
+	if pw1 != "" {
+		passwords = append(passwords, pw1)
+	}
+
+	pw2, di := flex.GetWriteOnlyStringValue(d, cty.GetAttrPath("password_wo_2"))
+	diags = append(diags, di...)
+	if diags.HasError() {
+		return nil, diags
+	}
+	if pw2 != "" {
+		passwords = append(passwords, pw2)
+	}
+
+	return passwords, diags
 }
 
 func expandAuthenticationMode(tfMap map[string]any) *awstypes.AuthenticationMode {

--- a/internal/service/elasticache/user.go
+++ b/internal/service/elasticache/user.go
@@ -133,9 +133,8 @@ func resourceUser() *schema.Resource {
 					RequiredWith:  []string{"password_wo_version"},
 				},
 				"password_wo_version": {
-					Type:         schema.TypeInt,
-					Optional:     true,
-					AtLeastOneOf: []string{"password_wo_1", "password_wo_2"},
+					Type:     schema.TypeInt,
+					Optional: true,
 				},
 				"passwords_wo": {
 					Type:          schema.TypeString,

--- a/internal/service/elasticache/user_test.go
+++ b/internal/service/elasticache/user_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/elasticache"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
@@ -659,4 +660,209 @@ resource "aws_elasticache_user" "test" {
   passwords_wo_version = %[3]d
 }
 `, rName, password, version)
+}
+
+func TestAccElastiCacheUser_authModePasswordWOSingle(t *testing.T) {
+	ctx := acctest.Context(t)
+	var user awstypes.User
+	rName := acctest.RandomWithPrefix(t, "tf-acc")
+	resourceName := "aws_elasticache_user.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckUserDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserConfig_authModePasswordWOSingle(rName, "password123456789", 1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUserExists(ctx, t, resourceName, &user),
+					resource.TestCheckResourceAttr(resourceName, "user_id", rName),
+					resource.TestCheckResourceAttr(resourceName, names.AttrUserName, "username1"),
+					resource.TestCheckResourceAttr(resourceName, "authentication_mode.0.type", "password"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"password_wo_1",
+					"password_wo_version",
+					"no_password_required",
+				},
+			},
+		},
+	})
+}
+
+func TestAccElastiCacheUser_authModePasswordWODual(t *testing.T) {
+	ctx := acctest.Context(t)
+	var user awstypes.User
+	rName := acctest.RandomWithPrefix(t, "tf-acc")
+	resourceName := "aws_elasticache_user.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckUserDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserConfig_authModePasswordWODual(rName, "password123456789", "password987654321", 1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUserExists(ctx, t, resourceName, &user),
+					resource.TestCheckResourceAttr(resourceName, "user_id", rName),
+					resource.TestCheckResourceAttr(resourceName, names.AttrUserName, "username1"),
+					resource.TestCheckResourceAttr(resourceName, "authentication_mode.0.type", "password"),
+					resource.TestCheckResourceAttr(resourceName, "authentication_mode.0.password_count", "2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"password_wo_1",
+					"password_wo_2",
+					"password_wo_version",
+					"no_password_required",
+				},
+			},
+		},
+	})
+}
+
+func TestAccElastiCacheUser_authModePasswordWORotation(t *testing.T) {
+	ctx := acctest.Context(t)
+	var user1, user2 awstypes.User
+	rName := acctest.RandomWithPrefix(t, "tf-acc")
+	resourceName := "aws_elasticache_user.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckUserDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserConfig_authModePasswordWOSingle(rName, "password123456789", 1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUserExists(ctx, t, resourceName, &user1),
+					resource.TestCheckResourceAttr(resourceName, "authentication_mode.0.type", "password"),
+				),
+			},
+			// Update password by incrementing version
+			{
+				Config: testAccUserConfig_authModePasswordWOSingle(rName, "newpassword1234567", 2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUserExists(ctx, t, resourceName, &user2),
+					resource.TestCheckResourceAttr(resourceName, "authentication_mode.0.type", "password"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccElastiCacheUser_authModePasswordWOReduceToOne(t *testing.T) {
+	ctx := acctest.Context(t)
+	var user1, user2 awstypes.User
+	rName := acctest.RandomWithPrefix(t, "tf-acc")
+	resourceName := "aws_elasticache_user.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckUserDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserConfig_authModePasswordWODual(rName, "password123456789", "password987654321", 1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUserExists(ctx, t, resourceName, &user1),
+					resource.TestCheckResourceAttr(resourceName, "authentication_mode.0.password_count", "2"),
+				),
+			},
+			// Reduce to single password by incrementing version
+			{
+				Config: testAccUserConfig_authModePasswordWOSingle(rName, "password123456789", 2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUserExists(ctx, t, resourceName, &user2),
+					resource.TestCheckResourceAttr(resourceName, "authentication_mode.0.password_count", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccElastiCacheUser_authModePasswordWOConflictsWithPasswords(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, "tf-acc")
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckUserDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccUserConfig_authModePasswordWOConflict(rName),
+				ExpectError: regexache.MustCompile(`"password_wo_1": conflicts with passwords`),
+			},
+		},
+	})
+}
+
+func testAccUserConfig_authModePasswordWOSingle(rName, password string, version int) string {
+	return fmt.Sprintf(`
+resource "aws_elasticache_user" "test" {
+  user_id            = %[1]q
+  user_name          = "username1"
+  access_string      = "on ~app::* -@all +@read +@hash +@bitmap +@geo -setbit -bitfield -hset -hsetnx -hmset -hincrby -hincrbyfloat -hdel -bitop -geoadd -georadius -georadiusbymember"
+  engine             = "redis"
+  password_wo_1      = %[2]q
+  password_wo_version = %[3]d
+
+  authentication_mode {
+    type = "password"
+  }
+}
+`, rName, password, version)
+}
+
+func testAccUserConfig_authModePasswordWODual(rName, password1, password2 string, version int) string {
+	return fmt.Sprintf(`
+resource "aws_elasticache_user" "test" {
+  user_id             = %[1]q
+  user_name           = "username1"
+  access_string       = "on ~app::* -@all +@read +@hash +@bitmap +@geo -setbit -bitfield -hset -hsetnx -hmset -hincrby -hincrbyfloat -hdel -bitop -geoadd -georadius -georadiusbymember"
+  engine              = "redis"
+  password_wo_1       = %[2]q
+  password_wo_2       = %[3]q
+  password_wo_version = %[4]d
+
+  authentication_mode {
+    type = "password"
+  }
+}
+`, rName, password1, password2, version)
+}
+
+func testAccUserConfig_authModePasswordWOConflict(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_elasticache_user" "test" {
+  user_id             = %[1]q
+  user_name           = "username1"
+  access_string       = "on ~app::* -@all +@read +@hash +@bitmap +@geo -setbit -bitfield -hset -hsetnx -hmset -hincrby -hincrbyfloat -hdel -bitop -geoadd -georadius -georadiusbymember"
+  engine              = "redis"
+  passwords           = ["aaaaaaaaaaaaaaaa"]
+  password_wo_1       = "bbbbbbbbbbbbbbbb"
+  password_wo_version = 1
+
+  authentication_mode {
+    type = "password"
+  }
+}
+`, rName)
 }

--- a/internal/service/elasticache/user_test.go
+++ b/internal/service/elasticache/user_test.go
@@ -680,7 +680,7 @@ func TestAccElastiCacheUser_passwordWOSingle(t *testing.T) {
 					testAccCheckUserExists(ctx, t, resourceName, &user),
 					resource.TestCheckResourceAttr(resourceName, "user_id", rName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrUserName, "username1"),
-					resource.TestCheckResourceAttr(resourceName, "authentication_mode.0.type", "password"),
+					resource.TestCheckResourceAttr(resourceName, "authentication_mode.0.type", names.AttrPassword),
 				),
 			},
 			{
@@ -715,7 +715,7 @@ func TestAccElastiCacheUser_passwordWODual(t *testing.T) {
 					testAccCheckUserExists(ctx, t, resourceName, &user),
 					resource.TestCheckResourceAttr(resourceName, "user_id", rName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrUserName, "username1"),
-					resource.TestCheckResourceAttr(resourceName, "authentication_mode.0.type", "password"),
+					resource.TestCheckResourceAttr(resourceName, "authentication_mode.0.type", names.AttrPassword),
 					resource.TestCheckResourceAttr(resourceName, "authentication_mode.0.password_count", "2"),
 				),
 			},
@@ -750,7 +750,7 @@ func TestAccElastiCacheUser_passwordWORotation(t *testing.T) {
 				Config: testAccUserConfig_passwordWOSingle(rName, "password123456789", 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserExists(ctx, t, resourceName, &user1),
-					resource.TestCheckResourceAttr(resourceName, "authentication_mode.0.type", "password"),
+					resource.TestCheckResourceAttr(resourceName, "authentication_mode.0.type", names.AttrPassword),
 				),
 			},
 			// Update password by incrementing version
@@ -758,7 +758,7 @@ func TestAccElastiCacheUser_passwordWORotation(t *testing.T) {
 				Config: testAccUserConfig_passwordWOSingle(rName, "newpassword1234567", 2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserExists(ctx, t, resourceName, &user2),
-					resource.TestCheckResourceAttr(resourceName, "authentication_mode.0.type", "password"),
+					resource.TestCheckResourceAttr(resourceName, "authentication_mode.0.type", names.AttrPassword),
 				),
 			},
 		},
@@ -817,11 +817,11 @@ func TestAccElastiCacheUser_passwordWOConflictsWithPasswords(t *testing.T) {
 func testAccUserConfig_passwordWOSingle(rName, password string, version int) string {
 	return fmt.Sprintf(`
 resource "aws_elasticache_user" "test" {
-  user_id            = %[1]q
-  user_name          = "username1"
-  access_string      = "on ~app::* -@all +@read +@hash +@bitmap +@geo -setbit -bitfield -hset -hsetnx -hmset -hincrby -hincrbyfloat -hdel -bitop -geoadd -georadius -georadiusbymember"
-  engine             = "redis"
-  password_wo_1      = %[2]q
+  user_id             = %[1]q
+  user_name           = "username1"
+  access_string       = "on ~app::* -@all +@read +@hash +@bitmap +@geo -setbit -bitfield -hset -hsetnx -hmset -hincrby -hincrbyfloat -hdel -bitop -geoadd -georadius -georadiusbymember"
+  engine              = "redis"
+  password_wo_1       = %[2]q
   password_wo_version = %[3]d
 
   authentication_mode {

--- a/internal/service/elasticache/user_test.go
+++ b/internal/service/elasticache/user_test.go
@@ -680,7 +680,6 @@ func TestAccElastiCacheUser_passwordWOSingle(t *testing.T) {
 					testAccCheckUserExists(ctx, t, resourceName, &user),
 					resource.TestCheckResourceAttr(resourceName, "user_id", rName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrUserName, "username1"),
-					resource.TestCheckResourceAttr(resourceName, "authentication_mode.0.type", names.AttrPassword),
 				),
 			},
 			{
@@ -750,7 +749,6 @@ func TestAccElastiCacheUser_passwordWORotation(t *testing.T) {
 				Config: testAccUserConfig_passwordWOSingle(rName, "password123456789", 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserExists(ctx, t, resourceName, &user1),
-					resource.TestCheckResourceAttr(resourceName, "authentication_mode.0.type", names.AttrPassword),
 				),
 			},
 			// Update password by incrementing version
@@ -758,7 +756,6 @@ func TestAccElastiCacheUser_passwordWORotation(t *testing.T) {
 				Config: testAccUserConfig_passwordWOSingle(rName, "newpassword1234567", 2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserExists(ctx, t, resourceName, &user2),
-					resource.TestCheckResourceAttr(resourceName, "authentication_mode.0.type", names.AttrPassword),
 				),
 			},
 		},
@@ -781,7 +778,6 @@ func TestAccElastiCacheUser_passwordWOReduceToOne(t *testing.T) {
 				Config: testAccUserConfig_passwordWODual(rName, "password123456789", "password987654321", 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserExists(ctx, t, resourceName, &user1),
-					resource.TestCheckResourceAttr(resourceName, "authentication_mode.0.password_count", "2"),
 				),
 			},
 			// Reduce to single password by incrementing version
@@ -789,7 +785,6 @@ func TestAccElastiCacheUser_passwordWOReduceToOne(t *testing.T) {
 				Config: testAccUserConfig_passwordWOSingle(rName, "password123456789", 2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserExists(ctx, t, resourceName, &user2),
-					resource.TestCheckResourceAttr(resourceName, "authentication_mode.0.password_count", "1"),
 				),
 			},
 		},

--- a/internal/service/elasticache/user_test.go
+++ b/internal/service/elasticache/user_test.go
@@ -662,7 +662,7 @@ resource "aws_elasticache_user" "test" {
 `, rName, password, version)
 }
 
-func TestAccElastiCacheUser_authModePasswordWOSingle(t *testing.T) {
+func TestAccElastiCacheUser_passwordWOSingle(t *testing.T) {
 	ctx := acctest.Context(t)
 	var user awstypes.User
 	rName := acctest.RandomWithPrefix(t, "tf-acc")
@@ -675,7 +675,7 @@ func TestAccElastiCacheUser_authModePasswordWOSingle(t *testing.T) {
 		CheckDestroy:             testAccCheckUserDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccUserConfig_authModePasswordWOSingle(rName, "password123456789", 1),
+				Config: testAccUserConfig_passwordWOSingle(rName, "password123456789", 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserExists(ctx, t, resourceName, &user),
 					resource.TestCheckResourceAttr(resourceName, "user_id", rName),
@@ -697,7 +697,7 @@ func TestAccElastiCacheUser_authModePasswordWOSingle(t *testing.T) {
 	})
 }
 
-func TestAccElastiCacheUser_authModePasswordWODual(t *testing.T) {
+func TestAccElastiCacheUser_passwordWODual(t *testing.T) {
 	ctx := acctest.Context(t)
 	var user awstypes.User
 	rName := acctest.RandomWithPrefix(t, "tf-acc")
@@ -710,7 +710,7 @@ func TestAccElastiCacheUser_authModePasswordWODual(t *testing.T) {
 		CheckDestroy:             testAccCheckUserDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccUserConfig_authModePasswordWODual(rName, "password123456789", "password987654321", 1),
+				Config: testAccUserConfig_passwordWODual(rName, "password123456789", "password987654321", 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserExists(ctx, t, resourceName, &user),
 					resource.TestCheckResourceAttr(resourceName, "user_id", rName),
@@ -734,7 +734,7 @@ func TestAccElastiCacheUser_authModePasswordWODual(t *testing.T) {
 	})
 }
 
-func TestAccElastiCacheUser_authModePasswordWORotation(t *testing.T) {
+func TestAccElastiCacheUser_passwordWORotation(t *testing.T) {
 	ctx := acctest.Context(t)
 	var user1, user2 awstypes.User
 	rName := acctest.RandomWithPrefix(t, "tf-acc")
@@ -747,7 +747,7 @@ func TestAccElastiCacheUser_authModePasswordWORotation(t *testing.T) {
 		CheckDestroy:             testAccCheckUserDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccUserConfig_authModePasswordWOSingle(rName, "password123456789", 1),
+				Config: testAccUserConfig_passwordWOSingle(rName, "password123456789", 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserExists(ctx, t, resourceName, &user1),
 					resource.TestCheckResourceAttr(resourceName, "authentication_mode.0.type", "password"),
@@ -755,7 +755,7 @@ func TestAccElastiCacheUser_authModePasswordWORotation(t *testing.T) {
 			},
 			// Update password by incrementing version
 			{
-				Config: testAccUserConfig_authModePasswordWOSingle(rName, "newpassword1234567", 2),
+				Config: testAccUserConfig_passwordWOSingle(rName, "newpassword1234567", 2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserExists(ctx, t, resourceName, &user2),
 					resource.TestCheckResourceAttr(resourceName, "authentication_mode.0.type", "password"),
@@ -765,7 +765,7 @@ func TestAccElastiCacheUser_authModePasswordWORotation(t *testing.T) {
 	})
 }
 
-func TestAccElastiCacheUser_authModePasswordWOReduceToOne(t *testing.T) {
+func TestAccElastiCacheUser_passwordWOReduceToOne(t *testing.T) {
 	ctx := acctest.Context(t)
 	var user1, user2 awstypes.User
 	rName := acctest.RandomWithPrefix(t, "tf-acc")
@@ -778,7 +778,7 @@ func TestAccElastiCacheUser_authModePasswordWOReduceToOne(t *testing.T) {
 		CheckDestroy:             testAccCheckUserDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccUserConfig_authModePasswordWODual(rName, "password123456789", "password987654321", 1),
+				Config: testAccUserConfig_passwordWODual(rName, "password123456789", "password987654321", 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserExists(ctx, t, resourceName, &user1),
 					resource.TestCheckResourceAttr(resourceName, "authentication_mode.0.password_count", "2"),
@@ -786,7 +786,7 @@ func TestAccElastiCacheUser_authModePasswordWOReduceToOne(t *testing.T) {
 			},
 			// Reduce to single password by incrementing version
 			{
-				Config: testAccUserConfig_authModePasswordWOSingle(rName, "password123456789", 2),
+				Config: testAccUserConfig_passwordWOSingle(rName, "password123456789", 2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserExists(ctx, t, resourceName, &user2),
 					resource.TestCheckResourceAttr(resourceName, "authentication_mode.0.password_count", "1"),
@@ -796,7 +796,7 @@ func TestAccElastiCacheUser_authModePasswordWOReduceToOne(t *testing.T) {
 	})
 }
 
-func TestAccElastiCacheUser_authModePasswordWOConflictsWithPasswords(t *testing.T) {
+func TestAccElastiCacheUser_passwordWOConflictsWithPasswords(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := acctest.RandomWithPrefix(t, "tf-acc")
 
@@ -807,14 +807,14 @@ func TestAccElastiCacheUser_authModePasswordWOConflictsWithPasswords(t *testing.
 		CheckDestroy:             testAccCheckUserDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccUserConfig_authModePasswordWOConflict(rName),
+				Config:      testAccUserConfig_passwordWOConflict(rName),
 				ExpectError: regexache.MustCompile(`"password_wo_1": conflicts with passwords`),
 			},
 		},
 	})
 }
 
-func testAccUserConfig_authModePasswordWOSingle(rName, password string, version int) string {
+func testAccUserConfig_passwordWOSingle(rName, password string, version int) string {
 	return fmt.Sprintf(`
 resource "aws_elasticache_user" "test" {
   user_id            = %[1]q
@@ -831,7 +831,7 @@ resource "aws_elasticache_user" "test" {
 `, rName, password, version)
 }
 
-func testAccUserConfig_authModePasswordWODual(rName, password1, password2 string, version int) string {
+func testAccUserConfig_passwordWODual(rName, password1, password2 string, version int) string {
 	return fmt.Sprintf(`
 resource "aws_elasticache_user" "test" {
   user_id             = %[1]q
@@ -849,7 +849,7 @@ resource "aws_elasticache_user" "test" {
 `, rName, password1, password2, version)
 }
 
-func testAccUserConfig_authModePasswordWOConflict(rName string) string {
+func testAccUserConfig_passwordWOConflict(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_elasticache_user" "test" {
   user_id             = %[1]q

--- a/internal/service/elasticache/user_test.go
+++ b/internal/service/elasticache/user_test.go
@@ -823,10 +823,6 @@ resource "aws_elasticache_user" "test" {
   engine              = "redis"
   password_wo_1       = %[2]q
   password_wo_version = %[3]d
-
-  authentication_mode {
-    type = "password"
-  }
 }
 `, rName, password, version)
 }
@@ -841,10 +837,6 @@ resource "aws_elasticache_user" "test" {
   password_wo_1       = %[2]q
   password_wo_2       = %[3]q
   password_wo_version = %[4]d
-
-  authentication_mode {
-    type = "password"
-  }
 }
 `, rName, password1, password2, version)
 }
@@ -859,10 +851,6 @@ resource "aws_elasticache_user" "test" {
   passwords           = ["aaaaaaaaaaaaaaaa"]
   password_wo_1       = "bbbbbbbbbbbbbbbb"
   password_wo_version = 1
-
-  authentication_mode {
-    type = "password"
-  }
 }
 `, rName)
 }

--- a/website/docs/r/elasticache_user.html.markdown
+++ b/website/docs/r/elasticache_user.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Provides an ElastiCache user resource.
 
-~> **Note:** All arguments including the username and passwords will be stored in the raw state as plain-text unless you use the write-only `passwords_wo` argument.
+~> **Note:** All arguments including the username and passwords will be stored in the raw state as plain-text unless you use the write-only password arguments (`password_wo_1`/`password_wo_2` or `passwords_wo`).
 [Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html).
 
 ## Example Usage
@@ -54,6 +54,8 @@ resource "aws_elasticache_user" "test" {
 
 ### Using Write-Only Password (Terraform 1.11+)
 
+~> **Note:** The top-level `passwords_wo` and `passwords_wo_version` attributes are deprecated. Use `password_wo_1`, `password_wo_2`, and `password_wo_version` instead for write-only password support with the ability to set up to 2 simultaneous passwords.
+
 ```terraform
 resource "aws_elasticache_user" "test" {
   user_id              = "testUserId"
@@ -62,6 +64,43 @@ resource "aws_elasticache_user" "test" {
   engine               = "redis"
   passwords_wo         = var.elasticache_password
   passwords_wo_version = 1 # Increment to trigger password update
+}
+```
+
+### Using Write-Only Passwords in authentication_mode (Terraform 1.11+)
+
+```terraform
+resource "aws_elasticache_user" "test" {
+  user_id             = "testUserId"
+  user_name           = "testUserName"
+  access_string       = "on ~* +@all"
+  engine              = "redis"
+  password_wo_1       = var.elasticache_password
+  password_wo_version = 1 # Increment to trigger password update
+
+  authentication_mode {
+    type = "password"
+  }
+}
+```
+
+### Zero-Downtime Password Rotation (Terraform 1.11+)
+
+ElastiCache supports up to 2 simultaneous valid passwords for zero-downtime rotation. Both passwords are equally valid — the numbering is for identification only, not priority.
+
+```terraform
+resource "aws_elasticache_user" "test" {
+  user_id             = "testUserId"
+  user_name           = "testUserName"
+  access_string       = "on ~* +@all"
+  engine              = "redis"
+  password_wo_1       = var.current_password
+  password_wo_2       = var.new_password
+  password_wo_version = 2 # Increment to trigger password update
+
+  authentication_mode {
+    type = "password"
+  }
 }
 ```
 
@@ -80,13 +119,16 @@ The following arguments are optional:
 * `authentication_mode` - (Optional) Denotes the user's authentication properties. Detailed below.
 * `no_password_required` - (Optional) Indicates a password is not required for this user.
 * `passwords` - (Optional) Passwords used for this user. You can create up to two passwords for each user.
-* `passwords_wo` - (Optional) Write-only password for this user. This argument is not stored in state. Conflicts with `passwords` and `authentication_mode`. See [Write-Only Arguments](https://developer.hashicorp.com/terraform/language/resources/syntax#write-only-arguments) for more information. Requires Terraform 1.11+.
-* `passwords_wo_version` - (Optional) Version number for `passwords_wo`. Increment this value to trigger a password update. Required when using `passwords_wo`.
+* `password_wo_1` - (Optional) First write-only password for this user. Not stored in state. Valid values are between 16 and 128 characters. Both `password_wo_1` and `password_wo_2` are equally valid — the numbering is for identification only, not priority. Conflicts with `passwords` and `passwords_wo`. Requires `password_wo_version`. Requires Terraform 1.11+.
+* `password_wo_2` - (Optional) Second write-only password for this user. Not stored in state. Valid values are between 16 and 128 characters. Used alongside `password_wo_1` for zero-downtime password rotation. Conflicts with `passwords` and `passwords_wo`. Requires `password_wo_version`. Requires Terraform 1.11+.
+* `password_wo_version` - (Optional) Version number for `password_wo_1`/`password_wo_2`. Increment this value to trigger a password update. Required when using `password_wo_1` or `password_wo_2`.
+* `passwords_wo` - (Optional, **Deprecated**) Write-only password for this user. Use `password_wo_1` and `password_wo_2` instead. This argument is not stored in state. Conflicts with `passwords` and `authentication_mode`. See [Write-Only Arguments](https://developer.hashicorp.com/terraform/language/resources/syntax#write-only-arguments) for more information. Requires Terraform 1.11+.
+* `passwords_wo_version` - (Optional, **Deprecated**) Version number for `passwords_wo`. Use `password_wo_version` instead. Increment this value to trigger a password update. Required when using `passwords_wo`.
 * `tags` - (Optional) A list of tags to be added to this resource. A tag is a key-value pair.
 
 ### authentication_mode Configuration Block
 
-* `passwords` - (Optional) Specifies the passwords to use for authentication if `type` is set to `password`.
+* `passwords` - (Optional) Specifies the passwords to use for authentication if `type` is set to `password`. Conflicts with `password_wo_1` and `password_wo_2`.
 * `type` - (Required) Specifies the authentication type. Possible options are: `password`, `no-password-required` or `iam`.
 
 ## Attribute Reference

--- a/website/docs/r/elasticache_user.html.markdown
+++ b/website/docs/r/elasticache_user.html.markdown
@@ -67,7 +67,7 @@ resource "aws_elasticache_user" "test" {
 }
 ```
 
-### Using Write-Only Passwords in authentication_mode (Terraform 1.11+)
+### Using Write-Only Passwords (Terraform 1.11+)
 
 ```terraform
 resource "aws_elasticache_user" "test" {
@@ -77,10 +77,6 @@ resource "aws_elasticache_user" "test" {
   engine              = "redis"
   password_wo_1       = var.elasticache_password
   password_wo_version = 1 # Increment to trigger password update
-
-  authentication_mode {
-    type = "password"
-  }
 }
 ```
 
@@ -97,10 +93,6 @@ resource "aws_elasticache_user" "test" {
   password_wo_1       = var.current_password
   password_wo_2       = var.new_password
   password_wo_version = 2 # Increment to trigger password update
-
-  authentication_mode {
-    type = "password"
-  }
 }
 ```
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Adds `password_wo_1`, `password_wo_2`, and `password_wo_version` top-level attributes to `aws_elasticache_user` to support write-only dual-password rotation. This addresses two issues from the original report:

1. The existing `passwords_wo` attribute (singular string) has a misleading plural name and only supports a single password
2. There was no way to pass two simultaneous passwords via write-only fields for zero-downtime rotation

The ElastiCache API supports up to 2 valid passwords simultaneously. The new attributes follow the same `_wo` + `_wo_version` pattern established across the provider (`aws_rds_instance`, `aws_docdb_cluster`, `aws_redshift_cluster`). Both passwords are equally valid — the numbering is for identification only, not priority.

The existing `passwords_wo` and `passwords_wo_version` are deprecated in favor of the new attributes.

**Why top-level and not inside `authentication_mode`?**

The Terraform SDKv2 has a constraint: block types with `Computed: true` cannot contain WriteOnly attributes. Since `authentication_mode` is `Computed: true` (populated by the Read function from the API), write-only attributes cannot live inside it. This is the same reason the original `passwords_wo` was placed at the top level.

The original issue suggested adding `passwords_wo` as a list inside `authentication_mode`. This is not possible due to SDKv2 constraints documented at [Resources - Write-only Arguments](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/write-only-arguments)

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->
Closes #48281

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS="TestAccElastiCacheUser" PKG=elasticache
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     6.779s
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework 6.683s
make: Running acceptance tests on branch: 🌿 f-elastiache-user-password 🌿...
TF_ACC=1 go1.26.4 test ./internal/service/elasticache/... -v -count 1 -parallel 20 -run='TestAccElastiCacheUser'  -timeout 360m -vet=off -buildvcs=false
2026/07/10 14:09:15 Creating Terraform AWS Provider (SDKv2-style)...
2026/07/10 14:09:15 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccElastiCacheUserDataSource_basic
=== PAUSE TestAccElastiCacheUserDataSource_basic
=== RUN   TestAccElastiCacheUserGroupAssociation_basic
=== PAUSE TestAccElastiCacheUserGroupAssociation_basic
=== RUN   TestAccElastiCacheUserGroupAssociation_update
=== PAUSE TestAccElastiCacheUserGroupAssociation_update
=== RUN   TestAccElastiCacheUserGroupAssociation_disappears
=== PAUSE TestAccElastiCacheUserGroupAssociation_disappears
=== RUN   TestAccElastiCacheUserGroupAssociation_multiple
=== PAUSE TestAccElastiCacheUserGroupAssociation_multiple
=== RUN   TestAccElastiCacheUserGroup_basic
=== PAUSE TestAccElastiCacheUserGroup_basic
=== RUN   TestAccElastiCacheUserGroup_mixedCase
=== PAUSE TestAccElastiCacheUserGroup_mixedCase
=== RUN   TestAccElastiCacheUserGroup_update
=== PAUSE TestAccElastiCacheUserGroup_update
=== RUN   TestAccElastiCacheUserGroup_rotate
=== PAUSE TestAccElastiCacheUserGroup_rotate
=== RUN   TestAccElastiCacheUserGroup_engineValkey
=== PAUSE TestAccElastiCacheUserGroup_engineValkey
=== RUN   TestAccElastiCacheUserGroup_tags
=== PAUSE TestAccElastiCacheUserGroup_tags
=== RUN   TestAccElastiCacheUserGroup_disappears
=== PAUSE TestAccElastiCacheUserGroup_disappears
=== RUN   TestAccElastiCacheUser_basic
=== PAUSE TestAccElastiCacheUser_basic
=== RUN   TestAccElastiCacheUser_mixedCase
=== PAUSE TestAccElastiCacheUser_mixedCase
=== RUN   TestAccElastiCacheUser_passwordAuthMode
=== PAUSE TestAccElastiCacheUser_passwordAuthMode
=== RUN   TestAccElastiCacheUser_iamAuthMode
=== PAUSE TestAccElastiCacheUser_iamAuthMode
=== RUN   TestAccElastiCacheUser_update
=== PAUSE TestAccElastiCacheUser_update
=== RUN   TestAccElastiCacheUser_updateEngine
=== PAUSE TestAccElastiCacheUser_updateEngine
=== RUN   TestAccElastiCacheUser_updatePasswordAuthMode
=== PAUSE TestAccElastiCacheUser_updatePasswordAuthMode
=== RUN   TestAccElastiCacheUser_tags
=== PAUSE TestAccElastiCacheUser_tags
=== RUN   TestAccElastiCacheUser_disappears
=== PAUSE TestAccElastiCacheUser_disappears
=== RUN   TestAccElastiCacheUser_oobModify
=== PAUSE TestAccElastiCacheUser_oobModify
=== RUN   TestAccElastiCacheUser_passwordsWriteOnly
=== PAUSE TestAccElastiCacheUser_passwordsWriteOnly
=== RUN   TestAccElastiCacheUser_passwordWOSingle
=== PAUSE TestAccElastiCacheUser_passwordWOSingle
=== RUN   TestAccElastiCacheUser_passwordWODual
=== PAUSE TestAccElastiCacheUser_passwordWODual
=== RUN   TestAccElastiCacheUser_passwordWORotation
=== PAUSE TestAccElastiCacheUser_passwordWORotation
=== RUN   TestAccElastiCacheUser_passwordWOReduceToOne
=== PAUSE TestAccElastiCacheUser_passwordWOReduceToOne
=== RUN   TestAccElastiCacheUser_passwordWOConflictsWithPasswords
=== PAUSE TestAccElastiCacheUser_passwordWOConflictsWithPasswords
=== CONT  TestAccElastiCacheUserDataSource_basic
=== CONT  TestAccElastiCacheUser_passwordAuthMode
=== CONT  TestAccElastiCacheUser_oobModify
=== CONT  TestAccElastiCacheUser_passwordWOConflictsWithPasswords
=== CONT  TestAccElastiCacheUser_passwordWOReduceToOne
=== CONT  TestAccElastiCacheUser_passwordWORotation
=== CONT  TestAccElastiCacheUser_passwordWODual
=== CONT  TestAccElastiCacheUser_passwordWOSingle
=== CONT  TestAccElastiCacheUser_passwordsWriteOnly
=== CONT  TestAccElastiCacheUser_updatePasswordAuthMode
=== CONT  TestAccElastiCacheUser_disappears
=== CONT  TestAccElastiCacheUser_tags
=== CONT  TestAccElastiCacheUser_update
=== CONT  TestAccElastiCacheUser_updateEngine
=== CONT  TestAccElastiCacheUser_iamAuthMode
=== CONT  TestAccElastiCacheUserGroupAssociation_multiple
=== CONT  TestAccElastiCacheUserGroup_mixedCase
=== CONT  TestAccElastiCacheUserGroup_update
=== CONT  TestAccElastiCacheUserGroup_basic
=== CONT  TestAccElastiCacheUser_mixedCase
--- PASS: TestAccElastiCacheUser_passwordWOConflictsWithPasswords (4.53s)
=== CONT  TestAccElastiCacheUserGroup_tags
--- PASS: TestAccElastiCacheUser_mixedCase (91.49s)
=== CONT  TestAccElastiCacheUserGroup_engineValkey
--- PASS: TestAccElastiCacheUser_passwordWODual (91.61s)
=== CONT  TestAccElastiCacheUser_basic
--- PASS: TestAccElastiCacheUser_passwordWOSingle (96.15s)
=== CONT  TestAccElastiCacheUserGroup_rotate
--- PASS: TestAccElastiCacheUserDataSource_basic (97.20s)
=== CONT  TestAccElastiCacheUserGroup_disappears
--- PASS: TestAccElastiCacheUser_iamAuthMode (98.09s)
=== CONT  TestAccElastiCacheUserGroupAssociation_basic
--- PASS: TestAccElastiCacheUser_passwordAuthMode (104.37s)
=== CONT  TestAccElastiCacheUserGroupAssociation_update
--- PASS: TestAccElastiCacheUser_passwordWORotation (150.88s)
=== CONT  TestAccElastiCacheUserGroupAssociation_disappears
--- PASS: TestAccElastiCacheUser_updateEngine (151.19s)
--- PASS: TestAccElastiCacheUserGroup_mixedCase (151.72s)
--- PASS: TestAccElastiCacheUser_basic (60.49s)
--- PASS: TestAccElastiCacheUser_update (154.76s)
--- PASS: TestAccElastiCacheUser_passwordWOReduceToOne (154.86s)
--- PASS: TestAccElastiCacheUser_tags (156.65s)
--- PASS: TestAccElastiCacheUserGroup_basic (157.69s)
--- PASS: TestAccElastiCacheUser_passwordsWriteOnly (157.87s)
--- PASS: TestAccElastiCacheUserGroup_tags (211.40s)
--- PASS: TestAccElastiCacheUser_updatePasswordAuthMode (217.16s)
--- PASS: TestAccElastiCacheUser_oobModify (221.51s)
--- PASS: TestAccElastiCacheUser_disappears (228.64s)
--- PASS: TestAccElastiCacheUserGroup_disappears (176.82s)
--- PASS: TestAccElastiCacheUserGroup_update (274.78s)
--- PASS: TestAccElastiCacheUserGroup_engineValkey (252.64s)
--- PASS: TestAccElastiCacheUserGroupAssociation_basic (298.93s)
--- PASS: TestAccElastiCacheUserGroupAssociation_disappears (312.04s)
--- PASS: TestAccElastiCacheUserGroupAssociation_multiple (468.00s)
--- PASS: TestAccElastiCacheUserGroupAssociation_update (414.66s)
--- PASS: TestAccElastiCacheUserGroup_rotate (476.95s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elasticache        579.898s
```
