### PR TITLE
resource/aws_cloudfront_anycast_ip_list: Add ip_address_type argument

### DIFF
--- a/.changelog/49131.txt
+++ b/.changelog/49131.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_cloudfront_anycast_ip_list: Add `ip_address_type` argument
+```

--- a/internal/service/cloudfront/anycast_ip_list.go
+++ b/internal/service/cloudfront/anycast_ip_list.go
@@ -73,6 +73,15 @@ func (r *anycastIPListResource) Schema(ctx context.Context, request resource.Sch
 				},
 			},
 			names.AttrID: framework.IDAttribute(),
+			names.AttrIPAddressType: schema.StringAttribute{
+				Optional:   true,
+				Computed:   true,
+				CustomType: fwtypes.StringEnumType[awstypes.IpAddressType](),
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
 			"ip_count": schema.Int32Attribute{
 				Required: true,
 				Validators: []validator.Int32{
@@ -141,6 +150,7 @@ func (r *anycastIPListResource) Create(ctx context.Context, request resource.Cre
 	data.AnycastIPs = fwflex.FlattenFrameworkStringValueListOfString(ctx, anycastIPList.AnycastIps)
 	data.ARN = fwflex.StringToFramework(ctx, anycastIPList.Arn)
 	data.ID = fwflex.StringToFramework(ctx, anycastIPList.Id)
+	data.IPAddressType = fwtypes.StringEnumValue(anycastIPList.IpAddressType)
 
 	outputGAIL, err := waitAnycastIPListDeployed(ctx, conn, data.ID.ValueString(), r.CreateTimeout(ctx, data.Timeouts))
 
@@ -303,13 +313,14 @@ func waitAnycastIPListDeployed(ctx context.Context, conn *cloudfront.Client, id 
 }
 
 type anycastIPListResourceModel struct {
-	AnycastIPs fwtypes.ListOfString `tfsdk:"anycast_ips"`
-	ARN        types.String         `tfsdk:"arn"`
-	ETag       types.String         `tfsdk:"etag"`
-	ID         types.String         `tfsdk:"id"`
-	IPCount    types.Int32          `tfsdk:"ip_count"`
-	Name       types.String         `tfsdk:"name"`
-	Tags       tftags.Map           `tfsdk:"tags"`
-	TagsAll    tftags.Map           `tfsdk:"tags_all"`
-	Timeouts   timeouts.Value       `tfsdk:"timeouts"`
+	AnycastIPs    fwtypes.ListOfString                       `tfsdk:"anycast_ips"`
+	ARN           types.String                               `tfsdk:"arn"`
+	ETag          types.String                               `tfsdk:"etag"`
+	ID            types.String                               `tfsdk:"id"`
+	IPAddressType fwtypes.StringEnum[awstypes.IpAddressType] `tfsdk:"ip_address_type"`
+	IPCount       types.Int32                                `tfsdk:"ip_count"`
+	Name          types.String                               `tfsdk:"name"`
+	Tags          tftags.Map                                 `tfsdk:"tags"`
+	TagsAll       tftags.Map                                 `tfsdk:"tags_all"`
+	Timeouts      timeouts.Value                             `tfsdk:"timeouts"`
 }

--- a/internal/service/cloudfront/anycast_ip_list_test.go
+++ b/internal/service/cloudfront/anycast_ip_list_test.go
@@ -30,6 +30,7 @@ func TestAccCloudFrontAnycastIPList_serial(t *testing.T) {
 	testCases := map[string]func(t *testing.T){
 		acctest.CtBasic:      testAccAnycastIPList_basic,
 		acctest.CtDisappears: testAccAnycastIPList_disappears,
+		"ipAddressType":      testAccAnycastIPList_ipAddressType,
 		"tags":               testAccCloudFrontAnycastIPList_tagsSerial,
 	}
 
@@ -64,6 +65,40 @@ func testAccAnycastIPList_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrID), knownvalue.NotNull()),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("ip_count"), knownvalue.Int32Exact(3)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
+				},
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccAnycastIPList_ipAddressType(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_cloudfront_anycast_ip_list.test"
+
+	acctest.Test(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.CloudFrontEndpointID) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CloudFrontServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckAnycastIPListDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAnycastIPListConfig_ipAddressType(rName, "dualstack"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAnycastIPListExists(ctx, t, resourceName),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrIPAddressType), knownvalue.StringExact("dualstack")),
 				},
 			},
 			{
@@ -155,4 +190,14 @@ resource "aws_cloudfront_anycast_ip_list" "test" {
   ip_count = 3
 }
 `, rName)
+}
+
+func testAccAnycastIPListConfig_ipAddressType(rName, ipAddressType string) string {
+	return fmt.Sprintf(`
+resource "aws_cloudfront_anycast_ip_list" "test" {
+  name            = %[1]q
+  ip_count        = 3
+  ip_address_type = %[2]q
+}
+`, rName, ipAddressType)
 }

--- a/website/docs/r/cloudfront_anycast_ip_list.html.markdown
+++ b/website/docs/r/cloudfront_anycast_ip_list.html.markdown
@@ -30,6 +30,7 @@ The following arguments are required:
 
 The following arguments are optional:
 
+* `ip_address_type` - (Optional, Forces new resource) The IP address type of the Anycast IP list. Valid values: `ipv4`, `ipv6`, `dualstack`. Defaults to `ipv4`.
 * `tags` - (Optional) Key-value tags for the place index. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## Attribute Reference


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

None.

### Description

Adds the `ip_address_type` argument to `aws_cloudfront_anycast_ip_list`, exposing the `IpAddressType` field already present on `CreateAnycastIpList`/`GetAnycastIpList` but never surfaced in the schema. Optional, defaults to `ipv4` server-side, forces replacement on change.

### Relations

Closes #49129

### References

- https://github.com/aws/aws-sdk-go-v2/blob/main/service/cloudfront/api_op_CreateAnycastIpList.go
- https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_CreateAnycastIpList.html

### Output from Acceptance Testing

`TestAccCloudFrontAnycastIPList_serial` is skipped (`acctest.Skip`) — Anycast static IP lists cost $3000/list/month, so this resource's acceptance tests are never run in CI.

## AI Disclosure

Claude Code (Claude Sonnet 5) was used to implement this change: the schema/model additions, the `ipAddressType` acceptance test, doc update, and changelog fragment. It followed this repo's existing `http_version` (multitenant_distribution.go) and `ip_count`/`name` (same file) patterns for conventions. I reviewed and verified every change (including a self-review pass) before opening this PR.