### PR TITLE
aws_autoscaling_group: Add list support

### DIFF
--- a/.changelog/48928.txt
+++ b/.changelog/48928.txt
@@ -1,0 +1,3 @@
+```release-note:new-list-resource
+aws_autoscaling_group
+```

--- a/internal/service/autoscaling/group.go
+++ b/internal/service/autoscaling/group.go
@@ -1329,7 +1329,6 @@ func resourceGroupCreate(ctx context.Context, d *schema.ResourceData, meta any) 
 func resourceGroupRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AutoScalingClient(ctx)
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig(ctx)
 
 	g, err := findGroupByName(ctx, conn, d.Id())
 
@@ -1342,6 +1341,12 @@ func resourceGroupRead(ctx context.Context, d *schema.ResourceData, meta any) di
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "reading Auto Scaling Group (%s): %s", d.Id(), err)
 	}
+
+	return append(diags, resourceGroupFlatten(ctx, meta.(*conns.AWSClient), g, d)...)
+}
+
+func resourceGroupFlatten(ctx context.Context, awsClient *conns.AWSClient, g *awstypes.AutoScalingGroup, d *schema.ResourceData) diag.Diagnostics {
+	var diags diag.Diagnostics
 
 	d.Set(names.AttrARN, g.AutoScalingGroupARN)
 	d.Set(names.AttrAvailabilityZones, g.AvailabilityZones)
@@ -1417,6 +1422,7 @@ func resourceGroupRead(ctx context.Context, d *schema.ResourceData, meta any) di
 	}
 	d.Set("warm_pool_size", g.WarmPoolSize)
 
+	ignoreTagsConfig := awsClient.IgnoreTagsConfig(ctx)
 	if err := d.Set("tag", listOfMap(keyValueTags(ctx, g.Tags, d.Id(), tagResourceTypeGroup).IgnoreAWS().IgnoreConfig(ignoreTagsConfig))); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting tag: %s", err)
 	}

