### PR TITLE
lr/aws_ssm_parameter: Removes resource Read function from List

### DIFF
--- a/.ci/semgrep/list/no-resource-read.yml
+++ b/.ci/semgrep/list/no-resource-read.yml
@@ -11,7 +11,6 @@ rules:
       exclude:
         - "/internal/service/secretsmanager/secret_version_list.go"
         - "/internal/service/sqs/queue_list.go"
-        - "/internal/service/ssm/parameter_list.go"
     patterns:
       - pattern: |
           func ($L *$TYPE) List($CTX context.Context, $REQ list.ListRequest, $STREAM *list.ListResultsStream) {

--- a/internal/service/ssm/parameter.go
+++ b/internal/service/ssm/parameter.go
@@ -293,10 +293,22 @@ func resourceParameterRead(ctx context.Context, d *schema.ResourceData, meta any
 	}
 
 	param := outputRaw.(*awstypes.Parameter)
-	d.Set(names.AttrARN, param.ARN)
-	d.Set(names.AttrName, param.Name)
-	d.Set(names.AttrType, param.Type)
-	d.Set(names.AttrVersion, param.Version)
+	detail, err := findParameterMetadataByName(ctx, conn, d.Id())
+
+	if !d.IsNewResource() && retry.NotFound(err) {
+		log.Printf("[WARN] SSM Parameter %s not found, removing from state", d.Id())
+		d.SetId("")
+		return diags
+	}
+
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "reading SSM Parameter metadata (%s): %s", d.Id(), err)
+	}
+
+	diags = append(diags, resourceParameterFlatten(d, param, detail)...)
+	if diags.HasError() {
+		return diags
+	}
 
 	hasWriteOnly := d.Get("has_value_wo").(bool)
 	rawConfig := d.GetRawConfig()
@@ -315,12 +327,6 @@ func resourceParameterRead(ctx context.Context, d *schema.ResourceData, meta any
 		}
 	}
 
-	if _, ok := d.GetOk("insecure_value"); ok && param.Type != awstypes.ParameterTypeSecureString {
-		d.Set("insecure_value", param.Value)
-	} else {
-		d.Set(names.AttrValue, param.Value)
-	}
-
 	if hasWriteOnly {
 		d.Set("has_value_wo", true)
 		d.Set(names.AttrValue, nil)
@@ -330,16 +336,21 @@ func resourceParameterRead(ctx context.Context, d *schema.ResourceData, meta any
 		return sdkdiag.AppendErrorf(diags, "invalid configuration, cannot set type = %s and insecure_value", param.Type)
 	}
 
-	detail, err := findParameterMetadataByName(ctx, conn, d.Get(names.AttrName).(string))
+	return diags
+}
 
-	if !d.IsNewResource() && retry.NotFound(err) {
-		log.Printf("[WARN] SSM Parameter %s not found, removing from state", d.Id())
-		d.SetId("")
-		return diags
-	}
+func resourceParameterFlatten(d *schema.ResourceData, param *awstypes.Parameter, detail *awstypes.ParameterMetadata) diag.Diagnostics {
+	var diags diag.Diagnostics
 
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "reading SSM Parameter metadata (%s): %s", d.Id(), err)
+	d.Set(names.AttrARN, param.ARN)
+	d.Set(names.AttrName, param.Name)
+	d.Set(names.AttrType, param.Type)
+	d.Set(names.AttrVersion, param.Version)
+
+	if _, ok := d.GetOk("insecure_value"); ok && param.Type != awstypes.ParameterTypeSecureString {
+		d.Set("insecure_value", param.Value)
+	} else {
+		d.Set(names.AttrValue, param.Value)
 	}
 
 	d.Set("allowed_pattern", detail.AllowedPattern)

--- a/internal/service/ssm/parameter_list.go
+++ b/internal/service/ssm/parameter_list.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/list"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
 	"github.com/hashicorp/terraform-provider-aws/internal/logging"
 	inttypes "github.com/hashicorp/terraform-provider-aws/internal/types"
