### PR TITLE
d/aws_bedrock_foundation_model: Add model_lifecycle attribute

### DIFF
--- a/.changelog/49215.txt
+++ b/.changelog/49215.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+data-source/aws_bedrock_foundation_model: Add `model_lifecycle` attribute
+```
+
+```release-note:enhancement
+data-source/aws_bedrock_foundation_models: Add `model_summaries.*.model_lifecycle` attribute
+```

--- a/internal/service/bedrock/foundation_model_data_source.go
+++ b/internal/service/bedrock/foundation_model_data_source.go
@@ -10,6 +10,8 @@ import (
 	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/service/bedrock"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/bedrock/types"
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -53,6 +55,10 @@ func (d *foundationModelDataSource) Schema(ctx context.Context, request datasour
 			},
 			"model_id": schema.StringAttribute{
 				Required: true,
+			},
+			"model_lifecycle": schema.ObjectAttribute{
+				CustomType: fwtypes.NewObjectTypeOf[foundationModelLifecycleModel](ctx),
+				Computed:   true,
 			},
 			"model_name": schema.StringAttribute{
 				Computed: true,
@@ -105,14 +111,25 @@ func (d *foundationModelDataSource) Read(ctx context.Context, request datasource
 
 type foundationModelDataSourceModel struct {
 	framework.WithRegionModel
-	CustomizationsSupported    fwtypes.SetOfString `tfsdk:"customizations_supported"`
-	ID                         types.String        `tfsdk:"id"`
-	InferenceTypesSupported    fwtypes.SetOfString `tfsdk:"inference_types_supported"`
-	InputModalities            fwtypes.SetOfString `tfsdk:"input_modalities"`
-	ModelARN                   fwtypes.ARN         `tfsdk:"model_arn"`
-	ModelID                    types.String        `tfsdk:"model_id"`
-	ModelName                  types.String        `tfsdk:"model_name"`
-	OutputModalities           fwtypes.SetOfString `tfsdk:"output_modalities"`
-	ProviderName               types.String        `tfsdk:"provider_name"`
-	ResponseStreamingSupported types.Bool          `tfsdk:"response_streaming_supported"`
+	CustomizationsSupported    fwtypes.SetOfString                                  `tfsdk:"customizations_supported"`
+	ID                         types.String                                         `tfsdk:"id"`
+	InferenceTypesSupported    fwtypes.SetOfString                                  `tfsdk:"inference_types_supported"`
+	InputModalities            fwtypes.SetOfString                                  `tfsdk:"input_modalities"`
+	ModelARN                   fwtypes.ARN                                          `tfsdk:"model_arn"`
+	ModelID                    types.String                                         `tfsdk:"model_id"`
+	ModelLifecycle             fwtypes.ObjectValueOf[foundationModelLifecycleModel] `tfsdk:"model_lifecycle"`
+	ModelName                  types.String                                         `tfsdk:"model_name"`
+	OutputModalities           fwtypes.SetOfString                                  `tfsdk:"output_modalities"`
+	ProviderName               types.String                                         `tfsdk:"provider_name"`
+	ResponseStreamingSupported types.Bool                                           `tfsdk:"response_streaming_supported"`
+}
+
+// foundationModelLifecycleModel maps AWS SDK FoundationModelLifecycle, shared by
+// both the singular and plural (aws_bedrock_foundation_models) data sources.
+type foundationModelLifecycleModel struct {
+	EndOfLifeTime            timetypes.RFC3339                                           `tfsdk:"end_of_life_time"`
+	LegacyTime               timetypes.RFC3339                                           `tfsdk:"legacy_time"`
+	PublicExtendedAccessTime timetypes.RFC3339                                           `tfsdk:"public_extended_access_time"`
+	StartOfLifeTime          timetypes.RFC3339                                           `tfsdk:"start_of_life_time"`
+	Status                   fwtypes.StringEnum[awstypes.FoundationModelLifecycleStatus] `tfsdk:"status"`
 }

--- a/internal/service/bedrock/foundation_model_data_source_test.go
+++ b/internal/service/bedrock/foundation_model_data_source_test.go
@@ -28,6 +28,7 @@ func TestAccBedrockFoundationModelDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(datasourceName, "inference_types_supported.#"),
 					resource.TestCheckResourceAttrSet(datasourceName, "input_modalities.#"),
 					resource.TestCheckResourceAttrSet(datasourceName, "model_arn"),
+					resource.TestCheckResourceAttrSet(datasourceName, "model_lifecycle.status"),
 					resource.TestCheckResourceAttrSet(datasourceName, "model_name"),
 					resource.TestCheckResourceAttrSet(datasourceName, "output_modalities.#"),
 					resource.TestCheckResourceAttrSet(datasourceName, names.AttrProviderName),

--- a/internal/service/bedrock/foundation_models_data_source.go
+++ b/internal/service/bedrock/foundation_models_data_source.go
@@ -102,13 +102,14 @@ type foundationModelsDataSourceModel struct {
 }
 
 type foundationModelSummaryModel struct {
-	CustomizationsSupported    fwtypes.SetOfString `tfsdk:"customizations_supported"`
-	InferenceTypesSupported    fwtypes.SetOfString `tfsdk:"inference_types_supported"`
-	InputModalities            fwtypes.SetOfString `tfsdk:"input_modalities"`
-	ModelARN                   fwtypes.ARN         `tfsdk:"model_arn"`
-	ModelID                    types.String        `tfsdk:"model_id"`
-	ModelName                  types.String        `tfsdk:"model_name"`
-	OutputModalities           fwtypes.SetOfString `tfsdk:"output_modalities"`
-	ProviderName               types.String        `tfsdk:"provider_name"`
-	ResponseStreamingSupported types.Bool          `tfsdk:"response_streaming_supported"`
+	CustomizationsSupported    fwtypes.SetOfString                                  `tfsdk:"customizations_supported"`
+	InferenceTypesSupported    fwtypes.SetOfString                                  `tfsdk:"inference_types_supported"`
+	InputModalities            fwtypes.SetOfString                                  `tfsdk:"input_modalities"`
+	ModelARN                   fwtypes.ARN                                          `tfsdk:"model_arn"`
+	ModelID                    types.String                                         `tfsdk:"model_id"`
+	ModelLifecycle             fwtypes.ObjectValueOf[foundationModelLifecycleModel] `tfsdk:"model_lifecycle"`
+	ModelName                  types.String                                         `tfsdk:"model_name"`
+	OutputModalities           fwtypes.SetOfString                                  `tfsdk:"output_modalities"`
+	ProviderName               types.String                                         `tfsdk:"provider_name"`
+	ResponseStreamingSupported types.Bool                                           `tfsdk:"response_streaming_supported"`
 }

--- a/website/docs/d/bedrock_foundation_model.html.markdown
+++ b/website/docs/d/bedrock_foundation_model.html.markdown
@@ -37,7 +37,16 @@ This data source exports the following attributes in addition to the arguments a
 * `inference_types_supported` - Inference types that the model supports.
 * `input_modalities` - Input modalities that the model supports.
 * `model_arn` - Model ARN.
+* `model_lifecycle` - Model lifecycle status. See [`model_lifecycle`](#model_lifecycle).
 * `model_name` - Model name.
 * `output_modalities` - Output modalities that the model supports.
 * `provider_name` - Model provider name.
 * `response_streaming_supported` - Indicates whether the model supports streaming.
+
+### `model_lifecycle`
+
+* `status` - Whether the model version is available (`ACTIVE`) or deprecated (`LEGACY`).
+* `end_of_life_time` - Time when the model is no longer available for use.
+* `legacy_time` - Time when the model enters legacy state. Models in legacy state can still be used, but users should plan to transition to an active model before the end-of-life time.
+* `public_extended_access_time` - Extended access portion of the legacy period, when users should expect higher pricing.
+* `start_of_life_time` - Launch time when the model first becomes available.

--- a/website/docs/d/bedrock_foundation_models.html.markdown
+++ b/website/docs/d/bedrock_foundation_models.html.markdown
@@ -50,7 +50,16 @@ This data source exports the following attributes in addition to the arguments a
 * `input_modalities` - Input modalities that the model supports.
 * `model_arn` - Model ARN.
 * `model_id` - Model identifier.
+* `model_lifecycle` - Model lifecycle status. See [`model_lifecycle`](#model_lifecycle).
 * `model_name` - Model name.
 * `output_modalities` - Output modalities that the model supports.
 * `provider_name` - Model provider name.
 * `response_streaming_supported` - Indicates whether the model supports streaming.
+
+### `model_lifecycle`
+
+* `status` - Whether the model version is available (`ACTIVE`) or deprecated (`LEGACY`).
+* `end_of_life_time` - Time when the model is no longer available for use.
+* `legacy_time` - Time when the model enters legacy state. Models in legacy state can still be used, but users should plan to transition to an active model before the end-of-life time.
+* `public_extended_access_time` - Extended access portion of the legacy period, when users should expect higher pricing.
+* `start_of_life_time` - Launch time when the model first becomes available.


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

None. This adds a new read-only `Computed` attribute to two existing data sources; no changes to authentication, encryption, or logging.

### Description

`aws_bedrock_foundation_model` and `aws_bedrock_foundation_models` don't expose the `modelLifecycle` field that the Bedrock API already returns for every foundation model (whether it's `ACTIVE` or `LEGACY`, plus the associated timestamps). This makes it impossible to filter foundation models by lifecycle status in Terraform without hardcoding model IDs.

The AWS SDK for Go v2 already carries this data — `FoundationModelDetails` and `FoundationModelSummary` both have a `ModelLifecycle *FoundationModelLifecycle` field. This PR just maps it into the schema:

- Adds a `model_lifecycle` nested attribute (`status`, `end_of_life_time`, `legacy_time`, `public_extended_access_time`, `start_of_life_time`) to `aws_bedrock_foundation_model`.
- Adds the same attribute to each entry of `model_summaries` in `aws_bedrock_foundation_models`.
- Updates both data source docs.
- Adds a `model_lifecycle.status` check to the existing `TestAccBedrockFoundationModelDataSource_basic` acceptance test.

### Relations

Closes #47779

### References

- https://docs.aws.amazon.com/bedrock/latest/APIReference/API_FoundationModelLifecycle.html

### Output from Acceptance Testing

I don't have AWS credentials with Bedrock access, so I wasn't able to run `make testacc` against live AWS myself. Locally verified:

```console
$ go build ./internal/service/bedrock/...
$ go vet ./internal/service/bedrock/...
$ go test -run '^$' ./internal/service/bedrock/...
ok    github.com/hashicorp/terraform-provider-aws/internal/service/bedrock    6.9s [no tests to run]

Build, vet, and test compilation all pass. The added assertion in TestAccBedrockFoundationModelDataSource_basic should run as part of normal CI/maintainer review.