### PR TITLE
r/aws_bedrockagentcore_memory_strategy: filter before asserting single strategy result

### DIFF
--- a/.changelog/49250.txt
+++ b/.changelog/49250.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_bedrockagentcore_memory_strategy: Fix `too many results: wanted 1, got 2` error when creating or updating a strategy on a memory that already has another strategy of a different type
+```

--- a/internal/service/bedrockagentcore/memory_strategy.go
+++ b/internal/service/bedrockagentcore/memory_strategy.go
@@ -295,9 +295,9 @@ func (r *resourceMemoryStrategy) Create(ctx context.Context, request resource.Cr
 		}
 
 		name := fwflex.StringValueFromFramework(ctx, plan.Name)
-		found, err := tfresource.AssertSingleValueResult(out.Memory.Strategies, func(v *awstypes.MemoryStrategy) bool {
+		found, err := tfresource.AssertSingleValueResult(tfslices.Filter(out.Memory.Strategies, func(v awstypes.MemoryStrategy) bool {
 			return aws.ToString(v.Name) == name
-		})
+		}))
 		if err != nil {
 			smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, name)
 			return
@@ -419,9 +419,9 @@ func (r *resourceMemoryStrategy) Update(ctx context.Context, request resource.Up
 				return
 			}
 
-			found, err := tfresource.AssertSingleValueResult(out.Memory.Strategies, func(v *awstypes.MemoryStrategy) bool {
+			found, err := tfresource.AssertSingleValueResult(tfslices.Filter(out.Memory.Strategies, func(v awstypes.MemoryStrategy) bool {
 				return aws.ToString(v.StrategyId) == memoryStrategyID
-			})
+			}))
 			if err != nil {
 				smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, memoryStrategyID)
 				return

--- a/internal/service/bedrockagentcore/memory_strategy_test.go
+++ b/internal/service/bedrockagentcore/memory_strategy_test.go
@@ -1210,6 +1210,48 @@ func TestAccBedrockAgentCoreMemoryStrategy_disappears(t *testing.T) {
 	})
 }
 
+func TestAccBedrockAgentCoreMemoryStrategy_multipleStrategies(t *testing.T) {
+	ctx := acctest.Context(t)
+	var m1, m2 awstypes.MemoryStrategy
+	rName := randomMemoryName(t)
+	resourceName1 := "aws_bedrockagentcore_memory_strategy.test"
+	resourceName2 := "aws_bedrockagentcore_memory_strategy.test2"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID)
+			testAccPreCheckMemories(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockAgentCoreServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckMemoryStrategyDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				// Two strategies of different types on the same memory: creating the
+				// second must not fail with "too many results" against the first.
+				Config: testAccMemoryStrategyConfig_multipleTypes(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckMemoryStrategyExists(ctx, t, resourceName1, &m1),
+					testAccCheckMemoryStrategyExists(ctx, t, resourceName2, &m2),
+					resource.TestCheckResourceAttr(resourceName1, names.AttrType, string(awstypes.MemoryStrategyTypeUserPreference)),
+					resource.TestCheckResourceAttr(resourceName2, names.AttrType, string(awstypes.MemoryStrategyTypeSummarization)),
+				),
+			},
+			{
+				// Updating one of the two strategies must not fail either, for the
+				// same reason.
+				Config: testAccMemoryStrategyConfig_multipleTypesUpdated(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckMemoryStrategyExists(ctx, t, resourceName1, &m1),
+					testAccCheckMemoryStrategyExists(ctx, t, resourceName2, &m2),
+					resource.TestCheckResourceAttr(resourceName2, names.AttrDescription, "Summarization strategy updated"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccBedrockAgentCoreMemoryStrategy_namespacesToNamespaceTemplates(t *testing.T) {
 	ctx := acctest.Context(t)
 	var m awstypes.MemoryStrategy
@@ -2124,6 +2166,32 @@ resource "aws_bedrockagentcore_memory_strategy" "test2" {
   namespace_templates       = [%[3]q]
 }
 `, rName, strategyType, duplicateNamespace))
