### PR TITLE
r/aws_glue_catalog_table: Fix storage_descriptor and view representat…

### DIFF
--- a/.changes/6.x/unreleased/fix-glue-catalog-table-view-storage-descriptor.yaml
+++ b/.changes/6.x/unreleased/fix-glue-catalog-table-view-storage-descriptor.yaml
@@ -1,0 +1,4 @@
+kind: bug
+custom:
+  Impact: resource/aws_glue_catalog_table
+  Body: Fix `InvalidInputException: Storage descriptor may not be defined when creating a validated Glue view` on `Update` for a multi-dialect view, and stop `Read` from wiping out configured `view_definition.representations.validation_connection` / `view_original_text` / `view_expanded_text` with the empty values Glue's `GetTable` returns for those fields once a view is validated, which previously produced a perpetual plan diff.

--- a/internal/service/glue/catalog_table.go
+++ b/internal/service/glue/catalog_table.go
@@ -734,7 +734,7 @@ func resourceCatalogTableRead(ctx context.Context, d *schema.ResourceData, meta 
 		d.Set("target_table", nil)
 	}
 	if table.ViewDefinition != nil {
-		if err := d.Set("view_definition", []any{flattenViewDefinition(table.ViewDefinition)}); err != nil {
+		if err := d.Set("view_definition", []any{flattenViewDefinition(table.ViewDefinition, existingViewRepresentations(d))}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting view_definition: %s", err)
 		}
 	} else {
@@ -979,7 +979,15 @@ func expandTableInput(d *schema.ResourceData) *awstypes.TableInput {
 		apiObject.Retention = int32(v.(int))
 	}
 
-	if v, ok := d.GetOk("storage_descriptor"); ok {
+	// storage_descriptor is Optional+Computed: for a validated multi-dialect
+	// view (one with a validation_connection), Glue resolves and returns the
+	// view's schema as a storage_descriptor, which Read stores in state for
+	// visibility. Since the attribute is Optional+Computed, d.GetOk alone
+	// can't tell that computed value apart from one the practitioner actually
+	// configured, so re-submitting it unconditionally on every Create/Update
+	// trips "Storage descriptor may not be defined when creating a validated
+	// Glue view". Only send it when it's actually present in the HCL config.
+	if v, ok := d.GetOk("storage_descriptor"); ok && attributeInRawConfig(d, "storage_descriptor") {
 		apiObject.StorageDescriptor = expandStorageDescriptor(v.([]any))
 	}
 
@@ -1338,6 +1346,34 @@ func expandPartitionIndexes(tfList []any) []awstypes.PartitionIndex {
 	}
 
 	return apiObjects
+}
+
+// attributeInRawConfig reports whether the practitioner has the named
+// top-level Optional+Computed attribute in their HCL configuration, as
+// opposed to its state value having been populated solely by Read. Since
+// d.GetOk can't distinguish the two for Optional+Computed attributes, this
+// inspects the raw config instead.
+//
+// Reference: https://github.com/hashicorp/terraform-provider-aws/issues/44192
+func attributeInRawConfig(d *schema.ResourceData, name string) bool {
+	rawConfig := d.GetRawConfig()
+	if !rawConfig.IsKnown() || rawConfig.IsNull() {
+		return false
+	}
+
+	v := rawConfig.GetAttr(name)
+	if !v.IsKnown() || v.IsNull() {
+		return false
+	}
+
+	// For collection types (most commonly nested block lists/sets), an
+	// unconfigured attribute reports as a non-null empty collection rather
+	// than null, so check the length explicitly.
+	if t := v.Type(); t.IsListType() || t.IsSetType() || t.IsMapType() || t.IsTupleType() || t.IsObjectType() {
+		return v.LengthInt() > 0
+	}
+
+	return true
 }
 
 func expandStorageDescriptor(tfList []any) *awstypes.StorageDescriptor {
@@ -1870,7 +1906,39 @@ func expandViewRepresentationInputs(tfList []any) []awstypes.ViewRepresentationI
 	return apiObjects
 }
 
-func flattenViewDefinition(apiObject *awstypes.ViewDefinition) map[string]any {
+// existingViewRepresentations captures the practitioner's currently-known
+// view_definition.representations (from state, or from config on the initial
+// Read of a Create) before Read overwrites them, keyed by "dialect|dialect_version".
+// Glue doesn't return validation_connection, view_original_text, or
+// view_expanded_text back on GetTable for a validated (is_protected) view, so
+// flattenViewRepresentation uses this to avoid treating that as drift.
+func existingViewRepresentations(d *schema.ResourceData) map[string]map[string]any {
+	existing := make(map[string]map[string]any)
+
+	v, ok := d.GetOk("view_definition")
+	if !ok || len(v.([]any)) == 0 || v.([]any)[0] == nil {
+		return existing
+	}
+	viewDefinition := v.([]any)[0].(map[string]any)
+
+	representations, ok := viewDefinition["representations"].([]any)
+	if !ok {
+		return existing
+	}
+
+	for _, r := range representations {
+		tfMap, ok := r.(map[string]any)
+		if !ok {
+			continue
+		}
+		key := fmt.Sprintf("%s|%s", tfMap["dialect"], tfMap["dialect_version"])
+		existing[key] = tfMap
+	}
+
+	return existing
+}
+
+func flattenViewDefinition(apiObject *awstypes.ViewDefinition, existingRepresentations map[string]map[string]any) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
@@ -1894,7 +1962,7 @@ func flattenViewDefinition(apiObject *awstypes.ViewDefinition) map[string]any {
 	}
 
 	if v := apiObject.Representations; len(v) > 0 {
-		tfMap["representations"] = flattenViewRepresentations(v)
+		tfMap["representations"] = flattenViewRepresentations(v, existingRepresentations)
 	}
 
 	tfMap["view_version_id"] = apiObject.ViewVersionId
@@ -1906,15 +1974,16 @@ func flattenViewDefinition(apiObject *awstypes.ViewDefinition) map[string]any {
 	return tfMap
 }
 
-func flattenViewRepresentations(apiObjects []awstypes.ViewRepresentation) []any {
+func flattenViewRepresentations(apiObjects []awstypes.ViewRepresentation, existingRepresentations map[string]map[string]any) []any {
 	tfList := make([]any, len(apiObjects))
 	for i, v := range apiObjects {
-		tfList[i] = flattenViewRepresentation(v)
+		key := fmt.Sprintf("%s|%s", v.Dialect, aws.ToString(v.DialectVersion))
+		tfList[i] = flattenViewRepresentation(v, existingRepresentations[key])
 	}
 	return tfList
 }
 
-func flattenViewRepresentation(apiObject awstypes.ViewRepresentation) map[string]any {
+func flattenViewRepresentation(apiObject awstypes.ViewRepresentation, existing map[string]any) map[string]any {
 	tfMap := make(map[string]any)
 
 	if v := apiObject.Dialect; v != "" {
@@ -1927,13 +1996,19 @@ func flattenViewRepresentation(apiObject awstypes.ViewRepresentation) map[string
 
 	if v := aws.ToString(apiObject.ValidationConnection); v != "" {
 		tfMap["validation_connection"] = v
+	} else if v, ok := existing["validation_connection"].(string); ok && v != "" {
+		tfMap["validation_connection"] = v
 	}
 
 	if v := aws.ToString(apiObject.ViewExpandedText); v != "" {
 		tfMap["view_expanded_text"] = v
+	} else if v, ok := existing["view_expanded_text"].(string); ok && v != "" {
+		tfMap["view_expanded_text"] = v
 	}
 
 	if v := aws.ToString(apiObject.ViewOriginalText); v != "" {
+		tfMap["view_original_text"] = v
+	} else if v, ok := existing["view_original_text"].(string); ok && v != "" {
 		tfMap["view_original_text"] = v
 	}
 

--- a/internal/service/glue/catalog_table_test.go
+++ b/internal/service/glue/catalog_table_test.go
@@ -398,6 +398,58 @@ func TestAccGlueCatalogTable_Update_viewInPlace(t *testing.T) {
 	})
 }
 
+// Covers two related bugs found when creating and then updating a validated
+// (is_protected) multi-dialect view: expandTableInput was unconditionally
+// re-submitting storage_descriptor (Optional+Computed, populated by Read
+// from Glue's resolved view schema) on Update, which Glue rejects; and Read
+// was wiping out configured representations.validation_connection /
+// view_original_text / view_expanded_text with the empty values Glue's
+// GetTable returns for those fields once a view is validated.
+func TestAccGlueCatalogTable_Update_validatedViewStorageDescriptor(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_glue_catalog_table.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.GlueServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckCatalogTableDestroy(ctx, t),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {
+				Source:            "hashicorp/time",
+				VersionConstraint: "0.12.1",
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCatalogTableConfig_validatedView(rName, "SELECT 1 AS col"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCatalogTableExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "table_type", "VIRTUAL_VIEW"),
+				),
+			},
+			{
+				// Read populates storage_descriptor in state with the schema
+				// Glue resolved for the view. A subsequent update must not
+				// resubmit that computed value, or Glue rejects it: "Storage
+				// descriptor may not be defined when creating a validated
+				// Glue view".
+				Config: testAccCatalogTableConfig_validatedView(rName, "SELECT 2 AS col"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCatalogTableExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "table_type", "VIRTUAL_VIEW"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+		},
+	})
+}
+
 // Reference: https://github.com/hashicorp/terraform-provider-aws/issues/11784
 func TestAccGlueCatalogTable_StorageDescriptor_emptyBlock(t *testing.T) {
 	ctx := acctest.Context(t)
@@ -1901,4 +1953,132 @@ resource "aws_glue_connection" "test_athena" {
   }
 }
 `, rName)
+}
+
+// testAccCatalogTableConfig_validatedView provisions a self-contained
+// (table-less) query so it only needs a definer role capable of running
+// Athena queries, without also requiring Lake Formation grants on a
+// referenced table.
+func testAccCatalogTableConfig_validatedView(rName, query string) string {
+	return fmt.Sprintf(`
+resource "aws_glue_catalog_database" "test" {
+  name = %[1]q
+
+  # Glue rejects view creation in a database that grants IAM_ALLOWED_PRINCIPALS
+  # Super/ALL permissions (the account-level hybrid-access default): "Create
+  # Table Default Permissions should be empty, either in the database or
+  # settings."
+  create_table_default_permission {
+    permissions = []
+
+    principal {
+      data_lake_principal_identifier = "IAM_ALLOWED_PRINCIPALS"
+    }
+  }
+}
+
+resource "aws_s3_bucket" "results" {
+  bucket        = "%[1]s-results"
+  force_destroy = true
+}
+
+resource "aws_athena_workgroup" "test" {
+  name          = %[1]q
+  force_destroy = true
+
+  configuration {
+    result_configuration {
+      output_location = "s3://${aws_s3_bucket.results.bucket}/"
+    }
+  }
+}
+
+resource "aws_iam_role" "definer" {
+  name = "%[1]s-definer"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect    = "Allow"
+        Principal = { Service = "glue.amazonaws.com" }
+        Action    = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "definer" {
+  name = "view-validation"
+  role = aws_iam_role.definer.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "athena:StartQueryExecution",
+          "athena:GetQueryExecution",
+          "athena:GetQueryResults",
+          "athena:StopQueryExecution",
+          "athena:GetWorkGroup",
+        ]
+        Resource = aws_athena_workgroup.test.arn
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:ListBucket",
+          "s3:GetBucketLocation",
+        ]
+        Resource = [
+          aws_s3_bucket.results.arn,
+          "${aws_s3_bucket.results.arn}/*",
+        ]
+      },
+    ]
+  })
+}
+
+resource "aws_glue_connection" "test_athena" {
+  name            = "%[1]s-a"
+  connection_type = "VIEW_VALIDATION_ATHENA"
+
+  connection_properties = {
+    WORKGROUP_NAME = aws_athena_workgroup.test.name
+  }
+}
+
+// Glue's view validation assumes the definer role in a one-shot attempt with
+// no retry of its own; a role/policy created moments earlier in the same
+// apply can trip IAM's eventual consistency and fail validation permanently.
+resource "time_sleep" "definer_propagation" {
+  create_duration = "10s"
+
+  depends_on = [aws_iam_role_policy.definer]
+}
+
+resource "aws_glue_catalog_table" "test" {
+  name          = %[1]q
+  database_name = aws_glue_catalog_database.test.name
+  table_type    = "VIRTUAL_VIEW"
+
+  depends_on = [time_sleep.definer_propagation]
+
+  view_definition {
+    is_protected = true
+    definer      = aws_iam_role.definer.arn
+
+    representations {
+      dialect               = "ATHENA"
+      dialect_version       = "3"
+      view_original_text    = %[2]q
+      validation_connection = aws_glue_connection.test_athena.name
+    }
+  }
+}
+`, rName, query)
 }


### PR DESCRIPTION
expandTableInput unconditionally re-submitted storage_descriptor (Optional+Computed, populated by Read from Glue's resolved view schema) on every Create/Update, which Glue rejects for a validated view with "Storage descriptor may not be defined when creating a validated Glue view". Only send it when the practitioner actually configured it.

Also stop Read from wiping out configured
view_definition.representations.validation_connection / view_original_text / view_expanded_text with the empty values Glue's GetTable returns for those fields once a view is validated, which previously produced a perpetual plan diff.


Claude-Session: https://claude.ai/code/session_017qSmdgonpN6aetVMdF5Sqk

<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Closes #49042 

or 
Closes #0000
--->

Closes #49042 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ TF_ACC=1 go test ./internal/service/glue/... -run TestAccGlueCatalogTable_Update_validatedViewStorageDescriptor -v -timeout 280s
2026/07/23 22:45:21 Creating Terraform AWS Provider (SDKv2-style)...
2026/07/23 22:45:21 Initializing Terraform AWS Provider (SDKv2-style)...
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/glue       0.129s [no tests to run]

...
```
