### PR TITLE
r/aws_route53recoverycontrolconfig_safety_rule: fix panic on CreateSafetyRule error

### DIFF
--- a/.changelog/49155.txt
+++ b/.changelog/49155.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_route53recoverycontrolconfig_safety_rule: Fix panic when `CreateSafetyRule` returns an error, such as `ServiceQuotaExceededException`
+resource/aws_route53recoverycontrolconfig_safety_rule: Fix crash when the create operation returns an error
 ```

--- a/.changelog/49155.txt
+++ b/.changelog/49155.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_route53recoverycontrolconfig_safety_rule: Fix panic when `CreateSafetyRule` returns an error, such as `ServiceQuotaExceededException`
+```

--- a/internal/service/route53recoverycontrolconfig/safety_rule.go
+++ b/internal/service/route53recoverycontrolconfig/safety_rule.go
@@ -272,9 +272,7 @@ func createAssertionRule(ctx context.Context, d *schema.ResourceData, meta any) 
 		return sdkdiag.AppendErrorf(diags, "creating Route53 Recovery Control Config Assertion Rule empty response")
 	}
 
-	result := output.AssertionRule
-
-	d.SetId(aws.ToString(result.SafetyRuleArn))
+	d.SetId(aws.ToString(output.AssertionRule.SafetyRuleArn))
 
 	if _, err := waitSafetyRuleCreated(ctx, conn, d.Id()); err != nil {
 		return sdkdiag.AppendErrorf(diags, "waiting for Route53 Recovery Control Config Assertion Rule (%s) to be Deployed: %s", d.Id(), err)
@@ -315,9 +313,7 @@ func createGatingRule(ctx context.Context, d *schema.ResourceData, meta any) dia
 		return sdkdiag.AppendErrorf(diags, "creating Route53 Recovery Control Config Gating Rule empty response")
 	}
 
-	result := output.GatingRule
-
-	d.SetId(aws.ToString(result.SafetyRuleArn))
+	d.SetId(aws.ToString(output.GatingRule.SafetyRuleArn))
 
 	if _, err := waitSafetyRuleCreated(ctx, conn, d.Id()); err != nil {
 		return sdkdiag.AppendErrorf(diags, "waiting for Route53 Recovery Control Config Gating Rule (%s) to be Deployed: %s", d.Id(), err)

--- a/internal/service/route53recoverycontrolconfig/safety_rule.go
+++ b/internal/service/route53recoverycontrolconfig/safety_rule.go
@@ -263,15 +263,16 @@ func createAssertionRule(ctx context.Context, d *schema.ResourceData, meta any) 
 	}
 
 	output, err := conn.CreateSafetyRule(ctx, input)
-	result := output.AssertionRule
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating Route53 Recovery Control Config Assertion Rule: %s", err)
 	}
 
-	if result == nil {
+	if output == nil || output.AssertionRule == nil {
 		return sdkdiag.AppendErrorf(diags, "creating Route53 Recovery Control Config Assertion Rule empty response")
 	}
+
+	result := output.AssertionRule
 
 	d.SetId(aws.ToString(result.SafetyRuleArn))
 
@@ -305,15 +306,16 @@ func createGatingRule(ctx context.Context, d *schema.ResourceData, meta any) dia
 	}
 
 	output, err := conn.CreateSafetyRule(ctx, input)
-	result := output.GatingRule
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating Route53 Recovery Control Config Gating Rule: %s", err)
 	}
 
-	if result == nil {
+	if output == nil || output.GatingRule == nil {
 		return sdkdiag.AppendErrorf(diags, "creating Route53 Recovery Control Config Gating Rule empty response")
 	}
+
+	result := output.GatingRule
 
 	d.SetId(aws.ToString(result.SafetyRuleArn))
 


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

### Description

`resourceSafetyRuleCreate` dispatches to `createAssertionRule` or `createGatingRule`. Both functions assigned `result` from the `CreateSafetyRule` response before checking the returned error:

```go
output, err := conn.CreateSafetyRule(ctx, input)
result := output.AssertionRule

if err != nil {
    return sdkdiag.AppendErrorf(diags, "creating ... Assertion Rule: %s", err)
}
```

When the API returns an error, `output` is nil, so `result := output.AssertionRule` dereferences a nil pointer and panics, crashing the provider before the error is reported. This is easy to trigger with a `ServiceQuotaExceededException` when a control panel already holds the maximum number of safety rules.

This change moves the `result` assignment below the error check and the nil-response check in both functions, and folds the `output == nil` guard into the existing nil-response check. The underlying API error now surfaces as a diagnostic instead of a crash.

### Relations

Closes #49154

### References

The nil-response guard already present in each function only ran after the panic could occur; this reorders the statements so both guards run first.

### Output from Acceptance Testing

The affected package (`route53recoverycontrolconfig`) has no unit-test harness for the create path, and its acceptance tests exercise live safety rules against the control-panel limit. I did not have an AWS account with spare safety-rule quota to run `make testacc` for this resource, so I have not run acceptance tests. The change is a statement reorder with no behavior change on the success path; the error path previously could not be reached because of the panic.

```console
% go build ./internal/service/route53recoverycontrolconfig/
(build succeeds)
```

---

AI assistance disclosure: I used an AI coding assistant to help locate the faulty statement ordering from a panic stack trace and to draft this description. I reviewed and own the change; the fix is a two-line statement reorder in each of the two functions and I understand its behavior and implications.
