### PR TITLE
r/aws_storagegateway_nfs_file_share: allow cache_stale_timeout_in_seconds = 0

### DIFF
--- a/.changelog/48908.txt
+++ b/.changelog/48908.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_storagegateway_nfs_file_share: Allow `cache_attributes.cache_stale_timeout_in_seconds` to be set to `0` to disable cache refresh
+```

--- a/internal/service/storagegateway/nfs_file_share.go
+++ b/internal/service/storagegateway/nfs_file_share.go
@@ -73,9 +73,12 @@ func resourceNFSFileShare() *schema.Resource {
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{
 							"cache_stale_timeout_in_seconds": {
-								Type:         schema.TypeInt,
-								Optional:     true,
-								ValidateFunc: validation.IntBetween(300, 2592000),
+								Type:     schema.TypeInt,
+								Optional: true,
+								ValidateFunc: validation.Any(
+									validation.IntInSlice([]int{0}),
+									validation.IntBetween(300, 2592000),
+								),
 							},
 						},
 					},

--- a/website/docs/r/storagegateway_nfs_file_share.html.markdown
+++ b/website/docs/r/storagegateway_nfs_file_share.html.markdown
@@ -60,7 +60,7 @@ Files and folders stored as Amazon S3 objects in S3 buckets don't, by default, h
 
 * `cache_stale_timeout_in_seconds` - (Optional) Refreshes a file share's cache by using Time To Live (TTL).
  TTL is the length of time since the last refresh after which access to the directory would cause the file gateway
-  to first refresh that directory's contents from the Amazon S3 bucket. Valid Values: 300 to 2,592,000 seconds (5 minutes to 30 days)
+  to first refresh that directory's contents from the Amazon S3 bucket. Valid Values: `0` or `300` to `2592000` seconds (5 minutes to 30 days). Setting this value to `0` disables cache refresh.
 
 ## Attribute Reference
 


### PR DESCRIPTION
### Description

`aws_storagegateway_nfs_file_share` rejected `cache_stale_timeout_in_seconds = 0` at plan time via `IntBetween(300, 2592000)`, even though the AWS Storage Gateway API accepts `0` to disable cache refresh.

This PR allows `0` alongside the existing `300`–`2592000` range via `validation.Any`. Unlike the SMB resource, `expandNFSFileShareCacheAttributes` already forwards the value unconditionally, so no expand change is needed — once validation permits `0`, it reaches the API correctly.

This mirrors the same fix applied to `aws_storagegateway_smb_file_share` in #48907, keeping the sibling resources consistent.

### Relations

Relates to #48907

### Output from Acceptance Testing

Acceptance tests require AWS credentials and were not run locally. `go build`, `go vet`, and `gofmt` pass against the modified package.
