### PR TITLE
resource/aws_glue_catalog_table: Fix UpdateTable failure on validated multi-dialect views

### DIFF
--- a/.changelog/49118.txt
+++ b/.changelog/49118.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_glue_catalog_table: Fix `UpdateTable` failure on validated multi-dialect views (`Storage descriptor may not be defined when creating a validated Glue view`)
+```

--- a/internal/service/glue/catalog_table.go
+++ b/internal/service/glue/catalog_table.go
@@ -1003,6 +1003,23 @@ func expandTableInput(d *schema.ResourceData) *awstypes.TableInput {
 		apiObject.ViewOriginalText = aws.String(v.(string))
 	}
 
+	// For a *validated* view (one with a representation's validation_connection
+	// set), Glue derives the storage descriptor from the view definition itself
+	// and rejects a client-supplied one on UpdateTable ("Storage descriptor may
+	// not be defined when creating a validated Glue view") -- even though it's
+	// the provider's own prior Read that populated storage_descriptor
+	// (Optional+Computed) with Glue's auto-derived value in the first place.
+	// Unvalidated multi-dialect views (no validation_connection) don't have
+	// this restriction, so only strip it in the validated case.
+	if apiObject.ViewDefinition != nil {
+		for _, representation := range apiObject.ViewDefinition.Representations {
+			if aws.ToString(representation.ValidationConnection) != "" {
+				apiObject.StorageDescriptor = nil
+				break
+			}
+		}
+	}
+
 	return apiObject
 }
 

--- a/internal/service/glue/catalog_table_test.go
+++ b/internal/service/glue/catalog_table_test.go
@@ -875,6 +875,55 @@ func TestAccGlueCatalogTable_viewDefinitionFailure(t *testing.T) {
 	})
 }
 
+// Reference: https://github.com/hashicorp/terraform-provider-aws/issues/49042
+//
+// Glue's Read populates the Optional+Computed storage_descriptor from the
+// schema it derives from a validated view's query. Confirm that updating the
+// view's SQL succeeds in place, rather than resending that derived
+// storage_descriptor to UpdateTable, which Glue rejects for validated views
+// ("Storage descriptor may not be defined when creating a validated Glue
+// view").
+func TestAccGlueCatalogTable_Update_validatedViewStorageDescriptor(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_glue_catalog_table.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.GlueServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckCatalogTableDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCatalogTableConfig_validatedViewStorageDescriptor(rName, "id, amount"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCatalogTableExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "table_type", "VIRTUAL_VIEW"),
+					resource.TestCheckResourceAttr(resourceName, "view_definition.#", "1"),
+				),
+			},
+			{
+				// This second apply is the actual regression check: prior to
+				// the fix, this UpdateTable call failed with "Storage
+				// descriptor may not be defined when creating a validated
+				// Glue view" because the provider replayed the
+				// storage_descriptor that Read populated after the first
+				// apply.
+				Config: testAccCatalogTableConfig_validatedViewStorageDescriptor(rName, "id"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCatalogTableExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "view_definition.0.representations.0.view_original_text", fmt.Sprintf("SELECT id FROM %q.%q", rName, rName+"-source")),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+		},
+	})
+}
+
 func testAccCheckCatalogTableDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.ProviderMeta(ctx, t).GlueClient(ctx)
@@ -1901,4 +1950,157 @@ resource "aws_glue_connection" "test_athena" {
   }
 }
 `, rName)
