### PR TITLE
docs: update supported metrics  for Lambda ESM resource

### DIFF
--- a/website/docs/r/lambda_event_source_mapping.html.markdown
+++ b/website/docs/r/lambda_event_source_mapping.html.markdown
@@ -262,7 +262,7 @@ The following arguments are optional:
 
 ### metrics_config Configuration Block
 
-* `metrics` - (Required) List containing the metrics to be produced by the event source mapping. Valid values: `EventCount`.
+* `metrics` - (Required) List containing the metrics to be produced by the event source mapping. Valid values: `EventCount`, `ErrorCount`, `KafkaMetrics`.
 
 ### provisioned_poller_config Configuration Block
 


### PR DESCRIPTION

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls implemented.

### Description
Add missing values 

- `ErrorCount`
- `KafkaMetrics` 

for `metrics_config.metrics` of resource [`aws_lambda_event_source_mapping`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_event_source_mapping)

### Relations

Closes #49029

### References

- [AWS - What's New - Jan 2026](https://aws.amazon.com/about-aws/whats-new/2026/01/aws-Lambda-observability-for-kafka-esm/)
- [AWS Lambda API Reference](https://docs.aws.amazon.com/lambda/latest/api/API_EventSourceMappingMetricsConfig.html)
- [Enum in AWS SDK Go V2](https://github.com/aws/aws-sdk-go-v2/blob/f4fd2723ed647078bced4bdf4b83e6a61c379546/service/lambda/types/enums.go#L147-L154) 


### Output from Acceptance Testing

Not applicable. Only documentation is updated.