### PR TITLE
d/aws_quicksight_account_subscription: clarify admin_group/admin_pro_group and realm requirements

### DIFF
--- a/website/docs/r/quicksight_account_subscription.html.markdown
+++ b/website/docs/r/quicksight_account_subscription.html.markdown
@@ -35,8 +35,8 @@ The following arguments are required:
 The following arguments are optional:
 
 * `active_directory_name` - (Optional) Name of your Active Directory. This field is required if `ACTIVE_DIRECTORY` is the selected authentication method of the new Amazon QuickSight account.
-* `admin_group` - (Optional) Admin group associated with your Active Directory or IAM Identity Center account. This field is required if `ACTIVE_DIRECTORY` or `IAM_IDENTITY_CENTER` is the selected authentication method of the new Amazon QuickSight account.
-* `admin_pro_group` - (Optional) Admin PRO group associated with your Active Directory or IAM Identity Center account.
+* `admin_group` - (Optional) Admin group associated with your Active Directory or IAM Identity Center account. Either this field or `admin_pro_group` is required if `ACTIVE_DIRECTORY` or `IAM_IDENTITY_CENTER` is the selected authentication method of the new Amazon QuickSight account.
+* `admin_pro_group` - (Optional) Admin PRO group associated with your Active Directory or IAM Identity Center account. Either this field or `admin_group` is required if `ACTIVE_DIRECTORY` or `IAM_IDENTITY_CENTER` is the selected authentication method of the new Amazon QuickSight account.
 * `author_group` - (Optional) Author group associated with your Active Directory or IAM Identity Center account.
 * `author_pro_group` - (Optional) Author PRO group associated with your Active Directory or IAM Identity Center account.
 * `aws_account_id` - (Optional, Forces new resource) AWS account ID. Defaults to automatically determined account ID of the Terraform AWS provider.
@@ -48,7 +48,7 @@ The following arguments are optional:
 * `last_name` - (Optional) Last name of the author of the Amazon QuickSight account to use for future communications. This field is required if `ENTERPRISE_AND_Q` is the selected edition of the new Amazon QuickSight account.
 * `reader_group` - (Optional) Reader group associated with your Active Directory or IAM Identity Center account.
 * `reader_pro_group` - (Optional) Reader PRO group associated with your Active Directory or IAM Identity Center account.
-* `realm` - (Optional) Realm of the Active Directory that is associated with your Amazon QuickSight account.
+* `realm` - (Optional) Realm of the Active Directory that is associated with your Amazon QuickSight account. This field is required if `ACTIVE_DIRECTORY` is the selected authentication method of the new Amazon QuickSight account.
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 
 ## Attribute Reference


### PR DESCRIPTION
## Description

The docs for `aws_quicksight_account_subscription` state that `admin_group` alone is required for `ACTIVE_DIRECTORY`/`IAM_IDENTITY_CENTER` authentication, and don't mention any requirement on `admin_pro_group`. Per the QuickSight `CreateAccountSubscription` API docs, it's actually an either/or requirement between the two fields:

> Either this field or the `AdminProGroup` field is required if `ACTIVE_DIRECTORY` or `IAM_IDENTITY_CENTER` is the selected authentication method

This caused confusion where users providing only `admin_pro_group` (with no `admin_group`) hit `InvalidParameterValueException: One or more required attributes for identity center are missing: Admin or Admin Pro group` despite following the documented requirements.

This PR:
- Updates `admin_group` and `admin_pro_group` docs to describe the either/or requirement
- Adds the missing `ACTIVE_DIRECTORY`-required note to `realm`, matching the AWS API docs and the existing note on `active_directory_name`

Docs-only change, no code/behavior changes.

Closes #42457