### PR TITLE
[bugfix]: `elasticache_replication_group` user group `transit_encryption_enabled`

### DIFF
--- a/.changelog/49221.txt
+++ b/.changelog/49221.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_elasticache_replication_group: Fix `InvalidParameterValue: User group based access control requires encryption-in-transit to be enabled` error when enabling `transit_encryption_enabled` and associating `user_group_ids` in the same apply
+```

--- a/internal/service/elasticache/replication_group.go
+++ b/internal/service/elasticache/replication_group.go
@@ -1165,6 +1165,8 @@ func resourceReplicationGroupUpdate(ctx context.Context, d *schema.ResourceData,
 
 		if len(userGroupsToAdd) > 0 && (transitEnabledChanged || transitModeChanged) {
 			// Sequenced path: apply transit encryption changes (each modify waits for "available") then associate user groups; AWS validates that encryption is enforced for RBAC.
+			const modifyDelay = 60 * time.Second
+
 			modifyReplicationGroupThenWait := func(modifyInput *elasticache.ModifyReplicationGroupInput, action string) func() error {
 				return func() error {
 					_, err := conn.ModifyReplicationGroup(ctx, modifyInput)
@@ -1174,7 +1176,7 @@ func resourceReplicationGroupUpdate(ctx context.Context, d *schema.ResourceData,
 					if err != nil {
 						return fmt.Errorf("modifying ElastiCache Replication Group (%s) %s: %w", d.Id(), action, err)
 					}
-					if _, err := waitReplicationGroupAvailable(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate), 60*time.Second); err != nil {
+					if _, err := waitReplicationGroupAvailable(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate), modifyDelay); err != nil {
 						return fmt.Errorf("waiting for ElastiCache Replication Group (%s) %s: %w", d.Id(), action, err)
 					}
 					return nil
@@ -1231,7 +1233,7 @@ func resourceReplicationGroupUpdate(ctx context.Context, d *schema.ResourceData,
 				if err != nil {
 					return fmt.Errorf("modifying ElastiCache Replication Group (%s) user groups: %w", d.Id(), err)
 				}
-				if _, err := waitReplicationGroupAvailable(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate), 60*time.Second); err != nil {
+				if _, err := waitReplicationGroupAvailable(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate), modifyDelay); err != nil {
 					return fmt.Errorf("waiting for ElastiCache Replication Group (%s) user groups: %w", d.Id(), err)
 				}
 				return nil

--- a/internal/service/elasticache/replication_group.go
+++ b/internal/service/elasticache/replication_group.go
@@ -1141,32 +1141,121 @@ func resourceReplicationGroupUpdate(ctx context.Context, d *schema.ResourceData,
 			requestUpdate = true
 		}
 
-		if d.HasChange("transit_encryption_enabled") {
-			input.TransitEncryptionEnabled = aws.Bool(d.Get("transit_encryption_enabled").(bool))
-			requestUpdate = true
-		}
+		// RBAC user groups require transit_encryption_mode = "required"; sequence transit encryption changes before associating user groups.
+		oldTransitEnabled, newTransitEnabled := d.GetChange("transit_encryption_enabled")
+		transitEnabledChanged := d.HasChange("transit_encryption_enabled")
+		transitModeChanged := d.HasChange("transit_encryption_mode")
+		targetTransitMode := awstypes.TransitEncryptionMode(d.Get("transit_encryption_mode").(string))
 
-		if d.HasChange("transit_encryption_mode") {
-			input.TransitEncryptionMode = awstypes.TransitEncryptionMode(d.Get("transit_encryption_mode").(string))
-			requestUpdate = true
-		}
-
+		var userGroupsToAdd, userGroupsToRemove []string
 		if d.HasChange("user_group_ids") {
 			o, n := d.GetChange("user_group_ids")
 			ns, os := n.(*schema.Set), o.(*schema.Set)
-			add, del := ns.Difference(os), os.Difference(ns)
+			if add := ns.Difference(os); add.Len() > 0 {
+				userGroupsToAdd = flex.ExpandStringValueSet(add)
+			}
+			if del := os.Difference(ns); del.Len() > 0 {
+				userGroupsToRemove = flex.ExpandStringValueSet(del)
+			}
+		}
 
-			if add.Len() > 0 {
-				if d.HasChanges("auth_token", "auth_token_update_strategy") && awstypes.AuthTokenUpdateStrategyType(d.Get("auth_token_update_strategy").(string)) == awstypes.AuthTokenUpdateStrategyTypeDelete {
-					// Transitioning to RBAC.
-					input.AuthTokenUpdateStrategy = awstypes.AuthTokenUpdateStrategyType(d.Get("auth_token_update_strategy").(string))
+		// Transitioning to RBAC while deleting the auth token.
+		authTokenToRBAC := d.HasChanges("auth_token", "auth_token_update_strategy") &&
+			awstypes.AuthTokenUpdateStrategyType(d.Get("auth_token_update_strategy").(string)) == awstypes.AuthTokenUpdateStrategyTypeDelete
+
+		if len(userGroupsToAdd) > 0 && (transitEnabledChanged || transitModeChanged) {
+			// Sequenced path: apply transit encryption changes first, then associate user groups (RBAC requires enforced encryption, which AWS validates).
+
+			// modifyReplicationGroupThenWait modifies the group and waits for it to return to "available" (non-zero delay avoids observing a stale status before the modification begins).
+			modifyReplicationGroupThenWait := func(modifyInput *elasticache.ModifyReplicationGroupInput, action string) func() error {
+				return func() error {
+					_, err := conn.ModifyReplicationGroup(ctx, modifyInput)
+					if errs.IsAErrorMessageContains[*awstypes.InvalidParameterCombinationException](err, "No modifications were requested") {
+						return nil
+					}
+					if err != nil {
+						return fmt.Errorf("modifying ElastiCache Replication Group (%s) %s: %w", d.Id(), action, err)
+					}
+					if _, err := waitReplicationGroupAvailable(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate), 60*time.Second); err != nil {
+						return fmt.Errorf("waiting for ElastiCache Replication Group (%s) %s: %w", d.Id(), action, err)
+					}
+					return nil
 				}
-				input.UserGroupIdsToAdd = flex.ExpandStringValueSet(add)
-				requestUpdate = true
 			}
 
-			if del.Len() > 0 {
-				input.UserGroupIdsToRemove = flex.ExpandStringValueSet(del)
+			if transitEnabledChanged && !oldTransitEnabled.(bool) && newTransitEnabled.(bool) {
+				preferredInput := elasticache.ModifyReplicationGroupInput{
+					ApplyImmediately:         aws.Bool(d.Get(names.AttrApplyImmediately).(bool)),
+					ReplicationGroupId:       aws.String(d.Id()),
+					TransitEncryptionEnabled: aws.Bool(true),
+					TransitEncryptionMode:    awstypes.TransitEncryptionModePreferred,
+				}
+				updateFuncs = append(updateFuncs, modifyReplicationGroupThenWait(&preferredInput, "transit encryption preferred"))
+			}
+
+			if transitModeChanged {
+				targetModeInput := elasticache.ModifyReplicationGroupInput{
+					ApplyImmediately:         aws.Bool(d.Get(names.AttrApplyImmediately).(bool)),
+					ReplicationGroupId:       aws.String(d.Id()),
+					TransitEncryptionEnabled: aws.Bool(true),
+					TransitEncryptionMode:    targetTransitMode,
+				}
+				updateFuncs = append(updateFuncs, modifyReplicationGroupThenWait(&targetModeInput, fmt.Sprintf("transit encryption %s", targetTransitMode)))
+			}
+
+			userGroupInput := elasticache.ModifyReplicationGroupInput{
+				ApplyImmediately:   aws.Bool(d.Get(names.AttrApplyImmediately).(bool)),
+				ReplicationGroupId: aws.String(d.Id()),
+				UserGroupIdsToAdd:  userGroupsToAdd,
+			}
+			if len(userGroupsToRemove) > 0 {
+				userGroupInput.UserGroupIdsToRemove = userGroupsToRemove
+			}
+			if authTokenToRBAC {
+				userGroupInput.AuthTokenUpdateStrategy = awstypes.AuthTokenUpdateStrategyTypeDelete
+			}
+			updateFuncs = append(updateFuncs, func() error {
+				_, err := tfresource.RetryWhen(ctx, d.Timeout(schema.TimeoutUpdate),
+					func(ctx context.Context) (any, error) {
+						return conn.ModifyReplicationGroup(ctx, &userGroupInput)
+					},
+					func(err error) (bool, error) {
+						// Retry only while the group is busy; encryption rejections are surfaced directly as AWS's constraint.
+						if errs.IsA[*awstypes.InvalidReplicationGroupStateFault](err) {
+							return true, err
+						}
+						return false, err
+					},
+				)
+				if errs.IsAErrorMessageContains[*awstypes.InvalidParameterCombinationException](err, "No modifications were requested") {
+					return nil
+				}
+				if err != nil {
+					return fmt.Errorf("modifying ElastiCache Replication Group (%s) user groups: %w", d.Id(), err)
+				}
+				if _, err := waitReplicationGroupAvailable(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate), 60*time.Second); err != nil {
+					return fmt.Errorf("waiting for ElastiCache Replication Group (%s) user groups: %w", d.Id(), err)
+				}
+				return nil
+			})
+		} else {
+			if transitEnabledChanged {
+				input.TransitEncryptionEnabled = aws.Bool(newTransitEnabled.(bool))
+				requestUpdate = true
+			}
+			if transitModeChanged {
+				input.TransitEncryptionMode = targetTransitMode
+				requestUpdate = true
+			}
+			if len(userGroupsToAdd) > 0 {
+				if authTokenToRBAC {
+					input.AuthTokenUpdateStrategy = awstypes.AuthTokenUpdateStrategyTypeDelete
+				}
+				input.UserGroupIdsToAdd = userGroupsToAdd
+				requestUpdate = true
+			}
+			if len(userGroupsToRemove) > 0 {
+				input.UserGroupIdsToRemove = userGroupsToRemove
 				requestUpdate = true
 			}
 		}

--- a/internal/service/elasticache/replication_group.go
+++ b/internal/service/elasticache/replication_group.go
@@ -1164,9 +1164,7 @@ func resourceReplicationGroupUpdate(ctx context.Context, d *schema.ResourceData,
 			awstypes.AuthTokenUpdateStrategyType(d.Get("auth_token_update_strategy").(string)) == awstypes.AuthTokenUpdateStrategyTypeDelete
 
 		if len(userGroupsToAdd) > 0 && (transitEnabledChanged || transitModeChanged) {
-			// Sequenced path: apply transit encryption changes first, then associate user groups (RBAC requires enforced encryption, which AWS validates).
-
-			// modifyReplicationGroupThenWait modifies the group and waits for it to return to "available" (non-zero delay avoids observing a stale status before the modification begins).
+			// Sequenced path: apply transit encryption changes (each modify waits for "available") then associate user groups; AWS validates that encryption is enforced for RBAC.
 			modifyReplicationGroupThenWait := func(modifyInput *elasticache.ModifyReplicationGroupInput, action string) func() error {
 				return func() error {
 					_, err := conn.ModifyReplicationGroup(ctx, modifyInput)

--- a/internal/service/elasticache/replication_group_test.go
+++ b/internal/service/elasticache/replication_group_test.go
@@ -660,6 +660,45 @@ func TestAccElastiCacheReplicationGroup_updateUserGroups(t *testing.T) {
 	})
 }
 
+func TestAccElastiCacheReplicationGroup_enableTLSAndUserGroup(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var rg awstypes.ReplicationGroup
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	userGroup := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	resourceName := "aws_elasticache_replication_group.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccReplicationGroupConfig_tlsUserGroup_step1(rName, userGroup),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
+					resource.TestCheckResourceAttr(resourceName, "transit_encryption_enabled", acctest.CtFalse),
+				),
+			},
+			{
+				Config: testAccReplicationGroupConfig_tlsUserGroup_step2(rName, userGroup),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
+					resource.TestCheckResourceAttr(resourceName, "transit_encryption_enabled", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "transit_encryption_mode", string(awstypes.TransitEncryptionModeRequired)),
+					testAccCheckReplicationGroupUserGroup(ctx, t, resourceName, userGroup),
+					resource.TestCheckTypeSetElemAttr(resourceName, "user_group_ids.*", userGroup),
+				),
+			},
+		},
+	})
+}
+
 func TestAccElastiCacheReplicationGroup_authToRBACMigration(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
@@ -5246,6 +5285,78 @@ resource "aws_elasticache_replication_group" "test" {
   user_group_ids             = [aws_elasticache_user_group.test[%[3]d].id]
 }
 `, rName, userGroup, flag)
