### PR TITLE
[Bug Fix] aws_api_gateway_rest_api - adding waiters in CUD

### DIFF
--- a/.changelog/49205.txt
+++ b/.changelog/49205.txt
@@ -1,3 +1,7 @@
 ```release-note:bug
 resource/aws_api_gateway_rest_api: Added waiters after CUD calls
 ```
+
+```release-note:enhancement
+resource/aws_api_gateway_rest_api: Added timeouts to schema for waiters
+```

--- a/.changelog/49205.txt
+++ b/.changelog/49205.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_api_gateway_rest_api: Added waiters after CUD calls
+```

--- a/internal/service/apigateway/rest_api.go
+++ b/internal/service/apigateway/rest_api.go
@@ -7,6 +7,7 @@ package apigateway
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"slices"
@@ -17,6 +18,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
 	"github.com/aws/aws-sdk-go-v2/service/apigateway/types"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/apigateway/types"
 	awspolicy "github.com/hashicorp/awspolicyequivalence"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -49,6 +51,12 @@ func resourceRestAPI() *schema.Resource {
 		ReadWithoutTimeout:   resourceRestAPIRead,
 		UpdateWithoutTimeout: resourceRestAPIUpdate,
 		DeleteWithoutTimeout: resourceRestAPIDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(3 * time.Minute),
+			Update: schema.DefaultTimeout(3 * time.Minute),
+			Delete: schema.DefaultTimeout(3 * time.Minute),
+		},
 
 		Importer: &schema.ResourceImporter{
 			StateContext: func(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
@@ -259,6 +267,11 @@ func resourceRestAPICreate(ctx context.Context, d *schema.ResourceData, meta any
 
 	d.SetId(aws.ToString(output.Id))
 
+	_, err = waitRestAPIAvailable(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "waiting for API Gateway REST API (%s) to become available: %s", d.Id(), err)
+	}
+
 	if body, ok := d.GetOk("body"); ok {
 		// Terraform implementation uses the `overwrite` mode by default.
 		// Overwrite mode will delete existing literal properties if they are not explicitly set in the OpenAPI definition.
@@ -285,6 +298,11 @@ func resourceRestAPICreate(ctx context.Context, d *schema.ResourceData, meta any
 			return sdkdiag.AppendErrorf(diags, "creating API Gateway REST API (%s) specification: %s", d.Id(), err)
 		}
 
+		_, err = waitRestAPIAvailable(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate))
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "waiting for API Gateway REST API (%s) to become available: %s", d.Id(), err)
+		}
+
 		// Using PutRestApi with mode overwrite will remove any configuration
 		// that was done with CreateRestApi. Reconcile these changes by having
 		// any Terraform configured values overwrite imported configuration.
@@ -298,6 +316,11 @@ func resourceRestAPICreate(ctx context.Context, d *schema.ResourceData, meta any
 
 			if err != nil {
 				return sdkdiag.AppendErrorf(diags, "updating API Gateway REST API (%s) after OpenAPI import: %s", d.Id(), err)
+			}
+
+			_, err = waitRestAPIAvailable(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate))
+			if err != nil {
+				return sdkdiag.AppendErrorf(diags, "waiting for API Gateway REST API (%s) to become available after OpenAPI import: %s", d.Id(), err)
 			}
 		}
 	}
@@ -570,6 +593,11 @@ func resourceRestAPIUpdate(ctx context.Context, d *schema.ResourceData, meta any
 			if err != nil {
 				return sdkdiag.AppendErrorf(diags, "updating API Gateway REST API (%s): %s", d.Id(), err)
 			}
+
+			_, err = waitRestAPIAvailable(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate))
+			if err != nil {
+				return sdkdiag.AppendErrorf(diags, "waiting for API Gateway REST API (%s) to become available: %s", d.Id(), err)
+			}
 		}
 
 		if d.HasChanges("body", names.AttrParameters) {
@@ -599,6 +627,11 @@ func resourceRestAPIUpdate(ctx context.Context, d *schema.ResourceData, meta any
 					return sdkdiag.AppendErrorf(diags, "updating API Gateway REST API (%s) specification: %s", d.Id(), err)
 				}
 
+				_, err = waitRestAPIAvailable(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate))
+				if err != nil {
+					return sdkdiag.AppendErrorf(diags, "waiting for API Gateway REST API (%s) to become available: %s", d.Id(), err)
+				}
+
 				// Using PutRestApi with mode overwrite will remove any configuration
 				// that was done previously. Reconcile these changes by having
 				// any Terraform configured values overwrite imported configuration.
@@ -612,6 +645,11 @@ func resourceRestAPIUpdate(ctx context.Context, d *schema.ResourceData, meta any
 
 					if err != nil {
 						return sdkdiag.AppendErrorf(diags, "updating API Gateway REST API (%s) after OpenAPI import: %s", d.Id(), err)
+					}
+
+					_, err = waitRestAPIAvailable(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate))
+					if err != nil {
+						return sdkdiag.AppendErrorf(diags, "waiting for API Gateway REST API (%s) to become available: %s", d.Id(), err)
 					}
 				}
 			}
@@ -637,6 +675,11 @@ func resourceRestAPIDelete(ctx context.Context, d *schema.ResourceData, meta any
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "deleting API Gateway REST API (%s): %s", d.Id(), err)
+	}
+
+	_, err = waitRestAPIDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete))
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "waiting for API Gateway REST API (%s) to be deleted: %s", d.Id(), err)
 	}
 
 	return diags
@@ -818,6 +861,59 @@ func resourceRestAPIWithBodyUpdateOperations(d *schema.ResourceData, output *api
 	}
 
 	return operations
+}
+
+func waitRestAPIAvailable(ctx context.Context, conn *apigateway.Client, id string, timeout time.Duration) (*apigateway.GetRestApiOutput, error) {
+	stateConf := &retry.StateChangeConf{
+		Pending: enum.Slice(awstypes.ApiStatusPending, awstypes.ApiStatusUpdating),
+		Target:  enum.Slice(awstypes.ApiStatusAvailable),
+		Refresh: statusRestAPI(conn, id),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+	if out, ok := outputRaw.(*apigateway.GetRestApiOutput); ok {
+		if status := out.ApiStatus; status == awstypes.ApiStatusFailed {
+			retry.SetLastError(err, errors.New(aws.ToString(out.ApiStatusMessage)))
+		}
+		return out, err
+	}
+
+	return nil, err
+}
+
+func waitRestAPIDeleted(ctx context.Context, conn *apigateway.Client, id string, timeout time.Duration) (*apigateway.GetRestApiOutput, error) {
+	stateConf := &retry.StateChangeConf{
+		Pending: enum.Slice(awstypes.ApiStatusPending, awstypes.ApiStatusUpdating),
+		Target:  []string{},
+		Refresh: statusRestAPI(conn, id),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+	if out, ok := outputRaw.(*apigateway.GetRestApiOutput); ok {
+		if status := out.ApiStatus; status == awstypes.ApiStatusFailed {
+			retry.SetLastError(err, errors.New(aws.ToString(out.ApiStatusMessage)))
+		}
+		return out, err
+	}
+
+	return nil, err
+}
+
+func statusRestAPI(conn *apigateway.Client, id string) retry.StateRefreshFunc {
+	return func(ctx context.Context) (any, string, error) {
+		out, err := findRestAPIByID(ctx, conn, id)
+		if retry.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return out, string(out.ApiStatus), nil
+	}
 }
 
 func resourceRestAPIAttrConfigured(d *schema.ResourceData, attr string) bool {

--- a/internal/service/apigateway/rest_api.go
+++ b/internal/service/apigateway/rest_api.go
@@ -18,7 +18,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
 	"github.com/aws/aws-sdk-go-v2/service/apigateway/types"
-	awstypes "github.com/aws/aws-sdk-go-v2/service/apigateway/types"
 	awspolicy "github.com/hashicorp/awspolicyequivalence"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -267,7 +266,7 @@ func resourceRestAPICreate(ctx context.Context, d *schema.ResourceData, meta any
 
 	d.SetId(aws.ToString(output.Id))
 
-	_, err = waitRestAPIAvailable(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate))
+	err = waitRestAPIAvailable(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "waiting for API Gateway REST API (%s) to become available: %s", d.Id(), err)
 	}
@@ -298,7 +297,7 @@ func resourceRestAPICreate(ctx context.Context, d *schema.ResourceData, meta any
 			return sdkdiag.AppendErrorf(diags, "creating API Gateway REST API (%s) specification: %s", d.Id(), err)
 		}
 
-		_, err = waitRestAPIAvailable(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate))
+		err = waitRestAPIAvailable(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "waiting for API Gateway REST API (%s) to become available: %s", d.Id(), err)
 		}
@@ -318,7 +317,7 @@ func resourceRestAPICreate(ctx context.Context, d *schema.ResourceData, meta any
 				return sdkdiag.AppendErrorf(diags, "updating API Gateway REST API (%s) after OpenAPI import: %s", d.Id(), err)
 			}
 
-			_, err = waitRestAPIAvailable(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate))
+			err = waitRestAPIAvailable(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate))
 			if err != nil {
 				return sdkdiag.AppendErrorf(diags, "waiting for API Gateway REST API (%s) to become available after OpenAPI import: %s", d.Id(), err)
 			}
@@ -594,7 +593,7 @@ func resourceRestAPIUpdate(ctx context.Context, d *schema.ResourceData, meta any
 				return sdkdiag.AppendErrorf(diags, "updating API Gateway REST API (%s): %s", d.Id(), err)
 			}
 
-			_, err = waitRestAPIAvailable(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate))
+			err = waitRestAPIAvailable(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate))
 			if err != nil {
 				return sdkdiag.AppendErrorf(diags, "waiting for API Gateway REST API (%s) to become available: %s", d.Id(), err)
 			}
@@ -627,7 +626,7 @@ func resourceRestAPIUpdate(ctx context.Context, d *schema.ResourceData, meta any
 					return sdkdiag.AppendErrorf(diags, "updating API Gateway REST API (%s) specification: %s", d.Id(), err)
 				}
 
-				_, err = waitRestAPIAvailable(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate))
+				err = waitRestAPIAvailable(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate))
 				if err != nil {
 					return sdkdiag.AppendErrorf(diags, "waiting for API Gateway REST API (%s) to become available: %s", d.Id(), err)
 				}
@@ -647,7 +646,7 @@ func resourceRestAPIUpdate(ctx context.Context, d *schema.ResourceData, meta any
 						return sdkdiag.AppendErrorf(diags, "updating API Gateway REST API (%s) after OpenAPI import: %s", d.Id(), err)
 					}
 
-					_, err = waitRestAPIAvailable(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate))
+					err = waitRestAPIAvailable(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate))
 					if err != nil {
 						return sdkdiag.AppendErrorf(diags, "waiting for API Gateway REST API (%s) to become available: %s", d.Id(), err)
 					}
@@ -677,7 +676,7 @@ func resourceRestAPIDelete(ctx context.Context, d *schema.ResourceData, meta any
 		return sdkdiag.AppendErrorf(diags, "deleting API Gateway REST API (%s): %s", d.Id(), err)
 	}
 
-	_, err = waitRestAPIDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete))
+	err = waitRestAPIDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete))
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "waiting for API Gateway REST API (%s) to be deleted: %s", d.Id(), err)
 	}
@@ -863,28 +862,28 @@ func resourceRestAPIWithBodyUpdateOperations(d *schema.ResourceData, output *api
 	return operations
 }
 
-func waitRestAPIAvailable(ctx context.Context, conn *apigateway.Client, id string, timeout time.Duration) (*apigateway.GetRestApiOutput, error) {
+func waitRestAPIAvailable(ctx context.Context, conn *apigateway.Client, id string, timeout time.Duration) error {
 	stateConf := &retry.StateChangeConf{
-		Pending: enum.Slice(awstypes.ApiStatusPending, awstypes.ApiStatusUpdating),
-		Target:  enum.Slice(awstypes.ApiStatusAvailable),
+		Pending: enum.Slice(types.ApiStatusPending, types.ApiStatusUpdating),
+		Target:  enum.Slice(types.ApiStatusAvailable),
 		Refresh: statusRestAPI(conn, id),
 		Timeout: timeout,
 	}
 
 	outputRaw, err := stateConf.WaitForStateContext(ctx)
 	if out, ok := outputRaw.(*apigateway.GetRestApiOutput); ok {
-		if status := out.ApiStatus; status == awstypes.ApiStatusFailed {
+		if status := out.ApiStatus; status == types.ApiStatusFailed {
 			retry.SetLastError(err, errors.New(aws.ToString(out.ApiStatusMessage)))
 		}
-		return out, err
+		return err
 	}
 
-	return nil, err
+	return err
 }
 
-func waitRestAPIDeleted(ctx context.Context, conn *apigateway.Client, id string, timeout time.Duration) (*apigateway.GetRestApiOutput, error) {
+func waitRestAPIDeleted(ctx context.Context, conn *apigateway.Client, id string, timeout time.Duration) error {
 	stateConf := &retry.StateChangeConf{
-		Pending: enum.Slice(awstypes.ApiStatusPending, awstypes.ApiStatusUpdating),
+		Pending: enum.Slice(types.ApiStatusPending, types.ApiStatusUpdating),
 		Target:  []string{},
 		Refresh: statusRestAPI(conn, id),
 		Timeout: timeout,
@@ -892,13 +891,13 @@ func waitRestAPIDeleted(ctx context.Context, conn *apigateway.Client, id string,
 
 	outputRaw, err := stateConf.WaitForStateContext(ctx)
 	if out, ok := outputRaw.(*apigateway.GetRestApiOutput); ok {
-		if status := out.ApiStatus; status == awstypes.ApiStatusFailed {
+		if status := out.ApiStatus; status == types.ApiStatusFailed {
 			retry.SetLastError(err, errors.New(aws.ToString(out.ApiStatusMessage)))
 		}
-		return out, err
+		return err
 	}
 
-	return nil, err
+	return err
 }
 
 func statusRestAPI(conn *apigateway.Client, id string) retry.StateRefreshFunc {

--- a/internal/service/apigateway/rest_api_test.go
+++ b/internal/service/apigateway/rest_api_test.go
@@ -1527,6 +1527,47 @@ func TestAccAPIGatewayRestAPI_Policy_setByBody(t *testing.T) {
 	})
 }
 
+func TestAccAPIGatewayRestAPI_waiters(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var conf apigateway.GetRestApiOutput
+
+	resourceName := "aws_api_gateway_rest_api.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx, t),
+
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRestAPIConfig_waiters(rName, "description1"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "description1"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, "test"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"body", "put_rest_api_mode"},
+			},
+			{
+				Config: testAccRestAPIConfig_waiters(rName, "description2"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "description2"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, "test"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckRestAPIRoutes(ctx context.Context, t *testing.T, conf *apigateway.GetRestApiOutput, routes []string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.ProviderMeta(ctx, t).APIGatewayClient(ctx)
@@ -2901,4 +2942,172 @@ resource "aws_api_gateway_rest_api" "test" {
   })
 }
 `, rName, title, failOnWarnings)
