### PR TITLE
aws_s3_bucket_notification: Add list support

### DIFF
--- a/.changelog/48974.txt
+++ b/.changelog/48974.txt
@@ -1,0 +1,3 @@
+```release-note:new-list-resource
+aws_s3_bucket_notification
+```

--- a/internal/service/s3/bucket_notification.go
+++ b/internal/service/s3/bucket_notification.go
@@ -360,7 +360,13 @@ func resourceBucketNotificationRead(ctx context.Context, d *schema.ResourceData,
 		return sdkdiag.AppendErrorf(diags, "reading S3 Bucket Notification (%s): %s", d.Id(), err)
 	}
 
-	d.Set(names.AttrBucket, bucket)
+	return resourceBucketNotificationFlatten(output, d)
+}
+
+func resourceBucketNotificationFlatten(output *s3.GetBucketNotificationConfigurationOutput, d *schema.ResourceData) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	d.Set(names.AttrBucket, d.Id())
 	d.Set("eventbridge", output.EventBridgeConfiguration != nil)
 	if err := d.Set("lambda_function", flattenLambdaFunctionConfigurations(output.LambdaFunctionConfigurations)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting lambda_function: %s", err)

--- a/internal/service/s3/bucket_notification_list.go
+++ b/internal/service/s3/bucket_notification_list.go
@@ -1,0 +1,116 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package s3
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/logging"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
+	inttypes "github.com/hashicorp/terraform-provider-aws/internal/types"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// Function annotations are used for list resource registration to the Provider. DO NOT EDIT.
+// @SDKListResource("aws_s3_bucket_notification")
+func newBucketNotificationResourceAsListResource() inttypes.ListResourceForSDK {
+	l := bucketNotificationListResource{}
+	l.SetResourceSchema(resourceBucketNotification())
+	return &l
+}
+
+var _ list.ListResource = &bucketNotificationListResource{}
+
+type bucketNotificationListResource struct {
+	framework.ListResourceWithSDKv2Resource
+}
+
+func (l *bucketNotificationListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
+	conn := l.Meta().S3Client(ctx)
+
+	var query listBucketNotificationModel
+	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
+		if diags := request.Config.Get(ctx, &query); diags.HasError() {
+			stream.Results = list.ListResultsStreamDiagnostics(diags)
+			return
+		}
+	}
+
+	tflog.Info(ctx, "Listing S3 Bucket Notifications")
+
+	stream.Results = func(yield func(list.ListResult) bool) {
+		input := s3.ListBucketsInput{
+			BucketRegion: aws.String(l.Meta().Region(ctx)),
+			MaxBuckets:   aws.Int32(int32(request.Limit)),
+		}
+		for bucket, err := range listBuckets(ctx, conn, &input) {
+			if err != nil {
+				result := fwdiag.NewListResultErrorDiagnostic(err)
+				yield(result)
+				return
+			}
+
+			bucketName := aws.ToString(bucket.Name)
+
+			// Directory buckets do not support standard notification configuration.
+			if isDirectoryBucket(bucketName) {
+				continue
+			}
+
+			ctx := tflog.SetField(ctx, logging.ResourceAttributeKey(names.AttrBucket), bucketName)
+
+			output, err := findBucketNotificationConfiguration(ctx, conn, bucketName, "")
+			if retry.NotFound(err) {
+				continue
+			}
+			if err != nil {
+				tflog.Error(ctx, "Reading S3 Bucket Notification", map[string]any{
+					"error": err.Error(),
+				})
+				continue
+			}
+
+			result := request.NewListResult(ctx)
+			rd := l.ResourceData()
+			rd.SetId(bucketName)
+			rd.Set(names.AttrBucket, bucketName)
+
+			if request.IncludeResource {
+				if diags := resourceBucketNotificationFlatten(output, rd); diags.HasError() {
+					tflog.Error(ctx, "Flattening S3 Bucket Notification", map[string]any{
+						"diags": sdkdiag.DiagnosticsString(diags),
+					})
+					continue
+				}
+				if rd.Id() == "" {
+					tflog.Warn(ctx, "Resource disappeared during listing, skipping")
+					continue
+				}
+			}
+
+			result.DisplayName = bucketName
+
+			l.SetResult(ctx, l.Meta(), request.IncludeResource, rd, &result)
+			if result.Diagnostics.HasError() {
+				yield(result)
+				return
+			}
+
+			if !yield(result) {
+				return
+			}
+		}
+	}
+}
+
+type listBucketNotificationModel struct {
+	framework.WithRegionModel
+}

