### PR TITLE
l/aws_secretsmanager_secret_policy: new list resource 

### DIFF
--- a/.changelog/49058.txt
+++ b/.changelog/49058.txt
@@ -1,0 +1,3 @@
+```release-note:new-list-resource
+aws_secretsmanager_secret_policy
+```

--- a/internal/service/secretsmanager/secret_policy_list.go
+++ b/internal/service/secretsmanager/secret_policy_list.go
@@ -1,0 +1,112 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package secretsmanager
+
+import (
+	"context"
+	"fmt"
+	"iter"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/logging"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
+	inttypes "github.com/hashicorp/terraform-provider-aws/internal/types"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @SDKListResource("aws_secretsmanager_secret_policy")
+func newSecretPolicyResourceAsListResource() inttypes.ListResourceForSDK {
+	l := secretPolicyListResource{}
+	l.SetResourceSchema(resourceSecretPolicy())
+	return &l
+}
+
+var _ list.ListResource = &secretPolicyListResource{}
+
+type secretPolicyListResource struct {
+	framework.ListResourceWithSDKv2Resource
+}
+
+func (l *secretPolicyListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
+	conn := l.Meta().SecretsManagerClient(ctx)
+
+	stream.Results = func(yield func(list.ListResult) bool) {
+		var input secretsmanager.ListSecretsInput
+		for item, err := range listSecretPolicies(ctx, conn, &input) {
+			if err != nil {
+				result := fwdiag.NewListResultErrorDiagnostic(err)
+				yield(result)
+				return
+			}
+
+			arn := aws.ToString(item.ARN)
+			ctx := tflog.SetField(ctx, logging.ResourceAttributeKey(names.AttrARN), arn)
+
+			result := request.NewListResult(ctx)
+
+			rd := l.ResourceData()
+			rd.SetId(arn)
+			rd.Set("secret_arn", arn)
+
+			if request.IncludeResource {
+				rd.Set(names.AttrPolicy, aws.ToString(item.ResourcePolicy))
+			}
+
+			result.DisplayName = aws.ToString(item.Name)
+
+			l.SetResult(ctx, l.Meta(), request.IncludeResource, rd, &result)
+			if result.Diagnostics.HasError() {
+				yield(result)
+				return
+			}
+
+			if !yield(result) {
+				return
+			}
+		}
+	}
+}
+
+func listSecretPolicies(ctx context.Context, conn *secretsmanager.Client, input *secretsmanager.ListSecretsInput) iter.Seq2[*secretsmanager.GetResourcePolicyOutput, error] {
+	return func(yield func(*secretsmanager.GetResourcePolicyOutput, error) bool) {
+		pages := secretsmanager.NewListSecretsPaginator(conn, input)
+		for pages.HasMorePages() {
+			page, err := pages.NextPage(ctx)
+			if err != nil {
+				yield(&secretsmanager.GetResourcePolicyOutput{}, fmt.Errorf("listing Secrets Manager Secret Policy resources: %w", err))
+				return
+			}
+
+			for _, item := range page.SecretList {
+				arn := aws.ToString(item.ARN)
+				output, err := findSecretPolicyByID(ctx, conn, arn)
+
+				if err != nil {
+					// Skip deleted secrets or those without policies
+					if errs.IsA[*awstypes.ResourceNotFoundException](err) ||
+						errs.IsAErrorMessageContains[*awstypes.InvalidRequestException](err, "You can't perform this operation on the secret because it was marked for deletion") ||
+						retry.NotFound(err) ||
+						output.ResourcePolicy == nil ||
+						aws.ToString(output.ResourcePolicy) == "" {
+						continue
+					}
+
+					yield(&secretsmanager.GetResourcePolicyOutput{}, fmt.Errorf("getting resource policy for secret %s: %w", arn, err))
+					return
+				}
+
+				if !yield(output, nil) {
+					return
+				}
+			}
+		}
+	}
+}

--- a/internal/service/secretsmanager/secret_policy_list_test.go
+++ b/internal/service/secretsmanager/secret_policy_list_test.go
@@ -1,0 +1,191 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package secretsmanager_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/YakDriver/regexache"
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	tfknownvalue "github.com/hashicorp/terraform-provider-aws/internal/acctest/knownvalue"
+	tfquerycheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/querycheck"
+	tfqueryfilter "github.com/hashicorp/terraform-provider-aws/internal/acctest/queryfilter"
+	tfstatecheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/statecheck"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccSecretsManagerSecretPolicy_List_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_secretsmanager_secret_policy.test[0]"
+	resourceName2 := "aws_secretsmanager_secret_policy.test[1]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity1 := tfstatecheck.Identity()
+	identity2 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.SecretsManagerServiceID),
+		CheckDestroy:             testAccCheckSecretPolicyDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/SecretPolicy/list_basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+					statecheck.ExpectKnownValue(resourceName1, tfjsonpath.New("secret_arn"), tfknownvalue.RegionalARNRegexp("secretsmanager", regexache.MustCompile(`secret:`+regexp.QuoteMeta(rName+"-0")+`-.+`))),
+					identity2.GetIdentity(resourceName2),
+					statecheck.ExpectKnownValue(resourceName2, tfjsonpath.New("secret_arn"), tfknownvalue.RegionalARNRegexp("secretsmanager", regexache.MustCompile(`secret:`+regexp.QuoteMeta(rName+"-1")+`-.+`))),
+				},
+			},
+
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/SecretPolicy/list_basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_secretsmanager_secret_policy.test", identity1.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_secretsmanager_secret_policy.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), knownvalue.StringExact(rName+"-0")),
+					tfquerycheck.ExpectNoResourceObject("aws_secretsmanager_secret_policy.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks())),
+					tfquerycheck.ExpectIdentityFunc("aws_secretsmanager_secret_policy.test", identity2.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_secretsmanager_secret_policy.test", tfqueryfilter.ByResourceIdentityFunc(identity2.Checks()), knownvalue.StringExact(rName+"-1")),
+					tfquerycheck.ExpectNoResourceObject("aws_secretsmanager_secret_policy.test", tfqueryfilter.ByResourceIdentityFunc(identity2.Checks())),
+				},
+			},
+		},
+	})
+}
+
+func TestAccSecretsManagerSecretPolicy_List_includeResource(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_secretsmanager_secret_policy.test[0]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity1 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.SecretsManagerServiceID),
+		CheckDestroy:             testAccCheckSecretPolicyDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/SecretPolicy/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(1),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+					statecheck.ExpectKnownValue(resourceName1, tfjsonpath.New("secret_arn"), tfknownvalue.RegionalARNRegexp("secretsmanager", regexache.MustCompile(`secret:`+regexp.QuoteMeta(rName+"-0")+`-.+`))),
+				},
+			},
+
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/SecretPolicy/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(1),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_secretsmanager_secret_policy.test", identity1.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_secretsmanager_secret_policy.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), knownvalue.StringExact(rName+"-0")),
+					querycheck.ExpectResourceKnownValues("aws_secretsmanager_secret_policy.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), []querycheck.KnownValueCheck{
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("secret_arn"), tfknownvalue.RegionalARNRegexp("secretsmanager", regexache.MustCompile(`secret:`+regexp.QuoteMeta(rName+"-0")+`-.+`))),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrID), tfknownvalue.RegionalARNRegexp("secretsmanager", regexache.MustCompile(`secret:`+regexp.QuoteMeta(rName+"-0")+`-.+`))),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrPolicy), knownvalue.NotNull()),
+					}),
+				},
+			},
+		},
+	})
+}
+
+func TestAccSecretsManagerSecretPolicy_List_regionOverride(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_secretsmanager_secret_policy.test[0]"
+	resourceName2 := "aws_secretsmanager_secret_policy.test[1]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity1 := tfstatecheck.Identity()
+	identity2 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.SecretsManagerServiceID),
+		CheckDestroy:             acctest.CheckDestroyNoop,
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/SecretPolicy/list_region_override/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+					"region":         config.StringVariable(acctest.AlternateRegion()),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+					statecheck.ExpectKnownValue(resourceName1, tfjsonpath.New("secret_arn"), tfknownvalue.RegionalARNAlternateRegionRegexp("secretsmanager", regexache.MustCompile(`secret:`+regexp.QuoteMeta(rName+"-0")+`-.+`))),
+					identity2.GetIdentity(resourceName2),
+					statecheck.ExpectKnownValue(resourceName2, tfjsonpath.New("secret_arn"), tfknownvalue.RegionalARNAlternateRegionRegexp("secretsmanager", regexache.MustCompile(`secret:`+regexp.QuoteMeta(rName+"-1")+`-.+`))),
+				},
+			},
+
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/SecretPolicy/list_region_override/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+					"region":         config.StringVariable(acctest.AlternateRegion()),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_secretsmanager_secret_policy.test", identity1.Checks()),
+					tfquerycheck.ExpectIdentityFunc("aws_secretsmanager_secret_policy.test", identity2.Checks()),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/secretsmanager/secret_policy_test.go
+++ b/internal/service/secretsmanager/secret_policy_test.go
@@ -117,6 +117,7 @@ func TestAccSecretsManagerSecretPolicy_disappears(t *testing.T) {
 				Config: testAccSecretPolicyConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecretPolicyExists(ctx, t, resourceName, &policy),
+					// nosemgrep:ci.semgrep.acctest.disappears-expect-resource-action
 					acctest.CheckSDKResourceDisappears(ctx, t, tfsecretsmanager.ResourceSecretPolicy(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -125,7 +126,11 @@ func TestAccSecretsManagerSecretPolicy_disappears(t *testing.T) {
 						plancheck.ExpectResourceAction("aws_secretsmanager_secret_policy.test", plancheck.ResourceActionCreate),
 					},
 					PostApplyPostRefresh: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction("aws_secretsmanager_secret_policy.test", plancheck.ResourceActionCreate),
+						// For backwards compatibility the Read operation does NOT check
+						// for nil/empty policy content and remove the resource from state.
+						// This means that out of band removal will result in a planned
+						// update instead of a creation.
+						plancheck.ExpectResourceAction("aws_secretsmanager_secret_policy.test", plancheck.ResourceActionUpdate),
 					},
 				},
 			},