+}
+
+func testAccRestAPIConfig_waiters(rName, oasDescription string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigAvailableAZsNoOptIn(),
+		fmt.Sprintf(`
+data "aws_region" "current" {}
+
+resource "aws_vpc" "test" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_default_security_group" "test" {
+  vpc_id = aws_vpc.test.id
+}
+
+resource "aws_subnet" "test" {
+  availability_zone = data.aws_availability_zones.available.names[0]
+  cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 8, 0)
+  vpc_id            = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_vpc_endpoint" "test" {
+  private_dns_enabled = false
+  security_group_ids  = [aws_default_security_group.test.id]
+
+  service_name      = "com.amazonaws.${data.aws_region.current.region}.execute-api"
+  subnet_ids        = [aws_subnet.test.id]
+  vpc_endpoint_type = "Interface"
+  vpc_id            = aws_vpc.test.id
+}
+
+resource "aws_api_gateway_rest_api" "test" {
+  name        = "test"
+  description = %[2]q
+  endpoint_access_mode = "BASIC"
+  security_policy      = "SecurityPolicy_TLS13_1_2_2021_06"
+
+  body = jsonencode({
+    openapi = "3.0.0"
+
+    info = {
+      title       = "Private API"
+      version     = "1.0.0"
+      description = %[2]q
+    }
+
+    paths = {
+      "/test" = {
+        get = {
+          summary     = "Health check"
+          description = "Health check endpoint"
+
+          responses = {
+            "200" = {
+              description = "Successful operation"
+
+              content = {
+                "application/json" = {
+                  schema = {
+                    type = "object"
+
+                    properties = {
+                      message = {
+                        type    = "string"
+                        example = "test"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+
+          "x-amazon-apigateway-integration" = {
+            type       = "MOCK"
+            httpMethod = "POST"
+
+            requestTemplates = {
+              "application/json" = jsonencode({
+                statusCode = 200
+                body       = "{\"message\":\"test\"}"
+              })
+            }
+
+            responses = {
+              default = {
+                statusCode = "200"
+
+                responseTemplates = {
+                  "application/json" = "$input.body"
+                }
+              }
+            }
+          }
+
+          "x-amazon-apigateway-request-validator" = "all"
+        }
+      }
+    }
+
+    "x-amazon-apigateway-minimum-compression-size"   = 0
+
+    "x-amazon-apigateway-request-validators" = {
+      all = {
+        validateRequestParameters = true
+        validateRequestBody       = true
+      }
+    }
+
+    "x-amazon-apigateway-endpoint-configuration" = {
+      disableExecuteApiEndpoint = false
+      ipAddressType             = "dualstack"
+
+      vpcEndpointIds = [
+        aws_vpc_endpoint.test.id
+      ]
+    }
+
+    "x-amazon-apigateway-policy" = {
+      Version = "2012-10-17"
+
+      Statement = [
+        {
+          Effect    = "Deny"
+          Principal = "*"
+          Action    = "execute-api:Invoke"
+
+          Resource = [
+            "execute-api:/*/*/*"
+          ]
+
+          Condition = {
+            StringNotEquals = {
+              "aws:SourceVpce" = [
+                aws_vpc_endpoint.test.id
+              ]
+            }
+          }
+        },
+        {
+          Effect    = "Allow"
+          Principal = "*"
+          Action    = "execute-api:Invoke"
+
+          Resource = [
+            "execute-api:/*/*/*"
+          ]
+        }
+      ]
+    }
+  })
+
+  endpoint_configuration {
+    types = ["PRIVATE"]
+  }
+}
+`, rName, oasDescription))
 }