--- a/internal/service/autoscaling/group_list.go
+++ b/internal/service/autoscaling/group_list.go
@@ -55,7 +55,7 @@ func (l *groupListResource) List(ctx context.Context, request list.ListRequest, 
 
 	stream.Results = func(yield func(list.ListResult) bool) {
 		input := autoscaling.DescribeAutoScalingGroupsInput{}
-		for g, err := range listAutoScalingGroups(ctx, conn, &input) {
+		for g, err := range listGroups(ctx, conn, &input) {
 			if err != nil {
 				result := fwdiag.NewListResultErrorDiagnostic(err)
 				yield(result)
@@ -73,7 +73,7 @@ func (l *groupListResource) List(ctx context.Context, request list.ListRequest, 
 
 			if request.IncludeResource {
 				diags := resourceGroupFlatten(ctx, awsClient, &g, rd)
-				if diags.HasError() || rd.Id() == "" {
+				if diags.HasError() {
 					tflog.Error(ctx, "Reading Auto Scaling Group", map[string]any{
 						names.AttrName: name,
 						"diags":        sdkdiag.DiagnosticsString(diags),
@@ -97,7 +97,7 @@ func (l *groupListResource) List(ctx context.Context, request list.ListRequest, 
 	}
 }
 
-func listAutoScalingGroups(ctx context.Context, conn *autoscaling.Client, input *autoscaling.DescribeAutoScalingGroupsInput) iter.Seq2[awstypes.AutoScalingGroup, error] {
+func listGroups(ctx context.Context, conn *autoscaling.Client, input *autoscaling.DescribeAutoScalingGroupsInput) iter.Seq2[awstypes.AutoScalingGroup, error] {
 	return func(yield func(awstypes.AutoScalingGroup, error) bool) {
 		pages := autoscaling.NewDescribeAutoScalingGroupsPaginator(conn, input)
 		for pages.HasMorePages() {

--- a/internal/service/autoscaling/group_list.go
+++ b/internal/service/autoscaling/group_list.go
@@ -1,0 +1,117 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package autoscaling
+
+import (
+	"context"
+	"fmt"
+	"iter"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/autoscaling/types"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/logging"
+	inttypes "github.com/hashicorp/terraform-provider-aws/internal/types"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// Function annotations are used for list resource registration to the Provider. DO NOT EDIT.
+// @SDKListResource("aws_autoscaling_group")
+func newGroupResourceAsListResource() inttypes.ListResourceForSDK {
+	l := groupListResource{}
+	l.SetResourceSchema(resourceGroup())
+	return &l
+}
+
+var _ list.ListResource = &groupListResource{}
+
+type groupListResource struct {
+	framework.ListResourceWithSDKv2Resource
+}
+
+type listGroupModel struct {
+	framework.WithRegionModel
+}
+
+func (l *groupListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
+	awsClient := l.Meta()
+	conn := awsClient.AutoScalingClient(ctx)
+
+	var query listGroupModel
+	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
+		if diags := request.Config.Get(ctx, &query); diags.HasError() {
+			stream.Results = list.ListResultsStreamDiagnostics(diags)
+			return
+		}
+	}
+
+	tflog.Info(ctx, "Listing Auto Scaling Groups")
+
+	stream.Results = func(yield func(list.ListResult) bool) {
+		input := autoscaling.DescribeAutoScalingGroupsInput{}
+		for g, err := range listAutoScalingGroups(ctx, conn, &input) {
+			if err != nil {
+				result := fwdiag.NewListResultErrorDiagnostic(err)
+				yield(result)
+				return
+			}
+
+			name := aws.ToString(g.AutoScalingGroupName)
+			ctx := tflog.SetField(ctx, logging.ResourceAttributeKey(names.AttrName), name)
+
+			result := request.NewListResult(ctx)
+
+			rd := l.ResourceData()
+			rd.SetId(name)
+			rd.Set(names.AttrName, g.AutoScalingGroupName)
+
+			if request.IncludeResource {
+				diags := resourceGroupFlatten(ctx, awsClient, &g, rd)
+				if diags.HasError() || rd.Id() == "" {
+					tflog.Error(ctx, "Reading Auto Scaling Group", map[string]any{
+						names.AttrName: name,
+						"diags":        sdkdiag.DiagnosticsString(diags),
+					})
+					continue
+				}
+			}
+
+			result.DisplayName = name
+
+			l.SetResult(ctx, awsClient, request.IncludeResource, rd, &result)
+			if result.Diagnostics.HasError() {
+				yield(result)
+				return
+			}
+
+			if !yield(result) {
+				return
+			}
+		}
+	}
+}
+
+func listAutoScalingGroups(ctx context.Context, conn *autoscaling.Client, input *autoscaling.DescribeAutoScalingGroupsInput) iter.Seq2[awstypes.AutoScalingGroup, error] {
+	return func(yield func(awstypes.AutoScalingGroup, error) bool) {
+		pages := autoscaling.NewDescribeAutoScalingGroupsPaginator(conn, input)
+		for pages.HasMorePages() {
+			page, err := pages.NextPage(ctx)
+			if err != nil {
+				yield(awstypes.AutoScalingGroup{}, fmt.Errorf("listing Auto Scaling Groups: %w", err))
+				return
+			}
+
+			for _, g := range page.AutoScalingGroups {
+				if !yield(g, nil) {
+					return
+				}
+			}
+		}
+	}
+}

--- a/internal/service/autoscaling/group_list_test.go
+++ b/internal/service/autoscaling/group_list_test.go
@@ -126,8 +126,8 @@ func TestAccAutoScalingGroup_List_includeResource(t *testing.T) {
 						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrName), knownvalue.StringExact(rName+"-0")),
 						tfquerycheck.KnownValueCheck(tfjsonpath.New("tag"), knownvalue.ListExact([]knownvalue.Check{
 							knownvalue.ObjectExact(map[string]knownvalue.Check{
-								"key":                 knownvalue.StringExact(acctest.CtKey1),
-								"value":               knownvalue.StringExact(acctest.CtValue1),
+								names.AttrKey:         knownvalue.StringExact(acctest.CtKey1),
+								names.AttrValue:       knownvalue.StringExact(acctest.CtValue1),
 								"propagate_at_launch": knownvalue.Bool(false),
 							}),
 						})),

--- a/internal/service/autoscaling/group_list_test.go
+++ b/internal/service/autoscaling/group_list_test.go
@@ -1,0 +1,194 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package autoscaling_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	tfquerycheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/querycheck"
+	tfqueryfilter "github.com/hashicorp/terraform-provider-aws/internal/acctest/queryfilter"
+	tfstatecheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/statecheck"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccAutoScalingGroup_List_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_autoscaling_group.test[0]"
+	resourceName2 := "aws_autoscaling_group.test[1]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity1 := tfstatecheck.Identity()
+	identity2 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.AutoScalingServiceID),
+		CheckDestroy:             testAccCheckGroupDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Group/list_basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+					identity2.GetIdentity(resourceName2),
+				},
+			},
+
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/Group/list_basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_autoscaling_group.test", identity1.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_autoscaling_group.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), knownvalue.StringExact(rName+"-0")),
+					tfquerycheck.ExpectNoResourceObject("aws_autoscaling_group.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks())),
+
+					tfquerycheck.ExpectIdentityFunc("aws_autoscaling_group.test", identity2.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_autoscaling_group.test", tfqueryfilter.ByResourceIdentityFunc(identity2.Checks()), knownvalue.StringExact(rName+"-1")),
+					tfquerycheck.ExpectNoResourceObject("aws_autoscaling_group.test", tfqueryfilter.ByResourceIdentityFunc(identity2.Checks())),
+				},
+			},
+		},
+	})
+}
+
+func TestAccAutoScalingGroup_List_includeResource(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_autoscaling_group.test[0]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity1 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.AutoScalingServiceID),
+		CheckDestroy:             testAccCheckGroupDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Group/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(1),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
+						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
+					}),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+				},
+			},
+
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/Group/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(1),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
+						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
+					}),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_autoscaling_group.test", identity1.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_autoscaling_group.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), knownvalue.StringExact(rName+"-0")),
+					querycheck.ExpectResourceKnownValues("aws_autoscaling_group.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), []querycheck.KnownValueCheck{
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.Region())),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrID), knownvalue.StringExact(rName+"-0")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrName), knownvalue.StringExact(rName+"-0")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("tag"), knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"key":                 knownvalue.StringExact(acctest.CtKey1),
+								"value":               knownvalue.StringExact(acctest.CtValue1),
+								"propagate_at_launch": knownvalue.Bool(false),
+							}),
+						})),
+					}),
+				},
+			},
+		},
+	})
+}
+
+func TestAccAutoScalingGroup_List_regionOverride(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_autoscaling_group.test[0]"
+	resourceName2 := "aws_autoscaling_group.test[1]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity1 := tfstatecheck.Identity()
+	identity2 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.AutoScalingServiceID),
+		CheckDestroy:             testAccCheckGroupDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Group/list_region_override/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+					"region":         config.StringVariable(acctest.AlternateRegion()),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+					identity2.GetIdentity(resourceName2),
+				},
+			},
+
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/Group/list_region_override/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+					"region":         config.StringVariable(acctest.AlternateRegion()),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_autoscaling_group.test", identity1.Checks()),
+
+					tfquerycheck.ExpectIdentityFunc("aws_autoscaling_group.test", identity2.Checks()),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/autoscaling/service_package_gen.go
+++ b/internal/service/autoscaling/service_package_gen.go
@@ -7,6 +7,8 @@ package autoscaling
 
 import (
 	"context"
+	"iter"
+	"slices"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
@@ -139,6 +141,18 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*inttypes.ServicePa
 			},
 		},
 	}
