### PR TITLE
r/aws_db_instance: Always pass existing param group from blue to green

### DIFF
--- a/.changelog/49167.txt
+++ b/.changelog/49167.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_db_instance: Fix issue where `target_db_parameter_group_name` was not passed during Blue/Green deployment creation when `parameter_group_name` was unchanged
+```

--- a/internal/service/rds/blue_green.go
+++ b/internal/service/rds/blue_green.go
@@ -137,9 +137,8 @@ func (h *instanceHandler) createBlueGreenInput(d *schema.ResourceData) *rds.Crea
 	if d.HasChange(names.AttrEngineVersion) {
 		input.TargetEngineVersion = aws.String(d.Get(names.AttrEngineVersion).(string))
 	}
-	if d.HasChange(names.AttrParameterGroupName) {
-		input.TargetDBParameterGroupName = aws.String(d.Get(names.AttrParameterGroupName).(string))
-	}
+
+	input.TargetDBParameterGroupName = aws.String(d.Get(names.AttrParameterGroupName).(string))
 
 	return input
 }

--- a/internal/service/rds/instance_test.go
+++ b/internal/service/rds/instance_test.go
@@ -6830,6 +6830,64 @@ func TestAccRDSInstance_BlueGreenDeployment_updateInstanceClass(t *testing.T) {
 	})
 }
 
+func TestAccRDSInstance_BlueGreenDeployment_customParamGroupAndUpdateInstanceClass(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	// All RDS Instance tests should skip for testing.Short() except the 20 shortest running tests.
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var v1, v2 types.DBInstance
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_db_instance.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_11_0),
+		},
+		CheckDestroy: testAccCheckDBInstanceDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceConfig_BlueGreenDeployment_customParamGroupAndUpdateableInstanceClass(rName, false, "custom-pg"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckDBInstanceExists(ctx, t, resourceName, &v1),
+					resource.TestCheckResourceAttrPair(resourceName, "instance_class", "data.aws_rds_orderable_db_instance.test", "instance_class"),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrParameterGroupName, "aws_db_parameter_group.custom", names.AttrName),
+					resource.TestCheckResourceAttr(resourceName, "backup_retention_period", "1"),
+				),
+			},
+			{
+				Config: testAccInstanceConfig_BlueGreenDeployment_customParamGroupAndUpdateableInstanceClass(rName, true, "custom-pg"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckDBInstanceExists(ctx, t, resourceName, &v2),
+					testAccCheckDBInstanceRecreated(&v1, &v2),
+					resource.TestCheckResourceAttrPair(resourceName, "instance_class", "data.aws_rds_orderable_db_instance.test", "instance_class"),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrParameterGroupName, "aws_db_parameter_group.custom", names.AttrName),
+					resource.TestCheckResourceAttr(resourceName, "blue_green_update.0.enabled", acctest.CtTrue),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					names.AttrApplyImmediately,
+					names.AttrFinalSnapshotIdentifier,
+					names.AttrPassword,
+					"skip_final_snapshot",
+					"delete_automated_backups",
+					"blue_green_update",
+					"latest_restorable_time",
+				},
+			},
+		},
+	})
+}
+
 func TestAccRDSInstance_BlueGreenDeployment_updateAndPromoteReplica(t *testing.T) {
 	ctx := acctest.Context(t)
 
@@ -14403,6 +14461,65 @@ resource "aws_db_instance" "test" {
   }
 }
 `, tfrds.InstanceEngineMySQL, "general-public-license", "standard", halfMainInstClass, rName))
