### PR TITLE
enhance(bedrockagentcore_memory_strategy): add reflection_configuration for EPISODIC type

### DIFF
--- a/.changelog/48758.txt
+++ b/.changelog/48758.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_bedrockagentcore_memory_strategy: Add `reflection_configuration` configuration block for `EPISODIC` strategy type
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 6.58.0 (Unreleased)
 
+BREAKING CHANGES:
+
+* resource/aws_bedrockagentcore_memory_strategy: Remove the deprecated `memory_execution_role_arn` attribute. Use the `memory_execution_role_arn` attribute on the `aws_bedrockagentcore_memory` resource instead. ([#49148](https://github.com/hashicorp/terraform-provider-aws/issues/49148))
+
 FEATURES:
 
 * **New List Resource:** `aws_prometheus_anomaly_detector` ([#49139](https://github.com/hashicorp/terraform-provider-aws/issues/49139))

--- a/internal/service/bedrockagentcore/memory_strategy.go
+++ b/internal/service/bedrockagentcore/memory_strategy.go
@@ -88,6 +88,15 @@ func (r *resourceMemoryStrategy) Schema(ctx context.Context, request resource.Sc
 				CustomType: fwtypes.SetOfStringType,
 				Required:   true,
 			},
+			names.AttrType: schema.StringAttribute{
+				Required:   true,
+				CustomType: fwtypes.StringEnumType[awstypes.MemoryStrategyType](),
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+		},
+		Blocks: map[string]schema.Block{
 			"reflection_configuration": schema.ListNestedBlock{
 				CustomType: fwtypes.NewListNestedObjectTypeOf[reflectionConfigurationModel](ctx),
 				Validators: []validator.List{
@@ -102,15 +111,6 @@ func (r *resourceMemoryStrategy) Schema(ctx context.Context, request resource.Sc
 					},
 				},
 			},
-			names.AttrType: schema.StringAttribute{
-				Required:   true,
-				CustomType: fwtypes.StringEnumType[awstypes.MemoryStrategyType](),
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
-				},
-			},
-		},
-		Blocks: map[string]schema.Block{
 			names.AttrConfiguration: schema.ListNestedBlock{
 				CustomType: fwtypes.NewListNestedObjectTypeOf[customConfigurationModel](ctx),
 				Validators: []validator.List{
@@ -163,29 +163,29 @@ func (r *resourceMemoryStrategy) Schema(ctx context.Context, request resource.Sc
 								},
 							},
 						},
-							"reflection": schema.ListNestedBlock{
-								CustomType: fwtypes.NewListNestedObjectTypeOf[reflectionOverrideModel](ctx),
-								Validators: []validator.List{
-									listvalidator.SizeAtMost(1),
-								},
-								PlanModifiers: []planmodifier.List{
-									errorIfSingleBlockRemoved("reflection"),
-								},
-								NestedObject: schema.NestedBlockObject{
-									Attributes: map[string]schema.Attribute{
-										"append_to_prompt": schema.StringAttribute{
-											Required: true,
-										},
-										"model_id": schema.StringAttribute{
-											Required: true,
-										},
-										"namespace_templates": schema.ListAttribute{
-											CustomType: fwtypes.ListOfStringType,
-											Optional:   true,
-										},
+						"reflection": schema.ListNestedBlock{
+							CustomType: fwtypes.NewListNestedObjectTypeOf[reflectionOverrideModel](ctx),
+							Validators: []validator.List{
+								listvalidator.SizeAtMost(1),
+							},
+							PlanModifiers: []planmodifier.List{
+								errorIfSingleBlockRemoved("reflection"),
+							},
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									"append_to_prompt": schema.StringAttribute{
+										Required: true,
+									},
+									"model_id": schema.StringAttribute{
+										Required: true,
+									},
+									"namespace_templates": schema.ListAttribute{
+										CustomType: fwtypes.ListOfStringType,
+										Optional:   true,
 									},
 								},
 							},
+						},
 					},
 				},
 			},
@@ -297,7 +297,6 @@ func (r *resourceMemoryStrategy) ValidateConfig(ctx context.Context, request res
 			}
 		}
 	}
