### PR TITLE
🤖🤖🤖 fix: preserve numeric string MSK topic configs

### DIFF
--- a/.changelog/49025.txt
+++ b/.changelog/49025.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_msk_topic: Prevent perpetual differences when numeric `configs` values are configured as strings.
+```

--- a/internal/service/kafka/exports_test.go
+++ b/internal/service/kafka/exports_test.go
@@ -27,5 +27,6 @@ var (
 
 	ClusterUUIDFromARN    = clusterUUIDFromARN
 	NormalizeKafkaVersion = normalizeKafkaVersion // nosemgrep:ci.kafka-in-var-name
+	ReconcileTopicConfigs = reconcileTopicConfigs
 	SortEndpointsString   = sortEndpointsString
 )

--- a/internal/service/kafka/topic.go
+++ b/internal/service/kafka/topic.go
@@ -7,6 +7,11 @@ package kafka
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/big"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -302,28 +307,12 @@ func (r *topicResource) flatten(ctx context.Context, topic *kafka.DescribeTopicO
 	data.ConfigsActual = v
 
 	if !data.Configs.IsNull() {
-		var serverConfigs map[string]any
-		if err := tfjson.DecodeFromString(fwflex.StringValueFromFramework(ctx, data.ConfigsActual), &serverConfigs); err != nil {
-			diags.AddError("JSON decoding server configs", err.Error())
-			return diags
-		}
-		var clientConfigs map[string]any
-		if err := tfjson.DecodeFromString(fwflex.StringValueFromFramework(ctx, data.Configs), &clientConfigs); err != nil {
-			diags.AddError("JSON decoding client configs", err.Error())
-			return diags
-		}
-
-		for k := range clientConfigs {
-			if v, ok := serverConfigs[k]; ok {
-				clientConfigs[k] = v
-			} else {
-				delete(clientConfigs, k)
-			}
-		}
-
-		v, err := tfjson.EncodeToString(clientConfigs)
+		v, err := reconcileTopicConfigs(
+			fwflex.StringValueFromFramework(ctx, data.Configs),
+			fwflex.StringValueFromFramework(ctx, data.ConfigsActual),
+		)
 		if err != nil {
-			diags.AddError("JSON encoding client configs", err.Error())
+			diags.AddError("Reconciling topic configs", err.Error())
 			return diags
 		}
 
@@ -333,6 +322,74 @@ func (r *topicResource) flatten(ctx context.Context, topic *kafka.DescribeTopicO
 	}
 
 	return diags
+}
+
+func reconcileTopicConfigs(clientConfigsJSON, serverConfigsJSON string) (string, error) {
+	var serverConfigs map[string]json.RawMessage
+	if err := tfjson.DecodeFromString(serverConfigsJSON, &serverConfigs); err != nil {
+		return "", fmt.Errorf("decoding server configs: %w", err)
+	}
+	var clientConfigs map[string]json.RawMessage
+	if err := tfjson.DecodeFromString(clientConfigsJSON, &clientConfigs); err != nil {
+		return "", fmt.Errorf("decoding client configs: %w", err)
+	}
+
+	for key, clientValue := range clientConfigs {
+		serverValue, ok := serverConfigs[key]
+		if !ok {
+			delete(clientConfigs, key)
+			continue
+		}
+
+		if !equivalentTopicConfigNumericString(clientValue, serverValue) {
+			clientConfigs[key] = serverValue
+		}
+	}
+
+	v, err := tfjson.EncodeToString(clientConfigs)
+	if err != nil {
+		return "", fmt.Errorf("encoding client configs: %w", err)
+	}
+
+	return v, nil
+}
+
+func equivalentTopicConfigNumericString(clientValue, serverValue json.RawMessage) bool {
+	var clientString string
+	if err := json.Unmarshal(clientValue, &clientString); err != nil {
+		return false
+	}
+
+	clientNumber, ok := parseTopicConfigNumber(clientString)
+	if !ok {
+		return false
+	}
+	serverNumber, ok := parseTopicConfigNumber(string(serverValue))
+	if !ok {
+		return false
+	}
+
+	return clientNumber.Cmp(serverNumber) == 0
+}
+
+func parseTopicConfigNumber(v string) (*big.Rat, bool) {
+	var value any
+	decoder := json.NewDecoder(strings.NewReader(v))
+	decoder.UseNumber()
+	if err := decoder.Decode(&value); err != nil {
+		return nil, false
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return nil, false
+	}
+
+	number, ok := value.(json.Number)
+	if !ok {
+		return nil, false
+	}
+
+	rational, ok := new(big.Rat).SetString(number.String())
+	return rational, ok
 }
 
 func waitTopicCreated(ctx context.Context, conn *kafka.Client, clusterARN, topicName string, timeout time.Duration) (*kafka.DescribeTopicOutput, error) {

--- a/internal/service/kafka/topic_test.go
+++ b/internal/service/kafka/topic_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	tfknownvalue "github.com/hashicorp/terraform-provider-aws/internal/acctest/knownvalue"
+	tfjson "github.com/hashicorp/terraform-provider-aws/internal/json"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfkafka "github.com/hashicorp/terraform-provider-aws/internal/service/kafka"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -29,6 +30,71 @@ func checkTopicARN(name string) knownvalue.Check {
 
 func checkTopicARNAlternateRegion(name string) knownvalue.Check {
 	return tfknownvalue.RegionalARNAlternateRegionRegexp("kafka", regexache.MustCompile(`topic/.+/.+/+`+name+`$`))
+}
+
+func TestReconcileTopicConfigs(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		client string
+		server string
+		want   string
+	}{
+		"equal integer": {
+			client: `{"segment.ms":"86400000"}`,
+			server: `{"segment.ms":86400000}`,
+			want:   `{"segment.ms":"86400000"}`,
+		},
+		"equal maximum integer": {
+			client: `{"flush.messages":"9223372036854775807"}`,
+			server: `{"flush.messages":9223372036854775807}`,
+			want:   `{"flush.messages":"9223372036854775807"}`,
+		},
+		"equal decimal": {
+			client: `{"min.cleanable.dirty.ratio":"0.20"}`,
+			server: `{"min.cleanable.dirty.ratio":0.2}`,
+			want:   `{"min.cleanable.dirty.ratio":"0.20"}`,
+		},
+		"equal exponent": {
+			client: `{"segment.ms":"1e3"}`,
+			server: `{"segment.ms":1000}`,
+			want:   `{"segment.ms":"1e3"}`,
+		},
+		"changed number": {
+			client: `{"segment.ms":"123"}`,
+			server: `{"segment.ms":456}`,
+			want:   `{"segment.ms":456}`,
+		},
+		"changed string": {
+			client: `{"cleanup.policy":"compact"}`,
+			server: `{"cleanup.policy":"delete"}`,
+			want:   `{"cleanup.policy":"delete"}`,
+		},
+		"invalid numeric string": {
+			client: `{"segment.ms":"1 trailing"}`,
+			server: `{"segment.ms":1}`,
+			want:   `{"segment.ms":1}`,
+		},
+		"removed and unconfigured keys": {
+			client: `{"cleanup.policy":"compact","segment.ms":"123"}`,
+			server: `{"cleanup.policy":"compact","retention.ms":456}`,
+			want:   `{"cleanup.policy":"compact"}`,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := tfkafka.ReconcileTopicConfigs(testCase.client, testCase.server)
+			if err != nil {
+				t.Fatalf("reconciling topic configs: %s", err)
+			}
+			if !tfjson.EqualStrings(got, testCase.want) {
+				t.Errorf("got %s, want %s", got, testCase.want)
+			}
+		})
+	}
 }
 
 func TestAccKafkaTopic_basic(t *testing.T) {


### PR DESCRIPTION
## Summary
- preserve client-side JSON string values when MSK returns an exactly equivalent JSON number
- continue surfacing real numeric or string drift and remove configs no longer reported by the server
- compare numbers exactly, including large integers, decimals, and exponent notation

## Testing
- `go test ./internal/service/kafka -run '^TestReconcileTopicConfigs$' -count=1`
- `go test ./internal/service/kafka -count=1`
- `go vet ./internal/service/kafka`
- `git diff --check`

Fixes #48712

## AI usage disclosure
OpenAI Codex was used to investigate the issue, implement the focused fix, and generate regression tests. This pull request remains a draft for human review.