### PR TITLE
r/aws_instance: fix perpetual source_dest_check diff with primary_network_interface

### DIFF
--- a/.changelog/49198.txt
+++ b/.changelog/49198.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_instance: Fix perpetual `source_dest_check` diff when the primary network interface is attached via a `primary_network_interface` block
+```

--- a/internal/service/ec2/ec2_instance.go
+++ b/internal/service/ec2/ec2_instance.go
@@ -1033,9 +1033,16 @@ func resourceInstanceSchema() map[string]*schema.Schema {
 			Optional: true,
 			Default:  true,
 			DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-				// Suppress diff if network_interface is set
-				_, ok := d.GetOk("network_interface")
-				return ok
+				// Suppress diff if the primary network interface is managed as a
+				// separate resource, via either network_interface or
+				// primary_network_interface. In that case source_dest_check is
+				// configured on aws_network_interface and this attribute only
+				// mirrors what Read observed there.
+				if _, ok := d.GetOk("network_interface"); ok {
+					return true
+				}
+
+				return hasConfiguredPrimaryNetworkInterface(d)
 			},
 		},
 		"spot_instance_request_id": {
@@ -1420,7 +1427,8 @@ func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta an
 
 	// SourceDestCheck can only be modified on an instance without manually specified network interfaces.
 	// SourceDestCheck, in that case, is configured at the network interface level
-	if _, ok := d.GetOk("network_interface"); !ok {
+	_, hasNetworkInterface := d.GetOk("network_interface")
+	if !hasNetworkInterface && !hasConfiguredPrimaryNetworkInterface(d) {
 		// If we have a new resource and source_dest_check is still true, don't modify
 		sourceDestCheck := d.Get("source_dest_check").(bool)
 
@@ -2383,6 +2391,26 @@ func findRootDeviceName(ctx context.Context, conn *ec2.Client, amiID string) (*s
 	}
 
 	return rootDeviceName, nil
+}
+
+// hasConfiguredPrimaryNetworkInterface reports whether a `primary_network_interface`
+// block is present in the practitioner's configuration.
+//
+// `primary_network_interface` is Optional+Computed and Read always populates it, so
+// `d.GetOk` returns true even for an instance that never configured the block. Only
+// the raw configuration distinguishes the two.
+func hasConfiguredPrimaryNetworkInterface(d *schema.ResourceData) bool {
+	rawConfig := d.GetRawConfig()
+	if rawConfig.IsNull() || !rawConfig.IsKnown() {
+		return false
+	}
+
+	v := rawConfig.GetAttr("primary_network_interface")
+	if v.IsNull() || !v.IsKnown() {
+		return false
+	}
+
+	return v.LengthInt() > 0
 }
 
 func buildNetworkInterfaceOpts(d *schema.ResourceData, groups []string, nInterfaces any, primaryNetworkInterface any) []awstypes.InstanceNetworkInterfaceSpecification {

--- a/internal/service/ec2/ec2_instance_test.go
+++ b/internal/service/ec2/ec2_instance_test.go
@@ -3400,6 +3400,56 @@ func TestAccEC2Instance_PrimaryNetworkInterface_basic(t *testing.T) {
 	})
 }
 
+// TestAccEC2Instance_PrimaryNetworkInterface_sourceDestCheck is regression
+// coverage for the perpetual diff described in
+// https://github.com/hashicorp/terraform-provider-aws/issues/44768.
+//
+// When an ENI with source_dest_check = false was attached via a
+// primary_network_interface block, consecutive applies toggled the value
+// forever: aws_instance planned false -> true (its schema default is true, and
+// the diff was only suppressed for the deprecated network_interface block), and
+// the resulting ModifyInstanceAttribute wrote through to the ENI, so the next
+// run had aws_network_interface plan true -> false.
+func TestAccEC2Instance_PrimaryNetworkInterface_sourceDestCheck(t *testing.T) {
+	ctx := acctest.Context(t)
+	var instance awstypes.Instance
+	var eni awstypes.NetworkInterface
+	resourceName := "aws_instance.test"
+	eniResourceName := "aws_network_interface.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckInstanceDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceConfig_primaryNetworkInterface_sourceDestCheck(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceExists(ctx, t, resourceName, &instance),
+					testAccCheckNetworkInterfaceExists(ctx, t, eniResourceName, &eni),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("source_dest_check"), knownvalue.Bool(false)),
+					statecheck.ExpectKnownValue(eniResourceName, tfjsonpath.New("source_dest_check"), knownvalue.Bool(false)),
+				},
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"user_data_replace_on_change"},
+			},
+		},
+	})
+}
+
 func TestAccEC2Instance_NetworkInterface_primaryNetworkInterface(t *testing.T) {
 	ctx := acctest.Context(t)
 	var instance awstypes.Instance
@@ -9572,6 +9622,36 @@ resource "aws_network_interface" "test" {
   private_ips = ["10.1.1.42"]
 }
 `)
