### PR TITLE
resource/aws_guardduty_filter: change rank field to optional

### DIFF
--- a/.changelog/49130.txt
+++ b/.changelog/49130.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_guardduty_filter: Change rank field to optional
+```

--- a/internal/service/guardduty/filter.go
+++ b/internal/service/guardduty/filter.go
@@ -155,7 +155,8 @@ func resourceFilter() *schema.Resource {
 				},
 				"rank": {
 					Type:     schema.TypeInt,
-					Required: true,
+					Optional: true,
+					Computed: true,
 				},
 				names.AttrTags:    tftags.TagsSchema(),
 				names.AttrTagsAll: tftags.TagsSchemaComputed(),
@@ -174,8 +175,11 @@ func resourceFilterCreate(ctx context.Context, d *schema.ResourceData, meta any)
 		Description: aws.String(d.Get(names.AttrDescription).(string)),
 		DetectorId:  aws.String(detectorID),
 		Name:        aws.String(name),
-		Rank:        aws.Int32(int32(d.Get("rank").(int))),
 		Tags:        getTagsIn(ctx),
+	}
+
+	if v, ok := d.GetOk("rank"); ok {
+		input.Rank = aws.Int32(int32(v.(int)))
 	}
 
 	var err error
@@ -246,7 +250,10 @@ func resourceFilterUpdate(ctx context.Context, d *schema.ResourceData, meta any)
 			Description: aws.String(d.Get(names.AttrDescription).(string)),
 			DetectorId:  aws.String(detectorID),
 			FilterName:  aws.String(name),
-			Rank:        aws.Int32(int32(d.Get("rank").(int))),
+		}
+
+		if v, ok := d.GetOk("rank"); ok {
+			input.Rank = aws.Int32(int32(v.(int)))
 		}
 
 		input.FindingCriteria, err = expandFindingCriteria(d.Get("finding_criteria").([]any))

--- a/internal/service/guardduty/filter_test.go
+++ b/internal/service/guardduty/filter_test.go
@@ -163,6 +163,45 @@ func testAccFilter_update(t *testing.T) {
 	})
 }
 
+func testAccFilter_noRank(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v guardduty.GetFilterOutput
+	resourceName := "aws_guardduty_filter.test"
+
+	acctest.Test(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheckDetectorNotExists(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.GuardDutyServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckFilterDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFilterConfig_noRank(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFilterExists(ctx, t, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "rank", "1"), // Automatically assigned by AWS
+				),
+			},
+			{
+				Config: testAccFilterConfig_noRank(),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
 func testAccFilter_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v guardduty.GetFilterOutput
@@ -337,6 +376,29 @@ resource "aws_guardduty_filter" "test" {
     criterion {
       field      = "service.additionalInfo.threatListName"
       not_equals = ["some-threat", "yet-another-threat"]
+    }
+  }
+}
+
+resource "aws_guardduty_detector" "test" {
+  enable = true
+}
+`
+}
+
+func testAccFilterConfig_noRank() string {
+	return `
+data "aws_region" "current" {}
+
+resource "aws_guardduty_filter" "test" {
+  detector_id = aws_guardduty_detector.test.id
+  name        = "test-filter"
+  action      = "ARCHIVE"
+
+  finding_criteria {
+    criterion {
+      field  = "region"
+      equals = [data.aws_region.current.region]
     }
   }
 }

--- a/internal/service/guardduty/guardduty_test.go
+++ b/internal/service/guardduty/guardduty_test.go
@@ -39,6 +39,7 @@ func TestAccGuardDuty_serial(t *testing.T) {
 		"Filter": {
 			acctest.CtBasic:      testAccFilter_basic,
 			"update":             testAccFilter_update,
+			"no_rank":            testAccFilter_noRank,
 			"tags":               testAccGuardDutyFilter_tagsSerial,
 			acctest.CtDisappears: testAccFilter_disappears,
 		},

--- a/website/docs/r/guardduty_filter.html.markdown
+++ b/website/docs/r/guardduty_filter.html.markdown
@@ -52,7 +52,7 @@ This resource supports the following arguments:
 * `detector_id` - (Required) ID of a GuardDuty detector, attached to your account.
 * `name` - (Required) The name of your filter.
 * `description` - (Optional) Description of the filter.
-* `rank` - (Required) Specifies the position of the filter in the list of current filters. Also specifies the order in which this filter is applied to the findings.
+* `rank` - (Optional) Specifies the position of the filter in the list of current filters. Also specifies the order in which this filter is applied to the findings.
 * `action` - (Required) Specifies the action that is to be applied to the findings that match the filter. Can be one of `ARCHIVE` or `NOOP`.
 * `tags` (Optional) - The tags that you want to add to the Filter resource. A tag consists of a key and a value. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `finding_criteria` (Required) - Represents the criteria to be used in the filter for querying findings. Contains one or more `criterion` blocks, documented [below](#criterion).


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

None

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

The rank field of `aws_guardduty_filter` resource should be optional as indicated in the [CreateFilter API document](https://docs.aws.amazon.com/guardduty/latest/APIReference/API_CreateFilter.html#guardduty-CreateFilter-request-rank)


I'm not very confident on the test structure. Feel free to request changes.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #49127

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

* AWS API: https://docs.aws.amazon.com/guardduty/latest/APIReference/API_CreateFilter.html#guardduty-CreateFilter-request-rank
* aws-sdk-go-v2 API: https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/guardduty#CreateFilterInput

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccGuardDuty_serial/Filter PKG=guardduty

make: Running acceptance tests on branch: 🌿 aws_guardduty_filter/change-rank-field-to-optional 🌿...
TF_ACC=1 go1.26.5 test ./internal/service/guardduty/... -v -count 1 -parallel 20 -run='TestAccGuardDuty_serial/Filter'  -timeout 360m -vet=off -buildvcs=false
2026/07/27 16:53:13 Creating Terraform AWS Provider (SDKv2-style)...
2026/07/27 16:53:13 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccGuardDuty_serial
=== PAUSE TestAccGuardDuty_serial
=== CONT  TestAccGuardDuty_serial
=== RUN   TestAccGuardDuty_serial/Filter
=== RUN   TestAccGuardDuty_serial/Filter/basic
=== RUN   TestAccGuardDuty_serial/Filter/update
=== RUN   TestAccGuardDuty_serial/Filter/no_rank
=== RUN   TestAccGuardDuty_serial/Filter/tags
=== RUN   TestAccGuardDuty_serial/Filter/tags/null
=== RUN   TestAccGuardDuty_serial/Filter/tags/DefaultTags_overlapping
=== RUN   TestAccGuardDuty_serial/Filter/tags/DefaultTags_updateToProviderOnly
=== RUN   TestAccGuardDuty_serial/Filter/tags/DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccGuardDuty_serial/Filter/tags/EmptyTag_OnCreate
=== RUN   TestAccGuardDuty_serial/Filter/tags/DefaultTags_providerOnly
=== RUN   TestAccGuardDuty_serial/Filter/tags/ComputedTag_OnCreate
=== RUN   TestAccGuardDuty_serial/Filter/tags/ComputedTag_OnUpdate_Add
=== RUN   TestAccGuardDuty_serial/Filter/tags/IgnoreTags_Overlap_ResourceTag
=== RUN   TestAccGuardDuty_serial/Filter/tags/basic
=== RUN   TestAccGuardDuty_serial/Filter/tags/EmptyMap
=== RUN   TestAccGuardDuty_serial/Filter/tags/EmptyTag_OnUpdate_Add
=== RUN   TestAccGuardDuty_serial/Filter/tags/EmptyTag_OnUpdate_Replace
=== RUN   TestAccGuardDuty_serial/Filter/tags/DefaultTags_nonOverlapping
=== RUN   TestAccGuardDuty_serial/Filter/tags/DefaultTags_updateToResourceOnly
=== RUN   TestAccGuardDuty_serial/Filter/tags/DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccGuardDuty_serial/Filter/tags/AddOnUpdate
=== RUN   TestAccGuardDuty_serial/Filter/tags/DefaultTags_emptyResourceTag
=== RUN   TestAccGuardDuty_serial/Filter/tags/ComputedTag_OnUpdate_Replace
=== RUN   TestAccGuardDuty_serial/Filter/tags/IgnoreTags_Overlap_DefaultTag
=== RUN   TestAccGuardDuty_serial/Filter/disappears
--- PASS: TestAccGuardDuty_serial (2909.19s)
    --- PASS: TestAccGuardDuty_serial/Filter (2909.19s)
        --- PASS: TestAccGuardDuty_serial/Filter/basic (104.70s)
        --- PASS: TestAccGuardDuty_serial/Filter/update (157.08s)
        --- PASS: TestAccGuardDuty_serial/Filter/no_rank (80.69s)
        --- PASS: TestAccGuardDuty_serial/Filter/tags (2511.54s)
            --- PASS: TestAccGuardDuty_serial/Filter/tags/null (97.25s)
            --- PASS: TestAccGuardDuty_serial/Filter/tags/DefaultTags_overlapping (176.89s)
            --- PASS: TestAccGuardDuty_serial/Filter/tags/DefaultTags_updateToProviderOnly (109.94s)
            --- PASS: TestAccGuardDuty_serial/Filter/tags/DefaultTags_nullNonOverlappingResourceTag (68.00s)
            --- PASS: TestAccGuardDuty_serial/Filter/tags/EmptyTag_OnCreate (118.96s)
            --- PASS: TestAccGuardDuty_serial/Filter/tags/DefaultTags_providerOnly (237.18s)
            --- PASS: TestAccGuardDuty_serial/Filter/tags/ComputedTag_OnCreate (73.21s)
            --- PASS: TestAccGuardDuty_serial/Filter/tags/ComputedTag_OnUpdate_Add (114.22s)
            --- PASS: TestAccGuardDuty_serial/Filter/tags/IgnoreTags_Overlap_ResourceTag (153.02s)
            --- PASS: TestAccGuardDuty_serial/Filter/tags/basic (226.12s)
            --- PASS: TestAccGuardDuty_serial/Filter/tags/EmptyMap (97.03s)
            --- PASS: TestAccGuardDuty_serial/Filter/tags/EmptyTag_OnUpdate_Add (159.59s)
            --- PASS: TestAccGuardDuty_serial/Filter/tags/EmptyTag_OnUpdate_Replace (107.55s)
            --- PASS: TestAccGuardDuty_serial/Filter/tags/DefaultTags_nonOverlapping (174.51s)
            --- PASS: TestAccGuardDuty_serial/Filter/tags/DefaultTags_updateToResourceOnly (108.65s)
            --- PASS: TestAccGuardDuty_serial/Filter/tags/DefaultTags_nullOverlappingResourceTag (67.10s)
            --- PASS: TestAccGuardDuty_serial/Filter/tags/AddOnUpdate (107.08s)
            --- PASS: TestAccGuardDuty_serial/Filter/tags/DefaultTags_emptyResourceTag (68.99s)
            --- PASS: TestAccGuardDuty_serial/Filter/tags/ComputedTag_OnUpdate_Replace (111.37s)
            --- PASS: TestAccGuardDuty_serial/Filter/tags/IgnoreTags_Overlap_DefaultTag (134.90s)
        --- PASS: TestAccGuardDuty_serial/Filter/disappears (55.18s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/guardduty	2909.434s

```