### PR TITLE
autoscaling: New style sweepers and reset `instance_lifecycle_policy`

### DIFF
--- a/internal/service/autoscaling/sweep.go
+++ b/internal/service/autoscaling/sweep.go
@@ -4,95 +4,77 @@
 package autoscaling
 
 import (
-	"fmt"
-	"log"
+	"context"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/autoscaling/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv2"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func RegisterSweepers() {
-	resource.AddTestSweepers("aws_autoscaling_group", &resource.Sweeper{
-		Name: "aws_autoscaling_group",
-		F:    sweepGroups,
-	})
-
-	resource.AddTestSweepers("aws_launch_configuration", &resource.Sweeper{
-		Name:         "aws_launch_configuration",
-		F:            sweepLaunchConfigurations,
-		Dependencies: []string{"aws_autoscaling_group"},
-	})
+	awsv2.Register("aws_autoscaling_group", sweepGroups)
+	awsv2.Register("aws_launch_configuration", sweepLaunchConfigurations, "aws_autoscaling_group")
 }
 
-func sweepGroups(region string) error {
-	ctx := sweep.Context(region)
-	client, err := sweep.SharedRegionalSweepClient(ctx, region)
-	if err != nil {
-		return fmt.Errorf("getting client: %w", err)
-	}
+func sweepGroups(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepable, error) {
 	conn := client.AutoScalingClient(ctx)
-	input := &autoscaling.DescribeAutoScalingGroupsInput{}
+	var input autoscaling.DescribeAutoScalingGroupsInput
 	sweepResources := make([]sweep.Sweepable, 0)
 
-	pages := autoscaling.NewDescribeAutoScalingGroupsPaginator(conn, input)
-
+	pages := autoscaling.NewDescribeAutoScalingGroupsPaginator(conn, &input)
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
 
-		if awsv2.SkipSweepError(err) {
-			log.Printf("[WARN] Skipping Auto Scaling Group sweep for %s: %s", region, err)
-			return nil
-		}
-
 		if err != nil {
-			return fmt.Errorf("error listing Auto Scaling Groups (%s): %w", region, err)
+			return nil, err
 		}
 
 		for _, v := range page.AutoScalingGroups {
+			asgName := aws.ToString(v.AutoScalingGroupName)
+
+			// "ValidationError: You can't force delete this Auto Scaling group because the TerminateHookAbandon retention trigger is set to retain. Change the retention trigger to terminate and try again".
+			if v.InstanceLifecyclePolicy != nil && v.InstanceLifecyclePolicy.RetentionTriggers != nil && v.InstanceLifecyclePolicy.RetentionTriggers.TerminateHookAbandon == awstypes.RetentionActionRetain {
+				input := autoscaling.UpdateAutoScalingGroupInput{
+					AutoScalingGroupName: aws.String(asgName),
+					InstanceLifecyclePolicy: &awstypes.InstanceLifecyclePolicy{
+						RetentionTriggers: &awstypes.RetentionTriggers{
+							TerminateHookAbandon: awstypes.RetentionActionTerminate,
+						},
+					},
+				}
+				_, err := conn.UpdateAutoScalingGroup(ctx, &input)
+				if err != nil {
+					return nil, err
+				}
+			}
+
 			r := resourceGroup()
 			d := r.Data(nil)
-			d.SetId(aws.ToString(v.AutoScalingGroupName))
+			d.SetId(asgName)
 			d.Set(names.AttrForceDelete, true)
 
 			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
 		}
 	}
 
-	err = sweep.SweepOrchestrator(ctx, sweepResources)
-
-	if err != nil {
-		return fmt.Errorf("error sweeping Auto Scaling Groups (%s): %w", region, err)
-	}
-
-	return nil
+	return sweepResources, nil
 }
 
