### PR TITLE
aws_iam_user: Make delete related functions skip `NoSuchEntityException`

### DIFF
--- a/.changelog/49260.txt
+++ b/.changelog/49260.txt
@@ -1,3 +1,3 @@
 ```release-note:bugfix
-resource/aws_iam_user: Add eventual consistency logic to `deleteUser`, ignore `NoSuchEntityException` for delete helpers and update documentation around `force_destroy`
+resource/aws_iam_user: Retry destroying users when there are conflicts, and ignore non-errors during destroy
 ```

--- a/.changelog/49260.txt
+++ b/.changelog/49260.txt
@@ -1,0 +1,3 @@
+```release-note:bugfix
+resource/aws_iam_user: Add eventual consistency logic to `deleteUser`, ignore `NoSuchEntityException` for delete helpers and update documentation around `force_destroy`
+```

--- a/internal/service/iam/user.go
+++ b/internal/service/iam/user.go
@@ -7,7 +7,6 @@ package iam
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log"
 	"time"
@@ -268,7 +267,10 @@ func resourceUserDelete(ctx context.Context, d *schema.ResourceData, meta any) d
 	input := iam.DeleteUserInput{
 		UserName: aws.String(d.Id()),
 	}
-	_, err := conn.DeleteUser(ctx, &input)
+
+	_, err := tfresource.RetryWhenIsA[any, *awstypes.DeleteConflictException](ctx, propagationTimeout, func(ctx context.Context) (any, error) {
+		return conn.DeleteUser(ctx, &input)
+	})
 
 	if errs.IsA[*awstypes.NoSuchEntityException](err) {
 		return diags
@@ -409,6 +411,9 @@ func deleteUserSSHKeys(ctx context.Context, conn *iam.Client, user string) error
 		_, err := conn.DeleteSSHPublicKey(ctx, &input)
 
 		if err != nil {
+			if errs.IsA[*awstypes.NoSuchEntityException](err) {
+				continue
+			}
 			return fmt.Errorf("deleting IAM User (%s) SSH public key (%s): %w", user, v, err)
 		}
 	}
@@ -445,6 +450,9 @@ func deleteUserVirtualMFADevices(ctx context.Context, conn *iam.Client, user str
 		_, err := conn.DeactivateMFADevice(ctx, &inputDeactivate)
 
 		if err != nil {
+			if errs.IsA[*awstypes.NoSuchEntityException](err) {
+				continue
+			}
 			return fmt.Errorf("deactivating IAM User (%s) virtual MFA device (%s): %w", user, v, err)
 		}
 
@@ -454,6 +462,9 @@ func deleteUserVirtualMFADevices(ctx context.Context, conn *iam.Client, user str
 		_, err = conn.DeleteVirtualMFADevice(ctx, &inputDelete)
 
 		if err != nil {
+			if errs.IsA[*awstypes.NoSuchEntityException](err) {
+				continue
+			}
 			return fmt.Errorf("deleting IAM Virtual MFA Device (%s): %w", v, err)
 		}
 	}
@@ -487,6 +498,9 @@ func deactivateUserMFADevices(ctx context.Context, conn *iam.Client, user string
 		_, err := conn.DeactivateMFADevice(ctx, &input)
 
 		if err != nil {
+			if errs.IsA[*awstypes.NoSuchEntityException](err) {
+				continue
+			}
 			return fmt.Errorf("deactivating IAM User (%s) MFA device (%s): %w", user, v, err)
 		}
 	}
@@ -530,7 +544,6 @@ func deleteUserAccessKeys(ctx context.Context, conn *iam.Client, user string) er
 		return fmt.Errorf("listing IAM User (%s) access keys: %w", user, err)
 	}
 
