### PR TITLE
Changie: Add `convert-changelog` script

### DIFF
--- a/.ci/scripts/convert-changelog.sh
+++ b/.ci/scripts/convert-changelog.sh
@@ -24,6 +24,20 @@ if ! grep -q '```release-note:' "$CHANGELOG_FILE"; then
     exit 1
 fi
 
+# Validate that no field contains shell metacharacters.
+# Backticks in body text are Markdown code spans, not shell; they are excluded.
+# The remaining characters ($, \, ;, |, &) are injection vectors when parsed
+# values are passed as arguments to changie new in a pull_request_target context.
+SHELL_METACHAR_PATTERN='[$\\;|&]'
+while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+    [[ "$line" == '```'* ]] && continue
+    if [[ "$line" =~ $SHELL_METACHAR_PATTERN ]]; then
+        echo "Error: Shell metacharacter detected in '$CHANGELOG_FILE': $line"
+        exit 1
+    fi
+done < "$CHANGELOG_FILE"
+
 # Extract PR number from filename
 PR_NUMBER=$(basename "$CHANGELOG_FILE" .txt)
 
@@ -111,7 +125,12 @@ while IFS= read -r line; do
         if [ "$KIND" = "feature" ]; then
             # For features, extract the resource/data source name from body
             NAME=$(echo "$BODY" | head -n1)
-            changie new --kind "$KIND" --custom "NewType=$FEATURE_TYPE" --custom "Name=$NAME" --custom "PullRequest=$PR_NUMBER"
+            changie new \
+                --interactive=false \
+                --kind "$KIND" \
+                --custom "NewType=$FEATURE_TYPE" \
+                --custom "Name=$NAME" \
+                --custom "PullRequest=$PR_NUMBER"
         else
             # For other kinds (breaking-change, note, enhancement, bug)
             # Extract Impact (resource/data-source prefix) and Body (description) separately
@@ -119,17 +138,26 @@ while IFS= read -r line; do
                 # Has Impact prefix (e.g., "resource/aws_example: Description")
                 IMPACT="${BASH_REMATCH[1]}${BASH_REMATCH[2]}"
                 DESCRIPTION="${BASH_REMATCH[3]}"
-                changie new --kind "$KIND" --custom "Impact=$IMPACT" --custom "Body=$DESCRIPTION" --custom "PullRequest=$PR_NUMBER"
+                changie new \
+                    --interactive=false \
+                    --kind "$KIND" \
+                    --custom "Impact=$IMPACT" \
+                    --custom "Body=$DESCRIPTION" \
+                    --custom "PullRequest=$PR_NUMBER"
             elif [[ "$BODY" =~ ^(provider):\ (.+)$ ]]; then
                 # Provider-level change without resource prefix (e.g., "provider: Description")
                 IMPACT="${BASH_REMATCH[1]}"
                 DESCRIPTION="${BASH_REMATCH[2]}"
-                changie new --kind "$KIND" --custom "Impact=$IMPACT" --custom "Body=$DESCRIPTION" --custom "PullRequest=$PR_NUMBER"
+                changie new \
+                    --interactive=false \
+                    --kind "$KIND" \
+                    --custom "Impact=$IMPACT" \
+                    --custom "Body=$DESCRIPTION" \
+                    --custom "PullRequest=$PR_NUMBER"
             else
-                # No Impact prefix - use full body as description with empty Impact
-                # This shouldn't happen in well-formed entries, but handle gracefully
-                echo "Warning: Entry does not follow expected format (missing Impact prefix): $BODY"
-                changie new --kind "$KIND" --custom "Body=$BODY" --custom "PullRequest=$PR_NUMBER"
+                # No Impact prefix - cannot create a valid fragment without an Impact value
+                echo "Error: Entry does not follow expected format (missing resource/data-source/provider prefix): $BODY"
+                exit 1
             fi
         fi
 

