### PR TITLE
list resource/aws_sqs_queue: Removes resource Read function from List

### DIFF
--- a/.ci/semgrep/list/no-resource-read.yml
+++ b/.ci/semgrep/list/no-resource-read.yml
@@ -9,7 +9,6 @@ rules:
       include:
         - "/internal/service"
       exclude:
-        - "/internal/service/sqs/queue_list.go"
         - "/internal/service/ssm/parameter_list.go"
     patterns:
       - pattern: |

--- a/internal/service/sqs/queue.go
+++ b/internal/service/sqs/queue.go
@@ -300,6 +300,12 @@ func resourceQueueRead(ctx context.Context, d *schema.ResourceData, meta any) di
 		return sdkdiag.AppendErrorf(diags, "reading SQS Queue (%s): %s", d.Id(), err)
 	}
 
+	return resourceQueueFlatten(d, output)
+}
+
+func resourceQueueFlatten(d *schema.ResourceData, output map[types.QueueAttributeName]string) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	name, err := queueNameFromURL(d.Id())
 	if err != nil {
 		return sdkdiag.AppendFromErr(diags, err)

--- a/internal/service/sqs/queue_list.go
+++ b/internal/service/sqs/queue_list.go
@@ -61,16 +61,24 @@ func (l *queueListResource) List(ctx context.Context, request list.ListRequest, 
 			result := request.NewListResult(ctx)
 			rd := l.ResourceData()
 			rd.SetId(queueUrl)
+			rd.Set(names.AttrURL, queueUrl)
 
-			diags := resourceQueueRead(ctx, rd, awsClient)
-			if diags.HasError() || rd.Id() == "" {
-				// Resource can't be read or is logically deleted.
-				// Log and continue.
-				tflog.Error(ctx, "Reading SQS queue", map[string]any{
-					names.AttrID: queueUrl,
-					"diags":      sdkdiag.DiagnosticsString(diags),
-				})
-				continue
+			if request.IncludeResource {
+				output, err := findQueueAttributesByURL(ctx, conn, queueUrl)
+				if err != nil {
+					tflog.Error(ctx, "Reading SQS queue", map[string]any{
+						"error": err,
+					})
+					continue
+				}
+
+				diags := resourceQueueFlatten(rd, output)
+				if diags.HasError() {
+					tflog.Error(ctx, "Reading SQS queue", map[string]any{
+						"error": sdkdiag.DiagnosticsString(diags),
+					})
+					continue
+				}
 			}
 
 			result.DisplayName = queueUrl

--- a/internal/service/sqs/queue_list_test.go
+++ b/internal/service/sqs/queue_list_test.go
@@ -6,6 +6,7 @@ package sqs_test
 import (
 	"testing"
 
+	"github.com/YakDriver/regexache"
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
@@ -14,7 +15,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	tfknownvalue "github.com/hashicorp/terraform-provider-aws/internal/acctest/knownvalue"
 	tfquerycheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/querycheck"
+	tfqueryfilter "github.com/hashicorp/terraform-provider-aws/internal/acctest/queryfilter"
 	tfstatecheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/statecheck"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -53,6 +56,119 @@ func TestAccSQSQueue_List_basic(t *testing.T) {
 				ConfigDirectory: config.StaticDirectory("testdata/Queue/list_basic/"),
 				ConfigVariables: config.Variables{
 					acctest.CtRName: config.StringVariable(rName),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_sqs_queue.test", identity1.Checks()),
+					tfquerycheck.ExpectIdentityFunc("aws_sqs_queue.test", identity2.Checks()),
+				},
+			},
+		},
+	})
+}
+
+func TestAccSQSQueue_List_includeResource(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	resourceName1 := "aws_sqs_queue.test[0]"
+
+	identity1 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SQSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckQueueDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Queue/list_include_resource"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(1),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+				},
+			},
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/Queue/list_include_resource"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(1),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_sqs_queue.test", identity1.Checks()),
+					querycheck.ExpectResourceKnownValues("aws_sqs_queue.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), []querycheck.KnownValueCheck{
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrARN), tfknownvalue.RegionalARNRegexp("sqs", regexache.MustCompile(`.+`))),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("delay_seconds"), knownvalue.Int64Exact(0)),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("fifo_queue"), knownvalue.Bool(false)),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("max_message_size"), knownvalue.Int64Exact(262144)),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("message_retention_seconds"), knownvalue.Int64Exact(345600)),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrName), knownvalue.StringExact(rName+"-0")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrNamePrefix), knownvalue.StringExact("")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("receive_wait_time_seconds"), knownvalue.Int64Exact(0)),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("sqs_managed_sse_enabled"), knownvalue.Bool(true)),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrURL), knownvalue.StringRegexp(regexache.MustCompile(`.+`))),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("visibility_timeout_seconds"), knownvalue.Int64Exact(30)),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
+							"Name": knownvalue.StringExact(rName + "-0"),
+						})),
+					}),
+				},
+			},
+		},
+	})
+}
+
+func TestAccSQSQueue_List_regionOverride(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	resourceName1 := "aws_sqs_queue.test[0]"
+	resourceName2 := "aws_sqs_queue.test[1]"
+
+	identity1 := tfstatecheck.Identity()
+	identity2 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.SQSServiceID),
+		CheckDestroy:             acctest.CheckDestroyNoop,
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Queue/list_region_override"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+					"region":         config.StringVariable(acctest.AlternateRegion()),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+					identity2.GetIdentity(resourceName2),
+				},
+			},
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/Queue/list_region_override"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+					"region":         config.StringVariable(acctest.AlternateRegion()),
 				},
 				QueryResultChecks: []querycheck.QueryResultCheck{
 					tfquerycheck.ExpectIdentityFunc("aws_sqs_queue.test", identity1.Checks()),

--- a/internal/service/sqs/testdata/Queue/list_include_resource/main.tf
+++ b/internal/service/sqs/testdata/Queue/list_include_resource/main.tf
@@ -1,0 +1,24 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_sqs_queue" "test" {
+  count = var.resource_count
+
+  name = "${var.rName}-${count.index}"
+
+  tags = {
+    Name = "${var.rName}-${count.index}"
+  }
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}

