### PR TITLE
r/aws_bedrockagentcore_memory_strategy: add namespace_templates

### DIFF
--- a/.changelog/48987.txt
+++ b/.changelog/48987.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_bedrockagentcore_memory_strategy: Add `namespace_templates` argument
+```

--- a/internal/service/bedrockagentcore/memory_strategy.go
+++ b/internal/service/bedrockagentcore/memory_strategy.go
@@ -18,6 +18,7 @@ import (
 	awstypes "github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol/types"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -85,9 +86,23 @@ func (r *resourceMemoryStrategy) Schema(ctx context.Context, request resource.Sc
 			names.AttrName: schema.StringAttribute{
 				Required: true,
 			},
+			"namespace_templates": schema.SetAttribute{
+				CustomType: fwtypes.SetOfStringType,
+				Optional:   true,
+				Computed:   true,
+				Validators: []validator.Set{
+					setvalidator.SizeBetween(1, 1),
+				},
+			},
 			"namespaces": schema.SetAttribute{
 				CustomType: fwtypes.SetOfStringType,
-				Required:   true,
+				Optional:   true,
+				Computed:   true,
+				Validators: []validator.Set{
+					setvalidator.ExactlyOneOf(
+						path.MatchRelative().AtParent().AtName("namespace_templates"),
+					),
+				},
 			},
 			names.AttrType: schema.StringAttribute{
 				Required:   true,
@@ -175,6 +190,36 @@ func (r *resourceMemoryStrategy) Schema(ctx context.Context, request resource.Sc
 				Delete: true,
 			}),
 		},
+	}
+}
+
+func (r *resourceMemoryStrategy) ModifyPlan(ctx context.Context, request resource.ModifyPlanRequest, response *resource.ModifyPlanResponse) {
+	// Skip create or destroy.
+	if request.State.Raw.IsNull() || request.Plan.Raw.IsNull() {
+		return
+	}
+
+	var config, plan, state memoryStrategyResourceModel
+	smerr.AddEnrich(ctx, &response.Diagnostics, request.Config.Get(ctx, &config))
+	smerr.AddEnrich(ctx, &response.Diagnostics, request.Plan.Get(ctx, &plan))
+	smerr.AddEnrich(ctx, &response.Diagnostics, request.State.Get(ctx, &state))
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	// The API mirrors namespaces <-> namespace_templates in its responses. When the
+	// user-configured attribute changes (or the computed counterpart has no state
+	// value yet), the counterpart's planned value is stale; mark it unknown so the
+	// post-apply value returned by the API is accepted.
+	if config.NamespaceTemplates.IsNull() {
+		if !plan.Namespaces.Equal(state.Namespaces) || state.NamespaceTemplates.IsNull() {
+			response.Plan.SetAttribute(ctx, path.Root("namespace_templates"), fwtypes.NewSetValueOfUnknown[types.String](ctx))
+		}
+	}
+	if config.Namespaces.IsNull() {
+		if !plan.NamespaceTemplates.Equal(state.NamespaceTemplates) || state.Namespaces.IsNull() {
+			response.Plan.SetAttribute(ctx, path.Root("namespaces"), fwtypes.NewSetValueOfUnknown[types.String](ctx))
+		}
 	}
 }
 
@@ -354,7 +399,8 @@ func (r *resourceMemoryStrategy) Read(ctx context.Context, request resource.Read
 func (r *resourceMemoryStrategy) Update(ctx context.Context, request resource.UpdateRequest, response *resource.UpdateResponse) {
 	conn := r.Meta().BedrockAgentCoreClient(ctx)
 
-	var plan, state memoryStrategyResourceModel
+	var config, plan, state memoryStrategyResourceModel
+	smerr.AddEnrich(ctx, &response.Diagnostics, request.Config.Get(ctx, &config))
 	smerr.AddEnrich(ctx, &response.Diagnostics, request.Plan.Get(ctx, &plan))
 	smerr.AddEnrich(ctx, &response.Diagnostics, request.State.Get(ctx, &state))
 	if response.Diagnostics.HasError() {
@@ -372,6 +418,15 @@ func (r *resourceMemoryStrategy) Update(ctx context.Context, request resource.Up
 		smerr.AddEnrich(ctx, &response.Diagnostics, fwflex.Expand(ctx, plan, &strategyInput))
 		if response.Diagnostics.HasError() {
 			return
+		}
+
+		// The API mirrors namespaces <-> namespace_templates, so after Read both
+		// model fields are populated. Send only the field present in configuration.
+		if config.Namespaces.IsNull() {
+			strategyInput.Namespaces = nil
+		}
+		if config.NamespaceTemplates.IsNull() {
+			strategyInput.NamespaceTemplates = nil
 		}
 
 		memoryID, memoryStrategyID := fwflex.StringValueFromFramework(ctx, plan.MemoryID), fwflex.StringValueFromFramework(ctx, plan.MemoryStrategyID)
@@ -601,6 +656,7 @@ type memoryStrategyResourceModel struct {
 	MemoryStrategyID       types.String                                              `tfsdk:"memory_strategy_id"`
 	MemoryID               types.String                                              `tfsdk:"memory_id"`
 	Name                   types.String                                              `tfsdk:"name"`
+	NamespaceTemplates     fwtypes.SetOfString                                       `tfsdk:"namespace_templates"`
 	Namespaces             fwtypes.SetOfString                                       `tfsdk:"namespaces"`
 	Type                   fwtypes.StringEnum[awstypes.MemoryStrategyType]           `tfsdk:"type"`
 	Timeouts               timeouts.Value                                            `tfsdk:"timeouts"`
@@ -675,15 +731,24 @@ func (m memoryStrategyResourceModel) expandToMemoryStrategyInput(ctx context.Con
 		var r awstypes.MemoryStrategyInputMemberEpisodicMemoryStrategy
 		r.Value.Name = m.Name.ValueStringPointer()
 		r.Value.Description = m.Description.ValueStringPointer()
-		smerr.AddEnrich(ctx, &diags, m.Namespaces.ElementsAs(ctx, &r.Value.Namespaces, false))
-		if diags.HasError() {
-			return nil, diags
-		}
 		// The API requires the reflection namespace to be the same as or a prefix
 		// of the episodic namespace. Set it to match the episodic namespaces.
-		r.Value.ReflectionConfiguration = &awstypes.EpisodicReflectionConfigurationInput{
-			Namespaces: r.Value.Namespaces,
+		reflection := &awstypes.EpisodicReflectionConfigurationInput{}
+		if !m.Namespaces.IsNull() && !m.Namespaces.IsUnknown() {
+			smerr.AddEnrich(ctx, &diags, m.Namespaces.ElementsAs(ctx, &r.Value.Namespaces, false))
+			if diags.HasError() {
+				return nil, diags
+			}
+			reflection.Namespaces = r.Value.Namespaces
 		}
+		if !m.NamespaceTemplates.IsNull() && !m.NamespaceTemplates.IsUnknown() {
+			smerr.AddEnrich(ctx, &diags, m.NamespaceTemplates.ElementsAs(ctx, &r.Value.NamespaceTemplates, false))
+			if diags.HasError() {
+				return nil, diags
+			}
+			reflection.NamespaceTemplates = r.Value.NamespaceTemplates
+		}
+		r.Value.ReflectionConfiguration = reflection
 		return &r, diags
 	default:
 		diags.AddError(

--- a/internal/service/bedrockagentcore/memory_strategy_test.go
+++ b/internal/service/bedrockagentcore/memory_strategy_test.go
@@ -48,6 +48,7 @@ func TestAccBedrockAgentCoreMemoryStrategy_standard(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, "EPISODIC"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "Episodic strategy"),
 					resource.TestCheckResourceAttr(resourceName, "namespaces.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "namespace_templates.#", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, "memory_strategy_id"),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
@@ -81,6 +82,7 @@ func TestAccBedrockAgentCoreMemoryStrategy_standard(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, names.AttrDescription),
 					resource.TestCheckResourceAttr(resourceName, "namespaces.#", "1"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "namespaces.*", "default"),
+					resource.TestCheckResourceAttr(resourceName, "namespace_templates.#", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, "memory_strategy_id"),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
@@ -260,6 +262,111 @@ func TestAccBedrockAgentCoreMemoryStrategy_custom(t *testing.T) {
 	})
 }
 
+func TestAccBedrockAgentCoreMemoryStrategy_namespaceTemplates(t *testing.T) {
+	ctx := acctest.Context(t)
+	var m awstypes.MemoryStrategy
+	rName := randomMemoryName(t)
+	resourceName := "aws_bedrockagentcore_memory_strategy.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID)
+			testAccPreCheckMemories(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockAgentCoreServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckMemoryStrategyDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			// Setup: Create memory with execution role (needed for EPISODIC step)
+			{
+				Config: testAccMemoryConfig_memoryExecutionRole(rName),
+			},
+			// Step 1: Validation - both namespaces and namespace_templates set → error
+			{
+				Config:      testAccMemoryStrategyConfig_bothNamespaces(rName, "SEMANTIC", "Both set", "default"),
+				ExpectError: regexache.MustCompile("Invalid Attribute Combination"),
+			},
+			// Step 2: Validation - neither namespaces nor namespace_templates set → error
+			{
+				Config:      testAccMemoryStrategyConfig_noNamespaces(rName, "SEMANTIC", "Neither set"),
+				ExpectError: regexache.MustCompile("Invalid Attribute Combination"),
+			},
+			// Step 3: Create SEMANTIC with namespace_templates only; API mirrors into namespaces
+			{
+				Config: testAccMemoryStrategyConfig_namespaceTemplates(rName, "SEMANTIC", "Semantic strategy", "default"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckMemoryStrategyExists(ctx, t, resourceName, &m),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					resource.TestCheckResourceAttr(resourceName, names.AttrType, "SEMANTIC"),
+					resource.TestCheckResourceAttr(resourceName, "namespace_templates.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "namespace_templates.*", "default"),
+					resource.TestCheckResourceAttr(resourceName, "namespaces.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "namespaces.*", "default"),
+					resource.TestCheckResourceAttrSet(resourceName, "memory_strategy_id"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+			},
+			// Step 4: Update namespace_templates in place; mirrored namespaces follows
+			{
+				Config: testAccMemoryStrategyConfig_namespaceTemplates(rName, "SEMANTIC", "Semantic strategy", "custom"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckMemoryStrategyExists(ctx, t, resourceName, &m),
+					resource.TestCheckResourceAttr(resourceName, "namespace_templates.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "namespace_templates.*", "custom"),
+					resource.TestCheckResourceAttr(resourceName, "namespaces.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "namespaces.*", "custom"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			// Step 5: Migrate config to legacy namespaces with the same value → no-op
+			// (state already mirrors both fields with this value)
+			{
+				Config: testAccMemoryStrategyConfig_withExecutionRole(rName, "SEMANTIC", "Semantic strategy", "custom"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+			// Step 6: EPISODIC with namespace_templates (replacement; exercises the
+			// manual expand path and the reflection-configuration mirror)
+			{
+				Config: testAccMemoryStrategyConfig_namespaceTemplates(rName, "EPISODIC", "Episodic strategy", "/strategies/{memoryStrategyId}/actors/{actorId}/sessions/{sessionId}"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckMemoryStrategyExists(ctx, t, resourceName, &m),
+					resource.TestCheckResourceAttr(resourceName, names.AttrType, "EPISODIC"),
+					resource.TestCheckResourceAttr(resourceName, "namespace_templates.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "namespaces.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "memory_strategy_id"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionReplace),
+					},
+				},
+			},
+			// Step 7: Import - both attributes round-trip from the API
+			{
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateIdFunc:                    testAccMemoryStrategyImportStateIDFunc(resourceName),
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "memory_strategy_id",
+				ImportStateVerifyIgnore:              []string{"memory_execution_role_arn"},
+			},
+		},
+	})
+}
+
 func TestAccBedrockAgentCoreMemoryStrategy_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var m awstypes.MemoryStrategy
@@ -368,6 +475,45 @@ resource "aws_bedrockagentcore_memory_strategy" "test" {
   namespaces                = [%[4]q]
 }
 `, rName, strategyType, description, namespace))
