### PR TITLE
resource/aws_eks_node_group: Add warm_pool configuration block

### DIFF
--- a/.changelog/48977.txt
+++ b/.changelog/48977.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_eks_node_group: Add `warm_pool` configuration block
+```
+
+```release-note:enhancement
+data-source/aws_eks_node_group: Add `warm_pool` attribute
+```

--- a/.changelog/48977.txt
+++ b/.changelog/48977.txt
@@ -1,7 +1,7 @@
 ```release-note:enhancement
-resource/aws_eks_node_group: Add `warm_pool` configuration block
+resource/aws_eks_node_group: Add `warm_pool_config` configuration block
 ```
 
 ```release-note:enhancement
-data-source/aws_eks_node_group: Add `warm_pool` attribute
+data-source/aws_eks_node_group: Add `warm_pool_config` attribute
 ```

--- a/internal/service/eks/node_group.go
+++ b/internal/service/eks/node_group.go
@@ -378,7 +378,7 @@ func resourceNodeGroup() *schema.Resource {
 					Optional: true,
 					Computed: true,
 				},
-				"warm_pool": {
+				"warm_pool_config": {
 					Type:     schema.TypeList,
 					Optional: true,
 					MaxItems: 1,
@@ -483,7 +483,7 @@ func resourceNodeGroupCreate(ctx context.Context, d *schema.ResourceData, meta a
 		input.Version = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("warm_pool"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+	if v, ok := d.GetOk("warm_pool_config"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
 		input.WarmPoolConfig = expandWarmPoolConfig(v.([]any)[0].(map[string]any))
 	}
 
@@ -571,11 +571,11 @@ func resourceNodeGroupRead(ctx context.Context, d *schema.ResourceData, meta any
 	}
 	d.Set(names.AttrVersion, nodeGroup.Version)
 	if nodeGroup.WarmPoolConfig != nil {
-		if err := d.Set("warm_pool", []any{flattenWarmPoolConfig(nodeGroup.WarmPoolConfig)}); err != nil {
-			return sdkdiag.AppendErrorf(diags, "setting warm_pool: %s", err)
+		if err := d.Set("warm_pool_config", []any{flattenWarmPoolConfig(nodeGroup.WarmPoolConfig)}); err != nil {
+			return sdkdiag.AppendErrorf(diags, "setting warm_pool_config: %s", err)
 		}
 	} else {
-		d.Set("warm_pool", nil)
+		d.Set("warm_pool_config", nil)
 	}
 
 	setTagsOut(ctx, nodeGroup.Tags)
@@ -642,7 +642,7 @@ func resourceNodeGroupUpdate(ctx context.Context, d *schema.ResourceData, meta a
 		}
 	}
 
-	if d.HasChanges("labels", "node_repair_config", "scaling_config", "taint", "update_config", "warm_pool") {
+	if d.HasChanges("labels", "node_repair_config", "scaling_config", "taint", "update_config", "warm_pool_config") {
 		oldLabelsRaw, newLabelsRaw := d.GetChange("labels")
 		oldTaintsRaw, newTaintsRaw := d.GetChange("taint")
 
@@ -672,8 +672,8 @@ func resourceNodeGroupUpdate(ctx context.Context, d *schema.ResourceData, meta a
 			}
 		}
 
-		if d.HasChange("warm_pool") {
-			if v, ok := d.GetOk("warm_pool"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		if d.HasChange("warm_pool_config") {
+			if v, ok := d.GetOk("warm_pool_config"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
 				input.WarmPoolConfig = expandWarmPoolConfig(v.([]any)[0].(map[string]any))
 			} else {
 				input.WarmPoolConfig = &types.WarmPoolConfig{Enabled: aws.Bool(false)}

--- a/internal/service/eks/node_group.go
+++ b/internal/service/eks/node_group.go
@@ -378,6 +378,38 @@ func resourceNodeGroup() *schema.Resource {
 					Optional: true,
 					Computed: true,
 				},
+				"warm_pool": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"max_group_prepared_capacity": {
+								Type:         schema.TypeInt,
+								Optional:     true,
+								Computed:     true,
+								ValidateFunc: validation.IntAtLeast(-1),
+							},
+							"min_size": {
+								Type:         schema.TypeInt,
+								Optional:     true,
+								Computed:     true,
+								ValidateFunc: validation.IntAtLeast(0),
+							},
+							"pool_state": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								Computed:         true,
+								ValidateDiagFunc: enum.Validate[types.WarmPoolState](),
+							},
+							"reuse_on_scale_in": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Computed: true,
+							},
+						},
+					},
+				},
 			}
 		},
 	}
@@ -450,6 +482,10 @@ func resourceNodeGroupCreate(ctx context.Context, d *schema.ResourceData, meta a
 
 	if v, ok := d.GetOk(names.AttrVersion); ok {
 		input.Version = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("warm_pool"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.WarmPoolConfig = expandWarmPoolConfig(v.([]any)[0].(map[string]any))
 	}
 
 	_, err := conn.CreateNodegroup(ctx, &input)
@@ -536,6 +572,13 @@ func resourceNodeGroupRead(ctx context.Context, d *schema.ResourceData, meta any
 		d.Set("update_config", nil)
 	}
 	d.Set(names.AttrVersion, nodeGroup.Version)
+	if nodeGroup.WarmPoolConfig != nil {
+		if err := d.Set("warm_pool", []any{flattenWarmPoolConfig(nodeGroup.WarmPoolConfig)}); err != nil {
+			return sdkdiag.AppendErrorf(diags, "setting warm_pool: %s", err)
+		}
+	} else {
+		d.Set("warm_pool", nil)
+	}
 
 	setTagsOut(ctx, nodeGroup.Tags)
 
@@ -602,7 +645,7 @@ func resourceNodeGroupUpdate(ctx context.Context, d *schema.ResourceData, meta a
 		}
 	}
 
-	if d.HasChanges("labels", "node_repair_config", "scaling_config", "taint", "update_config") {
+	if d.HasChanges("labels", "node_repair_config", "scaling_config", "taint", "update_config", "warm_pool") {
 		oldLabelsRaw, newLabelsRaw := d.GetChange("labels")
 		oldTaintsRaw, newTaintsRaw := d.GetChange("taint")
 
@@ -629,6 +672,14 @@ func resourceNodeGroupUpdate(ctx context.Context, d *schema.ResourceData, meta a
 		if d.HasChange("update_config") {
 			if v, ok := d.GetOk("update_config"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
 				input.UpdateConfig = expandNodegroupUpdateConfig(v.([]any)[0].(map[string]any))
+			}
+		}
+
+		if d.HasChange("warm_pool") {
+			if v, ok := d.GetOk("warm_pool"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+				input.WarmPoolConfig = expandWarmPoolConfig(v.([]any)[0].(map[string]any))
+			} else {
+				input.WarmPoolConfig = &types.WarmPoolConfig{Enabled: aws.Bool(false)}
 			}
 		}
 
@@ -1005,6 +1056,34 @@ func expandNodegroupUpdateConfig(tfMap map[string]any) *types.NodegroupUpdateCon
 	return apiObject
 }
 
+func expandWarmPoolConfig(tfMap map[string]any) *types.WarmPoolConfig {
+	if tfMap == nil {
+		return nil
+	}
+
+	apiObject := &types.WarmPoolConfig{
+		Enabled: aws.Bool(true),
+	}
+
+	if v, ok := tfMap["max_group_prepared_capacity"].(int); ok {
+		apiObject.MaxGroupPreparedCapacity = aws.Int32(int32(v))
+	}
+
+	if v, ok := tfMap["min_size"].(int); ok {
+		apiObject.MinSize = aws.Int32(int32(v))
+	}
+
+	if v, ok := tfMap["pool_state"].(string); ok && v != "" {
+		apiObject.PoolState = types.WarmPoolState(v)
+	}
+
+	if v, ok := tfMap["reuse_on_scale_in"].(bool); ok {
+		apiObject.ReuseOnScaleIn = aws.Bool(v)
+	}
+
+	return apiObject
+}
+
 func expandNodeRepairConfig(tfMap map[string]any) *types.NodeRepairConfig {
 	if tfMap == nil {
 		return nil
@@ -1257,6 +1336,30 @@ func flattenNodegroupUpdateConfig(apiObject *types.NodegroupUpdateConfig) map[st
 
 	if apiObject.UpdateStrategy != "" {
 		tfMap["update_strategy"] = string(apiObject.UpdateStrategy)
+	}
+
+	return tfMap
+}
+
+func flattenWarmPoolConfig(apiObject *types.WarmPoolConfig) map[string]any {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]any{
+		"pool_state": string(apiObject.PoolState),
+	}
+
+	if v := apiObject.MaxGroupPreparedCapacity; v != nil {
+		tfMap["max_group_prepared_capacity"] = aws.ToInt32(v)
+	}
+
+	if v := apiObject.MinSize; v != nil {
+		tfMap["min_size"] = aws.ToInt32(v)
+	}
+
+	if v := apiObject.ReuseOnScaleIn; v != nil {
+		tfMap["reuse_on_scale_in"] = aws.ToBool(v)
 	}
 
 	return tfMap

--- a/internal/service/eks/node_group.go
+++ b/internal/service/eks/node_group.go
@@ -417,7 +417,6 @@ func resourceNodeGroup() *schema.Resource {
 
 func resourceNodeGroupCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
-
 	conn := meta.(*conns.AWSClient).EKSClient(ctx)
 
 	clusterName := d.Get(names.AttrClusterName).(string)
@@ -505,7 +504,6 @@ func resourceNodeGroupCreate(ctx context.Context, d *schema.ResourceData, meta a
 
 func resourceNodeGroupRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
-
 	conn := meta.(*conns.AWSClient).EKSClient(ctx)
 
 	clusterName, nodeGroupName, err := nodeGroupParseResourceID(d.Id())
@@ -587,7 +585,6 @@ func resourceNodeGroupRead(ctx context.Context, d *schema.ResourceData, meta any
 
 func resourceNodeGroupUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
-
 	conn := meta.(*conns.AWSClient).EKSClient(ctx)
 
 	clusterName, nodeGroupName, err := nodeGroupParseResourceID(d.Id())
@@ -701,7 +698,6 @@ func resourceNodeGroupUpdate(ctx context.Context, d *schema.ResourceData, meta a
 
 func resourceNodeGroupDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
-
 	conn := meta.(*conns.AWSClient).EKSClient(ctx)
 
 	clusterName, nodeGroupName, err := nodeGroupParseResourceID(d.Id())
@@ -1297,7 +1293,9 @@ func flattenNodeRepairConfigOverrides(apiObjects []types.NodeRepairConfigOverrid
 	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := make(map[string]any)
+		tfMap := map[string]any{
+			"repair_action": apiObject.RepairAction,
+		}
 
 		if v := apiObject.MinRepairWaitTimeMins; v != nil {
 			tfMap["min_repair_wait_time_mins"] = aws.ToInt32(v)
@@ -1311,8 +1309,6 @@ func flattenNodeRepairConfigOverrides(apiObjects []types.NodeRepairConfigOverrid
 			tfMap["node_unhealthy_reason"] = aws.ToString(v)
 		}
 
-		tfMap["repair_action"] = string(apiObject.RepairAction)
-
 		tfList = append(tfList, tfMap)
 	}
 
@@ -1324,7 +1320,9 @@ func flattenNodegroupUpdateConfig(apiObject *types.NodegroupUpdateConfig) map[st
 		return nil
 	}
 
-	tfMap := map[string]any{}
+	tfMap := map[string]any{
+		"update_strategy": apiObject.UpdateStrategy,
+	}
 
 	if v := apiObject.MaxUnavailable; v != nil {
 		tfMap["max_unavailable"] = aws.ToInt32(v)
@@ -1332,10 +1330,6 @@ func flattenNodegroupUpdateConfig(apiObject *types.NodegroupUpdateConfig) map[st
 
 	if v := apiObject.MaxUnavailablePercentage; v != nil {
 		tfMap["max_unavailable_percentage"] = aws.ToInt32(v)
-	}
-
-	if apiObject.UpdateStrategy != "" {
-		tfMap["update_strategy"] = string(apiObject.UpdateStrategy)
 	}
 
 	return tfMap
@@ -1347,7 +1341,7 @@ func flattenWarmPoolConfig(apiObject *types.WarmPoolConfig) map[string]any {
 	}
 
 	tfMap := map[string]any{
-		"pool_state": string(apiObject.PoolState),
+		"pool_state": apiObject.PoolState,
 	}
 
 	if v := apiObject.MaxGroupPreparedCapacity; v != nil {

--- a/internal/service/eks/node_group_data_source.go
+++ b/internal/service/eks/node_group_data_source.go
@@ -205,7 +205,7 @@ func dataSourceNodeGroup() *schema.Resource {
 					Type:     schema.TypeString,
 					Computed: true,
 				},
-				"warm_pool": {
+				"warm_pool_config": {
 					Type:     schema.TypeList,
 					Computed: true,
 					Elem: &schema.Resource{
@@ -288,11 +288,11 @@ func dataSourceNodeGroupRead(ctx context.Context, d *schema.ResourceData, meta a
 	}
 	d.Set(names.AttrVersion, nodeGroup.Version)
 	if nodeGroup.WarmPoolConfig != nil {
-		if err := d.Set("warm_pool", []any{flattenWarmPoolConfig(nodeGroup.WarmPoolConfig)}); err != nil {
-			return sdkdiag.AppendErrorf(diags, "setting warm_pool: %s", err)
+		if err := d.Set("warm_pool_config", []any{flattenWarmPoolConfig(nodeGroup.WarmPoolConfig)}); err != nil {
+			return sdkdiag.AppendErrorf(diags, "setting warm_pool_config: %s", err)
 		}
 	} else {
-		d.Set("warm_pool", nil)
+		d.Set("warm_pool_config", nil)
 	}
 
 	setTagsOut(ctx, nodeGroup.Tags)

--- a/internal/service/eks/node_group_data_source.go
+++ b/internal/service/eks/node_group_data_source.go
@@ -205,6 +205,30 @@ func dataSourceNodeGroup() *schema.Resource {
 					Type:     schema.TypeString,
 					Computed: true,
 				},
+				"warm_pool": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"max_group_prepared_capacity": {
+								Type:     schema.TypeInt,
+								Computed: true,
+							},
+							"min_size": {
+								Type:     schema.TypeInt,
+								Computed: true,
+							},
+							"pool_state": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"reuse_on_scale_in": {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
+						},
+					},
+				},
 			}
 		},
 	}
@@ -263,6 +287,13 @@ func dataSourceNodeGroupRead(ctx context.Context, d *schema.ResourceData, meta a
 		d.Set("update_config", nil)
 	}
 	d.Set(names.AttrVersion, nodeGroup.Version)
+	if nodeGroup.WarmPoolConfig != nil {
+		if err := d.Set("warm_pool", []any{flattenWarmPoolConfig(nodeGroup.WarmPoolConfig)}); err != nil {
+			return sdkdiag.AppendErrorf(diags, "setting warm_pool: %s", err)
+		}
+	} else {
+		d.Set("warm_pool", nil)
+	}
 
 	setTagsOut(ctx, nodeGroup.Tags)
 

--- a/internal/service/eks/node_group_data_source_test.go
+++ b/internal/service/eks/node_group_data_source_test.go
@@ -56,8 +56,46 @@ func TestAccEKSNodeGroupDataSource_basic(t *testing.T) {
 	})
 }
 
+func TestAccEKSNodeGroupDataSource_warmPool(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	dataSourceResourceName := "data.aws_eks_node_group.test"
+	resourceName := "aws_eks_node_group.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EKSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNodeGroupConfig_warmPool(rName),
+				Check:  resource.ComposeTestCheckFunc(),
+			},
+			{
+				Config: testAccNodeGroupDataSourceConfig_warmPool(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resourceName, "warm_pool.#", dataSourceResourceName, "warm_pool.#"),
+					resource.TestCheckResourceAttrPair(resourceName, "warm_pool.0.max_group_prepared_capacity", dataSourceResourceName, "warm_pool.0.max_group_prepared_capacity"),
+					resource.TestCheckResourceAttrPair(resourceName, "warm_pool.0.min_size", dataSourceResourceName, "warm_pool.0.min_size"),
+					resource.TestCheckResourceAttrPair(resourceName, "warm_pool.0.pool_state", dataSourceResourceName, "warm_pool.0.pool_state"),
+					resource.TestCheckResourceAttrPair(resourceName, "warm_pool.0.reuse_on_scale_in", dataSourceResourceName, "warm_pool.0.reuse_on_scale_in"),
+				),
+			},
+		},
+	})
+}
+
 func testAccNodeGroupDataSourceConfig_basic(rName string) string {
 	return acctest.ConfigCompose(testAccNodeGroupConfig_name(rName), fmt.Sprintf(`
