### PR TITLE
🤖🤖🤖 r/aws_cognito_user_pool: Fix InvalidParameterException for a partially specified admin_create_user_config.invite_message_template

### DIFF
--- a/.changelog/49207.txt
+++ b/.changelog/49207.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cognito_user_pool: Fix `InvalidParameterException` when `admin_create_user_config.invite_message_template` omits `email_message`, `email_subject`, or `sms_message`
+```

--- a/internal/service/cognitoidp/flex_test.go
+++ b/internal/service/cognitoidp/flex_test.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider/types"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -259,6 +261,113 @@ func TestSkipFlatteningStringAttributeContraints(t *testing.T) {
 			got := skipFlatteningStringAttributeContraints(tc.configured, tc.input)
 			if got != tc.want {
 				t.Fatalf("skipFlatteningStringAttributeContraints() got %t, want %t\n\n%#v\n\n", got, tc.want, tc.input)
+			}
+		})
+	}
+}
+
+func TestExpandAdminCreateUserConfigType(t *testing.T) {
+	t.Parallel()
+
+	// The maps below mirror what Terraform Plugin SDKv2 supplies for a nested block:
+	// every declared attribute is present, unset ones holding the zero value.
+	cases := []struct {
+		name  string
+		input map[string]any
+		want  *awstypes.AdminCreateUserConfigType
+	}{
+		{
+			name: "no invite message template",
+			input: map[string]any{
+				"allow_admin_create_user_only": true,
+				"invite_message_template":      []any{},
+			},
+			want: &awstypes.AdminCreateUserConfigType{
+				AllowAdminCreateUserOnly: true,
+			},
+		},
+		{
+			name: "all fields",
+			input: map[string]any{
+				"allow_admin_create_user_only": true,
+				"invite_message_template": []any{
+					map[string]any{
+						"email_message": "Your username is {username} and temporary password is {####}.",
+						"email_subject": "FooBar {####}",
+						"sms_message":   "Your username is {username} and temporary password is {####}.",
+					},
+				},
+			},
+			want: &awstypes.AdminCreateUserConfigType{
+				AllowAdminCreateUserOnly: true,
+				InviteMessageTemplate: &awstypes.MessageTemplateType{
+					EmailMessage: aws.String("Your username is {username} and temporary password is {####}."),
+					EmailSubject: aws.String("FooBar {####}"),
+					SMSMessage:   aws.String("Your username is {username} and temporary password is {####}."),
+				},
+			},
+		},
+		{
+			name: "email only",
+			input: map[string]any{
+				"allow_admin_create_user_only": false,
+				"invite_message_template": []any{
+					map[string]any{
+						"email_message": "Your username is {username} and temporary password is {####}.",
+						"email_subject": "FooBar {####}",
+						"sms_message":   "",
+					},
+				},
+			},
+			want: &awstypes.AdminCreateUserConfigType{
+				InviteMessageTemplate: &awstypes.MessageTemplateType{
+					EmailMessage: aws.String("Your username is {username} and temporary password is {####}."),
+					EmailSubject: aws.String("FooBar {####}"),
+				},
+			},
+		},
+		{
+			name: "SMS only",
+			input: map[string]any{
+				"allow_admin_create_user_only": false,
+				"invite_message_template": []any{
+					map[string]any{
+						"email_message": "",
+						"email_subject": "",
+						"sms_message":   "Your username is {username} and temporary password is {####}.",
+					},
+				},
+			},
+			want: &awstypes.AdminCreateUserConfigType{
+				InviteMessageTemplate: &awstypes.MessageTemplateType{
+					SMSMessage: aws.String("Your username is {username} and temporary password is {####}."),
+				},
+			},
+		},
+		{
+			name: "empty invite message template",
+			input: map[string]any{
+				"allow_admin_create_user_only": false,
+				"invite_message_template": []any{
+					map[string]any{
+						"email_message": "",
+						"email_subject": "",
+						"sms_message":   "",
+					},
+				},
+			},
+			want: &awstypes.AdminCreateUserConfigType{
+				InviteMessageTemplate: &awstypes.MessageTemplateType{},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := expandAdminCreateUserConfigType(tc.input)
+			if diff := cmp.Diff(got, tc.want, cmpopts.IgnoreUnexported(awstypes.AdminCreateUserConfigType{}, awstypes.MessageTemplateType{})); diff != "" {
+				t.Errorf("unexpected diff (+want, -got):\n%s", diff)
 			}
 		})
 	}

--- a/internal/service/cognitoidp/user_pool.go
+++ b/internal/service/cognitoidp/user_pool.go
@@ -1604,15 +1604,15 @@ func expandAdminCreateUserConfigType(tfMap map[string]any) *awstypes.AdminCreate
 			if tfMap, ok := tfList[0].(map[string]any); ok {
 				imt := &awstypes.MessageTemplateType{}
 
-				if v, ok := tfMap["email_message"]; ok {
+				if v, ok := tfMap["email_message"]; ok && v.(string) != "" {
 					imt.EmailMessage = aws.String(v.(string))
 				}
 
-				if v, ok := tfMap["email_subject"]; ok {
+				if v, ok := tfMap["email_subject"]; ok && v.(string) != "" {
 					imt.EmailSubject = aws.String(v.(string))
 				}
 
-				if v, ok := tfMap["sms_message"]; ok {
+				if v, ok := tfMap["sms_message"]; ok && v.(string) != "" {
 					imt.SMSMessage = aws.String(v.(string))
 				}
 

--- a/internal/service/cognitoidp/user_pool_test.go
+++ b/internal/service/cognitoidp/user_pool_test.go
@@ -232,6 +232,68 @@ func TestAccCognitoIDPUserPool_withAdminCreateUser(t *testing.T) {
 	})
 }
 
+// Reference: https://github.com/hashicorp/terraform-provider-aws/issues/49203
+func TestAccCognitoIDPUserPool_withAdminCreateUserEmailOnlyInviteMessageTemplate(t *testing.T) {
+	ctx := acctest.Context(t)
+	var pool awstypes.UserPoolType
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_cognito_user_pool.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckIdentityProvider(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CognitoIDPServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckUserPoolDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserPoolConfig_adminCreateConfigurationEmailOnly(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckUserPoolExists(ctx, t, resourceName, &pool),
+					resource.TestCheckResourceAttr(resourceName, "admin_create_user_config.0.invite_message_template.0.email_message", "Your username is {username} and temporary password is {####}. "),
+					resource.TestCheckResourceAttr(resourceName, "admin_create_user_config.0.invite_message_template.0.email_subject", "FooBar {####}"),
+					resource.TestCheckResourceAttr(resourceName, "admin_create_user_config.0.invite_message_template.0.sms_message", ""),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// Reference: https://github.com/hashicorp/terraform-provider-aws/issues/49203
+func TestAccCognitoIDPUserPool_withAdminCreateUserSMSOnlyInviteMessageTemplate(t *testing.T) {
+	ctx := acctest.Context(t)
+	var pool awstypes.UserPoolType
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_cognito_user_pool.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckIdentityProvider(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CognitoIDPServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckUserPoolDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserPoolConfig_adminCreateConfigurationSMSOnly(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckUserPoolExists(ctx, t, resourceName, &pool),
+					resource.TestCheckResourceAttr(resourceName, "admin_create_user_config.0.invite_message_template.0.email_message", ""),
+					resource.TestCheckResourceAttr(resourceName, "admin_create_user_config.0.invite_message_template.0.email_subject", ""),
+					resource.TestCheckResourceAttr(resourceName, "admin_create_user_config.0.invite_message_template.0.sms_message", "Your username is {username} and temporary password is {####}."),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 // Reference: https://github.com/hashicorp/terraform-provider-aws/issues/11858
 func TestAccCognitoIDPUserPool_withAdminCreateUserAndPasswordPolicy(t *testing.T) {
 	ctx := acctest.Context(t)
@@ -2298,6 +2360,35 @@ resource "aws_cognito_user_pool" "test" {
       email_message = "Your username is {username} and temporary password is {####}. "
       email_subject = "FooBar {####}"
       sms_message   = "Your username is {username} and temporary password is {####}."
+    }
+  }
+}
+`, rName)
+}
+
+func testAccUserPoolConfig_adminCreateConfigurationEmailOnly(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_cognito_user_pool" "test" {
+  name = %[1]q
+
+  admin_create_user_config {
+    invite_message_template {
+      email_message = "Your username is {username} and temporary password is {####}. "
+      email_subject = "FooBar {####}"
+    }
+  }
+}
+`, rName)
+}
+
+func testAccUserPoolConfig_adminCreateConfigurationSMSOnly(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_cognito_user_pool" "test" {
+  name = %[1]q
+
+  admin_create_user_config {
+    invite_message_template {
+      sms_message = "Your username is {username} and temporary password is {####}."
     }
   }
 }


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No.

### Description

`admin_create_user_config.invite_message_template` cannot be partially specified today. All three attributes are documented `Optional`, but setting any one of them requires setting all three.

`expandAdminCreateUserConfigType` reads the block from a Plugin SDKv2 nested block map, in which every declared attribute is always present holding its zero value. The `if v, ok := tfMap[...]; ok` presence checks therefore never fail, so an unset attribute is marshalled as `aws.String("")`:

```go
if v, ok := tfMap["sms_message"]; ok {
	imt.SMSMessage = aws.String(v.(string))
}
```

Cognito enforces a minimum length on each field (`emailMessage` 6, `emailSubject` 1, `sMSMessage` 6), so `CreateUserPool`/`UpdateUserPool` fail:

```
InvalidParameterException: 1 validation error detected: Value '' at
'adminCreateUserConfig.inviteMessageTemplate.sMSMessage' failed to satisfy constraint:
Member must have length greater than or equal to 6
```

The defect is symmetric — an SMS-only template fails on the two email fields the same way.

This guards each assignment on a non-empty value, matching `expandVerificationMessageTemplateType` in the same file, which already does exactly this for the sibling `verification_message_template` block.

Why this is safe:

* **Cognito accepts an omitted field.** Only a present-and-empty one is rejected. Verified against the real API in `us-east-2`: `CreateUserPool` with `SMSMessage` absent from `InviteMessageTemplate` succeeds and stores an email-only template, on a pool with no `sms_configuration`.
* **`""` is not a legal value for any of the three.** The provider's own validators (`validUserPoolInviteTemplateEmailMessage`, `validUserPoolTemplateEmailSubject`, `validUserPoolInviteTemplateSMSMessage`) enforce the same minimum lengths as the API, so no configuration's intent is "send the empty string" and the guard discards nothing expressible.
* **No perpetual diff.** `flattenAdminCreateUserConfigType` already skips nil fields, so an omitted field reads back as the SDKv2 zero value `""` and matches the configuration. Covered by the `ImportState`/`ImportStateVerify` steps in the new tests.
* **Note on clearing a previously set field.** Removing `sms_message` from a configuration that had one will not clear it in Cognito. That is pre-existing and unavoidable — sending `""` cannot clear it either, since the API rejects `""`; clearing requires removing the whole `invite_message_template` block. The `verification_message_template` sibling behaves identically today.

A plan-time validator cannot address this: an SDKv2 `ValidateFunc` does not run on an unset attribute, so the minimum-length validators never fire on this path. Making the attributes `Required` was also considered and rejected — it would break working configurations that set all three, and would encode an API quirk in the provider's interface rather than fixing the marshalling.

Every existing test sets all three attributes, which is why this survived so long. Added:

* `TestExpandAdminCreateUserConfigType` — a unit test over the map shape SDKv2 actually supplies, covering all-fields, email-only, SMS-only, empty and absent templates. This fails on `main` without AWS credentials.
* `TestAccCognitoIDPUserPool_withAdminCreateUserEmailOnlyInviteMessageTemplate` and `..._withAdminCreateUserSMSOnlyInviteMessageTemplate`, each with an `ImportState`/`ImportStateVerify` step.

The two acceptance tests are deliberately separate rather than two steps of one test: transitioning between email-only and SMS-only cannot clear the previously set fields (see above), so a second step would report a non-empty plan for reasons unrelated to this change.

### AI usage disclosure

Per [`docs/ai-usage.md`](https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/ai-usage.md), this PR was prepared with the assistance of an LLM agent (Claude Code), hence `🤖🤖🤖` in the title.

* The agent was given the diagnosis and the intended fix — guard the three assignments to match `expandVerificationMessageTemplateType` — and wrote the guard, the unit test, and the two acceptance tests plus their config builders.
* It ran the unit test against unfixed and fixed code, and the acceptance tests against real Cognito in `us-east-2` both before (reproducing the `InvalidParameterException` above) and after the change, as well as `make build`, `make test`, and `make ci-quick`.
* I reviewed every line, verified the reasoning above independently, and am accountable for this code.

### Relations

Closes #49203
Relates #13060

### References

* [`CreateUserPool` — `MessageTemplateType`](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_MessageTemplateType.html) (minimum lengths for `EmailMessage`, `EmailSubject`, `SMSMessage`)

### Output from Acceptance Testing

Before the change (the reported failure, reproduced):

```console
% make testacc PKG=cognitoidp TESTS='TestAccCognitoIDPUserPool_withAdminCreateUser(Email|SMS)OnlyInviteMessageTemplate'