--- a/internal/service/s3/bucket_notification_list_test.go
+++ b/internal/service/s3/bucket_notification_list_test.go
@@ -1,0 +1,188 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package s3_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	tfquerycheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/querycheck"
+	tfqueryfilter "github.com/hashicorp/terraform-provider-aws/internal/acctest/queryfilter"
+	tfstatecheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/statecheck"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccS3BucketNotification_List_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_s3_bucket_notification.test[0]"
+	resourceName2 := "aws_s3_bucket_notification.test[1]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity1 := tfstatecheck.Identity()
+	identity2 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
+		CheckDestroy:             testAccCheckBucketNotificationDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/BucketNotification/list_basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+
+					identity2.GetIdentity(resourceName2),
+				},
+			},
+
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/BucketNotification/list_basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_s3_bucket_notification.test", identity1.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_s3_bucket_notification.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), knownvalue.StringExact(rName+"-0")),
+					tfquerycheck.ExpectNoResourceObject("aws_s3_bucket_notification.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks())),
+
+					tfquerycheck.ExpectIdentityFunc("aws_s3_bucket_notification.test", identity2.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_s3_bucket_notification.test", tfqueryfilter.ByResourceIdentityFunc(identity2.Checks()), knownvalue.StringExact(rName+"-1")),
+					tfquerycheck.ExpectNoResourceObject("aws_s3_bucket_notification.test", tfqueryfilter.ByResourceIdentityFunc(identity2.Checks())),
+				},
+			},
+		},
+	})
+}
+
+func TestAccS3BucketNotification_List_includeResource(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_s3_bucket_notification.test[0]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity1 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
+		CheckDestroy:             testAccCheckBucketNotificationDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/BucketNotification/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(1),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+				},
+			},
+
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/BucketNotification/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(1),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_s3_bucket_notification.test", identity1.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_s3_bucket_notification.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), knownvalue.StringExact(rName+"-0")),
+					querycheck.ExpectResourceKnownValues("aws_s3_bucket_notification.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), []querycheck.KnownValueCheck{
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrID), knownvalue.StringExact(rName+"-0")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrBucket), knownvalue.StringExact(rName+"-0")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.Region())),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("eventbridge"), knownvalue.Bool(true)),
+					}),
+				},
+			},
+		},
+	})
+}
+
+func TestAccS3BucketNotification_List_regionOverride(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_s3_bucket_notification.test[0]"
+	resourceName2 := "aws_s3_bucket_notification.test[1]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity1 := tfstatecheck.Identity()
+	identity2 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
+		CheckDestroy:             testAccCheckBucketNotificationDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/BucketNotification/list_region_override/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+					"region":         config.StringVariable(acctest.AlternateRegion()),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+
+					identity2.GetIdentity(resourceName2),
+				},
+			},
+
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/BucketNotification/list_region_override/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+					"region":         config.StringVariable(acctest.AlternateRegion()),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_s3_bucket_notification.test", identity1.Checks()),
+
+					tfquerycheck.ExpectIdentityFunc("aws_s3_bucket_notification.test", identity2.Checks()),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/s3/service_package_gen.go
+++ b/internal/service/s3/service_package_gen.go
@@ -436,6 +436,13 @@ func (p *servicePackage) SDKListResources(ctx context.Context) iter.Seq[*inttype
 			),
 		},
 		{
+			Factory:  newBucketNotificationResourceAsListResource,
+			TypeName: "aws_s3_bucket_notification",
+			Name:     "Bucket Notification",
+			Region:   inttypes.ResourceRegionDefault(),
+			Identity: inttypes.RegionalSingleParameterIdentity(inttypes.StringIdentityAttribute(names.AttrBucket, true)),
+		},
+		{
 			Factory:  newBucketOwnershipControlsResourceAsListResource,
 			TypeName: "aws_s3_bucket_ownership_controls",
 			Name:     "Bucket Ownership Controls",

--- a/internal/service/s3/testdata/BucketNotification/list_basic/main.tf
+++ b/internal/service/s3/testdata/BucketNotification/list_basic/main.tf
@@ -1,0 +1,28 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_s3_bucket_notification" "test" {
+  count = var.resource_count
+
+  bucket = aws_s3_bucket.test[count.index].id
+
+  eventbridge = true
+}
+
+resource "aws_s3_bucket" "test" {
+  count = var.resource_count
+
+  bucket = "${var.rName}-${count.index}"
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}

