### PR TITLE
Add Action option to Changie config

### DIFF
--- a/.changie.yaml
+++ b/.changie.yaml
@@ -66,7 +66,7 @@ kinds:
 
   - key: feature
     format: "FEATURES:"
-    label: "Resource, Data Source, Ephemeral Resource, Function, List Resource"
+    label: "Resource, Data Source, Ephemeral Resource, Function, List Resource, Action"
     skipBody: true
     changeFormat: |-
       {{- printf "* **%s**: `%s`" .Custom.NewType .Custom.Name }}
@@ -84,6 +84,7 @@ kinds:
           - New Ephemeral Resource
           - New Function
           - New List Resource
+          - New Action
 
       - key: Name
         label: Name of the Resource, Data Source, etc.

--- a/docs/design-decisions/changie-migration.md
+++ b/docs/design-decisions/changie-migration.md
@@ -76,7 +76,7 @@ Five entry types are configured:
 
 - **Breaking Change**: Backward-incompatible changes
 - **Note**: Important notices (deprecations, removals)
-- **Feature**: New resources, data sources, ephemeral resources, functions, list, or action resources
+- **Feature**: New resources, data sources, ephemeral resources, functions, list resources, or actions
 - **Enhancement**: New attributes or arguments
 - **Bug**: Incorrect behavior
 

--- a/docs/design-decisions/changie-migration.md
+++ b/docs/design-decisions/changie-migration.md
@@ -76,7 +76,7 @@ Five entry types are configured:
 
 - **Breaking Change**: Backward-incompatible changes
 - **Note**: Important notices (deprecations, removals)
-- **Feature**: New resources, data sources, ephemeral resources, functions, or list resources
+- **Feature**: New resources, data sources, ephemeral resources, functions, list, or action resources
 - **Enhancement**: New attributes or arguments
 - **Bug**: Incorrect behavior
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Adds an option for new actions to Changie config and updates the design decisions accordingly

### Relations

Relates #46618
