### PR TITLE
bedrockagentcore oauth2_credential_provider: add 'included' provider config

### DIFF
--- a/.changelog/49101.txt
+++ b/.changelog/49101.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_bedrockagentcore_oauth2_credential_provider: Add `included_oauth2_provider_config` configuration block to `oauth2_provider_config`, supporting additional credential provider vendors (e.g. `NotionOauth2`, `DropboxOauth2`, etc.)
+```

--- a/internal/service/bedrockagentcore/oauth2_credential_provider.go
+++ b/internal/service/bedrockagentcore/oauth2_credential_provider.go
@@ -227,6 +227,7 @@ func (r *oauth2CredentialProviderResource) Schema(ctx context.Context, request r
 						},
 						"github_oauth2_provider_config":     basicOAuth2ProviderConfigBlock[githubOAuth2ProviderConfigModel](ctx),
 						"google_oauth2_provider_config":     basicOAuth2ProviderConfigBlock[googleOAuth2ProviderConfigModel](ctx),
+						"included_oauth2_provider_config":   basicOAuth2ProviderConfigBlock[includedOAuth2ProviderConfigModel](ctx),
 						"microsoft_oauth2_provider_config":  basicOAuth2ProviderConfigBlock[microsoftOAuth2ProviderConfigModel](ctx),
 						"salesforce_oauth2_provider_config": basicOAuth2ProviderConfigBlock[salesforceOAuth2ProviderConfigModel](ctx),
 						"slack_oauth2_provider_config":      basicOAuth2ProviderConfigBlock[slackOAuth2ProviderConfigModel](ctx),
@@ -484,6 +485,7 @@ type oauth2ProviderConfigModel struct {
 	CustomOAuth2ProviderConfig     fwtypes.ListNestedObjectValueOf[customOAuth2ProviderConfigModel]     `tfsdk:"custom_oauth2_provider_config"`
 	GithubOAuth2ProviderConfig     fwtypes.ListNestedObjectValueOf[githubOAuth2ProviderConfigModel]     `tfsdk:"github_oauth2_provider_config"`
 	GoogleOAuth2ProviderConfig     fwtypes.ListNestedObjectValueOf[googleOAuth2ProviderConfigModel]     `tfsdk:"google_oauth2_provider_config"`
+	IncludedOAuth2ProviderConfig   fwtypes.ListNestedObjectValueOf[includedOAuth2ProviderConfigModel]   `tfsdk:"included_oauth2_provider_config"`
 	MicrosoftOAuth2ProviderConfig  fwtypes.ListNestedObjectValueOf[microsoftOAuth2ProviderConfigModel]  `tfsdk:"microsoft_oauth2_provider_config"`
 	SalesforceOAuth2ProviderConfig fwtypes.ListNestedObjectValueOf[salesforceOAuth2ProviderConfigModel] `tfsdk:"salesforce_oauth2_provider_config"`
 	SlackOAuth2ProviderConfig      fwtypes.ListNestedObjectValueOf[slackOAuth2ProviderConfigModel]      `tfsdk:"slack_oauth2_provider_config"`
@@ -542,6 +544,15 @@ func (m *oauth2ProviderConfigModel) Flatten(ctx context.Context, v any) diag.Dia
 		}
 		model.oauth2ClientCredentialsModel = clientCredentials
 		m.GoogleOAuth2ProviderConfig = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &model)
+
+	case awstypes.Oauth2ProviderConfigOutputMemberIncludedOauth2ProviderConfig:
+		var model includedOAuth2ProviderConfigModel
+		smerr.AddEnrich(ctx, &diags, fwflex.Flatten(ctx, t.Value, &model))
+		if diags.HasError() {
+			return diags
+		}
+		model.oauth2ClientCredentialsModel = clientCredentials
+		m.IncludedOAuth2ProviderConfig = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &model)
 
 	case awstypes.Oauth2ProviderConfigOutputMemberMicrosoftOauth2ProviderConfig:
 		var model microsoftOAuth2ProviderConfigModel
@@ -629,6 +640,20 @@ func (m oauth2ProviderConfigModel) Expand(ctx context.Context) (any, diag.Diagno
 		}
 		return &r, diags
 
+	case !m.IncludedOAuth2ProviderConfig.IsNull():
+		data, d := m.IncludedOAuth2ProviderConfig.ToPtr(ctx)
+		smerr.AddEnrich(ctx, &diags, d)
+		if diags.HasError() {
+			return nil, diags
+		}
+		data.oauth2ClientCredentialsModel = clientCredentials
+		var r awstypes.Oauth2ProviderConfigInputMemberIncludedOauth2ProviderConfig
+		smerr.AddEnrich(ctx, &diags, fwflex.Expand(ctx, data, &r.Value))
+		if diags.HasError() {
+			return nil, diags
+		}
+		return &r, diags
+
 	case !m.MicrosoftOAuth2ProviderConfig.IsNull():
 		data, d := m.MicrosoftOAuth2ProviderConfig.ToPtr(ctx)
 		smerr.AddEnrich(ctx, &diags, d)
@@ -702,6 +727,14 @@ func (m *oauth2ProviderConfigModel) clientCredentials(ctx context.Context) (oaut
 		}
 		return v.oauth2ClientCredentialsModel, diags
 
+	case !m.IncludedOAuth2ProviderConfig.IsNull():
+		v, d := m.IncludedOAuth2ProviderConfig.ToPtr(ctx)
+		diags.Append(d...)
+		if diags.HasError() {
+			return inttypes.Zero[oauth2ClientCredentialsModel](), diags
+		}
+		return v.oauth2ClientCredentialsModel, diags
+
 	case !m.MicrosoftOAuth2ProviderConfig.IsNull():
 		v, d := m.MicrosoftOAuth2ProviderConfig.ToPtr(ctx)
 		diags.Append(d...)
@@ -754,6 +787,11 @@ type githubOAuth2ProviderConfigModel struct {
 }
 
 type googleOAuth2ProviderConfigModel struct {
+	oauth2ClientCredentialsModel
+	OAuthDiscovery fwtypes.ListNestedObjectValueOf[oauth2DiscoveryModel] `tfsdk:"oauth_discovery"`
+}
+
+type includedOAuth2ProviderConfigModel struct {
 	oauth2ClientCredentialsModel
 	OAuthDiscovery fwtypes.ListNestedObjectValueOf[oauth2DiscoveryModel] `tfsdk:"oauth_discovery"`
 }

--- a/internal/service/bedrockagentcore/oauth2_credential_provider_test.go
+++ b/internal/service/bedrockagentcore/oauth2_credential_provider_test.go
@@ -73,6 +73,56 @@ func TestAccBedrockAgentCoreOAuth2CredentialProvider_basic(t *testing.T) {
 	})
 }
 
+func TestAccBedrockAgentCoreOAuth2CredentialProvider_included(t *testing.T) {
+	ctx := acctest.Context(t)
+	var oauth2credentialprovider bedrockagentcorecontrol.GetOauth2CredentialProviderOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_bedrockagentcore_oauth2_credential_provider.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID)
+			testAccPreCheckOAuth2CredentialProviders(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockAgentCoreServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckOAuth2CredentialProviderDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOAuth2CredentialProviderConfig_included(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckOAuth2CredentialProviderExists(ctx, t, resourceName, &oauth2credentialprovider),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("client_secret_arn"), knownvalue.ListExact([]knownvalue.Check{
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"secret_arn": tfknownvalue.RegionalARNRegexp("secretsmanager", regexache.MustCompile(`secret:.+`)),
+						}),
+					})),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("credential_provider_arn"), tfknownvalue.RegionalARNRegexp("bedrock-agentcore", regexache.MustCompile(`token-vault/default/oauth2credentialprovider/.+`))),
+				},
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, names.AttrName),
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: names.AttrName,
+				ImportStateVerifyIgnore: []string{
+					"oauth2_provider_config.0.included_oauth2_provider_config.0.client_secret",
+					"oauth2_provider_config.0.included_oauth2_provider_config.0.client_id",
+				},
+			},
+		},
+	})
+}
+
 func TestAccBedrockAgentCoreOAuth2CredentialProvider_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var oauth2credentialprovider bedrockagentcorecontrol.GetOauth2CredentialProviderOutput
@@ -391,6 +441,22 @@ resource "aws_bedrockagentcore_oauth2_credential_provider" "test" {
   credential_provider_vendor = "GithubOauth2"
   oauth2_provider_config {
     github_oauth2_provider_config {
+      client_id     = "test-client-id"
+      client_secret = "test-client-secret"
+    }
+  }
+}
+`, rName)
+}
+
+func testAccOAuth2CredentialProviderConfig_included(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_bedrockagentcore_oauth2_credential_provider" "test" {
+  name = %[1]q
+
+  credential_provider_vendor = "NotionOauth2"
+  oauth2_provider_config {
+    included_oauth2_provider_config {
       client_id     = "test-client-id"
       client_secret = "test-client-secret"
     }

--- a/website/docs/r/bedrockagentcore_oauth2_credential_provider.html.markdown
+++ b/website/docs/r/bedrockagentcore_oauth2_credential_provider.html.markdown
@@ -30,6 +30,22 @@ resource "aws_bedrockagentcore_oauth2_credential_provider" "github" {
 }
 ```
 
+### Notion OAuth Provider
+
+```terraform
+resource "aws_bedrockagentcore_oauth2_credential_provider" "notion" {
+  name = "notion-oauth-provider"
+
+  credential_provider_vendor = "NotionOauth2"
+  oauth2_provider_config {
+    included_oauth2_provider_config {
+      client_id     = "your-notion-client-id"
+      client_secret = "your-notion-client-secret"
+    }
+  }
+}
+```
+
 ### Custom OAuth Provider with Discovery URL
 
 ```terraform
@@ -81,7 +97,7 @@ resource "aws_bedrockagentcore_oauth2_credential_provider" "keycloak" {
 
 The following arguments are required:
 
-* `credential_provider_vendor` - (Required) Vendor of the OAuth2 credential provider. Valid values: `CustomOauth2`, `GithubOauth2`, `GoogleOauth2`, `Microsoft`, `SalesforceOauth2`, `SlackOauth2`.
+* `credential_provider_vendor` - (Required) Vendor of the OAuth2 credential provider. Valid values: `Auth0Oauth2`, `AtlassianOauth2`, `CognitoOauth2`, `CustomOauth2`, `CyberArkOauth2`, `DropboxOauth2`, `FacebookOauth2`, `FusionAuthOauth2`, `GithubOauth2`, `GoogleOauth2`, `HubspotOauth2`, `LinkedinOauth2`, `MicrosoftOauth2`, `NotionOauth2`, `OktaOauth2`, `OneLoginOauth2`, `PingOneOauth2`, `RedditOauth2`, `SalesforceOauth2`, `SlackOauth2`, `SpotifyOauth2`, `TwitchOauth2`, `XOauth2`, `YandexOauth2`, `ZoomOauth2`.
 * `name` - (Required) Name of the OAuth2 credential provider.
 * `oauth2_provider_config` - (Required) OAuth2 provider configuration. Must contain exactly one provider type. See [`oauth2_provider_config`](#oauth2_provider_config) below.
 
@@ -95,11 +111,12 @@ The following arguments are optional:
 The `oauth2_provider_config` block must contain exactly one of the following provider configurations:
 
 * `custom_oauth2_provider_config` - (Optional) Custom OAuth2 provider configuration. See [`custom`](#custom) below.
-* `github_oauth2_provider_config` - (Optional) GitHub OAuth provider configuration. See [`github`](#github-google-microsoft-salesforce-slack) below.
-* `google_oauth2_provider_config` - (Optional) Google OAuth provider configuration. See [`google`](#github-google-microsoft-salesforce-slack) below.
-* `microsoft_oauth2_provider_config` - (Optional) Microsoft OAuth provider configuration. See [`microsoft`](#github-google-microsoft-salesforce-slack) below.
-* `salesforce_oauth2_provider_config` - (Optional) Salesforce OAuth provider configuration. See [`salesforce`](#github-google-microsoft-salesforce-slack) below.
-* `slack_oauth2_provider_config` - (Optional) Slack OAuth provider configuration. See [`slack`](#github-google-microsoft-salesforce-slack) below.
+* `github_oauth2_provider_config` - (Optional) GitHub OAuth provider configuration. See [`github`](#github-google-included-microsoft-salesforce-slack) below.
+* `google_oauth2_provider_config` - (Optional) Google OAuth provider configuration. See [`google`](#github-google-included-microsoft-salesforce-slack) below.
+* `included_oauth2_provider_config` - (Optional) OAuth2 provider configuration for other built-in providers. See [`included`](#github-google-included-microsoft-salesforce-slack) below.
+* `microsoft_oauth2_provider_config` - (Optional) Microsoft OAuth provider configuration. See [`microsoft`](#github-google-included-microsoft-salesforce-slack) below.
+* `salesforce_oauth2_provider_config` - (Optional) Salesforce OAuth provider configuration. See [`salesforce`](#github-google-included-microsoft-salesforce-slack) below.
+* `slack_oauth2_provider_config` - (Optional) Slack OAuth provider configuration. See [`slack`](#github-google-included-microsoft-salesforce-slack) below.
 
 ### `custom`
 
@@ -120,9 +137,9 @@ The `custom_oauth2_provider_config` block supports the following:
 
 * `oauth_discovery` - (Optional) OAuth discovery configuration. See [`oauth_discovery`](#oauth_discovery) below.
 
-### `github`, `google`, `microsoft`, `salesforce`, `slack`
+### `github`, `google`, `included`, `microsoft`, `salesforce`, `slack`
 
-These predefined provider blocks support the following:
+These predefined provider blocks along with `included` support the following:
 
 **Standard Credentials (choose one pair):**
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls in this pull request.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Adds a new `included_oauth2_provider_config` block to `oauth2_provider_config` in the `aws_bedrockagentcore_oauth2_credential_provider` resource.

The Bedrock AgentCore Control API supports built-in vendors for `credentialProviderVendor`, but only the original vendors have dedicated members in the `oauth2ProviderConfigInput`. The newer vendors are all configured through a shared `includedOauth2ProviderConfig`, with the vendor selected by `credentialProviderVendor`. 

Example usage:
  ```terraform
  resource "aws_bedrockagentcore_oauth2_credential_provider" "notion" {
    name                       = "notion-oauth-provider"
    credential_provider_vendor = "NotionOauth2"
    oauth2_provider_config {
      included_oauth2_provider_config {
        client_id     = "your-notion-client-id"
        client_secret = "your-notion-client-secret"
      }
    }
  }
  ```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

No linked issues.


### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

* [CreateOauth2CredentialProvider API documentation](https://docs.aws.amazon.com/bedrock-agentcore-control/latest/APIReference/API_CreateOauth2CredentialProvider.html)

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccBedrockAgentCoreOAuth2CredentialProvider_ PKG=bedrockagentcore
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     2.167s
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework 2.173s
make: Running acceptance tests on branch: ðŸŒ¿ f-bedrockagentcore_oauth2_credential_provider_included-provider ðŸŒ¿...
TF_ACC=1 go1.26.5 test ./internal/service/bedrockagentcore/... -v -count 1 -parallel 20 -run='TestAccBedrockAgentCoreOAuth2CredentialProvider_'  -timeout 360m -vet=off -buildvcs=false
2026/07/23 20:34:04 Creating Terraform AWS Provider (SDKv2-style)...
2026/07/23 20:34:04 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccBedrockAgentCoreOAuth2CredentialProvider_basic
=== PAUSE TestAccBedrockAgentCoreOAuth2CredentialProvider_basic
=== RUN   TestAccBedrockAgentCoreOAuth2CredentialProvider_included
=== PAUSE TestAccBedrockAgentCoreOAuth2CredentialProvider_included
=== RUN   TestAccBedrockAgentCoreOAuth2CredentialProvider_disappears
=== PAUSE TestAccBedrockAgentCoreOAuth2CredentialProvider_disappears
=== RUN   TestAccBedrockAgentCoreOAuth2CredentialProvider_customDiscoveryURL
=== PAUSE TestAccBedrockAgentCoreOAuth2CredentialProvider_customDiscoveryURL
=== RUN   TestAccBedrockAgentCoreOAuth2CredentialProvider_authorizationServerMetadata
=== PAUSE TestAccBedrockAgentCoreOAuth2CredentialProvider_authorizationServerMetadata
=== RUN   TestAccBedrockAgentCoreOAuth2CredentialProvider_full
=== PAUSE TestAccBedrockAgentCoreOAuth2CredentialProvider_full
=== RUN   TestAccBedrockAgentCoreOAuth2CredentialProvider_tags
=== PAUSE TestAccBedrockAgentCoreOAuth2CredentialProvider_tags
=== CONT  TestAccBedrockAgentCoreOAuth2CredentialProvider_basic
=== CONT  TestAccBedrockAgentCoreOAuth2CredentialProvider_authorizationServerMetadata
=== CONT  TestAccBedrockAgentCoreOAuth2CredentialProvider_tags
=== CONT  TestAccBedrockAgentCoreOAuth2CredentialProvider_customDiscoveryURL
=== CONT  TestAccBedrockAgentCoreOAuth2CredentialProvider_full
=== CONT  TestAccBedrockAgentCoreOAuth2CredentialProvider_disappears
=== CONT  TestAccBedrockAgentCoreOAuth2CredentialProvider_included
--- PASS: TestAccBedrockAgentCoreOAuth2CredentialProvider_disappears (21.87s)
--- PASS: TestAccBedrockAgentCoreOAuth2CredentialProvider_authorizationServerMetadata (25.53s)
--- PASS: TestAccBedrockAgentCoreOAuth2CredentialProvider_full (25.58s)
--- PASS: TestAccBedrockAgentCoreOAuth2CredentialProvider_basic (26.78s)
--- PASS: TestAccBedrockAgentCoreOAuth2CredentialProvider_included (26.83s)
--- PASS: TestAccBedrockAgentCoreOAuth2CredentialProvider_customDiscoveryURL (38.19s)
--- PASS: TestAccBedrockAgentCoreOAuth2CredentialProvider_tags (53.65s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/bedrockagentcore   55.795s
...
```
