### PR TITLE
resource/aws_wafv2_web_acl_rule: Fix inconsistent result when enable_machine_learning is false for bot control

### DIFF
--- a/.changelog/48446.txt
+++ b/.changelog/48446.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_wafv2_web_acl_rule: Fix `Provider produced inconsistent result after apply` errors when `statement.managed_rule_group_statement.managed_rule_group_configs.aws_managed_rules_bot_control_rule_set.enable_machine_learning` is `false` and `inspection_level` is `COMMON`
+```

--- a/internal/service/wafv2/web_acl_rule.go
+++ b/internal/service/wafv2/web_acl_rule.go
@@ -1514,6 +1514,32 @@ type webACLRuleAWSManagedRulesBotControlRuleSetModel struct {
 	InspectionLevel       fwtypes.StringEnum[awstypes.InspectionLevel] `tfsdk:"inspection_level"`
 }
 
+var _ flex.Flattener = &webACLRuleAWSManagedRulesBotControlRuleSetModel{}
+
+// Flatten normalizes EnableMachineLearning to false when the inspection level is COMMON,
+// where machine learning is never active and the API may not return the field.
+func (m *webACLRuleAWSManagedRulesBotControlRuleSetModel) Flatten(ctx context.Context, v any) (diags diag.Diagnostics) {
+	switch val := v.(type) {
+	case *awstypes.AWSManagedRulesBotControlRuleSet:
+		m.InspectionLevel = fwtypes.StringEnumValue(val.InspectionLevel)
+		if val.InspectionLevel == awstypes.InspectionLevelCommon && (val.EnableMachineLearning == nil || !*val.EnableMachineLearning) {
+			m.EnableMachineLearning = types.BoolValue(false)
+		} else {
+			m.EnableMachineLearning = flex.BoolToFramework(ctx, val.EnableMachineLearning)
+		}
+	case awstypes.AWSManagedRulesBotControlRuleSet:
+		m.InspectionLevel = fwtypes.StringEnumValue(val.InspectionLevel)
+		if val.InspectionLevel == awstypes.InspectionLevelCommon && (val.EnableMachineLearning == nil || !*val.EnableMachineLearning) {
+			m.EnableMachineLearning = types.BoolValue(false)
+		} else {
+			m.EnableMachineLearning = flex.BoolToFramework(ctx, val.EnableMachineLearning)
+		}
+	default:
+		diags.AddError("Unexpected type", fmt.Sprintf("expected awstypes.AWSManagedRulesBotControlRuleSet, got %T", v))
+	}
+	return diags
+}
+
 type webACLRuleAWSManagedRulesACFPRuleSetModel struct {
 	CreationPath         types.String                                                          `tfsdk:"creation_path"`
 	EnableRegexInPath    types.Bool                                                            `tfsdk:"enable_regex_in_path"`

--- a/internal/service/wafv2/web_acl_rule_test.go
+++ b/internal/service/wafv2/web_acl_rule_test.go
@@ -245,12 +245,13 @@ func TestAccWAFV2WebACLRule_managedRuleGroupBotControl(t *testing.T) {
 		CheckDestroy:             testAccCheckWebACLRuleDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWebACLRuleConfig_managedRuleGroupBotControl(rName),
+				Config: testAccWebACLRuleConfig_managedRuleGroupBotControl(rName, "COMMON", false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWebACLRuleExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "statement.0.managed_rule_group_statement.0.name", "AWSManagedRulesBotControlRuleSet"),
 					resource.TestCheckResourceAttr(resourceName, "statement.0.managed_rule_group_statement.0.vendor_name", "AWS"),
 					resource.TestCheckResourceAttr(resourceName, "statement.0.managed_rule_group_statement.0.managed_rule_group_configs.0.aws_managed_rules_bot_control_rule_set.0.inspection_level", "COMMON"),
+					resource.TestCheckResourceAttr(resourceName, "statement.0.managed_rule_group_statement.0.managed_rule_group_configs.0.aws_managed_rules_bot_control_rule_set.0.enable_machine_learning", acctest.CtFalse),
 				),
 			},
 			{
@@ -259,6 +260,14 @@ func TestAccWAFV2WebACLRule_managedRuleGroupBotControl(t *testing.T) {
 				ImportStateIdFunc:                    acctest.AttrsImportStateIdFunc(resourceName, flex.ResourceIdSeparator, "web_acl_arn", names.AttrName),
 				ImportStateVerify:                    true,
 				ImportStateVerifyIdentifierAttribute: "web_acl_arn",
+			},
+			{
+				Config: testAccWebACLRuleConfig_managedRuleGroupBotControl(rName, "TARGETED", true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWebACLRuleExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "statement.0.managed_rule_group_statement.0.managed_rule_group_configs.0.aws_managed_rules_bot_control_rule_set.0.inspection_level", "TARGETED"),
+					resource.TestCheckResourceAttr(resourceName, "statement.0.managed_rule_group_statement.0.managed_rule_group_configs.0.aws_managed_rules_bot_control_rule_set.0.enable_machine_learning", acctest.CtTrue),
+				),
 			},
 		},
 	})
@@ -1670,7 +1679,7 @@ resource "aws_wafv2_web_acl_rule" "test" {
 `, rName)
 }
 
