### PR TITLE
docs: add supported value for mwaa environment webserver_access_mode

### DIFF
--- a/website/docs/r/mwaa_environment.html.markdown
+++ b/website/docs/r/mwaa_environment.html.markdown
@@ -150,7 +150,7 @@ This resource supports the following arguments:
 * `startup_script_s3_object_version` - (Optional) The version of the startup shell script you want to use. You must specify the version ID that Amazon S3 assigns to the file every time you update the script.
 * `startup_script_s3_path` - (Optional) The relative path to the script hosted in your bucket. The script runs as your environment starts before starting the Apache Airflow process. Use this script to install dependencies, modify configuration options, and set environment variables. See [Using a startup script](https://docs.aws.amazon.com/mwaa/latest/userguide/using-startup-script.html). Supported for environment versions 2.x and later.
 * `tags` - (Optional) A map of resource tags to associate with the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
-* `webserver_access_mode` - (Optional) Specifies whether the webserver should be accessible over the internet or via your specified VPC. Possible options: `PRIVATE_ONLY` (default) and `PUBLIC_ONLY`.
+* `webserver_access_mode` - (Optional) Specifies whether the webserver should be accessible over the internet or via your specified VPC. Possible options: `PRIVATE_ONLY` (default), `PUBLIC_ONLY` and `PUBLIC_AND_PRIVATE`.
 * `weekly_maintenance_window_start` - (Optional) Specifies the start date for the weekly maintenance window.
 * `worker_replacement_strategy` - (Optional) Worker replacement strategy. Valid values: `FORCED`, `GRACEFUL`.
 


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls implemented.

### Description

Add missing option `PUBLIC_AND_PRIVATE` to `webserver_access_mode` of resource `aws_mwaa_environment`.

In the linked issue dosu mentioned that the option is not supported at the moment 

> the SDK version used by the provider (v1.42.0) does not yet include the PUBLIC_AND_PRIVATE constant [[3]](https://github.com/hashicorp/terraform-provider-aws/blob/04247ed031ef57e587cf28e955c4764ad3803df8/internal/service/mwaa/environment_test.go#L79) [[4]](https://github.com/hashicorp/terraform-provider-aws/blob/04247ed031ef57e587cf28e955c4764ad3803df8/go.mod#L182).

but actually it is. We are on SDK version v1.42.0 and the support was added in v1.40.0 ) (see References).


### Relations

Closes #48835 

### References

- [AWS SDK Go V2 release notes](https://github.com/aws/aws-sdk-go-v2/releases/tag/release-2026-05-06) containing
  > github.com/aws/aws-sdk-go-v2/service/mwaa: [v1.40.0](https://github.com/aws/aws-sdk-go-v2/blob/release-2026-05-06/service/mwaa/CHANGELOG.md#v1400-2026-05-06)
Feature: Amazon MWAA now supports a PublicAndPrivate webserver access mode. The Airflow web server is accessible over both public and private endpoints, enabling workers in VPCs without internet access to reach the Task API privately while retaining public access to the Airflow UI.

### Output from Acceptance Testing

Not applicable. Only documentation is updated.