+}
+
+func testAccMemoryStrategyConfig_namespaceTemplates(rName, strategyType, description, namespaceTemplate string) string {
+	return acctest.ConfigCompose(testAccMemoryConfig_memoryExecutionRole(rName), fmt.Sprintf(`
+resource "aws_bedrockagentcore_memory_strategy" "test" {
+  name                      = %[1]q
+  memory_id                 = aws_bedrockagentcore_memory.test.id
+  memory_execution_role_arn = aws_bedrockagentcore_memory.test.memory_execution_role_arn
+  type                      = %[2]q
+  description               = %[3]q
+  namespace_templates       = [%[4]q]
+}
+`, rName, strategyType, description, namespaceTemplate))
+}
+
+func testAccMemoryStrategyConfig_bothNamespaces(rName, strategyType, description, namespace string) string {
+	return acctest.ConfigCompose(testAccMemoryConfig_memoryExecutionRole(rName), fmt.Sprintf(`
+resource "aws_bedrockagentcore_memory_strategy" "test" {
+  name                      = %[1]q
+  memory_id                 = aws_bedrockagentcore_memory.test.id
+  memory_execution_role_arn = aws_bedrockagentcore_memory.test.memory_execution_role_arn
+  type                      = %[2]q
+  description               = %[3]q
+  namespaces                = [%[4]q]
+  namespace_templates       = [%[4]q]
+}
+`, rName, strategyType, description, namespace))
+}
+
+func testAccMemoryStrategyConfig_noNamespaces(rName, strategyType, description string) string {
+	return acctest.ConfigCompose(testAccMemoryConfig_memoryExecutionRole(rName), fmt.Sprintf(`
+resource "aws_bedrockagentcore_memory_strategy" "test" {
+  name                      = %[1]q
+  memory_id                 = aws_bedrockagentcore_memory.test.id
+  memory_execution_role_arn = aws_bedrockagentcore_memory.test.memory_execution_role_arn
+  type                      = %[2]q
+  description               = %[3]q
+}
+`, rName, strategyType, description))
 }
 
 func testAccMemoryStrategyConfig_duplicateType(rName string, strategyType string) string {

--- a/website/docs/r/bedrockagentcore_memory_strategy.html.markdown
+++ b/website/docs/r/bedrockagentcore_memory_strategy.html.markdown
@@ -22,11 +22,11 @@ Manages an AWS Bedrock AgentCore Memory Strategy. Memory strategies define how t
 
 ```terraform
 resource "aws_bedrockagentcore_memory_strategy" "semantic" {
-  name        = "semantic-strategy"
-  memory_id   = aws_bedrockagentcore_memory.example.id
-  type        = "SEMANTIC"
-  description = "Semantic understanding strategy"
-  namespaces  = ["default"]
+  name                = "semantic-strategy"
+  memory_id           = aws_bedrockagentcore_memory.example.id
+  type                = "SEMANTIC"
+  description         = "Semantic understanding strategy"
+  namespace_templates = ["default"]
 }
 ```
 
@@ -58,11 +58,11 @@ resource "aws_bedrockagentcore_memory_strategy" "user_pref" {
 
 ```terraform
 resource "aws_bedrockagentcore_memory_strategy" "episodic" {
-  name        = "episodic-strategy"
-  memory_id   = aws_bedrockagentcore_memory.example.id
-  type        = "EPISODIC"
-  description = "Episodic memory strategy"
-  namespaces  = ["/strategies/{memoryStrategyId}/actors/{actorId}/sessions/{sessionId}"]
+  name                = "episodic-strategy"
+  memory_id           = aws_bedrockagentcore_memory.example.id
+  type                = "EPISODIC"
+  description         = "Episodic memory strategy"
+  namespace_templates = ["/strategies/{memoryStrategyId}/actors/{actorId}/sessions/{sessionId}"]
 }
 ```
 
@@ -174,12 +174,13 @@ The following arguments are required:
 * `name` - (Required) Name of the memory strategy.
 * `memory_id` - (Required) ID of the memory to associate with this strategy. Changing this forces a new resource.
 * `type` - (Required) Type of memory strategy. Valid values: `SEMANTIC`, `SUMMARIZATION`, `USER_PREFERENCE`, `EPISODIC`, `CUSTOM`. Changing this forces a new resource. Note that only one strategy of each built-in type (`SEMANTIC`, `SUMMARIZATION`, `USER_PREFERENCE`, `EPISODIC`) can exist per memory.
-* `namespaces` - (Required) Set of namespace identifiers where this strategy applies. Namespaces help organize and scope memory content.
 
 The following arguments are optional:
 
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `description` - (Optional) Description of the memory strategy.
+* `namespace_templates` - (Optional) Set containing exactly one namespace template where this strategy applies (for example `/strategies/{memoryStrategyId}/actors/{actorId}/sessions/{sessionId}`). Namespace templates help organize and scope memory content. Exactly one of `namespace_templates` or `namespaces` must be configured.
+* `namespaces` - (Optional) Set of namespace identifiers where this strategy applies. Exactly one of `namespaces` or `namespace_templates` must be configured. The API treats this as a legacy parameter; prefer `namespace_templates`. Since the API mirrors the two fields, switching an existing configuration from `namespaces` to `namespace_templates` with the same value is an in-place no-op.
 * `configuration` - (Optional) Custom configuration block. Required when `type` is `CUSTOM`, must be omitted for other types. See [`configuration`](#configuration) below.
 
 ### `configuration`


### PR DESCRIPTION
## Description

Adds the `namespace_templates` argument to `aws_bedrockagentcore_memory_strategy`. The Bedrock AgentCore control-plane API deprecated `namespaces` (since 2026-03-02, per the SDK model: "This is a legacy parameter, use `namespaceTemplates`") on every memory-strategy input shape, on `ModifyMemoryStrategyInput`, and on the `MemoryStrategy` output, in favor of `namespaceTemplates`. The Terraform resource previously only exposed `namespaces` (Required).

Changes:

- New `namespace_templates` attribute (Optional + Computed, `SizeBetween(1, 1)` per the API's `NamespacesList` length constraint).
- `namespaces` relaxed from Required to Optional + Computed, with `setvalidator.ExactlyOneOf` between the two — the "must configure a namespace" invariant is preserved, so **no existing configuration breaks**. No `DeprecationMessage` yet; deprecating the attribute is deferred to a follow-up so this PR stays purely additive.
- Both attributes are Computed because the GET API always returns **both** fields populated (the service mirrors whichever one you set). A new `ModifyPlan` marks the unconfigured counterpart Unknown when its sibling changes (or when its state is null, covering `-refresh=false` right after provider upgrade) to avoid "Provider produced inconsistent result after apply".
- Update sends only the config-present field to `ModifyMemoryStrategyInput`, never both.
- The EPISODIC manual expand path wires `namespace_templates` and mirrors whichever field is configured into the strategy's reflection configuration (the API requires the reflection namespace to match or prefix the episodic namespace).
- Docs: `namespace_templates` documented, `namespaces` moved to optional with migration note (renaming the attribute with the same value is an in-place no-op), semantic and episodic examples switched to the new attribute.

## Source

- Go SDK: `aws/aws-sdk-go-v2` @ `0ffbcb97471596ba81b4df82a95b7d7d12b261b1` (`service/bedrockagentcorecontrol` v1.48.0, already the version pinned by this repo — no SDK bump needed).

## Testing

`go build`, `go vet`, and `gofmt` are clean.

**Acceptance tests have not been run yet** — this draft is up early for visibility. Before marking ready for review I will run the full suite against a real account in us-west-2 and replace this section with the verbatim log:

```
TF_ACC=1 go test -v -timeout 180m ./internal/service/bedrockagentcore/ \
  -run 'TestAccBedrockAgentCoreMemoryStrategy_'
```

New coverage in `TestAccBedrockAgentCoreMemoryStrategy_namespaceTemplates`:

- Validation: both attributes set → error; neither set → error.
- Create SEMANTIC with `namespace_templates` only; assert the API-mirrored `namespaces` is populated.
- In-place update of `namespace_templates`.
- Migrate config from `namespace_templates` to legacy `namespaces` with the same value → expected plan Noop (proves the zero-diff migration path).
- EPISODIC with `namespace_templates` (replacement; exercises the manual expand + reflection mirror).
- Import with `ImportStateVerify`.

Existing `_standard` steps gained `namespace_templates.#` assertions to lock in the mirror behavior on the legacy path.

## Honest caveats

- The design assumes the service mirrors the two fields **verbatim** (the GET response marks both Required). If acceptance testing shows canonicalization instead, the Noop-migration test step and docs note will be adjusted — flagged in the test plan.
- Whether `UpdateMemory` accepts `namespaceTemplates` inside `EpisodicReflectionConfigurationInput` end-to-end is confirmed only by the acceptance run.
- Four open PRs touch `memory_strategy.go` (#48139, #48758 reflection_configuration; #48765 memory_record_schema; #48766 self_managed). This diff is kept minimal; trivial rebase for whichever lands second. Note #48139/#48758 add `namespace_templates` only *inside* `reflection_configuration` — this PR adds the top-level attribute and composes with them.

## Relations

Relates #48139, #48758 (reflection_configuration `namespace_templates`).
Relates #48765, #48766 (same file, memory strategy enhancements).
