### PR TITLE
fix: allow cache_stale_timeout_in_seconds to be 0 for smb/nfs file shares

### DIFF
--- a/.changelog/48876.txt
+++ b/.changelog/48876.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+resource/aws_storagegateway_smb_file_share: Allow `cache_stale_timeout_in_seconds` to be set to `0` to disable caching
+resource/aws_storagegateway_nfs_file_share: Allow `cache_stale_timeout_in_seconds` to be set to `0` to disable caching
+```

--- a/internal/service/storagegateway/nfs_file_share.go
+++ b/internal/service/storagegateway/nfs_file_share.go
@@ -75,7 +75,7 @@ func resourceNFSFileShare() *schema.Resource {
 							"cache_stale_timeout_in_seconds": {
 								Type:         schema.TypeInt,
 								Optional:     true,
-								ValidateFunc: validation.IntBetween(300, 2592000),
+								ValidateFunc: validation.Any(validation.IntBetween(300, 2592000), validation.IntInSlice([]int{0})),
 							},
 						},
 					},

--- a/internal/service/storagegateway/nfs_file_share_test.go
+++ b/internal/service/storagegateway/nfs_file_share_test.go
@@ -653,6 +653,14 @@ func TestAccStorageGatewayNFSFileShare_cacheAttributes(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "cache_attributes.0.cache_stale_timeout_in_seconds", "300"),
 				),
 			},
+			{
+				Config: testAccNFSFileShareConfig_cacheAttributes(rName, 0),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNFSFileShareExists(ctx, t, resourceName, &nfsFileShare),
+					resource.TestCheckResourceAttr(resourceName, "cache_attributes.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "cache_attributes.0.cache_stale_timeout_in_seconds", "0"),
+				),
+			},
 		},
 	})
 }

--- a/internal/service/storagegateway/smb_file_share.go
+++ b/internal/service/storagegateway/smb_file_share.go
@@ -91,7 +91,7 @@ func resourceSMBFileShare() *schema.Resource {
 							"cache_stale_timeout_in_seconds": {
 								Type:         schema.TypeInt,
 								Optional:     true,
-								ValidateFunc: validation.IntBetween(300, 2592000),
+								ValidateFunc: validation.Any(validation.IntBetween(300, 2592000), validation.IntInSlice([]int{0})),
 							},
 						},
 					},
@@ -585,7 +585,7 @@ func expandCacheAttributes(tfMap map[string]any) *awstypes.CacheAttributes {
 
 	apiObject := &awstypes.CacheAttributes{}
 
-	if v, ok := tfMap["cache_stale_timeout_in_seconds"].(int); ok && v != 0 {
+	if v, ok := tfMap["cache_stale_timeout_in_seconds"].(int); ok {
 		apiObject.CacheStaleTimeoutInSeconds = aws.Int32(int32(v))
 	}
 

--- a/internal/service/storagegateway/smb_file_share_test.go
+++ b/internal/service/storagegateway/smb_file_share_test.go
@@ -831,6 +831,14 @@ func TestAccStorageGatewaySMBFileShare_cacheAttributes(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "cache_attributes.0.cache_stale_timeout_in_seconds", "300"),
 				),
 			},
+			{
+				Config: testAccSMBFileShareConfig_cacheAttributes(rName, 0),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSMBFileShareExists(ctx, t, resourceName, &smbFileShare),
+					resource.TestCheckResourceAttr(resourceName, "cache_attributes.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "cache_attributes.0.cache_stale_timeout_in_seconds", "0"),
+				),
+			},
 		},
 	})
 }


### PR DESCRIPTION
Fixes #48876

## Description
This PR fixes an issue where setting `cache_stale_timeout_in_seconds = 0` on `aws_storagegateway_smb_file_share` or `aws_storagegateway_nfs_file_share` would fail validation and be rejected by the provider, despite being accepted by the AWS API to disable caching.

Changes made:
- Updated the `ValidateFunc` in `nfs_file_share.go` and `smb_file_share.go` to explicitly allow `0` via `validation.Any(validation.IntBetween(300, 2592000), validation.IntInSlice([]int{0}))`.
- Fixed the `expandCacheAttributes` mapping in `smb_file_share.go` to stop omitting `0` when converting the `tfMap` value.
- Added Acceptance Tests for `0` to verify convergence for both SMB and NFS file shares.

(Note: `file_system_association.go` already correctly handles `0`).
