### PR TITLE
added time-outs for sagemaker

### DIFF
--- a/.changelog/48927.txt
+++ b/.changelog/48927.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_sagemaker_app: Add configurable `create` and `delete` timeouts
+```

--- a/internal/service/sagemaker/app.go
+++ b/internal/service/sagemaker/app.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"time"
 
 	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -41,6 +42,11 @@ func resourceApp() *schema.Resource {
 		DeleteWithoutTimeout: resourceAppDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
 
 		SchemaFunc: func() map[string]*schema.Schema {
@@ -161,7 +167,7 @@ func resourceAppCreate(ctx context.Context, d *schema.ResourceData, meta any) di
 
 	d.SetId(appArn)
 
-	if _, err := waitAppInService(ctx, conn, domainID, userProfileOrSpaceName, appType, appName); err != nil {
+	if _, err := waitAppInService(ctx, conn, domainID, userProfileOrSpaceName, appType, appName, d.Timeout(schema.TimeoutCreate)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "create SageMaker AI App (%s): waiting for completion: %s", d.Id(), err)
 	}
 
@@ -247,7 +253,7 @@ func resourceAppDelete(ctx context.Context, d *schema.ResourceData, meta any) di
 		}
 	}
 
-	if _, err := waitAppDeleted(ctx, conn, domainID, userProfileOrSpaceName, appType, appName); err != nil {
+	if _, err := waitAppDeleted(ctx, conn, domainID, userProfileOrSpaceName, appType, appName, d.Timeout(schema.TimeoutDelete)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "waiting for SageMaker AI App (%s) to delete: %s", d.Id(), err)
 	}
 

--- a/internal/service/sagemaker/wait.go
+++ b/internal/service/sagemaker/wait.go
@@ -29,8 +29,6 @@ const (
 	domainDeletedTimeout              = 20 * time.Minute
 	featureGroupCreatedTimeout        = 20 * time.Minute
 	featureGroupDeletedTimeout        = 10 * time.Minute
-	appInServiceTimeout               = 10 * time.Minute
-	appDeletedTimeout                 = 10 * time.Minute
 	flowDefinitionActiveTimeout       = 2 * time.Minute
 	flowDefinitionDeletedTimeout      = 2 * time.Minute
 	projectCreatedTimeout             = 15 * time.Minute
@@ -356,12 +354,12 @@ func waitFeatureGroupUpdated(ctx context.Context, conn *sagemaker.Client, name s
 	return nil, err
 }
 
-func waitAppInService(ctx context.Context, conn *sagemaker.Client, domainID, userProfileOrSpaceName, appType, appName string) (*sagemaker.DescribeAppOutput, error) {
+func waitAppInService(ctx context.Context, conn *sagemaker.Client, domainID, userProfileOrSpaceName, appType, appName string, timeout time.Duration) (*sagemaker.DescribeAppOutput, error) {
 	stateConf := &retry.StateChangeConf{
 		Pending: enum.Slice(awstypes.AppStatusPending),
 		Target:  enum.Slice(awstypes.AppStatusInService),
 		Refresh: statusApp(conn, domainID, userProfileOrSpaceName, appType, appName),
-		Timeout: appInServiceTimeout,
+		Timeout: timeout,
 	}
 
 	outputRaw, err := stateConf.WaitForStateContext(ctx)
@@ -377,12 +375,12 @@ func waitAppInService(ctx context.Context, conn *sagemaker.Client, domainID, use
 	return nil, err
 }
 
-func waitAppDeleted(ctx context.Context, conn *sagemaker.Client, domainID, userProfileOrSpaceName, appType, appName string) (*sagemaker.DescribeAppOutput, error) {
+func waitAppDeleted(ctx context.Context, conn *sagemaker.Client, domainID, userProfileOrSpaceName, appType, appName string, timeout time.Duration) (*sagemaker.DescribeAppOutput, error) {
 	stateConf := &retry.StateChangeConf{
 		Pending: enum.Slice(awstypes.AppStatusDeleting),
 		Target:  []string{},
 		Refresh: statusApp(conn, domainID, userProfileOrSpaceName, appType, appName),
-		Timeout: appDeletedTimeout,
+		Timeout: timeout,
 	}
 
 	outputRaw, err := stateConf.WaitForStateContext(ctx)

--- a/website/docs/r/sagemaker_app.html.markdown
+++ b/website/docs/r/sagemaker_app.html.markdown
@@ -52,6 +52,13 @@ This resource exports the following attributes in addition to the arguments abov
 * `arn` - The Amazon Resource Name (ARN) of the app.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 
+## Timeouts
+
+[Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
+
+* `create` - (Default `10m`)
+* `delete` - (Default `10m`)
+
 ## Import
 
 In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import SageMaker AI Apps using the `id`. For example:


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

## Changes to Security Controls

No changes to security controls.

### Description

Adds a configurable `timeouts` block (`create` and `delete`, both defaulting to the previous hardcoded value of 10 minutes) to the `aws_sagemaker_app` resource.

Previously the create/delete waiters used hardcoded 10-minute timeouts (`appInServiceTimeout` / `appDeletedTimeout`), which is not always enough for apps on larger instance types. The waiter functions now accept the timeout from the resource configuration, and the resource documentation has been updated accordingly.

### Relations

Closes #48826


### References

https://github.com/hashicorp/terraform-provider-aws/issues/48826#issuecomment-4927046048
