### PR TITLE
New Data Source: `aws_elasticache_service_update_actions`

### DIFF
--- a/.changelog/48958.txt
+++ b/.changelog/48958.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_elasticache_service_update_actions
+```

--- a/internal/acctest/knownvalue/list_not_empty.go
+++ b/internal/acctest/knownvalue/list_not_empty.go
@@ -29,7 +29,7 @@ func (v listNotEmpty) CheckValue(other any) error {
 
 // String returns the string representation of the value.
 func (v listNotEmpty) String() string {
-	return "stuff"
+	return "non-empty list"
 }
 
 // ListNotEmpty returns a Check for asserting that a list is not empty.

--- a/internal/acctest/knownvalue/set_not_empty.go
+++ b/internal/acctest/knownvalue/set_not_empty.go
@@ -1,0 +1,38 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package knownvalue
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+)
+
+var _ knownvalue.Check = setNotEmpty{}
+
+type setNotEmpty struct{}
+
+func (v setNotEmpty) CheckValue(other any) error {
+	otherVal, ok := other.([]any)
+	if !ok {
+		return fmt.Errorf("expected []any value for SetNotEmpty check, got: %T", other)
+	}
+
+	if len(otherVal) == 0 {
+		return errors.New("expected non-empty set for SetNotEmpty check")
+	}
+
+	return nil
+}
+
+// String returns the string representation of the value.
+func (v setNotEmpty) String() string {
+	return "non-empty set"
+}
+
+// SetNotEmpty returns a Check for asserting that a set is not empty.
+func SetNotEmpty() setNotEmpty {
+	return setNotEmpty{}
+}

--- a/internal/service/elasticache/service_package_gen.go
+++ b/internal/service/elasticache/service_package_gen.go
@@ -35,6 +35,12 @@ func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*inttypes.S
 			Region:   inttypes.ResourceRegionDefault(),
 		},
 		{
+			Factory:  newServiceUpdateActionsDataSource,
+			TypeName: "aws_elasticache_service_update_actions",
+			Name:     "Service Update Actions",
+			Region:   inttypes.ResourceRegionDefault(),
+		},
+		{
 			Factory:  newServiceUpdatesDataSource,
 			TypeName: "aws_elasticache_service_updates",
 			Name:     "Service Updates",

--- a/internal/service/elasticache/service_update_actions_data_source.go
+++ b/internal/service/elasticache/service_update_actions_data_source.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
 	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/smerr"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 // @FrameworkDataSource("aws_elasticache_service_update_actions", name="Service Update Actions")
@@ -42,6 +43,11 @@ func (d *serviceUpdateActionsDataSource) Schema(ctx context.Context, req datasou
 			},
 			"replication_group_id": schema.StringAttribute{
 				Optional: true,
+			},
+			"service_update_status": schema.SetAttribute{
+				Optional:    true,
+				CustomType:  fwtypes.SetOfStringEnumType[awstypes.ServiceUpdateStatus](),
+				ElementType: fwtypes.StringEnumType[awstypes.ServiceUpdateStatus](),
 			},
 			"update_actions": framework.DataSourceComputedListOfObjectAttribute[updateActionModel](ctx),
 		},
@@ -99,9 +105,10 @@ func (d *serviceUpdateActionsDataSource) ConfigValidators(context.Context) []dat
 
 type serviceUpdateActionsDataSourceModel struct {
 	framework.WithRegionModel
-	CacheClusterID     types.String                                       `tfsdk:"cache_cluster_id" autoflex:"-"`
-	ReplicationGroupID types.String                                       `tfsdk:"replication_group_id" autoflex:"-"`
-	UpdateActions      fwtypes.ListNestedObjectValueOf[updateActionModel] `tfsdk:"update_actions" autoflex:"-"`
+	CacheClusterID      types.String                                          `tfsdk:"cache_cluster_id" autoflex:"-"`
+	ReplicationGroupID  types.String                                          `tfsdk:"replication_group_id" autoflex:"-"`
+	ServiceUpdateStatus fwtypes.SetOfStringEnum[awstypes.ServiceUpdateStatus] `tfsdk:"service_update_status"`
+	UpdateActions       fwtypes.ListNestedObjectValueOf[updateActionModel]    `tfsdk:"update_actions" autoflex:"-"`
 }
 
 type updateActionModel struct {
@@ -128,4 +135,14 @@ func findServiceUpdateActions(ctx context.Context, conn *elasticache.Client, inp
 	}
 
 	return output, nil
+}
+
+func findServiceUpdateAction(ctx context.Context, conn *elasticache.Client, input *elasticache.DescribeUpdateActionsInput) (*awstypes.UpdateAction, error) {
+	output, err := findServiceUpdateActions(ctx, conn, input)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return tfresource.AssertSingleValueResult(output)
 }

--- a/internal/service/elasticache/service_update_actions_data_source.go
+++ b/internal/service/elasticache/service_update_actions_data_source.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/elasticache"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/datasourcevalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -112,11 +113,17 @@ type serviceUpdateActionsDataSourceModel struct {
 }
 
 type updateActionModel struct {
-	CacheClusterID      types.String `tfsdk:"cache_cluster_id"`
-	Engine              types.String `tfsdk:"engine"`
-	EstimatedUpdateTime types.String `tfsdk:"estimated_update_time"`
-	ReplicationGroupID  types.String `tfsdk:"replication_group_id"`
-	ServiceUpdateName   types.String `tfsdk:"service_update_name"`
+	CacheClusterID                      types.String      `tfsdk:"cache_cluster_id"`
+	Engine                              types.String      `tfsdk:"engine"`
+	EstimatedUpdateTime                 types.String      `tfsdk:"estimated_update_time"`
+	ReplicationGroupID                  types.String      `tfsdk:"replication_group_id"`
+	ServiceUpdateName                   types.String      `tfsdk:"service_update_name"`
+	ServiceUpdateRecommendedApplyByDate timetypes.RFC3339 `tfsdk:"recommended_apply_by_date"`
+	ServiceUpdateReleaseDate            timetypes.RFC3339 `tfsdk:"release_date"`
+	ServiceUpdateSeverity               types.String      `tfsdk:"service_update_severity"`
+	ServiceUpdateStatus                 types.String      `tfsdk:"service_update_status"`
+	ServiceUpdateType                   types.String      `tfsdk:"service_update_type"`
+	UpdateActionStatus                  types.String      `tfsdk:"update_action_status"`
 }
 
 func findServiceUpdateActions(ctx context.Context, conn *elasticache.Client, input *elasticache.DescribeUpdateActionsInput) ([]awstypes.UpdateAction, error) {

--- a/internal/service/elasticache/service_update_actions_data_source.go
+++ b/internal/service/elasticache/service_update_actions_data_source.go
@@ -10,8 +10,10 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/elasticache"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
+	"github.com/hashicorp/terraform-plugin-framework-validators/datasourcevalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
@@ -35,6 +37,9 @@ type serviceUpdateActionsDataSource struct {
 func (d *serviceUpdateActionsDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
+			"cache_cluster_id": schema.StringAttribute{
+				Optional: true,
+			},
 			"replication_group_id": schema.StringAttribute{
 				Optional: true,
 			},
@@ -57,6 +62,7 @@ func (d *serviceUpdateActionsDataSource) Read(ctx context.Context, req datasourc
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	input.CacheClusterIds = flex.StringSliceValueFromFramework(ctx, data.CacheClusterID)
 	input.ReplicationGroupIds = flex.StringSliceValueFromFramework(ctx, data.ReplicationGroupID)
 
 	updateActions, err := findServiceUpdateActions(ctx, conn, &input)
@@ -82,8 +88,18 @@ func (d *serviceUpdateActionsDataSource) Read(ctx context.Context, req datasourc
 	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, &data))
 }
 
+func (d *serviceUpdateActionsDataSource) ConfigValidators(context.Context) []datasource.ConfigValidator {
+	return []datasource.ConfigValidator{
+		datasourcevalidator.Conflicting(
+			path.MatchRoot("cache_cluster_id"),
+			path.MatchRoot("replication_group_id"),
+		),
+	}
+}
+
 type serviceUpdateActionsDataSourceModel struct {
 	framework.WithRegionModel
+	CacheClusterID     types.String                                       `tfsdk:"cache_cluster_id" autoflex:"-"`
 	ReplicationGroupID types.String                                       `tfsdk:"replication_group_id" autoflex:"-"`
 	UpdateActions      fwtypes.ListNestedObjectValueOf[updateActionModel] `tfsdk:"update_actions" autoflex:"-"`
 }

--- a/internal/service/elasticache/service_update_actions_data_source.go
+++ b/internal/service/elasticache/service_update_actions_data_source.go
@@ -35,6 +35,9 @@ type serviceUpdateActionsDataSource struct {
 func (d *serviceUpdateActionsDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
+			"replication_group_id": schema.StringAttribute{
+				Optional: true,
+			},
 			"update_actions": framework.DataSourceComputedListOfObjectAttribute[updateActionModel](ctx),
 		},
 	}
@@ -50,29 +53,46 @@ func (d *serviceUpdateActionsDataSource) Read(ctx context.Context, req datasourc
 	}
 
 	var input elasticache.DescribeUpdateActionsInput
-	updateActions, err := findServiceUpdateActions(ctx, conn, &input)
-	if err != nil {
-		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, "xxx")
-		return
-	}
-
-	smerr.AddEnrich(ctx, &resp.Diagnostics, flex.Flatten(ctx, updateActions, &data.UpdateActions), smerr.ID, "xxx")
+	resp.Diagnostics.Append(flex.Expand(ctx, data, &input)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	input.ReplicationGroupIds = flex.StringSliceValueFromFramework(ctx, data.ReplicationGroupID)
 
-	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, &data), smerr.ID, "xxx")
+	updateActions, err := findServiceUpdateActions(ctx, conn, &input)
+	if err != nil {
+		smerr.AddError(ctx, &resp.Diagnostics, err)
+		return
+	}
+
+	if len(updateActions) == 0 {
+		v, d := fwtypes.NewListNestedObjectValueOfValueSlice(ctx, []updateActionModel{})
+		smerr.AddEnrich(ctx, &resp.Diagnostics, d)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		data.UpdateActions = v
+	} else {
+		smerr.AddEnrich(ctx, &resp.Diagnostics, flex.Flatten(ctx, updateActions, &data.UpdateActions))
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
+	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, &data))
 }
 
 type serviceUpdateActionsDataSourceModel struct {
 	framework.WithRegionModel
-	UpdateActions fwtypes.ListNestedObjectValueOf[updateActionModel] `tfsdk:"update_actions"`
+	ReplicationGroupID types.String                                       `tfsdk:"replication_group_id" autoflex:"-"`
+	UpdateActions      fwtypes.ListNestedObjectValueOf[updateActionModel] `tfsdk:"update_actions" autoflex:"-"`
 }
 
 type updateActionModel struct {
 	CacheClusterID      types.String `tfsdk:"cache_cluster_id"`
 	Engine              types.String `tfsdk:"engine"`
 	EstimatedUpdateTime types.String `tfsdk:"estimated_update_time"`
+	ReplicationGroupID  types.String `tfsdk:"replication_group_id"`
 	ServiceUpdateName   types.String `tfsdk:"service_update_name"`
 }
 

--- a/internal/service/elasticache/service_update_actions_data_source.go
+++ b/internal/service/elasticache/service_update_actions_data_source.go
@@ -20,7 +20,6 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
 	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/smerr"
-	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 // @FrameworkDataSource("aws_elasticache_service_update_actions", name="Service Update Actions")
@@ -138,18 +137,7 @@ func findServiceUpdateActions(ctx context.Context, conn *elasticache.Client, inp
 		}
 
 		output = append(output, page.UpdateActions...)
-
 	}
 
 	return output, nil
-}
-
-func findServiceUpdateAction(ctx context.Context, conn *elasticache.Client, input *elasticache.DescribeUpdateActionsInput) (*awstypes.UpdateAction, error) {
-	output, err := findServiceUpdateActions(ctx, conn, input)
-
-	if err != nil {
-		return nil, err
-	}
-
-	return tfresource.AssertSingleValueResult(output)
 }

--- a/internal/service/elasticache/service_update_actions_data_source.go
+++ b/internal/service/elasticache/service_update_actions_data_source.go
@@ -1,0 +1,95 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+// DONOTCOPY: Copying old resources spreads bad habits. Use skaff instead.
+
+package elasticache
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/elasticache"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/smerr"
+)
+
+// @FrameworkDataSource("aws_elasticache_service_update_actions", name="Service Update Actions")
+func newServiceUpdateActionsDataSource(context.Context) (datasource.DataSourceWithConfigure, error) {
+	return &serviceUpdateActionsDataSource{}, nil
+}
+
+const (
+	DSNameServiceUpdateActions = "Service Update Actions Data Source"
+)
+
+type serviceUpdateActionsDataSource struct {
+	framework.DataSourceWithModel[serviceUpdateActionsDataSourceModel]
+}
+
+func (d *serviceUpdateActionsDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"update_actions": framework.DataSourceComputedListOfObjectAttribute[updateActionModel](ctx),
+		},
+	}
+}
+
+func (d *serviceUpdateActionsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	conn := d.Meta().ElastiCacheClient(ctx)
+
+	var data serviceUpdateActionsDataSourceModel
+	smerr.AddEnrich(ctx, &resp.Diagnostics, req.Config.Get(ctx, &data))
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var input elasticache.DescribeUpdateActionsInput
+	updateActions, err := findServiceUpdateActions(ctx, conn, &input)
+	if err != nil {
+		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, "xxx")
+		return
+	}
+
+	smerr.AddEnrich(ctx, &resp.Diagnostics, flex.Flatten(ctx, updateActions, &data.UpdateActions), smerr.ID, "xxx")
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, &data), smerr.ID, "xxx")
+}
+
+type serviceUpdateActionsDataSourceModel struct {
+	framework.WithRegionModel
+	UpdateActions fwtypes.ListNestedObjectValueOf[updateActionModel] `tfsdk:"update_actions"`
+}
+
+type updateActionModel struct {
+	CacheClusterID      types.String `tfsdk:"cache_cluster_id"`
+	Engine              types.String `tfsdk:"engine"`
+	EstimatedUpdateTime types.String `tfsdk:"estimated_update_time"`
+	ServiceUpdateName   types.String `tfsdk:"service_update_name"`
+}
+
+func findServiceUpdateActions(ctx context.Context, conn *elasticache.Client, input *elasticache.DescribeUpdateActionsInput) ([]awstypes.UpdateAction, error) {
+	var output []awstypes.UpdateAction
+
+	pages := elasticache.NewDescribeUpdateActionsPaginator(conn, input)
+
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		output = append(output, page.UpdateActions...)
+
+	}
+
+	return output, nil
+}

--- a/internal/service/elasticache/service_update_actions_data_source_test.go
+++ b/internal/service/elasticache/service_update_actions_data_source_test.go
@@ -1,0 +1,46 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package elasticache_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccElastiCacheServiceUpdateActionsDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	dataSourceName := "data.aws_elasticache_service_update_actions.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.ElastiCacheEndpointID)
+			testAccPreCheck(t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             acctest.CheckDestroyNoop,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceUpdateActionsDataSourceConfig_basic(),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("update_actions"), knownvalue.NotNull()),
+				},
+			},
+		},
+	})
+}
+
+func testAccServiceUpdateActionsDataSourceConfig_basic() string {
+	return `
+data "aws_elasticache_service_update_actions" "test" {}
+`
+}

--- a/internal/service/elasticache/service_update_actions_data_source_test.go
+++ b/internal/service/elasticache/service_update_actions_data_source_test.go
@@ -171,7 +171,7 @@ data "aws_elasticache_service_update_actions" "test" {
 resource "time_sleep" "wait" {
   create_duration = "10m"
 
-  depends_on  = [aws_elasticache_replication_group.test]
+  depends_on = [aws_elasticache_replication_group.test]
 }
 `)
 }
