### PR TITLE
fix: allow non-destructive import and updates for aws_opensearch_package

### DIFF
--- a/.changelog/48788.txt
+++ b/.changelog/48788.txt
@@ -1,0 +1,1 @@
+resource/aws_opensearch_package: Remove \`ForceNew\` from \`package_source\` to allow non-destructive import and updates

--- a/internal/service/opensearch/package.go
+++ b/internal/service/opensearch/package.go
@@ -68,19 +68,16 @@ func resourcePackage() *schema.Resource {
 				"package_source": {
 					Type:     schema.TypeList,
 					Required: true,
-					ForceNew: true,
 					MaxItems: 1,
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{
 							names.AttrS3BucketName: {
 								Type:     schema.TypeString,
 								Required: true,
-								ForceNew: true,
 							},
 							"s3_key": {
 								Type:     schema.TypeString,
 								Required: true,
-								ForceNew: true,
 							},
 						},
 					},


### PR DESCRIPTION
Fixes #48788

### Description
Removes `ForceNew: true` from `package_source` (and its children) in the `aws_opensearch_package` resource.

This allows non-destructive importing of OpenSearch packages since `package_source` is not returned by the AWS API and therefore cannot be populated in the state during import. It also corrects the behavior for updating existing packages, allowing `terraform apply` to correctly invoke `UpdatePackage` to update the package source rather than replacing the resource entirely.
