### PR TITLE
l/aws_kinesis_firehose_delivery_stream: new list resource

### DIFF
--- a/.changelog/48946.txt
+++ b/.changelog/48946.txt
@@ -1,0 +1,3 @@
+```release-note:new-list-resource
+aws_kinesis_firehose_delivery_stream
+```

--- a/internal/service/firehose/delivery_stream.go
+++ b/internal/service/firehose/delivery_stream.go
@@ -1629,92 +1629,8 @@ func resourceDeliveryStreamRead(ctx context.Context, d *schema.ResourceData, met
 		return sdkdiag.AppendErrorf(diags, "reading Kinesis Firehose Delivery Stream (%s): %s", sn, err)
 	}
 
-	d.Set(names.AttrARN, s.DeliveryStreamARN)
-	if v := s.Source; v != nil {
-		if v := v.KinesisStreamSourceDescription; v != nil {
-			if err := d.Set("kinesis_source_configuration", flattenKinesisStreamSourceDescription(v)); err != nil {
-				return sdkdiag.AppendErrorf(diags, "setting kinesis_source_configuration: %s", err)
-			}
-		}
-		if v := v.MSKSourceDescription; v != nil {
-			if err := d.Set("msk_source_configuration", []any{flattenMSKSourceDescription(v)}); err != nil {
-				return sdkdiag.AppendErrorf(diags, "setting msk_source_configuration: %s", err)
-			}
-		}
-	}
-	d.Set(names.AttrName, s.DeliveryStreamName)
-	d.Set("version_id", s.VersionId)
-
-	tfMapSSEOptions := map[string]any{
-		names.AttrEnabled: false,
-		"key_type":        types.KeyTypeAwsOwnedCmk,
-	}
-	if v := s.DeliveryStreamEncryptionConfiguration; v != nil && v.Status == types.DeliveryStreamEncryptionStatusEnabled {
-		tfMapSSEOptions[names.AttrEnabled] = true
-		tfMapSSEOptions["key_type"] = v.KeyType
-
-		if v := v.KeyARN; v != nil {
-			tfMapSSEOptions["key_arn"] = aws.ToString(v)
-		}
-	}
-	if err := d.Set("server_side_encryption", []any{tfMapSSEOptions}); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting server_side_encryption: %s", err)
-	}
-
-	if len(s.Destinations) > 0 {
-		destination := s.Destinations[0]
-		switch {
-		case destination.ElasticsearchDestinationDescription != nil:
-			d.Set(names.AttrDestination, destinationTypeElasticsearch)
-			if err := d.Set("elasticsearch_configuration", flattenElasticsearchDestinationDescription(destination.ElasticsearchDestinationDescription)); err != nil {
-				return sdkdiag.AppendErrorf(diags, "setting elasticsearch_configuration: %s", err)
-			}
-		case destination.HttpEndpointDestinationDescription != nil:
-			d.Set(names.AttrDestination, destinationTypeHTTPEndpoint)
-			configuredAccessKey := d.Get("http_endpoint_configuration.0.access_key").(string)
-			if err := d.Set("http_endpoint_configuration", flattenHTTPEndpointDestinationDescription(destination.HttpEndpointDestinationDescription, configuredAccessKey)); err != nil {
-				return sdkdiag.AppendErrorf(diags, "setting http_endpoint_configuration: %s", err)
-			}
-		case destination.IcebergDestinationDescription != nil:
-			d.Set(names.AttrDestination, destinationTypeIceberg)
-			if err := d.Set("iceberg_configuration", flattenIcebergDestinationDescription(destination.IcebergDestinationDescription)); err != nil {
-				return sdkdiag.AppendErrorf(diags, "setting iceberg_configuration: %s", err)
-			}
-		case destination.AmazonopensearchserviceDestinationDescription != nil:
-			d.Set(names.AttrDestination, destinationTypeOpenSearch)
-			if err := d.Set("opensearch_configuration", flattenAmazonopensearchserviceDestinationDescription(destination.AmazonopensearchserviceDestinationDescription)); err != nil {
-				return sdkdiag.AppendErrorf(diags, "setting opensearch_configuration: %s", err)
-			}
-		case destination.AmazonOpenSearchServerlessDestinationDescription != nil:
-			d.Set(names.AttrDestination, destinationTypeOpenSearchServerless)
-			if err := d.Set("opensearchserverless_configuration", flattenAmazonOpenSearchServerlessDestinationDescription(destination.AmazonOpenSearchServerlessDestinationDescription)); err != nil {
-				return sdkdiag.AppendErrorf(diags, "setting opensearchserverless_configuration: %s", err)
-			}
-		case destination.RedshiftDestinationDescription != nil:
-			d.Set(names.AttrDestination, destinationTypeRedshift)
-			configuredPassword := d.Get("redshift_configuration.0.password").(string)
-			if err := d.Set("redshift_configuration", flattenRedshiftDestinationDescription(destination.RedshiftDestinationDescription, configuredPassword)); err != nil {
-				return sdkdiag.AppendErrorf(diags, "setting redshift_configuration: %s", err)
-			}
-		case destination.SnowflakeDestinationDescription != nil:
-			d.Set(names.AttrDestination, destinationTypeSnowflake)
-			configuredKeyPassphrase := d.Get("snowflake_configuration.0.key_passphrase").(string)
-			configuredPrivateKey := d.Get("snowflake_configuration.0.private_key").(string)
-			if err := d.Set("snowflake_configuration", flattenSnowflakeDestinationDescription(destination.SnowflakeDestinationDescription, configuredKeyPassphrase, configuredPrivateKey)); err != nil {
-				return sdkdiag.AppendErrorf(diags, "setting snowflake_configuration: %s", err)
-			}
-		case destination.SplunkDestinationDescription != nil:
-			d.Set(names.AttrDestination, destinationTypeSplunk)
-			if err := d.Set("splunk_configuration", flattenSplunkDestinationDescription(destination.SplunkDestinationDescription)); err != nil {
-				return sdkdiag.AppendErrorf(diags, "setting splunk_configuration: %s", err)
-			}
-		default:
-			d.Set(names.AttrDestination, destinationTypeExtendedS3)
-			if err := d.Set("extended_s3_configuration", flattenExtendedS3DestinationDescription(destination.ExtendedS3DestinationDescription)); err != nil {
-				return sdkdiag.AppendErrorf(diags, "setting extended_s3_configuration: %s", err)
-			}
-		}
-		d.Set("destination_id", destination.DestinationId)
+	if err := resourceDeliveryStreamFlatten(ctx, d, s); err != nil {
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	return diags
@@ -4426,6 +4342,98 @@ func isDeliveryStreamOptionDisabled(v any) bool {
 	}
 
 	return !enabled
+}
+
+func resourceDeliveryStreamFlatten(_ context.Context, d *schema.ResourceData, s *types.DeliveryStreamDescription) error {
+	d.Set(names.AttrARN, s.DeliveryStreamARN)
+	if v := s.Source; v != nil {
+		if v := v.KinesisStreamSourceDescription; v != nil {
+			if err := d.Set("kinesis_source_configuration", flattenKinesisStreamSourceDescription(v)); err != nil {
+				return fmt.Errorf("setting kinesis_source_configuration: %w", err)
+			}
+		}
+		if v := v.MSKSourceDescription; v != nil {
+			if err := d.Set("msk_source_configuration", []any{flattenMSKSourceDescription(v)}); err != nil {
+				return fmt.Errorf("setting msk_source_configuration: %w", err)
+			}
+		}
+	}
+	d.Set(names.AttrName, s.DeliveryStreamName)
+	d.Set("version_id", s.VersionId)
+
+	tfMapSSEOptions := map[string]any{
+		names.AttrEnabled: false,
+		"key_type":        types.KeyTypeAwsOwnedCmk,
+	}
+	if v := s.DeliveryStreamEncryptionConfiguration; v != nil && v.Status == types.DeliveryStreamEncryptionStatusEnabled {
+		tfMapSSEOptions[names.AttrEnabled] = true
+		tfMapSSEOptions["key_type"] = v.KeyType
+
+		if v := v.KeyARN; v != nil {
+			tfMapSSEOptions["key_arn"] = aws.ToString(v)
+		}
+	}
+	if err := d.Set("server_side_encryption", []any{tfMapSSEOptions}); err != nil {
+		return fmt.Errorf("setting server_side_encryption: %w", err)
+	}
+
+	if len(s.Destinations) > 0 {
+		destination := s.Destinations[0]
+		switch {
+		case destination.ElasticsearchDestinationDescription != nil:
+			d.Set(names.AttrDestination, destinationTypeElasticsearch)
+			if err := d.Set("elasticsearch_configuration", flattenElasticsearchDestinationDescription(destination.ElasticsearchDestinationDescription)); err != nil {
+				return fmt.Errorf("setting elasticsearch_configuration: %w", err)
+			}
+		case destination.HttpEndpointDestinationDescription != nil:
+			d.Set(names.AttrDestination, destinationTypeHTTPEndpoint)
+			configuredAccessKey := d.Get("http_endpoint_configuration.0.access_key").(string)
+			if err := d.Set("http_endpoint_configuration", flattenHTTPEndpointDestinationDescription(destination.HttpEndpointDestinationDescription, configuredAccessKey)); err != nil {
+				return fmt.Errorf("setting http_endpoint_configuration: %w", err)
+			}
+		case destination.IcebergDestinationDescription != nil:
+			d.Set(names.AttrDestination, destinationTypeIceberg)
+			if err := d.Set("iceberg_configuration", flattenIcebergDestinationDescription(destination.IcebergDestinationDescription)); err != nil {
+				return fmt.Errorf("setting iceberg_configuration: %w", err)
+			}
+		case destination.AmazonopensearchserviceDestinationDescription != nil:
+			d.Set(names.AttrDestination, destinationTypeOpenSearch)
+			if err := d.Set("opensearch_configuration", flattenAmazonopensearchserviceDestinationDescription(destination.AmazonopensearchserviceDestinationDescription)); err != nil {
+				return fmt.Errorf("setting opensearch_configuration: %w", err)
+			}
+		case destination.AmazonOpenSearchServerlessDestinationDescription != nil:
+			d.Set(names.AttrDestination, destinationTypeOpenSearchServerless)
+			if err := d.Set("opensearchserverless_configuration", flattenAmazonOpenSearchServerlessDestinationDescription(destination.AmazonOpenSearchServerlessDestinationDescription)); err != nil {
+				return fmt.Errorf("setting opensearchserverless_configuration: %w", err)
+			}
+		case destination.RedshiftDestinationDescription != nil:
+			d.Set(names.AttrDestination, destinationTypeRedshift)
+			configuredPassword := d.Get("redshift_configuration.0.password").(string)
+			if err := d.Set("redshift_configuration", flattenRedshiftDestinationDescription(destination.RedshiftDestinationDescription, configuredPassword)); err != nil {
+				return fmt.Errorf("setting redshift_configuration: %w", err)
+			}
+		case destination.SnowflakeDestinationDescription != nil:
+			d.Set(names.AttrDestination, destinationTypeSnowflake)
+			configuredKeyPassphrase := d.Get("snowflake_configuration.0.key_passphrase").(string)
+			configuredPrivateKey := d.Get("snowflake_configuration.0.private_key").(string)
+			if err := d.Set("snowflake_configuration", flattenSnowflakeDestinationDescription(destination.SnowflakeDestinationDescription, configuredKeyPassphrase, configuredPrivateKey)); err != nil {
+				return fmt.Errorf("setting snowflake_configuration: %w", err)
+			}
+		case destination.SplunkDestinationDescription != nil:
+			d.Set(names.AttrDestination, destinationTypeSplunk)
+			if err := d.Set("splunk_configuration", flattenSplunkDestinationDescription(destination.SplunkDestinationDescription)); err != nil {
+				return fmt.Errorf("setting splunk_configuration: %w", err)
+			}
+		default:
+			d.Set(names.AttrDestination, destinationTypeExtendedS3)
+			if err := d.Set("extended_s3_configuration", flattenExtendedS3DestinationDescription(destination.ExtendedS3DestinationDescription)); err != nil {
+				return fmt.Errorf("setting extended_s3_configuration: %w", err)
+			}
+		}
+		d.Set("destination_id", destination.DestinationId)
+	}
+
+	return nil
 }
 
 // See https://docs.aws.amazon.com/firehose/latest/dev/data-transformation.html.

--- a/internal/service/firehose/delivery_stream_list.go
+++ b/internal/service/firehose/delivery_stream_list.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"iter"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/firehose"
 	"github.com/hashicorp/terraform-plugin-framework/list"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -45,18 +44,9 @@ func (l *deliveryStreamListResource) List(ctx context.Context, request list.List
 
 			ctx := tflog.SetField(ctx, logging.ResourceAttributeKey(names.AttrName), name)
 
-			// The ListDeliveryStreams API only returns delivery stream name, but ARN
-			// is required for resource identity.
-			s, err := findDeliveryStreamByName(ctx, conn, name)
-			if err != nil {
-				result := fwdiag.NewListResultErrorDiagnostic(fmt.Errorf("reading Kinesis Firehose Delivery Stream (%s): %w", name, err))
-				if !yield(result) {
-					return
-				}
-				continue
-			}
-
-			arn := aws.ToString(s.DeliveryStreamARN)
+			// Construct ARN from stream name to avoid per-result finder calls
+			// when IncludeResource is not set
+			arn := awsClient.RegionalARN(ctx, "firehose", fmt.Sprintf("deliverystream/%s", name))
 			ctx = tflog.SetField(ctx, logging.ResourceAttributeKey(names.AttrARN), arn)
 
 			result := request.NewListResult(ctx)
@@ -66,6 +56,14 @@ func (l *deliveryStreamListResource) List(ctx context.Context, request list.List
 			rd.Set(names.AttrARN, arn)
 
 			if request.IncludeResource {
+				s, err := findDeliveryStreamByName(ctx, conn, name)
+				if err != nil {
+					tflog.Error(ctx, "Reading Kinesis Firehose Delivery Stream", map[string]any{
+						"error": err.Error(),
+					})
+					continue
+				}
+
 				if err := resourceDeliveryStreamFlatten(ctx, rd, s); err != nil {
 					tflog.Error(ctx, "Reading Kinesis Firehose Delivery Stream", map[string]any{
 						"error": err.Error(),

--- a/internal/service/firehose/delivery_stream_list.go
+++ b/internal/service/firehose/delivery_stream_list.go
@@ -1,0 +1,111 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package firehose
+
+import (
+	"context"
+	"fmt"
+	"iter"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/firehose"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/logging"
+	inttypes "github.com/hashicorp/terraform-provider-aws/internal/types"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @SDKListResource("aws_kinesis_firehose_delivery_stream")
+func newDeliveryStreamResourceAsListResource() inttypes.ListResourceForSDK {
+	l := deliveryStreamListResource{}
+	l.SetResourceSchema(resourceDeliveryStream())
+	return &l
+}
+
+type deliveryStreamListResource struct {
+	framework.ListResourceWithSDKv2Resource
+}
+
+func (l *deliveryStreamListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
+	awsClient := l.Meta()
+	conn := awsClient.FirehoseClient(ctx)
+
+	var input firehose.ListDeliveryStreamsInput
+	stream.Results = func(yield func(list.ListResult) bool) {
+		for name, err := range listDeliveryStreamNames(ctx, conn, &input) {
+			if err != nil {
+				result := fwdiag.NewListResultErrorDiagnostic(err)
+				yield(result)
+				return
+			}
+
+			ctx := tflog.SetField(ctx, logging.ResourceAttributeKey(names.AttrName), name)
+
+			// The ListDeliveryStreams API only returns delivery stream name, but ARN
+			// is required for resource identity.
+			s, err := findDeliveryStreamByName(ctx, conn, name)
+			if err != nil {
+				result := fwdiag.NewListResultErrorDiagnostic(fmt.Errorf("reading Kinesis Firehose Delivery Stream (%s): %w", name, err))
+				if !yield(result) {
+					return
+				}
+				continue
+			}
+
+			arn := aws.ToString(s.DeliveryStreamARN)
+			ctx = tflog.SetField(ctx, logging.ResourceAttributeKey(names.AttrARN), arn)
+
+			result := request.NewListResult(ctx)
+
+			rd := l.ResourceData()
+			rd.SetId(arn)
+			rd.Set(names.AttrARN, arn)
+
+			if request.IncludeResource {
+				if err := resourceDeliveryStreamFlatten(ctx, rd, s); err != nil {
+					tflog.Error(ctx, "Reading Kinesis Firehose Delivery Stream", map[string]any{
+						"error": err.Error(),
+					})
+					continue
+				}
+			}
+
+			result.DisplayName = name
+
+			l.SetResult(ctx, awsClient, request.IncludeResource, rd, &result)
+			if result.Diagnostics.HasError() {
+				yield(result)
+				return
+			}
+
+			if !yield(result) {
+				return
+			}
+		}
+	}
+}
+
+func listDeliveryStreamNames(ctx context.Context, conn *firehose.Client, input *firehose.ListDeliveryStreamsInput) iter.Seq2[string, error] {
+	return func(yield func(string, error) bool) {
+		var stopped bool
+		err := listDeliveryStreamsPages(ctx, conn, input, func(page *firehose.ListDeliveryStreamsOutput, lastPage bool) bool {
+			if page == nil {
+				return !lastPage
+			}
+			for _, name := range page.DeliveryStreamNames {
+				if !yield(name, nil) {
+					stopped = true
+					return false
+				}
+			}
+			return !lastPage
+		})
+		if !stopped && err != nil {
+			yield("", fmt.Errorf("listing Kinesis Firehose Delivery Streams: %w", err))
+		}
+	}
+}

--- a/internal/service/firehose/delivery_stream_list_test.go
+++ b/internal/service/firehose/delivery_stream_list_test.go
@@ -1,0 +1,202 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package firehose_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	tfknownvalue "github.com/hashicorp/terraform-provider-aws/internal/acctest/knownvalue"
+	tfquerycheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/querycheck"
+	tfqueryfilter "github.com/hashicorp/terraform-provider-aws/internal/acctest/queryfilter"
+	tfstatecheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/statecheck"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccFirehoseDeliveryStream_List_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_kinesis_firehose_delivery_stream.test[0]"
+	resourceName2 := "aws_kinesis_firehose_delivery_stream.test[1]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity1 := tfstatecheck.Identity()
+	identity2 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.FirehoseServiceID),
+		CheckDestroy:             testAccCheckDeliveryStreamDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/DeliveryStream/list_basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+					statecheck.ExpectKnownValue(resourceName1, tfjsonpath.New(names.AttrARN), tfknownvalue.RegionalARNExact("firehose", "deliverystream/"+rName+"-0")),
+
+					identity2.GetIdentity(resourceName2),
+					statecheck.ExpectKnownValue(resourceName2, tfjsonpath.New(names.AttrARN), tfknownvalue.RegionalARNExact("firehose", "deliverystream/"+rName+"-1")),
+				},
+			},
+
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/DeliveryStream/list_basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_kinesis_firehose_delivery_stream.test", identity1.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_kinesis_firehose_delivery_stream.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), knownvalue.StringExact(rName+"-0")),
+					tfquerycheck.ExpectNoResourceObject("aws_kinesis_firehose_delivery_stream.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks())),
+
+					tfquerycheck.ExpectIdentityFunc("aws_kinesis_firehose_delivery_stream.test", identity2.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_kinesis_firehose_delivery_stream.test", tfqueryfilter.ByResourceIdentityFunc(identity2.Checks()), knownvalue.StringExact(rName+"-1")),
+					tfquerycheck.ExpectNoResourceObject("aws_kinesis_firehose_delivery_stream.test", tfqueryfilter.ByResourceIdentityFunc(identity2.Checks())),
+				},
+			},
+		},
+	})
+}
+
+func TestAccFirehoseDeliveryStream_List_includeResource(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_kinesis_firehose_delivery_stream.test[0]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity1 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.FirehoseServiceID),
+		CheckDestroy:             testAccCheckDeliveryStreamDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/DeliveryStream/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(1),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
+						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
+					}),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+					statecheck.ExpectKnownValue(resourceName1, tfjsonpath.New(names.AttrARN), tfknownvalue.RegionalARNExact("firehose", "deliverystream/"+rName+"-0")),
+				},
+			},
+
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/DeliveryStream/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(1),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
+						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
+					}),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_kinesis_firehose_delivery_stream.test", identity1.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_kinesis_firehose_delivery_stream.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), knownvalue.StringExact(rName+"-0")),
+					querycheck.ExpectResourceKnownValues("aws_kinesis_firehose_delivery_stream.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), []querycheck.KnownValueCheck{
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrARN), tfknownvalue.RegionalARNExact("firehose", "deliverystream/"+rName+"-0")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.Region())),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrID), tfknownvalue.RegionalARNExact("firehose", "deliverystream/"+rName+"-0")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrName), knownvalue.StringExact(rName+"-0")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
+							acctest.CtKey1: knownvalue.StringExact(acctest.CtValue1),
+						})),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrTagsAll), knownvalue.MapExact(map[string]knownvalue.Check{
+							acctest.CtKey1: knownvalue.StringExact(acctest.CtValue1),
+						})),
+					}),
+				},
+			},
+		},
+	})
+}
+
+func TestAccFirehoseDeliveryStream_List_regionOverride(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_kinesis_firehose_delivery_stream.test[0]"
+	resourceName2 := "aws_kinesis_firehose_delivery_stream.test[1]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity1 := tfstatecheck.Identity()
+	identity2 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.FirehoseServiceID),
+		CheckDestroy:             acctest.CheckDestroyNoop,
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/DeliveryStream/list_region_override/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+					"region":         config.StringVariable(acctest.AlternateRegion()),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+					statecheck.ExpectKnownValue(resourceName1, tfjsonpath.New(names.AttrARN), tfknownvalue.RegionalARNAlternateRegionExact("firehose", "deliverystream/"+rName+"-0")),
+
+					identity2.GetIdentity(resourceName2),
+					statecheck.ExpectKnownValue(resourceName2, tfjsonpath.New(names.AttrARN), tfknownvalue.RegionalARNAlternateRegionExact("firehose", "deliverystream/"+rName+"-1")),
+				},
+			},
+
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/DeliveryStream/list_region_override/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+					"region":         config.StringVariable(acctest.AlternateRegion()),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_kinesis_firehose_delivery_stream.test", identity1.Checks()),
+
+					tfquerycheck.ExpectIdentityFunc("aws_kinesis_firehose_delivery_stream.test", identity2.Checks()),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/firehose/service_package_gen.go
+++ b/internal/service/firehose/service_package_gen.go
@@ -7,6 +7,8 @@ package firehose
 
 import (
 	"context"
+	"iter"
+	"slices"
 	"unique"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -57,6 +59,21 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*inttypes.ServicePa
 			},
 		},
 	}
