### PR TITLE
New Data Source: S3 Buckets 

### DIFF
--- a/.changelog/48965.txt
+++ b/.changelog/48965.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_s3_buckets
+```

--- a/internal/service/s3/buckets_data_source.go
+++ b/internal/service/s3/buckets_data_source.go
@@ -1,0 +1,107 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+// DONOTCOPY: Copying old resources spreads bad habits. Use skaff instead.
+
+package s3
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/smerr"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// Function annotations are used for datasource registration to the Provider. DO NOT EDIT.
+// @FrameworkDataSource("aws_s3_buckets", name="Buckets")
+func newBucketsDataSource(context.Context) (datasource.DataSourceWithConfigure, error) {
+	return &bucketsDataSource{}, nil
+}
+
+const (
+	DSNameBuckets = "Buckets Data Source"
+)
+
+type bucketsDataSource struct {
+	framework.DataSourceWithModel[bucketsDataSourceModel]
+}
+
+func (d *bucketsDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"bucket_summaries": framework.DataSourceComputedListOfObjectAttribute[bucketSummaryModel](ctx),
+			names.AttrNamePrefix: schema.StringAttribute{
+				Optional: true,
+			},
+		},
+	}
+}
+
+func (d *bucketsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	conn := d.Meta().S3Client(ctx)
+
+	var data bucketsDataSourceModel
+	smerr.AddEnrich(ctx, &resp.Diagnostics, req.Config.Get(ctx, &data))
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// BucketRegion must match the provider region to avoid cross-region errors.
+	// Prefix is an AWS-side filter; NamePrefix maps to it directly.
+	input := s3.ListBucketsInput{
+		BucketRegion: aws.String(d.Meta().Region(ctx)),
+		Prefix:       flex.StringFromFramework(ctx, data.NamePrefix),
+	}
+
+	out, err := findBucketSummaries(ctx, conn, &input)
+	if err != nil {
+		smerr.AddError(ctx, &resp.Diagnostics, err)
+		return
+	}
+
+	smerr.AddEnrich(ctx, &resp.Diagnostics, flex.Flatten(ctx, out, &data.BucketSummaries))
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, &data))
+}
+
+// findBucketSummaries collects all buckets matching the given input by iterating
+// over the listBuckets iterator. The caller can extend this function with
+// Terraform-side filtering before the return if needed in the future.
+func findBucketSummaries(ctx context.Context, conn *s3.Client, input *s3.ListBucketsInput) ([]awstypes.Bucket, error) {
+	var output []awstypes.Bucket
+
+	for item, err := range listBuckets(ctx, conn, input) {
+		if err != nil {
+			return nil, err
+		}
+		output = append(output, item)
+	}
+
+	return output, nil
+}
+
+type bucketsDataSourceModel struct {
+	framework.WithRegionModel
+	BucketSummaries fwtypes.ListNestedObjectValueOf[bucketSummaryModel] `tfsdk:"bucket_summaries"`
+	NamePrefix      types.String                                        `tfsdk:"name_prefix"`
+}
+
+type bucketSummaryModel struct {
+	BucketArn    types.String      `tfsdk:"bucket_arn"`
+	BucketRegion types.String      `tfsdk:"bucket_region"`
+	CreationDate timetypes.RFC3339 `tfsdk:"creation_date"`
+	Name         types.String      `tfsdk:"name"`
+}

--- a/internal/service/s3/buckets_data_source.go
+++ b/internal/service/s3/buckets_data_source.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
 	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/smerr"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 // Function annotations are used for datasource registration to the Provider. DO NOT EDIT.
@@ -42,6 +43,9 @@ func (d *bucketsDataSource) Schema(ctx context.Context, req datasource.SchemaReq
 			"max_buckets": schema.Int32Attribute{
 				Optional: true,
 			},
+			names.AttrRegion: schema.StringAttribute{
+				Optional: true,
+			},
 			"prefix": schema.StringAttribute{
 				Optional: true,
 			},
@@ -59,6 +63,9 @@ func (d *bucketsDataSource) Read(ctx context.Context, req datasource.ReadRequest
 	}
 
 	var input s3.ListBucketsInput
+	if !data.Region.IsNull() {
+		input.BucketRegion = aws.String(data.Region.ValueString())
+	}
 	if !data.Prefix.IsNull() {
 		input.Prefix = aws.String(data.Prefix.ValueString())
 	}

--- a/internal/service/s3/buckets_data_source.go
+++ b/internal/service/s3/buckets_data_source.go
@@ -27,7 +27,6 @@ func newBucketsDataSource(context.Context) (datasource.DataSourceWithConfigure, 
 	return &bucketsDataSource{}, nil
 }
 
-
 type bucketsDataSource struct {
 	framework.DataSourceWithModel[bucketsDataSourceModel]
 }

--- a/internal/service/s3/buckets_data_source.go
+++ b/internal/service/s3/buckets_data_source.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
-	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
 	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/smerr"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -35,6 +35,9 @@ func (d *bucketsDataSource) Schema(ctx context.Context, req datasource.SchemaReq
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"buckets": framework.DataSourceComputedListOfObjectAttribute[bucketsModel](ctx),
+			"bucket_region": schema.StringAttribute{
+				Optional: true,
+			},
 			"max_buckets": schema.Int32Attribute{
 				Optional: true,
 			},
@@ -55,8 +58,8 @@ func (d *bucketsDataSource) Read(ctx context.Context, req datasource.ReadRequest
 	}
 
 	var input s3.ListBucketsInput
-	if !data.Region.IsNull() {
-		input.BucketRegion = data.Region.ValueStringPointer()
+	if !data.BucketRegion.IsNull() {
+		input.BucketRegion = data.BucketRegion.ValueStringPointer()
 	}
 	if !data.Prefix.IsNull() {
 		input.Prefix = data.Prefix.ValueStringPointer()
@@ -71,7 +74,7 @@ func (d *bucketsDataSource) Read(ctx context.Context, req datasource.ReadRequest
 		return
 	}
 
-	smerr.AddEnrich(ctx, &resp.Diagnostics, flex.Flatten(ctx, out, &data.Buckets))
+	smerr.AddEnrich(ctx, &resp.Diagnostics, fwflex.Flatten(ctx, out, &data.Buckets))
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -97,9 +100,10 @@ func findBuckets(ctx context.Context, conn *s3.Client, input *s3.ListBucketsInpu
 
 type bucketsDataSourceModel struct {
 	framework.WithRegionModel
-	Buckets    fwtypes.ListNestedObjectValueOf[bucketsModel] `tfsdk:"buckets"`
-	MaxBuckets types.Int32                                   `tfsdk:"max_buckets"`
-	Prefix     types.String                                  `tfsdk:"prefix"`
+	Buckets      fwtypes.ListNestedObjectValueOf[bucketsModel] `tfsdk:"buckets"`
+	BucketRegion types.String                                  `tfsdk:"bucket_region"`
+	MaxBuckets   types.Int32                                   `tfsdk:"max_buckets"`
+	Prefix       types.String                                  `tfsdk:"prefix"`
 }
 
 type bucketsModel struct {

--- a/internal/service/s3/buckets_data_source.go
+++ b/internal/service/s3/buckets_data_source.go
@@ -100,8 +100,8 @@ func findBucketSummaries(ctx context.Context, conn *s3.Client, input *s3.ListBuc
 type bucketsDataSourceModel struct {
 	framework.WithRegionModel
 	BucketSummaries fwtypes.ListNestedObjectValueOf[bucketSummaryModel] `tfsdk:"bucket_summaries"`
-	NamePrefix      types.String    `tfsdk:"name_prefix"`
-	MaxBuckets      types.Int32     `tfsdk:"max_buckets"`
+	NamePrefix      types.String                                        `tfsdk:"name_prefix"`
+	MaxBuckets      types.Int32                                         `tfsdk:"max_buckets"`
 }
 
 type bucketSummaryModel struct {

--- a/internal/service/s3/buckets_data_source.go
+++ b/internal/service/s3/buckets_data_source.go
@@ -43,6 +43,9 @@ func (d *bucketsDataSource) Schema(ctx context.Context, req datasource.SchemaReq
 			names.AttrNamePrefix: schema.StringAttribute{
 				Optional: true,
 			},
+			"max_buckets": schema.Int32Attribute{
+				Optional: true,
+			},
 		},
 	}
 }
@@ -61,6 +64,7 @@ func (d *bucketsDataSource) Read(ctx context.Context, req datasource.ReadRequest
 	input := s3.ListBucketsInput{
 		BucketRegion: aws.String(d.Meta().Region(ctx)),
 		Prefix:       flex.StringFromFramework(ctx, data.NamePrefix),
+		MaxBuckets:   flex.Int32FromFramework(ctx, data.MaxBuckets),
 	}
 
 	out, err := findBucketSummaries(ctx, conn, &input)
@@ -96,7 +100,8 @@ func findBucketSummaries(ctx context.Context, conn *s3.Client, input *s3.ListBuc
 type bucketsDataSourceModel struct {
 	framework.WithRegionModel
 	BucketSummaries fwtypes.ListNestedObjectValueOf[bucketSummaryModel] `tfsdk:"bucket_summaries"`
-	NamePrefix      types.String                                        `tfsdk:"name_prefix"`
+	NamePrefix      types.String    `tfsdk:"name_prefix"`
+	MaxBuckets      types.Int32     `tfsdk:"max_buckets"`
 }
 
 type bucketSummaryModel struct {

--- a/internal/service/s3/buckets_data_source.go
+++ b/internal/service/s3/buckets_data_source.go
@@ -8,7 +8,6 @@ package s3
 import (
 	"context"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
@@ -43,10 +42,7 @@ func (d *bucketsDataSource) Schema(ctx context.Context, req datasource.SchemaReq
 			"max_buckets": schema.Int32Attribute{
 				Optional: true,
 			},
-			names.AttrRegion: schema.StringAttribute{
-				Optional: true,
-			},
-			"prefix": schema.StringAttribute{
+			names.AttrPrefix: schema.StringAttribute{
 				Optional: true,
 			},
 		},
@@ -64,13 +60,13 @@ func (d *bucketsDataSource) Read(ctx context.Context, req datasource.ReadRequest
 
 	var input s3.ListBucketsInput
 	if !data.Region.IsNull() {
-		input.BucketRegion = aws.String(data.Region.ValueString())
+		input.BucketRegion = data.Region.ValueStringPointer()
 	}
 	if !data.Prefix.IsNull() {
-		input.Prefix = aws.String(data.Prefix.ValueString())
+		input.Prefix = data.Prefix.ValueStringPointer()
 	}
 	if !data.MaxBuckets.IsNull() {
-		input.MaxBuckets = aws.Int32(data.MaxBuckets.ValueInt32())
+		input.MaxBuckets = data.MaxBuckets.ValueInt32Pointer()
 	}
 
 	out, err := findBuckets(ctx, conn, &input)

--- a/internal/service/s3/buckets_data_source.go
+++ b/internal/service/s3/buckets_data_source.go
@@ -11,8 +11,10 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int32validator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
 	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
@@ -40,6 +42,9 @@ func (d *bucketsDataSource) Schema(ctx context.Context, req datasource.SchemaReq
 			},
 			"max_buckets": schema.Int32Attribute{
 				Optional: true,
+				Validators: []validator.Int32{
+					int32validator.Between(1, 10000),
+				},
 			},
 			names.AttrPrefix: schema.StringAttribute{
 				Optional: true,

--- a/internal/service/s3/buckets_data_source.go
+++ b/internal/service/s3/buckets_data_source.go
@@ -27,9 +27,6 @@ func newBucketsDataSource(context.Context) (datasource.DataSourceWithConfigure, 
 	return &bucketsDataSource{}, nil
 }
 
-const (
-	DSNameBuckets = "Buckets Data Source"
-)
 
 type bucketsDataSource struct {
 	framework.DataSourceWithModel[bucketsDataSourceModel]

--- a/internal/service/s3/buckets_data_source.go
+++ b/internal/service/s3/buckets_data_source.go
@@ -83,7 +83,7 @@ func (d *bucketsDataSource) Read(ctx context.Context, req datasource.ReadRequest
 	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, &data))
 }
 
-// findBucketSummaries collects all buckets matching the given input by iterating
+// findBuckets collects all buckets matching the given input by iterating
 // over the listBuckets iterator. The caller can extend this function with
 // Terraform-side filtering before the return if needed in the future.
 func findBuckets(ctx context.Context, conn *s3.Client, input *s3.ListBucketsInput) ([]awstypes.Bucket, error) {

--- a/internal/service/s3/buckets_data_source.go
+++ b/internal/service/s3/buckets_data_source.go
@@ -8,13 +8,13 @@ package s3
 import (
 	"context"
 
+	"github.com/YakDriver/smarterr"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
-	"github.com/hashicorp/terraform-plugin-framework-validators/int32validator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
 	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
@@ -40,11 +40,9 @@ func (d *bucketsDataSource) Schema(ctx context.Context, req datasource.SchemaReq
 			"bucket_region": schema.StringAttribute{
 				Optional: true,
 			},
+			// max_buckets for the API is buckets per page, but we are implementing it as a limit on the total number of buckets
 			"max_buckets": schema.Int32Attribute{
 				Optional: true,
-				Validators: []validator.Int32{
-					int32validator.Between(1, 10000),
-				},
 			},
 			names.AttrPrefix: schema.StringAttribute{
 				Optional: true,
@@ -92,12 +90,22 @@ func (d *bucketsDataSource) Read(ctx context.Context, req datasource.ReadRequest
 // Terraform-side filtering before the return if needed in the future.
 func findBuckets(ctx context.Context, conn *s3.Client, input *s3.ListBucketsInput) ([]awstypes.Bucket, error) {
 	var output []awstypes.Bucket
+	limit := aws.ToInt32(input.MaxBuckets) // 0 when unset
+	if limit > 10000 {
+		input.MaxBuckets = aws.Int32(10000) // API per-page max
+	}
 
-	for item, err := range listBuckets(ctx, conn, input) {
+	pages := s3.NewListBucketsPaginator(conn, input)
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
 		if err != nil {
-			return nil, err
+			return nil, smarterr.NewError(err)
 		}
-		output = append(output, item)
+		output = append(output, page.Buckets...)
+		if limit > 0 && int32(len(output)) >= limit {
+			output = output[:limit]
+			break
+		}
 	}
 
 	return output, nil

--- a/internal/service/s3/buckets_data_source.go
+++ b/internal/service/s3/buckets_data_source.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
 	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/smerr"
-	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 // Function annotations are used for datasource registration to the Provider. DO NOT EDIT.
@@ -39,11 +38,11 @@ type bucketsDataSource struct {
 func (d *bucketsDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
-			"bucket_summaries": framework.DataSourceComputedListOfObjectAttribute[bucketSummaryModel](ctx),
-			names.AttrNamePrefix: schema.StringAttribute{
+			"buckets": framework.DataSourceComputedListOfObjectAttribute[bucketsModel](ctx),
+			"max_buckets": schema.Int32Attribute{
 				Optional: true,
 			},
-			"max_buckets": schema.Int32Attribute{
+			"prefix": schema.StringAttribute{
 				Optional: true,
 			},
 		},
@@ -59,21 +58,21 @@ func (d *bucketsDataSource) Read(ctx context.Context, req datasource.ReadRequest
 		return
 	}
 
-	// BucketRegion must match the provider region to avoid cross-region errors.
-	// Prefix is an AWS-side filter; NamePrefix maps to it directly.
-	input := s3.ListBucketsInput{
-		BucketRegion: aws.String(d.Meta().Region(ctx)),
-		Prefix:       flex.StringFromFramework(ctx, data.NamePrefix),
-		MaxBuckets:   flex.Int32FromFramework(ctx, data.MaxBuckets),
+	var input s3.ListBucketsInput
+	if !data.Prefix.IsNull() {
+		input.Prefix = aws.String(data.Prefix.ValueString())
+	}
+	if !data.MaxBuckets.IsNull() {
+		input.MaxBuckets = aws.Int32(data.MaxBuckets.ValueInt32())
 	}
 
-	out, err := findBucketSummaries(ctx, conn, &input)
+	out, err := findBuckets(ctx, conn, &input)
 	if err != nil {
 		smerr.AddError(ctx, &resp.Diagnostics, err)
 		return
 	}
 
-	smerr.AddEnrich(ctx, &resp.Diagnostics, flex.Flatten(ctx, out, &data.BucketSummaries))
+	smerr.AddEnrich(ctx, &resp.Diagnostics, flex.Flatten(ctx, out, &data.Buckets))
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -84,7 +83,7 @@ func (d *bucketsDataSource) Read(ctx context.Context, req datasource.ReadRequest
 // findBucketSummaries collects all buckets matching the given input by iterating
 // over the listBuckets iterator. The caller can extend this function with
 // Terraform-side filtering before the return if needed in the future.
-func findBucketSummaries(ctx context.Context, conn *s3.Client, input *s3.ListBucketsInput) ([]awstypes.Bucket, error) {
+func findBuckets(ctx context.Context, conn *s3.Client, input *s3.ListBucketsInput) ([]awstypes.Bucket, error) {
 	var output []awstypes.Bucket
 
 	for item, err := range listBuckets(ctx, conn, input) {
@@ -99,12 +98,12 @@ func findBucketSummaries(ctx context.Context, conn *s3.Client, input *s3.ListBuc
 
 type bucketsDataSourceModel struct {
 	framework.WithRegionModel
-	BucketSummaries fwtypes.ListNestedObjectValueOf[bucketSummaryModel] `tfsdk:"bucket_summaries"`
-	NamePrefix      types.String                                        `tfsdk:"name_prefix"`
-	MaxBuckets      types.Int32                                         `tfsdk:"max_buckets"`
+	Buckets    fwtypes.ListNestedObjectValueOf[bucketsModel] `tfsdk:"buckets"`
+	MaxBuckets types.Int32                                   `tfsdk:"max_buckets"`
+	Prefix     types.String                                  `tfsdk:"prefix"`
 }
 
-type bucketSummaryModel struct {
+type bucketsModel struct {
 	BucketArn    types.String      `tfsdk:"bucket_arn"`
 	BucketRegion types.String      `tfsdk:"bucket_region"`
 	CreationDate timetypes.RFC3339 `tfsdk:"creation_date"`

--- a/internal/service/s3/buckets_data_source_test.go
+++ b/internal/service/s3/buckets_data_source_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 

--- a/internal/service/s3/buckets_data_source_test.go
+++ b/internal/service/s3/buckets_data_source_test.go
@@ -17,8 +17,8 @@ func TestAccS3BucketsDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	// region := acctest.Region()
-	// resourceName := "aws_s3_bucket.test"
-	// dataSourceName := "data.aws_s3_bucket.test"
+	resourceName := "aws_s3_bucket.test"
+	dataSourceName := "data.aws_s3_buckets.test"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -27,7 +27,12 @@ func TestAccS3BucketsDataSource_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccBucketsDataSourceConfig_basic(rName),
-				Check:  resource.ComposeAggregateTestCheckFunc(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanOrEqualValue(dataSourceName, "buckets.#", 1),
+					resource.TestCheckResourceAttrPair(dataSourceName, "buckets.0.bucket_arn", resourceName, names.AttrARN),
+					resource.TestCheckResourceAttrPair(dataSourceName, "buckets.0.bucket_region", resourceName, "bucket_region"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "buckets.0.name", resourceName, names.AttrBucket),
+				),
 			},
 		},
 	})
@@ -40,7 +45,9 @@ resource "aws_s3_bucket" "test" {
 }
 
 data "aws_s3_buckets" "test" {
-  name_prefix = %[1]q
+  prefix = %[1]q
+
+  depends_on = [aws_s3_bucket.test]
 }
 `, rName)
 }