--- a/internal/service/s3/testdata/BucketNotification/list_basic/query.tfquery.hcl
+++ b/internal/service/s3/testdata/BucketNotification/list_basic/query.tfquery.hcl
@@ -1,0 +1,6 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_s3_bucket_notification" "test" {
+  provider = aws
+}

--- a/internal/service/s3/testdata/BucketNotification/list_include_resource/main.tf
+++ b/internal/service/s3/testdata/BucketNotification/list_include_resource/main.tf
@@ -1,0 +1,28 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_s3_bucket_notification" "test" {
+  count = var.resource_count
+
+  bucket = aws_s3_bucket.test[count.index].id
+
+  eventbridge = true
+}
+
+resource "aws_s3_bucket" "test" {
+  count = var.resource_count
+
+  bucket = "${var.rName}-${count.index}"
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}

--- a/internal/service/s3/testdata/BucketNotification/list_include_resource/query.tfquery.hcl
+++ b/internal/service/s3/testdata/BucketNotification/list_include_resource/query.tfquery.hcl
@@ -1,0 +1,8 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_s3_bucket_notification" "test" {
+  provider = aws
+
+  include_resource = true
+}

--- a/internal/service/s3/testdata/BucketNotification/list_region_override/main.tf
+++ b/internal/service/s3/testdata/BucketNotification/list_region_override/main.tf
@@ -1,0 +1,36 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_s3_bucket_notification" "test" {
+  count  = var.resource_count
+  region = var.region
+
+  bucket = aws_s3_bucket.test[count.index].id
+
+  eventbridge = true
+}
+
+resource "aws_s3_bucket" "test" {
+  count  = var.resource_count
+  region = var.region
+
+  bucket = "${var.rName}-${count.index}"
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}
+
+variable "region" {
+  description = "Region to deploy resource in"
+  type        = string
+  nullable    = false
+}

--- a/internal/service/s3/testdata/BucketNotification/list_region_override/query.tfquery.hcl
+++ b/internal/service/s3/testdata/BucketNotification/list_region_override/query.tfquery.hcl
@@ -1,0 +1,10 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_s3_bucket_notification" "test" {
+  provider = aws
+
+  config {
+    region = var.region
+  }
+}

--- a/website/docs/list-resources/s3_bucket_notification.html.markdown
+++ b/website/docs/list-resources/s3_bucket_notification.html.markdown
@@ -1,0 +1,37 @@
+---
+subcategory: "S3 (Simple Storage)"
+layout: "aws"
+page_title: "AWS: aws_s3_bucket_notification"
+description: |-
+  Lists S3 (Simple Storage) Bucket Notification resources.
+---
+
+# List Resource: aws_s3_bucket_notification
+
+Lists S3 (Simple Storage) Bucket Notification resources.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+list "aws_s3_bucket_notification" "example" {
+  provider = aws
+}
+```
+
+### Include Resource Data
+
+```terraform
+list "aws_s3_bucket_notification" "example" {
+  provider = aws
+
+  include_resource = true
+}
+```
+
+## Argument Reference
+
+This list resource supports the following arguments:
+
+* `region` - (Optional) Region to query. Defaults to provider region.


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Adds list support to `aws_s3_bucket_notification`

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #48592 

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t T=TestAccS3BucketNotification_List_ K=s3
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-s3-bucket-notification-list 🌿...
TF_ACC=1 go1.26.5 test ./internal/service/s3/... -v -count 1 -parallel 20 -run='TestAccS3BucketNotification_List_'  -timeout 360m -vet=off
2026/07/16 17:38:32 Creating Terraform AWS Provider (SDKv2-style)...
2026/07/16 17:38:32 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccS3BucketNotification_List_basic
=== PAUSE TestAccS3BucketNotification_List_basic
=== RUN   TestAccS3BucketNotification_List_includeResource
=== PAUSE TestAccS3BucketNotification_List_includeResource
=== RUN   TestAccS3BucketNotification_List_regionOverride
=== PAUSE TestAccS3BucketNotification_List_regionOverride
=== CONT  TestAccS3BucketNotification_List_basic
=== CONT  TestAccS3BucketNotification_List_regionOverride
=== CONT  TestAccS3BucketNotification_List_includeResource
--- PASS: TestAccS3BucketNotification_List_regionOverride (40.79s)
--- PASS: TestAccS3BucketNotification_List_includeResource (41.31s)
--- PASS: TestAccS3BucketNotification_List_basic (46.77s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/s3 52.154s
```
