### PR TITLE
r/aws_cloudwatch_event_rule, aws_cloudwatch_event_target: Suppress equivalent 'event_bus_name' name/ARN diff

### DIFF
--- a/.changelog/48985.txt
+++ b/.changelog/48985.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_cloudwatch_event_rule: Suppress `event_bus_name` diff when name and equivalent ARN refer to the same event bus
+```
+
+```release-note:bug
+resource/aws_cloudwatch_event_target: Suppress `event_bus_name` diff when name and equivalent ARN refer to the same event bus
+```

--- a/internal/service/events/diff.go
+++ b/internal/service/events/diff.go
@@ -1,0 +1,33 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package events
+
+import (
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// suppressEquivalentBusNameOrARN provides custom difference suppression
+// for event_bus_name values that may be specified as either a bus name
+// or its equivalent ARN.
+func suppressEquivalentBusNameOrARN(_, old, new string, _ *schema.ResourceData) bool {
+	return busNameFromNameOrARN(old) == busNameFromNameOrARN(new)
+}
+
+// busNameFromNameOrARN extracts the event bus name from either a plain
+// name string or a full event bus ARN.
+func busNameFromNameOrARN(nameOrARN string) string {
+	parsed, err := arn.Parse(nameOrARN)
+	if err != nil {
+		return nameOrARN
+	}
+	// ARN resource format: "event-bus/{bus-name}"
+	_, name, ok := strings.Cut(parsed.Resource, "/")
+	if ok && name != "" {
+		return name
+	}
+	return nameOrARN
+}

--- a/internal/service/events/exports_test.go
+++ b/internal/service/events/exports_test.go
@@ -37,5 +37,8 @@ var (
 	ValidBusNameOrARN       = validBusNameOrARN
 	ValidateRuleName        = validateRuleName
 
+	SuppressEquivalentBusNameOrARN = suppressEquivalentBusNameOrARN
+	BusNameFromNameOrARN           = busNameFromNameOrARN
+
 	DefaultEventBusName = defaultEventBusName
 )

--- a/internal/service/events/rule.go
+++ b/internal/service/events/rule.go
@@ -67,11 +67,12 @@ func resourceRule() *schema.Resource {
 					ValidateFunc: validation.StringLenBetween(0, 512),
 				},
 				"event_bus_name": {
-					Type:         schema.TypeString,
-					Optional:     true,
-					ForceNew:     true,
-					ValidateFunc: validBusNameOrARN,
-					Default:      defaultEventBusName,
+					Type:             schema.TypeString,
+					Optional:         true,
+					ForceNew:         true,
+					DiffSuppressFunc: suppressEquivalentBusNameOrARN,
+					ValidateFunc:     validBusNameOrARN,
+					Default:          defaultEventBusName,
 				},
 				"event_pattern": {
 					Type:         schema.TypeString,

--- a/internal/service/events/target.go
+++ b/internal/service/events/target.go
@@ -257,11 +257,12 @@ func resourceTarget() *schema.Resource {
 					},
 				},
 				"event_bus_name": {
-					Type:         schema.TypeString,
-					Optional:     true,
-					ForceNew:     true,
-					ValidateFunc: validBusNameOrARN,
-					Default:      defaultEventBusName,
+					Type:             schema.TypeString,
+					Optional:         true,
+					ForceNew:         true,
+					DiffSuppressFunc: suppressEquivalentBusNameOrARN,
+					ValidateFunc:     validBusNameOrARN,
+					Default:          defaultEventBusName,
 				},
 				names.AttrForceDestroy: {
 					Type:     schema.TypeBool,

--- a/internal/service/events/validate_test.go
+++ b/internal/service/events/validate_test.go
@@ -11,6 +11,122 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
+func TestSuppressEquivalentBusNameOrARN(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		Name     string
+		Old      string
+		New      string
+		Suppress bool
+	}{
+		{
+			Name:     "same name",
+			Old:      "my-bus",
+			New:      "my-bus",
+			Suppress: true,
+		},
+		{
+			Name:     "same ARN",
+			Old:      "arn:aws:events:us-east-1:123456789012:event-bus/my-bus", //lintignore:AWSAT003,AWSAT005
+			New:      "arn:aws:events:us-east-1:123456789012:event-bus/my-bus", //lintignore:AWSAT003,AWSAT005
+			Suppress: true,
+		},
+		{
+			Name:     "name to equivalent ARN",
+			Old:      "my-bus",
+			New:      "arn:aws:events:us-east-1:123456789012:event-bus/my-bus", //lintignore:AWSAT003,AWSAT005
+			Suppress: true,
+		},
+		{
+			Name:     "ARN to equivalent name",
+			Old:      "arn:aws:events:us-east-1:123456789012:event-bus/my-bus", //lintignore:AWSAT003,AWSAT005
+			New:      "my-bus",
+			Suppress: true,
+		},
+		{
+			Name:     "different bus names",
+			Old:      "my-bus",
+			New:      "other-bus",
+			Suppress: false,
+		},
+		{
+			Name:     "name vs different ARN",
+			Old:      "my-bus",
+			New:      "arn:aws:events:us-east-1:123456789012:event-bus/other-bus", //lintignore:AWSAT003,AWSAT005
+			Suppress: false,
+		},
+		{
+			// In practice, the provider configures a single region so cross-region
+			// comparison doesn't occur. We suppress based on bus name only.
+			Name:     "ARNs in different regions same bus name",
+			Old:      "arn:aws:events:us-east-1:123456789012:event-bus/my-bus", //lintignore:AWSAT003,AWSAT005
+			New:      "arn:aws:events:eu-west-1:123456789012:event-bus/my-bus", //lintignore:AWSAT003,AWSAT005
+			Suppress: true,
+		},
+		{
+			Name:     "default bus name vs default ARN",
+			Old:      "default",
+			New:      "arn:aws:events:us-east-1:123456789012:event-bus/default", //lintignore:AWSAT003,AWSAT005
+			Suppress: true,
+		},
+		{
+			Name:     "govcloud ARN to name",
+			Old:      "arn:aws-us-gov:events:us-gov-west-1:123456789012:event-bus/my-bus", //lintignore:AWSAT003,AWSAT005
+			New:      "my-bus",
+			Suppress: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			if got := tfevents.SuppressEquivalentBusNameOrARN("event_bus_name", tc.Old, tc.New, nil); got != tc.Suppress {
+				t.Errorf("SuppressEquivalentBusNameOrARN(%q, %q) = %t, want %t", tc.Old, tc.New, got, tc.Suppress)
+			}
+		})
+	}
+}
+
+func TestBusNameFromNameOrARN(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		Input    string
+		Expected string
+	}{
+		{
+			Input:    "my-bus",
+			Expected: "my-bus",
+		},
+		{
+			Input:    "arn:aws:events:us-east-1:123456789012:event-bus/my-bus", //lintignore:AWSAT003,AWSAT005
+			Expected: "my-bus",
+		},
+		{
+			Input:    "arn:aws-us-gov:events:us-gov-west-1:123456789012:event-bus/custom_bus-123", //lintignore:AWSAT003,AWSAT005
+			Expected: "custom_bus-123",
+		},
+		{
+			Input:    "default",
+			Expected: "default",
+		},
+		{
+			Input:    "arn:aws:events:us-east-1:123456789012:event-bus/default", //lintignore:AWSAT003,AWSAT005
+			Expected: "default",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Input, func(t *testing.T) {
+			t.Parallel()
+			if got := tfevents.BusNameFromNameOrARN(tc.Input); got != tc.Expected {
+				t.Errorf("BusNameFromNameOrARN(%q) = %q, want %q", tc.Input, got, tc.Expected)
+			}
+		})
+	}
+}
+
 func TestValidCustomEventBusSourceName(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

### Description

`aws_cloudwatch_event_rule` and `aws_cloudwatch_event_target` accept either a bus name or ARN for `event_bus_name`, but the current implementation forces resource replacement when switching between the two forms — even though they reference the same physical event bus.

When `create_before_destroy` is active, the replacement cycle causes data loss: the EventBridge API's upsert semantics (PutRule/PutTargets) mean the "create" and "delete" operations target the same physical resource, so the net result is deletion.

This change adds a `DiffSuppressFunc` that extracts the bus name from an ARN before comparison, suppressing the false-positive diff. Follows the same pattern as `vpclattice` (`suppressEquivalentIDOrARN`, PR #32658).

**AI Disclosure:** AI assisted with identifying the root cause, researching precedent patterns in the codebase, and generating the initial implementation. The human author reviewed all code, verified test coverage, and understands the change fully.

### Relations

Closes #48985

### References

- PR [#32658](https://github.com/hashicorp/terraform-provider-aws/pull/32658) — identical pattern for `vpclattice` service network identifier
- PR [#30109](https://github.com/hashicorp/terraform-provider-aws/pull/30109) — relaxed validation to accept ARNs but did not add diff suppression
- [EventBridge PutRule API](https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_PutRule.html) — `EventBusName` accepts name or ARN

### Output from Acceptance Testing

```console
% go test ./internal/service/events/... -run "TestSuppressEquivalentBusNameOrARN|TestBusNameFromNameOrARN" -v

