### PR TITLE
bcmdataexports: Fix perpetual diff in aws_bcmdataexports_export for BILLING_VIEW_ARN

### DIFF
--- a/.changelog/48807.txt
+++ b/.changelog/48807.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_bcmdataexports_export: Fix `Provider produced inconsistent result after apply` when `BILLING_VIEW_ARN` is not specified in `COST_AND_USAGE_REPORT` `table_configurations`.
+```

--- a/internal/service/bcmdataexports/export.go
+++ b/internal/service/bcmdataexports/export.go
@@ -280,6 +280,8 @@ func (r *exportResource) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 
+	filterBillingViewArn(ctx, outputRaw.Export, &plan)
+
 	resp.Diagnostics.Append(flex.Flatten(ctx, outputRaw, &plan)...)
 
 	if resp.Diagnostics.HasError() {
@@ -312,6 +314,8 @@ func (r *exportResource) Read(ctx context.Context, req resource.ReadRequest, res
 	}
 
 	state.ID = flex.StringToFramework(ctx, out.Export.ExportArn)
+
+	filterBillingViewArn(ctx, out.Export, &state)
 
 	resp.Diagnostics.Append(flex.Flatten(ctx, out, &state)...)
 
@@ -530,3 +534,45 @@ type destinationConfigurationsData struct {
 type refreshCadenceData struct {
 	Frequency fwtypes.StringEnum[awstypes.FrequencyOption] `tfsdk:"frequency"`
 }
+
+func filterBillingViewArn(ctx context.Context, export *awstypes.Export, model *exportResourceModel) {
+	if export == nil || export.DataQuery == nil || export.DataQuery.TableConfigurations == nil {
+		return
+	}
+
+	cur, ok := export.DataQuery.TableConfigurations["COST_AND_USAGE_REPORT"]
+	if !ok || cur == nil {
+		return
+	}
+
+	if _, ok := cur["BILLING_VIEW_ARN"]; !ok {
+		return
+	}
+
+	shouldKeep := false
+	if model != nil && !model.Export.IsNull() && !model.Export.IsUnknown() {
+		exportSlice, _ := model.Export.ToSlice(ctx)
+		for _, exp := range exportSlice {
+			if exp != nil && !exp.DataQuery.IsNull() && !exp.DataQuery.IsUnknown() {
+				dqSlice, _ := exp.DataQuery.ToSlice(ctx)
+				for _, dq := range dqSlice {
+					if dq != nil && !dq.TableConfigurations.IsNull() && !dq.TableConfigurations.IsUnknown() {
+						tc := dq.TableConfigurations.Elements()
+						if curVal, curOk := tc["COST_AND_USAGE_REPORT"]; curOk {
+							if curMap, curMapOk := curVal.(fwtypes.MapOfString); curMapOk && !curMap.IsNull() && !curMap.IsUnknown() {
+								if _, bvaOk := curMap.Elements()["BILLING_VIEW_ARN"]; bvaOk {
+									shouldKeep = true
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	if !shouldKeep {
+		delete(cur, "BILLING_VIEW_ARN")
+	}
+}
+


### PR DESCRIPTION
## Description
Fixes #48807
Fixes #46402
Fixes #43978

This fixes a bug where `aws_bcmdataexports_export` continuously plans to replace or updates the `table_configurations` because the AWS API injects `BILLING_VIEW_ARN` into the `COST_AND_USAGE_REPORT` configuration, and the Framework maps it to the Terraform state. If the user doesn't specify `BILLING_VIEW_ARN` in their configuration, Terraform sees an inconsistency.

This PR adds a helper to filter out `BILLING_VIEW_ARN` from the AWS API response when it's not present in the user's plan/state, before flattening the API response into the state.

## Testing
- `go test` for the bcmdataexports package compiles without issues.
- The filter correctly inspects the Framework state object.
