### PR TITLE
docs/aws_mwaa_environment: add PUBLIC_AND_PRIVATE to webserver_access_mode

### DIFF
--- a/website/docs/r/mwaa_environment.html.markdown
+++ b/website/docs/r/mwaa_environment.html.markdown
@@ -150,7 +150,7 @@ This resource supports the following arguments:
 * `startup_script_s3_object_version` - (Optional) The version of the startup shell script you want to use. You must specify the version ID that Amazon S3 assigns to the file every time you update the script.
 * `startup_script_s3_path` - (Optional) The relative path to the script hosted in your bucket. The script runs as your environment starts before starting the Apache Airflow process. Use this script to install dependencies, modify configuration options, and set environment variables. See [Using a startup script](https://docs.aws.amazon.com/mwaa/latest/userguide/using-startup-script.html). Supported for environment versions 2.x and later.
 * `tags` - (Optional) A map of resource tags to associate with the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
-* `webserver_access_mode` - (Optional) Specifies whether the webserver should be accessible over the internet or via your specified VPC. Possible options: `PRIVATE_ONLY` (default) and `PUBLIC_ONLY`.
+* `webserver_access_mode` - (Optional) Specifies whether the webserver should be accessible over the internet or via your specified VPC. Possible options: `PRIVATE_ONLY` (default), `PUBLIC_ONLY`, and `PUBLIC_AND_PRIVATE`.
 * `weekly_maintenance_window_start` - (Optional) Specifies the start date for the weekly maintenance window.
 * `worker_replacement_strategy` - (Optional) Worker replacement strategy. Valid values: `FORCED`, `GRACEFUL`.
 


### PR DESCRIPTION
### Description

Documents the third valid value for the `webserver_access_mode` argument of `aws_mwaa_environment`. AWS added `PUBLIC_AND_PRIVATE` to the MWAA `WebserverAccessMode` API enum, but the resource docs still only list `PRIVATE_ONLY` and `PUBLIC_ONLY`.

The schema already accepts the value — validation is derived from the SDK enum:

```go
"webserver_access_mode": {
    ...
    ValidateDiagFunc: enum.Validate[awstypes.WebserverAccessMode](),
},
```

and the vendored `github.com/aws/aws-sdk-go-v2/service/mwaa v1.42.0` includes:

```go
WebserverAccessModePublicAndPrivate WebserverAccessMode = "PUBLIC_AND_PRIVATE"
```

So this is a documentation-only gap: the value works today but isn't listed. This PR adds it to the argument's "Possible options" list.

### Relations

Closes #48835

### References

* AWS SDK for Go v2 — MWAA `PublicAndPrivate` webserver access mode: https://github.com/aws/aws-sdk-go-v2/blob/release-2026-05-06/service/mwaa/CHANGELOG.md#v1400-2026-05-06

### Output from Acceptance Testing

Documentation-only change; no acceptance tests affected.