@@ -189,7 +189,7 @@ data "aws_elasticache_service_update_actions" "test" {
 resource "time_sleep" "wait" {
   create_duration = "10m"
 
-  depends_on  = [aws_elasticache_cluster.test]
+  depends_on = [aws_elasticache_cluster.test]
 }
 `)
 }
@@ -209,7 +209,7 @@ data "aws_elasticache_service_update_actions" "test" {
 resource "time_sleep" "wait" {
   create_duration = "10m"
 
-  depends_on  = [aws_elasticache_replication_group.test]
+  depends_on = [aws_elasticache_replication_group.test]
 }
 `)
 }

--- a/internal/service/elasticache/service_update_actions_data_source_test.go
+++ b/internal/service/elasticache/service_update_actions_data_source_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	tfknownvalue "github.com/hashicorp/terraform-provider-aws/internal/acctest/knownvalue"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -19,7 +20,7 @@ func TestAccElastiCacheServiceUpdateActionsDataSource_basic(t *testing.T) {
 
 	dataSourceName := "data.aws_elasticache_service_update_actions.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, names.ElastiCacheEndpointID)
@@ -39,8 +40,58 @@ func TestAccElastiCacheServiceUpdateActionsDataSource_basic(t *testing.T) {
 	})
 }
 
+func TestAccElastiCacheServiceUpdateActionsDataSource_replicationGroupID(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	dataSourceName := "data.aws_elasticache_service_update_actions.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.ElastiCacheEndpointID)
+			testAccPreCheck(t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {
+				Source:            "hashicorp/time",
+				VersionConstraint: "0.14.0",
+			},
+		},
+		CheckDestroy: acctest.CheckDestroyNoop,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceUpdateActionsDataSourceConfig_replicationGroupID(rName),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("update_actions"), tfknownvalue.SetNotEmpty()),
+				},
+			},
+		},
+	})
+}
+
 func testAccServiceUpdateActionsDataSourceConfig_basic() string {
 	return `
 data "aws_elasticache_service_update_actions" "test" {}
 `
+}
+
+func testAccServiceUpdateActionsDataSourceConfig_replicationGroupID(rName string) string {
+	return acctest.ConfigCompose(
+		testAccReplicationGroupConfig_basic_engine(rName, "valkey"), `
+data "aws_elasticache_service_update_actions" "test" {
+  replication_group_id = aws_elasticache_replication_group.test.replication_group_id
+
+  depends_on = [time_sleep.wait]
+}
+
+# It takes approximately 10 minutes for Update Actions to be registered after the Replication Group becomes available.
+resource "time_sleep" "wait" {
+  create_duration = "10m"
+
+  depends_on  = [aws_elasticache_replication_group.test]
+}
+`)
 }

