### PR TITLE
r/aws_launch_template: validate user_data at plan time

### DIFF
--- a/.changelog/49234.txt
+++ b/.changelog/49234.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_launch_template: Validate `user_data` length (16384 bytes, base64-decoded) at plan time instead of failing with `InvalidUserData.Malformed` at apply time
+```

--- a/internal/service/ec2/ec2_launch_template.go
+++ b/internal/service/ec2/ec2_launch_template.go
@@ -1057,8 +1057,9 @@ func resourceLaunchTemplate() *schema.Resource {
 					ConflictsWith: []string{"default_version"},
 				},
 				"user_data": {
-					Type:     schema.TypeString,
-					Optional: true,
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validLaunchTemplateUserData,
 				},
 				names.AttrVPCSecurityGroupIDs: {
 					Type:          schema.TypeSet,

--- a/internal/service/ec2/ec2_launch_template_test.go
+++ b/internal/service/ec2/ec2_launch_template_test.go
@@ -4991,3 +4991,32 @@ resource "aws_launch_template" "test" {
 }
 `, rName, description, update)
 }
+
+func TestAccEC2LaunchTemplate_userDataTooLong(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckLaunchTemplateDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccLaunchTemplateConfig_userDataTooLong(rName),
+				ExpectError: regexache.MustCompile(`cannot be longer than 16384 bytes`),
+			},
+		},
+	})
+}
+
+func testAccLaunchTemplateConfig_userDataTooLong(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_launch_template" "test" {
+  name = %[1]q
+
+  # 16385 bytes once base64-decoded: one byte over the EC2 limit
+  user_data = base64encode(join("", ["#!", substr(join("", [for i in range(2048) : "eight_ch"]), 0, 16383)]))
+}
+`, rName)
+}

--- a/internal/service/ec2/validate.go
+++ b/internal/service/ec2/validate.go
@@ -8,7 +8,28 @@ import (
 	"strings"
 
 	"github.com/YakDriver/regexache"
+	inttypes "github.com/hashicorp/terraform-provider-aws/internal/types"
 )
+
+// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-add-user-data.html.
+// The limit applies to the raw (base64-decoded) data.
+const maxUserDataLength = 16384
+
+func validLaunchTemplateUserData(v any, k string) (ws []string, errors []error) {
+	value := v.(string)
+	blob, err := inttypes.Base64Decode(value)
+	if err != nil {
+		errors = append(errors, fmt.Errorf(
+			"%q must be base64-encoded", k))
+		return
+	}
+	if len(blob) > maxUserDataLength {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot be longer than %d bytes once base64-decoded; got %d bytes",
+			k, maxUserDataLength, len(blob)))
+	}
+	return
+}
 
 func validSecurityGroupRuleDescription(v any, k string) (ws []string, errors []error) {
 	value := v.(string)

--- a/internal/service/ec2/validate_test.go
+++ b/internal/service/ec2/validate_test.go
@@ -4,8 +4,10 @@
 package ec2
 
 import (
+	"bytes"
 	"testing"
 
+	inttypes "github.com/hashicorp/terraform-provider-aws/internal/types"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -34,6 +36,36 @@ func TestValidSecurityGroupRuleDescription(t *testing.T) {
 		_, errors := validSecurityGroupRuleDescription(v, names.AttrDescription)
 		if len(errors) == 0 {
 			t.Fatalf("%q should be an invalid security group rule description", v)
+		}
+	}
+}
+
+func TestValidLaunchTemplateUserData(t *testing.T) {
+	t.Parallel()
+
+	b64 := func(n int) string {
+		return inttypes.Base64Encode(bytes.Repeat([]byte("u"), n))
+	}
+	validUserData := map[string]string{
+		"empty":        "",
+		"one byte":     b64(1),
+		"at the limit": b64(maxUserDataLength),
+	}
+	for name, v := range validUserData {
+		_, errors := validLaunchTemplateUserData(v, "user_data")
+		if len(errors) != 0 {
+			t.Fatalf("%s: should be valid launch template user data: %q", name, errors)
+		}
+	}
+
+	invalidUserData := map[string]string{
+		"not base64":    "not base64!",
+		"one byte over": b64(maxUserDataLength + 1),
+	}
+	for name, v := range invalidUserData {
+		_, errors := validLaunchTemplateUserData(v, "user_data")
+		if len(errors) == 0 {
+			t.Fatalf("%s: should be invalid launch template user data", name)
 		}
 	}
 }


### PR DESCRIPTION
CreateLaunchTemplateVersion rejects user data whose base64-decoded length exceeds 16384 bytes with InvalidUserData.Malformed, but only at apply time. Mirror the plan-time validation aws_instance.user_data already has, adjusted for this attribute being base64-encoded: decode and check the decoded length against the documented 16 KB limit.

```release-note:enhancement
resource/aws_launch_template: Validate `user_data` length (16384 bytes, base64-decoded) at plan time instead of failing with `InvalidUserData.Malformed` at apply time
```

AI disclosure/disclaimer: Written by Claude with minimal manual edits after I ran into this issue. Looks reasonable to me on review, but I am not otherwise familiar with the implementation of this repo.