### PR TITLE
changelog: repair 6.58.0 links and stop README from being parsed as an entry

### DIFF
--- a/.changelog/README.md
+++ b/.changelog/README.md
@@ -12,6 +12,15 @@ pull request**, named for the PR number: `.changelog/<PR_NUMBER>.txt`.
 > [`docs/design-decisions/changie-migration.md`](../docs/design-decisions/changie-migration.md).
 > Keep new entries in this format until that migration lands.
 
+> [!IMPORTANT]
+> The example blocks in this file are **indented** on purpose. `go-changelog`
+> treats every file in this directory as a changelog entry and extracts any
+> fenced block that begins with ` ```release-note ` at the **start of a line**.
+> Indenting the examples keeps this README from being parsed as an entry (which
+> would otherwise emit bogus `#README.md` links into `CHANGELOG.md`). In a real
+> `.changelog/<PR_NUMBER>.txt` file, the fence must start at column 0 with no
+> leading whitespace.
+
 ## When is an entry required?
 
 Only for **user-facing** changes:
@@ -34,11 +43,12 @@ refactors, or dependency bumps that have no user-facing effect.
 
 ## Format
 
-Each entry is one or more fenced blocks tagged with a type:
+Each entry is one or more fenced blocks tagged with a type (shown indented here;
+in a real entry file the fence starts at column 0):
 
-```release-note:TYPE
-<component>: <description>
-```
+    ```release-note:TYPE
+    <component>: <description>
+    ```
 
 `<component>` is the resource/data source/etc. name (for example
 `resource/aws_s3_bucket`, `data-source/aws_s3_bucket`) or `provider` for
@@ -52,54 +62,54 @@ prefix, no verb).
 
 ### FEATURES
 
-```release-note:new-resource
-aws_bedrockagentcore_api_key_credential_provider
-```
+    ```release-note:new-resource
+    aws_bedrockagentcore_api_key_credential_provider
+    ```
 
-```release-note:new-data-source
-aws_s3control_access_points
-```
+    ```release-note:new-data-source
+    aws_s3control_access_points
+    ```
 
-```release-note:new-ephemeral
-aws_sts_web_identity_token
-```
+    ```release-note:new-ephemeral
+    aws_sts_web_identity_token
+    ```
 
-```release-note:new-list-resource
-aws_db_subnet_group
-```
+    ```release-note:new-list-resource
+    aws_db_subnet_group
+    ```
 
-```release-note:new-function
-arn_parse
-```
+    ```release-note:new-function
+    arn_parse
+    ```
 
-```release-note:new-action
-aws_sfn_start_execution
-```
+    ```release-note:new-action
+    aws_sfn_start_execution
+    ```
 
-```release-note:new-guide
-Tag Policy Compliance
-```
+    ```release-note:new-guide
+    Tag Policy Compliance
+    ```
 
 ### ENHANCEMENTS
 
-```release-note:enhancement
-resource/aws_ssm_resource_data_sync: Add `s3_destination.destination_data_sharing` argument
-```
+    ```release-note:enhancement
+    resource/aws_ssm_resource_data_sync: Add `s3_destination.destination_data_sharing` argument
+    ```
 
 ### BUG FIXES
 
-```release-note:bug
-resource/aws_glue_catalog_table: Fix `Invalid address to set` errors when reading `partition_keys.parameters`
-```
+    ```release-note:bug
+    resource/aws_glue_catalog_table: Fix `Invalid address to set` errors when reading `partition_keys.parameters`
+    ```
 
 ### NOTES
 
-```release-note:note
-resource/aws_dms_s3_endpoint: The `kms_key_arn` attribute has been deprecated. Use `server_side_encryption_kms_key_id` instead
-```
+    ```release-note:note
+    resource/aws_dms_s3_endpoint: The `kms_key_arn` attribute has been deprecated. Use `server_side_encryption_kms_key_id` instead
+    ```
 
 ### BREAKING CHANGES
 
