### PR TITLE
Changie: Add `sort-changelog-entries` script

### DIFF
--- a/.ci/scripts/sort-changelog-entries.sh
+++ b/.ci/scripts/sort-changelog-entries.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+#
+# Sort changelog entries alphabetically within each kind section.
+#
+# Usage:
+#     ./sort-changelog-entries.sh <changelog-file>
+#
+# Example:
+#     ./sort-changelog-entries.sh .changes/6.x/6.26.0.md
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+    echo "Usage: $0 <changelog-file>" >&2
+    exit 1
+fi
+
+CHANGELOG_FILE="$1"
+
+if [[ ! -f "$CHANGELOG_FILE" ]]; then
+    echo "Error: File not found: $CHANGELOG_FILE" >&2
+    exit 1
+fi
+
+# Create temporary files
+TEMP_FILE=$(mktemp)
+TEMP_ENTRIES=$(mktemp)
+trap "rm -f $TEMP_FILE $TEMP_ENTRIES" EXIT
+
+# Process the file line by line
+IN_SECTION=false
+
+while IFS= read -r line; do
+    # Check if this is a section header (all caps ending with colon)
+    if [[ "$line" =~ ^[A-Z][A-Z\ ]+:$ ]]; then
+        # If we have accumulated entries, sort and output them
+        if [[ -s "$TEMP_ENTRIES" ]]; then
+            sort -f "$TEMP_ENTRIES" >> "$TEMP_FILE"
+            > "$TEMP_ENTRIES"  # Clear the temp file
+        fi
+
+        # Output the header
+        echo "$line" >> "$TEMP_FILE"
+        IN_SECTION=true
+
+    # Check if this is an entry line (starts with "* ")
+    elif [[ "$line" =~ ^\*\  ]] && [[ "$IN_SECTION" == true ]]; then
+        # Accumulate entry for sorting
+        echo "$line" >> "$TEMP_ENTRIES"
+
+    # Any other line
+    else
+        # If we have accumulated entries, sort and output them
+        if [[ -s "$TEMP_ENTRIES" ]]; then
+            sort -f "$TEMP_ENTRIES" >> "$TEMP_FILE"
+            > "$TEMP_ENTRIES"  # Clear the temp file
+            IN_SECTION=false
+        fi
+
+        # Output the line as-is
+        echo "$line" >> "$TEMP_FILE"
+    fi
+done < "$CHANGELOG_FILE"
+
+# Handle any remaining entries at end of file
+if [[ -s "$TEMP_ENTRIES" ]]; then
+    sort -f "$TEMP_ENTRIES" >> "$TEMP_FILE"
+fi
+
+# Replace original file with sorted version
+mv "$TEMP_FILE" "$CHANGELOG_FILE"
+
+echo "✓ Sorted entries in $CHANGELOG_FILE"

--- a/.ci/scripts/sort-changelog-entries.sh
+++ b/.ci/scripts/sort-changelog-entries.sh
@@ -28,7 +28,7 @@ fi
 # Create temporary files
 TEMP_FILE=$(mktemp)
 TEMP_ENTRIES=$(mktemp)
-trap "rm -f $TEMP_FILE $TEMP_ENTRIES" EXIT
+trap 'rm -f $TEMP_FILE $TEMP_ENTRIES' EXIT
 
 # Process the file line by line
 IN_SECTION=false
@@ -39,7 +39,7 @@ while IFS= read -r line; do
         # If we have accumulated entries, sort and output them
         if [[ -s "$TEMP_ENTRIES" ]]; then
             sort -f "$TEMP_ENTRIES" >> "$TEMP_FILE"
-            > "$TEMP_ENTRIES"  # Clear the temp file
+            truncate -s 0 "$TEMP_ENTRIES"  # Clear the temp file
         fi
 
         # Output the header
@@ -56,7 +56,7 @@ while IFS= read -r line; do
         # If we have accumulated entries, sort and output them
         if [[ -s "$TEMP_ENTRIES" ]]; then
             sort -f "$TEMP_ENTRIES" >> "$TEMP_FILE"
-            > "$TEMP_ENTRIES"  # Clear the temp file
+            truncate -s 0 "$TEMP_ENTRIES"  # Clear the temp file
             IN_SECTION=false
         fi
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Adds a script that helps sort CHANGELOG entries after Changie generates the CHANGELOG. Sorts within each section (FEATURES, ENHANCEMENTS, etc.) so that multiple entries affecting a given resource are grouped together. Changie does not currently offer this functionality built in.

### Relations

Relates #46618