### PR TITLE
docs/aws_launch_template: clarify that description is the version description

### DIFF
--- a/website/docs/r/launch_template.html.markdown
+++ b/website/docs/r/launch_template.html.markdown
@@ -115,7 +115,7 @@ This resource supports the following arguments:
 * `credit_specification` - (Optional) Customize the credit specification of the instance. See [Credit
   Specification](#credit-specification) below for more details.
 * `default_version` - (Optional) Default Version of the launch template.
-* `description` - (Optional) Description of the launch template.
+* `description` - (Optional) Description of the launch template version (`VersionDescription` in the [EC2 API](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateLaunchTemplateVersion.html)). Launch templates in AWS do not have a template-level description; whenever a change to this resource creates a new version, the new version is created with this description. To give each version a distinct description, update this argument in the same apply as the other changes.
 * `disable_api_stop` - (Optional) If true, enables [EC2 Instance Stop Protection](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-stop-protection.html).
 * `disable_api_termination` - (Optional) If `true`, enables [EC2 Instance
   Termination Protection](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_ChangingDisableAPITermination.html)


### PR DESCRIPTION
### Description

Documentation-only change. Clarifies that the `description` argument of `aws_launch_template` is the launch template *version* description (`VersionDescription` in the EC2 API), since launch templates in AWS have no template-level description. Whenever a change creates a new version, the new version is created with this description.

This addresses the confusion in #48992, where the existing `description` argument already provides the requested `version_description` functionality.

### Relations

Closes #48992

### Output from Acceptance Testing

Documentation-only change; no acceptance tests apply.
