### PR TITLE
🤖🤖🤖 service/s3: Clarify bucket ACL Region errors

### DIFF
--- a/.changelog/48920.txt
+++ b/.changelog/48920.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_s3_bucket_acl: Add actionable context to bucket Region mismatch errors
+```

--- a/internal/service/s3/bucket_acl.go
+++ b/internal/service/s3/bucket_acl.go
@@ -313,6 +313,7 @@ func findBucketACL(ctx context.Context, conn *s3.Client, bucket, expectedBucketO
 	}
 
 	output, err := conn.GetBucketAcl(ctx, &input)
+	err = errBucketRegionMismatch(bucket, err)
 
 	if tfawserr.ErrCodeEquals(err, errCodeNoSuchBucket) {
 		return nil, &retry.NotFoundError{

--- a/internal/service/s3/errors.go
+++ b/internal/service/s3/errors.go
@@ -5,6 +5,9 @@ package s3
 
 import (
 	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
 )
 
 // Error code constants missing from AWS Go SDK:
@@ -12,6 +15,7 @@ import (
 
 const (
 	errCodeAccessDenied                         = "AccessDenied"
+	errCodeAuthorizationHeaderMalformed         = "AuthorizationHeaderMalformed"
 	errCodeBucketAlreadyExists                  = "BucketAlreadyExists"
 	errCodeBucketAlreadyOwnedByYou              = "BucketAlreadyOwnedByYou"
 	errCodeBucketNotEmpty                       = "BucketNotEmpty"
@@ -40,6 +44,7 @@ const (
 	errCodeObjectLockConfigurationNotFoundError      = "ObjectLockConfigurationNotFoundError"
 	errCodeOperationAborted                          = "OperationAborted"
 	errCodeOwnershipControlsNotFoundError            = "OwnershipControlsNotFoundError"
+	errCodePermanentRedirect                         = "PermanentRedirect"
 	errCodeReplicationConfigurationNotFound          = "ReplicationConfigurationNotFoundError"
 	errCodeServerSideEncryptionConfigurationNotFound = "ServerSideEncryptionConfigurationNotFoundError"
 	errCodeUnsupportedArgument                       = "UnsupportedArgument"
@@ -53,4 +58,18 @@ const (
 
 func errDirectoryBucket(err error) error {
 	return fmt.Errorf("directory buckets are not supported: %w", err)
+}
+
+func errBucketRegionMismatch(bucket string, err error) error {
+	if err == nil {
+		return nil
+	}
+
+	if tfawserr.ErrHTTPStatusCodeEquals(err, http.StatusMovedPermanently) ||
+		tfawserr.ErrCodeEquals(err, errCodePermanentRedirect) ||
+		tfawserr.ErrCodeEquals(err, errCodeAuthorizationHeaderMalformed) {
+		return fmt.Errorf("S3 Bucket (%s) was redirected to another Region; verify that the bucket name is the actual S3 bucket name and that the resource's `region` argument matches the bucket Region: %w", bucket, err)
+	}
+
+	return err
 }

--- a/internal/service/s3/errors_test.go
+++ b/internal/service/s3/errors_test.go
@@ -1,0 +1,60 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package s3
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+)
+
+func TestErrBucketRegionMismatch(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		err         error
+		wantWrapped bool
+	}{
+		"nil": {
+			err: nil,
+		},
+		"unrelated": {
+			err: errs.APIError(errCodeAccessDenied, "Access Denied"),
+		},
+		"permanent redirect": {
+			err:         errs.APIError(errCodePermanentRedirect, "The bucket is in this region"),
+			wantWrapped: true,
+		},
+		"authorization header malformed": {
+			err:         errs.APIError(errCodeAuthorizationHeaderMalformed, "The region is wrong"),
+			wantWrapped: true,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := errBucketRegionMismatch("example-bucket", testCase.err)
+
+			if testCase.err == nil {
+				if got != nil {
+					t.Fatalf("expected no error, got %s", got)
+				}
+				return
+			}
+
+			if !errors.Is(got, testCase.err) {
+				t.Fatalf("expected original error to be preserved, got %s", got)
+			}
+
+			wantMessage := "S3 Bucket (example-bucket) was redirected to another Region; verify that the bucket name is the actual S3 bucket name and that the resource's `region` argument matches the bucket Region"
+			if gotWrapped := strings.Contains(got.Error(), wantMessage); gotWrapped != testCase.wantWrapped {
+				t.Fatalf("expected wrapped = %t, got %q", testCase.wantWrapped, got)
+			}
+		})
+	}
+}

--- a/website/docs/r/s3_bucket_acl.html.markdown
+++ b/website/docs/r/s3_bucket_acl.html.markdown
@@ -167,6 +167,8 @@ This resource exports the following attributes in addition to the arguments abov
 
 ## Import
 
+~> **NOTE:** Use the actual S3 bucket name in the import ID, not the Terraform resource name. For example, if the resource is named `aws_s3_bucket.example` but its `bucket` argument is `"my-company-logs"`, use `my-company-logs` in the import ID. S3 can return a misleading `BucketRegionError` when the name identifies a different bucket in another AWS Region. If the bucket itself is in another Region, configure the imported resource with an AWS provider for that Region.
+
 In Terraform v1.12.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `identity` attribute. For example:
 
 ```terraform

--- a/website/docs/r/s3_bucket_acl.html.markdown
+++ b/website/docs/r/s3_bucket_acl.html.markdown
@@ -167,7 +167,7 @@ This resource exports the following attributes in addition to the arguments abov
 
 ## Import
 
-~> **NOTE:** Use the actual S3 bucket name in the import ID, not the Terraform resource name. For example, if the resource is named `aws_s3_bucket.example` but its `bucket` argument is `"my-company-logs"`, use `my-company-logs` in the import ID. S3 can return a misleading `BucketRegionError` when the name identifies a different bucket in another AWS Region. If the bucket itself is in another Region, configure the imported resource with an AWS provider for that Region.
+~> **NOTE:** Use the actual S3 bucket name in the import ID, not the Terraform resource name. For example, if the resource is named `aws_s3_bucket.example` but its `bucket` argument is `"my-company-logs"`, use `my-company-logs` in the import ID. S3 can return a misleading Region error when the name identifies a different bucket in another AWS Region. If the bucket itself is in another Region, set the resource's `region` argument to that Region.
 
 In Terraform v1.12.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `identity` attribute. For example:
 


### PR DESCRIPTION
Relates #23221

## What changed

- Adds actionable context when `aws_s3_bucket_acl` encounters an S3 redirect or authorization-header Region mismatch.
- Preserves the original AWS error while directing users to verify the actual bucket name and the resource-level `region` argument.
- Clarifies the import documentation with the same guidance.
- Adds unit coverage for the S3 error codes involved.

## Why

Issue #23221 and its follow-up reports show that AWS's redirect response can obscure two common configuration mistakes: importing with the Terraform resource name and managing the ACL in a different Region from its bucket. The raw AWS error does not explain how to correct either condition.

## User impact

Users troubleshooting bucket ACL imports and reads receive concrete remediation while retaining the underlying AWS diagnostic.

## Validation

- `go test ./internal/service/s3 -run '^TestErrBucketRegionMismatch$' -count=1`
- `go test ./internal/service/s3 -count=1`
- `make build`
- `make test`
- `make swissshepherd`

## AI disclosure

This pull request was prepared with direct assistance from an LLM agent. The submitting human remains responsible for reviewing and understanding the change.