--- PASS: TestBusNameFromNameOrARN (0.00s)
    --- PASS: TestBusNameFromNameOrARN/my-bus (0.00s)
    --- PASS: TestBusNameFromNameOrARN/arn:aws:events:us-east-1:123456789012:event-bus/default (0.00s)
    --- PASS: TestBusNameFromNameOrARN/arn:aws:events:us-east-1:123456789012:event-bus/my-bus (0.00s)
    --- PASS: TestBusNameFromNameOrARN/default (0.00s)
    --- PASS: TestBusNameFromNameOrARN/arn:aws-us-gov:events:us-gov-west-1:123456789012:event-bus/custom_bus-123 (0.00s)
--- PASS: TestSuppressEquivalentBusNameOrARN (0.00s)
    --- PASS: TestSuppressEquivalentBusNameOrARN/same_name (0.00s)
    --- PASS: TestSuppressEquivalentBusNameOrARN/govcloud_ARN_to_name (0.00s)
    --- PASS: TestSuppressEquivalentBusNameOrARN/default_bus_name_vs_default_ARN (0.00s)
    --- PASS: TestSuppressEquivalentBusNameOrARN/different_bus_names (0.00s)
    --- PASS: TestSuppressEquivalentBusNameOrARN/name_to_equivalent_ARN (0.00s)
    --- PASS: TestSuppressEquivalentBusNameOrARN/same_ARN (0.00s)
    --- PASS: TestSuppressEquivalentBusNameOrARN/ARN_to_equivalent_name (0.00s)
    --- PASS: TestSuppressEquivalentBusNameOrARN/name_vs_different_ARN (0.00s)
    --- PASS: TestSuppressEquivalentBusNameOrARN/ARNs_in_different_regions_same_bus_name (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/events	0.112s
```

**Note:** We do not have access to run full acceptance tests (`make testacc`) against live AWS infrastructure. The unit tests verify the suppress logic. Existing acceptance tests `TestAccEventsRule_eventBusARN` and `TestAccEventsTarget_eventBusARN` exercise the ARN code path and should continue to pass unchanged.