+}
+
+func (p *servicePackage) SDKListResources(ctx context.Context) iter.Seq[*inttypes.ServicePackageSDKListResource] {
+	return slices.Values([]*inttypes.ServicePackageSDKListResource{
+		{
+			Factory:  newDeliveryStreamResourceAsListResource,
+			TypeName: "aws_kinesis_firehose_delivery_stream",
+			Name:     "Delivery Stream",
+			Region:   inttypes.ResourceRegionDefault(),
+			Tags: unique.Make(inttypes.ServicePackageResourceTags{
+				IdentifierAttribute: names.AttrName,
+			}),
+			Identity: inttypes.RegionalARNIdentity(),
+		},
+	})
 }
 
 func (p *servicePackage) ServicePackageName() string {

--- a/internal/service/firehose/testdata/DeliveryStream/list_basic/main.tf
+++ b/internal/service/firehose/testdata/DeliveryStream/list_basic/main.tf
@@ -1,0 +1,107 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_kinesis_firehose_delivery_stream" "test" {
+  count = var.resource_count
+
+  depends_on  = [aws_iam_role_policy.test]
+  name        = "${var.rName}-${count.index}"
+  destination = "extended_s3"
+
+  extended_s3_configuration {
+    role_arn   = aws_iam_role.test.arn
+    bucket_arn = aws_s3_bucket.test.arn
+  }
+}
+
+data "aws_caller_identity" "current" {}
+
+resource "aws_iam_role" "test" {
+  name = var.rName
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "firehose.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole",
+      "Condition": {
+        "StringEquals": {
+          "sts:ExternalId": "${data.aws_caller_identity.current.account_id}"
+        }
+      }
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_s3_bucket" "test" {
+  bucket = var.rName
+}
+
+resource "aws_iam_role_policy" "test" {
+  name = var.rName
+  role = aws_iam_role.test.id
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Action": [
+        "s3:AbortMultipartUpload",
+        "s3:GetBucketLocation",
+        "s3:GetObject",
+        "s3:ListBucket",
+        "s3:ListBucketMultipartUploads",
+        "s3:PutObject"
+      ],
+      "Resource": [
+        "${aws_s3_bucket.test.arn}",
+        "${aws_s3_bucket.test.arn}/*"
+      ]
+    },
+    {
+      "Sid": "GlueAccess",
+      "Effect": "Allow",
+      "Action": [
+        "glue:GetTable",
+        "glue:GetTableVersion",
+        "glue:GetTableVersions"
+      ],
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Sid": "LakeFormationDataAccess",
+      "Effect": "Allow",
+      "Action": [
+        "lakeformation:GetDataAccess"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}

--- a/internal/service/firehose/testdata/DeliveryStream/list_basic/query.tfquery.hcl
+++ b/internal/service/firehose/testdata/DeliveryStream/list_basic/query.tfquery.hcl
@@ -1,0 +1,6 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_kinesis_firehose_delivery_stream" "test" {
+  provider = aws
+}

