### PR TITLE
fix: aws_rds_cluster storage_type change cases replacement

### DIFF
--- a/.changelog/49209.txt
+++ b/.changelog/49209.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_rds_cluster: Fix `storage_type` changes incorrectly forcing resource replacement for non-Aurora clusters
+```

--- a/internal/service/rds/cluster.go
+++ b/internal/service/rds/cluster.go
@@ -20,7 +20,6 @@ import (
 	"github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -708,27 +707,19 @@ func resourceCluster() *schema.Resource {
 			}
 		},
 
-		CustomizeDiff: customdiff.Sequence(
-			customdiff.ForceNewIf(names.AttrStorageType, func(_ context.Context, d *schema.ResourceDiff, meta any) bool {
-				// Aurora supports mutation of the storage_type parameter, other engines do not
-				return !strings.HasPrefix(d.Get(names.AttrEngine).(string), "aurora")
-			}),
-			func(_ context.Context, diff *schema.ResourceDiff, _ any) error {
-				if diff.Id() == "" {
-					return nil
-				}
-				// The control plane will always return an empty string if a cluster is created with a storage_type of aurora
-				old, new := diff.GetChange(names.AttrStorageType)
-
-				if new.(string) == "aurora" && old.(string) == "" {
-					if err := diff.SetNew(names.AttrStorageType, ""); err != nil {
-						return err
-					}
-					return nil
-				}
+		CustomizeDiff: func(_ context.Context, diff *schema.ResourceDiff, _ any) error {
+			if diff.Id() == "" {
 				return nil
-			},
-		),
+			}
+			// The control plane will always return an empty string if a cluster is created with a storage_type of aurora
+			old, new := diff.GetChange(names.AttrStorageType)
+			if new.(string) == "aurora" && old.(string) == "" {
+				if err := diff.SetNew(names.AttrStorageType, ""); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
 	}
 }
 
@@ -1715,7 +1706,20 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta any
 		}
 
 		if d.HasChange(names.AttrStorageType) {
-			input.StorageType = aws.String(d.Get(names.AttrStorageType).(string))
+			input.StorageType = aws.String(storageType)
+
+			gp3BelowAllocatedStorageThreshold := isStorageTypeGP3BelowAllocatedStorageThreshold(d)
+			if gp3BelowAllocatedStorageThreshold && d.HasChange(names.AttrIOPS) && d.Get(names.AttrIOPS).(int) == 0 {
+				// AWS forbids specifying IOPS for gp3 below the configurable-IOPS threshold.
+				input.Iops = nil
+			}
+
+			// AWS requires the current allocation and IOPS when changing to provisioned IOPS
+			// storage or to gp3 at or above its configurable-IOPS threshold.
+			if isProvisionedIOPSStorageType(storageType) || (storageType == storageTypeGP3 && !gp3BelowAllocatedStorageThreshold) {
+				input.AllocatedStorage = aws.Int32(int32(d.Get(names.AttrAllocatedStorage).(int)))
+				input.Iops = aws.Int32(int32(d.Get(names.AttrIOPS).(int)))
+			}
 		}
 
 		if d.HasChange(names.AttrVPCSecurityGroupIDs) {

--- a/internal/service/rds/cluster_test.go
+++ b/internal/service/rds/cluster_test.go
@@ -864,6 +864,91 @@ func TestAccRDSCluster_storageTypeAuroraIopt1UpdateAurora(t *testing.T) {
 	})
 }
 
+type testAccClusterStorageSettings struct {
+	storageType        string
+	allocatedStorage   int
+	iops               int
+	expectNonEmptyPlan bool
+}
+
+func TestAccRDSCluster_storageTypeUpdateNonAurora_io2ToGP3WithoutIOPS(t *testing.T) {
+	// AWS assigns 3000 IOPS to gp3 storage below 400 GiB, so a subsequent plan
+	// still reports drift. This test covers only the in-place storage transition;
+	// the existing drift is tracked in https://github.com/hashicorp/terraform-provider-aws/issues/41203.
+	testAccClusterStorageTypeUpdateNonAurora(t,
+		testAccClusterStorageSettings{storageType: "io2", allocatedStorage: 100, iops: 1000},
+		testAccClusterStorageSettings{storageType: "gp3", allocatedStorage: 100, expectNonEmptyPlan: true},
+	)
+}
+
+func TestAccRDSCluster_storageTypeUpdateNonAurora_gp3ToIO2WithDifferentIOPS(t *testing.T) {
+	testAccClusterStorageTypeUpdateNonAurora(t,
+		testAccClusterStorageSettings{storageType: "gp3", allocatedStorage: 400, iops: 12000},
+		testAccClusterStorageSettings{storageType: "io2", allocatedStorage: 400, iops: 10000},
+	)
+}
+
+func TestAccRDSCluster_storageTypeUpdateNonAurora_io1ToIO2WithSameIOPS(t *testing.T) {
+	testAccClusterStorageTypeUpdateNonAurora(t,
+		testAccClusterStorageSettings{storageType: "io1", allocatedStorage: 400, iops: 10000},
+		testAccClusterStorageSettings{storageType: "io2", allocatedStorage: 400, iops: 10000},
+	)
+}
+
+func TestAccRDSCluster_storageTypeUpdateNonAurora_io2ToGP3WithDifferentIOPS(t *testing.T) {
+	testAccClusterStorageTypeUpdateNonAurora(t,
+		testAccClusterStorageSettings{storageType: "io2", allocatedStorage: 400, iops: 10000},
+		testAccClusterStorageSettings{storageType: "gp3", allocatedStorage: 400, iops: 12000},
+	)
+}
+
+func testAccClusterStorageTypeUpdateNonAurora(t *testing.T, before, after testAccClusterStorageSettings) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	ctx := acctest.Context(t)
+	var dbCluster1, dbCluster2 types.DBCluster
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_rds_cluster.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterConfig_storageTypeNonAurora(rName, before),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClusterExists(ctx, t, resourceName, &dbCluster1),
+					testAccCheckClusterStorageSettings(resourceName, before),
+				),
+			},
+			{
+				Config:             testAccClusterConfig_storageTypeNonAurora(rName, after),
+				ExpectNonEmptyPlan: after.expectNonEmptyPlan,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClusterExists(ctx, t, resourceName, &dbCluster2),
+					testAccCheckClusterNotRecreated(&dbCluster1, &dbCluster2),
+					testAccCheckClusterStorageSettings(resourceName, after),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckClusterStorageSettings(resourceName string, settings testAccClusterStorageSettings) resource.TestCheckFunc {
+	checks := []resource.TestCheckFunc{
+		resource.TestCheckResourceAttr(resourceName, names.AttrStorageType, settings.storageType),
+		resource.TestCheckResourceAttr(resourceName, names.AttrAllocatedStorage, strconv.Itoa(settings.allocatedStorage)),
+	}
+	if settings.iops > 0 {
+		checks = append(checks, resource.TestCheckResourceAttr(resourceName, names.AttrIOPS, strconv.Itoa(settings.iops)))
+	}
+	return resource.ComposeAggregateTestCheckFunc(checks...)
+}
+
 func TestAccRDSCluster_iops(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
@@ -4651,6 +4736,42 @@ resource "aws_rds_cluster" "test" {
   skip_final_snapshot       = true
 }
 `, tfrds.ClusterEngineMySQL, mainInstanceClasses, rName, sType))