--- a/internal/service/secretsmanager/service_package_gen.go
+++ b/internal/service/secretsmanager/service_package_gen.go
@@ -169,6 +169,13 @@ func (p *servicePackage) SDKListResources(ctx context.Context) iter.Seq[*inttype
 			Identity: inttypes.RegionalARNIdentity(),
 		},
 		{
+			Factory:  newSecretPolicyResourceAsListResource,
+			TypeName: "aws_secretsmanager_secret_policy",
+			Name:     "Secret Policy",
+			Region:   inttypes.ResourceRegionDefault(),
+			Identity: inttypes.RegionalARNIdentityNamed("secret_arn"),
+		},
+		{
 			Factory:  secretVersionResourceAsListResource,
 			TypeName: "aws_secretsmanager_secret_version",
 			Name:     "Secret Version",

--- a/internal/service/secretsmanager/testdata/SecretPolicy/list_basic/main.tf
+++ b/internal/service/secretsmanager/testdata/SecretPolicy/list_basic/main.tf
@@ -1,0 +1,42 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+#
+resource "aws_secretsmanager_secret_policy" "test" {
+  count = var.resource_count
+
+  secret_arn = aws_secretsmanager_secret.test[count.index].arn
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "EnableAllPermissions"
+        Effect = "Allow"
+        Principal = {
+          AWS = "*"
+        }
+        Action   = "secretsmanager:GetSecretValue"
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+resource "aws_secretsmanager_secret" "test" {
+  count = var.resource_count
+
+  name = "${var.rName}-${count.index}"
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}
+

--- a/internal/service/secretsmanager/testdata/SecretPolicy/list_basic/query.tfquery.hcl
+++ b/internal/service/secretsmanager/testdata/SecretPolicy/list_basic/query.tfquery.hcl
@@ -1,0 +1,6 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_secretsmanager_secret_policy" "test" {
+  provider = aws
+}

--- a/internal/service/secretsmanager/testdata/SecretPolicy/list_include_resource/main.tf
+++ b/internal/service/secretsmanager/testdata/SecretPolicy/list_include_resource/main.tf
@@ -1,0 +1,42 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_secretsmanager_secret_policy" "test" {
+  count = var.resource_count
+
+  secret_arn = aws_secretsmanager_secret.test[count.index].arn
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "EnableAllPermissions"
+        Effect = "Allow"
+        Principal = {
+          AWS = "*"
+        }
+        Action   = "secretsmanager:GetSecretValue"
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+resource "aws_secretsmanager_secret" "test" {
+  count = var.resource_count
+
+  name = "${var.rName}-${count.index}"
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}
+

--- a/internal/service/secretsmanager/testdata/SecretPolicy/list_include_resource/query.tfquery.hcl
+++ b/internal/service/secretsmanager/testdata/SecretPolicy/list_include_resource/query.tfquery.hcl
@@ -1,0 +1,8 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_secretsmanager_secret_policy" "test" {
+  provider = aws
+
+  include_resource = true
+}

