### PR TITLE
[bugfix] aws_elasticache_user tagging race condition

### DIFF
--- a/.changelog/48919.txt
+++ b/.changelog/48919.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_elasticache_user: Fix intermittent `UserNotFound: ... is not available for tagging` errors during tag operations by adding retry logic for transient user state.
+```
+
+```release-note:bug
+resource/aws_elasticache_user_group: Fix intermittent `UserGroupNotFound` errors during tag operations by adding retry logic for transient user group state.
+```

--- a/internal/service/elasticache/generate.go
+++ b/internal/service/elasticache/generate.go
@@ -1,7 +1,7 @@
 // Copyright IBM Corp. 2014, 2026
 // SPDX-License-Identifier: MPL-2.0
 
-//go:generate go run ../../generate/tags/main.go -CreateTags -ListTags -ListTagsInIDElem=ResourceName -ListTagsOutTagsElem=TagList -ServiceTagsSlice -TagOp=AddTagsToResource -TagInIDElem=ResourceName -UntagOp=RemoveTagsFromResource -UpdateTags -RetryTagOps -RetryTagsListTagsType=ListTagsForResourceOutput -RetryErrorCode=awstypes.InvalidReplicationGroupStateFault "-RetryErrorMessage=not in available state" -RetryTimeout=15m
+//go:generate go run ../../generate/tags/main.go -CreateTags -ListTags -ListTagsInIDElem=ResourceName -ListTagsOutTagsElem=TagList -ServiceTagsSlice -TagOp=AddTagsToResource -TagInIDElem=ResourceName -UntagOp=RemoveTagsFromResource -UpdateTags -UpdateTagsFunc=updateTagsBase -RetryTagOps -RetryTagsListTagsType=ListTagsForResourceOutput -RetryErrorCode=awstypes.InvalidReplicationGroupStateFault "-RetryErrorMessage=not in available state" -RetryTimeout=15m
 //go:generate go run ../../generate/servicepackage/main.go
 //go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.

--- a/internal/service/elasticache/tags.go
+++ b/internal/service/elasticache/tags.go
@@ -14,13 +14,15 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
+const eventualConsistencyTimeout = 5 * time.Minute
+
 // updateTags wraps the generated updateTagsBase with additional retry logic
 // for UserNotFoundFault and UserGroupNotFoundFault, which occur transiently
 // when ElastiCache users/user groups are in a brief internal "modifying" state
 // during tag operations.
 // See: https://github.com/hashicorp/terraform-provider-aws/issues/47638
 func updateTags(ctx context.Context, conn *elasticache.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*elasticache.Options)) error {
-	_, err := tfresource.RetryWhen[any](ctx, 5*time.Minute,
+	_, err := tfresource.RetryWhen[any](ctx, eventualConsistencyTimeout,
 		func(ctx context.Context) (any, error) {
 			return nil, updateTagsBase(ctx, conn, identifier, oldTagsMap, newTagsMap, optFns...)
 		},

--- a/internal/service/elasticache/tags.go
+++ b/internal/service/elasticache/tags.go
@@ -1,0 +1,46 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package elasticache
+
+import (
+	"context"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/elasticache"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+)
+
+// updateTags wraps the generated updateTagsBase with additional retry logic
+// for UserNotFoundFault and UserGroupNotFoundFault, which occur transiently
+// when ElastiCache users/user groups are in a brief internal "modifying" state
+// during tag operations.
+// See: https://github.com/hashicorp/terraform-provider-aws/issues/47638
+func updateTags(ctx context.Context, conn *elasticache.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*elasticache.Options)) error {
+	_, err := tfresource.RetryWhen[any](ctx, 5*time.Minute,
+		func(ctx context.Context) (any, error) {
+			return nil, updateTagsBase(ctx, conn, identifier, oldTagsMap, newTagsMap, optFns...)
+		},
+		func(err error) (bool, error) {
+			// Retry when a user is not available for tagging (transient ~5s state).
+			if errs.IsAErrorMessageContains[*awstypes.UserNotFoundFault](err, "is not available for tagging") {
+				return true, err
+			}
+			// Retry when a user group is not available for tagging (same race condition).
+			if errs.IsA[*awstypes.UserGroupNotFoundFault](err) {
+				return true, err
+			}
+			return false, err
+		},
+	)
+	return err
+}
+
+// UpdateTags updates elasticache service tags.
+// It is called from outside this package (by the tagging interceptor).
+func (p *servicePackage) UpdateTags(ctx context.Context, meta any, identifier string, oldTags, newTags any) error {
+	return updateTags(ctx, meta.(*conns.AWSClient).ElastiCacheClient(ctx), identifier, oldTags, newTags)
+}

--- a/internal/service/elasticache/tags_gen.go
+++ b/internal/service/elasticache/tags_gen.go
@@ -113,13 +113,13 @@ func createTags(ctx context.Context, conn *elasticache.Client, identifier string
 		return nil
 	}
 
-	return updateTags(ctx, conn, identifier, nil, keyValueTags(ctx, tags), optFns...)
+	return updateTagsBase(ctx, conn, identifier, nil, keyValueTags(ctx, tags), optFns...)
 }
 
-// updateTags updates elasticache service tags.
+// updateTagsBase updates elasticache service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn *elasticache.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*elasticache.Options)) error {
+func updateTagsBase(ctx context.Context, conn *elasticache.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*elasticache.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -166,10 +166,4 @@ func updateTags(ctx context.Context, conn *elasticache.Client, identifier string
 	}
 
 	return nil
-}
-
-// UpdateTags updates elasticache service tags.
-// It is called from outside this package.
-func (p *servicePackage) UpdateTags(ctx context.Context, meta any, identifier string, oldTags, newTags any) error {
-	return updateTags(ctx, meta.(*conns.AWSClient).ElastiCacheClient(ctx), identifier, oldTags, newTags)
 }


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
There's a race condition where ElastiCache users and user groups enter a brief internal "modifying" state (~5 seconds) after creation. If the tagging interceptor fires during this window, the API rejects the tag operation with:
- UserNotFound: <user-id> is not available for tagging
- UserGroupNotFound

This happens because the resource appears "active" from Terraform's perspective (the create waiter passed), but internally ElastiCache hasn't finished making it available for tagging yet.

This PR adds retry logic around updateTags for these specific transient errors with a 5-minute timeout.

Why not PR #47700? : That PR modifies the shared tag generator (internal/generate/tags/) used by 200+ services to support multiple retry error types. This PR achieves the same fix with zero generator changes by using the existing `-UpdateTagsFunc` flag, the same pattern DynamoDB and Transfer already use.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #47638

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS="TestAccElastiCacheUser" PKG=elasticache
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     6.080s
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework 5.953s
make: Running acceptance tests on branch: 🌿 f-elasticache-user-race-condition 🌿...
TF_ACC=1 go1.26.4 test ./internal/service/elasticache/... -v -count 1 -parallel 20 -run='TestAccElastiCacheUser'  -timeout 360m -vet=off -buildvcs=false
2026/07/12 11:53:51 Creating Terraform AWS Provider (SDKv2-style)...
2026/07/12 11:53:51 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccElastiCacheUserDataSource_basic
=== PAUSE TestAccElastiCacheUserDataSource_basic
=== RUN   TestAccElastiCacheUserGroupAssociation_basic
=== PAUSE TestAccElastiCacheUserGroupAssociation_basic
=== RUN   TestAccElastiCacheUserGroupAssociation_update
=== PAUSE TestAccElastiCacheUserGroupAssociation_update
=== RUN   TestAccElastiCacheUserGroupAssociation_disappears
=== PAUSE TestAccElastiCacheUserGroupAssociation_disappears
=== RUN   TestAccElastiCacheUserGroupAssociation_multiple
=== PAUSE TestAccElastiCacheUserGroupAssociation_multiple
=== RUN   TestAccElastiCacheUserGroup_basic
=== PAUSE TestAccElastiCacheUserGroup_basic
=== RUN   TestAccElastiCacheUserGroup_mixedCase
=== PAUSE TestAccElastiCacheUserGroup_mixedCase
=== RUN   TestAccElastiCacheUserGroup_update
=== PAUSE TestAccElastiCacheUserGroup_update
=== RUN   TestAccElastiCacheUserGroup_rotate
=== PAUSE TestAccElastiCacheUserGroup_rotate
=== RUN   TestAccElastiCacheUserGroup_engineValkey
=== PAUSE TestAccElastiCacheUserGroup_engineValkey
=== RUN   TestAccElastiCacheUserGroup_tags
=== PAUSE TestAccElastiCacheUserGroup_tags
=== RUN   TestAccElastiCacheUserGroup_disappears
=== PAUSE TestAccElastiCacheUserGroup_disappears
=== RUN   TestAccElastiCacheUser_basic
=== PAUSE TestAccElastiCacheUser_basic
=== RUN   TestAccElastiCacheUser_mixedCase
=== PAUSE TestAccElastiCacheUser_mixedCase
=== RUN   TestAccElastiCacheUser_passwordAuthMode
=== PAUSE TestAccElastiCacheUser_passwordAuthMode
=== RUN   TestAccElastiCacheUser_iamAuthMode
=== PAUSE TestAccElastiCacheUser_iamAuthMode
=== RUN   TestAccElastiCacheUser_update
=== PAUSE TestAccElastiCacheUser_update
=== RUN   TestAccElastiCacheUser_updateEngine
=== PAUSE TestAccElastiCacheUser_updateEngine
=== RUN   TestAccElastiCacheUser_updatePasswordAuthMode
=== PAUSE TestAccElastiCacheUser_updatePasswordAuthMode
=== RUN   TestAccElastiCacheUser_tags
=== PAUSE TestAccElastiCacheUser_tags
=== RUN   TestAccElastiCacheUser_disappears
=== PAUSE TestAccElastiCacheUser_disappears
=== RUN   TestAccElastiCacheUser_oobModify
=== PAUSE TestAccElastiCacheUser_oobModify
=== RUN   TestAccElastiCacheUser_passwordsWriteOnly
=== PAUSE TestAccElastiCacheUser_passwordsWriteOnly
=== CONT  TestAccElastiCacheUserDataSource_basic
=== CONT  TestAccElastiCacheUser_basic
=== CONT  TestAccElastiCacheUserGroup_basic
=== CONT  TestAccElastiCacheUserGroup_mixedCase
=== CONT  TestAccElastiCacheUser_passwordsWriteOnly
=== CONT  TestAccElastiCacheUserGroup_disappears
=== CONT  TestAccElastiCacheUserGroup_tags
=== CONT  TestAccElastiCacheUserGroup_rotate
=== CONT  TestAccElastiCacheUserGroup_engineValkey
=== CONT  TestAccElastiCacheUserGroupAssociation_disappears
=== CONT  TestAccElastiCacheUserGroupAssociation_multiple
=== CONT  TestAccElastiCacheUser_updatePasswordAuthMode
=== CONT  TestAccElastiCacheUser_oobModify
=== CONT  TestAccElastiCacheUser_disappears
=== CONT  TestAccElastiCacheUser_tags
=== CONT  TestAccElastiCacheUserGroupAssociation_update
=== CONT  TestAccElastiCacheUserGroupAssociation_basic
=== CONT  TestAccElastiCacheUser_iamAuthMode
=== CONT  TestAccElastiCacheUser_updateEngine
=== CONT  TestAccElastiCacheUserGroup_update
--- PASS: TestAccElastiCacheUser_iamAuthMode (48.92s)
=== CONT  TestAccElastiCacheUser_update
--- PASS: TestAccElastiCacheUser_basic (55.65s)
=== CONT  TestAccElastiCacheUser_passwordAuthMode
--- PASS: TestAccElastiCacheUserDataSource_basic (75.22s)
=== CONT  TestAccElastiCacheUser_mixedCase
--- PASS: TestAccElastiCacheUser_tags (107.56s)
--- PASS: TestAccElastiCacheUser_mixedCase (33.36s)
--- PASS: TestAccElastiCacheUser_passwordAuthMode (55.17s)
--- PASS: TestAccElastiCacheUser_updateEngine (169.27s)
--- PASS: TestAccElastiCacheUserGroup_basic (171.25s)
--- PASS: TestAccElastiCacheUser_update (123.62s)
--- PASS: TestAccElastiCacheUserGroup_mixedCase (173.04s)
--- PASS: TestAccElastiCacheUser_updatePasswordAuthMode (174.07s)
--- PASS: TestAccElastiCacheUser_passwordsWriteOnly (175.46s)
--- PASS: TestAccElastiCacheUserGroup_disappears (176.02s)
--- PASS: TestAccElastiCacheUserGroup_tags (232.75s)
--- PASS: TestAccElastiCacheUserGroup_engineValkey (240.30s)
--- PASS: TestAccElastiCacheUser_disappears (244.81s)
--- PASS: TestAccElastiCacheUserGroupAssociation_disappears (291.90s)
--- PASS: TestAccElastiCacheUserGroupAssociation_basic (294.05s)
--- PASS: TestAccElastiCacheUser_oobModify (295.44s)
--- PASS: TestAccElastiCacheUserGroup_update (298.13s)
--- PASS: TestAccElastiCacheUserGroupAssociation_update (420.92s)
--- PASS: TestAccElastiCacheUserGroupAssociation_multiple (422.29s)
--- PASS: TestAccElastiCacheUserGroup_rotate (481.44s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elasticache        487.308s
```