+}
+
+func testAccInstanceConfig_primaryNetworkInterface_sourceDestCheck(rName string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigLatestAmazonLinux2HVMEBSX8664AMI(),
+		testAccInstanceConfig_vpcBase(rName, false, 0),
+		fmt.Sprintf(`
+resource "aws_network_interface" "test" {
+  subnet_id         = aws_subnet.test.id
+  private_ips       = ["10.1.1.42"]
+  source_dest_check = false
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_instance" "test" {
+  ami           = data.aws_ami.amzn2-ami-minimal-hvm-ebs-x86_64.id
+  instance_type = "t2.micro"
+
+  primary_network_interface {
+    network_interface_id = aws_network_interface.test.id
+  }
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName))
 }
 
 func testAccInstanceConfig_networkInterface_primaryNetworkInterface(rName string) string {

--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -243,7 +243,7 @@ This resource supports the following arguments:
 
 -> **NOTE:** If you are creating Instances in a VPC, use `vpc_security_group_ids` instead.
 
-* `source_dest_check` - (Optional) Controls if traffic is routed to the instance when the destination address does not match the instance. Used for NAT or VPNs. Defaults true.
+* `source_dest_check` - (Optional) Controls if traffic is routed to the instance when the destination address does not match the instance. Used for NAT or VPNs. Defaults true. Cannot be used together with `network_interface` or `primary_network_interface`; when the primary network interface is managed as a separate [`aws_network_interface`](network_interface.html) resource, set `source_dest_check` on that resource instead.
 * `subnet_id` - (Optional) VPC Subnet ID to launch in.
 * `tags` - (Optional) Map of tags to assign to the resource. Note that these tags apply to the instance and not block storage devices. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `tenancy` - (Optional) Tenancy of the instance (if the instance is running in a VPC). An instance with a tenancy of `dedicated` runs on single-tenant hardware. The `host` tenancy is not supported for the import-instance command. Valid values are `default`, `dedicated`, and `host`.


### PR DESCRIPTION
### Description

When an ENI with `source_dest_check = false` is attached to an instance through a `primary_network_interface` block, consecutive applies toggle the value forever:

- `aws_instance` plans `source_dest_check` `false -> true`
- applying that issues `ModifyInstanceAttribute`, which writes straight through to the primary ENI
- `aws_network_interface` then plans `source_dest_check` `true -> false`
- applying that returns to the first step

`source_dest_check` has `Default: true`, `Read` populates it from the primary ENI, and both its `DiffSuppressFunc` and the `ModifyInstanceAttribute` guard in `Update` only accounted for the deprecated `network_interface` block. Practitioners can't sidestep it by setting the correct value on the instance either — `source_dest_check` is in `ConflictsWith` for `primary_network_interface`.

This extends both checks to `primary_network_interface`, so the attribute is owned solely by the `aws_network_interface` resource, exactly as it already is for `network_interface`.

One wrinkle worth calling out for review: `primary_network_interface` is `Optional+Computed` and `Read` always populates it, so `d.GetOk` cannot distinguish a configured block from a computed one. Using `GetOk` here would suppress the diff for *every* instance and silently break `source_dest_check` on instances that don't manage their own ENI. The new `hasConfiguredPrimaryNetworkInterface` helper consults the raw configuration instead. (`network_interface` avoids this because `Read` only writes back the device indexes present in configuration, leaving it empty when unconfigured.)

Docs for `source_dest_check` are updated to state the `ConflictsWith` behavior and point at `aws_network_interface`.

### Relations

Fixes #44768

### References

- The instance-level `SourceDestCheck` attribute is the primary ENI's attribute, which is why the `Update` write is observable as drift on the `aws_network_interface` resource.

### Output from Acceptance Testing

Run in `eu-central-1`.

```console
% make testacc TESTS=TestAccEC2Instance_PrimaryNetworkInterface_sourceDestCheck PKG=ec2
--- PASS: TestAccEC2Instance_PrimaryNetworkInterface_sourceDestCheck (118.82s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2 124.541s
```

To confirm the new test is genuine regression coverage rather than something that would pass either way, I also ran it against unmodified `main` with only the test cherry-picked (i.e. the `ec2_instance.go` change reverted). It fails with exactly the behaviour reported in #44768:

```console
--- FAIL: TestAccEC2Instance_PrimaryNetworkInterface_sourceDestCheck (103.77s)
    ec2_instance_test.go:3421: Step 1/2 error: After applying this test step, the non-refresh plan was not empty.

        Terraform will perform the following actions:

          # aws_instance.test will be updated in-place
          ~ resource "aws_instance" "test" {
                id                                   = "i-0cd7b24c91111dc42"
              ~ source_dest_check                    = false -> true
                tags                                 = {
                    "Name" = "tf-acc-test-992075738155928027"
                }
                # (39 unchanged attributes hidden)

                # (9 unchanged blocks hidden)
            }

        Plan: 0 to add, 1 to change, 0 to destroy.
FAIL
```

I have not run the full `TestAccEC2Instance_` suite, so a maintainer run of the neighbouring `TestAccEC2Instance_PrimaryNetworkInterface_*`, `TestAccEC2Instance_NetworkInterface_*` and `TestAccEC2Instance_sourceDestCheck` tests would still be worthwhile to confirm nothing regressed on the paths this touches.
