### PR TITLE
support move for security group rule with single source

### DIFF
--- a/.changelog/49227.txt
+++ b/.changelog/49227.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_vpc_security_group_ingress_rule: Allow move from `aws_security_group_rule` resource with single source
+```
+
+```release-note:enhancement
+resource/aws_vpc_security_group_egress_rule: Allow move from `aws_security_group_rule` resource with single destination
+```

--- a/internal/service/ec2/vpc_security_group_egress_rule.go
+++ b/internal/service/ec2/vpc_security_group_egress_rule.go
@@ -32,8 +32,13 @@ type securityGroupEgressRuleResource struct {
 	securityGroupRuleResource
 }
 
-func (*securityGroupEgressRuleResource) MoveState(ctx context.Context) []resource.StateMover {
-	return []resource.StateMover{}
+func (r *securityGroupEgressRuleResource) MoveState(ctx context.Context) []resource.StateMover {
+	return []resource.StateMover{
+		{
+			SourceSchema: legacySecurityGroupRuleResourceSchemaV2(ctx),
+			StateMover:   r.moveStateResourceSecurityGroupRule,
+		},
+	}
 }
 
 func (r *securityGroupEgressRuleResource) create(ctx context.Context, data *securityGroupRuleResourceModel) (string, error) {
@@ -70,4 +75,14 @@ func (r *securityGroupEgressRuleResource) findByID(ctx context.Context, id strin
 	conn := r.Meta().EC2Client(ctx)
 
 	return findSecurityGroupEgressRuleByID(ctx, conn, id)
+}
+
+// moveStateResourceSecurityGroupRule transforms the state of an `aws_security_group_rule` resource to this resource's schema.
+func (r *securityGroupEgressRuleResource) moveStateResourceSecurityGroupRule(ctx context.Context, request resource.MoveStateRequest, response *resource.MoveStateResponse) {
+	source, done := r.validateMoveSupport(ctx, request, response, securityGroupRuleTypeEgress)
+	if done {
+		return
+	}
+
+	r.populateSgRuleModel(ctx, source, response)
 }

--- a/internal/service/ec2/vpc_security_group_egress_rule_test.go
+++ b/internal/service/ec2/vpc_security_group_egress_rule_test.go
@@ -89,7 +89,7 @@ func TestAccVPCSecurityGroupEgressRule_disappears(t *testing.T) {
 	})
 }
 
-func TestAccVPCSecurityGroupEgressRule_moveWithSingleSource(t *testing.T) {
+func TestAccVPCSecurityGroupEgressRule_moveWithSingleDestination(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.SecurityGroupRule
 	var group awstypes.SecurityGroup

--- a/internal/service/ec2/vpc_security_group_egress_rule_test.go
+++ b/internal/service/ec2/vpc_security_group_egress_rule_test.go
@@ -89,6 +89,81 @@ func TestAccVPCSecurityGroupEgressRule_disappears(t *testing.T) {
 	})
 }
 
+func TestAccVPCSecurityGroupEgressRule_moveWithSingleSource(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v awstypes.SecurityGroupRule
+	var group awstypes.SecurityGroup
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	fromResourceName := "aws_security_group_rule.test"
+	toResourceName := "aws_vpc_security_group_egress_rule.test"
+	sgResourceName := "aws_security_group.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckSecurityGroupEgressRuleDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVPCSecurityGroupEgressRuleConfig_moveFrom(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckSecurityGroupExists(ctx, t, sgResourceName, &group),
+					resource.TestCheckResourceAttr(fromResourceName, names.AttrType, "egress"),
+					resource.TestCheckResourceAttr(fromResourceName, "cidr_blocks.#", "1"),
+					resource.TestCheckResourceAttr(fromResourceName, "cidr_blocks.0", "10.0.0.0/8"),
+					resource.TestCheckResourceAttr(fromResourceName, "ipv6_cidr_blocks.#", "0"),
+					resource.TestCheckResourceAttr(fromResourceName, "from_port", "80"),
+					resource.TestCheckResourceAttr(fromResourceName, names.AttrProtocol, "tcp"),
+					resource.TestCheckResourceAttr(fromResourceName, "prefix_list_ids.#", "0"),
+					resource.TestCheckNoResourceAttr(fromResourceName, "source_security_group_id"),
+					resource.TestCheckResourceAttr(fromResourceName, "to_port", "8080"),
+				),
+			},
+			{
+				Config: testAccVPCSecurityGroupEgressRuleConfig_moveTo(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckSecurityGroupEgressRuleExists(ctx, t, toResourceName, &v),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, toResourceName, names.AttrARN, "ec2", "security-group-rule/{id}"),
+					resource.TestCheckResourceAttr(toResourceName, "cidr_ipv4", "10.0.0.0/8"),
+					resource.TestCheckNoResourceAttr(toResourceName, "cidr_ipv6"),
+					resource.TestCheckNoResourceAttr(toResourceName, names.AttrDescription),
+					resource.TestCheckResourceAttr(toResourceName, "from_port", "80"),
+					resource.TestCheckResourceAttrPair(toResourceName, names.AttrID, toResourceName, "security_group_rule_id"),
+					resource.TestCheckResourceAttr(toResourceName, "ip_protocol", "tcp"),
+					resource.TestCheckNoResourceAttr(toResourceName, "prefix_list_id"),
+					resource.TestCheckNoResourceAttr(toResourceName, "referenced_security_group_id"),
+					resource.TestCheckResourceAttrSet(toResourceName, "security_group_rule_id"),
+					resource.TestCheckNoResourceAttr(toResourceName, names.AttrTags),
+					resource.TestCheckResourceAttr(toResourceName, "to_port", "8080"),
+				),
+			},
+		},
+	})
+}
+
+func testAccVPCSecurityGroupEgressRuleConfig_moveFrom(rName string) string {
+	return acctest.ConfigCompose(testAccVPCSecurityGroupRuleConfig_base(rName), `
+resource "aws_security_group_rule" "test" {
+  security_group_id = aws_security_group.test.id
+
+  type        = "egress"
+  cidr_blocks = ["10.0.0.0/8"]
+  from_port   = 80
+  protocol    = "tcp"
+  to_port     = 8080
+}
+`)
+}
+
+func testAccVPCSecurityGroupEgressRuleConfig_moveTo(rName string) string {
+	return acctest.ConfigCompose(testAccVPCSecurityGroupEgressRuleConfig_basic(rName), `
+moved {
+  from = aws_security_group_rule.test
+  to   = aws_vpc_security_group_egress_rule.test
+}
+`)
+}
+
 func testAccCheckSecurityGroupEgressRuleDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.ProviderMeta(ctx, t).EC2Client(ctx)

--- a/internal/service/ec2/vpc_security_group_ingress_rule.go
+++ b/internal/service/ec2/vpc_security_group_ingress_rule.go
@@ -107,59 +107,76 @@ func (r *securityGroupIngressRuleResource) findByID(ctx context.Context, id stri
 
 // moveStateResourceSecurityGroupRule transforms the state of an `aws_security_group_rule` resource to this resource's schema.
 func (r *securityGroupIngressRuleResource) moveStateResourceSecurityGroupRule(ctx context.Context, request resource.MoveStateRequest, response *resource.MoveStateResponse) {
-	if request.SourceTypeName != "aws_security_group_rule" {
+	source, done := r.validateMoveSupport(ctx, request, response, securityGroupRuleTypeIngress)
+	if done {
 		return
+	}
+
+	r.populateSgRuleModel(ctx, source, response)
+}
+
+func (r *securityGroupRuleResource) populateSgRuleModel(ctx context.Context, source legacySecurityGroupRuleResourceModel, response *resource.MoveStateResponse) {
+	target := &securityGroupRuleResourceModel{
+		Description:         fwflex.EmptyStringAsNull(source.Description),
+		SecurityGroupID:     source.SecurityGroupID,
+		FromPort:            source.FromPort,
+		ToPort:              source.ToPort,
+		IPProtocol:          source.Protocol,
+		ID:                  source.SecurityGroupRuleID,
+		SecurityGroupRuleID: source.SecurityGroupRuleID,
+		Tags:                tftags.NewMapValueNull(),
+		TagsAll:             tftags.NewMapValueNull(),
+	}
+
+	if !source.CIDRBlocks.IsNull() && len(source.CIDRBlocks.Elements()) > 0 {
+		target.CIDRIPv4 = source.CIDRBlocks.Elements()[0].(types.String)
+	} else if !source.IPv6CIDRBlocksBlocks.IsNull() && len(source.IPv6CIDRBlocksBlocks.Elements()) > 0 {
+		target.CIDRIPv6 = source.IPv6CIDRBlocksBlocks.Elements()[0].(types.String)
+	} else if !source.PrefixListIDs.IsNull() && len(source.PrefixListIDs.Elements()) > 0 {
+		target.PrefixListID = source.PrefixListIDs.Elements()[0].(types.String)
+	} else if !source.SourceSecurityGroupID.IsNull() && source.SourceSecurityGroupID.ValueString() != "" {
+		target.ReferencedSecurityGroupID = source.SourceSecurityGroupID
+	} else if !source.Self.IsNull() && source.Self.ValueBool() {
+		target.ReferencedSecurityGroupID = source.SecurityGroupID
+	} else {
+		response.Diagnostics.AddError("Missing Source", "At least one source is expected")
+		return
+	}
+
+	response.Diagnostics.Append(response.TargetState.Set(ctx, target)...)
+}
+
+func (r *securityGroupRuleResource) validateMoveSupport(ctx context.Context, request resource.MoveStateRequest, response *resource.MoveStateResponse, expectedRuleType securityGroupRuleType) (legacySecurityGroupRuleResourceModel, bool) {
+	if request.SourceTypeName != "aws_security_group_rule" {
+		return legacySecurityGroupRuleResourceModel{}, true
 	}
 
 	if request.SourceSchemaVersion != 2 {
-		return
+		return legacySecurityGroupRuleResourceModel{}, true
 	}
 
 	if !strings.HasSuffix(request.SourceProviderAddress, "hashicorp/aws") {
-		return
+		return legacySecurityGroupRuleResourceModel{}, true
 	}
 
 	var source legacySecurityGroupRuleResourceModel
 	response.Diagnostics.Append(request.SourceState.Get(ctx, &source)...)
 	if response.Diagnostics.HasError() {
-		return
+		return legacySecurityGroupRuleResourceModel{}, true
 	}
 
-	// TODO: Need to find the security group rule ID.
+	if typ := source.Type.ValueEnum(); typ != expectedRuleType {
+		response.Diagnostics.AddError("Incorrect Type", string(typ))
+		return legacySecurityGroupRuleResourceModel{}, true
+	}
 
-	// if typ := source.Type.ValueEnum(); typ != securityGroupRuleTypeIngress {
-	// 	response.Diagnostics.AddError("Incorrect Type", string(typ))
-	// 	return
-	// }
+	// security group rule ID required in order to populate the target state but is null in case of multiple sources
+	if fwflex.EmptyStringAsNull(source.SecurityGroupRuleID).IsNull() || source.SecurityGroupRuleID.IsUnknown() {
+		response.Diagnostics.AddError("Multiple Sources", "Only one source is allowed")
+		return legacySecurityGroupRuleResourceModel{}, true
+	}
 
-	// nCIDRs := 0
-	// if !source.CIDRBlocks.IsNull() {
-	// 	nCIDRs += len(source.CIDRBlocks.Elements())
-	// }
-	// nIPv6CIDRs := 0
-	// if !source.IPv6CIDRBlocksBlocks.IsNull() {
-	// 	nIPv6CIDRs += len(source.IPv6CIDRBlocksBlocks.Elements())
-	// }
-	// nPrefxListIDs := 0
-	// if !source.PrefixListIDs.IsNull() {
-	// 	nPrefxListIDs += len(source.PrefixListIDs.Elements())
-	// }
-	// nSourceSecurityGroupIDs := 0
-	// if !source.SourceSecurityGroupID.IsNull() && source.SourceSecurityGroupID.ValueString() != "" {
-	// 	nSourceSecurityGroupIDs = 1
-	// }
-
-	// if nCIDRs+nIPv6CIDRs+nPrefxListIDs+nSourceSecurityGroupIDs > 1 {
-	// 	response.Diagnostics.AddError("Multiple Sources", "Only one source is allowed")
-	// 	return
-	// }
-
-	// target := &securityGroupRuleResourceModel{
-	// 	// ARN: 				  r.securityGroupRuleARN(ctx, securityGroupRuleID),
-	// 	Description: fwflex.EmptyStringAsNull(source.Description),
-	// }
-
-	// response.Diagnostics.Append(response.TargetState.Set(ctx, target)...)
+	return source, false
 }
 
 // Base structure and methods for VPC security group rules.

--- a/internal/service/ec2/vpc_security_group_ingress_rule.go
+++ b/internal/service/ec2/vpc_security_group_ingress_rule.go
@@ -172,7 +172,7 @@ func (r *securityGroupRuleResource) validateMoveSupport(ctx context.Context, req
 
 	// security group rule ID required in order to populate the target state but is null in case of multiple sources
 	if fwflex.EmptyStringAsNull(source.SecurityGroupRuleID).IsNull() || source.SecurityGroupRuleID.IsUnknown() {
-		response.Diagnostics.AddError("Multiple Sources", "Only one source is allowed")
+		response.Diagnostics.AddError("Multiple Sources/Destinations", "Only one source/destination is allowed")
 		return legacySecurityGroupRuleResourceModel{}, true
 	}
 

--- a/internal/service/ec2/vpc_security_group_ingress_rule_test.go
+++ b/internal/service/ec2/vpc_security_group_ingress_rule_test.go
@@ -618,6 +618,58 @@ func TestAccVPCSecurityGroupIngressRule_updateSourceType(t *testing.T) {
 	})
 }
 
+func TestAccVPCSecurityGroupIngressRule_moveWithSingleSource(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v awstypes.SecurityGroupRule
+	var group awstypes.SecurityGroup
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	fromResourceName := "aws_security_group_rule.test"
+	toResourceName := "aws_vpc_security_group_ingress_rule.test"
+	sgResourceName := "aws_security_group.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckSecurityGroupIngressRuleDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVPCSecurityGroupIngressRuleConfig_moveFrom(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckSecurityGroupExists(ctx, t, sgResourceName, &group),
+					resource.TestCheckResourceAttr(fromResourceName, names.AttrType, "ingress"),
+					resource.TestCheckResourceAttr(fromResourceName, "cidr_blocks.#", "0"),
+					resource.TestCheckResourceAttr(fromResourceName, "self", acctest.CtTrue),
+					resource.TestCheckResourceAttr(fromResourceName, "ipv6_cidr_blocks.#", "0"),
+					resource.TestCheckResourceAttr(fromResourceName, "from_port", "80"),
+					resource.TestCheckResourceAttr(fromResourceName, names.AttrProtocol, "tcp"),
+					resource.TestCheckResourceAttr(fromResourceName, "prefix_list_ids.#", "0"),
+					resource.TestCheckNoResourceAttr(fromResourceName, "source_security_group_id"),
+					resource.TestCheckResourceAttr(fromResourceName, "to_port", "8080"),
+				),
+			},
+			{
+				Config: testAccVPCSecurityGroupIngressRuleConfig_moveTo(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckSecurityGroupIngressRuleExists(ctx, t, toResourceName, &v),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, toResourceName, names.AttrARN, "ec2", "security-group-rule/{id}"),
+					resource.TestCheckNoResourceAttr(toResourceName, "cidr_ipv4"),
+					resource.TestCheckNoResourceAttr(toResourceName, "cidr_ipv6"),
+					resource.TestCheckNoResourceAttr(toResourceName, names.AttrDescription),
+					resource.TestCheckResourceAttr(toResourceName, "from_port", "80"),
+					resource.TestCheckResourceAttrPair(toResourceName, names.AttrID, toResourceName, "security_group_rule_id"),
+					resource.TestCheckResourceAttr(toResourceName, "ip_protocol", "tcp"),
+					resource.TestCheckNoResourceAttr(toResourceName, "prefix_list_id"),
+					resource.TestCheckResourceAttrPair(toResourceName, "referenced_security_group_id", sgResourceName, names.AttrID),
+					resource.TestCheckResourceAttrSet(toResourceName, "security_group_rule_id"),
+					resource.TestCheckNoResourceAttr(toResourceName, names.AttrTags),
+					resource.TestCheckResourceAttr(toResourceName, "to_port", "8080"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckSecurityGroupRuleNotRecreated(i, j *awstypes.SecurityGroupRule) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if aws.ToString(i.SecurityGroupRuleId) != aws.ToString(j.SecurityGroupRuleId) {
@@ -757,6 +809,29 @@ resource "aws_vpc_security_group_ingress_rule" "test" {
   from_port   = 53
   ip_protocol = "udp"
   to_port     = 53
+}
+`)
+}
+
+func testAccVPCSecurityGroupIngressRuleConfig_moveFrom(rName string) string {
+	return acctest.ConfigCompose(testAccVPCSecurityGroupRuleConfig_base(rName), `
+resource "aws_security_group_rule" "test" {
+  security_group_id = aws_security_group.test.id
+
+  type      = "ingress"
+  from_port = 80
+  protocol  = "tcp"
+  to_port   = 8080
+  self      = true
+}
+`)
+}
+
+func testAccVPCSecurityGroupIngressRuleConfig_moveTo(rName string) string {
+	return acctest.ConfigCompose(testAccVPCSecurityGroupIngressRuleConfig_referencedSecurityGroupID(rName), `
+moved {
+  from = aws_security_group_rule.test
+  to   = aws_vpc_security_group_ingress_rule.test
 }
 `)
 }


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