+}
+
+func testAccCatalogTableConfig_validatedViewStorageDescriptor(rName, selectColumns string) string {
+	return fmt.Sprintf(`
+resource "aws_glue_catalog_database" "test" {
+  name = %[1]q
+}
+
+resource "aws_s3_bucket" "source" {
+  bucket        = "%[1]s-source"
+  force_destroy = true
+}
+
+resource "aws_s3_bucket" "results" {
+  bucket        = "%[1]s-results"
+  force_destroy = true
+}
+
+resource "aws_glue_catalog_table" "source" {
+  name          = "%[1]s-source"
+  database_name = aws_glue_catalog_database.test.name
+  table_type    = "EXTERNAL_TABLE"
+
+  storage_descriptor {
+    location      = "s3://${aws_s3_bucket.source.bucket}/"
+    input_format  = "org.apache.hadoop.mapred.TextInputFormat"
+    output_format = "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat"
+
+    ser_de_info {
+      serialization_library = "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe"
+    }
+
+    columns {
+      name = "id"
+      type = "bigint"
+    }
+
+    columns {
+      name = "amount"
+      type = "double"
+    }
+  }
+}
+
+resource "aws_athena_workgroup" "test" {
+  name = %[1]q
+
+  configuration {
+    result_configuration {
+      output_location = "s3://${aws_s3_bucket.results.bucket}/"
+    }
+  }
+}
+
+resource "aws_iam_role" "test" {
+  name = %[1]q
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "glue.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "test" {
+  name = %[1]q
+  role = aws_iam_role.test.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "athena:StartQueryExecution",
+          "athena:GetQueryExecution",
+          "athena:GetQueryResults",
+          "athena:StopQueryExecution",
+          "athena:GetWorkGroup",
+        ]
+        Resource = aws_athena_workgroup.test.arn
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "glue:GetDatabase",
+          "glue:GetTable",
+          "glue:GetTables",
+          "glue:GetPartition",
+          "glue:GetPartitions",
+        ]
+        Resource = "*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:ListBucket",
+        ]
+        Resource = [
+          aws_s3_bucket.source.arn,
+          "${aws_s3_bucket.source.arn}/*",
+        ]
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:ListBucket",
+          "s3:GetBucketLocation",
+        ]
+        Resource = [
+          aws_s3_bucket.results.arn,
+          "${aws_s3_bucket.results.arn}/*",
+        ]
+      },
+    ]
+  })
+}
+
+resource "aws_glue_connection" "test" {
+  name            = %[1]q
+  connection_type = "VIEW_VALIDATION_ATHENA"
+
+  connection_properties = {
+    WORKGROUP_NAME = aws_athena_workgroup.test.name
+  }
+}
+
+resource "aws_glue_catalog_table" "test" {
+  name          = %[1]q
+  database_name = aws_glue_catalog_database.test.name
+  table_type    = "VIRTUAL_VIEW"
+
+  depends_on = [aws_glue_catalog_table.source]
+
+  view_definition {
+    is_protected = true
+    definer      = aws_iam_role.test.arn
+
+    representations {
+      dialect               = "ATHENA"
+      dialect_version       = "3"
+      view_original_text    = "SELECT %[2]s FROM \"%[1]s\".\"%[1]s-source\""
+      validation_connection = aws_glue_connection.test.name
+    }
+  }
+}
+`, rName, selectColumns)
 }


### PR DESCRIPTION
## Summary

Fixes #49042. `expandTableInput` unconditionally re-sends `storage_descriptor`
(Optional+Computed, populated by `Read` from Glue's auto-derived view schema)
on both `Create` and `Update`. For a *validated* view -- one with a
representation's `validation_connection` set -- Glue derives the storage
descriptor from the view definition itself and rejects a client-supplied one,
even on `Update`, with `Storage descriptor may not be defined when creating a
validated Glue view`. AWS Support confirmed this is intentional API behavior
and the defect is provider-side (see the issue's comments for the full
CloudTrail-backed diagnosis).

`Create` was unaffected in practice only because a brand-new resource's
`ResourceData` has no prior `storage_descriptor` to replay; the first
subsequent `Update` -- which inherits the value `Read` wrote after `Create` --
always failed.

The fix strips `StorageDescriptor` only when a representation's
`ValidationConnection` is set, so unvalidated multi-dialect views (which have
no such restriction, per the existing `TestAccGlueCatalogTable_Update_viewInPlace`
and `TestAccGlueCatalogTable_viewDefinition` tests, both of which use SPARK
dialect with an explicit `storage_descriptor`) keep working exactly as before.

## Test plan

- [x] `go build ./internal/service/glue/...`
- [x] `go vet ./internal/service/glue/...`
- [x] Verified the new test's generated HCL renders correctly (balanced
      braces/quotes) via a local scratch run of the config-generator function
- [ ] Acceptance test `TestAccGlueCatalogTable_Update_validatedViewStorageDescriptor`
      added, reproducing the exact reported scenario (create a validated
      ATHENA view, then update its SQL) -- not run locally (requires AWS
      credentials, an Athena workgroup, IAM role, and S3 buckets)
- [x] Confirmed existing `TestAccGlueCatalogTable_Update_viewInPlace` and
      `TestAccGlueCatalogTable_viewDefinition` configs use SPARK dialect with
      no `validation_connection`, so the narrower (validated-only) condition
      doesn't change their behavior