### PR TITLE
resource/aws_ecs_service: allow in-place removal of managed EBS volume_configuration

### DIFF
--- a/.changelog/49185.txt
+++ b/.changelog/49185.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ecs_service: Fix in-place removal of `volume_configuration` (managed EBS volume)
+```

--- a/internal/service/ecs/service.go
+++ b/internal/service/ecs/service.go
@@ -1804,7 +1804,15 @@ func resourceServiceUpdate(ctx context.Context, d *schema.ResourceData, meta any
 		}
 
 		if d.HasChange("volume_configuration") {
-			input.VolumeConfigurations = expandServiceVolumeConfigurations(ctx, d.Get("volume_configuration").([]any))
+			// Reference: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/configure-ebs-volume.html
+			// To remove a managed EBS volume, specify an empty array along with a task definition
+			// whose volume has configuredAtLaunch = false. A nil value is treated as "no change",
+			// which leaves the stale volume configuration in place and fails the update.
+			input.VolumeConfigurations = []awstypes.ServiceVolumeConfiguration{}
+
+			if v := d.Get("volume_configuration").([]any); len(v) > 0 {
+				input.VolumeConfigurations = expandServiceVolumeConfigurations(ctx, v)
+			}
 		}
 
 		if d.HasChange("vpc_lattice_configurations") {

--- a/internal/service/ecs/service_test.go
+++ b/internal/service/ecs/service_test.go
@@ -555,6 +555,41 @@ func TestAccECSService_VolumeConfiguration_basic(t *testing.T) {
 	})
 }
 
+func TestAccECSService_VolumeConfiguration_remove(t *testing.T) {
+	ctx := acctest.Context(t)
+	var service awstypes.Service
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_ecs_service.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ECSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckServiceDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceConfig_volumeConfiguration_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceExists(ctx, t, resourceName, &service),
+					resource.TestCheckResourceAttr(resourceName, "volume_configuration.#", "1"),
+				),
+			},
+			{
+				Config: testAccServiceConfig_volumeConfiguration_removed(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceExists(ctx, t, resourceName, &service),
+					resource.TestCheckResourceAttr(resourceName, "volume_configuration.#", "0"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+		},
+	})
+}
+
 func TestAccECSService_VolumeConfiguration_volumeInitializationRate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var service awstypes.Service
@@ -5315,6 +5350,39 @@ resource "aws_ecs_service" "test" {
       size_in_gb = "8"
     }
   }
+
+  network_configuration {
+    subnets = aws_subnet.test[*].id
+  }
+
+  depends_on = [aws_iam_role_policy.ecs_service]
+}
+`, rName))
+}
+
+func testAccServiceConfig_volumeConfiguration_removed(rName string) string {
+	return acctest.ConfigCompose(testAccServiceConfig_baseVolumeConfiguration(rName), fmt.Sprintf(`
+resource "aws_ecs_task_definition" "test_no_volume" {
+  family                = "%[1]s-no-volume"
+  network_mode          = "awsvpc"
+  container_definitions = <<DEFINITION
+[
+  {
+    "cpu": 128,
+    "essential": true,
+    "image": "mongo:latest",
+    "memory": 128,
+    "name": "mongodb"
+  }
+]
+DEFINITION
+}
+
+resource "aws_ecs_service" "test" {
+  name            = %[1]q
+  cluster         = aws_ecs_cluster.test.id
+  task_definition = aws_ecs_task_definition.test_no_volume.arn
+  desired_count   = 1
 
   network_configuration {
     subnets = aws_subnet.test[*].id


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

None.

### Description

Removing a managed EBS volume from an existing `aws_ecs_service` (deleting the `volume_configuration` block) currently fails on apply:

```
InvalidParameterException: Volume configuration provided but no matching configuredAtLaunch volume found in task definition
```

On update, the emptied `volume_configuration` was passed straight to `expandServiceVolumeConfigurations`, which returns `nil` for an empty list. `UpdateService` treats a nil `volumeConfigurations` as "no change" and keeps the existing volume configuration, which then conflicts with the new task-definition revision whose volume is no longer `configuredAtLaunch`.

AWS documents removal as passing an empty `volumeConfigurations` array together with a task definition whose volume has `configuredAtLaunch = false` ([Configure a service to no longer utilize Amazon EBS volumes](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/configure-ebs-volume.html)). This seeds an empty slice before conditionally expanding, mirroring how `placement_constraints` already handles removal in the same function. Enable/resize are unchanged.

### References

https://docs.aws.amazon.com/AmazonECS/latest/developerguide/configure-ebs-volume.html

### Output from Acceptance Testing

```console
% make testacc TESTS=TestAccECSService_VolumeConfiguration_remove PKG=ecs
TF_ACC=1 go test ./internal/service/ecs/... -run='TestAccECSService_VolumeConfiguration_remove' -timeout 360m
=== RUN   TestAccECSService_VolumeConfiguration_remove
--- PASS: TestAccECSService_VolumeConfiguration_remove (90.81s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecs	90.958s
```
