### PR TITLE
Lambda self-managed Amazon S3 buckets

### DIFF
--- a/.changelog/49117.txt
+++ b/.changelog/49117.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_lambda_function: Add `s3_object_storage_mode` argument in support of [self-managed S3 code storage](https://docs.aws.amazon.com/lambda/latest/dg/configuration-self-managed-storage.html)
+```

--- a/internal/service/lambda/function.go
+++ b/internal/service/lambda/function.go
@@ -437,6 +437,13 @@ func resourceFunction() *schema.Resource {
 					Optional:      true,
 					ConflictsWith: []string{"filename", "image_uri"},
 				},
+				"s3_object_storage_mode": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.S3ObjectStorageMode](),
+					ConflictsWith:    []string{"filename", "image_uri"},
+					RequiredWith:     []string{names.AttrS3Bucket},
+				},
 				"signing_job_arn": {
 					Type:     schema.TypeString,
 					Computed: true,
@@ -636,6 +643,9 @@ func resourceFunctionCreate(ctx context.Context, d *schema.ResourceData, meta an
 		input.Code.S3Key = aws.String(d.Get("s3_key").(string))
 		if v, ok := d.GetOk("s3_object_version"); ok {
 			input.Code.S3ObjectVersion = aws.String(v.(string))
+		}
+		if v, ok := d.GetOk("s3_object_storage_mode"); ok {
+			input.Code.S3ObjectStorageMode = awstypes.S3ObjectStorageMode(v.(string))
 		}
 	}
 
@@ -1037,6 +1047,11 @@ func resourceFunctionUpdate(ctx context.Context, d *schema.ResourceData, meta an
 			if v, ok := d.GetOk("s3_object_version"); ok {
 				input.S3ObjectVersion = aws.String(v.(string))
 			}
+			// If s3_object_storage_mode is set, always include it in the
+			// update; omitting it reverts the function to COPY mode.
+			if v, ok := d.GetOk("s3_object_storage_mode"); ok {
+				input.S3ObjectStorageMode = awstypes.S3ObjectStorageMode(v.(string))
+			}
 		}
 
 		// If source_kms_key_arn is set, it should be always included in the update
@@ -1044,7 +1059,10 @@ func resourceFunctionUpdate(ctx context.Context, d *schema.ResourceData, meta an
 			input.SourceKMSKeyArn = aws.String(v.(string))
 		}
 
-		_, err := conn.UpdateFunctionCode(ctx, &input)
+		_, err := tfresource.RetryWhenIsAErrorMessageContains[any, *awstypes.InvalidParameterValueException](
+			ctx, propagationTimeout, func(ctx context.Context) (any, error) {
+				return conn.UpdateFunctionCode(ctx, &input)
+			}, "versioning enabled for REFERENCE storage mode")
 
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating Lambda Function (%s) code: %s", d.Id(), err)
@@ -1581,6 +1599,9 @@ func retryFunctionOp[T functionCU](ctx context.Context, timeout time.Duration, f
 			if errs.IsAErrorMessageContains[*awstypes.InvalidParameterValueException](err, "Lambda was unable to configure access to your environment variables because the KMS key is invalid for CreateGrant") {
 				return true, err
 			}
+			if errs.IsAErrorMessageContains[*awstypes.InvalidParameterValueException](err, "versioning enabled for REFERENCE storage mode") {
+				return true, err
+			}
 
 			if errs.IsA[*awstypes.ResourceConflictException](err) {
 				return true, err
@@ -1601,6 +1622,25 @@ func retryFunctionOp[T functionCU](ctx context.Context, timeout time.Duration, f
 			},
 			func(err error) (bool, error) {
 				if errs.IsAErrorMessageContains[*awstypes.InvalidParameterValueException](err, "throttled by EC2") {
+					return true, err
+				}
+
+				return false, err
+			},
+		)
+	}
+
+	// Enabling versioning can take up to 15 minutes to become effective.
+	if errs.IsAErrorMessageContains[*awstypes.InvalidParameterValueException](err, "versioning enabled for REFERENCE storage mode") {
+		const (
+			functionExtraVersioningTimeout = 15 * time.Minute
+		)
+		output, err = tfresource.RetryWhen(ctx, functionExtraVersioningTimeout,
+			func(ctx context.Context) (any, error) {
+				return f()
+			},
+			func(err error) (bool, error) {
+				if errs.IsAErrorMessageContains[*awstypes.InvalidParameterValueException](err, "versioning enabled for REFERENCE storage mode") {
 					return true, err
 				}
 
@@ -1651,6 +1691,7 @@ func needsFunctionCodeUpdate(d sdkv2.ResourceDiffer) bool {
 		d.HasChange(names.AttrS3Bucket) ||
 		d.HasChange("s3_key") ||
 		d.HasChange("s3_object_version") ||
+		d.HasChange("s3_object_storage_mode") ||
 		d.HasChange("source_kms_key_arn") ||
 		d.HasChange("image_uri") ||
 		d.HasChange("architectures")
@@ -2002,7 +2043,7 @@ func flattenSnapStart(apiObject *awstypes.SnapStartResponse) []any {
 // Therefore, reset them to the previous value when the update fails.
 // https://developer.hashicorp.com/terraform/plugin/framework/diagnostics#how-errors-affect-state
 func resetNonRefreshableAttributes(d *schema.ResourceData) {
-	for _, key := range []string{names.AttrS3Bucket, "s3_key", "s3_object_version", "source_code_hash", "filename"} {
+	for _, key := range []string{names.AttrS3Bucket, "s3_key", "s3_object_version", "s3_object_storage_mode", "source_code_hash", "filename"} {
 		if d.HasChange(key) {
 			old, _ := d.GetChange(key)
 			d.Set(key, old)

--- a/internal/service/lambda/function.go
+++ b/internal/service/lambda/function.go
@@ -2043,7 +2043,12 @@ func flattenSnapStart(apiObject *awstypes.SnapStartResponse) []any {
 // Therefore, reset them to the previous value when the update fails.
 // https://developer.hashicorp.com/terraform/plugin/framework/diagnostics#how-errors-affect-state
 func resetNonRefreshableAttributes(d *schema.ResourceData) {
+	storageMode, _ := d.GetOk("s3_object_storage_mode")
+	isReference := storageMode.(string) == string(awstypes.S3ObjectStorageModeReference)
 	for _, key := range []string{names.AttrS3Bucket, "s3_key", "s3_object_version", "s3_object_storage_mode", "source_code_hash", "filename"} {
+		if isReference && (key == names.AttrS3Bucket || key == "s3_key" || key == "s3_object_version") {
+			continue
+		}
 		if d.HasChange(key) {
 			old, _ := d.GetChange(key)
 			d.Set(key, old)
@@ -2111,6 +2116,11 @@ func resourceFunctionFlatten(ctx context.Context, awsClient *conns.AWSClient, d 
 	}
 	if output.Code != nil {
 		d.Set("image_uri", output.Code.ImageUri)
+		if output.Code.ResolvedS3Object != nil {
+			d.Set(names.AttrS3Bucket, output.Code.ResolvedS3Object.S3Bucket)
+			d.Set("s3_key", output.Code.ResolvedS3Object.S3Key)
+			d.Set("s3_object_version", output.Code.ResolvedS3Object.S3ObjectVersion)
+		}
 	}
 	d.Set("invoke_arn", invokeARN(ctx, awsClient, functionARN))
 	d.Set(names.AttrKMSKeyARN, function.KMSKeyArn)

--- a/internal/service/lambda/function_test.go
+++ b/internal/service/lambda/function_test.go
@@ -2059,6 +2059,207 @@ func TestAccLambdaFunction_s3(t *testing.T) {
 	})
 }
 
+func TestAccLambdaFunction_s3ObjectStorageMode_reference(t *testing.T) {
+	ctx := acctest.Context(t)
+	var conf lambda.GetFunctionOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_lambda_function.test"
+
+	key := "lambdatest.zip"
+	path := "test-fixtures/lambdatest.zip"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.LambdaServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckFunctionDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFunctionConfig_s3ObjectStorageModeReference(rName, key, path),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFunctionExists(ctx, t, resourceName, &conf),
+					testAccCheckFunctionResolvedS3ObjectSet(&conf),
+					resource.TestCheckResourceAttr(resourceName, "s3_object_storage_mode", "REFERENCE"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"filename", "publish", names.AttrS3Bucket, "s3_key", "s3_object_version", "s3_object_storage_mode"},
+			},
+		},
+	})
+}
+
+func TestAccLambdaFunction_s3ObjectStorageMode_update(t *testing.T) {
+	ctx := acctest.Context(t)
+	var conf lambda.GetFunctionOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_lambda_function.test"
+
+	key := "lambdatest.zip"
+	path := "test-fixtures/lambdatest.zip"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.LambdaServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckFunctionDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				// Step 1: create with attribute unset (COPY).
+				Config: testAccFunctionConfig_s3ObjectStorageMode(rName, key, path, ""),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFunctionExists(ctx, t, resourceName, &conf),
+					resource.TestCheckNoResourceAttr(resourceName, "s3_object_storage_mode"),
+				),
+			},
+			{
+				// Step 2: set REFERENCE, same code -> in-place update.
+				Config: testAccFunctionConfig_s3ObjectStorageMode(rName, key, path, "REFERENCE"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFunctionExists(ctx, t, resourceName, &conf),
+					testAccCheckFunctionResolvedS3ObjectSet(&conf),
+					resource.TestCheckResourceAttr(resourceName, "s3_object_storage_mode", "REFERENCE"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				// Step 3: set COPY explicitly -> in-place update.
+				Config: testAccFunctionConfig_s3ObjectStorageMode(rName, key, path, "COPY"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFunctionExists(ctx, t, resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "s3_object_storage_mode", "COPY"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				// Step 4: remove attribute -> update back to default; subsequent plan is empty.
+				Config: testAccFunctionConfig_s3ObjectStorageMode(rName, key, path, ""),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFunctionExists(ctx, t, resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "s3_object_storage_mode", ""),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccLambdaFunction_s3ObjectStorageMode_codeUpdate(t *testing.T) {
+	ctx := acctest.Context(t)
+	var conf lambda.GetFunctionOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_lambda_function.test"
+
+	key := "lambdatest.zip"
+	path := "test-fixtures/lambdatest.zip"
+	pathModified := "test-fixtures/lambdatest_modified.zip"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.LambdaServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckFunctionDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				// Create a REFERENCE function.
+				Config: testAccFunctionConfig_s3ObjectStorageMode(rName, key, path, "REFERENCE"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFunctionExists(ctx, t, resourceName, &conf),
+					testAccCheckFunctionResolvedS3ObjectSet(&conf),
+					resource.TestCheckResourceAttr(resourceName, "s3_object_storage_mode", "REFERENCE"),
+				),
+			},
+			{
+				// Update ONLY the code object (new s3_object_version); mode must stay REFERENCE.
+				Config: testAccFunctionConfig_s3ObjectStorageMode(rName, key, pathModified, "REFERENCE"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFunctionExists(ctx, t, resourceName, &conf),
+					testAccCheckFunctionResolvedS3ObjectSet(&conf),
+					resource.TestCheckResourceAttr(resourceName, "s3_object_storage_mode", "REFERENCE"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccLambdaFunction_s3ObjectStorageMode_versioningPropagation(t *testing.T) {
+	ctx := acctest.Context(t)
+	var conf lambda.GetFunctionOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_lambda_function.test"
+
+	key := "lambdatest.zip"
+	path := "test-fixtures/lambdatest.zip"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.LambdaServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckFunctionDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				// Versioning propagation can take up to 15 minutes; creation must succeed via the retry path.
+				Config: testAccFunctionConfig_s3ObjectStorageModeReference(rName, key, path),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFunctionExists(ctx, t, resourceName, &conf),
+					testAccCheckFunctionResolvedS3ObjectSet(&conf),
+					resource.TestCheckResourceAttr(resourceName, "s3_object_storage_mode", "REFERENCE"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccLambdaFunction_s3ObjectStorageMode_validation(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.LambdaServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckFunctionDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccFunctionConfig_s3ObjectStorageModeConflictsFilename(rName),
+				ExpectError: regexache.MustCompile(`"s3_object_storage_mode": conflicts with filename`),
+			},
+			{
+				Config:      testAccFunctionConfig_s3ObjectStorageModeConflictsImageURI(rName),
+				ExpectError: regexache.MustCompile(`"s3_object_storage_mode": conflicts with image_uri`),
+			},
+			{
+				Config:      testAccFunctionConfig_s3ObjectStorageModeMissingS3Bucket(rName),
+				ExpectError: regexache.MustCompile(`"s3_object_storage_mode": all of ` + "`s3_bucket,s3_object_storage_mode`"),
+			},
+			{
+				Config:      testAccFunctionConfig_s3ObjectStorageModeInvalid(rName),
+				ExpectError: regexache.MustCompile(`expected s3_object_storage_mode to be one of`),
+			},
+		},
+	})
+}
+
 func TestAccLambdaFunction_LocalUpdate_sourceCodeHash(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
@@ -3069,6 +3270,16 @@ func testAccCheckFunctionExists(ctx context.Context, t *testing.T, n string, v *
 	}
 }
 
+func testAccCheckFunctionResolvedS3ObjectSet(function *lambda.GetFunctionOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if function.Code == nil || function.Code.ResolvedS3Object == nil {
+			return fmt.Errorf("expected Code.ResolvedS3Object to be set for REFERENCE storage mode")
+		}
+
+		return nil
+	}
+}
+
 func testAccPreCheckSignerSigningProfile(ctx context.Context, t *testing.T, platformID string) {
 	conn := acctest.ProviderMeta(ctx, t).SignerClient(ctx)
 
@@ -3538,6 +3749,69 @@ resource "aws_lambda_function" "test" {
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
   runtime       = "nodejs24.x"
+}
+`, rName))
+}
+
+func testAccFunctionConfig_s3ObjectStorageModeConflictsFilename(rName string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigLambdaBase(rName, rName, rName),
+		fmt.Sprintf(`
+resource "aws_lambda_function" "test" {
+  filename               = "test-fixtures/lambdatest.zip"
+  s3_bucket              = %[1]q
+  s3_key                 = "test.zip"
+  s3_object_storage_mode = "REFERENCE"
+  function_name          = %[1]q
+  role                   = aws_iam_role.iam_for_lambda.arn
+  handler                = "exports.example"
+  runtime                = "nodejs24.x"
+}
+`, rName))
+}
+
+func testAccFunctionConfig_s3ObjectStorageModeConflictsImageURI(rName string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigLambdaBase(rName, rName, rName),
+		fmt.Sprintf(`
+resource "aws_lambda_function" "test" {
+  image_uri              = "123456789012.dkr.ecr.us-east-1.amazonaws.com/test:latest"
+  package_type           = "Image"
+  s3_bucket              = %[1]q
+  s3_key                 = "test.zip"
+  s3_object_storage_mode = "REFERENCE"
+  function_name          = %[1]q
+  role                   = aws_iam_role.iam_for_lambda.arn
+}
+`, rName))
+}
+
+func testAccFunctionConfig_s3ObjectStorageModeMissingS3Bucket(rName string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigLambdaBase(rName, rName, rName),
+		fmt.Sprintf(`
+resource "aws_lambda_function" "test" {
+  s3_object_storage_mode = "REFERENCE"
+  function_name          = %[1]q
+  role                   = aws_iam_role.iam_for_lambda.arn
+  handler                = "exports.example"
+  runtime                = "nodejs24.x"
+}
+`, rName))
+}
+
+func testAccFunctionConfig_s3ObjectStorageModeInvalid(rName string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigLambdaBase(rName, rName, rName),
+		fmt.Sprintf(`
+resource "aws_lambda_function" "test" {
+  s3_bucket              = %[1]q
+  s3_key                 = "test.zip"
+  s3_object_storage_mode = "INVALID"
+  function_name          = %[1]q
+  role                   = aws_iam_role.iam_for_lambda.arn
+  handler                = "exports.example"
+  runtime                = "nodejs24.x"
 }
 `, rName))
 }
