### PR TITLE
Docs: `aws_elasticache_global_replication_group` fix docs gap related to parameter_group_name

### DIFF
--- a/.changelog/49110.txt
+++ b/.changelog/49110.txt
@@ -1,0 +1,3 @@
+```release-note:note
+resource/aws_elasticache_global_replication_group: Clarified `parameter_group_name` documentation to note that AWS auto-generates a `global-datastore-` prefixed parameter group when a replication group joins a global datastore, and that subsequent parameter group changes require a major engine version upgrade
+```

--- a/.changelog/49110.txt
+++ b/.changelog/49110.txt
@@ -1,3 +1,0 @@
-```release-note:note
-resource/aws_elasticache_global_replication_group: Clarified `parameter_group_name` documentation to note that AWS auto-generates a `global-datastore-` prefixed parameter group when a replication group joins a global datastore, and that subsequent parameter group changes require a major engine version upgrade
-```

--- a/website/docs/r/elasticache_global_replication_group.html.markdown
+++ b/website/docs/r/elasticache_global_replication_group.html.markdown
@@ -116,8 +116,10 @@ This resource supports the following arguments:
 * `global_replication_group_description` - (Optional) A user-created description for the global replication group.
 * `num_node_groups` - (Optional) The number of node groups (shards) on the global replication group.
 * `parameter_group_name` - (Optional) An ElastiCache Parameter Group to use for the Global Replication Group.
-  Required when upgrading an engine or major engine version, but will be ignored if left configured after the upgrade is complete.
+  Required when upgrading a major engine version, but will be ignored if left configured after the upgrade is complete.
   Specifying without a major version upgrade will fail.
+  Note that when a replication group joins a global datastore, AWS auto-generates a new parameter group (prefixed `global-datastore-`) derived from the primary's parameter group.
+  Subsequent parameter group changes must be made via a major engine version upgrade.
   Note that ElastiCache creates a copy of this parameter group for each member replication group.
 
 ## Attribute Reference

--- a/website/docs/r/elasticache_global_replication_group.html.markdown
+++ b/website/docs/r/elasticache_global_replication_group.html.markdown
@@ -116,11 +116,7 @@ This resource supports the following arguments:
 * `global_replication_group_description` - (Optional) A user-created description for the global replication group.
 * `num_node_groups` - (Optional) The number of node groups (shards) on the global replication group.
 * `parameter_group_name` - (Optional) An ElastiCache Parameter Group to use for the Global Replication Group.
-  Required when upgrading a major engine version, but will be ignored if left configured after the upgrade is complete.
-  Specifying without a major version upgrade will fail.
-  Note that when a replication group joins a global datastore, AWS auto-generates a new parameter group (prefixed `global-datastore-`) derived from the primary's parameter group.
-  Subsequent parameter group changes must be made via a major engine version upgrade.
-  Note that ElastiCache creates a copy of this parameter group for each member replication group.
+  Required when upgrading a major engine version, but will be ignored if left configured after the upgrade is complete. Specifying without a major version upgrade will fail. When a replication group joins a global datastore, AWS auto-generates a new parameter group (prefixed `global-datastore-`) derived from the primary's parameter group. Note that ElastiCache creates a copy of this parameter group for each member replication group.
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Clarifies the `parameter_group_name` documentation on `aws_elasticache_global_replication_group` to explain AWS API constraints around parameter group handling for global datastores.

Users were confused because setting parameter_group_name on the primary `aws_elasticache_replication_group` appeared to be "ignored" after the replication group joined a global datastore. This is expected AWS behavior , `CreateGlobalReplicationGroup` API does not accept a `CacheParameterGroupName` parameter, and `ModifyGlobalReplicationGroup` only allows parameter group changes during a major engine version upgrade. AWS auto-generates a new parameter group (prefixed global-datastore-) when a replication group joins a global datastore.

I confirmed this by attempting a standalone parameter group modification via the API, which returned:
```
InvalidParameterValue: ModifyGlobalReplicationGroup API does not support
cache parameter group modification without a change in major engine version.
```

The existing provider validation (paramGroupNameRequiresEngineOrMajorVersionUpgrade) is correct. This PR adds documentation to make the AWS constraint visible to users.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #42622

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