-```release-note:breaking-change
-resource/aws_db_instance: `character_set_name` can no longer be set with `replicate_source_db`, `restore_to_point_in_time`, `s3_import`, or `snapshot_identifier`
-```
+    ```release-note:breaking-change
+    resource/aws_db_instance: `character_set_name` can no longer be set with `replicate_source_db`, `restore_to_point_in_time`, `s3_import`, or `snapshot_identifier`
+    ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,35 +1,18 @@
 ## 6.58.0 (Unreleased)
 
-BREAKING CHANGES:
-
-* resource/aws_db_instance: `character_set_name` can no longer be set with `replicate_source_db`, `restore_to_point_in_time`, `s3_import`, or `snapshot_identifier` ([#README.md](https://github.com/hashicorp/terraform-provider-aws/issues/README.md))
-
-NOTES:
-
-* resource/aws_dms_s3_endpoint: The `kms_key_arn` attribute has been deprecated. Use `server_side_encryption_kms_key_id` instead ([#README.md](https://github.com/hashicorp/terraform-provider-aws/issues/README.md))
-
 FEATURES:
 
-* **New Action:** `aws_sfn_start_execution` ([#README.md](https://github.com/hashicorp/terraform-provider-aws/issues/README.md))
-* **New Data Source:** `aws_s3control_access_points` ([#README.md](https://github.com/hashicorp/terraform-provider-aws/issues/README.md))
-* **New Ephemeral Resource:** `aws_sts_web_identity_token` ([#README.md](https://github.com/hashicorp/terraform-provider-aws/issues/README.md))
-* **New Function:** `arn_parse` ([#README.md](https://github.com/hashicorp/terraform-provider-aws/issues/README.md))
-* **New Guide:** `Tag Policy Compliance` ([#README.md](https://github.com/hashicorp/terraform-provider-aws/issues/README.md))
-* **New List Resource:** `aws_db_subnet_group` ([#README.md](https://github.com/hashicorp/terraform-provider-aws/issues/README.md))
 * **New List Resource:** `aws_prometheus_anomaly_detector` ([#49139](https://github.com/hashicorp/terraform-provider-aws/issues/49139))
-* **New Resource:** `aws_bedrockagentcore_api_key_credential_provider` ([#README.md](https://github.com/hashicorp/terraform-provider-aws/issues/README.md))
 * **New Resource:** `aws_prometheus_anomaly_detector` ([#49139](https://github.com/hashicorp/terraform-provider-aws/issues/49139))
 
 ENHANCEMENTS:
 
 * resource/aws_dx_connection: Add `state` attribute ([#42150](https://github.com/hashicorp/terraform-provider-aws/issues/42150))
-* resource/aws_ssm_resource_data_sync: Add `s3_destination.destination_data_sharing` argument ([#README.md](https://github.com/hashicorp/terraform-provider-aws/issues/README.md))
 
 BUG FIXES:
 
 * resource/aws_bedrockagentcore_memory_strategy: Fix `Value Conversion Error ... Received null value, however the target type cannot handle null values` errors ([#49188](https://github.com/hashicorp/terraform-provider-aws/issues/49188))
 * resource/aws_bedrockagentcore_memory_strategy: Replace resource rather than erroring when `configuration.consolidation`, `configuration.extraction`, or `configuration.reflection` blocks are removed ([#49188](https://github.com/hashicorp/terraform-provider-aws/issues/49188))
-* resource/aws_glue_catalog_table: Fix `Invalid address to set` errors when reading `partition_keys.parameters` ([#README.md](https://github.com/hashicorp/terraform-provider-aws/issues/README.md))
 * resource/aws_glue_catalog_table: Fix `InvalidInputException: StorageDescriptor is not allowed` error when creating or updating ATHENA-dialect views ([#49156](https://github.com/hashicorp/terraform-provider-aws/issues/49156))
 * resource/aws_glue_catalog_table: Fix `InvalidInputException` error when creating or updating SPARK-dialect views without an explicit `storage_descriptor` block ([#49156](https://github.com/hashicorp/terraform-provider-aws/issues/49156))
 * resource/aws_glue_catalog_table: Fix perpetual diff on `view_definition.representations` fields (`validation_connection`, `view_original_text`, `view_expanded_text`) that AWS Glue does not echo back for validated ATHENA views ([#49156](https://github.com/hashicorp/terraform-provider-aws/issues/49156))


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

The 6.58.0 section rendered #README.md links because go-changelog parses
every new file in .changelog/, deriving the issue link from the filename
(only .txt is stripped) and extracting any column-0 release-note fence.
.changelog/README.md was added after v6.57.1, so its example blocks were
emitted as bogus #README.md entries.

Indent the README example blocks so ^```release-note no longer matches,
and restore the 6.58.0 section to the entries actually backed by PRs.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
