### PR TITLE
New List Resource: `aws_osis_pipeline`

### DIFF
--- a/.changelog/49157.txt
+++ b/.changelog/49157.txt
@@ -1,0 +1,3 @@
+```release-note:new-list-resource
+aws_osis_pipeline
+```

--- a/internal/generate/tagstests/main.go
+++ b/internal/generate/tagstests/main.go
@@ -686,7 +686,7 @@ func (v *visitor) processFuncDecl(funcDecl *ast.FuncDecl) {
 				return
 			}
 			if !hasIdentifierAttribute && len(d.overrideIdentifierAttribute) == 0 {
-				v.errs = append(v.errs, fmt.Errorf("%s.%s: @Tags specification for %s does not use identifierAttribute. Missing @Testing(tagsIdentifierAttribute) and possibly tagsResourceType", v.packageName, v.functionName))
+				v.errs = append(v.errs, fmt.Errorf("%s.%s: @Tags specification does not use identifierAttribute. Missing @Testing(tagsIdentifierAttribute) and possibly tagsResourceType", v.packageName, v.functionName))
 				return
 			}
 			if d.HasInherentRegionIdentity() {

--- a/internal/service/osis/pipeline.go
+++ b/internal/service/osis/pipeline.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -301,7 +302,7 @@ func (r *pipelineResource) Read(ctx context.Context, request resource.ReadReques
 		return
 	}
 
-	response.Diagnostics.Append(fwflex.Flatten(ctx, pipeline, &data)...)
+	response.Diagnostics.Append(r.flatten(ctx, pipeline, &data)...)
 	if response.Diagnostics.HasError() {
 		return
 	}
@@ -385,6 +386,10 @@ func (r *pipelineResource) Delete(ctx context.Context, request resource.DeleteRe
 
 		return
 	}
+}
+
+func (r *pipelineResource) flatten(ctx context.Context, pipeline *awstypes.Pipeline, data *pipelineResourceModel) diag.Diagnostics {
+	return fwflex.Flatten(ctx, pipeline, data)
 }
 
 func findPipelineByName(ctx context.Context, conn *osis.Client, name string) (*awstypes.Pipeline, error) {

--- a/internal/service/osis/pipeline.go
+++ b/internal/service/osis/pipeline.go
@@ -274,6 +274,8 @@ func (r *pipelineResource) Create(ctx context.Context, request resource.CreateRe
 	data.PipelineARN = fwflex.StringToFramework(ctx, pipeline.PipelineArn)
 	data.PipelineRoleARN = fwflex.StringToFrameworkARN(ctx, pipeline.PipelineRoleArn)
 
+	setTagsOut(ctx, pipeline.Tags)
+
 	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
 }
 
@@ -330,7 +332,7 @@ func (r *pipelineResource) Update(ctx context.Context, request resource.UpdateRe
 	}
 
 	if diff.HasChanges() {
-		input := osis.UpdatePipelineInput{}
+		var input osis.UpdatePipelineInput
 		response.Diagnostics.Append(fwflex.Expand(ctx, new, &input)...)
 		if response.Diagnostics.HasError() {
 			return
@@ -389,7 +391,14 @@ func (r *pipelineResource) Delete(ctx context.Context, request resource.DeleteRe
 }
 
 func (r *pipelineResource) flatten(ctx context.Context, pipeline *awstypes.Pipeline, data *pipelineResourceModel) diag.Diagnostics {
-	return fwflex.Flatten(ctx, pipeline, data)
+	diags := fwflex.Flatten(ctx, pipeline, data)
+	if diags.HasError() {
+		return diags
+	}
+
+	setTagsOut(ctx, pipeline.Tags)
+
+	return diags
 }
 
 func findPipelineByName(ctx context.Context, conn *osis.Client, name string) (*awstypes.Pipeline, error) {

--- a/internal/service/osis/pipeline_list.go
+++ b/internal/service/osis/pipeline_list.go
@@ -1,0 +1,109 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package osis
+
+import (
+	"context"
+	"fmt"
+	"iter"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/osis"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/osis/types"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/logging"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
+	"github.com/hashicorp/terraform-provider-aws/internal/smerr"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// Function annotations are used for list resource registration to the Provider. DO NOT EDIT.
+// @FrameworkListResource("aws_osis_pipeline")
+func newPipelineResourceAsListResource() list.ListResourceWithConfigure {
+	return &pipelineListResource{}
+}
+
+var _ list.ListResource = &pipelineListResource{}
+
+type pipelineListResource struct {
+	pipelineResource
+	framework.WithList
+}
+
+func (l *pipelineListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
+	conn := l.Meta().OpenSearchIngestionClient(ctx)
+
+	var query listPipelineModel
+	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
+		if diags := request.Config.Get(ctx, &query); diags.HasError() {
+			stream.Results = list.ListResultsStreamDiagnostics(diags)
+			return
+		}
+	}
+
+	stream.Results = func(yield func(list.ListResult) bool) {
+		var input osis.ListPipelinesInput
+		for item, err := range listPipelines(ctx, conn, &input) {
+			if err != nil {
+				result := fwdiag.NewListResultErrorDiagnostic(err)
+				yield(result)
+				return
+			}
+
+			name := aws.ToString(item.PipelineName)
+			ctx := tflog.SetField(ctx, logging.ResourceAttributeKey(names.AttrName), name)
+
+			result := request.NewListResult(ctx)
+
+			var data pipelineResourceModel
+			l.SetResult(ctx, l.Meta(), request.IncludeResource, &data, &result, func() {
+				pipeline, err := findPipelineByName(ctx, conn, name)
+				if retry.NotFound(err) {
+					return
+				}
+				if err != nil {
+					result.Diagnostics.AddError("reading OpenSearch Ingestion Pipeline", err.Error())
+					return
+				}
+
+				smerr.AddEnrich(ctx, &result.Diagnostics, l.flatten(ctx, pipeline, &data))
+				if result.Diagnostics.HasError() {
+					return
+				}
+
+				result.DisplayName = name
+			})
+
+			if !yield(result) {
+				return
+			}
+		}
+	}
+}
+
+type listPipelineModel struct {
+	framework.WithRegionModel
+}
+
+func listPipelines(ctx context.Context, conn *osis.Client, input *osis.ListPipelinesInput) iter.Seq2[awstypes.PipelineSummary, error] {
+	return func(yield func(awstypes.PipelineSummary, error) bool) {
+		pages := osis.NewListPipelinesPaginator(conn, input)
+		for pages.HasMorePages() {
+			page, err := pages.NextPage(ctx)
+			if err != nil {
+				yield(awstypes.PipelineSummary{}, fmt.Errorf("listing OpenSearch Ingestion Pipeline resources: %w", err))
+				return
+			}
+
+			for _, item := range page.Pipelines {
+				if !yield(item, nil) {
+					return
+				}
+			}
+		}
+	}
+}

--- a/internal/service/osis/pipeline_list_test.go
+++ b/internal/service/osis/pipeline_list_test.go
@@ -1,0 +1,209 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package osis_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	tfquerycheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/querycheck"
+	tfqueryfilter "github.com/hashicorp/terraform-provider-aws/internal/acctest/queryfilter"
+	tfstatecheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/statecheck"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccOpenSearchIngestionPipeline_List_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_osis_pipeline.test[0]"
+	resourceName2 := "aws_osis_pipeline.test[1]"
+	rName := randomPipelineName(t)
+
+	identity1 := tfstatecheck.Identity()
+	identity2 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.OpenSearchIngestionServiceID),
+		CheckDestroy:             testAccCheckPipelineDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Pipeline/list_basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+					statecheck.ExpectKnownValue(resourceName1, tfjsonpath.New("pipeline_name"), knownvalue.StringExact(rName+"-0")),
+
+					identity2.GetIdentity(resourceName2),
+					statecheck.ExpectKnownValue(resourceName2, tfjsonpath.New("pipeline_name"), knownvalue.StringExact(rName+"-1")),
+				},
+			},
+
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/Pipeline/list_basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_osis_pipeline.test", identity1.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_osis_pipeline.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), knownvalue.StringExact(rName+"-0")),
+					tfquerycheck.ExpectNoResourceObject("aws_osis_pipeline.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks())),
+
+					tfquerycheck.ExpectIdentityFunc("aws_osis_pipeline.test", identity2.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_osis_pipeline.test", tfqueryfilter.ByResourceIdentityFunc(identity2.Checks()), knownvalue.StringExact(rName+"-1")),
+					tfquerycheck.ExpectNoResourceObject("aws_osis_pipeline.test", tfqueryfilter.ByResourceIdentityFunc(identity2.Checks())),
+				},
+			},
+		},
+	})
+}
+
+func TestAccOpenSearchIngestionPipeline_List_includeResource(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_osis_pipeline.test[0]"
+	rName := randomPipelineName(t)
+
+	identity1 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.OpenSearchIngestionServiceID),
+		CheckDestroy:             testAccCheckPipelineDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Pipeline/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(1),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
+						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
+					}),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+					statecheck.ExpectKnownValue(resourceName1, tfjsonpath.New("pipeline_name"), knownvalue.StringExact(rName+"-0")),
+				},
+			},
+
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/Pipeline/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(1),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
+						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
+					}),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_osis_pipeline.test", identity1.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_osis_pipeline.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), knownvalue.StringExact(rName+"-0")),
+					querycheck.ExpectResourceKnownValues("aws_osis_pipeline.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), []querycheck.KnownValueCheck{
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("pipeline_name"), knownvalue.StringExact(rName+"-0")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.Region())),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("pipeline_arn"), knownvalue.NotNull()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("max_units"), knownvalue.Int64Exact(1)),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("min_units"), knownvalue.Int64Exact(1)),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
+							acctest.CtKey1: knownvalue.StringExact(acctest.CtValue1),
+						})),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrTagsAll), knownvalue.MapExact(map[string]knownvalue.Check{
+							acctest.CtKey1: knownvalue.StringExact(acctest.CtValue1),
+						})),
+					}),
+				},
+			},
+		},
+	})
+}
+
+func TestAccOpenSearchIngestionPipeline_List_regionOverride(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_osis_pipeline.test[0]"
+	resourceName2 := "aws_osis_pipeline.test[1]"
+	rName := randomPipelineName(t)
+
+	identity1 := tfstatecheck.Identity()
+	identity2 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.OpenSearchIngestionServiceID),
+		CheckDestroy:             acctest.CheckDestroyNoop,
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Pipeline/list_region_override/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+					"region":         config.StringVariable(acctest.AlternateRegion()),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+					statecheck.ExpectKnownValue(resourceName1, tfjsonpath.New("pipeline_name"), knownvalue.StringExact(rName+"-0")),
+
+					identity2.GetIdentity(resourceName2),
+					statecheck.ExpectKnownValue(resourceName2, tfjsonpath.New("pipeline_name"), knownvalue.StringExact(rName+"-1")),
+				},
+			},
+
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/Pipeline/list_region_override/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+					"region":         config.StringVariable(acctest.AlternateRegion()),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_osis_pipeline.test", identity1.Checks()),
+
+					tfquerycheck.ExpectIdentityFunc("aws_osis_pipeline.test", identity2.Checks()),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/osis/resource_policy_list.go
+++ b/internal/service/osis/resource_policy_list.go
@@ -82,30 +82,26 @@ type listResourcePolicyModel struct {
 
 func listResourcePolicies(ctx context.Context, conn *osis.Client, input *osis.ListPipelinesInput) iter.Seq2[*osis.GetResourcePolicyOutput, error] {
 	return func(yield func(*osis.GetResourcePolicyOutput, error) bool) {
-		pages := osis.NewListPipelinesPaginator(conn, input)
-		for pages.HasMorePages() {
-			page, err := pages.NextPage(ctx)
+		for pipeline, err := range listPipelines(ctx, conn, input) {
 			if err != nil {
-				yield(nil, fmt.Errorf("listing OpenSearch Ingestion Resource Policy resources: %w", err))
+				yield(nil, err)
 				return
 			}
 
-			for _, pipeline := range page.Pipelines {
-				pipelineARN := aws.ToString(pipeline.PipelineArn)
-				output, err := findResourcePolicyByResourceARN(ctx, conn, pipelineARN)
+			pipelineARN := aws.ToString(pipeline.PipelineArn)
+			output, err := findResourcePolicyByResourceARN(ctx, conn, pipelineARN)
 
-				if retry.NotFound(err) || errs.IsA[*awstypes.ResourceNotFoundException](err) {
-					continue
-				}
+			if retry.NotFound(err) || errs.IsA[*awstypes.ResourceNotFoundException](err) {
+				continue
+			}
 
-				if err != nil {
-					yield(nil, fmt.Errorf("getting resource policy for pipeline %s: %w", pipelineARN, err))
-					return
-				}
+			if err != nil {
+				yield(nil, fmt.Errorf("getting resource policy for pipeline %s: %w", pipelineARN, err))
+				return
+			}
 
-				if !yield(output, nil) {
-					return
-				}
+			if !yield(output, nil) {
+				return
 			}
 		}
 	}

--- a/internal/service/osis/service_package_gen.go
+++ b/internal/service/osis/service_package_gen.go
@@ -69,6 +69,17 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*inttypes.Ser
 func (p *servicePackage) FrameworkListResources(ctx context.Context) iter.Seq[*inttypes.ServicePackageFrameworkListResource] {
 	return slices.Values([]*inttypes.ServicePackageFrameworkListResource{
 		{
+			Factory:  newPipelineResourceAsListResource,
+			TypeName: "aws_osis_pipeline",
+			Name:     "Pipeline",
+			Tags: unique.Make(inttypes.ServicePackageResourceTags{
+				IdentifierAttribute: "pipeline_arn",
+			}),
+			Region: inttypes.ResourceRegionDefault(),
+			Identity: inttypes.RegionalSingleParameterIdentity(inttypes.StringIdentityAttributeWithMappedName(names.AttrName, true, "pipeline_name"),
+				inttypes.WithIdentityDuplicateAttrs(names.AttrID)),
+		},
+		{
 			Factory:  newPipelineEndpointResourceAsListResource,
 			TypeName: "aws_osis_pipeline_endpoint",
 			Name:     "Pipeline Endpoint",

--- a/internal/service/osis/testdata/Pipeline/list_basic/main.tf
+++ b/internal/service/osis/testdata/Pipeline/list_basic/main.tf
@@ -1,0 +1,59 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_osis_pipeline" "test" {
+  count = var.resource_count
+
+  pipeline_name               = "${var.rName}-${count.index}"
+  pipeline_configuration_body = <<-EOT
+            version: "2"
+            test-pipeline:
+              source:
+                http:
+                  path: "/test"
+              sink:
+                - s3:
+                    aws:
+                      sts_role_arn: "${aws_iam_role.test.arn}"
+                      region: "${data.aws_region.current.region}"
+                    bucket: "test"
+                    threshold:
+                      event_collect_timeout: "60s"
+                    codec:
+                      ndjson:
+        EOT
+  max_units                   = 1
+  min_units                   = 1
+}
+
+data "aws_region" "current" {}
+
+resource "aws_iam_role" "test" {
+  name = var.rName
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Sid    = ""
+        Principal = {
+          Service = "osis-pipelines.amazonaws.com"
+        }
+      },
+    ]
+  })
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}

--- a/internal/service/osis/testdata/Pipeline/list_basic/query.tfquery.hcl
+++ b/internal/service/osis/testdata/Pipeline/list_basic/query.tfquery.hcl
@@ -1,0 +1,6 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_osis_pipeline" "test" {
+  provider = aws
+}

--- a/internal/service/osis/testdata/Pipeline/list_include_resource/main.tf
+++ b/internal/service/osis/testdata/Pipeline/list_include_resource/main.tf
@@ -1,0 +1,67 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_osis_pipeline" "test" {
+  count = var.resource_count
+
+  pipeline_name               = "${var.rName}-${count.index}"
+  pipeline_configuration_body = <<-EOT
+            version: "2"
+            test-pipeline:
+              source:
+                http:
+                  path: "/test"
+              sink:
+                - s3:
+                    aws:
+                      sts_role_arn: "${aws_iam_role.test.arn}"
+                      region: "${data.aws_region.current.region}"
+                    bucket: "test"
+                    threshold:
+                      event_collect_timeout: "60s"
+                    codec:
+                      ndjson:
+        EOT
+  max_units                   = 1
+  min_units                   = 1
+
+  tags = var.resource_tags
+}
+
+data "aws_region" "current" {}
+
+resource "aws_iam_role" "test" {
+  name = var.rName
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Sid    = ""
+        Principal = {
+          Service = "osis-pipelines.amazonaws.com"
+        }
+      },
+    ]
+  })
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}
+
+variable "resource_tags" {
+  description = "Tags to set on resource"
+  type        = map(string)
+  nullable    = false
+}

