### PR TITLE
resource/aws_storagegateway_smb_file_share: Allow cache_stale_timeout_in_seconds to be set to 0

### DIFF
--- a/.changelog/49037.txt
+++ b/.changelog/49037.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_storagegateway_smb_file_share: Allow `cache_attributes.cache_stale_timeout_in_seconds` to be set to `0` to disable cache refresh
+```
+
+```release-note:bug
+resource/aws_storagegateway_nfs_file_share: Allow `cache_attributes.cache_stale_timeout_in_seconds` to be set to `0` to disable cache refresh
+```

--- a/internal/service/storagegateway/nfs_file_share.go
+++ b/internal/service/storagegateway/nfs_file_share.go
@@ -73,9 +73,13 @@ func resourceNFSFileShare() *schema.Resource {
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{
 							"cache_stale_timeout_in_seconds": {
-								Type:         schema.TypeInt,
-								Optional:     true,
-								ValidateFunc: validation.IntBetween(300, 2592000),
+								Type:     schema.TypeInt,
+								Optional: true,
+								Default:  0,
+								ValidateFunc: validation.Any(
+									validation.IntInSlice([]int{0}),
+									validation.IntBetween(300, 2592000),
+								),
 							},
 						},
 					},

--- a/internal/service/storagegateway/nfs_file_share_test.go
+++ b/internal/service/storagegateway/nfs_file_share_test.go
@@ -653,6 +653,14 @@ func TestAccStorageGatewayNFSFileShare_cacheAttributes(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "cache_attributes.0.cache_stale_timeout_in_seconds", "300"),
 				),
 			},
+			{
+				Config: testAccNFSFileShareConfig_cacheAttributes(rName, 0),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNFSFileShareExists(ctx, t, resourceName, &nfsFileShare),
+					resource.TestCheckResourceAttr(resourceName, "cache_attributes.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "cache_attributes.0.cache_stale_timeout_in_seconds", "0"),
+				),
+			},
 		},
 	})
 }

--- a/internal/service/storagegateway/smb_file_share.go
+++ b/internal/service/storagegateway/smb_file_share.go
@@ -89,9 +89,13 @@ func resourceSMBFileShare() *schema.Resource {
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{
 							"cache_stale_timeout_in_seconds": {
-								Type:         schema.TypeInt,
-								Optional:     true,
-								ValidateFunc: validation.IntBetween(300, 2592000),
+								Type:     schema.TypeInt,
+								Optional: true,
+								Default:  0,
+								ValidateFunc: validation.Any(
+									validation.IntInSlice([]int{0}),
+									validation.IntBetween(300, 2592000),
+								),
 							},
 						},
 					},
@@ -585,7 +589,7 @@ func expandCacheAttributes(tfMap map[string]any) *awstypes.CacheAttributes {
 
 	apiObject := &awstypes.CacheAttributes{}
 
-	if v, ok := tfMap["cache_stale_timeout_in_seconds"].(int); ok && v != 0 {
+	if v, ok := tfMap["cache_stale_timeout_in_seconds"].(int); ok {
 		apiObject.CacheStaleTimeoutInSeconds = aws.Int32(int32(v))
 	}
 

--- a/internal/service/storagegateway/smb_file_share_test.go
+++ b/internal/service/storagegateway/smb_file_share_test.go
@@ -831,6 +831,14 @@ func TestAccStorageGatewaySMBFileShare_cacheAttributes(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "cache_attributes.0.cache_stale_timeout_in_seconds", "300"),
 				),
 			},
+			{
+				Config: testAccSMBFileShareConfig_cacheAttributes(rName, 0),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSMBFileShareExists(ctx, t, resourceName, &smbFileShare),
+					resource.TestCheckResourceAttr(resourceName, "cache_attributes.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "cache_attributes.0.cache_stale_timeout_in_seconds", "0"),
+				),
+			},
 		},
 	})
 }

--- a/website/docs/r/storagegateway_nfs_file_share.html.markdown
+++ b/website/docs/r/storagegateway_nfs_file_share.html.markdown
@@ -60,7 +60,7 @@ Files and folders stored as Amazon S3 objects in S3 buckets don't, by default, h
 
 * `cache_stale_timeout_in_seconds` - (Optional) Refreshes a file share's cache by using Time To Live (TTL).
  TTL is the length of time since the last refresh after which access to the directory would cause the file gateway
-  to first refresh that directory's contents from the Amazon S3 bucket. Valid Values: 300 to 2,592,000 seconds (5 minutes to 30 days)
+  to first refresh that directory's contents from the Amazon S3 bucket. Valid Values: `0` or `300` to `2592000` seconds (5 minutes to 30 days). Defaults to `0`
 
 ## Attribute Reference
 

--- a/website/docs/r/storagegateway_smb_file_share.html.markdown
+++ b/website/docs/r/storagegateway_smb_file_share.html.markdown
@@ -77,7 +77,7 @@ The `cache_attributes` configuration block supports the following arguments:
 
 * `cache_stale_timeout_in_seconds` - (Optional) Refreshes a file share's cache by using Time To Live (TTL).
  TTL is the length of time since the last refresh after which access to the directory would cause the file gateway
-  to first refresh that directory's contents from the Amazon S3 bucket. Valid Values: 300 to 2,592,000 seconds (5 minutes to 30 days)
+  to first refresh that directory's contents from the Amazon S3 bucket. Valid Values: `0` or `300` to `2592000` seconds (5 minutes to 30 days). Defaults to `0`
 
 ## Attribute Reference
 


### PR DESCRIPTION
## Summary

Fixes #48876. The AWS Storage Gateway API accepts `0` (disable cache
refresh) or `300`-`2,592,000` for `CacheAttributes.CacheStaleTimeoutInSeconds`,
but `aws_storagegateway_smb_file_share` validated the field as
`IntBetween(300, 2592000)`, rejecting `0` at plan time. The identical
validator on `aws_storagegateway_nfs_file_share` had the same problem.

`aws_storagegateway_smb_file_share` also had a second, deeper bug: its
expand function explicitly skipped setting the API field whenever the
value was `0` (`ok && v != 0`), so even with the validator relaxed, `0`
would never reach AWS -- the existing API-side value would be read back
on every refresh, producing a permanent, non-convergent diff.
`aws_storagegateway_nfs_file_share`'s expand function didn't have this
guard, so it only needed the validator fix.

`aws_storagegateway_file_system_association` already handles this
correctly (`validation.Any(IntInSlice([]int{0}), IntBetween(300, 2592000))`
plus `Default: 0`); this applies the same pattern to the SMB and NFS
file share resources, and updates both resources' documentation
accordingly.

## Test plan

- [x] `go build ./internal/service/storagegateway/...`
- [x] `go vet ./internal/service/storagegateway/...`
- [ ] Acceptance tests (`TestAccStorageGatewaySMBFileShare_cacheAttributes`,
      `TestAccStorageGatewayNFSFileShare_cacheAttributes`) - extended with a
      `0` step each, not run locally (requires AWS credentials with Storage
      Gateway access)