### PR TITLE
 🤖🤖🤖 resource/aws_datasync_location_azure_blob: Make `agent_arns` optional

### DIFF
--- a/.changelog/48943.txt
+++ b/.changelog/48943.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_datasync_location_azure_blob: Make `agent_arns` optional to support agentless configurations
+```

--- a/internal/service/datasync/location_azure_blob.go
+++ b/internal/service/datasync/location_azure_blob.go
@@ -15,6 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/datasync"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/datasync/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
@@ -53,7 +54,7 @@ func resourceLocationAzureBlob() *schema.Resource {
 				},
 				"agent_arns": {
 					Type:     schema.TypeSet,
-					Required: true,
+					Optional: true,
 					Elem: &schema.Schema{
 						Type:         schema.TypeString,
 						ValidateFunc: verify.ValidARN,
@@ -115,6 +116,10 @@ func resourceLocationAzureBlob() *schema.Resource {
 				},
 			}
 		},
+
+		CustomizeDiff: customdiff.ForceNewIfChange("agent_arns", func(_ context.Context, old, new, meta any) bool {
+			return (old.(*schema.Set).Len() == 0 && new.(*schema.Set).Len() > 0) || (old.(*schema.Set).Len() > 0 && new.(*schema.Set).Len() == 0)
+		}),
 	}
 }
 
@@ -123,10 +128,13 @@ func resourceLocationAzureBlobCreate(ctx context.Context, d *schema.ResourceData
 	conn := meta.(*conns.AWSClient).DataSyncClient(ctx)
 
 	input := &datasync.CreateLocationAzureBlobInput{
-		AgentArns:          flex.ExpandStringValueSet(d.Get("agent_arns").(*schema.Set)),
 		AuthenticationType: awstypes.AzureBlobAuthenticationType(d.Get("authentication_type").(string)),
 		ContainerUrl:       aws.String(d.Get("container_url").(string)),
 		Tags:               getTagsIn(ctx),
+	}
+
+	if v, ok := d.GetOk("agent_arns"); ok && v.(*schema.Set).Len() > 0 {
+		input.AgentArns = flex.ExpandStringValueSet(v.(*schema.Set))
 	}
 
 	if v, ok := d.GetOk("access_tier"); ok {
@@ -211,7 +219,9 @@ func resourceLocationAzureBlobUpdate(ctx context.Context, d *schema.ResourceData
 		}
 
 		if d.HasChange("agent_arns") {
-			input.AgentArns = flex.ExpandStringValueSet(d.Get("agent_arns").(*schema.Set))
+			if v, ok := d.GetOk("agent_arns"); ok && v.(*schema.Set).Len() > 0 {
+				input.AgentArns = flex.ExpandStringValueSet(v.(*schema.Set))
+			}
 		}
 
 		if d.HasChange("authentication_type") {

--- a/internal/service/datasync/location_azure_blob_test.go
+++ b/internal/service/datasync/location_azure_blob_test.go
@@ -310,3 +310,155 @@ resource "aws_datasync_location_azure_blob" "test" {
 }
 `)
 }