--- a/.ci/scripts/convert-changelog.sh
+++ b/.ci/scripts/convert-changelog.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+set -euo pipefail
+
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 <path-to-changelog-file>"
+    echo "Example: $0 .changelog/44302.txt"
+    exit 1
+fi
+
+CHANGELOG_FILE="$1"
+
+if [ ! -f "$CHANGELOG_FILE" ]; then
+    echo "Error: File not found: $CHANGELOG_FILE"
+    exit 1
+fi
+
+# Validate file format
+if ! grep -q '```release-note:' "$CHANGELOG_FILE"; then
+    echo "Error: File does not contain go-changelog format entries"
+    exit 1
+fi
+
+# Extract PR number from filename
+PR_NUMBER=$(basename "$CHANGELOG_FILE" .txt)
+
+if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+    echo "Error: Could not extract valid PR number from filename"
+    exit 1
+fi
+
+ENTRY_COUNT=0
+
+# Parse the file and extract entries
+while IFS= read -r line; do
+    if [[ "$line" =~ ^\`\`\`release-note:(.+)$ ]]; then
+        # Start of a new entry
+        TYPE="${BASH_REMATCH[1]}"
+        BODY=""
+
+        # Read until closing ```
+        while IFS= read -r content_line; do
+            if [[ "$content_line" == '```' ]]; then
+                break
+            fi
+            if [ -n "$BODY" ]; then
+                BODY="${BODY}"$'\n'"${content_line}"
+            else
+                BODY="${content_line}"
+            fi
+        done
+
+        # Validate body is not empty
+        if [ -z "$BODY" ]; then
+            echo "Error: Empty body for entry type '$TYPE'"
+            exit 1
+        fi
+
+        # Map go-changelog type to Changie kind
+        case "$TYPE" in
+            new-resource)
+                KIND="feature"
+                FEATURE_TYPE="New Resource"
+                ;;
+            new-data-source)
+                KIND="feature"
+                FEATURE_TYPE="New Data Source"
+                ;;
+            new-ephemeral-resource)
+                KIND="feature"
+                FEATURE_TYPE="New Ephemeral Resource"
+                ;;
+            new-function)
+                KIND="feature"
+                FEATURE_TYPE="New Function"
+                ;;
+            new-list-resource)
+                KIND="feature"
+                FEATURE_TYPE="New List Resource"
+                ;;
+            new-action)
+                KIND="feature"
+                FEATURE_TYPE="New Action"
+                ;;
+            enhancement)
+                KIND="enhancement"
+                FEATURE_TYPE=""
+                ;;
+            bug)
+                KIND="bug"
+                FEATURE_TYPE=""
+                ;;
+            note)
+                KIND="note"
+                FEATURE_TYPE=""
+                ;;
+            breaking-change)
+                KIND="breaking-change"
+                FEATURE_TYPE=""
+                ;;
+            *)
+                echo "Error: Unknown entry type '$TYPE'"
+                exit 1
+                ;;
+        esac
+
+        # Create Changie fragment
+        if [ "$KIND" = "feature" ]; then
+            # For features, extract the resource/data source name from body
+            NAME=$(echo "$BODY" | head -n1)
+            changie new --kind "$KIND" --custom "NewType=$FEATURE_TYPE" --custom "Name=$NAME" --custom "PullRequest=$PR_NUMBER"
+        else
+            # For other kinds (breaking-change, note, enhancement, bug)
+            # Extract Impact (resource/data-source prefix) and Body (description) separately
+            if [[ "$BODY" =~ ^(resource/|data-source/|ephemeral-resource/|function/|list-resource/|provider)([^:]*):\ (.+)$ ]]; then
+                # Has Impact prefix (e.g., "resource/aws_example: Description")
+                IMPACT="${BASH_REMATCH[1]}${BASH_REMATCH[2]}"
+                DESCRIPTION="${BASH_REMATCH[3]}"
+                changie new --kind "$KIND" --custom "Impact=$IMPACT" --custom "Body=$DESCRIPTION" --custom "PullRequest=$PR_NUMBER"
+            elif [[ "$BODY" =~ ^(provider):\ (.+)$ ]]; then
+                # Provider-level change without resource prefix (e.g., "provider: Description")
+                IMPACT="${BASH_REMATCH[1]}"
+                DESCRIPTION="${BASH_REMATCH[2]}"
+                changie new --kind "$KIND" --custom "Impact=$IMPACT" --custom "Body=$DESCRIPTION" --custom "PullRequest=$PR_NUMBER"
+            else
+                # No Impact prefix - use full body as description with empty Impact
+                # This shouldn't happen in well-formed entries, but handle gracefully
+                echo "Warning: Entry does not follow expected format (missing Impact prefix): $BODY"
+                changie new --kind "$KIND" --custom "Body=$BODY" --custom "PullRequest=$PR_NUMBER"
+            fi
+        fi
+
+        ENTRY_COUNT=$((ENTRY_COUNT + 1))
+
+        # Add 1 second delay to ensure unique timestamps for Changie files
+        # Changie uses second-level precision in filenames (kind-YYYYMMDD-HHMMSS.yaml)
+        # Without this, multiple entries of the same kind can overwrite each other
+        sleep 1
+    fi
+done < "$CHANGELOG_FILE"
+
+if [ "$ENTRY_COUNT" -eq 0 ]; then
+    echo "Error: No valid entries found in $CHANGELOG_FILE"
+    exit 1
+fi
+
+# Delete the original file
+rm "$CHANGELOG_FILE"
+
+echo "Successfully converted $ENTRY_COUNT entry/entries and deleted: $CHANGELOG_FILE"

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -286,6 +286,9 @@ clean-tidy: prereq-go ## Clean up tidy
 	$$gover mod tidy
 	@echo "make: Go mods tidied"
 
+convert-changelog: ## Convert go-changelog fragment to Changie format
+	@.ci/scripts/convert-changelog.sh $(FILE)
+
 copyright: ## [CI] Copyright Checks / headers check
 	@echo "make: Copyright Checks / headers check..."
 	@which copyplop > /dev/null || go install github.com/YakDriver/copyplop