+}
+
+func testAccInstanceConfig_BlueGreenDeployment_customParamGroupAndUpdateableInstanceClass(rName string, oddClasses bool, pgName string) string {
+	var halfClasses []string
+	start := 0
+	if oddClasses {
+		start = 1
+	}
+	for i := start; i < len(instanceClassesSlice); i += 2 {
+		halfClasses = append(halfClasses, instanceClassesSlice[i])
+	}
+	halfMainInstClass := strings.Join(halfClasses, ", ")
+
+	return acctest.ConfigCompose(
+		acctest.ConfigRandomPassword(),
+		fmt.Sprintf(`
+data "aws_rds_engine_version" "default" {
+  engine = %[1]q
+}
+
+data "aws_rds_orderable_db_instance" "test" {
+  engine         = data.aws_rds_engine_version.default.engine
+  engine_version = data.aws_rds_engine_version.default.version
+  license_model  = %[2]q
+  storage_type   = %[3]q
+
+  preferred_instance_classes = [%[4]s]
+}
+
+resource "aws_db_parameter_group" "custom" {
+  name   = %[6]q
+  family = data.aws_rds_engine_version.default.parameter_group_family
+
+  parameter {
+    name         = "lower_case_table_names"
+    value        = "1"
+    apply_method = "pending-reboot"
+  }
+}
+
+resource "aws_db_instance" "test" {
+  identifier              = %[5]q
+  allocated_storage       = 10
+  backup_retention_period = 1
+  engine                  = data.aws_rds_orderable_db_instance.test.engine
+  engine_version          = data.aws_rds_orderable_db_instance.test.engine_version
+  instance_class          = data.aws_rds_orderable_db_instance.test.instance_class
+  db_name                 = "test"
+  parameter_group_name    = aws_db_parameter_group.custom.name
+  skip_final_snapshot     = true
+  password_wo             = ephemeral.aws_secretsmanager_random_password.test.random_password
+  password_wo_version     = 1
+  username                = "tfacctest"
+
+  blue_green_update {
+    enabled = true
+  }
+}
+`, tfrds.InstanceEngineMySQL, "general-public-license", "standard", halfMainInstClass, rName, pgName))
 }
 
 func testAccInstanceConfig_BlueGreenDeployment_prePromote(rName string) string {

--- a/internal/service/rds/instance_test.go
+++ b/internal/service/rds/instance_test.go
@@ -8279,7 +8279,7 @@ func testAccInstanceConfig_orderableClassDB2() string {
 }
 
 func testAccInstanceConfig_orderableClassMySQL() string {
-	return testAccInstanceConfig_orderableClass(tfrds.InstanceEngineMySQL, "general-public-license", "standard")
+	return testAccInstanceConfig_orderableClass(tfrds.InstanceEngineMySQL, "general-public-license", "gp2")
 }
 
 func testAccInstanceConfig_orderableClassMySQLGP3() string {
@@ -14237,7 +14237,7 @@ data "aws_rds_orderable_db_instance" "test" {
   engine         = local.engine_version.engine
   engine_version = local.engine_version.version
   license_model  = "general-public-license"
-  storage_type   = "standard"
+  storage_type   = "gp2"
 
   preferred_instance_classes = [%[2]s]
 }
@@ -14304,11 +14304,11 @@ resource "aws_db_instance" "test" {
   # validation error).
   maintenance_window = "Fri:09:00-Fri:09:30"
 }
-`, tfrds.InstanceEngineMySQL, "general-public-license", "standard", halfMainInstClass, rName))
+`, tfrds.InstanceEngineMySQL, "general-public-license", "gp2", halfMainInstClass, rName))
 }
 
 func testAccInstanceConfig_BlueGreenDeployment_parameterGroup(rName string, excludeTFamilyInstances bool) string {
-	instanceConfig := testAccInstanceConfig_orderableClassMySQL()
+	instanceConfig := testAccInstanceConfig_orderableClassMySQLGP3()
 	if excludeTFamilyInstances {
 		instanceConfig = strings.Replace(instanceConfig, "db.t", "frodo", -1)
 	}
@@ -14460,7 +14460,7 @@ resource "aws_db_instance" "test" {
     enabled = true
   }
 }
-`, tfrds.InstanceEngineMySQL, "general-public-license", "standard", halfMainInstClass, rName))
+`, tfrds.InstanceEngineMySQL, "general-public-license", "gp2", halfMainInstClass, rName))
 }
 
 func testAccInstanceConfig_BlueGreenDeployment_customParamGroupAndUpdateableInstanceClass(rName string, oddClasses bool, pgName string) string {
@@ -14519,7 +14519,7 @@ resource "aws_db_instance" "test" {
     enabled = true
   }
 }
-`, tfrds.InstanceEngineMySQL, "general-public-license", "standard", halfMainInstClass, rName, pgName))
+`, tfrds.InstanceEngineMySQL, "general-public-license", "gp2", halfMainInstClass, rName, pgName))
 }
 
 func testAccInstanceConfig_BlueGreenDeployment_prePromote(rName string) string {
@@ -14579,7 +14579,7 @@ resource "aws_db_instance" "test" {
   replicate_source_db     = aws_db_instance.source.identifier
   skip_final_snapshot     = true
 }
-`, tfrds.InstanceEngineMySQL, "general-public-license", "standard", oddClasses, evenClasses, rName))
+`, tfrds.InstanceEngineMySQL, "general-public-license", "gp2", oddClasses, evenClasses, rName))
 }
 
 func testAccInstanceConfig_BlueGreenDeployment_promote(rName string) string {
@@ -14641,7 +14641,7 @@ resource "aws_db_instance" "test" {
     enabled = true
   }
 }