-func sweepLaunchConfigurations(region string) error {
-	ctx := sweep.Context(region)
-	client, err := sweep.SharedRegionalSweepClient(ctx, region)
-	if err != nil {
-		return fmt.Errorf("getting client: %w", err)
-	}
+func sweepLaunchConfigurations(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepable, error) {
 	conn := client.AutoScalingClient(ctx)
-	input := &autoscaling.DescribeLaunchConfigurationsInput{}
+	var input autoscaling.DescribeLaunchConfigurationsInput
 	sweepResources := make([]sweep.Sweepable, 0)
 
-	pages := autoscaling.NewDescribeLaunchConfigurationsPaginator(conn, input)
-
+	pages := autoscaling.NewDescribeLaunchConfigurationsPaginator(conn, &input)
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
 
-		if awsv2.SkipSweepError(err) {
-			log.Printf("[WARN] Skipping Auto Scaling Launch Configuration sweep for %s: %s", region, err)
-			return nil
-		}
-
 		if err != nil {
-			return fmt.Errorf("error listing Auto Scaling Launch Configurations (%s): %w", region, err)
+			return nil, err
 		}
 
 		for _, v := range page.LaunchConfigurations {
@@ -104,11 +86,5 @@ func sweepLaunchConfigurations(region string) error {
 		}
 	}
 
-	err = sweep.SweepOrchestrator(ctx, sweepResources)
-
-	if err != nil {
-		return fmt.Errorf("error sweeping Auto Scaling Launch Configurations (%s): %w", region, err)
-	}
-
-	return nil
+	return sweepResources, nil
 }


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Prevents `ValidationError: You can't force delete this Auto Scaling group because the TerminateHookAbandon retention trigger is set to retain. Change the retention trigger to terminate and try again` errors.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/48973.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% SWEEPERS=aws_autoscaling_group make sweep
# make sweep SWEEPARGS=-sweep-run=aws_example_thing
# set SWEEPARGS=-sweep-allow-failures to continue after first failure
WARNING: This will destroy infrastructure. Use only in development accounts.
go1.26.5 test ./internal/sweep -v -sweep=us-west-2,us-east-1,us-east-2,us-west-1 -sweep-run='aws_autoscaling_group' -timeout 360m -vet=off
2026/07/22 13:37:24 [DEBUG] Running Sweepers for region (us-west-2):
2026/07/22 13:37:24 [DEBUG] Running Sweeper (aws_autoscaling_group) in region (us-west-2)
2026/07/22 13:37:24 [DEBUG] sweeper: Configuring Terraform AWS Provider: sweeper_region=us-west-2 tf_resource_type=aws_autoscaling_group
2026-07-22T13:37:24.803-0400 [DEBUG] sweeper.aws-base: Resolving credentials provider: sweeper_region=us-west-2 tf_resource_type=aws_autoscaling_group
2026-07-22T13:37:24.803-0400 [DEBUG] sweeper.aws-base: Loading configuration: sweeper_region=us-west-2 tf_resource_type=aws_autoscaling_group
2026-07-22T13:37:24.804-0400 [DEBUG] sweeper.aws-base: Retrieving credentials: sweeper_region=us-west-2 tf_resource_type=aws_autoscaling_group
2026-07-22T13:37:24.804-0400 [INFO]  sweeper.aws-base: Retrieved credentials: sweeper_region=us-west-2 tf_resource_type=aws_autoscaling_group tf_aws.credentials_source=EnvConfigCredentials
2026-07-22T13:37:24.804-0400 [DEBUG] sweeper.aws-base: Loading configuration: sweeper_region=us-west-2 tf_resource_type=aws_autoscaling_group
2026/07/22 13:37:24 [DEBUG] sweeper: Retrieving AWS account details: sweeper_region=us-west-2 tf_resource_type=aws_autoscaling_group
2026-07-22T13:37:24.804-0400 [DEBUG] sweeper.aws-base: Retrieving caller identity from STS: sweeper_region=us-west-2 tf_resource_type=aws_autoscaling_group
2026-07-22T13:37:25.304-0400 [INFO]  sweeper.aws-base: Retrieved caller identity from STS: sweeper_region=us-west-2 tf_resource_type=aws_autoscaling_group
2026/07/22 13:37:25 [INFO]  sweeper: listing resources: sweeper_region=us-west-2 tf_resource_type=aws_autoscaling_group
2026/07/22 13:37:25 [INFO]  sweeper: No resources to sweep: sweeper_region=us-west-2 tf_resource_type=aws_autoscaling_group
2026/07/22 13:37:25 [DEBUG] Completed Sweeper (aws_autoscaling_group) in region (us-west-2) in 977.020959ms
2026/07/22 13:37:25 Completed Sweepers for region (us-west-2) in 977.295583ms
2026/07/22 13:37:25 Sweeper Tests for region (us-west-2) ran successfully:
2026/07/22 13:37:25     - aws_autoscaling_group
2026/07/22 13:37:25 [DEBUG] Running Sweepers for region (us-east-1):
2026/07/22 13:37:25 [DEBUG] Running Sweeper (aws_autoscaling_group) in region (us-east-1)
2026/07/22 13:37:25 [DEBUG] sweeper: Configuring Terraform AWS Provider: sweeper_region=us-east-1 tf_resource_type=aws_autoscaling_group
2026-07-22T13:37:25.779-0400 [DEBUG] sweeper.aws-base: Resolving credentials provider: tf_resource_type=aws_autoscaling_group sweeper_region=us-east-1
2026-07-22T13:37:25.779-0400 [DEBUG] sweeper.aws-base: Loading configuration: tf_resource_type=aws_autoscaling_group sweeper_region=us-east-1
2026-07-22T13:37:25.780-0400 [DEBUG] sweeper.aws-base: Retrieving credentials: sweeper_region=us-east-1 tf_resource_type=aws_autoscaling_group
2026-07-22T13:37:25.780-0400 [INFO]  sweeper.aws-base: Retrieved credentials: tf_resource_type=aws_autoscaling_group sweeper_region=us-east-1 tf_aws.credentials_source=EnvConfigCredentials
2026-07-22T13:37:25.780-0400 [DEBUG] sweeper.aws-base: Loading configuration: sweeper_region=us-east-1 tf_resource_type=aws_autoscaling_group
2026/07/22 13:37:25 [DEBUG] sweeper: Retrieving AWS account details: tf_resource_type=aws_autoscaling_group sweeper_region=us-east-1
2026-07-22T13:37:25.780-0400 [DEBUG] sweeper.aws-base: Retrieving caller identity from STS: sweeper_region=us-east-1 tf_resource_type=aws_autoscaling_group
2026-07-22T13:37:25.915-0400 [INFO]  sweeper.aws-base: Retrieved caller identity from STS: sweeper_region=us-east-1 tf_resource_type=aws_autoscaling_group
2026/07/22 13:37:25 [INFO]  sweeper: listing resources: sweeper_region=us-east-1 tf_resource_type=aws_autoscaling_group
2026/07/22 13:37:26 [INFO]  sweeper: No resources to sweep: sweeper_region=us-east-1 tf_resource_type=aws_autoscaling_group
2026/07/22 13:37:26 [DEBUG] Completed Sweeper (aws_autoscaling_group) in region (us-east-1) in 383.007ms
2026/07/22 13:37:26 Completed Sweepers for region (us-east-1) in 383.039375ms
2026/07/22 13:37:26 Sweeper Tests for region (us-east-1) ran successfully:
2026/07/22 13:37:26     - aws_autoscaling_group
2026/07/22 13:37:26 [DEBUG] Running Sweepers for region (us-east-2):
2026/07/22 13:37:26 [DEBUG] Running Sweeper (aws_autoscaling_group) in region (us-east-2)
2026/07/22 13:37:26 [DEBUG] sweeper: Configuring Terraform AWS Provider: sweeper_region=us-east-2 tf_resource_type=aws_autoscaling_group
2026-07-22T13:37:26.162-0400 [DEBUG] sweeper.aws-base: Resolving credentials provider: sweeper_region=us-east-2 tf_resource_type=aws_autoscaling_group
2026-07-22T13:37:26.162-0400 [DEBUG] sweeper.aws-base: Loading configuration: tf_resource_type=aws_autoscaling_group sweeper_region=us-east-2
2026-07-22T13:37:26.163-0400 [DEBUG] sweeper.aws-base: Retrieving credentials: sweeper_region=us-east-2 tf_resource_type=aws_autoscaling_group
2026-07-22T13:37:26.163-0400 [INFO]  sweeper.aws-base: Retrieved credentials: sweeper_region=us-east-2 tf_resource_type=aws_autoscaling_group tf_aws.credentials_source=EnvConfigCredentials
2026-07-22T13:37:26.163-0400 [DEBUG] sweeper.aws-base: Loading configuration: sweeper_region=us-east-2 tf_resource_type=aws_autoscaling_group
2026/07/22 13:37:26 [DEBUG] sweeper: Retrieving AWS account details: tf_resource_type=aws_autoscaling_group sweeper_region=us-east-2
2026-07-22T13:37:26.163-0400 [DEBUG] sweeper.aws-base: Retrieving caller identity from STS: sweeper_region=us-east-2 tf_resource_type=aws_autoscaling_group
2026-07-22T13:37:26.409-0400 [INFO]  sweeper.aws-base: Retrieved caller identity from STS: sweeper_region=us-east-2 tf_resource_type=aws_autoscaling_group
2026/07/22 13:37:26 [INFO]  sweeper: listing resources: tf_resource_type=aws_autoscaling_group sweeper_region=us-east-2
2026/07/22 13:37:26 [INFO]  sweeper: No resources to sweep: sweeper_region=us-east-2 tf_resource_type=aws_autoscaling_group
2026/07/22 13:37:26 [DEBUG] Completed Sweeper (aws_autoscaling_group) in region (us-east-2) in 537.706375ms
2026/07/22 13:37:26 Completed Sweepers for region (us-east-2) in 537.73825ms
2026/07/22 13:37:26 Sweeper Tests for region (us-east-2) ran successfully:
2026/07/22 13:37:26     - aws_autoscaling_group
2026/07/22 13:37:26 [DEBUG] Running Sweepers for region (us-west-1):
2026/07/22 13:37:26 [DEBUG] Running Sweeper (aws_autoscaling_group) in region (us-west-1)
2026/07/22 13:37:26 [DEBUG] sweeper: Configuring Terraform AWS Provider: sweeper_region=us-west-1 tf_resource_type=aws_autoscaling_group
2026-07-22T13:37:26.700-0400 [DEBUG] sweeper.aws-base: Resolving credentials provider: sweeper_region=us-west-1 tf_resource_type=aws_autoscaling_group
2026-07-22T13:37:26.700-0400 [DEBUG] sweeper.aws-base: Loading configuration: sweeper_region=us-west-1 tf_resource_type=aws_autoscaling_group
2026-07-22T13:37:26.700-0400 [DEBUG] sweeper.aws-base: Retrieving credentials: sweeper_region=us-west-1 tf_resource_type=aws_autoscaling_group
2026-07-22T13:37:26.701-0400 [INFO]  sweeper.aws-base: Retrieved credentials: sweeper_region=us-west-1 tf_resource_type=aws_autoscaling_group tf_aws.credentials_source=EnvConfigCredentials
2026-07-22T13:37:26.701-0400 [DEBUG] sweeper.aws-base: Loading configuration: sweeper_region=us-west-1 tf_resource_type=aws_autoscaling_group
2026/07/22 13:37:26 [DEBUG] sweeper: Retrieving AWS account details: sweeper_region=us-west-1 tf_resource_type=aws_autoscaling_group
2026-07-22T13:37:26.701-0400 [DEBUG] sweeper.aws-base: Retrieving caller identity from STS: sweeper_region=us-west-1 tf_resource_type=aws_autoscaling_group
2026-07-22T13:37:27.174-0400 [INFO]  sweeper.aws-base: Retrieved caller identity from STS: sweeper_region=us-west-1 tf_resource_type=aws_autoscaling_group
2026/07/22 13:37:27 [INFO]  sweeper: listing resources: sweeper_region=us-west-1 tf_resource_type=aws_autoscaling_group
2026/07/22 13:37:27 [INFO]  sweeper: No resources to sweep: tf_resource_type=aws_autoscaling_group sweeper_region=us-west-1
2026/07/22 13:37:27 [DEBUG] Completed Sweeper (aws_autoscaling_group) in region (us-west-1) in 936.999042ms
2026/07/22 13:37:27 Completed Sweepers for region (us-west-1) in 937.025292ms
2026/07/22 13:37:27 Sweeper Tests for region (us-west-1) ran successfully:
2026/07/22 13:37:27     - aws_autoscaling_group
ok      github.com/hashicorp/terraform-provider-aws/internal/sweep      8.552s
```
