### PR TITLE
🤖🤖🤖 resource/aws_account_primary_contact: Fix import of member account producing spurious plan diff

### DIFF
--- a/.changelog/49229.txt
+++ b/.changelog/49229.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_account_primary_contact: Fix import of member account contacts producing spurious plan diff
+```

--- a/internal/service/account/account_test.go
+++ b/internal/service/account/account_test.go
@@ -20,6 +20,7 @@ func TestAccAccount_serial(t *testing.T) {
 		},
 		"PrimaryContact": {
 			acctest.CtBasic:       testAccPrimaryContact_basic,
+			"AccountID":           testAccPrimaryContact_accountID,
 			"dataSourceBasic":     testAccPrimaryContactDataSource_basic,
 			"dataSourceAccountID": testAccPrimaryContactDataSource_accountID,
 		},

--- a/internal/service/account/primary_contact.go
+++ b/internal/service/account/primary_contact.go
@@ -165,7 +165,12 @@ func resourcePrimaryContactRead(ctx context.Context, d *schema.ResourceData, met
 
 	conn := meta.(*conns.AWSClient).AccountClient(ctx)
 
-	contactInformation, err := findContactInformation(ctx, conn, d.Get(names.AttrAccountID).(string))
+	accountID := d.Get(names.AttrAccountID).(string)
+	if accountID == "" && d.Id() != "default" {
+		accountID = d.Id()
+	}
+
+	contactInformation, err := findContactInformation(ctx, conn, accountID)
 
 	if !d.IsNewResource() && retry.NotFound(err) {
 		log.Printf("[WARN] Account Primary Contact (%s) not found, removing from state", d.Id())
@@ -177,7 +182,7 @@ func resourcePrimaryContactRead(ctx context.Context, d *schema.ResourceData, met
 		return sdkdiag.AppendErrorf(diags, "reading Account Primary Contact (%s): %s", d.Id(), err)
 	}
 
-	d.Set(names.AttrAccountID, d.Get(names.AttrAccountID))
+	d.Set(names.AttrAccountID, accountID)
 	d.Set("address_line_1", contactInformation.AddressLine1)
 	d.Set("address_line_2", contactInformation.AddressLine2)
 	d.Set("address_line_3", contactInformation.AddressLine3)

--- a/internal/service/account/primary_contact_test.go
+++ b/internal/service/account/primary_contact_test.go
@@ -70,6 +70,56 @@ func testAccPrimaryContact_basic(t *testing.T) {
 	})
 }
 
+func testAccPrimaryContact_accountID(t *testing.T) { // nosemgrep:ci.account-in-func-name
+	ctx := acctest.Context(t)
+	resourceName := "aws_account_primary_contact.test"
+	rName1 := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	rName2 := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.Test(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckAlternateAccount(t)
+			acctest.PreCheckOrganizationManagementAccount(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.AccountServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5FactoriesAlternate(ctx, t),
+		CheckDestroy:             acctest.CheckDestroyNoop,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPrimaryContactConfig_organization(rName1),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckPrimaryContactExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, names.AttrAccountID),
+					resource.TestCheckResourceAttr(resourceName, "address_line_1", "123 Any Street"),
+					resource.TestCheckResourceAttr(resourceName, "city", "Seattle"),
+					resource.TestCheckResourceAttr(resourceName, "country_code", "US"),
+					resource.TestCheckResourceAttr(resourceName, "full_name", rName1),
+					resource.TestCheckResourceAttr(resourceName, "phone_number", "+64211111111"),
+					resource.TestCheckResourceAttr(resourceName, "postal_code", "98101"),
+				),
+			},
+			{
+				// Regression test for https://github.com/hashicorp/terraform-provider-aws/issues/41154:
+				// importing by member account ID must not produce a diff.
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				Config:            testAccPrimaryContactConfig_organization(rName1),
+			},
+			{
+				Config: testAccPrimaryContactConfig_organization(rName2),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckPrimaryContactExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, names.AttrAccountID),
+					resource.TestCheckResourceAttr(resourceName, "full_name", rName2),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckPrimaryContactExists(ctx context.Context, t *testing.T, n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -87,6 +137,25 @@ func testAccCheckPrimaryContactExists(ctx context.Context, t *testing.T, n strin
 
 		return err
 	}
+}
+
+func testAccPrimaryContactConfig_organization(name string) string {
+	return acctest.ConfigCompose(acctest.ConfigAlternateAccountProvider(), fmt.Sprintf(`
+data "aws_caller_identity" "test" {
+  provider = "awsalternate"
+}
+
+resource "aws_account_primary_contact" "test" {
+  account_id      = data.aws_caller_identity.test.account_id
+  address_line_1  = "123 Any Street"
+  city            = "Seattle"
+  country_code    = "US"
+  full_name       = %[1]q
+  phone_number    = "+64211111111"
+  postal_code     = "98101"
+  state_or_region = "WA"
+}
+`, name))
 }
 
 func testAccPrimaryConfig_basic(name string) string {


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

### Description

When importing `aws_account_primary_contact` for a member account using
the account ID as the import identifier, `ImportStatePassthroughContext`
correctly sets `d.Id()` to the account ID but does **not** populate the
`account_id` schema attribute. The Read function was calling
`d.Get("account_id")` which returned `""`, causing
`GetContactInformation` to be called without an `AccountId`. This
silently fetched the **management account's** contact information instead
of the member account's, producing a spurious diff on every subsequent
plan even when the Terraform config exactly matched the real state of the
member account.

Fix: in `resourcePrimaryContactRead`, when `account_id` is empty in
state and the resource ID is not `"default"`, fall back to the resource
ID as the account ID for the API call, and persist it back into the
`account_id` attribute so it is correctly stored in state after import.

A new acceptance test `TestAccAccount_serial/PrimaryContact/AccountID`
exercises this scenario end-to-end using a management account and a
member account: it creates the primary contact on the member account,
imports by account ID, and asserts `ImportStateVerify` produces no diff.

> **AI Usage:** This fix was developed with the assistance of Augment
> Agent (an LLM-based coding assistant). The root cause analysis, fix,
> and test were reviewed and verified by the PR author, who ran the
> acceptance tests against real AWS accounts to confirm correct
> behaviour both before (failing) and after (passing) the fix.

### Relations

Closes #41154

### References

- AWS Account API: `GetContactInformation` / `PutContactInformation`
- `ImportStatePassthroughContext` only sets `d.Id()`, not schema attributes

### Output from Acceptance Testing

```console
% AWS_PROFILE=mgmt-account AWS_ALTERNATE_PROFILE=member-2 TF_ACC=1 go1.26.5 test ./internal/service/account/ -v -count 1 -run 'TestAccAccount_serial/PrimaryContact/AccountID' -timeout 30m
--- PASS: TestAccAccount_serial/PrimaryContact/AccountID (59.99s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/account	96.244s
```
