### PR TITLE
r/aws_cloudfront_multitenant_distribution: add owner_account_id to vpc_origin_config

### DIFF
--- a/.changelog/49178.txt
+++ b/.changelog/49178.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_cloudfront_multitenant_distribution: Add `owner_account_id` argument to `origin.vpc_origin_config` configuration block, allowing a multi-tenant distribution to reference a VPC origin owned by another AWS account
+```

--- a/internal/service/cloudfront/multitenant_distribution.go
+++ b/internal/service/cloudfront/multitenant_distribution.go
@@ -555,6 +555,9 @@ func (r *multiTenantDistributionResource) Schema(ctx context.Context, request re
 										Computed: true,
 										Default:  int32default.StaticInt32(defaultOriginReadTimeout),
 									},
+									names.AttrOwnerAccountID: schema.StringAttribute{
+										Optional: true,
+									},
 									"vpc_origin_id": schema.StringAttribute{
 										Required: true,
 									},
@@ -1146,6 +1149,7 @@ type originShieldModel struct {
 type vpcOriginConfigModel struct {
 	OriginKeepaliveTimeout types.Int32  `tfsdk:"origin_keepalive_timeout"`
 	OriginReadTimeout      types.Int32  `tfsdk:"origin_read_timeout"`
+	OwnerAccountID         types.String `tfsdk:"owner_account_id"`
 	VpcOriginID            types.String `tfsdk:"vpc_origin_id"`
 }
 

--- a/internal/service/cloudfront/multitenant_distribution_test.go
+++ b/internal/service/cloudfront/multitenant_distribution_test.go
@@ -276,6 +276,46 @@ func TestAccCloudFrontMultiTenantDistribution_CustomOrigin_basic(t *testing.T) {
 	})
 }
 
+func TestAccCloudFrontMultiTenantDistribution_VPCOrigin_ownerAccountID(t *testing.T) {
+	ctx := acctest.Context(t)
+	var distribution awstypes.Distribution
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_cloudfront_multitenant_distribution.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.CloudFrontEndpointID) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CloudFrontServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckMultiTenantDistributionDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMultiTenantDistributionConfig_VPCOrigin_ownerAccountID(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMultiTenantDistributionExists(ctx, t, resourceName, &distribution),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("origin"), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.ObjectPartial(map[string]knownvalue.Check{
+							"vpc_origin_config": knownvalue.ListExact([]knownvalue.Check{
+								knownvalue.ObjectPartial(map[string]knownvalue.Check{
+									"origin_keepalive_timeout": knownvalue.Int32Exact(tfcloudfront.DefaultOriginKeepaliveTimeout),
+									"origin_read_timeout":      knownvalue.Int32Exact(tfcloudfront.DefaultOriginReadTimeout),
+									names.AttrOwnerAccountID:   tfknownvalue.AccountID(),
+								}),
+							}),
+						}),
+					})),
+				},
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccCloudFrontMultiTenantDistribution_s3OriginWithOAC(t *testing.T) {
 	ctx := acctest.Context(t)
 	var distribution awstypes.Distribution
@@ -1165,6 +1205,64 @@ data "aws_cloudfront_cache_policy" "caching_disabled" {
   name = "Managed-CachingDisabled"
 }
 `
