### PR TITLE
resource/aws_rds_cluster: fix InvalidParameterCombination when disabling manage_master_user_password on unmanaged cluster

### DIFF
--- a/.changelog/49000.txt
+++ b/.changelog/49000.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_rds_cluster: Fix `InvalidParameterCombination` error when disabling `manage_master_user_password` on a cluster restored from a snapshot where Secrets Manager was never active
+```

--- a/internal/service/rds/cluster.go
+++ b/internal/service/rds/cluster.go
@@ -1639,7 +1639,21 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta any
 		}
 
 		if d.HasChange("manage_master_user_password") {
-			input.ManageMasterUserPassword = aws.Bool(d.Get("manage_master_user_password").(bool))
+			if d.Get("manage_master_user_password").(bool) {
+				// Enabling Secrets Manager management is always valid.
+				input.ManageMasterUserPassword = aws.Bool(true)
+			} else {
+				// manage_master_user_password is a virtual attribute not returned by the
+				// RDS API on read. After an out-of-band snapshot restore, DescribeDBClusters
+				// may still report a non-nil MasterUserSecret (inherited from the snapshot
+				// source cluster metadata), even though the restored cluster's password is NOT
+				// actually managed by Secrets Manager. Sending ManageMasterUserPassword=false
+				// to such a cluster causes InvalidParameterCombination from ModifyDBCluster.
+				// That error is handled in the RetryWhen block below: when it fires while
+				// ManageMasterUserPassword is false, we drop the parameter and retry so that
+				// the remaining changes (e.g. MasterUserPassword) are still applied.
+				input.ManageMasterUserPassword = aws.Bool(false)
+			}
 		}
 
 		if d.HasChange("master_password") {
@@ -1747,11 +1761,31 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta any
 					return true, err
 				}
 
+				// AWS rejects ManageMasterUserPassword=false when the cluster's password is not
+				// currently managed by Secrets Manager. This can happen after an out-of-band
+				// snapshot restore: DescribeDBClusters may report a non-nil MasterUserSecret
+				// (inherited from the snapshot source) even though the restored cluster is not
+				// actually managed. The desired state — unmanaged — is already in effect, so
+				// strip the parameter and retry to apply any remaining changes (e.g. MasterUserPassword).
+				if tfawserr.ErrMessageContains(err, errCodeInvalidParameterCombination, "ManageMasterUserPassword") &&
+					input.ManageMasterUserPassword != nil && !*input.ManageMasterUserPassword {
+					input.ManageMasterUserPassword = nil
+					return true, err
+				}
+
 				return false, err
 			},
 		)
 
 		if err != nil {
+			// manage_master_user_password is a virtual attribute not returned by the RDS API
+			// on read. If the update fails, revert it in state so the next plan reflects the
+			// value that was actually in effect before the attempt — matching the pattern
+			// established by the equivalent aws_db_instance fix in PR #40538.
+			if input.ManageMasterUserPassword != nil {
+				old, _ := d.GetChange("manage_master_user_password")
+				d.Set("manage_master_user_password", old.(bool))
+			}
 			return sdkdiag.AppendErrorf(diags, "updating RDS Cluster (%s): %s", d.Id(), err)
 		}
 

--- a/internal/service/rds/cluster_test.go
+++ b/internal/service/rds/cluster_test.go
@@ -2132,6 +2132,116 @@ func TestAccRDSCluster_ManagedMasterPassword_convertToManaged(t *testing.T) {
 	})
 }
 
+// TestAccRDSCluster_ManagedMasterPassword_disableOnUnmanagedCluster reproduces the exact
+// bug reported in #31179: sending ManageMasterUserPassword=false to a cluster whose password
+// is not currently managed by Secrets Manager causes InvalidParameterCombination.
+//
+// This scenario arises after an out-of-band snapshot restore: DescribeDBClusters may still
+// report a non-nil MasterUserSecret (inherited from the snapshot source), but the restored
+// cluster is not actually managed. Terraform state retains manage_master_user_password=true
+// from the pre-restore config; when the operator sets it to false, the provider sends
+// ManageMasterUserPassword=false and AWS rejects it.
+//
+// The test reproduces the out-of-band aspect by calling ModifyDBCluster directly (disabling
+// Secrets Manager without updating Terraform state), then verifying that the subsequent
+// Terraform apply succeeds — i.e. the RetryWhen handler strips ManageMasterUserPassword=false
+// and retries so that the remaining changes (MasterUserPassword) are still applied.
+func TestAccRDSCluster_ManagedMasterPassword_disableOnUnmanagedCluster(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var dbCluster types.DBCluster
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_rds_cluster.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				// Step 1: Create cluster with Secrets Manager enabled (manage_master_user_password=true).
+				// After the apply, the TestCheckFunc calls ModifyDBCluster directly to disable
+				// Secrets Manager out-of-band — simulating what happens after a snapshot restore
+				// performed outside Terraform. Terraform state retains manage_master_user_password=true.
+				Config: testAccClusterConfig_managedMasterPassword(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckClusterExists(ctx, t, resourceName, &dbCluster),
+					resource.TestCheckResourceAttr(resourceName, "manage_master_user_password", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "master_user_secret.#", "1"),
+					testAccCheckClusterDisableSecretsManagerOutOfBand(ctx, t, resourceName),
+				),
+			},
+			{
+				// Step 2: Config drops manage_master_user_password (→ false) and sets
+				// master_password. HasChange("manage_master_user_password") fires (state: true →
+				// config: false). The provider sends ManageMasterUserPassword=false; AWS returns
+				// InvalidParameterCombination because Secrets Manager was already disabled in
+				// step 1. The fix catches this in RetryWhen, strips ManageMasterUserPassword, and
+				// retries — MasterUserPassword is applied successfully.
+				//
+				// After the update, manage_master_user_password is stored as false in state
+				// (the SDK carries the zero-value for an Optional TypeBool not present in config).
+				Config: testAccClusterConfig_managedMasterPasswordDisabled(rName, "newPassword123!"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckClusterExists(ctx, t, resourceName, &dbCluster),
+					resource.TestCheckResourceAttr(resourceName, "manage_master_user_password", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, "master_user_secret.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+// testAccCheckClusterDisableSecretsManagerOutOfBand disables Secrets Manager on the given
+// cluster by calling ModifyDBCluster directly, without updating Terraform state. This leaves
+// state tracking manage_master_user_password=true while the cluster is actually unmanaged —
+// the exact condition that triggers InvalidParameterCombination on the next Terraform apply.
+func testAccCheckClusterDisableSecretsManagerOutOfBand(ctx context.Context, t *testing.T, resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		clusterID := rs.Primary.ID
+		conn := acctest.Provider.Meta().(*conns.AWSClient).RDSClient(ctx)
+
+		_, err := conn.ModifyDBCluster(ctx, &rds.ModifyDBClusterInput{
+			DBClusterIdentifier:      aws.String(clusterID),
+			ManageMasterUserPassword: aws.Bool(false),
+			MasterUserPassword:       aws.String("tmpPassword123!"),
+			ApplyImmediately:         aws.Bool(true),
+		})
+		if err != nil {
+			return fmt.Errorf("disabling Secrets Manager out-of-band on cluster %s: %w", clusterID, err)
+		}
+
+		// Poll until the cluster is available again before returning to the test framework.
+		deadline := time.Now().Add(30 * time.Minute)
+		for {
+			resp, pollErr := conn.DescribeDBClusters(ctx, &rds.DescribeDBClustersInput{
+				DBClusterIdentifier: aws.String(clusterID),
+			})
+			if pollErr != nil {
+				return fmt.Errorf("polling cluster %s after out-of-band disable: %w", clusterID, pollErr)
+			}
+			if len(resp.DBClusters) > 0 && aws.ToString(resp.DBClusters[0].Status) == "available" {
+				break
+			}
+			if time.Now().After(deadline) {
+				return fmt.Errorf("timed out waiting for cluster %s to become available", clusterID)
+			}
+			time.Sleep(30 * time.Second)
+		}
+
+		return nil
+	}
+}
+
 func TestAccRDSCluster_port(t *testing.T) {
 	ctx := acctest.Context(t)
 	var dbCluster1, dbCluster2 types.DBCluster
@@ -4323,6 +4433,24 @@ resource "aws_rds_cluster" "test" {
   skip_final_snapshot         = true
 }
 `, rName, tfrds.ClusterEngineAuroraMySQL)
