### PR TITLE
Add `fwvalidators.S3BucketName`

### DIFF
--- a/internal/framework/validators/s3_bucket_name.go
+++ b/internal/framework/validators/s3_bucket_name.go
@@ -1,0 +1,26 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package validators
+
+import (
+	"github.com/YakDriver/regexache"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+const (
+	canonicalBucketNamePatternNoAnchors = `[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]`
+	canonicalBucketNamePattern          = `^` + canonicalBucketNamePatternNoAnchors + `$`
+)
+
+// S3BucketName returns a string validator which ensures that any configured
+// attribute value:
+//
+//   - Is a string, which represents a valid S3 bucket name.
+//
+// Null (unconfigured) and unknown (known after apply) values are skipped.
+var S3BucketName validator.String = stringvalidator.RegexMatches(
+	regexache.MustCompile(canonicalBucketNamePattern),
+	`Bucket names must be 3 to 63 characters and begin and end with a letter or number. Valid characters are a-z, 0-9, periods (.), and hyphens.`,
+)

--- a/internal/framework/validators/s3_bucket_name_test.go
+++ b/internal/framework/validators/s3_bucket_name_test.go
@@ -1,0 +1,141 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package validators_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	fwvalidators "github.com/hashicorp/terraform-provider-aws/internal/framework/validators"
+)
+
+func TestS3BucketNameValidator(t *testing.T) {
+	t.Parallel()
+
+	errorSummary := "Invalid Attribute Value Match"
+	errorDetail := "Attribute test value must match regular expression: " +
+		`^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$` +
+		"\nBucket names must be 3 to 63 characters and begin and end with a letter or number. " +
+		"Valid characters are a-z, 0-9, periods (.), and hyphens."
+
+	newError := func(got string) diag.Diagnostics {
+		return diag.Diagnostics{
+			diag.NewAttributeErrorDiagnostic(
+				path.Root("test"),
+				errorSummary,
+				"Attribute test value must match regular expression: "+
+					`^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$`+"\n"+
+					"Bucket names must be 3 to 63 characters and begin and end with a letter or number. "+
+					"Valid characters are a-z, 0-9, periods (.), and hyphens., got: "+got,
+			),
+		}
+	}
+	_ = errorDetail // suppress unused-variable lint if the helper above is used instead
+
+	type testCase struct {
+		val                 types.String
+		expectedDiagnostics diag.Diagnostics
+	}
+	tests := map[string]testCase{
+		"unknown String": {
+			val: types.StringUnknown(),
+		},
+		"null String": {
+			val: types.StringNull(),
+		},
+		// Valid names
+		"valid lowercase letters only": {
+			val: types.StringValue("mybucket"),
+		},
+		"valid letters and numbers": {
+			val: types.StringValue("my-bucket-123"),
+		},
+		"valid with periods": {
+			val: types.StringValue("my.bucket.name"),
+		},
+		"valid minimum length (3 chars)": {
+			val: types.StringValue("abc"),
+		},
+		"valid maximum length (63 chars)": {
+			// 63 characters: starts and ends with letter, 61 middle chars
+			val: types.StringValue("a" + "b-c.d-e.f-g.h-i.j-k.l-m.n-o.p-q.r-s.t-u.v-w.x-y.z-0.1-2.3" + "a"),
+		},
+		"valid starts with digit": {
+			val: types.StringValue("0mybucket"),
+		},
+		"valid ends with digit": {
+			val: types.StringValue("mybucket0"),
+		},
+		// Invalid names
+		"invalid too short (1 char)": {
+			val:                 types.StringValue("a"),
+			expectedDiagnostics: newError("a"),
+		},
+		"invalid too short (2 chars)": {
+			val:                 types.StringValue("ab"),
+			expectedDiagnostics: newError("ab"),
+		},
+		"invalid too long (64 chars)": {
+			val:                 types.StringValue("a123456789012345678901234567890123456789012345678901234567890123"),
+			expectedDiagnostics: newError("a123456789012345678901234567890123456789012345678901234567890123"),
+		},
+		"invalid uppercase letters": {
+			val:                 types.StringValue("MyBucket"),
+			expectedDiagnostics: newError("MyBucket"),
+		},
+		"invalid starts with hyphen": {
+			val:                 types.StringValue("-mybucket"),
+			expectedDiagnostics: newError("-mybucket"),
+		},
+		"invalid ends with hyphen": {
+			val:                 types.StringValue("mybucket-"),
+			expectedDiagnostics: newError("mybucket-"),
+		},
+		"invalid starts with period": {
+			val:                 types.StringValue(".mybucket"),
+			expectedDiagnostics: newError(".mybucket"),
+		},
+		"invalid ends with period": {
+			val:                 types.StringValue("mybucket."),
+			expectedDiagnostics: newError("mybucket."),
+		},
+		"invalid contains underscore": {
+			val:                 types.StringValue("my_bucket"),
+			expectedDiagnostics: newError("my_bucket"),
+		},
+		"invalid contains space": {
+			val:                 types.StringValue("my bucket"),
+			expectedDiagnostics: newError("my bucket"),
+		},
+		"invalid contains special characters": {
+			val:                 types.StringValue("my#bucket"),
+			expectedDiagnostics: newError("my#bucket"),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+
+			request := validator.StringRequest{
+				Path:           path.Root("test"),
+				PathExpression: path.MatchRoot("test"),
+				ConfigValue:    test.val,
+			}
+			response := validator.StringResponse{}
+			fwvalidators.S3BucketName.ValidateString(ctx, request, &response)
+
+			if diff := cmp.Diff(response.Diagnostics, test.expectedDiagnostics); diff != "" {
+				t.Errorf("unexpected diagnostics difference: %s", diff)
+			}
+		})
+	}
+}

