### PR TITLE
Clarify import ID format for Listener Certificates

### DIFF
--- a/website/docs/r/lb_listener_certificate.html.markdown
+++ b/website/docs/r/lb_listener_certificate.html.markdown
@@ -50,6 +50,7 @@ This resource exports the following attributes in addition to the arguments abov
 * `id` - The `listener_arn` and `certificate_arn` separated by a `_`.
 
 ## Import
+~> **Note:** The import ID joins two ARNs with an underscore (`_`). Because ARNs do not themselves contain underscores, the separator is the single underscore between the end of the listener ARN and the start of the certificate ARN (which begins with `arn:aws:iam:`).
 
 In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Listener Certificates using the listener arn and certificate arn, separated by an underscore (`_`). For example:
 


### PR DESCRIPTION
Added note about import ID format for Listener Certificates.

<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
