### PR TITLE
r/aws_bedrockagentcore_oauth2_credential_provider: add client_authentication_method to custom_oauth2_provider_config

### DIFF
--- a/.changelog/49261.txt
+++ b/.changelog/49261.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_bedrockagentcore_oauth2_credential_provider: Add `client_authentication_method` argument to `custom_oauth2_provider_config`
+```

--- a/internal/service/bedrockagentcore/oauth2_credential_provider.go
+++ b/internal/service/bedrockagentcore/oauth2_credential_provider.go
@@ -126,6 +126,15 @@ func oauth2ClientCredentialsAttributes(context.Context) map[string]schema.Attrib
 	}
 }
 
+func customOAuth2ProviderConfigAttributes(ctx context.Context) map[string]schema.Attribute {
+	attrs := oauth2ClientCredentialsAttributes(ctx)
+	attrs["client_authentication_method"] = schema.StringAttribute{
+		CustomType: fwtypes.StringEnumType[awstypes.ClientAuthenticationMethodType](),
+		Optional:   true,
+	}
+	return attrs
+}
+
 func basicOAuth2ProviderConfigBlock[T any](ctx context.Context) schema.ListNestedBlock {
 	attrs := oauth2ClientCredentialsAttributes(ctx)
 	attrs["oauth_discovery"] = framework.ResourceComputedListOfObjectsAttribute[oauth2DiscoveryModel](ctx)
@@ -181,7 +190,7 @@ func (r *oauth2CredentialProviderResource) Schema(ctx context.Context, request r
 								listvalidator.SizeAtMost(1),
 							},
 							NestedObject: schema.NestedBlockObject{
-								Attributes: oauth2ClientCredentialsAttributes(ctx),
+								Attributes: customOAuth2ProviderConfigAttributes(ctx),
 								Blocks: map[string]schema.Block{
 									"oauth_discovery": schema.ListNestedBlock{
 										CustomType: fwtypes.NewListNestedObjectTypeOf[oauth2DiscoveryModel](ctx),
@@ -745,7 +754,8 @@ type oauth2DiscoveryModel struct {
 
 type customOAuth2ProviderConfigModel struct {
 	oauth2ClientCredentialsModel
-	OAuthDiscovery fwtypes.ListNestedObjectValueOf[oauth2DiscoveryModel] `tfsdk:"oauth_discovery"`
+	ClientAuthenticationMethod fwtypes.StringEnum[awstypes.ClientAuthenticationMethodType] `tfsdk:"client_authentication_method"`
+	OAuthDiscovery             fwtypes.ListNestedObjectValueOf[oauth2DiscoveryModel]       `tfsdk:"oauth_discovery"`
 }
 
 type githubOAuth2ProviderConfigModel struct {

--- a/internal/service/bedrockagentcore/oauth2_credential_provider_test.go
+++ b/internal/service/bedrockagentcore/oauth2_credential_provider_test.go
@@ -161,6 +161,60 @@ func TestAccBedrockAgentCoreOAuth2CredentialProvider_customDiscoveryURL(t *testi
 	})
 }
 
+func TestAccBedrockAgentCoreOAuth2CredentialProvider_customClientAuthenticationMethod(t *testing.T) {
+	ctx := acctest.Context(t)
+	var oauth2credentialprovider bedrockagentcorecontrol.GetOauth2CredentialProviderOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_bedrockagentcore_oauth2_credential_provider.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID)
+			testAccPreCheckOAuth2CredentialProviders(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockAgentCoreServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckOAuth2CredentialProviderDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOAuth2CredentialProviderConfig_customWithClientAuthenticationMethod(rName, "auth0-client-id", "auth0-client-secret", 1, "https://dev-example.auth0.com/.well-known/openid-configuration", "CLIENT_SECRET_POST"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckOAuth2CredentialProviderExists(ctx, t, resourceName, &oauth2credentialprovider),
+					resource.TestCheckResourceAttr(resourceName, "oauth2_provider_config.0.custom_oauth2_provider_config.0.client_authentication_method", "CLIENT_SECRET_POST"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, names.AttrName),
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: names.AttrName,
+				ImportStateVerifyIgnore: []string{
+					"oauth2_provider_config.0.custom_oauth2_provider_config.0.client_credentials_wo_version",
+				},
+			},
+			{
+				Config: testAccOAuth2CredentialProviderConfig_customWithClientAuthenticationMethod(rName, "auth0-client-id", "auth0-client-secret", 1, "https://dev-example.auth0.com/.well-known/openid-configuration", "CLIENT_SECRET_BASIC"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckOAuth2CredentialProviderExists(ctx, t, resourceName, &oauth2credentialprovider),
+					resource.TestCheckResourceAttr(resourceName, "oauth2_provider_config.0.custom_oauth2_provider_config.0.client_authentication_method", "CLIENT_SECRET_BASIC"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+		},
+	})
+}
+
 func TestAccBedrockAgentCoreOAuth2CredentialProvider_authorizationServerMetadata(t *testing.T) {
 	ctx := acctest.Context(t)
 	var oauth2credentialprovider bedrockagentcorecontrol.GetOauth2CredentialProviderOutput
@@ -418,6 +472,28 @@ resource "aws_bedrockagentcore_oauth2_credential_provider" "test" {
   }
 }
 `, rName, clientId, clientSecret, version, discoveryURL)