@@ -66,17 +67,24 @@ func (l *parameterListResource) List(ctx context.Context, request list.ListReque
 
 			rd := l.ResourceData()
 			rd.SetId(name)
+			rd.Set(names.AttrName, name)
 
-			tflog.Info(ctx, "Reading SSM parameter")
-			diags := resourceParameterRead(ctx, rd, awsClient)
-			if diags.HasError() {
-				result = fwdiag.NewListResultErrorDiagnostic(fmt.Errorf("reading SSM parameter %s", name))
-				yield(result)
-				return
-			}
-			if rd.Id() == "" {
-				// Resource is logically deleted
-				continue
+			if request.IncludeResource {
+				param, err := findParameterByName(ctx, conn, name, true)
+				if err != nil {
+					tflog.Error(ctx, "Reading SSM parameter", map[string]any{
+						"error": err,
+					})
+					continue
+				}
+
+				diags := resourceParameterFlatten(rd, param, &parameter)
+				if diags.HasError() {
+					tflog.Error(ctx, "Reading SSM parameter", map[string]any{
+						"error": sdkdiag.DiagnosticsString(diags),
+					})
+					continue
+				}
 			}
 
 			result.DisplayName = name

--- a/internal/service/ssm/parameter_list_test.go
+++ b/internal/service/ssm/parameter_list_test.go
@@ -14,7 +14,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	tfknownvalue "github.com/hashicorp/terraform-provider-aws/internal/acctest/knownvalue"
 	tfquerycheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/querycheck"
+	tfqueryfilter "github.com/hashicorp/terraform-provider-aws/internal/acctest/queryfilter"
 	tfstatecheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/statecheck"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -42,13 +44,15 @@ func TestAccSSMParameter_List_basic(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Parameter/list_basic/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
 					identity1.GetIdentity(resourceName1),
-					statecheck.ExpectKnownValue(resourceName1, tfjsonpath.New(names.AttrName), knownvalue.StringExact(rName+"-0")),
+					statecheck.ExpectKnownValue(resourceName1, tfjsonpath.New(names.AttrARN), tfknownvalue.RegionalARNExact("ssm", "parameter:"+rName+"-0")),
+
 					identity2.GetIdentity(resourceName2),
-					statecheck.ExpectKnownValue(resourceName2, tfjsonpath.New(names.AttrName), knownvalue.StringExact(rName+"-1")),
+					statecheck.ExpectKnownValue(resourceName2, tfjsonpath.New(names.AttrARN), tfknownvalue.RegionalARNExact("ssm", "parameter:"+rName+"-1")),
 				},
 			},
 
@@ -57,7 +61,131 @@ func TestAccSSMParameter_List_basic(t *testing.T) {
 				Query:           true,
 				ConfigDirectory: config.StaticDirectory("testdata/Parameter/list_basic/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_ssm_parameter.test", identity1.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_ssm_parameter.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), knownvalue.StringExact(rName+"-0")),