--- a/internal/service/secretsmanager/testdata/SecretPolicy/list_region_override/main.tf
+++ b/internal/service/secretsmanager/testdata/SecretPolicy/list_region_override/main.tf
@@ -1,0 +1,49 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_secretsmanager_secret_policy" "test" {
+  count = var.resource_count
+
+  region     = var.region
+  secret_arn = aws_secretsmanager_secret.test[count.index].arn
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "EnableAllPermissions"
+        Effect = "Allow"
+        Principal = {
+          AWS = "*"
+        }
+        Action   = "secretsmanager:GetSecretValue"
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+resource "aws_secretsmanager_secret" "test" {
+  count = var.resource_count
+
+  region = var.region
+  name   = "${var.rName}-${count.index}"
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}
+
+variable "region" {
+  description = "Region to deploy resource in"
+  type        = string
+  nullable    = false
+}

--- a/internal/service/secretsmanager/testdata/SecretPolicy/list_region_override/query.tfquery.hcl
+++ b/internal/service/secretsmanager/testdata/SecretPolicy/list_region_override/query.tfquery.hcl
@@ -1,0 +1,10 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_secretsmanager_secret_policy" "test" {
+  provider = aws
+
+  config {
+    region = var.region
+  }
+}

--- a/website/docs/list-resources/secretsmanager_secret_policy.html.markdown
+++ b/website/docs/list-resources/secretsmanager_secret_policy.html.markdown
@@ -1,0 +1,25 @@
+---
+subcategory: "Secrets Manager"
+layout: "aws"
+page_title: "AWS: aws_secretsmanager_secret_policy"
+description: |-
+  Lists Secrets Manager Secret Policy resources.
+---
+
+# List Resource: aws_secretsmanager_secret_policy
+
+Lists Secrets Manager Secret Policy resources.
+
+## Example Usage
+
+```terraform
+list "aws_secretsmanager_secret_policy" "example" {
+  provider = aws
+}
+```
+
+## Argument Reference
+
+This list resource supports the following arguments:
+
+* `region` - (Optional) Region to query. Defaults to provider region.


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Creates a new list resource, `aws_secretsmanager_secret_policy`.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #48628
Relates https://github.com/hashicorp/terraform-provider-aws/issues/47005

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->


