### PR TITLE
r/aws_cloudfront_multitenant_distribution: fix IllegalUpdate on custom_error_response without response_code/response_page_path

### DIFF
--- a/.changelog/49251.txt
+++ b/.changelog/49251.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cloudfront_multitenant_distribution: Fix `IllegalUpdate: The specified list of custom error responses does not exist or is not valid` errors on update when a `custom_error_response` block omits `response_code` and `response_page_path`
+```

--- a/internal/service/cloudfront/multitenant_distribution.go
+++ b/internal/service/cloudfront/multitenant_distribution.go
@@ -1208,6 +1208,24 @@ type customErrorResponseModel struct {
 	ResponsePagePath   types.String `tfsdk:"response_page_path" autoflex:",omitempty"`
 }
 
+var (
+	_ fwflex.Expander = customErrorResponseModel{}
+)
+
+// UpdateDistribution rejects a custom error response with a nil ResponseCode or ResponsePagePath,
+// which is what AutoFlex expands the unset optional attributes to. Send empty strings, as the SDKv2
+// aws_cloudfront_distribution resource does.
+func (m customErrorResponseModel) Expand(_ context.Context) (any, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	return &awstypes.CustomErrorResponse{
+		ErrorCachingMinTTL: m.ErrorCachingMinTtl.ValueInt64Pointer(),
+		ErrorCode:          aws.Int32(int32(m.ErrorCode.ValueInt64())),
+		ResponseCode:       aws.String(m.ResponseCode.ValueString()),
+		ResponsePagePath:   aws.String(m.ResponsePagePath.ValueString()),
+	}, diags
+}
+
 type restrictionsModel struct {
 	GeoRestriction fwtypes.ListNestedObjectValueOf[geoRestrictionModel] `tfsdk:"geo_restriction"`
 }

--- a/internal/service/cloudfront/multitenant_distribution_test.go
+++ b/internal/service/cloudfront/multitenant_distribution_test.go
@@ -319,12 +319,24 @@ func TestAccCloudFrontMultiTenantDistribution_customErrorResponseWithoutResponse
 		CheckDestroy:             testAccCheckMultiTenantDistributionDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMultiTenantDistributionConfig_customErrorResponseWithoutResponsePagePath(),
+				Config: testAccMultiTenantDistributionConfig_customErrorResponseWithoutResponsePagePath("Test multi-tenant distribution"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMultiTenantDistributionExists(ctx, t, resourceName, &distribution),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEnabled, acctest.CtFalse),
 					resource.TestCheckResourceAttr(resourceName, "tenant_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tenant_config.0.parameter_definition.0.definition.0.string_schema.0.required", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "custom_error_response.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "custom_error_response.0.error_code", "404"),
+					resource.TestCheckNoResourceAttr(resourceName, "custom_error_response.0.response_code"),
+					resource.TestCheckNoResourceAttr(resourceName, "custom_error_response.0.response_page_path"),
+				),
+			},
+			{
+				// Updating a distribution that carries such a block used to fail.
+				Config: testAccMultiTenantDistributionConfig_customErrorResponseWithoutResponsePagePath("Test multi-tenant distribution updated"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMultiTenantDistributionExists(ctx, t, resourceName, &distribution),
+					resource.TestCheckResourceAttr(resourceName, names.AttrComment, "Test multi-tenant distribution updated"),
 					resource.TestCheckResourceAttr(resourceName, "custom_error_response.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "custom_error_response.0.error_code", "404"),
 					resource.TestCheckNoResourceAttr(resourceName, "custom_error_response.0.response_code"),
@@ -1167,11 +1179,11 @@ data "aws_cloudfront_cache_policy" "caching_disabled" {
 `
 }
 
-func testAccMultiTenantDistributionConfig_customErrorResponseWithoutResponsePagePath() string {
-	return `
+func testAccMultiTenantDistributionConfig_customErrorResponseWithoutResponsePagePath(comment string) string {
+	return fmt.Sprintf(`
 resource "aws_cloudfront_multitenant_distribution" "test" {
   enabled = false
-  comment = "Test multi-tenant distribution"
+  comment = %[1]q
 
   origin {
     domain_name = "example.com"
@@ -1222,7 +1234,7 @@ resource "aws_cloudfront_multitenant_distribution" "test" {
     }
   }
 }
-`
+`, comment)
 }
 
 func testAccMultiTenantDistributionConfig_tags_concurrentUpdate(comment, tagKey1, tagValue1 string) string {


### PR DESCRIPTION
### Description

`aws_cloudfront_multitenant_distribution` cannot be updated once it carries a `custom_error_response` block that omits `response_code` and `response_page_path`. Creation succeeds, then every subsequent apply fails regardless of what it changes:

```
Error: updating CloudFront Distribution (EXXXXXXXXXXXXX): operation error CloudFront:
UpdateDistribution, https response error StatusCode: 409,
IllegalUpdate: The specified list of custom error responses does not exist or is not valid.
```

Both attributes are `Optional` with no default, so omitting them leaves a null `types.String`. AutoFlex expands that to a nil `*string` — `expandString`, the `reflect.Pointer` branch, via `ValueStringPointer()` — and `UpdateDistribution` rejects a `CustomErrorResponse` whose `ResponseCode` or `ResponsePagePath` is absent. `CreateDistribution` accepts it, which is why this only appears on the second apply.

Note that removing the `autoflex:",omitempty"` tags would not fix this on its own: a null `types.String` expands to nil either way.

The SDKv2 `aws_cloudfront_distribution` resource sends empty strings for the same API shape, and has always worked — `expandCustomErrorResponse` in `internal/service/cloudfront/distribution.go`:

```go
if v, ok := tfMap["response_code"]; ok && v.(int) != 0 {
    apiObject.ResponseCode = flex.IntValueToString(v.(int))
} else {
    apiObject.ResponseCode = aws.String("")
}
```

This adds a `flex.Expander` implementation to `customErrorResponseModel` that does the same, so the two resources agree. Expansion only — the `omitempty` tags are left in place so a value CloudFront returns as `""` still reads back as null and produces no diff for practitioners who omitted the attributes.

`TestAccCloudFrontMultiTenantDistribution_customErrorResponseWithoutResponsePagePath` previously only created and imported, so it never issued an `UpdateDistribution` call and did not catch this. Its config helper now takes a `comment` argument and the test runs a second step that changes it.

### Relations

Closes #48288

### Output from Acceptance Testing

Acceptance test output to follow — flagging that rather than leaving the section empty. Verified locally so far:

```
$ gofmt -l internal/service/cloudfront/multitenant_distribution.go internal/service/cloudfront/multitenant_distribution_test.go
$ go build ./internal/service/cloudfront/
$ go vet ./internal/service/cloudfront/
```

all clean. The added test step is expected to fail on `main` and pass with this change; happy to have a maintainer confirm, or to adjust if the second step should assert something more specific.