--- a/internal/service/elasticache/service_update_actions_data_source_test.go
+++ b/internal/service/elasticache/service_update_actions_data_source_test.go
@@ -6,6 +6,7 @@ package elasticache_test
 import (
 	"testing"
 
+	awstypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
 	"github.com/hashicorp/terraform-plugin-testing/compare"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
@@ -36,6 +37,7 @@ func TestAccElastiCacheServiceUpdateActionsDataSource_basic(t *testing.T) {
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("cache_cluster_id"), knownvalue.Null()),
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("replication_group_id"), knownvalue.Null()),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("service_update_status"), knownvalue.Null()),
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("update_actions"), knownvalue.NotNull()),
 				},
 			},
@@ -70,6 +72,7 @@ func TestAccElastiCacheServiceUpdateActionsDataSource_replicationGroupID(t *test
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("cache_cluster_id"), knownvalue.Null()),
 					statecheck.CompareValuePairs(dataSourceName, tfjsonpath.New("replication_group_id"), "aws_elasticache_replication_group.test", tfjsonpath.New("replication_group_id"), compare.ValuesSame()),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("service_update_status"), knownvalue.Null()),
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("update_actions"), tfknownvalue.SetNotEmpty()),
 				},
 			},
@@ -104,6 +107,44 @@ func TestAccElastiCacheServiceUpdateActionsDataSource_clusterID(t *testing.T) {
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.CompareValuePairs(dataSourceName, tfjsonpath.New("cache_cluster_id"), "aws_elasticache_cluster.test", tfjsonpath.New("cluster_id"), compare.ValuesSame()),
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("replication_group_id"), knownvalue.Null()),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("service_update_status"), knownvalue.Null()),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("update_actions"), tfknownvalue.SetNotEmpty()),
+				},
+			},
+		},
+	})
+}
+
+func TestAccElastiCacheServiceUpdateActionsDataSource_serviceUpdateStatus(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	dataSourceName := "data.aws_elasticache_service_update_actions.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.ElastiCacheEndpointID)
+			testAccPreCheck(t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {
+				Source:            "hashicorp/time",
+				VersionConstraint: "0.14.0",
+			},
+		},
+		CheckDestroy: acctest.CheckDestroyNoop,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceUpdateActionsDataSourceConfig_serviceUpdateStatus(rName),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("cache_cluster_id"), knownvalue.Null()),
+					statecheck.CompareValuePairs(dataSourceName, tfjsonpath.New("replication_group_id"), "aws_elasticache_replication_group.test", tfjsonpath.New("replication_group_id"), compare.ValuesSame()),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("service_update_status"), knownvalue.SetExact([]knownvalue.Check{
+						tfknownvalue.StringExact(awstypes.ServiceUpdateStatusAvailable),
+					})),
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("update_actions"), tfknownvalue.SetNotEmpty()),
 				},
 			},
