### PR TITLE
New Action: `aws_elasticache_apply_service_update`

### DIFF
--- a/.changelog/48963.txt
+++ b/.changelog/48963.txt
@@ -1,0 +1,3 @@
+```release-note:new-action
+aws_elasticache_apply_service_update
+```

--- a/internal/framework/action_with_model.go
+++ b/internal/framework/action_with_model.go
@@ -5,11 +5,16 @@ package framework
 
 import (
 	"context"
+	"maps"
 
-	"github.com/hashicorp/terraform-plugin-framework/action/schema"
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/action/timeouts"
+	actionschema "github.com/hashicorp/terraform-plugin-framework/action/schema"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 // ActionWithModel is a structure to be embedded within an Action that has a corresponding model.
@@ -19,7 +24,26 @@ type ActionWithModel[T any] struct {
 }
 
 // ValidateModel validates the action's model against a schema.
-func (a *ActionWithModel[T]) ValidateModel(ctx context.Context, schema *schema.Schema) diag.Diagnostics {
+func (a *ActionWithModel[T]) ValidateModel(ctx context.Context, schema *actionschema.Schema) diag.Diagnostics {
+	// An actions's model will contain a field like:
+	// 	Timeouts timeouts.Value `tfsdk:"timeouts"`
+	// Swap a blank timeouts block into the schema, preventing errors like:
+	//   Expected framework type from provider logic: timeouts.Type / underlying type: tftypes.Object["invoke":tftypes.String]
+	//   Received framework type from provider logic: timeouts.Type / underlying type: tftypes.Object[]
+	if schema.Blocks[names.AttrTimeouts] != nil {
+		s := *schema
+		s.Blocks = maps.Clone(s.Blocks)
+		s.Blocks[names.AttrTimeouts] = actionschema.SingleNestedBlock{
+			Attributes: map[string]actionschema.Attribute{},
+			CustomType: timeouts.Type{
+				ObjectType: types.ObjectType{
+					AttrTypes: map[string]attr.Type{},
+				},
+			},
+		}
+		schema = &s
+	}
+
 	var diags diag.Diagnostics
 	state := tfsdk.State{
 		Raw:    tftypes.NewValue(schema.Type().TerraformType(ctx), nil),
@@ -32,5 +56,5 @@ func (a *ActionWithModel[T]) ValidateModel(ctx context.Context, schema *schema.S
 }
 
 type ActionValidateModel interface {
-	ValidateModel(ctx context.Context, schema *schema.Schema) diag.Diagnostics
+	ValidateModel(ctx context.Context, schema *actionschema.Schema) diag.Diagnostics
 }

--- a/internal/framework/action_with_timeouts.go
+++ b/internal/framework/action_with_timeouts.go
@@ -1,0 +1,34 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package framework
+
+import (
+	"context"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/action/timeouts"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+type ActionWithTimeouts struct {
+	defaultInvokeTimeout time.Duration
+}
+
+func (w *ActionWithTimeouts) SetDefaultInvokeTimeout(timeout time.Duration) {
+	w.defaultInvokeTimeout = timeout
+}
+
+// InvokeTimeout returns any configured Invoke timeout value or the default value.
+func (w *ActionWithTimeouts) InvokeTimeout(ctx context.Context, timeouts timeouts.Value) time.Duration {
+	timeout, diags := timeouts.Invoke(ctx, w.defaultInvokeTimeout)
+
+	if errors := diags.Errors(); len(errors) > 0 {
+		tflog.Warn(ctx, "reading configured Invoke timeout", map[string]any{
+			"summary": errors[0].Summary(),
+			"detail":  errors[0].Detail(),
+		})
+	}
+
+	return timeout
+}

--- a/internal/framework/data_source_with_model.go
+++ b/internal/framework/data_source_with_model.go
@@ -36,7 +36,7 @@ type DataSourceValidateModel interface {
 	ValidateModel(ctx context.Context, schema *schema.Schema) diag.Diagnostics
 }
 
-// withModel is a structure to be embedded within a DataSource, EphemeralResource, or Resource that has a corresponding model.
+// withModel is a structure to be embedded within an Action, DataSource, EphemeralResource, or Resource that has a corresponding model.
 type withModel[T any] struct{}
 
 // validateModel validates the data source's model against a schema.

--- a/internal/service/elasticache/apply_service_update_action.go
+++ b/internal/service/elasticache/apply_service_update_action.go
@@ -174,7 +174,7 @@ func (a *applyServiceUpdateAction) Invoke(ctx context.Context, req action.Invoke
 	tflog.Info(ctx, "ElastiCache service update applied successfully")
 }
 
-func (d *applyServiceUpdateAction) ConfigValidators(context.Context) []action.ConfigValidator {
+func (a *applyServiceUpdateAction) ConfigValidators(context.Context) []action.ConfigValidator {
 	return []action.ConfigValidator{
 		actionvalidator.Conflicting(
 			path.MatchRoot("cache_cluster_id"),

--- a/internal/service/elasticache/apply_service_update_action.go
+++ b/internal/service/elasticache/apply_service_update_action.go
@@ -1,0 +1,192 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package elasticache
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/elasticache"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/action/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework-validators/actionvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/action"
+	"github.com/hashicorp/terraform-plugin-framework/action/schema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-provider-aws/internal/actionwait"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	fwactions "github.com/hashicorp/terraform-provider-aws/internal/framework/actions"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @Action("aws_elasticache_apply_service_update", name="Apply Service Update")
+func newApplyServiceUpdateAction(_ context.Context) (action.ActionWithConfigure, error) {
+	var r applyServiceUpdateAction
+	r.SetDefaultInvokeTimeout(1 * time.Hour)
+
+	return &r, nil
+}
+
+type applyServiceUpdateAction struct {
+	framework.ActionWithModel[applyServiceUpdateModel]
+	framework.ActionWithTimeouts
+}
+
+func (a *applyServiceUpdateAction) Schema(ctx context.Context, req action.SchemaRequest, resp *action.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"cache_cluster_id": schema.StringAttribute{
+				Optional: true,
+			},
+			"replication_group_id": schema.StringAttribute{
+				Optional: true,
+			},
+			"service_update_name": schema.StringAttribute{
+				Required: true,
+			},
+		},
+		Blocks: map[string]schema.Block{
+			names.AttrTimeouts: timeouts.Block(ctx),
+		},
+	}
+}
+
+func (a *applyServiceUpdateAction) Invoke(ctx context.Context, req action.InvokeRequest, resp *action.InvokeResponse) {
+	var config applyServiceUpdateModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	timeout := a.InvokeTimeout(ctx, config.Timeouts)
+
+	var input elasticache.BatchApplyUpdateActionInput
+	resp.Diagnostics.Append(flex.Expand(ctx, config, &input)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	input.CacheClusterIds = flex.StringSliceValueFromFramework(ctx, config.CacheClusterID)
+	input.ReplicationGroupIds = flex.StringSliceValueFromFramework(ctx, config.ReplicationGroupID)
+
+	var (
+		targetType string
+		targetKey  string
+		targetID   string
+	)
+	if !config.CacheClusterID.IsNull() {
+		targetType = "Cache Cluster"
+		targetKey = "cache_cluster_id"
+		targetID = config.CacheClusterID.ValueString()
+	} else if !config.ReplicationGroupID.IsNull() {
+		targetType = "Replication Group"
+		targetKey = "replication_group_id"
+		targetID = config.ReplicationGroupID.ValueString()
+	}
+
+	ctx = tflog.SetField(ctx, "service_update_name", config.ServiceUpdateName.ValueString())
+	ctx = tflog.SetField(ctx, targetKey, targetID)
+
+	tflog.Info(ctx, "Applying ElastiCache service update")
+
+	// Send initial progress update
+	cb := fwactions.NewSendProgressFunc(resp)
+	cb(ctx, "Applying ElastiCache service update %q for %s %q...", config.ServiceUpdateName.ValueString(), targetType, targetID)
+
+	conn := a.Meta().ElastiCacheClient(ctx)
+
+	output, err := conn.BatchApplyUpdateAction(ctx, &input)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Failed to Apply Service Update",
+			fmt.Sprintf("Could not apply ElastiCache service update %q for %s %q: %s", config.ServiceUpdateName.ValueString(), targetType, targetID, err),
+		)
+		return
+	}
+	if len(output.UnprocessedUpdateActions) > 0 {
+		uprocessedAction := output.UnprocessedUpdateActions[0]
+		resp.Diagnostics.AddError(
+			"Failed to Apply Service Update",
+			fmt.Sprintf("Could not apply ElastiCache service update %q for %s %q.\n\n", config.ServiceUpdateName.ValueString(), targetType, targetID)+
+				fmt.Sprintf("Error Type: %s\nError Message: %s", aws.ToString(uprocessedAction.ErrorType), aws.ToString(uprocessedAction.ErrorMessage)),
+		)
+		return
+	}
+
+	cb(ctx, "ElastiCache service update %q for %s %q started, waiting for completion...", config.ServiceUpdateName.ValueString(), targetType, targetID)
+
+	_, err = actionwait.WaitForStatus(ctx, func(ctx context.Context) (actionwait.FetchResult[*awstypes.UpdateAction], error) {
+		input := elasticache.DescribeUpdateActionsInput{
+			ServiceUpdateName: config.ServiceUpdateName.ValueStringPointer(),
+		}
+		input.CacheClusterIds = flex.StringSliceValueFromFramework(ctx, config.CacheClusterID)
+		input.ReplicationGroupIds = flex.StringSliceValueFromFramework(ctx, config.ReplicationGroupID)
+
+		output, err := findServiceUpdateAction(ctx, conn, &input)
+		if err != nil {
+			return actionwait.FetchResult[*awstypes.UpdateAction]{}, fmt.Errorf("getting update status: %w", err)
+		}
+		return actionwait.FetchResult[*awstypes.UpdateAction]{
+			Status: actionwait.Status(output.UpdateActionStatus),
+		}, nil
+	}, actionwait.Options[*awstypes.UpdateAction]{
+		Timeout:          timeout,
+		Interval:         actionwait.FixedInterval(actionwait.DefaultPollInterval),
+		ProgressInterval: 60 * time.Second,
+		SuccessStates:    []actionwait.Status{actionwait.Status(awstypes.UpdateActionStatusComplete)},
+		TransitionalStates: []actionwait.Status{
+			actionwait.Status(awstypes.UpdateActionStatusWaitingToStart),
+			actionwait.Status(awstypes.UpdateActionStatusInProgress),
+		},
+		ProgressSink: func(fr actionwait.FetchResult[any], meta actionwait.ProgressMeta) {
+			cb(ctx, "ElastiCache service update %q for %s %q is currently %q, continuing to wait for completion...", config.ServiceUpdateName.ValueString(), targetType, targetID, fr.Status)
+		},
+	})
+	if err != nil {
+		if errs.IsA[*actionwait.TimeoutError](err) {
+			resp.Diagnostics.AddError(
+				"Timeout Waiting for Service Update to Complete",
+				fmt.Sprintf("ElastiCache service update %q for %s %q did not complete within %s: %s", config.ServiceUpdateName.ValueString(), targetType, targetID, timeout, err),
+			)
+		} else if errs.IsA[*actionwait.UnexpectedStateError](err) {
+			resp.Diagnostics.AddError(
+				"Unexpected Service Update State",
+				fmt.Sprintf("ElastiCache service update %q for %s %q entered unexpected state: %s", config.ServiceUpdateName.ValueString(), targetType, targetID, err),
+			)
+		} else {
+			resp.Diagnostics.AddError(
+				"Failed While Waiting for Service Update to Complete",
+				fmt.Sprintf("ElastiCache service update %q for %s %q: %s", config.ServiceUpdateName.ValueString(), targetType, targetID, err),
+			)
+		}
+		return
+	}
+
+	// Final success message
+	cb(ctx, "ElastiCache service update %q for %s %q applied successfully", config.ServiceUpdateName.ValueString(), targetType, targetID)
+
+	tflog.Info(ctx, "ElastiCache service update applied successfully")
+}
+
+func (d *applyServiceUpdateAction) ConfigValidators(context.Context) []action.ConfigValidator {
+	return []action.ConfigValidator{
+		actionvalidator.Conflicting(
+			path.MatchRoot("cache_cluster_id"),
+			path.MatchRoot("replication_group_id"),
+		),
+	}
+}
+
+type applyServiceUpdateModel struct {
+	framework.WithRegionModel
+	CacheClusterID     types.String   `tfsdk:"cache_cluster_id" autoflex:"-"`
+	ReplicationGroupID types.String   `tfsdk:"replication_group_id" autoflex:"-"`
+	ServiceUpdateName  types.String   `tfsdk:"service_update_name"`
+	Timeouts           timeouts.Value `tfsdk:"timeouts"`
+}

--- a/internal/service/elasticache/apply_service_update_action_test.go
+++ b/internal/service/elasticache/apply_service_update_action_test.go
@@ -87,17 +87,17 @@ func testAccApplyServiceUpdateActionConfig_replicationGroupID(rName string) stri
 action "aws_elasticache_apply_service_update" "test" {
   config {
     replication_group_id = local.update_action.replication_group_id
-	service_update_name  = local.update_action.service_update_name
+    service_update_name  = local.update_action.service_update_name
   }
 }
 
 locals {
   complete_update_actions = [
     for action in data.aws_elasticache_service_update_actions.test.update_actions : action
-	if action.update_action_status == "complete"
-	]
+    if action.update_action_status == "complete"
+  ]
 
-	update_action = local.complete_update_actions[0]
+  update_action = local.complete_update_actions[0]
 }
 
 resource "terraform_data" "trigger" {
@@ -120,7 +120,7 @@ data "aws_elasticache_service_update_actions" "test" {
 resource "time_sleep" "wait" {
   create_duration = "10m"
 
-  depends_on  = [aws_elasticache_replication_group.test]
+  depends_on = [aws_elasticache_replication_group.test]
 }
 `)
 }
@@ -131,17 +131,17 @@ func testAccApplyServiceUpdateActionConfig_cacheClusterID(rName string) string {
 action "aws_elasticache_apply_service_update" "test" {
   config {
     cache_cluster_id    = local.update_action.cache_cluster_id
-	service_update_name = local.update_action.service_update_name
+    service_update_name = local.update_action.service_update_name
   }
 }
 
 locals {
   complete_update_actions = [
     for action in data.aws_elasticache_service_update_actions.test.update_actions : action
-	if action.update_action_status == "complete"
-	]
+    if action.update_action_status == "complete"
+  ]
 
-	update_action = local.complete_update_actions[0]
+  update_action = local.complete_update_actions[0]
 }
 
 resource "terraform_data" "trigger" {
@@ -156,7 +156,7 @@ resource "terraform_data" "trigger" {
 
 data "aws_elasticache_service_update_actions" "test" {
   cache_cluster_id = aws_elasticache_cluster.test.cluster_id
-		
+
   depends_on = [time_sleep.wait]
 }
 
@@ -164,7 +164,7 @@ data "aws_elasticache_service_update_actions" "test" {
 resource "time_sleep" "wait" {
   create_duration = "10m"
 
-  depends_on  = [aws_elasticache_cluster.test]
+  depends_on = [aws_elasticache_cluster.test]
 }
 `)
 }

--- a/internal/service/elasticache/apply_service_update_action_test.go
+++ b/internal/service/elasticache/apply_service_update_action_test.go
@@ -1,0 +1,170 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package elasticache_test
+
+import (
+	"testing"
+
+	"github.com/YakDriver/regexache"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// Testing Strategy
+//
+// The ElastiCache service automatically applies current service updates when a new Cluster or Replication Group is created.
+// New service updates are not published frequently, so it is challenging to test a successful application of the action.
+// The testing approach is to trigger the action on a previously-applied service update, which results in an error.
+
+func TestAccElastiCacheApplyServiceUpdateAction_replicationGroupID(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.ElastiCacheEndpointID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {
+				Source:            "hashicorp/time",
+				VersionConstraint: "0.14.0",
+			},
+		},
+		CheckDestroy: acctest.CheckDestroyNoop,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccApplyServiceUpdateActionConfig_replicationGroupID(rName),
+				Check:       resource.ComposeAggregateTestCheckFunc(),
+				ExpectError: regexache.MustCompile(`The update action is not in a valid status\. Current status:\n\s*complete\.`),
+			},
+		},
+	})
+}
+
+func TestAccElastiCacheApplyServiceUpdateAction_cacheClusterID(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.ElastiCacheEndpointID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {
+				Source:            "hashicorp/time",
+				VersionConstraint: "0.14.0",
+			},
+		},
+		CheckDestroy: acctest.CheckDestroyNoop,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccApplyServiceUpdateActionConfig_cacheClusterID(rName),
+				Check:       resource.ComposeAggregateTestCheckFunc(),
+				ExpectError: regexache.MustCompile(`The update action is not in a valid status\. Current status:\n\s*complete\.`),
+			},
+		},
+	})
+}
+
+func testAccApplyServiceUpdateActionConfig_replicationGroupID(rName string) string {
+	return acctest.ConfigCompose(
+		testAccReplicationGroupConfig_basic_engine(rName, "valkey"), `
+action "aws_elasticache_apply_service_update" "test" {
+  config {
+    replication_group_id = local.update_action.replication_group_id
+	service_update_name  = local.update_action.service_update_name
+  }
+}
+
+locals {
+  complete_update_actions = [
+    for action in data.aws_elasticache_service_update_actions.test.update_actions : action
+	if action.update_action_status == "complete"
+	]
+
+	update_action = local.complete_update_actions[0]
+}
+
+resource "terraform_data" "trigger" {
+  input = "trigger"
+  lifecycle {
+    action_trigger {
+      events  = [before_create, before_update]
+      actions = [action.aws_elasticache_apply_service_update.test]
+    }
+  }
+}
+
+data "aws_elasticache_service_update_actions" "test" {
+  replication_group_id = aws_elasticache_replication_group.test.replication_group_id
+
+  depends_on = [time_sleep.wait]
+}
+
+# It takes approximately 10 minutes for Update Actions to be registered after the Replication Group becomes available.
+resource "time_sleep" "wait" {
+  create_duration = "10m"
+
+  depends_on  = [aws_elasticache_replication_group.test]
+}
+`)
+}
+
+func testAccApplyServiceUpdateActionConfig_cacheClusterID(rName string) string {
+	return acctest.ConfigCompose(
+		testAccClusterConfig_engineRedis(rName), `
+action "aws_elasticache_apply_service_update" "test" {
+  config {
+    cache_cluster_id    = local.update_action.cache_cluster_id
+	service_update_name = local.update_action.service_update_name
+  }
+}
+
+locals {
+  complete_update_actions = [
+    for action in data.aws_elasticache_service_update_actions.test.update_actions : action
+	if action.update_action_status == "complete"
+	]
+
+	update_action = local.complete_update_actions[0]
+}
+
+resource "terraform_data" "trigger" {
+  input = "trigger"
+  lifecycle {
+    action_trigger {
+      events  = [before_create, before_update]
+      actions = [action.aws_elasticache_apply_service_update.test]
+    }
+  }
+}
+
+data "aws_elasticache_service_update_actions" "test" {
+  cache_cluster_id = aws_elasticache_cluster.test.cluster_id
+		
+  depends_on = [time_sleep.wait]
+}
+
+# It takes approximately 10 minutes for Update Actions to be registered after the Replication Group becomes available.
+resource "time_sleep" "wait" {
+  create_duration = "10m"
+
+  depends_on  = [aws_elasticache_cluster.test]
+}
+`)
+}