+}
+
+func (p *servicePackage) SDKListResources(ctx context.Context) iter.Seq[*inttypes.ServicePackageSDKListResource] {
+	return slices.Values([]*inttypes.ServicePackageSDKListResource{
+		{
+			Factory:  newGroupResourceAsListResource,
+			TypeName: "aws_autoscaling_group",
+			Name:     "Group",
+			Region:   inttypes.ResourceRegionDefault(),
+			Identity: inttypes.RegionalSingleParameterIdentity(inttypes.StringIdentityAttribute(names.AttrName, true)),
+		},
+	})
 }
 
 func (p *servicePackage) ServicePackageName() string {

--- a/internal/service/autoscaling/testdata/Group/list_basic/main.tf
+++ b/internal/service/autoscaling/testdata/Group/list_basic/main.tf
@@ -1,0 +1,68 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_autoscaling_group" "test" {
+  count = var.resource_count
+
+  name                 = "${var.rName}-${count.index}"
+  availability_zones   = [data.aws_availability_zones.available.names[0]]
+  max_size             = 0
+  min_size             = 0
+  launch_configuration = aws_launch_configuration.test.name
+}
+
+resource "aws_launch_configuration" "test" {
+  name_prefix   = var.rName
+  image_id      = data.aws_ami.amzn2-ami-minimal-hvm-ebs-x86_64.id
+  instance_type = "t2.micro"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+data "aws_availability_zones" "available" {
+  exclude_zone_ids = local.default_exclude_zone_ids
+  state            = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
+locals {
+  default_exclude_zone_ids = ["usw2-az4", "usgw1-az2"]
+}
+
+data "aws_ami" "amzn2-ami-minimal-hvm-ebs-x86_64" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["amzn2-ami-minimal-hvm-*"]
+  }
+
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}

--- a/internal/service/autoscaling/testdata/Group/list_basic/query.tfquery.hcl
+++ b/internal/service/autoscaling/testdata/Group/list_basic/query.tfquery.hcl
@@ -1,0 +1,6 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_autoscaling_group" "test" {
+  provider = aws
+}

--- a/internal/service/autoscaling/testdata/Group/list_include_resource/main.tf
+++ b/internal/service/autoscaling/testdata/Group/list_include_resource/main.tf
@@ -1,0 +1,83 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_autoscaling_group" "test" {
+  count = var.resource_count
+
+  name                 = "${var.rName}-${count.index}"
+  availability_zones   = [data.aws_availability_zones.available.names[0]]
+  max_size             = 0
+  min_size             = 0
+  launch_configuration = aws_launch_configuration.test.name
+
+  dynamic "tag" {
+    for_each = var.resource_tags
+    content {
+      key                 = tag.key
+      value               = tag.value
+      propagate_at_launch = false
+    }
+  }
+}
+
+resource "aws_launch_configuration" "test" {
+  name_prefix   = var.rName
+  image_id      = data.aws_ami.amzn2-ami-minimal-hvm-ebs-x86_64.id
+  instance_type = "t2.micro"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+data "aws_availability_zones" "available" {
+  exclude_zone_ids = local.default_exclude_zone_ids
+  state            = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
+locals {
+  default_exclude_zone_ids = ["usw2-az4", "usgw1-az2"]
+}
+
+data "aws_ami" "amzn2-ami-minimal-hvm-ebs-x86_64" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["amzn2-ami-minimal-hvm-*"]
+  }
+
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}
+
+variable "resource_tags" {
+  description = "Tags to set on resource"
+  type        = map(string)
+  nullable    = false
+}

--- a/internal/service/autoscaling/testdata/Group/list_include_resource/query.tfquery.hcl
+++ b/internal/service/autoscaling/testdata/Group/list_include_resource/query.tfquery.hcl
@@ -1,0 +1,8 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_autoscaling_group" "test" {
+  provider = aws
+
+  include_resource = true
+}

--- a/internal/service/autoscaling/testdata/Group/list_region_override/main.tf
+++ b/internal/service/autoscaling/testdata/Group/list_region_override/main.tf
@@ -1,0 +1,81 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_autoscaling_group" "test" {
+  count  = var.resource_count
+  region = var.region
+
+  name                 = "${var.rName}-${count.index}"
+  availability_zones   = [data.aws_availability_zones.available.names[0]]
+  max_size             = 0
+  min_size             = 0
+  launch_configuration = aws_launch_configuration.test.name
+}
+
+resource "aws_launch_configuration" "test" {
+  region = var.region
+
+  name_prefix   = var.rName
+  image_id      = data.aws_ami.amzn2-ami-minimal-hvm-ebs-x86_64.id
+  instance_type = "t2.micro"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+data "aws_availability_zones" "available" {
+  region = var.region
+
+  exclude_zone_ids = local.default_exclude_zone_ids
+  state            = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
+locals {
+  default_exclude_zone_ids = ["usw2-az4", "usgw1-az2"]
+}
+
+data "aws_ami" "amzn2-ami-minimal-hvm-ebs-x86_64" {
+  region = var.region
+
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["amzn2-ami-minimal-hvm-*"]
+  }
+
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}
+
+variable "region" {
+  description = "Region to deploy resource in"
+  type        = string
+  nullable    = false
+}

--- a/internal/service/autoscaling/testdata/Group/list_region_override/query.tfquery.hcl
+++ b/internal/service/autoscaling/testdata/Group/list_region_override/query.tfquery.hcl
@@ -1,0 +1,10 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_autoscaling_group" "test" {
+  provider = aws
+
+  config {
+    region = var.region
+  }
+}