--- a/internal/service/apigateway/rest_api_test.go
+++ b/internal/service/apigateway/rest_api_test.go
@@ -2985,8 +2985,8 @@ resource "aws_vpc_endpoint" "test" {
 }
 
 resource "aws_api_gateway_rest_api" "test" {
-  name        = "test"
-  description = %[2]q
+  name                 = "test"
+  description          = %[2]q
   endpoint_access_mode = "BASIC"
   security_policy      = "SecurityPolicy_TLS13_1_2_2021_06"
 

--- a/internal/service/apigateway/rest_api_test.go
+++ b/internal/service/apigateway/rest_api_test.go
@@ -3053,7 +3053,7 @@ resource "aws_api_gateway_rest_api" "test" {
       }
     }
 
-    "x-amazon-apigateway-minimum-compression-size"   = 0
+    "x-amazon-apigateway-minimum-compression-size" = 0
 
     "x-amazon-apigateway-request-validators" = {
       all = {

--- a/internal/service/apigateway/rest_api_test.go
+++ b/internal/service/apigateway/rest_api_test.go
@@ -1527,7 +1527,7 @@ func TestAccAPIGatewayRestAPI_Policy_setByBody(t *testing.T) {
 	})
 }
 
-func TestAccAPIGatewayRestAPI_waiters(t *testing.T) {
+func TestAccAPIGatewayRestAPI_Description_updateAttributeAndBody(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	var conf apigateway.GetRestApiOutput
@@ -1543,7 +1543,7 @@ func TestAccAPIGatewayRestAPI_waiters(t *testing.T) {
 
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRestAPIConfig_waiters(rName, "description1"),
+				Config: testAccRestAPIConfig_Description_updateAttributeAndBody(rName, "description1"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "description1"),
@@ -1557,7 +1557,7 @@ func TestAccAPIGatewayRestAPI_waiters(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"body", "put_rest_api_mode"},
 			},
 			{
-				Config: testAccRestAPIConfig_waiters(rName, "description2"),
+				Config: testAccRestAPIConfig_Description_updateAttributeAndBody(rName, "description2"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "description2"),
@@ -2944,46 +2944,10 @@ resource "aws_api_gateway_rest_api" "test" {
 `, rName, title, failOnWarnings)
 }
 
-func testAccRestAPIConfig_waiters(rName, oasDescription string) string {
+func testAccRestAPIConfig_Description_updateAttributeAndBody(rName, oasDescription string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigAvailableAZsNoOptIn(),
 		fmt.Sprintf(`
-data "aws_region" "current" {}
-
-resource "aws_vpc" "test" {
-  cidr_block           = "10.0.0.0/16"
-  enable_dns_support   = true
-  enable_dns_hostnames = true
-
-  tags = {
-    Name = %[1]q
-  }
-}
-
-resource "aws_default_security_group" "test" {
-  vpc_id = aws_vpc.test.id
-}
-
-resource "aws_subnet" "test" {
-  availability_zone = data.aws_availability_zones.available.names[0]
-  cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 8, 0)
-  vpc_id            = aws_vpc.test.id
-
-  tags = {
-    Name = %[1]q
-  }
-}
-
-resource "aws_vpc_endpoint" "test" {
-  private_dns_enabled = false
-  security_group_ids  = [aws_default_security_group.test.id]
-
-  service_name      = "com.amazonaws.${data.aws_region.current.region}.execute-api"
-  subnet_ids        = [aws_subnet.test.id]
-  vpc_endpoint_type = "Interface"
-  vpc_id            = aws_vpc.test.id
-}
-
 resource "aws_api_gateway_rest_api" "test" {
   name                 = "test"
   description          = %[2]q
@@ -3108,6 +3072,42 @@ resource "aws_api_gateway_rest_api" "test" {
   endpoint_configuration {
     types = ["PRIVATE"]
   }
+}
+
+data "aws_region" "current" {}
+
+resource "aws_vpc" "test" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_default_security_group" "test" {
+  vpc_id = aws_vpc.test.id
+}
+
+resource "aws_subnet" "test" {
+  availability_zone = data.aws_availability_zones.available.names[0]
+  cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 8, 0)
+  vpc_id            = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_vpc_endpoint" "test" {
+  private_dns_enabled = false
+  security_group_ids  = [aws_default_security_group.test.id]
+
+  service_name      = "com.amazonaws.${data.aws_region.current.region}.execute-api"
+  subnet_ids        = [aws_subnet.test.id]
+  vpc_endpoint_type = "Interface"
+  vpc_id            = aws_vpc.test.id
 }
 `, rName, oasDescription))
 }

--- a/website/docs/r/api_gateway_rest_api.html.markdown
+++ b/website/docs/r/api_gateway_rest_api.html.markdown
@@ -272,6 +272,14 @@ This resource exports the following attributes in addition to the arguments abov
 * `root_resource_id` - Resource ID of the REST API's root
 * `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 
+## Timeouts
+
+[Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
+
+- `create` - (Default `3m`)
+- `update` - (Default `3m`)
+- `delete` - (Default `3m`)
+
 ## Import
 
 In Terraform v1.12.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `identity` attribute. For example:


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Added waiters to the CUD functions of `aws_api_gateway_rest_api`


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #45905

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t T=TestAccAPIGatewayRestAPI_Description_updateAttributeAndBody K=apigateway
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 apigateway_rest_api_waiters 🌿...
TF_ACC=1 go1.26.5 test ./internal/service/apigateway/... -v -count 1 -parallel 20 -run='TestAccAPIGatewayRestAPI_Description_updateAttributeAndBody'  -timeout 360m -vet=off
2026/07/31 13:28:17 Creating Terraform AWS Provider (SDKv2-style)...
2026/07/31 13:28:17 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccAPIGatewayRestAPI_Description_updateAttributeAndBody
=== PAUSE TestAccAPIGatewayRestAPI_Description_updateAttributeAndBody
=== CONT  TestAccAPIGatewayRestAPI_Description_updateAttributeAndBody
--- PASS: TestAccAPIGatewayRestAPI_Description_updateAttributeAndBody (172.08s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/apigateway	180.971s

...
```