--- a/internal/service/elasticache/apply_service_update_action_test.go
+++ b/internal/service/elasticache/apply_service_update_action_test.go
@@ -43,7 +43,6 @@ func TestAccElastiCacheApplyServiceUpdateAction_replicationGroupID(t *testing.T)
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccApplyServiceUpdateActionConfig_replicationGroupID(rName),
-				Check:       resource.ComposeAggregateTestCheckFunc(),
 				ExpectError: regexache.MustCompile(`The update action is not in a valid status\. Current status:\n\s*complete\.`),
 			},
 		},
@@ -74,7 +73,6 @@ func TestAccElastiCacheApplyServiceUpdateAction_cacheClusterID(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccApplyServiceUpdateActionConfig_cacheClusterID(rName),
-				Check:       resource.ComposeAggregateTestCheckFunc(),
 				ExpectError: regexache.MustCompile(`The update action is not in a valid status\. Current status:\n\s*complete\.`),
 			},
 		},

--- a/internal/service/elasticache/service_package_gen.go
+++ b/internal/service/elasticache/service_package_gen.go
@@ -20,6 +20,17 @@ import (
 
 type servicePackage struct{}
 
+func (p *servicePackage) Actions(ctx context.Context) []*inttypes.ServicePackageAction {
+	return []*inttypes.ServicePackageAction{
+		{
+			Factory:  newApplyServiceUpdateAction,
+			TypeName: "aws_elasticache_apply_service_update",
+			Name:     "Apply Service Update",
+			Region:   inttypes.ResourceRegionDefault(),
+		},
+	}
+}
+
 func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*inttypes.ServicePackageFrameworkDataSource {
 	return []*inttypes.ServicePackageFrameworkDataSource{
 		{

--- a/internal/service/elasticache/service_update_actions_data_source.go
+++ b/internal/service/elasticache/service_update_actions_data_source.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
 	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/smerr"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 // @FrameworkDataSource("aws_elasticache_service_update_actions", name="Service Update Actions")
@@ -140,4 +141,14 @@ func findServiceUpdateActions(ctx context.Context, conn *elasticache.Client, inp
 	}
 
 	return output, nil
+}
+
+func findServiceUpdateAction(ctx context.Context, conn *elasticache.Client, input *elasticache.DescribeUpdateActionsInput) (*awstypes.UpdateAction, error) {
+	output, err := findServiceUpdateActions(ctx, conn, input)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return tfresource.AssertSingleValueResult(output)
 }

--- a/website/docs/actions/elasticache_apply_service_update.html.markdown
+++ b/website/docs/actions/elasticache_apply_service_update.html.markdown
@@ -20,7 +20,7 @@ For information about applying service updates, see the [Service updates in Elas
 action "aws_elasticache_apply_service_update" "example" {
   config {
     replication_group_id = aws_elasticache_replication_group.replication_group_id
-    service_update_name  = <service update name>
+    service_update_name  = "example-service-update"
   }
 }
 

--- a/website/docs/actions/elasticache_apply_service_update.html.markdown
+++ b/website/docs/actions/elasticache_apply_service_update.html.markdown
@@ -1,0 +1,56 @@
+---
+subcategory: "ElastiCache"
+layout: "aws"
+page_title: "AWS: aws_elasticache_apply_service_update"
+description: |-
+  Applies ElastiCache service updates to a specified cache cluster or replication group.
+---
+
+# Action: aws_elasticache_apply_service_update
+
+Applies ElastiCache service updates to a specified cache cluster or replication group.
+
+For information about applying service updates, see the [Service updates in ElastiCache](https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/Self-Service-Updates.html) in the [Amazon ElastiCache User Guide](https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/WhatIs.html).
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+action "aws_elasticache_apply_service_update" "example" {
+  config {
+    replication_group_id = aws_elasticache_replication_group.replication_group_id
+    service_update_name  = <service update name>
+  }
+}
+
+resource "aws_elasticache_replication_group" "example" {
+  # ... replication group configuration
+}
+
+resource "terraform_data" "example" {
+  input = "trigger"
+
+  lifecycle {
+    action_trigger {
+      events  = [before_create, before_update]
+      actions = [action.aws_elasticache_apply_service_update.example]
+    }
+  }
+}
+```
+
+## Argument Reference
+
+This action supports the following arguments:
+
+* `cache_cluster_id` - (Optional) ID of Cache Cluster to apply update to. One of `cache_cluster_id` or `replication_group_id` is required.
+* `region` - (Optional) Region where this action will be [invoked](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
+* `replication_group_id` - (Optional) ID of Replication Group to apply update to. One of `replication_group_id` or `cache_cluster_id` is required.
+* `service_update_name` - (Required) Name of service update to apply.
+
+## Timeouts
+
+Configuration options:
+
+* `invoke` - (Default `60m`)


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

New Action: `aws_elasticache_apply_service_update`

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #20112

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=elasticache TESTS=TestAccElastiCacheApplyServiceUpdateAction_

--- PASS: TestAccElastiCacheApplyServiceUpdateAction_cacheClusterID (1006.37s)
--- PASS: TestAccElastiCacheApplyServiceUpdateAction_replicationGroupID (1393.39s)
```