--- a/internal/service/osis/testdata/Pipeline/list_include_resource/query.tfquery.hcl
+++ b/internal/service/osis/testdata/Pipeline/list_include_resource/query.tfquery.hcl
@@ -1,0 +1,8 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_osis_pipeline" "test" {
+  provider = aws
+
+  include_resource = true
+}

--- a/internal/service/osis/testdata/Pipeline/list_region_override/main.tf
+++ b/internal/service/osis/testdata/Pipeline/list_region_override/main.tf
@@ -1,0 +1,68 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_osis_pipeline" "test" {
+  count  = var.resource_count
+  region = var.region
+
+  pipeline_name               = "${var.rName}-${count.index}"
+  pipeline_configuration_body = <<-EOT
+            version: "2"
+            test-pipeline:
+              source:
+                http:
+                  path: "/test"
+              sink:
+                - s3:
+                    aws:
+                      sts_role_arn: "${aws_iam_role.test.arn}"
+                      region: "${data.aws_region.current.region}"
+                    bucket: "test"
+                    threshold:
+                      event_collect_timeout: "60s"
+                    codec:
+                      ndjson:
+        EOT
+  max_units                   = 1
+  min_units                   = 1
+}
+
+data "aws_region" "current" {
+  region = var.region
+}
+
+resource "aws_iam_role" "test" {
+  name = var.rName
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Sid    = ""
+        Principal = {
+          Service = "osis-pipelines.amazonaws.com"
+        }
+      },
+    ]
+  })
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}
+
+variable "region" {
+  description = "Region to deploy resource in"
+  type        = string
+  nullable    = false
+}