--- a/internal/service/sqs/testdata/Queue/list_include_resource/main.tfquery.hcl
+++ b/internal/service/sqs/testdata/Queue/list_include_resource/main.tfquery.hcl
@@ -1,0 +1,8 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_sqs_queue" "test" {
+  provider = aws
+
+  include_resource = true
+}

--- a/internal/service/sqs/testdata/Queue/list_region_override/main.tf
+++ b/internal/service/sqs/testdata/Queue/list_region_override/main.tf
@@ -1,0 +1,27 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_sqs_queue" "test" {
+  count = var.resource_count
+
+  region = var.region
+  name   = "${var.rName}-${count.index}"
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}
+
+variable "region" {
+  description = "Region to deploy resource in"
+  type        = string
+  nullable    = false
+}

--- a/internal/service/sqs/testdata/Queue/list_region_override/main.tfquery.hcl
+++ b/internal/service/sqs/testdata/Queue/list_region_override/main.tfquery.hcl
@@ -1,0 +1,10 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_sqs_queue" "test" {
+  provider = aws
+
+  config {
+    region = var.region
+  }
+}


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Removes resource Read function from `aws_sqs_queue` List

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #46697

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=sqs TESTS=TestAccSQSQueue_

--- PASS: TestAccSQSQueue_StandardQueue_expectContentBasedDeduplicationError (11.87s)
--- PASS: TestAccSQSQueue_FIFOQueue_expectNameError (11.92s)
--- PASS: TestAccSQSQueue_List_includeResource (146.07s)
--- PASS: TestAccSQSQueue_fifoQueue (152.38s)
--- PASS: TestAccSQSQueue_FIFOQueue_contentBasedDeduplication (153.23s)
--- PASS: TestAccSQSQueue_Tags_ComputedTag_onCreate (173.34s)
--- PASS: TestAccSQSQueue_Identity_ExistingResource_basic (185.92s)
--- PASS: TestAccSQSQueue_Identity_upgrade (189.63s)
--- PASS: TestAccSQSQueue_Identity_basic (199.22s)
--- PASS: TestAccSQSQueue_Tags_emptyMap (199.66s)
--- PASS: TestAccSQSQueue_Tags_null (192.04s)
--- PASS: TestAccSQSQueue_FIFOQueue_highThroughputMode (213.45s)
--- PASS: TestAccSQSQueue_Tags_DefaultTags_updateToResourceOnly (213.50s)
--- PASS: TestAccSQSQueue_Tags_ComputedTag_OnUpdate_add (213.92s)
--- PASS: TestAccSQSQueue_Tags_ComputedTag_OnUpdate_replace (213.93s)
--- PASS: TestAccSQSQueue_Tags_EmptyTag_onCreate (219.87s)
--- PASS: TestAccSQSQueue_redriveAllowPolicy (224.05s)
--- PASS: TestAccSQSQueue_Tags_IgnoreTags_Overlap_defaultTag (225.33s)
--- PASS: TestAccSQSQueue_Tags_EmptyTag_OnUpdate_add (231.85s)
--- FAIL: TestAccSQSQueue_managedEncryption (240.01s)
--- PASS: TestAccSQSQueue_List_basic (103.26s)
--- PASS: TestAccSQSQueue_List_regionOverride (110.50s)
--- PASS: TestAccSQSQueue_encryption (262.02s)
--- PASS: TestAccSQSQueue_tags (261.69s)
--- PASS: TestAccSQSQueue_Tags_addOnUpdate (129.65s)
--- PASS: TestAccSQSQueue_noEncryptionKMSDataKeyReusePeriodSeconds (112.38s)
--- PASS: TestAccSQSQueue_Identity_Upgrade_noRefresh (152.99s)
--- PASS: TestAccSQSQueue_ManagedEncryption_kmsDataKeyReusePeriodSeconds (113.70s)
--- PASS: TestAccSQSQueue_Tags_DefaultTags_nullNonOverlappingResourceTag (125.25s)
--- PASS: TestAccSQSQueue_Tags_DefaultTags_emptyProviderOnlyTag (118.96s)
--- PASS: TestAccSQSQueue_Tags_DefaultTags_nullOverlappingResourceTag (135.03s)
--- PASS: TestAccSQSQueue_defaultKMSDataKeyReusePeriodSeconds (109.89s)
--- PASS: TestAccSQSQueue_Identity_ExistingResource_noRefreshNoChange (169.37s)
--- PASS: TestAccSQSQueue_Tags_DefaultTags_updateToProviderOnly (161.91s)
--- PASS: TestAccSQSQueue_NamePrefix_fifoQueue (113.54s)
--- PASS: TestAccSQSQueue_timeouts (160.69s)
--- PASS: TestAccSQSQueue_Tags_EmptyTag_OnUpdate_replace (150.94s)
--- PASS: TestAccSQSQueue_Tags_DefaultTags_nonOverlapping (191.79s)
--- PASS: TestAccSQSQueue_Tags_DefaultTags_emptyResourceTag (125.89s)
--- PASS: TestAccSQSQueue_Identity_regionOverride (169.96s)
--- PASS: TestAccSQSQueue_Tags_DefaultTags_overlapping (206.03s)
--- PASS: TestAccSQSQueue_Policy_ignoreEquivalent (127.57s)
--- PASS: TestAccSQSQueue_Policy_basic (97.76s)
--- PASS: TestAccSQSQueue_zeroVisibilityTimeoutSeconds (105.13s)
--- PASS: TestAccSQSQueue_Name_generated (100.96s)
--- PASS: TestAccSQSQueue_Tags_DefaultTags_providerOnly (215.79s)
--- PASS: TestAccSQSQueue_NameGenerated_fifoQueue (100.93s)
--- PASS: TestAccSQSQueue_namePrefix (101.09s)
--- PASS: TestAccSQSQueue_redrivePolicy (181.90s)
--- PASS: TestAccSQSQueue_basic (95.07s)
--- PASS: TestAccSQSQueue_update (140.51s)
--- PASS: TestAccSQSQueue_disappears (122.80s)
--- PASS: TestAccSQSQueue_Tags_IgnoreTags_Overlap_resourceTag (121.50s)
--- PASS: TestAccSQSQueue_recentlyDeleted (252.83s)
```

`TestAccSQSQueue_managedEncryption` is a pre-existing failure