### PR TITLE
bug: Fix perpetual diff for origin timeouts in aws_cloudfront_multitenant_distribution

### DIFF
--- a/.changelog/48820.txt
+++ b/.changelog/48820.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cloudfront_multitenant_distribution: Fix perpetual diff in `origin` block due to nested timeouts `origin_read_timeout` and `origin_keepalive_timeout` when multiple origins are defined.
+```

--- a/internal/service/cloudfront/multitenant_distribution.go
+++ b/internal/service/cloudfront/multitenant_distribution.go
@@ -21,7 +21,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int32default"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int32planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
@@ -426,14 +426,14 @@ func (r *multiTenantDistributionResource) Schema(ctx context.Context, request re
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
 						"connection_attempts": schema.Int32Attribute{
-							Optional: true,
-							Computed: true,
-							Default:  int32default.StaticInt32(defaultConnectionAttempts),
+							Optional:      true,
+							Computed:      true,
+							PlanModifiers: []planmodifier.Int32{int32planmodifier.UseStateForUnknown()},
 						},
 						"connection_timeout": schema.Int32Attribute{
-							Optional: true,
-							Computed: true,
-							Default:  int32default.StaticInt32(defaultConnectionTimeout),
+							Optional:      true,
+							Computed:      true,
+							PlanModifiers: []planmodifier.Int32{int32planmodifier.UseStateForUnknown()},
 						},
 						names.AttrDomainName: schema.StringAttribute{
 							Required: true,
@@ -485,14 +485,14 @@ func (r *multiTenantDistributionResource) Schema(ctx context.Context, request re
 										CustomType: fwtypes.StringEnumType[awstypes.IpAddressType](),
 									},
 									"origin_keepalive_timeout": schema.Int32Attribute{
-										Optional: true,
-										Computed: true,
-										Default:  int32default.StaticInt32(defaultOriginKeepaliveTimeout),
+										Optional:      true,
+										Computed:      true,
+										PlanModifiers: []planmodifier.Int32{int32planmodifier.UseStateForUnknown()},
 									},
 									"origin_read_timeout": schema.Int32Attribute{
-										Optional: true,
-										Computed: true,
-										Default:  int32default.StaticInt32(defaultOriginReadTimeout),
+										Optional:      true,
+										Computed:      true,
+										PlanModifiers: []planmodifier.Int32{int32planmodifier.UseStateForUnknown()},
 									},
 									"origin_protocol_policy": schema.StringAttribute{
 										Required:   true,
@@ -546,14 +546,14 @@ func (r *multiTenantDistributionResource) Schema(ctx context.Context, request re
 							NestedObject: schema.NestedBlockObject{
 								Attributes: map[string]schema.Attribute{
 									"origin_keepalive_timeout": schema.Int32Attribute{
-										Optional: true,
-										Computed: true,
-										Default:  int32default.StaticInt32(defaultOriginKeepaliveTimeout),
+										Optional:      true,
+										Computed:      true,
+										PlanModifiers: []planmodifier.Int32{int32planmodifier.UseStateForUnknown()},
 									},
 									"origin_read_timeout": schema.Int32Attribute{
-										Optional: true,
-										Computed: true,
-										Default:  int32default.StaticInt32(defaultOriginReadTimeout),
+										Optional:      true,
+										Computed:      true,
+										PlanModifiers: []planmodifier.Int32{int32planmodifier.UseStateForUnknown()},
 									},
 									"vpc_origin_id": schema.StringAttribute{
 										Required: true,


### PR DESCRIPTION
Fixes #48820
Fixes #47735

This pull request resolves an issue with `aws_cloudfront_multitenant_distribution` where having multiple origins configured could cause a perpetual diff (oscillation) during `terraform plan`. The `origin` block in the framework was changed to a `SetNestedBlock` in #47199, which introduced a bug where schema `Default` configurations for nested origin fields (like `origin_keepalive_timeout` and `origin_read_timeout`) were evaluated incorrectly during Set matching, leading Terraform to override the explicitly configured non-default values with defaults in the plan output.

By replacing `Default: int32default.StaticInt32(...)` with `PlanModifiers: []planmodifier.Int32{int32planmodifier.UseStateForUnknown()}` on these Optional+Computed fields, the framework will now properly defer to the AWS API for default values during resource creation while bypassing the SetNestedBlock matching bug on subsequent plans.