### PR TITLE
r/aws_cognito_log_delivery_configuration: fix log_configurations order inconsistency

### DIFF
--- a/.changelog/49220.txt
+++ b/.changelog/49220.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cognito_log_delivery_configuration: Fix `Provider produced inconsistent result after apply` errors when `log_configurations` blocks are declared in a different order than the Cognito API returns them
+```

--- a/internal/service/cognitoidp/log_delivery_configuration.go
+++ b/internal/service/cognitoidp/log_delivery_configuration.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider/types"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -58,11 +59,11 @@ func (r *logDeliveryConfigurationResource) Schema(ctx context.Context, req resou
 			},
 		},
 		Blocks: map[string]schema.Block{
-			"log_configurations": schema.ListNestedBlock{
-				CustomType: fwtypes.NewListNestedObjectTypeOf[logConfigurationModel](ctx),
-				Validators: []validator.List{
-					listvalidator.SizeAtLeast(1),
-					listvalidator.IsRequired(),
+			"log_configurations": schema.SetNestedBlock{
+				CustomType: fwtypes.NewSetNestedObjectTypeOf[logConfigurationModel](ctx),
+				Validators: []validator.Set{
+					setvalidator.SizeAtLeast(1),
+					setvalidator.IsRequired(),
 				},
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
@@ -279,8 +280,8 @@ func findLogDeliveryConfigurationByUserPoolID(ctx context.Context, conn *cognito
 
 type resourceLogDeliveryConfigurationModel struct {
 	framework.WithRegionModel
-	UserPoolID        types.String                                           `tfsdk:"user_pool_id"`
-	LogConfigurations fwtypes.ListNestedObjectValueOf[logConfigurationModel] `tfsdk:"log_configurations"`
+	UserPoolID        types.String                                          `tfsdk:"user_pool_id"`
+	LogConfigurations fwtypes.SetNestedObjectValueOf[logConfigurationModel] `tfsdk:"log_configurations"`
 }
 
 type logConfigurationModel struct {

--- a/internal/service/cognitoidp/log_delivery_configuration_test.go
+++ b/internal/service/cognitoidp/log_delivery_configuration_test.go
@@ -40,8 +40,10 @@ func TestAccCognitoIDPLogDeliveryConfiguration_basic(t *testing.T) {
 					testAccCheckLogDeliveryConfigurationExists(ctx, t, resourceName, &logDeliveryConfiguration),
 					resource.TestCheckResourceAttrPair("aws_cognito_user_pool.test", names.AttrID, resourceName, names.AttrUserPoolID),
 					resource.TestCheckResourceAttr(resourceName, "log_configurations.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "log_configurations.0.event_source", "userNotification"),
-					resource.TestCheckResourceAttr(resourceName, "log_configurations.0.log_level", "ERROR"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "log_configurations.*", map[string]string{
+						"event_source": "userNotification",
+						"log_level":    "ERROR",
+					}),
 				),
 			},
 			{
@@ -74,8 +76,10 @@ func TestAccCognitoIDPLogDeliveryConfiguration_update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLogDeliveryConfigurationExists(ctx, t, resourceName, &logDeliveryConfiguration),
 					resource.TestCheckResourceAttr(resourceName, "log_configurations.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "log_configurations.0.event_source", "userNotification"),
-					resource.TestCheckResourceAttr(resourceName, "log_configurations.0.log_level", "ERROR"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "log_configurations.*", map[string]string{
+						"event_source": "userNotification",
+						"log_level":    "ERROR",
+					}),
 				),
 			},
 			{
@@ -83,10 +87,14 @@ func TestAccCognitoIDPLogDeliveryConfiguration_update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLogDeliveryConfigurationExists(ctx, t, resourceName, &logDeliveryConfiguration),
 					resource.TestCheckResourceAttr(resourceName, "log_configurations.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "log_configurations.0.event_source", "userNotification"),
-					resource.TestCheckResourceAttr(resourceName, "log_configurations.0.log_level", "INFO"),
-					resource.TestCheckResourceAttr(resourceName, "log_configurations.1.event_source", "userAuthEvents"),
-					resource.TestCheckResourceAttr(resourceName, "log_configurations.1.log_level", "ERROR"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "log_configurations.*", map[string]string{
+						"event_source": "userNotification",
+						"log_level":    "INFO",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "log_configurations.*", map[string]string{
+						"event_source": "userAuthEvents",
+						"log_level":    "ERROR",
+					}),
 				),
 			},
 			{
@@ -118,14 +126,18 @@ func TestAccCognitoIDPLogDeliveryConfiguration_logLevelUpdate(t *testing.T) {
 				Config: testAccLogDeliveryConfigurationConfig_logLevel(rName, "ERROR"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLogDeliveryConfigurationExists(ctx, t, resourceName, &logDeliveryConfiguration),
-					resource.TestCheckResourceAttr(resourceName, "log_configurations.0.log_level", "ERROR"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "log_configurations.*", map[string]string{
+						"log_level": "ERROR",
+					}),
 				),
 			},
 			{
 				Config: testAccLogDeliveryConfigurationConfig_logLevel(rName, "INFO"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLogDeliveryConfigurationExists(ctx, t, resourceName, &logDeliveryConfiguration),
-					resource.TestCheckResourceAttr(resourceName, "log_configurations.0.log_level", "INFO"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "log_configurations.*", map[string]string{
+						"log_level": "INFO",
+					}),
 				),
 			},
 		},
@@ -185,11 +197,15 @@ func TestAccCognitoIDPLogDeliveryConfiguration_firehose(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLogDeliveryConfigurationExists(ctx, t, resourceName, &logDeliveryConfiguration),
 					resource.TestCheckResourceAttr(resourceName, "log_configurations.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "log_configurations.0.event_source", "userNotification"),
-					resource.TestCheckResourceAttr(resourceName, "log_configurations.0.log_level", "INFO"),
-					resource.TestCheckResourceAttr(resourceName, "log_configurations.1.event_source", "userAuthEvents"),
-					resource.TestCheckResourceAttr(resourceName, "log_configurations.1.log_level", "ERROR"),
-					resource.TestCheckResourceAttrPair(resourceName, "log_configurations.1.firehose_configuration.0.stream_arn", "aws_kinesis_firehose_delivery_stream.test", names.AttrARN),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "log_configurations.*", map[string]string{
+						"event_source": "userNotification",
+						"log_level":    "INFO",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "log_configurations.*", map[string]string{
+						"event_source": "userAuthEvents",
+						"log_level":    "ERROR",
+					}),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "log_configurations.*.firehose_configuration.0.stream_arn", "aws_kinesis_firehose_delivery_stream.test", names.AttrARN),
 				),
 			},
 			{
@@ -198,6 +214,43 @@ func TestAccCognitoIDPLogDeliveryConfiguration_firehose(t *testing.T) {
 				ImportStateIdFunc:                    testAccLogDeliveryConfigurationImportStateIdFunc(resourceName),
 				ImportStateVerify:                    true,
 				ImportStateVerifyIdentifierAttribute: names.AttrUserPoolID,
+			},
+		},
+	})
+}
+
+// Verifies that declaring log_configurations blocks in a different order than
+// the Cognito API returns them does not cause a "Provider produced inconsistent
+// result after apply" error. Modeled as a set, block order is not significant,
+// so swapping the order must produce an empty plan.
+func TestAccCognitoIDPLogDeliveryConfiguration_orderSwap(t *testing.T) {
+	ctx := acctest.Context(t)
+	var logDeliveryConfiguration awstypes.LogDeliveryConfigurationType
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_cognito_log_delivery_configuration.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.CognitoIDPServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckLogDeliveryConfigurationDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLogDeliveryConfigurationConfig_order(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLogDeliveryConfigurationExists(ctx, t, resourceName, &logDeliveryConfiguration),
+					resource.TestCheckResourceAttr(resourceName, "log_configurations.#", "2"),
+				),
+			},
+			{
+				Config: testAccLogDeliveryConfigurationConfig_order(rName, true),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 		},
 	})
@@ -405,4 +458,44 @@ resource "aws_cognito_log_delivery_configuration" "test" {
   }
 }
 `, rName, logLevel)