--- a/internal/service/firehose/testdata/DeliveryStream/list_include_resource/main.tf
+++ b/internal/service/firehose/testdata/DeliveryStream/list_include_resource/main.tf
@@ -1,0 +1,115 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_kinesis_firehose_delivery_stream" "test" {
+  count = var.resource_count
+
+  depends_on  = [aws_iam_role_policy.test]
+  name        = "${var.rName}-${count.index}"
+  destination = "extended_s3"
+
+  extended_s3_configuration {
+    role_arn   = aws_iam_role.test.arn
+    bucket_arn = aws_s3_bucket.test.arn
+  }
+
+  tags = var.resource_tags
+}
+
+data "aws_caller_identity" "current" {}
+
+resource "aws_iam_role" "test" {
+  name = var.rName
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "firehose.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole",
+      "Condition": {
+        "StringEquals": {
+          "sts:ExternalId": "${data.aws_caller_identity.current.account_id}"
+        }
+      }
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_s3_bucket" "test" {
+  bucket = var.rName
+}
+
+resource "aws_iam_role_policy" "test" {
+  name = var.rName
+  role = aws_iam_role.test.id
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Action": [
+        "s3:AbortMultipartUpload",
+        "s3:GetBucketLocation",
+        "s3:GetObject",
+        "s3:ListBucket",
+        "s3:ListBucketMultipartUploads",
+        "s3:PutObject"
+      ],
+      "Resource": [
+        "${aws_s3_bucket.test.arn}",
+        "${aws_s3_bucket.test.arn}/*"
+      ]
+    },
+    {
+      "Sid": "GlueAccess",
+      "Effect": "Allow",
+      "Action": [
+        "glue:GetTable",
+        "glue:GetTableVersion",
+        "glue:GetTableVersions"
+      ],
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Sid": "LakeFormationDataAccess",
+      "Effect": "Allow",
+      "Action": [
+        "lakeformation:GetDataAccess"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}
+
+variable "resource_tags" {
+  description = "Tags to set on resource"
+  type        = map(string)
+  nullable    = false
+}

--- a/internal/service/firehose/testdata/DeliveryStream/list_include_resource/query.tfquery.hcl
+++ b/internal/service/firehose/testdata/DeliveryStream/list_include_resource/query.tfquery.hcl
@@ -1,0 +1,8 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_kinesis_firehose_delivery_stream" "test" {
+  provider = aws
+
+  include_resource = true
+}

