### PR TITLE
resource/aws_flow_log: Add tag_field_specifications argument

### DIFF
--- a/.changelog/48806.txt
+++ b/.changelog/48806.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_flow_log: Add `tag_field_specifications` argument to support the Flow Logs Amazon EC2 Tags feature fields (e.g., `${instance-tag}`) in `log_format`
+```

--- a/.changelog/48806.txt
+++ b/.changelog/48806.txt
@@ -1,3 +1,0 @@
-```release-note:enhancement
-resource/aws_flow_log: Add `tag_field_specifications` argument to support the Flow Logs Amazon EC2 Tags feature fields (e.g., `${instance-tag}`) in `log_format`
-```

--- a/.changelog/48913.txt
+++ b/.changelog/48913.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_flow_log: Add `tag_field_specifications` configuration block
+resource/aws_flow_log: Add `tag_field_specification` configuration block
 ```

--- a/.changelog/48913.txt
+++ b/.changelog/48913.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_flow_log: Add `tag_field_specifications` configuration block
+```

--- a/internal/service/ec2/vpc_flow_log.go
+++ b/internal/service/ec2/vpc_flow_log.go
@@ -140,7 +140,7 @@ func resourceFlowLog() *schema.Resource {
 								Type:             schema.TypeString,
 								Required:         true,
 								ForceNew:         true,
-							ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{"instance", "network-interface", "auto-scaling-group"}, false)),
+								ValidateDiagFunc: enum.Validate[awstypes.TaggableResourceType](),
 							},
 							"tag_keys": {
 								Type:     schema.TypeList,

--- a/internal/service/ec2/vpc_flow_log.go
+++ b/internal/service/ec2/vpc_flow_log.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -128,6 +129,27 @@ func resourceFlowLog() *schema.Resource {
 					Optional:     true,
 					ForceNew:     true,
 					ExactlyOneOf: []string{"eni_id", "regional_nat_gateway_id", names.AttrSubnetID, names.AttrVPCID, names.AttrTransitGatewayID, names.AttrTransitGatewayAttachmentID},
+				},
+				"tag_field_specifications": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					ForceNew: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrResourceType: {
+								Type:             schema.TypeString,
+								Required:         true,
+								ForceNew:         true,
+								ValidateDiagFunc: enum.Validate[awstypes.TaggableResourceType](),
+							},
+							"tag_keys": {
+								Type:     schema.TypeList,
+								Required: true,
+								ForceNew: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+							},
+						},
+					},
 				},
 				names.AttrSubnetID: {
 					Type:         schema.TypeString,
@@ -255,6 +277,10 @@ func resourceLogFlowCreate(ctx context.Context, d *schema.ResourceData, meta any
 		input.MaxAggregationInterval = aws.Int32(int32(v.(int)))
 	}
 
+	if v, ok := d.GetOk("tag_field_specifications"); ok && v.(*schema.Set).Len() > 0 {
+		input.TagFieldSpecifications = expandTagFieldSpecifications(v.(*schema.Set).List())
+	}
+
 	outputRaw, err := tfresource.RetryWhenAWSErrMessageContains(ctx, iamPropagationTimeout, func(ctx context.Context) (any, error) {
 		return conn.CreateFlowLogs(ctx, input)
 	}, errCodeInvalidParameter, "Unable to assume given IAM role")
@@ -308,6 +334,9 @@ func resourceLogFlowRead(ctx context.Context, d *schema.ResourceData, meta any) 
 	d.Set("log_destination_type", fl.LogDestinationType)
 	d.Set("log_format", fl.LogFormat)
 	d.Set("max_aggregation_interval", fl.MaxAggregationInterval)
+	if err := d.Set("tag_field_specifications", flattenTagFieldSpecifications(fl.TagFieldSpecifications)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting tag_field_specifications: %s", err)
+	}
 	switch resourceID := aws.ToString(fl.ResourceId); {
 	case strings.HasPrefix(resourceID, "vpc-"):
 		d.Set(names.AttrVPCID, resourceID)
@@ -402,6 +431,45 @@ func flattenDestinationOptionsResponse(apiObject *awstypes.DestinationOptionsRes
 	}
 
 	return tfMap
+}
+
+func expandTagFieldSpecifications(tfList []any) []awstypes.TagFieldSpecificationRequest {
+	if len(tfList) == 0 {
+		return nil
+	}
+
+	apiObjects := make([]awstypes.TagFieldSpecificationRequest, 0, len(tfList))
+
+	for _, tfMapRaw := range tfList {
+		tfMap, ok := tfMapRaw.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		apiObjects = append(apiObjects, awstypes.TagFieldSpecificationRequest{
+			ResourceType: awstypes.TaggableResourceType(tfMap[names.AttrResourceType].(string)),
+			TagKeys:      flex.ExpandStringValueList(tfMap["tag_keys"].([]any)),
+		})
+	}
+
+	return apiObjects
+}
+
+func flattenTagFieldSpecifications(apiObjects []awstypes.TagFieldSpecificationResponse) []any {
+	if len(apiObjects) == 0 {
+		return nil
+	}
+
+	tfList := make([]any, len(apiObjects))
+
+	for i, apiObject := range apiObjects {
+		tfList[i] = map[string]any{
+			names.AttrResourceType: apiObject.ResourceType,
+			"tag_keys":             flex.FlattenStringValueList(apiObject.TagKeys),
+		}
+	}
+
+	return tfList
 }
 
 func flowLogARN(ctx context.Context, c *conns.AWSClient, flowLogID string) string {

--- a/internal/service/ec2/vpc_flow_log.go
+++ b/internal/service/ec2/vpc_flow_log.go
@@ -130,7 +130,13 @@ func resourceFlowLog() *schema.Resource {
 					ForceNew:     true,
 					ExactlyOneOf: []string{"eni_id", "regional_nat_gateway_id", names.AttrSubnetID, names.AttrVPCID, names.AttrTransitGatewayID, names.AttrTransitGatewayAttachmentID},
 				},
-				"tag_field_specifications": {
+				names.AttrSubnetID: {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ForceNew:     true,
+					ExactlyOneOf: []string{"eni_id", "regional_nat_gateway_id", names.AttrSubnetID, names.AttrVPCID, names.AttrTransitGatewayID, names.AttrTransitGatewayAttachmentID},
+				},
+				"tag_field_specification": {
 					Type:     schema.TypeSet,
 					Optional: true,
 					ForceNew: true,
@@ -150,12 +156,6 @@ func resourceFlowLog() *schema.Resource {
 							},
 						},
 					},
-				},
-				names.AttrSubnetID: {
-					Type:         schema.TypeString,
-					Optional:     true,
-					ForceNew:     true,
-					ExactlyOneOf: []string{"eni_id", "regional_nat_gateway_id", names.AttrSubnetID, names.AttrVPCID, names.AttrTransitGatewayID, names.AttrTransitGatewayAttachmentID},
 				},
 				names.AttrTags:    tftags.TagsSchema(),
 				names.AttrTagsAll: tftags.TagsSchemaComputed(),
@@ -239,7 +239,7 @@ func resourceLogFlowCreate(ctx context.Context, d *schema.ResourceData, meta any
 		}
 	}
 
-	input := &ec2.CreateFlowLogsInput{
+	input := ec2.CreateFlowLogsInput{
 		ClientToken:        aws.String(create.UniqueId(ctx)),
 		LogDestinationType: awstypes.LogDestinationType(d.Get("log_destination_type").(string)),
 		ResourceIds:        []string{resourceID},
@@ -277,12 +277,12 @@ func resourceLogFlowCreate(ctx context.Context, d *schema.ResourceData, meta any
 		input.MaxAggregationInterval = aws.Int32(int32(v.(int)))
 	}
 
-	if v, ok := d.GetOk("tag_field_specifications"); ok && v.(*schema.Set).Len() > 0 {
-		input.TagFieldSpecifications = expandTagFieldSpecifications(v.(*schema.Set).List())
+	if v, ok := d.GetOk("tag_field_specification"); ok && v.(*schema.Set).Len() > 0 {
+		input.TagFieldSpecifications = expandTagFieldSpecificationRequests(v.(*schema.Set).List())
 	}
 
 	outputRaw, err := tfresource.RetryWhenAWSErrMessageContains(ctx, iamPropagationTimeout, func(ctx context.Context) (any, error) {
-		return conn.CreateFlowLogs(ctx, input)
+		return conn.CreateFlowLogs(ctx, &input)
 	}, errCodeInvalidParameter, "Unable to assume given IAM role")
 
 	if err == nil && outputRaw != nil {
@@ -334,8 +334,8 @@ func resourceLogFlowRead(ctx context.Context, d *schema.ResourceData, meta any) 
 	d.Set("log_destination_type", fl.LogDestinationType)
 	d.Set("log_format", fl.LogFormat)
 	d.Set("max_aggregation_interval", fl.MaxAggregationInterval)
-	if err := d.Set("tag_field_specifications", flattenTagFieldSpecifications(fl.TagFieldSpecifications)); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tag_field_specifications: %s", err)
+	if err := d.Set("tag_field_specification", flattenTagFieldSpecificationResponses(fl.TagFieldSpecifications)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting tag_field_specification: %s", err)
 	}
 	switch resourceID := aws.ToString(fl.ResourceId); {
 	case strings.HasPrefix(resourceID, "vpc-"):
@@ -433,7 +433,7 @@ func flattenDestinationOptionsResponse(apiObject *awstypes.DestinationOptionsRes
 	return tfMap
 }
 
-func expandTagFieldSpecifications(tfList []any) []awstypes.TagFieldSpecificationRequest {
+func expandTagFieldSpecificationRequests(tfList []any) []awstypes.TagFieldSpecificationRequest {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -455,7 +455,7 @@ func expandTagFieldSpecifications(tfList []any) []awstypes.TagFieldSpecification
 	return apiObjects
 }
 
-func flattenTagFieldSpecifications(apiObjects []awstypes.TagFieldSpecificationResponse) []any {
+func flattenTagFieldSpecificationResponses(apiObjects []awstypes.TagFieldSpecificationResponse) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
@@ -465,7 +465,7 @@ func flattenTagFieldSpecifications(apiObjects []awstypes.TagFieldSpecificationRe
 	for i, apiObject := range apiObjects {
 		tfList[i] = map[string]any{
 			names.AttrResourceType: apiObject.ResourceType,
-			"tag_keys":             flex.FlattenStringValueList(apiObject.TagKeys),
+			"tag_keys":             apiObject.TagKeys,
 		}
 	}
 

--- a/internal/service/ec2/vpc_flow_log.go
+++ b/internal/service/ec2/vpc_flow_log.go
@@ -140,7 +140,7 @@ func resourceFlowLog() *schema.Resource {
 								Type:             schema.TypeString,
 								Required:         true,
 								ForceNew:         true,
-								ValidateDiagFunc: enum.Validate[awstypes.TaggableResourceType](),
+							ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{"instance", "network-interface", "auto-scaling-group"}, false)),
 							},
 							"tag_keys": {
 								Type:     schema.TypeList,

--- a/internal/service/ec2/vpc_flow_log_test.go
+++ b/internal/service/ec2/vpc_flow_log_test.go
@@ -25,6 +25,10 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
+var (
+	checkFlowLogARN = tfknownvalue.RegionalARNRegexp("ec2", regexache.MustCompile(`vpc-flow-log/fl-.+`))
+)
+
 func TestAccVPCFlowLog_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var flowLog awstypes.FlowLog
@@ -44,16 +48,31 @@ func TestAccVPCFlowLog_basic(t *testing.T) {
 				Config: testAccVPCFlowLogConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckFlowLogExists(ctx, t, resourceName, &flowLog),
-					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "ec2", regexache.MustCompile(`vpc-flow-log/fl-.+`)),
-					resource.TestCheckResourceAttr(resourceName, "deliver_cross_account_role", ""),
-					resource.TestCheckResourceAttrPair(resourceName, names.AttrIAMRoleARN, iamRoleResourceName, names.AttrARN),
-					resource.TestCheckResourceAttrPair(resourceName, "log_destination", cloudwatchLogGroupResourceName, names.AttrARN),
-					resource.TestCheckResourceAttr(resourceName, "log_destination_type", "cloud-watch-logs"),
-					resource.TestCheckResourceAttr(resourceName, "max_aggregation_interval", "600"),
-					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "0"),
-					resource.TestCheckResourceAttr(resourceName, "traffic_type", "ALL"),
-					resource.TestCheckResourceAttrPair(resourceName, names.AttrVPCID, vpcResourceName, names.AttrID),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrARN), checkFlowLogARN),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("deliver_cross_account_role"), knownvalue.StringExact("")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("destination_options"), knownvalue.ListSizeExact(0)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("eni_id"), knownvalue.Null()),
+					statecheck.CompareValuePairs(resourceName, tfjsonpath.New(names.AttrIAMRoleARN), iamRoleResourceName, tfjsonpath.New(names.AttrARN), compare.ValuesSame()),
+					statecheck.CompareValuePairs(resourceName, tfjsonpath.New("log_destination"), cloudwatchLogGroupResourceName, tfjsonpath.New(names.AttrARN), compare.ValuesSame()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("log_destination_type"), tfknownvalue.StringExact(awstypes.LogDestinationTypeCloudWatchLogs)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("log_format"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("max_aggregation_interval"), knownvalue.Int64Exact(600)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("regional_nat_gateway_id"), knownvalue.Null()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrSubnetID), knownvalue.Null()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("tag_field_specification"), knownvalue.SetSizeExact(0)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("traffic_type"), tfknownvalue.StringExact(awstypes.TrafficTypeAll)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTransitGatewayAttachmentID), knownvalue.Null()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTransitGatewayID), knownvalue.Null()),
+					statecheck.CompareValuePairs(resourceName, tfjsonpath.New(names.AttrVPCID), vpcResourceName, tfjsonpath.New(names.AttrID), compare.ValuesSame()),
+				},
 			},
 			{
 				ResourceName:      resourceName,

--- a/internal/service/ec2/vpc_flow_log_test.go
+++ b/internal/service/ec2/vpc_flow_log_test.go
@@ -536,6 +536,40 @@ func TestAccVPCFlowLog_LogDestinationType_maxAggregationInterval(t *testing.T) {
 	})
 }
 
+func TestAccVPCFlowLog_tagFieldSpecifications(t *testing.T) {
+	ctx := acctest.Context(t)
+	var flowLog awstypes.FlowLog
+	resourceName := "aws_flow_log.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckFlowLogDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVPCFlowLogConfig_tagFieldSpecifications(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckFlowLogExists(ctx, t, resourceName, &flowLog),
+					resource.TestCheckResourceAttr(resourceName, "tag_field_specifications.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "tag_field_specifications.*", map[string]string{
+						names.AttrResourceType: "instance",
+						"tag_keys.#":           "2",
+						"tag_keys.0":           "Name",
+						"tag_keys.1":           "Environment",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccVPCFlowLog_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var flowLog awstypes.FlowLog
@@ -1172,6 +1206,32 @@ resource "aws_flow_log" "test" {
   traffic_type         = "ALL"
   vpc_id               = aws_vpc.test.id
   log_format           = "$${version} $${vpc-id} $${subnet-id}"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName))
+}
+
+func testAccVPCFlowLogConfig_tagFieldSpecifications(rName string) string {
+	return acctest.ConfigCompose(testAccFlowLogConfig_base(rName), fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket        = %[1]q
+  force_destroy = true
+}
+
+resource "aws_flow_log" "test" {
+  log_destination      = aws_s3_bucket.test.arn
+  log_destination_type = "s3"
+  traffic_type         = "ALL"
+  vpc_id               = aws_vpc.test.id
+  log_format           = "$${version} $${vpc-id} $${instance-tag} $${instance-tag-2}"
+
+  tag_field_specifications {
+    resource_type = "instance"
+    tag_keys      = ["Name", "Environment"]
+  }
 
   tags = {
     Name = %[1]q

--- a/internal/service/ec2/vpc_flow_log_test.go
+++ b/internal/service/ec2/vpc_flow_log_test.go
@@ -552,8 +552,8 @@ func TestAccVPCFlowLog_tagFieldSpecifications(t *testing.T) {
 				Config: testAccVPCFlowLogConfig_tagFieldSpecifications(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckFlowLogExists(ctx, t, resourceName, &flowLog),
-					resource.TestCheckResourceAttr(resourceName, "tag_field_specifications.#", "1"),
-					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "tag_field_specifications.*", map[string]string{
+					resource.TestCheckResourceAttr(resourceName, "tag_field_specification.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "tag_field_specification.*", map[string]string{
 						names.AttrResourceType: "instance",
 						"tag_keys.#":           "2",
 						"tag_keys.0":           "Name",
@@ -1228,7 +1228,7 @@ resource "aws_flow_log" "test" {
   vpc_id               = aws_vpc.test.id
   log_format           = "$${version} $${vpc-id} $${instance-tag} $${instance-tag-2}"
 
-  tag_field_specifications {
+  tag_field_specification {
     resource_type = "instance"
     tag_keys      = ["Name", "Environment"]
   }

--- a/website/docs/r/flow_log.html.markdown
+++ b/website/docs/r/flow_log.html.markdown
@@ -328,7 +328,7 @@ This resource supports the following arguments:
   When `transit_gateway_id` or `transit_gateway_attachment_id` is specified, `max_aggregation_interval` *must* be 60 seconds (1 minute).
 * `regional_nat_gateway_id` - (Optional) Regional NAT Gateway ID to attach to.
 * `subnet_id` - (Optional) Subnet ID to attach to.
-* `tag_field_specifications` - (Optional) Tag configuration for the Flow Logs Amazon EC2 Tags feature fields (e.g., `$${instance-tag}`) used in `log_format`. More details below.
+* `tag_field_specification` - (Optional) Tag configuration for the Flow Logs Amazon EC2 Tags feature fields (e.g., `$${instance-tag}`) used in `log_format`. More details below.
 * `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `traffic_type` - (Optional) The type of traffic to capture. Valid values: `ACCEPT`,`REJECT`, `ALL`. Required if `eni_id`, `regional_nat_gateway_id`, `subnet_id`, or `vpc_id` is specified.
 * `transit_gateway_id` - (Optional) Transit Gateway ID to attach to.
