### PR TITLE
r/aws_cognito_identity_provider: Change idp_identifiers to a set 🤖🤖🤖

### DIFF
--- a/.changelog/49210.txt
+++ b/.changelog/49210.txt
@@ -1,0 +1,7 @@
+```release-note:breaking-change
+resource/aws_cognito_identity_provider: `idp_identifiers` is now a set of strings and can no longer be indexed. Configurations referencing it by index, or passing it to functions that require a list, must wrap it in `tolist()`
+```
+
+```release-note:bug
+resource/aws_cognito_identity_provider: Change `idp_identifiers` to a set to prevent perpetual diffs when AWS returns the identifiers in a different order than configured
+```

--- a/internal/service/cognitoidp/identity_provider.go
+++ b/internal/service/cognitoidp/identity_provider.go
@@ -51,7 +51,7 @@ func resourceIdentityProvider() *schema.Resource {
 					},
 				},
 				"idp_identifiers": {
-					Type:     schema.TypeList,
+					Type:     schema.TypeSet,
 					Optional: true,
 					MaxItems: 50,
 					Elem: &schema.Schema{
@@ -106,8 +106,8 @@ func resourceIdentityProviderCreate(ctx context.Context, d *schema.ResourceData,
 		input.AttributeMapping = flex.ExpandStringValueMap(v.(map[string]any))
 	}
 
-	if v, ok := d.GetOk("idp_identifiers"); ok && len(v.([]any)) > 0 {
-		input.IdpIdentifiers = flex.ExpandStringValueList(v.([]any))
+	if v, ok := d.GetOk("idp_identifiers"); ok && v.(*schema.Set).Len() > 0 {
+		input.IdpIdentifiers = flex.ExpandStringValueSet(v.(*schema.Set))
 	}
 
 	if v, ok := d.GetOk("provider_details"); ok && len(v.(map[string]any)) > 0 {
@@ -175,7 +175,7 @@ func resourceIdentityProviderUpdate(ctx context.Context, d *schema.ResourceData,
 	}
 
 	if d.HasChange("idp_identifiers") {
-		input.IdpIdentifiers = flex.ExpandStringValueList(d.Get("idp_identifiers").([]any))
+		input.IdpIdentifiers = flex.ExpandStringValueSet(d.Get("idp_identifiers").(*schema.Set))
 	}
 
 	if d.HasChange("provider_details") {

--- a/internal/service/cognitoidp/identity_provider_test.go
+++ b/internal/service/cognitoidp/identity_provider_test.go
@@ -98,7 +98,7 @@ func TestAccCognitoIDPIdentityProvider_idpIdentifiers(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckIdentityProviderExists(ctx, t, resourceName, &identityProvider),
 					resource.TestCheckResourceAttr(resourceName, "idp_identifiers.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "idp_identifiers.0", "test"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "idp_identifiers.*", "test"),
 				),
 			},
 			{
@@ -111,8 +111,42 @@ func TestAccCognitoIDPIdentityProvider_idpIdentifiers(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckIdentityProviderExists(ctx, t, resourceName, &identityProvider),
 					resource.TestCheckResourceAttr(resourceName, "idp_identifiers.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "idp_identifiers.0", "test2"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "idp_identifiers.*", "test2"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccCognitoIDPIdentityProvider_idpIdentifiersOrder(t *testing.T) {
+	ctx := acctest.Context(t)
+	var identityProvider awstypes.IdentityProviderType
+	resourceName := "aws_cognito_identity_provider.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckIdentityProvider(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CognitoIDPServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckIdentityProviderDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIdentityProviderConfig_identifiers(rName, `["test1", "test2"]`),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIdentityProviderExists(ctx, t, resourceName, &identityProvider),
+					resource.TestCheckResourceAttr(resourceName, "idp_identifiers.#", "2"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "idp_identifiers.*", "test1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "idp_identifiers.*", "test2"),
+				),
+			},
+			{
+				// Reordering the identifiers is not a change: AWS returns them in its own order.
+				Config: testAccIdentityProviderConfig_identifiers(rName, `["test2", "test1"]`),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 		},
 	})
@@ -387,6 +421,35 @@ resource "aws_cognito_identity_provider" "test" {
   }
 }
 `, rName, attribute)
+}
+
+func testAccIdentityProviderConfig_identifiers(rName, identifiers string) string {
+	return fmt.Sprintf(`
+resource "aws_cognito_user_pool" "test" {
+  name                     = %[1]q
+  auto_verified_attributes = ["email"]
+}
+
+resource "aws_cognito_identity_provider" "test" {
+  user_pool_id  = aws_cognito_user_pool.test.id
+  provider_name = "Google"
+  provider_type = "Google"
+
+  idp_identifiers = %[2]s
+
+  provider_details = {
+    attributes_url                = "https://people.googleapis.com/v1/people/me?personFields="
+    attributes_url_add_attributes = "true"
+    authorize_scopes              = "email"
+    authorize_url                 = "https://accounts.google.com/o/oauth2/v2/auth"
+    client_id                     = "test-url.apps.googleusercontent.com"
+    client_secret                 = "client_secret"
+    oidc_issuer                   = "https://accounts.google.com"
+    token_request_method          = "POST"
+    token_url                     = "https://www.googleapis.com/oauth2/v4/token"
+  }
+}
+`, rName, identifiers)
 }
 
 func testAccIdentityProviderConfig_saml(rName, userPoolName, idpEntityId, encryptedResponses string) string {

--- a/internal/service/cognitoidp/identity_provider_test.go
+++ b/internal/service/cognitoidp/identity_provider_test.go
@@ -147,6 +147,23 @@ func TestAccCognitoIDPIdentityProvider_idpIdentifiersOrder(t *testing.T) {
 						plancheck.ExpectEmptyPlan(),
 					},
 				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIdentityProviderExists(ctx, t, resourceName, &identityProvider),
+					resource.TestCheckResourceAttr(resourceName, "idp_identifiers.#", "2"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "idp_identifiers.*", "test1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "idp_identifiers.*", "test2"),
+				),
+			},
+			{
+				// Adding an identifier that sorts before the existing ones does not leave a diff behind.
+				Config: testAccIdentityProviderConfig_identifiers(rName, `["test2", "test1", "aaa"]`),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIdentityProviderExists(ctx, t, resourceName, &identityProvider),
+					resource.TestCheckResourceAttr(resourceName, "idp_identifiers.#", "3"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "idp_identifiers.*", "aaa"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "idp_identifiers.*", "test1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "idp_identifiers.*", "test2"),
+				),
 			},
 		},
 	})

--- a/website/docs/r/cognito_identity_provider.html.markdown
+++ b/website/docs/r/cognito_identity_provider.html.markdown
@@ -46,7 +46,7 @@ This resource supports the following arguments:
 * `provider_name` (Required) - The provider name
 * `provider_type` (Required) - The provider type.  [See AWS API for valid values](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_CreateIdentityProvider.html#CognitoUserPools-CreateIdentityProvider-request-ProviderType)
 * `attribute_mapping` (Optional) - The map of attribute mapping of user pool attributes. [AttributeMapping in AWS API documentation](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_CreateIdentityProvider.html#CognitoUserPools-CreateIdentityProvider-request-AttributeMapping)
-* `idp_identifiers` (Optional) - The list of identity providers.
+* `idp_identifiers` (Optional) - The set of identity provider identifiers.
 * `provider_details` (Optional) - The map of identity details, such as access token
 
 ## Attribute Reference

--- a/website/docs/r/cognito_identity_provider.html.markdown
+++ b/website/docs/r/cognito_identity_provider.html.markdown
@@ -46,7 +46,7 @@ This resource supports the following arguments:
 * `provider_name` (Required) - The provider name
 * `provider_type` (Required) - The provider type.  [See AWS API for valid values](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_CreateIdentityProvider.html#CognitoUserPools-CreateIdentityProvider-request-ProviderType)
 * `attribute_mapping` (Optional) - The map of attribute mapping of user pool attributes. [AttributeMapping in AWS API documentation](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_CreateIdentityProvider.html#CognitoUserPools-CreateIdentityProvider-request-AttributeMapping)
-* `idp_identifiers` (Optional) - The set of identity provider identifiers.
+* `idp_identifiers` (Optional) - The set of identity provider identifiers. The order is not significant.
 * `provider_details` (Optional) - The map of identity details, such as access token
 
 ## Attribute Reference


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

None.

### Description

`aws_cognito_identity_provider.idp_identifiers` was modelled as a `TypeList`, but Cognito returns the identifiers in its own order, which does not necessarily match the order they were sent in. Whenever the two orders differ, the resource has a permanent diff: every apply rewrites the identifiers with the configured order, `DescribeIdentityProvider` returns a different order, and the next plan shows the same reordering again.

The order of the identifiers carries no meaning for Cognito, so this changes the attribute to a `TypeSet`.

CloudTrail for a single affected resource, showing the write and the subsequent read disagreeing (domains redacted):

```
UpdateIdentityProvider    requestParameters.idpIdentifiers: ["alpha.example.com","beta.example.org"]
DescribeIdentityProvider  IdentityProvider.IdpIdentifiers:  ["beta.example.org","alpha.example.com"]
```

Existing state written by the previous `TypeList` schema is read back into the set without a diff or a replacement, so no state upgrade is required. I verified this against real infrastructure that was showing the perpetual diff: a locally built provider with this patch produces `No changes. Your infrastructure matches the configuration.` for four `aws_cognito_identity_provider` resources that the released provider wanted to update in-place on every run, with no configuration change.

`TestAccCognitoIDPIdentityProvider_idpIdentifiersOrder` is a regression test: it applies two identifiers, then reorders them in the configuration and asserts an empty plan.

### AI Usage

Disclosed per the [AI usage policy](https://hashicorp.github.io/terraform-provider-aws/ai-usage/). This change was produced with an AI coding agent (Claude Code) working under my direction:

* The agent diagnosed the root cause from CloudTrail evidence in my own AWS account, wrote the schema and expander changes, wrote the new acceptance test and the test configuration function, and drafted this description.
* I directed the work, reviewed the diff, and ran the verification myself on my machine: `go build`, `go vet`, `gofmt`, the SDKv2 provider `InternalValidate` test, and the acceptance tests against a real AWS account.
* The regression test was validated in both directions: it fails on unpatched code with the exact reported drift, and passes with the change applied. Both runs are included below.

### Relations

Closes #46686

### References

* Maintainer-approved analysis in #46686 identifying `TypeList` as the root cause and `TypeSet` as the fix.
* `resource/aws_lakeformation_opt_in` (#46788) made the same kind of list-to-set change in a minor release, v6.37.0, where it was announced under BREAKING CHANGES.

### Output from Acceptance Testing

```console
% make testacc TESTS='TestAccCognitoIDPIdentityProvider_' PKG=cognitoidp

--- PASS: TestAccCognitoIDPIdentityProvider_Disappears_userPool (22.26s)
--- PASS: TestAccCognitoIDPIdentityProvider_disappears (23.00s)
--- PASS: TestAccCognitoIDPIdentityProvider_idpIdentifiersOrder (31.77s)
--- PASS: TestAccCognitoIDPIdentityProvider_basic (37.16s)
--- PASS: TestAccCognitoIDPIdentityProvider_idpIdentifiers (37.51s)
--- PASS: TestAccCognitoIDPIdentityProvider_saml (49.55s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cognitoidp 55.922s
```

Without the schema change (new test only, `TypeList` restored), the new test fails with exactly the reported drift:

```console
% make testacc TESTS='TestAccCognitoIDPIdentityProvider_idpIdentifiersOrder' PKG=cognitoidp

          # aws_cognito_identity_provider.test will be updated in-place
          ~ resource "aws_cognito_identity_provider" "test" {
                id                = "us-east-1_XXXXXXXXX:Google"
              ~ idp_identifiers   = [
                  - "test2",
                    "test1",
                  + "test2",
                ]
                # (6 unchanged attributes hidden)
            }

        Plan: 0 to add, 1 to change, 0 to destroy.
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/cognitoidp 23.839s
```

### Compatibility

`idp_identifiers` can no longer be indexed. Configurations using `aws_cognito_identity_provider.example.idp_identifiers[0]`, or passing the attribute to functions that require a list such as `join`, need `tolist()`. I am happy to retarget this at a major release if you would prefer to hold it. If the type change is not acceptable at all, the alternative is to keep `TypeList` and suppress the ordering difference with a sorted-comparison `DiffSuppressFunc`, which I think is more fragile than modelling the attribute correctly.