### PR TITLE
docs/aws_eks_capability: add controller log delivery example

### DIFF
--- a/website/docs/r/eks_capability.html.markdown
+++ b/website/docs/r/eks_capability.html.markdown
@@ -12,6 +12,8 @@ Manages an EKS Capability for an EKS cluster.
 
 ## Example Usage
 
+### Basic Usage
+
 ```terraform
 resource "aws_eks_capability" "example" {
   cluster_name              = aws_eks_cluster.example.name
@@ -32,6 +34,43 @@ resource "aws_eks_capability" "example" {
   tags = {
     Name = "example-capability"
   }
+}
+```
+
+### Controller Log Delivery
+
+Capability controllers run in AWS-managed infrastructure outside your cluster, and their logs are exposed through [CloudWatch Vended Logs](https://docs.aws.amazon.com/eks/latest/userguide/capabilities-controller-logs.html) rather than the EKS API. Configure delivery with the [`aws_cloudwatch_log_delivery_source`](/docs/providers/aws/r/cloudwatch_log_delivery_source.html), [`aws_cloudwatch_log_delivery_destination`](/docs/providers/aws/r/cloudwatch_log_delivery_destination.html), and [`aws_cloudwatch_log_delivery`](/docs/providers/aws/r/cloudwatch_log_delivery.html) resources, using the capability ARN as the source. Valid log types are `EKS_CAPABILITY_ACK_LOGS` (ACK), `EKS_CAPABILITY_KRO_LOGS` (kro), and `EKS_CAPABILITY_ARGOCD_APPLICATION_LOGS`, `EKS_CAPABILITY_ARGOCD_APPLICATIONSET_LOGS`, `EKS_CAPABILITY_ARGOCD_COMMITSERVER_LOGS`, `EKS_CAPABILITY_ARGOCD_REPOSERVER_LOGS`, and `EKS_CAPABILITY_ARGOCD_SERVER_LOGS` (Argo CD, one per controller component).
+
+```terraform
+resource "aws_eks_capability" "example" {
+  cluster_name              = aws_eks_cluster.example.name
+  capability_name           = "ack"
+  type                      = "ACK"
+  role_arn                  = aws_iam_role.example.arn
+  delete_propagation_policy = "RETAIN"
+}
+
+resource "aws_cloudwatch_log_group" "ack" {
+  name = "/aws/eks/example/capabilities/ack"
+}
+
+resource "aws_cloudwatch_log_delivery_source" "ack" {
+  name         = "eks-capability-ack-logs"
+  log_type     = "EKS_CAPABILITY_ACK_LOGS"
+  resource_arn = aws_eks_capability.example.arn
+}
+
+resource "aws_cloudwatch_log_delivery_destination" "ack" {
+  name = "eks-capability-ack-logs"
+
+  delivery_destination_configuration {
+    destination_resource_arn = aws_cloudwatch_log_group.ack.arn
+  }
+}
+
+resource "aws_cloudwatch_log_delivery" "ack" {
+  delivery_source_name     = aws_cloudwatch_log_delivery_source.ack.name
+  delivery_destination_arn = aws_cloudwatch_log_delivery_destination.ack.arn
 }
 ```
 


### PR DESCRIPTION
   ### Description

   Documentation-only change. Adds a "Controller Log Delivery" example section to the `aws_eks_capability` docs.

   Capability controller logging (ACK, kro, Argo CD) can't be an argument on this resource — the EKS API has no logging fields for capabilities. AWS implements it via CloudWatch Vended Logs, and the provider already supports the full flow with `aws_cloudwatch_log_delivery_source` (capability ARN + a log type such as `EKS_CAPABILITY_ACK_LOGS`), `aws_cloudwatch_log_delivery_destination`, and `aws_cloudwatch_log_delivery`. This documents the pattern and all seven valid log types.

   ### Relations

   Closes #48926

   ### Output from Acceptance Testing

   Documentation-only change; no acceptance tests apply.