### PR TITLE
docs: clarify host_header values for non-standard ports

### DIFF
--- a/website/docs/r/lb_listener_rule.html.markdown
+++ b/website/docs/r/lb_listener_rule.html.markdown
@@ -399,7 +399,7 @@ Condition Blocks (for `condition`) support the following:
 Host Header Blocks (for `host_header`) support the following:
 
 * `regex_values` - (Optional) List of regular expressions to compare against the host header. The maximum length of each string is 128 characters. Conflicts with `values`.
-* `values` - (Optional) List of host header value patterns to match. Maximum size of each pattern is 128 characters. Comparison is case-insensitive. Wildcard characters supported: * (matches 0 or more characters) and ? (matches exactly 1 character). Only one pattern needs to match for the condition to be satisfied. Conflicts with `regex_values`.
+* `values` - (Optional) List of host header value patterns to match. Maximum size of each pattern is 128 characters. Comparison is case-insensitive. Wildcard characters supported: * (matches 0 or more characters) and ? (matches exactly 1 character). Only one pattern needs to match for the condition to be satisfied. To match host headers containing a non-standard port (for example, `example.com:8443`), use `regex_values`. Conflicts with `regex_values`.
 
 #### HTTP Header Blocks
 


### PR DESCRIPTION
## Rollback Plan

Revert this documentation change.

## Changes to Security Controls

No changes to security controls.

### Description

Clarify the documentation for `host_header.values` by documenting that `regex_values` should be used when matching host headers containing a non-standard port (for example, `example.com:8443`). This helps users understand the correct configuration for this use case.

### Relations

Closes #49147

### References

N/A

### Output from Acceptance Testing

Documentation-only change. No acceptance tests required.