### PR TITLE
internal/backoff: move go-vcr check into `backoff.SDKv2HelperRetryCompatibleDelay`

### DIFF
--- a/internal/backoff/backoff.go
+++ b/internal/backoff/backoff.go
@@ -7,7 +7,10 @@ import (
 	"context"
 	"time"
 
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	inttypes "github.com/hashicorp/terraform-provider-aws/internal/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/vcr"
+	"gopkg.in/dnaeon/go-vcr.v4/pkg/recorder"
 )
 
 // Inspired by https://github.com/ServiceWeaver/weaver and https://github.com/avast/retry-go.
@@ -103,7 +106,17 @@ func (d *sdkv2HelperRetryCompatibleDelay) SetIncrementDelay(incrementDelay bool)
 }
 
 // SDKv2HelperRetryCompatibleDelay returns a Terraform Plugin SDK v2 helper/retry-compatible delay.
-func SDKv2HelperRetryCompatibleDelay(initialDelay, pollInterval, minTimeout time.Duration) Delay {
+//
+// When VCR testing is enabled in replay mode, the DelayFunc is overridden to
+// allow interactions to be replayed with no delay between state change refreshes.
+func SDKv2HelperRetryCompatibleDelay(ctx context.Context, initialDelay, pollInterval, minTimeout time.Duration) Delay {
+	// When VCR testing in replay mode, override the default DelayFunc
+	if inContext, ok := conns.FromContext(ctx); ok && inContext.VCREnabled() {
+		if mode, _ := vcr.Mode(); mode == recorder.ModeReplayOnly {
+			return ZeroDelay
+		}
+	}
+
 	return &sdkv2HelperRetryCompatibleDelay{
 		incrementDelay: true,
 		initialDelay:   initialDelay,
@@ -114,8 +127,8 @@ func SDKv2HelperRetryCompatibleDelay(initialDelay, pollInterval, minTimeout time
 
 // DefaultSDKv2HelperRetryCompatibleDelay returns a Terraform Plugin SDK v2 helper/retry-compatible delay
 // with default values (from the `RetryContext` function).
-func DefaultSDKv2HelperRetryCompatibleDelay() Delay {
-	return SDKv2HelperRetryCompatibleDelay(0, 0, 500*time.Millisecond) //nolint:mnd // 500ms is the Plugin SDKv2 default
+func DefaultSDKv2HelperRetryCompatibleDelay(ctx context.Context) Delay {
+	return SDKv2HelperRetryCompatibleDelay(ctx, 0, 0, 500*time.Millisecond) //nolint:mnd // 500ms is the Plugin SDKv2 default
 }
 
 var (
@@ -167,9 +180,9 @@ func (t *timerImpl) After(d time.Duration) <-chan time.Time {
 }
 
 // The default RetryConfig is backwards compatible with github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry.
-func defaultLoopConfig() LoopConfig {
+func defaultLoopConfig(ctx context.Context) LoopConfig {
 	return LoopConfig{
-		delay:       DefaultSDKv2HelperRetryCompatibleDelay(),
+		delay:       DefaultSDKv2HelperRetryCompatibleDelay(ctx),
 		gracePeriod: 30 * time.Second,
 		timer:       &timerImpl{},
 	}
@@ -184,8 +197,8 @@ type Loop struct {
 }
 
 // NewLoopWithOptions returns a new loop configured with the provided options.
-func NewLoopWithOptions(timeout time.Duration, opts ...Option) *Loop {
-	config := defaultLoopConfig()
+func NewLoopWithOptions(ctx context.Context, timeout time.Duration, opts ...Option) *Loop {
+	config := defaultLoopConfig(ctx)
 	for _, opt := range opts {
 		opt(&config)
 	}
@@ -198,8 +211,8 @@ func NewLoopWithOptions(timeout time.Duration, opts ...Option) *Loop {
 }
 
 // NewLoop returns a new loop configured with the default options.
-func NewLoop(timeout time.Duration) *Loop {
-	return NewLoopWithOptions(timeout)
+func NewLoop(ctx context.Context, timeout time.Duration) *Loop {
+	return NewLoopWithOptions(ctx, timeout)
 }
 
 // Continue sleeps between attempts.

--- a/internal/backoff/backoff_test.go
+++ b/internal/backoff/backoff_test.go
@@ -14,7 +14,7 @@ import (
 func TestDefaultSDKv2HelperRetryCompatibleDelay(t *testing.T) {
 	t.Parallel()
 
-	delay := DefaultSDKv2HelperRetryCompatibleDelay()
+	delay := DefaultSDKv2HelperRetryCompatibleDelay(t.Context())
 	want := []time.Duration{
 		0,
 		500 * time.Millisecond,
@@ -40,7 +40,7 @@ func TestDefaultSDKv2HelperRetryCompatibleDelay(t *testing.T) {
 func TestDefaultSDKv2HelperRetryCompatibleDelayWithIncrementDelay(t *testing.T) {
 	t.Parallel()
 
-	delay := DefaultSDKv2HelperRetryCompatibleDelay()
+	delay := DefaultSDKv2HelperRetryCompatibleDelay(t.Context())
 	want := []time.Duration{
 		0,
 		500 * time.Millisecond,
@@ -68,7 +68,7 @@ func TestDefaultSDKv2HelperRetryCompatibleDelayWithIncrementDelay(t *testing.T) 
 func TestSDKv2HelperRetryCompatibleDelay(t *testing.T) {
 	t.Parallel()
 
-	delay := SDKv2HelperRetryCompatibleDelay(200*time.Millisecond, 0, 3*time.Second)
+	delay := SDKv2HelperRetryCompatibleDelay(t.Context(), 200*time.Millisecond, 0, 3*time.Second)
 	want := []time.Duration{
 		200 * time.Millisecond,
 		3 * time.Second,
@@ -89,7 +89,7 @@ func TestSDKv2HelperRetryCompatibleDelay(t *testing.T) {
 func TestSDKv2HelperRetryCompatibleDelayWithPollTimeout(t *testing.T) {
 	t.Parallel()
 
-	delay := SDKv2HelperRetryCompatibleDelay(200*time.Millisecond, 20*time.Second, 3*time.Second)
+	delay := SDKv2HelperRetryCompatibleDelay(t.Context(), 200*time.Millisecond, 20*time.Second, 3*time.Second)
 	want := []time.Duration{
 		200 * time.Millisecond,
 		20 * time.Second,
@@ -113,7 +113,7 @@ func TestLoopWithTimeoutDefaultGracePeriod(t *testing.T) {
 	ctx := context.Background()
 
 	var n int
-	for r := NewLoopWithOptions(1*time.Minute, WithDelay(FixedDelay(1*time.Second))); r.Continue(ctx); {
+	for r := NewLoopWithOptions(t.Context(), 1*time.Minute, WithDelay(FixedDelay(1*time.Second))); r.Continue(ctx); {
 		time.Sleep(35 * time.Second)
 		n++
 	}
@@ -130,7 +130,7 @@ func TestLoopWithTimeoutNoGracePeriod(t *testing.T) {
 	ctx := context.Background()
 
 	var n int
-	for r := NewLoopWithOptions(1*time.Minute, WithDelay(FixedDelay(1*time.Second)), WithGracePeriod(0)); r.Continue(ctx); {
+	for r := NewLoopWithOptions(t.Context(), 1*time.Minute, WithDelay(FixedDelay(1*time.Second)), WithGracePeriod(0)); r.Continue(ctx); {
 		time.Sleep(35 * time.Second)
 		n++
 	}

--- a/internal/retry/op.go
+++ b/internal/retry/op.go
@@ -90,7 +90,7 @@ func (op opFunc[T]) If(predicate predicateFunc[T]) runFunc[T] {
 			t   T
 			err error
 		)
-		for l = backoff.NewLoopWithOptions(timeout, opts...); l.Continue(ctx); {
+		for l = backoff.NewLoopWithOptions(ctx, timeout, opts...); l.Continue(ctx); {
 			t, err = op(ctx)
 
 			var retry bool

--- a/internal/retry/state.go
+++ b/internal/retry/state.go
@@ -10,11 +10,8 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-provider-aws/internal/backoff"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 	inttypes "github.com/hashicorp/terraform-provider-aws/internal/types"
-	"github.com/hashicorp/terraform-provider-aws/internal/vcr"
-	"gopkg.in/dnaeon/go-vcr.v4/pkg/recorder"
 )
 
 //
@@ -67,9 +64,6 @@ type StateChangeConf = StateChangeConfOf[any, string]
 // reach the target state.
 //
 // Cancellation of the passed in context will cancel the refresh loop.
-//
-// When VCR testing is enabled in replay mode, the DelayFunc is overridden to
-// allow interactions to be replayed with no delay between state change refreshes.
 func (conf *StateChangeConfOf[T, S]) WaitForStateContext(ctx context.Context) (T, error) {
 	// Set a default for times to check for not found.
 	if conf.NotFoundChecks == 0 {
@@ -80,14 +74,7 @@ func (conf *StateChangeConfOf[T, S]) WaitForStateContext(ctx context.Context) (T
 	}
 
 	// Set a default Delay using the StateChangeConf values
-	delay := backoff.SDKv2HelperRetryCompatibleDelay(conf.Delay, conf.PollInterval, conf.MinTimeout)
-
-	// When VCR testing in replay mode, override the default Delay
-	if inContext, ok := conns.FromContext(ctx); ok && inContext.VCREnabled() {
-		if mode, _ := vcr.Mode(); mode == recorder.ModeReplayOnly {
-			delay = backoff.ZeroDelay
-		}
-	}
+	delay := backoff.SDKv2HelperRetryCompatibleDelay(ctx, conf.Delay, conf.PollInterval, conf.MinTimeout)
 
 	var (
 		t                             T
@@ -96,7 +83,7 @@ func (conf *StateChangeConfOf[T, S]) WaitForStateContext(ctx context.Context) (T
 		notFoundTick, targetOccurence int
 		l                             *backoff.Loop
 	)
-	for l = backoff.NewLoopWithOptions(conf.Timeout, backoff.WithDelay(delay)); l.Continue(ctx); {
+	for l = backoff.NewLoopWithOptions(ctx, conf.Timeout, backoff.WithDelay(delay)); l.Continue(ctx); {
 		t, currentState, err = conf.refreshWithTimeout(ctx, l.Remaining())
 
 		if errors.Is(err, context.DeadlineExceeded) {

--- a/internal/service/codebuild/start_build_action.go
+++ b/internal/service/codebuild/start_build_action.go
@@ -152,7 +152,7 @@ func (a *startBuildAction) Invoke(ctx context.Context, req action.InvokeRequest,
 		return actionwait.FetchResult[*awstypes.Build]{Status: actionwait.Status(b.BuildStatus), Value: &b}, nil
 	}, actionwait.Options[*awstypes.Build]{
 		Timeout:          timeout,
-		Interval:         actionwait.WithBackoffDelay(backoff.DefaultSDKv2HelperRetryCompatibleDelay()),
+		Interval:         actionwait.WithBackoffDelay(backoff.DefaultSDKv2HelperRetryCompatibleDelay(ctx)),
 		ProgressInterval: 2 * time.Minute,
 		SuccessStates:    []actionwait.Status{actionwait.Status(awstypes.StatusTypeSucceeded)},
 		TransitionalStates: []actionwait.Status{

--- a/internal/service/dynamodb/create_backup_action.go
+++ b/internal/service/dynamodb/create_backup_action.go
@@ -113,7 +113,7 @@ func (a *createBackupAction) Invoke(ctx context.Context, req action.InvokeReques
 
 	var output *dynamodb.CreateBackupOutput
 	var err error
-	for l := backoff.NewLoop(timeout); l.Continue(ctx); {
+	for l := backoff.NewLoop(ctx, timeout); l.Continue(ctx); {
 		output, err = conn.CreateBackup(ctx, &input)
 
 		if err != nil {
@@ -148,7 +148,7 @@ func (a *createBackupAction) Invoke(ctx context.Context, req action.InvokeReques
 		return actionwait.FetchResult[*awstypes.BackupDescription]{Status: actionwait.Status(desc.BackupDetails.BackupStatus), Value: desc}, nil
 	}, actionwait.Options[*awstypes.BackupDescription]{
 		Timeout:            timeout,
-		Interval:           actionwait.WithBackoffDelay(backoff.DefaultSDKv2HelperRetryCompatibleDelay()),
+		Interval:           actionwait.WithBackoffDelay(backoff.DefaultSDKv2HelperRetryCompatibleDelay(ctx)),
 		ProgressInterval:   30 * time.Second,
 		SuccessStates:      []actionwait.Status{actionwait.Status(awstypes.BackupStatusAvailable)},
 		TransitionalStates: []actionwait.Status{actionwait.Status(awstypes.BackupStatusCreating)},

--- a/internal/service/ec2/ec2_instance.go
+++ b/internal/service/ec2/ec2_instance.go
@@ -1201,7 +1201,7 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta an
 	}
 
 	var output *ec2.RunInstancesOutput
-	for l := backoff.NewLoop(iamPropagationTimeout); l.Continue(ctx); {
+	for l := backoff.NewLoop(ctx, iamPropagationTimeout); l.Continue(ctx); {
 		output, err = conn.RunInstances(ctx, &input)
 
 		// IAM instance profiles can take ~10 seconds to propagate in AWS:

--- a/internal/service/neptune/cluster.go
+++ b/internal/service/neptune/cluster.go
@@ -475,7 +475,7 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta any
 	var err error
 
 	if restoreDBClusterFromSnapshot {
-		for l := backoff.NewLoop(propagationTimeout); l.Continue(ctx); {
+		for l := backoff.NewLoop(ctx, propagationTimeout); l.Continue(ctx); {
 			_, err = conn.RestoreDBClusterFromSnapshot(ctx, inputR)
 
 			if tfawserr.ErrMessageContains(err, errCodeInvalidParameterValue, "IAM role ARN value is invalid") {
@@ -487,7 +487,7 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta any
 	}
 
 	if !restoreDBClusterFromSnapshot {
-		for l := backoff.NewLoop(d.Timeout(schema.TimeoutCreate)); l.Continue(ctx); {
+		for l := backoff.NewLoop(ctx, d.Timeout(schema.TimeoutCreate)); l.Continue(ctx); {
 			_, err = conn.CreateDBCluster(ctx, inputC)
 
 			if tfawserr.ErrMessageContains(err, errCodeInvalidGlobalClusterStateFault, "in progress") {
@@ -556,7 +556,7 @@ func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta any) 
 	}
 
 	// When upgrading, the Neptune Cluster may not be available immediately after creation.
-	for l := backoff.NewLoop(d.Timeout(schema.TimeoutRead)); err != nil && l.Continue(ctx); {
+	for l := backoff.NewLoop(ctx, d.Timeout(schema.TimeoutRead)); err != nil && l.Continue(ctx); {
 		dbc, err = findDBClusterByID(ctx, conn, d.Id())
 
 		if errors.Is(err, tfresource.ErrEmptyResult) {

--- a/internal/service/neptune/global_cluster.go
+++ b/internal/service/neptune/global_cluster.go
@@ -156,7 +156,7 @@ func resourceGlobalClusterCreate(ctx context.Context, d *schema.ResourceData, me
 
 	var output *neptune.CreateGlobalClusterOutput
 	var err error
-	for l := backoff.NewLoop(d.Timeout(schema.TimeoutCreate)); l.Continue(ctx); {
+	for l := backoff.NewLoop(ctx, d.Timeout(schema.TimeoutCreate)); l.Continue(ctx); {
 		output, err = conn.CreateGlobalCluster(ctx, input)
 
 		if tfawserr.ErrMessageContains(err, errCodeInvalidGlobalClusterStateFault, "in progress") {

--- a/internal/service/pinpointsmsvoicev2/phone_number.go
+++ b/internal/service/pinpointsmsvoicev2/phone_number.go
@@ -240,7 +240,7 @@ func (r *phoneNumberResource) Create(ctx context.Context, request resource.Creat
 			TwoWayChannelRole:         fwflex.StringFromFramework(ctx, data.TwoWayChannelRole),
 		}
 
-		for l := backoff.NewLoop(iamPropagationTimeout); l.Continue(ctx); {
+		for l := backoff.NewLoop(ctx, iamPropagationTimeout); l.Continue(ctx); {
 			_, err := conn.UpdatePhoneNumber(ctx, input)
 
 			// IAM roles can take time to propagate in AWS.
@@ -332,7 +332,7 @@ func (r *phoneNumberResource) Update(ctx context.Context, request resource.Updat
 			return
 		}
 
-		for l := backoff.NewLoop(iamPropagationTimeout); l.Continue(ctx); {
+		for l := backoff.NewLoop(ctx, iamPropagationTimeout); l.Continue(ctx); {
 			_, err := conn.UpdatePhoneNumber(ctx, input)
 
 			// IAM roles can take time to propagate in AWS.

--- a/internal/tfresource/retry.go
+++ b/internal/tfresource/retry.go
@@ -250,7 +250,7 @@ func Retry(ctx context.Context, timeout time.Duration, f func(context.Context) *
 
 			return false, err
 		},
-		backoff.WithDelay(backoff.SDKv2HelperRetryCompatibleDelay(options.Delay, options.PollInterval, options.MinPollInterval)),
+		backoff.WithDelay(backoff.SDKv2HelperRetryCompatibleDelay(ctx, options.Delay, options.PollInterval, options.MinPollInterval)),
 	)
 
 	return err


### PR DESCRIPTION



<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Moving this check upstream of the various Loop functions within `internal/backoff` and Retry functions in `internal/tfresource` allows the go-vcr override to apply more broadly without repeating the conditional handling code.

Previously `tfresource.Retry` and all variants based on it were _not_ VCR compatible. The following test which previously took 1500s+ in replay mode now properly replaces the configured delay and completes in under 20s.

```console
% make t K=opensearch T=TestAccOpenSearchPackageAssociation_basic
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 td-tfresource-retry-vcr 🌿...
TF_ACC=1 go1.26.5 test ./internal/service/opensearch/... -v -count 1 -parallel 20 -run='TestAccOpenSearchPackageAssociation_basic'  -timeout 360m -vet=off
2026/07/23 16:39:22 Creating Terraform AWS Provider (SDKv2-style)...
2026/07/23 16:39:22 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccOpenSearchPackageAssociation_basic (13.62s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/opensearch 21.782s
```

Tests using the traditional `WaitForStateConf` still see the same speedup as previous.

```console
% make t K=fsx T=TestAccFSxWindowsFileSystem_SelfManagedActiveDirectory_passwordWO
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 td-tfresource-retry-vcr 🌿...
TF_ACC=1 go1.26.5 test ./internal/service/fsx/... -v -count 1 -parallel 20 -run='TestAccFSxWindowsFileSystem_SelfManagedActiveDirectory_passwordWO'  -timeout 360m -vet=off
2026/07/23 16:45:35 Creating Terraform AWS Provider (SDKv2-style)...
2026/07/23 16:45:35 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccFSxWindowsFileSystem_SelfManagedActiveDirectory_passwordWO (13.67s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/fsx        21.947s
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #49091
Relates https://github.com/hashicorp/terraform-provider-aws/issues/25602


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make sanity
make: Sanity Smoke Tests (x tests of Top y resources)
make: Like 'sane' but less output and runs all tests despite most errors
make: NOTE: NOT an exhaustive set of tests! Finds big problems only.
18 of 54 complete: 18 passed, 0 failed
35 of 54 complete: 35 passed, 0 failed
54 of 54 complete: 54 passed, 0 failed
```
