### PR TITLE
Implement Keyspaces autoscaling

### DIFF
--- a/.changelog/49030.txt
+++ b/.changelog/49030.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_keyspaces_table: Add `auto_scaling_specification` argument
+```

--- a/internal/service/keyspaces/exports_test.go
+++ b/internal/service/keyspaces/exports_test.go
@@ -8,8 +8,18 @@ var (
 	ResourceKeyspace = resourceKeyspace
 	ResourceTable    = resourceTable
 
-	FindKeyspaceByName    = findKeyspaceByName
-	FindTableByTwoPartKey = findTableByTwoPartKey
+	FindKeyspaceByName                       = findKeyspaceByName
+	FindTableByTwoPartKey                    = findTableByTwoPartKey
+	FindTableAutoScalingSettingsByTwoPartKey = findTableAutoScalingSettingsByTwoPartKey
 
 	TableParseResourceID = tableParseResourceID
+
+	ExpandAutoScalingSpecification                 = expandAutoScalingSpecification
+	ExpandAutoScalingSpecificationDisabled         = expandAutoScalingSpecificationDisabled
+	ExpandAutoScalingSettings                      = expandAutoScalingSettings
+	ExpandTargetTrackingScalingPolicyConfiguration = expandTargetTrackingScalingPolicyConfiguration
+
+	FlattenAutoScalingSpecification                 = flattenAutoScalingSpecification
+	FlattenAutoScalingSettings                      = flattenAutoScalingSettings
+	FlattenTargetTrackingScalingPolicyConfiguration = flattenTargetTrackingScalingPolicyConfiguration
 )

--- a/internal/service/keyspaces/table.go
+++ b/internal/service/keyspaces/table.go
@@ -67,6 +67,86 @@ func resourceTable() *schema.Resource {
 
 				return false
 			}),
+			func(_ context.Context, diff *schema.ResourceDiff, meta any) error {
+				// Auto scaling requires provisioned throughput capacity.
+				if v, ok := diff.GetOk("auto_scaling_specification"); !ok || len(v.([]any)) == 0 || v.([]any)[0] == nil {
+					return nil
+				}
+
+				var throughputMode string
+				if v, ok := diff.GetOk("capacity_specification"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+					throughputMode = v.([]any)[0].(map[string]any)["throughput_mode"].(string)
+				}
+
+				if throughputMode != string(types.ThroughputModeProvisioned) {
+					return fmt.Errorf("auto_scaling_specification requires capacity_specification.throughput_mode to be %s", types.ThroughputModeProvisioned)
+				}
+
+				return nil
+			},
+			func(_ context.Context, diff *schema.ResourceDiff, meta any) error {
+				// PROVISIONED throughput requires both capacity units, and AWS needs them
+				// as part of the PAY_PER_REQUEST -> PROVISIONED transition. Reject at plan
+				// time when the planned value is missing a unit. This catches a bare
+				// misconfiguration and the case where read/write_capacity_units
+				// are under lifecycle.ignore_changes: the planned value then keeps zero units
+				// while throughput_mode still flips to PROVISIONED, which the API rejects.
+				// Effetcively this requires the user to make the mode change happen in its own apply first.
+				v, ok := diff.GetOk("capacity_specification")
+				if !ok || len(v.([]any)) == 0 || v.([]any)[0] == nil {
+					return nil
+				}
+				tfMap := v.([]any)[0].(map[string]any)
+
+				if tfMap["throughput_mode"].(string) != string(types.ThroughputModeProvisioned) {
+					return nil
+				}
+
+				read, _ := tfMap["read_capacity_units"].(int)
+				write, _ := tfMap["write_capacity_units"].(int)
+				if read == 0 || write == 0 {
+					return fmt.Errorf("capacity_specification.throughput_mode %s requires read_capacity_units and write_capacity_units to be set. "+
+						"If these are managed by auto scaling and held under lifecycle.ignore_changes, change throughput_mode to %[1]s in a separate apply before adding ignore_changes.",
+						types.ThroughputModeProvisioned)
+				}
+
+				return nil
+			},
+			func(_ context.Context, diff *schema.ResourceDiff, meta any) error {
+				v, ok := diff.GetOk("auto_scaling_specification")
+				if !ok || len(v.([]any)) == 0 || v.([]any)[0] == nil {
+					return nil
+				}
+				tfMap := v.([]any)[0].(map[string]any)
+
+				for _, key := range []string{"read_capacity_auto_scaling", "write_capacity_auto_scaling"} {
+					v, ok := tfMap[key].([]any)
+					if !ok || len(v) == 0 || v[0] == nil {
+						continue
+					}
+					settingsMap := v[0].(map[string]any)
+					if disabled, _ := settingsMap["auto_scaling_disabled"].(bool); disabled {
+						continue
+					}
+
+					minimumUnits, minimumUnitsOK := settingsMap["minimum_units"].(int)
+					maximumUnits, maximumUnitsOK := settingsMap["maximum_units"].(int)
+					if !minimumUnitsOK || minimumUnits == 0 || !maximumUnitsOK || maximumUnits == 0 {
+						return fmt.Errorf("auto_scaling_specification.0.%s: minimum_units and maximum_units must be configured when auto scaling is enabled", key)
+					}
+
+					policy, policyOK := settingsMap["target_tracking_scaling_policy_configuration"].([]any)
+					if !policyOK || len(policy) == 0 || policy[0] == nil {
+						return fmt.Errorf("auto_scaling_specification.0.%s: target_tracking_scaling_policy_configuration must be configured when auto scaling is enabled", key)
+					}
+
+					if minimumUnits > maximumUnits {
+						return fmt.Errorf("auto_scaling_specification.0.%s: minimum_units (%d) cannot be greater than maximum_units (%d)", key, minimumUnits, maximumUnits)
+					}
+				}
+
+				return nil
+			},
 		),
 
 		SchemaFunc: func() map[string]*schema.Schema {
@@ -74,6 +154,20 @@ func resourceTable() *schema.Resource {
 				names.AttrARN: {
 					Type:     schema.TypeString,
 					Computed: true,
+				},
+				"auto_scaling_specification": {
+					Type:     schema.TypeList,
+					Optional: true,
+					// Not Computed (unlike the sibling blocks): removing it from configuration must
+					// produce a diff so the update can disable auto scaling. Computed would make Terraform
+					// retain the prior value, silently leaving auto scaling enabled.
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"read_capacity_auto_scaling":  autoScalingSettingsSchema(),
+							"write_capacity_auto_scaling": autoScalingSettingsSchema(),
+						},
+					},
 				},
 				"capacity_specification": {
 					Type:     schema.TypeList,
@@ -306,6 +400,65 @@ func resourceTable() *schema.Resource {
 	}
 }
 
+func autoScalingSettingsSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		Computed: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"auto_scaling_disabled": {
+					Type:     schema.TypeBool,
+					Optional: true,
+				},
+				"maximum_units": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					Computed:     true,
+					ValidateFunc: validation.IntAtLeast(1),
+				},
+				"minimum_units": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					Computed:     true,
+					ValidateFunc: validation.IntAtLeast(1),
+				},
+				"target_tracking_scaling_policy_configuration": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Computed: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"disable_scale_in": {
+								Type:     schema.TypeBool,
+								Optional: true,
+							},
+							"scale_in_cooldown": {
+								Type:         schema.TypeInt,
+								Optional:     true,
+								ValidateFunc: validation.IntAtLeast(0),
+							},
+							"scale_out_cooldown": {
+								Type:         schema.TypeInt,
+								Optional:     true,
+								ValidateFunc: validation.IntAtLeast(0),
+							},
+							"target_value": {
+								Type:         schema.TypeFloat,
+								Optional:     true,
+								Computed:     true,
+								ValidateFunc: validation.FloatBetween(20, 90),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
 func resourceTableCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).KeyspacesClient(ctx)
@@ -317,6 +470,10 @@ func resourceTableCreate(ctx context.Context, d *schema.ResourceData, meta any) 
 		KeyspaceName: aws.String(keyspaceName),
 		TableName:    aws.String(tableName),
 		Tags:         getTagsIn(ctx),
+	}
+
+	if v, ok := d.GetOk("auto_scaling_specification"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.AutoScalingSpecification = expandAutoScalingSpecification(v.([]any)[0].(map[string]any))
 	}
 
 	if v, ok := d.GetOk("capacity_specification"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
@@ -387,6 +544,52 @@ func resourceTableRead(ctx context.Context, d *schema.ResourceData, meta any) di
 		return sdkdiag.AppendErrorf(diags, "reading Keyspaces Table (%s): %s", d.Id(), err)
 	}
 
+	autoScalingSettings, err := findTableAutoScalingSettingsByTwoPartKey(ctx, conn, keyspaceName, tableName)
+
+	switch {
+	case retry.NotFound(err):
+		// PAY_PER_REQUEST tables and tables without configured scalable targets can
+		// return ResourceNotFoundException even though GetTable succeeded.
+		if err := d.Set("auto_scaling_specification", nil); err != nil {
+			return sdkdiag.AppendErrorf(diags, "setting auto_scaling_specification: %s", err)
+		}
+	case errs.IsA[*types.AccessDeniedException](err):
+		// Reading auto scaling settings requires additional IAM permissions
+		// (application-autoscaling:DescribeScalableTargets and DescribeScalingPolicies)
+		// beyond what's needed to manage the table itself. Tolerate the missing
+		// permissions only for tables that aren't tracking auto scaling in state;
+		// if the resource manages auto_scaling_specification we cannot refresh or
+		// detect drift on it, so surface a clear permissions error instead of
+		// silently claiming to manage settings we can never verify. The prior state
+		// is still intact here because the attribute hasn't been overwritten yet.
+		if v, ok := d.GetOk("auto_scaling_specification"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+			return sdkdiag.AppendErrorf(diags, "reading Keyspaces Table (%s) auto scaling settings: %s\n\n"+
+				"The table manages auto_scaling_specification, which requires the "+
+				"application-autoscaling:DescribeScalableTargets and DescribeScalingPolicies permissions to read.", d.Id(), err)
+		}
+		log.Printf("[DEBUG] Keyspaces Table (%s): insufficient permissions to read auto scaling settings, leaving auto_scaling_specification unchanged: %s", d.Id(), err)
+	case err != nil:
+		return sdkdiag.AppendErrorf(diags, "reading Keyspaces Table (%s) auto scaling settings: %s", d.Id(), err)
+	default:
+		spec := autoScalingSettings.AutoScalingSpecification
+		switch {
+		case spec == nil:
+			d.Set("auto_scaling_specification", nil)
+		case autoScalingSpecificationDisabled(spec) && !autoScalingSpecificationInState(d):
+			// Auto scaling is fully disabled and the block is not tracked in state
+			// (it was removed to disable it, or the table was imported). Treat it as
+			// absent so there is no perpetual "remove" diff, since AWS may keep returning
+			// a disabled specification rather than ResourceNotFoundException. The in-state
+			// guard is what preserves an explicitly configured auto_scaling_disabled = true
+			// block instead of stripping it.
+			d.Set("auto_scaling_specification", nil)
+		default:
+			if err := d.Set("auto_scaling_specification", []any{flattenAutoScalingSpecification(spec)}); err != nil {
+				return sdkdiag.AppendErrorf(diags, "setting auto_scaling_specification: %s", err)
+			}
+		}
+	}
+
 	d.Set(names.AttrARN, table.ResourceArn)
 	if table.CapacitySpecification != nil {
 		if err := d.Set("capacity_specification", []any{flattenCapacitySpecificationSummary(table.CapacitySpecification)}); err != nil {
@@ -453,26 +656,106 @@ func resourceTableUpdate(ctx context.Context, d *schema.ResourceData, meta any) 
 		return sdkdiag.AppendFromErr(diags, err)
 	}
 
+	updateAutoScalingSpecification := func() diag.Diagnostics {
+		var diags diag.Diagnostics
+
+		if !d.HasChange("auto_scaling_specification") {
+			return diags
+		}
+
+		input := &keyspaces.UpdateTableInput{
+			KeyspaceName: aws.String(keyspaceName),
+			TableName:    aws.String(tableName),
+		}
+
+		if v, ok := d.GetOk("auto_scaling_specification"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+			input.AutoScalingSpecification = expandAutoScalingSpecification(v.([]any)[0].(map[string]any))
+		} else {
+			// The block was removed: explicitly disable auto scaling instead of leaving it
+			// active on the AWS side.
+			old, _ := d.GetChange("auto_scaling_specification")
+
+			oldList, ok := old.([]any)
+			if !ok || len(oldList) == 0 || oldList[0] == nil {
+				return diags
+			}
+
+			input.AutoScalingSpecification = expandAutoScalingSpecificationDisabled(oldList[0].(map[string]any))
+		}
+
+		_, err := conn.UpdateTable(ctx, input)
+
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "updating Keyspaces Table (%s) AutoScalingSpecification: %s", d.Id(), err)
+		}
+
+		if _, err := waitTableUpdated(ctx, conn, keyspaceName, tableName, d.Timeout(schema.TimeoutUpdate)); err != nil {
+			return sdkdiag.AppendErrorf(diags, "waiting for Keyspaces Table (%s) AutoScalingSpecification update: %s", d.Id(), err)
+		}
+
+		return diags
+	}
+
+	updateCapacitySpecification := func() diag.Diagnostics {
+		var diags diag.Diagnostics
+
+		if !d.HasChange("capacity_specification") {
+			return diags
+		}
+
+		v, ok := d.GetOk("capacity_specification")
+		if !ok || len(v.([]any)) == 0 || v.([]any)[0] == nil {
+			return diags
+		}
+
+		capacitySpecification := expandCapacitySpecification(v.([]any)[0].(map[string]any))
+
+		input := &keyspaces.UpdateTableInput{
+			CapacitySpecification: capacitySpecification,
+			KeyspaceName:          aws.String(keyspaceName),
+			TableName:             aws.String(tableName),
+		}
+
+		_, err := conn.UpdateTable(ctx, input)
+
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "updating Keyspaces Table (%s) CapacitySpecification: %s", d.Id(), err)
+		}
+
+		if _, err := waitTableUpdated(ctx, conn, keyspaceName, tableName, d.Timeout(schema.TimeoutUpdate)); err != nil {
+			return sdkdiag.AppendErrorf(diags, "waiting for Keyspaces Table (%s) CapacitySpecification update: %s", d.Id(), err)
+		}
+
+		return diags
+	}
+
 	if d.HasChangesExcept(names.AttrTags, names.AttrTagsAll) {
 		// https://docs.aws.amazon.com/keyspaces/latest/APIReference/API_UpdateTable.html
 		// Note that you can only update one specific table setting per update operation.
-		if d.HasChange("capacity_specification") {
-			if v, ok := d.GetOk("capacity_specification"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
-				input := &keyspaces.UpdateTableInput{
-					CapacitySpecification: expandCapacitySpecification(v.([]any)[0].(map[string]any)),
-					KeyspaceName:          aws.String(keyspaceName),
-					TableName:             aws.String(tableName),
-				}
+		//
+		// auto_scaling_specification and capacity_specification have an ordering dependency:
+		// enabling auto scaling requires the table to already be PROVISIONED, so capacity
+		// must be updated first; disabling auto scaling (or removing the block) should
+		// happen before switching away from PROVISIONED, so auto scaling must be updated
+		// first. Determine direction from the *new* auto_scaling_specification value.
+		disablingAutoScaling := true
+		if v, ok := d.GetOk("auto_scaling_specification"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+			disablingAutoScaling = false
+		}
 
-				_, err := conn.UpdateTable(ctx, input)
-
-				if err != nil {
-					return sdkdiag.AppendErrorf(diags, "updating Keyspaces Table (%s) CapacitySpecification: %s", d.Id(), err)
-				}
-
-				if _, err := waitTableUpdated(ctx, conn, keyspaceName, tableName, d.Timeout(schema.TimeoutUpdate)); err != nil {
-					return sdkdiag.AppendErrorf(diags, "waiting for Keyspaces Table (%s) CapacitySpecification update: %s", d.Id(), err)
-				}
+		if disablingAutoScaling {
+			if diags := updateAutoScalingSpecification(); diags.HasError() {
+				return diags
+			}
+			if diags := updateCapacitySpecification(); diags.HasError() {
+				return diags
+			}
+		} else {
+			if diags := updateCapacitySpecification(); diags.HasError() {
+				return diags
+			}
+			if diags := updateAutoScalingSpecification(); diags.HasError() {
+				return diags
 			}
 		}
 
@@ -694,6 +977,31 @@ func findTableByTwoPartKey(ctx context.Context, conn *keyspaces.Client, keyspace
 	return output, nil
 }
 
+func findTableAutoScalingSettingsByTwoPartKey(ctx context.Context, conn *keyspaces.Client, keyspaceName, tableName string) (*keyspaces.GetTableAutoScalingSettingsOutput, error) {
+	input := keyspaces.GetTableAutoScalingSettingsInput{
+		KeyspaceName: aws.String(keyspaceName),
+		TableName:    aws.String(tableName),
+	}
+
+	output, err := conn.GetTableAutoScalingSettings(ctx, &input)
+
+	if errs.IsA[*types.ResourceNotFoundException](err) {
+		return nil, &retry.NotFoundError{
+			LastError: err,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil {
+		return nil, tfresource.NewEmptyResultError()
+	}
+
+	return output, nil
+}
+
 func statusTable(conn *keyspaces.Client, keyspaceName, tableName string) retry.StateRefreshFunc {
 	return func(ctx context.Context) (any, string, error) {
 		output, err := findTableByTwoPartKey(ctx, conn, keyspaceName, tableName)
@@ -779,6 +1087,107 @@ func expandCapacitySpecification(tfMap map[string]any) *types.CapacitySpecificat
 
 	if v, ok := tfMap["write_capacity_units"].(int); ok && v != 0 {
 		apiObject.WriteCapacityUnits = aws.Int64(int64(v))
+	}
+
+	return apiObject
+}
+
+func expandAutoScalingSpecification(tfMap map[string]any) *types.AutoScalingSpecification {
+	if tfMap == nil {
+		return nil
+	}
+
+	apiObject := &types.AutoScalingSpecification{}
+
+	if v, ok := tfMap["read_capacity_auto_scaling"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.ReadCapacityAutoScaling = expandAutoScalingSettings(v[0].(map[string]any))
+	}
+
+	if v, ok := tfMap["write_capacity_auto_scaling"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.WriteCapacityAutoScaling = expandAutoScalingSettings(v[0].(map[string]any))
+	}
+
+	return apiObject
+}
+
+// expandAutoScalingSpecificationDisabled builds an AutoScalingSpecification that explicitly turns
+// off auto scaling. AWS rejects the update ("When disabled, auto scaling settings should not be
+// provided") if minimum_units/maximum_units/scaling_policy are also sent alongside
+// AutoScalingDisabled: true, so only that flag is set for whichever of read/write was configured.
+func expandAutoScalingSpecificationDisabled(tfMap map[string]any) *types.AutoScalingSpecification {
+	if tfMap == nil {
+		return nil
+	}
+
+	apiObject := &types.AutoScalingSpecification{}
+
+	if v, ok := tfMap["read_capacity_auto_scaling"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.ReadCapacityAutoScaling = &types.AutoScalingSettings{AutoScalingDisabled: true}
+	}
+
+	if v, ok := tfMap["write_capacity_auto_scaling"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.WriteCapacityAutoScaling = &types.AutoScalingSettings{AutoScalingDisabled: true}
+	}
+
+	return apiObject
+}
+
+func expandAutoScalingSettings(tfMap map[string]any) *types.AutoScalingSettings {
+	if tfMap == nil {
+		return nil
+	}
+
+	apiObject := &types.AutoScalingSettings{}
+
+	if v, ok := tfMap["auto_scaling_disabled"].(bool); ok {
+		apiObject.AutoScalingDisabled = v
+	}
+
+	// AWS rejects the update ("When disabled, auto scaling settings should not be provided")
+	// if minimum_units/maximum_units/scaling_policy are also sent alongside
+	// AutoScalingDisabled: true.
+	if apiObject.AutoScalingDisabled {
+		return apiObject
+	}
+
+	if v, ok := tfMap["maximum_units"].(int); ok && v != 0 {
+		apiObject.MaximumUnits = aws.Int64(int64(v))
+	}
+
+	if v, ok := tfMap["minimum_units"].(int); ok && v != 0 {
+		apiObject.MinimumUnits = aws.Int64(int64(v))
+	}
+
+	if v, ok := tfMap["target_tracking_scaling_policy_configuration"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.ScalingPolicy = &types.AutoScalingPolicy{
+			TargetTrackingScalingPolicyConfiguration: expandTargetTrackingScalingPolicyConfiguration(v[0].(map[string]any)),
+		}
+	}
+
+	return apiObject
+}
+
+func expandTargetTrackingScalingPolicyConfiguration(tfMap map[string]any) *types.TargetTrackingScalingPolicyConfiguration {
+	if tfMap == nil {
+		return nil
+	}
+
+	apiObject := &types.TargetTrackingScalingPolicyConfiguration{}
+
+	if v, ok := tfMap["disable_scale_in"].(bool); ok {
+		apiObject.DisableScaleIn = v
+	}
+
+	if v, ok := tfMap["scale_in_cooldown"].(int); ok {
+		apiObject.ScaleInCooldown = int32(v)
+	}
+
+	if v, ok := tfMap["scale_out_cooldown"].(int); ok {
+		apiObject.ScaleOutCooldown = int32(v)
+	}
+
+	if v, ok := tfMap["target_value"].(float64); ok {
+		apiObject.TargetValue = v
 	}
 
 	return apiObject
@@ -1067,6 +1476,94 @@ func flattenCapacitySpecificationSummary(apiObject *types.CapacitySpecificationS
 
 	if v := apiObject.WriteCapacityUnits; v != nil {
 		tfMap["write_capacity_units"] = aws.ToInt64(v)
+	}
+
+	return tfMap
+}
+
+// autoScalingSpecificationInState reports whether the prior state already tracks an
+// auto_scaling_specification block. During Read the resource data still holds the
+// prior state (the attribute has not been overwritten yet) and, after an update, the
+// planned value: present when the block is configured (including an explicit
+// auto_scaling_disabled = true) and absent when it was removed. The plugin protocol
+// does not provide configuration to Read, so this is the available signal for whether
+// the block is being managed.
+func autoScalingSpecificationInState(d *schema.ResourceData) bool {
+	v, ok := d.GetOk("auto_scaling_specification")
+	return ok && len(v.([]any)) > 0 && v.([]any)[0] != nil
+}
+
+// autoScalingSpecificationDisabled reports whether neither capacity dimension has
+// auto scaling actively enabled, i.e. every present dimension is disabled. Such a
+// specification is equivalent to having no auto scaling and is treated as absent.
+func autoScalingSpecificationDisabled(apiObject *types.AutoScalingSpecification) bool {
+	if apiObject == nil {
+		return true
+	}
+
+	if v := apiObject.ReadCapacityAutoScaling; v != nil && !v.AutoScalingDisabled {
+		return false
+	}
+
+	if v := apiObject.WriteCapacityAutoScaling; v != nil && !v.AutoScalingDisabled {
+		return false
+	}
+
+	return true
+}
+
+func flattenAutoScalingSpecification(apiObject *types.AutoScalingSpecification) map[string]any {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]any{}
+
+	if v := apiObject.ReadCapacityAutoScaling; v != nil {
+		tfMap["read_capacity_auto_scaling"] = []any{flattenAutoScalingSettings(v)}
+	}
+
+	if v := apiObject.WriteCapacityAutoScaling; v != nil {
+		tfMap["write_capacity_auto_scaling"] = []any{flattenAutoScalingSettings(v)}
+	}
+
+	return tfMap
+}
+
+func flattenAutoScalingSettings(apiObject *types.AutoScalingSettings) map[string]any {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]any{
+		"auto_scaling_disabled": apiObject.AutoScalingDisabled,
+	}
+
+	if v := apiObject.MaximumUnits; v != nil {
+		tfMap["maximum_units"] = aws.ToInt64(v)
+	}
+
+	if v := apiObject.MinimumUnits; v != nil {
+		tfMap["minimum_units"] = aws.ToInt64(v)
+	}
+
+	if v := apiObject.ScalingPolicy; v != nil && v.TargetTrackingScalingPolicyConfiguration != nil {
+		tfMap["target_tracking_scaling_policy_configuration"] = []any{flattenTargetTrackingScalingPolicyConfiguration(v.TargetTrackingScalingPolicyConfiguration)}
+	}
+
+	return tfMap
+}
+
+func flattenTargetTrackingScalingPolicyConfiguration(apiObject *types.TargetTrackingScalingPolicyConfiguration) map[string]any {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]any{
+		"disable_scale_in":   apiObject.DisableScaleIn,
+		"scale_in_cooldown":  apiObject.ScaleInCooldown,
+		"scale_out_cooldown": apiObject.ScaleOutCooldown,
+		"target_value":       apiObject.TargetValue,
 	}
 
 	return tfMap

--- a/internal/service/keyspaces/table_auto_scaling_unit_test.go
+++ b/internal/service/keyspaces/table_auto_scaling_unit_test.go
@@ -1,0 +1,448 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package keyspaces_test
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/keyspaces/types"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	tfkeyspaces "github.com/hashicorp/terraform-provider-aws/internal/service/keyspaces"
+)
+
+var ignoreUnexported = cmpopts.IgnoreUnexported(
+	types.AutoScalingSpecification{},
+	types.AutoScalingSettings{},
+	types.AutoScalingPolicy{},
+	types.TargetTrackingScalingPolicyConfiguration{},
+)
+
+func TestExpandTargetTrackingScalingPolicyConfiguration(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		tfMap    map[string]any
+		expected *types.TargetTrackingScalingPolicyConfiguration
+	}{
+		"nil map": {
+			tfMap:    nil,
+			expected: nil,
+		},
+		"zero-value bools and cooldowns are preserved, not dropped": {
+			tfMap: map[string]any{
+				"disable_scale_in":   false,
+				"scale_in_cooldown":  0,
+				"scale_out_cooldown": 0,
+				"target_value":       70.0,
+			},
+			expected: &types.TargetTrackingScalingPolicyConfiguration{
+				DisableScaleIn:   false,
+				ScaleInCooldown:  0,
+				ScaleOutCooldown: 0,
+				TargetValue:      70.0,
+			},
+		},
+		"non-zero-value bools and cooldowns": {
+			tfMap: map[string]any{
+				"disable_scale_in":   true,
+				"scale_in_cooldown":  60,
+				"scale_out_cooldown": 120,
+				"target_value":       55.5,
+			},
+			expected: &types.TargetTrackingScalingPolicyConfiguration{
+				DisableScaleIn:   true,
+				ScaleInCooldown:  60,
+				ScaleOutCooldown: 120,
+				TargetValue:      55.5,
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfkeyspaces.ExpandTargetTrackingScalingPolicyConfiguration(tc.tfMap)
+
+			if diff := cmp.Diff(tc.expected, got, ignoreUnexported); diff != "" {
+				t.Errorf("unexpected result (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestFlattenTargetTrackingScalingPolicyConfiguration(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		apiObject *types.TargetTrackingScalingPolicyConfiguration
+		expected  map[string]any
+	}{
+		"nil": {
+			apiObject: nil,
+			expected:  nil,
+		},
+		"zero-value bools and cooldowns surface, not omitted": {
+			apiObject: &types.TargetTrackingScalingPolicyConfiguration{
+				DisableScaleIn:   false,
+				ScaleInCooldown:  0,
+				ScaleOutCooldown: 0,
+				TargetValue:      70.0,
+			},
+			expected: map[string]any{
+				"disable_scale_in":   false,
+				"scale_in_cooldown":  int32(0),
+				"scale_out_cooldown": int32(0),
+				"target_value":       70.0,
+			},
+		},
+		"non-zero-value bools and cooldowns": {
+			apiObject: &types.TargetTrackingScalingPolicyConfiguration{
+				DisableScaleIn:   true,
+				ScaleInCooldown:  60,
+				ScaleOutCooldown: 120,
+				TargetValue:      55.5,
+			},
+			expected: map[string]any{
+				"disable_scale_in":   true,
+				"scale_in_cooldown":  int32(60),
+				"scale_out_cooldown": int32(120),
+				"target_value":       55.5,
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfkeyspaces.FlattenTargetTrackingScalingPolicyConfiguration(tc.apiObject)
+
+			if diff := cmp.Diff(tc.expected, got); diff != "" {
+				t.Errorf("unexpected result (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestExpandAutoScalingSettings(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		tfMap    map[string]any
+		expected *types.AutoScalingSettings
+	}{
+		"nil map": {
+			tfMap:    nil,
+			expected: nil,
+		},
+		"explicit false auto_scaling_disabled is preserved, with units and nested policy expanded": {
+			tfMap: map[string]any{
+				"auto_scaling_disabled": false,
+				"minimum_units":         5,
+				"maximum_units":         10,
+				"target_tracking_scaling_policy_configuration": []any{
+					map[string]any{
+						"disable_scale_in":   false,
+						"scale_in_cooldown":  0,
+						"scale_out_cooldown": 0,
+						"target_value":       70.0,
+					},
+				},
+			},
+			expected: &types.AutoScalingSettings{
+				AutoScalingDisabled: false,
+				MinimumUnits:        aws.Int64(5),
+				MaximumUnits:        aws.Int64(10),
+				ScalingPolicy: &types.AutoScalingPolicy{
+					TargetTrackingScalingPolicyConfiguration: &types.TargetTrackingScalingPolicyConfiguration{
+						TargetValue: 70.0,
+					},
+				},
+			},
+		},
+		"auto_scaling_disabled true omits minimum/maximum units and scaling policy": {
+			// AWS rejects the update with "When disabled, auto scaling settings should not be
+			// provided" if these are also sent alongside AutoScalingDisabled: true.
+			tfMap: map[string]any{
+				"auto_scaling_disabled": true,
+				"minimum_units":         5,
+				"maximum_units":         10,
+				"target_tracking_scaling_policy_configuration": []any{
+					map[string]any{"target_value": 70.0},
+				},
+			},
+			expected: &types.AutoScalingSettings{
+				AutoScalingDisabled: true,
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfkeyspaces.ExpandAutoScalingSettings(tc.tfMap)
+
+			if diff := cmp.Diff(tc.expected, got, ignoreUnexported); diff != "" {
+				t.Errorf("unexpected result (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestFlattenAutoScalingSettings(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		apiObject *types.AutoScalingSettings
+		expected  map[string]any
+	}{
+		"nil": {
+			apiObject: nil,
+			expected:  nil,
+		},
+		"false auto_scaling_disabled and units surface; nil scaling policy is omitted": {
+			apiObject: &types.AutoScalingSettings{
+				AutoScalingDisabled: false,
+				MinimumUnits:        aws.Int64(5),
+				MaximumUnits:        aws.Int64(10),
+			},
+			expected: map[string]any{
+				"auto_scaling_disabled": false,
+				"minimum_units":         int64(5),
+				"maximum_units":         int64(10),
+			},
+		},
+		"nil MinimumUnits/MaximumUnits pointers are omitted from the map": {
+			apiObject: &types.AutoScalingSettings{
+				AutoScalingDisabled: true,
+			},
+			expected: map[string]any{
+				"auto_scaling_disabled": true,
+			},
+		},
+		"full round trip includes the nested scaling policy": {
+			apiObject: &types.AutoScalingSettings{
+				AutoScalingDisabled: false,
+				MinimumUnits:        aws.Int64(5),
+				MaximumUnits:        aws.Int64(10),
+				ScalingPolicy: &types.AutoScalingPolicy{
+					TargetTrackingScalingPolicyConfiguration: &types.TargetTrackingScalingPolicyConfiguration{
+						TargetValue: 70.0,
+					},
+				},
+			},
+			expected: map[string]any{
+				"auto_scaling_disabled": false,
+				"minimum_units":         int64(5),
+				"maximum_units":         int64(10),
+				"target_tracking_scaling_policy_configuration": []any{
+					map[string]any{
+						"disable_scale_in":   false,
+						"scale_in_cooldown":  int32(0),
+						"scale_out_cooldown": int32(0),
+						"target_value":       70.0,
+					},
+				},
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfkeyspaces.FlattenAutoScalingSettings(tc.apiObject)
+
+			if diff := cmp.Diff(tc.expected, got); diff != "" {
+				t.Errorf("unexpected result (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestExpandAutoScalingSpecification(t *testing.T) {
+	t.Parallel()
+
+	settingsTfMap := map[string]any{
+		"minimum_units": 5,
+		"maximum_units": 10,
+		"target_tracking_scaling_policy_configuration": []any{
+			map[string]any{"target_value": 70.0},
+		},
+	}
+	expandedSettings := &types.AutoScalingSettings{
+		MinimumUnits: aws.Int64(5),
+		MaximumUnits: aws.Int64(10),
+		ScalingPolicy: &types.AutoScalingPolicy{
+			TargetTrackingScalingPolicyConfiguration: &types.TargetTrackingScalingPolicyConfiguration{
+				TargetValue: 70.0,
+			},
+		},
+	}
+
+	testCases := map[string]struct {
+		tfMap    map[string]any
+		expected *types.AutoScalingSpecification
+	}{
+		"nil map": {
+			tfMap:    nil,
+			expected: nil,
+		},
+		"neither read nor write set": {
+			tfMap:    map[string]any{},
+			expected: &types.AutoScalingSpecification{},
+		},
+		"only read_capacity_auto_scaling set": {
+			tfMap: map[string]any{
+				"read_capacity_auto_scaling": []any{settingsTfMap},
+			},
+			expected: &types.AutoScalingSpecification{
+				ReadCapacityAutoScaling: expandedSettings,
+			},
+		},
+		"only write_capacity_auto_scaling set": {
+			tfMap: map[string]any{
+				"write_capacity_auto_scaling": []any{settingsTfMap},
+			},
+			expected: &types.AutoScalingSpecification{
+				WriteCapacityAutoScaling: expandedSettings,
+			},
+		},
+		"both read and write set": {
+			tfMap: map[string]any{
+				"read_capacity_auto_scaling":  []any{settingsTfMap},
+				"write_capacity_auto_scaling": []any{settingsTfMap},
+			},
+			expected: &types.AutoScalingSpecification{
+				ReadCapacityAutoScaling:  expandedSettings,
+				WriteCapacityAutoScaling: expandedSettings,
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfkeyspaces.ExpandAutoScalingSpecification(tc.tfMap)
+
+			if diff := cmp.Diff(tc.expected, got, ignoreUnexported); diff != "" {
+				t.Errorf("unexpected result (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestFlattenAutoScalingSpecification(t *testing.T) {
+	t.Parallel()
+
+	settings := &types.AutoScalingSettings{
+		MinimumUnits: aws.Int64(5),
+		MaximumUnits: aws.Int64(10),
+	}
+	flattenedSettings := map[string]any{
+		"auto_scaling_disabled": false,
+		"minimum_units":         int64(5),
+		"maximum_units":         int64(10),
+	}
+
+	testCases := map[string]struct {
+		apiObject *types.AutoScalingSpecification
+		expected  map[string]any
+	}{
+		"nil": {
+			apiObject: nil,
+			expected:  nil,
+		},
+		"only ReadCapacityAutoScaling set": {
+			apiObject: &types.AutoScalingSpecification{
+				ReadCapacityAutoScaling: settings,
+			},
+			expected: map[string]any{
+				"read_capacity_auto_scaling": []any{flattenedSettings},
+			},
+		},
+		"only WriteCapacityAutoScaling set": {
+			apiObject: &types.AutoScalingSpecification{
+				WriteCapacityAutoScaling: settings,
+			},
+			expected: map[string]any{
+				"write_capacity_auto_scaling": []any{flattenedSettings},
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfkeyspaces.FlattenAutoScalingSpecification(tc.apiObject)
+
+			if diff := cmp.Diff(tc.expected, got); diff != "" {
+				t.Errorf("unexpected result (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestExpandAutoScalingSpecificationDisabled(t *testing.T) {
+	t.Parallel()
+
+	// AWS rejects the update with "When disabled, auto scaling settings should not be
+	// provided" if minimum_units/maximum_units/scaling_policy are sent alongside
+	// AutoScalingDisabled: true, so the prior values must NOT be preserved.
+	settingsTfMap := map[string]any{
+		"auto_scaling_disabled": false,
+		"minimum_units":         5,
+		"maximum_units":         10,
+		"target_tracking_scaling_policy_configuration": []any{
+			map[string]any{"target_value": 70.0},
+		},
+	}
+	disabled := &types.AutoScalingSettings{AutoScalingDisabled: true}
+
+	testCases := map[string]struct {
+		tfMap    map[string]any
+		expected *types.AutoScalingSpecification
+	}{
+		"nil map does not panic and returns nil": {
+			tfMap:    nil,
+			expected: nil,
+		},
+		"forces AutoScalingDisabled true on both settings and omits prior values": {
+			tfMap: map[string]any{
+				"read_capacity_auto_scaling":  []any{settingsTfMap},
+				"write_capacity_auto_scaling": []any{settingsTfMap},
+			},
+			expected: &types.AutoScalingSpecification{
+				ReadCapacityAutoScaling:  disabled,
+				WriteCapacityAutoScaling: disabled,
+			},
+		},
+		"only read set does not populate write": {
+			tfMap: map[string]any{
+				"read_capacity_auto_scaling": []any{settingsTfMap},
+			},
+			expected: &types.AutoScalingSpecification{
+				ReadCapacityAutoScaling: disabled,
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfkeyspaces.ExpandAutoScalingSpecificationDisabled(tc.tfMap)
+
+			if diff := cmp.Diff(tc.expected, got, ignoreUnexported); diff != "" {
+				t.Errorf("unexpected result (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/service/keyspaces/table_test.go
+++ b/internal/service/keyspaces/table_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/keyspaces"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -487,6 +488,323 @@ func TestAccKeyspacesTable_delColumns(t *testing.T) {
 	})
 }
 
+func TestAccKeyspacesTable_autoScaling_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v keyspaces.GetTableOutput
+	rName1 := "tf_acc_test_" + acctest.RandString(t, 20)
+	rName2 := "tf_acc_test_" + acctest.RandString(t, 20)
+	resourceName := "aws_keyspaces_table.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.KeyspacesServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTableDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTableConfig_autoScaling(rName1, rName2, 5, 10, 70),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckTableExists(ctx, t, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "capacity_specification.0.throughput_mode", "PROVISIONED"),
+					resource.TestCheckResourceAttr(resourceName, "auto_scaling_specification.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "auto_scaling_specification.0.read_capacity_auto_scaling.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "auto_scaling_specification.0.read_capacity_auto_scaling.0.auto_scaling_disabled", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, "auto_scaling_specification.0.read_capacity_auto_scaling.0.minimum_units", "5"),
+					resource.TestCheckResourceAttr(resourceName, "auto_scaling_specification.0.read_capacity_auto_scaling.0.maximum_units", "10"),
+					resource.TestCheckResourceAttr(resourceName, "auto_scaling_specification.0.read_capacity_auto_scaling.0.target_tracking_scaling_policy_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "auto_scaling_specification.0.read_capacity_auto_scaling.0.target_tracking_scaling_policy_configuration.0.target_value", "70"),
+					resource.TestCheckResourceAttr(resourceName, "auto_scaling_specification.0.write_capacity_auto_scaling.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "auto_scaling_specification.0.write_capacity_auto_scaling.0.minimum_units", "5"),
+					resource.TestCheckResourceAttr(resourceName, "auto_scaling_specification.0.write_capacity_auto_scaling.0.maximum_units", "10"),
+					resource.TestCheckResourceAttr(resourceName, "auto_scaling_specification.0.write_capacity_auto_scaling.0.target_tracking_scaling_policy_configuration.0.target_value", "70"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"capacity_specification.0.read_capacity_units", "capacity_specification.0.write_capacity_units"},
+			},
+		},
+	})
+}
+
+func TestAccKeyspacesTable_autoScaling_update(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v1, v2 keyspaces.GetTableOutput
+	rName1 := "tf_acc_test_" + acctest.RandString(t, 20)
+	rName2 := "tf_acc_test_" + acctest.RandString(t, 20)
+	resourceName := "aws_keyspaces_table.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.KeyspacesServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTableDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTableConfig_autoScaling(rName1, rName2, 5, 10, 70),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckTableExists(ctx, t, resourceName, &v1),
+					resource.TestCheckResourceAttr(resourceName, "auto_scaling_specification.0.read_capacity_auto_scaling.0.maximum_units", "10"),
+				),
+			},
+			{
+				Config: testAccTableConfig_autoScaling(rName1, rName2, 5, 20, 60),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckTableExists(ctx, t, resourceName, &v2),
+					testAccCheckTableNotRecreated(&v1, &v2),
+					resource.TestCheckResourceAttr(resourceName, "auto_scaling_specification.0.read_capacity_auto_scaling.0.maximum_units", "20"),
+					resource.TestCheckResourceAttr(resourceName, "auto_scaling_specification.0.read_capacity_auto_scaling.0.target_tracking_scaling_policy_configuration.0.target_value", "60"),
+					resource.TestCheckResourceAttr(resourceName, "auto_scaling_specification.0.write_capacity_auto_scaling.0.maximum_units", "20"),
+					resource.TestCheckResourceAttr(resourceName, "auto_scaling_specification.0.write_capacity_auto_scaling.0.target_tracking_scaling_policy_configuration.0.target_value", "60"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccKeyspacesTable_autoScaling_disabled(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v1, v2 keyspaces.GetTableOutput
+	rName1 := "tf_acc_test_" + acctest.RandString(t, 20)
+	rName2 := "tf_acc_test_" + acctest.RandString(t, 20)
+	resourceName := "aws_keyspaces_table.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.KeyspacesServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTableDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTableConfig_autoScaling(rName1, rName2, 5, 10, 70),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckTableExists(ctx, t, resourceName, &v1),
+					resource.TestCheckResourceAttr(resourceName, "auto_scaling_specification.0.read_capacity_auto_scaling.0.auto_scaling_disabled", acctest.CtFalse),
+				),
+			},
+			{
+				Config: testAccTableConfig_autoScalingDisabled(rName1, rName2, 5),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckTableExists(ctx, t, resourceName, &v2),
+					testAccCheckTableNotRecreated(&v1, &v2),
+					resource.TestCheckResourceAttr(resourceName, "auto_scaling_specification.0.read_capacity_auto_scaling.0.auto_scaling_disabled", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "auto_scaling_specification.0.write_capacity_auto_scaling.0.auto_scaling_disabled", acctest.CtTrue),
+					// Confirm against the API, not just state, that both dimensions are disabled.
+					testAccCheckTableAutoScalingDisabled(ctx, t, resourceName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccKeyspacesTable_autoScaling_payPerRequestConflict(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName1 := "tf_acc_test_" + acctest.RandString(t, 20)
+	rName2 := "tf_acc_test_" + acctest.RandString(t, 20)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.KeyspacesServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccTableConfig_autoScalingPayPerRequest(rName1, rName2),
+				ExpectError: regexache.MustCompile(`auto_scaling_specification requires capacity_specification.throughput_mode to be`),
+			},
+		},
+	})
+}
+
+func TestAccKeyspacesTable_autoScaling_omittedCapacitySpecificationConflict(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName1 := "tf_acc_test_" + acctest.RandString(t, 20)
+	rName2 := "tf_acc_test_" + acctest.RandString(t, 20)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.KeyspacesServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				// capacity_specification is entirely omitted here, which defaults to
+				// PAY_PER_REQUEST; this must be rejected the same way an explicit
+				// PAY_PER_REQUEST is.
+				Config:      testAccTableConfig_autoScalingOmittedCapacitySpecification(rName1, rName2),
+				ExpectError: regexache.MustCompile(`auto_scaling_specification requires capacity_specification.throughput_mode to be`),
+			},
+		},
+	})
+}
+
+func TestAccKeyspacesTable_autoScaling_invertedRangeConflict(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName1 := "tf_acc_test_" + acctest.RandString(t, 20)
+	rName2 := "tf_acc_test_" + acctest.RandString(t, 20)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.KeyspacesServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				// minimum_units > maximum_units must be rejected at plan time rather than
+				// left for the AWS API to reject at apply time.
+				Config:      testAccTableConfig_autoScaling(rName1, rName2, 10, 5, 70),
+				ExpectError: regexache.MustCompile(`minimum_units \(10\) cannot be greater than maximum_units \(5\)`),
+			},
+		},
+	})
+}
+
+func TestAccKeyspacesTable_autoScaling_removal(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v1, v2 keyspaces.GetTableOutput
+	rName1 := "tf_acc_test_" + acctest.RandString(t, 20)
+	rName2 := "tf_acc_test_" + acctest.RandString(t, 20)
+	resourceName := "aws_keyspaces_table.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.KeyspacesServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTableDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTableConfig_autoScaling(rName1, rName2, 5, 10, 70),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckTableExists(ctx, t, resourceName, &v1),
+				),
+			},
+			{
+				// Removing the block must disable auto scaling against the API
+				Config: testAccTableConfig_provisionedCapacity(rName1, rName2, 5),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckTableExists(ctx, t, resourceName, &v2),
+					testAccCheckTableNotRecreated(&v1, &v2),
+					resource.TestCheckResourceAttr(resourceName, "capacity_specification.0.throughput_mode", "PROVISIONED"),
+					resource.TestCheckResourceAttr(resourceName, "auto_scaling_specification.#", "0"),
+					testAccCheckTableAutoScalingDisabled(ctx, t, resourceName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccKeyspacesTable_autoScaling_enableWithModeSwitch(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v1, v2 keyspaces.GetTableOutput
+	rName1 := "tf_acc_test_" + acctest.RandString(t, 20)
+	rName2 := "tf_acc_test_" + acctest.RandString(t, 20)
+	resourceName := "aws_keyspaces_table.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.KeyspacesServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTableDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTableConfig_basic(rName1, rName2),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckTableExists(ctx, t, resourceName, &v1),
+					resource.TestCheckResourceAttr(resourceName, "capacity_specification.0.throughput_mode", "PAY_PER_REQUEST"),
+				),
+			},
+			{
+				// Step 1 of the two-step transition: switch PAY_PER_REQUEST -> PROVISIONED
+				// with explicit capacity units before auto scaling is involved. Enabling auto
+				// scaling in the same apply is intentionally rejected when the units are held
+				// under ignore_changes (see _modeSwitchWithIgnoredUnitsConflict).
+				Config: testAccTableConfig_provisionedCapacity(rName1, rName2, 5),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckTableExists(ctx, t, resourceName, &v2),
+					testAccCheckTableNotRecreated(&v1, &v2),
+					resource.TestCheckResourceAttr(resourceName, "capacity_specification.0.throughput_mode", "PROVISIONED"),
+				),
+			},
+			{
+				// Step 2: enable auto scaling now that the table is already PROVISIONED. The
+				// capacity units (5) are established in prior state, so ignore_changes keeps
+				// them in the plan and the transition succeeds.
+				Config: testAccTableConfig_autoScaling(rName1, rName2, 5, 10, 70),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckTableExists(ctx, t, resourceName, &v2),
+					testAccCheckTableNotRecreated(&v1, &v2),
+					resource.TestCheckResourceAttr(resourceName, "capacity_specification.0.throughput_mode", "PROVISIONED"),
+					resource.TestCheckResourceAttr(resourceName, "auto_scaling_specification.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccKeyspacesTable_autoScaling_modeSwitchWithIgnoredUnitsConflict(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v1 keyspaces.GetTableOutput
+	rName1 := "tf_acc_test_" + acctest.RandString(t, 20)
+	rName2 := "tf_acc_test_" + acctest.RandString(t, 20)
+	resourceName := "aws_keyspaces_table.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.KeyspacesServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTableDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTableConfig_basic(rName1, rName2),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckTableExists(ctx, t, resourceName, &v1),
+				),
+			},
+			{
+				// Switching PAY_PER_REQUEST -> PROVISIONED while the capacity units are held
+				// under ignore_changes must be rejected at plan time: the required units are
+				// not part of the planned change, and recovering them from raw configuration
+				// would bypass the plan. The transition must be done in two steps instead.
+				Config:      testAccTableConfig_autoScaling(rName1, rName2, 5, 10, 70),
+				ExpectError: regexache.MustCompile(`requires read_capacity_units and write_capacity_units`),
+			},
+		},
+	})
+}
+
+func TestAccKeyspacesTable_autoScaling_disableWithModeSwitch(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v1, v2 keyspaces.GetTableOutput
+	rName1 := "tf_acc_test_" + acctest.RandString(t, 20)
+	rName2 := "tf_acc_test_" + acctest.RandString(t, 20)
+	resourceName := "aws_keyspaces_table.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.KeyspacesServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTableDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTableConfig_autoScaling(rName1, rName2, 5, 10, 70),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckTableExists(ctx, t, resourceName, &v1),
+				),
+			},
+			{
+				// Disabling auto scaling and switching PROVISIONED -> PAY_PER_REQUEST in one apply:
+				// the provider must issue the auto-scaling-disable call before the capacity-mode
+				// call, since AWS rejects PAY_PER_REQUEST while provisioned auto scaling is still active.
+				Config: testAccTableConfig_payPerRequestExplicit(rName1, rName2),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckTableExists(ctx, t, resourceName, &v2),
+					testAccCheckTableNotRecreated(&v1, &v2),
+					resource.TestCheckResourceAttr(resourceName, "capacity_specification.0.throughput_mode", "PAY_PER_REQUEST"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckTableDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.ProviderMeta(ctx, t).KeyspacesClient(ctx)
@@ -554,6 +872,50 @@ func testAccCheckTableNotRecreated(i, j *keyspaces.GetTableOutput) resource.Test
 	return func(s *terraform.State) error {
 		if !aws.ToTime(i.CreationTimestamp).Equal(aws.ToTime(j.CreationTimestamp)) {
 			return errors.New("Keyspaces Table was recreated")
+		}
+
+		return nil
+	}
+}
+
+// testAccCheckTableAutoScalingDisabled asserts against the API that both capacity
+// dimensions report auto scaling as disabled, i.e. that removing the block actually
+// turned auto scaling off rather than leaving it silently active.
+func testAccCheckTableAutoScalingDisabled(ctx context.Context, t *testing.T, n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		conn := acctest.ProviderMeta(ctx, t).KeyspacesClient(ctx)
+
+		keyspaceName, tableName, err := tfkeyspaces.TableParseResourceID(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		output, err := tfkeyspaces.FindTableAutoScalingSettingsByTwoPartKey(ctx, conn, keyspaceName, tableName)
+
+		// AWS may drop the scalable targets entirely once auto scaling is disabled,
+		// which surfaces as a not-found error; that is a valid "disabled" outcome.
+		if retry.NotFound(err) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+
+		spec := output.AutoScalingSpecification
+		if spec == nil {
+			return nil
+		}
+
+		if v := spec.ReadCapacityAutoScaling; v != nil && !v.AutoScalingDisabled {
+			return fmt.Errorf("read capacity auto scaling is still enabled for %s", n)
+		}
+		if v := spec.WriteCapacityAutoScaling; v != nil && !v.AutoScalingDisabled {
+			return fmt.Errorf("write capacity auto scaling is still enabled for %s", n)
 		}
 
 		return nil
@@ -907,6 +1269,236 @@ resource "aws_keyspaces_table" "test" {
     partition_key {
       name = "message"
     }
+  }
+}
+`, rName1, rName2)
+}
+
+func testAccTableConfig_autoScaling(rName1, rName2 string, minimumUnits, maximumUnits, targetValue int) string {
+	return fmt.Sprintf(`
+resource "aws_keyspaces_keyspace" "test" {
+  name = %[1]q
+}
+
+resource "aws_keyspaces_table" "test" {
+  keyspace_name = aws_keyspaces_keyspace.test.name
+  table_name    = %[2]q
+
+  schema_definition {
+    column {
+      name = "message"
+      type = "ascii"
+    }
+
+    partition_key {
+      name = "message"
+    }
+  }
+
+  capacity_specification {
+    throughput_mode      = "PROVISIONED"
+    read_capacity_units  = %[3]d
+    write_capacity_units = %[3]d
+  }
+
+  auto_scaling_specification {
+    read_capacity_auto_scaling {
+      minimum_units = %[3]d
+      maximum_units = %[4]d
+      target_tracking_scaling_policy_configuration {
+        target_value = %[5]d
+      }
+    }
+    write_capacity_auto_scaling {
+      minimum_units = %[3]d
+      maximum_units = %[4]d
+      target_tracking_scaling_policy_configuration {
+        target_value = %[5]d
+      }
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      capacity_specification[0].read_capacity_units,
+      capacity_specification[0].write_capacity_units,
+    ]
+  }
+}
+`, rName1, rName2, minimumUnits, maximumUnits, targetValue)
+}
+
+func testAccTableConfig_autoScalingDisabled(rName1, rName2 string, capacityUnits int) string {
+	return fmt.Sprintf(`
+resource "aws_keyspaces_keyspace" "test" {
+  name = %[1]q
+}
+
+resource "aws_keyspaces_table" "test" {
+  keyspace_name = aws_keyspaces_keyspace.test.name
+  table_name    = %[2]q
+
+  schema_definition {
+    column {
+      name = "message"
+      type = "ascii"
+    }
+
+    partition_key {
+      name = "message"
+    }
+  }
+
+  capacity_specification {
+    throughput_mode      = "PROVISIONED"
+    read_capacity_units  = %[3]d
+    write_capacity_units = %[3]d
+  }
+
+  auto_scaling_specification {
+    read_capacity_auto_scaling {
+      auto_scaling_disabled = true
+    }
+    write_capacity_auto_scaling {
+      auto_scaling_disabled = true
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      capacity_specification[0].read_capacity_units,
+      capacity_specification[0].write_capacity_units,
+    ]
+  }
+}
+`, rName1, rName2, capacityUnits)
+}
+
+func testAccTableConfig_autoScalingPayPerRequest(rName1, rName2 string) string {
+	return fmt.Sprintf(`
+resource "aws_keyspaces_keyspace" "test" {
+  name = %[1]q
+}
+
+resource "aws_keyspaces_table" "test" {
+  keyspace_name = aws_keyspaces_keyspace.test.name
+  table_name    = %[2]q
+
+  schema_definition {
+    column {
+      name = "message"
+      type = "ascii"
+    }
+
+    partition_key {
+      name = "message"
+    }
+  }
+
+  capacity_specification {
+    throughput_mode = "PAY_PER_REQUEST"
+  }
+
+  auto_scaling_specification {
+    read_capacity_auto_scaling {
+      minimum_units = 5
+      maximum_units = 10
+      target_tracking_scaling_policy_configuration {
+        target_value = 70
+      }
+    }
+  }
+}
+`, rName1, rName2)
+}
+
+func testAccTableConfig_autoScalingOmittedCapacitySpecification(rName1, rName2 string) string {
+	return fmt.Sprintf(`
+resource "aws_keyspaces_keyspace" "test" {
+  name = %[1]q
+}
+
+resource "aws_keyspaces_table" "test" {
+  keyspace_name = aws_keyspaces_keyspace.test.name
+  table_name    = %[2]q
+
+  schema_definition {
+    column {
+      name = "message"
+      type = "ascii"
+    }
+
+    partition_key {
+      name = "message"
+    }
+  }
+
+  auto_scaling_specification {
+    read_capacity_auto_scaling {
+      minimum_units = 5
+      maximum_units = 10
+      target_tracking_scaling_policy_configuration {
+        target_value = 70
+      }
+    }
+  }
+}
+`, rName1, rName2)
+}
+
+func testAccTableConfig_provisionedCapacity(rName1, rName2 string, units int) string {
+	return fmt.Sprintf(`
+resource "aws_keyspaces_keyspace" "test" {
+  name = %[1]q
+}
+
+resource "aws_keyspaces_table" "test" {
+  keyspace_name = aws_keyspaces_keyspace.test.name
+  table_name    = %[2]q
+
+  schema_definition {
+    column {
+      name = "message"
+      type = "ascii"
+    }
+
+    partition_key {
+      name = "message"
+    }
+  }
+
+  capacity_specification {
+    throughput_mode      = "PROVISIONED"
+    read_capacity_units  = %[3]d
+    write_capacity_units = %[3]d
+  }
+}
+`, rName1, rName2, units)
+}
+
+func testAccTableConfig_payPerRequestExplicit(rName1, rName2 string) string {
+	return fmt.Sprintf(`
+resource "aws_keyspaces_keyspace" "test" {
+  name = %[1]q
+}
+
+resource "aws_keyspaces_table" "test" {
+  keyspace_name = aws_keyspaces_keyspace.test.name
+  table_name    = %[2]q
+
+  schema_definition {
+    column {
+      name = "message"
+      type = "ascii"
+    }
+
+    partition_key {
+      name = "message"
+    }
+  }
+
+  capacity_specification {
+    throughput_mode = "PAY_PER_REQUEST"
   }
 }
 `, rName1, rName2)

--- a/website/docs/r/keyspaces_table.html.markdown
+++ b/website/docs/r/keyspaces_table.html.markdown
@@ -32,6 +32,58 @@ resource "aws_keyspaces_table" "example" {
 }
 ```
 
+### Auto Scaling
+
+~> **Note:** We recommend using `lifecycle` [`ignore_changes`](https://www.terraform.io/docs/configuration/meta-arguments/lifecycle.html#ignore_changes) for `capacity_specification` when using `auto_scaling_specification`.
+
+```terraform
+resource "aws_keyspaces_table" "example" {
+  keyspace_name = aws_keyspaces_keyspace.example.name
+  table_name    = "my_table"
+
+  schema_definition {
+    column {
+      name = "Message"
+      type = "ASCII"
+    }
+
+    partition_key {
+      name = "Message"
+    }
+  }
+
+  capacity_specification {
+    throughput_mode      = "PROVISIONED"
+    read_capacity_units  = 5
+    write_capacity_units = 5
+  }
+
+  auto_scaling_specification {
+    read_capacity_auto_scaling {
+      minimum_units = 5
+      maximum_units = 10
+      target_tracking_scaling_policy_configuration {
+        target_value = 70
+      }
+    }
+    write_capacity_auto_scaling {
+      minimum_units = 5
+      maximum_units = 10
+      target_tracking_scaling_policy_configuration {
+        target_value = 70
+      }
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      capacity_specification[0].read_capacity_units,
+      capacity_specification[0].write_capacity_units,
+    ]
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are required:
@@ -42,6 +94,7 @@ The following arguments are required:
 The following arguments are optional:
 
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
+* `auto_scaling_specification` - (Optional) Specifies the auto scaling settings for a table in provisioned capacity mode. Can only be set when `capacity_specification.throughput_mode` is `PROVISIONED`. More information can be found in the [Developer Guide](https://docs.aws.amazon.com/keyspaces/latest/devguide/autoscaling.html).
 * `capacity_specification` - (Optional) Specifies the read/write throughput capacity mode for the table.
 * `client_side_timestamps` - (Optional) Enables client-side timestamps for the table. By default, the setting is disabled.
 * `comment` - (Optional) A description of the table.
@@ -51,6 +104,33 @@ The following arguments are optional:
 * `schema_definition` - (Optional) Describes the schema of the table.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `ttl` - (Optional) Enables Time to Live custom settings for the table. More information can be found in the [Developer Guide](https://docs.aws.amazon.com/keyspaces/latest/devguide/TTL.html).
+
+~> **Note:** We recommend using `lifecycle` [`ignore_changes`](https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle#ignore_changes) for `capacity_specification[0].read_capacity_units` and `capacity_specification[0].write_capacity_units` if `auto_scaling_specification` is set, since Amazon Keyspaces continually adjusts those values in the background. See the [Auto Scaling example](#auto-scaling) above.
+
+~> **Note:** Reading back `auto_scaling_specification` requires the `application-autoscaling:DescribeScalableTargets` and `application-autoscaling:DescribeScalingPolicies` IAM permissions, in addition to the usual `keyspaces:*` permissions, because Amazon Keyspaces auto scaling is implemented on top of Application Auto Scaling. See the [Developer Guide](https://docs.aws.amazon.com/keyspaces/latest/devguide/autoscaling.html) for details. When `auto_scaling_specification` is managed, missing these permissions is a hard error, because the setting cannot be refreshed or checked for drift. Tables that do not manage `auto_scaling_specification` are unaffected.
+
+~> **Note:** Removing the `auto_scaling_specification` block from your configuration disables auto scaling on the table (it does not retain the existing settings). Because of this, a table [imported](#import) with auto scaling enabled but no block in configuration will plan to disable auto scaling until you add the block.
+
+~> **Note:** Changing `capacity_specification.throughput_mode` from `PAY_PER_REQUEST` to `PROVISIONED` requires `read_capacity_units` and `write_capacity_units`. If those units are held under `ignore_changes` (as recommended when auto scaling is enabled), perform the `throughput_mode` change in a separate apply *before* adding `ignore_changes`; otherwise the plan is rejected because the required units are not part of the planned change.
+
+The `auto_scaling_specification` object takes the following arguments:
+
+* `read_capacity_auto_scaling` - (Optional) The auto scaling settings for the table's read capacity.
+* `write_capacity_auto_scaling` - (Optional) The auto scaling settings for the table's write capacity.
+
+The `read_capacity_auto_scaling` and `write_capacity_auto_scaling` objects take the following arguments:
+
+* `auto_scaling_disabled` - (Optional) Whether auto scaling is disabled for the table. Defaults to `false`.
+* `maximum_units` - (Required when auto scaling is enabled) The maximum level of throughput the table should always be ready to support. Must be between 1 and the max throughput per second quota for the account (40,000 by default).
+* `minimum_units` - (Required when auto scaling is enabled) The minimum level of throughput the table should always be ready to support. Must be between 1 and the max throughput per second quota for the account (40,000 by default).
+* `target_tracking_scaling_policy_configuration` - (Required when auto scaling is enabled) Describes a target tracking scaling policy configuration, the only scaling policy type Amazon Keyspaces auto scaling currently supports.
+
+The `target_tracking_scaling_policy_configuration` object takes the following arguments:
+
+* `disable_scale_in` - (Optional) A boolean that specifies if scale-in is disabled or enabled for the table. Defaults to `false`, meaning capacity can be automatically scaled down.
+* `scale_in_cooldown` - (Optional) The cooldown period in seconds between scale-in activities. Defaults to `0`.
+* `scale_out_cooldown` - (Optional) The cooldown period in seconds between scale-out activities. Defaults to `0`.
+* `target_value` - (Required when auto scaling is enabled) The target utilization rate of the table, as a percentage between `20` and `90`.
 
 The `capacity_specification` object takes the following arguments:
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

n/a

### Description

Implements autoscaling for Keyspaces.

AWS exposes autoscaling for Keyspaces in a different way than it does e.g. for DynamoDB, as part of a direct Keyspaces API call and not utilizing the generic Autoscaling API. This is mirrored in the PR.

- auto_scaling_specification is `Optional`, not `Optional` + `Computed` like its siblings. This is deliberate. With `Computed`, removing the block from config retains the prior value and autoscaling stays on. Without it, removal produces a diff and the update disables autoscaling. Removing the block should turn autoscaling off. An imported table with autoscaling on but no block in config will plan to disable it.
- Reading autoscaling needs `application-autoscaling:DescribeScalableTargets` and `DescribeScalingPolicies`, on top of `keyspaces:*` If a table manages the block and lacks these, the read errors. If it doesn't manage the block, the read tolerates the denial.
- Switching `PAY_PER_REQUEST` → `PROVISIONED` while capacity units sit under ignore_changes errors at plan time. The API needs the units, but the plan doesn't carry them. Rather than reach around the plan to pull them from raw config, we reject it. User would need to do the mode switch first, then add ignore_changes.
- A fully-disabled spec read back from AWS is treated as absent, so a table with no block doesn't drift. 

### Relations

Closes #35490 

### References

[AWS API ref docs](https://docs.aws.amazon.com/keyspaces/latest/APIReference/API_UpdateTable.html)

AWS Docs:

  - [Configure and update Amazon Keyspaces automatic scaling policies](https://docs.aws.amazon.com/keyspaces/latest/devguide/autoscaling.configure.html)
  - [Configure automatic scaling on an existing table](https://docs.aws.amazon.com/keyspaces/latest/devguide/autoscaling.configureTable.html)

### Output from Acceptance Testing

```console
❯ AWS_DEFAULT_REGION=eu-west-1 TF_ACC=1 make testacc PKG=keyspaces
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework (cached)
make: Running acceptance tests on branch: 🌿 f-add-keyspaces-autoscaling 🌿...
TF_ACC=1 go1.26.5 test ./internal/service/keyspaces/... -v -count 1 -parallel 20   -timeout 360m -vet=off -buildvcs=false
2026/07/22 15:54:21 Creating Terraform AWS Provider (SDKv2-style)...
2026/07/22 15:54:21 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccKeyspacesKeyspace_basic
=== PAUSE TestAccKeyspacesKeyspace_basic
=== RUN   TestAccKeyspacesKeyspace_replicationSpecificationMulti
=== PAUSE TestAccKeyspacesKeyspace_replicationSpecificationMulti
=== RUN   TestAccKeyspacesKeyspace_disappears
=== PAUSE TestAccKeyspacesKeyspace_disappears
=== RUN   TestAccKeyspacesKeyspace_tags
=== PAUSE TestAccKeyspacesKeyspace_tags
=== RUN   TestEndpointConfiguration
=== RUN   TestEndpointConfiguration/use_fips_config
=== RUN   TestEndpointConfiguration/no_config
=== RUN   TestEndpointConfiguration/service_aws_envvar_overrides_base_config_file
=== RUN   TestEndpointConfiguration/base_endpoint_envvar
=== RUN   TestEndpointConfiguration/base_endpoint_config_file
=== RUN   TestEndpointConfiguration/package_name_endpoint_config_overrides_aws_service_envvar
=== RUN   TestEndpointConfiguration/package_name_endpoint_config_overrides_base_envvar
=== RUN   TestEndpointConfiguration/package_name_endpoint_config_overrides_base_config_file
=== RUN   TestEndpointConfiguration/service_config_file_overrides_base_config_file
=== RUN   TestEndpointConfiguration/service_aws_envvar
=== RUN   TestEndpointConfiguration/service_aws_envvar_overrides_base_envvar
=== RUN   TestEndpointConfiguration/base_endpoint_envvar_overrides_base_config_file
=== RUN   TestEndpointConfiguration/use_fips_config_with_package_name_endpoint_config
=== RUN   TestEndpointConfiguration/package_name_endpoint_config
=== RUN   TestEndpointConfiguration/package_name_endpoint_config_overrides_service_config_file
=== RUN   TestEndpointConfiguration/service_aws_envvar_overrides_service_config_file
=== RUN   TestEndpointConfiguration/base_endpoint_envvar_overrides_service_config_file
=== RUN   TestEndpointConfiguration/service_config_file
--- PASS: TestEndpointConfiguration (0.34s)
    --- PASS: TestEndpointConfiguration/use_fips_config (0.01s)
    --- PASS: TestEndpointConfiguration/no_config (0.01s)
    --- PASS: TestEndpointConfiguration/service_aws_envvar_overrides_base_config_file (0.01s)
    --- PASS: TestEndpointConfiguration/base_endpoint_envvar (0.01s)
    --- PASS: TestEndpointConfiguration/base_endpoint_config_file (0.01s)
    --- PASS: TestEndpointConfiguration/package_name_endpoint_config_overrides_aws_service_envvar (0.03s)
    --- PASS: TestEndpointConfiguration/package_name_endpoint_config_overrides_base_envvar (0.02s)
    --- PASS: TestEndpointConfiguration/package_name_endpoint_config_overrides_base_config_file (0.03s)
    --- PASS: TestEndpointConfiguration/service_config_file_overrides_base_config_file (0.01s)
    --- PASS: TestEndpointConfiguration/service_aws_envvar (0.01s)
    --- PASS: TestEndpointConfiguration/service_aws_envvar_overrides_base_envvar (0.01s)
    --- PASS: TestEndpointConfiguration/base_endpoint_envvar_overrides_base_config_file (0.01s)
    --- PASS: TestEndpointConfiguration/use_fips_config_with_package_name_endpoint_config (0.03s)
    --- PASS: TestEndpointConfiguration/package_name_endpoint_config (0.03s)
    --- PASS: TestEndpointConfiguration/package_name_endpoint_config_overrides_service_config_file (0.03s)
    --- PASS: TestEndpointConfiguration/service_aws_envvar_overrides_service_config_file (0.01s)
    --- PASS: TestEndpointConfiguration/base_endpoint_envvar_overrides_service_config_file (0.01s)
    --- PASS: TestEndpointConfiguration/service_config_file (0.01s)
=== RUN   TestExpandTargetTrackingScalingPolicyConfiguration
=== PAUSE TestExpandTargetTrackingScalingPolicyConfiguration
=== RUN   TestFlattenTargetTrackingScalingPolicyConfiguration
=== PAUSE TestFlattenTargetTrackingScalingPolicyConfiguration
=== RUN   TestExpandAutoScalingSettings
=== PAUSE TestExpandAutoScalingSettings
=== RUN   TestFlattenAutoScalingSettings
=== PAUSE TestFlattenAutoScalingSettings
=== RUN   TestExpandAutoScalingSpecification
=== PAUSE TestExpandAutoScalingSpecification
=== RUN   TestFlattenAutoScalingSpecification
=== PAUSE TestFlattenAutoScalingSpecification
=== RUN   TestExpandAutoScalingSpecificationDisabled
=== PAUSE TestExpandAutoScalingSpecificationDisabled
=== RUN   TestAccKeyspacesTable_basic
=== PAUSE TestAccKeyspacesTable_basic
=== RUN   TestAccKeyspacesTable_disappears
=== PAUSE TestAccKeyspacesTable_disappears
=== RUN   TestAccKeyspacesTable_tags
=== PAUSE TestAccKeyspacesTable_tags
=== RUN   TestAccKeyspacesTable_clientSideTimestamps
=== PAUSE TestAccKeyspacesTable_clientSideTimestamps
=== RUN   TestAccKeyspacesTable_multipleColumns
=== PAUSE TestAccKeyspacesTable_multipleColumns
=== RUN   TestAccKeyspacesTable_update
=== PAUSE TestAccKeyspacesTable_update
=== RUN   TestAccKeyspacesTable_addColumns
=== PAUSE TestAccKeyspacesTable_addColumns
=== RUN   TestAccKeyspacesTable_delColumns
=== PAUSE TestAccKeyspacesTable_delColumns
=== RUN   TestAccKeyspacesTable_autoScaling_basic
=== PAUSE TestAccKeyspacesTable_autoScaling_basic
=== RUN   TestAccKeyspacesTable_autoScaling_update
=== PAUSE TestAccKeyspacesTable_autoScaling_update
=== RUN   TestAccKeyspacesTable_autoScaling_disabled
=== PAUSE TestAccKeyspacesTable_autoScaling_disabled
=== RUN   TestAccKeyspacesTable_autoScaling_payPerRequestConflict
=== PAUSE TestAccKeyspacesTable_autoScaling_payPerRequestConflict
=== RUN   TestAccKeyspacesTable_autoScaling_omittedCapacitySpecificationConflict
=== PAUSE TestAccKeyspacesTable_autoScaling_omittedCapacitySpecificationConflict
=== RUN   TestAccKeyspacesTable_autoScaling_invertedRangeConflict
=== PAUSE TestAccKeyspacesTable_autoScaling_invertedRangeConflict
=== RUN   TestAccKeyspacesTable_autoScaling_removal
=== PAUSE TestAccKeyspacesTable_autoScaling_removal
=== RUN   TestAccKeyspacesTable_autoScaling_enableWithModeSwitch
=== PAUSE TestAccKeyspacesTable_autoScaling_enableWithModeSwitch
=== RUN   TestAccKeyspacesTable_autoScaling_modeSwitchWithIgnoredUnitsConflict
=== PAUSE TestAccKeyspacesTable_autoScaling_modeSwitchWithIgnoredUnitsConflict
=== RUN   TestAccKeyspacesTable_autoScaling_disableWithModeSwitch
=== PAUSE TestAccKeyspacesTable_autoScaling_disableWithModeSwitch
=== CONT  TestAccKeyspacesKeyspace_basic
=== CONT  TestAccKeyspacesTable_multipleColumns
=== CONT  TestExpandAutoScalingSpecification
=== CONT  TestExpandTargetTrackingScalingPolicyConfiguration
=== CONT  TestExpandAutoScalingSettings
=== CONT  TestAccKeyspacesKeyspace_disappears
=== CONT  TestAccKeyspacesTable_autoScaling_modeSwitchWithIgnoredUnitsConflict
=== RUN   TestExpandAutoScalingSpecification/nil_map
=== RUN   TestExpandAutoScalingSettings/explicit_false_auto_scaling_disabled_is_preserved,_with_units_and_nested_policy_expanded
=== PAUSE TestExpandAutoScalingSpecification/nil_map
=== RUN   TestExpandAutoScalingSpecification/neither_read_nor_write_set
=== PAUSE TestExpandAutoScalingSettings/explicit_false_auto_scaling_disabled_is_preserved,_with_units_and_nested_policy_expanded
=== PAUSE TestExpandAutoScalingSpecification/neither_read_nor_write_set
=== CONT  TestAccKeyspacesTable_clientSideTimestamps
=== RUN   TestExpandAutoScalingSettings/auto_scaling_disabled_true_omits_minimum/maximum_units_and_scaling_policy
=== PAUSE TestExpandAutoScalingSettings/auto_scaling_disabled_true_omits_minimum/maximum_units_and_scaling_policy
=== CONT  TestAccKeyspacesKeyspace_tags
=== CONT  TestAccKeyspacesTable_disappears
=== CONT  TestAccKeyspacesTable_tags
=== CONT  TestExpandAutoScalingSpecificationDisabled
=== CONT  TestFlattenTargetTrackingScalingPolicyConfiguration
=== RUN   TestExpandTargetTrackingScalingPolicyConfiguration/nil_map
=== PAUSE TestExpandTargetTrackingScalingPolicyConfiguration/nil_map
=== CONT  TestAccKeyspacesTable_autoScaling_payPerRequestConflict
=== CONT  TestAccKeyspacesTable_basic
=== RUN   TestExpandAutoScalingSpecification/only_read_capacity_auto_scaling_set
=== PAUSE TestExpandAutoScalingSpecification/only_read_capacity_auto_scaling_set
=== CONT  TestFlattenAutoScalingSpecification
=== RUN   TestExpandAutoScalingSpecification/only_write_capacity_auto_scaling_set
=== CONT  TestAccKeyspacesTable_autoScaling_disableWithModeSwitch
=== PAUSE TestExpandAutoScalingSpecification/only_write_capacity_auto_scaling_set
=== RUN   TestExpandAutoScalingSpecification/both_read_and_write_set
=== RUN   TestExpandAutoScalingSettings/nil_map
=== RUN   TestFlattenAutoScalingSpecification/only_WriteCapacityAutoScaling_set
=== PAUSE TestFlattenAutoScalingSpecification/only_WriteCapacityAutoScaling_set
=== CONT  TestAccKeyspacesTable_autoScaling_removal
=== RUN   TestFlattenTargetTrackingScalingPolicyConfiguration/nil
=== CONT  TestFlattenAutoScalingSettings
=== RUN   TestExpandAutoScalingSpecificationDisabled/nil_map_does_not_panic_and_returns_nil
=== RUN   TestFlattenAutoScalingSettings/nil
=== PAUSE TestExpandAutoScalingSpecificationDisabled/nil_map_does_not_panic_and_returns_nil
=== PAUSE TestFlattenAutoScalingSettings/nil
=== RUN   TestExpandAutoScalingSpecificationDisabled/forces_AutoScalingDisabled_true_on_both_settings_and_omits_prior_values
=== RUN   TestExpandTargetTrackingScalingPolicyConfiguration/zero-value_bools_and_cooldowns_are_preserved,_not_dropped
=== RUN   TestFlattenAutoScalingSettings/false_auto_scaling_disabled_and_units_surface;_nil_scaling_policy_is_omitted
=== CONT  TestAccKeyspacesTable_autoScaling_enableWithModeSwitch
=== PAUSE TestExpandTargetTrackingScalingPolicyConfiguration/zero-value_bools_and_cooldowns_are_preserved,_not_dropped
=== PAUSE TestExpandAutoScalingSettings/nil_map
=== PAUSE TestFlattenAutoScalingSettings/false_auto_scaling_disabled_and_units_surface;_nil_scaling_policy_is_omitted
=== PAUSE TestExpandAutoScalingSpecification/both_read_and_write_set
=== RUN   TestFlattenAutoScalingSettings/nil_MinimumUnits/MaximumUnits_pointers_are_omitted_from_the_map
=== RUN   TestFlattenAutoScalingSpecification/nil
=== PAUSE TestFlattenAutoScalingSettings/nil_MinimumUnits/MaximumUnits_pointers_are_omitted_from_the_map
=== CONT  TestAccKeyspacesTable_autoScaling_disabled
=== PAUSE TestFlattenTargetTrackingScalingPolicyConfiguration/nil
=== PAUSE TestFlattenAutoScalingSpecification/nil
=== RUN   TestFlattenTargetTrackingScalingPolicyConfiguration/zero-value_bools_and_cooldowns_surface,_not_omitted
=== RUN   TestFlattenAutoScalingSpecification/only_ReadCapacityAutoScaling_set
=== PAUSE TestFlattenTargetTrackingScalingPolicyConfiguration/zero-value_bools_and_cooldowns_surface,_not_omitted
=== PAUSE TestFlattenAutoScalingSpecification/only_ReadCapacityAutoScaling_set
=== PAUSE TestExpandAutoScalingSpecificationDisabled/forces_AutoScalingDisabled_true_on_both_settings_and_omits_prior_values
=== CONT  TestAccKeyspacesTable_autoScaling_update
=== RUN   TestFlattenTargetTrackingScalingPolicyConfiguration/non-zero-value_bools_and_cooldowns
=== PAUSE TestFlattenTargetTrackingScalingPolicyConfiguration/non-zero-value_bools_and_cooldowns
=== CONT  TestAccKeyspacesKeyspace_replicationSpecificationMulti
=== RUN   TestExpandAutoScalingSpecificationDisabled/only_read_set_does_not_populate_write
=== PAUSE TestExpandAutoScalingSpecificationDisabled/only_read_set_does_not_populate_write
=== CONT  TestAccKeyspacesTable_autoScaling_basic
=== CONT  TestAccKeyspacesTable_addColumns
=== RUN   TestFlattenAutoScalingSettings/full_round_trip_includes_the_nested_scaling_policy
=== RUN   TestExpandTargetTrackingScalingPolicyConfiguration/non-zero-value_bools_and_cooldowns
=== PAUSE TestFlattenAutoScalingSettings/full_round_trip_includes_the_nested_scaling_policy
=== CONT  TestAccKeyspacesTable_delColumns
=== PAUSE TestExpandTargetTrackingScalingPolicyConfiguration/non-zero-value_bools_and_cooldowns
=== CONT  TestAccKeyspacesTable_autoScaling_invertedRangeConflict
--- PASS: TestAccKeyspacesTable_autoScaling_invertedRangeConflict (13.41s)
=== CONT  TestAccKeyspacesTable_autoScaling_omittedCapacitySpecificationConflict
--- PASS: TestAccKeyspacesTable_autoScaling_payPerRequestConflict (13.68s)
=== CONT  TestAccKeyspacesTable_update
--- PASS: TestAccKeyspacesTable_autoScaling_omittedCapacitySpecificationConflict (15.49s)
=== CONT  TestExpandAutoScalingSettings/explicit_false_auto_scaling_disabled_is_preserved,_with_units_and_nested_policy_expanded
=== CONT  TestExpandAutoScalingSettings/auto_scaling_disabled_true_omits_minimum/maximum_units_and_scaling_policy
=== CONT  TestExpandAutoScalingSettings/nil_map
--- PASS: TestExpandAutoScalingSettings (0.00s)
    --- PASS: TestExpandAutoScalingSettings/explicit_false_auto_scaling_disabled_is_preserved,_with_units_and_nested_policy_expanded (0.00s)
    --- PASS: TestExpandAutoScalingSettings/auto_scaling_disabled_true_omits_minimum/maximum_units_and_scaling_policy (0.00s)
    --- PASS: TestExpandAutoScalingSettings/nil_map (0.00s)
=== CONT  TestExpandAutoScalingSpecification/nil_map
=== CONT  TestExpandAutoScalingSpecification/only_read_capacity_auto_scaling_set
=== CONT  TestExpandAutoScalingSpecification/only_write_capacity_auto_scaling_set
=== CONT  TestExpandAutoScalingSpecification/both_read_and_write_set
=== CONT  TestExpandAutoScalingSpecification/neither_read_nor_write_set
--- PASS: TestExpandAutoScalingSpecification (0.00s)
    --- PASS: TestExpandAutoScalingSpecification/nil_map (0.00s)
    --- PASS: TestExpandAutoScalingSpecification/only_read_capacity_auto_scaling_set (0.00s)
    --- PASS: TestExpandAutoScalingSpecification/only_write_capacity_auto_scaling_set (0.00s)
    --- PASS: TestExpandAutoScalingSpecification/both_read_and_write_set (0.00s)
    --- PASS: TestExpandAutoScalingSpecification/neither_read_nor_write_set (0.00s)
=== CONT  TestFlattenAutoScalingSpecification/only_WriteCapacityAutoScaling_set
=== CONT  TestFlattenAutoScalingSpecification/only_ReadCapacityAutoScaling_set
=== CONT  TestFlattenAutoScalingSpecification/nil
--- PASS: TestFlattenAutoScalingSpecification (0.00s)
    --- PASS: TestFlattenAutoScalingSpecification/only_WriteCapacityAutoScaling_set (0.00s)
    --- PASS: TestFlattenAutoScalingSpecification/only_ReadCapacityAutoScaling_set (0.00s)
    --- PASS: TestFlattenAutoScalingSpecification/nil (0.00s)
=== CONT  TestFlattenTargetTrackingScalingPolicyConfiguration/nil
=== CONT  TestFlattenTargetTrackingScalingPolicyConfiguration/non-zero-value_bools_and_cooldowns
=== CONT  TestFlattenTargetTrackingScalingPolicyConfiguration/zero-value_bools_and_cooldowns_surface,_not_omitted
--- PASS: TestFlattenTargetTrackingScalingPolicyConfiguration (0.00s)
    --- PASS: TestFlattenTargetTrackingScalingPolicyConfiguration/nil (0.00s)
    --- PASS: TestFlattenTargetTrackingScalingPolicyConfiguration/non-zero-value_bools_and_cooldowns (0.00s)
    --- PASS: TestFlattenTargetTrackingScalingPolicyConfiguration/zero-value_bools_and_cooldowns_surface,_not_omitted (0.00s)
=== CONT  TestExpandAutoScalingSpecificationDisabled/nil_map_does_not_panic_and_returns_nil
=== CONT  TestExpandAutoScalingSpecificationDisabled/only_read_set_does_not_populate_write
=== CONT  TestExpandAutoScalingSpecificationDisabled/forces_AutoScalingDisabled_true_on_both_settings_and_omits_prior_values
--- PASS: TestExpandAutoScalingSpecificationDisabled (0.00s)
    --- PASS: TestExpandAutoScalingSpecificationDisabled/nil_map_does_not_panic_and_returns_nil (0.00s)
    --- PASS: TestExpandAutoScalingSpecificationDisabled/only_read_set_does_not_populate_write (0.00s)
    --- PASS: TestExpandAutoScalingSpecificationDisabled/forces_AutoScalingDisabled_true_on_both_settings_and_omits_prior_values (0.00s)
=== CONT  TestFlattenAutoScalingSettings/nil
=== CONT  TestFlattenAutoScalingSettings/nil_MinimumUnits/MaximumUnits_pointers_are_omitted_from_the_map
=== CONT  TestFlattenAutoScalingSettings/full_round_trip_includes_the_nested_scaling_policy
=== CONT  TestFlattenAutoScalingSettings/false_auto_scaling_disabled_and_units_surface;_nil_scaling_policy_is_omitted
--- PASS: TestFlattenAutoScalingSettings (0.00s)
    --- PASS: TestFlattenAutoScalingSettings/nil (0.00s)
    --- PASS: TestFlattenAutoScalingSettings/nil_MinimumUnits/MaximumUnits_pointers_are_omitted_from_the_map (0.00s)
    --- PASS: TestFlattenAutoScalingSettings/full_round_trip_includes_the_nested_scaling_policy (0.00s)
    --- PASS: TestFlattenAutoScalingSettings/false_auto_scaling_disabled_and_units_surface;_nil_scaling_policy_is_omitted (0.00s)
=== CONT  TestExpandTargetTrackingScalingPolicyConfiguration/nil_map
=== CONT  TestExpandTargetTrackingScalingPolicyConfiguration/non-zero-value_bools_and_cooldowns
=== CONT  TestExpandTargetTrackingScalingPolicyConfiguration/zero-value_bools_and_cooldowns_are_preserved,_not_dropped
--- PASS: TestExpandTargetTrackingScalingPolicyConfiguration (0.00s)
    --- PASS: TestExpandTargetTrackingScalingPolicyConfiguration/nil_map (0.00s)
    --- PASS: TestExpandTargetTrackingScalingPolicyConfiguration/non-zero-value_bools_and_cooldowns (0.00s)
    --- PASS: TestExpandTargetTrackingScalingPolicyConfiguration/zero-value_bools_and_cooldowns_are_preserved,_not_dropped (0.00s)
--- PASS: TestAccKeyspacesKeyspace_basic (99.79s)
--- PASS: TestAccKeyspacesKeyspace_disappears (130.42s)
--- PASS: TestAccKeyspacesTable_disappears (175.20s)
--- PASS: TestAccKeyspacesTable_autoScaling_modeSwitchWithIgnoredUnitsConflict (184.11s)
--- PASS: TestAccKeyspacesKeyspace_replicationSpecificationMulti (186.39s)
--- PASS: TestAccKeyspacesTable_basic (188.10s)
--- PASS: TestAccKeyspacesTable_autoScaling_basic (188.26s)
--- PASS: TestAccKeyspacesKeyspace_tags (188.74s)
--- PASS: TestAccKeyspacesTable_multipleColumns (198.18s)
--- PASS: TestAccKeyspacesTable_clientSideTimestamps (198.65s)
--- PASS: TestAccKeyspacesTable_autoScaling_disabled (212.00s)
--- PASS: TestAccKeyspacesTable_autoScaling_update (212.06s)
--- PASS: TestAccKeyspacesTable_autoScaling_removal (212.09s)
--- PASS: TestAccKeyspacesTable_addColumns (229.06s)
--- PASS: TestAccKeyspacesTable_tags (238.07s)
--- PASS: TestAccKeyspacesTable_delColumns (242.31s)
--- PASS: TestAccKeyspacesTable_autoScaling_enableWithModeSwitch (332.24s)
--- PASS: TestAccKeyspacesTable_autoScaling_disableWithModeSwitch (336.00s)
--- PASS: TestAccKeyspacesTable_update (430.47s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/keyspaces  451.215s
...
```