@@ -1483,6 +1486,7 @@ yamllint: ## [CI] YAML Linting / yamllint
 	clean-go-cache-trim \
 	clean-make-tests \
 	clean-tidy \
+	convert-changelog \
 	copyright \
 	copyright-fix \
 	default \

--- a/docs/makefile-cheat-sheet.md
+++ b/docs/makefile-cheat-sheet.md
@@ -106,6 +106,7 @@ Variables are often defined before the `make` call on the same line, such as `MY
 | `clean-go`<sup>D</sup> | Clean up Go cache |  |  | `GO_VER` |
 | `clean-go-cache-trim` | Trim Go build cache to manageable size |  |  |  |
 | `clean-make-tests` | Clean up artifacts from make tests |  |  |  |
+| `convert-changelog` | Convert `go-changelog` fragment to Changie format |  |  | `FILE` |
 | `clean-tidy`<sup>D</sup> | Clean up tidy |  |  | `GO_VER` |
 | `copyright` | Copyright Checks / headers check | ✔️ |  |  |
 | `copyright-fix` | Fix copyright headers |  |  |  |

--- a/docs/makefile-cheat-sheet.md
+++ b/docs/makefile-cheat-sheet.md
@@ -98,7 +98,6 @@ Variables are often defined before the `make` call on the same line, such as `MY
 | `acctest-lint`<sup>M</sup> | Run all CI acceptance test checks | ✔️ |  | `K`, `PKG`, `SVC_DIR` |
 | `build`<sup>D</sup> | Build the provider |  |  | `GO_VER` |
 | `cache-info` | Display Go cache and GitHub Actions cache information |  |  |  |
-| `changelog-convert` | Convert `go-changelog` fragment to Changie format |  |  | `FILE` |
 | `changelog-misspell` | CHANGELOG Misspell / misspell | ✔️ |  |  |
 | `ci`<sup>M</sup> | Run all CI checks (requires docker) | ✔️ |  | `BASE_REF`, `GO_VER`, `K`, `PKG`, `SEMGREP_ARGS`, `SVC_DIR`, `TEST`, `TESTARGS` |
 | `ci-quick`<sup>M</sup> | Run quicker CI checks (no docker) | ✔️ |  | `BASE_REF`, `GO_VER`, `K`, `PKG`, `SEMGREP_ARGS`, `SVC_DIR`, `TEST`, `TESTARGS` |

--- a/docs/makefile-cheat-sheet.md
+++ b/docs/makefile-cheat-sheet.md
@@ -105,8 +105,8 @@ Variables are often defined before the `make` call on the same line, such as `MY
 | `clean-go`<sup>D</sup> | Clean up Go cache |  |  | `GO_VER` |
 | `clean-go-cache-trim` | Trim Go build cache to manageable size |  |  |  |
 | `clean-make-tests` | Clean up artifacts from make tests |  |  |  |
-| `convert-changelog` | Convert `go-changelog` fragment to Changie format |  |  | `FILE` |
 | `clean-tidy`<sup>D</sup> | Clean up tidy |  |  | `GO_VER` |
+| `convert-changelog` | Convert `go-changelog` fragment to Changie format |  |  | `FILE` |
 | `copyright` | Copyright Checks / headers check | ✔️ |  |  |
 | `copyright-fix` | Fix copyright headers |  |  |  |
 | _default_ | = `build` |  |  | `GO_VER` |

--- a/docs/makefile-cheat-sheet.md
+++ b/docs/makefile-cheat-sheet.md
@@ -98,6 +98,7 @@ Variables are often defined before the `make` call on the same line, such as `MY
 | `acctest-lint`<sup>M</sup> | Run all CI acceptance test checks | ✔️ |  | `K`, `PKG`, `SVC_DIR` |
 | `build`<sup>D</sup> | Build the provider |  |  | `GO_VER` |
 | `cache-info` | Display Go cache and GitHub Actions cache information |  |  |  |
+| `changelog-convert` | Convert `go-changelog` fragment to Changie format |  |  | `FILE` |
 | `changelog-misspell` | CHANGELOG Misspell / misspell | ✔️ |  |  |
 | `ci`<sup>M</sup> | Run all CI checks (requires docker) | ✔️ |  | `BASE_REF`, `GO_VER`, `K`, `PKG`, `SEMGREP_ARGS`, `SVC_DIR`, `TEST`, `TESTARGS` |
 | `ci-quick`<sup>M</sup> | Run quicker CI checks (no docker) | ✔️ |  | `BASE_REF`, `GO_VER`, `K`, `PKG`, `SEMGREP_ARGS`, `SVC_DIR`, `TEST`, `TESTARGS` |


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

- Adds a script to convert `go-changelog` fragments to Changie fragments
- Adds a GNUmakefile target and related documentation to call the script

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #46618