### PR TITLE
New Resource: `aws_directory_service_ad_assessment` for hybrid ad assessments 

### DIFF
--- a/.changelog/48935.txt
+++ b/.changelog/48935.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_directory_service_ad_assessment
+```

--- a/internal/service/ds/ad_assessment.go
+++ b/internal/service/ds/ad_assessment.go
@@ -1,0 +1,369 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+// DONOTCOPY: Copying old resources spreads bad habits. Use skaff instead.
+
+package ds
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/YakDriver/smarterr"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/directoryservice"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/directoryservice/types"
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
+	"github.com/hashicorp/terraform-provider-aws/internal/smerr"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
+	sweepfw "github.com/hashicorp/terraform-provider-aws/internal/sweep/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkResource("aws_directory_service_ad_assessment", name="AD Assessment")
+// @IdentityAttribute("assessment_id")
+// @Testing(hasNoPreExistingResource=true)
+// @Testing(tagsTest=false)
+// @Testing(identityTest=false)
+func newADAssessmentResource(_ context.Context) (resource.ResourceWithConfigure, error) {
+	r := &adAssessmentResource{}
+
+	r.SetDefaultCreateTimeout(45 * time.Minute)
+	r.SetDefaultUpdateTimeout(30 * time.Minute)
+	r.SetDefaultDeleteTimeout(30 * time.Minute)
+
+	return r, nil
+}
+
+type adAssessmentResource struct {
+	framework.ResourceWithModel[adAssessmentResourceModel]
+	framework.WithTimeouts
+	framework.WithImportByIdentity
+}
+
+const (
+	ResNameADAssessment = "AD Assessment"
+)
+
+func (r *adAssessmentResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"assessment_id": framework.IDAttribute(),
+			"customer_dns_ips": schema.ListAttribute{
+				CustomType:  fwtypes.ListOfStringType,
+				ElementType: types.StringType,
+				Required:    true,
+				PlanModifiers: []planmodifier.List{
+					listplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.List{
+					listvalidator.SizeBetween(2, 2),
+				},
+			},
+			names.AttrDNSName: schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			names.AttrSecurityGroupIDs: schema.SetAttribute{
+				CustomType: fwtypes.SetOfStringType,
+				Optional:   true,
+				Computed:   true,
+				Validators: []validator.Set{
+					setvalidator.SizeBetween(1, 1),
+				},
+				PlanModifiers: []planmodifier.Set{
+					setplanmodifier.UseStateForUnknown(),
+					setplanmodifier.RequiresReplace(),
+				},
+			},
+			"self_managed_instance_ids": schema.ListAttribute{
+				CustomType:  fwtypes.ListOfStringType,
+				ElementType: types.StringType,
+				Required:    true,
+				PlanModifiers: []planmodifier.List{
+					listplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.List{
+					listvalidator.SizeBetween(2, 2),
+				},
+			},
+			names.AttrSubnetIDs: schema.SetAttribute{
+				CustomType:  fwtypes.SetOfStringType,
+				ElementType: types.StringType,
+				Required:    true,
+				Validators: []validator.Set{
+					setvalidator.SizeBetween(2, 2),
+				},
+				PlanModifiers: []planmodifier.Set{
+					setplanmodifier.RequiresReplace(),
+				},
+			},
+			names.AttrVPCID: schema.StringAttribute{
+				Required: true,
+			},
+		},
+		Blocks: map[string]schema.Block{
+			names.AttrTimeouts: timeouts.Block(ctx, timeouts.Opts{
+				Create: true,
+				Update: true,
+				Delete: true,
+			}),
+		},
+	}
+}
+
+func (r *adAssessmentResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	conn := r.Meta().DSClient(ctx)
+
+	var plan adAssessmentResourceModel
+	smerr.AddEnrich(ctx, &resp.Diagnostics, req.Plan.Get(ctx, &plan))
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var input = directoryservice.StartADAssessmentInput{
+		AssessmentConfiguration: &awstypes.AssessmentConfiguration{
+			CustomerDnsIps: flex.ExpandFrameworkStringValueList(ctx, plan.CustomerDnsIps),
+			DnsName:        plan.DnsName.ValueStringPointer(),
+			InstanceIds:    flex.ExpandFrameworkStringValueList(ctx, plan.SelfManagedInstanceIds),
+			VpcSettings: &awstypes.DirectoryVpcSettings{
+				SubnetIds: flex.ExpandFrameworkStringValueSet(ctx, plan.SubnetIds),
+				VpcId:     plan.VpcId.ValueStringPointer(),
+			},
+		},
+	}
+
+	if !plan.SecurityGroupIds.IsNull() {
+		input.AssessmentConfiguration.SecurityGroupIds = flex.ExpandFrameworkStringValueSet(ctx, plan.SecurityGroupIds)
+	}
+
+	out, err := conn.StartADAssessment(ctx, &input)
+	if err != nil {
+		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID)
+		return
+	}
+	if out == nil || out.AssessmentId == nil {
+		smerr.AddError(ctx, &resp.Diagnostics, errors.New("empty output"), smerr.ID)
+		return
+	}
+	plan.AssessmentId = flex.StringToFramework(ctx, out.AssessmentId)
+	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.SetAttribute(ctx, path.Root("assessment_id"), plan.AssessmentId))
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	createTimeout := r.CreateTimeout(ctx, plan.Timeouts)
+	created, err := waitADAssessmentCreated(ctx, conn, plan.AssessmentId.ValueString(), createTimeout)
+	if err != nil {
+		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID)
+		return
+	}
+	smerr.AddEnrich(ctx, &resp.Diagnostics, flex.Flatten(ctx, created, &plan))
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, plan))
+}
+
+func (r *adAssessmentResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	conn := r.Meta().DSClient(ctx)
+
+	var state adAssessmentResourceModel
+	smerr.AddEnrich(ctx, &resp.Diagnostics, req.State.Get(ctx, &state))
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	out, err := findADAssessmentByID(ctx, conn, state.AssessmentId.ValueString())
+	if retry.NotFound(err) {
+		resp.Diagnostics.Append(fwdiag.NewResourceNotFoundWarningDiagnostic(err))
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	if err != nil {
+		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, state.AssessmentId.String())
+		return
+	}
+
+	smerr.AddEnrich(ctx, &resp.Diagnostics, r.flatten(ctx, out, &state))
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, &state))
+}
+
+func (r *adAssessmentResource) flatten(ctx context.Context, adAssessment *awstypes.Assessment, data *adAssessmentResourceModel) (diags diag.Diagnostics) {
+	diags.Append(flex.Flatten(ctx, adAssessment, data)...)
+	return diags
+}
+
+func (r *adAssessmentResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	conn := r.Meta().DSClient(ctx)
+
+	var state adAssessmentResourceModel
+	smerr.AddEnrich(ctx, &resp.Diagnostics, req.State.Get(ctx, &state))
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	input := directoryservice.DeleteADAssessmentInput{
+		AssessmentId: state.AssessmentId.ValueStringPointer(),
+	}
+
+	_, err := conn.DeleteADAssessment(ctx, &input)
+	if err != nil {
+		if errs.IsA[*awstypes.EntityDoesNotExistException](err) || errs.IsA[*awstypes.ServiceException](err) {
+			return
+		}
+		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, state.AssessmentId.String())
+		return
+	}
+
+	deleteTimeout := r.DeleteTimeout(ctx, state.Timeouts)
+	_, err = waitADAssessmentDeleted(ctx, conn, state.AssessmentId.ValueString(), deleteTimeout)
+	if err != nil {
+		if errs.IsA[*awstypes.EntityDoesNotExistException](err) || errs.IsA[*awstypes.ServiceException](err) {
+			return
+		}
+		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, state.AssessmentId.String())
+		return
+	}
+}
+
+const (
+	statusSuccess    = "SUCCESS"
+	statusFailed     = "FAILED"
+	statusPending    = "PENDING"
+	statusInProgress = "IN_PROGRESS"
+)
+
+func waitADAssessmentCreated(ctx context.Context, conn *directoryservice.Client, id string, timeout time.Duration) (*awstypes.Assessment, error) {
+	stateConf := &retry.StateChangeConf{
+		Pending:                   []string{statusPending, statusInProgress},
+		Target:                    []string{statusSuccess},
+		Refresh:                   statusADAssessment(conn, id),
+		Timeout:                   timeout,
+		NotFoundChecks:            20,
+		ContinuousTargetOccurence: 2,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+	if out, ok := outputRaw.(*awstypes.Assessment); ok {
+		retry.SetLastError(err, errors.New(aws.ToString(out.StatusReason)))
+		return out, smarterr.NewError(err)
+	}
+
+	return nil, smarterr.NewError(err)
+}
+
+func waitADAssessmentDeleted(ctx context.Context, conn *directoryservice.Client, id string, timeout time.Duration) (*awstypes.Assessment, error) {
+	stateConf := &retry.StateChangeConf{
+		Pending: []string{statusFailed, statusPending, statusSuccess, statusInProgress},
+		Target:  []string{},
+		Refresh: statusADAssessment(conn, id),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+	if out, ok := outputRaw.(*awstypes.Assessment); ok {
+		return out, smarterr.NewError(err)
+	}
+
+	return nil, smarterr.NewError(err)
+}
+
+func statusADAssessment(conn *directoryservice.Client, id string) retry.StateRefreshFunc {
+	return func(ctx context.Context) (any, string, error) {
+		out, err := findADAssessmentByID(ctx, conn, id)
+		if retry.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", smarterr.NewError(err)
+		}
+
+		return out, aws.ToString(out.Status), nil
+	}
+}
+
+func findADAssessmentByID(ctx context.Context, conn *directoryservice.Client, id string) (*awstypes.Assessment, error) {
+	input := directoryservice.DescribeADAssessmentInput{
+		AssessmentId: aws.String(id),
+	}
+
+	out, err := conn.DescribeADAssessment(ctx, &input)
+	if err != nil {
+		if errs.IsA[*awstypes.EntityDoesNotExistException](err) {
+			return nil, &retry.NotFoundError{
+				LastError: err,
+			}
+		}
+		return nil, smarterr.NewError(err)
+	}
+
+	if out == nil || out.Assessment == nil {
+		return nil, smarterr.NewError(tfresource.NewEmptyResultError())
+	}
+
+	return out.Assessment, nil
+}
+
+type adAssessmentResourceModel struct {
+	framework.WithRegionModel
+	AssessmentId           types.String                      `tfsdk:"assessment_id"`
+	CustomerDnsIps         fwtypes.ListValueOf[types.String] `tfsdk:"customer_dns_ips"`
+	DnsName                types.String                      `tfsdk:"dns_name"`
+	SecurityGroupIds       fwtypes.SetValueOf[types.String]  `tfsdk:"security_group_ids"`
+	SelfManagedInstanceIds fwtypes.ListValueOf[types.String] `tfsdk:"self_managed_instance_ids"`
+	SubnetIds              fwtypes.SetValueOf[types.String]  `tfsdk:"subnet_ids"`
+	VpcId                  types.String                      `tfsdk:"vpc_id"`
+	Timeouts               timeouts.Value                    `tfsdk:"timeouts"`
+}
+
+func sweepADAssessments(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepable, error) {
+	input := directoryservice.ListADAssessmentsInput{}
+	conn := client.DSClient(ctx)
+	var sweepResources []sweep.Sweepable
+
+	pages := directoryservice.NewListADAssessmentsPaginator(conn, &input)
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
+		if err != nil {
+			return nil, smarterr.NewError(err)
+		}
+
+		for _, v := range page.Assessments {
+			sweepResources = append(sweepResources, sweepfw.NewSweepResource(newADAssessmentResource, client,
+				sweepfw.NewAttribute("assessment_id", aws.ToString(v.AssessmentId))),
+			)
+		}
+	}
+
+	return sweepResources, nil
+}

--- a/internal/service/ds/ad_assessment_test.go
+++ b/internal/service/ds/ad_assessment_test.go
@@ -1,0 +1,538 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package ds_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/YakDriver/regexache"
+	"github.com/aws/aws-sdk-go-v2/service/directoryservice"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
+	tfds "github.com/hashicorp/terraform-provider-aws/internal/service/ds"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccDSADAssessment_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	domainName := acctest.RandomDomainName(t)
+	resourceName := "aws_directory_service_ad_assessment.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckDirectoryService(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.DSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckADAssessmentDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccADAssessmentConfig_basic(rName, domainName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckADAssessmentExists(ctx, t, resourceName),
+					resource.TestMatchResourceAttr(resourceName, "assessment_id", regexache.MustCompile(`^da-.+$`)),
+					resource.TestCheckResourceAttr(resourceName, names.AttrDNSName, domainName),
+					resource.TestCheckResourceAttr(resourceName, "customer_dns_ips.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "customer_dns_ips.0", "10.0.0.10"),
+					resource.TestCheckResourceAttr(resourceName, "customer_dns_ips.1", "10.0.1.10"),
+					resource.TestCheckResourceAttr(resourceName, "self_managed_instance_ids.#", "2"),
+					resource.TestMatchResourceAttr(resourceName, "self_managed_instance_ids.0", regexache.MustCompile(`^i-.+$`)),
+					resource.TestMatchResourceAttr(resourceName, "self_managed_instance_ids.1", regexache.MustCompile(`^i-.+$`)),
+					resource.TestCheckResourceAttr(resourceName, "security_group_ids.#", "1"),
+					resource.TestMatchResourceAttr(resourceName, "security_group_ids.0", regexache.MustCompile(`^sg-.+$`)),
+					resource.TestCheckResourceAttr(resourceName, "subnet_ids.#", "2"),
+					resource.TestMatchResourceAttr(resourceName, "subnet_ids.0", regexache.MustCompile(`^subnet-.+$`)),
+					resource.TestMatchResourceAttr(resourceName, "subnet_ids.1", regexache.MustCompile(`^subnet-.+$`)),
+					resource.TestMatchResourceAttr(resourceName, names.AttrVPCID, regexache.MustCompile(`^vpc-.+$`)),
+				),
+			},
+			{
+				ResourceName:    resourceName,
+				ImportState:     true,
+				ImportStateKind: resource.ImportBlockWithResourceIdentity,
+				ImportPlanChecks: resource.ImportPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccDSADAssessment_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	domainName := acctest.RandomDomainName(t)
+	resourceName := "aws_directory_service_ad_assessment.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckDirectoryService(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.DSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckADAssessmentDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccADAssessmentConfig_basic(rName, domainName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckADAssessmentExists(ctx, t, resourceName),
+					acctest.CheckFrameworkResourceDisappears(ctx, t, tfds.ResourceADAssessment, resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccCheckADAssessmentDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.ProviderMeta(ctx, t).DSClient(ctx)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_directory_service_ad_assessment" {
+				continue
+			}
+			_, err := tfds.FindADAssessmentByID(ctx, conn, rs.Primary.Attributes["assessment_id"])
+			if retry.NotFound(err) {
+				return nil
+			}
+			if err != nil {
+				return create.Error(names.DS, create.ErrActionCheckingDestroyed, tfds.ResNameADAssessment, rs.Primary.Attributes["assessment_id"], err)
+			}
+
+			return create.Error(names.DS, create.ErrActionCheckingDestroyed, tfds.ResNameADAssessment, rs.Primary.Attributes["assessment_id"], errors.New("not destroyed"))
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckADAssessmentExists(ctx context.Context, t *testing.T, name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return create.Error(names.DS, create.ErrActionCheckingExistence, tfds.ResNameADAssessment, name, errors.New("not found"))
+		}
+
+		if rs.Primary.Attributes["assessment_id"] == "" {
+			return create.Error(names.DS, create.ErrActionCheckingExistence, tfds.ResNameADAssessment, name, errors.New("not set"))
+		}
+
+		conn := acctest.ProviderMeta(ctx, t).DSClient(ctx)
+
+		_, err := tfds.FindADAssessmentByID(ctx, conn, rs.Primary.Attributes["assessment_id"])
+		if err != nil {
+			return create.Error(names.DS, create.ErrActionCheckingExistence, tfds.ResNameADAssessment, rs.Primary.Attributes["assessment_id"], err)
+		}
+		return nil
+	}
+}
+
+func testAccPreCheck(ctx context.Context, t *testing.T) {
+	conn := acctest.ProviderMeta(ctx, t).DSClient(ctx)
+
+	input := &directoryservice.ListADAssessmentsInput{}
+
+	_, err := conn.ListADAssessments(ctx, input)
+
+	if acctest.PreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
+}
+
+func testAccADAssessmentConfig_basic(rName, domain string) string {
+	return acctest.ConfigCompose(
+		testAccADAssessmentConfig_base(rName, domain),
+		fmt.Sprintf(`
+resource "aws_directory_service_ad_assessment" "test" {
+  customer_dns_ips = ["10.0.0.10", "10.0.1.10"]
+  dns_name         = %[2]q
+  self_managed_instance_ids = [
+    aws_cloudformation_stack.test.outputs.DomainController1InstanceId,
+    aws_cloudformation_stack.test.outputs.DomainController2InstanceId,
+  ]
+  security_group_ids = [aws_security_group.test.id]
+  subnet_ids         = aws_subnet.test[*].id
+  vpc_id             = aws_vpc.test.id
+}
+
+`, rName, domain))
+}
+
+// lintignore:AWSAT005
+func testAccADAssessmentConfig_base(rName, domain string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigVPCWithSubnets(rName, 2),
+		testAccLatestWindowsServer2022CoreAMIConfig(),
+		fmt.Sprintf(`
+resource "aws_subnet" "public" {
+  vpc_id                  = aws_vpc.test.id
+  cidr_block              = cidrsubnet(aws_vpc.test.cidr_block, 8, 2)
+  availability_zone       = data.aws_availability_zones.available.names[0]
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_internet_gateway" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = "%[1]s-igw"
+  }
+}
+
+resource "aws_eip" "test" {
+  domain = "vpc"
+}
+
+resource "aws_nat_gateway" "test" {
+  allocation_id = aws_eip.test.id
+  subnet_id     = aws_subnet.public.id
+
+  tags = {
+    Name = "%[1]s-nat"
+  }
+  depends_on = [aws_internet_gateway.test]
+}
+
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.test.id
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.test.id
+  }
+
+  tags = {
+    Name = "%[1]s-priv"
+  }
+}
+
+resource "aws_route_table_association" "private" {
+  count          = 2
+  subnet_id      = aws_subnet.test[count.index].id
+  route_table_id = aws_route_table.private.id
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.test.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.test.id
+  }
+
+  tags = {
+    Name = "%[1]s-pub"
+  }
+}
+
+resource "aws_route_table_association" "public" {
+  subnet_id      = aws_subnet.public.id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_security_group" "test" {
+  name   = %[1]q
+  vpc_id = aws_vpc.test.id
+}
+
+resource "aws_vpc_security_group_ingress_rule" "test" {
+  security_group_id = aws_security_group.test.id
+  cidr_ipv4         = aws_vpc.test.cidr_block
+  ip_protocol       = "-1"
+}
+
+resource "aws_vpc_security_group_egress_rule" "test" {
+  security_group_id = aws_security_group.test.id
+  cidr_ipv4         = "0.0.0.0/0"
+  ip_protocol       = "-1"
+}
+
+resource "aws_iam_role" "test" {
+  name = %[1]q
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Sid    = ""
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        }
+      },
+    ]
+  })
+
+  tags = {
+    Name = %[1]q
+  }
+}
+resource "aws_iam_role_policy_attachment" "test" {
+  role       = aws_iam_role.test.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_instance_profile" "test" {
+  name = aws_iam_role.test.name
+  role = aws_iam_role.test.name
+}
+
+resource "aws_cloudformation_stack" "test" {
+  name = %[1]q
+
+  parameters = {
+    AMI                = data.aws_ami.win2022core-ami.id
+    SecurityGroupId    = aws_security_group.test.id
+    PrivateSubnet1     = aws_subnet.test[0].id
+    PrivateSubnet2     = aws_subnet.test[1].id
+    EC2InstanceProfile = aws_iam_instance_profile.test.name
+    Domain             = %[2]q
+  }
+  template_body = <<EOF
+Parameters:
+  AMI:
+    Type: AWS::EC2::Image::Id
+  SecurityGroupId:
+    Type: AWS::EC2::SecurityGroup::Id
+  PrivateSubnet1: 
+    Type: AWS::EC2::Subnet::Id
+  PrivateSubnet2: 
+    Type: AWS::EC2::Subnet::Id
+  EC2InstanceProfile:
+    Type: String
+  Domain:
+    Type: String
+Resources:
+  DomainController1:
+    Type: AWS::EC2::Instance
+    CreationPolicy:
+      ResourceSignal:
+        Timeout: PT30M
+        Count: 1
+    Properties:
+      ImageId: !Ref AMI
+      InstanceType: t3.medium
+      SubnetId: !Ref PrivateSubnet1
+      SecurityGroupIds:
+        - !Ref SecurityGroupId
+      IamInstanceProfile: !Ref EC2InstanceProfile
+      PrivateIpAddress: 10.0.0.10
+      MetadataOptions:
+        HttpEndpoint: enabled
+        HttpTokens: required
+      BlockDeviceMappings:
+        - DeviceName: /dev/sda1
+          Ebs:
+            Encrypted: true
+            VolumeType: gp3
+            DeleteOnTermination: true
+      UserData:
+        Fn::Base64: !Sub |
+          <powershell>
+          # Create a scheduled task to run after restart
+          $action = New-ScheduledTaskAction -Execute "powershell.exe" -Argument '-Command "cfn-signal.exe -e 0 --stack $${AWS::StackName} --resource DomainController1 --region $${AWS::Region}"'
+          $trigger = New-ScheduledTaskTrigger -AtStartup
+          $principal = New-ScheduledTaskPrincipal -UserId "SYSTEM" -LogonType ServiceAccount
+          Register-ScheduledTask -TaskName "CFNSignal" -Action $action -Trigger $trigger -Principal $principal
+
+          $NewPassword = ConvertTo-SecureString "SuperSecretPassw0rd" -AsPlainText -Force
+          
+          # Reset Administrator password
+          Set-LocalUser -Name "Administrator" -Password $NewPassword
+          
+          # Enable Administrator account (in case it's disabled)
+          Enable-LocalUser -Name "Administrator"
+
+          # Install AD DS Role
+          Install-WindowsFeature -Name AD-Domain-Services -IncludeManagementTools
+
+          Start-Sleep -Seconds 5  # Wait for network to stabilize   
+      
+          # Install new forest
+
+          $maxAttempts = 3
+          $delaySeconds = 60
+          $attempt = 0
+          $success = $false
+
+          while (-not $success -and $attempt -lt $maxAttempts) {
+            $attempt++
+            try {
+                Install-ADDSForest -DomainName "$${Domain}" -SafeModeAdministratorPassword $NewPassword -Force -ErrorAction Stop
+                $success = $true
+            }
+            catch {
+                if ($attempt -lt $maxAttempts) {
+                    Start-Sleep -Seconds $delaySeconds
+                }
+                else {
+                    cfn-signal.exe -e 1 --stack $${AWS::StackName} --resource DomainController1 --region $${AWS::Region}
+                    throw "Install new forest failed after $maxAttempts attempts."
+                }
+            }
+          }
+          </powershell>
+      Tags:
+        - Key: Name
+          Value: %[1]s-dc1
+        - Key: StackName
+          Value: !Ref AWS::StackName
+  DomainController2:
+    Type: AWS::EC2::Instance
+    DependsOn: DomainController1
+    CreationPolicy:
+      ResourceSignal:
+        Timeout: PT30M
+        Count: 1
+    Properties:
+      ImageId: !Ref AMI
+      InstanceType: t3.medium
+      SubnetId: !Ref PrivateSubnet2
+      SecurityGroupIds:
+        - !Ref SecurityGroupId
+      IamInstanceProfile: !Ref EC2InstanceProfile
+      PrivateIpAddress: 10.0.1.10
+      MetadataOptions:
+        HttpEndpoint: enabled
+        HttpTokens: required
+      BlockDeviceMappings:
+        - DeviceName: /dev/sda1
+          Ebs:
+            Encrypted: true
+            VolumeType: gp3
+            DeleteOnTermination: true
+      UserData:
+        Fn::Base64: !Sub |
+          <powershell>
+          # Create a scheduled task to run after restart
+          $action = New-ScheduledTaskAction -Execute "powershell.exe" -Argument '-Command "cfn-signal.exe -e 0 --stack $${AWS::StackName} --resource DomainController2 --region $${AWS::Region}"'
+          $trigger = New-ScheduledTaskTrigger -AtStartup
+          $principal = New-ScheduledTaskPrincipal -UserId "SYSTEM" -LogonType ServiceAccount
+          Register-ScheduledTask -TaskName "CFNSignal" -Action $action -Trigger $trigger -Principal $principal
+
+          # Set DNS to first DC
+          $adapter = Get-NetAdapter | Where-Object {$_.Status -eq "Up"}
+          Set-DnsClientServerAddress -InterfaceIndex $adapter.InterfaceIndex -ServerAddresses "10.0.0.10"
+
+          Start-Sleep -Seconds 3  # Wait for network to stabilize
+
+          $domain = "$${Domain}"
+          $Username = "Administrator"
+          $FinalUserName = $domain + '\' + $Username
+
+          $NewPassword = ConvertTo-SecureString "SuperSecretPassw0rd" -AsPlainText -Force
+          $Credential = New-Object System.Management.Automation.PsCredential($FinalUserName, $NewPassword)  
+          
+          # Reset Administrator password
+          Set-LocalUser -Name "Administrator" -Password $NewPassword    
+
+          # Enable Administrator account (in case it's disabled)
+          Enable-LocalUser -Name "Administrator"  
+
+          # Install AD DS Role
+          Install-WindowsFeature -Name AD-Domain-Services -IncludeManagementTools
+
+          $maxAttempts = 3
+          $delaySeconds = 60
+          $attempt = 0
+          $success = $false
+
+          while (-not $success -and $attempt -lt $maxAttempts) {
+            $attempt++
+            try {
+                Install-ADDSDomainController -DomainName $domain -InstallDns:$true -Credential $Credential -SafeModeAdministratorPassword $NewPassword -confirm:$false -ErrorAction Stop
+                $success = $true
+            }
+            catch {
+                if ($attempt -lt $maxAttempts) {
+                    Start-Sleep -Seconds $delaySeconds
+                }
+                else {
+                    cfn-signal.exe -e 1 --stack $${AWS::StackName} --resource DomainController2 --region $${AWS::Region}
+                    throw "Domain controller promotion failed after $maxAttempts attempts."
+                }
+            }
+          }
+          </powershell>
+      Tags:
+        - Key: Name
+          Value: %[1]s-dc2
+        - Key: StackName
+          Value: !Ref AWS::StackName
+Outputs:
+  DomainController1InstanceId:
+    Description: Primary Domain Controller Instance Id
+    Value: !GetAtt DomainController1.InstanceId
+
+  DomainController2InstanceId:
+    Description: Secondary Domain Controller Instance Id
+    Value: !GetAtt DomainController2.InstanceId
+
+EOF
+  timeouts {
+    create = "30m"
+  }
+  depends_on = [
+    aws_route_table_association.private
+  ]
+}
+
+`, rName, domain))
+}
+
+// testAccLatestWindowsServer2022CoreAMIConfig returns the configuration for a data source that
+// describes the latest Microsoft Windows Server 2022 Core AMI.
+// The data source is named 'win2022core-ami'.
+func testAccLatestWindowsServer2022CoreAMIConfig() string {
+	return `
+data "aws_ami" "win2022core-ami" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["Windows_Server-2022-English-Core-Base-*"]
+  }
+}
+`
+}

--- a/internal/service/ds/exports_test.go
+++ b/internal/service/ds/exports_test.go
@@ -13,6 +13,7 @@ var (
 	ResourceSharedDirectory         = resourceSharedDirectory
 	ResourceSharedDirectoryAccepter = resourceSharedDirectoryAccepter
 	ResourceTrust                   = newTrustResource
+	ResourceADAssessment            = newADAssessmentResource
 
 	FindConditionalForwarderByTwoPartKey = findConditionalForwarderByTwoPartKey
 	FindDirectoryByID                    = findDirectoryByID
@@ -21,4 +22,5 @@ var (
 	FindRegionByTwoPartKey               = findRegionByTwoPartKey
 	FindSharedDirectoryByTwoPartKey      = findSharedDirectoryByTwoPartKey // nosemgrep:ci.ds-in-var-name
 	FindTrustByTwoPartKey                = findTrustByTwoPartKey
+	FindADAssessmentByID                 = findADAssessmentByID
 )

--- a/internal/service/ds/service_package_gen.go
+++ b/internal/service/ds/service_package_gen.go
@@ -27,6 +27,16 @@ func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*inttypes.S
 func (p *servicePackage) FrameworkResources(ctx context.Context) []*inttypes.ServicePackageFrameworkResource {
 	return []*inttypes.ServicePackageFrameworkResource{
 		{
+			Factory:  newADAssessmentResource,
+			TypeName: "aws_directory_service_ad_assessment",
+			Name:     "AD Assessment",
+			Region:   inttypes.ResourceRegionDefault(),
+			Identity: inttypes.RegionalSingleParameterIdentity(inttypes.StringIdentityAttribute("assessment_id", true)),
+			Import: inttypes.FrameworkImport{
+				WrappedImport: true,
+			},
+		},
+		{
 			Factory:  newTrustResource,
 			TypeName: "aws_directory_service_trust",
 			Name:     "Trust",

--- a/internal/service/ds/sweep.go
+++ b/internal/service/ds/sweep.go
@@ -38,6 +38,7 @@ func RegisterSweepers() {
 		Name: "aws_directory_service_region",
 		F:    sweepRegions,
 	})
+	awsv2.Register("aws_ds_ad_assessment", sweepADAssessments)
 }
 
 func sweepDirectories(region string) error {

--- a/website/docs/r/directory_service_ad_assessment.html.markdown
+++ b/website/docs/r/directory_service_ad_assessment.html.markdown
@@ -1,0 +1,103 @@
+---
+subcategory: "Directory Service"
+layout: "aws"
+page_title: "AWS: aws_directory_service_directory"
+description: |-
+  Manages an AWS Directory Service AD Assessment.
+---
+
+# Resource: aws_directory_service_directory
+
+Manages an AWS Directory Service AD Assessment, required for creation of AWS Managed AD (Hybrid Edition)
+
+~> **Note:** The `self_managed_instance_ids` must have a one-to-one correspondence with `customer_dns_ips`, meaning that if the IP address for instance `i-10243410` is `10.24.34.100` and the IP address for instance `i-10243420` is `10.24.34.200`, then the inputs arrays must maintain the same order relationship, either `["10.24.34.100", "10.24.34.200"]` paired with `["i-10243410", "i-10243420"]` or `["10.24.34.200", "10.24.34.100"]` paired with `["i-10243420", "i-10243410"]`.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_directory_service_ad_assessment" "test" {
+  customer_dns_ips = ["10.24.34.100", "10.24.34.200"]
+  dns_name         = "corp.notexample.com"
+  self_managed_instance_ids = [
+    "i-10243410",
+    "i-10243420",
+  ]
+  security_group_ids = [aws_security_group.test.id]
+  subnet_ids         = [aws_subnet.foo.id, aws_subnet.bar.id]
+  vpc_id             = aws_vpc.main.id
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
+* `customer_dns_ips` - (Required) List of IP addresses for the DNS servers or domain controllers in your self-managed AD that are tested during the assessment.
+* `dns_name` - (Required) [FQDN](https://en.wikipedia.org/wiki/Fully_qualified_domain_name) of the self-managed AD domain to assess.
+* `self_managed_instance_ids` - (Required) IDs of the self-managed instances with SSM that are used to perform connectivity and validation tests.
+* `subnet_ids` - (Required) IDs of the subnets in which you intend to deploy directory servers (2 subnets in 2 different AZs).
+* `vpc_id` - (Required) Identifier of the VPC in which  you intend to deploy directory servers
+
+The following arguments are optional:
+
+* `security_group_ids` - (Optional) List with exactly one security group id that allows network traffic to and from your self-managed domain controllers outside of your Amazon VPC. By default, the service attaches a security group to allow network access to the self-managed nodes in your Amazon VPC.
+
+## Attribute Reference
+
+This resource exports the following attributes in addition to the arguments above:
+
+* `assessment_id` - ID of the AD Assessment.
+
+## Timeouts
+
+[Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
+
+* `create` - (Default `45m`)
+* `update` - (Default `30m`)
+* `delete` - (Default `30m`)
+
+## Import
+
+In Terraform v1.12.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `identity` attribute. For example:
+
+```terraform
+import {
+  to = aws_directory_service_ad_assessment.example
+  identity = {
+    assessment_id = "da-12345678"
+  }
+}
+
+resource "aws_directory_service_ad_assessment" "example" {
+  ### Configuration omitted for brevity ###
+}
+```
+
+### Identity Schema
+
+#### Required
+
+* `assessment_id` - ID argument of the AD Assessment.
+
+#### Optional
+
+* `account_id` (String) AWS Account where this resource is managed.
+* `region` (String) Region where this resource is managed.
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Directory Service AD Assessment using the `assessment_id`. For example:
+
+```terraform
+import {
+  to = aws_directory_service_ad_assessment.example
+  id = "da-12345678"
+}
+```
+
+Using `terraform import`, import Directory Service AD Assessment using the `assessment_id`. For example:
+
+```console
+% terraform import aws_directory_service_ad_assessment.example da-12345678
+```


### PR DESCRIPTION


<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
New resource `aws_directory_service_ad_assessment` required to create AWS ActiveDirectory (Hybrid Edition).
### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:


--->

Relates #43731,  #48773

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2	(cached)
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider/framework	(cached)
make: Running acceptance tests on branch: 🌿 f-aws_directory_service_ad_assessment 🌿...
TF_ACC=1 go1.26.4 test ./internal/service/ds/... -v -count 1 -parallel 20 -run='TestAccDSADAssessment'  -timeout 360m -vet=off -buildvcs=false
2026/07/15 18:29:06 Creating Terraform AWS Provider (SDKv2-style)...
2026/07/15 18:29:06 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccDSADAssessment_basic
=== PAUSE TestAccDSADAssessment_basic
=== RUN   TestAccDSADAssessment_disappears
=== PAUSE TestAccDSADAssessment_disappears
=== CONT  TestAccDSADAssessment_basic
=== CONT  TestAccDSADAssessment_disappears
--- PASS: TestAccDSADAssessment_basic (2734.59s)
--- PASS: TestAccDSADAssessment_disappears (2776.94s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ds	2784.277s
...
```
