### PR TITLE
r/aws_redshift_idc_application: allow multiple authorized_token_issuer blocks

### DIFF
--- a/.changelog/48940.txt
+++ b/.changelog/48940.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_redshift_idc_application: Allow multiple `authorized_token_issuer` blocks
+```

--- a/internal/service/redshift/idc_application.go
+++ b/internal/service/redshift/idc_application.go
@@ -107,9 +107,6 @@ func (r *idcApplicationResource) Schema(ctx context.Context, req resource.Schema
 		Blocks: map[string]schema.Block{
 			"authorized_token_issuer": schema.ListNestedBlock{
 				CustomType: fwtypes.NewListNestedObjectTypeOf[authorizedTokenIssuerModel](ctx),
-				Validators: []validator.List{
-					listvalidator.SizeAtMost(1),
-				},
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
 						"authorized_audiences_list": schema.ListAttribute{

--- a/internal/service/redshift/idc_application_test.go
+++ b/internal/service/redshift/idc_application_test.go
@@ -108,6 +108,15 @@ func TestAccRedshiftIDCApplication_authorizedTokenIssuerList(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccIdcApplicationConfig_authorizedTokenIssuerListMultiple(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIDCApplicationExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "authorized_token_issuer.#", "2"),
+					resource.TestCheckResourceAttrPair(resourceName, "authorized_token_issuer.0.trusted_token_issuer_arn", "aws_ssoadmin_trusted_token_issuer.test", names.AttrARN),
+					resource.TestCheckResourceAttrPair(resourceName, "authorized_token_issuer.1.trusted_token_issuer_arn", "aws_ssoadmin_trusted_token_issuer.test2", names.AttrARN),
+				),
+			},
+			{
 				ResourceName:                         resourceName,
 				ImportState:                          true,
 				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, "redshift_idc_application_arn"),
@@ -391,6 +400,57 @@ resource "aws_redshift_idc_application" "test" {
   authorized_token_issuer {
     authorized_audiences_list = ["client_id"]
     trusted_token_issuer_arn  = aws_ssoadmin_trusted_token_issuer.test.arn
+  }
+  iam_role_arn                  = aws_iam_role.test.arn
+  idc_display_name              = %[1]q
+  idc_instance_arn              = tolist(data.aws_ssoadmin_instances.test.arns)[0]
+  redshift_idc_application_name = %[1]q
+}
+`, rName))
+}
+
+func testAccIdcApplicationConfig_authorizedTokenIssuerListMultiple(rName string) string {
+	return acctest.ConfigCompose(testAccIdcApplicationConfig_baseIAMRole(rName), fmt.Sprintf(`
+resource "aws_ssoadmin_trusted_token_issuer" "test" {
+  name                      = %[1]q
+  instance_arn              = tolist(data.aws_ssoadmin_instances.test.arns)[0]
+  trusted_token_issuer_type = "OIDC_JWT"
+
+  trusted_token_issuer_configuration {
+    oidc_jwt_configuration {
+      claim_attribute_path          = "email"
+      identity_store_attribute_path = "emails.value"
+      issuer_url                    = "https://example.com"
+      jwks_retrieval_option         = "OPEN_ID_DISCOVERY"
+    }
+  }
+}
+
+resource "aws_ssoadmin_trusted_token_issuer" "test2" {
+  name                      = "%[1]s-2"
+  instance_arn              = tolist(data.aws_ssoadmin_instances.test.arns)[0]
+  trusted_token_issuer_type = "OIDC_JWT"
+
+  trusted_token_issuer_configuration {
+    oidc_jwt_configuration {
+      claim_attribute_path          = "email"
+      identity_store_attribute_path = "emails.value"
+      issuer_url                    = "https://example2.com"
+      jwks_retrieval_option         = "OPEN_ID_DISCOVERY"
+    }
+  }
+}
+
+data "aws_ssoadmin_instances" "test" {}
+
+resource "aws_redshift_idc_application" "test" {
+  authorized_token_issuer {
+    authorized_audiences_list = ["client_id"]
+    trusted_token_issuer_arn  = aws_ssoadmin_trusted_token_issuer.test.arn
+  }
+  authorized_token_issuer {
+    authorized_audiences_list = ["client_id_2"]
+    trusted_token_issuer_arn  = aws_ssoadmin_trusted_token_issuer.test2.arn
   }
   iam_role_arn                  = aws_iam_role.test.arn
   idc_display_name              = %[1]q


### PR DESCRIPTION
### Description

Removes the `listvalidator.SizeAtMost(1)` on the `authorized_token_issuer` block of `aws_redshift_idc_application`. The underlying API field (`AuthorizedTokenIssuerList`) is an array with no documented maximum, and the service accepts multiple entries — verified against a live application running three issuers (set via `aws redshift modify-redshift-idc-application`; `DescribeRedshiftIdcApplications` returns all three and trusted identity propagation works for each). The use case is one trusted token issuer per identity-provider application (e.g. one Cognito user pool per environment) feeding a single Redshift IdC application.

The existing acceptance test gains an update step exercising two issuers.

### Relations

Closes #48939
Possibly related: #47866 (`service_integration` on the same resource is also serialized as a single element)

### Output from Acceptance Testing

Not run locally — the test requires an IAM Identity Center-enabled organization instance, which I can only exercise against a production org. `go build` / `go vet` on the package pass; the schema change is validator-removal only. Happy to adjust if maintainers' acceptance run surfaces anything.
