### PR TITLE
r/aws_opensearch_application: add acceptance test for app_config with users and groups together

### DIFF
--- a/internal/service/opensearch/application_test.go
+++ b/internal/service/opensearch/application_test.go
@@ -245,6 +245,63 @@ func TestAccOpenSearchApplication_appConfigMultiple(t *testing.T) {
 	})
 }
 
+func TestAccOpenSearchApplication_appConfigAddGroups(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var application opensearch.GetApplicationOutput
+	rName := acctest.RandomWithPrefix(t, "tf-acc-test")[:30]
+	resourceName := "aws_opensearch_application.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.OpenSearchServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckApplicationDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				// Start with only "users" configured.
+				Config: testAccApplicationConfig_appConfig1(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckApplicationExists(ctx, t, resourceName, &application),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+			},
+			{
+				// Add "groups" alongside the existing "users" via update -- the
+				// literal scenario reported in #49240. Must converge like any
+				// other update: no perpetual diff on the next plan.
+				Config: testAccApplicationConfig_appConfigMultiple(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckApplicationExists(ctx, t, resourceName, &application),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "app_config.*", map[string]string{
+						names.AttrKey:   "opensearchDashboards.dashboardAdmin.users",
+						names.AttrValue: "admin-user",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "app_config.*", map[string]string{
+						names.AttrKey:   "opensearchDashboards.dashboardAdmin.groups",
+						names.AttrValue: "admin-group",
+					}),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+		},
+	})
+}
+
 func TestAccOpenSearchApplication_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {

--- a/internal/service/opensearch/application_test.go
+++ b/internal/service/opensearch/application_test.go
@@ -195,6 +195,56 @@ func TestAccOpenSearchApplication_appConfig(t *testing.T) {
 	})
 }
 
+func TestAccOpenSearchApplication_appConfigMultiple(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var application opensearch.GetApplicationOutput
+	rName := acctest.RandomWithPrefix(t, "tf-acc-test")[:30]
+	resourceName := "aws_opensearch_application.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.OpenSearchServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckApplicationDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				// Both a "users" and a "groups" app_config together: creating the
+				// second must not prevent the first from converging, and neither
+				// should show a perpetual diff on the next plan.
+				Config: testAccApplicationConfig_appConfigMultiple(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckApplicationExists(ctx, t, resourceName, &application),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "app_config.*", map[string]string{
+						names.AttrKey:   "opensearchDashboards.dashboardAdmin.users",
+						names.AttrValue: "admin-user",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "app_config.*", map[string]string{
+						names.AttrKey:   "opensearchDashboards.dashboardAdmin.groups",
+						names.AttrValue: "admin-group",
+					}),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccOpenSearchApplication_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
@@ -346,6 +396,24 @@ func testAccApplicationConfig_appConfig2(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_opensearch_application" "test" {
   name = %[1]q
+
+  app_config {
+    key   = "opensearchDashboards.dashboardAdmin.groups"
+    value = "admin-group"
+  }
+}
+`, rName)
+}
+
+func testAccApplicationConfig_appConfigMultiple(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_opensearch_application" "test" {
+  name = %[1]q
+
+  app_config {
+    key   = "opensearchDashboards.dashboardAdmin.users"
+    value = "admin-user"
+  }
 
   app_config {
     key   = "opensearchDashboards.dashboardAdmin.groups"


### PR DESCRIPTION
## Summary

Relates to #49240, which reports that adding a `groups` `app_config` block alongside an existing `users` block produces a perpetual plan diff -- the apply reports success, but the `groups` entry is proposed again on every subsequent plan, and doesn't appear to take effect in the AWS console either.

I went through `internal/service/opensearch/application.go` looking for a provider-side cause and didn't find one: `app_config` is a plain `SetNestedBlock` with no custom Expand/Flatten (fully generic AutoFlex, `Key`/`Value` map directly to the SDK's `AppConfig` struct), and `Update`'s pattern of setting state from `plan` rather than re-flattening the API response is the standard convention across this codebase (confirmed against `bedrockagentcore/gateway.go` as a second example), not something unique to this resource.

What I did find is a real test-coverage gap: the existing `TestAccOpenSearchApplication_appConfig` test only ever configures one `app_config` block at a time (`users` alone, then replaced entirely by `groups`) -- never both together. This PR adds two tests to close that gap:

* `TestAccOpenSearchApplication_appConfigMultiple` -- configures `users` and `groups` together at create time.
* `TestAccOpenSearchApplication_appConfigAddGroups` -- starts from a `users`-only application and updates it to add `groups`, matching the literal scenario described in #49240 more closely (the issue reads as adding `groups` to an already-existing configuration, i.e. an update, not necessarily a fresh create with both declared from the start). AWS APIs can behave differently for "specify at creation" versus "add via update", so covering only the create path risked a false "all clear" if the bug is update-path-specific.

The acceptance test framework's standard post-apply plan check will surface a perpetual diff automatically in either test if the bug reproduces, which should help confirm (or rule out) whether this is a provider bug versus an AWS API-side behavior for the `groups` `AppConfigType` specifically.

Test-only change, no production code modified.

## Test plan

- [x] `go build ./internal/service/opensearch/...`
- [x] `go vet ./internal/service/opensearch/...`
- [x] `go test ./internal/service/opensearch/...` (offline unit tests)
- [ ] `TestAccOpenSearchApplication_appConfigMultiple`, `TestAccOpenSearchApplication_appConfigAddGroups` (new, added in this PR) -- not run locally, requires AWS credentials with OpenSearch access