+}
+
+func testAccLogDeliveryConfigurationConfig_order(rName string, swapped bool) string {
+	notification := `  log_configurations {
+    event_source = "userNotification"
+    log_level    = "INFO"
+
+    cloud_watch_logs_configuration {
+      log_group_arn = aws_cloudwatch_log_group.test.arn
+    }
+  }`
+	authEvents := `  log_configurations {
+    event_source = "userAuthEvents"
+    log_level    = "ERROR"
+
+    cloud_watch_logs_configuration {
+      log_group_arn = aws_cloudwatch_log_group.test.arn
+    }
+  }`
+
+	blocks := notification + "\n\n" + authEvents
+	if swapped {
+		blocks = authEvents + "\n\n" + notification
+	}
+
+	return fmt.Sprintf(`
+resource "aws_cognito_user_pool" "test" {
+  name = %[1]q
+}
+
+resource "aws_cloudwatch_log_group" "test" {
+  name = %[1]q
+}
+
+resource "aws_cognito_log_delivery_configuration" "test" {
+  user_pool_id = aws_cognito_user_pool.test.id
+
+%[2]s
+}
+`, rName, blocks)
 }

--- a/internal/service/cognitoidp/log_delivery_configuration_test.go
+++ b/internal/service/cognitoidp/log_delivery_configuration_test.go
@@ -93,7 +93,7 @@ func TestAccCognitoIDPLogDeliveryConfiguration_update(t *testing.T) {
 					}),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "log_configurations.*", map[string]string{
 						"event_source": "userAuthEvents",
-						"log_level":    "ERROR",
+						"log_level":    "INFO",
 					}),
 				),
 			},
