### PR TITLE
list resource/aws_secretsmanager_secret_version: Removes resource Read function from List

### DIFF
--- a/.ci/semgrep/list/no-resource-read.yml
+++ b/.ci/semgrep/list/no-resource-read.yml
@@ -9,7 +9,6 @@ rules:
       include:
         - "/internal/service"
       exclude:
-        - "/internal/service/secretsmanager/secret_version_list.go"
         - "/internal/service/sqs/queue_list.go"
         - "/internal/service/ssm/parameter_list.go"
     patterns:

--- a/internal/service/secretsmanager/secret_version.go
+++ b/internal/service/secretsmanager/secret_version.go
@@ -281,6 +281,19 @@ func resourceSecretVersionRead(ctx context.Context, d *schema.ResourceData, meta
 	return diags
 }
 
+func resourceSecretVersionFlatten(d *schema.ResourceData, output *secretsmanager.GetSecretValueOutput) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	d.Set(names.AttrARN, output.ARN)
+	d.Set("secret_arn", output.ARN)
+	d.Set("secret_binary", inttypes.Base64EncodeOnce(output.SecretBinary))
+	d.Set("secret_string", output.SecretString)
+	d.Set("version_id", output.VersionId)
+	d.Set("version_stages", output.VersionStages)
+
+	return diags
+}
+
 func resourceSecretVersionUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SecretsManagerClient(ctx)

--- a/internal/service/secretsmanager/secret_version.go
+++ b/internal/service/secretsmanager/secret_version.go
@@ -271,27 +271,18 @@ func resourceSecretVersionRead(ctx context.Context, d *schema.ResourceData, meta
 		return sdkdiag.AppendErrorf(diags, "reading Secrets Manager Secret Version (%s): %s", d.Id(), err)
 	}
 
-	d.Set(names.AttrARN, output.ARN)
-	d.Set("secret_arn", output.ARN)
-	d.Set("secret_binary", inttypes.Base64EncodeOnce(output.SecretBinary))
-	d.Set("secret_string", output.SecretString)
-	d.Set("version_id", output.VersionId)
-	d.Set("version_stages", output.VersionStages)
+	resourceSecretVersionFlatten(d, output)
 
 	return diags
 }
 