+}
+
+func testAccReplicationGroupConfig_tlsUserGroup_step1(rName, userGroup string) string {
+	return acctest.ConfigCompose(
+		testAccReplicationGroupConfig_transitEncryptionBase(rName),
+		fmt.Sprintf(`
+resource "aws_elasticache_user" "test" {
+  user_id       = %[2]q
+  user_name     = "default"
+  access_string = "on ~app::* -@all +@read +@hash +@bitmap +@geo -setbit -bitfield -hset -hsetnx -hmset -hincrby -hincrbyfloat -hdel -bitop -geoadd -georadius -georadiusbymember"
+  engine        = "REDIS"
+  passwords     = ["password123456789"]
+}
+
+resource "aws_elasticache_user_group" "test" {
+  user_group_id = %[2]q
+  engine        = "REDIS"
+  user_ids      = [aws_elasticache_user.test.user_id]
+}
+
+resource "aws_elasticache_replication_group" "test" {
+  replication_group_id       = %[1]q
+  description                = "test description"
+  node_type                  = "cache.t3.micro"
+  num_cache_clusters         = "1"
+  port                       = 6379
+  subnet_group_name          = aws_elasticache_subnet_group.test.name
+  security_group_ids         = [aws_security_group.test.id]
+  parameter_group_name       = "default.redis7"
+  engine_version             = "7.0"
+  transit_encryption_enabled = false
+  apply_immediately          = true
+}
+`, rName, userGroup),
+	)
+}
+
+func testAccReplicationGroupConfig_tlsUserGroup_step2(rName, userGroup string) string {
+	return acctest.ConfigCompose(
+		testAccReplicationGroupConfig_transitEncryptionBase(rName),
+		fmt.Sprintf(`
+resource "aws_elasticache_user" "test" {
+  user_id       = %[2]q
+  user_name     = "default"
+  access_string = "on ~app::* -@all +@read +@hash +@bitmap +@geo -setbit -bitfield -hset -hsetnx -hmset -hincrby -hincrbyfloat -hdel -bitop -geoadd -georadius -georadiusbymember"
+  engine        = "REDIS"
+  passwords     = ["password123456789"]
+}
+
+resource "aws_elasticache_user_group" "test" {
+  user_group_id = %[2]q
+  engine        = "REDIS"
+  user_ids      = [aws_elasticache_user.test.user_id]
+}
+
+resource "aws_elasticache_replication_group" "test" {
+  replication_group_id       = %[1]q
+  description                = "test description"
+  node_type                  = "cache.t3.micro"
+  num_cache_clusters         = "1"
+  port                       = 6379
+  subnet_group_name          = aws_elasticache_subnet_group.test.name
+  security_group_ids         = [aws_security_group.test.id]
+  parameter_group_name       = "default.redis7"
+  engine_version             = "7.0"
+  transit_encryption_enabled = true
+  transit_encryption_mode    = "required"
+  user_group_ids             = [aws_elasticache_user_group.test.id]
+  apply_immediately          = true
+}
+`, rName, userGroup),
+	)
 }
 
 func testAccReplicationGroupConfig_inVPC(rName string) string {

--- a/website/docs/r/elasticache_replication_group.html.markdown
+++ b/website/docs/r/elasticache_replication_group.html.markdown
@@ -296,7 +296,7 @@ The following arguments are optional:
   Valid values are `preferred` and `required`.
   When enabling encryption on an existing replication group, this must first be set to `preferred` before setting it to `required` in a subsequent apply.
   See the `TransitEncryptionMode` field in the [`CreateReplicationGroup` API documentation](https://docs.aws.amazon.com/AmazonElastiCache/latest/APIReference/API_CreateReplicationGroup.html) for additional details.
-* `user_group_ids` - (Optional) User Group ID to associate with the replication group. Only a maximum of one (1) user group ID is valid. **NOTE:** This argument _is_ a set because the AWS specification allows for multiple IDs. However, in practice, AWS only allows a maximum size of one.
+* `user_group_ids` - (Optional) User Group ID to associate with the replication group. Only a maximum of one (1) user group ID is valid. **NOTE:** This argument _is_ a set because the AWS specification allows for multiple IDs. However, in practice, AWS only allows a maximum size of one. Requires `transit_encryption_enabled` to be `true`. When enabling in-transit encryption on an existing replication group, `transit_encryption_mode` must be set to `required` before a user group can be associated.
 
 ### Log Delivery Configuration
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Previously, turning on in-transit encryption and adding `user_group_ids` in the same apply failed with an error saying user groups require encryption-in-transit to be enabled. This happened because the provider tried to make both changes in one API call, but AWS won't let you attach user groups until encryption is fully turned on `(transit_encryption_mode = "required")`, and turning on encryption for an existing cluster has to go through preferred first and then required. This change makes those updates happen one step at a time in the right order. It switches to preferred if encryption was off, moves to the mode you configured, then attaches the user groups, waiting for the cluster to be ready between each step. If AWS still rejects the user group change, its original error is shown as-is instead of being hidden by the provider. Updates that don't involve this combination keep working exactly as before.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #42966

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccElastiCacheReplicationGroup PKG=elasticache ACCTEST_PARALLELISM=1 ACCTEST_TIMEOUT=4880m
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
xargs: gofmt: No such file or directory
make: Validating schemas
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2	0.245s
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider/framework	0.227s
make: Running acceptance tests on branch: 🌿 f-elasticache-rg-user-group-enc 🌿...
TF_ACC=1 go1.26.5 test ./internal/service/elasticache/... -v -count 1 -parallel 1 -run='TestAccElastiCacheReplicationGroup'  -timeout 4880m -vet=off -buildvcs=false
2026/07/30 22:50:57 Creating Terraform AWS Provider (SDKv2-style)...
2026/07/30 22:50:57 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccElastiCacheReplicationGroupDataSource_basic
=== PAUSE TestAccElastiCacheReplicationGroupDataSource_basic
=== RUN   TestAccElastiCacheReplicationGroupDataSource_clusterMode
=== PAUSE TestAccElastiCacheReplicationGroupDataSource_clusterMode
=== RUN   TestAccElastiCacheReplicationGroupDataSource_multiAZ
=== PAUSE TestAccElastiCacheReplicationGroupDataSource_multiAZ
=== RUN   TestAccElastiCacheReplicationGroupDataSource_Engine_Redis_LogDeliveryConfigurations
=== PAUSE TestAccElastiCacheReplicationGroupDataSource_Engine_Redis_LogDeliveryConfigurations
=== RUN   TestAccElastiCacheReplicationGroup_Redis_basic
=== PAUSE TestAccElastiCacheReplicationGroup_Redis_basic
=== RUN   TestAccElastiCacheReplicationGroup_Redis_basic_v5
=== PAUSE TestAccElastiCacheReplicationGroup_Redis_basic_v5
=== RUN   TestAccElastiCacheReplicationGroup_Valkey_basic
=== PAUSE TestAccElastiCacheReplicationGroup_Valkey_basic
=== RUN   TestAccElastiCacheReplicationGroup_Valkey_durability
=== PAUSE TestAccElastiCacheReplicationGroup_Valkey_durability
=== RUN   TestAccElastiCacheReplicationGroup_uppercase
=== PAUSE TestAccElastiCacheReplicationGroup_uppercase
=== RUN   TestAccElastiCacheReplicationGroup_Redis_EngineVersion_v7
=== PAUSE TestAccElastiCacheReplicationGroup_Redis_EngineVersion_v7
=== RUN   TestAccElastiCacheReplicationGroup_OutOfBandUpgrade
=== PAUSE TestAccElastiCacheReplicationGroup_OutOfBandUpgrade
=== RUN   TestAccElastiCacheReplicationGroup_EngineVersion_update
=== PAUSE TestAccElastiCacheReplicationGroup_EngineVersion_update
=== RUN   TestAccElastiCacheReplicationGroup_EngineVersion_6xToRealVersion
=== PAUSE TestAccElastiCacheReplicationGroup_EngineVersion_6xToRealVersion
=== RUN   TestAccElastiCacheReplicationGroup_Engine_RedisToValkey
=== PAUSE TestAccElastiCacheReplicationGroup_Engine_RedisToValkey
=== RUN   TestAccElastiCacheReplicationGroup_disappears
=== PAUSE TestAccElastiCacheReplicationGroup_disappears
=== RUN   TestAccElastiCacheReplicationGroup_updateDescription
=== PAUSE TestAccElastiCacheReplicationGroup_updateDescription
=== RUN   TestAccElastiCacheReplicationGroup_updateMaintenanceWindow
=== PAUSE TestAccElastiCacheReplicationGroup_updateMaintenanceWindow
=== RUN   TestAccElastiCacheReplicationGroup_updateUserGroups
=== PAUSE TestAccElastiCacheReplicationGroup_updateUserGroups
=== RUN   TestAccElastiCacheReplicationGroup_enableTLSAndUserGroup
=== PAUSE TestAccElastiCacheReplicationGroup_enableTLSAndUserGroup
=== RUN   TestAccElastiCacheReplicationGroup_authToRBACMigration
=== PAUSE TestAccElastiCacheReplicationGroup_authToRBACMigration
=== RUN   TestAccElastiCacheReplicationGroup_updateNodeSize
=== PAUSE TestAccElastiCacheReplicationGroup_updateNodeSize
=== RUN   TestAccElastiCacheReplicationGroup_updateParameterGroup
=== PAUSE TestAccElastiCacheReplicationGroup_updateParameterGroup
=== RUN   TestAccElastiCacheReplicationGroup_authToken
=== PAUSE TestAccElastiCacheReplicationGroup_authToken
=== RUN   TestAccElastiCacheReplicationGroup_authToken_fromResource
=== PAUSE TestAccElastiCacheReplicationGroup_authToken_fromResource
=== RUN   TestAccElastiCacheReplicationGroup_upgrade_6_0_0
=== PAUSE TestAccElastiCacheReplicationGroup_upgrade_6_0_0
=== RUN   TestAccElastiCacheReplicationGroup_upgrade_5_27_0
=== PAUSE TestAccElastiCacheReplicationGroup_upgrade_5_27_0
=== RUN   TestAccElastiCacheReplicationGroup_upgrade_4_68_0
=== PAUSE TestAccElastiCacheReplicationGroup_upgrade_4_68_0
=== RUN   TestAccElastiCacheReplicationGroup_vpc
=== PAUSE TestAccElastiCacheReplicationGroup_vpc
=== RUN   TestAccElastiCacheReplicationGroup_multiAzNotInVPC
=== PAUSE TestAccElastiCacheReplicationGroup_multiAzNotInVPC
=== RUN   TestAccElastiCacheReplicationGroup_multiAzNotInVPC_repeated
=== PAUSE TestAccElastiCacheReplicationGroup_multiAzNotInVPC_repeated
=== RUN   TestAccElastiCacheReplicationGroup_multiAzInVPC
=== PAUSE TestAccElastiCacheReplicationGroup_multiAzInVPC
=== RUN   TestAccElastiCacheReplicationGroup_deprecatedAvailabilityZones_multiAzInVPC
=== PAUSE TestAccElastiCacheReplicationGroup_deprecatedAvailabilityZones_multiAzInVPC
=== RUN   TestAccElastiCacheReplicationGroup_ValidationMultiAz_noAutomaticFailover
=== PAUSE TestAccElastiCacheReplicationGroup_ValidationMultiAz_noAutomaticFailover
=== RUN   TestAccElastiCacheReplicationGroup_ipDiscovery
=== PAUSE TestAccElastiCacheReplicationGroup_ipDiscovery
=== RUN   TestAccElastiCacheReplicationGroup_networkType
=== PAUSE TestAccElastiCacheReplicationGroup_networkType
=== RUN   TestAccElastiCacheReplicationGroup_ClusterMode_basic
=== PAUSE TestAccElastiCacheReplicationGroup_ClusterMode_basic
=== RUN   TestAccElastiCacheReplicationGroup_ClusterMode_nonClusteredParameterGroup
=== PAUSE TestAccElastiCacheReplicationGroup_ClusterMode_nonClusteredParameterGroup
=== RUN   TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleUp
=== PAUSE TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleUp
=== RUN   TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleDown
=== PAUSE TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleDown
=== RUN   TestAccElastiCacheReplicationGroup_ClusterMode_updateReplicasPerNodeGroup
=== PAUSE TestAccElastiCacheReplicationGroup_ClusterMode_updateReplicasPerNodeGroup
=== RUN   TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplicasPerNodeGroup_scaleUp
=== PAUSE TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplicasPerNodeGroup_scaleUp
=== RUN   TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplicasPerNodeGroup_scaleDown
=== PAUSE TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplicasPerNodeGroup_scaleDown
=== RUN   TestAccElastiCacheReplicationGroup_ClusterMode_singleNode
=== PAUSE TestAccElastiCacheReplicationGroup_ClusterMode_singleNode
=== RUN   TestAccElastiCacheReplicationGroup_ClusterMode_nodeGroupConfiguration
=== PAUSE TestAccElastiCacheReplicationGroup_ClusterMode_nodeGroupConfiguration
=== RUN   TestAccElastiCacheReplicationGroup_ClusterMode_nodeGroupConfiguration_availabilityZones
=== PAUSE TestAccElastiCacheReplicationGroup_ClusterMode_nodeGroupConfiguration_availabilityZones
=== RUN   TestAccElastiCacheReplicationGroup_ClusterMode_updateFromDisabled_Compatible_Enabled
=== PAUSE TestAccElastiCacheReplicationGroup_ClusterMode_updateFromDisabled_Compatible_Enabled
=== RUN   TestAccElastiCacheReplicationGroup_cacheClustersConflictsWithReplicasPerNodeGroup
=== PAUSE TestAccElastiCacheReplicationGroup_cacheClustersConflictsWithReplicasPerNodeGroup
=== RUN   TestAccElastiCacheReplicationGroup_clusteringAndCacheNodesCausesError
=== PAUSE TestAccElastiCacheReplicationGroup_clusteringAndCacheNodesCausesError
=== RUN   TestAccElastiCacheReplicationGroup_enableSnapshotting
=== PAUSE TestAccElastiCacheReplicationGroup_enableSnapshotting
=== RUN   TestAccElastiCacheReplicationGroup_transitEncryptionWithAuthToken
=== PAUSE TestAccElastiCacheReplicationGroup_transitEncryptionWithAuthToken
=== RUN   TestAccElastiCacheReplicationGroup_transitEncryption5x
=== PAUSE TestAccElastiCacheReplicationGroup_transitEncryption5x
=== RUN   TestAccElastiCacheReplicationGroup_transitEncryption7x_basic
=== PAUSE TestAccElastiCacheReplicationGroup_transitEncryption7x_basic
=== RUN   TestAccElastiCacheReplicationGroup_transitEncryption7x_Enable
=== PAUSE TestAccElastiCacheReplicationGroup_transitEncryption7x_Enable
=== RUN   TestAccElastiCacheReplicationGroup_transitEncryption7x_Disable
=== PAUSE TestAccElastiCacheReplicationGroup_transitEncryption7x_Disable
=== RUN   TestAccElastiCacheReplicationGroup_Redis_enableAtRestEncryption
=== PAUSE TestAccElastiCacheReplicationGroup_Redis_enableAtRestEncryption
=== RUN   TestAccElastiCacheReplicationGroup_Valkey_disableAtRestEncryption
=== PAUSE TestAccElastiCacheReplicationGroup_Valkey_disableAtRestEncryption
=== RUN   TestAccElastiCacheReplicationGroup_useCMKKMSKeyID
=== PAUSE TestAccElastiCacheReplicationGroup_useCMKKMSKeyID
=== RUN   TestAccElastiCacheReplicationGroup_NumberCacheClusters_basic
=== PAUSE TestAccElastiCacheReplicationGroup_NumberCacheClusters_basic
=== RUN   TestAccElastiCacheReplicationGroup_NumberCacheClusters_autoFailoverDisabled
=== PAUSE TestAccElastiCacheReplicationGroup_NumberCacheClusters_autoFailoverDisabled
=== RUN   TestAccElastiCacheReplicationGroup_NumberCacheClusters_autoFailoverEnabled
=== PAUSE TestAccElastiCacheReplicationGroup_NumberCacheClusters_autoFailoverEnabled
=== RUN   TestAccElastiCacheReplicationGroup_autoFailoverEnabled_validateNumberCacheClusters
=== PAUSE TestAccElastiCacheReplicationGroup_autoFailoverEnabled_validateNumberCacheClusters
=== RUN   TestAccElastiCacheReplicationGroup_NumberCacheClusters_multiAZEnabled
=== PAUSE TestAccElastiCacheReplicationGroup_NumberCacheClusters_multiAZEnabled
=== RUN   TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappears_noChange
=== PAUSE TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappears_noChange
=== RUN   TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappears_addMemberCluster
=== PAUSE TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappears_addMemberCluster
=== RUN   TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappearsRemoveMemberCluster_atTargetSize
=== PAUSE TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappearsRemoveMemberCluster_atTargetSize
=== RUN   TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappearsRemoveMemberCluster_scaleDown
=== PAUSE TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappearsRemoveMemberCluster_scaleDown
=== RUN   TestAccElastiCacheReplicationGroup_tags
=== PAUSE TestAccElastiCacheReplicationGroup_tags
=== RUN   TestAccElastiCacheReplicationGroup_TagWithOtherModification_version
=== PAUSE TestAccElastiCacheReplicationGroup_TagWithOtherModification_version
=== RUN   TestAccElastiCacheReplicationGroup_TagWithOtherModification_numCacheClusters
=== PAUSE TestAccElastiCacheReplicationGroup_TagWithOtherModification_numCacheClusters
=== RUN   TestAccElastiCacheReplicationGroup_finalSnapshot
=== PAUSE TestAccElastiCacheReplicationGroup_finalSnapshot
=== RUN   TestAccElastiCacheReplicationGroup_autoMinorVersionUpgrade
=== PAUSE TestAccElastiCacheReplicationGroup_autoMinorVersionUpgrade
=== RUN   TestAccElastiCacheReplicationGroup_Validation_noNodeType
=== PAUSE TestAccElastiCacheReplicationGroup_Validation_noNodeType
=== RUN   TestAccElastiCacheReplicationGroup_Validation_globalReplicationGroupIdAndNodeType
=== PAUSE TestAccElastiCacheReplicationGroup_Validation_globalReplicationGroupIdAndNodeType
=== RUN   TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_basic
=== PAUSE TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_basic
=== RUN   TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_full
=== PAUSE TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_full
=== RUN   TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_disappears
=== PAUSE TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_disappears
=== RUN   TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterMode_basic
=== PAUSE TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterMode_basic
=== RUN   TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterModeValidation_numNodeGroupsOnSecondary
=== PAUSE TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterModeValidation_numNodeGroupsOnSecondary
=== RUN   TestAccElastiCacheReplicationGroup_dataTiering
=== PAUSE TestAccElastiCacheReplicationGroup_dataTiering
=== RUN   TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_ClusterMode_Disabled
=== PAUSE TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_ClusterMode_Disabled
=== RUN   TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_ClusterMode_Enabled
=== PAUSE TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_ClusterMode_Enabled
=== RUN   TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_engineUpgradeAfterDisassociate
=== PAUSE TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_engineUpgradeAfterDisassociate
=== RUN   TestAccElastiCacheReplicationGroup_RemoveNodeGroups_Valkey7
=== PAUSE TestAccElastiCacheReplicationGroup_RemoveNodeGroups_Valkey7
=== RUN   TestAccElastiCacheReplicationGroup_RemoveNodeGroups_Valkey7_3NodeGroups
=== PAUSE TestAccElastiCacheReplicationGroup_RemoveNodeGroups_Valkey7_3NodeGroups
=== RUN   TestAccElastiCacheReplicationGroup_RemoveNodeGroups_Valkey8
=== PAUSE TestAccElastiCacheReplicationGroup_RemoveNodeGroups_Valkey8
=== RUN   TestAccElastiCacheReplicationGroup_RemoveNodeGroups_Redis7ToValkey8
=== PAUSE TestAccElastiCacheReplicationGroup_RemoveNodeGroups_Redis7ToValkey8
=== RUN   TestAccElastiCacheReplicationGroup_RemoveNodeGroups_Redis7ToValkey8_3NodeGroups
=== PAUSE TestAccElastiCacheReplicationGroup_RemoveNodeGroups_Redis7ToValkey8_3NodeGroups
=== RUN   TestAccElastiCacheReplicationGroup_Snapshot_ClusterModeDisabled_Redis7
=== PAUSE TestAccElastiCacheReplicationGroup_Snapshot_ClusterModeDisabled_Redis7
=== RUN   TestAccElastiCacheReplicationGroup_Snapshot_ClusterModeDisabled_Valkey7
=== PAUSE TestAccElastiCacheReplicationGroup_Snapshot_ClusterModeDisabled_Valkey7
=== RUN   TestAccElastiCacheReplicationGroup_Snapshot_ClusterModeEnabled_Redis7
=== PAUSE TestAccElastiCacheReplicationGroup_Snapshot_ClusterModeEnabled_Redis7
=== RUN   TestAccElastiCacheReplicationGroup_Snapshot_ClusterModeEnabled_Valkey7
=== PAUSE TestAccElastiCacheReplicationGroup_Snapshot_ClusterModeEnabled_Valkey7
=== RUN   TestAccElastiCacheReplicationGroup_SlowLog_Redis5ToRedis6
=== PAUSE TestAccElastiCacheReplicationGroup_SlowLog_Redis5ToRedis6
=== RUN   TestAccElastiCacheReplicationGroup_SlowLog_Redis5ToValkey7
=== PAUSE TestAccElastiCacheReplicationGroup_SlowLog_Redis5ToValkey7
=== CONT  TestAccElastiCacheReplicationGroupDataSource_basic
--- PASS: TestAccElastiCacheReplicationGroupDataSource_basic (624.99s)
=== CONT  TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterMode_basic
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterMode_basic (3276.07s)
=== CONT  TestAccElastiCacheReplicationGroup_SlowLog_Redis5ToValkey7
--- PASS: TestAccElastiCacheReplicationGroup_SlowLog_Redis5ToValkey7 (1078.48s)
=== CONT  TestAccElastiCacheReplicationGroup_SlowLog_Redis5ToRedis6
--- PASS: TestAccElastiCacheReplicationGroup_SlowLog_Redis5ToRedis6 (1149.20s)
=== CONT  TestAccElastiCacheReplicationGroup_Snapshot_ClusterModeEnabled_Valkey7
--- PASS: TestAccElastiCacheReplicationGroup_Snapshot_ClusterModeEnabled_Valkey7 (834.35s)
=== CONT  TestAccElastiCacheReplicationGroup_Snapshot_ClusterModeEnabled_Redis7
--- PASS: TestAccElastiCacheReplicationGroup_Snapshot_ClusterModeEnabled_Redis7 (713.13s)
=== CONT  TestAccElastiCacheReplicationGroup_Snapshot_ClusterModeDisabled_Valkey7
--- PASS: TestAccElastiCacheReplicationGroup_Snapshot_ClusterModeDisabled_Valkey7 (1141.62s)
=== CONT  TestAccElastiCacheReplicationGroup_Snapshot_ClusterModeDisabled_Redis7
--- PASS: TestAccElastiCacheReplicationGroup_Snapshot_ClusterModeDisabled_Redis7 (1088.67s)
=== CONT  TestAccElastiCacheReplicationGroup_RemoveNodeGroups_Redis7ToValkey8_3NodeGroups
--- PASS: TestAccElastiCacheReplicationGroup_RemoveNodeGroups_Redis7ToValkey8_3NodeGroups (2422.50s)
=== CONT  TestAccElastiCacheReplicationGroup_RemoveNodeGroups_Redis7ToValkey8
--- PASS: TestAccElastiCacheReplicationGroup_RemoveNodeGroups_Redis7ToValkey8 (3362.87s)
=== CONT  TestAccElastiCacheReplicationGroup_RemoveNodeGroups_Valkey8
--- PASS: TestAccElastiCacheReplicationGroup_RemoveNodeGroups_Valkey8 (1591.62s)
=== CONT  TestAccElastiCacheReplicationGroup_RemoveNodeGroups_Valkey7_3NodeGroups
--- PASS: TestAccElastiCacheReplicationGroup_RemoveNodeGroups_Valkey7_3NodeGroups (2492.47s)
=== CONT  TestAccElastiCacheReplicationGroup_RemoveNodeGroups_Valkey7
--- PASS: TestAccElastiCacheReplicationGroup_RemoveNodeGroups_Valkey7 (2511.19s)
=== CONT  TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_engineUpgradeAfterDisassociate
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_engineUpgradeAfterDisassociate (1740.83s)
=== CONT  TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_ClusterMode_Enabled
--- PASS: TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_ClusterMode_Enabled (810.62s)
=== CONT  TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleDown
--- PASS: TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleDown (1656.93s)
=== CONT  TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_ClusterMode_Disabled
--- PASS: TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_ClusterMode_Disabled (768.09s)
=== CONT  TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_disappears
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_disappears (2335.32s)
=== CONT  TestAccElastiCacheReplicationGroup_dataTiering
--- PASS: TestAccElastiCacheReplicationGroup_dataTiering (553.74s)
=== CONT  TestAccElastiCacheReplicationGroup_useCMKKMSKeyID
--- PASS: TestAccElastiCacheReplicationGroup_useCMKKMSKeyID (823.84s)
=== CONT  TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterModeValidation_numNodeGroupsOnSecondary
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterModeValidation_numNodeGroupsOnSecondary (1202.66s)
=== CONT  TestAccElastiCacheReplicationGroup_Valkey_disableAtRestEncryption
--- PASS: TestAccElastiCacheReplicationGroup_Valkey_disableAtRestEncryption (620.15s)
=== CONT  TestAccElastiCacheReplicationGroup_Redis_enableAtRestEncryption
--- PASS: TestAccElastiCacheReplicationGroup_Redis_enableAtRestEncryption (608.45s)
=== CONT  TestAccElastiCacheReplicationGroup_authToRBACMigration
--- PASS: TestAccElastiCacheReplicationGroup_authToRBACMigration (1665.72s)
=== CONT  TestAccElastiCacheReplicationGroup_transitEncryption7x_Disable
--- PASS: TestAccElastiCacheReplicationGroup_transitEncryption7x_Disable (1956.57s)
=== CONT  TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleUp
--- PASS: TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleUp (1819.89s)
=== CONT  TestAccElastiCacheReplicationGroup_transitEncryption7x_Enable
--- PASS: TestAccElastiCacheReplicationGroup_transitEncryption7x_Enable (2021.86s)
=== CONT  TestAccElastiCacheReplicationGroup_NumberCacheClusters_basic
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClusters_basic (1460.47s)
=== CONT  TestAccElastiCacheReplicationGroup_ClusterMode_nonClusteredParameterGroup
--- PASS: TestAccElastiCacheReplicationGroup_ClusterMode_nonClusteredParameterGroup (558.16s)
=== CONT  TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_full
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_full (3014.95s)
=== CONT  TestAccElastiCacheReplicationGroup_ClusterMode_basic
--- PASS: TestAccElastiCacheReplicationGroup_ClusterMode_basic (838.66s)
=== CONT  TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappearsRemoveMemberCluster_scaleDown
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappearsRemoveMemberCluster_scaleDown (1263.15s)
=== CONT  TestAccElastiCacheReplicationGroup_transitEncryption7x_basic
--- PASS: TestAccElastiCacheReplicationGroup_transitEncryption7x_basic (624.44s)
=== CONT  TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappearsRemoveMemberCluster_atTargetSize
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappearsRemoveMemberCluster_atTargetSize (1089.98s)
=== CONT  TestAccElastiCacheReplicationGroup_transitEncryption5x
--- PASS: TestAccElastiCacheReplicationGroup_transitEncryption5x (1223.68s)
=== CONT  TestAccElastiCacheReplicationGroup_networkType
--- PASS: TestAccElastiCacheReplicationGroup_networkType (796.87s)
=== CONT  TestAccElastiCacheReplicationGroup_transitEncryptionWithAuthToken
--- PASS: TestAccElastiCacheReplicationGroup_transitEncryptionWithAuthToken (753.38s)
=== CONT  TestAccElastiCacheReplicationGroup_ipDiscovery
--- PASS: TestAccElastiCacheReplicationGroup_ipDiscovery (748.09s)
=== CONT  TestAccElastiCacheReplicationGroup_enableSnapshotting
--- PASS: TestAccElastiCacheReplicationGroup_enableSnapshotting (479.47s)
=== CONT  TestAccElastiCacheReplicationGroup_ValidationMultiAz_noAutomaticFailover
--- PASS: TestAccElastiCacheReplicationGroup_ValidationMultiAz_noAutomaticFailover (2.76s)
=== CONT  TestAccElastiCacheReplicationGroup_tags
--- PASS: TestAccElastiCacheReplicationGroup_tags (605.88s)
=== CONT  TestAccElastiCacheReplicationGroup_deprecatedAvailabilityZones_multiAzInVPC
--- PASS: TestAccElastiCacheReplicationGroup_deprecatedAvailabilityZones_multiAzInVPC (572.79s)
=== CONT  TestAccElastiCacheReplicationGroup_multiAzInVPC
--- PASS: TestAccElastiCacheReplicationGroup_multiAzInVPC (563.24s)
=== CONT  TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_basic
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_basic (2175.99s)
=== CONT  TestAccElastiCacheReplicationGroup_multiAzNotInVPC_repeated
--- PASS: TestAccElastiCacheReplicationGroup_multiAzNotInVPC_repeated (558.59s)
=== CONT  TestAccElastiCacheReplicationGroup_Validation_globalReplicationGroupIdAndNodeType
--- PASS: TestAccElastiCacheReplicationGroup_Validation_globalReplicationGroupIdAndNodeType (865.59s)
=== CONT  TestAccElastiCacheReplicationGroup_authToken_fromResource
--- PASS: TestAccElastiCacheReplicationGroup_authToken_fromResource (669.56s)
=== CONT  TestAccElastiCacheReplicationGroup_Validation_noNodeType
--- PASS: TestAccElastiCacheReplicationGroup_Validation_noNodeType (12.70s)
=== CONT  TestAccElastiCacheReplicationGroup_authToken
--- PASS: TestAccElastiCacheReplicationGroup_authToken (1335.69s)
=== CONT  TestAccElastiCacheReplicationGroup_clusteringAndCacheNodesCausesError
--- PASS: TestAccElastiCacheReplicationGroup_clusteringAndCacheNodesCausesError (2.43s)
=== CONT  TestAccElastiCacheReplicationGroup_autoMinorVersionUpgrade
--- PASS: TestAccElastiCacheReplicationGroup_autoMinorVersionUpgrade (560.73s)
=== CONT  TestAccElastiCacheReplicationGroup_updateParameterGroup
--- PASS: TestAccElastiCacheReplicationGroup_updateParameterGroup (633.25s)
=== CONT  TestAccElastiCacheReplicationGroup_cacheClustersConflictsWithReplicasPerNodeGroup
--- PASS: TestAccElastiCacheReplicationGroup_cacheClustersConflictsWithReplicasPerNodeGroup (2.56s)
=== CONT  TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappears_addMemberCluster
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappears_addMemberCluster (1326.10s)
=== CONT  TestAccElastiCacheReplicationGroup_ClusterMode_updateFromDisabled_Compatible_Enabled
--- PASS: TestAccElastiCacheReplicationGroup_ClusterMode_updateFromDisabled_Compatible_Enabled (2245.25s)
=== CONT  TestAccElastiCacheReplicationGroup_upgrade_6_0_0
--- PASS: TestAccElastiCacheReplicationGroup_upgrade_6_0_0 (553.61s)
=== CONT  TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappears_noChange
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappears_noChange (1355.80s)
=== CONT  TestAccElastiCacheReplicationGroup_ClusterMode_nodeGroupConfiguration_availabilityZones
--- PASS: TestAccElastiCacheReplicationGroup_ClusterMode_nodeGroupConfiguration_availabilityZones (911.46s)
=== CONT  TestAccElastiCacheReplicationGroup_multiAzNotInVPC
--- PASS: TestAccElastiCacheReplicationGroup_multiAzNotInVPC (639.74s)
=== CONT  TestAccElastiCacheReplicationGroup_ClusterMode_nodeGroupConfiguration
--- PASS: TestAccElastiCacheReplicationGroup_ClusterMode_nodeGroupConfiguration (1121.71s)
=== CONT  TestAccElastiCacheReplicationGroup_vpc
--- PASS: TestAccElastiCacheReplicationGroup_vpc (505.06s)
=== CONT  TestAccElastiCacheReplicationGroup_ClusterMode_singleNode
--- PASS: TestAccElastiCacheReplicationGroup_ClusterMode_singleNode (498.09s)
=== CONT  TestAccElastiCacheReplicationGroup_upgrade_4_68_0
--- PASS: TestAccElastiCacheReplicationGroup_upgrade_4_68_0 (555.83s)
=== CONT  TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplicasPerNodeGroup_scaleDown
--- PASS: TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplicasPerNodeGroup_scaleDown (2010.98s)
=== CONT  TestAccElastiCacheReplicationGroup_upgrade_5_27_0
--- PASS: TestAccElastiCacheReplicationGroup_upgrade_5_27_0 (555.02s)
=== CONT  TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplicasPerNodeGroup_scaleUp
--- PASS: TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplicasPerNodeGroup_scaleUp (2190.87s)
=== CONT  TestAccElastiCacheReplicationGroup_TagWithOtherModification_numCacheClusters
--- PASS: TestAccElastiCacheReplicationGroup_TagWithOtherModification_numCacheClusters (814.09s)
=== CONT  TestAccElastiCacheReplicationGroup_NumberCacheClusters_multiAZEnabled
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClusters_multiAZEnabled (1172.30s)
=== CONT  TestAccElastiCacheReplicationGroup_ClusterMode_updateReplicasPerNodeGroup
--- PASS: TestAccElastiCacheReplicationGroup_ClusterMode_updateReplicasPerNodeGroup (1881.37s)
=== CONT  TestAccElastiCacheReplicationGroup_autoFailoverEnabled_validateNumberCacheClusters
--- PASS: TestAccElastiCacheReplicationGroup_autoFailoverEnabled_validateNumberCacheClusters (2.81s)
=== CONT  TestAccElastiCacheReplicationGroup_updateNodeSize
--- PASS: TestAccElastiCacheReplicationGroup_updateNodeSize (1418.43s)
=== CONT  TestAccElastiCacheReplicationGroup_NumberCacheClusters_autoFailoverEnabled
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClusters_autoFailoverEnabled (1160.53s)
=== CONT  TestAccElastiCacheReplicationGroup_OutOfBandUpgrade
--- PASS: TestAccElastiCacheReplicationGroup_OutOfBandUpgrade (2246.14s)
=== CONT  TestAccElastiCacheReplicationGroup_NumberCacheClusters_autoFailoverDisabled
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClusters_autoFailoverDisabled (1087.35s)
=== CONT  TestAccElastiCacheReplicationGroup_updateDescription
--- PASS: TestAccElastiCacheReplicationGroup_updateDescription (501.43s)
=== CONT  TestAccElastiCacheReplicationGroup_disappears
--- PASS: TestAccElastiCacheReplicationGroup_disappears (535.82s)
=== CONT  TestAccElastiCacheReplicationGroup_uppercase
--- PASS: TestAccElastiCacheReplicationGroup_uppercase (612.18s)
=== CONT  TestAccElastiCacheReplicationGroup_EngineVersion_update
--- PASS: TestAccElastiCacheReplicationGroup_EngineVersion_update (4962.70s)
=== CONT  TestAccElastiCacheReplicationGroupDataSource_Engine_Redis_LogDeliveryConfigurations
--- PASS: TestAccElastiCacheReplicationGroupDataSource_Engine_Redis_LogDeliveryConfigurations (610.88s)
=== CONT  TestAccElastiCacheReplicationGroup_Redis_EngineVersion_v7
--- PASS: TestAccElastiCacheReplicationGroup_Redis_EngineVersion_v7 (548.12s)
=== CONT  TestAccElastiCacheReplicationGroup_finalSnapshot
--- PASS: TestAccElastiCacheReplicationGroup_finalSnapshot (723.83s)
=== CONT  TestAccElastiCacheReplicationGroup_Redis_basic
--- PASS: TestAccElastiCacheReplicationGroup_Redis_basic (477.99s)
=== CONT  TestAccElastiCacheReplicationGroup_Engine_RedisToValkey
--- PASS: TestAccElastiCacheReplicationGroup_Engine_RedisToValkey (1297.22s)
=== CONT  TestAccElastiCacheReplicationGroupDataSource_multiAZ
--- PASS: TestAccElastiCacheReplicationGroupDataSource_multiAZ (694.32s)
=== CONT  TestAccElastiCacheReplicationGroup_Valkey_durability
--- PASS: TestAccElastiCacheReplicationGroup_Valkey_durability (2048.94s)
=== CONT  TestAccElastiCacheReplicationGroup_enableTLSAndUserGroup
--- PASS: TestAccElastiCacheReplicationGroup_enableTLSAndUserGroup (2015.43s)
=== CONT  TestAccElastiCacheReplicationGroupDataSource_clusterMode
--- PASS: TestAccElastiCacheReplicationGroupDataSource_clusterMode (704.21s)
=== CONT  TestAccElastiCacheReplicationGroup_updateUserGroups
--- PASS: TestAccElastiCacheReplicationGroup_updateUserGroups (787.11s)
=== CONT  TestAccElastiCacheReplicationGroup_updateMaintenanceWindow
--- PASS: TestAccElastiCacheReplicationGroup_updateMaintenanceWindow (480.92s)
=== CONT  TestAccElastiCacheReplicationGroup_Valkey_basic
--- PASS: TestAccElastiCacheReplicationGroup_Valkey_basic (601.71s)
=== CONT  TestAccElastiCacheReplicationGroup_EngineVersion_6xToRealVersion
--- PASS: TestAccElastiCacheReplicationGroup_EngineVersion_6xToRealVersion (607.03s)
=== CONT  TestAccElastiCacheReplicationGroup_Redis_basic_v5
--- PASS: TestAccElastiCacheReplicationGroup_Redis_basic_v5 (496.61s)
=== CONT  TestAccElastiCacheReplicationGroup_TagWithOtherModification_version
--- PASS: TestAccElastiCacheReplicationGroup_TagWithOtherModification_version (1679.22s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elasticache	106923.265s

```

### AI Usage Disclosure
This change was developed with the assistance of an LLM-based coding agent (Kiro). I have reviewed and understand all submitted code.