-	var errs []error
 	for _, v := range accessKeys {
 		accessKeyID := aws.ToString(v.AccessKeyId)
 		input := iam.DeleteAccessKeyInput{
@@ -540,11 +553,14 @@ func deleteUserAccessKeys(ctx context.Context, conn *iam.Client, user string) er
 		_, err := conn.DeleteAccessKey(ctx, &input)
 
 		if err != nil {
+			if errs.IsA[*awstypes.NoSuchEntityException](err) {
+				continue
+			}
 			return fmt.Errorf("deleting IAM User (%s) access key (%s): %w", user, accessKeyID, err)
 		}
 	}
 
-	return errors.Join(errs...)
+	return nil
 }
 
 func deleteUserSigningCertificates(ctx context.Context, conn *iam.Client, user string) error {
@@ -573,6 +589,9 @@ func deleteUserSigningCertificates(ctx context.Context, conn *iam.Client, user s
 		_, err := conn.DeleteSigningCertificate(ctx, &input)
 
 		if err != nil {
+			if errs.IsA[*awstypes.NoSuchEntityException](err) {
+				continue
+			}
 			return fmt.Errorf("deleting IAM User (%s) signing certificate (%s): %w", user, v, err)
 		}
 	}
@@ -610,6 +629,9 @@ func deleteServiceSpecificCredentials(ctx context.Context, conn *iam.Client, use
 		_, err := conn.DeleteServiceSpecificCredential(ctx, &input)
 
 		if err != nil {
+			if errs.IsA[*awstypes.NoSuchEntityException](err) {
+				continue
+			}
 			return fmt.Errorf("deleting IAM User (%s) service-specific credential (%s): %w", user, v, err)
 		}
 	}
@@ -642,6 +664,9 @@ func deleteUserPolicies(ctx context.Context, conn *iam.Client, user string) erro
 		_, err := conn.DeleteUserPolicy(ctx, &input)
 
 		if err != nil {
+			if errs.IsA[*awstypes.NoSuchEntityException](err) {
+				continue
+			}
 			return fmt.Errorf("deleting IAM User (%s) policy (%s): %w", user, v, err)
 		}
 	}

--- a/internal/service/iam/user.go
+++ b/internal/service/iam/user.go
@@ -410,10 +410,11 @@ func deleteUserSSHKeys(ctx context.Context, conn *iam.Client, user string) error
 		}
 		_, err := conn.DeleteSSHPublicKey(ctx, &input)
 
+		if errs.IsA[*awstypes.NoSuchEntityException](err) {
+			continue
+		}
+
 		if err != nil {
-			if errs.IsA[*awstypes.NoSuchEntityException](err) {
-				continue
-			}
 			return fmt.Errorf("deleting IAM User (%s) SSH public key (%s): %w", user, v, err)
 		}
 	}
@@ -449,10 +450,11 @@ func deleteUserVirtualMFADevices(ctx context.Context, conn *iam.Client, user str
 		}
 		_, err := conn.DeactivateMFADevice(ctx, &inputDeactivate)
 
+		if errs.IsA[*awstypes.NoSuchEntityException](err) {
+			continue
+		}
+
 		if err != nil {
-			if errs.IsA[*awstypes.NoSuchEntityException](err) {
-				continue
-			}
 			return fmt.Errorf("deactivating IAM User (%s) virtual MFA device (%s): %w", user, v, err)
 		}
 
@@ -461,10 +463,11 @@ func deleteUserVirtualMFADevices(ctx context.Context, conn *iam.Client, user str
 		}
 		_, err = conn.DeleteVirtualMFADevice(ctx, &inputDelete)
 
+		if errs.IsA[*awstypes.NoSuchEntityException](err) {
+			continue
+		}
+
 		if err != nil {
-			if errs.IsA[*awstypes.NoSuchEntityException](err) {
-				continue
-			}
 			return fmt.Errorf("deleting IAM Virtual MFA Device (%s): %w", v, err)
 		}
 	}
@@ -497,10 +500,11 @@ func deactivateUserMFADevices(ctx context.Context, conn *iam.Client, user string
 		}
 		_, err := conn.DeactivateMFADevice(ctx, &input)
 
