### PR TITLE
d/aws_emr_cluster: clarify configurations argument accepts a string, not a list

### DIFF
--- a/website/docs/r/emr_cluster.html.markdown
+++ b/website/docs/r/emr_cluster.html.markdown
@@ -617,7 +617,7 @@ The following arguments are optional:
 * `autoscaling_role` - (Optional) IAM role for automatic scaling policies. The IAM role provides permissions that the automatic scaling feature requires to launch and terminate EC2 instances in an instance group.
 * `auto_termination_policy` - (Optional) An auto-termination policy for an Amazon EMR cluster. An auto-termination policy defines the amount of idle time in seconds after which a cluster automatically terminates. See [Auto Termination Policy](#auto_termination_policy) Below.
 * `bootstrap_action` - (Optional) Ordered list of bootstrap actions that will be run before Hadoop is started on the cluster nodes. See below.
-* `configurations` - (Optional) List of configurations supplied for the EMR cluster you are creating. Supply a configuration object for applications to override their default configuration. See [AWS Documentation](https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-configure-apps.html) for more information.
+* `configurations` - (Optional) List of configurations supplied for the EMR cluster you are creating, expressed as a string: an HTTP(S) URL to a JSON file, a path to a local `.json` file, or a raw JSON string. To supply configuration objects using Terraform syntax instead, use `configurations_json`. See [AWS Documentation](https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-configure-apps.html) for more information.
 * `configurations_json` - (Optional) JSON string for supplying list of configurations for the EMR cluster.
 
 ~> **NOTE on `configurations_json`:** If the `Configurations` value is empty then you should skip the `Configurations` field instead of providing an empty list as a value, `"Configurations": []`.


### PR DESCRIPTION
## Description

`aws_emr_cluster`'s `configurations` argument is documented as "List of configurations supplied for the EMR cluster," but it's actually a `TypeString`: [`expandConfigures`](https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/emr/cluster.go#L2072) treats its value as an HTTP(S) URL, a local `.json` file path, or a raw JSON string, not a native HCL list of configuration objects.

That mismatch leads users to write configuration objects directly in HCL under `configurations`, which fails with `Inappropriate value for attribute "configurations": string required`, when `configurations_json` (which already accepts values built with Terraform syntax) is the argument they want.

This updates the `configurations` docs entry to describe the actual accepted string forms and points to `configurations_json` for the HCL use case. Docs-only change, no code/behavior changes.

Closes #39959