### PR TITLE
Updates naming guidance for `aws_sagemaker_endpoint` and `aws_sagemaker_endpoint_configuration`

### DIFF
--- a/internal/service/sagemaker/endpoint_test.go
+++ b/internal/service/sagemaker/endpoint_test.go
@@ -74,6 +74,11 @@ func TestAccSageMakerEndpoint_endpointConfigName(t *testing.T) {
 					testAccCheckEndpointExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "endpoint_config_name", sagemakerEndpointConfigurationResourceName2, names.AttrName),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
 			},
 			{
 				ResourceName:      resourceName,

--- a/internal/service/sagemaker/endpoint_test.go
+++ b/internal/service/sagemaker/endpoint_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/YakDriver/regexache"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -262,6 +263,150 @@ func TestAccSageMakerEndpoint_disappears(t *testing.T) {
 					},
 					PostApplyPostRefresh: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction("aws_sagemaker_endpoint.test", plancheck.ResourceActionCreate),
+					},
+				},
+			},
+		},
+	})
+}
+
+// TestAccSageMakerEndpoint_changeEndpointConfig_sameName tests for an Endpoint Configuration being replaced due to a change,
+// but since the Endpoint Configuration name doesn't change, the Endpoint does not pick up the change.
+// NOTE: This is *not* what users want to happen!
+func TestAccSageMakerEndpoint_changeEndpointConfig_sameName(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_sagemaker_endpoint.test"
+	sagemakerEndpointConfigurationResourceName := "aws_sagemaker_endpoint_configuration.test"
+
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	variantName1 := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	variantName2 := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SageMakerServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEndpointDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEndpointConfig_changeEndpointConfig_variantName(rName, variantName1, 2),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckEndpointExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "endpoint_config_name", sagemakerEndpointConfigurationResourceName, names.AttrName),
+					resource.TestCheckResourceAttr(sagemakerEndpointConfigurationResourceName, names.AttrName, rName),
+					resource.TestCheckResourceAttr(sagemakerEndpointConfigurationResourceName, "production_variants.0.variant_name", variantName1),
+					resource.TestCheckResourceAttr(sagemakerEndpointConfigurationResourceName, "production_variants.0.initial_instance_count", "2"),
+				),
+			},
+			{
+				Config: testAccEndpointConfig_changeEndpointConfig_variantName(rName, variantName2, 1),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckEndpointExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "endpoint_config_name", sagemakerEndpointConfigurationResourceName, names.AttrName),
+					resource.TestCheckResourceAttr(sagemakerEndpointConfigurationResourceName, names.AttrName, rName),
+					resource.TestCheckResourceAttr(sagemakerEndpointConfigurationResourceName, "production_variants.0.variant_name", variantName2),
+					resource.TestCheckResourceAttr(sagemakerEndpointConfigurationResourceName, "production_variants.0.initial_instance_count", "1"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(sagemakerEndpointConfigurationResourceName, plancheck.ResourceActionReplace),
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// TestAccSageMakerEndpoint_changeEndpointConfig_namePrefix_createBeforeDestroy tests for an Endpoint Configuration being
+// replaced due to a change and creating the replacement remote resource before destroying the original.
+// This is the correct configuration.
+func TestAccSageMakerEndpoint_changeEndpointConfig_namePrefix_createBeforeDestroy(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_sagemaker_endpoint.test"
+	sagemakerEndpointConfigurationResourceName := "aws_sagemaker_endpoint_configuration.test"
+
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SageMakerServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEndpointDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEndpointConfig_changeEndpointConfig_namePrefix_createBeforeDestroy(rName, 2),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckEndpointExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "endpoint_config_name", sagemakerEndpointConfigurationResourceName, names.AttrName),
+					acctest.CheckResourceAttrHasPrefix(sagemakerEndpointConfigurationResourceName, names.AttrName, rName),
+					resource.TestCheckResourceAttr(sagemakerEndpointConfigurationResourceName, "production_variants.0.variant_name", rName),
+					resource.TestCheckResourceAttr(sagemakerEndpointConfigurationResourceName, "production_variants.0.initial_instance_count", "2"),
+				),
+			},
+			{
+				Config: testAccEndpointConfig_changeEndpointConfig_namePrefix_createBeforeDestroy(rName, 1),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckEndpointExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "endpoint_config_name", sagemakerEndpointConfigurationResourceName, names.AttrName),
+					acctest.CheckResourceAttrHasPrefix(sagemakerEndpointConfigurationResourceName, names.AttrName, rName),
+					resource.TestCheckResourceAttr(sagemakerEndpointConfigurationResourceName, "production_variants.0.variant_name", rName),
+					resource.TestCheckResourceAttr(sagemakerEndpointConfigurationResourceName, "production_variants.0.initial_instance_count", "1"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(sagemakerEndpointConfigurationResourceName, plancheck.ResourceActionReplace),
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// TestAccSageMakerEndpoint_changeEndpointConfig_namePrefix_noCreateBeforeDestroy tests for an Endpoint Configuration being
+// replaced due to a change, but not creating the replacement remote resource before destroying the original.
+// NOTE: This results in an error
+func TestAccSageMakerEndpoint_changeEndpointConfig_namePrefix_noCreateBeforeDestroy(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_sagemaker_endpoint.test"
+	sagemakerEndpointConfigurationResourceName := "aws_sagemaker_endpoint_configuration.test"
+
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SageMakerServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEndpointDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEndpointConfig_changeEndpointConfig_namePrefix_noCreateBeforeDestroy(rName, 2),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckEndpointExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "endpoint_config_name", sagemakerEndpointConfigurationResourceName, names.AttrName),
+					acctest.CheckResourceAttrHasPrefix(sagemakerEndpointConfigurationResourceName, names.AttrName, rName),
+					resource.TestCheckResourceAttr(sagemakerEndpointConfigurationResourceName, "production_variants.0.variant_name", rName),
+					resource.TestCheckResourceAttr(sagemakerEndpointConfigurationResourceName, "production_variants.0.initial_instance_count", "2"),
+				),
+			},
+			{
+				Config:      testAccEndpointConfig_changeEndpointConfig_namePrefix_noCreateBeforeDestroy(rName, 1),
+				ExpectError: regexache.MustCompile(`Could not find endpoint configuration`),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(sagemakerEndpointConfigurationResourceName, plancheck.ResourceActionReplace),
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
 					},
 				},
 			},