None

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Allow to move `aws_security_group_rule`(with single source or destination) to `aws_vpc_security_group_egress_rule` or `aws_vpc_security_group_ingress_rule` with `moved` block.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #49149

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccVPCSecurityGroupIngressRule PKG=ec2 ACCTEST_PARALLELISM=4
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2	(cached)
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider/framework	(cached)
make: Running acceptance tests on branch: 🌿 f-sg-rule-move 🌿...
TF_ACC=1 go1.26.5 test ./internal/service/ec2/... -v -count 1 -parallel 4 -run='TestAccVPCSecurityGroupIngressRule'  -timeout 360m -vet=off -buildvcs=false
2026/07/30 23:58:05 Creating Terraform AWS Provider (SDKv2-style)...
2026/07/30 23:58:05 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccVPCSecurityGroupIngressRule_Identity_basic
=== PAUSE TestAccVPCSecurityGroupIngressRule_Identity_basic
=== RUN   TestAccVPCSecurityGroupIngressRule_Identity_regionOverride
=== PAUSE TestAccVPCSecurityGroupIngressRule_Identity_regionOverride
=== RUN   TestAccVPCSecurityGroupIngressRule_Identity_ExistingResource_basic
=== PAUSE TestAccVPCSecurityGroupIngressRule_Identity_ExistingResource_basic
=== RUN   TestAccVPCSecurityGroupIngressRule_Identity_ExistingResource_noRefreshNoChange
=== PAUSE TestAccVPCSecurityGroupIngressRule_Identity_ExistingResource_noRefreshNoChange
=== RUN   TestAccVPCSecurityGroupIngressRule_List_basic
=== PAUSE TestAccVPCSecurityGroupIngressRule_List_basic
=== RUN   TestAccVPCSecurityGroupIngressRule_List_filter
=== PAUSE TestAccVPCSecurityGroupIngressRule_List_filter
=== RUN   TestAccVPCSecurityGroupIngressRule_List_regionOverride
=== PAUSE TestAccVPCSecurityGroupIngressRule_List_regionOverride
=== RUN   TestAccVPCSecurityGroupIngressRule_tags
=== PAUSE TestAccVPCSecurityGroupIngressRule_tags
=== RUN   TestAccVPCSecurityGroupIngressRule_Tags_null
=== PAUSE TestAccVPCSecurityGroupIngressRule_Tags_null
=== RUN   TestAccVPCSecurityGroupIngressRule_Tags_emptyMap
=== PAUSE TestAccVPCSecurityGroupIngressRule_Tags_emptyMap
=== RUN   TestAccVPCSecurityGroupIngressRule_Tags_addOnUpdate
=== PAUSE TestAccVPCSecurityGroupIngressRule_Tags_addOnUpdate
=== RUN   TestAccVPCSecurityGroupIngressRule_Tags_EmptyTag_onCreate
=== PAUSE TestAccVPCSecurityGroupIngressRule_Tags_EmptyTag_onCreate
=== RUN   TestAccVPCSecurityGroupIngressRule_Tags_EmptyTag_OnUpdate_add
=== PAUSE TestAccVPCSecurityGroupIngressRule_Tags_EmptyTag_OnUpdate_add
=== RUN   TestAccVPCSecurityGroupIngressRule_Tags_EmptyTag_OnUpdate_replace
=== PAUSE TestAccVPCSecurityGroupIngressRule_Tags_EmptyTag_OnUpdate_replace
=== RUN   TestAccVPCSecurityGroupIngressRule_Tags_DefaultTags_providerOnly
=== PAUSE TestAccVPCSecurityGroupIngressRule_Tags_DefaultTags_providerOnly
=== RUN   TestAccVPCSecurityGroupIngressRule_Tags_DefaultTags_nonOverlapping
=== PAUSE TestAccVPCSecurityGroupIngressRule_Tags_DefaultTags_nonOverlapping
=== RUN   TestAccVPCSecurityGroupIngressRule_Tags_DefaultTags_overlapping
=== PAUSE TestAccVPCSecurityGroupIngressRule_Tags_DefaultTags_overlapping
=== RUN   TestAccVPCSecurityGroupIngressRule_Tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccVPCSecurityGroupIngressRule_Tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccVPCSecurityGroupIngressRule_Tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccVPCSecurityGroupIngressRule_Tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccVPCSecurityGroupIngressRule_Tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccVPCSecurityGroupIngressRule_Tags_DefaultTags_emptyResourceTag
=== RUN   TestAccVPCSecurityGroupIngressRule_Tags_DefaultTags_emptyProviderOnlyTag
=== PAUSE TestAccVPCSecurityGroupIngressRule_Tags_DefaultTags_emptyProviderOnlyTag
=== RUN   TestAccVPCSecurityGroupIngressRule_Tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccVPCSecurityGroupIngressRule_Tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccVPCSecurityGroupIngressRule_Tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccVPCSecurityGroupIngressRule_Tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccVPCSecurityGroupIngressRule_Tags_ComputedTag_onCreate
=== PAUSE TestAccVPCSecurityGroupIngressRule_Tags_ComputedTag_onCreate
=== RUN   TestAccVPCSecurityGroupIngressRule_Tags_ComputedTag_OnUpdate_add
=== PAUSE TestAccVPCSecurityGroupIngressRule_Tags_ComputedTag_OnUpdate_add
=== RUN   TestAccVPCSecurityGroupIngressRule_Tags_ComputedTag_OnUpdate_replace
=== PAUSE TestAccVPCSecurityGroupIngressRule_Tags_ComputedTag_OnUpdate_replace
=== RUN   TestAccVPCSecurityGroupIngressRule_Tags_IgnoreTags_Overlap_defaultTag
=== PAUSE TestAccVPCSecurityGroupIngressRule_Tags_IgnoreTags_Overlap_defaultTag
=== RUN   TestAccVPCSecurityGroupIngressRule_Tags_IgnoreTags_Overlap_resourceTag
=== PAUSE TestAccVPCSecurityGroupIngressRule_Tags_IgnoreTags_Overlap_resourceTag
=== RUN   TestAccVPCSecurityGroupIngressRule_basic
=== PAUSE TestAccVPCSecurityGroupIngressRule_basic
=== RUN   TestAccVPCSecurityGroupIngressRule_disappears
=== PAUSE TestAccVPCSecurityGroupIngressRule_disappears
=== RUN   TestAccVPCSecurityGroupIngressRule_tags_defaultAndIgnoreTags
=== PAUSE TestAccVPCSecurityGroupIngressRule_tags_defaultAndIgnoreTags
=== RUN   TestAccVPCSecurityGroupIngressRule_tags_ignoreTags
=== PAUSE TestAccVPCSecurityGroupIngressRule_tags_ignoreTags
=== RUN   TestAccVPCSecurityGroupIngressRule_cidrIPv4
=== PAUSE TestAccVPCSecurityGroupIngressRule_cidrIPv4
=== RUN   TestAccVPCSecurityGroupIngressRule_cidrIPv6
=== PAUSE TestAccVPCSecurityGroupIngressRule_cidrIPv6
=== RUN   TestAccVPCSecurityGroupIngressRule_description
=== PAUSE TestAccVPCSecurityGroupIngressRule_description
=== RUN   TestAccVPCSecurityGroupIngressRule_prefixListID
=== PAUSE TestAccVPCSecurityGroupIngressRule_prefixListID
=== RUN   TestAccVPCSecurityGroupIngressRule_referencedSecurityGroupID
=== PAUSE TestAccVPCSecurityGroupIngressRule_referencedSecurityGroupID
=== RUN   TestAccVPCSecurityGroupIngressRule_ReferencedSecurityGroupID_peerVPC
=== PAUSE TestAccVPCSecurityGroupIngressRule_ReferencedSecurityGroupID_peerVPC
=== RUN   TestAccVPCSecurityGroupIngressRule_updateSourceType
=== PAUSE TestAccVPCSecurityGroupIngressRule_updateSourceType
=== RUN   TestAccVPCSecurityGroupIngressRule_moveWithSingleSource
=== PAUSE TestAccVPCSecurityGroupIngressRule_moveWithSingleSource
=== CONT  TestAccVPCSecurityGroupIngressRule_Identity_basic
=== CONT  TestAccVPCSecurityGroupIngressRule_Tags_DefaultTags_emptyProviderOnlyTag
=== CONT  TestAccVPCSecurityGroupIngressRule_Tags_addOnUpdate
=== CONT  TestAccVPCSecurityGroupIngressRule_Tags_DefaultTags_nonOverlapping
=== NAME  TestAccVPCSecurityGroupIngressRule_Identity_basic
    vpc_security_group_ingress_rule_identity_gen_test.go:33: Terraform CLI version 1.9.8-dev is below minimum version 1.12.0: skipping test