=== NAME  TestAccCognitoIDPUserPool_withAdminCreateUserEmailOnlyInviteMessageTemplate
    user_pool_test.go:242: Step 1/2 error: Error running apply: exit status 1

        Error: creating Cognito User Pool (tf-acc-test-145519881179330092): operation error Cognito Identity Provider: CreateUserPool, https response error StatusCode: 400, RequestID: 0bc96905-e0a9-43db-ab1b-e59010db9c18, InvalidParameterException: 1 validation error detected: Value '' at 'adminCreateUserConfig.inviteMessageTemplate.sMSMessage' failed to satisfy constraint: Member must have length greater than or equal to 6

=== NAME  TestAccCognitoIDPUserPool_withAdminCreateUserSMSOnlyInviteMessageTemplate
    user_pool_test.go:273: Step 1/2 error: Error running apply: exit status 1

        Error: creating Cognito User Pool (tf-acc-test-92831952279861135): operation error Cognito Identity Provider: CreateUserPool, https response error StatusCode: 400, RequestID: 43853e46-9a12-404e-8e42-529d77313c8e, InvalidParameterException: 3 validation errors detected: Value '' at 'adminCreateUserConfig.inviteMessageTemplate.emailMessage' failed to satisfy constraint: Member must have length greater than or equal to 6; Value '' at 'adminCreateUserConfig.inviteMessageTemplate.emailSubject' failed to satisfy constraint: Member must satisfy regular expression pattern: [\p{L}\p{M}\p{S}\p{N}\p{P}\s]+; Value '' at 'adminCreateUserConfig.inviteMessageTemplate.emailSubject' failed to satisfy constraint: Member must have length greater than or equal to 1