@@ -564,4 +709,74 @@ resource "aws_sagemaker_endpoint" "test" {
   }
 }
 `, rName))
+}
+
+func testAccEndpointConfig_changeEndpointConfig_variantName(rName, variantName string, instanceCount int) string {
+	return acctest.ConfigCompose(
+		testAccEndpointConfig_model_base(rName), fmt.Sprintf(`
+resource "aws_sagemaker_endpoint" "test" {
+  endpoint_config_name = aws_sagemaker_endpoint_configuration.test.name
+  name                 = %[1]q
+}
+
+resource "aws_sagemaker_endpoint_configuration" "test" {
+  name = %[1]q
+
+  production_variants {
+    initial_instance_count = %[3]d
+    initial_variant_weight = 1
+    instance_type          = "ml.t2.medium"
+    model_name             = aws_sagemaker_model.test.name
+    variant_name           = %[2]q
+  }
+}
+`, rName, variantName, instanceCount))
+}
+
+func testAccEndpointConfig_changeEndpointConfig_namePrefix_createBeforeDestroy(rName string, instanceCount int) string {
+	return acctest.ConfigCompose(
+		testAccEndpointConfig_model_base(rName), fmt.Sprintf(`
+resource "aws_sagemaker_endpoint" "test" {
+  endpoint_config_name = aws_sagemaker_endpoint_configuration.test.name
+  name                 = %[1]q
+}
+
+resource "aws_sagemaker_endpoint_configuration" "test" {
+  name_prefix = "%[1]s-"
+
+  production_variants {
+    initial_instance_count = %[2]d
+    initial_variant_weight = 1
+    instance_type          = "ml.t2.medium"
+    model_name             = aws_sagemaker_model.test.name
+    variant_name           = %[1]q
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+`, rName, instanceCount))
+}
+
+func testAccEndpointConfig_changeEndpointConfig_namePrefix_noCreateBeforeDestroy(rName string, instanceCount int) string {
+	return acctest.ConfigCompose(
+		testAccEndpointConfig_model_base(rName), fmt.Sprintf(`
+resource "aws_sagemaker_endpoint" "test" {
+  endpoint_config_name = aws_sagemaker_endpoint_configuration.test.name
+  name                 = %[1]q
+}
+
+resource "aws_sagemaker_endpoint_configuration" "test" {
+  name_prefix = "%[1]s-"
+
+  production_variants {
+    initial_instance_count = %[2]d
+    initial_variant_weight = 1
+    instance_type          = "ml.t2.medium"
+    model_name             = aws_sagemaker_model.test.name
+    variant_name           = %[1]q
+  }
+}
+`, rName, instanceCount))
 }

--- a/internal/service/sagemaker/endpoint_test.go
+++ b/internal/service/sagemaker/endpoint_test.go
@@ -713,7 +713,8 @@ resource "aws_sagemaker_endpoint" "test" {
 
 func testAccEndpointConfig_changeEndpointConfig_variantName(rName, variantName string, instanceCount int) string {
 	return acctest.ConfigCompose(
-		testAccEndpointConfig_model_base(rName), fmt.Sprintf(`
+		testAccEndpointConfig_model_base(rName),
+		fmt.Sprintf(`
 resource "aws_sagemaker_endpoint" "test" {
   endpoint_config_name = aws_sagemaker_endpoint_configuration.test.name
   name                 = %[1]q
@@ -735,7 +736,8 @@ resource "aws_sagemaker_endpoint_configuration" "test" {
 
 func testAccEndpointConfig_changeEndpointConfig_namePrefix_createBeforeDestroy(rName string, instanceCount int) string {
 	return acctest.ConfigCompose(
-		testAccEndpointConfig_model_base(rName), fmt.Sprintf(`
+		testAccEndpointConfig_model_base(rName),
+		fmt.Sprintf(`
 resource "aws_sagemaker_endpoint" "test" {
   endpoint_config_name = aws_sagemaker_endpoint_configuration.test.name
   name                 = %[1]q
@@ -761,7 +763,8 @@ resource "aws_sagemaker_endpoint_configuration" "test" {
 
 func testAccEndpointConfig_changeEndpointConfig_namePrefix_noCreateBeforeDestroy(rName string, instanceCount int) string {
 	return acctest.ConfigCompose(
-		testAccEndpointConfig_model_base(rName), fmt.Sprintf(`
+		testAccEndpointConfig_model_base(rName),
+		fmt.Sprintf(`
 resource "aws_sagemaker_endpoint" "test" {
   endpoint_config_name = aws_sagemaker_endpoint_configuration.test.name
   name                 = %[1]q

--- a/internal/service/sagemaker/endpoint_test.go
+++ b/internal/service/sagemaker/endpoint_test.go
@@ -309,7 +309,7 @@ func testAccCheckEndpointExists(ctx context.Context, t *testing.T, n string) res
 	}
 }
 
-func testAccEndpointConfig_base(rName string) string {
+func testAccEndpointConfig_model_base(rName string) string {
 	return fmt.Sprintf(`
 data "aws_iam_policy_document" "access" {
   statement {
@@ -382,7 +382,13 @@ resource "aws_sagemaker_model" "test" {
 
   depends_on = [aws_iam_role_policy.test]
 }
+`, rName)
+}
 
+func testAccEndpointConfig_endpointConfiguration_base(rName string) string {
+	return acctest.ConfigCompose(
+		testAccEndpointConfig_model_base(rName),
+		fmt.Sprintf(`
 resource "aws_sagemaker_endpoint_configuration" "test" {
   name = %[1]q
 
@@ -394,11 +400,11 @@ resource "aws_sagemaker_endpoint_configuration" "test" {
     variant_name           = "variant-1"
   }
 }
-`, rName)
+`, rName))
 }
 
 func testAccEndpointConfig_basic(rName string) string {
-	return acctest.ConfigCompose(testAccEndpointConfig_base(rName), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccEndpointConfig_endpointConfiguration_base(rName), fmt.Sprintf(`
 resource "aws_sagemaker_endpoint" "test" {
   endpoint_config_name = aws_sagemaker_endpoint_configuration.test.name
   name                 = %[1]q
@@ -407,7 +413,7 @@ resource "aws_sagemaker_endpoint" "test" {
 }
 
 func testAccEndpointConfig_endpointConfigNameUpdate(rName string) string {
-	return acctest.ConfigCompose(testAccEndpointConfig_base(rName), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccEndpointConfig_endpointConfiguration_base(rName), fmt.Sprintf(`
 resource "aws_sagemaker_endpoint_configuration" "test2" {
   name = "%[1]s-updated"
 
@@ -428,7 +434,7 @@ resource "aws_sagemaker_endpoint" "test" {
 }
 
 func testAccEndpointConfig_tags(rName string) string {
-	return acctest.ConfigCompose(testAccEndpointConfig_base(rName), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccEndpointConfig_endpointConfiguration_base(rName), fmt.Sprintf(`
 resource "aws_sagemaker_endpoint" "test" {
   endpoint_config_name = aws_sagemaker_endpoint_configuration.test.name
   name                 = %[1]q
@@ -441,7 +447,7 @@ resource "aws_sagemaker_endpoint" "test" {
 }
 
 func testAccEndpointConfig_tagsUpdate(rName string) string {
-	return acctest.ConfigCompose(testAccEndpointConfig_base(rName), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccEndpointConfig_endpointConfiguration_base(rName), fmt.Sprintf(`
 resource "aws_sagemaker_endpoint" "test" {
   endpoint_config_name = aws_sagemaker_endpoint_configuration.test.name
   name                 = %[1]q
@@ -454,7 +460,7 @@ resource "aws_sagemaker_endpoint" "test" {
 }
 
 func testAccEndpointConfig_deploymentBasic(rName, tType string, wait int) string {
-	return acctest.ConfigCompose(testAccEndpointConfig_base(rName), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccEndpointConfig_endpointConfiguration_base(rName), fmt.Sprintf(`
 resource "aws_sagemaker_endpoint" "test" {
   endpoint_config_name = aws_sagemaker_endpoint_configuration.test.name
   name                 = %[1]q
@@ -472,7 +478,7 @@ resource "aws_sagemaker_endpoint" "test" {
 }
 
 func testAccEndpointConfig_deploymentBlueGreen(rName string) string {
-	return acctest.ConfigCompose(testAccEndpointConfig_base(rName), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccEndpointConfig_endpointConfiguration_base(rName), fmt.Sprintf(`
 resource "aws_cloudwatch_metric_alarm" "test" {
   alarm_name                = %[1]q
   comparison_operator       = "GreaterThanOrEqualToThreshold"
@@ -518,7 +524,7 @@ resource "aws_sagemaker_endpoint" "test" {
 }
 
 func testAccEndpointConfig_deploymentRolling(rName string) string {
-	return acctest.ConfigCompose(testAccEndpointConfig_base(rName), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccEndpointConfig_endpointConfiguration_base(rName), fmt.Sprintf(`
 resource "aws_cloudwatch_metric_alarm" "test" {
   alarm_name                = %[1]q
   comparison_operator       = "GreaterThanOrEqualToThreshold"

--- a/internal/service/sagemaker/endpoint_test.go
+++ b/internal/service/sagemaker/endpoint_test.go
@@ -48,7 +48,7 @@ func TestAccSageMakerEndpoint_basic(t *testing.T) {
 	})
 }
 
-func TestAccSageMakerEndpoint_endpointName(t *testing.T) {
+func TestAccSageMakerEndpoint_endpointConfigName(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_sagemaker_endpoint.test"
@@ -69,7 +69,7 @@ func TestAccSageMakerEndpoint_endpointName(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccEndpointConfig_nameUpdate(rName),
+				Config: testAccEndpointConfig_endpointConfigNameUpdate(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEndpointExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "endpoint_config_name", sagemakerEndpointConfigurationResourceName2, names.AttrName),
@@ -401,10 +401,10 @@ resource "aws_sagemaker_endpoint" "test" {
 `, rName))
 }
 
-func testAccEndpointConfig_nameUpdate(rName string) string {
+func testAccEndpointConfig_endpointConfigNameUpdate(rName string) string {
 	return acctest.ConfigCompose(testAccEndpointConfig_base(rName), fmt.Sprintf(`
 resource "aws_sagemaker_endpoint_configuration" "test2" {
-  name = "%[1]s2"
+  name = "%[1]s-updated"
 
   production_variants {
     initial_instance_count = 1

--- a/website/docs/r/sagemaker_endpoint.html.markdown
+++ b/website/docs/r/sagemaker_endpoint.html.markdown
@@ -10,17 +10,25 @@ description: |-
 
 Provides a SageMaker AI Endpoint resource.
 
+~> **Note:** `aws_sagemaker_endpoint` resources cannot recognize changes to an `aws_sagemaker_endpoint_configuration` resource unless the Endpoint Configuration's `name` attribute, changes. Endpoint Configuration names should be randomized by either specifying `name_prefix` or specifying no name. This will automatically change the name when the Endpoint Configuration is modified. The Endpoint Configuration's lifecycle meta-argument `lifecycle.create_before_destroy` should also be set to `true` to prevent conflicts.
+
 ## Example Usage
 
 Basic usage:
 
 ```terraform
-resource "aws_sagemaker_endpoint" "e" {
-  name                 = "my-endpoint"
-  endpoint_config_name = aws_sagemaker_endpoint_configuration.ec.name
+resource "aws_sagemaker_endpoint" "example" {
+  name                 = "example-endpoint"
+  endpoint_config_name = aws_sagemaker_endpoint_configuration.example.name
+}
 
-  tags = {
-    Name = "foo"
+resource "aws_sagemaker_endpoint_configuration" "example" {
+  name_prefix = "example-endpoint-config"
+
+  # Endpoint Configuration parameters
+
+  lifecycle {
+    create_before_destroy = true
   }
 }
 ```

--- a/website/docs/r/sagemaker_endpoint.html.markdown
+++ b/website/docs/r/sagemaker_endpoint.html.markdown
@@ -94,7 +94,6 @@ This resource supports the following arguments:
 This resource exports the following attributes in addition to the arguments above:
 
 * `arn` - The Amazon Resource Name (ARN) assigned by AWS to this endpoint.
-* `name` - The name of the endpoint.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 
 ## Import

--- a/website/docs/r/sagemaker_endpoint_configuration.html.markdown
+++ b/website/docs/r/sagemaker_endpoint_configuration.html.markdown
@@ -10,23 +10,25 @@ description: |-
 
 Provides a SageMaker AI endpoint configuration resource.
 
+~> **Note:** `aws_sagemaker_endpoint` resources cannot recognize changes to an `aws_sagemaker_endpoint_configuration` resource unless the Endpoint Configuration's `name` attribute, changes. Endpoint Configuration names should be randomized by either specifying `name_prefix` or specifying no name. This will automatically change the name when the Endpoint Configuration is modified. The Endpoint Configuration's lifecycle meta-argument `lifecycle.create_before_destroy` should also be set to `true` to prevent conflicts.
+
 ## Example Usage
 
 Basic usage:
 
 ```terraform
-resource "aws_sagemaker_endpoint_configuration" "ec" {
-  name = "my-endpoint-config"
+resource "aws_sagemaker_endpoint_configuration" "example" {
+  name_prefix = "example-endpoint-config"
 
   production_variants {
     variant_name           = "variant-1"
-    model_name             = aws_sagemaker_model.m.name
+    model_name             = aws_sagemaker_model.example.name
     initial_instance_count = 1
     instance_type          = "ml.t2.medium"
   }
 
-  tags = {
-    Name = "foo"
+  lifecycle {
+    create_before_destroy = true
   }
 }
 ```
@@ -40,7 +42,7 @@ This resource supports the following arguments:
 * `execution_role_arn` - (Optional) ARN of an IAM role that SageMaker AI can assume to perform actions on your behalf. Required when `model_name` is not specified in `production_variants` to support Inference Components.
 * `kms_key_arn` - (Optional) ARN of a AWS KMS key that SageMaker AI uses to encrypt data on the storage volume attached to the ML compute instance that hosts the endpoint.
 * `name_prefix` - (Optional) Unique endpoint configuration name beginning with the specified prefix. Conflicts with `name`.
-* `name` - (Optional) Name of the endpoint configuration. If omitted, Terraform will assign a random, unique name. Conflicts with `name_prefix`.
+* `name` - (Optional) Name of the endpoint configuration. If omitted, Terraform will assign a random, unique name. Conflicts with `name_prefix`. If `name_prefix` is specified, `name` is populated with the full name.
 * `production_variants` - (Required) List each model that you want to host at this endpoint. [See below](#production_variants).
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `shadow_production_variants` - (Optional) Models that you want to host at this endpoint in shadow mode with production traffic replicated from the model specified on `production_variants`. If you use this field, you can only specify one variant for `production_variants` and one variant for `shadow_production_variants`. [See below](#production_variants) (same arguments as `production_variants`).

--- a/website/docs/r/sagemaker_endpoint_configuration.html.markdown
+++ b/website/docs/r/sagemaker_endpoint_configuration.html.markdown
@@ -136,7 +136,6 @@ This resource supports the following arguments:
 This resource exports the following attributes in addition to the arguments above:
 
 * `arn` - ARN assigned by AWS to this endpoint configuration.
-* `name` - Name of the endpoint configuration.
 * `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 
 ## Import


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

An `aws_sagemaker_endpoint` resource uses an associated `aws_sagemaker_endpoint_configuration` for configuration. All attributes in `aws_sagemaker_endpoint_configuration` trigger replacement when changed. If the `aws_sagemaker_endpoint_configuration` is replaced without changing the name, the `aws_sagemaker_endpoint` will not pick up the change.

Updates documentation to recommend using a randomized name using either `name_prefix` or not specifying a name.

Adds tests for recommended configuration and related error conditions.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=sagemaker TESTS=TestAccSageMakerEndpoint_

--- PASS: TestAccSageMakerEndpoint_basic (185.21s)
--- PASS: TestAccSageMakerEndpoint_disappears (210.38s)
--- PASS: TestAccSageMakerEndpoint_deploymentConfig_rolling (216.38s)
--- PASS: TestAccSageMakerEndpoint_changeEndpointConfig_namePrefix_noCreateBeforeDestroy (223.78s)
--- PASS: TestAccSageMakerEndpoint_deploymentConfig_blueGreen (230.34s)
--- PASS: TestAccSageMakerEndpoint_tags (232.39s)
--- PASS: TestAccSageMakerEndpoint_deploymentConfig (233.33s)
--- PASS: TestAccSageMakerEndpoint_changeEndpointConfig_sameName (316.22s)
--- PASS: TestAccSageMakerEndpoint_endpointConfigName (378.11s)
--- PASS: TestAccSageMakerEndpoint_changeEndpointConfig_namePrefix_createBeforeDestroy (400.52s)
```