--- a/internal/service/firehose/testdata/DeliveryStream/list_region_override/main.tf
+++ b/internal/service/firehose/testdata/DeliveryStream/list_region_override/main.tf
@@ -1,0 +1,116 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_kinesis_firehose_delivery_stream" "test" {
+  count  = var.resource_count
+  region = var.region
+
+  depends_on  = [aws_iam_role_policy.test]
+  name        = "${var.rName}-${count.index}"
+  destination = "extended_s3"
+
+  extended_s3_configuration {
+    role_arn   = aws_iam_role.test.arn
+    bucket_arn = aws_s3_bucket.test.arn
+  }
+}
+
+data "aws_caller_identity" "current" {}
+
+resource "aws_iam_role" "test" {
+  name = var.rName
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "firehose.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole",
+      "Condition": {
+        "StringEquals": {
+          "sts:ExternalId": "${data.aws_caller_identity.current.account_id}"
+        }
+      }
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_s3_bucket" "test" {
+  region = var.region
+
+  bucket = var.rName
+}
+
+resource "aws_iam_role_policy" "test" {
+  name = var.rName
+  role = aws_iam_role.test.id
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Action": [
+        "s3:AbortMultipartUpload",
+        "s3:GetBucketLocation",
+        "s3:GetObject",
+        "s3:ListBucket",
+        "s3:ListBucketMultipartUploads",
+        "s3:PutObject"
+      ],
+      "Resource": [
+        "${aws_s3_bucket.test.arn}",
+        "${aws_s3_bucket.test.arn}/*"
+      ]
+    },
+    {
+      "Sid": "GlueAccess",
+      "Effect": "Allow",
+      "Action": [
+        "glue:GetTable",
+        "glue:GetTableVersion",
+        "glue:GetTableVersions"
+      ],
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Sid": "LakeFormationDataAccess",
+      "Effect": "Allow",
+      "Action": [
+        "lakeformation:GetDataAccess"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}
+
+variable "region" {
+  description = "Region to deploy resource in"
+  type        = string
+  nullable    = false
+}

--- a/internal/service/firehose/testdata/DeliveryStream/list_region_override/query.tfquery.hcl
+++ b/internal/service/firehose/testdata/DeliveryStream/list_region_override/query.tfquery.hcl
@@ -1,0 +1,10 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_kinesis_firehose_delivery_stream" "test" {
+  provider = aws
+
+  config {
+    region = var.region
+  }
+}

