### PR TITLE
apigateway_rest_api: Minor fixes

### DIFF
--- a/.changelog/49205.txt
+++ b/.changelog/49205.txt
@@ -1,7 +1,7 @@
 ```release-note:bug
-resource/aws_api_gateway_rest_api: Added waiters after CUD calls
+resource/aws_api_gateway_rest_api: Wait for the REST API to reach an available state on create and update, and to be fully deleted on delete, preventing intermittent `BadRequestException: There is already an update in progress` errors
 ```
 
 ```release-note:enhancement
-resource/aws_api_gateway_rest_api: Added timeouts to schema for waiters
+resource/aws_api_gateway_rest_api: Add configurable resource timeouts.
 ```

--- a/internal/service/apigateway/rest_api.go
+++ b/internal/service/apigateway/rest_api.go
@@ -871,11 +871,13 @@ func waitRestAPIAvailable(ctx context.Context, conn *apigateway.Client, id strin
 	}
 
 	outputRaw, err := stateConf.WaitForStateContext(ctx)
-	if out, ok := outputRaw.(*apigateway.GetRestApiOutput); ok {
-		if status := out.ApiStatus; status == types.ApiStatusFailed {
-			retry.SetLastError(err, errors.New(aws.ToString(out.ApiStatusMessage)))
-		}
+	out, ok := outputRaw.(*apigateway.GetRestApiOutput)
+	if !ok {
 		return err
+	}
+
+	if out.ApiStatus == types.ApiStatusFailed {
+		retry.SetLastError(err, errors.New(aws.ToString(out.ApiStatusMessage)))
 	}
 
 	return err
@@ -883,18 +885,20 @@ func waitRestAPIAvailable(ctx context.Context, conn *apigateway.Client, id strin
 
 func waitRestAPIDeleted(ctx context.Context, conn *apigateway.Client, id string, timeout time.Duration) error {
 	stateConf := &retry.StateChangeConf{
-		Pending: enum.Slice(types.ApiStatusPending, types.ApiStatusUpdating),
+		Pending: enum.Slice(types.ApiStatusAvailable, types.ApiStatusPending, types.ApiStatusUpdating),
 		Target:  []string{},
 		Refresh: statusRestAPI(conn, id),
 		Timeout: timeout,
 	}
 
 	outputRaw, err := stateConf.WaitForStateContext(ctx)
-	if out, ok := outputRaw.(*apigateway.GetRestApiOutput); ok {
-		if status := out.ApiStatus; status == types.ApiStatusFailed {
-			retry.SetLastError(err, errors.New(aws.ToString(out.ApiStatusMessage)))
-		}
+	out, ok := outputRaw.(*apigateway.GetRestApiOutput)
+	if !ok {
 		return err
+	}
+
+	if out.ApiStatus == types.ApiStatusFailed {
+		retry.SetLastError(err, errors.New(aws.ToString(out.ApiStatusMessage)))
 	}
 
 	return err


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #49205

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t T=TestAccAPIGatewayRestAPI_ K=apigateway P=7
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 td-apigateway-waiters-minor 🌿...
TF_ACC=1 go1.26.5 test ./internal/service/apigateway/... -v -count 1 -parallel 7 -run='TestAccAPIGatewayRestAPI_'  -timeout 360m -vet=off
2026/07/31 16:38:46 Creating Terraform AWS Provider (SDKv2-style)...
2026/07/31 16:38:46 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccAPIGatewayRestAPI_basic
=== PAUSE TestAccAPIGatewayRestAPI_basic
=== RUN   TestAccAPIGatewayRestAPI_disappears
=== PAUSE TestAccAPIGatewayRestAPI_disappears
=== RUN   TestAccAPIGatewayRestAPI_endpoint
=== PAUSE TestAccAPIGatewayRestAPI_endpoint
=== RUN   TestAccAPIGatewayRestAPI_Endpoint_private
=== PAUSE TestAccAPIGatewayRestAPI_Endpoint_private
=== RUN   TestAccAPIGatewayRestAPI_securityPolicy
=== PAUSE TestAccAPIGatewayRestAPI_securityPolicy
=== RUN   TestAccAPIGatewayRestAPI_apiKeySource
=== PAUSE TestAccAPIGatewayRestAPI_apiKeySource
=== RUN   TestAccAPIGatewayRestAPI_APIKeySource_overrideBody
=== PAUSE TestAccAPIGatewayRestAPI_APIKeySource_overrideBody
=== RUN   TestAccAPIGatewayRestAPI_APIKeySource_setByBody
=== PAUSE TestAccAPIGatewayRestAPI_APIKeySource_setByBody
=== RUN   TestAccAPIGatewayRestAPI_binaryMediaTypes
=== PAUSE TestAccAPIGatewayRestAPI_binaryMediaTypes
=== RUN   TestAccAPIGatewayRestAPI_BinaryMediaTypes_overrideBody
=== PAUSE TestAccAPIGatewayRestAPI_BinaryMediaTypes_overrideBody
=== RUN   TestAccAPIGatewayRestAPI_BinaryMediaTypes_setByBody
=== PAUSE TestAccAPIGatewayRestAPI_BinaryMediaTypes_setByBody
=== RUN   TestAccAPIGatewayRestAPI_body
=== PAUSE TestAccAPIGatewayRestAPI_body
=== RUN   TestAccAPIGatewayRestAPI_description
=== PAUSE TestAccAPIGatewayRestAPI_description
=== RUN   TestAccAPIGatewayRestAPI_Description_overrideBody
=== PAUSE TestAccAPIGatewayRestAPI_Description_overrideBody
=== RUN   TestAccAPIGatewayRestAPI_Description_setByBody
=== PAUSE TestAccAPIGatewayRestAPI_Description_setByBody
=== RUN   TestAccAPIGatewayRestAPI_disableExecuteAPIEndpoint
=== PAUSE TestAccAPIGatewayRestAPI_disableExecuteAPIEndpoint
=== RUN   TestAccAPIGatewayRestAPI_DisableExecuteAPIEndpoint_overrideBody
=== PAUSE TestAccAPIGatewayRestAPI_DisableExecuteAPIEndpoint_overrideBody
=== RUN   TestAccAPIGatewayRestAPI_DisableExecuteAPIEndpoint_setByBody
=== PAUSE TestAccAPIGatewayRestAPI_DisableExecuteAPIEndpoint_setByBody
=== RUN   TestAccAPIGatewayRestAPI_Endpoint_vpcEndpointIDs
=== PAUSE TestAccAPIGatewayRestAPI_Endpoint_vpcEndpointIDs
=== RUN   TestAccAPIGatewayRestAPI_EndpointVPCEndpointIDs_overrideBody
=== PAUSE TestAccAPIGatewayRestAPI_EndpointVPCEndpointIDs_overrideBody
=== RUN   TestAccAPIGatewayRestAPI_EndpointVPCEndpointIDs_mergeBody
=== PAUSE TestAccAPIGatewayRestAPI_EndpointVPCEndpointIDs_mergeBody
=== RUN   TestAccAPIGatewayRestAPI_EndpointVPCEndpointIDs_overrideToMergeBody
=== PAUSE TestAccAPIGatewayRestAPI_EndpointVPCEndpointIDs_overrideToMergeBody
=== RUN   TestAccAPIGatewayRestAPI_EndpointVPCEndpointIDs_setByBody
=== PAUSE TestAccAPIGatewayRestAPI_EndpointVPCEndpointIDs_setByBody
=== RUN   TestAccAPIGatewayRestAPI_ipAddressType
=== PAUSE TestAccAPIGatewayRestAPI_ipAddressType
=== RUN   TestAccAPIGatewayRestAPI_ipAddressType_overrideBody
=== PAUSE TestAccAPIGatewayRestAPI_ipAddressType_overrideBody
=== RUN   TestAccAPIGatewayRestAPI_ipAddressType_privateError
=== PAUSE TestAccAPIGatewayRestAPI_ipAddressType_privateError
=== RUN   TestAccAPIGatewayRestAPI_minimumCompressionSize
=== PAUSE TestAccAPIGatewayRestAPI_minimumCompressionSize
=== RUN   TestAccAPIGatewayRestAPI_MinimumCompressionSize_overrideBody
=== PAUSE TestAccAPIGatewayRestAPI_MinimumCompressionSize_overrideBody
=== RUN   TestAccAPIGatewayRestAPI_MinimumCompressionSize_setByBody
=== PAUSE TestAccAPIGatewayRestAPI_MinimumCompressionSize_setByBody
=== RUN   TestAccAPIGatewayRestAPI_Name_overrideBody
=== PAUSE TestAccAPIGatewayRestAPI_Name_overrideBody
=== RUN   TestAccAPIGatewayRestAPI_FailOnWarnings
=== PAUSE TestAccAPIGatewayRestAPI_FailOnWarnings
=== RUN   TestAccAPIGatewayRestAPI_parameters
=== PAUSE TestAccAPIGatewayRestAPI_parameters
=== RUN   TestAccAPIGatewayRestAPI_Policy_basic
=== PAUSE TestAccAPIGatewayRestAPI_Policy_basic
=== RUN   TestAccAPIGatewayRestAPI_Policy_order
=== PAUSE TestAccAPIGatewayRestAPI_Policy_order
=== RUN   TestAccAPIGatewayRestAPI_Policy_overrideBody
=== PAUSE TestAccAPIGatewayRestAPI_Policy_overrideBody
=== RUN   TestAccAPIGatewayRestAPI_Policy_setByBody
=== PAUSE TestAccAPIGatewayRestAPI_Policy_setByBody
=== RUN   TestAccAPIGatewayRestAPI_Description_updateAttributeAndBody
=== PAUSE TestAccAPIGatewayRestAPI_Description_updateAttributeAndBody
=== CONT  TestAccAPIGatewayRestAPI_basic
=== CONT  TestAccAPIGatewayRestAPI_EndpointVPCEndpointIDs_overrideBody
=== CONT  TestAccAPIGatewayRestAPI_Endpoint_vpcEndpointIDs
=== CONT  TestAccAPIGatewayRestAPI_Description_setByBody
=== CONT  TestAccAPIGatewayRestAPI_DisableExecuteAPIEndpoint_setByBody
=== CONT  TestAccAPIGatewayRestAPI_DisableExecuteAPIEndpoint_overrideBody
=== CONT  TestAccAPIGatewayRestAPI_BinaryMediaTypes_setByBody
--- PASS: TestAccAPIGatewayRestAPI_basic (21.33s)
=== CONT  TestAccAPIGatewayRestAPI_disableExecuteAPIEndpoint
--- PASS: TestAccAPIGatewayRestAPI_DisableExecuteAPIEndpoint_overrideBody (57.43s)
=== CONT  TestAccAPIGatewayRestAPI_apiKeySource
--- PASS: TestAccAPIGatewayRestAPI_apiKeySource (41.05s)
=== CONT  TestAccAPIGatewayRestAPI_BinaryMediaTypes_overrideBody
--- PASS: TestAccAPIGatewayRestAPI_BinaryMediaTypes_overrideBody (49.09s)
=== CONT  TestAccAPIGatewayRestAPI_binaryMediaTypes
--- PASS: TestAccAPIGatewayRestAPI_EndpointVPCEndpointIDs_overrideBody (179.10s)
=== CONT  TestAccAPIGatewayRestAPI_APIKeySource_setByBody
--- PASS: TestAccAPIGatewayRestAPI_binaryMediaTypes (54.26s)
=== CONT  TestAccAPIGatewayRestAPI_APIKeySource_overrideBody
--- PASS: TestAccAPIGatewayRestAPI_DisableExecuteAPIEndpoint_setByBody (224.83s)
=== CONT  TestAccAPIGatewayRestAPI_description
--- PASS: TestAccAPIGatewayRestAPI_APIKeySource_overrideBody (38.90s)
=== CONT  TestAccAPIGatewayRestAPI_Description_overrideBody
--- PASS: TestAccAPIGatewayRestAPI_description (29.12s)
=== CONT  TestAccAPIGatewayRestAPI_endpoint
--- PASS: TestAccAPIGatewayRestAPI_Endpoint_vpcEndpointIDs (293.77s)
=== CONT  TestAccAPIGatewayRestAPI_securityPolicy
--- PASS: TestAccAPIGatewayRestAPI_securityPolicy (41.36s)
=== CONT  TestAccAPIGatewayRestAPI_disappears
--- PASS: TestAccAPIGatewayRestAPI_Description_overrideBody (128.96s)
=== CONT  TestAccAPIGatewayRestAPI_MinimumCompressionSize_setByBody
--- PASS: TestAccAPIGatewayRestAPI_MinimumCompressionSize_setByBody (22.44s)
=== CONT  TestAccAPIGatewayRestAPI_Description_updateAttributeAndBody
--- PASS: TestAccAPIGatewayRestAPI_endpoint (256.92s)
=== CONT  TestAccAPIGatewayRestAPI_Policy_setByBody
--- PASS: TestAccAPIGatewayRestAPI_Description_updateAttributeAndBody (153.81s)
=== CONT  TestAccAPIGatewayRestAPI_Endpoint_private
--- PASS: TestAccAPIGatewayRestAPI_Policy_setByBody (50.94s)
=== CONT  TestAccAPIGatewayRestAPI_Policy_overrideBody
--- PASS: TestAccAPIGatewayRestAPI_Endpoint_private (72.76s)
=== CONT  TestAccAPIGatewayRestAPI_Policy_order
--- PASS: TestAccAPIGatewayRestAPI_Policy_order (26.38s)
=== CONT  TestAccAPIGatewayRestAPI_ipAddressType_overrideBody
--- PASS: TestAccAPIGatewayRestAPI_ipAddressType_overrideBody (30.43s)
=== CONT  TestAccAPIGatewayRestAPI_Policy_basic
--- PASS: TestAccAPIGatewayRestAPI_Description_setByBody (714.41s)
=== CONT  TestAccAPIGatewayRestAPI_MinimumCompressionSize_overrideBody
--- PASS: TestAccAPIGatewayRestAPI_MinimumCompressionSize_overrideBody (64.05s)
=== CONT  TestAccAPIGatewayRestAPI_parameters
--- PASS: TestAccAPIGatewayRestAPI_parameters (39.54s)
=== CONT  TestAccAPIGatewayRestAPI_minimumCompressionSize
--- PASS: TestAccAPIGatewayRestAPI_minimumCompressionSize (39.88s)
=== CONT  TestAccAPIGatewayRestAPI_FailOnWarnings
--- PASS: TestAccAPIGatewayRestAPI_FailOnWarnings (64.41s)
=== CONT  TestAccAPIGatewayRestAPI_ipAddressType_privateError
--- PASS: TestAccAPIGatewayRestAPI_ipAddressType_privateError (1.62s)
=== CONT  TestAccAPIGatewayRestAPI_Name_overrideBody
--- PASS: TestAccAPIGatewayRestAPI_Name_overrideBody (39.47s)
=== CONT  TestAccAPIGatewayRestAPI_body
--- PASS: TestAccAPIGatewayRestAPI_body (29.17s)
=== CONT  TestAccAPIGatewayRestAPI_EndpointVPCEndpointIDs_setByBody
--- PASS: TestAccAPIGatewayRestAPI_EndpointVPCEndpointIDs_setByBody (114.81s)
=== CONT  TestAccAPIGatewayRestAPI_EndpointVPCEndpointIDs_overrideToMergeBody
--- PASS: TestAccAPIGatewayRestAPI_disableExecuteAPIEndpoint (1133.43s)
=== CONT  TestAccAPIGatewayRestAPI_EndpointVPCEndpointIDs_mergeBody
--- PASS: TestAccAPIGatewayRestAPI_Policy_overrideBody (713.90s)
=== CONT  TestAccAPIGatewayRestAPI_ipAddressType
--- PASS: TestAccAPIGatewayRestAPI_EndpointVPCEndpointIDs_overrideToMergeBody (218.94s)
--- PASS: TestAccAPIGatewayRestAPI_EndpointVPCEndpointIDs_mergeBody (214.02s)
--- PASS: TestAccAPIGatewayRestAPI_BinaryMediaTypes_setByBody (1397.07s)
--- PASS: TestAccAPIGatewayRestAPI_ipAddressType (128.38s)
--- PASS: TestAccAPIGatewayRestAPI_Policy_basic (1029.89s)
--- PASS: TestAccAPIGatewayRestAPI_disappears (1383.27s)
--- PASS: TestAccAPIGatewayRestAPI_APIKeySource_setByBody (1761.06s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/apigateway	1947.234s
```
