### PR TITLE
d/aws_servicecatalog_portfolio: add name argument as an alternative to id

### DIFF
--- a/.changelog/49278.txt
+++ b/.changelog/49278.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data-source/aws_servicecatalog_portfolio: Add `name` argument as an alternative to `id`
+```

--- a/internal/service/servicecatalog/find.go
+++ b/internal/service/servicecatalog/find.go
@@ -102,6 +102,49 @@ func findProductPortfolioAssociations(ctx context.Context, conn *servicecatalog.
 	return result, nil
 }
 
+func findPortfolioByName(ctx context.Context, conn *servicecatalog.Client, acceptLanguage, name string) (*awstypes.PortfolioDetail, error) {
+	output, err := findPortfoliosByName(ctx, conn, acceptLanguage, name)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return tfresource.AssertSingleValueResult(output)
+}
+
+func findPortfoliosByName(ctx context.Context, conn *servicecatalog.Client, acceptLanguage, name string) ([]awstypes.PortfolioDetail, error) {
+	input := &servicecatalog.ListPortfoliosInput{}
+
+	if acceptLanguage != "" {
+		input.AcceptLanguage = aws.String(acceptLanguage)
+	}
+
+	var result []awstypes.PortfolioDetail
+
+	pages := servicecatalog.NewListPortfoliosPaginator(conn, input)
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
+
+		if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+			return nil, &retry.NotFoundError{
+				LastError: err,
+			}
+		}
+
+		if err != nil {
+			return nil, err
+		}
+
+		for _, detail := range page.PortfolioDetails {
+			if aws.ToString(detail.DisplayName) == name {
+				result = append(result, detail)
+			}
+		}
+	}
+
+	return result, nil
+}
+
 func findBudgetResourceAssociation(ctx context.Context, conn *servicecatalog.Client, budgetName, resourceID string) (*awstypes.BudgetDetail, error) {
 	output, err := findBudgetResourceAssociations(ctx, conn, budgetName, resourceID)
 

--- a/internal/service/servicecatalog/find.go
+++ b/internal/service/servicecatalog/find.go
@@ -125,6 +125,9 @@ func findPortfoliosByName(ctx context.Context, conn *servicecatalog.Client, acce
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
 
+		// ListPortfolios does not document ResourceNotFoundException; kept for
+		// consistency with the paginate-and-filter pattern used elsewhere in
+		// this file (e.g. findProductPortfolioAssociations).
 		if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 			return nil, &retry.NotFoundError{
 				LastError: err,

--- a/internal/service/servicecatalog/portfolio_data_source.go
+++ b/internal/service/servicecatalog/portfolio_data_source.go
@@ -53,12 +53,16 @@ func dataSourcePortfolio() *schema.Resource {
 					Computed: true,
 				},
 				names.AttrID: {
-					Type:     schema.TypeString,
-					Required: true,
+					Type:         schema.TypeString,
+					Optional:     true,
+					Computed:     true,
+					ExactlyOneOf: []string{names.AttrID, names.AttrName},
 				},
 				names.AttrName: {
-					Type:     schema.TypeString,
-					Computed: true,
+					Type:         schema.TypeString,
+					Optional:     true,
+					Computed:     true,
+					ExactlyOneOf: []string{names.AttrID, names.AttrName},
 				},
 				names.AttrProviderName: {
 					Type:     schema.TypeString,
@@ -74,22 +78,38 @@ func dataSourcePortfolioRead(ctx context.Context, d *schema.ResourceData, meta a
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ServiceCatalogClient(ctx)
 
-	input := &servicecatalog.DescribePortfolioInput{
-		Id: aws.String(d.Get(names.AttrID).(string)),
+	acceptLanguage := d.Get("accept_language").(string)
+
+	id := d.Get(names.AttrID).(string)
+
+	if id == "" {
+		name := d.Get(names.AttrName).(string)
+
+		portfolio, err := findPortfolioByName(ctx, conn, acceptLanguage, name)
+
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "reading Service Catalog Portfolio (%s): %s", name, err)
+		}
+
+		id = aws.ToString(portfolio.Id)
 	}
 
-	if v, ok := d.GetOk("accept_language"); ok {
-		input.AcceptLanguage = aws.String(v.(string))
+	input := &servicecatalog.DescribePortfolioInput{
+		Id: aws.String(id),
+	}
+
+	if acceptLanguage != "" {
+		input.AcceptLanguage = aws.String(acceptLanguage)
 	}
 
 	output, err := conn.DescribePortfolio(ctx, input)
 
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "getting Service Catalog Portfolio (%s): %s", d.Get(names.AttrID).(string), err)
+		return sdkdiag.AppendErrorf(diags, "getting Service Catalog Portfolio (%s): %s", id, err)
 	}
 
 	if output == nil || output.PortfolioDetail == nil {
-		return sdkdiag.AppendErrorf(diags, "getting Service Catalog Portfolio (%s): empty response", d.Get(names.AttrID).(string))
+		return sdkdiag.AppendErrorf(diags, "getting Service Catalog Portfolio (%s): empty response", id)
 	}
 
 	detail := output.PortfolioDetail

--- a/internal/service/servicecatalog/portfolio_data_source_test.go
+++ b/internal/service/servicecatalog/portfolio_data_source_test.go
@@ -43,10 +43,44 @@ func TestAccServiceCatalogPortfolioDataSource_basic(t *testing.T) {
 	})
 }
 
+func TestAccServiceCatalogPortfolioDataSource_name(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	dataSourceName := "data.aws_servicecatalog_portfolio.test"
+	resourceName := "aws_servicecatalog_portfolio.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckPortfolioDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPortfolioDataSourceConfig_name(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrID, dataSourceName, names.AttrID),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrARN, dataSourceName, names.AttrARN),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrCreatedTime, dataSourceName, names.AttrCreatedTime),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrDescription, dataSourceName, names.AttrDescription),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrProviderName, dataSourceName, names.AttrProviderName),
+				),
+			},
+		},
+	})
+}
+
 func testAccPortfolioDataSourceConfig_basic(rName string) string {
 	return acctest.ConfigCompose(testAccPortfolioConfig_basic(rName), `
 data "aws_servicecatalog_portfolio" "test" {
   id = aws_servicecatalog_portfolio.test.id
+}
+`)
+}
+
+func testAccPortfolioDataSourceConfig_name(rName string) string {
+	return acctest.ConfigCompose(testAccPortfolioConfig_basic(rName), `
+data "aws_servicecatalog_portfolio" "test" {
+  name = aws_servicecatalog_portfolio.test.name
 }
 `)
 }

--- a/website/docs/d/servicecatalog_portfolio.html.markdown
+++ b/website/docs/d/servicecatalog_portfolio.html.markdown
@@ -18,14 +18,20 @@ data "aws_servicecatalog_portfolio" "portfolio" {
 }
 ```
 