--- a/website/docs/list-resources/kinesis_firehose_delivery_stream.html.markdown
+++ b/website/docs/list-resources/kinesis_firehose_delivery_stream.html.markdown
@@ -1,0 +1,25 @@
+---
+subcategory: "Kinesis Firehose"
+layout: "aws"
+page_title: "AWS: aws_kinesis_firehose_delivery_stream"
+description: |-
+  Lists Kinesis Firehose Delivery Stream resources.
+---
+
+# List Resource: aws_kinesis_firehose_delivery_stream
+
+Lists Kinesis Firehose Delivery Stream resources.
+
+## Example Usage
+
+```terraform
+list "aws_kinesis_firehose_delivery_stream" "example" {
+  provider = aws
+}
+```
+
+## Argument Reference
+
+This list resource supports the following arguments:
+
+* `region` - (Optional) Region to query. Defaults to provider region.


### PR DESCRIPTION


<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Creates a new list resource, `aws_kinesis_firehose_delivery_stream`.




### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->
Closes #48606
Relates https://github.com/hashicorp/terraform-provider-aws/issues/47005


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t K=firehose T=TestAccFirehoseDeliveryStream_ ACCTEST_PARALLELISM=5
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-firehose_delivery_stream-list 🌿...
TF_ACC=1 go1.26.4 test ./internal/service/firehose/... -v -count 1 -parallel 5 -run='TestAccFirehoseDeliveryStream_'  -timeout 360m -vet=off
2026/07/14 11:26:53 Creating Terraform AWS Provider (SDKv2-style)...
2026/07/14 11:26:53 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccFirehoseDeliveryStream_Identity_basic (105.80s)
=== CONT  TestAccFirehoseDeliveryStream_Splunk_SecretsManagerConfiguration
--- PASS: TestAccFirehoseDeliveryStream_HTTPEndpoint_retryDuration (105.94s)
=== CONT  TestAccFirehoseDeliveryStream_HTTPEndpoint_ErrorOutputPrefix
--- PASS: TestAccFirehoseDeliveryStream_extendedS3Updates (133.47s)
=== CONT  TestAccFirehoseDeliveryStream_httpEndpoint
--- PASS: TestAccFirehoseDeliveryStream_snowflakeUpdates (173.44s)
=== CONT  TestAccFirehoseDeliveryStream_Splunk_ErrorOutputPrefix
--- PASS: TestAccFirehoseDeliveryStream_Splunk_SecretsManagerConfiguration (88.83s)
=== CONT  TestAccFirehoseDeliveryStream_ExtendedS3_readFromTimestamp
--- PASS: TestAccFirehoseDeliveryStream_httpEndpoint (132.77s)
=== CONT  TestAccFirehoseDeliveryStream_Redshift_SecretsManagerConfiguration
--- PASS: TestAccFirehoseDeliveryStream_HTTPEndpoint_ErrorOutputPrefix (162.89s)
=== CONT  TestAccFirehoseDeliveryStream_redshiftUpdates
--- PASS: TestAccFirehoseDeliveryStream_Splunk_ErrorOutputPrefix (99.86s)
=== CONT  TestAccFirehoseDeliveryStream_splunkUpdates
=== NAME  TestAccFirehoseDeliveryStream_ExtendedS3_readFromTimestamp
    delivery_stream_test.go:1034: Step 1/2 error: Error running apply: exit status 1

        Error: waiting for Kinesis Firehose Delivery Stream (tf-acc-test-1600751274745675976) create: unexpected state 'CREATING_FAILED', wanted target 'ACTIVE'. last error: CREATE_PRIVATE_LINK_FAILED: AWS Firehose is not authorized to perform kafka:CreateVpcConnection on resource arn:aws:iam::727561393803:role/tf-acc-test-1600751274745675976-cluster

          with aws_kinesis_firehose_delivery_stream.test,
          on terraform_plugin_test.tf line 211, in resource "aws_kinesis_firehose_delivery_stream" "test":
         211: resource "aws_kinesis_firehose_delivery_stream" "test" {

--- PASS: TestAccFirehoseDeliveryStream_splunkUpdates (120.75s)
=== CONT  TestAccFirehoseDeliveryStream_ExtendedS3_externalUpdate
--- FAIL: TestAccFirehoseDeliveryStream_ExtendedS3_readFromTimestamp (214.65s)
=== CONT  TestAccFirehoseDeliveryStream_extendedS3DynamicPartitioningUpdate
--- PASS: TestAccFirehoseDeliveryStream_ExtendedS3_externalUpdate (88.70s)
=== CONT  TestAccFirehoseDeliveryStream_extendedS3DynamicPartitioning
--- PASS: TestAccFirehoseDeliveryStream_extendedS3DynamicPartitioningUpdate (150.81s)
=== CONT  TestAccFirehoseDeliveryStream_extendedS3KMSKeyARN
--- PASS: TestAccFirehoseDeliveryStream_extendedS3DynamicPartitioning (108.91s)
=== CONT  TestAccFirehoseDeliveryStream_ExtendedS3Processing_empty
--- PASS: TestAccFirehoseDeliveryStream_extendedS3KMSKeyARN (98.50s)
=== CONT  TestAccFirehoseDeliveryStream_ExtendedS3_S3BackupConfiguration_ErrorOutputPrefix
--- PASS: TestAccFirehoseDeliveryStream_ExtendedS3Processing_empty (85.44s)
=== CONT  TestAccFirehoseDeliveryStream_ExtendedS3_errorOutputPrefix
--- PASS: TestAccFirehoseDeliveryStream_Redshift_SecretsManagerConfiguration (418.57s)
=== CONT  TestAccFirehoseDeliveryStream_ExtendedS3DataFormatConversionSerializer_update
--- PASS: TestAccFirehoseDeliveryStream_redshiftUpdates (468.94s)
=== CONT  TestAccFirehoseDeliveryStream_ExtendedS3DataFormatConversionParquetSerDe_empty
--- PASS: TestAccFirehoseDeliveryStream_ExtendedS3_S3BackupConfiguration_ErrorOutputPrefix (118.66s)
=== CONT  TestAccFirehoseDeliveryStream_ExtendedS3DataFormatConversionOrcSerDe_empty
--- PASS: TestAccFirehoseDeliveryStream_ExtendedS3DataFormatConversionSerializer_update (93.54s)
=== CONT  TestAccFirehoseDeliveryStream_ExtendedS3DataFormatConversionOpenXJSONSerDe_empty
--- PASS: TestAccFirehoseDeliveryStream_ExtendedS3_errorOutputPrefix (118.17s)
=== CONT  TestAccFirehoseDeliveryStream_ExtendedS3DataFormatConversionHiveJSONSerDe_empty
--- PASS: TestAccFirehoseDeliveryStream_ExtendedS3DataFormatConversionParquetSerDe_empty (78.47s)
=== CONT  TestAccFirehoseDeliveryStream_ExtendedS3DataFormatConversionDeserializer_update
--- PASS: TestAccFirehoseDeliveryStream_ExtendedS3DataFormatConversionOpenXJSONSerDe_empty (88.24s)
=== CONT  TestAccFirehoseDeliveryStream_ExtendedS3_kinesisStreamSource
--- PASS: TestAccFirehoseDeliveryStream_ExtendedS3DataFormatConversionOrcSerDe_empty (99.07s)
=== CONT  TestAccFirehoseDeliveryStream_ExtendedS3_mskClusterSource
--- PASS: TestAccFirehoseDeliveryStream_ExtendedS3DataFormatConversionHiveJSONSerDe_empty (98.08s)
=== CONT  TestAccFirehoseDeliveryStream_basic
--- PASS: TestAccFirehoseDeliveryStream_ExtendedS3DataFormatConversionDeserializer_update (124.61s)
=== CONT  TestAccFirehoseDeliveryStream_ExtendedS3DataFormatConversion_enabled
--- PASS: TestAccFirehoseDeliveryStream_ExtendedS3_kinesisStreamSource (74.48s)
=== CONT  TestAccFirehoseDeliveryStream_extendedS3basic
--- PASS: TestAccFirehoseDeliveryStream_basic (102.96s)
=== CONT  TestAccFirehoseDeliveryStream_s3WithCloudWatchLogging
--- PASS: TestAccFirehoseDeliveryStream_extendedS3basic (90.29s)
=== CONT  TestAccFirehoseDeliveryStream_tags
=== NAME  TestAccFirehoseDeliveryStream_ExtendedS3_mskClusterSource
    delivery_stream_test.go:999: Step 1/2 error: Error running apply: exit status 1

        Error: waiting for Kinesis Firehose Delivery Stream (tf-acc-test-8075313253262188714) create: unexpected state 'CREATING_FAILED', wanted target 'ACTIVE'. last error: CREATE_PRIVATE_LINK_FAILED: AWS Firehose is not authorized to perform kafka:CreateVpcConnection on resource arn:aws:iam::727561393803:role/tf-acc-test-8075313253262188714-cluster

          with aws_kinesis_firehose_delivery_stream.test,
          on terraform_plugin_test.tf line 211, in resource "aws_kinesis_firehose_delivery_stream" "test":
         211: resource "aws_kinesis_firehose_delivery_stream" "test" {

--- PASS: TestAccFirehoseDeliveryStream_ExtendedS3DataFormatConversion_enabled (109.64s)
=== CONT  TestAccFirehoseDeliveryStream_disappears
--- PASS: TestAccFirehoseDeliveryStream_s3WithCloudWatchLogging (85.62s)
=== CONT  TestAccFirehoseDeliveryStream_Opensearch_ErrorOutputPrefix
--- FAIL: TestAccFirehoseDeliveryStream_ExtendedS3_mskClusterSource (235.73s)
=== CONT  TestAccFirehoseDeliveryStream_missingProcessing
--- PASS: TestAccFirehoseDeliveryStream_disappears (88.53s)
=== CONT  TestAccFirehoseDeliveryStream_openSearchServerlessUpdates
--- PASS: TestAccFirehoseDeliveryStream_tags (123.02s)
=== CONT  TestAccFirehoseDeliveryStream_elasticSearchEndpointUpdates
--- PASS: TestAccFirehoseDeliveryStream_missingProcessing (86.86s)
=== CONT  TestAccFirehoseDeliveryStream_Elasticsearch_ErrorOutputPrefix
--- PASS: TestAccFirehoseDeliveryStream_openSearchServerlessUpdates (374.52s)
=== CONT  TestAccFirehoseDeliveryStream_elasticSearchWithVPCUpdates
--- PASS: TestAccFirehoseDeliveryStream_openSearchUpdates (1741.18s)
=== CONT  TestAccFirehoseDeliveryStream_elasticSearchUpdates
=== NAME  TestAccFirehoseDeliveryStream_Elasticsearch_ErrorOutputPrefix
    delivery_stream_test.go:2082: Step 3/5 error: Error running apply: exit status 1

        Error: updating Kinesis Firehose Delivery Stream (tf-acc-test-511923820272307728): operation error Firehose: UpdateDestination, https response error StatusCode: 400, RequestID: ed4ee86e-cf31-2d27-8f9e-b61039fe274b, InvalidArgumentException: Received ThrottlingException while describing the ElasticSearch domain.

          with aws_kinesis_firehose_delivery_stream.test,
          on terraform_plugin_test.tf line 134, in resource "aws_kinesis_firehose_delivery_stream" "test":
         134: resource "aws_kinesis_firehose_delivery_stream" "test" {

=== NAME  TestAccFirehoseDeliveryStream_elasticSearchWithVPCUpdates
    delivery_stream_test.go:2039: Step 1/3 error: Error running apply: exit status 1

        Error: creating Kinesis Firehose Delivery Stream (tf-acc-test-1368420769740545140): operation error Firehose: CreateDeliveryStream, https response error StatusCode: 400, RequestID: dbe55722-c22b-87af-b935-3711a3eb9d5f, InvalidArgumentException: Received ThrottlingException while describing the ElasticSearch domain.

          with aws_kinesis_firehose_delivery_stream.test,
          on terraform_plugin_test.tf line 189, in resource "aws_kinesis_firehose_delivery_stream" "test":
         189: resource "aws_kinesis_firehose_delivery_stream" "test" {

--- FAIL: TestAccFirehoseDeliveryStream_Elasticsearch_ErrorOutputPrefix (1169.47s)
=== CONT  TestAccFirehoseDeliveryStream_openSearchWithVPCUpdates
--- PASS: TestAccFirehoseDeliveryStream_elasticSearchEndpointUpdates (1423.35s)
=== CONT  TestAccFirehoseDeliveryStream_HTTPEndpoint_SecretsManagerConfiguration
--- PASS: TestAccFirehoseDeliveryStream_HTTPEndpoint_SecretsManagerConfiguration (98.54s)
=== CONT  TestAccFirehoseDeliveryStream_List_basic
--- PASS: TestAccFirehoseDeliveryStream_List_basic (96.01s)
=== CONT  TestAccFirehoseDeliveryStream_List_regionOverride
--- PASS: TestAccFirehoseDeliveryStream_List_regionOverride (113.40s)
=== CONT  TestAccFirehoseDeliveryStream_List_includeResource
--- PASS: TestAccFirehoseDeliveryStream_Opensearch_ErrorOutputPrefix (1833.88s)
=== CONT  TestAccFirehoseDeliveryStream_Identity_ExistingResource_basic
--- PASS: TestAccFirehoseDeliveryStream_List_includeResource (70.38s)
=== CONT  TestAccFirehoseDeliveryStream_Identity_ExistingResource_noRefreshNoChange
--- PASS: TestAccFirehoseDeliveryStream_Identity_ExistingResource_basic (117.81s)
=== CONT  TestAccFirehoseDeliveryStream_Identity_regionOverride
--- PASS: TestAccFirehoseDeliveryStream_Identity_ExistingResource_noRefreshNoChange (147.63s)
=== CONT  TestAccFirehoseDeliveryStream_openSearchEndpointUpdates
--- FAIL: TestAccFirehoseDeliveryStream_elasticSearchWithVPCUpdates (1623.05s)
=== CONT  TestAccFirehoseDeliveryStream_extendedS3CustomTimeZoneAndFileExtensionUpdates
--- PASS: TestAccFirehoseDeliveryStream_Identity_regionOverride (119.00s)
--- PASS: TestAccFirehoseDeliveryStream_elasticSearchUpdates (1496.33s)
--- PASS: TestAccFirehoseDeliveryStream_extendedS3CustomTimeZoneAndFileExtensionUpdates (110.10s)
--- PASS: TestAccFirehoseDeliveryStream_openSearchEndpointUpdates (1728.47s)
--- PASS: TestAccFirehoseDeliveryStream_openSearchWithVPCUpdates (2612.90s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/firehose   4990.803s
```

Failures are pre-existing and unrelated to this change.