-`, tfrds.InstanceEngineMySQL, "general-public-license", "standard", oddClasses, evenClasses, rName))
+`, tfrds.InstanceEngineMySQL, "general-public-license", "gp2", oddClasses, evenClasses, rName))
 }
 
 func testAccInstanceConfig_BlueGreenDeployment_deletionProtection(rName string, deletionProtection bool, oddClasses bool) string {
@@ -14691,7 +14691,7 @@ resource "aws_db_instance" "test" {
 
   deletion_protection = %[6]t
 }
-`, tfrds.InstanceEngineMySQL, "general-public-license", "standard", halfMainInstClass, rName, deletionProtection))
+`, tfrds.InstanceEngineMySQL, "general-public-license", "gp2", halfMainInstClass, rName, deletionProtection))
 }
 
 func testAccInstanceConfig_BlueGreenDeployment_password(rName, password string) string {
@@ -14741,7 +14741,7 @@ data "aws_rds_orderable_db_instance" "test" {
   engine         = local.engine_version.engine
   engine_version = local.engine_version.version
   license_model  = "general-public-license"
-  storage_type   = "standard"
+  storage_type   = "gp2"
 
   preferred_instance_classes = [%[2]s]
 }

--- a/internal/service/rds/instance_test.go
+++ b/internal/service/rds/instance_test.go
@@ -14311,7 +14311,7 @@ resource "aws_db_instance" "test" {
 }
 
 func testAccInstanceConfig_BlueGreenDeployment_parameterGroup(rName string, excludeTFamilyInstances bool) string {
-	instanceConfig := testAccInstanceConfig_orderableClassMySQL()
+	instanceConfig := testAccInstanceConfig_orderableClassMySQLGP3()
 	if excludeTFamilyInstances {
 		instanceConfig = strings.Replace(instanceConfig, "db.t", "frodo", -1)
 	}
@@ -14522,7 +14522,7 @@ resource "aws_db_instance" "test" {
     enabled = true
   }
 }
-`, tfrds.InstanceEngineMySQL, "general-public-license", "standard", halfMainInstClass, rName, pgName))
+`, tfrds.InstanceEngineMySQL, "general-public-license", "gp2", halfMainInstClass, rName, pgName))
 }
 
 func testAccInstanceConfig_BlueGreenDeployment_prePromote(rName string) string {

--- a/internal/service/rds/instance_test.go
+++ b/internal/service/rds/instance_test.go
@@ -6830,6 +6830,64 @@ func TestAccRDSInstance_BlueGreenDeployment_updateInstanceClass(t *testing.T) {
 	})
 }
 