+```terraform
+data "aws_servicecatalog_portfolio" "portfolio" {
+  name = "example-portfolio"
+}
+```
+
 ## Argument Reference
 
-The following arguments are required:
-
-* `id` - (Required) Portfolio identifier.
+Exactly one of `id` or `name` must be specified.
 
 The following arguments are optional:
 
+* `id` - (Optional) Portfolio identifier.
+* `name` - (Optional) Portfolio name. Returns an error if more than one portfolio matches the given name.
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `accept_language` - (Optional) Language code. Valid values: `en` (English), `jp` (Japanese), `zh` (Chinese). Default value is `en`.
 
@@ -36,7 +42,6 @@ This data source exports the following attributes in addition to the arguments a
 * `arn` - Portfolio ARN.
 * `created_time` - Time the portfolio was created.
 * `description` - Description of the portfolio
-* `name` - Portfolio name.
 * `provider_name` - Name of the person or organization who owns the portfolio.
 * `tags` - Tags applied to the portfolio.
 


### PR DESCRIPTION
## Summary

Closes #49258. The `aws_servicecatalog_portfolio` data source required `id` for lookup, even though `id` is only unique within a single account and `name` (`DisplayName`) is what's actually known and referenced in most workflows -- e.g. associating a portfolio with a product or an IAM principal by name. A prior issue requesting this (#20719) was closed without action.

`ListPortfolios` has no server-side name filter (confirmed against the API model), so the `name` lookup path paginates through `ListPortfolios` and filters client-side on `DisplayName`, following the exact same paginate-and-filter pattern already used in this package for `findProductPortfolioAssociations` in `find.go`. It errors if more than one portfolio matches the given name (via the existing `tfresource.AssertSingleValueResult` helper), since `DisplayName` isn't guaranteed unique. Once resolved to an `id`, the rest of the read path (`DescribePortfolio`) is unchanged.

`id` changes from `Required` to `Optional`+`Computed`, `name` from `Computed`-only to `Optional`+`Computed`, with `ExactlyOneOf` enforcing exactly one is set.

## Test plan

- [x] `go build ./internal/service/servicecatalog/...`
- [x] `go vet ./internal/service/servicecatalog/...`
- [x] `go test ./internal/service/servicecatalog/...` (offline unit tests)
- [ ] `TestAccServiceCatalogPortfolioDataSource_name` (new, added in this PR) -- not run locally, requires AWS credentials with Service Catalog access