--- a/internal/service/s3/buckets_data_source_test.go
+++ b/internal/service/s3/buckets_data_source_test.go
@@ -23,6 +23,7 @@ func TestAccS3BucketsDataSource_basic(t *testing.T) {
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckBucketDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccBucketsDataSourceConfig_basic(rName),

--- a/internal/service/s3/buckets_data_source_test.go
+++ b/internal/service/s3/buckets_data_source_test.go
@@ -1,0 +1,214 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package s3_test
+// **PLEASE DELETE THIS AND ALL TIP COMMENTS BEFORE SUBMITTING A PR FOR REVIEW!**
+//
+// TIP: ==== INTRODUCTION ====
+// Thank you for trying the skaff tool!
+//
+// You have opted to include these helpful comments. They all include "TIP:"
+// to help you find and remove them when you're done with them.
+//
+// While some aspects of this file are customized to your input, the
+// scaffold tool does *not* look at the AWS API and ensure it has correct
+// function, structure, and variable names. It makes guesses based on
+// commonalities. You will need to make significant adjustments.
+//
+// In other words, as generated, this is a rough outline of the work you will
+// need to do. If something doesn't make sense for your situation, get rid of
+// it.
+
+import (
+	// TIP: ==== IMPORTS ====
+	// This is a common set of imports but not customized to your code since
+	// your code hasn't been written yet. Make sure you, your IDE, or
+	// goimports -w <file> fixes these imports.
+	//
+	// The provider linter wants your imports to be in two groups: first,
+	// standard library (i.e., "fmt" or "strings"), second, everything else.
+	//
+	// Also, AWS Go SDK v2 may handle nested structures differently than v1,
+	// using the services/s3/types package. If so, you'll
+	// need to import types and reference the nested types, e.g., as
+	// types.<Type Name>.
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/YakDriver/regexache"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+
+	// TIP: You will often need to import the package that this test file lives
+    // in. Since it is in the "test" context, it must import the package to use
+    // any normal context constants, variables, or functions.
+	tfs3 "github.com/hashicorp/terraform-provider-aws/internal/service/s3"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// TIP: File Structure. The basic outline for all test files should be as
+// follows. Improve this data source's maintainability by following this
+// outline.
+//
+// 1. Package declaration (add "_test" since this is a test file)
+// 2. Imports
+// 3. Unit tests
+// 4. Basic test
+// 5. Disappears test
+// 6. All the other tests
+// 7. Helper functions (exists, destroy, check, etc.)
+// 8. Functions that return Terraform configurations
+
+
+// TIP: ==== UNIT TESTS ====
+// This is an example of a unit test. Its name is not prefixed with
+// "TestAcc" like an acceptance test.
+//
+// Unlike acceptance tests, unit tests do not access AWS and are focused on a
+// function (or method). Because of this, they are quick and cheap to run.
+//
+// In designing a data source's implementation, isolate complex bits from AWS bits
+// so that they can be tested through a unit test. We encourage more unit tests
+// in the provider.
+//
+// Cut and dry functions using well-used patterns, like typical flatteners and
+// expanders, don't need unit testing. However, if they are complex or
+// intricate, they should be unit tested.
+func TestBucketsExampleUnitTest(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		TestName string
+		Input    string
+		Expected string
+		Error    bool
+	}{
+		{
+			TestName: "empty",
+			Input:    "",
+			Expected: "",
+			Error:    true,
+		},
+		{
+			TestName: "descriptive name",
+			Input:    "some input",
+			Expected: "some output",
+			Error:    false,
+		},
+		{
+			TestName: "another descriptive name",
+			Input:    "more input",
+			Expected: "more output",
+			Error:    false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.TestName, func(t *testing.T) {
+			t.Parallel()
+			got, err := tfs3.FunctionFromDataSource(testCase.Input)
+
+			if err != nil && !testCase.Error {
+				t.Errorf("got error (%s), expected no error", err)
+			}
+
+			if err == nil && testCase.Error {
+				t.Errorf("got (%s) and no error, expected error", got)
+			}
+
+			if got != testCase.Expected {
+				t.Errorf("got %s, expected %s", got, testCase.Expected)
+			}
+		})
+	}
+}
+
+
+// TIP: ==== ACCEPTANCE TESTS ====
+// This is an example of a basic acceptance test. This should test as much of
+// standard functionality of the data source as possible, and test importing, if
+// applicable. We prefix its name with "TestAcc", the service, and the
+// data source name.
+//
+// Acceptance test access AWS and cost money to run.
+func TestAccS3BucketsDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+    // TIP: This is a long-running test guard for tests that run longer than
+    // 300s (5 min) generally.
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var buckets s3.DescribeBucketsResponse
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_s3_buckets.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.S3EndpointID)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckBucketsDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketsDataSourceConfig_basic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckBucketsExists(ctx, dataSourceName, &buckets),
+					resource.TestCheckResourceAttr(dataSourceName, "auto_minor_version_upgrade", "false"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "maintenance_window_start_time.0.day_of_week"),
+					resource.TestCheckTypeSetElemNestedAttrs(dataSourceName, "user.*", map[string]string{
+						"console_access": "false",
+						"groups.#":       "0",
+						"username":       "Test",
+						"password":       "TestTest1234",
+					}),
+					// TIP: If the ARN can be partially or completely determined by the parameters passed, e.g. it contains the
+					// value of `rName`, either include the values in the regex or check for an exact match using `acctest.CheckResourceAttrRegionalARN`
+					// Alternatively, if the data source returns the values for a corresponding resource, use `resource.TestCheckResourceAttrPair` to
+					// check that the values are the same.
+					acctest.MatchResourceAttrRegionalARN(ctx, dataSourceName, names.AttrARN, "s3", regexache.MustCompile(`buckets:.+$`)),
+				),
+			},
+		},
+	})
+}
+
+func testAccBucketsDataSourceConfig_basic(rName, version string) string {
+	return fmt.Sprintf(`
+data "aws_security_group" "test" {
+  name = %[1]q
+}
+
+data "aws_s3_buckets" "test" {
+  buckets_name             = %[1]q
+  engine_type             = "ActiveS3"
+  engine_version          = %[2]q
+  host_instance_type      = "s3.t2.micro"
+  security_groups         = [aws_security_group.test.id]
+  authentication_strategy = "simple"
+  storage_type            = "efs"
+
+  logs {
+    general = true
+  }
+
+  user {
+    username = "Test"
+    password = "TestTest1234"
+  }
+}
+`, rName, version)
+}

