### PR TITLE
resource/aws_dynamodb_table: No longer replace resource when decreasing `warm_throughput` values

### DIFF
--- a/.changelog/49032.txt
+++ b/.changelog/49032.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_dynamodb_table: No longer replace resource when decreasing `warm_throughput` values
+```

--- a/internal/service/dynamodb/table.go
+++ b/internal/service/dynamodb/table.go
@@ -109,24 +109,22 @@ func resourceTable() *schema.Resource {
 			customdiff.ForceNewIfChange("restore_backup_arn", func(_ context.Context, old, new, meta any) bool {
 				return old.(string) != new.(string) && new.(string) != ""
 			}),
-			customdiff.ForceNewIfChange("warm_throughput.0.read_units_per_second", func(_ context.Context, old, new, meta any) bool {
-				// warm_throughput can only be increased, not decreased
-				// i.e., "api error ValidationException: One or more parameter values were invalid: Requested ReadUnitsPerSecond for WarmThroughput for table is lower than current WarmThroughput, decreasing WarmThroughput is not supported"
-				if old, new := old.(int), new.(int); new != 0 && new < old {
-					return true
+			func(_ context.Context, diff *schema.ResourceDiff, _ any) error {
+				if diff.Id() == "" {
+					return nil
 				}
 
-				return false
-			}),
-			customdiff.ForceNewIfChange("warm_throughput.0.write_units_per_second", func(_ context.Context, old, new, meta any) bool {
-				// warm_throughput can only be increased, not decreased
-				// i.e., "api error ValidationException: One or more parameter values were invalid: Requested ReadUnitsPerSecond for WarmThroughput for table is lower than current WarmThroughput, decreasing WarmThroughput is not supported"
-				if old, new := old.(int), new.(int); new != 0 && new < old {
-					return true
+				for _, attr := range []string{"warm_throughput.0.read_units_per_second", "warm_throughput.0.write_units_per_second"} {
+					if diff.HasChange(attr) {
+						old, new := diff.GetChange(attr)
+						if oldVal, newVal := old.(int), new.(int); newVal != 0 && newVal < oldVal {
+							return fmt.Errorf("%s cannot be decreased (current value: %d, requested value: %d)", attr, oldVal, newVal)
+						}
+					}
 				}
 
-				return false
-			}),
+				return nil
+			},
 			suppressTableWarmThroughputDefaults,
 			customDiffGlobalSecondaryIndex,
 			func(_ context.Context, diff *schema.ResourceDiff, _ any) error {

--- a/internal/service/dynamodb/table_test.go
+++ b/internal/service/dynamodb/table_test.go
@@ -8509,7 +8509,7 @@ func TestAccDynamoDBTable_importTable(t *testing.T) {
 
 func TestAccDynamoDBTable_warmThroughput(t *testing.T) {
 	ctx := acctest.Context(t)
-	var conf, confDecreasedThroughput awstypes.TableDescription
+	var conf awstypes.TableDescription
 	resourceName := "aws_dynamodb_table.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
@@ -8564,20 +8564,37 @@ func TestAccDynamoDBTable_warmThroughput(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "warm_throughput.0.write_units_per_second", "4300"),
 				),
 			},
+		},
+	})
+}
+
+func TestAccDynamoDBTable_warmThroughput_decreaseError(t *testing.T) {
+	ctx := acctest.Context(t)
+	var conf awstypes.TableDescription
+	resourceName := "aws_dynamodb_table.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.DynamoDBServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTableDestroy(ctx, t),
+		Steps: []resource.TestStep{
 			{
-				Config: testAccTableConfig_warmThroughput(rName, 6, 6, 12100, 4100),
+				Config: testAccTableConfig_warmThroughput(rName, 5, 5, 12200, 4200),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckInitialTableExists(ctx, t, resourceName, &confDecreasedThroughput),
-					resource.TestCheckResourceAttr(resourceName, "billing_mode", string(awstypes.BillingModePayPerRequest)),
-					resource.TestCheckResourceAttr(resourceName, "warm_throughput.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "warm_throughput.0.read_units_per_second", "12100"),
-					resource.TestCheckResourceAttr(resourceName, "warm_throughput.0.write_units_per_second", "4100"),
+					testAccCheckInitialTableExists(ctx, t, resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "warm_throughput.0.read_units_per_second", "12200"),
+					resource.TestCheckResourceAttr(resourceName, "warm_throughput.0.write_units_per_second", "4200"),
 				),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionDestroyBeforeCreate),
-					},
-				},
+			},
+			{
+				Config:      testAccTableConfig_warmThroughput(rName, 5, 5, 12100, 4200),
+				ExpectError: regexache.MustCompile(`warm_throughput\.0\.read_units_per_second cannot be decreased \(current value: 12200, requested value: 12100\)`),
+			},
+			{
+				Config:      testAccTableConfig_warmThroughput(rName, 5, 5, 12200, 4100),
+				ExpectError: regexache.MustCompile(`warm_throughput\.0\.write_units_per_second cannot be decreased \(current value: 4200, requested value: 4100\)`),
 			},
 		},
 	})

--- a/website/docs/r/dynamodb_table.html.markdown
+++ b/website/docs/r/dynamodb_table.html.markdown
@@ -473,15 +473,14 @@ The following arguments are optional:
 
 ~> **Note:** Explicitly configuring both `read_units_per_second` and `write_units_per_second` to the default/minimum values will cause Terraform to report differences.
 
-* `read_units_per_second` - (Optional) Number of read operations a table or index can instantaneously support. For the base table, decreasing this value will force a new resource. For a global secondary index, this value can be increased or decreased without recreation. Minimum value of `12000` (default).
-* `write_units_per_second` - (Optional) Number of write operations a table or index can instantaneously support. For the base table, decreasing this value will force a new resource. For a global secondary index, this value can be increased or decreased without recreation. Minimum value of `4000` (default).
+* `read_units_per_second` - (Optional) Number of read operations a table or index can instantaneously support. For the base table, this value cannot be decreased. For a global secondary index, this value can be increased or decreased. Minimum value of `12000` (default).
+* `write_units_per_second` - (Optional) Number of write operations a table or index can instantaneously support. For the base table, this value cannot be decreased. For a global secondary index, this value can be increased or decreased. Minimum value of `4000` (default).
 
 ## Attribute Reference
 
 This resource exports the following attributes in addition to the arguments above:
 
 * `arn` - ARN of the table
-* `id` - Name of the table
 * `replica.*.arn` - ARN of the replica
 * `replica.*.stream_arn` - ARN of the replica Table Stream. Only available when `stream_enabled = true`.
 * `replica.*.stream_label` - Timestamp, in ISO 8601 format, for the replica stream. Note that this timestamp is not a unique identifier for the stream on its own. However, the combination of AWS customer ID, table name and this field is guaranteed to be unique. It can be used for creating CloudWatch Alarms. Only available when `stream_enabled = true`.


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

No longer replaces resource when decreasing `warm_throughput` values, returns plan-time error instead.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

--- PASS: TestAccDynamoDBTable_streamSpecificationValidation (13.88s)
--- PASS: TestAccDynamoDBTable_basic (81.77s)
--- PASS: TestAccDynamoDBTable_Tags_DefaultTags_emptyResourceTag (90.72s)
--- PASS: TestAccDynamoDBTable_lsiNonKeyAttributes (91.30s)
--- PASS: TestAccDynamoDBTable_TTL_disabled (125.86s)
--- PASS: TestAccDynamoDBTable_Identity_basic (125.91s)
--- PASS: TestAccDynamoDBTable_TTL_enabled (127.22s)
--- PASS: TestAccDynamoDBTable_Tags_DefaultTags_updateToResourceOnly (128.44s)
--- PASS: TestAccDynamoDBTable_GsiUpdateNonKeyAttributes_emptyPlan (136.21s)
--- PASS: TestAccDynamoDBTable_Tags_ComputedTag_OnUpdate_replace (138.56s)
--- PASS: TestAccDynamoDBTable_Tags_ComputedTag_OnUpdate_add (139.69s)
--- PASS: TestAccDynamoDBTable_GSI_transitionKeySchemaToHashKey_noChange (153.96s)
--- PASS: TestAccDynamoDBTable_Tags_IgnoreTags_Overlap_defaultTag (156.00s)
--- PASS: TestAccDynamoDBTable_provisioned_gsiUpdateCapacity_DifferentFromTable (156.09s)
--- PASS: TestAccDynamoDBTable_nameKnownAfterApply_attribute_notIndexed (5.05s)
--- PASS: TestAccDynamoDBTable_provisioned_gsiUpdateCapacity_SameAsTable (161.60s)
--- PASS: TestAccDynamoDBTable_Tags_IgnoreTags_Overlap_resourceTag (175.20s)
--- PASS: TestAccDynamoDBTable_GSI_unknown (43.80s)
--- PASS: TestAccDynamoDBTable_streamSpecification (102.20s)
--- PASS: TestAccDynamoDBTable_nameKnownAfterApply_attribute_notIndexed_onUpdate (49.95s)
--- PASS: TestAccDynamoDBTable_nameKnownAfterApply (49.30s)
--- PASS: TestAccDynamoDBTable_GSI_keySchema_OnCreate_multipleHashKeys (91.10s)
--- PASS: TestAccDynamoDBTable_GSI_keySchema_OnCreate_singleHashKey (88.72s)
--- PASS: TestAccDynamoDBTable_BillingMode_payPerRequestToProvisionedIgnoreChanges (217.19s)
--- PASS: TestAccDynamoDBTable_GSI_keySchema_unknown (78.65s)
--- PASS: TestAccDynamoDBTable_gsiOnDemandThroughput (126.52s)
--- PASS: TestAccDynamoDBTable_GSI_keySchema_OnCreate_singleRangeKey (111.08s)
--- PASS: TestAccDynamoDBTable_GSI_transitionHashKeyToKeySchema_noChange (112.44s)
--- PASS: TestAccDynamoDBTable_warmThroughput_decreaseError (55.51s)
--- PASS: TestAccDynamoDBTable_warmThroughputDefault (60.93s)
--- PASS: TestAccDynamoDBTable_onDemandThroughput (159.91s)
--- FAIL: TestAccDynamoDBTable_restoreBackupARN (36.56s)
--- PASS: TestAccDynamoDBTable_tableClass_migrate (74.19s)
--- PASS: TestAccDynamoDBTable_tableClassExplicitDefault (79.36s)
--- PASS: TestAccDynamoDBTable_tableClass_ConcurrentModification (96.76s)
--- PASS: TestAccDynamoDBTable_streamSpecificationDiffs (316.93s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_MixedConsistencyModes (45.54s)
--- PASS: TestAccDynamoDBTable_warmThroughput (118.63s)
--- PASS: TestAccDynamoDBTable_tableClassInfrequentAccess (85.25s)
--- PASS: TestAccDynamoDBTable_importTable (129.85s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_NotEnoughReplicas (50.15s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_TooManyReplicas (50.62s)
--- PASS: TestAccDynamoDBTable_gsiWarmThroughput_switchBilling (221.88s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_tags_updateIsPropagated_twoOfTwo (317.45s)
--- PASS: TestAccDynamoDBTable_backup_overrideEncryption (293.01s)
--- PASS: TestAccDynamoDBTable_Replica_upgradeV6_2_0 (268.03s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_tags_notPropagatedToAddedReplica (255.71s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_tags_nonPropagatedTagsAreUnmanaged (274.38s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_tags_propagateToAddedReplica (271.30s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_tags_nonPropagatedTagsAreUnmanaged (286.19s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_tags_propagateToAddedReplica (271.96s)
--- PASS: TestAccDynamoDBTable_BillingMode_payPerRequestBasic (621.24s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_tags_updateIsPropagated_twoOfTwo (300.53s)
--- PASS: TestAccDynamoDBTable_gsiUpdateNonKeyAttributes (649.77s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_Create_witness_too_many_replicas (41.94s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_tags_updateIsPropagated_oneOfTwo (254.48s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_CreateEventuallyConsistent (493.34s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_tagsUpdate (445.70s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_tagsUpdate (456.49s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_tags_updateIsPropagated_oneOfTwo (308.80s)
--- PASS: TestAccDynamoDBTable_Tags_DefaultTags_nullNonOverlappingResourceTag (35.97s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_pitr (276.52s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_Create (227.55s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_Create_witness (234.05s)
--- PASS: TestAccDynamoDBTable_gsiWarmThroughput_billingPayPerRequest (722.97s)
--- PASS: TestAccDynamoDBTable_gsiWarmThroughput_billingProvisioned (711.42s)
--- PASS: TestAccDynamoDBTable_GSIvalidate_keySchema_tooManyRangeKeys (1.93s)
--- PASS: TestAccDynamoDBTable_GSI_validate_keySchema_tooManyHashKeys (1.95s)
--- PASS: TestAccDynamoDBTable_GSI_validate_exactlyOneOfKeySchemaHashKey (1.71s)
--- PASS: TestAccDynamoDBTable_GSI_validate_rangeKeyConflictsWithKeySchema (1.75s)
--- PASS: TestAccDynamoDBTable_Tags_ComputedTag_onCreate (41.41s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_pitr (305.72s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_pitrKMS (425.33s)
--- PASS: TestAccDynamoDBTable_GSI_keySchema_maxSet (57.31s)
--- PASS: TestAccDynamoDBTable_GSI_keySchema_removeGSI (89.98s)
--- PASS: TestAccDynamoDBTable_enablePITR (85.59s)
--- PASS: TestAccDynamoDBTable_GSI_rangeKeyExplicitEmptyString (88.08s)
--- PASS: TestAccDynamoDBTable_enablePITRWithCustomRecoveryPeriod (106.72s)
--- PASS: TestAccDynamoDBTable_Replica_tags_updateIsPropagated_oneOfTwo (608.19s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_pitrKMS (416.57s)
--- PASS: TestAccDynamoDBTable_Tags_emptyMap (51.68s)
--- PASS: TestAccDynamoDBTable_GSI_keySchema_OnCreate_multipleRangeKeys (64.33s)
--- PASS: TestAccDynamoDBTable_BillingMode_payPerRequestToProvisioned (143.93s)
--- PASS: TestAccDynamoDBTable_Tags_DefaultTags_updateToProviderOnly (62.90s)
--- PASS: TestAccDynamoDBTable_backupEncryption (857.36s)
--- PASS: TestAccDynamoDBTable_Tags_EmptyTag_OnUpdate_replace (86.11s)
--- PASS: TestAccDynamoDBTable_Tags_DefaultTags_overlapping (136.55s)
--- PASS: TestAccDynamoDBTable_Tags_addOnUpdate (99.62s)
--- PASS: TestAccDynamoDBTable_Tags_EmptyTag_onCreate (109.88s)
--- PASS: TestAccDynamoDBTable_Tags_DefaultTags_nonOverlapping (140.13s)
--- PASS: TestAccDynamoDBTable_Tags_EmptyTag_OnUpdate_add (133.54s)
--- PASS: TestAccDynamoDBTable_Tags_DefaultTags_providerOnly (178.18s)
--- PASS: TestAccDynamoDBTable_gsiUpdateOtherAttributes (1169.54s)
--- PASS: TestAccDynamoDBTable_lsiUpdate (62.82s)
--- PASS: TestAccDynamoDBTable_Disappears_payPerRequestWithGSI (106.89s)
--- PASS: TestAccDynamoDBTable_Replica_tags_notPropagatedToAddedReplica (630.21s)
--- PASS: TestAccDynamoDBTable_Replica_tags_propagateToAddedReplica (615.32s)
--- PASS: TestAccDynamoDBTable_Replica_tags_updateIsPropagated_twoOfTwo (605.41s)
--- PASS: TestAccDynamoDBTable_Replica_tags_nonPropagatedTagsAreUnmanaged (672.31s)
--- PASS: TestAccDynamoDBTable_attributeUpdateValidation (5.90s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_witness_doubleAddCMK (780.81s)
--- PASS: TestAccDynamoDBTable_Replica_tagsUpdate (736.79s)
--- PASS: TestAccDynamoDBTable_Tags_DefaultTags_nullOverlappingResourceTag (45.19s)
--- PASS: TestAccDynamoDBTable_Replica_MRSC_doubleAddCMK (839.68s)
--- PASS: TestAccDynamoDBTable_Tags_DefaultTags_emptyProviderOnlyTag (42.31s)
--- PASS: TestAccDynamoDBTable_GSI_keySchema_removeRangeKey (583.73s)
--- PASS: TestAccDynamoDBTable_TTL_validate (2.73s)
--- PASS: TestAccDynamoDBTable_Replica_singleCMK (389.06s)
--- PASS: TestAccDynamoDBTable_Replica_singleStreamSpecification (363.81s)
--- PASS: TestAccDynamoDBTable_encryption (136.88s)
--- PASS: TestAccDynamoDBTable_Replica_singleDefaultKeyEncrypted (384.30s)
--- PASS: TestAccDynamoDBTable_Replica_deletionProtection (1277.38s)
--- PASS: TestAccDynamoDBTable_GSI_keySchema_addRangeKey (609.40s)
--- PASS: TestAccDynamoDBTable_List_includeResource (64.89s)
--- PASS: TestAccDynamoDBTable_List_regionOverride (42.91s)
--- PASS: TestAccDynamoDBTable_disappears (41.99s)
--- PASS: TestAccDynamoDBTable_Tags_null (61.78s)
--- PASS: TestAccDynamoDBTable_BillingModeGSI_payPerRequestToProvisioned (185.69s)
--- PASS: TestAccDynamoDBTable_Replica_singleDefaultKeyEncryptedAmazonOwned (458.22s)
--- PASS: TestAccDynamoDBTable_List_basic (47.14s)
--- PASS: TestAccDynamoDBTable_BillingModeGSI_provisionedToPayPerRequest (207.73s)
--- PASS: TestAccDynamoDBTable_TTL_updateEnable (68.42s)
--- PASS: TestAccDynamoDBTable_deletion_protection (73.46s)
--- PASS: TestAccDynamoDBTable_Identity_ExistingResource_noRefreshNoChange (81.85s)
--- PASS: TestAccDynamoDBTable_tags (148.35s)
--- PASS: TestAccDynamoDBTable_Replica_pitr (578.69s)
--- PASS: TestAccDynamoDBTable_Identity_ExistingResource_basic (77.28s)
--- PASS: TestAccDynamoDBTable_Identity_regionOverride (47.87s)
--- PASS: TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequestIgnoreChanges (168.85s)
--- PASS: TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequest (179.18s)
--- PASS: TestAccDynamoDBTable_Replica_pitrKMS (723.23s)
--- PASS: TestAccDynamoDBTable_Replica_single (650.48s)
--- PASS: TestAccDynamoDBTable_extended (613.35s)
--- PASS: TestAccDynamoDBTable_GSI_transitionKeySchemaToHashKey_removeKey (601.44s)
--- PASS: TestAccDynamoDBTable_GSI_keySchema_removeHashKey (600.24s)
--- PASS: TestAccDynamoDBTable_Replica_multiple (1020.40s)
--- PASS: TestAccDynamoDBTable_restoreCrossRegion (854.13s)
--- PASS: TestAccDynamoDBTable_GSI_keySchema_addHashKey (598.37s)
--- PASS: TestAccDynamoDBTable_GSI_transitionHashKeyToKeySchema_addHashKey (597.24s)
--- PASS: TestAccDynamoDBTable_attributeUpdate (1666.33s)
--- FAIL: TestAccDynamoDBTable_Replica_doubleAddCMK (2506.88s)
--- PASS: TestAccDynamoDBTable_TTL_updateDisable (3673.34s)
```

`TestAccDynamoDBTable_restoreBackupARN` and `TestAccDynamoDBTable_Replica_doubleAddCMK` are pre-existing failures