### PR TITLE
d/aws_amplify_app: document package version overrides via _LIVE_UPDATES

### DIFF
--- a/website/docs/r/amplify_app.html.markdown
+++ b/website/docs/r/amplify_app.html.markdown
@@ -136,6 +136,26 @@ resource "aws_amplify_app" "example" {
 }
 ```
 
+### Package Version Overrides
+
+Amplify picks a package version (e.g. the Node.js version) automatically unless `package.json` specifies otherwise. To override a package version for the build, set the `_LIVE_UPDATES` environment variable to a JSON-encoded list of packages to update. See [Updating the Next.js version for an existing app](https://docs.aws.amazon.com/amplify/latest/userguide/server-side-rendering-amplify.html) in the Amplify User Guide.
+
+```terraform
+resource "aws_amplify_app" "example" {
+  name = "example"
+
+  environment_variables = {
+    "_LIVE_UPDATES" = jsonencode([
+      {
+        pkg     = "node"
+        type    = "nvm"
+        version = "20"
+      },
+    ])
+  }
+}
+```
+
 ### Custom Headers
 
 ```terraform


### PR DESCRIPTION
## Description

`aws_amplify_app` picks build package versions (e.g. Node.js) automatically based on `package.json` unless overridden. Amplify supports overriding this via the `_LIVE_UPDATES` environment variable, but the resource docs had no example of it, so users were left to reverse-engineer the format from console-generated diffs.

This adds a "Package Version Overrides" example, following the same pattern already used for the existing "Custom Image" section (a special-cased `environment_variables` entry).

Docs-only change, no code/behavior changes.

Closes #27768