--- a/internal/service/s3/buckets_data_source_test.go
+++ b/internal/service/s3/buckets_data_source_test.go
@@ -15,7 +15,7 @@ import (
 func TestAccS3BucketsDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	// region := acctest.Region()
+	rName2 := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_s3_bucket.test"
 	dataSourceName := "data.aws_s3_buckets.test"
 
@@ -26,7 +26,7 @@ func TestAccS3BucketsDataSource_basic(t *testing.T) {
 		CheckDestroy:             testAccCheckBucketDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBucketsDataSourceConfig_basic(rName),
+				Config: testAccBucketsDataSourceConfig_basic(rName, rName2),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					acctest.CheckResourceAttrGreaterThanOrEqualValue(dataSourceName, "buckets.#", 1),
 					resource.TestCheckResourceAttrPair(dataSourceName, "buckets.0.bucket_arn", resourceName, names.AttrARN),
@@ -38,16 +38,64 @@ func TestAccS3BucketsDataSource_basic(t *testing.T) {
 	})
 }
 
-func testAccBucketsDataSourceConfig_basic(rName string) string {
+func TestAccS3BucketsDataSource_maxBuckets(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket.test"
+	dataSourceName := "data.aws_s3_buckets.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckBucketDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketsDataSourceConfig_maxBuckets(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanOrEqualValue(dataSourceName, "buckets.#", 1),
+					resource.TestCheckResourceAttrPair(dataSourceName, "buckets.0.bucket_arn", resourceName, names.AttrARN),
+					resource.TestCheckResourceAttrPair(dataSourceName, "buckets.0.bucket_region", resourceName, "bucket_region"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "buckets.0.name", resourceName, names.AttrBucket),
+				),
+			},
+		},
+	})
+}
+
+func testAccBucketsDataSourceConfig_basic(rName, rName2 string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
 
+resource "aws_s3_bucket" "test2" {
+  bucket = %[2]q
+}
+
 data "aws_s3_buckets" "test" {
   prefix = %[1]q
 
-  depends_on = [aws_s3_bucket.test]
+  depends_on = [aws_s3_bucket.test, aws_s3_bucket.test2]
+}
+`, rName, rName2)
+}
+
+func testAccBucketsDataSourceConfig_maxBuckets(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+}
+
+resource "aws_s3_bucket" "test2" {
+  bucket = "%[1]s-2"
+}
+
+data "aws_s3_buckets" "test" {
+  prefix      = %[1]q
+  max_buckets = 1
+
+  depends_on = [aws_s3_bucket.test, aws_s3_bucket.test2]
 }
 `, rName)
 }