+data "aws_eks_node_group" "test" {
+  cluster_name    = aws_eks_cluster.test.name
+  node_group_name = %[1]q
+}
+`, rName))
+}
+
+func testAccNodeGroupDataSourceConfig_warmPool(rName string) string {
+	return acctest.ConfigCompose(testAccNodeGroupConfig_warmPool(rName), fmt.Sprintf(`
 data "aws_eks_node_group" "test" {
   cluster_name    = aws_eks_cluster.test.name
   node_group_name = %[1]q

--- a/internal/service/eks/node_group_test.go
+++ b/internal/service/eks/node_group_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/YakDriver/regexache"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/eks/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -1247,6 +1248,68 @@ func TestAccEKSNodeGroup_updateStrategy(t *testing.T) {
 	})
 }
 
+func TestAccEKSNodeGroup_warmPool(t *testing.T) {
+	ctx := acctest.Context(t)
+	var nodeGroup1, nodeGroup2, nodeGroup3 types.Nodegroup
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_eks_node_group.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EKSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckNodeGroupDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNodeGroupConfig_warmPool(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup1),
+					resource.TestCheckResourceAttr(resourceName, "warm_pool.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "warm_pool.0.max_group_prepared_capacity", "2"),
+					resource.TestCheckResourceAttr(resourceName, "warm_pool.0.min_size", "1"),
+					resource.TestCheckResourceAttr(resourceName, "warm_pool.0.pool_state", "STOPPED"),
+					resource.TestCheckResourceAttr(resourceName, "warm_pool.0.reuse_on_scale_in", acctest.CtTrue),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccNodeGroupConfig_warmPoolUpdated(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup2),
+					testAccCheckNodeGroupNotRecreated(&nodeGroup1, &nodeGroup2),
+					resource.TestCheckResourceAttr(resourceName, "warm_pool.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "warm_pool.0.max_group_prepared_capacity", "3"),
+					resource.TestCheckResourceAttr(resourceName, "warm_pool.0.min_size", "2"),
+					resource.TestCheckResourceAttr(resourceName, "warm_pool.0.pool_state", "STOPPED"),
+					resource.TestCheckResourceAttr(resourceName, "warm_pool.0.reuse_on_scale_in", acctest.CtFalse),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccNodeGroupConfig_warmPoolDisabled(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup3),
+					testAccCheckNodeGroupNotRecreated(&nodeGroup2, &nodeGroup3),
+					resource.TestCheckResourceAttr(resourceName, "warm_pool.#", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccEKSNodeGroup_version(t *testing.T) {
 	ctx := acctest.Context(t)
 	var nodeGroup1, nodeGroup2 types.Nodegroup
@@ -1339,6 +1402,16 @@ func testAccCheckNodeGroupDestroy(ctx context.Context, t *testing.T) resource.Te
 			}
 
 			return fmt.Errorf("EKS Node Group %s still exists", rs.Primary.ID)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckNodeGroupNotRecreated(i, j *types.Nodegroup) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if !aws.ToTime(i.CreatedAt).Equal(aws.ToTime(j.CreatedAt)) {
+			return fmt.Errorf("EKS Node Group (%s) recreated", aws.ToString(i.NodegroupName))
 		}
 
 		return nil
@@ -2587,6 +2660,92 @@ resource "aws_eks_node_group" "test" {
   ]
 }
 `, rName, updateStrategy))
+}
+
+func testAccNodeGroupConfig_warmPool(rName string) string {
+	return acctest.ConfigCompose(testAccNodeGroupConfig_base(rName), fmt.Sprintf(`
+resource "aws_eks_node_group" "test" {
+  cluster_name    = aws_eks_cluster.test.name
+  node_group_name = %[1]q
+  node_role_arn   = aws_iam_role.node.arn
+  subnet_ids      = aws_subnet.test[*].id
+
+  scaling_config {
+    desired_size = 1
+    max_size     = 3
+    min_size     = 1
+  }
+
+  warm_pool {
+    max_group_prepared_capacity = 2
+    min_size                    = 1
+    pool_state                  = "STOPPED"
+    reuse_on_scale_in           = true
+  }
+
+  depends_on = [
+    aws_iam_role_policy_attachment.node-AmazonEKSWorkerNodePolicy,
+    aws_iam_role_policy_attachment.node-AmazonEKS_CNI_Policy,
+    aws_iam_role_policy_attachment.node-AmazonEC2ContainerRegistryReadOnly,
+    aws_iam_role_policy_attachment.node-AmazonEKSWorkerNodeMinimalPolicy,
+  ]
+}
+`, rName))
+}
+
+func testAccNodeGroupConfig_warmPoolUpdated(rName string) string {
+	return acctest.ConfigCompose(testAccNodeGroupConfig_base(rName), fmt.Sprintf(`
+resource "aws_eks_node_group" "test" {
+  cluster_name    = aws_eks_cluster.test.name
+  node_group_name = %[1]q
+  node_role_arn   = aws_iam_role.node.arn
+  subnet_ids      = aws_subnet.test[*].id
+
+  scaling_config {
+    desired_size = 1
+    max_size     = 3
+    min_size     = 1
+  }
+
+  warm_pool {
+    max_group_prepared_capacity = 3
+    min_size                    = 2
+    pool_state                  = "STOPPED"
+    reuse_on_scale_in           = false
+  }
+
+  depends_on = [
+    aws_iam_role_policy_attachment.node-AmazonEKSWorkerNodePolicy,
+    aws_iam_role_policy_attachment.node-AmazonEKS_CNI_Policy,
+    aws_iam_role_policy_attachment.node-AmazonEC2ContainerRegistryReadOnly,
+    aws_iam_role_policy_attachment.node-AmazonEKSWorkerNodeMinimalPolicy,
+  ]
+}
+`, rName))
+}
+
+func testAccNodeGroupConfig_warmPoolDisabled(rName string) string {
+	return acctest.ConfigCompose(testAccNodeGroupConfig_base(rName), fmt.Sprintf(`
+resource "aws_eks_node_group" "test" {
+  cluster_name    = aws_eks_cluster.test.name
+  node_group_name = %[1]q
+  node_role_arn   = aws_iam_role.node.arn
+  subnet_ids      = aws_subnet.test[*].id
+
+  scaling_config {
+    desired_size = 1
+    max_size     = 3
+    min_size     = 1
+  }
+
+  depends_on = [
+    aws_iam_role_policy_attachment.node-AmazonEKSWorkerNodePolicy,
+    aws_iam_role_policy_attachment.node-AmazonEKS_CNI_Policy,
+    aws_iam_role_policy_attachment.node-AmazonEC2ContainerRegistryReadOnly,
+    aws_iam_role_policy_attachment.node-AmazonEKSWorkerNodeMinimalPolicy,
+  ]
+}
+`, rName))
 }
 
 func testAccNodeGroupConfig_version(rName, version string) string {

--- a/internal/service/eks/node_group_test.go
+++ b/internal/service/eks/node_group_test.go
@@ -1365,10 +1365,10 @@ func TestAccEKSNodeGroup_warmPool(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup),
 					resource.TestCheckResourceAttr(resourceName, "warm_pool_config.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "warm_pool_config.0.max_group_prepared_capacity", "2"),
-					resource.TestCheckResourceAttr(resourceName, "warm_pool_config.0.min_size", "1"),
-					resource.TestCheckResourceAttr(resourceName, "warm_pool_config.0.pool_state", "STOPPED"),
-					resource.TestCheckResourceAttr(resourceName, "warm_pool_config.0.reuse_on_scale_in", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "warm_pool_config.0.max_group_prepared_capacity", "0"),
+					resource.TestCheckResourceAttr(resourceName, "warm_pool_config.0.min_size", "0"),
+					resource.TestCheckResourceAttr(resourceName, "warm_pool_config.0.pool_state", ""),
+					resource.TestCheckResourceAttr(resourceName, "warm_pool_config.0.reuse_on_scale_in", acctest.CtFalse),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -1388,8 +1388,8 @@ func TestAccEKSNodeGroup_warmPool(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "warm_pool_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "warm_pool_config.0.max_group_prepared_capacity", "3"),
 					resource.TestCheckResourceAttr(resourceName, "warm_pool_config.0.min_size", "2"),
-					resource.TestCheckResourceAttr(resourceName, "warm_pool_config.0.pool_state", "STOPPED"),
-					resource.TestCheckResourceAttr(resourceName, "warm_pool_config.0.reuse_on_scale_in", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, "warm_pool_config.0.pool_state", "RUNNING"),
+					resource.TestCheckResourceAttr(resourceName, "warm_pool_config.0.reuse_on_scale_in", acctest.CtTrue),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -2774,12 +2774,7 @@ resource "aws_eks_node_group" "test" {
     min_size     = 1
   }
 
-  warm_pool_config {
-    max_group_prepared_capacity = 2
-    min_size                    = 1
-    pool_state                  = "STOPPED"
-    reuse_on_scale_in           = true
-  }
+  warm_pool_config {}
 
   depends_on = [
     aws_iam_role_policy_attachment.node-AmazonEKSWorkerNodePolicy,
@@ -2808,8 +2803,8 @@ resource "aws_eks_node_group" "test" {
   warm_pool_config {
     max_group_prepared_capacity = 3
     min_size                    = 2
-    pool_state                  = "STOPPED"
-    reuse_on_scale_in           = false
+    pool_state                  = "RUNNING"
+    reuse_on_scale_in           = true
   }
 
   depends_on = [

--- a/internal/service/eks/node_group_test.go
+++ b/internal/service/eks/node_group_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/YakDriver/regexache"
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/eks/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -185,7 +184,7 @@ func TestAccEKSNodeGroup_disappears(t *testing.T) {
 
 func TestAccEKSNodeGroup_amiType(t *testing.T) {
 	ctx := acctest.Context(t)
-	var nodeGroup1 types.Nodegroup
+	var nodeGroup types.Nodegroup
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_eks_node_group.test"
 
@@ -198,7 +197,7 @@ func TestAccEKSNodeGroup_amiType(t *testing.T) {
 			{
 				Config: testAccNodeGroupConfig_amiType(rName, string(types.AMITypesAl2X8664Gpu)),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup1),
+					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup),
 					resource.TestCheckResourceAttr(resourceName, "ami_type", string(types.AMITypesAl2X8664Gpu)),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
@@ -218,7 +217,7 @@ func TestAccEKSNodeGroup_amiType(t *testing.T) {
 
 func TestAccEKSNodeGroup_CapacityType_spot(t *testing.T) {
 	ctx := acctest.Context(t)
-	var nodeGroup1 types.Nodegroup
+	var nodeGroup types.Nodegroup
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_eks_node_group.test"
 
@@ -231,7 +230,7 @@ func TestAccEKSNodeGroup_CapacityType_spot(t *testing.T) {
 			{
 				Config: testAccNodeGroupConfig_capacityType(rName, string(types.CapacityTypesSpot)),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup1),
+					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup),
 					resource.TestCheckResourceAttr(resourceName, "capacity_type", string(types.CapacityTypesSpot)),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
@@ -251,7 +250,7 @@ func TestAccEKSNodeGroup_CapacityType_spot(t *testing.T) {
 
 func TestAccEKSNodeGroup_diskSize(t *testing.T) {
 	ctx := acctest.Context(t)
-	var nodeGroup1 types.Nodegroup
+	var nodeGroup types.Nodegroup
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_eks_node_group.test"
 
@@ -264,7 +263,7 @@ func TestAccEKSNodeGroup_diskSize(t *testing.T) {
 			{
 				Config: testAccNodeGroupConfig_diskSize(rName, 21),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup1),
+					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup),
 					resource.TestCheckResourceAttr(resourceName, "disk_size", "21"),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
@@ -284,7 +283,7 @@ func TestAccEKSNodeGroup_diskSize(t *testing.T) {
 
 func TestAccEKSNodeGroup_forceUpdateVersion(t *testing.T) {
 	ctx := acctest.Context(t)
-	var nodeGroup1 types.Nodegroup
+	var nodeGroup types.Nodegroup
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_eks_node_group.test"
 
@@ -297,7 +296,7 @@ func TestAccEKSNodeGroup_forceUpdateVersion(t *testing.T) {
 			{
 				Config: testAccNodeGroupConfig_forceUpdateVersion(rName, clusterVersionUpgradeInitial),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup1),
+					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup),
 					resource.TestCheckResourceAttr(resourceName, names.AttrVersion, clusterVersionUpgradeInitial),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
@@ -315,7 +314,7 @@ func TestAccEKSNodeGroup_forceUpdateVersion(t *testing.T) {
 			{
 				Config: testAccNodeGroupConfig_forceUpdateVersion(rName, clusterVersionUpgradeUpdated),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup1),
+					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup),
 					resource.TestCheckResourceAttr(resourceName, names.AttrVersion, clusterVersionUpgradeUpdated),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
@@ -330,7 +329,7 @@ func TestAccEKSNodeGroup_forceUpdateVersion(t *testing.T) {
 
 func TestAccEKSNodeGroup_InstanceTypes_multiple(t *testing.T) {
 	ctx := acctest.Context(t)
-	var nodeGroup1 types.Nodegroup
+	var nodeGroup types.Nodegroup
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_eks_node_group.test"
 	instanceTypes := fmt.Sprintf("%q, %q, %q, %q", "t2.medium", "t3.medium", "t2.large", "t3.large")
@@ -344,13 +343,18 @@ func TestAccEKSNodeGroup_InstanceTypes_multiple(t *testing.T) {
 			{
 				Config: testAccNodeGroupConfig_instanceTypesMultiple(rName, instanceTypes),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup1),
+					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup),
 					resource.TestCheckResourceAttr(resourceName, "instance_types.#", "4"),
 					resource.TestCheckResourceAttr(resourceName, "instance_types.0", "t2.medium"),
 					resource.TestCheckResourceAttr(resourceName, "instance_types.1", "t3.medium"),
 					resource.TestCheckResourceAttr(resourceName, "instance_types.2", "t2.large"),
 					resource.TestCheckResourceAttr(resourceName, "instance_types.3", "t3.large"),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
 			},
 			{
 				ResourceName:      resourceName,
@@ -363,7 +367,7 @@ func TestAccEKSNodeGroup_InstanceTypes_multiple(t *testing.T) {
 
 func TestAccEKSNodeGroup_InstanceTypes_single(t *testing.T) {
 	ctx := acctest.Context(t)
-	var nodeGroup1 types.Nodegroup
+	var nodeGroup types.Nodegroup
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_eks_node_group.test"
 
@@ -376,9 +380,14 @@ func TestAccEKSNodeGroup_InstanceTypes_single(t *testing.T) {
 			{
 				Config: testAccNodeGroupConfig_instanceTypesSingle(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup1),
+					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup),
 					resource.TestCheckResourceAttr(resourceName, "instance_types.#", "1"),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
 			},
 			{
 				ResourceName:      resourceName,
@@ -391,7 +400,7 @@ func TestAccEKSNodeGroup_InstanceTypes_single(t *testing.T) {
 
 func TestAccEKSNodeGroup_labels(t *testing.T) {
 	ctx := acctest.Context(t)
-	var nodeGroup1, nodeGroup2, nodeGroup3 types.Nodegroup
+	var nodeGroup types.Nodegroup
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_eks_node_group.test"
 
@@ -404,10 +413,15 @@ func TestAccEKSNodeGroup_labels(t *testing.T) {
 			{
 				Config: testAccNodeGroupConfig_labels1(rName, acctest.CtKey1, acctest.CtValue1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup1),
+					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup),
 					resource.TestCheckResourceAttr(resourceName, "labels.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "labels.key1", acctest.CtValue1),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
 			},
 			{
 				ResourceName:      resourceName,
@@ -417,19 +431,29 @@ func TestAccEKSNodeGroup_labels(t *testing.T) {
 			{
 				Config: testAccNodeGroupConfig_labels2(rName, acctest.CtKey1, acctest.CtValue1Updated, acctest.CtKey2, acctest.CtValue2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup2),
+					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup),
 					resource.TestCheckResourceAttr(resourceName, "labels.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "labels.key1", acctest.CtValue1Updated),
 					resource.TestCheckResourceAttr(resourceName, "labels.key2", acctest.CtValue2),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
 			},
 			{
 				Config: testAccNodeGroupConfig_labels1(rName, acctest.CtKey2, acctest.CtValue2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup3),
+					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup),
 					resource.TestCheckResourceAttr(resourceName, "labels.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "labels.key2", acctest.CtValue2),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
 			},
 		},
 	})
@@ -437,7 +461,7 @@ func TestAccEKSNodeGroup_labels(t *testing.T) {
 
 func TestAccEKSNodeGroup_LaunchTemplate_id(t *testing.T) {
 	ctx := acctest.Context(t)
-	var nodeGroup1, nodeGroup2 types.Nodegroup
+	var nodeGroup types.Nodegroup
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	launchTemplateResourceName1 := "aws_launch_template.test1"
 	launchTemplateResourceName2 := "aws_launch_template.test2"
@@ -452,7 +476,7 @@ func TestAccEKSNodeGroup_LaunchTemplate_id(t *testing.T) {
 			{
 				Config: testAccNodeGroupConfig_launchTemplateId1(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup1),
+					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup),
 					resource.TestCheckResourceAttr(resourceName, "launch_template.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, "launch_template.0.id", launchTemplateResourceName1, names.AttrID),
 				),
@@ -470,7 +494,7 @@ func TestAccEKSNodeGroup_LaunchTemplate_id(t *testing.T) {
 			{
 				Config: testAccNodeGroupConfig_launchTemplateId2(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup2),
+					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup),
 					resource.TestCheckResourceAttr(resourceName, "launch_template.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, "launch_template.0.id", launchTemplateResourceName2, names.AttrID),
 				),
@@ -486,7 +510,7 @@ func TestAccEKSNodeGroup_LaunchTemplate_id(t *testing.T) {
 
 func TestAccEKSNodeGroup_LaunchTemplate_name(t *testing.T) {
 	ctx := acctest.Context(t)
-	var nodeGroup1, nodeGroup2 types.Nodegroup
+	var nodeGroup types.Nodegroup
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	launchTemplateResourceName1 := "aws_launch_template.test1"
 	launchTemplateResourceName2 := "aws_launch_template.test2"
@@ -501,7 +525,7 @@ func TestAccEKSNodeGroup_LaunchTemplate_name(t *testing.T) {
 			{
 				Config: testAccNodeGroupConfig_launchTemplateName1(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup1),
+					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup),
 					resource.TestCheckResourceAttr(resourceName, "launch_template.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, "launch_template.0.name", launchTemplateResourceName1, names.AttrName),
 				),
@@ -519,7 +543,7 @@ func TestAccEKSNodeGroup_LaunchTemplate_name(t *testing.T) {
 			{
 				Config: testAccNodeGroupConfig_launchTemplateName2(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup2),
+					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup),
 					resource.TestCheckResourceAttr(resourceName, "launch_template.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, "launch_template.0.name", launchTemplateResourceName2, names.AttrName),
 				),
@@ -535,7 +559,7 @@ func TestAccEKSNodeGroup_LaunchTemplate_name(t *testing.T) {
 
 func TestAccEKSNodeGroup_LaunchTemplate_version(t *testing.T) {
 	ctx := acctest.Context(t)
-	var nodeGroup1, nodeGroup2 types.Nodegroup
+	var nodeGroup types.Nodegroup
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	launchTemplateResourceName := "aws_launch_template.test"
 	resourceName := "aws_eks_node_group.test"
@@ -549,7 +573,7 @@ func TestAccEKSNodeGroup_LaunchTemplate_version(t *testing.T) {
 			{
 				Config: testAccNodeGroupConfig_launchTemplateVersion1(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup1),
+					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup),
 					resource.TestCheckResourceAttr(resourceName, "launch_template.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, "launch_template.0.version", launchTemplateResourceName, "default_version"),
 				),
@@ -567,7 +591,7 @@ func TestAccEKSNodeGroup_LaunchTemplate_version(t *testing.T) {
 			{
 				Config: testAccNodeGroupConfig_launchTemplateVersion2(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup2),
+					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup),
 					resource.TestCheckResourceAttr(resourceName, "launch_template.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, "launch_template.0.version", launchTemplateResourceName, "default_version"),
 				),
@@ -583,7 +607,7 @@ func TestAccEKSNodeGroup_LaunchTemplate_version(t *testing.T) {
 
 func TestAccEKSNodeGroup_nodeRepairConfig_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	var nodeGroup1 types.Nodegroup
+	var nodeGroup types.Nodegroup
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_eks_node_group.test"
 
@@ -596,10 +620,15 @@ func TestAccEKSNodeGroup_nodeRepairConfig_basic(t *testing.T) {
 			{
 				Config: testAccNodeGroupConfig_nodeRepairConfigBasic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup1),
+					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup),
 					resource.TestCheckResourceAttr(resourceName, "node_repair_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "node_repair_config.0.enabled", acctest.CtTrue),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
 			},
 			{
 				ResourceName:      resourceName,
@@ -612,7 +641,7 @@ func TestAccEKSNodeGroup_nodeRepairConfig_basic(t *testing.T) {
 
 func TestAccEKSNodeGroup_nodeRepairConfig_counts(t *testing.T) {
 	ctx := acctest.Context(t)
-	var nodeGroup1 types.Nodegroup
+	var nodeGroup types.Nodegroup
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_eks_node_group.test"
 
@@ -625,12 +654,17 @@ func TestAccEKSNodeGroup_nodeRepairConfig_counts(t *testing.T) {
 			{
 				Config: testAccNodeGroupConfig_nodeRepairConfigCounts(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup1),
+					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup),
 					resource.TestCheckResourceAttr(resourceName, "node_repair_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "node_repair_config.0.enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "node_repair_config.0.max_parallel_nodes_repaired_count", "2"),
 					resource.TestCheckResourceAttr(resourceName, "node_repair_config.0.max_unhealthy_node_threshold_count", "3"),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
 			},
 			{
 				ResourceName:      resourceName,
@@ -643,7 +677,7 @@ func TestAccEKSNodeGroup_nodeRepairConfig_counts(t *testing.T) {
 
 func TestAccEKSNodeGroup_nodeRepairConfig_percentages(t *testing.T) {
 	ctx := acctest.Context(t)
-	var nodeGroup1 types.Nodegroup
+	var nodeGroup types.Nodegroup
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_eks_node_group.test"
 
@@ -656,12 +690,17 @@ func TestAccEKSNodeGroup_nodeRepairConfig_percentages(t *testing.T) {
 			{
 				Config: testAccNodeGroupConfig_nodeRepairConfigPercentages(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup1),
+					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup),
 					resource.TestCheckResourceAttr(resourceName, "node_repair_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "node_repair_config.0.enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "node_repair_config.0.max_parallel_nodes_repaired_percentage", "25"),
 					resource.TestCheckResourceAttr(resourceName, "node_repair_config.0.max_unhealthy_node_threshold_percentage", "40"),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
 			},
 			{
 				ResourceName:      resourceName,
@@ -674,7 +713,7 @@ func TestAccEKSNodeGroup_nodeRepairConfig_percentages(t *testing.T) {
 
 func TestAccEKSNodeGroup_nodeRepairConfig_overrides(t *testing.T) {
 	ctx := acctest.Context(t)
-	var nodeGroup1 types.Nodegroup
+	var nodeGroup types.Nodegroup
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_eks_node_group.test"
 
@@ -687,7 +726,7 @@ func TestAccEKSNodeGroup_nodeRepairConfig_overrides(t *testing.T) {
 			{
 				Config: testAccNodeGroupConfig_nodeRepairConfigOverrides(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup1),
+					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup),
 					resource.TestCheckResourceAttr(resourceName, "node_repair_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "node_repair_config.0.enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "node_repair_config.0.node_repair_config_overrides.#", "2"),
@@ -700,6 +739,11 @@ func TestAccEKSNodeGroup_nodeRepairConfig_overrides(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "node_repair_config.0.node_repair_config_overrides.1.node_unhealthy_reason", "AutoScalingGroupNotFound"),
 					resource.TestCheckResourceAttr(resourceName, "node_repair_config.0.node_repair_config_overrides.1.repair_action", "Reboot"),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
 			},
 			{
 				ResourceName:      resourceName,
@@ -712,7 +756,7 @@ func TestAccEKSNodeGroup_nodeRepairConfig_overrides(t *testing.T) {
 
 func TestAccEKSNodeGroup_releaseVersion(t *testing.T) {
 	ctx := acctest.Context(t)
-	var nodeGroup1, nodeGroup2 types.Nodegroup
+	var nodeGroup types.Nodegroup
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	ssmParameterDataSourceName := "data.aws_ssm_parameter.test"
 	resourceName := "aws_eks_node_group.test"
@@ -726,7 +770,7 @@ func TestAccEKSNodeGroup_releaseVersion(t *testing.T) {
 			{
 				Config: testAccNodeGroupConfig_releaseVersion(rName, clusterVersion130),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup1),
+					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup),
 					resource.TestCheckResourceAttrPair(resourceName, "release_version", ssmParameterDataSourceName, names.AttrValue),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
@@ -743,7 +787,7 @@ func TestAccEKSNodeGroup_releaseVersion(t *testing.T) {
 			{
 				Config: testAccNodeGroupConfig_releaseVersion(rName, clusterVersion131),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup2),
+					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup),
 					resource.TestCheckResourceAttrPair(resourceName, "release_version", ssmParameterDataSourceName, names.AttrValue),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
@@ -758,7 +802,7 @@ func TestAccEKSNodeGroup_releaseVersion(t *testing.T) {
 
 func TestAccEKSNodeGroup_RemoteAccess_ec2SSHKey(t *testing.T) {
 	ctx := acctest.Context(t)
-	var nodeGroup1 types.Nodegroup
+	var nodeGroup types.Nodegroup
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_eks_node_group.test"
 
@@ -776,10 +820,15 @@ func TestAccEKSNodeGroup_RemoteAccess_ec2SSHKey(t *testing.T) {
 			{
 				Config: testAccNodeGroupConfig_remoteAccessEC2SSHKey(rName, publicKey),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup1),
+					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup),
 					resource.TestCheckResourceAttr(resourceName, "remote_access.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "remote_access.0.ec2_ssh_key", rName),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
 			},
 			{
 				ResourceName:      resourceName,
@@ -792,7 +841,7 @@ func TestAccEKSNodeGroup_RemoteAccess_ec2SSHKey(t *testing.T) {
 
 func TestAccEKSNodeGroup_RemoteAccess_sourceSecurityGroupIDs(t *testing.T) {
 	ctx := acctest.Context(t)
-	var nodeGroup1 types.Nodegroup
+	var nodeGroup types.Nodegroup
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_eks_node_group.test"
 
@@ -810,10 +859,15 @@ func TestAccEKSNodeGroup_RemoteAccess_sourceSecurityGroupIDs(t *testing.T) {
 			{
 				Config: testAccNodeGroupConfig_remoteAccessSourceSecurityIds1(rName, publicKey),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup1),
+					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup),
 					resource.TestCheckResourceAttr(resourceName, "remote_access.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "remote_access.0.source_security_group_ids.#", "1"),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
 			},
 			{
 				ResourceName:      resourceName,
@@ -826,7 +880,7 @@ func TestAccEKSNodeGroup_RemoteAccess_sourceSecurityGroupIDs(t *testing.T) {
 
 func TestAccEKSNodeGroup_Scaling_desiredSize(t *testing.T) {
 	ctx := acctest.Context(t)
-	var nodeGroup1, nodeGroup2 types.Nodegroup
+	var nodeGroup types.Nodegroup
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_eks_node_group.test"
 
@@ -839,7 +893,7 @@ func TestAccEKSNodeGroup_Scaling_desiredSize(t *testing.T) {
 			{
 				Config: testAccNodeGroupConfig_scalingSizes(rName, 2, 2, 1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup1),
+					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup),
 					resource.TestCheckResourceAttr(resourceName, "scaling_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "scaling_config.0.desired_size", "2"),
 					resource.TestCheckResourceAttr(resourceName, "scaling_config.0.max_size", "2"),
@@ -859,7 +913,7 @@ func TestAccEKSNodeGroup_Scaling_desiredSize(t *testing.T) {
 			{
 				Config: testAccNodeGroupConfig_scalingSizes(rName, 1, 2, 1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup2),
+					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup),
 					resource.TestCheckResourceAttr(resourceName, "scaling_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "scaling_config.0.desired_size", "1"),
 					resource.TestCheckResourceAttr(resourceName, "scaling_config.0.max_size", "2"),
@@ -877,7 +931,7 @@ func TestAccEKSNodeGroup_Scaling_desiredSize(t *testing.T) {
 
 func TestAccEKSNodeGroup_Scaling_maxSize(t *testing.T) {
 	ctx := acctest.Context(t)
-	var nodeGroup1, nodeGroup2 types.Nodegroup
+	var nodeGroup types.Nodegroup
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_eks_node_group.test"
 
@@ -890,7 +944,7 @@ func TestAccEKSNodeGroup_Scaling_maxSize(t *testing.T) {
 			{
 				Config: testAccNodeGroupConfig_scalingSizes(rName, 1, 2, 1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup1),
+					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup),
 					resource.TestCheckResourceAttr(resourceName, "scaling_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "scaling_config.0.desired_size", "1"),
 					resource.TestCheckResourceAttr(resourceName, "scaling_config.0.max_size", "2"),
@@ -910,7 +964,7 @@ func TestAccEKSNodeGroup_Scaling_maxSize(t *testing.T) {
 			{
 				Config: testAccNodeGroupConfig_scalingSizes(rName, 1, 1, 1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup2),
+					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup),
 					resource.TestCheckResourceAttr(resourceName, "scaling_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "scaling_config.0.desired_size", "1"),
 					resource.TestCheckResourceAttr(resourceName, "scaling_config.0.max_size", "1"),
@@ -928,7 +982,7 @@ func TestAccEKSNodeGroup_Scaling_maxSize(t *testing.T) {
 
 func TestAccEKSNodeGroup_Scaling_minSize(t *testing.T) {
 	ctx := acctest.Context(t)
-	var nodeGroup1, nodeGroup2 types.Nodegroup
+	var nodeGroup types.Nodegroup
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_eks_node_group.test"
 
@@ -941,7 +995,7 @@ func TestAccEKSNodeGroup_Scaling_minSize(t *testing.T) {
 			{
 				Config: testAccNodeGroupConfig_scalingSizes(rName, 2, 2, 2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup1),
+					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup),
 					resource.TestCheckResourceAttr(resourceName, "scaling_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "scaling_config.0.desired_size", "2"),
 					resource.TestCheckResourceAttr(resourceName, "scaling_config.0.max_size", "2"),
@@ -961,7 +1015,7 @@ func TestAccEKSNodeGroup_Scaling_minSize(t *testing.T) {
 			{
 				Config: testAccNodeGroupConfig_scalingSizes(rName, 2, 2, 1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup2),
+					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup),
 					resource.TestCheckResourceAttr(resourceName, "scaling_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "scaling_config.0.desired_size", "2"),
 					resource.TestCheckResourceAttr(resourceName, "scaling_config.0.max_size", "2"),
@@ -979,7 +1033,7 @@ func TestAccEKSNodeGroup_Scaling_minSize(t *testing.T) {
 
 func TestAccEKSNodeGroup_ScalingZeroDesiredSize_minSize(t *testing.T) {
 	ctx := acctest.Context(t)
-	var nodeGroup1, nodeGroup2 types.Nodegroup
+	var nodeGroup types.Nodegroup
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_eks_node_group.test"
 
@@ -992,7 +1046,7 @@ func TestAccEKSNodeGroup_ScalingZeroDesiredSize_minSize(t *testing.T) {
 			{
 				Config: testAccNodeGroupConfig_scalingSizes(rName, 0, 1, 0),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup1),
+					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup),
 					resource.TestCheckResourceAttr(resourceName, "scaling_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "scaling_config.0.desired_size", "0"),
 					resource.TestCheckResourceAttr(resourceName, "scaling_config.0.max_size", "1"),
@@ -1012,7 +1066,7 @@ func TestAccEKSNodeGroup_ScalingZeroDesiredSize_minSize(t *testing.T) {
 			{
 				Config: testAccNodeGroupConfig_scalingSizes(rName, 1, 2, 1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup2),
+					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup),
 					resource.TestCheckResourceAttr(resourceName, "scaling_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "scaling_config.0.desired_size", "1"),
 					resource.TestCheckResourceAttr(resourceName, "scaling_config.0.max_size", "2"),
@@ -1027,7 +1081,7 @@ func TestAccEKSNodeGroup_ScalingZeroDesiredSize_minSize(t *testing.T) {
 			{
 				Config: testAccNodeGroupConfig_scalingSizes(rName, 0, 1, 0),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup1),
+					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup),
 					resource.TestCheckResourceAttr(resourceName, "scaling_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "scaling_config.0.desired_size", "0"),
 					resource.TestCheckResourceAttr(resourceName, "scaling_config.0.max_size", "1"),
@@ -1045,7 +1099,7 @@ func TestAccEKSNodeGroup_ScalingZeroDesiredSize_minSize(t *testing.T) {
 
 func TestAccEKSNodeGroup_tags(t *testing.T) {
 	ctx := acctest.Context(t)
-	var nodeGroup1, nodeGroup2, nodeGroup3 types.Nodegroup
+	var nodeGroup types.Nodegroup
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_eks_node_group.test"
 
@@ -1058,10 +1112,15 @@ func TestAccEKSNodeGroup_tags(t *testing.T) {
 			{
 				Config: testAccNodeGroupConfig_tags1(rName, acctest.CtKey1, acctest.CtValue1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup1),
+					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey1, acctest.CtValue1),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
 			},
 			{
 				ResourceName:      resourceName,
@@ -1071,19 +1130,29 @@ func TestAccEKSNodeGroup_tags(t *testing.T) {
 			{
 				Config: testAccNodeGroupConfig_tags2(rName, acctest.CtKey1, acctest.CtValue1Updated, acctest.CtKey2, acctest.CtValue2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup2),
+					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "2"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey1, acctest.CtValue1Updated),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey2, acctest.CtValue2),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
 			},
 			{
 				Config: testAccNodeGroupConfig_tags1(rName, acctest.CtKey2, acctest.CtValue2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup3),
+					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey2, acctest.CtValue2),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
 			},
 		},
 	})
@@ -1091,7 +1160,7 @@ func TestAccEKSNodeGroup_tags(t *testing.T) {
 
 func TestAccEKSNodeGroup_taints(t *testing.T) {
 	ctx := acctest.Context(t)
-	var nodeGroup1 types.Nodegroup
+	var nodeGroup types.Nodegroup
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_eks_node_group.test"
 
@@ -1104,7 +1173,7 @@ func TestAccEKSNodeGroup_taints(t *testing.T) {
 			{
 				Config: testAccNodeGroupConfig_taints1(rName, acctest.CtKey1, acctest.CtValue1, "NO_SCHEDULE"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup1),
+					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup),
 					resource.TestCheckResourceAttr(resourceName, "taint.#", "1"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "taint.*", map[string]string{
 						names.AttrKey:   acctest.CtKey1,
@@ -1112,6 +1181,11 @@ func TestAccEKSNodeGroup_taints(t *testing.T) {
 						"effect":        "NO_SCHEDULE",
 					}),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
 			},
 			{
 				ResourceName:      resourceName,
@@ -1123,7 +1197,7 @@ func TestAccEKSNodeGroup_taints(t *testing.T) {
 					acctest.CtKey1, acctest.CtValue1Updated, "NO_EXECUTE",
 					acctest.CtKey2, acctest.CtValue2, "NO_SCHEDULE"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup1),
+					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup),
 					resource.TestCheckResourceAttr(resourceName, "taint.#", "2"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "taint.*", map[string]string{
 						names.AttrKey:   acctest.CtKey1,
@@ -1136,11 +1210,16 @@ func TestAccEKSNodeGroup_taints(t *testing.T) {
 						"effect":        "NO_SCHEDULE",
 					}),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
 			},
 			{
 				Config: testAccNodeGroupConfig_taints1(rName, acctest.CtKey2, acctest.CtValue2, "NO_SCHEDULE"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup1),
+					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup),
 					resource.TestCheckResourceAttr(resourceName, "taint.#", "1"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "taint.*", map[string]string{
 						names.AttrKey:   acctest.CtKey2,
@@ -1148,6 +1227,11 @@ func TestAccEKSNodeGroup_taints(t *testing.T) {
 						"effect":        "NO_SCHEDULE",
 					}),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
 			},
 		},
 	})
@@ -1155,7 +1239,7 @@ func TestAccEKSNodeGroup_taints(t *testing.T) {
 
 func TestAccEKSNodeGroup_update(t *testing.T) {
 	ctx := acctest.Context(t)
-	var nodeGroup1 types.Nodegroup
+	var nodeGroup types.Nodegroup
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_eks_node_group.test"
 
@@ -1168,7 +1252,7 @@ func TestAccEKSNodeGroup_update(t *testing.T) {
 			{
 				Config: testAccNodeGroupConfig_update1(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup1),
+					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup),
 					resource.TestCheckResourceAttr(resourceName, "update_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "update_config.0.max_unavailable", "1"),
 					resource.TestCheckResourceAttr(resourceName, "update_config.0.max_unavailable_percentage", "0"),
@@ -1187,7 +1271,7 @@ func TestAccEKSNodeGroup_update(t *testing.T) {
 			{
 				Config: testAccNodeGroupConfig_update2(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup1),
+					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup),
 					resource.TestCheckResourceAttr(resourceName, "update_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "update_config.0.max_unavailable", "0"),
 					resource.TestCheckResourceAttr(resourceName, "update_config.0.max_unavailable_percentage", "40"),
@@ -1204,7 +1288,7 @@ func TestAccEKSNodeGroup_update(t *testing.T) {
 
 func TestAccEKSNodeGroup_updateStrategy(t *testing.T) {
 	ctx := acctest.Context(t)
-	var nodeGroup1, nodeGroup2 types.Nodegroup
+	var nodeGroup types.Nodegroup
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_eks_node_group.test"
 
@@ -1217,19 +1301,29 @@ func TestAccEKSNodeGroup_updateStrategy(t *testing.T) {
 			{
 				Config: testAccNodeGroupConfig_update1(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup1),
+					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup),
 					resource.TestCheckResourceAttr(resourceName, "update_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "update_config.0.max_unavailable", "1"),
 					resource.TestCheckResourceAttr(resourceName, "update_config.0.max_unavailable_percentage", "0"),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
 			},
 			{
 				Config: testAccNodeGroupConfig_updateStrategy(rName, "DEFAULT"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup1),
+					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup),
 					resource.TestCheckResourceAttr(resourceName, "update_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "update_config.0.update_strategy", "DEFAULT"),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
 			},
 			{
 				ResourceName:      resourceName,
@@ -1239,10 +1333,15 @@ func TestAccEKSNodeGroup_updateStrategy(t *testing.T) {
 			{
 				Config: testAccNodeGroupConfig_updateStrategy(rName, "MINIMAL"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup2),
+					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup),
 					resource.TestCheckResourceAttr(resourceName, "update_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "update_config.0.update_strategy", "MINIMAL"),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
 			},
 		},
 	})
@@ -1250,7 +1349,7 @@ func TestAccEKSNodeGroup_updateStrategy(t *testing.T) {
 
 func TestAccEKSNodeGroup_warmPool(t *testing.T) {
 	ctx := acctest.Context(t)
-	var nodeGroup1, nodeGroup2, nodeGroup3 types.Nodegroup
+	var nodeGroup types.Nodegroup
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_eks_node_group.test"
 
@@ -1263,13 +1362,18 @@ func TestAccEKSNodeGroup_warmPool(t *testing.T) {
 			{
 				Config: testAccNodeGroupConfig_warmPool(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup1),
+					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup),
 					resource.TestCheckResourceAttr(resourceName, "warm_pool.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "warm_pool.0.max_group_prepared_capacity", "2"),
 					resource.TestCheckResourceAttr(resourceName, "warm_pool.0.min_size", "1"),
 					resource.TestCheckResourceAttr(resourceName, "warm_pool.0.pool_state", "STOPPED"),
 					resource.TestCheckResourceAttr(resourceName, "warm_pool.0.reuse_on_scale_in", acctest.CtTrue),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
 			},
 			{
 				ResourceName:      resourceName,
@@ -1279,14 +1383,18 @@ func TestAccEKSNodeGroup_warmPool(t *testing.T) {
 			{
 				Config: testAccNodeGroupConfig_warmPoolUpdated(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup2),
-					testAccCheckNodeGroupNotRecreated(&nodeGroup1, &nodeGroup2),
+					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup),
 					resource.TestCheckResourceAttr(resourceName, "warm_pool.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "warm_pool.0.max_group_prepared_capacity", "3"),
 					resource.TestCheckResourceAttr(resourceName, "warm_pool.0.min_size", "2"),
 					resource.TestCheckResourceAttr(resourceName, "warm_pool.0.pool_state", "STOPPED"),
 					resource.TestCheckResourceAttr(resourceName, "warm_pool.0.reuse_on_scale_in", acctest.CtFalse),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
 			},
 			{
 				ResourceName:      resourceName,
@@ -1296,15 +1404,14 @@ func TestAccEKSNodeGroup_warmPool(t *testing.T) {
 			{
 				Config: testAccNodeGroupConfig_warmPoolDisabled(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup3),
-					testAccCheckNodeGroupNotRecreated(&nodeGroup2, &nodeGroup3),
+					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup),
 					resource.TestCheckResourceAttr(resourceName, "warm_pool.#", "0"),
 				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
 			},
 		},
 	})
@@ -1312,7 +1419,7 @@ func TestAccEKSNodeGroup_warmPool(t *testing.T) {
 
 func TestAccEKSNodeGroup_version(t *testing.T) {
 	ctx := acctest.Context(t)
-	var nodeGroup1, nodeGroup2 types.Nodegroup
+	var nodeGroup types.Nodegroup
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_eks_node_group.test"
 
@@ -1325,7 +1432,7 @@ func TestAccEKSNodeGroup_version(t *testing.T) {
 			{
 				Config: testAccNodeGroupConfig_version(rName, clusterVersionUpgradeInitial),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup1),
+					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup),
 					resource.TestCheckResourceAttr(resourceName, names.AttrVersion, clusterVersionUpgradeInitial),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
@@ -1342,7 +1449,7 @@ func TestAccEKSNodeGroup_version(t *testing.T) {
 			{
 				Config: testAccNodeGroupConfig_version(rName, clusterVersionUpgradeUpdated),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup2),
+					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup),
 					resource.TestCheckResourceAttr(resourceName, names.AttrVersion, clusterVersionUpgradeUpdated),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
@@ -1402,16 +1509,6 @@ func testAccCheckNodeGroupDestroy(ctx context.Context, t *testing.T) resource.Te
 			}
 
 			return fmt.Errorf("EKS Node Group %s still exists", rs.Primary.ID)
-		}
-
-		return nil
-	}
-}
-
-func testAccCheckNodeGroupNotRecreated(i, j *types.Nodegroup) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if !aws.ToTime(i.CreatedAt).Equal(aws.ToTime(j.CreatedAt)) {
-			return fmt.Errorf("EKS Node Group (%s) recreated", aws.ToString(i.NodegroupName))
 		}
 
 		return nil

--- a/internal/service/eks/node_group_test.go
+++ b/internal/service/eks/node_group_test.go
@@ -1392,7 +1392,7 @@ func TestAccEKSNodeGroup_warmPool(t *testing.T) {
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
 					},
 				},
 			},
@@ -1409,7 +1409,7 @@ func TestAccEKSNodeGroup_warmPool(t *testing.T) {
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
 					},
 				},
 			},

--- a/internal/service/eks/node_group_test.go
+++ b/internal/service/eks/node_group_test.go
@@ -66,7 +66,7 @@ func TestAccEKSNodeGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "taint.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "update_config.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrVersion, eksClusterResourceName, names.AttrVersion),
-					resource.TestCheckResourceAttr(resourceName, "warm_pool.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "warm_pool_config.#", "0"),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -1364,11 +1364,11 @@ func TestAccEKSNodeGroup_warmPool(t *testing.T) {
 				Config: testAccNodeGroupConfig_warmPool(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup),
-					resource.TestCheckResourceAttr(resourceName, "warm_pool.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "warm_pool.0.max_group_prepared_capacity", "2"),
-					resource.TestCheckResourceAttr(resourceName, "warm_pool.0.min_size", "1"),
-					resource.TestCheckResourceAttr(resourceName, "warm_pool.0.pool_state", "STOPPED"),
-					resource.TestCheckResourceAttr(resourceName, "warm_pool.0.reuse_on_scale_in", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "warm_pool_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "warm_pool_config.0.max_group_prepared_capacity", "2"),
+					resource.TestCheckResourceAttr(resourceName, "warm_pool_config.0.min_size", "1"),
+					resource.TestCheckResourceAttr(resourceName, "warm_pool_config.0.pool_state", "STOPPED"),
+					resource.TestCheckResourceAttr(resourceName, "warm_pool_config.0.reuse_on_scale_in", acctest.CtTrue),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -1385,11 +1385,11 @@ func TestAccEKSNodeGroup_warmPool(t *testing.T) {
 				Config: testAccNodeGroupConfig_warmPoolUpdated(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup),
-					resource.TestCheckResourceAttr(resourceName, "warm_pool.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "warm_pool.0.max_group_prepared_capacity", "3"),
-					resource.TestCheckResourceAttr(resourceName, "warm_pool.0.min_size", "2"),
-					resource.TestCheckResourceAttr(resourceName, "warm_pool.0.pool_state", "STOPPED"),
-					resource.TestCheckResourceAttr(resourceName, "warm_pool.0.reuse_on_scale_in", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, "warm_pool_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "warm_pool_config.0.max_group_prepared_capacity", "3"),
+					resource.TestCheckResourceAttr(resourceName, "warm_pool_config.0.min_size", "2"),
+					resource.TestCheckResourceAttr(resourceName, "warm_pool_config.0.pool_state", "STOPPED"),
+					resource.TestCheckResourceAttr(resourceName, "warm_pool_config.0.reuse_on_scale_in", acctest.CtFalse),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -1406,7 +1406,7 @@ func TestAccEKSNodeGroup_warmPool(t *testing.T) {
 				Config: testAccNodeGroupConfig_warmPoolRemoved(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup),
-					resource.TestCheckResourceAttr(resourceName, "warm_pool.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "warm_pool_config.#", "0"),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -2774,7 +2774,7 @@ resource "aws_eks_node_group" "test" {
     min_size     = 1
   }
 
-  warm_pool {
+  warm_pool_config {
     max_group_prepared_capacity = 2
     min_size                    = 1
     pool_state                  = "STOPPED"
@@ -2805,7 +2805,7 @@ resource "aws_eks_node_group" "test" {
     min_size     = 1
   }
 
-  warm_pool {
+  warm_pool_config {
     max_group_prepared_capacity = 3
     min_size                    = 2
     pool_state                  = "STOPPED"

--- a/internal/service/eks/node_group_test.go
+++ b/internal/service/eks/node_group_test.go
@@ -66,6 +66,7 @@ func TestAccEKSNodeGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "taint.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "update_config.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrVersion, eksClusterResourceName, names.AttrVersion),
+					resource.TestCheckResourceAttr(resourceName, "warm_pool.#", "0"),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -1402,7 +1403,7 @@ func TestAccEKSNodeGroup_warmPool(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccNodeGroupConfig_warmPoolDisabled(rName),
+				Config: testAccNodeGroupConfig_warmPoolRemoved(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNodeGroupExists(ctx, t, resourceName, &nodeGroup),
 					resource.TestCheckResourceAttr(resourceName, "warm_pool.#", "0"),
@@ -2821,7 +2822,7 @@ resource "aws_eks_node_group" "test" {
 `, rName))
 }
 