--- a/internal/service/osis/testdata/Pipeline/list_region_override/query.tfquery.hcl
+++ b/internal/service/osis/testdata/Pipeline/list_region_override/query.tfquery.hcl
@@ -1,0 +1,10 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_osis_pipeline" "test" {
+  provider = aws
+
+  config {
+    region = var.region
+  }
+}

--- a/website/docs/list-resources/osis_pipeline.html.markdown
+++ b/website/docs/list-resources/osis_pipeline.html.markdown
@@ -1,0 +1,25 @@
+---
+subcategory: "OpenSearch Ingestion (OSIS)"
+layout: "aws"
+page_title: "AWS: aws_osis_pipeline"
+description: |-
+  Lists OpenSearch Ingestion (OSIS) Pipeline resources.
+---
+
+# List Resource: aws_osis_pipeline
+
+Lists OpenSearch Ingestion (OSIS) Pipeline resources.
+
+## Example Usage
+
+```terraform
+list "aws_osis_pipeline" "example" {
+  provider = aws
+}
+```
+
+## Argument Reference
+
+This list resource supports the following arguments:
+
+* `region` - (Optional) Region to query. Defaults to provider region.


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

New List Resource: `aws_osis_pipeline`

Relates #47005

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=osis TESTS=TestAccOpenSearchIngestionPipeline_

