### PR TITLE
r/aws_storagegateway_smb_file_share: allow cache_stale_timeout_in_seconds = 0

### DIFF
--- a/.changelog/48907.txt
+++ b/.changelog/48907.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_storagegateway_smb_file_share: Allow `cache_attributes.cache_stale_timeout_in_seconds` to be set to `0` to disable cache refresh
+```

--- a/internal/service/storagegateway/smb_file_share.go
+++ b/internal/service/storagegateway/smb_file_share.go
@@ -89,9 +89,12 @@ func resourceSMBFileShare() *schema.Resource {
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{
 							"cache_stale_timeout_in_seconds": {
-								Type:         schema.TypeInt,
-								Optional:     true,
-								ValidateFunc: validation.IntBetween(300, 2592000),
+								Type:     schema.TypeInt,
+								Optional: true,
+								ValidateFunc: validation.Any(
+									validation.IntInSlice([]int{0}),
+									validation.IntBetween(300, 2592000),
+								),
 							},
 						},
 					},
@@ -585,7 +588,7 @@ func expandCacheAttributes(tfMap map[string]any) *awstypes.CacheAttributes {
 
 	apiObject := &awstypes.CacheAttributes{}
 
-	if v, ok := tfMap["cache_stale_timeout_in_seconds"].(int); ok && v != 0 {
+	if v, ok := tfMap["cache_stale_timeout_in_seconds"].(int); ok {
 		apiObject.CacheStaleTimeoutInSeconds = aws.Int32(int32(v))
 	}
 

--- a/website/docs/r/storagegateway_smb_file_share.html.markdown
+++ b/website/docs/r/storagegateway_smb_file_share.html.markdown
@@ -77,7 +77,7 @@ The `cache_attributes` configuration block supports the following arguments:
 
 * `cache_stale_timeout_in_seconds` - (Optional) Refreshes a file share's cache by using Time To Live (TTL).
  TTL is the length of time since the last refresh after which access to the directory would cause the file gateway
-  to first refresh that directory's contents from the Amazon S3 bucket. Valid Values: 300 to 2,592,000 seconds (5 minutes to 30 days)
+  to first refresh that directory's contents from the Amazon S3 bucket. Valid Values: `0` or `300` to `2592000` seconds (5 minutes to 30 days). Setting this value to `0` disables cache refresh.
 
 ## Attribute Reference
 


### PR DESCRIPTION
### Description

`aws_storagegateway_smb_file_share` rejected `cache_stale_timeout_in_seconds = 0` at plan time via `IntBetween(300, 2592000)`, even though the AWS Storage Gateway API accepts `0` to disable cache refresh. This also caused a permanent `0 -> null` diff for shares configured to `0` outside Terraform.

This PR:

- Allows `0` alongside the existing `300`–`2592000` range via `validation.Any`.
- Removes the `&& v != 0` guard in `expandCacheAttributes` so a configured `0` is actually sent to the API (matches `aws_storagegateway_nfs_file_share`, which already sends the value).
- Updates the resource documentation.

Note: since `cache_stale_timeout_in_seconds` is the only field in the `cache_attributes` block, an empty block now sends `0` (disable refresh) rather than omitting it — an empty block was previously a no-op.

### Relations

Closes #48876

### Output from Acceptance Testing

Acceptance tests require AWS credentials and were not run locally. `go build`, `go vet`, and `gofmt` pass against the modified package.
