### PR TITLE
fix: make data_read_cache_configuration.size Computed

### DIFF
--- a/.changelog/49023.txt
+++ b/.changelog/49023.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_fsx_lustre_file_system: Fix perpetual diff in `data_read_cache_configuration.size` when `sizing_mode` is `PROPORTIONAL_TO_THROUGHPUT_CAPACITY` and `size` is not specified
+```

--- a/internal/service/fsx/lustre_file_system.go
+++ b/internal/service/fsx/lustre_file_system.go
@@ -114,6 +114,7 @@ func resourceLustreFileSystem() *schema.Resource {
 							names.AttrSize: {
 								Type:     schema.TypeInt,
 								Optional: true,
+								Computed: true,
 							},
 							"sizing_mode": {
 								Type:             schema.TypeString,

--- a/internal/service/fsx/lustre_file_system_test.go
+++ b/internal/service/fsx/lustre_file_system_test.go
@@ -983,6 +983,37 @@ func TestAccFSxLustreFileSystem_intelligentTiering(t *testing.T) {
 	})
 }
 
+func TestAccFSxLustreFileSystem_dataReadCacheConfiguration_proportional(t *testing.T) {
+	ctx := acctest.Context(t)
+	var filesystem awstypes.FileSystem
+	resourceName := "aws_fsx_lustre_file_system.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.FSxEndpointID) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.FSxServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckLustreFileSystemDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLustreFileSystemConfig_dataReadCacheConfiguration_proportional(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckLustreFileSystemExists(ctx, t, resourceName, &filesystem),
+					resource.TestCheckResourceAttr(resourceName, "data_read_cache_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "data_read_cache_configuration.0.sizing_mode", "PROPORTIONAL_TO_THROUGHPUT_CAPACITY"),
+					resource.TestCheckResourceAttrSet(resourceName, "data_read_cache_configuration.0.size"),
+				),
+			},
+			{
+				// Verify no perpetual diff on subsequent plan
+				Config:             testAccLustreFileSystemConfig_dataReadCacheConfiguration_proportional(rName),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
 func TestAccFSxLustreFileSystem_logConfig(t *testing.T) {
 	ctx := acctest.Context(t)
 	var filesystem awstypes.FileSystem
@@ -2201,4 +2232,22 @@ resource "aws_fsx_lustre_file_system" "test" {
 
 }
 `, throughputCapacity, cacheSize))
+}
+
+func testAccLustreFileSystemConfig_dataReadCacheConfiguration_proportional(rName string) string {
+	return acctest.ConfigCompose(testAccLustreFileSystemConfig_base(rName), `
+resource "aws_fsx_lustre_file_system" "test" {
+  subnet_ids          = aws_subnet.test[*].id
+  deployment_type     = "PERSISTENT_2"
+  storage_type        = "INTELLIGENT_TIERING"
+  throughput_capacity = 4000
+
+  metadata_configuration {
+    mode = "USER_PROVISIONED"
+    iops = 6000
+  }
+
+  data_read_cache_configuration {
+    sizing_mode = "PROPORTIONAL_TO_THROUGHPUT_CAPACITY"
+  }
 }

--- a/internal/service/fsx/lustre_file_system_test.go
+++ b/internal/service/fsx/lustre_file_system_test.go
@@ -2251,3 +2251,5 @@ resource "aws_fsx_lustre_file_system" "test" {
     sizing_mode = "PROPORTIONAL_TO_THROUGHPUT_CAPACITY"
   }
 }
+`)
+}

--- a/internal/service/fsx/lustre_file_system_test.go
+++ b/internal/service/fsx/lustre_file_system_test.go
@@ -1006,9 +1006,12 @@ func TestAccFSxLustreFileSystem_dataReadCacheConfiguration_proportional(t *testi
 			},
 			{
 				// Verify no perpetual diff on subsequent plan
-				Config:             testAccLustreFileSystemConfig_dataReadCacheConfiguration_proportional(rName),
-				PlanOnly:           true,
-				ExpectNonEmptyPlan: false,
+				Config: testAccLustreFileSystemConfig_dataReadCacheConfiguration_proportional(rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 		},
 	})


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations

Closes #49002

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
make testacc T=TestAccFSxLustreFileSystem_dataReadCacheConfiguration_proportional K=fsx
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework (cached)
make: Running acceptance tests on branch: 🌿 b-aws_fsx_lustre_file_system-fix-perpetual-drift 🌿...
TF_ACC=1 go1.26.5 test ./internal/service/fsx/... -v -count 1 -parallel 20 -run='TestAccFSxLustreFileSystem_dataReadCacheConfiguration_proportional'  -timeout 360m -vet=off -buildvcs=false
2026/07/18 16:58:31 Creating Terraform AWS Provider (SDKv2-style)...
2026/07/18 16:58:31 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccFSxLustreFileSystem_dataReadCacheConfiguration_proportional
=== PAUSE TestAccFSxLustreFileSystem_dataReadCacheConfiguration_proportional
=== CONT  TestAccFSxLustreFileSystem_dataReadCacheConfiguration_proportional
--- PASS: TestAccFSxLustreFileSystem_dataReadCacheConfiguration_proportional (1164.61s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/fsx        1164.763s
```