+}
+
+func testAccClusterConfig_storageTypeNonAurora(rName string, settings testAccClusterStorageSettings) string {
+	var iopsConfig string
+	if settings.iops > 0 {
+		iopsConfig = fmt.Sprintf("  iops = %d", settings.iops)
+	}
+
+	return acctest.ConfigCompose(
+		testAccClusterConfig_clusterSubnetGroup(rName),
+		fmt.Sprintf(`
+data "aws_rds_orderable_db_instance" "test" {
+  engine                     = %[1]q
+  engine_latest_version      = true
+  preferred_instance_classes = [%[2]s]
+  storage_type               = %[3]q
+  supports_iops              = true
+  supports_clusters          = true
+}
+`, tfrds.ClusterEnginePostgres, mainInstanceClasses, settings.storageType),
+		fmt.Sprintf(`
+resource "aws_rds_cluster" "test" {
+  apply_immediately         = true
+  cluster_identifier        = %[1]q
+  db_cluster_instance_class = data.aws_rds_orderable_db_instance.test.instance_class
+  db_subnet_group_name      = aws_db_subnet_group.test.name
+  engine                    = data.aws_rds_orderable_db_instance.test.engine
+  engine_version            = data.aws_rds_orderable_db_instance.test.engine_version
+  storage_type              = %[2]q
+  allocated_storage         = %[3]d
+  master_password           = "mustbeeightcharaters"
+  master_username           = "test"
+  skip_final_snapshot       = true
+%[4]s
+}
+`, rName, settings.storageType, settings.allocatedStorage, iopsConfig))
 }
 
 func testAccClusterConfig_storageChange(rName string, sType string) string {


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

None

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Changing `storage_type` on a non-Aurora Multi-AZ RDS cluster forced a replacement even though AWS supports the change through `ModifyDBCluster`.

This PR removes that replacement condition. In addition, when you update the storage_type AWS also makes you send the `AllocatedStorage` and the `Iops` values along with the new `storage_type`.

One special case is when you change from `io2` => `gp3` and the allocated storage is below `400` AWS does not allow you to send an Iops value. We handle this by making sure we send a null value instead of the 0 value.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.
--->

Closes #48438


### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

This is built on top of https://github.com/hashicorp/terraform-provider-aws/pull/48545 and adds the additional tests and handling of AllocatedStorage and Iops.


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccRDSCluster_storageType PKG=rds

2026/07/30 07:05:01 Creating Terraform AWS Provider (SDKv2-style)...
2026/07/30 07:05:01 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccRDSCluster_storageTypeUpdateNonAurora_io2ToGP3WithoutIOPS
=== PAUSE TestAccRDSCluster_storageTypeUpdateNonAurora_io2ToGP3WithoutIOPS
=== CONT  TestAccRDSCluster_storageTypeUpdateNonAurora_io2ToGP3WithoutIOPS
--- PASS: TestAccRDSCluster_storageTypeUpdateNonAurora_io2ToGP3WithoutIOPS (2447.65s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/rds        2453.446s

2026/07/29 15:01:57 Creating Terraform AWS Provider (SDKv2-style)...
2026/07/29 15:01:57 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccRDSCluster_storageTypeAuroraUpdateAuroraIopt1
=== PAUSE TestAccRDSCluster_storageTypeAuroraUpdateAuroraIopt1
=== RUN   TestAccRDSCluster_storageTypeAuroraIopt1UpdateAurora
=== PAUSE TestAccRDSCluster_storageTypeAuroraIopt1UpdateAurora
=== CONT  TestAccRDSCluster_storageTypeAuroraUpdateAuroraIopt1
=== CONT  TestAccRDSCluster_storageTypeAuroraIopt1UpdateAurora
--- PASS: TestAccRDSCluster_storageTypeAuroraIopt1UpdateAurora (127.41s)
--- PASS: TestAccRDSCluster_storageTypeAuroraUpdateAuroraIopt1 (137.86s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/rds        143.819s

2026/07/29 12:55:14 Creating Terraform AWS Provider (SDKv2-style)...
2026/07/29 12:55:14 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccRDSCluster_storageTypeUpdateNonAurora_gp3ToIO2WithDifferentIOPS
=== PAUSE TestAccRDSCluster_storageTypeUpdateNonAurora_gp3ToIO2WithDifferentIOPS
=== RUN   TestAccRDSCluster_storageTypeUpdateNonAurora_io1ToIO2WithSameIOPS
=== PAUSE TestAccRDSCluster_storageTypeUpdateNonAurora_io1ToIO2WithSameIOPS
=== RUN   TestAccRDSCluster_storageTypeUpdateNonAurora_io2ToGP3WithDifferentIOPS
=== PAUSE TestAccRDSCluster_storageTypeUpdateNonAurora_io2ToGP3WithDifferentIOPS
=== CONT  TestAccRDSCluster_storageTypeUpdateNonAurora_gp3ToIO2WithDifferentIOPS
=== CONT  TestAccRDSCluster_storageTypeUpdateNonAurora_io2ToGP3WithDifferentIOPS
=== CONT  TestAccRDSCluster_storageTypeUpdateNonAurora_io1ToIO2WithSameIOPS
--- PASS: TestAccRDSCluster_storageTypeUpdateNonAurora_io2ToGP3WithDifferentIOPS (2295.89s)
--- PASS: TestAccRDSCluster_storageTypeUpdateNonAurora_gp3ToIO2WithDifferentIOPS (2302.79s)
--- PASS: TestAccRDSCluster_storageTypeUpdateNonAurora_io1ToIO2WithSameIOPS (2372.21s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/rds        2378.361s
```