### PR TITLE
[bugfix]`aws_elasticache_global_replication_group` destroy replication group with same replicationId

### DIFF
--- a/.changelog/48942.txt
+++ b/.changelog/48942.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_elasticache_replication_group: Fix timeout during dissociation from global replication group when primary and replica share the same replication group ID in different regions
+resource/aws_elasticache_replication_group: Fix timeout during dissociation from global replication group when primary and replica share the same replication group ID in different regions 
 ```

--- a/.changelog/48942.txt
+++ b/.changelog/48942.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_elasticache_replication_group: Fix timeout during dissociation from global replication group when primary and replica share the same replication group ID in different regions
+```

--- a/internal/service/elasticache/global_replication_group.go
+++ b/internal/service/elasticache/global_replication_group.go
@@ -792,7 +792,7 @@ func waitGlobalReplicationGroupDeleted(ctx context.Context, conn *elasticache.Cl
 	return nil, err
 }
 
-func findGlobalReplicationGroupMemberByID(ctx context.Context, conn *elasticache.Client, globalReplicationGroupID, replicationGroupID string) (*awstypes.GlobalReplicationGroupMember, error) {
+func findGlobalReplicationGroupMemberByID(ctx context.Context, conn *elasticache.Client, globalReplicationGroupID, replicationGroupID, region string) (*awstypes.GlobalReplicationGroupMember, error) {
 	globalReplicationGroup, err := findGlobalReplicationGroupByID(ctx, conn, globalReplicationGroupID)
 
 	if err != nil {
@@ -804,7 +804,7 @@ func findGlobalReplicationGroupMemberByID(ctx context.Context, conn *elasticache
 	}
 
 	for _, v := range globalReplicationGroup.Members {
-		if aws.ToString(v.ReplicationGroupId) == replicationGroupID {
+		if aws.ToString(v.ReplicationGroupId) == replicationGroupID && aws.ToString(v.ReplicationGroupRegion) == region {
 			return &v, nil
 		}
 	}
@@ -814,9 +814,9 @@ func findGlobalReplicationGroupMemberByID(ctx context.Context, conn *elasticache
 	}
 }
 
-func statusGlobalReplicationGroupMember(conn *elasticache.Client, globalReplicationGroupID, replicationGroupID string) retry.StateRefreshFunc {
+func statusGlobalReplicationGroupMember(conn *elasticache.Client, globalReplicationGroupID, replicationGroupID, region string) retry.StateRefreshFunc {
 	return func(ctx context.Context) (any, string, error) {
-		output, err := findGlobalReplicationGroupMemberByID(ctx, conn, globalReplicationGroupID, replicationGroupID)
+		output, err := findGlobalReplicationGroupMemberByID(ctx, conn, globalReplicationGroupID, replicationGroupID, region)
 
 		if retry.NotFound(err) {
 			return nil, "", nil
@@ -834,11 +834,11 @@ const (
 	globalReplicationGroupMemberStatusAssociated = "associated"
 )
 
-func waitGlobalReplicationGroupMemberDetached(ctx context.Context, conn *elasticache.Client, globalReplicationGroupID, replicationGroupID string, timeout time.Duration) (*awstypes.GlobalReplicationGroupMember, error) {
+func waitGlobalReplicationGroupMemberDetached(ctx context.Context, conn *elasticache.Client, globalReplicationGroupID, replicationGroupID, region string, timeout time.Duration) (*awstypes.GlobalReplicationGroupMember, error) {
 	stateConf := &retry.StateChangeConf{
 		Pending:    []string{globalReplicationGroupMemberStatusAssociated},
 		Target:     []string{},
-		Refresh:    statusGlobalReplicationGroupMember(conn, globalReplicationGroupID, replicationGroupID),
+		Refresh:    statusGlobalReplicationGroupMember(conn, globalReplicationGroupID, replicationGroupID, region),
 		Timeout:    timeout,
 		MinTimeout: 10 * time.Second,
 		Delay:      30 * time.Second,

--- a/internal/service/elasticache/global_replication_group_test.go
+++ b/internal/service/elasticache/global_replication_group_test.go
@@ -13,10 +13,12 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/elasticache"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfelasticache "github.com/hashicorp/terraform-provider-aws/internal/service/elasticache"
@@ -1807,6 +1809,51 @@ func TestAccElastiCacheGlobalReplicationGroup_InheritValkeyEngine_SecondaryRepli
 	})
 }
 
+func TestAccElastiCacheGlobalReplicationGroup_sameReplicationGroupIDDifferentRegion(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var providers []*schema.Provider
+	var globalReplicationGroup awstypes.GlobalReplicationGroup
+	var primaryReplicationGroup, secondaryReplicationGroup awstypes.ReplicationGroup
+
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	replicationGroupID := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	resourceName := "aws_elasticache_global_replication_group.test"
+	primaryReplicationGroupResourceName := "aws_elasticache_replication_group.test"
+	secondaryReplicationGroupResourceName := "aws_elasticache_replication_group.secondary"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+			testAccPreCheckGlobalReplicationGroup(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5FactoriesPlusProvidersAlternate(ctx, t, &providers),
+		CheckDestroy: resource.ComposeAggregateTestCheckFunc(
+			testAccCheckGlobalReplicationGroupDestroy(ctx, t),
+			acctest.CheckWithProviders(testAccCheckReplicationGroupDestroyWithProvider(ctx), &providers),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGlobalReplicationGroupConfig_sameReplicationGroupID(rName, replicationGroupID),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckGlobalReplicationGroupExists(ctx, t, resourceName, &globalReplicationGroup),
+					testAccCheckReplicationGroupExistsWithProvider(ctx, primaryReplicationGroupResourceName, &primaryReplicationGroup, acctest.RegionProviderFunc(ctx, acctest.Region(), &providers)),
+					testAccCheckReplicationGroupExistsWithProvider(ctx, secondaryReplicationGroupResourceName, &secondaryReplicationGroup, acctest.RegionProviderFunc(ctx, acctest.AlternateRegion(), &providers)),
+					resource.TestCheckResourceAttr(resourceName, "global_replication_group_id_suffix", rName),
+					resource.TestCheckResourceAttr(primaryReplicationGroupResourceName, "replication_group_id", replicationGroupID),
+					resource.TestCheckResourceAttr(secondaryReplicationGroupResourceName, "replication_group_id", replicationGroupID),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckGlobalReplicationGroupExists(ctx context.Context, t *testing.T, resourceName string, v *awstypes.GlobalReplicationGroup) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]
@@ -2609,4 +2656,81 @@ resource "aws_elasticache_replication_group" "secondary" {
 }
 `, rName, primaryReplicationGroupId, secondaryReplicationGroupId, globalAF, primaryAF, secondaryAF, engineName, engineVersion),
 	)
+}
+
+func testAccGlobalReplicationGroupConfig_sameReplicationGroupID(rName, replicationGroupID string) string {
+	return acctest.ConfigCompose(acctest.ConfigMultipleRegionProvider(2), fmt.Sprintf(`
+resource "aws_elasticache_global_replication_group" "test" {
+  global_replication_group_id_suffix = %[1]q
+  primary_replication_group_id       = aws_elasticache_replication_group.test.id
+}
+
+resource "aws_elasticache_replication_group" "test" {
+  replication_group_id = %[2]q
+  description          = "primary"
+
+  engine             = "redis"
+  engine_version     = "5.0.6"
+  node_type          = "cache.m5.large"
+  num_cache_clusters = 1
+}
+
+resource "aws_elasticache_replication_group" "secondary" {
+  provider = awsalternate
+
+  replication_group_id        = %[2]q
+  description                 = "secondary"
+  global_replication_group_id = aws_elasticache_global_replication_group.test.id
+}
+`, rName, replicationGroupID))
+}
+
+func testAccCheckReplicationGroupExistsWithProvider(ctx context.Context, n string, v *awstypes.ReplicationGroup, providerF acctest.ProviderFunc) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ElastiCache Replication Group ID is set")
+		}
+
+		conn := providerF().Meta().(*conns.AWSClient).ElastiCacheClient(ctx)
+
+		output, err := tfelasticache.FindReplicationGroupByID(ctx, conn, rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		*v = *output
+
+		return nil
+	}
+}
+
+func testAccCheckReplicationGroupDestroyWithProvider(ctx context.Context) acctest.TestCheckWithProviderFunc {
+	return func(s *terraform.State, provider *schema.Provider) error {
+		conn := provider.Meta().(*conns.AWSClient).ElastiCacheClient(ctx)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_elasticache_replication_group" {
+				continue
+			}
+
+			_, err := tfelasticache.FindReplicationGroupByID(ctx, conn, rs.Primary.ID)
+
+			if retry.NotFound(err) {
+				continue
+			}
+
+			if err != nil {
+				return err
+			}
+
+			return fmt.Errorf("ElastiCache Replication Group (%s) still exists", rs.Primary.ID)
+		}
+
+		return nil
+	}
 }

--- a/internal/service/elasticache/replication_group.go
+++ b/internal/service/elasticache/replication_group.go
@@ -1313,7 +1313,7 @@ func disassociateReplicationGroup(ctx context.Context, conn *elasticache.Client,
 		return fmt.Errorf("disassociating ElastiCache Replication Group (%s) from Global Replication Group (%s): %w", replicationGroupID, globalReplicationGroupID, err)
 	}
 
-	if _, err := waitGlobalReplicationGroupMemberDetached(ctx, conn, globalReplicationGroupID, replicationGroupID, timeout); err != nil {
+	if _, err := waitGlobalReplicationGroupMemberDetached(ctx, conn, globalReplicationGroupID, replicationGroupID, region, timeout); err != nil {
 		return fmt.Errorf("waiting for ElastiCache Replication Group (%s) detach: %w", replicationGroupID, err)
 	}
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
When a global replication group has a primary and secondary replication group that share the same replication_group_id in different regions, terraform destroy times out waiting for the secondary to detach.

The root cause is in findGlobalReplicationGroupMemberByID. It matches members by ReplicationGroupId only. When both members share the same ID, the function always returns the first match (the primary), so the status poller never observes the secondary's detachment and eventually times out.

The fix adds a region filter to the member lookup, so it matches on both ReplicationGroupId and ReplicationGroupRegion. The region value was already available at the call site in disassociateReplicationGroup (passed to the AWS API in DisassociateGlobalReplicationGroupInput), it just wasn't being threaded through to the waiter.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #38919

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS="TestAccElastiCacheGlobalReplicationGroup|TestAccElastiCacheReplicationGroup" PKG=elasticache ACCTEST_PARALLELISM=1 ACCTEST_TIMEOUT=4880m
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
xargs: gofmt: No such file or directory
make: Validating schemas
go: downloading github.com/aws/aws-sdk-go-v2 v1.42.1
go: downloading github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.30
go: downloading github.com/aws/aws-sdk-go-v2/config v1.32.28
go: downloading github.com/aws/aws-sdk-go-v2/service/sts v1.44.0
go: downloading github.com/aws/smithy-go v1.27.3
go: downloading github.com/aws/aws-sdk-go-v2/service/chimesdkmediapipelines v1.28.0
go: downloading github.com/aws/aws-sdk-go-v2/service/account v1.33.0
go: downloading github.com/aws/aws-sdk-go-v2/service/appintegrations v1.39.0
go: downloading github.com/aws/aws-sdk-go-v2/service/applicationautoscaling v1.44.0
go: downloading github.com/aws/aws-sdk-go-v2/service/costexplorer v1.66.0
go: downloading github.com/aws/aws-sdk-go-v2/service/accessanalyzer v1.50.0
go: downloading github.com/aws/aws-sdk-go-v2/service/acm v1.42.0
go: downloading github.com/aws/aws-sdk-go-v2/service/acmpca v1.48.0
go: downloading github.com/aws/aws-sdk-go-v2/service/amp v1.45.0
go: downloading github.com/aws/aws-sdk-go-v2/service/amplify v1.40.0
go: downloading github.com/aws/aws-sdk-go-v2/service/apigatewayv2 v1.36.0
go: downloading github.com/aws/aws-sdk-go-v2/service/apprunner v1.41.0
go: downloading github.com/aws/aws-sdk-go-v2/service/appfabric v1.18.0
go: downloading github.com/aws/aws-sdk-go-v2/service/appconfig v1.46.0
go: downloading github.com/aws/aws-sdk-go-v2/service/appflow v1.53.0
go: downloading github.com/aws/aws-sdk-go-v2/service/apigateway v1.41.0
go: downloading github.com/aws/aws-sdk-go-v2/service/applicationinsights v1.36.0
go: downloading github.com/aws/aws-sdk-go-v2/service/applicationsignals v1.24.0
go: downloading github.com/aws/aws-sdk-go-v2/service/appmesh v1.37.0
go: downloading github.com/aws/aws-sdk-go-v2/service/codeartifact v1.40.0
go: downloading github.com/aws/aws-sdk-go-v2/service/appstream v1.62.0
go: downloading github.com/aws/aws-sdk-go-v2/service/appsync v1.55.0
go: downloading github.com/aws/aws-sdk-go-v2/service/arcregionswitch v1.10.0
go: downloading github.com/aws/aws-sdk-go-v2/service/cloudtrail v1.57.0
go: downloading github.com/aws/aws-sdk-go-v2/service/billing v1.12.0
go: downloading github.com/aws/aws-sdk-go-v2/service/arczonalshift v1.24.0
go: downloading github.com/aws/aws-sdk-go-v2/service/batch v1.67.0
go: downloading github.com/aws/aws-sdk-go-v2/service/athena v1.59.0
go: downloading github.com/aws/aws-sdk-go-v2/service/auditmanager v1.48.0
go: downloading github.com/aws/aws-sdk-go-v2/service/cloudsearch v1.34.0
go: downloading github.com/aws/aws-sdk-go-v2/service/iam v1.55.0
go: downloading github.com/aws/aws-sdk-go-v2/service/autoscaling v1.69.0
go: downloading github.com/aws/aws-sdk-go-v2/service/autoscalingplans v1.32.0
go: downloading github.com/aws/aws-sdk-go-v2/service/backup v1.58.0
go: downloading github.com/aws/aws-sdk-go-v2/service/bcmdataexports v1.17.0
go: downloading github.com/aws/aws-sdk-go-v2/service/bedrock v1.65.0
go: downloading github.com/aws/aws-sdk-go-v2/service/bedrockagent v1.57.0
go: downloading github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol v1.46.0
go: downloading github.com/aws/aws-sdk-go-v2/service/budgets v1.45.0
go: downloading github.com/aws/aws-sdk-go-v2/service/chatbot v1.16.0
go: downloading github.com/aws/aws-sdk-go-v2/service/chime v1.43.0
go: downloading github.com/aws/aws-sdk-go-v2/service/chimesdkvoice v1.30.0
go: downloading github.com/aws/aws-sdk-go-v2/service/cleanrooms v1.47.0
go: downloading github.com/aws/aws-sdk-go-v2/service/cloud9 v1.35.0
go: downloading github.com/aws/aws-sdk-go-v2/service/cloudcontrol v1.31.0
go: downloading github.com/aws/aws-sdk-go-v2/service/cloudformation v1.74.0
go: downloading github.com/aws/aws-sdk-go-v2/service/cloudfront v1.66.0
go: downloading github.com/aws/aws-sdk-go-v2/service/cloudfrontkeyvaluestore v1.14.0
go: downloading github.com/aws/aws-sdk-go-v2/service/cloudhsmv2 v1.36.0
go: downloading github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.62.0
go: downloading github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.79.0
go: downloading github.com/aws/aws-sdk-go-v2/service/codebuild v1.71.0
go: downloading github.com/aws/aws-sdk-go-v2/service/codecatalyst v1.23.0
go: downloading github.com/aws/aws-sdk-go-v2/service/codecommit v1.35.0
go: downloading github.com/aws/aws-sdk-go-v2/service/codeconnections v1.12.0
go: downloading github.com/aws/aws-sdk-go-v2/service/codedeploy v1.37.0
go: downloading github.com/aws/aws-sdk-go-v2/service/codeguruprofiler v1.31.0
go: downloading github.com/aws/aws-sdk-go-v2/service/codegurureviewer v1.36.0
go: downloading github.com/aws/aws-sdk-go-v2/service/codepipeline v1.48.0
go: downloading github.com/aws/aws-sdk-go-v2/service/codestarconnections v1.37.0
go: downloading github.com/aws/aws-sdk-go-v2/service/codestarnotifications v1.33.0
go: downloading github.com/aws/aws-sdk-go-v2/service/cognitoidentity v1.35.0
go: downloading github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.64.0
go: downloading github.com/aws/aws-sdk-go-v2/service/comprehend v1.42.0
go: downloading github.com/aws/aws-sdk-go-v2/service/computeoptimizer v1.55.0
go: downloading github.com/aws/aws-sdk-go-v2/service/configservice v1.66.0
go: downloading github.com/aws/aws-sdk-go-v2/service/connect v1.180.0
go: downloading github.com/aws/aws-sdk-go-v2/service/connectcases v1.43.0
go: downloading github.com/aws/aws-sdk-go-v2/service/controltower v1.30.0
go: downloading github.com/aws/aws-sdk-go-v2/service/costandusagereportservice v1.36.0
go: downloading github.com/aws/aws-sdk-go-v2/service/costoptimizationhub v1.25.0
go: downloading github.com/aws/aws-sdk-go-v2/service/customerprofiles v1.64.0
go: downloading github.com/aws/aws-sdk-go-v2/service/databasemigrationservice v1.65.0
go: downloading github.com/aws/aws-sdk-go-v2/service/databrew v1.41.0
go: downloading github.com/aws/aws-sdk-go-v2/service/dataexchange v1.43.0
go: downloading github.com/aws/aws-sdk-go-v2/service/datapipeline v1.32.0
go: downloading github.com/aws/aws-sdk-go-v2/service/datazone v1.65.0
go: downloading github.com/aws/aws-sdk-go-v2/service/datasync v1.60.0
go: downloading github.com/aws/aws-sdk-go-v2/service/detective v1.40.0
go: downloading github.com/aws/aws-sdk-go-v2/service/dax v1.31.0
go: downloading github.com/aws/aws-sdk-go-v2/service/devicefarm v1.40.0
go: downloading github.com/aws/aws-sdk-go-v2/service/devopsagent v1.9.0
go: downloading github.com/aws/aws-sdk-go-v2/service/devopsguru v1.42.0
go: downloading github.com/aws/aws-sdk-go-v2/service/directconnect v1.42.0
go: downloading github.com/aws/aws-sdk-go-v2/service/directoryservice v1.40.0
go: downloading github.com/aws/aws-sdk-go-v2/service/dlm v1.38.0
go: downloading github.com/aws/aws-sdk-go-v2/service/docdb v1.50.0
go: downloading github.com/aws/aws-sdk-go-v2/service/docdbelastic v1.22.0
go: downloading github.com/aws/aws-sdk-go-v2/service/drs v1.40.0
go: downloading github.com/aws/aws-sdk-go-v2/service/dsql v1.15.0
go: downloading github.com/aws/aws-sdk-go-v2/service/dynamodb v1.60.0
go: downloading github.com/aws/aws-sdk-go-v2/service/ec2 v1.312.0
go: downloading github.com/aws/aws-sdk-go-v2/service/ecr v1.59.0
go: downloading github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.40.0
go: downloading github.com/aws/aws-sdk-go-v2/service/ecs v1.87.0
go: downloading github.com/aws/aws-sdk-go-v2/service/efs v1.43.0
go: downloading github.com/aws/aws-sdk-go-v2/service/eks v1.89.0
go: downloading github.com/aws/aws-sdk-go-v2/service/elasticache v1.55.0
go: downloading github.com/aws/aws-sdk-go-v2/service/elasticbeanstalk v1.36.0
go: downloading github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing v1.35.0
go: downloading github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.56.0
go: downloading github.com/aws/aws-sdk-go-v2/service/elasticsearchservice v1.43.0
go: downloading github.com/aws/aws-sdk-go-v2/service/emr v1.62.0
go: downloading github.com/aws/aws-sdk-go-v2/service/emrcontainers v1.42.0
go: downloading github.com/aws/aws-sdk-go-v2/service/emrserverless v1.43.0
go: downloading github.com/aws/aws-sdk-go-v2/service/eventbridge v1.47.0
go: downloading github.com/aws/aws-sdk-go-v2/service/evs v1.12.0
go: downloading github.com/aws/aws-sdk-go-v2/service/firehose v1.45.0
go: downloading github.com/aws/aws-sdk-go-v2/service/finspace v1.35.0
go: downloading github.com/aws/aws-sdk-go-v2/service/fis v1.39.0
go: downloading github.com/aws/aws-sdk-go-v2/service/fms v1.46.0
go: downloading github.com/aws/aws-sdk-go-v2/service/fsx v1.67.0
go: downloading github.com/aws/aws-sdk-go-v2/service/gamelift v1.57.0
go: downloading github.com/aws/aws-sdk-go-v2/service/glacier v1.34.0
go: downloading github.com/aws/aws-sdk-go-v2/service/globalaccelerator v1.37.0
go: downloading github.com/aws/aws-sdk-go-v2/service/glue v1.148.0
go: downloading github.com/aws/aws-sdk-go-v2/service/grafana v1.37.0
go: downloading github.com/aws/aws-sdk-go-v2/service/groundstation v1.44.0
go: downloading github.com/aws/aws-sdk-go-v2/service/greengrass v1.34.0
go: downloading github.com/aws/aws-sdk-go-v2/service/guardduty v1.81.0
go: downloading github.com/aws/aws-sdk-go-v2/service/healthlake v1.40.0
go: downloading github.com/aws/aws-sdk-go-v2/service/identitystore v1.38.0
go: downloading github.com/aws/aws-sdk-go-v2/service/imagebuilder v1.57.0
go: downloading github.com/aws/aws-sdk-go-v2/service/inspector v1.32.0
go: downloading github.com/aws/aws-sdk-go-v2/service/inspector2 v1.50.0
go: downloading github.com/aws/aws-sdk-go-v2/service/interconnect v1.2.0
go: downloading github.com/aws/aws-sdk-go-v2/service/internetmonitor v1.28.0
go: downloading github.com/aws/aws-sdk-go-v2/service/invoicing v1.12.0
go: downloading github.com/aws/aws-sdk-go-v2/service/iot v1.76.0
go: downloading github.com/aws/aws-sdk-go-v2/service/ivs v1.53.0
go: downloading github.com/aws/aws-sdk-go-v2/service/ivschat v1.23.0
go: downloading github.com/aws/aws-sdk-go-v2/service/kafka v1.55.0
go: downloading github.com/aws/aws-sdk-go-v2/service/kafkaconnect v1.32.0
go: downloading github.com/aws/aws-sdk-go-v2/service/kendra v1.62.0
go: downloading github.com/aws/aws-sdk-go-v2/service/keyspaces v1.27.0
go: downloading github.com/aws/aws-sdk-go-v2/service/kinesis v1.45.0
go: downloading github.com/aws/aws-sdk-go-v2/service/kinesisanalytics v1.32.0
go: downloading github.com/aws/aws-sdk-go-v2/service/kinesisanalyticsv2 v1.39.0
go: downloading github.com/aws/aws-sdk-go-v2/service/kinesisvideo v1.35.0
go: downloading github.com/aws/aws-sdk-go-v2/service/kms v1.54.0
go: downloading github.com/aws/aws-sdk-go-v2/service/lakeformation v1.49.0
go: downloading github.com/aws/aws-sdk-go-v2/service/lambda v1.95.0
go: downloading github.com/aws/aws-sdk-go-v2/service/launchwizard v1.16.0
go: downloading github.com/aws/aws-sdk-go-v2/service/lexmodelbuildingservice v1.37.0
go: downloading github.com/aws/aws-sdk-go-v2/service/lexmodelsv2 v1.63.0
go: downloading github.com/aws/aws-sdk-go-v2/service/licensemanager v1.39.0
go: downloading github.com/aws/aws-sdk-go-v2/service/lightsail v1.57.0
go: downloading github.com/aws/aws-sdk-go-v2/service/location v1.53.0
go: downloading github.com/aws/aws-sdk-go-v2/service/m2 v1.28.0
go: downloading github.com/aws/aws-sdk-go-v2/service/macie2 v1.53.0
go: downloading github.com/aws/aws-sdk-go-v2/service/mediaconnect v1.52.0
go: downloading github.com/aws/aws-sdk-go-v2/service/mediaconvert v1.95.0
go: downloading github.com/aws/aws-sdk-go-v2/service/medialive v1.100.0
go: downloading github.com/aws/aws-sdk-go-v2/service/mediapackage v1.41.0
go: downloading github.com/aws/aws-sdk-go-v2/service/mediapackagev2 v1.41.0
go: downloading github.com/aws/aws-sdk-go-v2/service/mediapackagevod v1.41.0
go: downloading github.com/aws/aws-sdk-go-v2/service/mediastore v1.31.0
go: downloading github.com/aws/aws-sdk-go-v2/service/memorydb v1.35.0
go: downloading github.com/aws/aws-sdk-go-v2/service/mgn v1.47.0
go: downloading github.com/aws/aws-sdk-go-v2/service/mpa v1.9.0
go: downloading github.com/aws/aws-sdk-go-v2/service/mq v1.37.0
go: downloading github.com/aws/aws-sdk-go-v2/service/mwaa v1.42.0
go: downloading github.com/aws/aws-sdk-go-v2/service/mwaaserverless v1.2.0
go: downloading github.com/aws/aws-sdk-go-v2/service/neptune v1.47.0
go: downloading github.com/aws/aws-sdk-go-v2/service/neptunegraph v1.23.0
go: downloading github.com/aws/aws-sdk-go-v2/service/networkfirewall v1.63.0
go: downloading github.com/aws/aws-sdk-go-v2/service/networkflowmonitor v1.13.0
go: downloading github.com/aws/aws-sdk-go-v2/service/networkmanager v1.43.0
go: downloading github.com/aws/aws-sdk-go-v2/service/networkmonitor v1.15.0
go: downloading github.com/aws/aws-sdk-go-v2/service/notifications v1.9.0
go: downloading github.com/aws/aws-sdk-go-v2/service/notificationscontacts v1.7.0
go: downloading github.com/aws/aws-sdk-go-v2/service/oam v1.25.0
go: downloading github.com/aws/aws-sdk-go-v2/service/observabilityadmin v1.19.0
go: downloading github.com/aws/aws-sdk-go-v2/service/odb v1.13.0
go: downloading github.com/aws/aws-sdk-go-v2/service/opensearch v1.74.0
go: downloading github.com/aws/aws-sdk-go-v2/service/opensearchserverless v1.33.0
go: downloading github.com/aws/aws-sdk-go-v2/service/organizations v1.52.0
go: downloading github.com/aws/aws-sdk-go-v2/service/osis v1.23.0
go: downloading github.com/aws/aws-sdk-go-v2/service/outposts v1.64.0
go: downloading github.com/aws/aws-sdk-go-v2/service/paymentcryptography v1.32.0
go: downloading github.com/aws/aws-sdk-go-v2/service/pcaconnectorad v1.17.0
go: downloading github.com/aws/aws-sdk-go-v2/service/pcs v1.22.0
go: downloading github.com/aws/aws-sdk-go-v2/service/pinpoint v1.41.0
go: downloading github.com/aws/aws-sdk-go-v2/service/pipes v1.25.0
go: downloading github.com/aws/aws-sdk-go-v2/service/pinpointsmsvoicev2 v1.31.0
go: downloading github.com/aws/aws-sdk-go-v2/service/polly v1.59.0
go: downloading github.com/aws/aws-sdk-go-v2/service/pricing v1.43.0
go: downloading github.com/aws/aws-sdk-go-v2/service/qbusiness v1.36.0
go: downloading github.com/aws/aws-sdk-go-v2/service/quicksight v1.117.0
go: downloading github.com/aws/aws-sdk-go-v2/service/ram v1.38.0
go: downloading github.com/aws/aws-sdk-go-v2/service/rbin v1.29.0
go: downloading github.com/aws/aws-sdk-go-v2/service/rds v1.120.0
go: downloading github.com/aws/aws-sdk-go-v2/service/rdsdata v1.34.0
go: downloading github.com/aws/aws-sdk-go-v2/service/redshift v1.64.0
go: downloading github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.41.0
go: downloading github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.36.0
go: downloading github.com/aws/aws-sdk-go-v2/service/rekognition v1.53.0
go: downloading github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.37.0
go: downloading github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.26.0
go: downloading github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.35.0
go: downloading github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.34.0
go: downloading github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.24.0
go: downloading github.com/aws/aws-sdk-go-v2/service/route53 v1.64.0
go: downloading github.com/aws/aws-sdk-go-v2/service/route53domains v1.37.0
go: downloading github.com/aws/aws-sdk-go-v2/service/route53profiles v1.11.0
go: downloading github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.34.0
go: downloading github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.28.0
go: downloading github.com/aws/aws-sdk-go-v2/service/route53resolver v1.47.0
go: downloading github.com/aws/aws-sdk-go-v2/service/rum v1.32.0
go: downloading github.com/aws/aws-sdk-go-v2/service/s3 v1.105.0
go: downloading github.com/aws/aws-sdk-go-v2/service/s3control v1.72.0
go: downloading github.com/aws/aws-sdk-go-v2/service/s3files v1.2.0
go: downloading github.com/aws/aws-sdk-go-v2/service/s3outposts v1.36.0
go: downloading github.com/aws/aws-sdk-go-v2/service/s3tables v1.17.0
go: downloading github.com/aws/aws-sdk-go-v2/service/s3vectors v1.9.0
go: downloading github.com/aws/aws-sdk-go-v2/service/sagemaker v1.257.0
go: downloading github.com/aws/aws-sdk-go-v2/service/savingsplans v1.34.0
go: downloading github.com/aws/aws-sdk-go-v2/service/scheduler v1.19.0
go: downloading github.com/aws/aws-sdk-go-v2/service/schemas v1.36.0
go: downloading github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.43.0
go: downloading github.com/aws/aws-sdk-go-v2/service/securityhub v1.72.0
go: downloading github.com/aws/aws-sdk-go-v2/service/securitylake v1.27.0
go: downloading github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.32.0
go: downloading github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.41.0
go: downloading github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry v1.37.0
go: downloading github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.41.0
go: downloading github.com/aws/aws-sdk-go-v2/service/servicequotas v1.36.0
go: downloading github.com/aws/aws-sdk-go-v2/service/ses v1.36.0
go: downloading github.com/aws/aws-sdk-go-v2/service/sesv2 v1.63.0
go: downloading github.com/aws/aws-sdk-go-v2/service/sfn v1.44.0
go: downloading github.com/aws/aws-sdk-go-v2/service/shield v1.36.0
go: downloading github.com/aws/aws-sdk-go-v2/service/signer v1.34.0
go: downloading github.com/aws/aws-sdk-go-v2/service/sns v1.41.0
go: downloading github.com/aws/aws-sdk-go-v2/service/sqs v1.45.0
go: downloading github.com/aws/aws-sdk-go-v2/service/ssm v1.70.0
go: downloading github.com/aws/aws-sdk-go-v2/service/ssmcontacts v1.33.0
go: downloading github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.41.0
go: downloading github.com/aws/aws-sdk-go-v2/service/ssmquicksetup v1.10.0
go: downloading github.com/aws/aws-sdk-go-v2/service/ssmsap v1.28.0
go: downloading github.com/aws/aws-sdk-go-v2/service/sso v1.32.0
go: downloading github.com/aws/aws-sdk-go-v2/service/ssoadmin v1.41.0
go: downloading github.com/aws/aws-sdk-go-v2/service/storagegateway v1.45.0
go: downloading github.com/aws/aws-sdk-go-v2/service/swf v1.36.0
go: downloading github.com/aws/aws-sdk-go-v2/service/synthetics v1.45.0
go: downloading github.com/aws/aws-sdk-go-v2/service/taxsettings v1.19.0
go: downloading github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.21.0
go: downloading github.com/aws/aws-sdk-go-v2/service/timestreamquery v1.38.0
go: downloading github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.37.0
go: downloading github.com/aws/aws-sdk-go-v2/service/transcribe v1.57.0
go: downloading github.com/aws/aws-sdk-go-v2/service/transfer v1.74.0
go: downloading github.com/aws/aws-sdk-go-v2/service/uxc v1.2.0
go: downloading github.com/aws/aws-sdk-go-v2/service/verifiedpermissions v1.35.0
go: downloading github.com/aws/aws-sdk-go-v2/service/vpclattice v1.24.0
go: downloading github.com/aws/aws-sdk-go-v2/service/waf v1.32.0
go: downloading github.com/aws/aws-sdk-go-v2/service/wafregional v1.32.0
go: downloading github.com/aws/aws-sdk-go-v2/service/wafv2 v1.75.0
go: downloading github.com/aws/aws-sdk-go-v2/credentials v1.19.27
go: downloading github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.41.0
go: downloading github.com/aws/aws-sdk-go-v2/service/workmail v1.38.0
go: downloading github.com/aws/aws-sdk-go-v2/service/workspaces v1.71.0
go: downloading github.com/aws/aws-sdk-go-v2/service/workspacesweb v1.41.0
go: downloading github.com/aws/aws-sdk-go-v2/service/xray v1.38.0
go: downloading github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.22.31
go: downloading github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.30
go: downloading github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.31
go: downloading github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.13
go: downloading github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.30
go: downloading github.com/aws/aws-sdk-go-v2/service/signin v1.3.0
go: downloading github.com/aws/aws-sdk-go-v2/service/ssooidc v1.37.0
go: downloading github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.14
go: downloading github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.12.7
go: downloading github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.30
go: downloading github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.31
go: downloading github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.23
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2	0.244s
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider/framework	0.225s
make: Running acceptance tests on branch: 🌿 f-elasticache-grg-same-replicationid 🌿...
TF_ACC=1 go1.26.4 test ./internal/service/elasticache/... -v -count 1 -parallel 1 -run='TestAccElastiCacheGlobalReplicationGroup|TestAccElastiCacheReplicationGroup'  -timeout 4880m -vet=off -buildvcs=false
2026/07/14 15:03:28 Creating Terraform AWS Provider (SDKv2-style)...
2026/07/14 15:03:28 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccElastiCacheGlobalReplicationGroup_Redis_basic
=== PAUSE TestAccElastiCacheGlobalReplicationGroup_Redis_basic
=== RUN   TestAccElastiCacheGlobalReplicationGroup_Valkey_basic
=== PAUSE TestAccElastiCacheGlobalReplicationGroup_Valkey_basic
=== RUN   TestAccElastiCacheGlobalReplicationGroup_disappears
=== PAUSE TestAccElastiCacheGlobalReplicationGroup_disappears
=== RUN   TestAccElastiCacheGlobalReplicationGroup_description
=== PAUSE TestAccElastiCacheGlobalReplicationGroup_description
=== RUN   TestAccElastiCacheGlobalReplicationGroup_nodeType_createNoChange
=== PAUSE TestAccElastiCacheGlobalReplicationGroup_nodeType_createNoChange
=== RUN   TestAccElastiCacheGlobalReplicationGroup_nodeType_createWithChange
=== PAUSE TestAccElastiCacheGlobalReplicationGroup_nodeType_createWithChange
=== RUN   TestAccElastiCacheGlobalReplicationGroup_nodeType_setNoChange
=== PAUSE TestAccElastiCacheGlobalReplicationGroup_nodeType_setNoChange
=== RUN   TestAccElastiCacheGlobalReplicationGroup_nodeType_update
=== PAUSE TestAccElastiCacheGlobalReplicationGroup_nodeType_update
=== RUN   TestAccElastiCacheGlobalReplicationGroup_AutomaticFailover_createNoChange
=== PAUSE TestAccElastiCacheGlobalReplicationGroup_AutomaticFailover_createNoChange
=== RUN   TestAccElastiCacheGlobalReplicationGroup_AutomaticFailover_createWithChange
=== PAUSE TestAccElastiCacheGlobalReplicationGroup_AutomaticFailover_createWithChange
=== RUN   TestAccElastiCacheGlobalReplicationGroup_AutomaticFailover_setNoChange
=== PAUSE TestAccElastiCacheGlobalReplicationGroup_AutomaticFailover_setNoChange
=== RUN   TestAccElastiCacheGlobalReplicationGroup_AutomaticFailover_update
=== PAUSE TestAccElastiCacheGlobalReplicationGroup_AutomaticFailover_update
=== RUN   TestAccElastiCacheGlobalReplicationGroup_AutomaticFailover_memberDiffSuppressed_redis
=== PAUSE TestAccElastiCacheGlobalReplicationGroup_AutomaticFailover_memberDiffSuppressed_redis
=== RUN   TestAccElastiCacheGlobalReplicationGroup_AutomaticFailover_memberDiffSuppressed_valkey
=== PAUSE TestAccElastiCacheGlobalReplicationGroup_AutomaticFailover_memberDiffSuppressed_valkey
=== RUN   TestAccElastiCacheGlobalReplicationGroup_multipleSecondaries
=== PAUSE TestAccElastiCacheGlobalReplicationGroup_multipleSecondaries
=== RUN   TestAccElastiCacheGlobalReplicationGroup_ReplaceSecondary_differentRegion
=== PAUSE TestAccElastiCacheGlobalReplicationGroup_ReplaceSecondary_differentRegion
=== RUN   TestAccElastiCacheGlobalReplicationGroup_clusterMode_basic
=== PAUSE TestAccElastiCacheGlobalReplicationGroup_clusterMode_basic
=== RUN   TestAccElastiCacheGlobalReplicationGroup_SetNumNodeGroupsOnCreate_NoChange
=== PAUSE TestAccElastiCacheGlobalReplicationGroup_SetNumNodeGroupsOnCreate_NoChange
=== RUN   TestAccElastiCacheGlobalReplicationGroup_SetNumNodeGroupsOnCreate_Increase
=== PAUSE TestAccElastiCacheGlobalReplicationGroup_SetNumNodeGroupsOnCreate_Increase
=== RUN   TestAccElastiCacheGlobalReplicationGroup_SetNumNodeGroupsOnCreate_Decrease
=== PAUSE TestAccElastiCacheGlobalReplicationGroup_SetNumNodeGroupsOnCreate_Decrease
=== RUN   TestAccElastiCacheGlobalReplicationGroup_SetNumNodeGroupsOnUpdate_Increase
=== PAUSE TestAccElastiCacheGlobalReplicationGroup_SetNumNodeGroupsOnUpdate_Increase
=== RUN   TestAccElastiCacheGlobalReplicationGroup_SetNumNodeGroupsOnUpdate_Decrease
=== PAUSE TestAccElastiCacheGlobalReplicationGroup_SetNumNodeGroupsOnUpdate_Decrease
=== RUN   TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_NoChange_Redis_v6
=== PAUSE TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_NoChange_Redis_v6
=== RUN   TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_NoChange_Redis_v6x
=== PAUSE TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_NoChange_Redis_v6x
=== RUN   TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_NoChange_Redis_v5
=== PAUSE TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_NoChange_Redis_v5
=== RUN   TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_NoChange_Valkey_v7
=== PAUSE TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_NoChange_Valkey_v7
=== RUN   TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_MinorUpgrade
=== PAUSE TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_MinorUpgrade
=== RUN   TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_MinorUpgrade_6x
=== PAUSE TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_MinorUpgrade_6x
=== RUN   TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_MajorUpgrade
=== PAUSE TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_MajorUpgrade
=== RUN   TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_MajorUpgrade_6x
=== PAUSE TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_MajorUpgrade_6x
=== RUN   TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_MinorDowngrade
=== PAUSE TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_MinorDowngrade
=== RUN   TestAccElastiCacheGlobalReplicationGroup_SetParameterGroupOnCreate_NoVersion
=== PAUSE TestAccElastiCacheGlobalReplicationGroup_SetParameterGroupOnCreate_NoVersion
=== RUN   TestAccElastiCacheGlobalReplicationGroup_SetParameterGroupOnCreate_MinorUpgrade
=== PAUSE TestAccElastiCacheGlobalReplicationGroup_SetParameterGroupOnCreate_MinorUpgrade
=== RUN   TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnUpdate_MinorUpgrade
=== PAUSE TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnUpdate_MinorUpgrade
=== RUN   TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnUpdate_MinorUpgrade_6x
=== PAUSE TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnUpdate_MinorUpgrade_6x
=== RUN   TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnUpdate_MinorDowngrade
=== PAUSE TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnUpdate_MinorDowngrade
=== RUN   TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnUpdate_MajorUpgrade
=== PAUSE TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnUpdate_MajorUpgrade
=== RUN   TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnUpdate_MajorUpgrade_6x
=== PAUSE TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnUpdate_MajorUpgrade_6x
=== RUN   TestAccElastiCacheGlobalReplicationGroup_SetParameterGroupOnUpdate_NoVersion
=== PAUSE TestAccElastiCacheGlobalReplicationGroup_SetParameterGroupOnUpdate_NoVersion
=== RUN   TestAccElastiCacheGlobalReplicationGroup_SetParameterGroupOnUpdate_MinorUpgrade
=== PAUSE TestAccElastiCacheGlobalReplicationGroup_SetParameterGroupOnUpdate_MinorUpgrade
=== RUN   TestAccElastiCacheGlobalReplicationGroup_UpdateParameterGroupName
=== PAUSE TestAccElastiCacheGlobalReplicationGroup_UpdateParameterGroupName
=== RUN   TestAccElastiCacheGlobalReplicationGroup_SetEngineOnCreate_ValkeyUpgrade
=== PAUSE TestAccElastiCacheGlobalReplicationGroup_SetEngineOnCreate_ValkeyUpgrade
=== RUN   TestAccElastiCacheGlobalReplicationGroup_SetEngineOnUpdate_ValkeyUpgrade
=== PAUSE TestAccElastiCacheGlobalReplicationGroup_SetEngineOnUpdate_ValkeyUpgrade
=== RUN   TestAccElastiCacheGlobalReplicationGroup_InheritValkeyEngine_SecondaryReplicationGroup
=== PAUSE TestAccElastiCacheGlobalReplicationGroup_InheritValkeyEngine_SecondaryReplicationGroup
=== RUN   TestAccElastiCacheGlobalReplicationGroup_sameReplicationGroupIDDifferentRegion
=== PAUSE TestAccElastiCacheGlobalReplicationGroup_sameReplicationGroupIDDifferentRegion
=== RUN   TestAccElastiCacheReplicationGroupDataSource_basic
=== PAUSE TestAccElastiCacheReplicationGroupDataSource_basic
=== RUN   TestAccElastiCacheReplicationGroupDataSource_clusterMode
=== PAUSE TestAccElastiCacheReplicationGroupDataSource_clusterMode
=== RUN   TestAccElastiCacheReplicationGroupDataSource_multiAZ
=== PAUSE TestAccElastiCacheReplicationGroupDataSource_multiAZ
=== RUN   TestAccElastiCacheReplicationGroupDataSource_Engine_Redis_LogDeliveryConfigurations
=== PAUSE TestAccElastiCacheReplicationGroupDataSource_Engine_Redis_LogDeliveryConfigurations
=== RUN   TestAccElastiCacheReplicationGroup_Redis_basic
=== PAUSE TestAccElastiCacheReplicationGroup_Redis_basic
=== RUN   TestAccElastiCacheReplicationGroup_Redis_basic_v5
=== PAUSE TestAccElastiCacheReplicationGroup_Redis_basic_v5
=== RUN   TestAccElastiCacheReplicationGroup_Valkey_basic
=== PAUSE TestAccElastiCacheReplicationGroup_Valkey_basic
=== RUN   TestAccElastiCacheReplicationGroup_Valkey_durability
=== PAUSE TestAccElastiCacheReplicationGroup_Valkey_durability
=== RUN   TestAccElastiCacheReplicationGroup_uppercase
=== PAUSE TestAccElastiCacheReplicationGroup_uppercase
=== RUN   TestAccElastiCacheReplicationGroup_Redis_EngineVersion_v7
=== PAUSE TestAccElastiCacheReplicationGroup_Redis_EngineVersion_v7
=== RUN   TestAccElastiCacheReplicationGroup_OutOfBandUpgrade
=== PAUSE TestAccElastiCacheReplicationGroup_OutOfBandUpgrade
=== RUN   TestAccElastiCacheReplicationGroup_EngineVersion_update
=== PAUSE TestAccElastiCacheReplicationGroup_EngineVersion_update
=== RUN   TestAccElastiCacheReplicationGroup_EngineVersion_6xToRealVersion
=== PAUSE TestAccElastiCacheReplicationGroup_EngineVersion_6xToRealVersion
=== RUN   TestAccElastiCacheReplicationGroup_Engine_RedisToValkey
=== PAUSE TestAccElastiCacheReplicationGroup_Engine_RedisToValkey
=== RUN   TestAccElastiCacheReplicationGroup_disappears
=== PAUSE TestAccElastiCacheReplicationGroup_disappears
=== RUN   TestAccElastiCacheReplicationGroup_updateDescription
=== PAUSE TestAccElastiCacheReplicationGroup_updateDescription
=== RUN   TestAccElastiCacheReplicationGroup_updateMaintenanceWindow
=== PAUSE TestAccElastiCacheReplicationGroup_updateMaintenanceWindow
=== RUN   TestAccElastiCacheReplicationGroup_updateUserGroups
=== PAUSE TestAccElastiCacheReplicationGroup_updateUserGroups
=== RUN   TestAccElastiCacheReplicationGroup_authToRBACMigration
=== PAUSE TestAccElastiCacheReplicationGroup_authToRBACMigration
=== RUN   TestAccElastiCacheReplicationGroup_updateNodeSize
=== PAUSE TestAccElastiCacheReplicationGroup_updateNodeSize
=== RUN   TestAccElastiCacheReplicationGroup_updateParameterGroup
=== PAUSE TestAccElastiCacheReplicationGroup_updateParameterGroup
=== RUN   TestAccElastiCacheReplicationGroup_authToken
=== PAUSE TestAccElastiCacheReplicationGroup_authToken
=== RUN   TestAccElastiCacheReplicationGroup_authToken_fromResource
=== PAUSE TestAccElastiCacheReplicationGroup_authToken_fromResource
=== RUN   TestAccElastiCacheReplicationGroup_upgrade_6_0_0
=== PAUSE TestAccElastiCacheReplicationGroup_upgrade_6_0_0
=== RUN   TestAccElastiCacheReplicationGroup_upgrade_5_27_0
=== PAUSE TestAccElastiCacheReplicationGroup_upgrade_5_27_0
=== RUN   TestAccElastiCacheReplicationGroup_upgrade_4_68_0
=== PAUSE TestAccElastiCacheReplicationGroup_upgrade_4_68_0
=== RUN   TestAccElastiCacheReplicationGroup_vpc
=== PAUSE TestAccElastiCacheReplicationGroup_vpc
=== RUN   TestAccElastiCacheReplicationGroup_multiAzNotInVPC
=== PAUSE TestAccElastiCacheReplicationGroup_multiAzNotInVPC
=== RUN   TestAccElastiCacheReplicationGroup_multiAzNotInVPC_repeated
=== PAUSE TestAccElastiCacheReplicationGroup_multiAzNotInVPC_repeated
=== RUN   TestAccElastiCacheReplicationGroup_multiAzInVPC
=== PAUSE TestAccElastiCacheReplicationGroup_multiAzInVPC
=== RUN   TestAccElastiCacheReplicationGroup_deprecatedAvailabilityZones_multiAzInVPC
=== PAUSE TestAccElastiCacheReplicationGroup_deprecatedAvailabilityZones_multiAzInVPC
=== RUN   TestAccElastiCacheReplicationGroup_ValidationMultiAz_noAutomaticFailover
=== PAUSE TestAccElastiCacheReplicationGroup_ValidationMultiAz_noAutomaticFailover
=== RUN   TestAccElastiCacheReplicationGroup_ipDiscovery
=== PAUSE TestAccElastiCacheReplicationGroup_ipDiscovery
=== RUN   TestAccElastiCacheReplicationGroup_networkType
=== PAUSE TestAccElastiCacheReplicationGroup_networkType
=== RUN   TestAccElastiCacheReplicationGroup_ClusterMode_basic
=== PAUSE TestAccElastiCacheReplicationGroup_ClusterMode_basic
=== RUN   TestAccElastiCacheReplicationGroup_ClusterMode_nonClusteredParameterGroup
=== PAUSE TestAccElastiCacheReplicationGroup_ClusterMode_nonClusteredParameterGroup
=== RUN   TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleUp
=== PAUSE TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleUp
=== RUN   TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleDown
=== PAUSE TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleDown
=== RUN   TestAccElastiCacheReplicationGroup_ClusterMode_updateReplicasPerNodeGroup
=== PAUSE TestAccElastiCacheReplicationGroup_ClusterMode_updateReplicasPerNodeGroup
=== RUN   TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplicasPerNodeGroup_scaleUp
=== PAUSE TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplicasPerNodeGroup_scaleUp
=== RUN   TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplicasPerNodeGroup_scaleDown
=== PAUSE TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplicasPerNodeGroup_scaleDown
=== RUN   TestAccElastiCacheReplicationGroup_ClusterMode_singleNode
=== PAUSE TestAccElastiCacheReplicationGroup_ClusterMode_singleNode
=== RUN   TestAccElastiCacheReplicationGroup_ClusterMode_nodeGroupConfiguration
=== PAUSE TestAccElastiCacheReplicationGroup_ClusterMode_nodeGroupConfiguration
=== RUN   TestAccElastiCacheReplicationGroup_ClusterMode_nodeGroupConfiguration_availabilityZones
=== PAUSE TestAccElastiCacheReplicationGroup_ClusterMode_nodeGroupConfiguration_availabilityZones
=== RUN   TestAccElastiCacheReplicationGroup_ClusterMode_updateFromDisabled_Compatible_Enabled
=== PAUSE TestAccElastiCacheReplicationGroup_ClusterMode_updateFromDisabled_Compatible_Enabled
=== RUN   TestAccElastiCacheReplicationGroup_cacheClustersConflictsWithReplicasPerNodeGroup
=== PAUSE TestAccElastiCacheReplicationGroup_cacheClustersConflictsWithReplicasPerNodeGroup
=== RUN   TestAccElastiCacheReplicationGroup_clusteringAndCacheNodesCausesError
=== PAUSE TestAccElastiCacheReplicationGroup_clusteringAndCacheNodesCausesError
=== RUN   TestAccElastiCacheReplicationGroup_enableSnapshotting
=== PAUSE TestAccElastiCacheReplicationGroup_enableSnapshotting
=== RUN   TestAccElastiCacheReplicationGroup_transitEncryptionWithAuthToken
=== PAUSE TestAccElastiCacheReplicationGroup_transitEncryptionWithAuthToken
=== RUN   TestAccElastiCacheReplicationGroup_transitEncryption5x
=== PAUSE TestAccElastiCacheReplicationGroup_transitEncryption5x
=== RUN   TestAccElastiCacheReplicationGroup_transitEncryption7x_basic
=== PAUSE TestAccElastiCacheReplicationGroup_transitEncryption7x_basic
=== RUN   TestAccElastiCacheReplicationGroup_transitEncryption7x_Enable
=== PAUSE TestAccElastiCacheReplicationGroup_transitEncryption7x_Enable
=== RUN   TestAccElastiCacheReplicationGroup_transitEncryption7x_Disable
=== PAUSE TestAccElastiCacheReplicationGroup_transitEncryption7x_Disable
=== RUN   TestAccElastiCacheReplicationGroup_Redis_enableAtRestEncryption
=== PAUSE TestAccElastiCacheReplicationGroup_Redis_enableAtRestEncryption
=== RUN   TestAccElastiCacheReplicationGroup_Valkey_disableAtRestEncryption
=== PAUSE TestAccElastiCacheReplicationGroup_Valkey_disableAtRestEncryption
=== RUN   TestAccElastiCacheReplicationGroup_useCMKKMSKeyID
=== PAUSE TestAccElastiCacheReplicationGroup_useCMKKMSKeyID
=== RUN   TestAccElastiCacheReplicationGroup_NumberCacheClusters_basic
=== PAUSE TestAccElastiCacheReplicationGroup_NumberCacheClusters_basic
=== RUN   TestAccElastiCacheReplicationGroup_NumberCacheClusters_autoFailoverDisabled
=== PAUSE TestAccElastiCacheReplicationGroup_NumberCacheClusters_autoFailoverDisabled
=== RUN   TestAccElastiCacheReplicationGroup_NumberCacheClusters_autoFailoverEnabled
=== PAUSE TestAccElastiCacheReplicationGroup_NumberCacheClusters_autoFailoverEnabled
=== RUN   TestAccElastiCacheReplicationGroup_autoFailoverEnabled_validateNumberCacheClusters
=== PAUSE TestAccElastiCacheReplicationGroup_autoFailoverEnabled_validateNumberCacheClusters
=== RUN   TestAccElastiCacheReplicationGroup_NumberCacheClusters_multiAZEnabled
=== PAUSE TestAccElastiCacheReplicationGroup_NumberCacheClusters_multiAZEnabled
=== RUN   TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappears_noChange
=== PAUSE TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappears_noChange
=== RUN   TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappears_addMemberCluster
=== PAUSE TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappears_addMemberCluster
=== RUN   TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappearsRemoveMemberCluster_atTargetSize
=== PAUSE TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappearsRemoveMemberCluster_atTargetSize
=== RUN   TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappearsRemoveMemberCluster_scaleDown
=== PAUSE TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappearsRemoveMemberCluster_scaleDown
=== RUN   TestAccElastiCacheReplicationGroup_tags
=== PAUSE TestAccElastiCacheReplicationGroup_tags
=== RUN   TestAccElastiCacheReplicationGroup_TagWithOtherModification_version
=== PAUSE TestAccElastiCacheReplicationGroup_TagWithOtherModification_version
=== RUN   TestAccElastiCacheReplicationGroup_TagWithOtherModification_numCacheClusters
=== PAUSE TestAccElastiCacheReplicationGroup_TagWithOtherModification_numCacheClusters
=== RUN   TestAccElastiCacheReplicationGroup_finalSnapshot
=== PAUSE TestAccElastiCacheReplicationGroup_finalSnapshot
=== RUN   TestAccElastiCacheReplicationGroup_autoMinorVersionUpgrade
=== PAUSE TestAccElastiCacheReplicationGroup_autoMinorVersionUpgrade
=== RUN   TestAccElastiCacheReplicationGroup_Validation_noNodeType
=== PAUSE TestAccElastiCacheReplicationGroup_Validation_noNodeType
=== RUN   TestAccElastiCacheReplicationGroup_Validation_globalReplicationGroupIdAndNodeType
=== PAUSE TestAccElastiCacheReplicationGroup_Validation_globalReplicationGroupIdAndNodeType
=== RUN   TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_basic
=== PAUSE TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_basic
=== RUN   TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_full
=== PAUSE TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_full
=== RUN   TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_disappears
=== PAUSE TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_disappears
=== RUN   TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterMode_basic
=== PAUSE TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterMode_basic
=== RUN   TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterModeValidation_numNodeGroupsOnSecondary
=== PAUSE TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterModeValidation_numNodeGroupsOnSecondary
=== RUN   TestAccElastiCacheReplicationGroup_dataTiering
=== PAUSE TestAccElastiCacheReplicationGroup_dataTiering
=== RUN   TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_ClusterMode_Disabled
=== PAUSE TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_ClusterMode_Disabled
=== RUN   TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_ClusterMode_Enabled
=== PAUSE TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_ClusterMode_Enabled
=== RUN   TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_engineUpgradeAfterDisassociate
=== PAUSE TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_engineUpgradeAfterDisassociate
=== RUN   TestAccElastiCacheReplicationGroup_RemoveNodeGroups_Valkey7
=== PAUSE TestAccElastiCacheReplicationGroup_RemoveNodeGroups_Valkey7
=== RUN   TestAccElastiCacheReplicationGroup_RemoveNodeGroups_Valkey7_3NodeGroups
=== PAUSE TestAccElastiCacheReplicationGroup_RemoveNodeGroups_Valkey7_3NodeGroups
=== RUN   TestAccElastiCacheReplicationGroup_RemoveNodeGroups_Valkey8
=== PAUSE TestAccElastiCacheReplicationGroup_RemoveNodeGroups_Valkey8
=== RUN   TestAccElastiCacheReplicationGroup_RemoveNodeGroups_Redis7ToValkey8
=== PAUSE TestAccElastiCacheReplicationGroup_RemoveNodeGroups_Redis7ToValkey8
=== RUN   TestAccElastiCacheReplicationGroup_RemoveNodeGroups_Redis7ToValkey8_3NodeGroups
=== PAUSE TestAccElastiCacheReplicationGroup_RemoveNodeGroups_Redis7ToValkey8_3NodeGroups
=== RUN   TestAccElastiCacheReplicationGroup_Snapshot_ClusterModeDisabled_Redis7
=== PAUSE TestAccElastiCacheReplicationGroup_Snapshot_ClusterModeDisabled_Redis7
=== RUN   TestAccElastiCacheReplicationGroup_Snapshot_ClusterModeDisabled_Valkey7
=== PAUSE TestAccElastiCacheReplicationGroup_Snapshot_ClusterModeDisabled_Valkey7
=== RUN   TestAccElastiCacheReplicationGroup_Snapshot_ClusterModeEnabled_Redis7
=== PAUSE TestAccElastiCacheReplicationGroup_Snapshot_ClusterModeEnabled_Redis7
=== RUN   TestAccElastiCacheReplicationGroup_Snapshot_ClusterModeEnabled_Valkey7
=== PAUSE TestAccElastiCacheReplicationGroup_Snapshot_ClusterModeEnabled_Valkey7
=== RUN   TestAccElastiCacheReplicationGroup_SlowLog_Redis5ToRedis6
=== PAUSE TestAccElastiCacheReplicationGroup_SlowLog_Redis5ToRedis6
=== RUN   TestAccElastiCacheReplicationGroup_SlowLog_Redis5ToValkey7
=== PAUSE TestAccElastiCacheReplicationGroup_SlowLog_Redis5ToValkey7
=== CONT  TestAccElastiCacheReplicationGroup_Snapshot_ClusterModeEnabled_Redis7
--- PASS: TestAccElastiCacheReplicationGroup_Snapshot_ClusterModeEnabled_Redis7 (704.32s)
=== CONT  TestAccElastiCacheGlobalReplicationGroup_Redis_basic
--- PASS: TestAccElastiCacheGlobalReplicationGroup_Redis_basic (888.71s)
=== CONT  TestAccElastiCacheReplicationGroup_Snapshot_ClusterModeDisabled_Valkey7
--- PASS: TestAccElastiCacheReplicationGroup_Snapshot_ClusterModeDisabled_Valkey7 (1108.46s)
=== CONT  TestAccElastiCacheReplicationGroup_Snapshot_ClusterModeDisabled_Redis7
--- PASS: TestAccElastiCacheReplicationGroup_Snapshot_ClusterModeDisabled_Redis7 (1170.17s)
=== CONT  TestAccElastiCacheReplicationGroup_RemoveNodeGroups_Redis7ToValkey8_3NodeGroups
--- PASS: TestAccElastiCacheReplicationGroup_RemoveNodeGroups_Redis7ToValkey8_3NodeGroups (2619.78s)
=== CONT  TestAccElastiCacheReplicationGroup_RemoveNodeGroups_Redis7ToValkey8
--- PASS: TestAccElastiCacheReplicationGroup_RemoveNodeGroups_Redis7ToValkey8 (3355.66s)
=== CONT  TestAccElastiCacheReplicationGroup_RemoveNodeGroups_Valkey8
--- PASS: TestAccElastiCacheReplicationGroup_RemoveNodeGroups_Valkey8 (1571.66s)
=== CONT  TestAccElastiCacheReplicationGroup_RemoveNodeGroups_Valkey7_3NodeGroups
--- PASS: TestAccElastiCacheReplicationGroup_RemoveNodeGroups_Valkey7_3NodeGroups (2561.79s)
=== CONT  TestAccElastiCacheReplicationGroup_RemoveNodeGroups_Valkey7
--- PASS: TestAccElastiCacheReplicationGroup_RemoveNodeGroups_Valkey7 (2234.53s)
=== CONT  TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_engineUpgradeAfterDisassociate
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_engineUpgradeAfterDisassociate (1488.87s)
=== CONT  TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_ClusterMode_Enabled
--- PASS: TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_ClusterMode_Enabled (707.81s)
=== CONT  TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_ClusterMode_Disabled
--- PASS: TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_ClusterMode_Disabled (799.14s)
=== CONT  TestAccElastiCacheReplicationGroup_dataTiering
--- PASS: TestAccElastiCacheReplicationGroup_dataTiering (482.06s)
=== CONT  TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterModeValidation_numNodeGroupsOnSecondary
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterModeValidation_numNodeGroupsOnSecondary (1094.19s)
=== CONT  TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterMode_basic
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterMode_basic (3122.97s)
=== CONT  TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_disappears
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_disappears (2184.39s)
=== CONT  TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_full
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_full (2646.51s)
=== CONT  TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_basic
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_basic (2094.53s)
=== CONT  TestAccElastiCacheReplicationGroup_Validation_globalReplicationGroupIdAndNodeType
--- PASS: TestAccElastiCacheReplicationGroup_Validation_globalReplicationGroupIdAndNodeType (826.04s)
=== CONT  TestAccElastiCacheReplicationGroup_Validation_noNodeType
--- PASS: TestAccElastiCacheReplicationGroup_Validation_noNodeType (12.62s)
=== CONT  TestAccElastiCacheReplicationGroup_autoMinorVersionUpgrade
--- PASS: TestAccElastiCacheReplicationGroup_autoMinorVersionUpgrade (550.37s)
=== CONT  TestAccElastiCacheReplicationGroup_finalSnapshot
--- PASS: TestAccElastiCacheReplicationGroup_finalSnapshot (854.73s)
=== CONT  TestAccElastiCacheReplicationGroup_TagWithOtherModification_numCacheClusters
--- PASS: TestAccElastiCacheReplicationGroup_TagWithOtherModification_numCacheClusters (811.81s)
=== CONT  TestAccElastiCacheReplicationGroup_SlowLog_Redis5ToRedis6
--- PASS: TestAccElastiCacheReplicationGroup_SlowLog_Redis5ToRedis6 (1056.60s)
=== CONT  TestAccElastiCacheReplicationGroup_TagWithOtherModification_version
--- PASS: TestAccElastiCacheReplicationGroup_TagWithOtherModification_version (1524.83s)
=== CONT  TestAccElastiCacheReplicationGroup_SlowLog_Redis5ToValkey7
--- PASS: TestAccElastiCacheReplicationGroup_SlowLog_Redis5ToValkey7 (1116.06s)
=== CONT  TestAccElastiCacheReplicationGroup_tags
--- PASS: TestAccElastiCacheReplicationGroup_tags (635.84s)
=== CONT  TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappearsRemoveMemberCluster_scaleDown
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappearsRemoveMemberCluster_scaleDown (1222.28s)
=== CONT  TestAccElastiCacheReplicationGroup_Redis_EngineVersion_v7
--- PASS: TestAccElastiCacheReplicationGroup_Redis_EngineVersion_v7 (486.77s)
=== CONT  TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_MinorUpgrade
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_MinorUpgrade (1591.68s)
=== CONT  TestAccElastiCacheReplicationGroup_OutOfBandUpgrade
--- PASS: TestAccElastiCacheReplicationGroup_OutOfBandUpgrade (1346.19s)
=== CONT  TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappearsRemoveMemberCluster_atTargetSize
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappearsRemoveMemberCluster_atTargetSize (966.07s)
=== CONT  TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappears_addMemberCluster
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappears_addMemberCluster (1446.44s)
=== CONT  TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_MinorUpgrade_6x
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_MinorUpgrade_6x (814.08s)
=== CONT  TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_NoChange_Valkey_v7
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_NoChange_Valkey_v7 (787.87s)
=== CONT  TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappears_noChange
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappears_noChange (1294.73s)
=== CONT  TestAccElastiCacheReplicationGroup_uppercase
--- PASS: TestAccElastiCacheReplicationGroup_uppercase (622.38s)
=== CONT  TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_NoChange_Redis_v5
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_NoChange_Redis_v5 (868.43s)
=== CONT  TestAccElastiCacheReplicationGroup_NumberCacheClusters_multiAZEnabled
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClusters_multiAZEnabled (1202.73s)
=== CONT  TestAccElastiCacheReplicationGroup_Valkey_durability
--- PASS: TestAccElastiCacheReplicationGroup_Valkey_durability (2408.82s)
=== CONT  TestAccElastiCacheReplicationGroup_Valkey_basic
--- PASS: TestAccElastiCacheReplicationGroup_Valkey_basic (678.90s)
=== CONT  TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_NoChange_Redis_v6x
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_NoChange_Redis_v6x (878.05s)
=== CONT  TestAccElastiCacheReplicationGroup_ClusterMode_basic
--- PASS: TestAccElastiCacheReplicationGroup_ClusterMode_basic (927.99s)
=== CONT  TestAccElastiCacheReplicationGroup_Redis_basic_v5
--- PASS: TestAccElastiCacheReplicationGroup_Redis_basic_v5 (567.42s)
=== CONT  TestAccElastiCacheReplicationGroup_networkType
--- PASS: TestAccElastiCacheReplicationGroup_networkType (663.35s)
=== CONT  TestAccElastiCacheReplicationGroup_Redis_basic
--- PASS: TestAccElastiCacheReplicationGroup_Redis_basic (507.40s)
=== CONT  TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_NoChange_Redis_v6
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_NoChange_Redis_v6 (828.42s)
=== CONT  TestAccElastiCacheReplicationGroupDataSource_Engine_Redis_LogDeliveryConfigurations
--- PASS: TestAccElastiCacheReplicationGroupDataSource_Engine_Redis_LogDeliveryConfigurations (692.67s)
=== CONT  TestAccElastiCacheGlobalReplicationGroup_SetNumNodeGroupsOnUpdate_Decrease
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetNumNodeGroupsOnUpdate_Decrease (2186.78s)
=== CONT  TestAccElastiCacheReplicationGroupDataSource_multiAZ
--- PASS: TestAccElastiCacheReplicationGroupDataSource_multiAZ (625.13s)
=== CONT  TestAccElastiCacheGlobalReplicationGroup_SetNumNodeGroupsOnUpdate_Increase
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetNumNodeGroupsOnUpdate_Increase (1986.67s)
=== CONT  TestAccElastiCacheReplicationGroupDataSource_clusterMode
--- PASS: TestAccElastiCacheReplicationGroupDataSource_clusterMode (695.54s)
=== CONT  TestAccElastiCacheReplicationGroup_ClusterMode_nonClusteredParameterGroup
--- PASS: TestAccElastiCacheReplicationGroup_ClusterMode_nonClusteredParameterGroup (608.46s)
=== CONT  TestAccElastiCacheGlobalReplicationGroup_SetNumNodeGroupsOnCreate_Decrease
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetNumNodeGroupsOnCreate_Decrease (2455.87s)
=== CONT  TestAccElastiCacheReplicationGroupDataSource_basic
--- PASS: TestAccElastiCacheReplicationGroupDataSource_basic (614.11s)
=== CONT  TestAccElastiCacheReplicationGroup_ipDiscovery
--- PASS: TestAccElastiCacheReplicationGroup_ipDiscovery (785.92s)
=== CONT  TestAccElastiCacheGlobalReplicationGroup_sameReplicationGroupIDDifferentRegion
--- PASS: TestAccElastiCacheGlobalReplicationGroup_sameReplicationGroupIDDifferentRegion (5111.01s)
=== CONT  TestAccElastiCacheGlobalReplicationGroup_SetNumNodeGroupsOnCreate_Increase
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetNumNodeGroupsOnCreate_Increase (2206.75s)
=== CONT  TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnUpdate_MinorDowngrade
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnUpdate_MinorDowngrade (887.35s)
=== CONT  TestAccElastiCacheGlobalReplicationGroup_SetNumNodeGroupsOnCreate_NoChange
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetNumNodeGroupsOnCreate_NoChange (1170.79s)
=== CONT  TestAccElastiCacheReplicationGroup_autoFailoverEnabled_validateNumberCacheClusters
--- PASS: TestAccElastiCacheReplicationGroup_autoFailoverEnabled_validateNumberCacheClusters (2.75s)
=== CONT  TestAccElastiCacheGlobalReplicationGroup_clusterMode_basic
--- PASS: TestAccElastiCacheGlobalReplicationGroup_clusterMode_basic (1040.00s)
=== CONT  TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnUpdate_MinorUpgrade_6x
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnUpdate_MinorUpgrade_6x (900.29s)
=== CONT  TestAccElastiCacheReplicationGroup_NumberCacheClusters_autoFailoverEnabled
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClusters_autoFailoverEnabled (1194.13s)
=== CONT  TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnUpdate_MinorUpgrade
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnUpdate_MinorUpgrade (1611.82s)
=== CONT  TestAccElastiCacheReplicationGroup_NumberCacheClusters_autoFailoverDisabled
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClusters_autoFailoverDisabled (1037.00s)
=== CONT  TestAccElastiCacheGlobalReplicationGroup_SetParameterGroupOnCreate_MinorUpgrade
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetParameterGroupOnCreate_MinorUpgrade (856.12s)
=== CONT  TestAccElastiCacheReplicationGroup_NumberCacheClusters_basic
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClusters_basic (1287.30s)
=== CONT  TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnUpdate_MajorUpgrade
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnUpdate_MajorUpgrade (1484.59s)
=== CONT  TestAccElastiCacheReplicationGroup_useCMKKMSKeyID
--- PASS: TestAccElastiCacheReplicationGroup_useCMKKMSKeyID (742.25s)
=== CONT  TestAccElastiCacheReplicationGroup_Valkey_disableAtRestEncryption
--- PASS: TestAccElastiCacheReplicationGroup_Valkey_disableAtRestEncryption (536.67s)
=== CONT  TestAccElastiCacheGlobalReplicationGroup_SetParameterGroupOnCreate_NoVersion
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetParameterGroupOnCreate_NoVersion (2.74s)
=== CONT  TestAccElastiCacheGlobalReplicationGroup_InheritValkeyEngine_SecondaryReplicationGroup
--- PASS: TestAccElastiCacheGlobalReplicationGroup_InheritValkeyEngine_SecondaryReplicationGroup (2724.59s)
=== CONT  TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_MinorDowngrade
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_MinorDowngrade (786.06s)
=== CONT  TestAccElastiCacheReplicationGroup_Redis_enableAtRestEncryption
--- PASS: TestAccElastiCacheReplicationGroup_Redis_enableAtRestEncryption (669.24s)
=== CONT  TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_MajorUpgrade_6x
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_MajorUpgrade_6x (1553.30s)
=== CONT  TestAccElastiCacheGlobalReplicationGroup_SetParameterGroupOnUpdate_MinorUpgrade
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetParameterGroupOnUpdate_MinorUpgrade (816.48s)
=== CONT  TestAccElastiCacheGlobalReplicationGroup_ReplaceSecondary_differentRegion
--- PASS: TestAccElastiCacheGlobalReplicationGroup_ReplaceSecondary_differentRegion (3124.74s)
=== CONT  TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_MajorUpgrade
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_MajorUpgrade (1500.67s)
=== CONT  TestAccElastiCacheGlobalReplicationGroup_SetParameterGroupOnUpdate_NoVersion
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetParameterGroupOnUpdate_NoVersion (855.65s)
=== CONT  TestAccElastiCacheGlobalReplicationGroup_multipleSecondaries
--- PASS: TestAccElastiCacheGlobalReplicationGroup_multipleSecondaries (2826.53s)
=== CONT  TestAccElastiCacheReplicationGroup_Snapshot_ClusterModeEnabled_Valkey7
--- PASS: TestAccElastiCacheReplicationGroup_Snapshot_ClusterModeEnabled_Valkey7 (833.42s)
=== CONT  TestAccElastiCacheGlobalReplicationGroup_AutomaticFailover_memberDiffSuppressed_valkey
--- PASS: TestAccElastiCacheGlobalReplicationGroup_AutomaticFailover_memberDiffSuppressed_valkey (2255.69s)
=== CONT  TestAccElastiCacheReplicationGroup_transitEncryption7x_Disable
--- PASS: TestAccElastiCacheReplicationGroup_transitEncryption7x_Disable (1944.04s)
=== CONT  TestAccElastiCacheReplicationGroup_ValidationMultiAz_noAutomaticFailover
--- PASS: TestAccElastiCacheReplicationGroup_ValidationMultiAz_noAutomaticFailover (2.76s)
=== CONT  TestAccElastiCacheGlobalReplicationGroup_UpdateParameterGroupName
--- PASS: TestAccElastiCacheGlobalReplicationGroup_UpdateParameterGroupName (1570.00s)
=== CONT  TestAccElastiCacheReplicationGroup_deprecatedAvailabilityZones_multiAzInVPC
--- PASS: TestAccElastiCacheReplicationGroup_deprecatedAvailabilityZones_multiAzInVPC (613.92s)
=== CONT  TestAccElastiCacheGlobalReplicationGroup_AutomaticFailover_memberDiffSuppressed_redis
--- PASS: TestAccElastiCacheGlobalReplicationGroup_AutomaticFailover_memberDiffSuppressed_redis (2813.81s)
=== CONT  TestAccElastiCacheReplicationGroup_multiAzInVPC
--- PASS: TestAccElastiCacheReplicationGroup_multiAzInVPC (643.76s)
=== CONT  TestAccElastiCacheGlobalReplicationGroup_SetEngineOnCreate_ValkeyUpgrade
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineOnCreate_ValkeyUpgrade (1682.40s)
=== CONT  TestAccElastiCacheReplicationGroup_multiAzNotInVPC_repeated
--- PASS: TestAccElastiCacheReplicationGroup_multiAzNotInVPC_repeated (689.60s)
=== CONT  TestAccElastiCacheReplicationGroup_multiAzNotInVPC
--- PASS: TestAccElastiCacheReplicationGroup_multiAzNotInVPC (628.57s)
=== CONT  TestAccElastiCacheGlobalReplicationGroup_AutomaticFailover_createWithChange
--- PASS: TestAccElastiCacheGlobalReplicationGroup_AutomaticFailover_createWithChange (969.45s)
=== CONT  TestAccElastiCacheReplicationGroup_vpc
--- PASS: TestAccElastiCacheReplicationGroup_vpc (495.37s)
=== CONT  TestAccElastiCacheReplicationGroup_transitEncryption7x_Enable
--- PASS: TestAccElastiCacheReplicationGroup_transitEncryption7x_Enable (1955.54s)
=== CONT  TestAccElastiCacheReplicationGroup_upgrade_4_68_0
--- PASS: TestAccElastiCacheReplicationGroup_upgrade_4_68_0 (636.15s)
=== CONT  TestAccElastiCacheReplicationGroup_transitEncryption7x_basic
--- PASS: TestAccElastiCacheReplicationGroup_transitEncryption7x_basic (614.96s)
=== CONT  TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnUpdate_MajorUpgrade_6x
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnUpdate_MajorUpgrade_6x (1675.66s)
=== CONT  TestAccElastiCacheGlobalReplicationGroup_nodeType_createWithChange
--- PASS: TestAccElastiCacheGlobalReplicationGroup_nodeType_createWithChange (1600.45s)
=== CONT  TestAccElastiCacheReplicationGroup_transitEncryption5x
--- PASS: TestAccElastiCacheReplicationGroup_transitEncryption5x (1182.23s)
=== CONT  TestAccElastiCacheGlobalReplicationGroup_nodeType_createNoChange
--- PASS: TestAccElastiCacheGlobalReplicationGroup_nodeType_createNoChange (869.85s)
=== CONT  TestAccElastiCacheGlobalReplicationGroup_SetEngineOnUpdate_ValkeyUpgrade
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineOnUpdate_ValkeyUpgrade (1607.22s)
=== CONT  TestAccElastiCacheGlobalReplicationGroup_nodeType_setNoChange
--- PASS: TestAccElastiCacheGlobalReplicationGroup_nodeType_setNoChange (921.51s)
=== CONT  TestAccElastiCacheReplicationGroup_updateUserGroups
--- PASS: TestAccElastiCacheReplicationGroup_updateUserGroups (696.39s)
=== CONT  TestAccElastiCacheGlobalReplicationGroup_AutomaticFailover_createNoChange
--- PASS: TestAccElastiCacheGlobalReplicationGroup_AutomaticFailover_createNoChange (938.85s)
=== CONT  TestAccElastiCacheGlobalReplicationGroup_nodeType_update
--- PASS: TestAccElastiCacheGlobalReplicationGroup_nodeType_update (1534.08s)
=== CONT  TestAccElastiCacheReplicationGroup_transitEncryptionWithAuthToken
--- PASS: TestAccElastiCacheReplicationGroup_transitEncryptionWithAuthToken (613.54s)
=== CONT  TestAccElastiCacheReplicationGroup_EngineVersion_6xToRealVersion
--- PASS: TestAccElastiCacheReplicationGroup_EngineVersion_6xToRealVersion (606.63s)
=== CONT  TestAccElastiCacheReplicationGroup_disappears
--- PASS: TestAccElastiCacheReplicationGroup_disappears (484.31s)
=== CONT  TestAccElastiCacheReplicationGroup_ClusterMode_singleNode
--- PASS: TestAccElastiCacheReplicationGroup_ClusterMode_singleNode (487.38s)
=== CONT  TestAccElastiCacheGlobalReplicationGroup_AutomaticFailover_update
--- PASS: TestAccElastiCacheGlobalReplicationGroup_AutomaticFailover_update (1004.44s)
=== CONT  TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplicasPerNodeGroup_scaleDown
--- PASS: TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplicasPerNodeGroup_scaleDown (1871.47s)
=== CONT  TestAccElastiCacheGlobalReplicationGroup_AutomaticFailover_setNoChange
--- PASS: TestAccElastiCacheGlobalReplicationGroup_AutomaticFailover_setNoChange (930.36s)
=== CONT  TestAccElastiCacheReplicationGroup_updateMaintenanceWindow
--- PASS: TestAccElastiCacheReplicationGroup_updateMaintenanceWindow (511.31s)
=== CONT  TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplicasPerNodeGroup_scaleUp
--- PASS: TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplicasPerNodeGroup_scaleUp (2200.93s)
=== CONT  TestAccElastiCacheReplicationGroup_updateDescription
--- PASS: TestAccElastiCacheReplicationGroup_updateDescription (511.44s)
=== CONT  TestAccElastiCacheReplicationGroup_ClusterMode_updateReplicasPerNodeGroup
--- PASS: TestAccElastiCacheReplicationGroup_ClusterMode_updateReplicasPerNodeGroup (1602.19s)
=== CONT  TestAccElastiCacheReplicationGroup_ClusterMode_nodeGroupConfiguration
--- PASS: TestAccElastiCacheReplicationGroup_ClusterMode_nodeGroupConfiguration (829.90s)
=== CONT  TestAccElastiCacheReplicationGroup_Engine_RedisToValkey
--- PASS: TestAccElastiCacheReplicationGroup_Engine_RedisToValkey (1186.73s)
=== CONT  TestAccElastiCacheGlobalReplicationGroup_disappears
--- PASS: TestAccElastiCacheGlobalReplicationGroup_disappears (876.75s)
=== CONT  TestAccElastiCacheReplicationGroup_enableSnapshotting
--- PASS: TestAccElastiCacheReplicationGroup_enableSnapshotting (520.65s)
=== CONT  TestAccElastiCacheGlobalReplicationGroup_Valkey_basic
--- PASS: TestAccElastiCacheGlobalReplicationGroup_Valkey_basic (909.03s)
=== CONT  TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleDown
--- PASS: TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleDown (1635.67s)
=== CONT  TestAccElastiCacheReplicationGroup_clusteringAndCacheNodesCausesError
--- PASS: TestAccElastiCacheReplicationGroup_clusteringAndCacheNodesCausesError (2.61s)
=== CONT  TestAccElastiCacheReplicationGroup_updateParameterGroup
--- PASS: TestAccElastiCacheReplicationGroup_updateParameterGroup (631.87s)
=== CONT  TestAccElastiCacheReplicationGroup_ClusterMode_nodeGroupConfiguration_availabilityZones
--- PASS: TestAccElastiCacheReplicationGroup_ClusterMode_nodeGroupConfiguration_availabilityZones (990.51s)
=== CONT  TestAccElastiCacheReplicationGroup_authToken_fromResource
--- PASS: TestAccElastiCacheReplicationGroup_authToken_fromResource (628.36s)
=== CONT  TestAccElastiCacheReplicationGroup_authToken
--- PASS: TestAccElastiCacheReplicationGroup_authToken (1244.72s)
=== CONT  TestAccElastiCacheReplicationGroup_cacheClustersConflictsWithReplicasPerNodeGroup
--- PASS: TestAccElastiCacheReplicationGroup_cacheClustersConflictsWithReplicasPerNodeGroup (2.45s)
=== CONT  TestAccElastiCacheReplicationGroup_ClusterMode_updateFromDisabled_Compatible_Enabled
--- PASS: TestAccElastiCacheReplicationGroup_ClusterMode_updateFromDisabled_Compatible_Enabled (2125.56s)
=== CONT  TestAccElastiCacheReplicationGroup_updateNodeSize
--- PASS: TestAccElastiCacheReplicationGroup_updateNodeSize (1126.97s)
=== CONT  TestAccElastiCacheGlobalReplicationGroup_description
--- PASS: TestAccElastiCacheGlobalReplicationGroup_description (931.00s)
=== CONT  TestAccElastiCacheReplicationGroup_authToRBACMigration
--- PASS: TestAccElastiCacheReplicationGroup_authToRBACMigration (1524.75s)
=== CONT  TestAccElastiCacheReplicationGroup_EngineVersion_update
--- PASS: TestAccElastiCacheReplicationGroup_EngineVersion_update (4747.74s)
=== CONT  TestAccElastiCacheReplicationGroup_upgrade_6_0_0
--- PASS: TestAccElastiCacheReplicationGroup_upgrade_6_0_0 (491.30s)
=== CONT  TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleUp
--- PASS: TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleUp (1594.64s)
=== CONT  TestAccElastiCacheReplicationGroup_upgrade_5_27_0
--- PASS: TestAccElastiCacheReplicationGroup_upgrade_5_27_0 (544.33s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elasticache	166659.794s
```