+func TestAccRDSInstance_BlueGreenDeployment_customParamGroupAndUpdateInstanceClass(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	// All RDS Instance tests should skip for testing.Short() except the 20 shortest running tests.
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var v1, v2 types.DBInstance
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_db_instance.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_11_0),
+		},
+		CheckDestroy: testAccCheckDBInstanceDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceConfig_BlueGreenDeployment_customParamGroupAndUpdateableInstanceClass(rName, false, "custom-pg"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckDBInstanceExists(ctx, t, resourceName, &v1),
+					resource.TestCheckResourceAttrPair(resourceName, "instance_class", "data.aws_rds_orderable_db_instance.test", "instance_class"),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrParameterGroupName, "aws_db_parameter_group.custom", names.AttrName),
+					resource.TestCheckResourceAttr(resourceName, "backup_retention_period", "1"),
+				),
+			},
+			{
+				Config: testAccInstanceConfig_BlueGreenDeployment_customParamGroupAndUpdateableInstanceClass(rName, true, "custom-pg"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckDBInstanceExists(ctx, t, resourceName, &v2),
+					testAccCheckDBInstanceRecreated(&v1, &v2),
+					resource.TestCheckResourceAttrPair(resourceName, "instance_class", "data.aws_rds_orderable_db_instance.test", "instance_class"),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrParameterGroupName, "aws_db_parameter_group.custom", names.AttrName),
+					resource.TestCheckResourceAttr(resourceName, "blue_green_update.0.enabled", acctest.CtTrue),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					names.AttrApplyImmediately,
+					names.AttrFinalSnapshotIdentifier,
+					names.AttrPassword,
+					"skip_final_snapshot",
+					"delete_automated_backups",
+					"blue_green_update",
+					"latest_restorable_time",
+				},
+			},
+		},
+	})
+}
+
 func TestAccRDSInstance_BlueGreenDeployment_updateAndPromoteReplica(t *testing.T) {
 	ctx := acctest.Context(t)
 
@@ -14406,6 +14464,65 @@ resource "aws_db_instance" "test" {
   }
 }
 `, tfrds.InstanceEngineMySQL, "general-public-license", "gp2", halfMainInstClass, rName))
+}
+
+func testAccInstanceConfig_BlueGreenDeployment_customParamGroupAndUpdateableInstanceClass(rName string, oddClasses bool, pgName string) string {
+	var halfClasses []string
+	start := 0
+	if oddClasses {
+		start = 1
+	}
+	for i := start; i < len(instanceClassesSlice); i += 2 {
+		halfClasses = append(halfClasses, instanceClassesSlice[i])
+	}
+	halfMainInstClass := strings.Join(halfClasses, ", ")
+
+	return acctest.ConfigCompose(
+		acctest.ConfigRandomPassword(),
+		fmt.Sprintf(`
+data "aws_rds_engine_version" "default" {
+  engine = %[1]q
+}
+
+data "aws_rds_orderable_db_instance" "test" {
+  engine         = data.aws_rds_engine_version.default.engine
+  engine_version = data.aws_rds_engine_version.default.version
+  license_model  = %[2]q
+  storage_type   = %[3]q
+
+  preferred_instance_classes = [%[4]s]
+}
+
+resource "aws_db_parameter_group" "custom" {
+  name   = %[6]q
+  family = data.aws_rds_engine_version.default.parameter_group_family
+
+  parameter {
+    name         = "lower_case_table_names"
+    value        = "1"
+    apply_method = "pending-reboot"
+  }
+}
+
+resource "aws_db_instance" "test" {
+  identifier              = %[5]q
+  allocated_storage       = 10
+  backup_retention_period = 1
+  engine                  = data.aws_rds_orderable_db_instance.test.engine
+  engine_version          = data.aws_rds_orderable_db_instance.test.engine_version
+  instance_class          = data.aws_rds_orderable_db_instance.test.instance_class
+  db_name                 = "test"
+  parameter_group_name    = aws_db_parameter_group.custom.name
+  skip_final_snapshot     = true
+  password_wo             = ephemeral.aws_secretsmanager_random_password.test.random_password
+  password_wo_version     = 1
+  username                = "tfacctest"
+
+  blue_green_update {
+    enabled = true
+  }
+}
+`, tfrds.InstanceEngineMySQL, "general-public-license", "standard", halfMainInstClass, rName, pgName))
 }
 
 func testAccInstanceConfig_BlueGreenDeployment_prePromote(rName string) string {


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to existing security controls

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Pameter groups from a blue deployment are not being passed down to a green deployment if the parameter group did not change creating a drift in the state. This PR fixes that by always passing in the target parameter group to the green deployment

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #49132

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=rds T=TestAccRDSInstance_BlueGreenDeployment
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework (cached)
make: Running acceptance tests on branch: 🌿 b-aws_db_instance-bg-deploy-target-db-param-group-name-fix 🌿...
TF_ACC=1 go1.26.5 test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccRDSInstance_BlueGreenDeployment'  -timeout 360m -vet=off -buildvcs=false
2026/07/29 17:36:43 Creating Terraform AWS Provider (SDKv2-style)...
2026/07/29 17:36:43 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccRDSInstance_BlueGreenDeployment_updateEngineVersion
=== PAUSE TestAccRDSInstance_BlueGreenDeployment_updateEngineVersion
=== RUN   TestAccRDSInstance_BlueGreenDeployment_updateParameterGroup
=== PAUSE TestAccRDSInstance_BlueGreenDeployment_updateParameterGroup
=== RUN   TestAccRDSInstance_BlueGreenDeployment_updateParameterGroupNonTFamilyInstances
=== PAUSE TestAccRDSInstance_BlueGreenDeployment_updateParameterGroupNonTFamilyInstances
=== RUN   TestAccRDSInstance_BlueGreenDeployment_tags
=== PAUSE TestAccRDSInstance_BlueGreenDeployment_tags
=== RUN   TestAccRDSInstance_BlueGreenDeployment_updateInstanceClass
=== PAUSE TestAccRDSInstance_BlueGreenDeployment_updateInstanceClass
=== RUN   TestAccRDSInstance_BlueGreenDeployment_customParamGroupAndUpdateInstanceClass
=== PAUSE TestAccRDSInstance_BlueGreenDeployment_customParamGroupAndUpdateInstanceClass
=== RUN   TestAccRDSInstance_BlueGreenDeployment_updateAndPromoteReplica
=== PAUSE TestAccRDSInstance_BlueGreenDeployment_updateAndPromoteReplica
=== RUN   TestAccRDSInstance_BlueGreenDeployment_updateAndEnableBackups
=== PAUSE TestAccRDSInstance_BlueGreenDeployment_updateAndEnableBackups
=== RUN   TestAccRDSInstance_BlueGreenDeployment_deletionProtectionBypassesBlueGreen
=== PAUSE TestAccRDSInstance_BlueGreenDeployment_deletionProtectionBypassesBlueGreen
=== RUN   TestAccRDSInstance_BlueGreenDeployment_passwordBypassesBlueGreen
=== PAUSE TestAccRDSInstance_BlueGreenDeployment_passwordBypassesBlueGreen
=== RUN   TestAccRDSInstance_BlueGreenDeployment_updateWithDeletionProtection
=== PAUSE TestAccRDSInstance_BlueGreenDeployment_updateWithDeletionProtection
=== RUN   TestAccRDSInstance_BlueGreenDeployment_outOfBand
=== PAUSE TestAccRDSInstance_BlueGreenDeployment_outOfBand
=== CONT  TestAccRDSInstance_BlueGreenDeployment_updateEngineVersion
=== CONT  TestAccRDSInstance_BlueGreenDeployment_updateAndPromoteReplica
=== CONT  TestAccRDSInstance_BlueGreenDeployment_tags
=== CONT  TestAccRDSInstance_BlueGreenDeployment_passwordBypassesBlueGreen
=== CONT  TestAccRDSInstance_BlueGreenDeployment_outOfBand
=== CONT  TestAccRDSInstance_BlueGreenDeployment_deletionProtectionBypassesBlueGreen
=== CONT  TestAccRDSInstance_BlueGreenDeployment_customParamGroupAndUpdateInstanceClass
=== CONT  TestAccRDSInstance_BlueGreenDeployment_updateInstanceClass
=== CONT  TestAccRDSInstance_BlueGreenDeployment_updateAndEnableBackups
=== CONT  TestAccRDSInstance_BlueGreenDeployment_updateWithDeletionProtection
=== CONT  TestAccRDSInstance_BlueGreenDeployment_updateParameterGroupNonTFamilyInstances
=== CONT  TestAccRDSInstance_BlueGreenDeployment_updateParameterGroup
--- PASS: TestAccRDSInstance_BlueGreenDeployment_passwordBypassesBlueGreen (644.95s)
--- PASS: TestAccRDSInstance_BlueGreenDeployment_tags (730.10s)
--- PASS: TestAccRDSInstance_BlueGreenDeployment_deletionProtectionBypassesBlueGreen (762.86s)
--- PASS: TestAccRDSInstance_BlueGreenDeployment_updateParameterGroup (1974.71s)
--- PASS: TestAccRDSInstance_BlueGreenDeployment_updateInstanceClass (2085.53s)
--- PASS: TestAccRDSInstance_BlueGreenDeployment_outOfBand (2292.62s)
--- PASS: TestAccRDSInstance_BlueGreenDeployment_updateAndEnableBackups (2355.47s)
--- PASS: TestAccRDSInstance_BlueGreenDeployment_updateEngineVersion (2336.85s)
--- PASS: TestAccRDSInstance_BlueGreenDeployment_updateWithDeletionProtection (2461.48s)
--- PASS: TestAccRDSInstance_BlueGreenDeployment_updateParameterGroupNonTFamilyInstances (2502.28s)
--- PASS: TestAccRDSInstance_BlueGreenDeployment_customParamGroupAndUpdateInstanceClass (2828.31s)
--- PASS: TestAccRDSInstance_BlueGreenDeployment_updateAndPromoteReplica (3166.37s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/rds        3166.37s
...
```
