### PR TITLE
docs: update invoke_api argument documentation

### DIFF
--- a/website/docs/r/apigatewayv2_routing_rule.html.markdown
+++ b/website/docs/r/apigatewayv2_routing_rule.html.markdown
@@ -77,9 +77,9 @@ The following arguments are optional:
 
 ### `invoke_api`
 
-* `api_id` - (Required) Action to invoke a stage of a target API. Only REST APIs are supported.
-* `stage` - (Required) Action to invoke a stage of a target API. Only REST APIs are supported.
-* `strip_base_path` - (Required) Action to invoke a stage of a target API. Only REST APIs are supported.
+* `api_id` - (Required) API identifier of the target API.
+* `stage` - (Required) Name of the target stage.
+* `strip_base_path` - (Optional) Whether to strip the base path when forwarding the request to the target API. Defaults to `false`.
 
 ## Attribute Reference
 

--- a/website/docs/r/apigatewayv2_routing_rule.html.markdown
+++ b/website/docs/r/apigatewayv2_routing_rule.html.markdown
@@ -79,7 +79,7 @@ The following arguments are optional:
 
 * `api_id` - (Required) API identifier of the target API.
 * `stage` - (Required) Name of the target stage.
-* `strip_base_path` - (Optional) Whether to strip the base path when forwarding the request to the target API. Defaults to `false`.
+* `strip_base_path` - (Optional) Whether to strip the base path when forwarding the request to the target API.
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Updates `invoke_api` block documentation to correct argument descriptions and defaults.

- Clarified `api_id` description
- Corrected `stage` description from duplicate "Action to invoke a stage" to "Name of the target stage"
- Changed `strip_base_path` from (Required) to (Optional) with default value of `false`


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #49160 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
* [Cloudformation](https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-properties-apigatewayv2-routingrule-actioninvokeapi.html) - Descriptions are present for the InvokeApi properties in the cloudformation documentation
* [construct hub](https://construct-hub-testing.dev-tools.aws.dev/packages/aws-cdk-lib/v/2.205.0/api/ActionInvokeApiProperty?lang=typescript&submodule=aws_apigatewayv2) - Shows the default value for the `strip_base_path` property

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

Not applicable. Only documentation is updated.
