### PR TITLE
creation of a new data source snapshots

### DIFF
--- a/.changelog/49259.txt
+++ b/.changelog/49259.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_rds_snapshots
+```

--- a/internal/service/rds/service_package_gen.go
+++ b/internal/service/rds/service_package_gen.go
@@ -39,6 +39,12 @@ func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*inttypes.S
 			}),
 			Region: inttypes.ResourceRegionDefault(),
 		},
+		{
+			Factory:  newSnapshotsDataSource,
+			TypeName: "aws_rds_snapshots",
+			Name:     "Snapshots",
+			Region:   inttypes.ResourceRegionDefault(),
+		},
 	}
 }
 

--- a/internal/service/rds/snapshots_data_source.go
+++ b/internal/service/rds/snapshots_data_source.go
@@ -19,7 +19,6 @@ import (
 	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
 	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 	"github.com/hashicorp/terraform-provider-aws/internal/smerr"
-	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -74,7 +73,6 @@ func (d *snapshotsDataSource) Schema(ctx context.Context, req datasource.SchemaR
 
 func (d *snapshotsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	conn := d.Meta().RDSClient(ctx)
-	ignoreTagsConfig := d.Meta().IgnoreTagsConfig(ctx)
 
 	var data snapshotsDataSourceModel
 	smerr.AddEnrich(ctx, &resp.Diagnostics, req.Config.Get(ctx, &data))
@@ -94,21 +92,10 @@ func (d *snapshotsDataSource) Read(ctx context.Context, req datasource.ReadReque
 		return
 	}
 
-	smerr.AddEnrich(ctx, &resp.Diagnostics, flex.Flatten(ctx, out, &data.Snapshots))
+	smerr.AddEnrich(ctx, &resp.Diagnostics, flex.Flatten(ctx, out, &data.Snapshots, flex.WithNoIgnoredFieldNames()))
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	// Tags are ignored by AutoFlex; populate them manually.
-	snapshots, diags := data.Snapshots.ToSlice(ctx)
-	smerr.AddEnrich(ctx, &resp.Diagnostics, diags)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	for i, snapshot := range snapshots {
-		snapshot.Tags = tftags.NewMapFromMapValue(flex.FlattenFrameworkStringValueMapLegacy(ctx, keyValueTags(ctx, out[i].TagList).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()))
-	}
-	data.Snapshots = fwtypes.NewListNestedObjectValueOfSliceMust[snapshotModel](ctx, snapshots)
 
 	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, &data))
 }
@@ -130,26 +117,31 @@ type snapshotFilterModel struct {
 }
 
 type snapshotModel struct {
-	AllocatedStorage           types.Int64       `tfsdk:"allocated_storage"`
-	AvailabilityZone           types.String      `tfsdk:"availability_zone"`
-	DBInstanceIdentifier       types.String      `tfsdk:"db_instance_identifier"`
-	DBSnapshotARN              types.String      `tfsdk:"db_snapshot_arn"`
-	DBSnapshotIdentifier       types.String      `tfsdk:"db_snapshot_identifier"`
-	Encrypted                  types.Bool        `tfsdk:"encrypted"`
-	Engine                     types.String      `tfsdk:"engine"`
-	EngineVersion              types.String      `tfsdk:"engine_version"`
-	IOPS                       types.Int64       `tfsdk:"iops"`
-	KMSKeyID                   types.String      `tfsdk:"kms_key_id"`
-	LicenseModel               types.String      `tfsdk:"license_model"`
-	OptionGroupName            types.String      `tfsdk:"option_group_name"`
-	OriginalSnapshotCreateTime timetypes.RFC3339 `tfsdk:"original_snapshot_create_time"`
-	Port                       types.Int64       `tfsdk:"port"`
-	SnapshotCreateTime         timetypes.RFC3339 `tfsdk:"snapshot_create_time"`
-	SnapshotType               types.String      `tfsdk:"snapshot_type"`
-	SourceDBSnapshotIdentifier types.String      `tfsdk:"source_db_snapshot_identifier"`
-	SourceRegion               types.String      `tfsdk:"source_region"`
-	Status                     types.String      `tfsdk:"status"`
-	StorageType                types.String      `tfsdk:"storage_type"`
-	Tags                       tftags.Map        `tfsdk:"tags"`
-	VPCID                      types.String      `tfsdk:"vpc_id"`
+	AllocatedStorage           types.Int64                                       `tfsdk:"allocated_storage"`
+	AvailabilityZone           types.String                                      `tfsdk:"availability_zone"`
+	DBInstanceIdentifier       types.String                                      `tfsdk:"db_instance_identifier"`
+	DBSnapshotARN              types.String                                      `tfsdk:"db_snapshot_arn"`
+	DBSnapshotIdentifier       types.String                                      `tfsdk:"db_snapshot_identifier"`
+	Encrypted                  types.Bool                                        `tfsdk:"encrypted"`
+	Engine                     types.String                                      `tfsdk:"engine"`
+	EngineVersion              types.String                                      `tfsdk:"engine_version"`
+	IOPS                       types.Int64                                       `tfsdk:"iops"`
+	KMSKeyID                   types.String                                      `tfsdk:"kms_key_id"`
+	LicenseModel               types.String                                      `tfsdk:"license_model"`
+	OptionGroupName            types.String                                      `tfsdk:"option_group_name"`
+	OriginalSnapshotCreateTime timetypes.RFC3339                                 `tfsdk:"original_snapshot_create_time"`
+	Port                       types.Int64                                       `tfsdk:"port"`
+	SnapshotCreateTime         timetypes.RFC3339                                 `tfsdk:"snapshot_create_time"`
+	SnapshotType               types.String                                      `tfsdk:"snapshot_type"`
+	SourceDBSnapshotIdentifier types.String                                      `tfsdk:"source_db_snapshot_identifier"`
+	SourceRegion               types.String                                      `tfsdk:"source_region"`
+	Status                     types.String                                      `tfsdk:"status"`
+	StorageType                types.String                                      `tfsdk:"storage_type"`
+	TagList                    fwtypes.ListNestedObjectValueOf[tagListItemModel] `tfsdk:"tag_list"`
+	VPCID                      types.String                                      `tfsdk:"vpc_id"`
+}
+
+type tagListItemModel struct {
+	Key   types.String `tfsdk:"key"`
+	Value types.String `tfsdk:"value"`
 }

--- a/internal/service/rds/snapshots_data_source.go
+++ b/internal/service/rds/snapshots_data_source.go
@@ -1,0 +1,183 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+// DONOTCOPY: Copying old resources spreads bad habits. Use skaff instead.
+
+package rds
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/rds"
+	rdstypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
+	"github.com/hashicorp/terraform-provider-aws/internal/smerr"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkDataSource("aws_rds_snapshots", name="Snapshots")
+func newSnapshotsDataSource(context.Context) (datasource.DataSourceWithConfigure, error) {
+	return &snapshotsDataSource{}, nil
+}
+
+const (
+	DSNameSnapshots = "Snapshots Data Source"
+)
+
+type snapshotsDataSource struct {
+	framework.DataSourceWithModel[snapshotsDataSourceModel]
+}
+
+func (d *snapshotsDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"db_instance_identifier": schema.StringAttribute{
+				Optional: true,
+			},
+			"db_snapshot_identifier": schema.StringAttribute{
+				Optional: true,
+			},
+			"include_public": schema.BoolAttribute{
+				Optional: true,
+			},
+			"include_shared": schema.BoolAttribute{
+				Optional: true,
+			},
+			"snapshot_type": schema.StringAttribute{
+				Optional: true,
+			},
+			"snapshots": framework.DataSourceComputedListOfObjectAttribute[snapshotModel](ctx),
+		},
+		Blocks: map[string]schema.Block{
+			names.AttrFilter: schema.SetNestedBlock{
+				CustomType: fwtypes.NewSetNestedObjectTypeOf[snapshotFilterModel](ctx),
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						names.AttrName: schema.StringAttribute{
+							Required: true,
+						},
+						names.AttrValues: schema.SetAttribute{
+							CustomType:  fwtypes.SetOfStringType,
+							ElementType: types.StringType,
+							Required:    true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *snapshotsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	conn := d.Meta().RDSClient(ctx)
+	ignoreTagsConfig := d.Meta().IgnoreTagsConfig(ctx)
+
+	var data snapshotsDataSourceModel
+	smerr.AddEnrich(ctx, &resp.Diagnostics, req.Config.Get(ctx, &data))
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	input := &rds.DescribeDBSnapshotsInput{}
+	if !data.DBInstanceIdentifier.IsNull() {
+		input.DBInstanceIdentifier = data.DBInstanceIdentifier.ValueStringPointer()
+	}
+	if !data.DBSnapshotIdentifier.IsNull() {
+		input.DBSnapshotIdentifier = data.DBSnapshotIdentifier.ValueStringPointer()
+	}
+	if !data.IncludePublic.IsNull() {
+		input.IncludePublic = data.IncludePublic.ValueBoolPointer()
+	}
+	if !data.IncludeShared.IsNull() {
+		input.IncludeShared = data.IncludeShared.ValueBoolPointer()
+	}
+	if !data.SnapshotType.IsNull() {
+		input.SnapshotType = data.SnapshotType.ValueStringPointer()
+	}
+	if !data.Filters.IsNull() && !data.Filters.IsUnknown() {
+		for _, v := range data.Filters.Elements() {
+			var f snapshotFilterModel
+			if tfsdk.ValueAs(ctx, v, &f).HasError() {
+				continue
+			}
+			input.Filters = append(input.Filters, rdstypes.Filter{
+				Name:   f.Name.ValueStringPointer(),
+				Values: flex.ExpandFrameworkStringValueSet(ctx, f.Values),
+			})
+		}
+	}
+
+	out, err := findDBSnapshots(ctx, conn, input, tfslices.PredicateTrue[*rdstypes.DBSnapshot]())
+	if err != nil {
+		smerr.AddError(ctx, &resp.Diagnostics, err)
+		return
+	}
+
+	smerr.AddEnrich(ctx, &resp.Diagnostics, flex.Flatten(ctx, out, &data.Snapshots))
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Tags are ignored by AutoFlex; populate them manually.
+	snapshots, diags := data.Snapshots.ToSlice(ctx)
+	smerr.AddEnrich(ctx, &resp.Diagnostics, diags)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	for i, snapshot := range snapshots {
+		snapshot.Tags = tftags.NewMapFromMapValue(flex.FlattenFrameworkStringValueMapLegacy(ctx, keyValueTags(ctx, out[i].TagList).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()))
+	}
+	data.Snapshots = fwtypes.NewListNestedObjectValueOfSliceMust[snapshotModel](ctx, snapshots)
+
+	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, &data))
+}
+
+type snapshotsDataSourceModel struct {
+	framework.WithRegionModel
+	DBInstanceIdentifier types.String                                        `tfsdk:"db_instance_identifier"`
+	DBSnapshotIdentifier types.String                                        `tfsdk:"db_snapshot_identifier"`
+	Filters              fwtypes.SetNestedObjectValueOf[snapshotFilterModel] `tfsdk:"filter"`
+	IncludePublic        types.Bool                                          `tfsdk:"include_public"`
+	IncludeShared        types.Bool                                          `tfsdk:"include_shared"`
+	SnapshotType         types.String                                        `tfsdk:"snapshot_type"`
+	Snapshots            fwtypes.ListNestedObjectValueOf[snapshotModel]      `tfsdk:"snapshots"`
+}
+
+type snapshotFilterModel struct {
+	Name   types.String        `tfsdk:"name"`
+	Values fwtypes.SetOfString `tfsdk:"values"`
+}
+
+type snapshotModel struct {
+	AllocatedStorage           types.Int64       `tfsdk:"allocated_storage"`
+	AvailabilityZone           types.String      `tfsdk:"availability_zone"`
+	DBInstanceIdentifier       types.String      `tfsdk:"db_instance_identifier"`
+	DBSnapshotARN              types.String      `tfsdk:"db_snapshot_arn"`
+	DBSnapshotIdentifier       types.String      `tfsdk:"db_snapshot_identifier"`
+	Encrypted                  types.Bool        `tfsdk:"encrypted"`
+	Engine                     types.String      `tfsdk:"engine"`
+	EngineVersion              types.String      `tfsdk:"engine_version"`
+	IOPS                       types.Int64       `tfsdk:"iops"`
+	KMSKeyID                   types.String      `tfsdk:"kms_key_id"`
+	LicenseModel               types.String      `tfsdk:"license_model"`
+	OptionGroupName            types.String      `tfsdk:"option_group_name"`
+	OriginalSnapshotCreateTime timetypes.RFC3339 `tfsdk:"original_snapshot_create_time"`
+	Port                       types.Int64       `tfsdk:"port"`
+	SnapshotCreateTime         timetypes.RFC3339 `tfsdk:"snapshot_create_time"`
+	SnapshotType               types.String      `tfsdk:"snapshot_type"`
+	SourceDBSnapshotIdentifier types.String      `tfsdk:"source_db_snapshot_identifier"`
+	SourceRegion               types.String      `tfsdk:"source_region"`
+	Status                     types.String      `tfsdk:"status"`
+	StorageType                types.String      `tfsdk:"storage_type"`
+	Tags                       tftags.Map        `tfsdk:"tags"`
+	VPCID                      types.String      `tfsdk:"vpc_id"`
+}

--- a/internal/service/rds/snapshots_data_source.go
+++ b/internal/service/rds/snapshots_data_source.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
@@ -87,36 +86,13 @@ func (d *snapshotsDataSource) Read(ctx context.Context, req datasource.ReadReque
 		return
 	}
 
-	input := &rds.DescribeDBSnapshotsInput{}
-	if !data.DBInstanceIdentifier.IsNull() {
-		input.DBInstanceIdentifier = data.DBInstanceIdentifier.ValueStringPointer()
-	}
-	if !data.DBSnapshotIdentifier.IsNull() {
-		input.DBSnapshotIdentifier = data.DBSnapshotIdentifier.ValueStringPointer()
-	}
-	if !data.IncludePublic.IsNull() {
-		input.IncludePublic = data.IncludePublic.ValueBoolPointer()
-	}
-	if !data.IncludeShared.IsNull() {
-		input.IncludeShared = data.IncludeShared.ValueBoolPointer()
-	}
-	if !data.SnapshotType.IsNull() {
-		input.SnapshotType = data.SnapshotType.ValueStringPointer()
-	}
-	if !data.Filters.IsNull() && !data.Filters.IsUnknown() {
-		for _, v := range data.Filters.Elements() {
-			var f snapshotFilterModel
-			if tfsdk.ValueAs(ctx, v, &f).HasError() {
-				continue
-			}
-			input.Filters = append(input.Filters, rdstypes.Filter{
-				Name:   f.Name.ValueStringPointer(),
-				Values: flex.ExpandFrameworkStringValueSet(ctx, f.Values),
-			})
-		}
+	var input rds.DescribeDBSnapshotsInput
+	smerr.AddEnrich(ctx, &resp.Diagnostics, flex.Expand(ctx, data, &input))
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
-	out, err := findDBSnapshots(ctx, conn, input, tfslices.PredicateTrue[*rdstypes.DBSnapshot]())
+	out, err := findDBSnapshots(ctx, conn, &input, tfslices.PredicateTrue[*rdstypes.DBSnapshot]())
 	if err != nil {
 		smerr.AddError(ctx, &resp.Diagnostics, err)
 		return

--- a/internal/service/rds/snapshots_data_source.go
+++ b/internal/service/rds/snapshots_data_source.go
@@ -28,10 +28,6 @@ func newSnapshotsDataSource(context.Context) (datasource.DataSourceWithConfigure
 	return &snapshotsDataSource{}, nil
 }
 
-const (
-	DSNameSnapshots = "Snapshots Data Source"
-)
-
 type snapshotsDataSource struct {
 	framework.DataSourceWithModel[snapshotsDataSourceModel]
 }

--- a/internal/service/rds/snapshots_data_source_test.go
+++ b/internal/service/rds/snapshots_data_source_test.go
@@ -1,0 +1,115 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package rds_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccRDSSnapshotsDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	dataSourceName := "data.aws_rds_snapshots.test"
+	resourceName := "aws_db_snapshot.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDBSnapshotDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSnapshotsDataSourceConfig_basic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "snapshots.#", "1"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "snapshots.0.db_instance_identifier", resourceName, "db_instance_identifier"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "snapshots.0.db_snapshot_identifier", resourceName, "db_snapshot_identifier"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "snapshots.0.db_snapshot_arn", resourceName, "db_snapshot_arn"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "snapshots.0.snapshot_create_time"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "snapshots.0.status"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "snapshots.0.engine"),
+					resource.TestCheckResourceAttr(dataSourceName, "snapshots.0.tags.Name", rName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRDSSnapshotsDataSource_filter(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	dataSourceName := "data.aws_rds_snapshots.test"
+	resourceName := "aws_db_snapshot.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDBSnapshotDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSnapshotsDataSourceConfig_filter(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "snapshots.#", "1"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "snapshots.0.db_snapshot_identifier", resourceName, "db_snapshot_identifier"),
+				),
+			},
+		},
+	})
+}
+
+func testAccSnapshotsDataSourceConfig_basic(rName string) string {
+	return acctest.ConfigCompose(testAccSnapshotConfig_base(rName), fmt.Sprintf(`
+resource "aws_db_snapshot" "test" {
+  db_instance_identifier = aws_db_instance.test.identifier
+  db_snapshot_identifier = %[1]q
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+data "aws_rds_snapshots" "test" {
+  db_instance_identifier = aws_db_snapshot.test.db_instance_identifier
+
+  depends_on = [aws_db_snapshot.test]
+}
+`, rName))
+}
+
+func testAccSnapshotsDataSourceConfig_filter(rName string) string {
+	return acctest.ConfigCompose(testAccSnapshotConfig_base(rName), fmt.Sprintf(`
+resource "aws_db_snapshot" "test" {
+  db_instance_identifier = aws_db_instance.test.identifier
+  db_snapshot_identifier = %[1]q
+}
+
+resource "aws_db_snapshot" "wrong" {
+  db_instance_identifier = aws_db_instance.test.identifier
+  db_snapshot_identifier = "%[1]s-wrong"
+}
+
+data "aws_rds_snapshots" "test" {
+  filter {
+    name   = "db-snapshot-id"
+    values = [aws_db_snapshot.test.db_snapshot_identifier]
+  }
+
+  depends_on = [aws_db_snapshot.wrong]
+}
+`, rName))
+}

--- a/internal/service/rds/snapshots_data_source_test.go
+++ b/internal/service/rds/snapshots_data_source_test.go
@@ -38,8 +38,8 @@ func TestAccRDSSnapshotsDataSource_basic(t *testing.T) {
 							"db_instance_identifier": knownvalue.StringExact(rName),
 							"db_snapshot_identifier": knownvalue.StringExact(rName),
 							"snapshot_create_time":   knownvalue.NotNull(),
-							"status":                 knownvalue.NotNull(),
-							"engine":                 knownvalue.NotNull(),
+							names.AttrStatus:         knownvalue.NotNull(),
+							names.AttrEngine:         knownvalue.NotNull(),
 							names.AttrTags: knownvalue.MapExact(map[string]knownvalue.Check{
 								"Name": knownvalue.StringExact(rName),
 							}),

--- a/internal/service/rds/snapshots_data_source_test.go
+++ b/internal/service/rds/snapshots_data_source_test.go
@@ -101,8 +101,6 @@ resource "aws_db_snapshot" "test" {
 resource "aws_db_snapshot" "wrong" {
   db_instance_identifier = aws_db_instance.test.identifier
   db_snapshot_identifier = "%[1]s-wrong"
-
-  depends_on = [aws_db_snapshot.test]
 }
 
 data "aws_rds_snapshots" "test" {

--- a/internal/service/rds/snapshots_data_source_test.go
+++ b/internal/service/rds/snapshots_data_source_test.go
@@ -40,8 +40,11 @@ func TestAccRDSSnapshotsDataSource_basic(t *testing.T) {
 							"snapshot_create_time":   knownvalue.NotNull(),
 							names.AttrStatus:         knownvalue.NotNull(),
 							names.AttrEngine:         knownvalue.NotNull(),
-							names.AttrTags: knownvalue.MapExact(map[string]knownvalue.Check{
-								"Name": knownvalue.StringExact(rName),
+							"tag_list": knownvalue.ListExact([]knownvalue.Check{
+								knownvalue.ObjectExact(map[string]knownvalue.Check{
+									"key":   knownvalue.StringExact("Name"),
+									"value": knownvalue.StringExact(rName),
+								}),
 							}),
 						}),
 					})),

--- a/internal/service/rds/snapshots_data_source_test.go
+++ b/internal/service/rds/snapshots_data_source_test.go
@@ -8,6 +8,9 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -20,7 +23,6 @@ func TestAccRDSSnapshotsDataSource_basic(t *testing.T) {
 
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	dataSourceName := "data.aws_rds_snapshots.test"
-	resourceName := "aws_db_snapshot.test"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -30,16 +32,20 @@ func TestAccRDSSnapshotsDataSource_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSnapshotsDataSourceConfig_basic(rName),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(dataSourceName, "snapshots.#", "1"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "snapshots.0.db_instance_identifier", resourceName, "db_instance_identifier"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "snapshots.0.db_snapshot_identifier", resourceName, "db_snapshot_identifier"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "snapshots.0.db_snapshot_arn", resourceName, "db_snapshot_arn"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "snapshots.0.snapshot_create_time"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "snapshots.0.status"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "snapshots.0.engine"),
-					resource.TestCheckResourceAttr(dataSourceName, "snapshots.0.tags.Name", rName),
-				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("snapshots"), knownvalue.ListExact([]knownvalue.Check{
+						knownvalue.ObjectPartial(map[string]knownvalue.Check{
+							"db_instance_identifier": knownvalue.StringExact(rName),
+							"db_snapshot_identifier": knownvalue.StringExact(rName),
+							"snapshot_create_time":   knownvalue.NotNull(),
+							"status":                 knownvalue.NotNull(),
+							"engine":                 knownvalue.NotNull(),
+							names.AttrTags: knownvalue.MapExact(map[string]knownvalue.Check{
+								"Name": knownvalue.StringExact(rName),
+							}),
+						}),
+					})),
+				},
 			},
 		},
 	})
@@ -101,6 +107,8 @@ resource "aws_db_snapshot" "test" {
 resource "aws_db_snapshot" "wrong" {
   db_instance_identifier = aws_db_instance.test.identifier
   db_snapshot_identifier = "%[1]s-wrong"
+
+  depends_on = [aws_db_snapshot.test]
 }
 
 data "aws_rds_snapshots" "test" {

--- a/internal/service/rds/snapshots_data_source_test.go
+++ b/internal/service/rds/snapshots_data_source_test.go
@@ -59,7 +59,6 @@ func TestAccRDSSnapshotsDataSource_filter(t *testing.T) {
 
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	dataSourceName := "data.aws_rds_snapshots.test"
-	resourceName := "aws_db_snapshot.test"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -69,10 +68,13 @@ func TestAccRDSSnapshotsDataSource_filter(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSnapshotsDataSourceConfig_filter(rName),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(dataSourceName, "snapshots.#", "1"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "snapshots.0.db_snapshot_identifier", resourceName, "db_snapshot_identifier"),
-				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New("snapshots"), knownvalue.ListExact([]knownvalue.Check{
+						knownvalue.ObjectPartial(map[string]knownvalue.Check{
+							"db_snapshot_identifier": knownvalue.StringExact(rName),
+						}),
+					})),
+				},
 			},
 		},
 	})

--- a/internal/service/rds/snapshots_data_source_test.go
+++ b/internal/service/rds/snapshots_data_source_test.go
@@ -42,8 +42,8 @@ func TestAccRDSSnapshotsDataSource_basic(t *testing.T) {
 							names.AttrEngine:         knownvalue.NotNull(),
 							"tag_list": knownvalue.ListExact([]knownvalue.Check{
 								knownvalue.ObjectExact(map[string]knownvalue.Check{
-									"key":   knownvalue.StringExact("Name"),
-									"value": knownvalue.StringExact(rName),
+									names.AttrKey:   knownvalue.StringExact("Name"),
+									names.AttrValue: knownvalue.StringExact(rName),
 								}),
 							}),
 						}),

--- a/internal/service/rds/snapshots_data_source_test.go
+++ b/internal/service/rds/snapshots_data_source_test.go
@@ -101,6 +101,8 @@ resource "aws_db_snapshot" "test" {
 resource "aws_db_snapshot" "wrong" {
   db_instance_identifier = aws_db_instance.test.identifier
   db_snapshot_identifier = "%[1]s-wrong"
+
+  depends_on = [aws_db_snapshot.test]
 }
 
 data "aws_rds_snapshots" "test" {

--- a/website/docs/d/rds_snapshots.html.markdown
+++ b/website/docs/d/rds_snapshots.html.markdown
@@ -33,7 +33,7 @@ data "aws_rds_snapshots" "example" {
 
 ## Argument Reference
 
-The data source supports the following arguments:
+This data source supports the following arguments:
 
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `db_instance_identifier` - (Optional) Returns the list of snapshots created by the specific db_instance.
@@ -43,7 +43,7 @@ The data source supports the following arguments:
 * `include_shared` - (Optional) Set this value to `true` to include shared manual DB snapshots from other AWS accounts that this AWS account has been given permission to copy or restore, otherwise set this value to `false`. The default is `false`.
 * `snapshot_type` - (Optional) Type of snapshots to be returned. If you don't specify a SnapshotType value, then both automated and manual snapshots are returned. Shared and public DB snapshots are not included in the returned results by default. Possible values are `automated`, `manual`, `shared`, `public` and `awsbackup`.
 
-### filter Configuration Block
+### `filter` Block
 
 * `name` - (Required) Name of the filter field. Valid values can be found in the RDS DescribeDBSnapshots API Reference.
 * `values` - (Required) Set of values accepted for the given filter field. Results will be selected if any given value matches.
@@ -51,6 +51,10 @@ The data source supports the following arguments:
 ## Attribute Reference
 
 This data source exports the following attributes in addition to the arguments above:
+
+* `snapshots` - List of snapshots. 
+
+### `snapshots` Attribute Reference
 
 * `allocated_storage` - Allocated storage size in gigabytes (GB).
 * `availability_zone` - Name of the Availability Zone the DB instance was located in at the time of the DB snapshot.
@@ -64,9 +68,9 @@ This data source exports the following attributes in addition to the arguments a
 * `kms_key_id` - ARN for the KMS encryption key.
 * `license_model` - License model information for the restored DB instance.
 * `option_group_name` - Option group name for the DB snapshot.
-* `original_snapshot_create_time` - The time when the snapshot was taken, in Universal Coordinated Time (UTC). Doesn't change when the snapshot is copied.
+* `original_snapshot_create_time` - Time when the snapshot was taken, in Universal Coordinated Time (UTC). Doesn't change when the snapshot is copied.
 * `port` - Port that the database engine was listening on at the time of the snapshot.
-* `snapshot_create_time` - The time when the snapshot was taken, in Universal Coordinated Time (UTC). Changes when the snapshot is copied.
+* `snapshot_create_time` - Time when the snapshot was taken, in Universal Coordinated Time (UTC). Changes when the snapshot is copied.
 * `snapshot_type` - Type of the DB snapshot.
 * `source_db_snapshot_identifier` - DB snapshot ARN that the DB snapshot was copied from. Only set for cross-account or cross-region copies.
 * `source_region` - Region that the DB snapshot was created in or copied from.

--- a/website/docs/d/rds_snapshots.html.markdown
+++ b/website/docs/d/rds_snapshots.html.markdown
@@ -78,4 +78,3 @@ This data source exports the following attributes in addition to the arguments a
 * `storage_type` - Storage type associated with the DB snapshot.
 * `tags` - Map of tags assigned to the snapshot.
 * `vpc_id` - ID of the VPC associated with the DB snapshot.
-

--- a/website/docs/d/rds_snapshots.html.markdown
+++ b/website/docs/d/rds_snapshots.html.markdown
@@ -1,0 +1,76 @@
+---
+subcategory: "RDS (Relational Database)"
+layout: "aws"
+page_title: "AWS: aws_rds_snapshots"
+description: |-
+  Provides details about an AWS RDS (Relational Database) Snapshots.
+---
+
+# Data Source: aws_rds_snapshots
+
+Provides details about an AWS RDS (Relational Database) Snapshots.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_rds_snapshots" "example" {
+  db_instance_identifier = "my-db-instance"
+}
+```
+
+### Filter by snapshot ID
+
+```terraform
+data "aws_rds_snapshots" "example" {
+  filter {
+    name   = "db-snapshot-id"
+    values = ["my-snapshot-id"]
+  }
+}
+```
+
+## Argument Reference
+
+The data source supports the following arguments:
+
+* `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
+* `db_instance_identifier` - (Optional) Returns the list of snapshots created by the specific db_instance.
+* `db_snapshot_identifier` - (Optional) Returns information on a specific snapshot_id.
+* `filter` - (Optional) Configuration block(s) used to filter snapshots with AWS supported attributes. Detailed below.
+* `include_public` - (Optional) Set this value to `true` to include manual DB snapshots that are public and can be copied or restored by any AWS account, otherwise set this value to `false`. The default is `false`.
+* `include_shared` - (Optional) Set this value to `true` to include shared manual DB snapshots from other AWS accounts that this AWS account has been given permission to copy or restore, otherwise set this value to `false`. The default is `false`.
+* `snapshot_type` - (Optional) Type of snapshots to be returned. If you don't specify a SnapshotType value, then both automated and manual snapshots are returned. Shared and public DB snapshots are not included in the returned results by default. Possible values are `automated`, `manual`, `shared`, `public` and `awsbackup`.
+
+### filter Configuration Block
+
+* `name` - (Required) Name of the filter field. Valid values can be found in the RDS DescribeDBSnapshots API Reference.
+* `values` - (Required) Set of values accepted for the given filter field. Results will be selected if any given value matches.
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `allocated_storage` - Allocated storage size in gigabytes (GB).
+* `availability_zone` - Name of the Availability Zone the DB instance was located in at the time of the DB snapshot.
+* `db_instance_identifier` - Identifier of the DB instance from which the snapshot was taken.
+* `db_snapshot_arn` - ARN for the DB snapshot.
+* `db_snapshot_identifier` - Identifier of the DB snapshot.
+* `encrypted` - Whether the DB snapshot is encrypted.
+* `engine` - Name of the database engine.
+* `engine_version` - Version of the database engine.
+* `iops` - Provisioned IOPS (I/O operations per second) value of the DB instance at the time of the snapshot.
+* `kms_key_id` - ARN for the KMS encryption key.
+* `license_model` - License model information for the restored DB instance.
+* `option_group_name` - Option group name for the DB snapshot.
+* `original_snapshot_create_time` - The time when the snapshot was taken, in Universal Coordinated Time (UTC). Doesn't change when the snapshot is copied.
+* `port` - Port that the database engine was listening on at the time of the snapshot.
+* `snapshot_create_time` - The time when the snapshot was taken, in Universal Coordinated Time (UTC). Changes when the snapshot is copied.
+* `snapshot_type` - Type of the DB snapshot.
+* `source_db_snapshot_identifier` - DB snapshot ARN that the DB snapshot was copied from. Only set for cross-account or cross-region copies.
+* `source_region` - Region that the DB snapshot was created in or copied from.
+* `status` - Status of this DB snapshot.
+* `storage_type` - Storage type associated with the DB snapshot.
+* `tags` - Map of tags assigned to the snapshot.
+* `vpc_id` - ID of the VPC associated with the DB snapshot.

--- a/website/docs/d/rds_snapshots.html.markdown
+++ b/website/docs/d/rds_snapshots.html.markdown
@@ -36,11 +36,11 @@ data "aws_rds_snapshots" "example" {
 This data source supports the following arguments:
 
 * `db_instance_identifier` - (Optional) Returns the list of snapshots created by the specific db_instance.
-* `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `db_snapshot_identifier` - (Optional) Returns information on a specific snapshot_id.
 * `filter` - (Optional) Configuration block(s) used to filter snapshots with AWS supported attributes. Detailed below.
 * `include_public` - (Optional) Set this value to `true` to include manual DB snapshots that are public and can be copied or restored by any AWS account, otherwise set this value to `false`. The default is `false`.
 * `include_shared` - (Optional) Set this value to `true` to include shared manual DB snapshots from other AWS accounts that this AWS account has been given permission to copy or restore, otherwise set this value to `false`. The default is `false`.
+* `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `snapshot_type` - (Optional) Type of snapshots to be returned. If you don't specify a SnapshotType value, then both automated and manual snapshots are returned. Shared and public DB snapshots are not included in the returned results by default. Possible values are `automated`, `manual`, `shared`, `public` and `awsbackup`.
 
 ### `filter` Block

--- a/website/docs/d/rds_snapshots.html.markdown
+++ b/website/docs/d/rds_snapshots.html.markdown
@@ -35,8 +35,8 @@ data "aws_rds_snapshots" "example" {
 
 This data source supports the following arguments:
 
-* `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `db_instance_identifier` - (Optional) Returns the list of snapshots created by the specific db_instance.
+* `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `db_snapshot_identifier` - (Optional) Returns information on a specific snapshot_id.
 * `filter` - (Optional) Configuration block(s) used to filter snapshots with AWS supported attributes. Detailed below.
 * `include_public` - (Optional) Set this value to `true` to include manual DB snapshots that are public and can be copied or restored by any AWS account, otherwise set this value to `false`. The default is `false`.

--- a/website/docs/d/rds_snapshots.html.markdown
+++ b/website/docs/d/rds_snapshots.html.markdown
@@ -20,7 +20,7 @@ data "aws_rds_snapshots" "example" {
 }
 ```
 
-### Filter by snapshot ID
+### Filter by Snapshot ID
 
 ```terraform
 data "aws_rds_snapshots" "example" {

--- a/website/docs/d/rds_snapshots.html.markdown
+++ b/website/docs/d/rds_snapshots.html.markdown
@@ -52,7 +52,7 @@ This data source supports the following arguments:
 
 This data source exports the following attributes in addition to the arguments above:
 
-* `snapshots` - List of snapshots. 
+* `snapshots` - List of snapshots.
 
 ### `snapshots` Attribute Reference
 
@@ -78,3 +78,4 @@ This data source exports the following attributes in addition to the arguments a
 * `storage_type` - Storage type associated with the DB snapshot.
 * `tags` - Map of tags assigned to the snapshot.
 * `vpc_id` - ID of the VPC associated with the DB snapshot.
+


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Adds New Data Source: aws_rds_snapshots

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
make t K=rds T=TestAccRDSSnapshotsDataSource      
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-snapshots 🌿...
TF_ACC=1 go1.26.5 test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccRDSSnapshotsDataSource'  -timeout 360m -vet=off
2026/08/03 11:46:41 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/03 11:46:41 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccRDSSnapshotsDataSource_basic
=== PAUSE TestAccRDSSnapshotsDataSource_basic
=== RUN   TestAccRDSSnapshotsDataSource_filter
=== PAUSE TestAccRDSSnapshotsDataSource_filter
=== CONT  TestAccRDSSnapshotsDataSource_basic
=== CONT  TestAccRDSSnapshotsDataSource_filter
--- PASS: TestAccRDSSnapshotsDataSource_basic (628.56s)
--- PASS: TestAccRDSSnapshotsDataSource_filter (689.82s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/rds        695.775s
```