--- PASS: TestAccOpenSearchIngestionPipeline_basic (420.73s)
--- PASS: TestAccOpenSearchIngestionPipeline_vpc (441.92s)
--- PASS: TestAccOpenSearchIngestionPipeline_disappears (443.51s)
--- PASS: TestAccOpenSearchIngestionPipeline_Tags_DefaultTags_nullNonOverlappingResourceTag (479.85s)
--- PASS: TestAccOpenSearchIngestionPipeline_Tags_DefaultTags_updateToProviderOnly (482.89s)
--- PASS: TestAccOpenSearchIngestionPipeline_Tags_DefaultTags_updateToResourceOnly (502.34s)
--- PASS: TestAccOpenSearchIngestionPipeline_Tags_ComputedTag_OnUpdate_add (509.34s)
--- PASS: TestAccOpenSearchIngestionPipeline_encryption (520.39s)
--- PASS: TestAccOpenSearchIngestionPipeline_Tags_EmptyTag_OnUpdate_add (527.91s)
--- PASS: TestAccOpenSearchIngestionPipeline_Tags_DefaultTags_providerOnly (567.02s)
--- PASS: TestAccOpenSearchIngestionPipeline_Tags_ComputedTag_onCreate (591.88s)
--- PASS: TestAccOpenSearchIngestionPipeline_Tags_DefaultTags_overlapping (683.12s)
--- PASS: TestAccOpenSearchIngestionPipeline_Tags_DefaultTags_emptyProviderOnlyTag (460.65s)
--- PASS: TestAccOpenSearchIngestionPipeline_Tags_addOnUpdate (416.88s)
--- PASS: TestAccOpenSearchIngestionPipeline_Tags_emptyMap (457.01s)
--- PASS: TestAccOpenSearchIngestionPipeline_List_regionOverride (502.84s)
--- PASS: TestAccOpenSearchIngestionPipeline_Identity_ExistingResource_noRefreshNoChange (455.80s)
--- PASS: TestAccOpenSearchIngestionPipeline_tags (478.01s)
--- PASS: TestAccOpenSearchIngestionPipeline_Tags_IgnoreTags_Overlap_resourceTag (996.05s)
--- PASS: TestAccOpenSearchIngestionPipeline_List_basic (436.87s)
--- PASS: TestAccOpenSearchIngestionPipeline_Tags_EmptyTag_onCreate (560.77s)
--- PASS: TestAccOpenSearchIngestionPipeline_Identity_basic (1011.53s)
--- PASS: TestAccOpenSearchIngestionPipeline_Tags_DefaultTags_nonOverlapping (1014.93s)
--- PASS: TestAccOpenSearchIngestionPipeline_Tags_DefaultTags_emptyResourceTag (426.80s)
--- PASS: TestAccOpenSearchIngestionPipeline_logPublishing (1026.16s)
--- PASS: TestAccOpenSearchIngestionPipeline_List_includeResource (500.55s)
--- PASS: TestAccOpenSearchIngestionPipeline_Tags_DefaultTags_nullOverlappingResourceTag (1106.73s)
--- PASS: TestAccOpenSearchIngestionPipeline_Identity_ExistingResource_basic (425.09s)
--- PASS: TestAccOpenSearchIngestionPipeline_upgradeV5_90_0 (1168.69s)
--- PASS: TestAccOpenSearchIngestionPipeline_pipelineRole (1241.07s)
--- PASS: TestAccOpenSearchIngestionPipeline_Identity_regionOverride (423.27s)
--- PASS: TestAccOpenSearchIngestionPipeline_Tags_IgnoreTags_Overlap_defaultTag (466.16s)
--- PASS: TestAccOpenSearchIngestionPipeline_Tags_null (955.07s)
--- PASS: TestAccOpenSearchIngestionPipeline_buffer (1608.54s)
--- PASS: TestAccOpenSearchIngestionPipeline_Tags_ComputedTag_OnUpdate_replace (966.57s)
--- PASS: TestAccOpenSearchIngestionPipeline_Tags_EmptyTag_OnUpdate_replace (972.91s)
```

```console
% make testacc PKG=osis TESTS=TestAccOpenSearchIngestionResourcePolicy_List_

--- PASS: TestAccOpenSearchIngestionResourcePolicy_List_regionOverride (467.59s)
--- PASS: TestAccOpenSearchIngestionResourcePolicy_List_includeResource (959.09s)
--- PASS: TestAccOpenSearchIngestionResourcePolicy_List_basic (982.50s)
```