--- FAIL: TestAccCognitoIDPUserPool_withAdminCreateUserSMSOnlyInviteMessageTemplate (5.01s)
--- FAIL: TestAccCognitoIDPUserPool_withAdminCreateUserEmailOnlyInviteMessageTemplate (5.02s)
FAIL
```

After the change, including the previously passing all-fields tests:

```console
% make testacc PKG=cognitoidp TESTS=TestAccCognitoIDPUserPool_withAdminCreateUser

--- PASS: TestAccCognitoIDPUserPool_withAdminCreateUserAndPasswordPolicy (17.66s)
--- PASS: TestAccCognitoIDPUserPool_withAdminCreateUserSMSOnlyInviteMessageTemplate (17.67s)
--- PASS: TestAccCognitoIDPUserPool_withAdminCreateUserEmailOnlyInviteMessageTemplate (17.72s)
--- PASS: TestAccCognitoIDPUserPool_withAdminCreateUser (26.71s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cognitoidp 33.046s
```

Unit test:

```console
% go test ./internal/service/cognitoidp/ -run TestExpandAdminCreateUserConfigType -v

--- PASS: TestExpandAdminCreateUserConfigType (0.00s)
    --- PASS: TestExpandAdminCreateUserConfigType/all_fields (0.00s)
    --- PASS: TestExpandAdminCreateUserConfigType/empty_invite_message_template (0.00s)
    --- PASS: TestExpandAdminCreateUserConfigType/no_invite_message_template (0.00s)
    --- PASS: TestExpandAdminCreateUserConfigType/email_only (0.00s)
    --- PASS: TestExpandAdminCreateUserConfigType/SMS_only (0.00s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cognitoidp 6.535s
```