+}
+
+func testAccOAuth2CredentialProviderConfig_customWithClientAuthenticationMethod(rName, clientId, clientSecret string, version int, discoveryURL, clientAuthenticationMethod string) string {
+	return fmt.Sprintf(`
+resource "aws_bedrockagentcore_oauth2_credential_provider" "test" {
+  name = %[1]q
+
+  credential_provider_vendor = "CustomOauth2"
+  oauth2_provider_config {
+    custom_oauth2_provider_config {
+      client_id_wo                  = %[2]q
+      client_secret_wo              = %[3]q
+      client_credentials_wo_version = %[4]d
+      client_authentication_method  = %[6]q
+
+      oauth_discovery {
+        discovery_url = %[5]q
+      }
+    }
+  }
+}
+`, rName, clientId, clientSecret, version, discoveryURL, clientAuthenticationMethod)
 }
 
 func testAccOAuth2CredentialProviderConfig_customWithAuthServerMetadata(rName, clientId, clientSecret string, version int, issuer, authEndpoint, tokenEndpoint, responseType1, responseType2 string) string {

--- a/website/docs/r/bedrockagentcore_oauth2_credential_provider.html.markdown
+++ b/website/docs/r/bedrockagentcore_oauth2_credential_provider.html.markdown
@@ -120,6 +120,10 @@ The `custom_oauth2_provider_config` block supports the following:
 
 * `oauth_discovery` - (Optional) OAuth discovery configuration. See [`oauth_discovery`](#oauth_discovery) below.
 
+**Other:**
+
+* `client_authentication_method` - (Optional) Client authentication method to use when authenticating with the token endpoint. Valid values: `CLIENT_SECRET_BASIC`, `CLIENT_SECRET_POST`, `AWS_IAM_ID_TOKEN_JWT`.
+
 ### `github`, `google`, `microsoft`, `salesforce`, `slack`
 
 These predefined provider blocks support the following:


### PR DESCRIPTION
## Summary

Closes #49082. `custom_oauth2_provider_config` didn't expose `client_authentication_method`, even though the underlying `CustomOauth2ProviderConfigInput`/`CustomOauth2ProviderConfigOutput` API types support it (valid values per the SDK: `CLIENT_SECRET_BASIC`, `CLIENT_SECRET_POST`, `AWS_IAM_ID_TOKEN_JWT`).

Without this attribute there's no way to work around AgentCore Identity's PKCE issue (sends `code_challenge` during authorization but not `code_verifier` during token exchange) for providers that advertise `code_challenge_methods_supported` -- the only workaround was an out-of-band `UpdateOauth2CredentialProvider` SDK call plus `lifecycle { ignore_changes = all }`.

This attribute is specific to `CustomOauth2ProviderConfigInput`/`Output` -- the other vendor configs (github/google/microsoft/salesforce/slack) don't have it in the SDK -- so it's added via a small `customOAuth2ProviderConfigAttributes` wrapper alongside the shared `oauth2ClientCredentialsAttributes`, rather than into the shared function itself. Expand/flatten both go through AutoFlex automatically since the field name matches the SDK struct field.

## Test plan

- [x] `go build ./internal/service/bedrockagentcore/...`
- [x] `go vet ./internal/service/bedrockagentcore/...`
- [x] `go test ./internal/service/bedrockagentcore/...` (offline unit tests)
- [ ] `TestAccBedrockAgentCoreOAuth2CredentialProvider_customClientAuthenticationMethod` (new, added in this PR: create with `CLIENT_SECRET_POST`, import, update to `CLIENT_SECRET_BASIC`) -- not run locally, requires AWS credentials with Bedrock AgentCore access