### PR TITLE
r/`aws_glue_catalog_table`: SPARK-dialect views require a StorageDescriptor with columns + skips sending StorageDescriptor entirely if any representations dialect is ATEHNA +  preserve values when AWS does not echo back

### DIFF
--- a/.changelog/49156.txt
+++ b/.changelog/49156.txt
@@ -1,0 +1,11 @@
+```release-note:bug
+resource/aws_glue_catalog_table: Fix perpetual diff on `view_definition.representations` fields (`validation_connection`, `view_original_text`, `view_expanded_text`) that AWS Glue does not echo back for validated ATHENA views
+```
+
+```release-note:bug
+resource/aws_glue_catalog_table: Fix `InvalidInputException: StorageDescriptor is not allowed` error when creating or updating ATHENA-dialect views
+```
+
+```release-note:bug
+resource/aws_glue_catalog_table: Fix `InvalidInputException` error when creating or updating SPARK-dialect views without an explicit `storage_descriptor` block
+```

--- a/internal/service/glue/catalog_table.go
+++ b/internal/service/glue/catalog_table.go
@@ -592,16 +592,19 @@ func resourceCatalogTable() *schema.Resource {
 										"validation_connection": {
 											Type:         schema.TypeString,
 											Optional:     true,
+											Computed:     true,
 											ValidateFunc: validation.StringLenBetween(1, 255),
 										},
 										"view_expanded_text": {
 											Type:         schema.TypeString,
 											Optional:     true,
+											Computed:     true,
 											ValidateFunc: validation.StringLenBetween(0, 409600),
 										},
 										"view_original_text": {
 											Type:         schema.TypeString,
 											Optional:     true,
+											Computed:     true,
 											ValidateFunc: validation.StringLenBetween(0, 409600),
 										},
 									},