+}
+
+func testAccMultiTenantDistributionConfig_VPCOrigin_ownerAccountID(rName string) string {
+	return acctest.ConfigCompose(testAccVPCOriginConfig_basic(rName), `
+data "aws_caller_identity" "current" {}
+
+resource "aws_cloudfront_multitenant_distribution" "test" {
+  enabled = false
+  comment = "Test multi-tenant distribution"
+
+  origin {
+    domain_name = "example.com"
+    id          = "example"
+
+    vpc_origin_config {
+      vpc_origin_id    = aws_cloudfront_vpc_origin.test.id
+      owner_account_id = data.aws_caller_identity.current.account_id
+    }
+  }
+
+  default_cache_behavior {
+    target_origin_id       = "example"
+    viewer_protocol_policy = "redirect-to-https"
+    cache_policy_id        = data.aws_cloudfront_cache_policy.caching_disabled.id
+
+    allowed_methods {
+      items          = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+      cached_methods = ["GET", "HEAD", "OPTIONS"]
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  tenant_config {
+    parameter_definition {
+      name = "origin_domain"
+      definition {
+        string_schema {
+          required = true
+          comment  = "Origin domain parameter for tenants"
+        }
+      }
+    }
+  }
+}
+
+data "aws_cloudfront_cache_policy" "caching_disabled" {
+  name = "Managed-CachingDisabled"
+}
+`)
 }
 
 func testAccMultiTenantDistributionConfig_customErrorResponseWithoutResponsePagePath() string {

--- a/website/docs/r/cloudfront_multitenant_distribution.html.markdown
+++ b/website/docs/r/cloudfront_multitenant_distribution.html.markdown
@@ -228,6 +228,7 @@ Cache behavior supports all the same arguments as [Default Cache Behavior](#defa
 
 * `origin_keepalive_timeout` - (Optional) Custom keep-alive timeout, in seconds. By default, CloudFront uses a default timeout. Default: 5.
 * `origin_read_timeout` - (Optional) Custom read timeout, in seconds. By default, CloudFront uses a default timeout. Default: 30.
+* `owner_account_id` - (Optional) AWS account ID that owns the VPC origin. Required when referencing a VPC origin from a different AWS account for cross-account VPC origin access.
 * `vpc_origin_id` - (Required) ID of the VPC origin that you want CloudFront to route requests to.
 
 ### Custom Error Response


### PR DESCRIPTION
### Description

`aws_cloudfront_multitenant_distribution` cannot reference a VPC origin owned by another AWS account.

Its `vpc_origin_config` block exposes only `origin_keepalive_timeout`, `origin_read_timeout` and `vpc_origin_id`, so `CreateDistribution` is sent without `VpcOriginConfig.OwnerAccountId`. CloudFront then resolves the origin id within the calling account and fails:

```
operation error CloudFront: CreateDistributionWithTags, https response
error StatusCode: 404, EntityNotFound: The specified vpc origin does not exist
```

The API supports this. `OwnerAccountId` is a member of `types.VpcOriginConfig`, which is shared by `CreateDistribution` for both the `direct` and `tenant-only` connection modes — the same struct, the same call. `aws_cloudfront_distribution` already exposes it as `owner_account_id`; only the multi-tenant resource was left without it. The result is that a RAM-shared cross-account VPC origin is reachable from a regular distribution but not from a multi-tenant one, even though CloudFront treats them identically here.

`plan` cannot surface the gap, because the origin id is an opaque string — it only fails at apply.

This blocks the standard SaaS Manager topology where the multi-tenant distribution lives in a dedicated account and the origin (an internal ALB behind a VPC origin) is owned by the application account and RAM-shared in.

### Changes

* `owner_account_id` added to the `vpc_origin_config` nested block schema, using `names.AttrOwnerAccountID` for parity with `aws_cloudfront_distribution`.
* `OwnerAccountID` added to `vpcOriginConfigModel`; autoflex maps it to the SDK's `OwnerAccountId` exactly as it already maps `VpcOriginID` -> `VpcOriginId` in the same struct.
* Docs updated, wording matched to the existing `aws_cloudfront_distribution` entry.
* Acceptance test added, mirroring `TestAccCloudFrontDistribution_vpcOriginConfigOwnerAccountID`. It uses `data.aws_caller_identity.current.account_id`, so it exercises the field round-trip without needing a second account.

### Relations

Relates the cross-account VPC origin support added for `aws_cloudfront_distribution`.

### Output from Acceptance Testing

`go build ./internal/service/cloudfront/...` and `go vet ./internal/service/cloudfront/...` are clean, and `gofmt` reports no changes.

I do not have a suitable account pair set up to run the CloudFront acceptance suite; the new test follows the existing same-account pattern used by the classic resource's equivalent test. Happy to iterate if a maintainer run turns up anything.

Verified against the live API instead: creating a `tenant-only` distribution via `CreateDistributionWithTags` with `VpcOriginConfig.OwnerAccountId` set to a different account succeeds and the field round-trips through `GetDistribution`, while the same call without it fails with the `EntityNotFound` above.

```console
$ aws cloudfront get-distribution --id <tenant-only distribution> \
    --query 'Distribution.DistributionConfig.Origins.Items[0].VpcOriginConfig'
{
    "VpcOriginId": "vo_...",
    "OwnerAccountId": "<other account>",
    "OriginReadTimeout": 30,
    "OriginKeepaliveTimeout": 10
}
```