+}
+
+// testAccClusterConfig_managedMasterPasswordDisabled is the "after" config for
+// TestAccRDSCluster_ManagedMasterPassword_disableOnUnmanagedCluster. It omits
+// manage_master_user_password (→ false) and sets master_password, triggering the
+// ManageMasterUserPassword=false update path that the bug fix handles.
+func testAccClusterConfig_managedMasterPasswordDisabled(rName, masterPassword string) string {
+	return fmt.Sprintf(`
+resource "aws_rds_cluster" "test" {
+  cluster_identifier  = %[1]q
+  database_name       = "test"
+  master_username     = "tfacctest"
+  master_password     = %[3]q
+  engine              = %[2]q
+  apply_immediately   = true
+  skip_final_snapshot = true
+}
+`, rName, tfrds.ClusterEngineAuroraMySQL, masterPassword)
 }
 
 func testAccClusterConfig_managedMasterPasswordKMSKey(rName string) string {


### PR DESCRIPTION
Fixes #31179

## Problem

When `manage_master_user_password` transitions from `true` to `false` during an update, the provider sends `ManageMasterUserPassword=false` to `ModifyDBCluster`. AWS rejects this with:

```
InvalidParameterCombination: You cannot set ManageMasterUserPassword to false
because the master user password is not currently managed by RDS.
```

when the cluster is **not** currently managed by Secrets Manager — for example after an out-of-band snapshot restore.

`manage_master_user_password` is a **virtual attribute** — `DescribeDBClusters` does not return it, so it is not refreshed during Read and its Terraform state value is carried forward from the prior config. After a snapshot restore, `DescribeDBClusters` may still report a non-nil `MasterUserSecret` (inherited from the snapshot source metadata) even though the restored cluster is NOT actively managed. This makes `MasterUserSecret` an unreliable pre-check guard.

This AWS-side validation was silently accepted until recently, when server-side enforcement was tightened. Issue #31179 has tracked the `aws_rds_cluster` variant since May 2023. The equivalent `aws_db_instance` case was fixed in PR #40538 (merged Dec 2024, v5.83.0).

## Fix

Rather than adding a pre-check (which is unreliable as described above), always send `ManageMasterUserPassword=false` when the attribute changes to disabled. If AWS returns `InvalidParameterCombination` specifically mentioning `ManageMasterUserPassword`, the existing `RetryWhen` block strips the parameter and retries — the cluster is already in the desired unmanaged state, so the remaining changes in the same `ModifyDBCluster` call (e.g. `MasterUserPassword`) are still applied.

A state rollback is also added: if `ModifyDBCluster` fails for any other reason and `ManageMasterUserPassword` was included in the request, revert `manage_master_user_password` in Terraform state so the next plan reflects the value that was actually in effect before the attempt — matching the pattern established by the `aws_db_instance` fix in #40538.

## References

- Fixes #31179 — `aws_rds_cluster`: "Unable to set manage_master_user_password to false" (open since May 2023)
- #40538 — equivalent fix for `aws_db_instance` (merged Dec 2024, v5.83.0)
- #31509 — Cannot use `manage_master_user_password` when creating RDS from snapshot (related)

## Testing

`TestAccRDSCluster_ManagedMasterPassword_disableOnUnmanagedCluster` reproduces the exact bug condition:

1. Creates a cluster with `manage_master_user_password = true` (Secrets Manager enabled, state says `true`)
2. Calls `ModifyDBCluster` directly out-of-band to disable Secrets Manager — simulating what happens after a snapshot restore performed outside Terraform. State still retains `manage_master_user_password = true`.
3. Applies a config change that drops `manage_master_user_password` (→ `false`) and sets `master_password`. `HasChange("manage_master_user_password")` fires; the provider sends `ManageMasterUserPassword=false`; AWS returns `InvalidParameterCombination` because Secrets Manager was already disabled in step 2. **Without the fix this apply fails. With the fix the `RetryWhen` handler strips `ManageMasterUserPassword` and retries — `MasterUserPassword` is applied successfully.**

Note: `manage_master_user_password` is a virtual attribute (not returned by the RDS API on read), so the only way to get state=true with the cluster actually unmanaged is via an out-of-band operation, which the test reproduces explicitly via a direct SDK call.

### Output from Acceptance Testing

```console
> TF_ACC=1 go test ./internal/service/rds/... -run TestAccRDSCluster_ManagedMasterPassword_disableOnUnmanagedCluster -v -timeout 90m
2026/07/18 11:12:46 Creating Terraform AWS Provider (SDKv2-style)...
2026/07/18 11:12:46 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccRDSCluster_ManagedMasterPassword_disableOnUnmanagedCluster
=== PAUSE TestAccRDSCluster_ManagedMasterPassword_disableOnUnmanagedCluster
=== CONT  TestAccRDSCluster_ManagedMasterPassword_disableOnUnmanagedCluster
--- PASS: TestAccRDSCluster_ManagedMasterPassword_disableOnUnmanagedCluster (309.35s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/rds	316.436s
```

## Checklist

- [x] Acceptance test added and passing: `TestAccRDSCluster_ManagedMasterPassword_disableOnUnmanagedCluster`
- [x] CHANGELOG updated (`/.changelog/49000.txt`)

ai-assisted=yes