@@ -345,7 +345,7 @@ Describes the destination options for a flow log.
 * `hive_compatible_partitions` - (Optional) Indicates whether to use Hive-compatible prefixes for flow logs stored in Amazon S3. Default value: `false`.
 * `per_hour_partition` - (Optional) Indicates whether to partition the flow log per hour. This reduces the cost and response time for queries. Default value: `false`.
 
-### tag_field_specifications
+### tag_field_specification
 
 Maps a taggable resource type to the tag keys, on resources of that type, to display in Flow Log records via the Amazon EC2 Tags feature fields (e.g., `$${instance-tag}`) in `log_format`. Multiple blocks may be specified to configure tag keys for different resource types.
 

--- a/website/docs/r/flow_log.html.markdown
+++ b/website/docs/r/flow_log.html.markdown
@@ -328,6 +328,7 @@ This resource supports the following arguments:
   When `transit_gateway_id` or `transit_gateway_attachment_id` is specified, `max_aggregation_interval` *must* be 60 seconds (1 minute).
 * `regional_nat_gateway_id` - (Optional) Regional NAT Gateway ID to attach to.
 * `subnet_id` - (Optional) Subnet ID to attach to.
+* `tag_field_specifications` - (Optional) Tag configuration for the Flow Logs Amazon EC2 Tags feature fields (e.g., `$${instance-tag}`) used in `log_format`. More details below.
 * `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `traffic_type` - (Optional) The type of traffic to capture. Valid values: `ACCEPT`,`REJECT`, `ALL`. Required if `eni_id`, `regional_nat_gateway_id`, `subnet_id`, or `vpc_id` is specified.
 * `transit_gateway_id` - (Optional) Transit Gateway ID to attach to.
@@ -343,6 +344,13 @@ Describes the destination options for a flow log.
 * `file_format` - (Optional) File format for the flow log. Default value: `plain-text`. Valid values: `plain-text`, `parquet`.
 * `hive_compatible_partitions` - (Optional) Indicates whether to use Hive-compatible prefixes for flow logs stored in Amazon S3. Default value: `false`.
 * `per_hour_partition` - (Optional) Indicates whether to partition the flow log per hour. This reduces the cost and response time for queries. Default value: `false`.
+
+### tag_field_specifications
+
+Maps a taggable resource type to the tag keys, on resources of that type, to display in Flow Log records via the Amazon EC2 Tags feature fields (e.g., `$${instance-tag}`) in `log_format`. Multiple blocks may be specified to configure tag keys for different resource types.
+
+* `resource_type` - (Required) Resource type to associate the tag keys with. Valid values: `instance`, `network-interface`, `auto-scaling-group`.
+* `tag_keys` - (Required) Ordered list of tag keys, on resources of `resource_type`, to display in Flow Log records. The position of each key determines which field it populates in `log_format` (e.g., the first `instance` tag key populates `$${instance-tag}` and the second populates `$${instance-tag-2}`).
 
 ## Attribute Reference
 


### PR DESCRIPTION
Supports the Flow Logs Amazon EC2 Tags feature fields (e.g. ${instance-tag}) in log_format by mapping a resource type to the tag keys that should be displayed, via the CreateFlowLogs TagFieldSpecifications parameter.

<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

None. 

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
```console 