-func testAccNodeGroupConfig_warmPoolDisabled(rName string) string {
+func testAccNodeGroupConfig_warmPoolRemoved(rName string) string {
 	return acctest.ConfigCompose(testAccNodeGroupConfig_base(rName), fmt.Sprintf(`
 resource "aws_eks_node_group" "test" {
   cluster_name    = aws_eks_cluster.test.name

--- a/website/docs/d/eks_node_group.html.markdown
+++ b/website/docs/d/eks_node_group.html.markdown
@@ -63,7 +63,7 @@ This data source exports the following attributes in addition to the arguments a
     * `effect` - The effect of the taint.
 * `tags` - Key-value map of resource tags.
 * `version` - Kubernetes version.
-* `warm_pool` - Configuration block with EC2 Auto Scaling warm pool settings.
+* `warm_pool_config` - Configuration block with EC2 Auto Scaling warm pool settings.
     * `max_group_prepared_capacity` - Maximum number of instances allowed to be in the warm pool combined with the Auto Scaling Group.
     * `min_size` - Minimum number of instances maintained in the warm pool.
     * `pool_state` - Instance state that warm pool instances are transitioned to.

--- a/website/docs/d/eks_node_group.html.markdown
+++ b/website/docs/d/eks_node_group.html.markdown
@@ -63,3 +63,8 @@ This data source exports the following attributes in addition to the arguments a
     * `effect` - The effect of the taint.
 * `tags` - Key-value map of resource tags.
 * `version` - Kubernetes version.
+* `warm_pool` - Configuration block with EC2 Auto Scaling warm pool settings.
+    * `max_group_prepared_capacity` - Maximum number of instances allowed to be in the warm pool combined with the Auto Scaling Group.
+    * `min_size` - Minimum number of instances maintained in the warm pool.
+    * `pool_state` - Instance state that warm pool instances are transitioned to.
+    * `reuse_on_scale_in` - Whether instances in the Auto Scaling Group are returned to the warm pool on scale in.

--- a/website/docs/r/eks_node_group.html.markdown
+++ b/website/docs/r/eks_node_group.html.markdown
@@ -158,6 +158,7 @@ The following arguments are optional:
 * `taint` - (Optional) The Kubernetes taints to be applied to the nodes in the node group. Maximum of 50 taints per node group. See [taint](#taint-configuration-block) below for details.
 * `update_config` - (Optional) Configuration block with update settings. See [`update_config`](#update_config-configuration-block) below for details.
 * `version` - (Optional) Kubernetes version. Defaults to EKS Cluster Kubernetes version. Terraform will only perform drift detection if a configuration value is provided.
+* `warm_pool` - (Optional) Configuration block with EC2 Auto Scaling warm pool settings. Including this block enables the warm pool; removing it disables and removes the warm pool. See [`warm_pool`](#warm_pool-configuration-block) below for details.
 
 ### launch_template Configuration Block
 
@@ -207,6 +208,15 @@ The following arguments are mutually exclusive.
 * `max_unavailable` - (Optional) Desired max number of unavailable worker nodes during node group update.
 * `max_unavailable_percentage` - (Optional) Desired max percentage of unavailable worker nodes during node group update.
 * `update_strategy` - (Optional) Strategy to use for updating the node group. Valid values: `MINIMAL` and `DEFAULT`.
+
+### warm_pool Configuration Block
+
+Including a `warm_pool` block enables the warm pool for the node group. To disable and remove the warm pool, remove the `warm_pool` block.
+
+* `max_group_prepared_capacity` - (Optional) Maximum number of instances that are allowed to be in the warm pool combined with the Auto Scaling Group. Use `-1` to specify an unlimited capacity.
+* `min_size` - (Optional) Minimum number of instances to maintain in the warm pool. Defaults to `0`.
+* `pool_state` - (Optional) Instance state to transition warm pool instances to. Valid values: `STOPPED`, `RUNNING`, `HIBERNATED`. Defaults to `STOPPED`.
+* `reuse_on_scale_in` - (Optional) Whether instances in the Auto Scaling Group are returned to the warm pool on scale in. Not supported on Bottlerocket. Defaults to `false`.
 
 ## Attribute Reference
 

--- a/website/docs/r/eks_node_group.html.markdown
+++ b/website/docs/r/eks_node_group.html.markdown
@@ -217,6 +217,7 @@ Including a `warm_pool` block enables the warm pool for the node group. To disab
 * `min_size` - (Optional) Minimum number of instances to maintain in the warm pool. Defaults to `0`.
 * `pool_state` - (Optional) Instance state to transition warm pool instances to. Valid values: `STOPPED`, `RUNNING`, `HIBERNATED`. Defaults to `STOPPED`.
 * `reuse_on_scale_in` - (Optional) Whether to return instances in the Auto Scaling Group to the warm pool on scale in. Not supported on Bottlerocket. Defaults to `false`.
+
 ## Attribute Reference
 
 This resource exports the following attributes in addition to the arguments above:

--- a/website/docs/r/eks_node_group.html.markdown
+++ b/website/docs/r/eks_node_group.html.markdown
@@ -216,8 +216,7 @@ Including a `warm_pool` block enables the warm pool for the node group. To disab
 * `max_group_prepared_capacity` - (Optional) Maximum number of instances that are allowed to be in the warm pool combined with the Auto Scaling Group. Use `-1` to specify an unlimited capacity.
 * `min_size` - (Optional) Minimum number of instances to maintain in the warm pool. Defaults to `0`.
 * `pool_state` - (Optional) Instance state to transition warm pool instances to. Valid values: `STOPPED`, `RUNNING`, `HIBERNATED`. Defaults to `STOPPED`.
-* `reuse_on_scale_in` - (Optional) Whether instances in the Auto Scaling Group are returned to the warm pool on scale in. Not supported on Bottlerocket. Defaults to `false`.
-
+* `reuse_on_scale_in` - (Optional) Whether to return instances in the Auto Scaling Group to the warm pool on scale in. Not supported on Bottlerocket. Defaults to `false`.
 ## Attribute Reference
 
 This resource exports the following attributes in addition to the arguments above:

--- a/website/docs/r/eks_node_group.html.markdown
+++ b/website/docs/r/eks_node_group.html.markdown
@@ -158,7 +158,7 @@ The following arguments are optional:
 * `taint` - (Optional) The Kubernetes taints to be applied to the nodes in the node group. Maximum of 50 taints per node group. See [taint](#taint-configuration-block) below for details.
 * `update_config` - (Optional) Configuration block with update settings. See [`update_config`](#update_config-configuration-block) below for details.
 * `version` - (Optional) Kubernetes version. Defaults to EKS Cluster Kubernetes version. Terraform will only perform drift detection if a configuration value is provided.
-* `warm_pool` - (Optional) Configuration block with EC2 Auto Scaling warm pool settings. Including this block enables the warm pool; removing it disables and removes the warm pool. See [`warm_pool`](#warm_pool-configuration-block) below for details.
+* `warm_pool_config` - (Optional) Configuration block with EC2 Auto Scaling warm pool settings. Including this block enables the warm pool; removing it disables and removes the warm pool. See [`warm_pool_config`](#warm_pool_config-configuration-block) below for details.
 
 ### launch_template Configuration Block
 
@@ -209,9 +209,9 @@ The following arguments are mutually exclusive.
 * `max_unavailable_percentage` - (Optional) Desired max percentage of unavailable worker nodes during node group update.
 * `update_strategy` - (Optional) Strategy to use for updating the node group. Valid values: `MINIMAL` and `DEFAULT`.
 
-### warm_pool Configuration Block
+### warm_pool_config Configuration Block
 
-Including a `warm_pool` block enables the warm pool for the node group. To disable and remove the warm pool, remove the `warm_pool` block.
+Including a `warm_pool_config` block enables the warm pool for the node group. To disable and remove the warm pool, remove the `warm_pool_config` block.
 
 * `max_group_prepared_capacity` - (Optional) Maximum number of instances that are allowed to be in the warm pool combined with the Auto Scaling Group. Use `-1` to specify an unlimited capacity.
 * `min_size` - (Optional) Minimum number of instances to maintain in the warm pool. Defaults to `0`.


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

N/A

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Warm pool support for EKS managed node groups is a recently introduced AWS feature (released in April 2026), and is not yet supported by the Terraform AWS Provider.

This PR adds support for EC2 Auto Scaling warm pools on EKS managed node groups via a new `warm_pool` block, which maps to the EKS API's `WarmPoolConfig` (`enabled`, `max_group_prepared_capacity`, `min_size`, `pool_state`, and `reuse_on_scale_in`). The block is integrated into the create, read, and update operations, allowing warm pools to be enabled, updated, or disabled in place without recreating the node group.

It adds acceptance test coverage for the full lifecycle (create, import, update, and disable), including a check that verifies the node group is not recreated.

Also exposes `warm_pool` as a read-only attribute on the `aws_eks_node_group` data source. Please let me know if it's okay to include the data source and test changes in the same PR, or if you would prefer that I open a separate PR for them.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #47389

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
# Resource lifecycle
% make testacc PKG=eks TESTS='TestAccEKSNodeGroup_warmPool'
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework (cached)
make: Running acceptance tests on branch: 🌿 f-eks-node-group-warm-pool 🌿...
TF_ACC=1 go1.26.5 test ./internal/service/eks/... -v -count 1 -parallel 20 -run='TestAccEKSNodeGroup_warmPool'  -timeout 360m -vet=off -buildvcs=false
2026/07/17 12:03:06 Creating Terraform AWS Provider (SDKv2-style)...
2026/07/17 12:03:06 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccEKSNodeGroup_warmPool
=== PAUSE TestAccEKSNodeGroup_warmPool
=== CONT  TestAccEKSNodeGroup_warmPool
--- PASS: TestAccEKSNodeGroup_warmPool (1162.58s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/eks        1162.750s

# Data source
% make testacc PKG=eks TESTS='TestAccEKSNodeGroupDataSource_warmPool'
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework (cached)
make: Running acceptance tests on branch: 🌿 f-eks-node-group-warm-pool 🌿...
TF_ACC=1 go1.26.5 test ./internal/service/eks/... -v -count 1 -parallel 20 -run='TestAccEKSNodeGroupDataSource_warmPool'  -timeout 360m -vet=off -buildvcs=false
2026/07/17 12:24:16 Creating Terraform AWS Provider (SDKv2-style)...
2026/07/17 12:24:16 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccEKSNodeGroupDataSource_warmPool
=== PAUSE TestAccEKSNodeGroupDataSource_warmPool
=== CONT  TestAccEKSNodeGroupDataSource_warmPool
--- PASS: TestAccEKSNodeGroupDataSource_warmPool (1174.34s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/eks        1174.475s

# Backward compatibility check on existing test
% make testacc PKG=eks TESTS='TestAccEKSNodeGroup_basic'
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     0.255s
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework 0.214s
make: Running acceptance tests on branch: 🌿 f-eks-node-group-warm-pool 🌿...
TF_ACC=1 go1.26.5 test ./internal/service/eks/... -v -count 1 -parallel 20 -run='TestAccEKSNodeGroup_basic'  -timeout 360m -vet=off -buildvcs=false
2026/07/17 13:12:19 Creating Terraform AWS Provider (SDKv2-style)...
2026/07/17 13:12:19 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccEKSNodeGroup_basic
=== PAUSE TestAccEKSNodeGroup_basic
=== CONT  TestAccEKSNodeGroup_basic
--- PASS: TestAccEKSNodeGroup_basic (1131.70s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/eks        1131.867s
```
