### PR TITLE
closed_items: pin checkout to base ref for merged fork PRs

### DIFF
--- a/.github/workflows/closed_items.yml
+++ b/.github/workflows/closed_items.yml
@@ -49,6 +49,13 @@ jobs:
         id: checkout
         if: github.event.pull_request.merged
         with:
+          # Explicitly check out the trusted base branch (not the fork PR head/merge
+          # commit). On a merged pull_request_target closed event, the default checkout
+          # ref resolves to github.sha, which equals pull_request.merge_commit_sha. Since
+          # checkout v7 (2026), that match on a fork PR is refused as a "pwn request".
+          # This workflow only needs the base repository's .ci scripts, so pin to the
+          # base ref, which is a branch name rather than a SHA and is always trusted.
+          ref: ${{ github.event.pull_request.base.ref }}
           sparse-checkout: .ci
 
       - name: Get Current Milestone Name


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No reduction in security controls. This change keeps the `actions/checkout` v7 "pwn request" protection enabled (it does not set `allow-unsafe-pr-checkout`). The `.ci` scripts are now fetched from the trusted base branch instead of relying on the default ref.

### Description

The `Closed Items` workflow runs on `pull_request_target` (closed) and, for merged PRs, checks out the base repository's `.ci` scripts to add the PR to the current milestone.

**Why it broke:** `actions/checkout` v7 added a guard that refuses to check out fork pull request code from `pull_request_target` workflows. It refuses when the PR head is a fork *and* the resolved checkout commit matches `pull_request.head.sha` or `pull_request.merge_commit_sha`. The checkout step specified no `ref`, so it defaulted to `github.sha`. On a merged `pull_request_target` closed event, `github.sha` is the merge commit, which equals `pull_request.merge_commit_sha`. For fork PRs the guard therefore refused the checkout and failed the job. Same-repository PRs were unaffected because the guard short-circuits when the PR head repo is not a fork. As a result, merged fork PRs were never added to the milestone, which cascaded into later milestone-dependent workflows.

**Why this fixes it:** The workflow only needs the base repository's `.ci` scripts and `CHANGELOG.md`, never the fork's code. Pinning the checkout to the base branch (`github.event.pull_request.base.ref`) uses a branch name rather than a SHA, so checkout resolves an empty commit and cannot match the fork PR head/merge SHA. The checkout succeeds and fetches trusted base-repository content, so the guard stays in place while milestoning works again for merged fork PRs.

### Relations

<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.
--->

### References

- https://github.blog/changelog/2026-06-18-safer-pull_request_target-defaults-for-github-actions-checkout/
- https://gh.io/securely-using-pull_request_target

### Output from Acceptance Testing

Not applicable; this change only affects a GitHub Actions workflow.