@@ -149,6 +190,26 @@ resource "time_sleep" "wait" {
   create_duration = "10m"
 
   depends_on  = [aws_elasticache_cluster.test]
+}
+`)
+}
+
+func testAccServiceUpdateActionsDataSourceConfig_serviceUpdateStatus(rName string) string {
+	return acctest.ConfigCompose(
+		testAccReplicationGroupConfig_basic_engine(rName, "valkey"), `
+data "aws_elasticache_service_update_actions" "test" {
+  replication_group_id = aws_elasticache_replication_group.test.replication_group_id
+
+  service_update_status = ["available"]
+
+  depends_on = [time_sleep.wait]
+}
+
+# It takes approximately 10 minutes for Update Actions to be registered after the Replication Group becomes available.
+resource "time_sleep" "wait" {
+  create_duration = "10m"
+
+  depends_on  = [aws_elasticache_replication_group.test]
 }
 `)
 }

--- a/internal/service/elasticache/service_update_actions_data_source_test.go
+++ b/internal/service/elasticache/service_update_actions_data_source_test.go
@@ -6,6 +6,7 @@ package elasticache_test
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-testing/compare"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -33,6 +34,8 @@ func TestAccElastiCacheServiceUpdateActionsDataSource_basic(t *testing.T) {
 			{
 				Config: testAccServiceUpdateActionsDataSourceConfig_basic(),
 				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("cache_cluster_id"), knownvalue.Null()),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("replication_group_id"), knownvalue.Null()),
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("update_actions"), knownvalue.NotNull()),
 				},
 			},
@@ -65,6 +68,42 @@ func TestAccElastiCacheServiceUpdateActionsDataSource_replicationGroupID(t *test
 			{
 				Config: testAccServiceUpdateActionsDataSourceConfig_replicationGroupID(rName),
 				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("cache_cluster_id"), knownvalue.Null()),
+					statecheck.CompareValuePairs(dataSourceName, tfjsonpath.New("replication_group_id"), "aws_elasticache_replication_group.test", tfjsonpath.New("replication_group_id"), compare.ValuesSame()),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("update_actions"), tfknownvalue.SetNotEmpty()),
+				},
+			},
+		},
+	})
+}
+
+func TestAccElastiCacheServiceUpdateActionsDataSource_clusterID(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	dataSourceName := "data.aws_elasticache_service_update_actions.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.ElastiCacheEndpointID)
+			testAccPreCheck(t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {
+				Source:            "hashicorp/time",
+				VersionConstraint: "0.14.0",
+			},
+		},
+		CheckDestroy: acctest.CheckDestroyNoop,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceUpdateActionsDataSourceConfig_clusterID(rName),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.CompareValuePairs(dataSourceName, tfjsonpath.New("cache_cluster_id"), "aws_elasticache_cluster.test", tfjsonpath.New("cluster_id"), compare.ValuesSame()),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("replication_group_id"), knownvalue.Null()),
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("update_actions"), tfknownvalue.SetNotEmpty()),
 				},
 			},
@@ -92,6 +131,24 @@ resource "time_sleep" "wait" {
   create_duration = "10m"
 
   depends_on  = [aws_elasticache_replication_group.test]
+}
+`)
+}
+
+func testAccServiceUpdateActionsDataSourceConfig_clusterID(rName string) string {
+	return acctest.ConfigCompose(
+		testAccClusterConfig_engineRedis(rName), `
+data "aws_elasticache_service_update_actions" "test" {
+  cache_cluster_id = aws_elasticache_cluster.test.cluster_id
+
+  depends_on = [time_sleep.wait]
+}
+
+# It takes approximately 10 minutes for Update Actions to be registered after the Cache Cluster becomes available.
+resource "time_sleep" "wait" {
+  create_duration = "10m"
+
+  depends_on  = [aws_elasticache_cluster.test]
 }
 `)
 }