@@ -734,7 +737,20 @@ func resourceCatalogTableRead(ctx context.Context, d *schema.ResourceData, meta 
 		d.Set("target_table", nil)
 	}
 	if table.ViewDefinition != nil {
-		if err := d.Set("view_definition", []any{flattenViewDefinition(table.ViewDefinition)}); err != nil {
+		// Glue does not echo back ValidationConnection, ViewOriginalText, or
+		// ViewExpandedText for validated ATHENA views — GetTable returns them as
+		// null. Preserve user supplied values.
+		var priorRepresentations []any
+		if v, ok := d.GetOk("view_definition"); ok {
+			vdList := v.([]any)
+			if len(vdList) > 0 && vdList[0] != nil {
+				vdMap := vdList[0].(map[string]any)
+				if reps, ok := vdMap["representations"].([]any); ok {
+					priorRepresentations = reps
+				}
+			}
+		}
+		if err := d.Set("view_definition", []any{flattenViewDefinition(table.ViewDefinition, priorRepresentations)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting view_definition: %s", err)
 		}
 	} else {
@@ -1549,7 +1565,7 @@ func expandSchemaId(tfList []any) *awstypes.SchemaId {
 
 func flattenStorageDescriptor(apiObject *awstypes.StorageDescriptor) []any {
 	if apiObject == nil {
-		return make([]any, 0)
+		return nil
 	}
 
 	tfList := make([]any, 1)
@@ -1870,7 +1886,7 @@ func expandViewRepresentationInputs(tfList []any) []awstypes.ViewRepresentationI
 	return apiObjects
 }
 
-func flattenViewDefinition(apiObject *awstypes.ViewDefinition) map[string]any {
+func flattenViewDefinition(apiObject *awstypes.ViewDefinition, priorRepresentations []any) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
@@ -1894,7 +1910,7 @@ func flattenViewDefinition(apiObject *awstypes.ViewDefinition) map[string]any {
 	}
 
 	if v := apiObject.Representations; len(v) > 0 {
-		tfMap["representations"] = flattenViewRepresentations(v)
+		tfMap["representations"] = flattenViewRepresentations(v, priorRepresentations)
 	}
 
 	tfMap["view_version_id"] = apiObject.ViewVersionId
@@ -1906,15 +1922,34 @@ func flattenViewDefinition(apiObject *awstypes.ViewDefinition) map[string]any {
 	return tfMap
 }
 
-func flattenViewRepresentations(apiObjects []awstypes.ViewRepresentation) []any {
+// flattenViewRepresentations flattens API representations, falling back to
+// prior state values for fields Glue does not echo back on GetTable
+// (ValidationConnection, ViewOriginalText, ViewExpandedText). Matching is by
+// dialect so the merge is order-independent.
+func flattenViewRepresentations(apiObjects []awstypes.ViewRepresentation, prior []any) []any {
+	// Build a lookup of prior state representations keyed by dialect string.
+	priorByDialect := make(map[string]map[string]any, len(prior))
+	for _, raw := range prior {
+		if m, ok := raw.(map[string]any); ok {
+			if d, ok := m["dialect"].(string); ok && d != "" {
+				priorByDialect[d] = m
+			}
+		}
+	}
+
 	tfList := make([]any, len(apiObjects))
 	for i, v := range apiObjects {
-		tfList[i] = flattenViewRepresentation(v)
+		tfList[i] = flattenViewRepresentation(v, priorByDialect[string(v.Dialect)])
 	}
 	return tfList
 }
 
-func flattenViewRepresentation(apiObject awstypes.ViewRepresentation) map[string]any {
+// flattenViewRepresentation flattens one API representation. For the three
+// fields Glue strips on validated views (ValidationConnection,
+// ViewOriginalText, ViewExpandedText), the API value takes precedence when
+// non-empty; otherwise the prior state value is preserved so state stays
+// consistent with what the user configured.
+func flattenViewRepresentation(apiObject awstypes.ViewRepresentation, prior map[string]any) map[string]any {
 	tfMap := make(map[string]any)
 
 	if v := apiObject.Dialect; v != "" {
@@ -1925,16 +1960,30 @@ func flattenViewRepresentation(apiObject awstypes.ViewRepresentation) map[string
 		tfMap["dialect_version"] = v
 	}
 
+	// Glue does not store these fields back for validated ATHENA views.
+	// Use the API value when present; fall back to prior state otherwise.
 	if v := aws.ToString(apiObject.ValidationConnection); v != "" {
 		tfMap["validation_connection"] = v
+	} else if prior != nil {
+		if v, ok := prior["validation_connection"].(string); ok && v != "" {
+			tfMap["validation_connection"] = v
+		}
 	}
 
 	if v := aws.ToString(apiObject.ViewExpandedText); v != "" {
 		tfMap["view_expanded_text"] = v
+	} else if prior != nil {
+		if v, ok := prior["view_expanded_text"].(string); ok && v != "" {
+			tfMap["view_expanded_text"] = v
+		}
 	}
 
 	if v := aws.ToString(apiObject.ViewOriginalText); v != "" {
 		tfMap["view_original_text"] = v
+	} else if prior != nil {
+		if v, ok := prior["view_original_text"].(string); ok && v != "" {
+			tfMap["view_original_text"] = v
+		}
 	}
 
 	return tfMap

--- a/internal/service/glue/catalog_table.go
+++ b/internal/service/glue/catalog_table.go
@@ -1039,6 +1039,16 @@ func expandTableInput(d *schema.ResourceData) *awstypes.TableInput {
 		apiObject.ViewDefinition = expandViewDefinitionInput(v.([]any)[0].(map[string]any))
 	}
 
+	// SPARK-dialect views require a StorageDescriptor with columns on both
+	// CreateTable and UpdateTable. If the user did not supply one explicitly,
+	// synthesise a minimal descriptor so Glue accepts the request. Glue will
+	// populate the actual columns after validating the view SQL.
+	if viewDefinitionHasDialect(d, awstypes.ViewDialectSpark) && apiObject.StorageDescriptor == nil {
+		apiObject.StorageDescriptor = &awstypes.StorageDescriptor{
+			Columns: []awstypes.Column{},
+		}
+	}
+
 	if v, ok := d.GetOk("view_expanded_text"); ok {
 		apiObject.ViewExpandedText = aws.String(v.(string))
 	}

--- a/internal/service/glue/catalog_table.go
+++ b/internal/service/glue/catalog_table.go
@@ -968,6 +968,31 @@ func waitTableViewSucceeded(ctx context.Context, conn *glue.Client, catalogID, d
 	return output, err
 }
 
+// viewDefinitionHasDialect returns true if view_definition.representations
+// contains at least one entry whose dialect matches the given value.
+func viewDefinitionHasDialect(d *schema.ResourceData, dialect awstypes.ViewDialect) bool {
+	v, ok := d.GetOk("view_definition")
+	if !ok {
+		return false
+	}
+	vdList := v.([]any)
+	if len(vdList) == 0 || vdList[0] == nil {
+		return false
+	}
+	reps, ok := vdList[0].(map[string]any)["representations"].([]any)
+	if !ok {
+		return false
+	}
+	for _, raw := range reps {
+		if m, ok := raw.(map[string]any); ok {
+			if d, ok := m["dialect"].(string); ok && d == string(dialect) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func expandTableInput(d *schema.ResourceData) *awstypes.TableInput {
 	apiObject := &awstypes.TableInput{
 		Name: aws.String(d.Get(names.AttrName).(string)),
@@ -995,7 +1020,10 @@ func expandTableInput(d *schema.ResourceData) *awstypes.TableInput {
 		apiObject.Retention = int32(v.(int))
 	}
 
-	if v, ok := d.GetOk("storage_descriptor"); ok {
+	// For validated ATHENA views, Glue forbids StorageDescriptor on both
+	// CreateTable and UpdateTable. Skip it when any representation carries
+	// dialect = ATHENA, regardless of what is in state.
+	if v, ok := d.GetOk("storage_descriptor"); ok && !viewDefinitionHasDialect(d, awstypes.ViewDialectAthena) {
 		apiObject.StorageDescriptor = expandStorageDescriptor(v.([]any))
 	}
 

--- a/internal/service/glue/catalog_table_test.go
+++ b/internal/service/glue/catalog_table_test.go
@@ -1067,6 +1067,42 @@ func TestAccGlueCatalogTable_viewDefinitionFailure(t *testing.T) {
 	})
 }
 
+func TestAccGlueCatalogTable_viewDefinition_noPerpetualDiff(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_glue_catalog_table.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.GlueServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckCatalogTableDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCatalogTableConfig_viewDefinitionNoPerpetualDiff(rName, "view_original_text_1", "view_expanded_text_1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCatalogTableExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "view_definition.0.representations.0.view_original_text", "view_original_text_1"),
+					resource.TestCheckResourceAttr(resourceName, "view_definition.0.representations.0.view_expanded_text", "view_expanded_text_1"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+			},
+			{
+				Config: testAccCatalogTableConfig_viewDefinitionNoPerpetualDiff(rName, "view_original_text_1", "view_expanded_text_1"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+		},
+	})
+}
+
 func testAccCheckCatalogTableDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.ProviderMeta(ctx, t).GlueClient(ctx)
@@ -2093,4 +2129,44 @@ resource "aws_glue_connection" "test_athena" {
   }
 }
 `, rName)
+}
+
+func testAccCatalogTableConfig_viewDefinitionNoPerpetualDiff(rName, viewOriginalText, viewExpandedText string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "test" {
+  name = %[1]q
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "glue.amazonaws.com"
+      }
+    }]
+  })
+}
+
+resource "aws_glue_catalog_database" "test" {
+  name = %[1]q
+}
+
+resource "aws_glue_catalog_table" "test" {
+  name          = %[1]q
+  database_name = aws_glue_catalog_database.test.name
+  table_type    = "VIRTUAL_VIEW"
+
+  view_definition {
+    definer = aws_iam_role.test.arn
+
+    representations {
+      dialect            = "SPARK"
+      dialect_version    = "1.0"
+      view_original_text = %[2]q
+      view_expanded_text = %[3]q
+    }
+  }
+}
+`, rName, viewOriginalText, viewExpandedText)
 }

--- a/internal/service/glue/catalog_table_test.go
+++ b/internal/service/glue/catalog_table_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 
 	"github.com/YakDriver/regexache"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/glue/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -29,6 +31,196 @@ func testAccErrorCheckSkip(t *testing.T) resource.ErrorCheckFunc {
 	return acctest.ErrorCheckSkipMessagesContaining(t,
 		"AccessDeniedException: Operation not allowed",
 	)
+}
+
+func TestFlattenViewRepresentation(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name      string
+		apiObject awstypes.ViewRepresentation
+		prior     map[string]any
+		want      map[string]any
+	}{
+		{
+			name: "api values take precedence over prior state",
+			apiObject: awstypes.ViewRepresentation{
+				Dialect:              awstypes.ViewDialectAthena,
+				DialectVersion:       aws.String("3"),
+				ValidationConnection: aws.String("api-conn"),
+				ViewExpandedText:     aws.String("api-expanded"),
+				ViewOriginalText:     aws.String("api-original"),
+			},
+			prior: map[string]any{
+				"dialect":               "ATHENA",
+				"validation_connection": "prior-conn",
+				"view_expanded_text":    "prior-expanded",
+				"view_original_text":    "prior-original",
+			},
+			want: map[string]any{
+				"dialect":               awstypes.ViewDialectAthena,
+				"dialect_version":       "3",
+				"validation_connection": "api-conn",
+				"view_expanded_text":    "api-expanded",
+				"view_original_text":    "api-original",
+			},
+		},
+		{
+			name: "falls back to prior state when glue strips fields for validated athena view",
+			apiObject: awstypes.ViewRepresentation{
+				Dialect:              awstypes.ViewDialectAthena,
+				DialectVersion:       aws.String("3"),
+				ValidationConnection: nil,
+				ViewExpandedText:     nil,
+				ViewOriginalText:     nil,
+			},
+			prior: map[string]any{
+				"dialect":               "ATHENA",
+				"validation_connection": "prior-conn",
+				"view_expanded_text":    "prior-expanded",
+				"view_original_text":    "prior-original",
+			},
+			want: map[string]any{
+				"dialect":               awstypes.ViewDialectAthena,
+				"dialect_version":       "3",
+				"validation_connection": "prior-conn",
+				"view_expanded_text":    "prior-expanded",
+				"view_original_text":    "prior-original",
+			},
+		},
+		{
+			name: "nil prior does not panic and omits empty optional fields",
+			apiObject: awstypes.ViewRepresentation{
+				Dialect:        awstypes.ViewDialectSpark,
+				DialectVersion: aws.String("3.3"),
+			},
+			prior: nil,
+			want: map[string]any{
+				"dialect":         awstypes.ViewDialectSpark,
+				"dialect_version": "3.3",
+			},
+		},
+		{
+			name: "empty-string prior values are not written into flattened map",
+			apiObject: awstypes.ViewRepresentation{
+				Dialect: awstypes.ViewDialectAthena,
+			},
+			prior: map[string]any{
+				"dialect":               "ATHENA",
+				"validation_connection": "",
+				"view_expanded_text":    "",
+				"view_original_text":    "",
+			},
+			want: map[string]any{
+				"dialect": awstypes.ViewDialectAthena,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfglue.FlattenViewRepresentation(tc.apiObject, tc.prior)
+
+			for k, wantVal := range tc.want {
+				if got[k] != wantVal {
+					t.Errorf("key %q: got %v, want %v", k, got[k], wantVal)
+				}
+			}
+			for k := range got {
+				if _, ok := tc.want[k]; !ok {
+					t.Errorf("unexpected key %q in result", k)
+				}
+			}
+		})
+	}
+}
+
+func TestFlattenViewRepresentations(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name       string
+		apiObjects []awstypes.ViewRepresentation
+		prior      []any
+		wantLen    int
+		checkFn    func(t *testing.T, got []any)
+	}{
+		{
+			name: "prior matched by dialect not list position",
+			apiObjects: []awstypes.ViewRepresentation{
+				// API returns SPARK first, ATHENA second.
+				{
+					Dialect:        awstypes.ViewDialectSpark,
+					DialectVersion: aws.String("3.3"),
+				},
+				{
+					Dialect:        awstypes.ViewDialectAthena,
+					DialectVersion: aws.String("3"),
+				},
+			},
+			// Prior state has ATHENA first, SPARK second (reversed).
+			prior: []any{
+				map[string]any{
+					"dialect":               "ATHENA",
+					"validation_connection": "athena-conn",
+					"view_original_text":    "athena-sql",
+				},
+				map[string]any{
+					"dialect":            "SPARK",
+					"view_original_text": "spark-sql",
+				},
+			},
+			wantLen: 2,
+			checkFn: func(t *testing.T, got []any) {
+				t.Helper()
+				spark := got[0].(map[string]any)
+				if spark["view_original_text"] != "spark-sql" {
+					t.Errorf("SPARK view_original_text = %q, want %q", spark["view_original_text"], "spark-sql")
+				}
+				athena := got[1].(map[string]any)
+				if athena["validation_connection"] != "athena-conn" {
+					t.Errorf("ATHENA validation_connection = %q, want %q", athena["validation_connection"], "athena-conn")
+				}
+				if athena["view_original_text"] != "athena-sql" {
+					t.Errorf("ATHENA view_original_text = %q, want %q", athena["view_original_text"], "athena-sql")
+				}
+			},
+		},
+		{
+			name: "nil prior does not panic and propagates api fields",
+			apiObjects: []awstypes.ViewRepresentation{
+				{
+					Dialect:          awstypes.ViewDialectAthena,
+					DialectVersion:   aws.String("3"),
+					ViewOriginalText: aws.String("SELECT 1"),
+				},
+			},
+			prior:   nil,
+			wantLen: 1,
+			checkFn: func(t *testing.T, got []any) {
+				t.Helper()
+				m := got[0].(map[string]any)
+				if m["view_original_text"] != "SELECT 1" {
+					t.Errorf("view_original_text = %q, want %q", m["view_original_text"], "SELECT 1")
+				}
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfglue.FlattenViewRepresentations(tc.apiObjects, tc.prior)
+
+			if len(got) != tc.wantLen {
+				t.Fatalf("len(got) = %d, want %d", len(got), tc.wantLen)
+			}
+			tc.checkFn(t, got)
+		})
+	}
 }
 
 func TestAccGlueCatalogTable_basic(t *testing.T) {

--- a/internal/service/glue/exports_test.go
+++ b/internal/service/glue/exports_test.go
@@ -5,6 +5,9 @@ package glue
 
 // Exports for use in tests only.
 var (
+	FlattenViewRepresentation  = flattenViewRepresentation
+	FlattenViewRepresentations = flattenViewRepresentations
+
 	ResourceCatalog                       = newCatalogResource
 	ResourceCatalogTable                  = resourceCatalogTable
 	ResourceCatalogTableOptimizer         = newCatalogTableOptimizerResource


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

### Description

1. Fix perpetual diff on `view_definition.representations` fields (`validation_connection`, `view_original_text`, `view_expanded_text`) that AWS Glue does not echo back for validated ATHENA views

```console
aws glue get-table \
  --database-name glue-view-bug-db \
  --name iceberg_view \
  --region eu-west-2 \
  --query 'Table.ViewDefinition.Representations[0].{Dialect:Dialect,ViewOriginalText:ViewOriginalText,ValidationConnection:ValidationConnection,ViewExpandedText:ViewExpandedText}' \
  --output json
{
    "Dialect": "ATHENA",
    "ViewOriginalText": null,
    "ValidationConnection": null,
    "ViewExpandedText": null
}
```



2. Fix `InvalidInputException: StorageDescriptor is not allowed` error when creating or updating ATHENA-dialect views.
     Original Error: InvalidInputException: Storage descriptor may not be defined when creating a validated Glue view


3. Fix `InvalidInputException` error when creating or updating SPARK-dialect views without an explicit `storage_descriptor` block
      Original Error: InvalidInputException: Storage Descriptor and columns must be provided with View Definition!



### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #49042

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
make t K=glue T=TestAccGlueCatalogTable_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 b-aws_glue_catalog_table-dialect-blind-issue 🌿...
TF_ACC=1 go1.26.5 test ./internal/service/glue/... -v -count 1 -parallel 20 -run='TestAccGlueCatalogTable_'  -timeout 360m -vet=off
2026/07/29 01:20:05 Creating Terraform AWS Provider (SDKv2-style)...
2026/07/29 01:20:05 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccGlueCatalogTable_basic
=== PAUSE TestAccGlueCatalogTable_basic
=== RUN   TestAccGlueCatalogTable_columnParameters
=== PAUSE TestAccGlueCatalogTable_columnParameters
=== RUN   TestAccGlueCatalogTable_full
=== PAUSE TestAccGlueCatalogTable_full
=== RUN   TestAccGlueCatalogTable_Update_addValues
=== PAUSE TestAccGlueCatalogTable_Update_addValues
=== RUN   TestAccGlueCatalogTable_Update_replaceValues
=== PAUSE TestAccGlueCatalogTable_Update_replaceValues
=== RUN   TestAccGlueCatalogTable_Update_viewInPlace
=== PAUSE TestAccGlueCatalogTable_Update_viewInPlace
=== RUN   TestAccGlueCatalogTable_StorageDescriptor_emptyBlock
=== PAUSE TestAccGlueCatalogTable_StorageDescriptor_emptyBlock
=== RUN   TestAccGlueCatalogTable_StorageDescriptorSerDeInfo_emptyBlock
=== PAUSE TestAccGlueCatalogTable_StorageDescriptorSerDeInfo_emptyBlock
=== RUN   TestAccGlueCatalogTable_StorageDescriptorSerDeInfo_updateValues
=== PAUSE TestAccGlueCatalogTable_StorageDescriptorSerDeInfo_updateValues
=== RUN   TestAccGlueCatalogTable_StorageDescriptorSkewedInfo_emptyBlock
=== PAUSE TestAccGlueCatalogTable_StorageDescriptorSkewedInfo_emptyBlock
=== RUN   TestAccGlueCatalogTable_StorageDescriptor_schemaReference
=== PAUSE TestAccGlueCatalogTable_StorageDescriptor_schemaReference
=== RUN   TestAccGlueCatalogTable_StorageDescriptor_schemaReferenceARN
=== PAUSE TestAccGlueCatalogTable_StorageDescriptor_schemaReferenceARN
=== RUN   TestAccGlueCatalogTable_partitionIndexesSingle
=== PAUSE TestAccGlueCatalogTable_partitionIndexesSingle
=== RUN   TestAccGlueCatalogTable_partitionIndexesMultiple
=== PAUSE TestAccGlueCatalogTable_partitionIndexesMultiple
=== RUN   TestAccGlueCatalogTable_Disappears_database
=== PAUSE TestAccGlueCatalogTable_Disappears_database
=== RUN   TestAccGlueCatalogTable_targetTable
=== PAUSE TestAccGlueCatalogTable_targetTable
=== RUN   TestAccGlueCatalogTable_disappears
=== PAUSE TestAccGlueCatalogTable_disappears
=== RUN   TestAccGlueCatalogTable_openTableFormat
=== PAUSE TestAccGlueCatalogTable_openTableFormat
=== RUN   TestAccGlueCatalogTable_viewDefinition
=== PAUSE TestAccGlueCatalogTable_viewDefinition
=== RUN   TestAccGlueCatalogTable_icebergTableInput
=== PAUSE TestAccGlueCatalogTable_icebergTableInput
=== RUN   TestAccGlueCatalogTable_viewDefinitionFailure
=== PAUSE TestAccGlueCatalogTable_viewDefinitionFailure
=== CONT  TestAccGlueCatalogTable_basic
=== CONT  TestAccGlueCatalogTable_StorageDescriptor_schemaReferenceARN
=== CONT  TestAccGlueCatalogTable_disappears
=== CONT  TestAccGlueCatalogTable_StorageDescriptor_emptyBlock
=== CONT  TestAccGlueCatalogTable_StorageDescriptorSkewedInfo_emptyBlock
=== CONT  TestAccGlueCatalogTable_Update_addValues
=== CONT  TestAccGlueCatalogTable_Disappears_database
=== CONT  TestAccGlueCatalogTable_targetTable
=== CONT  TestAccGlueCatalogTable_icebergTableInput
=== CONT  TestAccGlueCatalogTable_StorageDescriptorSerDeInfo_updateValues
=== CONT  TestAccGlueCatalogTable_StorageDescriptorSerDeInfo_emptyBlock
=== CONT  TestAccGlueCatalogTable_viewDefinitionFailure
=== CONT  TestAccGlueCatalogTable_full
=== CONT  TestAccGlueCatalogTable_columnParameters
=== CONT  TestAccGlueCatalogTable_Update_viewInPlace
=== CONT  TestAccGlueCatalogTable_StorageDescriptor_schemaReference
=== CONT  TestAccGlueCatalogTable_partitionIndexesMultiple
=== CONT  TestAccGlueCatalogTable_Update_replaceValues
=== CONT  TestAccGlueCatalogTable_partitionIndexesSingle
=== CONT  TestAccGlueCatalogTable_viewDefinition
    catalog_table_test.go:790: Step 1/2 error: Error running apply: exit status 1

        Error: creating Glue Catalog Table (927163995318:tf-acc-test-2730659639470226417:tf-acc-test-2730659639470226417): operation error Glue: CreateTable, https response error StatusCode: 400, RequestID: dc86ffa1-9a95-497f-93c9-554c91c2011c, InvalidInputException: Definer arn must be an IAM role. If definer arn is not specified, the requester must be an IAM role.

          with aws_glue_catalog_table.test,
          on terraform_plugin_test.tf line 16, in resource "aws_glue_catalog_table" "test":
          16: resource "aws_glue_catalog_table" "test" {

=== NAME  TestAccGlueCatalogTable_viewDefinitionFailure
    catalog_table_test.go:864: Step 1/1, expected an error with pattern, no match on: Error running apply: exit status 1

        Error: creating Glue Catalog Table (927163995318:tf-acc-test-7344229714397217015:tf-acc-test-7344229714397217015): operation error Glue: CreateTable, https response error StatusCode: 400, RequestID: 2ebc2787-4cc1-4d42-a4e8-bc2a139ef285, InvalidInputException: Definer arn must be an IAM role. If definer arn is not specified, the requester must be an IAM role.

          with aws_glue_catalog_table.test,
          on terraform_plugin_test.tf line 16, in resource "aws_glue_catalog_table" "test":
          16: resource "aws_glue_catalog_table" "test" {

=== NAME  TestAccGlueCatalogTable_Update_viewInPlace
    catalog_table_test.go:358: Step 1/2 error: Error running apply: exit status 1

        Error: creating Glue Catalog Table (927163995318:tf-acc-test-8100322630642876408:tf-acc-test-8100322630642876408): operation error Glue: CreateTable, https response error StatusCode: 400, RequestID: cba94621-8667-487e-8c59-89d0d1a6a49f, InvalidInputException: Definer arn must be an IAM role. If definer arn is not specified, the requester must be an IAM role.

          with aws_glue_catalog_table.test,
          on terraform_plugin_test.tf line 16, in resource "aws_glue_catalog_table" "test":
          16: resource "aws_glue_catalog_table" "test" {

--- FAIL: TestAccGlueCatalogTable_viewDefinition (29.38s)
=== CONT  TestAccGlueCatalogTable_openTableFormat
--- FAIL: TestAccGlueCatalogTable_viewDefinitionFailure (31.77s)
--- FAIL: TestAccGlueCatalogTable_Update_viewInPlace (32.57s)
--- PASS: TestAccGlueCatalogTable_StorageDescriptor_emptyBlock (53.44s)
--- PASS: TestAccGlueCatalogTable_disappears (59.32s)
--- PASS: TestAccGlueCatalogTable_Disappears_database (59.37s)
--- PASS: TestAccGlueCatalogTable_StorageDescriptorSkewedInfo_emptyBlock (59.85s)
--- PASS: TestAccGlueCatalogTable_StorageDescriptorSerDeInfo_emptyBlock (59.88s)
--- PASS: TestAccGlueCatalogTable_columnParameters (63.72s)
--- PASS: TestAccGlueCatalogTable_full (64.01s)
--- PASS: TestAccGlueCatalogTable_basic (67.23s)
--- PASS: TestAccGlueCatalogTable_partitionIndexesSingle (67.26s)
--- PASS: TestAccGlueCatalogTable_partitionIndexesMultiple (67.30s)
--- PASS: TestAccGlueCatalogTable_targetTable (68.08s)
--- PASS: TestAccGlueCatalogTable_StorageDescriptor_schemaReferenceARN (68.16s)
--- PASS: TestAccGlueCatalogTable_StorageDescriptorSerDeInfo_updateValues (81.47s)
--- PASS: TestAccGlueCatalogTable_Update_addValues (81.53s)
--- PASS: TestAccGlueCatalogTable_Update_replaceValues (83.36s)
--- PASS: TestAccGlueCatalogTable_StorageDescriptor_schemaReference (86.79s)
--- PASS: TestAccGlueCatalogTable_icebergTableInput (98.15s)
--- PASS: TestAccGlueCatalogTable_openTableFormat (79.35s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/glue       117.022s
FAIL
```

Failure are not related to this change , same tests fail in upstream branch :

```console
make t K=glue T=TestAccGlueCatalogTable_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 main 🌿...
TF_ACC=1 go1.26.5 test ./internal/service/glue/... -v -count 1 -parallel 20 -run='TestAccGlueCatalogTable_'  -timeout 360m -vet=off
2026/07/29 02:07:09 Creating Terraform AWS Provider (SDKv2-style)...
2026/07/29 02:07:09 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccGlueCatalogTable_basic
=== PAUSE TestAccGlueCatalogTable_basic
=== RUN   TestAccGlueCatalogTable_columnParameters
=== PAUSE TestAccGlueCatalogTable_columnParameters
=== RUN   TestAccGlueCatalogTable_full
=== PAUSE TestAccGlueCatalogTable_full
=== RUN   TestAccGlueCatalogTable_Update_addValues
=== PAUSE TestAccGlueCatalogTable_Update_addValues
=== RUN   TestAccGlueCatalogTable_Update_replaceValues
=== PAUSE TestAccGlueCatalogTable_Update_replaceValues
=== RUN   TestAccGlueCatalogTable_Update_viewInPlace
=== PAUSE TestAccGlueCatalogTable_Update_viewInPlace
=== RUN   TestAccGlueCatalogTable_StorageDescriptor_emptyBlock
=== PAUSE TestAccGlueCatalogTable_StorageDescriptor_emptyBlock
=== RUN   TestAccGlueCatalogTable_StorageDescriptorSerDeInfo_emptyBlock
=== PAUSE TestAccGlueCatalogTable_StorageDescriptorSerDeInfo_emptyBlock
=== RUN   TestAccGlueCatalogTable_StorageDescriptorSerDeInfo_updateValues
=== PAUSE TestAccGlueCatalogTable_StorageDescriptorSerDeInfo_updateValues
=== RUN   TestAccGlueCatalogTable_StorageDescriptorSkewedInfo_emptyBlock
=== PAUSE TestAccGlueCatalogTable_StorageDescriptorSkewedInfo_emptyBlock
=== RUN   TestAccGlueCatalogTable_StorageDescriptor_schemaReference
=== PAUSE TestAccGlueCatalogTable_StorageDescriptor_schemaReference
=== RUN   TestAccGlueCatalogTable_StorageDescriptor_schemaReferenceARN
=== PAUSE TestAccGlueCatalogTable_StorageDescriptor_schemaReferenceARN
=== RUN   TestAccGlueCatalogTable_partitionIndexesSingle
=== PAUSE TestAccGlueCatalogTable_partitionIndexesSingle
=== RUN   TestAccGlueCatalogTable_partitionIndexesMultiple
=== PAUSE TestAccGlueCatalogTable_partitionIndexesMultiple
=== RUN   TestAccGlueCatalogTable_Disappears_database
=== PAUSE TestAccGlueCatalogTable_Disappears_database
=== RUN   TestAccGlueCatalogTable_targetTable
=== PAUSE TestAccGlueCatalogTable_targetTable
=== RUN   TestAccGlueCatalogTable_disappears
=== PAUSE TestAccGlueCatalogTable_disappears
=== RUN   TestAccGlueCatalogTable_openTableFormat
=== PAUSE TestAccGlueCatalogTable_openTableFormat
=== RUN   TestAccGlueCatalogTable_viewDefinition
=== PAUSE TestAccGlueCatalogTable_viewDefinition
=== RUN   TestAccGlueCatalogTable_icebergTableInput
=== PAUSE TestAccGlueCatalogTable_icebergTableInput
=== RUN   TestAccGlueCatalogTable_viewDefinitionFailure
=== PAUSE TestAccGlueCatalogTable_viewDefinitionFailure
=== CONT  TestAccGlueCatalogTable_basic
=== CONT  TestAccGlueCatalogTable_StorageDescriptor_schemaReferenceARN
=== CONT  TestAccGlueCatalogTable_disappears
=== CONT  TestAccGlueCatalogTable_StorageDescriptor_emptyBlock
=== CONT  TestAccGlueCatalogTable_Disappears_database
=== CONT  TestAccGlueCatalogTable_targetTable
=== CONT  TestAccGlueCatalogTable_partitionIndexesMultiple
=== CONT  TestAccGlueCatalogTable_partitionIndexesSingle
=== CONT  TestAccGlueCatalogTable_StorageDescriptorSkewedInfo_emptyBlock
=== CONT  TestAccGlueCatalogTable_StorageDescriptor_schemaReference
=== CONT  TestAccGlueCatalogTable_StorageDescriptorSerDeInfo_updateValues
=== CONT  TestAccGlueCatalogTable_Update_addValues
=== CONT  TestAccGlueCatalogTable_Update_viewInPlace
=== CONT  TestAccGlueCatalogTable_Update_replaceValues
=== CONT  TestAccGlueCatalogTable_icebergTableInput
=== CONT  TestAccGlueCatalogTable_viewDefinitionFailure
=== CONT  TestAccGlueCatalogTable_viewDefinition
=== CONT  TestAccGlueCatalogTable_full
=== CONT  TestAccGlueCatalogTable_openTableFormat
=== CONT  TestAccGlueCatalogTable_StorageDescriptorSerDeInfo_emptyBlock
=== NAME  TestAccGlueCatalogTable_viewDefinition
    catalog_table_test.go:790: Step 1/2 error: Error running apply: exit status 1

        Error: creating Glue Catalog Table (927163995318:tf-acc-test-8081668174315176632:tf-acc-test-8081668174315176632): operation error Glue: CreateTable, https response error StatusCode: 400, RequestID: e98e9a23-6fbd-4494-8173-eb98df58de2c, InvalidInputException: Definer arn must be an IAM role. If definer arn is not specified, the requester must be an IAM role.

          with aws_glue_catalog_table.test,
          on terraform_plugin_test.tf line 16, in resource "aws_glue_catalog_table" "test":
          16: resource "aws_glue_catalog_table" "test" {

=== NAME  TestAccGlueCatalogTable_viewDefinitionFailure
    catalog_table_test.go:864: Step 1/1, expected an error with pattern, no match on: Error running apply: exit status 1

        Error: creating Glue Catalog Table (927163995318:tf-acc-test-6773004543696640462:tf-acc-test-6773004543696640462): operation error Glue: CreateTable, https response error StatusCode: 400, RequestID: 5e0a978a-ccfb-44e9-ad21-b2d6a0f8440c, InvalidInputException: Definer arn must be an IAM role. If definer arn is not specified, the requester must be an IAM role.

          with aws_glue_catalog_table.test,
          on terraform_plugin_test.tf line 16, in resource "aws_glue_catalog_table" "test":
          16: resource "aws_glue_catalog_table" "test" {

=== NAME  TestAccGlueCatalogTable_Update_viewInPlace
    catalog_table_test.go:358: Step 1/2 error: Error running apply: exit status 1

        Error: creating Glue Catalog Table (927163995318:tf-acc-test-3176581040420920951:tf-acc-test-3176581040420920951): operation error Glue: CreateTable, https response error StatusCode: 400, RequestID: c8f6a4b8-fedb-48eb-8bf9-201624a9e39c, InvalidInputException: Definer arn must be an IAM role. If definer arn is not specified, the requester must be an IAM role.

          with aws_glue_catalog_table.test,
          on terraform_plugin_test.tf line 16, in resource "aws_glue_catalog_table" "test":
          16: resource "aws_glue_catalog_table" "test" {

--- FAIL: TestAccGlueCatalogTable_viewDefinition (25.62s)
=== CONT  TestAccGlueCatalogTable_columnParameters
--- FAIL: TestAccGlueCatalogTable_viewDefinitionFailure (25.80s)
--- FAIL: TestAccGlueCatalogTable_Update_viewInPlace (30.03s)
--- PASS: TestAccGlueCatalogTable_StorageDescriptor_emptyBlock (53.15s)
--- PASS: TestAccGlueCatalogTable_disappears (57.95s)
--- PASS: TestAccGlueCatalogTable_StorageDescriptorSerDeInfo_emptyBlock (58.27s)
--- PASS: TestAccGlueCatalogTable_StorageDescriptorSkewedInfo_emptyBlock (58.37s)
--- PASS: TestAccGlueCatalogTable_Disappears_database (59.03s)
--- PASS: TestAccGlueCatalogTable_partitionIndexesSingle (62.31s)
--- PASS: TestAccGlueCatalogTable_basic (63.00s)
--- PASS: TestAccGlueCatalogTable_partitionIndexesMultiple (63.09s)
--- PASS: TestAccGlueCatalogTable_full (63.12s)
--- PASS: TestAccGlueCatalogTable_StorageDescriptor_schemaReferenceARN (65.19s)
--- PASS: TestAccGlueCatalogTable_targetTable (65.38s)
--- PASS: TestAccGlueCatalogTable_columnParameters (45.93s)
--- PASS: TestAccGlueCatalogTable_Update_addValues (78.09s)
--- PASS: TestAccGlueCatalogTable_StorageDescriptorSerDeInfo_updateValues (79.72s)
--- PASS: TestAccGlueCatalogTable_Update_replaceValues (80.03s)
--- PASS: TestAccGlueCatalogTable_StorageDescriptor_schemaReference (84.75s)
--- PASS: TestAccGlueCatalogTable_openTableFormat (93.29s)
--- PASS: TestAccGlueCatalogTable_icebergTableInput (96.55s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/glue       104.747s
FAIL
```

All failed tests seem to have the error : InvalidInputException: Definer arn must be an IAM role. If definer arn is not specified, the requester must be an IAM role. Trying to fix them results in lot more issues and it is not related to this change, so skipping for now and work on them on a separate PR.