### PR TITLE
docs: clarify transit_encryption_enabled support for aws_elasticache_cluster

### DIFF
--- a/website/docs/r/elasticache_cluster.html.markdown
+++ b/website/docs/r/elasticache_cluster.html.markdown
@@ -181,7 +181,7 @@ The minimum maintenance window is a 60 minute period. Example: `sun:05:00-sun:09
 * `snapshot_window` - (Optional, Redis only) Daily time range (in UTC) during which ElastiCache will begin taking a daily snapshot of your cache cluster. Example: 05:00-09:00
 * `subnet_group_name` - (Optional, VPC only) Name of the subnet group to be used for the cache cluster. Changing this value will re-create the resource. Cannot be provided with `replication_group_id.`
 * `tags` - (Optional) Map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
-* `transit_encryption_enabled` - (Optional) Enable encryption in-transit. Supported with Memcached versions `1.6.12` and later, Redis OSS versions `3.2.6`, `4.0.10` and later, running in a VPC. See the [ElastiCache in-transit encryption documentation](https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/in-transit-encryption.html#in-transit-encryption-constraints) for more details.
+* `transit_encryption_enabled` - (Optional) Enable encryption in-transit. Supported with Memcached versions `1.6.12` and later, running in a VPC. For Redis OSS, configure `transit_encryption_enabled` using the [`aws_elasticache_replication_group` resource](/docs/providers/aws/r/elasticache_replication_group.html). See the [ElastiCache in-transit encryption documentation](https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/in-transit-encryption.html#in-transit-encryption-constraints) for more details.
 
 ### Log Delivery Configuration
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If this change needs to be reverted, restoring the previous documentation will return the original behavior. This is a documentation-only change.

## Changes to Security Controls

None. This is a documentation-only change.

### Description

Updates the `aws_elasticache_cluster` documentation to remove the incorrect Redis OSS version compatibility guidance for `transit_encryption_enabled`.

The documentation now clarifies that Redis OSS users should configure `transit_encryption_enabled` using the `aws_elasticache_replication_group` resource.

### Relations

Closes #49066

### References

N/A

### Output from Acceptance Testing

```console
Not applicable. Documentation-only change.
```