--- SKIP: TestAccVPCSecurityGroupIngressRule_Identity_basic (2.02s)
=== CONT  TestAccVPCSecurityGroupIngressRule_List_filter
    vpc_security_group_ingress_rule_list_test.go:86: Terraform CLI version 1.9.8-dev is below minimum version 1.14.0: skipping test
--- SKIP: TestAccVPCSecurityGroupIngressRule_List_filter (0.05s)
=== CONT  TestAccVPCSecurityGroupIngressRule_Tags_emptyMap
--- PASS: TestAccVPCSecurityGroupIngressRule_Tags_emptyMap (82.17s)
=== CONT  TestAccVPCSecurityGroupIngressRule_Tags_null
--- PASS: TestAccVPCSecurityGroupIngressRule_Tags_DefaultTags_emptyProviderOnlyTag (84.93s)
=== CONT  TestAccVPCSecurityGroupIngressRule_tags
--- PASS: TestAccVPCSecurityGroupIngressRule_Tags_addOnUpdate (121.97s)
=== CONT  TestAccVPCSecurityGroupIngressRule_List_regionOverride
    vpc_security_group_ingress_rule_list_test.go:139: Terraform CLI version 1.9.8-dev is below minimum version 1.14.0: skipping test
--- SKIP: TestAccVPCSecurityGroupIngressRule_List_regionOverride (0.08s)
=== CONT  TestAccVPCSecurityGroupIngressRule_Tags_EmptyTag_OnUpdate_replace
--- PASS: TestAccVPCSecurityGroupIngressRule_Tags_null (70.31s)
=== CONT  TestAccVPCSecurityGroupIngressRule_Tags_DefaultTags_providerOnly
--- PASS: TestAccVPCSecurityGroupIngressRule_Tags_DefaultTags_nonOverlapping (197.11s)
=== CONT  TestAccVPCSecurityGroupIngressRule_Tags_DefaultTags_updateToResourceOnly
--- PASS: TestAccVPCSecurityGroupIngressRule_Tags_EmptyTag_OnUpdate_replace (114.10s)
=== CONT  TestAccVPCSecurityGroupIngressRule_Tags_DefaultTags_emptyResourceTag
--- PASS: TestAccVPCSecurityGroupIngressRule_Tags_DefaultTags_emptyResourceTag (72.68s)
=== CONT  TestAccVPCSecurityGroupIngressRule_Tags_EmptyTag_OnUpdate_add
--- PASS: TestAccVPCSecurityGroupIngressRule_Tags_DefaultTags_updateToResourceOnly (116.05s)
=== CONT  TestAccVPCSecurityGroupIngressRule_Identity_ExistingResource_noRefreshNoChange
    vpc_security_group_ingress_rule_identity_gen_test.go:268: Terraform CLI version 1.9.8-dev is below minimum version 1.12.0: skipping test
