### PR TITLE
bug/48778: change aws_sagemaker_domain subnet_ids so replacement is not required

### DIFF
--- a/internal/service/sagemaker/domain.go
+++ b/internal/service/sagemaker/domain.go
@@ -1450,7 +1450,7 @@ func resourceDomain() *schema.Resource {
 				names.AttrSubnetIDs: {
 					Type:     schema.TypeSet,
 					Required: true,
-					ForceNew: true,
+					ForceNew: false,
 					MaxItems: 16,
 					Elem:     &schema.Schema{Type: schema.TypeString},
 				},


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

```console
resource "aws_vpc" "main" {
  cidr_block = "10.0.0.0/16"

  tags = {
    Name = "main-vpc"
  }
}

# 2. Create the Subnet inside the VPC
resource "aws_subnet" "example" {
  vpc_id            = aws_vpc.main.id
  cidr_block        = "10.0.1.0/24"
  availability_zone = "us-east-2a"

  tags = {
    Name = "example-subnet"
  }
}

resource "aws_subnet" "example2" {
  vpc_id            = aws_vpc.main.id
  cidr_block        = "10.0.2.0/24"
  availability_zone = "us-east-2a"

  tags = {
    Name = "example-subnet"
  }
}

resource "aws_subnet" "example3" {
  vpc_id            = aws_vpc.main.id
  cidr_block        = "10.0.3.0/24"
  availability_zone = "us-east-2a"

  tags = {
    Name = "example-subnet"
  }
}
resource "aws_security_group" "allow_tls" {
  name        = "allow_tls"
  description = "Allow TLS inbound traffic and all outbound traffic"
  vpc_id      = aws_vpc.main.id

  tags = {
    Name = "allow_tls"
  }
}

resource "aws_vpc_security_group_ingress_rule" "allow_tls_ipv4" {
  security_group_id = aws_security_group.allow_tls.id
  cidr_ipv4         = aws_vpc.main.cidr_block
  from_port         = 443
  ip_protocol       = "tcp"
  to_port           = 443
}

resource "aws_vpc_security_group_egress_rule" "allow_all_traffic_ipv4" {
  security_group_id = aws_security_group.allow_tls.id
  cidr_ipv4         = "0.0.0.0/0"
  ip_protocol       = "-1"
}

resource "aws_sagemaker_domain" "example" {
  domain_name = "example"
  auth_mode   = "IAM"
  vpc_id      = aws_vpc.main.id
  subnet_ids  = [aws_subnet.example.id, aws_subnet.example2.id, aws_subnet.example3.id]

  default_user_settings {
    execution_role = aws_iam_role.example.arn
    security_groups = [ aws_security_group.allow_tls.id]
  }
}

resource "aws_iam_role" "example" {
  name               = "example"
  path               = "/"
  assume_role_policy = data.aws_iam_policy_document.example.json
}

data "aws_iam_policy_document" "example" {
  statement {
    actions = ["sts:AssumeRole"]

    principals {
      type        = "Service"
      identifiers = ["sagemaker.amazonaws.com"]
    }
  }
}
```

```console   
  # aws_sagemaker_domain.example will be updated in-place
  ~ resource "aws_sagemaker_domain" "example" {
        id                                             = "d-paknamoq33di"
      ~ subnet_ids                                     = [
          - "subnet-032df55979755c05a",
          - "subnet-0cda89684c4a3e4b5",
        ] -> (known after apply)
        tags                                           = {}
        # (15 unchanged attributes hidden)

      ~ default_user_settings {
            # (5 unchanged attributes hidden)

          - studio_web_portal_settings {}
        }
    }
```


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #48778 


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ TF_ACC=1 go test ./internal/service/sagemaker/... -run '^TestAccSageMaker_serial$/^Domain$/^subnetIDs$' -v -timeout 60m
2026/07/11 16:53:10 Creating Terraform AWS Provider (SDKv2-style)...
2026/07/11 16:53:10 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccSageMaker_serial
=== PAUSE TestAccSageMaker_serial
=== CONT  TestAccSageMaker_serial
=== RUN   TestAccSageMaker_serial/Domain
=== RUN   TestAccSageMaker_serial/Domain/subnetIDs
--- PASS: TestAccSageMaker_serial (313.91s)
    --- PASS: TestAccSageMaker_serial/Domain (313.91s)
        --- PASS: TestAccSageMaker_serial/Domain/subnetIDs (313.91s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/sagemaker  314.054s
```