+		if errs.IsA[*awstypes.NoSuchEntityException](err) {
+			continue
+		}
+
 		if err != nil {
-			if errs.IsA[*awstypes.NoSuchEntityException](err) {
-				continue
-			}
 			return fmt.Errorf("deactivating IAM User (%s) MFA device (%s): %w", user, v, err)
 		}
 	}
@@ -552,10 +556,11 @@ func deleteUserAccessKeys(ctx context.Context, conn *iam.Client, user string) er
 		}
 		_, err := conn.DeleteAccessKey(ctx, &input)
 
+		if errs.IsA[*awstypes.NoSuchEntityException](err) {
+			continue
+		}
+
 		if err != nil {
-			if errs.IsA[*awstypes.NoSuchEntityException](err) {
-				continue
-			}
 			return fmt.Errorf("deleting IAM User (%s) access key (%s): %w", user, accessKeyID, err)
 		}
 	}
@@ -588,10 +593,11 @@ func deleteUserSigningCertificates(ctx context.Context, conn *iam.Client, user s
 		}
 		_, err := conn.DeleteSigningCertificate(ctx, &input)
 
+		if errs.IsA[*awstypes.NoSuchEntityException](err) {
+			continue
+		}
+
 		if err != nil {
-			if errs.IsA[*awstypes.NoSuchEntityException](err) {
-				continue
-			}
 			return fmt.Errorf("deleting IAM User (%s) signing certificate (%s): %w", user, v, err)
 		}
 	}
@@ -628,10 +634,11 @@ func deleteServiceSpecificCredentials(ctx context.Context, conn *iam.Client, use
 		}
 		_, err := conn.DeleteServiceSpecificCredential(ctx, &input)
 
+		if errs.IsA[*awstypes.NoSuchEntityException](err) {
+			continue
+		}
+
 		if err != nil {
-			if errs.IsA[*awstypes.NoSuchEntityException](err) {
-				continue
-			}
 			return fmt.Errorf("deleting IAM User (%s) service-specific credential (%s): %w", user, v, err)
 		}
 	}
@@ -663,10 +670,11 @@ func deleteUserPolicies(ctx context.Context, conn *iam.Client, user string) erro
 
 		_, err := conn.DeleteUserPolicy(ctx, &input)
 
+		if errs.IsA[*awstypes.NoSuchEntityException](err) {
+			continue
+		}
+
 		if err != nil {
-			if errs.IsA[*awstypes.NoSuchEntityException](err) {
-				continue
-			}
 			return fmt.Errorf("deleting IAM User (%s) policy (%s): %w", user, v, err)
 		}
 	}

--- a/website/docs/r/iam_user.html.markdown
+++ b/website/docs/r/iam_user.html.markdown
@@ -52,7 +52,7 @@ This resource supports the following arguments:
 * `permissions_boundary` - (Optional) The ARN of the policy that is used to set the permissions boundary for the user.
 * `force_destroy` - (Optional, default false) When destroying this user, destroy even if it
   has non-Terraform-managed IAM access keys, login profile or MFA devices. Without `force_destroy`
