### PR TITLE
resource/aws_sagemaker_endpoint: Prevent error why retrying creation

### DIFF
--- a/.changelog/48966.txt
+++ b/.changelog/48966.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_sagemaker_endpoint: Prevents `Cannot create already existing endpoint` error when retrying creation.
+```

--- a/internal/service/sagemaker/endpoint.go
+++ b/internal/service/sagemaker/endpoint.go
@@ -269,7 +269,7 @@ func resourceEndpointCreate(ctx context.Context, d *schema.ResourceData, meta an
 
 	tflog.Info(ctx, "Creating SageMaker AI Endpoint")
 
-	err := tfresource.Retry(ctx, propagationTimeout*3, func(ctx context.Context) *tfresource.RetryError {
+	err := tfresource.Retry(ctx, propagationTimeout*2, func(ctx context.Context) *tfresource.RetryError {
 		tflog.Info(ctx, "Calling CreateEndpoint")
 		_, err := conn.CreateEndpoint(ctx, &input)
 
@@ -312,7 +312,7 @@ func resourceEndpointRead(ctx context.Context, d *schema.ResourceData, meta any)
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SageMakerClient(ctx)
 
-	endpoint, err := findEndpointByName(ctx, conn, d.Id())
+	endpoint, err := findEndpointByNameExcludeDeleting(ctx, conn, d.Id())
 
 	if !d.IsNewResource() && retry.NotFound(err) {
 		log.Printf("[WARN] SageMaker AI Endpoint (%s) not found, removing from state", d.Id())
@@ -398,7 +398,7 @@ func endpointDeleteSync(ctx context.Context, conn *sagemaker.Client, name string
 	tflog.Trace(ctx, "Waiting for SageMaker AI Endpoint deletion")
 
 	if _, err := waitEndpointDeleted(ctx, conn, name); err != nil {
-		return fmt.Errorf("waiting for SageMaker AI Endpoint (%s) delete: %s", name, err)
+		return fmt.Errorf("waiting for SageMaker AI Endpoint (%s) delete: %w", name, err)
 	}
 
 	tflog.Info(ctx, "Deleted SageMaker AI Endpoint")
@@ -406,6 +406,7 @@ func endpointDeleteSync(ctx context.Context, conn *sagemaker.Client, name string
 	return nil
 }
 
+// findEndpointByName finds an Endpoint by name
 func findEndpointByName(ctx context.Context, conn *sagemaker.Client, name string) (*sagemaker.DescribeEndpointOutput, error) {
 	input := sagemaker.DescribeEndpointInput{
 		EndpointName: aws.String(name),
@@ -413,6 +414,16 @@ func findEndpointByName(ctx context.Context, conn *sagemaker.Client, name string
 
 	output, err := findEndpoint(ctx, conn, &input)
 
+	if err != nil {
+		return nil, err
+	}
+
+	return output, nil
+}
+
+// findEndpointByNameExcludeDeleting finds an Endpoint by name, but excludes it if it is in status "Deleting"
+func findEndpointByNameExcludeDeleting(ctx context.Context, conn *sagemaker.Client, name string) (*sagemaker.DescribeEndpointOutput, error) {
+	output, err := findEndpointByName(ctx, conn, name)
 	if err != nil {
 		return nil, err
 	}
@@ -491,11 +502,10 @@ func waitEndpointDeleted(ctx context.Context, conn *sagemaker.Client, name strin
 		timeout = 10 * time.Minute
 	)
 	stateConf := &retry.StateChangeConf{
-		Pending:                   enum.Slice(awstypes.EndpointStatusDeleting),
-		Target:                    []string{},
-		Refresh:                   statusEndpoint(conn, name),
-		Timeout:                   timeout,
-		ContinuousTargetOccurence: 3,
+		Pending: enum.Slice(awstypes.EndpointStatusDeleting),
+		Target:  []string{},
+		Refresh: statusEndpoint(conn, name),
+		Timeout: timeout,
 	}
 
 	outputRaw, err := stateConf.WaitForStateContext(ctx)

--- a/internal/service/sagemaker/endpoint.go
+++ b/internal/service/sagemaker/endpoint.go
@@ -16,6 +16,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sagemaker"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/sagemaker/types"
 	"github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -24,6 +25,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/logging"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -263,7 +265,12 @@ func resourceEndpointCreate(ctx context.Context, d *schema.ResourceData, meta an
 		input.DeploymentConfig = expandDeploymentConfig(v.([]any))
 	}
 
-	err := tfresource.Retry(ctx, propagationTimeout, func(ctx context.Context) *tfresource.RetryError {
+	ctx = tflog.SetField(ctx, logging.ResourceAttributeKey(names.AttrName), name)
+
+	tflog.Info(ctx, "Creating SageMaker AI Endpoint")
+
+	err := tfresource.Retry(ctx, propagationTimeout*3, func(ctx context.Context) *tfresource.RetryError {
+		tflog.Info(ctx, "Calling CreateEndpoint")
 		_, err := conn.CreateEndpoint(ctx, &input)
 
 		if err != nil {
@@ -274,12 +281,12 @@ func resourceEndpointCreate(ctx context.Context, d *schema.ResourceData, meta an
 
 		// unexpected state 'Failed', wanted target 'InService'. last error: The execution role ARN "..." is invalid. Please ensure that the role exists and that its trust relationship policy allows the action "sts:AssumeRole" for the service principal "sagemaker.amazonaws.com"
 		if errs.Contains(err, `Please ensure that the role exists and that its trust relationship policy allows the action "sts:AssumeRole" for the service principal "sagemaker.amazonaws.com"`) {
-			d := resourceEndpoint().Data(nil)
-			d.SetId(name)
-			if diags := resourceEndpointDelete(ctx, d, meta); diags.HasError() {
-				return tfresource.NonRetryableError(sdkdiag.DiagnosticsError(diags))
+			tflog.Warn(ctx, "Error creating SageMaker AI Endpoint: Rolling back", map[string]any{
+				"error": err.Error(),
+			})
+			if err := endpointDeleteSync(ctx, conn, name); err != nil {
+				return tfresource.NonRetryableError(err)
 			}
-
 			return tfresource.RetryableError(err)
 		}
 
@@ -293,6 +300,8 @@ func resourceEndpointCreate(ctx context.Context, d *schema.ResourceData, meta an
 	if err != nil {
 		return sdkdiag.AppendFromErr(diags, err)
 	}
+
+	tflog.Info(ctx, "Created SageMaker AI Endpoint")
 
 	d.SetId(name)
 
@@ -358,25 +367,43 @@ func resourceEndpointDelete(ctx context.Context, d *schema.ResourceData, meta an
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SageMakerClient(ctx)
 
-	log.Printf("[INFO] Deleting SageMaker AI Endpoint: %s", d.Id())
-	input := sagemaker.DeleteEndpointInput{
-		EndpointName: aws.String(d.Id()),
-	}
-	_, err := conn.DeleteEndpoint(ctx, &input)
-
-	if tfawserr.ErrMessageContains(err, ErrCodeValidationException, "Could not find endpoint") {
-		return diags
-	}
-
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "deleting SageMaker AI Endpoint (%s): %s", d.Id(), err)
-	}
-
-	if _, err := waitEndpointDeleted(ctx, conn, d.Id()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "waiting for SageMaker AI Endpoint (%s) delete: %s", d.Id(), err)
+	if err := endpointDeleteSync(ctx, conn, d.Id()); err != nil {
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	return diags
+}
+
+func endpointDeleteSync(ctx context.Context, conn *sagemaker.Client, name string) error {
+	ctx = tflog.SetField(ctx, logging.ResourceAttributeKey(names.AttrName), name)
+
+	tflog.Info(ctx, "Deleting SageMaker AI Endpoint")
+
+	input := sagemaker.DeleteEndpointInput{
+		EndpointName: aws.String(name),
+	}
+
+	_, err := conn.DeleteEndpoint(ctx, &input)
+	if tfawserr.ErrMessageContains(err, ErrCodeValidationException, "Could not find endpoint") {
+		tflog.Info(ctx, "SageMaker AI Endpoint not found")
+		return nil
+	}
+	if err != nil {
+		tflog.Info(ctx, "Error deleting SageMaker AI Endpoint", map[string]any{
+			"error": err.Error(),
+		})
+		return err
+	}
+
+	tflog.Trace(ctx, "Waiting for SageMaker AI Endpoint deletion")
+
+	if _, err := waitEndpointDeleted(ctx, conn, name); err != nil {
+		return fmt.Errorf("waiting for SageMaker AI Endpoint (%s) delete: %s", name, err)
+	}
+
+	tflog.Info(ctx, "Deleted SageMaker AI Endpoint")
+
+	return nil
 }
 
 func findEndpointByName(ctx context.Context, conn *sagemaker.Client, name string) (*sagemaker.DescribeEndpointOutput, error) {

--- a/internal/service/sagemaker/endpoint.go
+++ b/internal/service/sagemaker/endpoint.go
@@ -464,10 +464,11 @@ func waitEndpointDeleted(ctx context.Context, conn *sagemaker.Client, name strin
 		timeout = 10 * time.Minute
 	)
 	stateConf := &retry.StateChangeConf{
-		Pending: enum.Slice(awstypes.EndpointStatusDeleting),
-		Target:  []string{},
-		Refresh: statusEndpoint(conn, name),
-		Timeout: timeout,
+		Pending:                   enum.Slice(awstypes.EndpointStatusDeleting),
+		Target:                    []string{},
+		Refresh:                   statusEndpoint(conn, name),
+		Timeout:                   timeout,
+		ContinuousTargetOccurence: 3,
 	}
 
 	outputRaw, err := stateConf.WaitForStateContext(ctx)

--- a/internal/service/sagemaker/endpoint_test.go
+++ b/internal/service/sagemaker/endpoint_test.go
@@ -298,7 +298,7 @@ func testAccCheckEndpointExists(ctx context.Context, t *testing.T, n string) res
 
 		conn := acctest.ProviderMeta(ctx, t).SageMakerClient(ctx)
 
-		_, err := tfsagemaker.FindEndpointByName(ctx, conn, rs.Primary.ID)
+		_, err := tfsagemaker.FindEndpointByNameExcludeDeleting(ctx, conn, rs.Primary.ID)
 
 		return err
 	}

--- a/internal/service/sagemaker/exports_test.go
+++ b/internal/service/sagemaker/exports_test.go
@@ -98,6 +98,7 @@ var (
 	FindDeviceFleetByName                     = findDeviceFleetByName
 	FindDomainByName                          = findDomainByName
 	FindEndpointByName                        = findEndpointByName
+	FindEndpointByNameExcludeDeleting         = findEndpointByNameExcludeDeleting
 	FindEndpointConfigByName                  = findEndpointConfigByName
 	FindFeatureGroupByName                    = findFeatureGroupByName
 	FindFlowDefinitionByName                  = findFlowDefinitionByName


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

There is a potential race condition when retrying to create the SageMaker AI Endpoint. This results in the error

> Cannot create already existing endpoint

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=sagemaker TESTS=TestAccSageMakerEndpoint_

--- PASS: TestAccSageMakerEndpoint_deploymentConfig_blueGreen (188.63s)
--- PASS: TestAccSageMakerEndpoint_deploymentConfig (190.19s)
--- PASS: TestAccSageMakerEndpoint_disappears (191.96s)
--- PASS: TestAccSageMakerEndpoint_deploymentConfig_rolling (196.15s)
--- PASS: TestAccSageMakerEndpoint_basic (196.41s)
--- PASS: TestAccSageMakerEndpoint_tags (208.22s)
--- PASS: TestAccSageMakerEndpoint_endpointName (332.17s)
```