@@ -4975,6 +5249,164 @@ resource "aws_lambda_function" "test" {
   runtime           = "nodejs24.x"
 }
 `, key, path, rName))
+}
+
+func testAccFunctionConfig_s3ObjectStorageModeReference(rName, key, path string) string {
+	return acctest.ConfigCompose(
+		testAccFunctionConfigBase_iamRole(rName),
+		fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+data "aws_region" "current" {}
+
+data "aws_caller_identity" "current" {}
+
+resource "aws_s3_bucket" "artifacts" {
+  bucket        = %[3]q
+  force_destroy = true
+}
+
+resource "aws_s3_bucket_versioning" "artifacts" {
+  bucket = aws_s3_bucket.artifacts.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_object" "o" {
+  # Must have versioning enabled first
+  depends_on = [aws_s3_bucket_versioning.artifacts]
+
+  bucket = aws_s3_bucket.artifacts.bucket
+  key    = %[1]q
+  source = %[2]q
+  etag   = filemd5(%[2]q)
+}
+
+resource "aws_s3_bucket_policy" "artifacts" {
+  bucket = aws_s3_bucket.artifacts.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "lambda.amazonaws.com"
+        }
+        Action   = ["s3:GetObject", "s3:GetObjectVersion"]
+        Resource = "${aws_s3_bucket.artifacts.arn}/${aws_s3_object.o.key}"
+        Condition = {
+          StringEquals = {
+            "aws:SourceArn" = "arn:${data.aws_partition.current.partition}:lambda:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:function:%[3]s"
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_lambda_function" "test" {
+  depends_on = [
+    aws_s3_bucket_versioning.artifacts,
+    aws_s3_bucket_policy.artifacts,
+  ]
+
+  s3_bucket               = aws_s3_object.o.bucket
+  s3_key                  = aws_s3_object.o.key
+  s3_object_version       = aws_s3_object.o.version_id
+  s3_object_storage_mode  = "REFERENCE"
+  function_name           = %[3]q
+  role                    = aws_iam_role.iam_for_lambda.arn
+  handler                 = "exports.example"
+  runtime                 = "nodejs24.x"
+
+  timeouts {
+    create = "20m"
+  }
+}
+`, key, path, rName))
+}
+
+func testAccFunctionConfig_s3ObjectStorageMode(rName, key, path, mode string) string {
+	modeConfig := ""
+	if mode != "" {
+		modeConfig = fmt.Sprintf("s3_object_storage_mode = %q", mode)
+	}
+
+	return acctest.ConfigCompose(
+		testAccFunctionConfigBase_iamRole(rName),
+		fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+data "aws_region" "current" {}
+
+data "aws_caller_identity" "current" {}
+
+resource "aws_s3_bucket" "artifacts" {
+  bucket        = %[3]q
+  force_destroy = true
+}
+
+resource "aws_s3_bucket_versioning" "artifacts" {
+  bucket = aws_s3_bucket.artifacts.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_object" "o" {
+  # Must have versioning enabled first
+  depends_on = [aws_s3_bucket_versioning.artifacts]
+
+  bucket = aws_s3_bucket.artifacts.bucket
+  key    = %[1]q
+  source = %[2]q
+  etag   = filemd5(%[2]q)
+}
+
+resource "aws_s3_bucket_policy" "artifacts" {
+  bucket = aws_s3_bucket.artifacts.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "lambda.amazonaws.com"
+        }
+        Action   = ["s3:GetObject", "s3:GetObjectVersion"]
+        Resource = "${aws_s3_bucket.artifacts.arn}/${aws_s3_object.o.key}"
+        Condition = {
+          StringEquals = {
+            "aws:SourceArn" = "arn:${data.aws_partition.current.partition}:lambda:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:function:%[3]s"
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_lambda_function" "test" {
+  depends_on = [
+    aws_s3_bucket_versioning.artifacts,
+    aws_s3_bucket_policy.artifacts,
+  ]
+
+  s3_bucket         = aws_s3_object.o.bucket
+  s3_key            = aws_s3_object.o.key
+  s3_object_version = aws_s3_object.o.version_id
+  %[4]s
+  function_name = %[3]q
+  role          = aws_iam_role.iam_for_lambda.arn
+  handler       = "exports.example"
+  runtime       = "nodejs24.x"
+
+  timeouts {
+    create = "20m"
+    update = "20m"
+  }
+}
+`, key, path, rName, modeConfig))
 }
 
 func testAccFunctionConfig_s3UnversionedTPL(rName, key, path string) string {

--- a/internal/service/lambda/function_test.go
+++ b/internal/service/lambda/function_test.go
@@ -3774,8 +3774,10 @@ func testAccFunctionConfig_s3ObjectStorageModeConflictsImageURI(rName string) st
 	return acctest.ConfigCompose(
 		acctest.ConfigLambdaBase(rName, rName, rName),
 		fmt.Sprintf(`
+data "aws_region" "current" {}
+
 resource "aws_lambda_function" "test" {
-  image_uri              = "123456789012.dkr.ecr.us-east-1.amazonaws.com/test:latest"
+  image_uri              = "123456789012.dkr.ecr.${data.aws_region.current.region}.amazonaws.com/test:latest"
   package_type           = "Image"
   s3_bucket              = %[1]q
   s3_key                 = "test.zip"

--- a/internal/service/lambda/function_test.go
+++ b/internal/service/lambda/function_test.go
@@ -5311,14 +5311,14 @@ resource "aws_lambda_function" "test" {
     aws_s3_bucket_policy.artifacts,
   ]
 
-  s3_bucket               = aws_s3_object.o.bucket
-  s3_key                  = aws_s3_object.o.key
-  s3_object_version       = aws_s3_object.o.version_id
-  s3_object_storage_mode  = "REFERENCE"
-  function_name           = %[3]q
-  role                    = aws_iam_role.iam_for_lambda.arn
-  handler                 = "exports.example"
-  runtime                 = "nodejs24.x"
+  s3_bucket              = aws_s3_object.o.bucket
+  s3_key                 = aws_s3_object.o.key
+  s3_object_version      = aws_s3_object.o.version_id
+  s3_object_storage_mode = "REFERENCE"
+  function_name          = %[3]q
+  role                   = aws_iam_role.iam_for_lambda.arn
+  handler                = "exports.example"
+  runtime                = "nodejs24.x"
 
   timeouts {
     create = "20m"

--- a/website/docs/r/lambda_function.html.markdown
+++ b/website/docs/r/lambda_function.html.markdown
@@ -643,6 +643,88 @@ resource "aws_lambda_capacity_provider" "example" {
 ```
 
 See [the `aws_lambda_capacity_provider` resource](lambda_capacity_provider.html) for more details, such as configuring instance requirements and the scaling policy.
+
+### Self-managed S3 code storage
+
+With `s3_object_storage_mode = "REFERENCE"`, Lambda references the deployment package directly from your S3 bucket instead of copying it into Lambda-managed storage. This requires S3 versioning enabled on the bucket and a bucket policy granting `lambda.amazonaws.com` access to the object.
+
+```terraform
+resource "aws_s3_bucket" "example" {
+  bucket = "example-lambda-code"
+}
+
+resource "aws_s3_bucket_versioning" "example" {
+  bucket = aws_s3_bucket.example.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_object" "example" {
+  # Versioning must be enabled before uploading the object.
+  depends_on = [aws_s3_bucket_versioning.example]
+
+  bucket = aws_s3_bucket.example.id
+  key    = "function.zip"
+  source = "function.zip"
+}
+
+resource "aws_s3_bucket_policy" "example" {
+  bucket = aws_s3_bucket.example.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "lambda.amazonaws.com"
+        }
+        Action   = ["s3:GetObject", "s3:GetObjectVersion"]
+        Resource = "${aws_s3_bucket.example.arn}/${aws_s3_object.example.key}"
+        Condition = {
+          StringEquals = {
+            "aws:SourceArn" = "arn:${data.aws_partition.current.partition}:lambda:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:function:example"
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_lambda_function" "example" {
+  # Ensure versioning has propagated and the bucket policy exists first.
+  depends_on = [
+    aws_s3_bucket_versioning.example,
+    aws_s3_bucket_policy.example,
+  ]
+
+  function_name          = "example"
+  role                   = aws_iam_role.example.arn
+  handler                = "index.handler"
+  runtime                = "nodejs24.x"
+  s3_bucket              = aws_s3_object.example.bucket
+  s3_key                 = aws_s3_object.example.key
+  s3_object_version      = aws_s3_object.example.version_id
+  s3_object_storage_mode = "REFERENCE"
+}
+
+data "aws_partition" "current" {}
+
+data "aws_region" "current" {}
+
+data "aws_caller_identity" "current" {}
+```
+
+~> **Note:** S3 versioning must be enabled on the bucket, and enabling it can take up to 15 minutes to become effective. When enabling versioning and creating a `REFERENCE` function in the same apply, the provider automatically retries while propagation completes. Setting `timeouts` (and `use_resource_timeout_for_propagation = true`) extends the retry window if needed. Additional considerations:
+
+* Removing the `s3_object_storage_mode` argument reverts the function to `COPY` on the next code update.
+* Deleting or losing access to the source S3 object makes the function `Inactive`.
+* Switching from `REFERENCE` to `COPY` may fail if the account exceeds its Lambda-managed storage quota.
+* `REFERENCE` mode is not supported for container images (`image_uri`).
+* The value is not returned by the AWS API, so `terraform import` does not populate `s3_object_storage_mode`.
+
 AWS Lambda expects source code to be provided as a deployment package whose structure varies depending on which `runtime` is in use. See [Runtimes](https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-Runtime) for the valid values of `runtime`. The expected structure of the deployment package can be found in [the AWS Lambda documentation for each runtime](https://docs.aws.amazon.com/lambda/latest/dg/deployment-package-v2.html).
 
 Once you have created your deployment package you can specify it either directly as a local file (using the `filename` argument) or indirectly via Amazon S3 (using the `s3_bucket`, `s3_key` and `s3_object_version` arguments). When providing the deployment package via S3 it may be useful to use [the `aws_s3_object` resource](s3_object.html) to upload it.
@@ -687,6 +769,7 @@ The following arguments are optional:
 * `s3_bucket` - (Optional) S3 bucket location containing the function's deployment package. Conflicts with `filename` and `image_uri`. One of `filename`, `image_uri`, or `s3_bucket` must be specified.
 * `s3_key` - (Optional) S3 key of an object containing the function's deployment package. Required if `s3_bucket` is set.
 * `s3_object_version` - (Optional) Object version containing the function's deployment package. Conflicts with `filename` and `image_uri`.
+* `s3_object_storage_mode` - (Optional) How Lambda stores the deployment package. Valid values: `COPY` (default) — Lambda stores a copy of the package in Lambda-managed storage; `REFERENCE` — Lambda references the package directly from your S3 bucket ([self-managed S3 code storage](https://docs.aws.amazon.com/lambda/latest/dg/configuration-self-managed-storage.html)). Conflicts with `filename` and `image_uri`. Must be used with `s3_bucket`. See the [Self-managed S3 code storage](#self-managed-s3-code-storage) example and notes below.
 * `skip_destroy` - (Optional) Whether to retain the old version of a previously deployed Lambda Layer. Default is `false`.
 * `snap_start` - (Optional) Configuration block for snap start settings. [See below](#snap_start-configuration-block).
 * `source_code_hash` - (Optional) User-defined hash of the source code package file. Use this argument to trigger updates when the local function source code changes. This is a synthetic argument tracked only by the AWS provider and does not need to match the hashing algorithm used by Lambda to compute the `CodeSha256` response value. Out-of-band changes to the source code _will not_ be captured by this argument. To include out-of-band source code changes as an update trigger, use the `code_sha256` argument instead.


### PR DESCRIPTION
- **updated resource behavior with new attribute**
- **new acceptance tests for s3 code storage**
- **update the website doc**
- **fixing lint issues**

<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls

### Description
- This PR adds the `s3_object_storage_mode` attribute to the `aws_lambda_function` resource.
- Important to note that enabling versioning on S3 takes a maximum of 15 minutes. So added the error message in `retryFunctionOp` so that it is retried.

### Relations

Relates #48957 

### References
- [AWS Lambda announces self-managed code storage](https://aws.amazon.com/about-aws/whats-new/2026/07/lambda-self-managed-code-storage/)
- [AWS Lambda Developer Guide](https://docs.aws.amazon.com/lambda/latest/dg/configuration-self-managed-storage.html)

### Output from Acceptance Testing
```
$ make testacc PKG=lambda TESTS=TestAccLambdaFunction_s3ObjectStorageMode_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework (cached)
make: Running acceptance tests on branch: 🌿 f-lambda-s3-code-storage 🌿...
TF_ACC=1 go1.26.5 test ./internal/service/lambda/... -v -count 1 -parallel 20 -run='TestAccLambdaFunction_s3ObjectStorageMode_'  -timeout 360m -vet=off -buildvcs=false
2026/07/25 04:13:28 Creating Terraform AWS Provider (SDKv2-style)...
2026/07/25 04:13:28 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccLambdaFunction_s3ObjectStorageMode_reference
=== PAUSE TestAccLambdaFunction_s3ObjectStorageMode_reference
=== RUN   TestAccLambdaFunction_s3ObjectStorageMode_update
=== PAUSE TestAccLambdaFunction_s3ObjectStorageMode_update
=== RUN   TestAccLambdaFunction_s3ObjectStorageMode_codeUpdate
=== PAUSE TestAccLambdaFunction_s3ObjectStorageMode_codeUpdate
=== RUN   TestAccLambdaFunction_s3ObjectStorageMode_versioningPropagation
=== PAUSE TestAccLambdaFunction_s3ObjectStorageMode_versioningPropagation
=== RUN   TestAccLambdaFunction_s3ObjectStorageMode_validation
=== PAUSE TestAccLambdaFunction_s3ObjectStorageMode_validation
=== CONT  TestAccLambdaFunction_s3ObjectStorageMode_reference
=== CONT  TestAccLambdaFunction_s3ObjectStorageMode_versioningPropagation
=== CONT  TestAccLambdaFunction_s3ObjectStorageMode_validation
=== CONT  TestAccLambdaFunction_s3ObjectStorageMode_codeUpdate
=== CONT  TestAccLambdaFunction_s3ObjectStorageMode_update
--- PASS: TestAccLambdaFunction_s3ObjectStorageMode_validation (9.05s)
--- PASS: TestAccLambdaFunction_s3ObjectStorageMode_versioningPropagation (63.15s)
--- PASS: TestAccLambdaFunction_s3ObjectStorageMode_reference (69.40s)
--- PASS: TestAccLambdaFunction_s3ObjectStorageMode_codeUpdate (106.19s)
--- PASS: TestAccLambdaFunction_s3ObjectStorageMode_update (184.41s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lambda     184.535s
```

**Tried running `make testacc PKG=lambda TESTS=TestAccLambdaFunction` but ran into VPC per region limit. Will re-run once the limits are increased.**