```console
% make t K=secretsmanager T=TestAccSecretsManagerSecretPolicy_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-secret_policy-list 🌿...
TF_ACC=1 go1.26.5 test ./internal/service/secretsmanager/... -v -count 1 -parallel 20 -run='TestAccSecretsManagerSecretPolicy_'  -timeout 360m -vet=off
2026/07/21 14:37:31 Creating Terraform AWS Provider (SDKv2-style)...
2026/07/21 14:37:31 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccSecretsManagerSecretPolicy_List_regionOverride (24.92s)
--- PASS: TestAccSecretsManagerSecretPolicy_List_basic (28.34s)
--- PASS: TestAccSecretsManagerSecretPolicy_List_includeResource (28.43s)
--- PASS: TestAccSecretsManagerSecretPolicy_disappears (40.17s)
--- PASS: TestAccSecretsManagerSecretPolicy_Disappears_secret (40.38s)
--- PASS: TestAccSecretsManagerSecretPolicy_Identity_basic (46.15s)
--- PASS: TestAccSecretsManagerSecretPolicy_Identity_regionOverride (53.22s)
--- PASS: TestAccSecretsManagerSecretPolicy_basic (55.58s)
--- PASS: TestAccSecretsManagerSecretPolicy_Identity_ExistingResource_basic (63.67s)
--- PASS: TestAccSecretsManagerSecretPolicy_Identity_ExistingResource_noRefreshNoChange (65.37s)
--- PASS: TestAccSecretsManagerSecretPolicy_blockPublicPolicy (67.90s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/secretsmanager     76.094s
```