-	}
 }
 
 func (r *resourceMemoryStrategy) Create(ctx context.Context, request resource.CreateRequest, response *resource.CreateResponse) {
@@ -363,7 +362,7 @@ func (r *resourceMemoryStrategy) Create(ctx context.Context, request resource.Cr
 			if episodicReflection, ok := found.Configuration.Reflection.(*awstypes.ReflectionConfigurationMemberEpisodicReflectionConfiguration); ok {
 				var rc reflectionConfigurationModel
 				if episodicReflection.Value.NamespaceTemplates != nil {
-					rc.NamespaceTemplates, _ = fwtypes.ListOfStringValueFrom(ctx, episodicReflection.Value.NamespaceTemplates)
+					rc.NamespaceTemplates = fwflex.FlattenFrameworkStringValueListOfString(ctx, episodicReflection.Value.NamespaceTemplates)
 				}
 				plan.ReflectionConfiguration, _ = fwtypes.NewListNestedObjectValueOfPtr(ctx, &rc)
 			}
@@ -425,7 +424,7 @@ func (r *resourceMemoryStrategy) Read(ctx context.Context, request resource.Read
 		if episodicReflection, ok := out.Configuration.Reflection.(*awstypes.ReflectionConfigurationMemberEpisodicReflectionConfiguration); ok {
 			var rc reflectionConfigurationModel
 			if episodicReflection.Value.NamespaceTemplates != nil {
-				rc.NamespaceTemplates, _ = fwtypes.ListOfStringValueFrom(ctx, episodicReflection.Value.NamespaceTemplates)
+				rc.NamespaceTemplates = fwflex.FlattenFrameworkStringValueListOfString(ctx, episodicReflection.Value.NamespaceTemplates)
 			}
 			state.ReflectionConfiguration, _ = fwtypes.NewListNestedObjectValueOfPtr(ctx, &rc)
 		}
@@ -681,16 +680,16 @@ func findMemoryStrategyByTwoPartKey(ctx context.Context, conn *bedrockagentcorec
 
 type memoryStrategyResourceModel struct {
 	framework.WithRegionModel
-	Configuration          fwtypes.ListNestedObjectValueOf[customConfigurationModel] `tfsdk:"configuration"`
-	Description            types.String                                              `tfsdk:"description"`
-	MemoryExecutionRoleARN fwtypes.ARN                                               `tfsdk:"memory_execution_role_arn"`
-	MemoryStrategyID       types.String                                              `tfsdk:"memory_strategy_id"`
-	MemoryID               types.String                                              `tfsdk:"memory_id"`
-	Name                   types.String                                              `tfsdk:"name"`
-	Namespaces             fwtypes.SetOfString                                       `tfsdk:"namespaces"`
-	ReflectionConfiguration  fwtypes.ListNestedObjectValueOf[reflectionConfigurationModel] `tfsdk:"reflection_configuration"`
-	Type                   fwtypes.StringEnum[awstypes.MemoryStrategyType]           `tfsdk:"type"`
-	Timeouts               timeouts.Value                                            `tfsdk:"timeouts"`
+	Configuration           fwtypes.ListNestedObjectValueOf[customConfigurationModel]     `tfsdk:"configuration"`
+	Description             types.String                                                  `tfsdk:"description"`
+	MemoryExecutionRoleARN  fwtypes.ARN                                                   `tfsdk:"memory_execution_role_arn"`
+	MemoryStrategyID        types.String                                                  `tfsdk:"memory_strategy_id"`
+	MemoryID                types.String                                                  `tfsdk:"memory_id"`
+	Name                    types.String                                                  `tfsdk:"name"`
+	Namespaces              fwtypes.SetOfString                                           `tfsdk:"namespaces"`
+	ReflectionConfiguration fwtypes.ListNestedObjectValueOf[reflectionConfigurationModel] `tfsdk:"reflection_configuration"`
+	Type                    fwtypes.StringEnum[awstypes.MemoryStrategyType]               `tfsdk:"type"`
+	Timeouts                timeouts.Value                                                `tfsdk:"timeouts"`
 }
 
 func (m *memoryStrategyResourceModel) GetIdentifier() string {
@@ -815,10 +814,10 @@ func (m memoryStrategyResourceModel) expandToModifyMemoryStrategyInput(ctx conte
 }
 
 type customConfigurationModel struct {
-	Type          fwtypes.StringEnum[awstypes.OverrideType]             `tfsdk:"type"`
-	Consolidation fwtypes.ListNestedObjectValueOf[overrideDetailsModel] `tfsdk:"consolidation"`
-	Extraction    fwtypes.ListNestedObjectValueOf[overrideDetailsModel] `tfsdk:"extraction"`
-	Reflection    fwtypes.ListNestedObjectValueOf[reflectionOverrideModel]   `tfsdk:"reflection"`
+	Type          fwtypes.StringEnum[awstypes.OverrideType]                `tfsdk:"type"`
+	Consolidation fwtypes.ListNestedObjectValueOf[overrideDetailsModel]    `tfsdk:"consolidation"`
+	Extraction    fwtypes.ListNestedObjectValueOf[overrideDetailsModel]    `tfsdk:"extraction"`
+	Reflection    fwtypes.ListNestedObjectValueOf[reflectionOverrideModel] `tfsdk:"reflection"`
 }
 
 var (
@@ -860,6 +859,7 @@ func (m *customConfigurationModel) Flatten(ctx context.Context, v any) (diags di
 					return diags
 				}
 			}
+		}
 
 		if t.Reflection != nil {
 			switch rt := t.Reflection.(type) {
@@ -879,8 +879,6 @@ func (m *customConfigurationModel) Flatten(ctx context.Context, v any) (diags di
 					}
 				}
 			}
-		}
-		}
 		}
 	default:
 		diags.AddError(
@@ -972,7 +970,6 @@ func (m customConfigurationModel) expandToModifyStrategyConfiguration(ctx contex
 			return nil, diags
 		}
 	}
-
 
 	var reflection *reflectionOverrideModel
 	if !m.Reflection.IsNull() {

--- a/internal/service/bedrockagentcore/memory_strategy.go
+++ b/internal/service/bedrockagentcore/memory_strategy.go
@@ -9,17 +9,15 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strings"
 	"time"
 
-	"github.com/YakDriver/regexache"
 	"github.com/YakDriver/smarterr"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol/types"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
-	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
-	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -36,10 +34,7 @@ import (
 	intflex "github.com/hashicorp/terraform-provider-aws/internal/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
 	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
-	tflistplanmodifier "github.com/hashicorp/terraform-provider-aws/internal/framework/planmodifiers/listplanmodifier"
-	tfsetplanmodifier "github.com/hashicorp/terraform-provider-aws/internal/framework/planmodifiers/setplanmodifier"
 	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
-	tfstringvalidator "github.com/hashicorp/terraform-provider-aws/internal/framework/validators/stringvalidator"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 	"github.com/hashicorp/terraform-provider-aws/internal/smerr"
@@ -51,9 +46,9 @@ import (
 func newResourceMemoryStrategy(_ context.Context) (resource.ResourceWithConfigure, error) {
 	r := &resourceMemoryStrategy{}
 
-	r.SetDefaultCreateTimeout(45 * time.Minute)
-	r.SetDefaultUpdateTimeout(45 * time.Minute)
-	r.SetDefaultDeleteTimeout(45 * time.Minute)
+	r.SetDefaultCreateTimeout(30 * time.Minute)
+	r.SetDefaultUpdateTimeout(30 * time.Minute)
+	r.SetDefaultDeleteTimeout(30 * time.Minute)
 
 	return r, nil
 }
@@ -70,9 +65,8 @@ func (r *resourceMemoryStrategy) Schema(ctx context.Context, request resource.Sc
 				Optional: true,
 			},
 			"memory_execution_role_arn": schema.StringAttribute{
-				CustomType:         fwtypes.ARNType,
-				Optional:           true,
-				DeprecationMessage: "memory_execution_role_arn is deprecated. Use memory_execution_role_arn on the aws_bedrockagentcore_memory resource instead.",
+				CustomType: fwtypes.ARNType,
+				Optional:   true,
 			},
 			"memory_id": schema.StringAttribute{
 				Required: true,
@@ -88,51 +82,29 @@ func (r *resourceMemoryStrategy) Schema(ctx context.Context, request resource.Sc
 				},
 			},
 			names.AttrName: schema.StringAttribute{
-				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexache.MustCompile(`^[a-zA-Z][a-zA-Z0-9_]{0,47}$`), ""),
-				},
 				Required: true,
 			},
 			"namespaces": schema.SetAttribute{
-				CustomType:         fwtypes.SetOfStringType,
-				Optional:           true,
-				Computed:           true,
-				DeprecationMessage: "namespaces is deprecated. Use namespace_templates instead.",
-				PlanModifiers: []planmodifier.Set{
-					tfsetplanmodifier.DefaultValueFromPath[fwtypes.SetOfString](path.Root("namespace_templates")),
-				},
-			},
-			"namespace_templates": schema.SetAttribute{
 				CustomType: fwtypes.SetOfStringType,
-				Optional:   true,
-				Computed:   true,
-				Validators: []validator.Set{
-					setvalidator.ExactlyOneOf(
-						path.MatchRelative().AtParent().AtName("namespaces"),
-						path.MatchRelative().AtParent().AtName("namespace_templates"),
-					),
+				Required:   true,
+			},
+			"reflection_configuration": schema.ListNestedBlock{
+				CustomType: fwtypes.NewListNestedObjectTypeOf[reflectionConfigurationModel](ctx),
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
 				},
-				PlanModifiers: []planmodifier.Set{
-					tfsetplanmodifier.DefaultValueFromPath[fwtypes.SetOfString](path.Root("namespaces")),
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"namespace_templates": schema.ListAttribute{
+							CustomType: fwtypes.ListOfStringType,
+							Optional:   true,
+						},
+					},
 				},
 			},
 			names.AttrType: schema.StringAttribute{
 				Required:   true,
 				CustomType: fwtypes.StringEnumType[awstypes.MemoryStrategyType](),
-				Validators: []validator.String{
-					tfstringvalidator.AlsoRequiresWhenEquals(
-						awstypes.MemoryStrategyTypeCustom,
-						path.MatchRelative().AtParent().AtName(names.AttrConfiguration),
-					),
-					tfstringvalidator.ConflictsWithWhenNotEquals(
-						awstypes.MemoryStrategyTypeCustom,
-						path.MatchRelative().AtParent().AtName(names.AttrConfiguration),
-					),
-					tfstringvalidator.ConflictsWithWhenNotEquals(
-						awstypes.MemoryStrategyTypeEpisodic,
-						path.MatchRelative().AtParent().AtName("reflection_configuration"),
-					),
-				},
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
@@ -149,20 +121,6 @@ func (r *resourceMemoryStrategy) Schema(ctx context.Context, request resource.Sc
 						names.AttrType: schema.StringAttribute{
 							Required:   true,
 							CustomType: fwtypes.StringEnumType[awstypes.OverrideType](),
-							Validators: []validator.String{
-								tfstringvalidator.AlsoRequiresWhenEquals(
-									awstypes.OverrideTypeEpisodicOverride,
-									path.MatchRelative().AtParent().AtName("reflection"),
-								),
-								tfstringvalidator.ConflictsWithWhenNotEquals(
-									awstypes.OverrideTypeEpisodicOverride,
-									path.MatchRelative().AtParent().AtName("reflection"),
-								),
-								tfstringvalidator.ConflictsWithWhenEquals(
-									awstypes.OverrideTypeSummaryOverride,
-									path.MatchRelative().AtParent().AtName("extraction"),
-								),
-							},
 							PlanModifiers: []planmodifier.String{
 								stringplanmodifier.RequiresReplace(),
 							},
@@ -175,7 +133,7 @@ func (r *resourceMemoryStrategy) Schema(ctx context.Context, request resource.Sc
 								listvalidator.SizeAtMost(1),
 							},
 							PlanModifiers: []planmodifier.List{
-								tflistplanmodifier.RequiresReplaceIfEmptied,
+								errorIfSingleBlockRemoved("consolidation"),
 							},
 							NestedObject: schema.NestedBlockObject{
 								Attributes: map[string]schema.Attribute{
@@ -192,7 +150,7 @@ func (r *resourceMemoryStrategy) Schema(ctx context.Context, request resource.Sc
 							CustomType: fwtypes.NewListNestedObjectTypeOf[overrideDetailsModel](ctx),
 							Validators: []validator.List{listvalidator.SizeAtMost(1)},
 							PlanModifiers: []planmodifier.List{
-								tflistplanmodifier.RequiresReplaceIfEmptied,
+								errorIfSingleBlockRemoved("extraction"),
 							},
 							NestedObject: schema.NestedBlockObject{
 								Attributes: map[string]schema.Attribute{
@@ -205,46 +163,29 @@ func (r *resourceMemoryStrategy) Schema(ctx context.Context, request resource.Sc
 								},
 							},
 						},
-						"reflection": schema.ListNestedBlock{
-							CustomType: fwtypes.NewListNestedObjectTypeOf[episodicReflectionOverrideDetailsModel](ctx),
-							Validators: []validator.List{
-								listvalidator.SizeAtMost(1),
-							},
-							PlanModifiers: []planmodifier.List{
-								tflistplanmodifier.RequiresReplaceIfEmptied,
-							},
-							NestedObject: schema.NestedBlockObject{
-								Attributes: map[string]schema.Attribute{
-									"append_to_prompt": schema.StringAttribute{
-										Required: true,
-									},
-									"model_id": schema.StringAttribute{
-										Required: true,
-									},
-									"namespace_templates": schema.SetAttribute{
-										CustomType: fwtypes.SetOfStringType,
-										Required:   true,
+							"reflection": schema.ListNestedBlock{
+								CustomType: fwtypes.NewListNestedObjectTypeOf[reflectionOverrideModel](ctx),
+								Validators: []validator.List{
+									listvalidator.SizeAtMost(1),
+								},
+								PlanModifiers: []planmodifier.List{
+									errorIfSingleBlockRemoved("reflection"),
+								},
+								NestedObject: schema.NestedBlockObject{
+									Attributes: map[string]schema.Attribute{
+										"append_to_prompt": schema.StringAttribute{
+											Required: true,
+										},
+										"model_id": schema.StringAttribute{
+											Required: true,
+										},
+										"namespace_templates": schema.ListAttribute{
+											CustomType: fwtypes.ListOfStringType,
+											Optional:   true,
+										},
 									},
 								},
 							},
-						},
-					},
-				},
-			},
-			"reflection_configuration": schema.ListNestedBlock{
-				CustomType: fwtypes.NewListNestedObjectTypeOf[episodicReflectionConfigurationModel](ctx),
-				Validators: []validator.List{
-					listvalidator.SizeAtMost(1),
-				},
-				PlanModifiers: []planmodifier.List{
-					tflistplanmodifier.RequiresReplaceIfEmptied,
-				},
-				NestedObject: schema.NestedBlockObject{
-					Attributes: map[string]schema.Attribute{
-						"namespace_templates": schema.SetAttribute{
-							CustomType: fwtypes.SetOfStringType,
-							Required:   true,
-						},
 					},
 				},
 			},
@@ -257,11 +198,112 @@ func (r *resourceMemoryStrategy) Schema(ctx context.Context, request resource.Sc
 	}
 }
 
+type errorIfSingleBlockRemoved_ struct {
+	label string
+}
+
+func errorIfSingleBlockRemoved(label string) planmodifier.List {
+	return errorIfSingleBlockRemoved_{label: label}
+}
+
+func (m errorIfSingleBlockRemoved_) Description(context.Context) string {
+	return "Disallow removing previously configured " + m.label + " block"
+}
+
+func (m errorIfSingleBlockRemoved_) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (m errorIfSingleBlockRemoved_) PlanModifyList(ctx context.Context, req planmodifier.ListRequest, resp *planmodifier.ListResponse) {
+	// Skip create or destroy.
+	if req.State.Raw.IsNull() || req.Plan.Raw.IsNull() {
+		return
+	}
+
+	// Defer until known values
+	if req.StateValue.IsUnknown() || req.PlanValue.IsUnknown() {
+		return
+	}
+
+	var plannedType awstypes.OverrideType
+	overrideTypePath := path.Root(names.AttrConfiguration).AtListIndex(0).AtName(names.AttrType)
+	smerr.AddEnrich(ctx, &resp.Diagnostics, req.Plan.GetAttribute(ctx, overrideTypePath, &plannedType))
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var stateType awstypes.OverrideType
+	smerr.AddEnrich(ctx, &resp.Diagnostics, req.State.GetAttribute(ctx, overrideTypePath, &stateType))
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if plannedType != stateType {
+		return
+	}
+
+	stateList, sDiags := req.StateValue.ToListValue(ctx)
+	smerr.AddEnrich(ctx, &resp.Diagnostics, sDiags)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	planList, pDiags := req.PlanValue.ToListValue(ctx)
+	smerr.AddEnrich(ctx, &resp.Diagnostics, pDiags)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if len(stateList.Elements()) == 1 && len(planList.Elements()) == 0 {
+		smerr.AddError(ctx, &resp.Diagnostics, fmt.Errorf("Removing the previously configured %q block is not allowed. Re-add the block or recreate the resource manually if you truly intend to remove it.", m.label))
+	}
+}
+
+func (r *resourceMemoryStrategy) ValidateConfig(ctx context.Context, request resource.ValidateConfigRequest, response *resource.ValidateConfigResponse) {
+	var data memoryStrategyResourceModel
+
+	smerr.AddEnrich(ctx, &response.Diagnostics, request.Config.Get(ctx, &data))
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	if data.Type.IsUnknown() {
+		return
+	}
+
+	if data.Type.ValueEnum() == awstypes.MemoryStrategyTypeCustom {
+		if data.Configuration.IsNull() || data.Configuration.IsUnknown() {
+			smerr.AddError(ctx, &response.Diagnostics, fmt.Errorf("When type is `CUSTOM`, the configuration block is required."))
+			return
+		} else {
+			c, diags := data.Configuration.ToPtr(ctx)
+			smerr.AddEnrich(ctx, &response.Diagnostics, diags)
+			if response.Diagnostics.HasError() {
+				return
+			}
+			if c.Type.ValueEnum() == awstypes.OverrideTypeSummaryOverride && !(c.Extraction.IsNull() || c.Extraction.IsUnknown()) {
+				smerr.AddError(ctx, &response.Diagnostics, fmt.Errorf("When configuration type is `SUMMARY_OVERRIDE`, the extraction block cannot be defined."))
+			}
+			if !(data.ReflectionConfiguration.IsNull() || data.ReflectionConfiguration.IsUnknown()) {
+				smerr.AddError(ctx, &response.Diagnostics, fmt.Errorf("When type is `CUSTOM`, the reflection_configuration block must be omitted."))
+			}
+		}
+	} else {
+		if !(data.Configuration.IsNull() || data.Configuration.IsUnknown()) {
+			smerr.AddError(ctx, &response.Diagnostics, fmt.Errorf("When type is not `CUSTOM`, the configuration block must be omitted."))
+		}
+		if data.Type.ValueEnum() != awstypes.MemoryStrategyTypeEpisodic {
+			if !(data.ReflectionConfiguration.IsNull() || data.ReflectionConfiguration.IsUnknown()) {
+				smerr.AddError(ctx, &response.Diagnostics, fmt.Errorf("When type is not `EPISODIC`, the reflection_configuration block must be omitted."))
+			}
+		}
+	}
+	}
+}
+
 func (r *resourceMemoryStrategy) Create(ctx context.Context, request resource.CreateRequest, response *resource.CreateResponse) {
 	conn := r.Meta().BedrockAgentCoreClient(ctx)
 
-	var config, plan memoryStrategyResourceModel
-	smerr.AddEnrich(ctx, &response.Diagnostics, request.Config.Get(ctx, &config))
+	var plan memoryStrategyResourceModel
 	smerr.AddEnrich(ctx, &response.Diagnostics, request.Plan.Get(ctx, &plan))
 	if response.Diagnostics.HasError() {
 		return
@@ -273,7 +315,7 @@ func (r *resourceMemoryStrategy) Create(ctx context.Context, request resource.Cr
 		return
 	}
 
-	memoryID, name := fwflex.StringValueFromFramework(ctx, plan.MemoryID), fwflex.StringValueFromFramework(ctx, plan.Name)
+	memoryID := fwflex.StringValueFromFramework(ctx, plan.MemoryID)
 	input := bedrockagentcorecontrol.UpdateMemoryInput{
 		ClientToken: aws.String(create.UniqueId(ctx)),
 		MemoryId:    aws.String(memoryID),
@@ -288,45 +330,53 @@ func (r *resourceMemoryStrategy) Create(ctx context.Context, request resource.Cr
 
 	withMemoryLock(ctx, memoryID, func(ctx context.Context) {
 		createTimeout := r.CreateTimeout(ctx, plan.Timeouts)
-		out, err := retryUpdateMemoryStrategy(ctx, conn, &input, createTimeout)
+		out, err := updateMemoryWithRetry(ctx, conn, createTimeout, &input, false)
 		if err != nil {
-			smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, name)
+			smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, plan.GetIdentifier())
 			return
 		}
 
 		name := fwflex.StringValueFromFramework(ctx, plan.Name)
-		found, err := tfresource.AssertSingleValueResult(out.Memory.Strategies, func(v *awstypes.MemoryStrategy) bool {
-			return aws.ToString(v.Name) == name
-		})
-		if err != nil {
-			smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, name)
+		var found *awstypes.MemoryStrategy
+		if out != nil && out.Memory != nil {
+			for i := range out.Memory.Strategies {
+				s := &out.Memory.Strategies[i]
+				if s.Name != nil && aws.ToString(s.Name) == name {
+					found = s
+				}
+			}
+		}
+		if found == nil {
+			smerr.AddError(ctx, &response.Diagnostics, fmt.Errorf("create memory strategy: API response missing strategy name %q", name), smerr.ID, plan.GetIdentifier())
 			return
 		}
-
+		// For non-CUSTOM types, clear Configuration from the API response before
+		// flattening. The API returns a StrategyConfiguration with Type values
+		// (e.g. "EPISODIC") that are not valid OverrideType enum values.
+		if plan.Type.ValueEnum() != awstypes.MemoryStrategyTypeCustom {
+			found.Configuration = nil
+		}
 		smerr.AddEnrich(ctx, &response.Diagnostics, fwflex.Flatten(ctx, found, &plan, fwflex.WithFieldNamePrefix("Memory")))
+
+		// Flatten reflection configuration for built-in EPISODIC type
+		if plan.Type.ValueEnum() == awstypes.MemoryStrategyTypeEpisodic && found.Configuration != nil && found.Configuration.Reflection != nil {
+			if episodicReflection, ok := found.Configuration.Reflection.(*awstypes.ReflectionConfigurationMemberEpisodicReflectionConfiguration); ok {
+				var rc reflectionConfigurationModel
+				if episodicReflection.Value.NamespaceTemplates != nil {
+					rc.NamespaceTemplates, _ = fwtypes.ListOfStringValueFrom(ctx, episodicReflection.Value.NamespaceTemplates)
+				}
+				plan.ReflectionConfiguration, _ = fwtypes.NewListNestedObjectValueOfPtr(ctx, &rc)
+			}
+		}
 		if response.Diagnostics.HasError() {
 			return
 		}
 
-		// If no `reflection_configuration` is configured, don't overwrite with returned value.
-		if config.ReflectionConfiguration.IsNull() {
-			plan.ReflectionConfiguration = fwtypes.NewListNestedObjectValueOfNull[episodicReflectionConfigurationModel](ctx)
-		}
-
-		memoryStrategyID := fwflex.StringValueFromFramework(ctx, plan.MemoryStrategyID)
-		if _, err := waitMemoryStrategyCreated(ctx, conn, memoryID, memoryStrategyID, createTimeout); err != nil {
+		_, err = waitMemoryStrategyCreated(ctx, conn, memoryID, fwflex.StringValueFromFramework(ctx, plan.MemoryStrategyID), createTimeout)
+		if err != nil {
 			// Taint the resource.
 			response.State.SetAttribute(ctx, path.Root("memory_id"), memoryID)
-			response.State.SetAttribute(ctx, path.Root("memory_strategy_id"), memoryStrategyID)
-			smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, memoryStrategyID)
-			return
-		}
-
-		if _, err := waitMemoryUpdated(ctx, conn, memoryID, createTimeout); err != nil {
-			// Taint the resource.
-			response.State.SetAttribute(ctx, path.Root("memory_id"), memoryID)
-			response.State.SetAttribute(ctx, path.Root("memory_strategy_id"), memoryStrategyID)
-			smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, memoryStrategyID)
+			smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, plan.GetIdentifier())
 			return
 		}
 	})
@@ -359,16 +409,29 @@ func (r *resourceMemoryStrategy) Read(ctx context.Context, request resource.Read
 		return
 	}
 
-	nullReflectionConfiguration := state.ReflectionConfiguration.IsNull()
-
-	smerr.AddEnrich(ctx, &response.Diagnostics, fwflex.Flatten(ctx, out, &state, fwflex.WithFieldNamePrefix("Memory")))
-	if response.Diagnostics.HasError() {
-		return
+	// For non-CUSTOM types, clear Configuration from the API response before
+	// flattening. The API returns a StrategyConfiguration with Type values
+	// (e.g. "EPISODIC") that are not valid OverrideType enum values.
+	if state.Type.ValueEnum() != awstypes.MemoryStrategyTypeCustom {
+		out.Configuration = nil
 	}
 
-	// If no `reflection_configuration` was configured, don't overwrite with returned value.
-	if nullReflectionConfiguration {
-		state.ReflectionConfiguration = fwtypes.NewListNestedObjectValueOfNull[episodicReflectionConfigurationModel](ctx)
+	smerr.AddEnrich(ctx, &response.Diagnostics, fwflex.Flatten(ctx, out, &state, fwflex.WithFieldNamePrefix("Memory")))
+
+	// Flatten reflection configuration for built-in EPISODIC type.
+	// The API returns reflection config inside StrategyConfiguration, which is
+	// cleared for non-CUSTOM types before flattening. We handle it separately.
+	if state.Type.ValueEnum() == awstypes.MemoryStrategyTypeEpisodic && out.Configuration != nil && out.Configuration.Reflection != nil {
+		if episodicReflection, ok := out.Configuration.Reflection.(*awstypes.ReflectionConfigurationMemberEpisodicReflectionConfiguration); ok {
+			var rc reflectionConfigurationModel
+			if episodicReflection.Value.NamespaceTemplates != nil {
+				rc.NamespaceTemplates, _ = fwtypes.ListOfStringValueFrom(ctx, episodicReflection.Value.NamespaceTemplates)
+			}
+			state.ReflectionConfiguration, _ = fwtypes.NewListNestedObjectValueOfPtr(ctx, &rc)
+		}
+	}
+	if response.Diagnostics.HasError() {
+		return
 	}
 
 	smerr.AddEnrich(ctx, &response.Diagnostics, response.State.Set(ctx, &state))
@@ -377,8 +440,7 @@ func (r *resourceMemoryStrategy) Read(ctx context.Context, request resource.Read
 func (r *resourceMemoryStrategy) Update(ctx context.Context, request resource.UpdateRequest, response *resource.UpdateResponse) {
 	conn := r.Meta().BedrockAgentCoreClient(ctx)
 
-	var config, plan, state memoryStrategyResourceModel
-	smerr.AddEnrich(ctx, &response.Diagnostics, request.Config.Get(ctx, &config))
+	var plan, state memoryStrategyResourceModel
 	smerr.AddEnrich(ctx, &response.Diagnostics, request.Plan.Get(ctx, &plan))
 	smerr.AddEnrich(ctx, &response.Diagnostics, request.State.Get(ctx, &state))
 	if response.Diagnostics.HasError() {
@@ -413,34 +475,28 @@ func (r *resourceMemoryStrategy) Update(ctx context.Context, request resource.Up
 
 		withMemoryLock(ctx, memoryID, func(ctx context.Context) {
 			updateTimeout := r.UpdateTimeout(ctx, plan.Timeouts)
-			out, err := retryUpdateMemoryStrategy(ctx, conn, &input, updateTimeout)
+			out, err := updateMemoryWithRetry(ctx, conn, updateTimeout, &input, false)
 			if err != nil {
 				smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, memoryStrategyID)
 				return
 			}
-
-			found, err := tfresource.AssertSingleValueResult(out.Memory.Strategies, func(v *awstypes.MemoryStrategy) bool {
-				return aws.ToString(v.StrategyId) == memoryStrategyID
-			})
-			if err != nil {
-				smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, memoryStrategyID)
+			var found *awstypes.MemoryStrategy
+			if out != nil && out.Memory != nil {
+				for i := range out.Memory.Strategies {
+					s := &out.Memory.Strategies[i]
+					if s.StrategyId != nil && aws.ToString(s.StrategyId) == memoryStrategyID {
+						found = s
+					}
+				}
+			}
+			if found == nil {
+				smerr.AddError(ctx, &response.Diagnostics, fmt.Errorf("update memory strategy: API response missing strategy id %q", memoryStrategyID))
 				return
 			}
-
+			if plan.Type.ValueEnum() != awstypes.MemoryStrategyTypeCustom {
+				found.Configuration = nil
+			}
 			smerr.AddEnrich(ctx, &response.Diagnostics, fwflex.Flatten(ctx, found, &plan, fwflex.WithFieldNamePrefix("Memory")))
-			if response.Diagnostics.HasError() {
-				return
-			}
-
-			// If no `reflection_configuration` is configured, don't overwrite with returned value.
-			if config.ReflectionConfiguration.IsNull() {
-				plan.ReflectionConfiguration = fwtypes.NewListNestedObjectValueOfNull[episodicReflectionConfigurationModel](ctx)
-			}
-
-			if _, err := waitMemoryUpdated(ctx, conn, memoryID, updateTimeout); err != nil {
-				smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, memoryStrategyID)
-				return
-			}
 		})
 	}
 	if response.Diagnostics.HasError() {
@@ -474,18 +530,14 @@ func (r *resourceMemoryStrategy) Delete(ctx context.Context, request resource.De
 
 	withMemoryLock(ctx, memoryID, func(ctx context.Context) {
 		deleteTimeout := r.DeleteTimeout(ctx, state.Timeouts)
-		_, err := retryUpdateMemoryStrategy(ctx, conn, &input, deleteTimeout)
+		_, err := updateMemoryWithRetry(ctx, conn, deleteTimeout, &input, true)
 		if err != nil {
 			smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, memoryStrategyID)
 			return
 		}
 
-		if _, err := waitMemoryStrategyDeleted(ctx, conn, memoryID, memoryStrategyID, deleteTimeout); err != nil {
-			smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, memoryStrategyID)
-			return
-		}
-
-		if _, err := waitMemoryUpdated(ctx, conn, memoryID, deleteTimeout); err != nil {
+		_, err = waitMemoryStrategyDeleted(ctx, conn, memoryID, memoryStrategyID, deleteTimeout)
+		if err != nil {
 			smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, memoryStrategyID)
 			return
 		}
@@ -515,8 +567,13 @@ func withMemoryLock(ctx context.Context, memoryID string, fn func(ctx context.Co
 	fn(ctx)
 }
 
-func retryUpdateMemoryStrategy(ctx context.Context, conn *bedrockagentcorecontrol.Client, input *bedrockagentcorecontrol.UpdateMemoryInput, timeout time.Duration) (*bedrockagentcorecontrol.UpdateMemoryOutput, error) {
-	deleteOp := len(input.MemoryStrategies.DeleteMemoryStrategies) > 0
+func updateMemoryWithRetry(
+	ctx context.Context,
+	conn *bedrockagentcorecontrol.Client,
+	timeout time.Duration,
+	input *bedrockagentcorecontrol.UpdateMemoryInput,
+	deleteOp bool,
+) (*bedrockagentcorecontrol.UpdateMemoryOutput, error) {
 	return tfresource.RetryWhen(
 		ctx,
 		timeout,
@@ -534,23 +591,27 @@ func retryUpdateMemoryStrategy(ctx context.Context, conn *bedrockagentcorecontro
 func memoryStrategyRetryable(deleteOp bool) tfresource.Retryable {
 	const (
 		// Retry message substrings for transitional/ignored states
-		msgMemoryTransitionalState         = "Memory is in transitional state"
 		msgMemoryStrategiesBeingModified   = "Cannot update memory while strategies are being modified"
 		msgMemoryStrategyTransitionalState = "MemoryStrategy is in transitional state"
 		msgDeleteNonExistentStrategy       = "Cannot delete non-existent memory strategies"
 	)
 	return func(err error) (bool, error) {
+		if err == nil {
+			return false, nil
+		}
+
 		switch {
 		case errs.IsA[*awstypes.ConflictException](err):
 			return true, smarterr.NewError(err)
 
-		case deleteOp && errs.IsAErrorMessageContains[*awstypes.ValidationException](err, msgDeleteNonExistentStrategy):
-			return false, nil
-
-		case errs.IsAErrorMessageContains[*awstypes.ValidationException](err, msgMemoryStrategiesBeingModified),
-			errs.IsAErrorMessageContains[*awstypes.ValidationException](err, msgMemoryStrategyTransitionalState),
-			errs.IsAErrorMessageContains[*awstypes.ValidationException](err, msgMemoryTransitionalState):
-			return true, smarterr.NewError(err)
+		case errs.IsA[*awstypes.ValidationException](err):
+			msg := err.Error()
+			if deleteOp && strings.Contains(msg, msgDeleteNonExistentStrategy) {
+				return false, nil
+			}
+			if strings.Contains(msg, msgMemoryStrategiesBeingModified) || strings.Contains(msg, msgMemoryStrategyTransitionalState) {
+				return true, smarterr.NewError(err)
+			}
 		}
 
 		return false, smarterr.NewError(err)
@@ -620,88 +681,48 @@ func findMemoryStrategyByTwoPartKey(ctx context.Context, conn *bedrockagentcorec
 
 type memoryStrategyResourceModel struct {
 	framework.WithRegionModel
-	Configuration           fwtypes.ListNestedObjectValueOf[customConfigurationModel]             `tfsdk:"configuration"`
-	Description             types.String                                                          `tfsdk:"description"`
-	MemoryExecutionRoleARN  fwtypes.ARN                                                           `tfsdk:"memory_execution_role_arn"`
-	MemoryStrategyID        types.String                                                          `tfsdk:"memory_strategy_id"`
-	MemoryID                types.String                                                          `tfsdk:"memory_id"`
-	Name                    types.String                                                          `tfsdk:"name"`
-	Namespaces              fwtypes.SetOfString                                                   `tfsdk:"namespaces"`
-	NamespaceTemplates      fwtypes.SetOfString                                                   `tfsdk:"namespace_templates"`
-	ReflectionConfiguration fwtypes.ListNestedObjectValueOf[episodicReflectionConfigurationModel] `tfsdk:"reflection_configuration"`
-	Timeouts                timeouts.Value                                                        `tfsdk:"timeouts"`
-	Type                    fwtypes.StringEnum[awstypes.MemoryStrategyType]                       `tfsdk:"type"`
+	Configuration          fwtypes.ListNestedObjectValueOf[customConfigurationModel] `tfsdk:"configuration"`
+	Description            types.String                                              `tfsdk:"description"`
+	MemoryExecutionRoleARN fwtypes.ARN                                               `tfsdk:"memory_execution_role_arn"`
+	MemoryStrategyID       types.String                                              `tfsdk:"memory_strategy_id"`
+	MemoryID               types.String                                              `tfsdk:"memory_id"`
+	Name                   types.String                                              `tfsdk:"name"`
+	Namespaces             fwtypes.SetOfString                                       `tfsdk:"namespaces"`
+	ReflectionConfiguration  fwtypes.ListNestedObjectValueOf[reflectionConfigurationModel] `tfsdk:"reflection_configuration"`
+	Type                   fwtypes.StringEnum[awstypes.MemoryStrategyType]           `tfsdk:"type"`
+	Timeouts               timeouts.Value                                            `tfsdk:"timeouts"`
+}
+
+func (m *memoryStrategyResourceModel) GetIdentifier() string {
+	if !m.MemoryStrategyID.IsNull() {
+		return m.MemoryStrategyID.ValueString()
+	} else {
+		return m.Name.ValueString()
+	}
 }
 
 var (
-	_ fwflex.TypedExpander = memoryStrategyResourceModel{}
-	_ fwflex.Flattener     = &memoryStrategyResourceModel{}
+	_ fwflex.TypedExpander = &memoryStrategyResourceModel{}
 )
 
-func (m *memoryStrategyResourceModel) Flatten(ctx context.Context, v any) diag.Diagnostics {
-	var diags diag.Diagnostics
-	switch t := v.(type) {
-	case awstypes.MemoryStrategy:
-		// For non-CUSTOM types, clear Configuration from the API response before
-		// flattening. The API returns a StrategyConfiguration with Type values
-		// (e.g. "EPISODIC") that are not valid OverrideType enum values.
-		switch t.Type {
-		case awstypes.MemoryStrategyTypeCustom:
-		case awstypes.MemoryStrategyTypeEpisodic:
-			if t.Configuration != nil {
-				switch t := t.Configuration.Reflection.(type) {
-				case *awstypes.ReflectionConfigurationMemberEpisodicReflectionConfiguration:
-					m.ReflectionConfiguration, diags = fwtypes.NewListNestedObjectValueOfPtr(ctx, &episodicReflectionConfigurationModel{
-						NamespaceTemplates: fwflex.FlattenFrameworkStringValueSetOfString(ctx, t.Value.NamespaceTemplates),
-					})
-				}
-
-				t.Configuration = nil
-			}
-		default:
-			t.Configuration = nil
-		}
-
-		// To prevent infinite recursion...
-		type modelAlias *memoryStrategyResourceModel
-		alias := modelAlias(m)
-		smerr.AddEnrich(ctx, &diags, fwflex.Flatten(ctx, t, alias, fwflex.WithFieldNamePrefix("Memory")))
-		if diags.HasError() {
-			return diags
-		}
-
-	default:
-		diags.AddError(
-			"Unsupported Type",
-			fmt.Sprintf("memoryStrategyResourceModel.Flatten: %T", v),
-		)
-	}
-
-	return diags
-}
-
-func (m memoryStrategyResourceModel) ExpandTo(ctx context.Context, targetType reflect.Type) (any, diag.Diagnostics) {
-	var diags diag.Diagnostics
+func (m memoryStrategyResourceModel) ExpandTo(ctx context.Context, targetType reflect.Type) (result any, diags diag.Diagnostics) {
 	switch targetType {
-	case reflect.TypeFor[awstypes.MemoryStrategyInput](): // Create
+	case reflect.TypeFor[awstypes.MemoryStrategyInput]():
 		return m.expandToMemoryStrategyInput(ctx)
 
-	case reflect.TypeFor[awstypes.ModifyMemoryStrategyInput](): // Update
+	case reflect.TypeFor[awstypes.ModifyMemoryStrategyInput]():
 		return m.expandToModifyMemoryStrategyInput(ctx)
-
 	default:
 		diags.AddError(
 			"Unsupported Type",
-			fmt.Sprintf("memoryStrategyResourceModel.ExpandTo: %s", targetType),
+			fmt.Sprintf("expand target type: %T", targetType),
 		)
 	}
 
 	return nil, diags
 }
 
-func (m memoryStrategyResourceModel) expandToMemoryStrategyInput(ctx context.Context) (awstypes.MemoryStrategyInput, diag.Diagnostics) {
-	var diags diag.Diagnostics
-	// To prevent infinite recursion...
+func (m memoryStrategyResourceModel) expandToMemoryStrategyInput(ctx context.Context) (result any, diags diag.Diagnostics) {
 	type modelAlias memoryStrategyResourceModel
 	alias := modelAlias(m)
 	switch m.Type.ValueEnum() {
@@ -739,34 +760,44 @@ func (m memoryStrategyResourceModel) expandToMemoryStrategyInput(ctx context.Con
 
 	case awstypes.MemoryStrategyTypeEpisodic:
 		var r awstypes.MemoryStrategyInputMemberEpisodicMemoryStrategy
-		smerr.AddEnrich(ctx, &diags, fwflex.Expand(ctx, alias, &r.Value))
+		r.Value.Name = m.Name.ValueStringPointer()
+		r.Value.Description = m.Description.ValueStringPointer()
+		smerr.AddEnrich(ctx, &diags, m.Namespaces.ElementsAs(ctx, &r.Value.Namespaces, false))
 		if diags.HasError() {
 			return nil, diags
 		}
-
-		if r.Value.ReflectionConfiguration == nil {
-			// The API requires the reflection namespace to be the same as or a prefix
-			// of the episodic namespace. Set it to match the episodic namespaces.
-			r.Value.ReflectionConfiguration = &awstypes.EpisodicReflectionConfigurationInput{
-				NamespaceTemplates: r.Value.NamespaceTemplates,
+		// Build reflection configuration from user-provided values or defaults.
+		// If no reflection_configuration block is provided, set namespaceTemplates
+		// to match the episodic namespaces (matching the legacy default behavior).
+		reflectionConfig := &awstypes.EpisodicReflectionConfigurationInput{}
+		if !m.ReflectionConfiguration.IsNull() && !m.ReflectionConfiguration.IsUnknown() {
+			rc, rcDiags := m.ReflectionConfiguration.ToPtr(ctx)
+			smerr.AddEnrich(ctx, &diags, rcDiags)
+			if diags.HasError() {
+				return nil, diags
 			}
+			if !rc.NamespaceTemplates.IsNull() && !rc.NamespaceTemplates.IsUnknown() {
+				smerr.AddEnrich(ctx, &diags, rc.NamespaceTemplates.ElementsAs(ctx, &reflectionConfig.NamespaceTemplates, false))
+				if diags.HasError() {
+					return nil, diags
+				}
+			}
+		} else {
+			// Default: use episodic namespaces as reflection namespaces
+			reflectionConfig.Namespaces = r.Value.Namespaces
 		}
-
+		r.Value.ReflectionConfiguration = reflectionConfig
 		return &r, diags
-
 	default:
 		diags.AddError(
 			"Unsupported Type",
-			fmt.Sprintf("memoryStrategyResourceModel.Type: %s", m.Type),
+			fmt.Sprintf("memory strategy type: %q", m.Type.ValueString()),
 		)
 	}
-
 	return nil, diags
 }
 
-func (m memoryStrategyResourceModel) expandToModifyMemoryStrategyInput(ctx context.Context) (*awstypes.ModifyMemoryStrategyInput, diag.Diagnostics) {
-	var diags diag.Diagnostics
-	// To prevent infinite recursion...
+func (m memoryStrategyResourceModel) expandToModifyMemoryStrategyInput(ctx context.Context) (result any, diags diag.Diagnostics) {
 	type modelAlias memoryStrategyResourceModel
 	alias := modelAlias(m)
 	var r awstypes.ModifyMemoryStrategyInput
@@ -774,40 +805,20 @@ func (m memoryStrategyResourceModel) expandToModifyMemoryStrategyInput(ctx conte
 	if diags.HasError() {
 		return nil, diags
 	}
-
 	// For non-CUSTOM types, Configuration should not be sent.
 	// Auto-flex may produce an empty ModifyStrategyConfiguration from the
 	// null model Configuration field, which the API rejects.
-	switch m.Type.ValueEnum() {
-	case awstypes.MemoryStrategyTypeCustom:
-	case awstypes.MemoryStrategyTypeEpisodic:
-		if !m.ReflectionConfiguration.IsNull() {
-			var rReflectionConfiguration awstypes.EpisodicReflectionConfigurationInput
-			smerr.AddEnrich(ctx, &diags, fwflex.Expand(ctx, m.ReflectionConfiguration, &rReflectionConfiguration))
-			if diags.HasError() {
-				return nil, diags
-			}
-
-			r.Configuration = &awstypes.ModifyStrategyConfiguration{
-				Reflection: &awstypes.ModifyReflectionConfigurationMemberEpisodicReflectionConfiguration{
-					Value: rReflectionConfiguration,
-				},
-			}
-		} else {
-			r.Configuration = nil
-		}
-	default:
+	if m.Configuration.IsNull() || m.Configuration.IsUnknown() {
 		r.Configuration = nil
 	}
-
 	return &r, diags
 }
 
 type customConfigurationModel struct {
-	Consolidation fwtypes.ListNestedObjectValueOf[overrideDetailsModel]                   `tfsdk:"consolidation"`
-	Extraction    fwtypes.ListNestedObjectValueOf[overrideDetailsModel]                   `tfsdk:"extraction"`
-	Reflection    fwtypes.ListNestedObjectValueOf[episodicReflectionOverrideDetailsModel] `tfsdk:"reflection"`
-	Type          fwtypes.StringEnum[awstypes.OverrideType]                               `tfsdk:"type"`
+	Type          fwtypes.StringEnum[awstypes.OverrideType]             `tfsdk:"type"`
+	Consolidation fwtypes.ListNestedObjectValueOf[overrideDetailsModel] `tfsdk:"consolidation"`
+	Extraction    fwtypes.ListNestedObjectValueOf[overrideDetailsModel] `tfsdk:"extraction"`
+	Reflection    fwtypes.ListNestedObjectValueOf[reflectionOverrideModel]   `tfsdk:"reflection"`
 }
 
 var (
@@ -815,8 +826,8 @@ var (
 	_ fwflex.Flattener     = &customConfigurationModel{}
 )
 
-func (m *customConfigurationModel) Flatten(ctx context.Context, v any) diag.Diagnostics {
-	var diags diag.Diagnostics
+func (m *customConfigurationModel) Flatten(ctx context.Context, v any) (diags diag.Diagnostics) {
+	var d diag.Diagnostics
 	switch t := v.(type) {
 	case awstypes.StrategyConfiguration:
 		m.Type = fwtypes.StringEnumValue(t.Type)
@@ -828,7 +839,6 @@ func (m *customConfigurationModel) Flatten(ctx context.Context, v any) diag.Diag
 				return diags
 			}
 			if !consolidation.AppendToPrompt.IsNull() && !consolidation.ModelID.IsNull() {
-				var d diag.Diagnostics
 				m.Consolidation, d = fwtypes.NewListNestedObjectValueOfPtr(ctx, &consolidation)
 				smerr.AddEnrich(ctx, &diags, d)
 				if diags.HasError() {
@@ -844,68 +854,65 @@ func (m *customConfigurationModel) Flatten(ctx context.Context, v any) diag.Diag
 				return diags
 			}
 			if !extraction.AppendToPrompt.IsNull() && !extraction.ModelID.IsNull() {
-				var d diag.Diagnostics
 				m.Extraction, d = fwtypes.NewListNestedObjectValueOfPtr(ctx, &extraction)
 				smerr.AddEnrich(ctx, &diags, d)
 				if diags.HasError() {
 					return diags
 				}
 			}
-		}
 
 		if t.Reflection != nil {
-			var reflection episodicReflectionOverrideDetailsModel
-			smerr.AddEnrich(ctx, &diags, fwflex.Flatten(ctx, t.Reflection, &reflection))
-			if diags.HasError() {
-				return diags
-			}
-			if !reflection.AppendToPrompt.IsNull() && !reflection.ModelID.IsNull() && !reflection.NamespaceTemplates.IsNull() {
-				var d diag.Diagnostics
-				m.Reflection, d = fwtypes.NewListNestedObjectValueOfPtr(ctx, &reflection)
-				smerr.AddEnrich(ctx, &diags, d)
-				if diags.HasError() {
-					return diags
+			switch rt := t.Reflection.(type) {
+			case *awstypes.ReflectionConfigurationMemberCustomReflectionConfiguration:
+				if customReflection, ok := rt.Value.(*awstypes.CustomReflectionConfigurationMemberEpisodicReflectionOverride); ok {
+					var reflection reflectionOverrideModel
+					smerr.AddEnrich(ctx, &diags, fwflex.Flatten(ctx, customReflection.Value, &reflection))
+					if diags.HasError() {
+						return diags
+					}
+					if !reflection.AppendToPrompt.IsNull() && !reflection.ModelID.IsNull() {
+						m.Reflection, d = fwtypes.NewListNestedObjectValueOfPtr(ctx, &reflection)
+						smerr.AddEnrich(ctx, &diags, d)
+						if diags.HasError() {
+							return diags
+						}
+					}
 				}
 			}
 		}
-
+		}
+		}
 	default:
 		diags.AddError(
 			"Unsupported Type",
-			fmt.Sprintf("customConfigurationModel.Flatten: %T", v),
+			fmt.Sprintf("strategy configuration flatten: %s", reflect.TypeOf(v).String()),
 		)
 	}
-
 	return diags
 }
-
-func (m customConfigurationModel) ExpandTo(ctx context.Context, targetType reflect.Type) (any, diag.Diagnostics) {
-	var diags diag.Diagnostics
+func (m customConfigurationModel) ExpandTo(ctx context.Context, targetType reflect.Type) (result any, diags diag.Diagnostics) {
 	switch targetType {
-	case reflect.TypeFor[awstypes.CustomConfigurationInput](): // Create
+	case reflect.TypeFor[awstypes.CustomConfigurationInput]():
 		return m.expandToCustomConfigurationInput(ctx)
 
-	case reflect.TypeFor[awstypes.ModifyStrategyConfiguration](): // Update
+	case reflect.TypeFor[awstypes.ModifyStrategyConfiguration]():
 		return m.expandToModifyStrategyConfiguration(ctx)
-
 	default:
 		diags.AddError(
 			"Unsupported Type",
-			fmt.Sprintf("customConfigurationModel.ExpandTo: %s", targetType),
+			fmt.Sprintf("configuration expand target type: %s", targetType),
 		)
 	}
-
 	return nil, diags
 }
 
-func (m customConfigurationModel) expandToCustomConfigurationInput(ctx context.Context) (awstypes.CustomConfigurationInput, diag.Diagnostics) {
-	var diags diag.Diagnostics
-	// To prevent infinite recursion...
+func (m customConfigurationModel) expandToCustomConfigurationInput(ctx context.Context) (result awstypes.CustomConfigurationInput, diags diag.Diagnostics) {
 	type modelAlias customConfigurationModel
 	alias := modelAlias(m)
 
 	switch m.Type.ValueEnum() {
 	case awstypes.OverrideTypeSemanticOverride:
+
 		var r awstypes.CustomConfigurationInputMemberSemanticOverride
 		smerr.AddEnrich(ctx, &diags, fwflex.Expand(ctx, alias, &r.Value))
 		if diags.HasError() {
@@ -936,88 +943,79 @@ func (m customConfigurationModel) expandToCustomConfigurationInput(ctx context.C
 			return nil, diags
 		}
 		return &r, diags
-
 	default:
 		diags.AddError(
 			"Unsupported Type",
-			fmt.Sprintf("customConfigurationModel.Type: %s", m.Type),
+			fmt.Sprintf("override type (custom configuration input): %q", m.Type.ValueString()),
 		)
 	}
-
 	return nil, diags
 }
 
-func (m customConfigurationModel) expandToModifyStrategyConfiguration(ctx context.Context) (*awstypes.ModifyStrategyConfiguration, diag.Diagnostics) {
-	var diags diag.Diagnostics
-	var r awstypes.ModifyStrategyConfiguration
-	var rConsolidation awstypes.ModifyConsolidationConfigurationMemberCustomConsolidationConfiguration
-	var rExtraction awstypes.ModifyExtractionConfigurationMemberCustomExtractionConfiguration
-	var rReflection awstypes.ModifyReflectionConfigurationMemberCustomReflectionConfiguration
+func (m customConfigurationModel) expandToModifyStrategyConfiguration(ctx context.Context) (result *awstypes.ModifyStrategyConfiguration, diags diag.Diagnostics) {
+	result = &awstypes.ModifyStrategyConfiguration{}
+
 	var consolidation, extraction *overrideDetailsModel
-	var reflection *episodicReflectionOverrideDetailsModel
+	var d diag.Diagnostics
 
 	if !m.Consolidation.IsNull() {
-		var d diag.Diagnostics
 		consolidation, d = m.Consolidation.ToPtr(ctx)
 		smerr.AddEnrich(ctx, &diags, d)
 		if diags.HasError() {
 			return nil, diags
 		}
-
-		r.Consolidation = &rConsolidation
 	}
 	if !m.Extraction.IsNull() {
-		var d diag.Diagnostics
 		extraction, d = m.Extraction.ToPtr(ctx)
 		smerr.AddEnrich(ctx, &diags, d)
 		if diags.HasError() {
 			return nil, diags
 		}
-
-		r.Extraction = &rExtraction
 	}
+
+
+	var reflection *reflectionOverrideModel
 	if !m.Reflection.IsNull() {
-		var d diag.Diagnostics
 		reflection, d = m.Reflection.ToPtr(ctx)
 		smerr.AddEnrich(ctx, &diags, d)
 		if diags.HasError() {
 			return nil, diags
 		}
-
-		r.Reflection = &rReflection
 	}
-
 	switch m.Type.ValueEnum() {
 	case awstypes.OverrideTypeSemanticOverride:
 		if consolidation != nil {
-			var r awstypes.CustomConsolidationConfigurationInputMemberSemanticConsolidationOverride
-			smerr.AddEnrich(ctx, &diags, fwflex.Expand(ctx, consolidation, &r.Value))
+			var consolidationInput awstypes.CustomConsolidationConfigurationInputMemberSemanticConsolidationOverride
+			smerr.AddEnrich(ctx, &diags, fwflex.Expand(ctx, consolidation, &consolidationInput.Value))
 			if diags.HasError() {
 				return nil, diags
 			}
-
-			rConsolidation.Value = &r
+			result.Consolidation = &awstypes.ModifyConsolidationConfigurationMemberCustomConsolidationConfiguration{
+				Value: &consolidationInput,
+			}
 		}
 
 		if extraction != nil {
-			var r awstypes.CustomExtractionConfigurationInputMemberSemanticExtractionOverride
-			smerr.AddEnrich(ctx, &diags, fwflex.Expand(ctx, extraction, &r.Value))
+			var extractionInput awstypes.CustomExtractionConfigurationInputMemberSemanticExtractionOverride
+			smerr.AddEnrich(ctx, &diags, fwflex.Expand(ctx, extraction, &extractionInput.Value))
 			if diags.HasError() {
 				return nil, diags
 			}
-
-			rExtraction.Value = &r
+			result.Extraction = &awstypes.ModifyExtractionConfigurationMemberCustomExtractionConfiguration{
+				Value: &extractionInput,
+			}
 		}
 
 	case awstypes.OverrideTypeSummaryOverride:
 		if consolidation != nil {
-			var r awstypes.CustomConsolidationConfigurationInputMemberSummaryConsolidationOverride
-			smerr.AddEnrich(ctx, &diags, fwflex.Expand(ctx, consolidation, &r.Value))
+			var consolidationInput awstypes.CustomConsolidationConfigurationInputMemberSummaryConsolidationOverride
+			smerr.AddEnrich(ctx, &diags, fwflex.Expand(ctx, consolidation, &consolidationInput.Value))
 			if diags.HasError() {
 				return nil, diags
 			}
-
-			rConsolidation.Value = &r
+			result.Consolidation = &awstypes.ModifyConsolidationConfigurationMemberCustomConsolidationConfiguration{
+				Value: &consolidationInput,
+			}
 		}
 
 		// Note: AWS SDK doesn't have SummaryExtractionOverride - only Semantic and UserPreference
@@ -1026,65 +1024,68 @@ func (m customConfigurationModel) expandToModifyStrategyConfiguration(ctx contex
 
 	case awstypes.OverrideTypeUserPreferenceOverride:
 		if consolidation != nil {
-			var r awstypes.CustomConsolidationConfigurationInputMemberUserPreferenceConsolidationOverride
-			smerr.AddEnrich(ctx, &diags, fwflex.Expand(ctx, consolidation, &r.Value))
+			var consolidationInput awstypes.CustomConsolidationConfigurationInputMemberUserPreferenceConsolidationOverride
+			smerr.AddEnrich(ctx, &diags, fwflex.Expand(ctx, consolidation, &consolidationInput.Value))
 			if diags.HasError() {
 				return nil, diags
 			}
-
-			rConsolidation.Value = &r
+			result.Consolidation = &awstypes.ModifyConsolidationConfigurationMemberCustomConsolidationConfiguration{
+				Value: &consolidationInput,
+			}
 		}
 
 		if extraction != nil {
-			var r awstypes.CustomExtractionConfigurationInputMemberUserPreferenceExtractionOverride
-			smerr.AddEnrich(ctx, &diags, fwflex.Expand(ctx, extraction, &r.Value))
+			var extractionInput awstypes.CustomExtractionConfigurationInputMemberUserPreferenceExtractionOverride
+			smerr.AddEnrich(ctx, &diags, fwflex.Expand(ctx, extraction, &extractionInput.Value))
 			if diags.HasError() {
 				return nil, diags
 			}
-
-			rExtraction.Value = &r
+			result.Extraction = &awstypes.ModifyExtractionConfigurationMemberCustomExtractionConfiguration{
+				Value: &extractionInput,
+			}
 		}
 
 	case awstypes.OverrideTypeEpisodicOverride:
 		if consolidation != nil {
-			var r awstypes.CustomConsolidationConfigurationInputMemberEpisodicConsolidationOverride
-			smerr.AddEnrich(ctx, &diags, fwflex.Expand(ctx, consolidation, &r.Value))
+			var consolidationInput awstypes.CustomConsolidationConfigurationInputMemberEpisodicConsolidationOverride
+			smerr.AddEnrich(ctx, &diags, fwflex.Expand(ctx, consolidation, &consolidationInput.Value))
 			if diags.HasError() {
 				return nil, diags
 			}
-
-			rConsolidation.Value = &r
+			result.Consolidation = &awstypes.ModifyConsolidationConfigurationMemberCustomConsolidationConfiguration{
+				Value: &consolidationInput,
+			}
 		}
 
 		if extraction != nil {
-			var r awstypes.CustomExtractionConfigurationInputMemberEpisodicExtractionOverride
-			smerr.AddEnrich(ctx, &diags, fwflex.Expand(ctx, extraction, &r.Value))
+			var extractionInput awstypes.CustomExtractionConfigurationInputMemberEpisodicExtractionOverride
+			smerr.AddEnrich(ctx, &diags, fwflex.Expand(ctx, extraction, &extractionInput.Value))
 			if diags.HasError() {
 				return nil, diags
 			}
-
-			rExtraction.Value = &r
+			result.Extraction = &awstypes.ModifyExtractionConfigurationMemberCustomExtractionConfiguration{
+				Value: &extractionInput,
+			}
 		}
 
 		if reflection != nil {
-			var r awstypes.CustomReflectionConfigurationInputMemberEpisodicReflectionOverride
-			smerr.AddEnrich(ctx, &diags, fwflex.Expand(ctx, reflection, &r.Value))
+			var reflectionInput awstypes.CustomReflectionConfigurationInputMemberEpisodicReflectionOverride
+			smerr.AddEnrich(ctx, &diags, fwflex.Expand(ctx, reflection, &reflectionInput.Value))
 			if diags.HasError() {
 				return nil, diags
 			}
-
-			rReflection.Value = &r
+			result.Reflection = &awstypes.ModifyReflectionConfigurationMemberCustomReflectionConfiguration{
+				Value: &reflectionInput,
+			}
 		}
-
 	default:
 		diags.AddError(
 			"Unsupported Type",
-			fmt.Sprintf("customConfigurationModel.Type: %s", m.Type),
+			fmt.Sprintf("override type (modify strategy configuration): %q", m.Type.ValueString()),
 		)
 		return nil, diags
 	}
-
-	return &r, diags
+	return result, diags
 }
 
 type overrideDetailsModel struct {
@@ -1092,136 +1093,88 @@ type overrideDetailsModel struct {
 	ModelID        types.String `tfsdk:"model_id"`
 }
 
+// reflectionConfigurationModel is the model for the built-in EPISODIC reflection_configuration block.
+type reflectionConfigurationModel struct {
+	NamespaceTemplates fwtypes.ListOfString `tfsdk:"namespace_templates"`
+}
+
+// reflectionOverrideModel is the model for the reflection block inside configuration (CUSTOM EPISODIC_OVERRIDE).
+type reflectionOverrideModel struct {
+	AppendToPrompt     types.String         `tfsdk:"append_to_prompt"`
+	ModelID            types.String         `tfsdk:"model_id"`
+	NamespaceTemplates fwtypes.ListOfString `tfsdk:"namespace_templates"`
+}
+
 var (
 	_ fwflex.Flattener = &overrideDetailsModel{}
 )
 
-func (m *overrideDetailsModel) Flatten(ctx context.Context, v any) diag.Diagnostics {
-	var diags diag.Diagnostics
-	// To prevent infinite recursion...
-	type modelAlias *overrideDetailsModel
-	alias := modelAlias(m)
+func (m *overrideDetailsModel) Flatten(ctx context.Context, v any) (diags diag.Diagnostics) {
 	switch t := v.(type) {
-	// Consolidation.
+	// Consolidation
 	case awstypes.ConsolidationConfigurationMemberCustomConsolidationConfiguration:
 		return m.Flatten(ctx, t.Value)
 
 	case *awstypes.CustomConsolidationConfigurationMemberSemanticConsolidationOverride:
 		return m.Flatten(ctx, t.Value)
-
 	case *awstypes.CustomConsolidationConfigurationMemberSummaryConsolidationOverride:
 		return m.Flatten(ctx, t.Value)
-
 	case *awstypes.CustomConsolidationConfigurationMemberUserPreferenceConsolidationOverride:
 		return m.Flatten(ctx, t.Value)
-
 	case *awstypes.CustomConsolidationConfigurationMemberEpisodicConsolidationOverride:
 		return m.Flatten(ctx, t.Value)
 
 	case awstypes.SemanticConsolidationOverride:
-		smerr.AddEnrich(ctx, &diags, fwflex.Flatten(ctx, t, alias))
-		if diags.HasError() {
-			return diags
-		}
+		m.AppendToPrompt = types.StringPointerValue(t.AppendToPrompt)
+		m.ModelID = types.StringPointerValue(t.ModelId)
+		return diags
 
 	case awstypes.SummaryConsolidationOverride:
-		smerr.AddEnrich(ctx, &diags, fwflex.Flatten(ctx, t, alias))
-		if diags.HasError() {
-			return diags
-		}
+		m.AppendToPrompt = types.StringPointerValue(t.AppendToPrompt)
+		m.ModelID = types.StringPointerValue(t.ModelId)
+		return diags
 
 	case awstypes.UserPreferenceConsolidationOverride:
-		smerr.AddEnrich(ctx, &diags, fwflex.Flatten(ctx, t, alias))
-		if diags.HasError() {
-			return diags
-		}
+		m.AppendToPrompt = types.StringPointerValue(t.AppendToPrompt)
+		m.ModelID = types.StringPointerValue(t.ModelId)
+		return diags
 
 	case awstypes.EpisodicConsolidationOverride:
-		smerr.AddEnrich(ctx, &diags, fwflex.Flatten(ctx, t, alias))
-		if diags.HasError() {
-			return diags
-		}
+		m.AppendToPrompt = types.StringPointerValue(t.AppendToPrompt)
+		m.ModelID = types.StringPointerValue(t.ModelId)
+		return diags
 
-	//	Extraction.
+	//	Extraction
 	case awstypes.ExtractionConfigurationMemberCustomExtractionConfiguration:
 		return m.Flatten(ctx, t.Value)
 
 	case *awstypes.CustomExtractionConfigurationMemberSemanticExtractionOverride:
 		return m.Flatten(ctx, t.Value)
-
 	case *awstypes.CustomExtractionConfigurationMemberUserPreferenceExtractionOverride:
 		return m.Flatten(ctx, t.Value)
-
 	case *awstypes.CustomExtractionConfigurationMemberEpisodicExtractionOverride:
 		return m.Flatten(ctx, t.Value)
 
 	case awstypes.SemanticExtractionOverride:
-		smerr.AddEnrich(ctx, &diags, fwflex.Flatten(ctx, t, alias))
-		if diags.HasError() {
-			return diags
-		}
+		m.AppendToPrompt = types.StringPointerValue(t.AppendToPrompt)
+		m.ModelID = types.StringPointerValue(t.ModelId)
+		return diags
 
 	case awstypes.UserPreferenceExtractionOverride:
-		smerr.AddEnrich(ctx, &diags, fwflex.Flatten(ctx, t, alias))
-		if diags.HasError() {
-			return diags
-		}
+		m.AppendToPrompt = types.StringPointerValue(t.AppendToPrompt)
+		m.ModelID = types.StringPointerValue(t.ModelId)
+		return diags
 
 	case awstypes.EpisodicExtractionOverride:
-		smerr.AddEnrich(ctx, &diags, fwflex.Flatten(ctx, t, alias))
-		if diags.HasError() {
-			return diags
-		}
+		m.AppendToPrompt = types.StringPointerValue(t.AppendToPrompt)
+		m.ModelID = types.StringPointerValue(t.ModelId)
+		return diags
 
 	default:
 		diags.AddError(
 			"Unsupported Type",
-			fmt.Sprintf("overrideDetailsModel.Flatten: %T", v),
+			fmt.Sprintf("override details flatten: %s", reflect.TypeOf(v).String()),
 		)
+		return diags
 	}
-
-	return diags
-}
-
-type episodicReflectionConfigurationModel struct {
-	NamespaceTemplates fwtypes.SetOfString `tfsdk:"namespace_templates"`
-}
-
-type episodicReflectionOverrideDetailsModel struct {
-	AppendToPrompt     types.String        `tfsdk:"append_to_prompt"`
-	ModelID            types.String        `tfsdk:"model_id"`
-	NamespaceTemplates fwtypes.SetOfString `tfsdk:"namespace_templates"`
-}
-
-var (
-	_ fwflex.Flattener = &episodicReflectionOverrideDetailsModel{}
-)
-
-func (m *episodicReflectionOverrideDetailsModel) Flatten(ctx context.Context, v any) diag.Diagnostics {
-	var diags diag.Diagnostics
-	switch t := v.(type) {
-	//	Reflection.
-	case *awstypes.CustomReflectionConfigurationMemberEpisodicReflectionOverride:
-		return m.Flatten(ctx, t.Value)
-
-	case awstypes.EpisodicReflectionOverride:
-		// To prevent infinite recursion...
-		type modelAlias *episodicReflectionOverrideDetailsModel
-		alias := modelAlias(m)
-		smerr.AddEnrich(ctx, &diags, fwflex.Flatten(ctx, t, alias))
-		if diags.HasError() {
-			return diags
-		}
-
-	case awstypes.ReflectionConfigurationMemberCustomReflectionConfiguration:
-		return m.Flatten(ctx, t.Value)
-
-	default:
-		diags.AddError(
-			"Unsupported Type",
-			fmt.Sprintf("episodicReflectionOverrideDetailsModel.Flatten: %T", v),
-		)
-	}
-
-	return diags
 }

--- a/website/docs/r/bedrockagentcore_memory_strategy.html.markdown
+++ b/website/docs/r/bedrockagentcore_memory_strategy.html.markdown
@@ -89,7 +89,6 @@ resource "aws_bedrockagentcore_memory_strategy" "episodic_reflection" {
 resource "aws_bedrockagentcore_memory_strategy" "custom_semantic" {
   name                      = "custom-semantic-strategy"
   memory_id                 = aws_bedrockagentcore_memory.example.id
-  memory_execution_role_arn = aws_bedrockagentcore_memory.example.memory_execution_role_arn
   type                      = "CUSTOM"
   description               = "Custom semantic processing strategy"
   namespaces                = ["{sessionId}"]
@@ -163,7 +162,6 @@ resource "aws_bedrockagentcore_memory_strategy" "custom_user_pref" {
 resource "aws_bedrockagentcore_memory_strategy" "custom_episodic" {
   name                      = "custom-episodic-strategy"
   memory_id                 = aws_bedrockagentcore_memory.example.id
-  memory_execution_role_arn = aws_bedrockagentcore_memory.example.memory_execution_role_arn
   type                      = "CUSTOM"
   description               = "Custom episodic processing strategy"
   namespaces                = ["/strategies/{memoryStrategyId}/actors/{actorId}/sessions/{sessionId}"]
@@ -191,7 +189,6 @@ resource "aws_bedrockagentcore_memory_strategy" "custom_episodic" {
 resource "aws_bedrockagentcore_memory_strategy" "custom_episodic_reflection" {
   name                      = "custom-episodic-reflection-strategy"
   memory_id                 = aws_bedrockagentcore_memory.example.id
-  memory_execution_role_arn = aws_bedrockagentcore_memory.example.memory_execution_role_arn
   type                      = "CUSTOM"
   description               = "Custom episodic strategy with reflection override"
   namespaces                = ["/strategies/{memoryStrategyId}/actors/{actorId}/sessions/{sessionId}"]

--- a/website/docs/r/bedrockagentcore_memory_strategy.html.markdown
+++ b/website/docs/r/bedrockagentcore_memory_strategy.html.markdown
@@ -22,11 +22,11 @@ Manages an AWS Bedrock AgentCore Memory Strategy. Memory strategies define how t
 
 ```terraform
 resource "aws_bedrockagentcore_memory_strategy" "semantic" {
-  name                = "semantic-strategy"
-  memory_id           = aws_bedrockagentcore_memory.example.id
-  type                = "SEMANTIC"
-  description         = "Semantic understanding strategy"
-  namespace_templates = ["default"]
+  name        = "semantic-strategy"
+  memory_id   = aws_bedrockagentcore_memory.example.id
+  type        = "SEMANTIC"
+  description = "Semantic understanding strategy"
+  namespaces  = ["default"]
 }
 ```
 
@@ -34,11 +34,11 @@ resource "aws_bedrockagentcore_memory_strategy" "semantic" {
 
 ```terraform
 resource "aws_bedrockagentcore_memory_strategy" "summary" {
-  name                = "summary-strategy"
-  memory_id           = aws_bedrockagentcore_memory.example.id
-  type                = "SUMMARIZATION"
-  description         = "Text summarization strategy"
-  namespace_templates = ["{sessionId}"]
+  name        = "summary-strategy"
+  memory_id   = aws_bedrockagentcore_memory.example.id
+  type        = "SUMMARIZATION"
+  description = "Text summarization strategy"
+  namespaces  = ["{sessionId}"]
 }
 ```
 
@@ -46,11 +46,11 @@ resource "aws_bedrockagentcore_memory_strategy" "summary" {
 
 ```terraform
 resource "aws_bedrockagentcore_memory_strategy" "user_pref" {
-  name                = "user-preference-strategy"
-  memory_id           = aws_bedrockagentcore_memory.example.id
-  type                = "USER_PREFERENCE"
-  description         = "User preference tracking strategy"
-  namespace_templates = ["preferences"]
+  name        = "user-preference-strategy"
+  memory_id   = aws_bedrockagentcore_memory.example.id
+  type        = "USER_PREFERENCE"
+  description = "User preference tracking strategy"
+  namespaces  = ["preferences"]
 }
 ```
 
@@ -58,11 +58,28 @@ resource "aws_bedrockagentcore_memory_strategy" "user_pref" {
 
 ```terraform
 resource "aws_bedrockagentcore_memory_strategy" "episodic" {
-  name                = "episodic-strategy"
-  memory_id           = aws_bedrockagentcore_memory.example.id
-  type                = "EPISODIC"
-  description         = "Episodic memory strategy"
-  namespace_templates = ["/strategies/{memoryStrategyId}/actors/{actorId}/sessions/{sessionId}"]
+  name        = "episodic-strategy"
+  memory_id   = aws_bedrockagentcore_memory.example.id
+  type        = "EPISODIC"
+  description = "Episodic memory strategy"
+  namespaces  = ["/strategies/{memoryStrategyId}/actors/{actorId}/sessions/{sessionId}"]
+}
+```
+
+
+### Episodic Strategy with Custom Reflection Configuration
+
+```terraform
+resource "aws_bedrockagentcore_memory_strategy" "episodic_reflection" {
+  name        = "episodic-reflection-strategy"
+  memory_id   = aws_bedrockagentcore_memory.example.id
+  type        = "EPISODIC"
+  description = "Episodic strategy with custom reflection namespaces"
+  namespaces  = ["/strategies/{memoryStrategyId}/actors/{actorId}/sessions/{sessionId}"]
+
+  reflection_configuration {
+    namespace_templates = ["/strategies/{memoryStrategyId}/actors/{actorId}/reflections"]
+  }
 }
 ```
 
@@ -75,7 +92,7 @@ resource "aws_bedrockagentcore_memory_strategy" "custom_semantic" {
   memory_execution_role_arn = aws_bedrockagentcore_memory.example.memory_execution_role_arn
   type                      = "CUSTOM"
   description               = "Custom semantic processing strategy"
-  namespace_templates       = ["{sessionId}"]
+  namespaces                = ["{sessionId}"]
 
   configuration {
     type = "SEMANTIC_OVERRIDE"
@@ -97,11 +114,11 @@ resource "aws_bedrockagentcore_memory_strategy" "custom_semantic" {
 
 ```terraform
 resource "aws_bedrockagentcore_memory_strategy" "custom_summary" {
-  name                = "custom-summary-strategy"
-  memory_id           = aws_bedrockagentcore_memory.example.id
-  type                = "CUSTOM"
-  description         = "Custom summarization strategy"
-  namespace_templates = ["summaries"]
+  name        = "custom-summary-strategy"
+  memory_id   = aws_bedrockagentcore_memory.example.id
+  type        = "CUSTOM"
+  description = "Custom summarization strategy"
+  namespaces  = ["summaries"]
 
   configuration {
     type = "SUMMARY_OVERRIDE"
@@ -118,11 +135,11 @@ resource "aws_bedrockagentcore_memory_strategy" "custom_summary" {
 
 ```terraform
 resource "aws_bedrockagentcore_memory_strategy" "custom_user_pref" {
-  name                = "custom-user-preference-strategy"
-  memory_id           = aws_bedrockagentcore_memory.example.id
-  type                = "CUSTOM"
-  description         = "Custom user preference tracking strategy"
-  namespace_templates = ["user_prefs"]
+  name        = "custom-user-preference-strategy"
+  memory_id   = aws_bedrockagentcore_memory.example.id
+  type        = "CUSTOM"
+  description = "Custom user preference tracking strategy"
+  namespaces  = ["user_prefs"]
 
   configuration {
     type = "USER_PREFERENCE_OVERRIDE"
@@ -149,7 +166,7 @@ resource "aws_bedrockagentcore_memory_strategy" "custom_episodic" {
   memory_execution_role_arn = aws_bedrockagentcore_memory.example.memory_execution_role_arn
   type                      = "CUSTOM"
   description               = "Custom episodic processing strategy"
-  namespace_templates       = ["/strategies/{memoryStrategyId}/actors/{actorId}/sessions/{sessionId}"]
+  namespaces                = ["/strategies/{memoryStrategyId}/actors/{actorId}/sessions/{sessionId}"]
 
   configuration {
     type = "EPISODIC_OVERRIDE"
@@ -167,60 +184,93 @@ resource "aws_bedrockagentcore_memory_strategy" "custom_episodic" {
 }
 ```
 
+
+### Custom Strategy with Episodic Override and Reflection
+
+```terraform
+resource "aws_bedrockagentcore_memory_strategy" "custom_episodic_reflection" {
+  name                      = "custom-episodic-reflection-strategy"
+  memory_id                 = aws_bedrockagentcore_memory.example.id
+  memory_execution_role_arn = aws_bedrockagentcore_memory.example.memory_execution_role_arn
+  type                      = "CUSTOM"
+  description               = "Custom episodic strategy with reflection override"
+  namespaces                = ["/strategies/{memoryStrategyId}/actors/{actorId}/sessions/{sessionId}"]
+
+  configuration {
+    type = "EPISODIC_OVERRIDE"
+
+    consolidation {
+      append_to_prompt = "Consolidate episodic memories into coherent narratives"
+      model_id         = "anthropic.claude-3-sonnet-20240229-v1:0"
+    }
+
+    extraction {
+      append_to_prompt = "Extract key events and episodes from interactions"
+      model_id         = "anthropic.claude-3-haiku-20240307-v1:0"
+    }
+
+    reflection {
+      append_to_prompt    = "Identify successful patterns and recurring failure modes across episodes"
+      model_id            = "anthropic.claude-3-sonnet-20240229-v1:0"
+      namespace_templates = ["/strategies/{memoryStrategyId}/actors/{actorId}/reflections"]
+    }
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are required:
 
-* `memory_id` - (Required) ID of the memory to associate with this strategy. Changing this forces a new resource.
 * `name` - (Required) Name of the memory strategy.
+* `memory_id` - (Required) ID of the memory to associate with this strategy. Changing this forces a new resource.
 * `type` - (Required) Type of memory strategy. Valid values: `SEMANTIC`, `SUMMARIZATION`, `USER_PREFERENCE`, `EPISODIC`, `CUSTOM`. Changing this forces a new resource. Note that only one strategy of each built-in type (`SEMANTIC`, `SUMMARIZATION`, `USER_PREFERENCE`, `EPISODIC`) can exist per memory.
+* `namespaces` - (Required) Set of namespace identifiers where this strategy applies. Namespaces help organize and scope memory content.
 
 The following arguments are optional:
 
-* `configuration` - (Optional) Custom configuration block. Required when `type` is `CUSTOM`, must be omitted for other types. See [`configuration` Block](#configuration-block) below.
-* `description` - (Optional) Description of the memory strategy.
-* `memory_execution_role_arn` - (Optional, **Deprecated**) ARN of the IAM role that the memory service assumes to perform operations.
-* `namespace_templates` - (Optional) Set containing exactly one namespace template where this strategy applies (for example `/strategies/{memoryStrategyId}/actors/{actorId}/sessions/{sessionId}`). Namespace templates help organize and scope memory content. Exactly one of `namespace_templates` or `namespaces` must be configured.
-* `namespaces` - (Optional, **Deprecated**) Set of namespace identifiers where this strategy applies. Exactly one of `namespaces` or `namespace_templates` must be configured. The API treats this as a legacy parameter; prefer `namespace_templates`. Since the API mirrors the two fields, switching an existing configuration from `namespaces` to `namespace_templates` with the same value is an in-place no-op.
-* `reflection_configuration` - (Optional) Configuration for the reflections created with the episodic memory strategy. Valid when `type` is `EPISODIC`, must be omitted for other types. See [`reflection_configuration` Block](#reflection_configuration-block) below.
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
+* `description` - (Optional) Description of the memory strategy.
+* `reflection_configuration` - (Optional) Reflection configuration block for built-in `EPISODIC` strategies. Controls where reflections (cross-episode insights) are stored. Must be omitted when `type` is not `EPISODIC`. See [`reflection_configuration`](#reflection_configuration) below.
+* `configuration` - (Optional) Custom configuration block. Required when `type` is `CUSTOM`, must be omitted for other types. See [`configuration`](#configuration) below.
 
-### `configuration` Block
+### `configuration`
 
-The `configuration` block supports the following arguments:
+The `configuration` block supports the following:
 
-* `consolidation` - (Optional) Consolidation configuration for the memory strategy. See [`consolidation` Block](#consolidation-block) below. Once added, this block cannot be removed without recreating the resource.
-* `extraction` - (Optional) Extraction configuration for the memory strategy. See [`extraction` Block](#extraction-block) below. Cannot be used with `type` set to `SUMMARY_OVERRIDE`. Once added, this block cannot be removed without recreating the resource.
-* `reflection` - (Optional) Reflection configuration for the memory strategy. See [`reflection` Block](#reflection-block) below. Can only be used, and is required, with `type` set to `EPISODIC_OVERRIDE`. Once added, this block cannot be removed without recreating the resource.
 * `type` - (Required) Type of custom override. Valid values: `SEMANTIC_OVERRIDE`, `SUMMARY_OVERRIDE`, `USER_PREFERENCE_OVERRIDE`, `EPISODIC_OVERRIDE`. Changing this forces a new resource.
+* `consolidation` - (Optional) Consolidation configuration for processing and organizing memory content. See [`consolidation`](#consolidation) below. Once added, this block cannot be removed without recreating the resource.
+* `extraction` - (Optional) Extraction configuration for identifying and extracting relevant information. See [`extraction`](#extraction) below. Cannot be used with `type` set to `SUMMARY_OVERRIDE`. Once added, this block cannot be removed without recreating the resource.
+* `reflection` - (Optional) Reflection configuration for customizing the reflection step. Only valid when `type` is `EPISODIC_OVERRIDE`. See [`reflection`](#reflection) below. Once added, this block cannot be removed without recreating the resource.
 
-### `consolidation` Block
+### `consolidation`
 
-The `consolidation` block supports the following arguments:
+The `consolidation` block supports the following:
 
 * `append_to_prompt` - (Required) Additional text to append to the model prompt for consolidation processing.
 * `model_id` - (Required) ID of the foundation model to use for consolidation processing.
 
-### `extraction` Block
+### `extraction`
 
-The `extraction` block supports the following arguments:
+The `extraction` block supports the following:
 
 * `append_to_prompt` - (Required) Additional text to append to the model prompt for extraction processing.
 * `model_id` - (Required) ID of the foundation model to use for extraction processing.
 
-### `reflection` Block
+### `reflection`
 
-The `reflection` block supports the following arguments:
+The `reflection` block supports the following (only valid when `configuration.type` is `EPISODIC_OVERRIDE`):
 
 * `append_to_prompt` - (Required) Additional text to append to the model prompt for reflection processing.
 * `model_id` - (Required) ID of the foundation model to use for reflection processing.
-* `namespace_templates` - (Required) Namespace templates for episodic reflection. Can be less nested than the episodic namespaces.
+* `namespace_templates` - (Optional) Set of namespace templates where reflection records are stored. Can be less nested than episode namespaces.
 
-### `reflection_configuration` Block
+### `reflection_configuration`
 
-The `reflection_configuration` supports the following arguments:
+The `reflection_configuration` block supports the following (only valid when `type` is `EPISODIC`):
 
-* `namespace_templates` - (Required) Namespace templates over which to create reflections. Can be less nested than episode namespaces.
+* `namespace_templates` - (Optional) Set of namespace templates where reflection records are stored. Can be less nested than episode namespaces. If omitted, defaults to the episodic namespaces.
+
 
 ## Attribute Reference
 
@@ -232,9 +282,9 @@ This resource exports the following attributes in addition to the arguments abov
 
 [Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
 
-* `create` - (Default `45m`)
-* `update` - (Default `45m`)
-* `delete` - (Default `45m`)
+* `create` - (Default `30m`)
+* `update` - (Default `30m`)
+* `delete` - (Default `30m`)
 
 ## Import
 


### PR DESCRIPTION
## Description
Adds `reflection_configuration` support for the `aws_bedrockagentcore_memory_strategy` resource.

### Changes
- Adds `reflection_configuration` block for built-in EPISODIC strategies with `namespace_templates` field
- Adds `reflection` sub-block inside `configuration` for CUSTOM EPISODIC_OVERRIDE strategies
- Implement flattening in Create/Read for built-in episodic reflection config
- Update `expandToModifyStrategyConfiguration` to send reflection data for CUSTOM overrides
- Add appropriate `ValidateConfig` rules

## Closes
#47938