--- a/internal/service/s3/buckets_data_source_test.go
+++ b/internal/service/s3/buckets_data_source_test.go
@@ -2,213 +2,45 @@
 // SPDX-License-Identifier: MPL-2.0
 
 package s3_test
-// **PLEASE DELETE THIS AND ALL TIP COMMENTS BEFORE SUBMITTING A PR FOR REVIEW!**
-//
-// TIP: ==== INTRODUCTION ====
-// Thank you for trying the skaff tool!
-//
-// You have opted to include these helpful comments. They all include "TIP:"
-// to help you find and remove them when you're done with them.
-//
-// While some aspects of this file are customized to your input, the
-// scaffold tool does *not* look at the AWS API and ensure it has correct
-// function, structure, and variable names. It makes guesses based on
-// commonalities. You will need to make significant adjustments.
-//
-// In other words, as generated, this is a rough outline of the work you will
-// need to do. If something doesn't make sense for your situation, get rid of
-// it.
 
 import (
-	// TIP: ==== IMPORTS ====
-	// This is a common set of imports but not customized to your code since
-	// your code hasn't been written yet. Make sure you, your IDE, or
-	// goimports -w <file> fixes these imports.
-	//
-	// The provider linter wants your imports to be in two groups: first,
-	// standard library (i.e., "fmt" or "strings"), second, everything else.
-	//
-	// Also, AWS Go SDK v2 may handle nested structures differently than v1,
-	// using the services/s3/types package. If so, you'll
-	// need to import types and reference the nested types, e.g., as
-	// types.<Type Name>.
 	"fmt"
-	"strings"
 	"testing"
 
-	"github.com/YakDriver/regexache"
-	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/service/s3"
-	"github.com/aws/aws-sdk-go-v2/service/s3/types"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
-	"github.com/hashicorp/terraform-provider-aws/internal/create"
 
-	// TIP: You will often need to import the package that this test file lives
-    // in. Since it is in the "test" context, it must import the package to use
-    // any normal context constants, variables, or functions.
-	tfs3 "github.com/hashicorp/terraform-provider-aws/internal/service/s3"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// TIP: File Structure. The basic outline for all test files should be as
-// follows. Improve this data source's maintainability by following this
-// outline.
-//
-// 1. Package declaration (add "_test" since this is a test file)
-// 2. Imports
-// 3. Unit tests
-// 4. Basic test
-// 5. Disappears test
-// 6. All the other tests
-// 7. Helper functions (exists, destroy, check, etc.)
-// 8. Functions that return Terraform configurations
-
-
-// TIP: ==== UNIT TESTS ====
-// This is an example of a unit test. Its name is not prefixed with
-// "TestAcc" like an acceptance test.
-//
-// Unlike acceptance tests, unit tests do not access AWS and are focused on a
-// function (or method). Because of this, they are quick and cheap to run.
-//
-// In designing a data source's implementation, isolate complex bits from AWS bits
-// so that they can be tested through a unit test. We encourage more unit tests
-// in the provider.
-//
-// Cut and dry functions using well-used patterns, like typical flatteners and
-// expanders, don't need unit testing. However, if they are complex or
-// intricate, they should be unit tested.
-func TestBucketsExampleUnitTest(t *testing.T) {
-	t.Parallel()
-
-	testCases := []struct {
-		TestName string
-		Input    string
-		Expected string
-		Error    bool
-	}{
-		{
-			TestName: "empty",
-			Input:    "",
-			Expected: "",
-			Error:    true,
-		},
-		{
-			TestName: "descriptive name",
-			Input:    "some input",
-			Expected: "some output",
-			Error:    false,
-		},
-		{
-			TestName: "another descriptive name",
-			Input:    "more input",
-			Expected: "more output",
-			Error:    false,
-		},
-	}
-
-	for _, testCase := range testCases {
-		t.Run(testCase.TestName, func(t *testing.T) {
-			t.Parallel()
-			got, err := tfs3.FunctionFromDataSource(testCase.Input)
-
-			if err != nil && !testCase.Error {
-				t.Errorf("got error (%s), expected no error", err)
-			}
-
-			if err == nil && testCase.Error {
-				t.Errorf("got (%s) and no error, expected error", got)
-			}
-
-			if got != testCase.Expected {
-				t.Errorf("got %s, expected %s", got, testCase.Expected)
-			}
-		})
-	}
-}
-
-
-// TIP: ==== ACCEPTANCE TESTS ====
-// This is an example of a basic acceptance test. This should test as much of
-// standard functionality of the data source as possible, and test importing, if
-// applicable. We prefix its name with "TestAcc", the service, and the
-// data source name.
-//
-// Acceptance test access AWS and cost money to run.
 func TestAccS3BucketsDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-    // TIP: This is a long-running test guard for tests that run longer than
-    // 300s (5 min) generally.
-	if testing.Short() {
-		t.Skip("skipping long-running test in short mode")
-	}
-
-	var buckets s3.DescribeBucketsResponse
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	dataSourceName := "data.aws_s3_buckets.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	// region := acctest.Region()
+	// resourceName := "aws_s3_bucket.test"
+	// dataSourceName := "data.aws_s3_bucket.test"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
-		PreCheck: func() {
-			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, names.S3EndpointID)
-			testAccPreCheck(ctx, t)
-		},
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckBucketsDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccBucketsDataSourceConfig_basic(rName),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBucketsExists(ctx, dataSourceName, &buckets),
-					resource.TestCheckResourceAttr(dataSourceName, "auto_minor_version_upgrade", "false"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "maintenance_window_start_time.0.day_of_week"),
-					resource.TestCheckTypeSetElemNestedAttrs(dataSourceName, "user.*", map[string]string{
-						"console_access": "false",
-						"groups.#":       "0",
-						"username":       "Test",
-						"password":       "TestTest1234",
-					}),
-					// TIP: If the ARN can be partially or completely determined by the parameters passed, e.g. it contains the
-					// value of `rName`, either include the values in the regex or check for an exact match using `acctest.CheckResourceAttrRegionalARN`
-					// Alternatively, if the data source returns the values for a corresponding resource, use `resource.TestCheckResourceAttrPair` to
-					// check that the values are the same.
-					acctest.MatchResourceAttrRegionalARN(ctx, dataSourceName, names.AttrARN, "s3", regexache.MustCompile(`buckets:.+$`)),
-				),
+				Check:  resource.ComposeAggregateTestCheckFunc(),
 			},
 		},
 	})
 }
 
