### PR TITLE
resource/aws_sagemaker_endpoint: Adds tests for Auto Scaling

### DIFF
--- a/internal/service/sagemaker/endpoint_test.go
+++ b/internal/service/sagemaker/endpoint_test.go
@@ -414,6 +414,53 @@ func TestAccSageMakerEndpoint_changeEndpointConfig_namePrefix_noCreateBeforeDest
 	})
 }
 
+func TestAccSageMakerEndpoint_AppAutoScaling_replaceEndpointConfiguration(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_sagemaker_endpoint.test"
+	sagemakerEndpointConfigurationResourceName := "aws_sagemaker_endpoint_configuration.test"
+
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	variantName1 := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	variantName2 := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SageMakerServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEndpointDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEndpointConfig_AppAutoScaling_basic(rName, variantName1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEndpointExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "endpoint_config_name", sagemakerEndpointConfigurationResourceName, names.AttrName),
+					acctest.CheckResourceAttrHasPrefix(sagemakerEndpointConfigurationResourceName, names.AttrName, rName),
+					resource.TestCheckResourceAttr(sagemakerEndpointConfigurationResourceName, "production_variants.0.variant_name", variantName1),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccEndpointConfig_AppAutoScaling_basic(rName, variantName2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEndpointExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "endpoint_config_name", sagemakerEndpointConfigurationResourceName, names.AttrName),
+					acctest.CheckResourceAttrHasPrefix(sagemakerEndpointConfigurationResourceName, names.AttrName, rName),
+					resource.TestCheckResourceAttr(sagemakerEndpointConfigurationResourceName, "production_variants.0.variant_name", variantName2),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckEndpointDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.ProviderMeta(ctx, t).SageMakerClient(ctx)
@@ -782,4 +829,57 @@ resource "aws_sagemaker_endpoint_configuration" "test" {
   }
 }
 `, rName, instanceCount))
+}
+
+func testAccEndpointConfig_AppAutoScaling_basic(rName, variantName string) string {
+	return acctest.ConfigCompose(
+		testAccEndpointConfig_model_base(rName),
+		fmt.Sprintf(`
+resource "aws_sagemaker_endpoint" "test" {
+  endpoint_config_name = aws_sagemaker_endpoint_configuration.test.name
+  name                 = %[1]q
+}
+
+resource "aws_sagemaker_endpoint_configuration" "test" {
+  name_prefix = "%[1]s-"
+
+  production_variants {
+    initial_instance_count = 2
+    initial_variant_weight = 1
+    instance_type          = "ml.m5.large"
+    model_name             = aws_sagemaker_model.test.name
+    variant_name           = %[2]q
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_appautoscaling_target" "test" {
+  service_namespace  = "sagemaker"
+  resource_id        = "endpoint/${aws_sagemaker_endpoint.test.name}/variant/${aws_sagemaker_endpoint_configuration.test.production_variants[0].variant_name}"
+  scalable_dimension = "sagemaker:variant:DesiredInstanceCount"
+  min_capacity       = 1
+  max_capacity       = 3
+}
+
+resource "aws_appautoscaling_policy" "test" {
+  name = %[1]q
+
+  service_namespace  = aws_appautoscaling_target.test.service_namespace
+  resource_id        = aws_appautoscaling_target.test.resource_id
+  scalable_dimension = aws_appautoscaling_target.test.scalable_dimension
+
+  policy_type = "TargetTrackingScaling"
+
+  target_tracking_scaling_policy_configuration {
+    target_value = 70.0
+
+    predefined_metric_specification {
+      predefined_metric_type = "SageMakerVariantInvocationsPerInstance"
+    }
+  }
+}
+`, rName, variantName))
 }


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Add test for Endpoint with Application Auto Scaling. Tests initial configuration and replacement of Endpoint Configuration..

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=sagemaker TESTS= TestAccSageMakerEndpoint_AppAutoScaling_replaceEndpointConfiguration

--- PASS: TestAccSageMakerEndpoint_AppAutoScaling_replaceEndpointConfiguration (328.94s)
```