-func resourceSecretVersionFlatten(d *schema.ResourceData, output *secretsmanager.GetSecretValueOutput) diag.Diagnostics {
-	var diags diag.Diagnostics
-
+func resourceSecretVersionFlatten(d *schema.ResourceData, output *secretsmanager.GetSecretValueOutput) {
 	d.Set(names.AttrARN, output.ARN)
 	d.Set("secret_arn", output.ARN)
 	d.Set("secret_binary", inttypes.Base64EncodeOnce(output.SecretBinary))
 	d.Set("secret_string", output.SecretString)
 	d.Set("version_id", output.VersionId)
 	d.Set("version_stages", output.VersionStages)
-
-	return diags
 }
 
 func resourceSecretVersionUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/internal/service/secretsmanager/secret_version_list.go
+++ b/internal/service/secretsmanager/secret_version_list.go
@@ -90,13 +90,22 @@ func (l *secretVersionListResource) List(ctx context.Context, request list.ListR
 				rd.Set("secret_id", secretID)
 				rd.Set("version_id", versionID)
 
-				diags := resourceSecretVersionRead(ctx, rd, awsClient)
-				if diags.HasError() || rd.Id() == "" {
-					tflog.Error(ctx, "Reading Secrets Manager secret version", map[string]any{
-						names.AttrID: versionID,
-						"diags":      sdkdiag.DiagnosticsString(diags),
-					})
-					continue
+				if request.IncludeResource {
+					output, err := findSecretVersionByTwoPartKey(ctx, conn, secretID, versionID)
+					if err != nil {
+						tflog.Error(ctx, "Reading Secrets Manager secret version", map[string]any{
+							"error": err,
+						})
+						continue
+					}
+
+					diags := resourceSecretVersionFlatten(rd, output)
+					if diags.HasError() {
+						tflog.Error(ctx, "Reading Secrets Manager secret version", map[string]any{
+							"error": sdkdiag.DiagnosticsString(diags),
+						})
+						continue
+					}
 				}
 
 				result.DisplayName = versionID

--- a/internal/service/secretsmanager/secret_version_list.go
+++ b/internal/service/secretsmanager/secret_version_list.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
-	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
 	"github.com/hashicorp/terraform-provider-aws/internal/logging"
 	inttypes "github.com/hashicorp/terraform-provider-aws/internal/types"
@@ -99,13 +98,7 @@ func (l *secretVersionListResource) List(ctx context.Context, request list.ListR
 						continue
 					}
 
-					diags := resourceSecretVersionFlatten(rd, output)
-					if diags.HasError() {
-						tflog.Error(ctx, "Reading Secrets Manager secret version", map[string]any{
-							"error": sdkdiag.DiagnosticsString(diags),
-						})
-						continue
-					}
+					resourceSecretVersionFlatten(rd, output)
 				}
 
 				result.DisplayName = versionID

--- a/internal/service/secretsmanager/secret_version_list_test.go
+++ b/internal/service/secretsmanager/secret_version_list_test.go
@@ -6,6 +6,7 @@ package secretsmanager_test
 import (
 	"testing"
 
+	"github.com/YakDriver/regexache"
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
@@ -15,6 +16,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	tfknownvalue "github.com/hashicorp/terraform-provider-aws/internal/acctest/knownvalue"
+	tfquerycheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/querycheck"
+	tfqueryfilter "github.com/hashicorp/terraform-provider-aws/internal/acctest/queryfilter"
 	tfstatecheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/statecheck"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -71,6 +74,109 @@ func TestAccSecretsManagerSecretVersion_List_basic(t *testing.T) {
 						"secret_id":         secretID.ValueCheck(),
 						"version_id":        versionID2.ValueCheck(),
 					}),
+				},
+			},
+		},
+	})
+}
+
+func TestAccSecretsManagerSecretVersion_List_includeResource(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	resourceName1 := "aws_secretsmanager_secret_version.test[0]"
+
+	identity1 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SecretsManagerServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckSecretVersionDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/SecretVersion/list_include_resource"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(1),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+				},
+			},
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/SecretVersion/list_include_resource"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(1),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_secretsmanager_secret_version.test", identity1.Checks()),
+					querycheck.ExpectResourceKnownValues("aws_secretsmanager_secret_version.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), []querycheck.KnownValueCheck{
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrARN), tfknownvalue.RegionalARNRegexp("secretsmanager", regexache.MustCompile(`secret:.+`))),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("secret_string"), knownvalue.StringExact("test-string-0")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("version_id"), knownvalue.StringRegexp(regexache.MustCompile(`.+`))),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("version_stages"), knownvalue.SetSizeExact(1)),
+					}),
+				},
+			},
+		},
+	})
+}
+
+func TestAccSecretsManagerSecretVersion_List_regionOverride(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	resourceName1 := "aws_secretsmanager_secret_version.test[0]"
+	resourceName2 := "aws_secretsmanager_secret_version.test[1]"
+
+	identity1 := tfstatecheck.Identity()
+	identity2 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.SecretsManagerServiceID),
+		CheckDestroy:             acctest.CheckDestroyNoop,
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/SecretVersion/list_region_override"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+					"region":         config.StringVariable(acctest.AlternateRegion()),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+					identity2.GetIdentity(resourceName2),
+				},
+			},
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/SecretVersion/list_region_override"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+					"region":         config.StringVariable(acctest.AlternateRegion()),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_secretsmanager_secret_version.test", identity1.Checks()),
+					tfquerycheck.ExpectIdentityFunc("aws_secretsmanager_secret_version.test", identity2.Checks()),
 				},
 			},
 		},

--- a/internal/service/secretsmanager/testdata/SecretVersion/list_include_resource/main.tf
+++ b/internal/service/secretsmanager/testdata/SecretVersion/list_include_resource/main.tf
@@ -1,0 +1,25 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_secretsmanager_secret_version" "test" {
+  count = var.resource_count
+
+  secret_id     = aws_secretsmanager_secret.test.id
+  secret_string = "test-string-${count.index}"
+}
+
+resource "aws_secretsmanager_secret" "test" {
+  name = var.rName
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}

