### PR TITLE
resource/aws_odb_cloud_vm_cluster: Add optional system_version argument 🤖🤖🤖

### DIFF
--- a/.changelog/49113.txt
+++ b/.changelog/49113.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_odb_cloud_vm_cluster: Add `system_version` argument
+```

--- a/internal/service/odb/cloud_vm_cluster.go
+++ b/internal/service/odb/cloud_vm_cluster.go
@@ -370,11 +370,12 @@ func (r *resourceCloudVmCluster) Schema(ctx context.Context, req resource.Schema
 				Description: "The local node storage allocated to the VM cluster, in gigabytes (GB).",
 			},
 			"system_version": schema.StringAttribute{
+				Optional: true,
 				Computed: true,
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
+					stringplanmodifier.RequiresReplaceIfConfigured(),
 				},
-				Description: "The operating system version of the image chosen for the VM cluster.",
+				Description: "Operating system version for the VM cluster image. Use the ListSystemVersions operation to list versions available for the specified GI version and Exadata infrastructure shape. If omitted, AWS selects the system version. Changing this creates a new resource.",
 			},
 			"scan_listener_port_tcp": schema.Int32Attribute{
 				Computed: true,
@@ -527,6 +528,8 @@ func (r *resourceCloudVmCluster) ValidateConfig(ctx context.Context, req resourc
 func (r *resourceCloudVmCluster) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	conn := r.Meta().ODBClient(ctx)
 	var plan cloudVmClusterResourceModel
+	var configuredSystemVersion types.String
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("system_version"), &configuredSystemVersion)...)
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -550,6 +553,7 @@ func (r *resourceCloudVmCluster) Create(ctx context.Context, req resource.Create
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	input.SystemVersion = cloudVmClusterSystemVersionForCreate(ctx, configuredSystemVersion, plan.SystemVersion)
 	out, err := conn.CreateCloudVmCluster(ctx, &input)
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -645,6 +649,20 @@ func (r *resourceCloudVmCluster) Read(ctx context.Context, req resource.ReadRequ
 		return
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *resourceCloudVmCluster) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan cloudVmClusterResourceModel
+	var configuredSystemVersion, priorSystemVersion types.String
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("system_version"), &configuredSystemVersion)...)
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("system_version"), &priorSystemVersion)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	plan.SystemVersion = cloudVmClusterSystemVersionForUpdate(configuredSystemVersion, plan.SystemVersion, priorSystemVersion)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
 func (r *resourceCloudVmCluster) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
@@ -825,7 +843,7 @@ type cloudVmClusterResourceModel struct {
 	Status                        fwtypes.StringEnum[odbtypes.ResourceStatus]                                 `tfsdk:"status"`
 	StatusReason                  types.String                                                                `tfsdk:"status_reason"`
 	StorageSizeInGBs              types.Int32                                                                 `tfsdk:"storage_size_in_gbs"`
-	SystemVersion                 types.String                                                                `tfsdk:"system_version"`
+	SystemVersion                 types.String                                                                `tfsdk:"system_version" autoflex:",noexpand"`
 	Timeouts                      timeouts.Value                                                              `tfsdk:"timeouts"`
 	Timezone                      types.String                                                                `tfsdk:"timezone"`
 	VipIds                        fwtypes.ListValueOf[types.String]                                           `tfsdk:"vip_ids"`
@@ -834,6 +852,22 @@ type cloudVmClusterResourceModel struct {
 	ScanListenerPortTcp           types.Int32                                                                 `tfsdk:"scan_listener_port_tcp" autoflex:",noflatten"`
 	Tags                          tftags.Map                                                                  `tfsdk:"tags"`
 	TagsAll                       tftags.Map                                                                  `tfsdk:"tags_all"`
+}
+
+func cloudVmClusterSystemVersionForCreate(ctx context.Context, config, plan types.String) *string {
+	if config.IsNull() {
+		return nil
+	}
+
+	return flex.StringFromFramework(ctx, plan)
+}
+
+func cloudVmClusterSystemVersionForUpdate(config, plan, state types.String) types.String {
+	if config.IsNull() && plan.IsUnknown() {
+		return state
+	}
+
+	return plan
 }
 
 type cloudVMCDataCollectionOptionsResourceModel struct {

--- a/internal/service/odb/cloud_vm_cluster_internal_test.go
+++ b/internal/service/odb/cloud_vm_cluster_internal_test.go
@@ -1,0 +1,189 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package odb
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func TestCloudVmClusterSystemVersionPlanModifier(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	r := &resourceCloudVmCluster{}
+	var schemaResponse resource.SchemaResponse
+	r.Schema(ctx, resource.SchemaRequest{}, &schemaResponse)
+
+	attribute, ok := schemaResponse.Schema.Attributes["system_version"].(schema.StringAttribute)
+	if !ok {
+		t.Fatalf("expected system_version to be a schema.StringAttribute, got %T", schemaResponse.Schema.Attributes["system_version"])
+	}
+
+	nonNullPlan := tfsdk.Plan{
+		Raw: tftypes.NewValue(tftypes.String, "plan"),
+	}
+	nonNullState := tfsdk.State{
+		Raw: tftypes.NewValue(tftypes.String, "state"),
+	}
+
+	tests := map[string]struct {
+		config          types.String
+		plan            types.String
+		state           types.String
+		requiresReplace bool
+	}{
+		"unconfigured value stays unknown": {
+			config:          types.StringNull(),
+			plan:            types.StringUnknown(),
+			state:           types.StringValue("old-version"),
+			requiresReplace: false,
+		},
+		"configured value change requires replacement": {
+			config:          types.StringValue("new-version"),
+			plan:            types.StringValue("new-version"),
+			state:           types.StringValue("old-version"),
+			requiresReplace: true,
+		},
+		"unchanged configured value does not require replacement": {
+			config:          types.StringValue("old-version"),
+			plan:            types.StringValue("old-version"),
+			state:           types.StringValue("old-version"),
+			requiresReplace: false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			request := planmodifier.StringRequest{
+				ConfigValue: test.config,
+				Plan:        nonNullPlan,
+				PlanValue:   test.plan,
+				State:       nonNullState,
+				StateValue:  test.state,
+			}
+			response := &planmodifier.StringResponse{
+				PlanValue: test.plan,
+			}
+
+			for _, modifier := range attribute.PlanModifiers {
+				modifier.PlanModifyString(ctx, request, response)
+				request.PlanValue = response.PlanValue
+			}
+
+			if got, want := response.RequiresReplace, test.requiresReplace; got != want {
+				t.Errorf("expected RequiresReplace to be %t, got %t", want, got)
+			}
+			if !response.PlanValue.Equal(test.plan) {
+				t.Errorf("expected planned system_version %s, got %s", test.plan, response.PlanValue)
+			}
+		})
+	}
+}
+
+func TestCloudVmClusterSystemVersionForCreate(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	tests := map[string]struct {
+		config  types.String
+		plan    types.String
+		want    string
+		wantNil bool
+	}{
+		"unconfigured omits stale planned value": {
+			config:  types.StringNull(),
+			plan:    types.StringValue("old-computed-version"),
+			wantNil: true,
+		},
+		"configured uses apply-resolved planned value": {
+			config: types.StringValue("configured-version"),
+			plan:   types.StringValue("resolved-version"),
+			want:   "resolved-version",
+		},
+		"unknown configuration uses apply-resolved planned value": {
+			config: types.StringUnknown(),
+			plan:   types.StringValue("resolved-version"),
+			want:   "resolved-version",
+		},
+		"unknown planned value is omitted": {
+			config:  types.StringValue("configured-version"),
+			plan:    types.StringUnknown(),
+			wantNil: true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := cloudVmClusterSystemVersionForCreate(ctx, test.config, test.plan)
+
+			switch {
+			case test.wantNil && got != nil:
+				t.Errorf("expected no system version, got %q", *got)
+			case !test.wantNil && got == nil:
+				t.Errorf("expected system version %q, got nil", test.want)
+			case !test.wantNil && *got != test.want:
+				t.Errorf("expected system version %q, got %q", test.want, *got)
+			}
+		})
+	}
+}
+
+func TestCloudVmClusterSystemVersionForUpdate(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		config types.String
+		plan   types.String
+		state  types.String
+		want   types.String
+	}{
+		"unconfigured unknown plan preserves state": {
+			config: types.StringNull(),
+			plan:   types.StringUnknown(),
+			state:  types.StringValue("old-version"),
+			want:   types.StringValue("old-version"),
+		},
+		"unknown configuration remains unknown": {
+			config: types.StringUnknown(),
+			plan:   types.StringUnknown(),
+			state:  types.StringValue("old-version"),
+			want:   types.StringUnknown(),
+		},
+		"configured plan is unchanged": {
+			config: types.StringValue("configured-version"),
+			plan:   types.StringValue("configured-version"),
+			state:  types.StringValue("old-version"),
+			want:   types.StringValue("configured-version"),
+		},
+		"known unconfigured plan is unchanged": {
+			config: types.StringNull(),
+			plan:   types.StringValue("old-version"),
+			state:  types.StringValue("old-version"),
+			want:   types.StringValue("old-version"),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := cloudVmClusterSystemVersionForUpdate(test.config, test.plan, test.state)
+			if !got.Equal(test.want) {
+				t.Errorf("expected system version %s, got %s", test.want, got)
+			}
+		})
+	}
+}

--- a/internal/service/odb/cloud_vm_cluster_test.go
+++ b/internal/service/odb/cloud_vm_cluster_test.go
@@ -10,12 +10,15 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/odb"
 	odbtypes "github.com/aws/aws-sdk-go-v2/service/odb/types"
+	"github.com/hashicorp/terraform-plugin-testing/config"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
@@ -126,6 +129,7 @@ func TestAccODBCloudVmCluster_taggingTest(t *testing.T) {
 		return
 	}
 	vmcNoTag, vmcWithTag := vmClusterTestEntity.testAccCloudVmClusterConfigBasic(t, vmcDisplayName, publicKey)
+	vmcReplacement := strings.Replace(vmcWithTag, `hostname_prefix                 = "apollo-12"`, `hostname_prefix                 = "apollo-13"`, 1)
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
@@ -168,6 +172,17 @@ func TestAccODBCloudVmCluster_taggingTest(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+			{
+				Config:             vmcReplacement,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionReplace),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("system_version")),
+					},
+				},
 			},
 		},
 	})
@@ -383,6 +398,63 @@ func TestAccODBCloudVmCluster_usingARN(t *testing.T) {
 	})
 }
 
+func TestAccODBCloudVmCluster_systemVersion(t *testing.T) {
+	// This acceptance test suite runs against fake resources, where the DBaaS
+	// backend currently returns a system version that can differ from the
+	// requested value. The DBaaS backend owners are working to fix this mismatch
+	// for fake resources. As part of this change, the behavior was separately
+	// validated against a real resource, where the configured and returned system
+	// versions matched.
+	t.Skip("skipping until fake DBaaS resources return the requested system version")
+
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+	var cloudvmcluster odbtypes.CloudVmCluster
+	var systemVersion string
+	systemVersionVariables := config.Variables{}
+	vmcClusterDisplayName := acctest.RandomWithPrefix(t, vmClusterTestEntity.vmClusterDisplayNamePrefix)
+	publicKey, _, err := sdkacctest.RandSSHKeyPair(acctest.DefaultEmailAddress)
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+	resourceName := "aws_odb_cloud_vm_cluster.test"
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			vmClusterTestEntity.testAccPreCheck(ctx, t)
+			systemVersion = vmClusterTestEntity.testAccSystemVersion(ctx, t, "23.0.0.0", "Exadata.X9M")
+			systemVersionVariables["system_version"] = config.StringVariable(systemVersion)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ODBServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             vmClusterTestEntity.testAccCheckCloudVmClusterDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config:          vmClusterTestEntity.cloudVmClusterWithSystemVersion(t, vmcClusterDisplayName, publicKey),
+				ConfigVariables: systemVersionVariables,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					vmClusterTestEntity.testAccCheckCloudVmClusterExists(ctx, t, resourceName, &cloudvmcluster),
+					resource.TestCheckResourceAttrWith(resourceName, "system_version", func(value string) error {
+						if value != systemVersion {
+							return fmt.Errorf("expected system_version %q, got %q", systemVersion, value)
+						}
+						return nil
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ConfigVariables:   systemVersionVariables,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccODBCloudVmCluster_variables(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
@@ -458,6 +530,30 @@ func (cloudVmClusterResourceTest) testAccPreCheck(ctx context.Context, t *testin
 	if err != nil {
 		t.Fatalf("unexpected PreCheck error: %s", err)
 	}
+}
+
+func (cloudVmClusterResourceTest) testAccSystemVersion(ctx context.Context, t *testing.T, giVersion, shape string) string {
+	t.Helper()
+
+	conn := acctest.ProviderMeta(ctx, t).ODBClient(ctx)
+	output, err := conn.ListSystemVersions(ctx, &odb.ListSystemVersionsInput{
+		GiVersion: aws.String(giVersion),
+		Shape:     aws.String(shape),
+	})
+	if acctest.PreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+	if err != nil {
+		t.Fatalf("listing ODB system versions: %s", err)
+	}
+	for _, summary := range output.SystemVersions {
+		if len(summary.SystemVersions) > 0 {
+			return summary.SystemVersions[0]
+		}
+	}
+
+	t.Skipf("skipping acceptance testing: no ODB system versions available for GI version %q and shape %q", giVersion, shape)
+	return ""
 }
 
 func testAccCloudVmClusterConfig_useVariables(rName string) string {
@@ -618,6 +714,52 @@ resource "aws_odb_cloud_vm_cluster" "test" {
     is_diagnostics_events_enabled = true
     is_health_monitoring_enabled  = true
     is_incident_logs_enabled      = true
+  }
+}
+`, exaInfra, odbNet, vmClusterDisplayName, sshKey)
+	return res
+}
+
+func (cloudVmClusterResourceTest) cloudVmClusterWithSystemVersion(t *testing.T, vmClusterDisplayName, sshKey string) string {
+	exaInfraDisplayName := acctest.RandomWithPrefix(t, vmClusterTestEntity.exaInfraDisplayNamePrefix)
+	odbNetDisplayName := acctest.RandomWithPrefix(t, vmClusterTestEntity.odbNetDisplayNamePrefix)
+	exaInfra := vmClusterTestEntity.exaInfra(exaInfraDisplayName)
+	odbNet := vmClusterTestEntity.oracleDBNetwork(odbNetDisplayName)
+
+	res := fmt.Sprintf(`
+
+%s
+
+%s
+
+variable "system_version" {
+  type = string
+}
+
+data "aws_odb_db_servers" "test" {
+  cloud_exadata_infrastructure_id = aws_odb_cloud_exadata_infrastructure.test.id
+}
+
+resource "aws_odb_cloud_vm_cluster" "test" {
+  display_name                    = %[3]q
+  cloud_exadata_infrastructure_id = aws_odb_cloud_exadata_infrastructure.test.id
+  cpu_core_count                  = 6
+  gi_version                      = "23.0.0.0"
+  hostname_prefix                 = "apollo12"
+  ssh_public_keys                 = ["%[4]s"]
+  odb_network_id                  = aws_odb_network.test.id
+  is_local_backup_enabled         = true
+  is_sparse_diskgroup_enabled     = true
+  license_model                   = "LICENSE_INCLUDED"
+  data_storage_size_in_tbs        = 20.0
+  db_servers                      = [for db_server in data.aws_odb_db_servers.test.db_servers : db_server.id]
+  db_node_storage_size_in_gbs     = 120.0
+  memory_size_in_gbs              = 60
+  system_version                  = var.system_version
+  data_collection_options {
+    is_diagnostics_events_enabled = false
+    is_health_monitoring_enabled  = false
+    is_incident_logs_enabled      = false
   }
 }
 `, exaInfra, odbNet, vmClusterDisplayName, sshKey)

--- a/website/docs/r/odb_cloud_vm_cluster.html.markdown
+++ b/website/docs/r/odb_cloud_vm_cluster.html.markdown
@@ -61,6 +61,7 @@ resource "aws_odb_cloud_vm_cluster" "with_all_parameters" {
   cluster_name                    = "julia-13"
   timezone                        = "UTC"
   scan_listener_port_tcp          = 1521
+  system_version                  = "25.1.14.0.0.260206"
   tags = {
     "env" = "dev"
   }
@@ -130,6 +131,7 @@ The following arguments are optional:
 * `license_model` - (Optional) The Oracle license model to apply to the VM cluster. Default: LICENSE_INCLUDED. Changing this will create a new resource.
 * `memory_size_in_gbs` - (Optional) The amount of memory, in gigabytes (GBs), to allocate for the VM cluster. Changing this will create a new resource.
 * `scan_listener_port_tcp` - (Optional) The port number for TCP connections to the single client access name (SCAN) listener. Valid values: 1024–8999, except 2484, 6100, 6200, 7060, 7070, 7085, and 7879. Default: 1521. Changing this will create a new resource.
+* `system_version` - (Optional) Operating system version for the VM cluster image. See [ListSystemVersions](https://docs.aws.amazon.com/odb/latest/APIReference/API_ListSystemVersions.html) for versions available for the specified GI version and Exadata infrastructure shape. If omitted, AWS selects the system version. Changing this creates a new resource.
 * `timezone` - (Optional) The configured time zone of the VM cluster. Changing this will create a new resource.
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `tags` - (Optional) A map of tags to assign to the exadata infrastructure. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
@@ -158,7 +160,6 @@ This data source exports the following attributes in addition to the arguments a
 * `status` - The current lifecycle status of the VM cluster.
 * `status_reason` - Additional information regarding the current status of the VM cluster.
 * `storage_size_in_gbs` - The local node storage allocated to the VM cluster, in gigabytes (GB).
-* `system_version` - The operating system version of the image chosen for the VM cluster.
 * `vip_ids` - The virtual IP (VIP) addresses assigned to the VM cluster. CRS assigns one VIP per node for failover support.
 * `created_at` - The timestamp when the VM cluster was created.
 * `gi_version_computed` - A complete software version of Oracle Grid Infrastructure (GI).


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If this change needs to be reverted, we will publish an updated provider version reverting the schema and request/state handling changes.

## Changes to Security Controls

No changes to access controls, encryption, or logging.

### Description

This PR adds an optional `system_version` argument to the `aws_odb_cloud_vm_cluster` resource while preserving the existing behavior when the argument is omitted.

The change:

- Marks `system_version` as both Optional and Computed.
- Sends the requested version to `CreateCloudVmCluster` only when it is explicitly configured.
- Omits `SystemVersion` from the API request when the argument is not configured, allowing AWS to select the version.
- Requires replacement when an explicitly configured version changes.
- Keeps an omitted value unknown during replacement planning so that a version computed for the old VM cluster is not unintentionally reused for its replacement.
- Preserves the existing computed value during unrelated in-place updates.
- Adds unit and acceptance-test coverage.
- Updates the resource documentation and adds an enhancement changelog entry.

This remains backward compatible with configurations that do not specify `system_version`.

AI use disclosure: I used OpenAI Codex to review the original implementation, implement the plan/create/update state-handling fixes, generate tests, update documentation, run focused validation, and prepare this description. I reviewed and understand the submitted changes and remain responsible for them.

### Relations

Closes #46880

### References

- Builds on #46881.
- [AWS ODB ListSystemVersions API documentation](https://docs.aws.amazon.com/odb/latest/APIReference/API_ListSystemVersions.html)

### Output from Acceptance Testing

#### Focused unit tests

The unit tests cover:

- Replacement behavior for configured and omitted values.
- Omitting stale computed values from create requests.
- Passing explicitly configured values to create requests.
- Preserving computed state during unrelated updates.

```console
$ go test ./internal/service/odb -run '^TestCloudVmClusterSystemVersion' -count=1 -v

--- PASS: TestCloudVmClusterSystemVersionPlanModifier
--- PASS: TestCloudVmClusterSystemVersionForCreate
--- PASS: TestCloudVmClusterSystemVersionForUpdate
PASS
ok   github.com/hashicorp/terraform-provider-aws/internal/service/odb
```

#### Acceptance-test invocation

```console
$ make testacc \
    PKG=odb \
    TESTS='^TestAccODBCloudVmCluster_systemVersion$' \
    TESTARGS='-short' \
    ACCTEST_PARALLELISM=1

=== RUN   TestAccODBCloudVmCluster_systemVersion
    cloud_vm_cluster_test.go:408: skipping until fake DBaaS resources return the requested system version
--- SKIP: TestAccODBCloudVmCluster_systemVersion (0.00s)
PASS
ok   github.com/hashicorp/terraform-provider-aws/internal/service/odb
```

The explicit-version acceptance test is temporarily skipped because the fake DBaaS backend can return a system version different from the requested version. The backend owners are working to correct this behavior for fake resources.

The test remains in place and, once enabled, dynamically selects an available version using `ListSystemVersions`, provisions the VM cluster with that version, verifies exact equality, and verifies import.

The acceptance coverage also includes a replacement-plan assertion confirming that an omitted `system_version` remains unknown instead of reusing the value computed for the existing VM cluster.

#### Manual real-resource validation

The locally built provider was tested through a Terraform development override against a real resource.

With an explicit `system_version`:

```console
$ terraform plan -out=create.tfplan

...
+ system_version = "24.1.19.0.0.251214"

Plan: 1 to add, 0 to change, 0 to destroy.

$ terraform apply create.tfplan

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

resolved_system_version = "24.1.19.0.0.251214"
```

The configured and returned system versions matched exactly.

#### Regression validation with `system_version` omitted

A separate provisioning test verified that existing configurations can continue to omit the argument:

```console
$ terraform validate

Success! The configuration is valid.

$ terraform plan -out=create.tfplan

...
+ system_version = (known after apply)

Plan: 1 to add, 0 to change, 0 to destroy.

$ terraform apply create.tfplan

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

resolved_system_version = "24.1.0.0.0.0"
```

This confirms that `system_version` remains optional: provisioning succeeds when it is omitted, and the backend-selected version is stored as computed state.