--- a/website/docs/d/elasticache_service_update_actions.html.markdown
+++ b/website/docs/d/elasticache_service_update_actions.html.markdown
@@ -1,0 +1,53 @@
+---
+subcategory: "ElastiCache"
+layout: "aws"
+page_title: "AWS: aws_elasticache_service_update_actions"
+description: |-
+  Provides details about an AWS ElastiCache Service Update Actions.
+---
+
+# Data Source: aws_elasticache_service_update_actions
+
+Provides details about an AWS ElastiCache Service Update Actions for a given Cache Cluster or Replication Group.
+
+When creating a new Cache Cluster or Replication Group, it takes approximately 10 minutes for Update Actions to be listed.
+
+## Example Usage
+
+### Basic Usage
+
+The following example will list all Update Actions for the Cache Cluster with a service update status of `available`.
+
+```terraform
+data "aws_elasticache_service_update_actions" "example" {
+  cache_cluster_id = aws_elasticache_cluster.example.cluster_id
+
+  service_update_status = ["available"]
+}
+```
+
+## Argument Reference
+
+This data source supports the following arguments:
+
+* `cache_cluster_id` - (Optional) ID of Cache Cluster to list updates for. If neither `cache_cluster_id` nor `replication_group_id` are specified, all service update actions will be listed.
+* `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
+* `replication_group_id` - (Optional) ID of Replication Group to list updates for. If neither `replication_group_id` nor `cache_cluster_id` are specified, all service update actions will be listed.
+* `service_update_status` - (Optional) Service update statuses to include in list. Valid values are `available`, `cancelled`, and `expired`. If no value is specified, service updates in all statuses will be listed.
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `update_actions` - Set of Service Update Actions. Each element has the following attributes:
+    * `cache_cluster_id` - ID of Cache Cluster this update action applies to.
+    * `engine` - Engine this update applies to.
+    * `estimated_update_time` - Estimated duration of update.
+    * `replication_group_id` - ID of Replication Group this update action applies to.
+    * `service_update_name` - Name of the update.
+    * `recommended_apply_by_date` - Date the update should be applied by.
+    * `release_date` - Date the update was released.
+    * `service_update_severity` - Severity of the update. One of `critical`, `important`, `medium`, or `low`.
+    * `service_update_status` - Availability of the update. One of `available`, `cancelled`, or `expired`.
+    * `service_update_type` - Type of the update.
+    * `update_action_status` - Status of the update action.


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

New Data Source: `aws_elasticache_service_updates`

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #20112

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=elasticache TESTS=TestAccElastiCacheServiceUpdateActionsDataSource_

--- PASS: TestAccElastiCacheServiceUpdateActionsDataSource_basic (13.25s)
--- PASS: TestAccElastiCacheServiceUpdateActionsDataSource_clusterID (1014.82s)
--- PASS: TestAccElastiCacheServiceUpdateActionsDataSource_replicationGroupID (1273.87s)
--- PASS: TestAccElastiCacheServiceUpdateActionsDataSource_serviceUpdateStatus (1273.87s)
```