--- a/internal/service/secretsmanager/testdata/SecretVersion/list_include_resource/query.tfquery.hcl
+++ b/internal/service/secretsmanager/testdata/SecretVersion/list_include_resource/query.tfquery.hcl
@@ -1,0 +1,12 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_secretsmanager_secret_version" "test" {
+  provider = aws
+
+  include_resource = true
+
+  config {
+    secret_id = aws_secretsmanager_secret.test.id
+  }
+}

--- a/internal/service/secretsmanager/testdata/SecretVersion/list_region_override/main.tf
+++ b/internal/service/secretsmanager/testdata/SecretVersion/list_region_override/main.tf
@@ -1,0 +1,33 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_secretsmanager_secret_version" "test" {
+  count = var.resource_count
+
+  region        = var.region
+  secret_id     = aws_secretsmanager_secret.test.id
+  secret_string = "test-string-${count.index}"
+}
+
+resource "aws_secretsmanager_secret" "test" {
+  region = var.region
+  name   = var.rName
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}
+
+variable "region" {
+  description = "Region to deploy resource in"
+  type        = string
+  nullable    = false
+}

--- a/internal/service/secretsmanager/testdata/SecretVersion/list_region_override/query.tfquery.hcl
+++ b/internal/service/secretsmanager/testdata/SecretVersion/list_region_override/query.tfquery.hcl
@@ -1,0 +1,11 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_secretsmanager_secret_version" "test" {
+  provider = aws
+
+  config {
+    region    = var.region
+    secret_id = aws_secretsmanager_secret.test.id
+  }
+}


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Removes resource Read function from `aws_secretsmanager_secret_version` List

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=secretsmanager TESTS=TestAccSecretsManagerSecretVersion_

--- PASS: TestAccSecretsManagerSecretVersion_List_includeResource (83.72s)
--- PASS: TestAccSecretsManagerSecretVersion_disappears (84.02s)
--- PASS: TestAccSecretsManagerSecretVersion_List_basic (84.39s)
--- PASS: TestAccSecretsManagerSecretVersion_Disappears_secret (89.91s)
--- PASS: TestAccSecretsManagerSecretVersion_List_regionOverride (90.55s)
--- PASS: TestAccSecretsManagerSecretVersion_basicString (104.72s)
--- PASS: TestAccSecretsManagerSecretVersion_base64Binary (104.80s)
--- PASS: TestAccSecretsManagerSecretVersion_Identity_ExistingResource_noRefreshNoChange (122.71s)
--- PASS: TestAccSecretsManagerSecretVersion_ConvertStringToStringWriteOnly_withChange (135.33s)
--- PASS: TestAccSecretsManagerSecretVersion_ConvertStringWriteOnlyToString_noChange (135.45s)
--- PASS: TestAccSecretsManagerSecretVersion_StringWriteOnly_sameWOVersion (136.03s)
--- PASS: TestAccSecretsManagerSecretVersion_Identity_ExistingResource_basic (136.07s)
--- PASS: TestAccSecretsManagerSecretVersion_versionStagesExternalUpdate (136.12s)
--- PASS: TestAccSecretsManagerSecretVersion_ConvertStringToStringWriteOnly_noChange (136.37s)
--- PASS: TestAccSecretsManagerSecretVersion_UpdateForcesReplacement_string (136.39s)
--- PASS: TestAccSecretsManagerSecretVersion_ConvertStringWriteOnlyToString_withChange (136.42s)
--- PASS: TestAccSecretsManagerSecretVersion_Identity_basic (136.59s)
--- PASS: TestAccSecretsManagerSecretVersion_Identity_regionOverride (136.64s)
--- PASS: TestAccSecretsManagerSecretVersion_multipleVersions (58.58s)
--- PASS: TestAccSecretsManagerSecretVersion_stringWriteOnly_stages (149.06s)
--- PASS: TestAccSecretsManagerSecretVersion_StringWriteOnly_changeWOVersion (69.77s)
--- PASS: TestAccSecretsManagerSecretVersion_versionStages (153.94s)
--- PASS: TestAccSecretsManagerSecretVersion_unknownSecretStringWriteOnlyVersion (72.19s)
--- PASS: TestAccSecretsManagerSecretVersion_unknownSecretString (69.28s)
```
