### PR TITLE
r/aws_s3_bucket_lifecycle_configuration: Fix timeout against non-AWS S3-compatible endpoints

### DIFF
--- a/.changelog/49021.txt
+++ b/.changelog/49021.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_s3_bucket_lifecycle_configuration: Fix `timeout while waiting for state to become 'true'` error when used against non-AWS, S3-compatible endpoints (for example, MinIO and Ceph RGW) that do not return the `x-amz-transition-default-minimum-object-size` response header
+```

--- a/internal/service/s3/bucket_lifecycle_configuration.go
+++ b/internal/service/s3/bucket_lifecycle_configuration.go
@@ -433,7 +433,9 @@ func (r *bucketLifecycleConfigurationResource) Create(ctx context.Context, reque
 		return
 	}
 
+	transitionDefaultMinimumObjectSize := data.TransitionDefaultMinimumObjectSize
 	response.Diagnostics.Append(fwflex.Flatten(ctx, output, &data)...)
+	data.TransitionDefaultMinimumObjectSize = keepTransitionDefaultMinimumObjectSize(transitionDefaultMinimumObjectSize, data.TransitionDefaultMinimumObjectSize)
 
 	data.ID = types.StringValue(createResourceID(bucket, expectedBucketOwner))
 	data.ExpectedBucketOwner = types.StringValue(expectedBucketOwner)
@@ -485,10 +487,12 @@ func (r *bucketLifecycleConfigurationResource) Read(ctx context.Context, request
 		return
 	}
 
+	transitionDefaultMinimumObjectSize := data.TransitionDefaultMinimumObjectSize
 	flattenBucketLifecycleConfigurationResource(ctx, output, &data, &response.Diagnostics)
 	if response.Diagnostics.HasError() {
 		return
 	}
+	data.TransitionDefaultMinimumObjectSize = keepTransitionDefaultMinimumObjectSize(transitionDefaultMinimumObjectSize, data.TransitionDefaultMinimumObjectSize)
 
 	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
 }
@@ -546,7 +550,9 @@ func (r *bucketLifecycleConfigurationResource) Update(ctx context.Context, reque
 		return
 	}
 
+	transitionDefaultMinimumObjectSize := new.TransitionDefaultMinimumObjectSize
 	response.Diagnostics.Append(fwflex.Flatten(ctx, output, &new)...)
+	new.TransitionDefaultMinimumObjectSize = keepTransitionDefaultMinimumObjectSize(transitionDefaultMinimumObjectSize, new.TransitionDefaultMinimumObjectSize)
 
 	new.ID = types.StringValue(createResourceID(bucket, expectedBucketOwner))
 	new.ExpectedBucketOwner = types.StringValue(expectedBucketOwner)
@@ -656,7 +662,8 @@ func findBucketLifecycleConfiguration(ctx context.Context, conn *s3.Client, buck
 }
 
 func lifecycleConfigEqual(transitionMinSize1 awstypes.TransitionDefaultMinimumObjectSize, rules1 []awstypes.LifecycleRule, transitionMinSize2 awstypes.TransitionDefaultMinimumObjectSize, rules2 []awstypes.LifecycleRule) bool {
-	if transitionMinSize1 != transitionMinSize2 {
+	// S3-compatible endpoints don't report this value; only compare it when both sides do.
+	if transitionMinSize1 != "" && transitionMinSize2 != "" && transitionMinSize1 != transitionMinSize2 {
 		return false
 	}
 
@@ -673,6 +680,14 @@ func lifecycleConfigEqual(transitionMinSize1 awstypes.TransitionDefaultMinimumOb
 	}
 
 	return true
+}
+
+// keepTransitionDefaultMinimumObjectSize keeps the planned value when the endpoint doesn't report one.
+func keepTransitionDefaultMinimumObjectSize(keep, readBack fwtypes.StringEnum[awstypes.TransitionDefaultMinimumObjectSize]) fwtypes.StringEnum[awstypes.TransitionDefaultMinimumObjectSize] {
+	if readBack.ValueString() == "" && !keep.IsUnknown() {
+		return keep
+	}
+	return readBack
 }
 
 func statusLifecycleConfigEquals(conn *s3.Client, bucket, owner string, transitionMinSize awstypes.TransitionDefaultMinimumObjectSize, rules []awstypes.LifecycleRule) retry.StateRefreshFunc {

--- a/internal/service/s3/bucket_lifecycle_configuration_unit_test.go
+++ b/internal/service/s3/bucket_lifecycle_configuration_unit_test.go
@@ -1,0 +1,146 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package s3_test
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	tfs3 "github.com/hashicorp/terraform-provider-aws/internal/service/s3"
+)
+
+func TestLifecycleConfigEqual(t *testing.T) {
+	t.Parallel()
+
+	const (
+		allStorageClasses128K = awstypes.TransitionDefaultMinimumObjectSizeAllStorageClasses128k
+		variesByStorageClass  = awstypes.TransitionDefaultMinimumObjectSizeVariesByStorageClass
+	)
+
+	rulesA := []awstypes.LifecycleRule{{
+		ID:     aws.String("rule-a"),
+		Status: awstypes.ExpirationStatusEnabled,
+	}}
+	rulesB := []awstypes.LifecycleRule{{
+		ID:     aws.String("rule-b"),
+		Status: awstypes.ExpirationStatusEnabled,
+	}}
+
+	testCases := map[string]struct {
+		transitionMinSize1 awstypes.TransitionDefaultMinimumObjectSize
+		rules1             []awstypes.LifecycleRule
+		transitionMinSize2 awstypes.TransitionDefaultMinimumObjectSize
+		rules2             []awstypes.LifecycleRule
+		want               bool
+	}{
+		// Both sides read back empty: an S3-compatible endpoint that doesn't send
+		// the x-amz-transition-default-minimum-object-size header, comparing two
+		// consecutive reads.
+		"both empty, equal rules": {
+			transitionMinSize1: "", rules1: rulesA,
+			transitionMinSize2: "", rules2: rulesA,
+			want: true,
+		},
+		// The reported bug: the value read back from an S3-compatible endpoint is
+		// empty, but the provider defaults the desired value to all_storage_classes_128K.
+		// The rules match, so the configuration has converged.
+		"empty read-back vs default, equal rules": {
+			transitionMinSize1: "", rules1: rulesA,
+			transitionMinSize2: allStorageClasses128K, rules2: rulesA,
+			want: true,
+		},
+		// Same as above with the arguments reversed (the comparison must be symmetric).
+		"default vs empty read-back, equal rules": {
+			transitionMinSize1: allStorageClasses128K, rules1: rulesA,
+			transitionMinSize2: "", rules2: rulesA,
+			want: true,
+		},
+		// AWS happy path: both sides report the same value.
+		"both default, equal rules": {
+			transitionMinSize1: allStorageClasses128K, rules1: rulesA,
+			transitionMinSize2: allStorageClasses128K, rules2: rulesA,
+			want: true,
+		},
+		"both default, different rules": {
+			transitionMinSize1: allStorageClasses128K, rules1: rulesA,
+			transitionMinSize2: allStorageClasses128K, rules2: rulesB,
+			want: false,
+		},
+		// A genuine difference between two reported values (e.g. mid-propagation on
+		// AWS) must not be treated as converged.
+		"different reported values, equal rules": {
+			transitionMinSize1: allStorageClasses128K, rules1: rulesA,
+			transitionMinSize2: variesByStorageClass, rules2: rulesA,
+			want: false,
+		},
+		// Even when the transition size is skipped, differing rules are still compared.
+		"empty read-back, different rules": {
+			transitionMinSize1: "", rules1: rulesA,
+			transitionMinSize2: allStorageClasses128K, rules2: rulesB,
+			want: false,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := tfs3.LifecycleConfigEqual(tc.transitionMinSize1, tc.rules1, tc.transitionMinSize2, tc.rules2); got != tc.want {
+				t.Errorf("LifecycleConfigEqual() = %t, want %t", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestKeepTransitionDefaultMinimumObjectSize(t *testing.T) {
+	t.Parallel()
+
+	allStorageClasses128K := fwtypes.StringEnumValue(awstypes.TransitionDefaultMinimumObjectSizeAllStorageClasses128k)
+	variesByStorageClass := fwtypes.StringEnumValue(awstypes.TransitionDefaultMinimumObjectSizeVariesByStorageClass)
+	empty := fwtypes.StringEnumValue(awstypes.TransitionDefaultMinimumObjectSize(""))
+	null := fwtypes.StringEnumNull[awstypes.TransitionDefaultMinimumObjectSize]()
+	unknown := fwtypes.StringEnumUnknown[awstypes.TransitionDefaultMinimumObjectSize]()
+
+	testCases := map[string]struct {
+		keep     fwtypes.StringEnum[awstypes.TransitionDefaultMinimumObjectSize]
+		readBack fwtypes.StringEnum[awstypes.TransitionDefaultMinimumObjectSize]
+		want     fwtypes.StringEnum[awstypes.TransitionDefaultMinimumObjectSize]
+	}{
+		// The endpoint didn't report the value (empty), so the planned default is
+		// preserved to keep the result consistent with the plan.
+		"empty read-back keeps planned default": {
+			keep: allStorageClasses128K, readBack: empty, want: allStorageClasses128K,
+		},
+		"null read-back keeps planned default": {
+			keep: allStorageClasses128K, readBack: null, want: allStorageClasses128K,
+		},
+		// The endpoint reported a value: it is authoritative.
+		"reported value is authoritative": {
+			keep: allStorageClasses128K, readBack: variesByStorageClass, want: variesByStorageClass,
+		},
+		"equal reported value": {
+			keep: allStorageClasses128K, readBack: allStorageClasses128K, want: allStorageClasses128K,
+		},
+		// A planned value can be unknown (e.g. an S3 Express directory bucket). An
+		// unknown value can't be stored, so the (known) empty read-back is used.
+		"unknown planned with empty read-back uses read-back": {
+			keep: unknown, readBack: empty, want: empty,
+		},
+		"null planned with empty read-back keeps null": {
+			keep: null, readBack: empty, want: null,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := tfs3.KeepTransitionDefaultMinimumObjectSize(tc.keep, tc.readBack); !got.Equal(tc.want) {
+				t.Errorf("KeepTransitionDefaultMinimumObjectSize() = %#v, want %#v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/service/s3/exports_test.go
+++ b/internal/service/s3/exports_test.go
@@ -84,7 +84,8 @@ var (
 	AccountRegionalBucketNameRegex        = accountRegionalBucketNameRegex
 	DirectoryBucketNameSuffixRegexPattern = directoryBucketNameSuffixRegexPattern
 
-	LifecycleConfigEqual = lifecycleConfigEqual
+	KeepTransitionDefaultMinimumObjectSize = keepTransitionDefaultMinimumObjectSize
+	LifecycleConfigEqual                   = lifecycleConfigEqual
 )
 
 type (


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No. This change only affects the create/update convergence wait and the value stored for `transition_default_minimum_object_size`. There are no changes to access controls, encryption, or logging.

### Description

`aws_s3_bucket_lifecycle_configuration` never converges against non-AWS, S3-compatible endpoints such as MinIO and Ceph RGW. The `PUT` succeeds but `terraform apply` hangs and fails after the 3-minute timeout with `timeout while waiting for state to become 'true'`, and every later apply repeats it. See #49019 for the full report and root-cause analysis. Briefly, the create/update wait rejects on the value read back for `transition_default_minimum_object_size` before it compares the rules. That value comes from the AWS-only `x-amz-transition-default-minimum-object-size` response header, which these endpoints do not send, so it reads back empty and never matches the provider's default of `all_storage_classes_128K`.

The issue suggests skipping that comparison. That is necessary but not sufficient: `transition_default_minimum_object_size` is flattened with the `legacy` AutoFlex option, which always overwrites the target, so skipping only the comparison trades the timeout for two new failures against these endpoints:

- create/update: the empty read-back overwrites the planned `all_storage_classes_128K`, producing `Provider produced inconsistent result after apply`.
- read: the same overwrite on refresh leaves state empty, producing a perpetual `"" -> "all_storage_classes_128K"` diff on every subsequent plan.

So this PR makes two changes:

1. `lifecycleConfigEqual` compares `transition_default_minimum_object_size` only when both sides report a value, and otherwise falls back to comparing the rules, which is what actually determines convergence. The check is symmetric, so it also covers S3 Express directory buckets, which do not report the field either.
2. A new `keepTransitionDefaultMinimumObjectSize` helper keeps the planned (or prior-state) value when the endpoint does not report one. It runs at all three flatten sites (`Create`, `Update`, `Read`), so the result stays consistent with the plan and later plans are empty.

Behavior against AWS S3, which always returns the header, is unchanged: the helper returns the API value verbatim and the comparison path is identical, so this is a no-op for AWS users.

### AI-assisted development

Following the provider's [AI usage guidelines](https://hashicorp.github.io/terraform-provider-aws/ai-usage/): this change was developed with Claude Code, which was used to investigate the root cause, write the code and unit tests, and draft this description. Nothing was accepted on the model's word. The unit tests pass, and the fix was verified end-to-end against a stock MinIO container (create, update, and refresh all converge, with an empty follow-up plan) as shown under *Output from Acceptance Testing*. The linked issue (#49019) was likewise prepared with Claude Code. I have reviewed every line, understand the change, and take responsibility for it as the human contributor.

### Relations

Closes #49019

### References

- #39578, which introduced `transition_default_minimum_object_size` (v5.70.0)
- The linked issue lists the related reports (#41073, #41199, #41126) and AWS background.

### Output from Acceptance Testing

This defect only manifests against non-AWS, S3-compatible endpoints, so it cannot be reproduced by the acceptance-test framework, which runs against real AWS S3 (where the resource already works and always returns the header). The change is a no-op on AWS. Verification is therefore provided by unit tests on the changed functions and an end-to-end reproduction against a stock MinIO container.

Unit tests on both changed functions pass (`TestLifecycleConfigEqual`, 7 cases; `TestKeepTransitionDefaultMinimumObjectSize`, 6 cases):

```console
% go test ./internal/service/s3/ -run 'TestLifecycleConfigEqual|TestKeepTransitionDefaultMinimumObjectSize'
ok      github.com/hashicorp/terraform-provider-aws/internal/service/s3  5.209s
```

End-to-end reproduction against a stock MinIO container, using the fixed provider via `dev_overrides` and the exact configuration from #49019 (before the fix this apply fails after 3 minutes):

```console
# create
% terraform apply -auto-approve
aws_s3_bucket_lifecycle_configuration.probe: Creation complete after 55s [id=lifecycle-probe]
Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

# re-plan (no perpetual diff)
% terraform plan
No changes. Your infrastructure matches the configuration.

# update, expiration.days 14 -> 30
% terraform apply -auto-approve
aws_s3_bucket_lifecycle_configuration.probe: Modifications complete after 55s [id=lifecycle-probe]
Apply complete! Resources: 0 added, 1 changed, 0 destroyed.

# re-plan (still no diff)
% terraform plan
No changes. Your infrastructure matches the configuration.
```

Since the change is a no-op on AWS, the existing acceptance tests should pass unchanged. The most relevant for a reviewer with AWS access to confirm no regression:

```console
% make testacc PKG=s3 TESTS='TestAccS3BucketLifecycleConfiguration_transitionDefaultMinimumObjectSize_update|TestAccS3BucketLifecycleConfiguration_transitionDefaultMinimumObjectSize_remove|TestAccS3BucketLifecycleConfiguration_directoryBucket|TestAccS3BucketLifecycleConfiguration_basic'
```

(Not run here, no AWS credentials.)