+
+func TestAccDataSyncLocationAzureBlob_preservation(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v datasync.DescribeLocationAzureBlobOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_datasync_location_azure_blob.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.DataSyncServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckLocationAzureBlobDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLocationAzureBlobConfig_preservationBase(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLocationAzureBlobExists(ctx, t, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "agent_arns.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "agent_arns.0"),
+					resource.TestCheckResourceAttr(resourceName, "authentication_type", "SAS"),
+					resource.TestCheckResourceAttr(resourceName, "container_url", "https://myaccount.blob.core.windows.net/mycontainer"),
+					resource.TestCheckResourceAttr(resourceName, "access_tier", "HOT"),
+					resource.TestCheckResourceAttr(resourceName, "blob_type", "BLOCK"),
+				),
+			},
+			{
+				Config: testAccLocationAzureBlobConfig_preservationUpdated(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLocationAzureBlobExists(ctx, t, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "agent_arns.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "agent_arns.0"),
+					resource.TestCheckResourceAttr(resourceName, "access_tier", "COOL"),
+					resource.TestCheckResourceAttr(resourceName, "subdirectory", "/updated/"),
+				),
+			},
+		},
+	})
+}
+
+func testAccLocationAzureBlobConfig_preservationBase(rName string) string {
+	return acctest.ConfigCompose(testAccLocationAzureBlobConfig_base(rName), `
+resource "aws_datasync_location_azure_blob" "test" {
+  agent_arns          = [aws_datasync_agent.test.arn]
+  authentication_type = "SAS"
+  container_url       = "https://myaccount.blob.core.windows.net/mycontainer"
+  subdirectory        = "/preserve/test"
+
+  sas_configuration {
+    token = "sp=r&st=2023-12-20T14:54:52Z&se=2023-12-20T22:54:52Z&spr=https&sv=2021-06-08&sr=c&sig=aBBKDWQvyuVcTPH9EBp%%2FXTI9E%%2F%%2Fmq171%%2BZU178wcwqU%%3D"
+  }
+}
+`)
+}
+
+func testAccLocationAzureBlobConfig_preservationUpdated(rName string) string {
+	return acctest.ConfigCompose(testAccLocationAzureBlobConfig_base(rName), `
+resource "aws_datasync_location_azure_blob" "test" {
+  access_tier         = "COOL"
+  agent_arns          = [aws_datasync_agent.test.arn]
+  authentication_type = "SAS"
+  container_url       = "https://myaccount.blob.core.windows.net/mycontainer"
+  subdirectory        = "/updated/"
+
+  sas_configuration {
+    token = "sp=r&st=2023-12-20T14:54:52Z&se=2023-12-20T22:54:52Z&spr=https&sv=2021-06-08&sr=c&sig=aBBKDWQvyuVcTPH9EBp%%2FXTI9E%%2F%%2Fmq171%%2BZU178wcwqU%%3D"
+  }
+}
+`)
+}
+
+func TestAccDataSyncLocationAzureBlob_agentless(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v datasync.DescribeLocationAzureBlobOutput
+	resourceName := "aws_datasync_location_azure_blob.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.DataSyncServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckLocationAzureBlobDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLocationAzureBlobConfig_agentless(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckLocationAzureBlobExists(ctx, t, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "agent_arns.#", "0"),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "datasync", regexache.MustCompile(`location/loc-.+`)),
+					resource.TestCheckResourceAttr(resourceName, "authentication_type", "SAS"),
+					resource.TestCheckResourceAttr(resourceName, "blob_type", "BLOCK"),
+					resource.TestCheckResourceAttr(resourceName, "container_url", "https://myaccount.blob.core.windows.net/mycontainer"),
+					resource.TestCheckResourceAttr(resourceName, "sas_configuration.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "sas_configuration.0.token"),
+					resource.TestMatchResourceAttr(resourceName, names.AttrURI, regexache.MustCompile(`^azure-blob://.+/`)),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"sas_configuration"},
+			},
+		},
+	})
+}
+
+func TestAccDataSyncLocationAzureBlob_modeTransition(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v1, v2 datasync.DescribeLocationAzureBlobOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_datasync_location_azure_blob.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.DataSyncServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckLocationAzureBlobDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLocationAzureBlobConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLocationAzureBlobExists(ctx, t, resourceName, &v1),
+					resource.TestCheckResourceAttr(resourceName, "agent_arns.#", "1"),
+				),
+			},
+			{
+				Config: testAccLocationAzureBlobConfig_agentless(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLocationAzureBlobExists(ctx, t, resourceName, &v2),
+					resource.TestCheckResourceAttr(resourceName, "agent_arns.#", "0"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionDestroyBeforeCreate),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccLocationAzureBlobConfig_agentless() string {
+	return `
+resource "aws_datasync_location_azure_blob" "test" {
+  authentication_type = "SAS"
+  container_url       = "https://myaccount.blob.core.windows.net/mycontainer"
+
+  sas_configuration {
+    token = "sp=r&st=2023-12-20T14:54:52Z&se=2023-12-20T22:54:52Z&spr=https&sv=2021-06-08&sr=c&sig=aBBKDWQvyuVcTPH9EBp%%2FXTI9E%%2F%%2Fmq171%%2BZU178wcwqU%%3D"
+  }
+}
+`
+}

--- a/website/docs/r/datasync_location_azure_blob.html.markdown
+++ b/website/docs/r/datasync_location_azure_blob.html.markdown
@@ -10,13 +10,28 @@ description: |-
 
 Manages a Microsoft Azure Blob Storage Location within AWS DataSync.
 
-~> **NOTE:** The DataSync Agents must be available before creating this resource.
+~> **NOTE:** DataSync Agents are required when using agent-based configurations. For agentless configurations, omit the `agent_arns` argument.
 
 ## Example Usage
+
+### Agent-Based Configuration
 
 ```terraform
 resource "aws_datasync_location_azure_blob" "example" {
   agent_arns          = [aws_datasync_agent.example.arn]
+  authentication_type = "SAS"
+  container_url       = "https://myaccount.blob.core.windows.net/mycontainer"
+
+  sas_configuration {
+    token = "sp=r&st=2023-12-20T14:54:52Z&se=2023-12-20T22:54:52Z&spr=https&sv=2021-06-08&sr=c&sig=aBBKDWQvyuVcTPH9EBp%2FXTI9E%2F%2Fmq171%2BZU178wcwqU%3D"
+  }
+}
+```
+
+### Agentless Configuration
+
+```terraform
+resource "aws_datasync_location_azure_blob" "example" {
   authentication_type = "SAS"
   container_url       = "https://myaccount.blob.core.windows.net/mycontainer"
 
@@ -32,7 +47,7 @@ This resource supports the following arguments:
 
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `access_tier` - (Optional) The access tier that you want your objects or files transferred into. Valid values: `HOT`, `COOL` and `ARCHIVE`. Default: `HOT`.
-* `agent_arns` - (Required) A list of DataSync Agent ARNs with which this location will be associated.
+* `agent_arns` - (Optional) A list of DataSync Agent ARNs with which this location will be associated. If omitted, the location will be created as an agentless configuration.
 * `authentication_type` - (Required) The authentication method DataSync uses to access your Azure Blob Storage. Valid values: `SAS`.
 * `blob_type` - (Optional) The type of blob that you want your objects or files to be when transferring them into Azure Blob Storage. Valid values: `BLOB`. Default: `BLOB`.
 * `container_url` - (Required) The URL of the Azure Blob Storage container involved in your transfer.


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

### Description
Makes `agent_arns` optional for `aws_datasync_location_azure_blob` resource.

Currently, the agent_arns field is marked as required in Terraform, which prevents users from creating DataSync Azure Blob Storage locations without specifying agent ARNs. However, the AWS DataSync API and console support [agentless transfers in Enhanced mode](https://docs.aws.amazon.com/datasync/latest/userguide/creating-other-cloud-object-location.html), which allows creating Azure Blob Storage locations without specifying any agents. Before this fix:


```
Error: creating DataSync Location Microsoft Azure Blob Storage: operation error DataSync: CreateLocationAzureBlob, https response error StatusCode: 400, RequestID: 26c31615-28d5-4ad3-901b-d22204eb2f4b, api error ValidationException: 1 validation error detected: Value '[]' at 'agentArns' failed to satisfy constraint: Member must have length greater than or equal to 1
│ 
│   with aws_datasync_location_azure_blob.source,
│   on datasync.tf line 6, in resource "aws_datasync_location_azure_blob" "source":
│    6: resource "aws_datasync_location_azure_blob" "source" {
```
This change allows users to create DataSync Azure Blob Storage locations without specifying agent ARNs, which is useful for scenarios where agents are not required or will be configured separately. This aligns the Terraform resource behavior with the AWS Console and API capabilities.

### Changes

  - Changed agent_arns field from Required: true to Optional: true
  - Added conditional logic to set AgentArns only when the field is specified
  - Added `ForceNew` behavior via `CustomizeDiff` to replace the resource when transitioning between agent and agentless configurations, consistent with other DataSync location resources
  - Updated acceptance tests to reflect the new behavior
  - Updated documentation to reflect `agent_arns` as optional



### Relations
Relates [#43400](https://github.com/hashicorp/terraform-provider-aws/pull/43400)
Closes [#43066](https://github.com/hashicorp/terraform-provider-aws/issues/43066)
### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
```console
% make testacc TESTS=TestAccDataSyncLocationAzureBlob PKG=datasync
2026/07/14 15:22:37 Creating Terraform AWS Provider (SDKv2-style)...
2026/07/14 15:22:37 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccDataSyncLocationAzureBlob_Identity_basic
=== PAUSE TestAccDataSyncLocationAzureBlob_Identity_basic
=== RUN   TestAccDataSyncLocationAzureBlob_Identity_regionOverride
=== PAUSE TestAccDataSyncLocationAzureBlob_Identity_regionOverride
=== RUN   TestAccDataSyncLocationAzureBlob_Identity_ExistingResource_basic
=== PAUSE TestAccDataSyncLocationAzureBlob_Identity_ExistingResource_basic
=== RUN   TestAccDataSyncLocationAzureBlob_Identity_ExistingResource_noRefreshNoChange
=== PAUSE TestAccDataSyncLocationAzureBlob_Identity_ExistingResource_noRefreshNoChange
=== RUN   TestAccDataSyncLocationAzureBlob_basic
=== PAUSE TestAccDataSyncLocationAzureBlob_basic
=== RUN   TestAccDataSyncLocationAzureBlob_disappears
=== PAUSE TestAccDataSyncLocationAzureBlob_disappears
=== RUN   TestAccDataSyncLocationAzureBlob_tags
=== PAUSE TestAccDataSyncLocationAzureBlob_tags
=== RUN   TestAccDataSyncLocationAzureBlob_update
=== PAUSE TestAccDataSyncLocationAzureBlob_update
=== RUN   TestAccDataSyncLocationAzureBlob_preservation
=== PAUSE TestAccDataSyncLocationAzureBlob_preservation
=== RUN   TestAccDataSyncLocationAzureBlob_agentless
=== PAUSE TestAccDataSyncLocationAzureBlob_agentless
=== RUN   TestAccDataSyncLocationAzureBlob_modeTransition
=== PAUSE TestAccDataSyncLocationAzureBlob_modeTransition
=== CONT  TestAccDataSyncLocationAzureBlob_Identity_basic
=== CONT  TestAccDataSyncLocationAzureBlob_tags
=== CONT  TestAccDataSyncLocationAzureBlob_Identity_ExistingResource_noRefreshNoChange
=== CONT  TestAccDataSyncLocationAzureBlob_preservation
=== CONT  TestAccDataSyncLocationAzureBlob_update
=== CONT  TestAccDataSyncLocationAzureBlob_Identity_regionOverride
=== CONT  TestAccDataSyncLocationAzureBlob_disappears
=== CONT  TestAccDataSyncLocationAzureBlob_agentless
=== CONT  TestAccDataSyncLocationAzureBlob_modeTransition
=== CONT  TestAccDataSyncLocationAzureBlob_Identity_ExistingResource_basic
=== CONT  TestAccDataSyncLocationAzureBlob_basic
--- PASS: TestAccDataSyncLocationAzureBlob_agentless (25.24s)
--- PASS: TestAccDataSyncLocationAzureBlob_disappears (105.70s)
--- PASS: TestAccDataSyncLocationAzureBlob_preservation (113.01s)
--- PASS: TestAccDataSyncLocationAzureBlob_Identity_regionOverride (132.45s)
--- PASS: TestAccDataSyncLocationAzureBlob_Identity_basic (134.26s)
--- PASS: TestAccDataSyncLocationAzureBlob_modeTransition (158.18s)
--- PASS: TestAccDataSyncLocationAzureBlob_basic (161.91s)
--- PASS: TestAccDataSyncLocationAzureBlob_tags (163.42s)
--- PASS: TestAccDataSyncLocationAzureBlob_Identity_ExistingResource_basic (167.70s)
--- PASS: TestAccDataSyncLocationAzureBlob_Identity_ExistingResource_noRefreshNoChange (219.42s)
--- PASS: TestAccDataSyncLocationAzureBlob_update (235.89s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/datasync   236.056s
...
```

```console
% make testacc TESTS="TestAccDataSyncLocationAzureBlob_agentless" PKG=datasync
=== RUN   TestAccDataSyncLocationAzureBlob_agentless
=== PAUSE TestAccDataSyncLocationAzureBlob_agentless
=== CONT  TestAccDataSyncLocationAzureBlob_agentless
--- PASS: TestAccDataSyncLocationAzureBlob_agentless (19.50s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/datasync   19.621s
```

```console
% make testacc TESTS="TestAccDataSyncLocationAzureBlob_modeTransition" PKG=datasync
=== RUN   TestAccDataSyncLocationAzureBlob_modeTransition
=== PAUSE TestAccDataSyncLocationAzureBlob_modeTransition
=== CONT  TestAccDataSyncLocationAzureBlob_modeTransition
--- PASS: TestAccDataSyncLocationAzureBlob_modeTransition (95.77s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/datasync   95.895s
```

```console
% make testacc TESTS="TestAccDataSyncLocationAzureBlob_preservation" PKG=datasync
=== RUN   TestAccDataSyncLocationAzureBlob_preservation
=== PAUSE TestAccDataSyncLocationAzureBlob_preservation
=== CONT  TestAccDataSyncLocationAzureBlob_preservation
--- PASS: TestAccDataSyncLocationAzureBlob_preservation (123.95s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/datasync   124.071s
```

### AI Disclosure
Kiro (AI assistant) was used to validate the bug, implement the fix, and write acceptance tests. All code was reviewed and validated by the contributor.
