### PR TITLE
resource/aws_bedrockagent_data_source: Fix validator requiring bedrock_data_automation_configuration

### DIFF
--- a/.changelog/49111.txt
+++ b/.changelog/49111.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_bedrockagent_data_source: Fix validator incorrectly requiring `bedrock_data_automation_configuration` when `parsing_strategy = "BEDROCK_DATA_AUTOMATION"`, a regression introduced in v6.56.0
+```

--- a/internal/service/bedrockagent/bedrockagent_test.go
+++ b/internal/service/bedrockagent/bedrockagent_test.go
@@ -38,6 +38,7 @@ func TestAccBedrockAgent_serial(t *testing.T) {
 			"parsing":                           testAccDataSource_parsing,
 			"parsingModality":                   testAccDataSource_parsingModality,
 			"bedrockDataAutomation":             testAccDataSource_bedrockDataAutomation,
+			"bedrockDataAutomationNoConfig":     testAccDataSource_bedrockDataAutomationNoConfig,
 			"customTransformation":              testAccDataSource_fullCustomTranformation,
 			"webConfiguration":                  testAccDataSource_webConfiguration,
 			"managedKBConnectorBasic":           testAccDataSource_managedKBConnector_basic,

--- a/internal/service/bedrockagent/data_source.go
+++ b/internal/service/bedrockagent/data_source.go
@@ -880,7 +880,6 @@ func (r *dataSourceResource) Schema(ctx context.Context, request resource.Schema
 										Required:   true,
 										Validators: []validator.String{
 											tfstringvalidator.DiscriminatorRequires(map[awstypes.ParsingStrategy]path.Expression{
-												awstypes.ParsingStrategyBedrockDataAutomation:  path.MatchRelative().AtParent().AtName("bedrock_data_automation_configuration"),
 												awstypes.ParsingStrategyBedrockFoundationModel: path.MatchRelative().AtParent().AtName("bedrock_foundation_model_configuration"),
 											}),
 										},

--- a/internal/service/bedrockagent/data_source_test.go
+++ b/internal/service/bedrockagent/data_source_test.go
@@ -539,6 +539,50 @@ func testAccDataSource_bedrockDataAutomation(t *testing.T) {
 	})
 }
 
+func testAccDataSource_bedrockDataAutomationNoConfig(t *testing.T) {
+	acctest.SkipIfExeNotOnPath(t, "psql")
+	acctest.SkipIfExeNotOnPath(t, "jq")
+	acctest.SkipIfExeNotOnPath(t, "aws")
+
+	acctest.SkipIfEnvVarNotSet(t, TitanModelsAllowedEnvVar)
+
+	ctx := acctest.Context(t)
+	var dataSource types.DataSource
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_bedrockagent_data_source.test"
+	foundationModel := "amazon.titan-embed-text-v1"
+
+	acctest.Test(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockAgentServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"null": {
+				Source:            "hashicorp/null",
+				VersionConstraint: "3.2.2",
+			},
+		},
+		CheckDestroy: testAccCheckDataSourceDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceConfig_bedrockDataAutomationNoConfig(rName, foundationModel),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckDataSourceExists(ctx, t, resourceName, &dataSource),
+					resource.TestCheckResourceAttr(resourceName, "vector_ingestion_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "vector_ingestion_configuration.0.parsing_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "vector_ingestion_configuration.0.parsing_configuration.0.parsing_strategy", "BEDROCK_DATA_AUTOMATION"),
+					resource.TestCheckResourceAttr(resourceName, "vector_ingestion_configuration.0.parsing_configuration.0.bedrock_data_automation_configuration.#", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccDataSource_managedKBConnector_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var dataSource types.DataSource
@@ -998,6 +1042,33 @@ resource "aws_bedrockagent_data_source" "test" {
       bedrock_data_automation_configuration {
         parsing_modality = "MULTIMODAL"
       }
+    }
+  }
+}
+`, rName))
+}
+
+func testAccDataSourceConfig_bedrockDataAutomationNoConfig(rName, embeddingModel string) string {
+	return acctest.ConfigCompose(testAccKnowledgeBaseConfig_RDS_supplementalDataStorage(rName, embeddingModel), fmt.Sprintf(`
+resource "aws_s3_bucket" "test2" {
+  bucket        = "%[1]s-2"
+  force_destroy = true
+}
+
+resource "aws_bedrockagent_data_source" "test" {
+  knowledge_base_id = aws_bedrockagent_knowledge_base.test.id
+  name              = %[1]q
+
+  data_source_configuration {
+    type = "S3"
+    s3_configuration {
+      bucket_arn = aws_s3_bucket.test2.arn
+    }
+  }
+
+  vector_ingestion_configuration {
+    parsing_configuration {
+      parsing_strategy = "BEDROCK_DATA_AUTOMATION"
     }
   }
 }


### PR DESCRIPTION
## Summary

Fixes #49080. A regression in v6.56.0: `parsing_strategy = BEDROCK_DATA_AUTOMATION`
incorrectly required the `bedrock_data_automation_configuration` block via
`DiscriminatorRequires`, contradicting both the schema (which marks the block
`Optional`) and the AWS API (which rejects an empty block if one is sent just
to satisfy the validator).

This made it impossible to use `BEDROCK_DATA_AUTOMATION` in its default,
text-only mode, and forced replacement of existing data sources that had no
such block in state -- replacements that then failed against the AWS API,
leaving the data source deleted but not recreated.

`bedrock_foundation_model_configuration`'s discriminator entry is unaffected:
that strategy has a `Required` `model_arn` inside the block, so the block
genuinely must be present, and that pairing was not in dispute.

## Test plan

- [x] `go build ./internal/service/bedrockagent/...`
- [x] `go vet ./internal/service/bedrockagent/...`
- [ ] Acceptance test `bedrockDataAutomationNoConfig` added, covering the
      exact scenario from the issue (`BEDROCK_DATA_AUTOMATION` with no
      `bedrock_data_automation_configuration` block) - not run locally
      (requires AWS credentials and Bedrock model access)