### PR TITLE
aws_redshift_idc_application: allow multiple authorized_token_issuer blocks

### DIFF
--- a/.changelog/48940.txt
+++ b/.changelog/48940.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_redshift_idc_application: Allow multiple `authorized_token_issuer` blocks
+```

--- a/internal/service/redshift/idc_application.go
+++ b/internal/service/redshift/idc_application.go
@@ -107,9 +107,6 @@ func (r *idcApplicationResource) Schema(ctx context.Context, req resource.Schema
 		Blocks: map[string]schema.Block{
 			"authorized_token_issuer": schema.ListNestedBlock{
 				CustomType: fwtypes.NewListNestedObjectTypeOf[authorizedTokenIssuerModel](ctx),
-				Validators: []validator.List{
-					listvalidator.SizeAtMost(1),
-				},
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
 						"authorized_audiences_list": schema.ListAttribute{

--- a/internal/service/redshift/idc_application_test.go
+++ b/internal/service/redshift/idc_application_test.go
@@ -108,6 +108,15 @@ func TestAccRedshiftIDCApplication_authorizedTokenIssuerList(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccIdcApplicationConfig_authorizedTokenIssuerListMultiple(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIDCApplicationExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "authorized_token_issuer.#", "2"),
+					resource.TestCheckResourceAttrPair(resourceName, "authorized_token_issuer.0.trusted_token_issuer_arn", "aws_ssoadmin_trusted_token_issuer.test", names.AttrARN),
+					resource.TestCheckResourceAttrPair(resourceName, "authorized_token_issuer.1.trusted_token_issuer_arn", "aws_ssoadmin_trusted_token_issuer.test2", names.AttrARN),
+				),
+			},
+			{
 				ResourceName:                         resourceName,
 				ImportState:                          true,
 				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, "redshift_idc_application_arn"),
@@ -391,6 +400,57 @@ resource "aws_redshift_idc_application" "test" {
   authorized_token_issuer {
     authorized_audiences_list = ["client_id"]
     trusted_token_issuer_arn  = aws_ssoadmin_trusted_token_issuer.test.arn
+  }
+  iam_role_arn                  = aws_iam_role.test.arn
+  idc_display_name              = %[1]q
+  idc_instance_arn              = tolist(data.aws_ssoadmin_instances.test.arns)[0]
+  redshift_idc_application_name = %[1]q
+}
+`, rName))
+}
+
+func testAccIdcApplicationConfig_authorizedTokenIssuerListMultiple(rName string) string {
+	return acctest.ConfigCompose(testAccIdcApplicationConfig_baseIAMRole(rName), fmt.Sprintf(`
+resource "aws_ssoadmin_trusted_token_issuer" "test" {
+  name                      = %[1]q
+  instance_arn              = tolist(data.aws_ssoadmin_instances.test.arns)[0]
+  trusted_token_issuer_type = "OIDC_JWT"
+
+  trusted_token_issuer_configuration {
+    oidc_jwt_configuration {
+      claim_attribute_path          = "email"
+      identity_store_attribute_path = "emails.value"
+      issuer_url                    = "https://example.com"
+      jwks_retrieval_option         = "OPEN_ID_DISCOVERY"
+    }
+  }
+}
+
+resource "aws_ssoadmin_trusted_token_issuer" "test2" {
+  name                      = "%[1]s-2"
+  instance_arn              = tolist(data.aws_ssoadmin_instances.test.arns)[0]
+  trusted_token_issuer_type = "OIDC_JWT"
+
+  trusted_token_issuer_configuration {
+    oidc_jwt_configuration {
+      claim_attribute_path          = "email"
+      identity_store_attribute_path = "emails.value"
+      issuer_url                    = "https://example2.com"
+      jwks_retrieval_option         = "OPEN_ID_DISCOVERY"
+    }
+  }
+}
+
+data "aws_ssoadmin_instances" "test" {}
+
+resource "aws_redshift_idc_application" "test" {
+  authorized_token_issuer {
+    authorized_audiences_list = ["client_id"]
+    trusted_token_issuer_arn  = aws_ssoadmin_trusted_token_issuer.test.arn
+  }
+  authorized_token_issuer {
+    authorized_audiences_list = ["client_id_2"]
+    trusted_token_issuer_arn  = aws_ssoadmin_trusted_token_issuer.test2.arn
   }
   iam_role_arn                  = aws_iam_role.test.arn
   idc_display_name              = %[1]q

--- a/internal/service/redshift/idc_application_test.go
+++ b/internal/service/redshift/idc_application_test.go
@@ -113,7 +113,11 @@ func TestAccRedshiftIDCApplication_authorizedTokenIssuerList(t *testing.T) {
 					testAccCheckIDCApplicationExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "authorized_token_issuer.#", "2"),
 					resource.TestCheckResourceAttrPair(resourceName, "authorized_token_issuer.0.trusted_token_issuer_arn", "aws_ssoadmin_trusted_token_issuer.test", names.AttrARN),
+					resource.TestCheckResourceAttr(resourceName, "authorized_token_issuer.0.authorized_audiences_list.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "authorized_token_issuer.0.authorized_audiences_list.0", names.AttrClientID),
 					resource.TestCheckResourceAttrPair(resourceName, "authorized_token_issuer.1.trusted_token_issuer_arn", "aws_ssoadmin_trusted_token_issuer.test2", names.AttrARN),
+					resource.TestCheckResourceAttr(resourceName, "authorized_token_issuer.1.authorized_audiences_list.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "authorized_token_issuer.1.authorized_audiences_list.0", "client_id_2"),
 				),
 			},
 			{


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls. The change removes a provider-side schema validator; authorization for the underlying API calls is unchanged.

### Description
Removes the `listvalidator.SizeAtMost(1)` constraint from the authorized_token_issuer block. The AWS API models this field as a list (`AuthorizedTokenIssuerList`) with no documented maximum, and the service accepts multiple entries. `modify-redshift-idc-application` with three issuers succeeds and `DescribeRedshiftIdcApplications` returns all of them. The resource uses AutoFlex expand/flatten on the full model, so no other code path assumes a single element; the service_integration validators (#47866) are untouched. `TestAccRedshiftIDCApplication_authorizedTokenIssuerList` gains an update step configuring two issuers, verifying both nested objects round-trip, followed by the existing `ImportStateVerify` step.


### Relations

Closes #48939
Kind of relates to: #47866

### References

https://docs.aws.amazon.com/redshift/latest/APIReference/API_CreateRedshiftIdcApplication.html
https://docs.aws.amazon.com/redshift/latest/APIReference/API_ModifyRedshiftIdcApplication.html


### AI Usage
The validator removal, test changes, and changelog entry were drafted with an AI coding agent; I reviewed every line, and verified the behavior against a live three-issuer application and an offline plan with the patched provider.

### Output from Acceptance Testing
I cannot run the acceptance test: it requires an IAM Identity Center-enabled organization instance, which I can't create in the accounts available to me. For maintainers:
```console
% make testacc TESTS=TestAccRedshiftIDCApplication_authorizedTokenIssuerList PKG=redshift
```
Verified locally instead: go build / go vet / package unit tests / gofmt / all five .ci/.golangci*.yml configs / providerlint / terrafmt - clean; plus a terraform plan with this branch's provider via dev_overrides accepting a three-authorized_token_issuer configuration that the released provider rejects. 
One note for the acceptance run: if the API returns issuers in a different order than configured, the indexed test checks will flake.