### PR TITLE
autoflex: Expand to `map[string][]string`

### DIFF
--- a/internal/framework/flex/autoflex_expand.go
+++ b/internal/framework/flex/autoflex_expand.go
@@ -968,6 +968,34 @@ func expandMap(ctx context.Context, expander *autoExpander, vFrom basetypes.MapV
 		diags.Append(expandMapOfString(ctx, expander, v, vTo)...)
 		return diags
 
+	case basetypes.ListTypable:
+		data, d := v.ToMapValue(ctx)
+		diags.Append(d...)
+		if diags.HasError() {
+			return diags
+		}
+		switch tMapElem := vTo.Type().Elem(); tMapElem.Kind() {
+		case reflect.Slice:
+			//
+			// types.Map(OfList[types.String]) -> map[string][]string.
+			//
+			switch k := tMapElem.Elem().Kind(); k {
+			case reflect.String:
+				tflog.SubsystemTrace(ctx, subsystemName, "Expanding with ElementsAs", map[string]any{
+					logAttrKeySourceSize: len(data.Elements()),
+				})
+				var out map[string][]string
+				diags.Append(data.ElementsAs(ctx, &out, false)...)
+
+				if diags.HasError() {
+					return diags
+				}
+
+				vTo.Set(reflect.ValueOf(out))
+				return diags
+			}
+		}
+
 	case basetypes.MapTypable:
 		data, d := v.ToMapValue(ctx)
 		diags.Append(d...)
@@ -977,7 +1005,7 @@ func expandMap(ctx context.Context, expander *autoExpander, vFrom basetypes.MapV
 		switch tMapElem := vTo.Type().Elem(); tMapElem.Kind() {
 		case reflect.Map:
 			//
-			// types.Map(OfMap) -> map[string]map[string]string.
+			// types.Map(OfMap[types.String]) -> map[string]map[string]string.
 			//
 			switch k := tMapElem.Elem().Kind(); k {
 			case reflect.String:
@@ -998,7 +1026,7 @@ func expandMap(ctx context.Context, expander *autoExpander, vFrom basetypes.MapV
 				switch k := tMapElem.Elem().Elem().Kind(); k {
 				case reflect.String:
 					//
-					// types.Map(OfMap) -> map[string]map[string]*string.
+					// types.Map(OfMap[types.String]) -> map[string]map[string]*string.
 					//
 					tflog.SubsystemTrace(ctx, subsystemName, "Expanding with ElementsAs", map[string]any{
 						logAttrKeySourceSize: len(data.Elements()),

--- a/internal/framework/flex/autoflex_maps_test.go
+++ b/internal/framework/flex/autoflex_maps_test.go
@@ -64,6 +64,14 @@ type awsMapOfStringPointer struct {
 	FieldInner map[string]*string
 }
 
+type tfMapOfListOfString struct {
+	Field1 fwtypes.MapValueOf[fwtypes.ListValueOf[types.String]] `tfsdk:"field1"`
+}
+
+type awsMapOfListOfString struct {
+	Field1 map[string][]string
+}
+
 type awsMapOfInt struct {
 	Field1 map[string]int
 }
@@ -159,6 +167,22 @@ func TestExpandMaps(t *testing.T) {
 			WantTarget: &awsMapOfStringPointer{
 				FieldInner: map[string]*string{
 					"x": aws.String("y"),
+				},
+			},
+		},
+		"map of list of string": {
+			Source: &tfMapOfListOfString{
+				Field1: fwtypes.NewMapValueOfMust[fwtypes.ListValueOf[types.String]](ctx, map[string]attr.Value{
+					"x": fwtypes.NewListValueOfMust[types.String](ctx, []attr.Value{
+						types.StringValue("y"),
+						types.StringValue("z"),
+					}),
+				}),
+			},
+			Target: &awsMapOfListOfString{},
+			WantTarget: &awsMapOfListOfString{
+				Field1: map[string][]string{
+					"x": {"y", "z"},
 				},
 			},
 		},

--- a/internal/framework/flex/map.go
+++ b/internal/framework/flex/map.go
@@ -28,6 +28,14 @@ func ExpandFrameworkStringValueMap(ctx context.Context, v basetypes.MapValuable)
 	return output
 }
 
+func ExpandFrameworkStringValueListMap(ctx context.Context, v basetypes.MapValuable) map[string][]string {
+	var output map[string][]string
+
+	must(Expand(ctx, v, &output))
+
+	return output
+}
+
 // FlattenFrameworkStringValueMap converts a map of strings to a framework Map value.
 //
 // A nil map is converted to a null Map.

--- a/internal/framework/flex/map_test.go
+++ b/internal/framework/flex/map_test.go
@@ -4,14 +4,15 @@
 package flex_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
 )
 
 func TestExpandFrameworkStringMap(t *testing.T) {
@@ -66,7 +67,7 @@ func TestExpandFrameworkStringMap(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			got := flex.ExpandFrameworkStringMap(context.Background(), test.input)
+			got := flex.ExpandFrameworkStringMap(t.Context(), test.input)
 
 			if diff := cmp.Diff(got, test.expected); diff != "" {
 				t.Errorf("unexpected diff (+wanted, -got): %s", diff)
@@ -117,7 +118,75 @@ func TestExpandFrameworkStringValueMap(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			got := flex.ExpandFrameworkStringValueMap(context.Background(), test.input)
+			got := flex.ExpandFrameworkStringValueMap(t.Context(), test.input)
+
+			if diff := cmp.Diff(got, test.expected); diff != "" {
+				t.Errorf("unexpected diff (+wanted, -got): %s", diff)
+			}
+		})
+	}
+}
+
+func TestExpandFrameworkStringValueListMap(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	type testCase struct {
+		input    basetypes.MapValuable
+		expected map[string][]string
+	}
+	tests := map[string]testCase{
+		"null": {
+			input:    types.MapNull(types.ListType{ElemType: types.StringType}),
+			expected: nil,
+		},
+		"unknown": {
+			input:    types.MapUnknown(types.ListType{ElemType: types.StringType}),
+			expected: nil,
+		},
+		"two elements": {
+			input: types.MapValueMust(types.ListType{ElemType: types.StringType}, map[string]attr.Value{
+				"one": types.ListValueMust(types.StringType, []attr.Value{
+					types.StringValue("HEAD"),
+				}),
+				"two": types.ListValueMust(types.StringType, []attr.Value{
+					types.StringValue("GET"),
+					types.StringValue("PUT"),
+				}),
+			}),
+			expected: map[string][]string{
+				"one": {"HEAD"},
+				"two": {"GET", "PUT"},
+			},
+		},
+		"zero elements": {
+			input:    types.MapValueMust(types.ListType{ElemType: types.StringType}, map[string]attr.Value{}),
+			expected: map[string][]string{},
+		},
+		"two elements MapOfListOfString": {
+			input: fwtypes.NewMapValueOfMust[fwtypes.ListOfString](ctx, map[string]attr.Value{
+				"one": flex.FlattenFrameworkStringValueListOfString(ctx, []string{"HEAD"}),
+				"two": flex.FlattenFrameworkStringValueListOfString(ctx, []string{"GET", "PUT"}),
+			}),
+			expected: map[string][]string{
+				"one": {"HEAD"},
+				"two": {"GET", "PUT"},
+			},
+		},
+		"invalid element type": {
+			input: types.MapValueMust(types.BoolType, map[string]attr.Value{
+				"one": types.BoolValue(true),
+			}),
+			expected: nil,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := flex.ExpandFrameworkStringValueListMap(ctx, test.input)
 
 			if diff := cmp.Diff(got, test.expected); diff != "" {
 				t.Errorf("unexpected diff (+wanted, -got): %s", diff)
@@ -158,7 +227,7 @@ func TestFlattenFrameworkStringValueMap(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			got := flex.FlattenFrameworkStringValueMap(context.Background(), test.input)
+			got := flex.FlattenFrameworkStringValueMap(t.Context(), test.input)
 
 			if diff := cmp.Diff(got, test.expected); diff != "" {
 				t.Errorf("unexpected diff (+wanted, -got): %s", diff)
@@ -199,7 +268,7 @@ func TestFlattenFrameworkStringValueMapLegacy(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			got := flex.FlattenFrameworkStringValueMapLegacy(context.Background(), test.input)
+			got := flex.FlattenFrameworkStringValueMapLegacy(t.Context(), test.input)
 
 			if diff := cmp.Diff(got, test.expected); diff != "" {
 				t.Errorf("unexpected diff (+wanted, -got): %s", diff)

--- a/internal/framework/flex/testdata/autoflex/maps/expand_maps/map_of_list_of_string.golden
+++ b/internal/framework/flex/testdata/autoflex/maps/expand_maps/map_of_list_of_string.golden
@@ -1,0 +1,48 @@
+[
+  {
+    "@level": "info",
+    "@message": "Expanding",
+    "@module": "provider.autoflex",
+    "autoflex.source.type": "*github.com/hashicorp/terraform-provider-aws/internal/framework/flex.tfMapOfListOfString",
+    "autoflex.target.type": "*github.com/hashicorp/terraform-provider-aws/internal/framework/flex.awsMapOfListOfString"
+  },
+  {
+    "@level": "info",
+    "@message": "Converting",
+    "@module": "provider.autoflex",
+    "autoflex.source.path": "",
+    "autoflex.source.type": "github.com/hashicorp/terraform-provider-aws/internal/framework/flex.tfMapOfListOfString",
+    "autoflex.target.path": "",
+    "autoflex.target.type": "*github.com/hashicorp/terraform-provider-aws/internal/framework/flex.awsMapOfListOfString"
+  },
+  {
+    "@level": "trace",
+    "@message": "Matched fields",
+    "@module": "provider.autoflex",
+    "autoflex.source.fieldname": "Field1",
+    "autoflex.source.path": "",
+    "autoflex.source.type": "github.com/hashicorp/terraform-provider-aws/internal/framework/flex.tfMapOfListOfString",
+    "autoflex.target.fieldname": "Field1",
+    "autoflex.target.path": "",
+    "autoflex.target.type": "*github.com/hashicorp/terraform-provider-aws/internal/framework/flex.awsMapOfListOfString"
+  },
+  {
+    "@level": "info",
+    "@message": "Converting",
+    "@module": "provider.autoflex",
+    "autoflex.source.path": "Field1",
+    "autoflex.source.type": "github.com/hashicorp/terraform-provider-aws/internal/framework/types.MapValueOf[github.com/hashicorp/terraform-provider-aws/internal/framework/types.ListValueOf[github.com/hashicorp/terraform-plugin-framework/types/basetypes.StringValue]]",
+    "autoflex.target.path": "Field1",
+    "autoflex.target.type": "map[string][]string"
+  },
+  {
+    "@level": "trace",
+    "@message": "Expanding with ElementsAs",
+    "@module": "provider.autoflex",
+    "autoflex.source.path": "Field1",
+    "autoflex.source.size": 1,
+    "autoflex.source.type": "github.com/hashicorp/terraform-provider-aws/internal/framework/types.MapValueOf[github.com/hashicorp/terraform-provider-aws/internal/framework/types.ListValueOf[github.com/hashicorp/terraform-plugin-framework/types/basetypes.StringValue]]",
+    "autoflex.target.path": "Field1",
+    "autoflex.target.type": "map[string][]string"
+  }
+]

--- a/internal/framework/types/mapof.go
+++ b/internal/framework/types/mapof.go
@@ -22,7 +22,7 @@ var (
 
 var (
 	// MapOfListOfStringType is a custom type used for defining a map[string][]string.
-	MapOfListOfStringType = mapTypeOf[MapOfString]{basetypes.MapType{ElemType: ListOfStringType}}
+	MapOfListOfStringType = mapTypeOf[ListOfString]{basetypes.MapType{ElemType: ListOfStringType}}
 
 	// MapOfMapOfStringType is a custom type used for defining a map[string]map[string]string.
 	MapOfMapOfStringType = mapTypeOf[MapOfString]{basetypes.MapType{ElemType: MapOfStringType}}

--- a/internal/framework/types/mapof.go
+++ b/internal/framework/types/mapof.go
@@ -21,6 +21,9 @@ var (
 )
 
 var (
+	// MapOfListOfStringType is a custom type used for defining a map[string][]string.
+	MapOfListOfStringType = mapTypeOf[MapOfString]{basetypes.MapType{ElemType: ListOfStringType}}
+
 	// MapOfMapOfStringType is a custom type used for defining a map[string]map[string]string.
 	MapOfMapOfStringType = mapTypeOf[MapOfString]{basetypes.MapType{ElemType: MapOfStringType}}
 
@@ -104,8 +107,9 @@ type MapValueOf[T attr.Value] struct {
 }
 
 type (
-	MapOfMapOfString = MapValueOf[MapOfString]
-	MapOfString      = MapValueOf[basetypes.StringValue]
+	MapOfListOfString = MapValueOf[ListOfString]
+	MapOfMapOfString  = MapValueOf[MapOfString]
+	MapOfString       = MapValueOf[basetypes.StringValue]
 )
 
 func (v MapValueOf[T]) Equal(o attr.Value) bool {


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Adds AutoFlEx support for expanding to `map[string][]string`.
Conciously _not_ adding equivalent flattening support as the only use case I have is as an input filter type for a list API call.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% go test ./internal/framework/flex
ok      github.com/hashicorp/terraform-provider-aws/internal/framework/flex     1.127s
```
