### PR TITLE
Reverts change to `Disappears` step

### DIFF
--- a/internal/service/sqs/queue_test.go
+++ b/internal/service/sqs/queue_test.go
@@ -776,7 +776,7 @@ func TestAccSQSQueue_managedEncryption(t *testing.T) {
 				Config: testAccQueueConfig_managedEncryption(rName, acctest.CtFalse),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckQueueExists(ctx, t, resourceName, &queueAttributes),
-					acctest.CheckSDKResourceDisappears(ctx, t, tfsqs.ResourceQueue(), resourceName), // nosemgrep:disappears-expect-resource-action
+					resource.TestCheckResourceAttr(resourceName, "sqs_managed_sse_enabled", acctest.CtFalse),
 				),
 			},
 			{


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

A test step in `TestAccSQSQueue_managedEncryption` was accidentally changed to a `Disappears` step in #47989. Revert the change.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=sqs TESTS=TestAccSQSQueue_managedEncryption

--- PASS: TestAccSQSQueue_managedEncryption (156.71s)
```