+}
+
+func testAccMemoryStrategyConfig_multipleTypes(rName string) string {
+	return acctest.ConfigCompose(testAccMemoryStrategyConfig_withExecutionRole(rName, awstypes.MemoryStrategyTypeUserPreference, "User preference strategy", "preferences"), fmt.Sprintf(`
+resource "aws_bedrockagentcore_memory_strategy" "test2" {
+  name                      = "%[1]s_summary"
+  memory_id                 = aws_bedrockagentcore_memory.test.id
+  memory_execution_role_arn = aws_bedrockagentcore_memory.test.memory_execution_role_arn
+  type                      = %[2]q
+  description               = "Summarization strategy"
+  namespace_templates       = ["{sessionId}"]
+}
+`, rName, awstypes.MemoryStrategyTypeSummarization))
+}
+
+func testAccMemoryStrategyConfig_multipleTypesUpdated(rName string) string {
+	return acctest.ConfigCompose(testAccMemoryStrategyConfig_withExecutionRole(rName, awstypes.MemoryStrategyTypeUserPreference, "User preference strategy", "preferences"), fmt.Sprintf(`
+resource "aws_bedrockagentcore_memory_strategy" "test2" {
+  name                      = "%[1]s_summary"
+  memory_id                 = aws_bedrockagentcore_memory.test.id
+  memory_execution_role_arn = aws_bedrockagentcore_memory.test.memory_execution_role_arn
+  type                      = %[2]q
+  description               = "Summarization strategy updated"
+  namespace_templates       = ["{sessionId}"]
+}
+`, rName, awstypes.MemoryStrategyTypeSummarization))
 }
 
 func testAccMemoryStrategyConfig_custom(rName string, overrideType awstypes.OverrideType, consolidationPrompt, consolidationModel, extractionPrompt, extractionModel string) string {

--- a/internal/service/bedrockagentcore/memory_strategy_test.go
+++ b/internal/service/bedrockagentcore/memory_strategy_test.go
@@ -1230,7 +1230,7 @@ func TestAccBedrockAgentCoreMemoryStrategy_multipleStrategies(t *testing.T) {
 			{
 				// Two strategies of different types on the same memory: creating the
 				// second must not fail with "too many results" against the first.
-				Config: testAccMemoryStrategyConfig_multipleTypes(rName),
+				Config: testAccMemoryStrategyConfig_multipleTypes(rName, "Summarization strategy"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMemoryStrategyExists(ctx, t, resourceName1, &m1),
 					testAccCheckMemoryStrategyExists(ctx, t, resourceName2, &m2),
@@ -1241,7 +1241,7 @@ func TestAccBedrockAgentCoreMemoryStrategy_multipleStrategies(t *testing.T) {
 			{
 				// Updating one of the two strategies must not fail either, for the
 				// same reason.
-				Config: testAccMemoryStrategyConfig_multipleTypesUpdated(rName),
+				Config: testAccMemoryStrategyConfig_multipleTypes(rName, "Summarization strategy updated"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMemoryStrategyExists(ctx, t, resourceName1, &m1),
 					testAccCheckMemoryStrategyExists(ctx, t, resourceName2, &m2),
@@ -2168,30 +2168,17 @@ resource "aws_bedrockagentcore_memory_strategy" "test2" {
 `, rName, strategyType, duplicateNamespace))
 }
 
-func testAccMemoryStrategyConfig_multipleTypes(rName string) string {
+func testAccMemoryStrategyConfig_multipleTypes(rName, description string) string {
 	return acctest.ConfigCompose(testAccMemoryStrategyConfig_withExecutionRole(rName, awstypes.MemoryStrategyTypeUserPreference, "User preference strategy", "preferences"), fmt.Sprintf(`
 resource "aws_bedrockagentcore_memory_strategy" "test2" {
   name                      = "%[1]s_summary"
   memory_id                 = aws_bedrockagentcore_memory.test.id
   memory_execution_role_arn = aws_bedrockagentcore_memory.test.memory_execution_role_arn
   type                      = %[2]q
-  description               = "Summarization strategy"
+  description               = %[3]q
   namespace_templates       = ["{sessionId}"]
 }
-`, rName, awstypes.MemoryStrategyTypeSummarization))
-}
-
-func testAccMemoryStrategyConfig_multipleTypesUpdated(rName string) string {
-	return acctest.ConfigCompose(testAccMemoryStrategyConfig_withExecutionRole(rName, awstypes.MemoryStrategyTypeUserPreference, "User preference strategy", "preferences"), fmt.Sprintf(`
-resource "aws_bedrockagentcore_memory_strategy" "test2" {
-  name                      = "%[1]s_summary"
-  memory_id                 = aws_bedrockagentcore_memory.test.id
-  memory_execution_role_arn = aws_bedrockagentcore_memory.test.memory_execution_role_arn
-  type                      = %[2]q
-  description               = "Summarization strategy updated"
-  namespace_templates       = ["{sessionId}"]
-}
-`, rName, awstypes.MemoryStrategyTypeSummarization))
+`, rName, awstypes.MemoryStrategyTypeSummarization, description))
 }
 
 func testAccMemoryStrategyConfig_custom(rName string, overrideType awstypes.OverrideType, consolidationPrompt, consolidationModel, extractionPrompt, extractionModel string) string {


### PR DESCRIPTION
## Summary

Fixes #49231. `Create` and `Update` pass the full, unfiltered `out.Memory.Strategies` list to `tfresource.AssertSingleValueResult` along with a name/`StrategyId` predicate:

```go
found, err := tfresource.AssertSingleValueResult(out.Memory.Strategies, func(v *awstypes.MemoryStrategy) bool {
    return aws.ToString(v.Name) == name
})
```

`AssertSingleValueResult` rejects `len(a) > 1` before ever running the predicate:

```go
} else if l > 1 {
    return nil, NewTooManyResultsError(l, nil)
```

So as soon as a memory has two strategies, creating (or updating) either one fails with `too many results: wanted 1, got 2` -- after the `UpdateMemory` API call has already succeeded, leaving an orphaned strategy in AWS that Terraform has no record of. Reapplying doesn't retry; it creates yet another strategy and fails again against a longer list.

`findMemoryStrategyByTwoPartKey` (used by `Read`) already gets this right, filtering with `tfslices.Filter` before asserting -- this applies the same pattern to `Create` and `Update`.

## Test plan

- [x] `go build ./internal/service/bedrockagentcore/...`
- [x] `go vet ./internal/service/bedrockagentcore/...`
- [x] `go test ./internal/service/bedrockagentcore/...` (offline unit tests)
- [ ] `TestAccBedrockAgentCoreMemoryStrategy_multipleStrategies` (new, added in this PR: creates two strategies of different types on one memory, then updates one) -- not run locally, requires AWS credentials with Bedrock AgentCore access