-  a user with non-Terraform-managed access keys and login profile will fail to be destroyed.
+  a user with non-Terraform-managed access keys and login profile will fail to be destroyed. This only deletes objects when the user is destroyed, not when setting this parameter to true. Once this parameter is set to true, there must be a successful terraform apply run before a destroy is required to update this value in the resource state. Without a successful terraform apply after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the user or destroying the user, this flag will not work. Additionally when importing a user, a successful terraform apply is required to set this value in state before it will take effect on a destroy operation.
 * `tags` - Key-value map of tags for the IAM user. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## Attribute Reference


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Ignore `NoSuchEntityException` after each API call in Delete.
Add eventual consistency retry logic to DeleteUser call to avoid `DeleteConflict` error.
Update documentation around force_destroy to better reflect behavior.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://hashicorp.atlassian.net/browse/IPL-9653

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t T=TestAccIAMUser_ K=iam
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-iam-user-policy-removal 🌿...
TF_ACC=1 go1.26.5 test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMUser_'  -timeout 360m -vet=off
2026/08/03 19:26:06 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/03 19:26:06 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccIAMUser_Identity_basic
=== PAUSE TestAccIAMUser_Identity_basic
=== RUN   TestAccIAMUser_Identity_ExistingResource_basic
=== PAUSE TestAccIAMUser_Identity_ExistingResource_basic
=== RUN   TestAccIAMUser_Identity_ExistingResource_noRefreshNoChange
=== PAUSE TestAccIAMUser_Identity_ExistingResource_noRefreshNoChange
=== RUN   TestAccIAMUser_List_basic
=== PAUSE TestAccIAMUser_List_basic
=== RUN   TestAccIAMUser_List_includeResource
=== PAUSE TestAccIAMUser_List_includeResource
=== RUN   TestAccIAMUser_List_pathPrefix
=== PAUSE TestAccIAMUser_List_pathPrefix
=== RUN   TestAccIAMUser_tags
=== PAUSE TestAccIAMUser_tags
=== RUN   TestAccIAMUser_Tags_null
=== PAUSE TestAccIAMUser_Tags_null
=== RUN   TestAccIAMUser_Tags_emptyMap
=== PAUSE TestAccIAMUser_Tags_emptyMap
=== RUN   TestAccIAMUser_Tags_addOnUpdate
=== PAUSE TestAccIAMUser_Tags_addOnUpdate
=== RUN   TestAccIAMUser_Tags_EmptyTag_onCreate
=== PAUSE TestAccIAMUser_Tags_EmptyTag_onCreate
=== RUN   TestAccIAMUser_Tags_EmptyTag_OnUpdate_add
=== PAUSE TestAccIAMUser_Tags_EmptyTag_OnUpdate_add
=== RUN   TestAccIAMUser_Tags_EmptyTag_OnUpdate_replace
=== PAUSE TestAccIAMUser_Tags_EmptyTag_OnUpdate_replace
=== RUN   TestAccIAMUser_Tags_DefaultTags_providerOnly
=== PAUSE TestAccIAMUser_Tags_DefaultTags_providerOnly
=== RUN   TestAccIAMUser_Tags_DefaultTags_nonOverlapping
=== PAUSE TestAccIAMUser_Tags_DefaultTags_nonOverlapping
=== RUN   TestAccIAMUser_Tags_DefaultTags_overlapping
=== PAUSE TestAccIAMUser_Tags_DefaultTags_overlapping
=== RUN   TestAccIAMUser_Tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccIAMUser_Tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccIAMUser_Tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccIAMUser_Tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccIAMUser_Tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccIAMUser_Tags_DefaultTags_emptyResourceTag
=== RUN   TestAccIAMUser_Tags_DefaultTags_emptyProviderOnlyTag
=== PAUSE TestAccIAMUser_Tags_DefaultTags_emptyProviderOnlyTag
=== RUN   TestAccIAMUser_Tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccIAMUser_Tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccIAMUser_Tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccIAMUser_Tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccIAMUser_Tags_ComputedTag_onCreate
=== PAUSE TestAccIAMUser_Tags_ComputedTag_onCreate
=== RUN   TestAccIAMUser_Tags_ComputedTag_OnUpdate_add
=== PAUSE TestAccIAMUser_Tags_ComputedTag_OnUpdate_add
=== RUN   TestAccIAMUser_Tags_ComputedTag_OnUpdate_replace
=== PAUSE TestAccIAMUser_Tags_ComputedTag_OnUpdate_replace
=== RUN   TestAccIAMUser_Tags_IgnoreTags_Overlap_defaultTag
=== PAUSE TestAccIAMUser_Tags_IgnoreTags_Overlap_defaultTag
=== RUN   TestAccIAMUser_Tags_IgnoreTags_Overlap_resourceTag
=== PAUSE TestAccIAMUser_Tags_IgnoreTags_Overlap_resourceTag
=== RUN   TestAccIAMUser_basic
=== PAUSE TestAccIAMUser_basic
=== RUN   TestAccIAMUser_disappears
=== PAUSE TestAccIAMUser_disappears
=== RUN   TestAccIAMUser_ForceDestroy_accessKey
=== PAUSE TestAccIAMUser_ForceDestroy_accessKey
=== RUN   TestAccIAMUser_ForceDestroy_loginProfile
=== PAUSE TestAccIAMUser_ForceDestroy_loginProfile
=== RUN   TestAccIAMUser_ForceDestroy_mfaDevice
=== PAUSE TestAccIAMUser_ForceDestroy_mfaDevice
=== RUN   TestAccIAMUser_ForceDestroy_sshKey
=== PAUSE TestAccIAMUser_ForceDestroy_sshKey
=== RUN   TestAccIAMUser_ForceDestroy_serviceSpecificCred
=== PAUSE TestAccIAMUser_ForceDestroy_serviceSpecificCred
=== RUN   TestAccIAMUser_ForceDestroy_signingCertificate
=== PAUSE TestAccIAMUser_ForceDestroy_signingCertificate
=== RUN   TestAccIAMUser_ForceDestroy_policyAttached
=== PAUSE TestAccIAMUser_ForceDestroy_policyAttached
=== RUN   TestAccIAMUser_ForceDestroy_policyInline
=== PAUSE TestAccIAMUser_ForceDestroy_policyInline
=== RUN   TestAccIAMUser_ForceDestroy_policyInlineAttached
=== PAUSE TestAccIAMUser_ForceDestroy_policyInlineAttached
=== RUN   TestAccIAMUser_nameChange
=== PAUSE TestAccIAMUser_nameChange
=== RUN   TestAccIAMUser_pathChange
=== PAUSE TestAccIAMUser_pathChange
=== RUN   TestAccIAMUser_permissionsBoundary
=== PAUSE TestAccIAMUser_permissionsBoundary
=== RUN   TestAccIAMUser_nameAndTags
=== PAUSE TestAccIAMUser_nameAndTags
=== CONT  TestAccIAMUser_Identity_basic
=== CONT  TestAccIAMUser_Tags_DefaultTags_nullNonOverlappingResourceTag
=== CONT  TestAccIAMUser_ForceDestroy_loginProfile
=== CONT  TestAccIAMUser_ForceDestroy_accessKey
=== CONT  TestAccIAMUser_ForceDestroy_sshKey
=== CONT  TestAccIAMUser_Tags_ComputedTag_OnUpdate_replace
=== CONT  TestAccIAMUser_basic
=== CONT  TestAccIAMUser_Tags_EmptyTag_OnUpdate_add
=== CONT  TestAccIAMUser_Tags_DefaultTags_nullOverlappingResourceTag
=== CONT  TestAccIAMUser_disappears
=== CONT  TestAccIAMUser_Tags_DefaultTags_emptyProviderOnlyTag
=== CONT  TestAccIAMUser_Tags_DefaultTags_emptyResourceTag
=== CONT  TestAccIAMUser_Tags_DefaultTags_updateToResourceOnly
=== CONT  TestAccIAMUser_Tags_DefaultTags_updateToProviderOnly
=== CONT  TestAccIAMUser_Tags_DefaultTags_overlapping
=== CONT  TestAccIAMUser_Tags_DefaultTags_nonOverlapping
=== CONT  TestAccIAMUser_Tags_DefaultTags_providerOnly
=== CONT  TestAccIAMUser_Tags_EmptyTag_OnUpdate_replace
=== CONT  TestAccIAMUser_Tags_IgnoreTags_Overlap_resourceTag
=== CONT  TestAccIAMUser_ForceDestroy_mfaDevice
--- PASS: TestAccIAMUser_disappears (41.64s)
=== CONT  TestAccIAMUser_Tags_IgnoreTags_Overlap_defaultTag
--- PASS: TestAccIAMUser_basic (48.86s)
=== CONT  TestAccIAMUser_ForceDestroy_policyInlineAttached
--- PASS: TestAccIAMUser_ForceDestroy_loginProfile (51.72s)
=== CONT  TestAccIAMUser_nameAndTags
--- PASS: TestAccIAMUser_ForceDestroy_sshKey (51.73s)
=== CONT  TestAccIAMUser_permissionsBoundary
--- PASS: TestAccIAMUser_ForceDestroy_accessKey (51.74s)
=== CONT  TestAccIAMUser_pathChange
--- PASS: TestAccIAMUser_ForceDestroy_mfaDevice (52.18s)
=== CONT  TestAccIAMUser_nameChange
--- PASS: TestAccIAMUser_Tags_DefaultTags_nullOverlappingResourceTag (55.19s)
=== CONT  TestAccIAMUser_Tags_ComputedTag_OnUpdate_add
--- PASS: TestAccIAMUser_Tags_DefaultTags_emptyProviderOnlyTag (55.43s)
=== CONT  TestAccIAMUser_List_basic
--- PASS: TestAccIAMUser_Tags_DefaultTags_nullNonOverlappingResourceTag (55.52s)
=== CONT  TestAccIAMUser_List_pathPrefix
--- PASS: TestAccIAMUser_Tags_DefaultTags_emptyResourceTag (55.60s)
=== CONT  TestAccIAMUser_List_includeResource
--- PASS: TestAccIAMUser_Identity_basic (69.20s)
=== CONT  TestAccIAMUser_ForceDestroy_policyAttached
--- PASS: TestAccIAMUser_Tags_DefaultTags_updateToResourceOnly (81.72s)
=== CONT  TestAccIAMUser_ForceDestroy_policyInline
--- PASS: TestAccIAMUser_Tags_DefaultTags_updateToProviderOnly (86.48s)
=== CONT  TestAccIAMUser_ForceDestroy_signingCertificate
--- PASS: TestAccIAMUser_Tags_EmptyTag_OnUpdate_replace (86.49s)
=== CONT  TestAccIAMUser_Tags_ComputedTag_onCreate
--- PASS: TestAccIAMUser_ForceDestroy_policyInlineAttached (40.40s)
=== CONT  TestAccIAMUser_Identity_ExistingResource_noRefreshNoChange
--- PASS: TestAccIAMUser_Tags_ComputedTag_OnUpdate_replace (90.63s)
=== CONT  TestAccIAMUser_ForceDestroy_serviceSpecificCred
=== NAME  TestAccIAMUser_List_includeResource
    user_list_test.go:91: Step 2/2 error running query checks: running terraform query command returned diagnostics: [{baseLogMessage:{Lvl:error Msg:Error: Error Listing Tags Time:2026-08-03 19:27:41.302498 +0530 IST} Diagnostic:{Severity:error Address:list.aws_iam_user.test Summary:Error Listing Tags Detail:An error occurred while listing tags for iam: listing tags for resource (tf-acc-test-3621033621371255763): operation error IAM: ListUserTags, https response error StatusCode: 404, RequestID: cf87f534-f9ae-409f-b6c5-f38bc9766181, NoSuchEntity: The user with name tf-acc-test-3621033621371255763 cannot be found. Range:0x2c0978781c0 Snippet:0x2c09bf648c0}}]