-func testAccBucketsDataSourceConfig_basic(rName, version string) string {
+func testAccBucketsDataSourceConfig_basic(rName string) string {
 	return fmt.Sprintf(`
-data "aws_security_group" "test" {
-  name = %[1]q
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
 }
 
 data "aws_s3_buckets" "test" {
-  buckets_name             = %[1]q
-  engine_type             = "ActiveS3"
-  engine_version          = %[2]q
-  host_instance_type      = "s3.t2.micro"
-  security_groups         = [aws_security_group.test.id]
-  authentication_strategy = "simple"
-  storage_type            = "efs"
-
-  logs {
-    general = true
-  }
-
-  user {
-    username = "Test"
-    password = "TestTest1234"
-  }
+  name_prefix = %[1]q
 }
-`, rName, version)
+`, rName)
 }

--- a/internal/service/s3/service_package_gen.go
+++ b/internal/service/s3/service_package_gen.go
@@ -43,6 +43,12 @@ func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*inttypes.S
 			Region:   inttypes.ResourceRegionDefault(),
 		},
 		{
+			Factory:  newBucketsDataSource,
+			TypeName: "aws_s3_buckets",
+			Name:     "Buckets",
+			Region:   inttypes.ResourceRegionDefault(),
+		},
+		{
 			Factory:  newDirectoryBucketsDataSource,
 			TypeName: "aws_s3_directory_buckets",
 			Name:     "Directory Buckets",

--- a/website/docs/d/s3_buckets.html.markdown
+++ b/website/docs/d/s3_buckets.html.markdown
@@ -1,0 +1,47 @@
+---
+subcategory: "S3 (Simple Storage)"
+layout: "aws"
+page_title: "AWS: aws_s3_buckets"
+description: |-
+  Provides details about an AWS S3 (Simple Storage) Buckets.
+---
+<!---
+Documentation guidelines:
+- Begin data source descriptions with "Provides details about..."
+- Use simple language and avoid jargon
+- Focus on brevity and clarity
+- Use present tense and active voice
+- Don't begin argument/attribute descriptions with "An", "The", "Defines", "Indicates", or "Specifies"
+- Boolean arguments should begin with "Whether to"
+- Use "example" instead of "test" in examples
+--->
+
+# Data Source: aws_s3_buckets
+
+Provides details about an AWS S3 (Simple Storage) Buckets.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_s3_buckets" "example" {
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `example_arg` - (Required) Brief description of the required argument.
+
+The following arguments are optional:
+
+* `optional_arg` - (Optional) Brief description of the optional argument.
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `arn` - ARN of the Buckets.
+* `example_attribute` - Brief description of the attribute.

--- a/website/docs/d/s3_buckets.html.markdown
+++ b/website/docs/d/s3_buckets.html.markdown
@@ -23,9 +23,9 @@ data "aws_s3_buckets" "example" {
 
 ```terraform
 data "aws_s3_buckets" "example" {
-  max_buckets = 3
-  prefix      = "tf-"
-  region      = "us-west-2"
+  bucket_region      = "us-west-2"
+  max_buckets        = 3
+  prefix             = "tf-"
 }
 ```
 
@@ -33,6 +33,7 @@ data "aws_s3_buckets" "example" {
 
 The following arguments are optional:
 
+* `bucket_region` - (Optional) imits the response to buckets that are located in the specified AWS Region. The AWS Region must be expressed according to the AWS Region code
 * `max_buckets` - (Optional) Maximum number of buckets to return.
     * Valid Range: Minimum value of 1. Maximum value of 10000.
 * `prefix` - (Optional) Limits the response to bucket names that begin with the specified bucket name prefix.

--- a/website/docs/d/s3_buckets.html.markdown
+++ b/website/docs/d/s3_buckets.html.markdown
@@ -3,24 +3,21 @@ subcategory: "S3 (Simple Storage)"
 layout: "aws"
 page_title: "AWS: aws_s3_buckets"
 description: |-
-  Provides details about an AWS S3 (Simple Storage) Buckets.
+  Provides details about AWS S3 (Simple Storage) buckets with optional filters.
 ---
-<!---
-Documentation guidelines:
-- Begin data source descriptions with "Provides details about..."
-- Use simple language and avoid jargon
-- Focus on brevity and clarity
-- Use present tense and active voice
-- Don't begin argument/attribute descriptions with "An", "The", "Defines", "Indicates", or "Specifies"
-- Boolean arguments should begin with "Whether to"
-- Use "example" instead of "test" in examples
---->
 
 # Data Source: aws_s3_buckets
 
-Provides details about an AWS S3 (Simple Storage) Buckets.
+Provides details about AWS S3 (Simple Storage) buckets with optional filters.
 
 ## Example Usage
+```terraform
+data "aws_s3_buckets" "example" {
+  max_buckets = 3
+  prefix = "tf-"
+  region = "us-west-2"
+}
+```
 
 ### Basic Usage
 
@@ -31,17 +28,18 @@ data "aws_s3_buckets" "example" {
 
 ## Argument Reference
 
-The following arguments are required:
-
-* `example_arg` - (Required) Brief description of the required argument.
-
 The following arguments are optional:
-
-* `optional_arg` - (Optional) Brief description of the optional argument.
+ * `max_buckets` - (Optional) Maximum number of buckets to return.
+    * Valid Range: Minimum value of 1. Maximum value of 10000.
+ * `prefix` - (Optional) Limits the response to bucket names that begin with the specified bucket name prefix.
+ * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 
 ## Attribute Reference
 
 This data source exports the following attributes in addition to the arguments above:
 
-* `arn` - ARN of the Buckets.
-* `example_attribute` - Brief description of the attribute.
+* `buckets` - List of bucket objects:
+   * `bucket_arn` - Bucket ARN.
+   * `bucket_region` - Bucket region.
+   * `creation_date` - Bucket creation date.
+   * `name` - Bucket name.

--- a/website/docs/d/s3_buckets.html.markdown
+++ b/website/docs/d/s3_buckets.html.markdown
@@ -23,9 +23,9 @@ data "aws_s3_buckets" "example" {
 
 ```terraform
 data "aws_s3_buckets" "example" {
-  bucket_region      = "us-west-2"
-  max_buckets        = 3
-  prefix             = "tf-"
+  bucket_region = "us-west-2"
+  max_buckets   = 3
+  prefix        = "tf-"
 }
 ```
 
@@ -33,7 +33,7 @@ data "aws_s3_buckets" "example" {
 
 The following arguments are optional:
 
-* `bucket_region` - (Optional) imits the response to buckets that are located in the specified AWS Region. The AWS Region must be expressed according to the AWS Region code.
+* `bucket_region` - (Optional) Limits the response to buckets that are located in the specified AWS Region. The AWS Region must be expressed according to the AWS Region code.
 * `max_buckets` - (Optional) Maximum number of buckets returned. Unlike the AWS API parameter, this is a provider-level total cap.
 * `prefix` - (Optional) Limits the response to bucket names that begin with the specified bucket name prefix.
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).

--- a/website/docs/d/s3_buckets.html.markdown
+++ b/website/docs/d/s3_buckets.html.markdown
@@ -12,18 +12,20 @@ Provides details about AWS S3 (Simple Storage) buckets with optional filters.
 
 ## Example Usage
 
+### Basic Usage
+
+```terraform
+data "aws_s3_buckets" "example" {
+}
+```
+
+### Full Usage
+
 ```terraform
 data "aws_s3_buckets" "example" {
   max_buckets = 3
   prefix      = "tf-"
   region      = "us-west-2"
-}
-```
-
-### Basic Usage
-
-```terraform
-data "aws_s3_buckets" "example" {
 }
 ```
 

--- a/website/docs/d/s3_buckets.html.markdown
+++ b/website/docs/d/s3_buckets.html.markdown
@@ -33,9 +33,8 @@ data "aws_s3_buckets" "example" {
 
 The following arguments are optional:
 
-* `bucket_region` - (Optional) imits the response to buckets that are located in the specified AWS Region. The AWS Region must be expressed according to the AWS Region code
-* `max_buckets` - (Optional) Maximum number of buckets to return.
-    * Valid Range: Minimum value of 1. Maximum value of 10000.
+* `bucket_region` - (Optional) imits the response to buckets that are located in the specified AWS Region. The AWS Region must be expressed according to the AWS Region code.
+* `max_buckets` - (Optional) Maximum number of buckets returned. Unlike the AWS API parameter, this is a provider-level total cap.
 * `prefix` - (Optional) Limits the response to bucket names that begin with the specified bucket name prefix.
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 

--- a/website/docs/d/s3_buckets.html.markdown
+++ b/website/docs/d/s3_buckets.html.markdown
@@ -32,7 +32,7 @@ data "aws_s3_buckets" "example" {
 The following arguments are optional:
 
 * `max_buckets` - (Optional) Maximum number of buckets to return.
-  * Valid Range: Minimum value of 1. Maximum value of 10000.
+    * Valid Range: Minimum value of 1. Maximum value of 10000.
 * `prefix` - (Optional) Limits the response to bucket names that begin with the specified bucket name prefix.
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 
@@ -41,7 +41,7 @@ The following arguments are optional:
 This data source exports the following attributes in addition to the arguments above:
 
 * `buckets` - List of bucket objects:
-   * `bucket_arn` - Bucket ARN.
-   * `bucket_region` - Bucket region.
-   * `creation_date` - Bucket creation date.
-   * `name` - Bucket name.
+    * `bucket_arn` - Bucket ARN.
+    * `bucket_region` - Bucket region.
+    * `creation_date` - Bucket creation date.
+    * `name` - Bucket name.

--- a/website/docs/d/s3_buckets.html.markdown
+++ b/website/docs/d/s3_buckets.html.markdown
@@ -11,11 +11,12 @@ description: |-
 Provides details about AWS S3 (Simple Storage) buckets with optional filters.
 
 ## Example Usage
+
 ```terraform
 data "aws_s3_buckets" "example" {
   max_buckets = 3
-  prefix = "tf-"
-  region = "us-west-2"
+  prefix      = "tf-"
+  region      = "us-west-2"
 }
 ```
 
@@ -29,10 +30,11 @@ data "aws_s3_buckets" "example" {
 ## Argument Reference
 
 The following arguments are optional:
- * `max_buckets` - (Optional) Maximum number of buckets to return.
-    * Valid Range: Minimum value of 1. Maximum value of 10000.
- * `prefix` - (Optional) Limits the response to bucket names that begin with the specified bucket name prefix.
- * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
+
+* `max_buckets` - (Optional) Maximum number of buckets to return.
+  * Valid Range: Minimum value of 1. Maximum value of 10000.
+* `prefix` - (Optional) Limits the response to bucket names that begin with the specified bucket name prefix.
+* `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #25891
Closes #15544
Closes #41400

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBuckets.html


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t T=TestAccS3BucketsDataSource_ K=s3
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 aws_s3_buckets 🌿...
TF_ACC=1 go1.26.4 test ./internal/service/s3/... -v -count 1 -parallel 20 -run='TestAccS3BucketsDataSource_'  -timeout 360m -vet=off
2026/07/17 17:06:40 Creating Terraform AWS Provider (SDKv2-style)...
2026/07/17 17:06:40 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccS3BucketsDataSource_basic
=== PAUSE TestAccS3BucketsDataSource_basic
=== RUN   TestAccS3BucketsDataSource_maxBuckets
=== PAUSE TestAccS3BucketsDataSource_maxBuckets
=== CONT  TestAccS3BucketsDataSource_basic
=== CONT  TestAccS3BucketsDataSource_maxBuckets
--- PASS: TestAccS3BucketsDataSource_basic (16.56s)
--- PASS: TestAccS3BucketsDataSource_maxBuckets (16.56s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3	23.328s

...
```
