### PR TITLE
resource/aws_glue_catalog_table: fix StorageDescriptor error when updating validated Athena views

### DIFF
--- a/.changelog/49042.txt
+++ b/.changelog/49042.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_glue_catalog_table: Fix `ValidationException: Storage descriptor may not be defined when creating a validated Glue view` error when updating a validated ATHENA multi-dialect view
+```

--- a/internal/service/glue/catalog_table.go
+++ b/internal/service/glue/catalog_table.go
@@ -815,6 +815,14 @@ func resourceCatalogTableUpdate(ctx context.Context, d *schema.ResourceData, met
 	if input.TableInput != nil && input.TableInput.ViewDefinition != nil {
 		input.ViewUpdateAction = awstypes.ViewUpdateActionReplace
 		input.Force = true
+
+		// A view with a validation_connection on any representation (e.g. a
+		// validated Athena multi-dialect view) fails UpdateTable with
+		// "Storage descriptor may not be defined when creating a validated
+		// Glue view" if StorageDescriptor is also set.
+		if isValidatedView(input.TableInput.ViewDefinition) {
+			input.TableInput.StorageDescriptor = nil
+		}
 	}
 
 	_, err = conn.UpdateTable(ctx, &input)
@@ -1827,6 +1835,20 @@ func expandViewDefinitionInput(tfMap map[string]any) *awstypes.ViewDefinitionInp
 	}
 
 	return apiObject
+}
+
+func isValidatedView(apiObject *awstypes.ViewDefinitionInput) bool {
+	if apiObject == nil {
+		return false
+	}
+
+	for _, representation := range apiObject.Representations {
+		if aws.ToString(representation.ValidationConnection) != "" {
+			return true
+		}
+	}
+
+	return false
 }
 
 func expandViewRepresentationInputs(tfList []any) []awstypes.ViewRepresentationInput {

--- a/internal/service/glue/catalog_table_test.go
+++ b/internal/service/glue/catalog_table_test.go
@@ -398,6 +398,52 @@ func TestAccGlueCatalogTable_Update_viewInPlace(t *testing.T) {
 	})
 }
 
+// Reference: https://github.com/hashicorp/terraform-provider-aws/issues/49042
+func TestAccGlueCatalogTable_Update_validatedAthenaViewInPlace(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_glue_catalog_table.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.GlueServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckCatalogTableDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCatalogTableConfig_validatedAthenaView(rName, "SELECT 1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCatalogTableExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "table_type", "VIRTUAL_VIEW"),
+					resource.TestCheckResourceAttr(resourceName, "view_definition.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "view_definition.0.representations.0.dialect", "ATHENA"),
+					resource.TestCheckResourceAttr(resourceName, "view_definition.0.representations.0.view_original_text", "SELECT 1"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+			},
+			{
+				// Updating view_original_text on a validated Athena view must succeed
+				// without the "Storage descriptor may not be defined" error — the fix
+				// strips StorageDescriptor from the UpdateTable payload for validated views.
+				Config: testAccCatalogTableConfig_validatedAthenaView(rName, "SELECT 2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCatalogTableExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "view_definition.0.representations.0.view_original_text", "SELECT 2"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+		},
+	})
+}
+
 // Reference: https://github.com/hashicorp/terraform-provider-aws/issues/11784
 func TestAccGlueCatalogTable_StorageDescriptor_emptyBlock(t *testing.T) {
 	ctx := acctest.Context(t)
@@ -1901,4 +1947,38 @@ resource "aws_glue_connection" "test_athena" {
   }
 }
 `, rName)
+}
+
+func testAccCatalogTableConfig_validatedAthenaView(rName, sql string) string {
+	return fmt.Sprintf(`
+resource "aws_glue_catalog_database" "test" {
+  name = %[1]q
+}
+
+resource "aws_glue_connection" "test" {
+  name            = %[1]q
+  connection_type = "VIEW_VALIDATION_ATHENA"
+
+  connection_properties = {
+    WORKGROUP_NAME = "primary"
+  }
+}
+
+resource "aws_glue_catalog_table" "test" {
+  name          = %[1]q
+  database_name = aws_glue_catalog_database.test.name
+  table_type    = "VIRTUAL_VIEW"
+
+  view_definition {
+    is_protected = false
+
+    representations {
+      dialect               = "ATHENA"
+      dialect_version       = "3"
+      view_original_text    = %[2]q
+      validation_connection = aws_glue_connection.test.name
+    }
+  }
+}
+`, rName, sql)
 }


### PR DESCRIPTION
Fixes #49042.

When a Glue catalog table is a validated multi-dialect view — meaning it uses `validation_connection` in one of its `view_definition.representations` blocks — subsequent `terraform apply` runs that change the view SQL fail with:

    InvalidInputException: Storage descriptor may not be defined when creating a validated Glue view.

The root cause is that `expandTableInput` always includes `StorageDescriptor` in the `UpdateTable` payload when it is present in state. AWS Glue infers a storage descriptor when creating a validated view, so it ends up in state after the first apply, and from that point on every update call carries it — which the API rejects.

The fix adds a small `isValidatedView` helper that checks whether any representation on the `ViewDefinitionInput` has a non-empty `ValidationConnection`. If so, `StorageDescriptor` is cleared from the `UpdateTable` input before the API call. This is narrowly scoped to the update path for validated views and does not affect regular tables, Iceberg tables, or legacy virtual views.

Tested locally by creating a validated Athena view and running a second `terraform apply` with updated SQL — the update succeeded without error. Previously it would fail on every subsequent apply.

Added `TestAccGlueCatalogTable_Update_validatedAthenaViewInPlace` to cover the create-then-update flow for a validated Athena view.