@@ -203,7 +203,7 @@ func TestAccCognitoIDPLogDeliveryConfiguration_firehose(t *testing.T) {
 					}),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "log_configurations.*", map[string]string{
 						"event_source": "userAuthEvents",
-						"log_level":    "ERROR",
+						"log_level":    "INFO",
 					}),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "log_configurations.*.firehose_configuration.0.stream_arn", "aws_kinesis_firehose_delivery_stream.test", names.AttrARN),
 				),
@@ -414,6 +414,12 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
     role_arn   = aws_iam_role.firehose.arn
     bucket_arn = aws_s3_bucket.test.arn
   }
+
+  # Cognito adds a "LogDeliveryEnabled" tag to the stream when log delivery is
+  # configured against it; ignore that out-of-band tag to keep the plan empty.
+  lifecycle {
+    ignore_changes = [tags, tags_all]
+  }
 }
 
 resource "aws_cognito_log_delivery_configuration" "test" {
@@ -430,7 +436,7 @@ resource "aws_cognito_log_delivery_configuration" "test" {
 
   log_configurations {
     event_source = "userAuthEvents"
-    log_level    = "ERROR"
+    log_level    = "INFO"
 
     firehose_configuration {
       stream_arn = aws_kinesis_firehose_delivery_stream.test.arn
@@ -476,7 +482,7 @@ func testAccLogDeliveryConfigurationConfig_order(rName string, swapped bool) str
   }`
 	authEvents := `  log_configurations {
     event_source = "userAuthEvents"
-    log_level    = "ERROR"
+    log_level    = "INFO"
 
     cloud_watch_logs_configuration {
       log_group_arn = aws_cloudwatch_log_group.test.arn

--- a/internal/service/cognitoidp/log_delivery_configuration_test.go
+++ b/internal/service/cognitoidp/log_delivery_configuration_test.go
@@ -346,7 +346,12 @@ resource "aws_cognito_log_delivery_configuration" "test" {
 func testAccLogDeliveryConfigurationConfig_firehose(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_cognito_user_pool" "test" {
-  name = %[1]q
+  name           = %[1]q
+  user_pool_tier = "PLUS"
+
+  user_pool_add_ons {
+    advanced_security_mode = "AUDIT"
+  }
 }
 
 resource "aws_cloudwatch_log_group" "test" {
@@ -485,7 +490,12 @@ func testAccLogDeliveryConfigurationConfig_order(rName string, swapped bool) str
 
 	return fmt.Sprintf(`
 resource "aws_cognito_user_pool" "test" {
-  name = %[1]q
+  name           = %[1]q
+  user_pool_tier = "PLUS"
+
+  user_pool_add_ons {
+    advanced_security_mode = "AUDIT"
+  }
 }
 
 resource "aws_cloudwatch_log_group" "test" {


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No. This is purely a fix for a Terraform plan/apply consistency error — a schema type change from a list to a set. It doesn't change what gets logged, where it's delivered, the log levels, or anything to do with access, encryption, or IAM.

### Description

Right now, if you write the `log_configurations` blocks in a different order than Cognito hands them back, `terraform apply` fails with `Error: Provider produced inconsistent result after apply`.

Here's why: Cognito's `GetLogDeliveryConfiguration` always returns the blocks in its own fixed order (`userNotification` before `userAuthEvents`), no matter what order you sent. The resource stored `log_configurations` as an ordered list, so after apply `flex.Flatten` writes AWS's order into state — and if that doesn't match your config, the block at index 0 isn't the one Terraform planned for index 0, so it throws the inconsistent-result error.

The fix is to stop treating it as ordered: make `log_configurations` a `SetNestedBlock` instead of a `ListNestedBlock` (and switch the model field to the set type). Each block is keyed by `event_source` and the order means nothing, so a set is what this should have been. Sets don't care about order, so the error is gone for create, update, and read — no sorting code needed. The inner blocks (`cloud_watch_logs_configuration`, `firehose_configuration`, `s3_configuration`) stay as they are. Same fix that already landed for `aws_cloudfront_multitenant_distribution` (#46045).

**Tests.** With a set, the old index-based checks (`log_configurations.0.…`) don't work anymore, so I moved them to `TestCheckTypeSetElemNestedAttrs` / `TestCheckTypeSetElemAttrPair`. I also added `TestAccCognitoIDPLogDeliveryConfiguration_orderSwap` — it applies two blocks, swaps their order, and expects an empty plan. That's exactly the case that used to break.

Getting the `userAuthEvents` tests to actually pass against real AWS meant fixing a few unrelated things the existing fixtures got wrong:

- The test pools default to the `ESSENTIALS` tier, but `userAuthEvents` needs Threat Protection, which needs `PLUS`. Added `user_pool_tier = "PLUS"` + `advanced_security_mode = "AUDIT"`.
- `userAuthEvents` only sends `INFO` logs, so `log_level = "ERROR"` gets rejected. Changed those to `INFO`.
- Cognito adds a `LogDeliveryEnabled` tag to the Firehose stream on its own, which leaves a dirty plan. Added `ignore_changes = [tags, tags_all]` on the stream in the test.

**One test I left alone.** `TestAccCognitoIDPLogDeliveryConfiguration_disappears` fails with `expected Create, got update`. That's not from this change — delete just empties the config, but `Read` still returns the empty config, so the plan is an update instead of a recreate (same behavior whether it's a list or a set). Fixing it means touching the read/delete logic, so I kept it out of this PR to stay focused. Happy to do it separately.

**Heads-up on compatibility.** List → set is technically breaking if someone references these blocks by index (`log_configurations[0]`). But the resource is new and today it just errors whenever the order doesn't match AWS, so I think this is the right trade. Glad to switch to a non-breaking reorder approach if you'd rather.

---

_AI disclaimer: The acceptance tests were amended with AI help. I've reviewed everything and confirmed it with real acceptance-test runs against AWS._


### Relations

Closes #49202

### References

Same bug and the same fix on another Plugin Framework resource: #46045 (`aws_cloudfront_multitenant_distribution` origin ordering).


### Output from Acceptance Testing

--- PASS: TestAccCognitoIDPLogDeliveryConfiguration_basic (51.86s)
--- PASS: TestAccCognitoIDPLogDeliveryConfiguration_logLevelUpdate (60.28s)
--- PASS: TestAccCognitoIDPLogDeliveryConfiguration_orderSwap (61.51s)
--- PASS: TestAccCognitoIDPLogDeliveryConfiguration_Identity_regionOverride (61.91s)
--- PASS: TestAccCognitoIDPLogDeliveryConfiguration_Identity_basic (62.18s)
--- PASS: TestAccCognitoIDPLogDeliveryConfiguration_firehose (161.33s)
--- PASS: TestAccCognitoIDPLogDeliveryConfiguration_update (224.89s)

### Pre-existing, unrelated to this change (see Description):
--- FAIL: TestAccCognitoIDPLogDeliveryConfiguration_disappears


```console
AWS_DEFAULT_REGION=us-east-1 make testacc TESTS=TestAccCognitoIDPLogDeliveryConfiguration_ PKG=cognitoidp
```
