### PR TITLE
r/glue_catalog_table_optimizer: add validation

### DIFF
--- a/internal/service/glue/catalog_table_optimizer.go
+++ b/internal/service/glue/catalog_table_optimizer.go
@@ -182,8 +182,9 @@ func (r *catalogTableOptimizerResource) Schema(ctx context.Context, _ resource.S
 										NestedObject: schema.NestedBlockObject{
 											Attributes: map[string]schema.Attribute{
 												"strategy": schema.StringAttribute{
-													Optional: true,
-													Computed: true,
+													CustomType: fwtypes.StringEnumType[awstypes.CompactionStrategy](),
+													Optional:   true,
+													Computed:   true,
 													PlanModifiers: []planmodifier.String{
 														stringplanmodifier.UseStateForUnknown(),
 													},
@@ -276,7 +277,7 @@ func (r *catalogTableOptimizerResource) Create(ctx context.Context, request reso
 		return
 	}
 
-	plan.flatten(ctx, output.TableOptimizer, response.Diagnostics)
+	plan.flatten(ctx, output.TableOptimizer, &response.Diagnostics)
 	if response.Diagnostics.HasError() {
 		return
 	}
@@ -317,7 +318,7 @@ func (r *catalogTableOptimizerResource) Read(ctx context.Context, request resour
 		return
 	}
 
-	data.flatten(ctx, output.TableOptimizer, response.Diagnostics)
+	data.flatten(ctx, output.TableOptimizer, &response.Diagnostics)
 	if response.Diagnostics.HasError() {
 		return
 	}
@@ -376,7 +377,7 @@ func (r *catalogTableOptimizerResource) Update(ctx context.Context, request reso
 			return
 		}
 
-		plan.flatten(ctx, output.TableOptimizer, response.Diagnostics)
+		plan.flatten(ctx, output.TableOptimizer, &response.Diagnostics)
 		if response.Diagnostics.HasError() {
 			return
 		}
@@ -446,7 +447,7 @@ func (r *catalogTableOptimizerResource) ImportState(ctx context.Context, request
 	response.Diagnostics.Append(response.State.SetAttribute(ctx, path.Root(names.AttrType), parts[3])...)
 }
 
-func (c *catalogTableOptimizerResourceModel) flatten(ctx context.Context, data *awstypes.TableOptimizer, diags diag.Diagnostics) {
+func (c *catalogTableOptimizerResourceModel) flatten(ctx context.Context, data *awstypes.TableOptimizer, diags *diag.Diagnostics) {
 	configuration, d := c.Configuration.ToPtr(ctx)
 	diags.Append(d...)
 	if diags.HasError() {
@@ -478,11 +479,11 @@ type catalogTableOptimizerResourceModel struct {
 }
 
 type configurationData struct {
+	CompactionConfiguration         fwtypes.ListNestedObjectValueOf[compactionConfigurationData]         `tfsdk:"compaction_configuration"`
 	Enabled                         types.Bool                                                           `tfsdk:"enabled"`
 	RoleARN                         fwtypes.ARN                                                          `tfsdk:"role_arn"`
 	RetentionConfiguration          fwtypes.ListNestedObjectValueOf[retentionConfigurationData]          `tfsdk:"retention_configuration"`
 	OrphanFileDeletionConfiguration fwtypes.ListNestedObjectValueOf[orphanFileDeletionConfigurationData] `tfsdk:"orphan_file_deletion_configuration"`
-	CompactionConfiguration         fwtypes.ListNestedObjectValueOf[compactionConfigurationData]         `tfsdk:"compaction_configuration"`
 }
 
 type retentionConfigurationData struct {
@@ -511,9 +512,9 @@ type compactionConfigurationData struct {
 }
 
 type icebergCompactionConfigurationData struct {
-	Strategy            types.String `tfsdk:"strategy"`
-	MinInputFiles       types.Int32  `tfsdk:"min_input_files"`
-	DeleteFileThreshold types.Int32  `tfsdk:"delete_file_threshold"`
+	DeleteFileThreshold types.Int32                                     `tfsdk:"delete_file_threshold"`
+	MinInputFiles       types.Int32                                     `tfsdk:"min_input_files"`
+	Strategy            fwtypes.StringEnum[awstypes.CompactionStrategy] `tfsdk:"strategy"`
 }
 
 func findCatalogTableOptimizer(ctx context.Context, conn *glue.Client, catalogID, dbName, tableName, optimizerType string) (*glue.GetTableOptimizerOutput, error) {


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

Relates #43868

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=glue TESTARGS='-run=TestAccGlue_serial/CatalogTableOptimizer/'

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework (cached)
make: Running acceptance tests on branch: 🌿 main 🌿...
TF_ACC=1 go1.26.5 test ./internal/service/glue/... -v -count 1 -parallel 20  -run=TestAccGlue_serial/CatalogTableOptimizer/ -timeout 360m -vet=off -buildvcs=false
2026/08/04 12:46:28 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/04 12:46:28 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccGlue_serial
=== PAUSE TestAccGlue_serial
=== CONT  TestAccGlue_serial
=== RUN   TestAccGlue_serial/CatalogTableOptimizer
=== RUN   TestAccGlue_serial/CatalogTableOptimizer/basic
=== RUN   TestAccGlue_serial/CatalogTableOptimizer/compactionConfiguration
=== RUN   TestAccGlue_serial/CatalogTableOptimizer/deleteOrphanFileConfiguration
=== RUN   TestAccGlue_serial/CatalogTableOptimizer/deleteOrphanFileConfigurationWithRunRateInHours
=== RUN   TestAccGlue_serial/CatalogTableOptimizer/disappears
=== RUN   TestAccGlue_serial/CatalogTableOptimizer/retentionConfiguration
=== RUN   TestAccGlue_serial/CatalogTableOptimizer/retentionConfigurationWithRunRateInHours
=== RUN   TestAccGlue_serial/CatalogTableOptimizer/update
=== PAUSE TestAccGlue_serial/CatalogTableOptimizer/update
=== CONT  TestAccGlue_serial/CatalogTableOptimizer/update
--- PASS: TestAccGlue_serial (357.49s)
    --- PASS: TestAccGlue_serial/CatalogTableOptimizer (311.71s)
        --- PASS: TestAccGlue_serial/CatalogTableOptimizer/basic (36.10s)
        --- PASS: TestAccGlue_serial/CatalogTableOptimizer/compactionConfiguration (34.32s)
        --- PASS: TestAccGlue_serial/CatalogTableOptimizer/deleteOrphanFileConfiguration (49.51s)
        --- PASS: TestAccGlue_serial/CatalogTableOptimizer/deleteOrphanFileConfigurationWithRunRateInHours (50.15s)
        --- PASS: TestAccGlue_serial/CatalogTableOptimizer/disappears (32.63s)
        --- PASS: TestAccGlue_serial/CatalogTableOptimizer/retentionConfiguration (59.06s)
        --- PASS: TestAccGlue_serial/CatalogTableOptimizer/retentionConfigurationWithRunRateInHours (49.95s)
        --- PASS: TestAccGlue_serial/CatalogTableOptimizer/update (45.77s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/glue       365.905s
```