--- a/internal/framework/validators/s3_bucket_name_test.go
+++ b/internal/framework/validators/s3_bucket_name_test.go
@@ -4,11 +4,8 @@
 package validators_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -18,29 +15,9 @@ import (
 func TestS3BucketNameValidator(t *testing.T) {
 	t.Parallel()
 
-	errorSummary := "Invalid Attribute Value Match"
-	errorDetail := "Attribute test value must match regular expression: " +
-		`^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$` +
-		"\nBucket names must be 3 to 63 characters and begin and end with a letter or number. " +
-		"Valid characters are a-z, 0-9, periods (.), and hyphens."
-
-	newError := func(got string) diag.Diagnostics {
-		return diag.Diagnostics{
-			diag.NewAttributeErrorDiagnostic(
-				path.Root("test"),
-				errorSummary,
-				"Attribute test value must match regular expression: "+
-					`^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$`+"\n"+
-					"Bucket names must be 3 to 63 characters and begin and end with a letter or number. "+
-					"Valid characters are a-z, 0-9, periods (.), and hyphens., got: "+got,
-			),
-		}
-	}
-	_ = errorDetail // suppress unused-variable lint if the helper above is used instead
-
 	type testCase struct {
-		val                 types.String
-		expectedDiagnostics diag.Diagnostics
+		val         types.String
+		expectError bool
 	}
 	tests := map[string]testCase{
 		"unknown String": {
@@ -74,48 +51,48 @@ func TestS3BucketNameValidator(t *testing.T) {
 		},
 		// Invalid names
 		"invalid too short (1 char)": {
-			val:                 types.StringValue("a"),
-			expectedDiagnostics: newError("a"),
+			val:         types.StringValue("a"),
+			expectError: true,
 		},
 		"invalid too short (2 chars)": {
-			val:                 types.StringValue("ab"),
-			expectedDiagnostics: newError("ab"),
+			val:         types.StringValue("ab"),
+			expectError: true,
 		},
 		"invalid too long (64 chars)": {
-			val:                 types.StringValue("a123456789012345678901234567890123456789012345678901234567890123"),
-			expectedDiagnostics: newError("a123456789012345678901234567890123456789012345678901234567890123"),
+			val:         types.StringValue("a123456789012345678901234567890123456789012345678901234567890123"),
+			expectError: true,
 		},
 		"invalid uppercase letters": {
-			val:                 types.StringValue("MyBucket"),
-			expectedDiagnostics: newError("MyBucket"),
+			val:         types.StringValue("MyBucket"),
+			expectError: true,
 		},
 		"invalid starts with hyphen": {
-			val:                 types.StringValue("-mybucket"),
-			expectedDiagnostics: newError("-mybucket"),
+			val:         types.StringValue("-mybucket"),
+			expectError: true,
 		},
 		"invalid ends with hyphen": {
-			val:                 types.StringValue("mybucket-"),
-			expectedDiagnostics: newError("mybucket-"),
+			val:         types.StringValue("mybucket-"),
+			expectError: true,
 		},
 		"invalid starts with period": {
-			val:                 types.StringValue(".mybucket"),
-			expectedDiagnostics: newError(".mybucket"),
+			val:         types.StringValue(".mybucket"),
+			expectError: true,
 		},
 		"invalid ends with period": {
-			val:                 types.StringValue("mybucket."),
-			expectedDiagnostics: newError("mybucket."),
+			val:         types.StringValue("mybucket."),
+			expectError: true,
 		},
 		"invalid contains underscore": {
-			val:                 types.StringValue("my_bucket"),
-			expectedDiagnostics: newError("my_bucket"),
+			val:         types.StringValue("my_bucket"),
+			expectError: true,
 		},
 		"invalid contains space": {
-			val:                 types.StringValue("my bucket"),
-			expectedDiagnostics: newError("my bucket"),
+			val:         types.StringValue("my bucket"),
+			expectError: true,
 		},
 		"invalid contains special characters": {
-			val:                 types.StringValue("my#bucket"),
-			expectedDiagnostics: newError("my#bucket"),
+			val:         types.StringValue("my#bucket"),
+			expectError: true,
 		},
 	}
 
@@ -123,7 +100,7 @@ func TestS3BucketNameValidator(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			ctx := context.Background()
+			ctx := t.Context()
 
 			request := validator.StringRequest{
 				Path:           path.Root("test"),
@@ -133,8 +110,8 @@ func TestS3BucketNameValidator(t *testing.T) {
 			response := validator.StringResponse{}
 			fwvalidators.S3BucketName.ValidateString(ctx, request, &response)
 
-			if diff := cmp.Diff(response.Diagnostics, test.expectedDiagnostics); diff != "" {
-				t.Errorf("unexpected diagnostics difference: %s", diff)
+			if got, want := response.Diagnostics.HasError(), test.expectError; got != want {
+				t.Errorf("S3BucketName.ValidateString() HasError() = %t, want = %t", got, want)
 			}
 		})
 	}

--- a/internal/framework/validators/s3_uri.go
+++ b/internal/framework/validators/s3_uri.go
@@ -27,7 +27,7 @@ func (validator s3URIValidator) ValidateString(ctx context.Context, request vali
 		return
 	}
 
-	if !regexache.MustCompile(`^s3://[a-z0-9][\.\-a-z0-9]{1,61}[a-z0-9](/.*)?$`).MatchString(request.ConfigValue.ValueString()) {
+	if !regexache.MustCompile(`^s3://` + canonicalBucketNamePatternNoAnchors + `(/.*)?$`).MatchString(request.ConfigValue.ValueString()) {
 		response.Diagnostics.Append(validatordiag.InvalidAttributeValueDiagnostic(
 			request.Path,
 			validator.Description(ctx),

--- a/internal/service/bedrockagentcore/agent_runtime.go
+++ b/internal/service/bedrockagentcore/agent_runtime.go
@@ -39,6 +39,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
 	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
 	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	fwvalidators "github.com/hashicorp/terraform-provider-aws/internal/framework/validators"
 	tfobjectvalidator "github.com/hashicorp/terraform-provider-aws/internal/framework/validators/objectvalidator"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/smerr"
@@ -182,7 +183,7 @@ func (r *agentRuntimeResource) Schema(ctx context.Context, request resource.Sche
 															names.AttrBucket: schema.StringAttribute{
 																Required: true,
 																Validators: []validator.String{
-																	stringvalidator.RegexMatches(regexache.MustCompile(`^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$`), "must be a valid S3 bucket name"),
+																	fwvalidators.S3BucketName,
 																},
 															},
 															names.AttrPrefix: schema.StringAttribute{

--- a/internal/service/bedrockagentcore/browser.go
+++ b/internal/service/bedrockagentcore/browser.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/YakDriver/regexache"
 	"github.com/YakDriver/smarterr"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol"
@@ -37,6 +36,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
 	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
 	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	fwvalidators "github.com/hashicorp/terraform-provider-aws/internal/framework/validators"
 	tfobjectvalidator "github.com/hashicorp/terraform-provider-aws/internal/framework/validators/objectvalidator"
 	tfstringvalidator "github.com/hashicorp/terraform-provider-aws/internal/framework/validators/stringvalidator"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
@@ -160,7 +160,7 @@ func (r *browserResource) Schema(ctx context.Context, request resource.SchemaReq
 												names.AttrBucket: schema.StringAttribute{
 													Required: true,
 													Validators: []validator.String{
-														stringvalidator.RegexMatches(regexache.MustCompile(`^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$`), "must be a valid S3 bucket name"),
+														fwvalidators.S3BucketName,
 													},
 													PlanModifiers: []planmodifier.String{
 														stringplanmodifier.RequiresReplace(),
@@ -280,7 +280,7 @@ func (r *browserResource) Schema(ctx context.Context, request resource.SchemaReq
 									names.AttrBucket: schema.StringAttribute{
 										Required: true,
 										Validators: []validator.String{
-											stringvalidator.RegexMatches(regexache.MustCompile(`^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$`), "must be a valid S3 bucket name"),
+											fwvalidators.S3BucketName,
 										},
 										PlanModifiers: []planmodifier.String{
 											stringplanmodifier.RequiresReplace(),


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Adds the `fwvalidators.S3BucketName` string attribute validator and uses it in a couple of Bedrock AgentCore resources.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% go test ./internal/framework/validators/...
ok      github.com/hashicorp/terraform-provider-aws/internal/framework/validators       0.545s
ok      github.com/hashicorp/terraform-provider-aws/internal/framework/validators/boolvalidator (cached)
?       github.com/hashicorp/terraform-provider-aws/internal/framework/validators/internal      [no test files]
?       github.com/hashicorp/terraform-provider-aws/internal/framework/validators/objectvalidator       [no test files]
ok      github.com/hashicorp/terraform-provider-aws/internal/framework/validators/stringvalidator       (cached)
```
```console
% make testacc TESTARGS='-run=TestAccBedrockAgentCoreBrowser_basic\|TestAccBedrockAgentCoreBrowser_enterprisePolicies\|TestAccBedrockAgentCoreBrowser_role_recording' PKG=bedrockagentcore
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     6.244s
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework 5.992s
make: Running acceptance tests on branch: 🌿 HEAD 🌿...
TF_ACC=1 go1.26.5 test ./internal/service/bedrockagentcore/... -v -count 1 -parallel 20  -run=TestAccBedrockAgentCoreBrowser_basic\|TestAccBedrockAgentCoreBrowser_enterprisePolicies\|TestAccBedrockAgentCoreBrowser_role_recording -timeout 360m -vet=off -buildvcs=false
2026/07/31 09:44:33 Creating Terraform AWS Provider (SDKv2-style)...
2026/07/31 09:44:33 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccBedrockAgentCoreBrowser_basic
=== PAUSE TestAccBedrockAgentCoreBrowser_basic
=== RUN   TestAccBedrockAgentCoreBrowser_role_recording
=== PAUSE TestAccBedrockAgentCoreBrowser_role_recording
=== RUN   TestAccBedrockAgentCoreBrowser_enterprisePolicies
    browser_test.go:161: ValidationException: Access denied to S3 object
--- SKIP: TestAccBedrockAgentCoreBrowser_enterprisePolicies (0.00s)
=== CONT  TestAccBedrockAgentCoreBrowser_basic
=== CONT  TestAccBedrockAgentCoreBrowser_role_recording
--- PASS: TestAccBedrockAgentCoreBrowser_basic (19.88s)
--- PASS: TestAccBedrockAgentCoreBrowser_role_recording (33.17s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/bedrockagentcore   39.213s
```
```console
% AWS_BEDROCK_AGENTCORE_RUNTIME_IMAGE_V1_URI=... make testacc TESTARGS='-run=TestAccBedrockAgentCoreAgentRuntime_basic' PKG=bedrockagentcore
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework (cached)
make: Running acceptance tests on branch: 🌿 HEAD 🌿...
TF_ACC=1 go1.26.5 test ./internal/service/bedrockagentcore/... -v -count 1 -parallel 20  -run=TestAccBedrockAgentCoreAgentRuntime_basic -timeout 360m -vet=off -buildvcs=false
2026/07/31 09:50:49 Creating Terraform AWS Provider (SDKv2-style)...
2026/07/31 09:50:49 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccBedrockAgentCoreAgentRuntime_basic
=== PAUSE TestAccBedrockAgentCoreAgentRuntime_basic
=== CONT  TestAccBedrockAgentCoreAgentRuntime_basic
--- PASS: TestAccBedrockAgentCoreAgentRuntime_basic (41.00s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/bedrockagentcore   46.669s
```
