### PR TITLE
🤖🤖🤖 r/aws_cloudwatch_log_subscription_filter: Add `@source.log` to `emit_system_fields`

### DIFF
--- a/.changelog/48956.txt
+++ b/.changelog/48956.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_cloudwatch_log_subscription_filter: Add `@source.log` as a valid value for `emit_system_fields`
+```

--- a/internal/service/logs/subscription_filter.go
+++ b/internal/service/logs/subscription_filter.go
@@ -75,7 +75,7 @@ func resourceSubscriptionFilter() *schema.Resource {
 					Optional: true,
 					Elem: &schema.Schema{
 						Type:         schema.TypeString,
-						ValidateFunc: validation.StringInSlice([]string{"@aws.account", "@aws.region"}, false),
+						ValidateFunc: validation.StringInSlice([]string{"@aws.account", "@aws.region", "@source.log"}, false),
 					},
 				},
 				"filter_pattern": {

--- a/internal/service/logs/subscription_filter_test.go
+++ b/internal/service/logs/subscription_filter_test.go
@@ -276,6 +276,14 @@ func TestAccLogsSubscriptionFilter_emitSystemFields(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccSubscriptionFilterConfig_emitSystemFields(rName, "[\"@aws.account\", \"@aws.region\", \"@source.log\"]"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSubscriptionFilterExists(ctx, t, resourceName, &filter),
+					resource.TestCheckResourceAttr(resourceName, "emit_system_fields.#", "3"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "emit_system_fields.*", "@source.log"),
+				),
+			},
+			{
 				Config: testAccSubscriptionFilterConfig_emitSystemFields(rName, "[]"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubscriptionFilterExists(ctx, t, resourceName, &filter),

--- a/internal/service/logs/subscription_filter_test.go
+++ b/internal/service/logs/subscription_filter_test.go
@@ -11,8 +11,11 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tflogs "github.com/hashicorp/terraform-provider-aws/internal/service/logs"
@@ -255,9 +258,17 @@ func TestAccLogsSubscriptionFilter_emitSystemFields(t *testing.T) {
 				Config: testAccSubscriptionFilterConfig_emitSystemFields(rName, "[\"@aws.region\"]"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubscriptionFilterExists(ctx, t, resourceName, &filter),
-					resource.TestCheckResourceAttr(resourceName, "emit_system_fields.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "emit_system_fields.0", "@aws.region"),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("emit_system_fields"), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.StringExact("@aws.region"),
+					})),
+				},
 			},
 			{
 				ResourceName:            resourceName,
@@ -270,18 +281,36 @@ func TestAccLogsSubscriptionFilter_emitSystemFields(t *testing.T) {
 				Config: testAccSubscriptionFilterConfig_emitSystemFields(rName, "[\"@aws.account\", \"@aws.region\"]"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubscriptionFilterExists(ctx, t, resourceName, &filter),
-					resource.TestCheckResourceAttr(resourceName, "emit_system_fields.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "emit_system_fields.0", "@aws.account"),
-					resource.TestCheckResourceAttr(resourceName, "emit_system_fields.1", "@aws.region"),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("emit_system_fields"), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.StringExact("@aws.account"),
+						knownvalue.StringExact("@aws.region"),
+					})),
+				},
 			},
 			{
 				Config: testAccSubscriptionFilterConfig_emitSystemFields(rName, "[\"@aws.account\", \"@aws.region\", \"@source.log\"]"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubscriptionFilterExists(ctx, t, resourceName, &filter),
-					resource.TestCheckResourceAttr(resourceName, "emit_system_fields.#", "3"),
-					resource.TestCheckTypeSetElemAttr(resourceName, "emit_system_fields.*", "@source.log"),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("emit_system_fields"), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.StringExact("@aws.account"),
+						knownvalue.StringExact("@aws.region"),
+						knownvalue.StringExact("@source.log"),
+					})),
+				},
 			},
 			{
 				Config: testAccSubscriptionFilterConfig_emitSystemFields(rName, "[]"),
@@ -289,6 +318,14 @@ func TestAccLogsSubscriptionFilter_emitSystemFields(t *testing.T) {
 					testAccCheckSubscriptionFilterExists(ctx, t, resourceName, &filter),
 					resource.TestCheckResourceAttr(resourceName, "emit_system_fields.#", "0"),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("emit_system_fields"), knownvalue.SetSizeExact(0)),
+				},
 			},
 			{
 				ResourceName:            resourceName,

--- a/website/docs/r/cloudwatch_log_subscription_filter.html.markdown
+++ b/website/docs/r/cloudwatch_log_subscription_filter.html.markdown
@@ -29,7 +29,7 @@ This resource supports the following arguments:
 
 * `destination_arn` - (Required) ARN of the destination to deliver matching log events to. Kinesis stream or Lambda function ARN.
 * `distribution` - (Optional) Method used to distribute log data to the destination. By default log data is grouped by log stream, but the grouping can be set to random for a more even distribution. This property is only applicable when the destination is an Amazon Kinesis stream. Valid values are "Random" and "ByLogStream".
-* `emit_system_fields` - (Optional) List of system fields to include in the log events sent to the subscription destination. These fields provide source information for centralized log data in the forwarded payload. Valid values: `"@aws.account"`, `"@aws.region"`. To remove this argument after it has been set, specify an empty list `[]` explicitly to avoid perpetual differences.
+* `emit_system_fields` - (Optional) List of system fields to include in the log events sent to the subscription destination. These fields provide source information for centralized log data in the forwarded payload. Valid values: `"@aws.account"`, `"@aws.region"`, `"@source.log"`. To remove this argument after it has been set, specify an empty list `[]` explicitly to avoid perpetual differences.
 * `filter_pattern` - (Required) Valid CloudWatch Logs filter pattern for subscribing to a filtered stream of log events. Use empty string `""` to match everything. For more information, see the [Amazon CloudWatch Logs User Guide](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html).
 * `log_group_name` - (Required) Name of the log group to associate the subscription filter with.
 * `name` - (Required) Name for the subscription filter.


### PR DESCRIPTION
### Description

AWS added the `@source.log` system field to CloudWatch Logs subscription filters, completing the set alongside the existing `@aws.account` and `@aws.region`. When it is included in a subscription filter's `emitSystemFields`, each delivered log event carries the original source log group name under `extractedFields`:

```json
{
  "message": "your log line",
  "extractedFields": {
    "@aws.account": "111122223333",
    "@aws.region": "us-east-1",
    "@source.log": "/my/app/log-group"
  }
}
```

This lets operators centralize many log groups into a single static destination log group (via Firehose, cross-account subscriptions, etc.) while still identifying the origin of each event — previously the source log group name was lost when a static destination was used.

`aws_cloudwatch_log_subscription_filter` already exposes `emit_system_fields`, but its validation allowed only `@aws.account` and `@aws.region`. This PR adds `@source.log` to that allowlist. The AWS SDK field is a free-form `[]string` (`EmitSystemFields`), so only the provider-side validation, documentation, and acceptance test are updated.

### References

* CloudWatch Logs `PutSubscriptionFilter` API — `emitSystemFields`
* AWS CLI usage:
  ```
  aws logs put-subscription-filter \
    --emit-system-fields '@aws.account' '@aws.region' '@source.log' \
    ...
  ```

> [!NOTE]
> Opening as a **draft**: `@source.log` is live on the CloudWatch Logs API, but the public API reference that lists it as a valid `emitSystemFields` value is still being published by AWS. I'll add the doc link and mark ready for review once it's available.

### Output from Acceptance Testing

Acceptance tests require live AWS credentials and were not run in this environment. `TestAccLogsSubscriptionFilter_emitSystemFields` was extended to cover `@source.log`. `gofmt`, `go build`, and `go vet` on `./internal/service/logs/` pass locally.

```
$ make testacc TESTS=TestAccLogsSubscriptionFilter_emitSystemFields PKG=logs
# not run locally — requires AWS credentials
```

---
<sub>Drafted with an AI coding agent at my direction; I own and am accountable for this change.</sub>