--- a/website/docs/list-resources/autoscaling_group.html.markdown
+++ b/website/docs/list-resources/autoscaling_group.html.markdown
@@ -1,0 +1,25 @@
+---
+subcategory: "Auto Scaling"
+layout: "aws"
+page_title: "AWS: aws_autoscaling_group"
+description: |-
+  Lists Auto Scaling Group resources.
+---
+
+# List Resource: aws_autoscaling_group
+
+Lists Auto Scaling Group resources.
+
+## Example Usage
+
+```terraform
+list "aws_autoscaling_group" "example" {
+  provider = aws
+}
+```
+
+## Argument Reference
+
+This list resource supports the following arguments:
+
+* `region` - (Optional) Region to query. Defaults to provider region.


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Add list support for `aws_autoscaling_group`

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #48602 

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t T=TestAccAutoScalingGroup_ K=autoscaling 
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-asg-list 🌿...
TF_ACC=1 go1.26.4 test ./internal/service/autoscaling/... -v -count 1 -parallel 20 -run='TestAccAutoScalingGroup_'  -timeout 360m -vet=off
2026/07/13 17:37:35 Creating Terraform AWS Provider (SDKv2-style)...
2026/07/13 17:37:35 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccAutoScalingGroup_Identity_basic
=== PAUSE TestAccAutoScalingGroup_Identity_basic
=== RUN   TestAccAutoScalingGroup_Identity_regionOverride
=== PAUSE TestAccAutoScalingGroup_Identity_regionOverride
=== RUN   TestAccAutoScalingGroup_Identity_ExistingResource_basic
=== PAUSE TestAccAutoScalingGroup_Identity_ExistingResource_basic
=== RUN   TestAccAutoScalingGroup_Identity_ExistingResource_noRefreshNoChange
=== PAUSE TestAccAutoScalingGroup_Identity_ExistingResource_noRefreshNoChange
=== RUN   TestAccAutoScalingGroup_List_basic
=== PAUSE TestAccAutoScalingGroup_List_basic
=== RUN   TestAccAutoScalingGroup_List_includeResource
=== PAUSE TestAccAutoScalingGroup_List_includeResource
=== RUN   TestAccAutoScalingGroup_List_regionOverride
=== PAUSE TestAccAutoScalingGroup_List_regionOverride
=== RUN   TestAccAutoScalingGroup_basic
=== PAUSE TestAccAutoScalingGroup_basic
=== RUN   TestAccAutoScalingGroup_disappears
=== PAUSE TestAccAutoScalingGroup_disappears
=== RUN   TestAccAutoScalingGroup_defaultInstanceWarmup
=== PAUSE TestAccAutoScalingGroup_defaultInstanceWarmup
=== RUN   TestAccAutoScalingGroup_nameGenerated
=== PAUSE TestAccAutoScalingGroup_nameGenerated
=== RUN   TestAccAutoScalingGroup_namePrefix
=== PAUSE TestAccAutoScalingGroup_namePrefix
=== RUN   TestAccAutoScalingGroup_tags
=== PAUSE TestAccAutoScalingGroup_tags
=== RUN   TestAccAutoScalingGroup_simple
=== PAUSE TestAccAutoScalingGroup_simple
=== RUN   TestAccAutoScalingGroup_terminationPolicies
=== PAUSE TestAccAutoScalingGroup_terminationPolicies
=== RUN   TestAccAutoScalingGroup_vpcUpdates
=== PAUSE TestAccAutoScalingGroup_vpcUpdates
=== RUN   TestAccAutoScalingGroup_withInstanceMaintenancePolicyAfterCreation
=== PAUSE TestAccAutoScalingGroup_withInstanceMaintenancePolicyAfterCreation
=== RUN   TestAccAutoScalingGroup_withInstanceMaintenancePolicyAtCreation
=== PAUSE TestAccAutoScalingGroup_withInstanceMaintenancePolicyAtCreation
=== RUN   TestAccAutoScalingGroup_withInstanceMaintenancePolicyNegativeValues
=== PAUSE TestAccAutoScalingGroup_withInstanceMaintenancePolicyNegativeValues
=== RUN   TestAccAutoScalingGroup_withLoadBalancer
=== PAUSE TestAccAutoScalingGroup_withLoadBalancer
=== RUN   TestAccAutoScalingGroup_WithLoadBalancer_toTargetGroup
=== PAUSE TestAccAutoScalingGroup_WithLoadBalancer_toTargetGroup
=== RUN   TestAccAutoScalingGroup_withTrafficSourceELB
=== PAUSE TestAccAutoScalingGroup_withTrafficSourceELB
=== RUN   TestAccAutoScalingGroup_withTrafficSourcesELBs
=== PAUSE TestAccAutoScalingGroup_withTrafficSourcesELBs
=== RUN   TestAccAutoScalingGroup_withTrafficSourceELB_toTargetGroup
=== PAUSE TestAccAutoScalingGroup_withTrafficSourceELB_toTargetGroup
=== RUN   TestAccAutoScalingGroup_withTrafficSourceELBV2
=== PAUSE TestAccAutoScalingGroup_withTrafficSourceELBV2
=== RUN   TestAccAutoScalingGroup_withTrafficSourceVPCLatticeTargetGroup
=== PAUSE TestAccAutoScalingGroup_withTrafficSourceVPCLatticeTargetGroup
=== RUN   TestAccAutoScalingGroup_withTrafficSourceVPCLatticeTargetGroups
=== PAUSE TestAccAutoScalingGroup_withTrafficSourceVPCLatticeTargetGroups
=== RUN   TestAccAutoScalingGroup_withPlacementGroup
=== PAUSE TestAccAutoScalingGroup_withPlacementGroup
=== RUN   TestAccAutoScalingGroup_availabilityZoneDistribution
=== PAUSE TestAccAutoScalingGroup_availabilityZoneDistribution
=== RUN   TestAccAutoScalingGroup_withScalingActivityErrorPlacementGroupNotSupportedOnInstanceType
=== PAUSE TestAccAutoScalingGroup_withScalingActivityErrorPlacementGroupNotSupportedOnInstanceType
=== RUN   TestAccAutoScalingGroup_withScalingActivityErrorIncorrectInstanceArchitecture
=== PAUSE TestAccAutoScalingGroup_withScalingActivityErrorIncorrectInstanceArchitecture
=== RUN   TestAccAutoScalingGroup_withScalingActivityErrorIncorrectInstanceArchitecture_IgnoreFailedScalingActivities
=== PAUSE TestAccAutoScalingGroup_withScalingActivityErrorIncorrectInstanceArchitecture_IgnoreFailedScalingActivities
=== RUN   TestAccAutoScalingGroup_withScalingActivityErrorIncorrectInstanceArchitecture_Recovers
=== PAUSE TestAccAutoScalingGroup_withScalingActivityErrorIncorrectInstanceArchitecture_Recovers
=== RUN   TestAccAutoScalingGroup_enablingMetrics
=== PAUSE TestAccAutoScalingGroup_enablingMetrics
=== RUN   TestAccAutoScalingGroup_withMetrics
=== PAUSE TestAccAutoScalingGroup_withMetrics
=== RUN   TestAccAutoScalingGroup_suspendingProcesses
=== PAUSE TestAccAutoScalingGroup_suspendingProcesses
=== RUN   TestAccAutoScalingGroup_serviceLinkedRoleARN
=== PAUSE TestAccAutoScalingGroup_serviceLinkedRoleARN
=== RUN   TestAccAutoScalingGroup_maxInstanceLifetime
=== PAUSE TestAccAutoScalingGroup_maxInstanceLifetime
=== RUN   TestAccAutoScalingGroup_initialLifecycleHook
=== PAUSE TestAccAutoScalingGroup_initialLifecycleHook
=== RUN   TestAccAutoScalingGroup_launchTemplate
=== PAUSE TestAccAutoScalingGroup_launchTemplate
=== RUN   TestAccAutoScalingGroup_LaunchTemplate_update
=== PAUSE TestAccAutoScalingGroup_LaunchTemplate_update
=== RUN   TestAccAutoScalingGroup_largeDesiredCapacity
=== PAUSE TestAccAutoScalingGroup_largeDesiredCapacity
=== RUN   TestAccAutoScalingGroup_InstanceRefresh_basic
=== PAUSE TestAccAutoScalingGroup_InstanceRefresh_basic
=== RUN   TestAccAutoScalingGroup_InstanceRefresh_start
=== PAUSE TestAccAutoScalingGroup_InstanceRefresh_start
=== RUN   TestAccAutoScalingGroup_InstanceRefresh_triggers
=== PAUSE TestAccAutoScalingGroup_InstanceRefresh_triggers
=== RUN   TestAccAutoScalingGroup_InstanceRefresh_autoRollback
=== PAUSE TestAccAutoScalingGroup_InstanceRefresh_autoRollback
=== RUN   TestAccAutoScalingGroup_InstanceRefresh_alarmSpecification
=== PAUSE TestAccAutoScalingGroup_InstanceRefresh_alarmSpecification
=== RUN   TestAccAutoScalingGroup_loadBalancers
=== PAUSE TestAccAutoScalingGroup_loadBalancers
=== RUN   TestAccAutoScalingGroup_targetGroups
=== PAUSE TestAccAutoScalingGroup_targetGroups
=== RUN   TestAccAutoScalingGroup_ALBTargetGroups_elbCapacity
=== PAUSE TestAccAutoScalingGroup_ALBTargetGroups_elbCapacity
=== RUN   TestAccAutoScalingGroup_warmPool
=== PAUSE TestAccAutoScalingGroup_warmPool
=== RUN   TestAccAutoScalingGroup_launchTempPartitionNum
=== PAUSE TestAccAutoScalingGroup_launchTempPartitionNum
=== RUN   TestAccAutoScalingGroup_launchTemplateIAMInstanceProfile
=== PAUSE TestAccAutoScalingGroup_launchTemplateIAMInstanceProfile
=== RUN   TestAccAutoScalingGroup_Destroy_whenProtectedFromScaleIn
=== PAUSE TestAccAutoScalingGroup_Destroy_whenProtectedFromScaleIn
=== RUN   TestAccAutoScalingGroup_mixedInstancesPolicy
=== PAUSE TestAccAutoScalingGroup_mixedInstancesPolicy
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicy_capacityRebalance
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicy_capacityRebalance
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_onDemandAllocationStrategy
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_onDemandAllocationStrategy
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_onDemandBaseCapacity
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_onDemandBaseCapacity
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_updateToZeroOnDemandBaseCapacity
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_updateToZeroOnDemandBaseCapacity
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_onDemandPercentageAboveBaseCapacity
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_onDemandPercentageAboveBaseCapacity
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_spotAllocationStrategy
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_spotAllocationStrategy
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_spotInstancePools
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_spotInstancePools
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_spotMaxPrice
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_spotMaxPrice
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateLaunchTemplateSpecification_launchTemplateName
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateLaunchTemplateSpecification_launchTemplateName
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateLaunchTemplateSpecification_version
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateLaunchTemplateSpecification_version
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceType
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceType
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceTypeWithLaunchTemplateSpecification
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceTypeWithLaunchTemplateSpecification
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_weightedCapacity
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_weightedCapacity
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_weightedCapacity_withELB
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_weightedCapacity_withELB
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_memoryMiBAndVCPUCount
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_memoryMiBAndVCPUCount
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_acceleratorCount
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_acceleratorCount
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_acceleratorManufacturers
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_acceleratorManufacturers
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_acceleratorNames
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_acceleratorNames
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_acceleratorTotalMemoryMiB
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_acceleratorTotalMemoryMiB
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_acceleratorTypes
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_acceleratorTypes
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_allowedInstanceTypes
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_allowedInstanceTypes
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_bareMetal
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_bareMetal
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_baselineEBSBandwidthMbps
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_baselineEBSBandwidthMbps
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_burstablePerformance
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_burstablePerformance
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_cpuManufacturers
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_cpuManufacturers
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_excludedInstanceTypes
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_excludedInstanceTypes
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_instanceGenerations
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_instanceGenerations
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_localStorage
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_localStorage
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_localStorageTypes
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_localStorageTypes
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_maxSpotPriceAsPercentageOfOptimalOnDemandPrice
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_maxSpotPriceAsPercentageOfOptimalOnDemandPrice
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_memoryGiBPerVCPU
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_memoryGiBPerVCPU
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_networkBandwidthGbps
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_networkBandwidthGbps
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_networkInterfaceCount
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_networkInterfaceCount
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_onDemandMaxPricePercentageOverLowestPrice
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_onDemandMaxPricePercentageOverLowestPrice
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_requireHibernateSupport
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_requireHibernateSupport
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_spotMaxPricePercentageOverLowestPrice
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_spotMaxPricePercentageOverLowestPrice
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_totalLocalStorageGB
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_totalLocalStorageGB
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_desiredCapacityTypeUnits
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_desiredCapacityTypeUnits
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_desiredCapacityTypeVCPU
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_desiredCapacityTypeVCPU
=== RUN   TestAccAutoScalingGroup_capacityReservationSpecificationBasic
=== PAUSE TestAccAutoScalingGroup_capacityReservationSpecificationBasic
=== RUN   TestAccAutoScalingGroup_capacityReservationSpecificationWithTarget
=== PAUSE TestAccAutoScalingGroup_capacityReservationSpecificationWithTarget
=== CONT  TestAccAutoScalingGroup_Identity_basic
=== CONT  TestAccAutoScalingGroup_targetGroups
=== CONT  TestAccAutoScalingGroup_withTrafficSourceELBV2
=== CONT  TestAccAutoScalingGroup_loadBalancers
=== CONT  TestAccAutoScalingGroup_InstanceRefresh_alarmSpecification
=== CONT  TestAccAutoScalingGroup_InstanceRefresh_autoRollback
=== CONT  TestAccAutoScalingGroup_InstanceRefresh_triggers
=== CONT  TestAccAutoScalingGroup_InstanceRefresh_start
=== CONT  TestAccAutoScalingGroup_InstanceRefresh_basic
=== CONT  TestAccAutoScalingGroup_largeDesiredCapacity
=== CONT  TestAccAutoScalingGroup_LaunchTemplate_update
=== CONT  TestAccAutoScalingGroup_launchTemplate
=== CONT  TestAccAutoScalingGroup_initialLifecycleHook
=== CONT  TestAccAutoScalingGroup_maxInstanceLifetime
=== CONT  TestAccAutoScalingGroup_serviceLinkedRoleARN
=== CONT  TestAccAutoScalingGroup_suspendingProcesses
=== CONT  TestAccAutoScalingGroup_withScalingActivityErrorPlacementGroupNotSupportedOnInstanceType
=== CONT  TestAccAutoScalingGroup_availabilityZoneDistribution
=== CONT  TestAccAutoScalingGroup_withPlacementGroup
=== CONT  TestAccAutoScalingGroup_withTrafficSourceVPCLatticeTargetGroups
--- PASS: TestAccAutoScalingGroup_withScalingActivityErrorPlacementGroupNotSupportedOnInstanceType (33.58s)
=== CONT  TestAccAutoScalingGroup_withTrafficSourceVPCLatticeTargetGroup
--- PASS: TestAccAutoScalingGroup_serviceLinkedRoleARN (63.85s)
=== CONT  TestAccAutoScalingGroup_withScalingActivityErrorIncorrectInstanceArchitecture
--- PASS: TestAccAutoScalingGroup_launchTemplate (78.04s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_acceleratorNames
--- PASS: TestAccAutoScalingGroup_availabilityZoneDistribution (79.48s)
=== CONT  TestAccAutoScalingGroup_withMetrics
--- PASS: TestAccAutoScalingGroup_maxInstanceLifetime (87.37s)
=== CONT  TestAccAutoScalingGroup_capacityReservationSpecificationWithTarget
--- PASS: TestAccAutoScalingGroup_withScalingActivityErrorIncorrectInstanceArchitecture (31.53s)
=== CONT  TestAccAutoScalingGroup_capacityReservationSpecificationBasic
--- PASS: TestAccAutoScalingGroup_Identity_basic (95.69s)
=== CONT  TestAccAutoScalingGroup_enablingMetrics
--- PASS: TestAccAutoScalingGroup_withPlacementGroup (117.39s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_desiredCapacityTypeVCPU
--- PASS: TestAccAutoScalingGroup_withMetrics (75.48s)
=== CONT  TestAccAutoScalingGroup_withScalingActivityErrorIncorrectInstanceArchitecture_Recovers
--- PASS: TestAccAutoScalingGroup_withTrafficSourceELBV2 (167.30s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_desiredCapacityTypeUnits
--- PASS: TestAccAutoScalingGroup_targetGroups (167.73s)
=== CONT  TestAccAutoScalingGroup_withScalingActivityErrorIncorrectInstanceArchitecture_IgnoreFailedScalingActivities
--- PASS: TestAccAutoScalingGroup_InstanceRefresh_triggers (168.87s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_totalLocalStorageGB
--- PASS: TestAccAutoScalingGroup_enablingMetrics (89.23s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_spotMaxPricePercentageOverLowestPrice
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_acceleratorNames (107.15s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_spotAllocationStrategy
--- PASS: TestAccAutoScalingGroup_LaunchTemplate_update (201.23s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_requireHibernateSupport
--- PASS: TestAccAutoScalingGroup_capacityReservationSpecificationBasic (105.90s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_acceleratorManufacturers
--- PASS: TestAccAutoScalingGroup_InstanceRefresh_autoRollback (203.50s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_onDemandMaxPricePercentageOverLowestPrice
--- PASS: TestAccAutoScalingGroup_InstanceRefresh_alarmSpecification (212.44s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_acceleratorCount
--- PASS: TestAccAutoScalingGroup_largeDesiredCapacity (213.49s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_networkInterfaceCount
--- PASS: TestAccAutoScalingGroup_capacityReservationSpecificationWithTarget (136.01s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_memoryMiBAndVCPUCount
--- PASS: TestAccAutoScalingGroup_suspendingProcesses (235.00s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_networkBandwidthGbps
--- PASS: TestAccAutoScalingGroup_withTrafficSourceVPCLatticeTargetGroup (203.82s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_weightedCapacity_withELB
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_spotAllocationStrategy (52.60s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_memoryGiBPerVCPU
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_spotMaxPricePercentageOverLowestPrice (67.58s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_weightedCapacity
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_onDemandMaxPricePercentageOverLowestPrice (59.98s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_maxSpotPriceAsPercentageOfOptimalOnDemandPrice
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_desiredCapacityTypeVCPU (159.85s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceTypeWithLaunchTemplateSpecification
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_desiredCapacityTypeUnits (120.08s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_localStorageTypes
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_acceleratorManufacturers (86.36s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_instanceGenerations
--- PASS: TestAccAutoScalingGroup_withTrafficSourceVPCLatticeTargetGroups (298.08s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_localStorage
--- PASS: TestAccAutoScalingGroup_loadBalancers (303.82s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_excludedInstanceTypes
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_totalLocalStorageGB (135.67s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_cpuManufacturers
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_memoryMiBAndVCPUCount (90.71s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_burstablePerformance
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_maxSpotPriceAsPercentageOfOptimalOnDemandPrice (63.17s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_baselineEBSBandwidthMbps
--- PASS: TestAccAutoScalingGroup_InstanceRefresh_start (328.42s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_bareMetal
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_networkInterfaceCount (116.19s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_allowedInstanceTypes
--- PASS: TestAccAutoScalingGroup_withScalingActivityErrorIncorrectInstanceArchitecture_IgnoreFailedScalingActivities (168.36s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_acceleratorTypes
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceTypeWithLaunchTemplateSpecification (71.08s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_acceleratorTotalMemoryMiB
--- PASS: TestAccAutoScalingGroup_InstanceRefresh_basic (348.65s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateLaunchTemplateSpecification_launchTemplateName
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_networkBandwidthGbps (135.52s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateLaunchTemplateSpecification_version
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_memoryGiBPerVCPU (132.98s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceType
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_localStorageTypes (97.85s)
=== CONT  TestAccAutoScalingGroup_mixedInstancesPolicy
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_cpuManufacturers (96.23s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_spotMaxPrice
--- PASS: TestAccAutoScalingGroup_withScalingActivityErrorIncorrectInstanceArchitecture_Recovers (247.93s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_onDemandPercentageAboveBaseCapacity
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_weightedCapacity (152.06s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_spotInstancePools
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_instanceGenerations (119.05s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_updateToZeroOnDemandBaseCapacity
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_excludedInstanceTypes (108.93s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_onDemandAllocationStrategy
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_acceleratorTypes (87.51s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicy_capacityRebalance
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_allowedInstanceTypes (97.95s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_onDemandBaseCapacity
--- PASS: TestAccAutoScalingGroup_mixedInstancesPolicy (52.54s)
=== CONT  TestAccAutoScalingGroup_tags
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_baselineEBSBandwidthMbps (111.63s)
=== CONT  TestAccAutoScalingGroup_List_regionOverride
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateLaunchTemplateSpecification_launchTemplateName (92.79s)
=== CONT  TestAccAutoScalingGroup_withTrafficSourceELB_toTargetGroup
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_localStorage (144.44s)
=== CONT  TestAccAutoScalingGroup_namePrefix
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateLaunchTemplateSpecification_version (72.87s)
=== CONT  TestAccAutoScalingGroup_withTrafficSourcesELBs
--- PASS: TestAccAutoScalingGroup_initialLifecycleHook (445.29s)
=== CONT  TestAccAutoScalingGroup_nameGenerated
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceType (74.81s)
=== CONT  TestAccAutoScalingGroup_withTrafficSourceELB
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_onDemandAllocationStrategy (55.65s)
=== CONT  TestAccAutoScalingGroup_defaultInstanceWarmup
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_acceleratorTotalMemoryMiB (129.33s)
=== CONT  TestAccAutoScalingGroup_WithLoadBalancer_toTargetGroup
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_onDemandPercentageAboveBaseCapacity (78.08s)
=== CONT  TestAccAutoScalingGroup_disappears
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_burstablePerformance (170.90s)
=== CONT  TestAccAutoScalingGroup_withLoadBalancer
--- PASS: TestAccAutoScalingGroup_namePrefix (43.97s)
=== CONT  TestAccAutoScalingGroup_basic
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_spotInstancePools (85.13s)
=== CONT  TestAccAutoScalingGroup_withInstanceMaintenancePolicyNegativeValues
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicy_capacityRebalance (66.51s)
=== CONT  TestAccAutoScalingGroup_withInstanceMaintenancePolicyAtCreation
--- PASS: TestAccAutoScalingGroup_List_regionOverride (53.48s)
=== CONT  TestAccAutoScalingGroup_Identity_ExistingResource_basic
--- PASS: TestAccAutoScalingGroup_nameGenerated (47.49s)
=== CONT  TestAccAutoScalingGroup_withInstanceMaintenancePolicyAfterCreation
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_spotMaxPrice (96.20s)
=== CONT  TestAccAutoScalingGroup_terminationPolicies
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_bareMetal (169.34s)
=== CONT  TestAccAutoScalingGroup_simple
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_acceleratorCount (302.14s)
=== CONT  TestAccAutoScalingGroup_vpcUpdates
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_updateToZeroOnDemandBaseCapacity (110.53s)
=== CONT  TestAccAutoScalingGroup_launchTempPartitionNum
--- PASS: TestAccAutoScalingGroup_tags (91.66s)
=== CONT  TestAccAutoScalingGroup_warmPool
--- PASS: TestAccAutoScalingGroup_disappears (49.80s)
=== CONT  TestAccAutoScalingGroup_Destroy_whenProtectedFromScaleIn
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_onDemandBaseCapacity (104.32s)
=== CONT  TestAccAutoScalingGroup_launchTemplateIAMInstanceProfile
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_weightedCapacity_withELB (302.99s)
=== CONT  TestAccAutoScalingGroup_ALBTargetGroups_elbCapacity
--- PASS: TestAccAutoScalingGroup_basic (54.19s)
=== CONT  TestAccAutoScalingGroup_List_includeResource
--- PASS: TestAccAutoScalingGroup_defaultInstanceWarmup (103.09s)
=== CONT  TestAccAutoScalingGroup_Identity_ExistingResource_noRefreshNoChange
--- PASS: TestAccAutoScalingGroup_vpcUpdates (61.68s)
=== CONT  TestAccAutoScalingGroup_Identity_regionOverride
--- PASS: TestAccAutoScalingGroup_List_includeResource (36.70s)
=== CONT  TestAccAutoScalingGroup_List_basic
--- PASS: TestAccAutoScalingGroup_Identity_ExistingResource_basic (98.32s)
--- PASS: TestAccAutoScalingGroup_launchTempPartitionNum (75.56s)
--- PASS: TestAccAutoScalingGroup_terminationPolicies (109.57s)
--- PASS: TestAccAutoScalingGroup_List_basic (57.06s)
--- PASS: TestAccAutoScalingGroup_withInstanceMaintenancePolicyNegativeValues (147.55s)
--- PASS: TestAccAutoScalingGroup_Identity_regionOverride (61.23s)
--- PASS: TestAccAutoScalingGroup_Identity_ExistingResource_noRefreshNoChange (74.85s)
--- PASS: TestAccAutoScalingGroup_simple (165.97s)
--- PASS: TestAccAutoScalingGroup_Destroy_whenProtectedFromScaleIn (158.99s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_requireHibernateSupport (492.82s)
--- PASS: TestAccAutoScalingGroup_withInstanceMaintenancePolicyAtCreation (241.33s)
--- PASS: TestAccAutoScalingGroup_withTrafficSourcesELBs (290.03s)
--- PASS: TestAccAutoScalingGroup_withTrafficSourceELB (305.35s)
--- PASS: TestAccAutoScalingGroup_launchTemplateIAMInstanceProfile (220.51s)
--- PASS: TestAccAutoScalingGroup_withInstanceMaintenancePolicyAfterCreation (277.94s)
--- PASS: TestAccAutoScalingGroup_withLoadBalancer (287.50s)
--- PASS: TestAccAutoScalingGroup_warmPool (294.45s)
--- PASS: TestAccAutoScalingGroup_WithLoadBalancer_toTargetGroup (373.40s)
--- PASS: TestAccAutoScalingGroup_ALBTargetGroups_elbCapacity (596.15s)
--- PASS: TestAccAutoScalingGroup_withTrafficSourceELB_toTargetGroup (744.62s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/autoscaling        1191.166s
```