--- SKIP: TestAccVPCSecurityGroupIngressRule_Identity_ExistingResource_noRefreshNoChange (0.06s)
=== CONT  TestAccVPCSecurityGroupIngressRule_List_basic
    vpc_security_group_ingress_rule_list_test.go:32: Terraform CLI version 1.9.8-dev is below minimum version 1.14.0: skipping test
--- SKIP: TestAccVPCSecurityGroupIngressRule_List_basic (0.04s)
=== CONT  TestAccVPCSecurityGroupIngressRule_Identity_ExistingResource_basic
    vpc_security_group_ingress_rule_identity_gen_test.go:210: Terraform CLI version 1.9.8-dev is below minimum version 1.12.0: skipping test
--- SKIP: TestAccVPCSecurityGroupIngressRule_Identity_ExistingResource_basic (0.04s)
=== CONT  TestAccVPCSecurityGroupIngressRule_Identity_regionOverride
    vpc_security_group_ingress_rule_identity_gen_test.go:120: Terraform CLI version 1.9.8-dev is below minimum version 1.12.0: skipping test
--- SKIP: TestAccVPCSecurityGroupIngressRule_Identity_regionOverride (0.04s)
=== CONT  TestAccVPCSecurityGroupIngressRule_tags_defaultAndIgnoreTags
--- PASS: TestAccVPCSecurityGroupIngressRule_tags (231.08s)
=== CONT  TestAccVPCSecurityGroupIngressRule_moveWithSingleSource
--- PASS: TestAccVPCSecurityGroupIngressRule_Tags_DefaultTags_providerOnly (248.18s)
=== CONT  TestAccVPCSecurityGroupIngressRule_updateSourceType
--- PASS: TestAccVPCSecurityGroupIngressRule_moveWithSingleSource (93.64s)
=== CONT  TestAccVPCSecurityGroupIngressRule_ReferencedSecurityGroupID_peerVPC
    vpc_security_group_ingress_rule_test.go:530: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
