### PR TITLE
🤖🤖🤖 aws_ecs_service: fix sigint_rollback deployment terminal wait

### DIFF
--- a/.changelog/49243.txt
+++ b/.changelog/49243.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+ecs
+`aws_ecs_service` - Fix `sigint_rollback` wait for deployment terminal status to use raw AWS statuses and return a non-nil Refresh result so Target matching works
+```

--- a/.changelog/49243.txt
+++ b/.changelog/49243.txt
@@ -1,4 +1,3 @@
 ```release-note:bug
-ecs
-`aws_ecs_service` - Fix `sigint_rollback` wait for deployment terminal status to use raw AWS statuses and return a non-nil Refresh result so Target matching works
+resource/aws_ecs_service: Fix `sigint_rollback` wait for deployment terminal status so successful rollbacks are recognized
 ```

--- a/internal/service/ecs/service.go
+++ b/internal/service/ecs/service.go
@@ -2416,16 +2416,52 @@ func waitForDeploymentTerminalStatus(ctx context.Context, conn *ecs.Client, prim
 			awstypes.ServiceDeploymentStatusRollbackRequested,
 			awstypes.ServiceDeploymentStatusRollbackInProgress,
 		),
-		Target: deploymentTerminalStates,
+		// Successful terminals only. Failed terminals are Refresh errors.
+		// Do not use findDeploymentStatus here: it maps SUCCESSFUL → tfSTABLE and
+		// returns errors for rollback terminals, which breaks Target matching.
+		Target: enum.Slice(
+			awstypes.ServiceDeploymentStatusSuccessful,
+			awstypes.ServiceDeploymentStatusRollbackSuccessful,
+		),
 		Refresh: func(ctx context.Context) (any, string, error) {
-			status, err := findDeploymentStatus(ctx, conn, primaryDeploymentArn)
-			return nil, status, err
+			input := ecs.DescribeServiceDeploymentsInput{
+				ServiceDeploymentArns: []string{primaryDeploymentArn},
+			}
+			output, err := findServiceDeployments(ctx, conn, &input)
+			if err != nil {
+				return nil, "", err
+			}
+			if len(output) == 0 {
+				// Stay in Pending with a raw AWS status (not tfPENDING). Return a
+				// non-nil result so StateChangeConf evaluates Target/Pending.
+				return &awstypes.ServiceDeployment{}, string(awstypes.ServiceDeploymentStatusPending), nil
+			}
+
+			deployment := output[0]
+			status, err := serviceDeploymentWaitRefreshStatus(string(deployment.Status), deployment.StatusReason)
+			// Non-nil result required: a nil any is IsZero and skips Target matching.
+			return &deployment, status, err
 		},
 		Timeout: 1 * time.Hour, // Maximum time before SIGKILL
 	}
 
 	_, err := stateConf.WaitForStateContext(ctx)
 	return err
+}
+
+// serviceDeploymentWaitRefreshStatus maps a raw AWS service deployment status for
+// waitForDeploymentTerminalStatus. Failed terminals become errors; others pass through.
+func serviceDeploymentWaitRefreshStatus(status string, statusReason *string) (string, error) {
+	switch awstypes.ServiceDeploymentStatus(status) {
+	case awstypes.ServiceDeploymentStatusStopped, awstypes.ServiceDeploymentStatusRollbackFailed:
+		message := "Deployment failed"
+		if statusReason != nil {
+			message = aws.ToString(statusReason)
+		}
+		return status, errors.New(message)
+	default:
+		return status, nil
+	}
 }
 
 // waitServiceStable waits for an ECS Service to reach the status "ACTIVE" and have all desired tasks running.

--- a/internal/service/ecs/service_deployment_wait_test.go
+++ b/internal/service/ecs/service_deployment_wait_test.go
@@ -1,0 +1,54 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package ecs
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
+)
+
+func TestServiceDeploymentWaitRefreshStatus(t *testing.T) {
+	t.Parallel()
+
+	t.Run("successful and in-progress statuses pass through", func(t *testing.T) {
+		t.Parallel()
+		for _, status := range []string{
+			string(awstypes.ServiceDeploymentStatusSuccessful),
+			string(awstypes.ServiceDeploymentStatusRollbackSuccessful),
+			string(awstypes.ServiceDeploymentStatusInProgress),
+			string(awstypes.ServiceDeploymentStatusPending),
+			string(awstypes.ServiceDeploymentStatusRollbackRequested),
+			string(awstypes.ServiceDeploymentStatusRollbackInProgress),
+		} {
+			got, err := serviceDeploymentWaitRefreshStatus(status, nil)
+			if err != nil {
+				t.Fatalf("status %s: unexpected err: %v", status, err)
+			}
+			if got != status {
+				t.Fatalf("status %s: got %q", status, got)
+			}
+		}
+	})
+
+	t.Run("failed terminals return errors", func(t *testing.T) {
+		t.Parallel()
+		for _, status := range []string{
+			string(awstypes.ServiceDeploymentStatusStopped),
+			string(awstypes.ServiceDeploymentStatusRollbackFailed),
+		} {
+			got, err := serviceDeploymentWaitRefreshStatus(status, aws.String("boom"))
+			if err == nil {
+				t.Fatalf("status %s: expected error", status)
+			}
+			if err.Error() != "boom" {
+				t.Fatalf("status %s: got err %v", status, err)
+			}
+			if got != status {
+				t.Fatalf("status %s: got %q", status, got)
+			}
+		}
+	})
+}

--- a/internal/service/ecs/service_deployment_wait_test.go
+++ b/internal/service/ecs/service_deployment_wait_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 )
 
 func TestServiceDeploymentWaitRefreshStatus(t *testing.T) {
@@ -15,14 +16,14 @@ func TestServiceDeploymentWaitRefreshStatus(t *testing.T) {
 
 	t.Run("successful and in-progress statuses pass through", func(t *testing.T) {
 		t.Parallel()
-		for _, status := range []string{
-			string(awstypes.ServiceDeploymentStatusSuccessful),
-			string(awstypes.ServiceDeploymentStatusRollbackSuccessful),
-			string(awstypes.ServiceDeploymentStatusInProgress),
-			string(awstypes.ServiceDeploymentStatusPending),
-			string(awstypes.ServiceDeploymentStatusRollbackRequested),
-			string(awstypes.ServiceDeploymentStatusRollbackInProgress),
-		} {
+		for _, status := range enum.Slice(
+			awstypes.ServiceDeploymentStatusSuccessful,
+			awstypes.ServiceDeploymentStatusRollbackSuccessful,
+			awstypes.ServiceDeploymentStatusInProgress,
+			awstypes.ServiceDeploymentStatusPending,
+			awstypes.ServiceDeploymentStatusRollbackRequested,
+			awstypes.ServiceDeploymentStatusRollbackInProgress,
+		) {
 			got, err := serviceDeploymentWaitRefreshStatus(status, nil)
 			if err != nil {
 				t.Fatalf("status %s: unexpected err: %v", status, err)
@@ -35,10 +36,10 @@ func TestServiceDeploymentWaitRefreshStatus(t *testing.T) {
 
 	t.Run("failed terminals return errors", func(t *testing.T) {
 		t.Parallel()
-		for _, status := range []string{
-			string(awstypes.ServiceDeploymentStatusStopped),
-			string(awstypes.ServiceDeploymentStatusRollbackFailed),
-		} {
+		for _, status := range enum.Slice(
+			awstypes.ServiceDeploymentStatusStopped,
+			awstypes.ServiceDeploymentStatusRollbackFailed,
+		) {
 			got, err := serviceDeploymentWaitRefreshStatus(status, aws.String("boom"))
 			if err == nil {
 				t.Fatalf("status %s: expected error", status)


### PR DESCRIPTION
<!--
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
-->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No.

### Description

Follow-up to #49077 (merged). After `StopServiceDeployment(Rollback)`, `waitForDeploymentTerminalStatus` did not reliably confirm a successful rollback:

1. Refresh always returned `nil` as the result value. `internal/retry` treats a nil/`IsZero` result as “not found” and never evaluates `Target`/`Pending` (it only increments not-found checks).
2. Refresh used `findDeploymentStatus`, which maps `SUCCESSFUL` → `tfSTABLE` and returns errors for rollback terminal statuses — so `Target: deploymentTerminalStates` could not match cleanly even if (1) were fixed.

#### Fix

- Return a non-nil `*ServiceDeployment` from Refresh so Target matching runs.
- Use **raw** AWS deployment statuses (do not go through `findDeploymentStatus`).
- `Target`: `SUCCESSFUL`, `ROLLBACK_SUCCESSFUL` only.
- `STOPPED` / `ROLLBACK_FAILED` → Refresh errors (via `serviceDeploymentWaitRefreshStatus`), with `StatusReason` when present.
- Empty Describe result stays in Pending with raw `PENDING` (not `tfPENDING`) and a non-nil stub result.

This intentionally describes the deployment inline rather than using `findRawServiceDeploymentStatus` from #49077, because the wait needs `StatusReason` for failed-terminal errors.

### Relations

Relates #49031  
Relates #49077

### Output from Acceptance Testing

No new acceptance test (SIGINT rollback path remains hard to exercise in CI). Unit test:

```console
% go test ./internal/service/ecs/ -count=1 -run TestServiceDeploymentWaitRefreshStatus
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecs
```

### AI usage

Assisted by Cursor; human-reviewed.