terraform {
  required_providers {
    aws = {
      source = "hashicorp/aws"
    }
  }
}

provider "aws" {
  region = "us-east-2"
}

resource "aws_vpc" "test" {
  cidr_block = "10.0.0.0/16"

  tags = {
    Name = "tftest-flow-log-tag-fields"
  }
}

resource "aws_subnet" "test" {
  vpc_id     = aws_vpc.test.id
  cidr_block = "10.0.0.0/24"

  tags = {
    Name = "tftest-flow-log-tag-fields"
  }
}

data "aws_ami" "amzn2" {
  most_recent = true
  owners      = ["amazon"]

  filter {
    name   = "name"
    values = ["amzn2-ami-hvm-*-x86_64-gp2"]
  }
}

resource "aws_instance" "test" {
  ami           = data.aws_ami.amzn2.id
  instance_type = "t3.micro"
  subnet_id     = aws_subnet.test.id
}

resource "aws_s3_bucket" "test" {
  bucket        = "tftest-flow-log-tag-fields-${data.aws_caller_identity.current.account_id}"
  force_destroy = true
}

data "aws_caller_identity" "current" {}

# Exercises the new tag_field_specifications block on aws_flow_log:
# maps the "instance" resource type to the Name/Environment tag keys so that
# ${instance-tag} / ${instance-tag-2} in log_format resolve to those tag values.
resource "aws_flow_log" "test" {
  log_destination      = aws_s3_bucket.test.arn
  log_destination_type = "s3"
  traffic_type         = "ALL"
  eni_id               = aws_instance.test.primary_network_interface_id
  log_format            = "$${version} $${vpc-id} $${instance-id} $${instance-tag} $${instance-tag-2}"

  tag_field_specifications {
    resource_type = "instance"
    tag_keys      = ["Name", "Environment"]
  }

  tags = {
    Name = "tftest-flow-log-tag-fields"
  }
}

output "flow_log_id" {
  value = aws_flow_log.test.id
}

output "tag_field_specifications" {
  value = aws_flow_log.test.tag_field_specifications
}
```

### Relations

Closes #48806 


### Output from Acceptance Testing

```console
$ TF_ACC=1 go test ./internal/service/ec2/...   -run '^TestAccVPCFlowLog_tagFieldSpecifications$'   -v -timeout 120m
2026/07/11 15:07:34 Creating Terraform AWS Provider (SDKv2-style)...
2026/07/11 15:07:34 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccVPCFlowLog_tagFieldSpecifications
=== PAUSE TestAccVPCFlowLog_tagFieldSpecifications
=== CONT  TestAccVPCFlowLog_tagFieldSpecifications
--- PASS: TestAccVPCFlowLog_tagFieldSpecifications (28.74s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        28.881s

...
```
