### PR TITLE
tctest action via chatopps

### DIFF
--- a/.github/workflows/pr-test-trigger.yml
+++ b/.github/workflows/pr-test-trigger.yml
@@ -1,0 +1,96 @@
+# Copyright IBM Corp. 2014, 2026
+# "SPDX-License-Identifier: MPL-2.0"
+
+name: PR Test Trigger
+
+permissions:
+  contents: read        # required for checkout
+  pull-requests: write  # required to post feedback comments
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  trigger:
+    name: Trigger Tests from Comment
+    runs-on: ubuntu-latest
+    # Only run when the comment is on a pull request and starts with /test
+    if: |
+      github.event.issue.pull_request
+      && startsWith(github.event.comment.body, '/test')
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          sparse-checkout: .github/actions/community_check
+
+      - name: Run Community Check
+        id: community_check
+        uses: ./.github/actions/community_check
+        with:
+          user_login: ${{ github.event.comment.user.login }}
+          maintainers: ${{ secrets.MAINTAINERS }}
+
+      - name: Setup Go
+        if: steps.community_check.outputs.maintainer == 'true'
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+
+      - name: Install tctest
+        if: steps.community_check.outputs.maintainer == 'true'
+        run: go install github.com/katbyte/tctest@v0.9.0
+
+      - name: Determine Changed Packages
+        if: steps.community_check.outputs.maintainer == 'true'
+        id: pkgs
+        env:
+          PR_NUMBER: ${{ github.event.issue.number }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          pkgs=$(gh api repos/${{ github.repository }}/pulls/${PR_NUMBER}/files --paginate \
+            --jq '[.[].filename | select(startswith("internal/service/")) | split("/")[2]] | unique | join(",")')
+          echo "pkgs=${pkgs}" >> "$GITHUB_OUTPUT"
+
+      - name: Comment on Multiple Packages
+        if: |
+          steps.community_check.outputs.maintainer == 'true'
+          && contains(steps.pkgs.outputs.pkgs, ',')
+        env:
+          PKGS: ${{ steps.pkgs.outputs.pkgs }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          gh pr comment ${{ github.event.issue.html_url }} --body \
+            "This PR touches multiple packages (\`${PKGS}\`). Please run tests manually."
+
+      - name: Run Tests
+        if: |
+          steps.community_check.outputs.maintainer == 'true'
+          && !contains(steps.pkgs.outputs.pkgs, ',')
+        id: run_tests
+        env:
+          PR_NUMBER: ${{ github.event.issue.number }}
+          PKGS: ${{ steps.pkgs.outputs.pkgs }}
+          TCTEST_SERVER: ${{ secrets.TCTEST_SERVER }}
+          TCTEST_BUILDTYPEID: ${{ secrets.TCTEST_BUILDTYPEID }}
+          TCTEST_REPO: hashicorp/terraform-provider-aws
+          TCTEST_FILEREGEX: "^internal/.*"
+          TCTEST_SKIP_QUEUE: 1
+          TCTEST_TOKEN_TC: ${{ secrets.TCTEST_TOKEN_TC }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          output=$(tctest pr ${PR_NUMBER} --properties PKG=${PKGS} --comment)
+          echo "${output}"
+          if ! echo "${output}" | grep -q "triggered tests for 1 PRs!"; then
+            echo "::error::tctest did not successfully trigger tests: ${output}"
+            exit 1
+          fi
+
+      - name: Comment on Test Start
+        if: steps.run_tests.outcome == 'success'
+        env:
+          PKGS: ${{ steps.pkgs.outputs.pkgs }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          gh pr comment ${{ github.event.issue.html_url }} --body \
+            "Automated tests have been triggered for package \`${PKGS}\`. Results will be posted when complete."


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Simple GitHub action that triggers automated testing via `tctest`. This is a simplified version of shared actions so that we can validate functionality without complexity.

Shared actions will be integrated at a later date.

This action looks for `/test` in a comment and discovers which tests to be run. For testing simplicity, this will only execute if all changes are in the same package.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->


### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