-func testAccWebACLRuleConfig_managedRuleGroupBotControl(rName string) string {
+func testAccWebACLRuleConfig_managedRuleGroupBotControl(rName, inspectionLevel string, enableMachineLearning bool) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_web_acl" "test" {
   name  = %[1]q
@@ -1707,7 +1716,8 @@ resource "aws_wafv2_web_acl_rule" "test" {
 
       managed_rule_group_configs {
         aws_managed_rules_bot_control_rule_set {
-          inspection_level = "COMMON"
+          inspection_level        = %[2]q
+          enable_machine_learning = %[3]t
         }
       }
     }
@@ -1719,7 +1729,7 @@ resource "aws_wafv2_web_acl_rule" "test" {
     sampled_requests_enabled   = false
   }
 }
-`, rName)
+`, rName, inspectionLevel, enableMachineLearning)
 }
 
 func testAccWebACLRuleConfig_asnMatchStatement(rName string) string {


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

None.

### Description

Setting `enable_machine_learning = false` on the `aws_managed_rules_bot_control_rule_set` block of `aws_wafv2_web_acl_rule` fails with:

```
Error: Provider produced inconsistent result after apply
...enable_machine_learning: was cty.False, but now null.
```

This happens because the WAFv2 API does not return `EnableMachineLearning` when `inspection_level` is `COMMON`. The `webACLRuleAWSManagedRulesBotControlRuleSetModel` struct relied on generic AutoFlex flattening, which maps the API's nil `*bool` to a null `types.Bool`, contradicting the configured `false`.

The sibling resource `aws_wafv2_web_acl_rule_group_association` already handles this correctly via a custom `Flatten` method on its equivalent model. This PR adds the same custom `Flatten` to `webACLRuleAWSManagedRulesBotControlRuleSetModel` in `internal/service/wafv2/web_acl_rule.go`, normalizing `EnableMachineLearning` to `false` when `InspectionLevel` is `COMMON` and the API returns nil or false.

The existing acceptance test `TestAccWAFV2WebACLRule_managedRuleGroupBotControl` previously only exercised `inspection_level` and omitted `enable_machine_learning` entirely, which is why the regression wasn't caught. It's now extended to cover:
- Create with `enable_machine_learning = false` at `COMMON` (the reported repro), asserting the value round-trips as `false`.
- Import verification.
- Update to `TARGETED` / `enable_machine_learning = true`, confirming the non-`COMMON` path still round-trips correctly.

### Relations

Closes #48446

### References

- Root cause and fix pattern originally identified in the issue thread, pointing at the equivalent fix in `web_acl_rule_group_association.go`.

### Output from Acceptance Testing

```console
% make testacc TESTS=TestAccWAFV2WebACLRule_managedRuleGroupBotControl PKG=wafv2

--- PASS: TestAccWAFV2WebACLRule_managedRuleGroupBotControl (84.37s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/wafv2    92.862s
```