--- SKIP: TestAccVPCSecurityGroupIngressRule_ReferencedSecurityGroupID_peerVPC (0.00s)
=== CONT  TestAccVPCSecurityGroupIngressRule_referencedSecurityGroupID
--- PASS: TestAccVPCSecurityGroupIngressRule_tags_defaultAndIgnoreTags (136.68s)
=== CONT  TestAccVPCSecurityGroupIngressRule_prefixListID
--- PASS: TestAccVPCSecurityGroupIngressRule_Tags_EmptyTag_OnUpdate_add (183.89s)
=== CONT  TestAccVPCSecurityGroupIngressRule_description
--- PASS: TestAccVPCSecurityGroupIngressRule_updateSourceType (122.37s)
=== CONT  TestAccVPCSecurityGroupIngressRule_cidrIPv6
--- PASS: TestAccVPCSecurityGroupIngressRule_referencedSecurityGroupID (130.00s)
=== CONT  TestAccVPCSecurityGroupIngressRule_cidrIPv4
--- PASS: TestAccVPCSecurityGroupIngressRule_prefixListID (137.58s)
=== CONT  TestAccVPCSecurityGroupIngressRule_tags_ignoreTags
--- PASS: TestAccVPCSecurityGroupIngressRule_description (104.04s)
=== CONT  TestAccVPCSecurityGroupIngressRule_Tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccVPCSecurityGroupIngressRule_cidrIPv6 (108.82s)
=== CONT  TestAccVPCSecurityGroupIngressRule_Tags_ComputedTag_OnUpdate_replace
--- PASS: TestAccVPCSecurityGroupIngressRule_cidrIPv4 (112.13s)
=== CONT  TestAccVPCSecurityGroupIngressRule_disappears
--- PASS: TestAccVPCSecurityGroupIngressRule_tags_ignoreTags (126.52s)
=== CONT  TestAccVPCSecurityGroupIngressRule_basic
--- PASS: TestAccVPCSecurityGroupIngressRule_disappears (63.87s)
=== CONT  TestAccVPCSecurityGroupIngressRule_Tags_IgnoreTags_Overlap_resourceTag
--- PASS: TestAccVPCSecurityGroupIngressRule_Tags_DefaultTags_updateToProviderOnly (123.29s)
=== CONT  TestAccVPCSecurityGroupIngressRule_Tags_IgnoreTags_Overlap_defaultTag
--- PASS: TestAccVPCSecurityGroupIngressRule_Tags_ComputedTag_OnUpdate_replace (118.59s)
=== CONT  TestAccVPCSecurityGroupIngressRule_Tags_ComputedTag_onCreate
--- PASS: TestAccVPCSecurityGroupIngressRule_basic (68.30s)
=== CONT  TestAccVPCSecurityGroupIngressRule_Tags_ComputedTag_OnUpdate_add
--- PASS: TestAccVPCSecurityGroupIngressRule_Tags_ComputedTag_onCreate (83.73s)
=== CONT  TestAccVPCSecurityGroupIngressRule_Tags_DefaultTags_nullNonOverlappingResourceTag
--- PASS: TestAccVPCSecurityGroupIngressRule_Tags_IgnoreTags_Overlap_defaultTag (151.08s)
=== CONT  TestAccVPCSecurityGroupIngressRule_Tags_EmptyTag_onCreate
--- PASS: TestAccVPCSecurityGroupIngressRule_Tags_IgnoreTags_Overlap_resourceTag (166.19s)
=== CONT  TestAccVPCSecurityGroupIngressRule_Tags_DefaultTags_nullOverlappingResourceTag
--- PASS: TestAccVPCSecurityGroupIngressRule_Tags_ComputedTag_OnUpdate_add (126.50s)
=== CONT  TestAccVPCSecurityGroupIngressRule_Tags_DefaultTags_overlapping
--- PASS: TestAccVPCSecurityGroupIngressRule_Tags_DefaultTags_nullNonOverlappingResourceTag (73.59s)
--- PASS: TestAccVPCSecurityGroupIngressRule_Tags_DefaultTags_nullOverlappingResourceTag (68.71s)
--- PASS: TestAccVPCSecurityGroupIngressRule_Tags_EmptyTag_onCreate (117.42s)
--- PASS: TestAccVPCSecurityGroupIngressRule_Tags_DefaultTags_overlapping (162.87s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	1072.011s
% make testacc TESTS=TestAccVPCSecurityGroupEgressRule PKG=ec2 ACCTEST_PARALLELISM=4
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2	(cached)
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider/framework	(cached)
make: Running acceptance tests on branch: 🌿 f-sg-rule-move 🌿...
TF_ACC=1 go1.26.5 test ./internal/service/ec2/... -v -count 1 -parallel 4 -run='TestAccVPCSecurityGroupEgressRule'  -timeout 360m -vet=off -buildvcs=false
2026/07/31 00:19:59 Creating Terraform AWS Provider (SDKv2-style)...
2026/07/31 00:19:59 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccVPCSecurityGroupEgressRule_Identity_basic
=== PAUSE TestAccVPCSecurityGroupEgressRule_Identity_basic
=== RUN   TestAccVPCSecurityGroupEgressRule_Identity_regionOverride
=== PAUSE TestAccVPCSecurityGroupEgressRule_Identity_regionOverride
=== RUN   TestAccVPCSecurityGroupEgressRule_Identity_ExistingResource_basic
=== PAUSE TestAccVPCSecurityGroupEgressRule_Identity_ExistingResource_basic
=== RUN   TestAccVPCSecurityGroupEgressRule_Identity_ExistingResource_noRefreshNoChange
=== PAUSE TestAccVPCSecurityGroupEgressRule_Identity_ExistingResource_noRefreshNoChange
=== RUN   TestAccVPCSecurityGroupEgressRule_List_basic
=== PAUSE TestAccVPCSecurityGroupEgressRule_List_basic
=== RUN   TestAccVPCSecurityGroupEgressRule_List_filter
=== PAUSE TestAccVPCSecurityGroupEgressRule_List_filter
=== RUN   TestAccVPCSecurityGroupEgressRule_List_regionOverride
=== PAUSE TestAccVPCSecurityGroupEgressRule_List_regionOverride
=== RUN   TestAccVPCSecurityGroupEgressRule_tags
=== PAUSE TestAccVPCSecurityGroupEgressRule_tags
=== RUN   TestAccVPCSecurityGroupEgressRule_Tags_null
=== PAUSE TestAccVPCSecurityGroupEgressRule_Tags_null
=== RUN   TestAccVPCSecurityGroupEgressRule_Tags_emptyMap
=== PAUSE TestAccVPCSecurityGroupEgressRule_Tags_emptyMap
=== RUN   TestAccVPCSecurityGroupEgressRule_Tags_addOnUpdate
=== PAUSE TestAccVPCSecurityGroupEgressRule_Tags_addOnUpdate
=== RUN   TestAccVPCSecurityGroupEgressRule_Tags_EmptyTag_onCreate
=== PAUSE TestAccVPCSecurityGroupEgressRule_Tags_EmptyTag_onCreate
=== RUN   TestAccVPCSecurityGroupEgressRule_Tags_EmptyTag_OnUpdate_add
=== PAUSE TestAccVPCSecurityGroupEgressRule_Tags_EmptyTag_OnUpdate_add
=== RUN   TestAccVPCSecurityGroupEgressRule_Tags_EmptyTag_OnUpdate_replace
=== PAUSE TestAccVPCSecurityGroupEgressRule_Tags_EmptyTag_OnUpdate_replace
=== RUN   TestAccVPCSecurityGroupEgressRule_Tags_DefaultTags_providerOnly
=== PAUSE TestAccVPCSecurityGroupEgressRule_Tags_DefaultTags_providerOnly
=== RUN   TestAccVPCSecurityGroupEgressRule_Tags_DefaultTags_nonOverlapping
=== PAUSE TestAccVPCSecurityGroupEgressRule_Tags_DefaultTags_nonOverlapping
=== RUN   TestAccVPCSecurityGroupEgressRule_Tags_DefaultTags_overlapping
=== PAUSE TestAccVPCSecurityGroupEgressRule_Tags_DefaultTags_overlapping
=== RUN   TestAccVPCSecurityGroupEgressRule_Tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccVPCSecurityGroupEgressRule_Tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccVPCSecurityGroupEgressRule_Tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccVPCSecurityGroupEgressRule_Tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccVPCSecurityGroupEgressRule_Tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccVPCSecurityGroupEgressRule_Tags_DefaultTags_emptyResourceTag
=== RUN   TestAccVPCSecurityGroupEgressRule_Tags_DefaultTags_emptyProviderOnlyTag
=== PAUSE TestAccVPCSecurityGroupEgressRule_Tags_DefaultTags_emptyProviderOnlyTag
=== RUN   TestAccVPCSecurityGroupEgressRule_Tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccVPCSecurityGroupEgressRule_Tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccVPCSecurityGroupEgressRule_Tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccVPCSecurityGroupEgressRule_Tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccVPCSecurityGroupEgressRule_Tags_ComputedTag_onCreate
=== PAUSE TestAccVPCSecurityGroupEgressRule_Tags_ComputedTag_onCreate
=== RUN   TestAccVPCSecurityGroupEgressRule_Tags_ComputedTag_OnUpdate_add
=== PAUSE TestAccVPCSecurityGroupEgressRule_Tags_ComputedTag_OnUpdate_add
=== RUN   TestAccVPCSecurityGroupEgressRule_Tags_ComputedTag_OnUpdate_replace
=== PAUSE TestAccVPCSecurityGroupEgressRule_Tags_ComputedTag_OnUpdate_replace
=== RUN   TestAccVPCSecurityGroupEgressRule_Tags_IgnoreTags_Overlap_defaultTag
=== PAUSE TestAccVPCSecurityGroupEgressRule_Tags_IgnoreTags_Overlap_defaultTag
=== RUN   TestAccVPCSecurityGroupEgressRule_Tags_IgnoreTags_Overlap_resourceTag
=== PAUSE TestAccVPCSecurityGroupEgressRule_Tags_IgnoreTags_Overlap_resourceTag
=== RUN   TestAccVPCSecurityGroupEgressRule_basic
=== PAUSE TestAccVPCSecurityGroupEgressRule_basic
=== RUN   TestAccVPCSecurityGroupEgressRule_disappears
=== PAUSE TestAccVPCSecurityGroupEgressRule_disappears
=== RUN   TestAccVPCSecurityGroupEgressRule_moveWithSingleDestination
=== PAUSE TestAccVPCSecurityGroupEgressRule_moveWithSingleDestination
=== CONT  TestAccVPCSecurityGroupEgressRule_Identity_basic
=== CONT  TestAccVPCSecurityGroupEgressRule_Tags_null
=== CONT  TestAccVPCSecurityGroupEgressRule_Tags_ComputedTag_OnUpdate_add
=== CONT  TestAccVPCSecurityGroupEgressRule_Tags_DefaultTags_overlapping
=== NAME  TestAccVPCSecurityGroupEgressRule_Identity_basic
    vpc_security_group_egress_rule_identity_gen_test.go:33: Terraform CLI version 1.9.8-dev is below minimum version 1.12.0: skipping test
--- SKIP: TestAccVPCSecurityGroupEgressRule_Identity_basic (2.13s)
=== CONT  TestAccVPCSecurityGroupEgressRule_Tags_ComputedTag_onCreate
--- PASS: TestAccVPCSecurityGroupEgressRule_Tags_null (80.85s)
=== CONT  TestAccVPCSecurityGroupEgressRule_Tags_DefaultTags_nullNonOverlappingResourceTag
--- PASS: TestAccVPCSecurityGroupEgressRule_Tags_ComputedTag_onCreate (82.16s)
=== CONT  TestAccVPCSecurityGroupEgressRule_Tags_DefaultTags_nullOverlappingResourceTag
--- PASS: TestAccVPCSecurityGroupEgressRule_Tags_ComputedTag_OnUpdate_add (127.07s)
=== CONT  TestAccVPCSecurityGroupEgressRule_Tags_DefaultTags_emptyProviderOnlyTag
--- PASS: TestAccVPCSecurityGroupEgressRule_Tags_DefaultTags_nullNonOverlappingResourceTag (71.32s)
=== CONT  TestAccVPCSecurityGroupEgressRule_Tags_DefaultTags_emptyResourceTag
--- PASS: TestAccVPCSecurityGroupEgressRule_Tags_DefaultTags_nullOverlappingResourceTag (71.00s)
=== CONT  TestAccVPCSecurityGroupEgressRule_Tags_DefaultTags_updateToResourceOnly
--- PASS: TestAccVPCSecurityGroupEgressRule_Tags_DefaultTags_overlapping (198.36s)
=== CONT  TestAccVPCSecurityGroupEgressRule_Tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccVPCSecurityGroupEgressRule_Tags_DefaultTags_emptyProviderOnlyTag (73.84s)
=== CONT  TestAccVPCSecurityGroupEgressRule_basic
--- PASS: TestAccVPCSecurityGroupEgressRule_Tags_DefaultTags_emptyResourceTag (72.18s)
=== CONT  TestAccVPCSecurityGroupEgressRule_moveWithSingleDestination
--- PASS: TestAccVPCSecurityGroupEgressRule_basic (67.74s)
=== CONT  TestAccVPCSecurityGroupEgressRule_disappears
--- PASS: TestAccVPCSecurityGroupEgressRule_Tags_DefaultTags_updateToResourceOnly (116.85s)
=== CONT  TestAccVPCSecurityGroupEgressRule_Tags_IgnoreTags_Overlap_defaultTag
--- PASS: TestAccVPCSecurityGroupEgressRule_moveWithSingleDestination (93.65s)
=== CONT  TestAccVPCSecurityGroupEgressRule_Tags_IgnoreTags_Overlap_resourceTag
--- PASS: TestAccVPCSecurityGroupEgressRule_Tags_DefaultTags_updateToProviderOnly (122.58s)
=== CONT  TestAccVPCSecurityGroupEgressRule_Tags_ComputedTag_OnUpdate_replace
--- PASS: TestAccVPCSecurityGroupEgressRule_disappears (62.75s)
=== CONT  TestAccVPCSecurityGroupEgressRule_Tags_EmptyTag_OnUpdate_add
--- PASS: TestAccVPCSecurityGroupEgressRule_Tags_IgnoreTags_Overlap_defaultTag (153.64s)
=== CONT  TestAccVPCSecurityGroupEgressRule_Tags_DefaultTags_nonOverlapping
--- PASS: TestAccVPCSecurityGroupEgressRule_Tags_ComputedTag_OnUpdate_replace (128.61s)
=== CONT  TestAccVPCSecurityGroupEgressRule_Tags_DefaultTags_providerOnly
--- PASS: TestAccVPCSecurityGroupEgressRule_Tags_IgnoreTags_Overlap_resourceTag (168.73s)
=== CONT  TestAccVPCSecurityGroupEgressRule_Tags_EmptyTag_OnUpdate_replace
--- PASS: TestAccVPCSecurityGroupEgressRule_Tags_EmptyTag_OnUpdate_add (184.59s)
=== CONT  TestAccVPCSecurityGroupEgressRule_List_basic
    vpc_security_group_egress_rule_list_test.go:32: Terraform CLI version 1.9.8-dev is below minimum version 1.14.0: skipping test
--- SKIP: TestAccVPCSecurityGroupEgressRule_List_basic (0.07s)
=== CONT  TestAccVPCSecurityGroupEgressRule_tags
--- PASS: TestAccVPCSecurityGroupEgressRule_Tags_EmptyTag_OnUpdate_replace (120.52s)
=== CONT  TestAccVPCSecurityGroupEgressRule_List_regionOverride
    vpc_security_group_egress_rule_list_test.go:139: Terraform CLI version 1.9.8-dev is below minimum version 1.14.0: skipping test
--- SKIP: TestAccVPCSecurityGroupEgressRule_List_regionOverride (0.08s)
=== CONT  TestAccVPCSecurityGroupEgressRule_List_filter
    vpc_security_group_egress_rule_list_test.go:86: Terraform CLI version 1.9.8-dev is below minimum version 1.14.0: skipping test
--- SKIP: TestAccVPCSecurityGroupEgressRule_List_filter (0.05s)
=== CONT  TestAccVPCSecurityGroupEgressRule_Identity_ExistingResource_basic
    vpc_security_group_egress_rule_identity_gen_test.go:210: Terraform CLI version 1.9.8-dev is below minimum version 1.12.0: skipping test
--- SKIP: TestAccVPCSecurityGroupEgressRule_Identity_ExistingResource_basic (0.06s)
=== CONT  TestAccVPCSecurityGroupEgressRule_Identity_regionOverride
    vpc_security_group_egress_rule_identity_gen_test.go:120: Terraform CLI version 1.9.8-dev is below minimum version 1.12.0: skipping test
--- SKIP: TestAccVPCSecurityGroupEgressRule_Identity_regionOverride (0.05s)
=== CONT  TestAccVPCSecurityGroupEgressRule_Tags_addOnUpdate
--- PASS: TestAccVPCSecurityGroupEgressRule_Tags_DefaultTags_nonOverlapping (207.11s)
=== CONT  TestAccVPCSecurityGroupEgressRule_Identity_ExistingResource_noRefreshNoChange
    vpc_security_group_egress_rule_identity_gen_test.go:268: Terraform CLI version 1.9.8-dev is below minimum version 1.12.0: skipping test
--- SKIP: TestAccVPCSecurityGroupEgressRule_Identity_ExistingResource_noRefreshNoChange (0.03s)
=== CONT  TestAccVPCSecurityGroupEgressRule_Tags_EmptyTag_onCreate
--- PASS: TestAccVPCSecurityGroupEgressRule_Tags_DefaultTags_providerOnly (264.30s)
=== CONT  TestAccVPCSecurityGroupEgressRule_Tags_emptyMap
--- PASS: TestAccVPCSecurityGroupEgressRule_Tags_addOnUpdate (131.28s)
--- PASS: TestAccVPCSecurityGroupEgressRule_tags (251.58s)
--- PASS: TestAccVPCSecurityGroupEgressRule_Tags_EmptyTag_onCreate (135.83s)
--- PASS: TestAccVPCSecurityGroupEgressRule_Tags_emptyMap (70.26s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	784.319s
...
```