--- PASS: TestAccIAMUser_List_basic (42.53s)
=== CONT  TestAccIAMUser_Identity_ExistingResource_basic
--- PASS: TestAccIAMUser_List_pathPrefix (43.97s)
=== CONT  TestAccIAMUser_tags
--- FAIL: TestAccIAMUser_List_includeResource (48.68s)
=== CONT  TestAccIAMUser_Tags_emptyMap
--- PASS: TestAccIAMUser_ForceDestroy_policyAttached (36.43s)
=== CONT  TestAccIAMUser_Tags_null
=== NAME  TestAccIAMUser_Identity_ExistingResource_basic
    user_identity_gen_test.go:117: Step 1/2 error: Post-apply refresh state check(s) failed:
        aws_iam_user.test - Identity found in state, and was not expected.
=== NAME  TestAccIAMUser_Identity_ExistingResource_noRefreshNoChange
    user_identity_gen_test.go:174: Step 1/2 error: Post-apply refresh state check(s) failed:
        aws_iam_user.test - Identity found in state, and was not expected.
--- PASS: TestAccIAMUser_Tags_IgnoreTags_Overlap_resourceTag (118.76s)
=== CONT  TestAccIAMUser_Tags_EmptyTag_onCreate
--- PASS: TestAccIAMUser_ForceDestroy_policyInline (38.10s)
=== CONT  TestAccIAMUser_Tags_addOnUpdate
--- PASS: TestAccIAMUser_Tags_EmptyTag_OnUpdate_add (120.81s)
--- PASS: TestAccIAMUser_nameAndTags (73.01s)
--- FAIL: TestAccIAMUser_Identity_ExistingResource_basic (27.32s)
--- FAIL: TestAccIAMUser_Identity_ExistingResource_noRefreshNoChange (36.12s)
--- PASS: TestAccIAMUser_ForceDestroy_signingCertificate (45.25s)
--- PASS: TestAccIAMUser_pathChange (81.16s)
--- PASS: TestAccIAMUser_Tags_ComputedTag_onCreate (47.30s)
--- PASS: TestAccIAMUser_nameChange (81.66s)
--- PASS: TestAccIAMUser_Tags_ComputedTag_OnUpdate_add (79.94s)
--- PASS: TestAccIAMUser_Tags_DefaultTags_nonOverlapping (135.75s)
--- PASS: TestAccIAMUser_Tags_IgnoreTags_Overlap_defaultTag (94.60s)
--- PASS: TestAccIAMUser_ForceDestroy_serviceSpecificCred (45.81s)
--- PASS: TestAccIAMUser_Tags_DefaultTags_overlapping (138.32s)
--- PASS: TestAccIAMUser_Tags_emptyMap (50.64s)
--- PASS: TestAccIAMUser_Tags_null (51.21s)
--- PASS: TestAccIAMUser_Tags_DefaultTags_providerOnly (157.98s)
--- PASS: TestAccIAMUser_Tags_addOnUpdate (46.41s)
--- PASS: TestAccIAMUser_Tags_EmptyTag_onCreate (51.63s)
--- PASS: TestAccIAMUser_permissionsBoundary (137.92s)
--- PASS: TestAccIAMUser_tags (100.30s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/iam        204.906s
FAIL

% make t T=TestAccIAMUser_Identity_ K=iam
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-iam-user-policy-removal 🌿...
TF_ACC=1 go1.26.5 test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMUser_Identity_'  -timeout 360m -vet=off
2026/08/03 19:30:55 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/03 19:30:55 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccIAMUser_Identity_basic
=== PAUSE TestAccIAMUser_Identity_basic
=== RUN   TestAccIAMUser_Identity_ExistingResource_basic
=== PAUSE TestAccIAMUser_Identity_ExistingResource_basic
=== RUN   TestAccIAMUser_Identity_ExistingResource_noRefreshNoChange
=== PAUSE TestAccIAMUser_Identity_ExistingResource_noRefreshNoChange
=== CONT  TestAccIAMUser_Identity_basic
=== CONT  TestAccIAMUser_Identity_ExistingResource_noRefreshNoChange
=== CONT  TestAccIAMUser_Identity_ExistingResource_basic
--- PASS: TestAccIAMUser_Identity_basic (35.51s)
--- PASS: TestAccIAMUser_Identity_ExistingResource_noRefreshNoChange (55.65s)
--- PASS: TestAccIAMUser_Identity_ExistingResource_basic (56.72s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/iam        61.800s

% make t T=TestAccIAMUser_List_includeResource K=iam
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-iam-user-policy-removal 🌿...
TF_ACC=1 go1.26.5 test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMUser_List_includeResource'  -timeout 360m -vet=off
2026/08/03 19:46:50 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/03 19:46:50 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccIAMUser_List_includeResource
=== PAUSE TestAccIAMUser_List_includeResource
=== CONT  TestAccIAMUser_List_includeResource
--- PASS: TestAccIAMUser_List_includeResource (26.60s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/iam        31.658s
```