+					tfquerycheck.ExpectNoResourceObject("aws_ssm_parameter.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks())),
+
+					tfquerycheck.ExpectIdentityFunc("aws_ssm_parameter.test", identity2.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_ssm_parameter.test", tfqueryfilter.ByResourceIdentityFunc(identity2.Checks()), knownvalue.StringExact(rName+"-1")),
+					tfquerycheck.ExpectNoResourceObject("aws_ssm_parameter.test", tfqueryfilter.ByResourceIdentityFunc(identity2.Checks())),
+				},
+			},
+		},
+	})
+}
+
+func TestAccSSMParameter_List_includeResource(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_ssm_parameter.test[0]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity1 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
+		CheckDestroy:             testAccCheckParameterDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Parameter/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(1),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
+						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
+					}),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+					statecheck.ExpectKnownValue(resourceName1, tfjsonpath.New(names.AttrARN), tfknownvalue.RegionalARNExact("ssm", "parameter:"+rName+"-0")),
+				},
+			},
+
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/Parameter/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(1),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
+						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
+					}),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_ssm_parameter.test", identity1.Checks()),
+					querycheck.ExpectResourceKnownValues(
+						"aws_ssm_parameter.test",
+						tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()),
+						[]querycheck.KnownValueCheck{
+							tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrARN), tfknownvalue.RegionalARNExact("ssm", "parameter:"+rName+"-0")),
+							tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.Region())),
+							tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrName), knownvalue.StringExact(rName+"-0")),
+						},
+					),
+				},
+			},
+		},
+	})
+}
+
+func TestAccSSMParameter_List_regionOverride(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_ssm_parameter.test[0]"
+	resourceName2 := "aws_ssm_parameter.test[1]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity1 := tfstatecheck.Identity()
+	identity2 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
+		CheckDestroy:             testAccCheckParameterDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Parameter/list_region_override/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+					"region":         config.StringVariable(acctest.AlternateRegion()),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+					statecheck.ExpectKnownValue(resourceName1, tfjsonpath.New(names.AttrARN), tfknownvalue.RegionalARNAlternateRegionExact("ssm", "parameter:"+rName+"-0")),
+
+					identity2.GetIdentity(resourceName2),
+					statecheck.ExpectKnownValue(resourceName2, tfjsonpath.New(names.AttrARN), tfknownvalue.RegionalARNAlternateRegionExact("ssm", "parameter:"+rName+"-1")),
+				},
+			},
+
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/Parameter/list_region_override/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+					"region":         config.StringVariable(acctest.AlternateRegion()),
 				},
 				QueryResultChecks: []querycheck.QueryResultCheck{
 					tfquerycheck.ExpectIdentityFunc("aws_ssm_parameter.test", identity1.Checks()),

--- a/internal/service/ssm/parameter_list_test.go
+++ b/internal/service/ssm/parameter_list_test.go
@@ -44,8 +44,7 @@ func TestAccSSMParameter_List_basic(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Parameter/list_basic/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:  config.StringVariable(rName),
-					"resource_count": config.IntegerVariable(2),
+					acctest.CtRName: config.StringVariable(rName),
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
 					identity1.GetIdentity(resourceName1),
@@ -61,8 +60,7 @@ func TestAccSSMParameter_List_basic(t *testing.T) {
 				Query:           true,
 				ConfigDirectory: config.StaticDirectory("testdata/Parameter/list_basic/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:  config.StringVariable(rName),
-					"resource_count": config.IntegerVariable(2),
+					acctest.CtRName: config.StringVariable(rName),
 				},
 				QueryResultChecks: []querycheck.QueryResultCheck{
 					tfquerycheck.ExpectIdentityFunc("aws_ssm_parameter.test", identity1.Checks()),

--- a/internal/service/ssm/testdata/Parameter/list_basic/main.tf
+++ b/internal/service/ssm/testdata/Parameter/list_basic/main.tf
@@ -2,19 +2,15 @@
 # SPDX-License-Identifier: MPL-2.0
 
 resource "aws_ssm_parameter" "test" {
-  count = var.resource_count
+  count = 2
 
-  name = "${var.rName}-${count.index}"
+  name  = "${var.rName}-${count.index}"
+  type  = "String"
+  value = "${var.rName}-${count.index}"
 }
 
 variable "rName" {
   description = "Name for resource"
   type        = string
-  nullable    = false
-}
-
-variable "resource_count" {
-  description = "Number of resources to create"
-  type        = number
   nullable    = false
 }

--- a/internal/service/ssm/testdata/Parameter/list_basic/query.tfquery.hcl
+++ b/internal/service/ssm/testdata/Parameter/list_basic/query.tfquery.hcl
@@ -1,0 +1,6 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_ssm_parameter" "test" {
+  provider = aws
+}

--- a/internal/service/ssm/testdata/Parameter/list_basic/query.tfquery.hcl
+++ b/internal/service/ssm/testdata/Parameter/list_basic/query.tfquery.hcl
@@ -1,6 +1,0 @@
-# Copyright IBM Corp. 2014, 2026
-# SPDX-License-Identifier: MPL-2.0
-
-list "aws_ssm_parameter" "test" {
-  provider = aws
-}

--- a/internal/service/ssm/testdata/Parameter/list_include_resource/main.tf
+++ b/internal/service/ssm/testdata/Parameter/list_include_resource/main.tf
@@ -4,7 +4,9 @@
 resource "aws_ssm_parameter" "test" {
   count = var.resource_count
 
-  name = "${var.rName}-${count.index}"
+  name  = "${var.rName}-${count.index}"
+  type  = "String"
+  value = "${var.rName}-${count.index}"
 
   tags = var.resource_tags
 }

--- a/internal/service/ssm/testdata/Parameter/list_include_resource/main.tf
+++ b/internal/service/ssm/testdata/Parameter/list_include_resource/main.tf
@@ -5,6 +5,8 @@ resource "aws_ssm_parameter" "test" {
   count = var.resource_count
 
   name = "${var.rName}-${count.index}"
+
+  tags = var.resource_tags
 }
 
 variable "rName" {
@@ -16,5 +18,11 @@ variable "rName" {
 variable "resource_count" {
   description = "Number of resources to create"
   type        = number
+  nullable    = false
+}
+
+variable "resource_tags" {
+  description = "Tags to set on resource"
+  type        = map(string)
   nullable    = false
 }

--- a/internal/service/ssm/testdata/Parameter/list_include_resource/query.tfquery.hcl
+++ b/internal/service/ssm/testdata/Parameter/list_include_resource/query.tfquery.hcl
@@ -1,0 +1,8 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_ssm_parameter" "test" {
+  provider = aws
+
+  include_resource = true
+}

--- a/internal/service/ssm/testdata/Parameter/list_region_override/main.tf
+++ b/internal/service/ssm/testdata/Parameter/list_region_override/main.tf
@@ -5,7 +5,9 @@ resource "aws_ssm_parameter" "test" {
   count  = var.resource_count
   region = var.region
 
-  name = "${var.rName}-${count.index}"
+  name  = "${var.rName}-${count.index}"
+  type  = "String"
+  value = "${var.rName}-${count.index}"
 }
 
 variable "rName" {

--- a/internal/service/ssm/testdata/Parameter/list_region_override/main.tf
+++ b/internal/service/ssm/testdata/Parameter/list_region_override/main.tf
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: MPL-2.0
 
 resource "aws_ssm_parameter" "test" {
-  count = var.resource_count
+  count  = var.resource_count
+  region = var.region
 
   name = "${var.rName}-${count.index}"
 }
@@ -16,5 +17,11 @@ variable "rName" {
 variable "resource_count" {
   description = "Number of resources to create"
   type        = number
+  nullable    = false
+}
+
+variable "region" {
+  description = "Region to deploy resource in"
+  type        = string
   nullable    = false
 }

--- a/internal/service/ssm/testdata/Parameter/list_region_override/query.tfquery.hcl
+++ b/internal/service/ssm/testdata/Parameter/list_region_override/query.tfquery.hcl
@@ -1,0 +1,10 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_ssm_parameter" "test" {
+  provider = aws
+
+  config {
+    region = var.region
+  }
+}


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
- Extract shared flatten logic into `resourceParameterFlatten`.
- Remove `resourceParameterRead` usage from `aws_ssm_parameter` List.
- Add `includeResource` and `regionOverride` acceptance tests.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #46697 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
Due to current AWS costs, I was not able to run the acceptance tests locally.