### PR TITLE
AutoFlex: Allow ignoring unhandled custom Flatteners

### DIFF
--- a/internal/framework/flex/autoflex_dispatch_test.go
+++ b/internal/framework/flex/autoflex_dispatch_test.go
@@ -1373,6 +1373,19 @@ func TestFlattenInterface(t *testing.T) {
 				}),
 			},
 		},
+		"single unmapped interface Source and list Target": {
+			Source: awsInterfaceSingle{
+				Field1: &awsInterfaceInterfaceUnmappedImpl{
+					Value: awsInterfaceInterfaceUnmappedImplValue{
+						UnmappedField1: "value1",
+					},
+				},
+			},
+			Target: &tfListNestedObject[tfInterfaceFlexer]{},
+			WantTarget: &tfListNestedObject[tfInterfaceFlexer]{
+				Field1: fwtypes.NewListNestedObjectValueOfNull[tfInterfaceFlexer](ctx),
+			},
+		},
 		"nil interface Source and non-Flattener list Target": {
 			Source: awsInterfaceSingle{
 				Field1: nil,
@@ -1424,6 +1437,19 @@ func TestFlattenInterface(t *testing.T) {
 						}),
 					},
 				}),
+			},
+		},
+		"single unmapped interface Source and set Target": {
+			Source: awsInterfaceSingle{
+				Field1: &awsInterfaceInterfaceUnmappedImpl{
+					Value: awsInterfaceInterfaceUnmappedImplValue{
+						UnmappedField1: "value1",
+					},
+				},
+			},
+			Target: &tfSetNestedObject[tfInterfaceFlexer]{},
+			WantTarget: &tfSetNestedObject[tfInterfaceFlexer]{
+				Field1: fwtypes.NewSetNestedObjectValueOfNull[tfInterfaceFlexer](ctx),
 			},
 		},
 

--- a/internal/framework/flex/autoflex_dispatch_test.go
+++ b/internal/framework/flex/autoflex_dispatch_test.go
@@ -37,7 +37,11 @@ type tfObjectValue[T any] struct {
 }
 
 type tfInterfaceFlexer struct {
-	Field1 types.String `tfsdk:"field1"`
+	Impl fwtypes.ListNestedObjectValueOf[tfImpl] `tfsdk:"impl"`
+}
+
+type tfImpl struct {
+	ImplField1 types.String `tfsdk:"impl_field1"`
 }
 
 var (
@@ -46,20 +50,32 @@ var (
 )
 
 func (t tfInterfaceFlexer) Expand(ctx context.Context) (any, diag.Diagnostics) {
-	return &awsInterfaceInterfaceImpl{
-		AWSField: StringValueFromFramework(ctx, t.Field1),
-	}, nil
+	var v awsInterfaceInterface
+	switch {
+	case !t.Impl.IsNull():
+		data, _ := t.Impl.ToPtr(ctx)
+		v = &awsInterfaceInterfaceImpl{
+			Value: awsInterfaceInterfaceImplValue{
+				ImplField1: StringValueFromFramework(ctx, data.ImplField1),
+			},
+		}
+	}
+
+	return v, nil
 }
 
 func (t *tfInterfaceFlexer) Flatten(ctx context.Context, v any) (diags diag.Diagnostics) {
 	switch val := v.(type) {
 	case awsInterfaceInterfaceImpl:
-		t.Field1 = StringValueToFramework(ctx, val.AWSField)
-		return diags
+		data := tfImpl{
+			ImplField1: StringValueToFramework(ctx, val.Value.ImplField1),
+		}
+		t.Impl = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &data)
 
-	default:
-		return diags
+		// awsInterfaceInterfaceUnmappedImpl is intentionally not mapped
 	}
+
+	return diags
 }
 
 type tfInterfaceIncompatibleExpander struct {
@@ -91,12 +107,30 @@ type awsInterfaceInterface interface {
 }
 
 type awsInterfaceInterfaceImpl struct {
-	AWSField string
+	Value awsInterfaceInterfaceImplValue
+}
+
+type awsInterfaceInterfaceImplValue struct {
+	ImplField1 string
 }
 
 var _ awsInterfaceInterface = &awsInterfaceInterfaceImpl{}
 
 func (t *awsInterfaceInterfaceImpl) isAWSInterfaceInterface() {} // nosemgrep:ci.aws-in-func-name
+
+// awsInterfaceInterfaceUnmappedImpl should not be mapped in tfInterfaceFlexer's Flatten function
+// to simulate silently ignoring cases, such as unrecognized tagged union types.
+type awsInterfaceInterfaceUnmappedImpl struct {
+	Value awsInterfaceInterfaceUnmappedImplValue
+}
+
+var _ awsInterfaceInterface = &awsInterfaceInterfaceUnmappedImpl{}
+
+func (t *awsInterfaceInterfaceUnmappedImpl) isAWSInterfaceInterface() {} // nosemgrep:ci.aws-in-func-name
+
+type awsInterfaceInterfaceUnmappedImplValue struct {
+	UnmappedField1 string
+}
 
 type tfFlexer struct {
 	Field1 types.String `tfsdk:"field1"`
@@ -187,7 +221,7 @@ func (t tfTypedExpanderToNil) ExpandTo(ctx context.Context, targetType reflect.T
 }
 
 type tfInterfaceTypedExpander struct {
-	Field1 types.String `tfsdk:"field1"`
+	Impl fwtypes.ListNestedObjectValueOf[tfImpl] `tfsdk:"impl"`
 }
 
 var _ TypedExpander = tfInterfaceTypedExpander{}
@@ -195,9 +229,17 @@ var _ TypedExpander = tfInterfaceTypedExpander{}
 func (t tfInterfaceTypedExpander) ExpandTo(ctx context.Context, targetType reflect.Type) (any, diag.Diagnostics) {
 	switch targetType {
 	case reflect.TypeFor[awsInterfaceInterface]():
-		return &awsInterfaceInterfaceImpl{
-			AWSField: StringValueFromFramework(ctx, t.Field1),
-		}, nil
+		var v awsInterfaceInterface
+		switch {
+		case !t.Impl.IsNull():
+			data, _ := t.Impl.ToPtr(ctx)
+			v = &awsInterfaceInterfaceImpl{
+				Value: awsInterfaceInterfaceImplValue{
+					ImplField1: StringValueFromFramework(ctx, data.ImplField1),
+				},
+			}
+		}
+		return v, nil
 	}
 
 	return nil, nil
@@ -574,11 +616,17 @@ func TestExpandInterface(t *testing.T) {
 	testCases := autoFlexTestCases{
 		"top level": {
 			Source: tfInterfaceFlexer{
-				Field1: types.StringValue("value1"),
+				Impl: fwtypes.NewListNestedObjectValueOfValueSliceMust(ctx, []tfImpl{
+					{
+						ImplField1: types.StringValue("value1"),
+					},
+				}),
 			},
 			Target: &targetInterface,
 			WantTarget: testFlexAWSInterfaceInterfacePtr(&awsInterfaceInterfaceImpl{
-				AWSField: "value1",
+				Value: awsInterfaceInterfaceImplValue{
+					ImplField1: "value1",
+				},
 			}),
 		},
 		"top level return value does not implement target interface": {
@@ -592,14 +640,20 @@ func TestExpandInterface(t *testing.T) {
 			Source: tfListNestedObject[tfInterfaceFlexer]{
 				Field1: fwtypes.NewListNestedObjectValueOfValueSliceMust(ctx, []tfInterfaceFlexer{
 					{
-						Field1: types.StringValue("value1"),
+						Impl: fwtypes.NewListNestedObjectValueOfValueSliceMust(ctx, []tfImpl{
+							{
+								ImplField1: types.StringValue("value1"),
+							},
+						}),
 					},
 				}),
 			},
 			Target: &awsInterfaceSingle{},
 			WantTarget: &awsInterfaceSingle{
 				Field1: &awsInterfaceInterfaceImpl{
-					AWSField: "value1",
+					Value: awsInterfaceInterfaceImplValue{
+						ImplField1: "value1",
+					},
 				},
 			},
 		},
@@ -620,14 +674,20 @@ func TestExpandInterface(t *testing.T) {
 			Source: tfSetNestedObject[tfInterfaceFlexer]{
 				Field1: fwtypes.NewSetNestedObjectValueOfValueSliceMust(ctx, []tfInterfaceFlexer{
 					{
-						Field1: types.StringValue("value1"),
+						Impl: fwtypes.NewListNestedObjectValueOfValueSliceMust(ctx, []tfImpl{
+							{
+								ImplField1: types.StringValue("value1"),
+							},
+						}),
 					},
 				}),
 			},
 			Target: &awsInterfaceSingle{},
 			WantTarget: &awsInterfaceSingle{
 				Field1: &awsInterfaceInterfaceImpl{
-					AWSField: "value1",
+					Value: awsInterfaceInterfaceImplValue{
+						ImplField1: "value1",
+					},
 				},
 			},
 		},
@@ -644,10 +704,18 @@ func TestExpandInterface(t *testing.T) {
 			Source: tfListNestedObject[tfInterfaceFlexer]{
 				Field1: fwtypes.NewListNestedObjectValueOfValueSliceMust(ctx, []tfInterfaceFlexer{
 					{
-						Field1: types.StringValue("value1"),
+						Impl: fwtypes.NewListNestedObjectValueOfValueSliceMust(ctx, []tfImpl{
+							{
+								ImplField1: types.StringValue("value1"),
+							},
+						}),
 					},
 					{
-						Field1: types.StringValue("value2"),
+						Impl: fwtypes.NewListNestedObjectValueOfValueSliceMust(ctx, []tfImpl{
+							{
+								ImplField1: types.StringValue("value2"),
+							},
+						}),
 					},
 				}),
 			},
@@ -655,10 +723,14 @@ func TestExpandInterface(t *testing.T) {
 			WantTarget: &awsInterfaceSlice{
 				Field1: []awsInterfaceInterface{
 					&awsInterfaceInterfaceImpl{
-						AWSField: "value1",
+						Value: awsInterfaceInterfaceImplValue{
+							ImplField1: "value1",
+						},
 					},
 					&awsInterfaceInterfaceImpl{
-						AWSField: "value2",
+						Value: awsInterfaceInterfaceImplValue{
+							ImplField1: "value2",
+						},
 					},
 				},
 			},
@@ -676,10 +748,18 @@ func TestExpandInterface(t *testing.T) {
 			Source: tfSetNestedObject[tfInterfaceFlexer]{
 				Field1: fwtypes.NewSetNestedObjectValueOfValueSliceMust(ctx, []tfInterfaceFlexer{
 					{
-						Field1: types.StringValue("value1"),
+						Impl: fwtypes.NewListNestedObjectValueOfValueSliceMust(ctx, []tfImpl{
+							{
+								ImplField1: types.StringValue("value1"),
+							},
+						}),
 					},
 					{
-						Field1: types.StringValue("value2"),
+						Impl: fwtypes.NewListNestedObjectValueOfValueSliceMust(ctx, []tfImpl{
+							{
+								ImplField1: types.StringValue("value2"),
+							},
+						}),
 					},
 				}),
 			},
@@ -687,10 +767,14 @@ func TestExpandInterface(t *testing.T) {
 			WantTarget: &awsInterfaceSlice{
 				Field1: []awsInterfaceInterface{
 					&awsInterfaceInterfaceImpl{
-						AWSField: "value1",
+						Value: awsInterfaceInterfaceImplValue{
+							ImplField1: "value1",
+						},
 					},
 					&awsInterfaceInterfaceImpl{
-						AWSField: "value2",
+						Value: awsInterfaceInterfaceImplValue{
+							ImplField1: "value2",
+						},
 					},
 				},
 			},
@@ -698,13 +782,19 @@ func TestExpandInterface(t *testing.T) {
 		"object value Source and struct Target": {
 			Source: tfObjectValue[tfInterfaceFlexer]{
 				Field1: fwtypes.NewObjectValueOfMust(ctx, &tfInterfaceFlexer{
-					Field1: types.StringValue("value1"),
+					Impl: fwtypes.NewListNestedObjectValueOfValueSliceMust(ctx, []tfImpl{
+						{
+							ImplField1: types.StringValue("value1"),
+						},
+					}),
 				}),
 			},
 			Target: &awsInterfaceSingle{},
 			WantTarget: &awsInterfaceSingle{
 				Field1: &awsInterfaceInterfaceImpl{
-					AWSField: "value1",
+					Value: awsInterfaceInterfaceImplValue{
+						ImplField1: "value1",
+					},
 				},
 			},
 		},
@@ -722,11 +812,17 @@ func TestExpandInterfaceTypedExpander(t *testing.T) {
 	testCases := autoFlexTestCases{
 		"top level": {
 			Source: tfInterfaceTypedExpander{
-				Field1: types.StringValue("value1"),
+				Impl: fwtypes.NewListNestedObjectValueOfValueSliceMust(ctx, []tfImpl{
+					{
+						ImplField1: types.StringValue("value1"),
+					},
+				}),
 			},
 			Target: &targetInterface,
 			WantTarget: testFlexAWSInterfaceInterfacePtr(&awsInterfaceInterfaceImpl{
-				AWSField: "value1",
+				Value: awsInterfaceInterfaceImplValue{
+					ImplField1: "value1",
+				},
 			}),
 		},
 		"top level return value does not implement target interface": {
@@ -740,14 +836,20 @@ func TestExpandInterfaceTypedExpander(t *testing.T) {
 			Source: tfListNestedObject[tfInterfaceTypedExpander]{
 				Field1: fwtypes.NewListNestedObjectValueOfValueSliceMust(ctx, []tfInterfaceTypedExpander{
 					{
-						Field1: types.StringValue("value1"),
+						Impl: fwtypes.NewListNestedObjectValueOfValueSliceMust(ctx, []tfImpl{
+							{
+								ImplField1: types.StringValue("value1"),
+							},
+						}),
 					},
 				}),
 			},
 			Target: &awsInterfaceSingle{},
 			WantTarget: &awsInterfaceSingle{
 				Field1: &awsInterfaceInterfaceImpl{
-					AWSField: "value1",
+					Value: awsInterfaceInterfaceImplValue{
+						ImplField1: "value1",
+					},
 				},
 			},
 		},
@@ -768,14 +870,20 @@ func TestExpandInterfaceTypedExpander(t *testing.T) {
 			Source: tfSetNestedObject[tfInterfaceTypedExpander]{
 				Field1: fwtypes.NewSetNestedObjectValueOfValueSliceMust(ctx, []tfInterfaceTypedExpander{
 					{
-						Field1: types.StringValue("value1"),
+						Impl: fwtypes.NewListNestedObjectValueOfValueSliceMust(ctx, []tfImpl{
+							{
+								ImplField1: types.StringValue("value1"),
+							},
+						}),
 					},
 				}),
 			},
 			Target: &awsInterfaceSingle{},
 			WantTarget: &awsInterfaceSingle{
 				Field1: &awsInterfaceInterfaceImpl{
-					AWSField: "value1",
+					Value: awsInterfaceInterfaceImplValue{
+						ImplField1: "value1",
+					},
 				},
 			},
 		},
@@ -792,10 +900,18 @@ func TestExpandInterfaceTypedExpander(t *testing.T) {
 			Source: tfListNestedObject[tfInterfaceTypedExpander]{
 				Field1: fwtypes.NewListNestedObjectValueOfValueSliceMust(ctx, []tfInterfaceTypedExpander{
 					{
-						Field1: types.StringValue("value1"),
+						Impl: fwtypes.NewListNestedObjectValueOfValueSliceMust(ctx, []tfImpl{
+							{
+								ImplField1: types.StringValue("value1"),
+							},
+						}),
 					},
 					{
-						Field1: types.StringValue("value2"),
+						Impl: fwtypes.NewListNestedObjectValueOfValueSliceMust(ctx, []tfImpl{
+							{
+								ImplField1: types.StringValue("value2"),
+							},
+						}),
 					},
 				}),
 			},
@@ -803,10 +919,14 @@ func TestExpandInterfaceTypedExpander(t *testing.T) {
 			WantTarget: &awsInterfaceSlice{
 				Field1: []awsInterfaceInterface{
 					&awsInterfaceInterfaceImpl{
-						AWSField: "value1",
+						Value: awsInterfaceInterfaceImplValue{
+							ImplField1: "value1",
+						},
 					},
 					&awsInterfaceInterfaceImpl{
-						AWSField: "value2",
+						Value: awsInterfaceInterfaceImplValue{
+							ImplField1: "value2",
+						},
 					},
 				},
 			},
@@ -824,10 +944,18 @@ func TestExpandInterfaceTypedExpander(t *testing.T) {
 			Source: tfSetNestedObject[tfInterfaceTypedExpander]{
 				Field1: fwtypes.NewSetNestedObjectValueOfValueSliceMust(ctx, []tfInterfaceTypedExpander{
 					{
-						Field1: types.StringValue("value1"),
+						Impl: fwtypes.NewListNestedObjectValueOfValueSliceMust(ctx, []tfImpl{
+							{
+								ImplField1: types.StringValue("value1"),
+							},
+						}),
 					},
 					{
-						Field1: types.StringValue("value2"),
+						Impl: fwtypes.NewListNestedObjectValueOfValueSliceMust(ctx, []tfImpl{
+							{
+								ImplField1: types.StringValue("value2"),
+							},
+						}),
 					},
 				}),
 			},
@@ -835,10 +963,14 @@ func TestExpandInterfaceTypedExpander(t *testing.T) {
 			WantTarget: &awsInterfaceSlice{
 				Field1: []awsInterfaceInterface{
 					&awsInterfaceInterfaceImpl{
-						AWSField: "value1",
+						Value: awsInterfaceInterfaceImplValue{
+							ImplField1: "value1",
+						},
 					},
 					&awsInterfaceInterfaceImpl{
-						AWSField: "value2",
+						Value: awsInterfaceInterfaceImplValue{
+							ImplField1: "value2",
+						},
 					},
 				},
 			},
@@ -846,13 +978,19 @@ func TestExpandInterfaceTypedExpander(t *testing.T) {
 		"object value Source and struct Target": {
 			Source: tfObjectValue[tfInterfaceTypedExpander]{
 				Field1: fwtypes.NewObjectValueOfMust(ctx, &tfInterfaceTypedExpander{
-					Field1: types.StringValue("value1"),
+					Impl: fwtypes.NewListNestedObjectValueOfValueSliceMust(ctx, []tfImpl{
+						{
+							ImplField1: types.StringValue("value1"),
+						},
+					}),
 				}),
 			},
 			Target: &awsInterfaceSingle{},
 			WantTarget: &awsInterfaceSingle{
 				Field1: &awsInterfaceInterfaceImpl{
-					AWSField: "value1",
+					Value: awsInterfaceInterfaceImplValue{
+						ImplField1: "value1",
+					},
 				},
 			},
 		},
@@ -1217,14 +1355,20 @@ func TestFlattenInterface(t *testing.T) {
 		"single interface Source and single list Target": {
 			Source: awsInterfaceSingle{
 				Field1: &awsInterfaceInterfaceImpl{
-					AWSField: "value1",
+					Value: awsInterfaceInterfaceImplValue{
+						ImplField1: "value1",
+					},
 				},
 			},
 			Target: &tfListNestedObject[tfInterfaceFlexer]{},
 			WantTarget: &tfListNestedObject[tfInterfaceFlexer]{
 				Field1: fwtypes.NewListNestedObjectValueOfValueSliceMust(ctx, []tfInterfaceFlexer{
 					{
-						Field1: types.StringValue("value1"),
+						Impl: fwtypes.NewListNestedObjectValueOfValueSliceMust(ctx, []tfImpl{
+							{
+								ImplField1: types.StringValue("value1"),
+							},
+						}),
 					},
 				}),
 			},
@@ -1241,7 +1385,9 @@ func TestFlattenInterface(t *testing.T) {
 		"single interface Source and non-Flattener list Target": {
 			Source: awsInterfaceSingle{
 				Field1: &awsInterfaceInterfaceImpl{
-					AWSField: "value1",
+					Value: awsInterfaceInterfaceImplValue{
+						ImplField1: "value1",
+					},
 				},
 			},
 			Target: &tfListNestedObject[tfSingleStringField]{},
@@ -1262,14 +1408,20 @@ func TestFlattenInterface(t *testing.T) {
 		"single interface Source and single set Target": {
 			Source: awsInterfaceSingle{
 				Field1: &awsInterfaceInterfaceImpl{
-					AWSField: "value1",
+					Value: awsInterfaceInterfaceImplValue{
+						ImplField1: "value1",
+					},
 				},
 			},
 			Target: &tfSetNestedObject[tfInterfaceFlexer]{},
 			WantTarget: &tfSetNestedObject[tfInterfaceFlexer]{
 				Field1: fwtypes.NewSetNestedObjectValueOfValueSliceMust(ctx, []tfInterfaceFlexer{
 					{
-						Field1: types.StringValue("value1"),
+						Impl: fwtypes.NewListNestedObjectValueOfValueSliceMust(ctx, []tfImpl{
+							{
+								ImplField1: types.StringValue("value1"),
+							},
+						}),
 					},
 				}),
 			},
@@ -1297,10 +1449,14 @@ func TestFlattenInterface(t *testing.T) {
 			Source: awsInterfaceSlice{
 				Field1: []awsInterfaceInterface{
 					&awsInterfaceInterfaceImpl{
-						AWSField: "value1",
+						Value: awsInterfaceInterfaceImplValue{
+							ImplField1: "value1",
+						},
 					},
 					&awsInterfaceInterfaceImpl{
-						AWSField: "value2",
+						Value: awsInterfaceInterfaceImplValue{
+							ImplField1: "value2",
+						},
 					},
 				},
 			},
@@ -1308,10 +1464,18 @@ func TestFlattenInterface(t *testing.T) {
 			WantTarget: &tfListNestedObject[tfInterfaceFlexer]{
 				Field1: fwtypes.NewListNestedObjectValueOfValueSliceMust(ctx, []tfInterfaceFlexer{
 					{
-						Field1: types.StringValue("value1"),
+						Impl: fwtypes.NewListNestedObjectValueOfValueSliceMust(ctx, []tfImpl{
+							{
+								ImplField1: types.StringValue("value1"),
+							},
+						}),
 					},
 					{
-						Field1: types.StringValue("value2"),
+						Impl: fwtypes.NewListNestedObjectValueOfValueSliceMust(ctx, []tfImpl{
+							{
+								ImplField1: types.StringValue("value2"),
+							},
+						}),
 					},
 				}),
 			},
@@ -1339,10 +1503,14 @@ func TestFlattenInterface(t *testing.T) {
 			Source: awsInterfaceSlice{
 				Field1: []awsInterfaceInterface{
 					&awsInterfaceInterfaceImpl{
-						AWSField: "value1",
+						Value: awsInterfaceInterfaceImplValue{
+							ImplField1: "value1",
+						},
 					},
 					&awsInterfaceInterfaceImpl{
-						AWSField: "value2",
+						Value: awsInterfaceInterfaceImplValue{
+							ImplField1: "value2",
+						},
 					},
 				},
 			},
@@ -1350,10 +1518,18 @@ func TestFlattenInterface(t *testing.T) {
 			WantTarget: &tfSetNestedObject[tfInterfaceFlexer]{
 				Field1: fwtypes.NewSetNestedObjectValueOfValueSliceMust(ctx, []tfInterfaceFlexer{
 					{
-						Field1: types.StringValue("value1"),
+						Impl: fwtypes.NewListNestedObjectValueOfValueSliceMust(ctx, []tfImpl{
+							{
+								ImplField1: types.StringValue("value1"),
+							},
+						}),
 					},
 					{
-						Field1: types.StringValue("value2"),
+						Impl: fwtypes.NewListNestedObjectValueOfValueSliceMust(ctx, []tfImpl{
+							{
+								ImplField1: types.StringValue("value2"),
+							},
+						}),
 					},
 				}),
 			},
@@ -1370,13 +1546,19 @@ func TestFlattenInterface(t *testing.T) {
 		"interface Source and nested object Target": {
 			Source: awsInterfaceSingle{
 				Field1: &awsInterfaceInterfaceImpl{
-					AWSField: "value1",
+					Value: awsInterfaceInterfaceImplValue{
+						ImplField1: "value1",
+					},
 				},
 			},
 			Target: &tfObjectValue[tfInterfaceFlexer]{},
 			WantTarget: &tfObjectValue[tfInterfaceFlexer]{
 				Field1: fwtypes.NewObjectValueOfMust(ctx, &tfInterfaceFlexer{
-					Field1: types.StringValue("value1"),
+					Impl: fwtypes.NewListNestedObjectValueOfValueSliceMust(ctx, []tfImpl{
+						{
+							ImplField1: types.StringValue("value1"),
+						},
+					}),
 				}),
 			},
 		},

--- a/internal/framework/flex/autoflex_flatten.go
+++ b/internal/framework/flex/autoflex_flatten.go
@@ -1360,6 +1360,7 @@ func flattenInterfaceToNestedObject(ctx context.Context, _ *autoFlattener, vFrom
 	var diags diag.Diagnostics
 
 	if vFrom.IsNil() {
+		tflog.SubsystemTrace(ctx, subsystemName, "Flattening null value")
 		val, d := tTo.NullValue(ctx)
 		diags.Append(d...)
 		if diags.HasError() {

--- a/internal/framework/flex/autoflex_flatten.go
+++ b/internal/framework/flex/autoflex_flatten.go
@@ -1406,6 +1406,18 @@ func flattenInterfaceToNestedObject(ctx context.Context, _ *autoFlattener, vFrom
 		return diags
 	}
 
+	if isZero(toFlattener) {
+		tflog.SubsystemWarn(ctx, subsystemName, "No values set by Flatten")
+		val, d := tTo.NullValue(ctx)
+		diags.Append(d...)
+		if diags.HasError() {
+			return diags
+		}
+
+		vTo.Set(reflect.ValueOf(val))
+		return diags
+	}
+
 	// Set the target structure as a mapped Object.
 	val, d := tTo.ValueFromObjectPtr(ctx, toFlattener)
 	diags.Append(d...)
@@ -1415,6 +1427,25 @@ func flattenInterfaceToNestedObject(ctx context.Context, _ *autoFlattener, vFrom
 
 	vTo.Set(reflect.ValueOf(val))
 	return diags
+}
+
+func isZero(v any) bool {
+	val := reflect.ValueOf(v)
+	val = reflect.Indirect(val)
+
+	for field := range tfreflect.ExportedStructFields(val.Type()) {
+		fieldVal := val.FieldByIndex(field.Index)
+
+		fieldTo, ok := fieldVal.Interface().(attr.Value)
+		if !ok {
+			continue // Skip non-attr.Type fields.
+		}
+		if !fieldTo.IsNull() {
+			return false
+		}
+	}
+
+	return true
 }
 
 // flattenSliceOfPrimitiveToList copies an AWS API slice of primitive (or pointer to primitive) value to a compatible Plugin Framework List value.

--- a/internal/framework/flex/autoflex_flatten.go
+++ b/internal/framework/flex/autoflex_flatten.go
@@ -3341,8 +3341,8 @@ func flattenXMLWrapperRule2(ctx context.Context, flattener *autoFlattener, vFrom
 	return diags
 }
 
-// HandleFlattenUnkownUnionMember is used to handle an `awstypes.UnknownUnionMember` when Flattening
-func HandleFlattenUnkownUnionMember(ctx context.Context, unionTag string, diags *diag.Diagnostics) {
+// HandleFlattenUnknownUnionMember is used to handle an `awstypes.UnknownUnionMember` when Flattening
+func HandleFlattenUnknownUnionMember(ctx context.Context, unionTag string, diags *diag.Diagnostics) {
 	tflog.Warn(ctx, "Unexpected tagged union member", map[string]any{
 		"tag": unionTag,
 	})

--- a/internal/framework/flex/autoflex_flatten.go
+++ b/internal/framework/flex/autoflex_flatten.go
@@ -670,7 +670,7 @@ func flattenInterface(ctx context.Context, flattener *autoFlattener, vFrom refle
 		//
 		// interface -> types.List(OfObject) or types.Object.
 		//
-		diags.Append(flattenInterfaceToNestedObject(ctx, flattener, vFrom, vFrom.IsNil(), tTo, vTo)...)
+		diags.Append(flattenInterfaceToNestedObject(ctx, flattener, vFrom, tTo, vTo)...)
 		return diags
 	}
 
@@ -1356,10 +1356,10 @@ func flattenStructToNestedObject(ctx context.Context, flattener *autoFlattener, 
 }
 
 // flattenInterfaceToNestedObject copies an AWS API interface value to a compatible Plugin Framework NestedObjectValue value.
-func flattenInterfaceToNestedObject(ctx context.Context, _ *autoFlattener, vFrom reflect.Value, isNullFrom bool, tTo fwtypes.NestedObjectType, vTo reflect.Value) diag.Diagnostics {
+func flattenInterfaceToNestedObject(ctx context.Context, _ *autoFlattener, vFrom reflect.Value, tTo fwtypes.NestedObjectType, vTo reflect.Value) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	if isNullFrom {
+	if vFrom.IsNil() {
 		val, d := tTo.NullValue(ctx)
 		diags.Append(d...)
 		if diags.HasError() {

--- a/internal/framework/flex/autoflex_flatten.go
+++ b/internal/framework/flex/autoflex_flatten.go
@@ -2748,6 +2748,16 @@ func DiagFlatteningIncompatibleTypes(sourceType, targetType reflect.Type) diag.E
 	)
 }
 
+func diagFlatteningUnknownUnionMember(unionTag string) diag.WarningDiagnostic {
+	return diag.NewWarningDiagnostic(
+		"Unexpected Result",
+		"The API response contained data with an unrecognized type, which will be ignored by the provider.\n\n"+
+			"This may be resolved by updating the provider. "+
+			"If you are on the latest version of the provider, please report the following to the provider developer:\n\n"+
+			fmt.Sprintf("Unrecognized tagged union member with tag %q.", unionTag),
+	)
+}
+
 // handleDirectXMLWrapperStruct handles direct XML wrapper struct to target with xmlwrapper tags
 func handleDirectXMLWrapperStruct(ctx context.Context, sourcePath path.Path, sourceFieldName string, valFrom, valTo reflect.Value, _, typeTo reflect.Type, targetPath path.Path, targetFieldName string, flattener *autoFlattener) diag.Diagnostics {
 	var diags diag.Diagnostics
@@ -3329,4 +3339,12 @@ func flattenXMLWrapperRule2(ctx context.Context, flattener *autoFlattener, vFrom
 	}
 
 	return diags
+}
+
+// HandleFlattenUnkownUnionMember is used to handle an `awstypes.UnknownUnionMember` when Flattening
+func HandleFlattenUnkownUnionMember(ctx context.Context, unionTag string, diags *diag.Diagnostics) {
+	tflog.Warn(ctx, "Unexpected tagged union member", map[string]any{
+		"tag": unionTag,
+	})
+	diags.Append(diagFlatteningUnknownUnionMember(unionTag))
 }

--- a/internal/framework/flex/autoflex_flatten.go
+++ b/internal/framework/flex/autoflex_flatten.go
@@ -1387,7 +1387,7 @@ func flattenInterfaceToNestedObject(ctx context.Context, _ *autoFlattener, vFrom
 
 		vTo.Set(reflect.ValueOf(val))
 
-		tflog.SubsystemError(ctx, subsystemName, "Source does not implement flex.Flattener")
+		tflog.SubsystemError(ctx, subsystemName, "Target does not implement flex.Flattener")
 		// diags.Append(diagFlatteningTargetDoesNotImplementFlexFlattener(reflect.TypeOf(vTo.Interface())))
 		return diags
 	}

--- a/internal/framework/flex/autoflex_special_types_test.go
+++ b/internal/framework/flex/autoflex_special_types_test.go
@@ -339,7 +339,9 @@ func TestFlattenJSONInterfaceToStringTypable(t *testing.T) {
 		"non-json interface Source string Target": {
 			Source: awsInterfaceSingle{
 				Field1: &awsInterfaceInterfaceImpl{
-					AWSField: "value1",
+					Value: awsInterfaceInterfaceImplValue{
+						ImplField1: "value1",
+					},
 				},
 			},
 			Target: &tfSingleStringField{},

--- a/internal/framework/flex/autoflex_test.go
+++ b/internal/framework/flex/autoflex_test.go
@@ -144,6 +144,15 @@ func runAutoFlattenTestCases(t *testing.T, testCases autoFlexTestCases, checks r
 				t.Errorf("unexpected diagnostics difference: %s", diff)
 			}
 
+			if !diags.HasError() {
+				less := func(a, b any) bool { return fmt.Sprintf("%+v", a) < fmt.Sprintf("%+v", b) }
+				if diff := cmp.Diff(testCase.Target, testCase.WantTarget, append(opts, cmpopts.SortSlices(less))...); diff != "" {
+					if !testCase.WantDiff {
+						t.Errorf("unexpected diff (+wanted, -got): %s", diff)
+					}
+				}
+			}
+
 			if !checks.SkipGoldenLogs {
 				lines, err := tflogtest.MultilineJSONDecode(&buf)
 				if err != nil {
@@ -164,15 +173,6 @@ func runAutoFlattenTestCases(t *testing.T, testCases autoFlexTestCases, checks r
 				for _, line := range lines {
 					if msg, ok := line["@message"].(string); ok {
 						t.Logf("%s", msg)
-					}
-				}
-			}
-
-			if !diags.HasError() {
-				less := func(a, b any) bool { return fmt.Sprintf("%+v", a) < fmt.Sprintf("%+v", b) }
-				if diff := cmp.Diff(testCase.Target, testCase.WantTarget, append(opts, cmpopts.SortSlices(less))...); diff != "" {
-					if !testCase.WantDiff {
-						t.Errorf("unexpected diff (+wanted, -got): %s", diff)
 					}
 				}
 			}

--- a/internal/framework/flex/testdata/autoflex/dispatch/flatten_interface/nil_interface_source_and_list_target.golden
+++ b/internal/framework/flex/testdata/autoflex/dispatch/flatten_interface/nil_interface_source_and_list_target.golden
@@ -43,5 +43,14 @@
     "autoflex.source.type": "github.com/hashicorp/terraform-provider-aws/internal/framework/flex.awsInterfaceInterface",
     "autoflex.target.path": "Field1",
     "autoflex.target.type": "github.com/hashicorp/terraform-provider-aws/internal/framework/types.ListNestedObjectValueOf[github.com/hashicorp/terraform-provider-aws/internal/framework/flex.tfInterfaceFlexer]"
+  },
+  {
+    "@level": "trace",
+    "@message": "Flattening null value",
+    "@module": "provider.autoflex",
+    "autoflex.source.path": "Field1",
+    "autoflex.source.type": "github.com/hashicorp/terraform-provider-aws/internal/framework/flex.awsInterfaceInterface",
+    "autoflex.target.path": "Field1",
+    "autoflex.target.type": "github.com/hashicorp/terraform-provider-aws/internal/framework/types.ListNestedObjectValueOf[github.com/hashicorp/terraform-provider-aws/internal/framework/flex.tfInterfaceFlexer]"
   }
 ]

--- a/internal/framework/flex/testdata/autoflex/dispatch/flatten_interface/nil_interface_source_and_nested_object_target.golden
+++ b/internal/framework/flex/testdata/autoflex/dispatch/flatten_interface/nil_interface_source_and_nested_object_target.golden
@@ -43,5 +43,14 @@
     "autoflex.source.type": "github.com/hashicorp/terraform-provider-aws/internal/framework/flex.awsInterfaceInterface",
     "autoflex.target.path": "Field1",
     "autoflex.target.type": "github.com/hashicorp/terraform-provider-aws/internal/framework/types.ObjectValueOf[github.com/hashicorp/terraform-provider-aws/internal/framework/flex.tfInterfaceFlexer]"
+  },
+  {
+    "@level": "trace",
+    "@message": "Flattening null value",
+    "@module": "provider.autoflex",
+    "autoflex.source.path": "Field1",
+    "autoflex.source.type": "github.com/hashicorp/terraform-provider-aws/internal/framework/flex.awsInterfaceInterface",
+    "autoflex.target.path": "Field1",
+    "autoflex.target.type": "github.com/hashicorp/terraform-provider-aws/internal/framework/types.ObjectValueOf[github.com/hashicorp/terraform-provider-aws/internal/framework/flex.tfInterfaceFlexer]"
   }
 ]

--- a/internal/framework/flex/testdata/autoflex/dispatch/flatten_interface/nil_interface_source_and_nonflattener_list_target.golden
+++ b/internal/framework/flex/testdata/autoflex/dispatch/flatten_interface/nil_interface_source_and_nonflattener_list_target.golden
@@ -43,5 +43,14 @@
     "autoflex.source.type": "github.com/hashicorp/terraform-provider-aws/internal/framework/flex.awsInterfaceInterface",
     "autoflex.target.path": "Field1",
     "autoflex.target.type": "github.com/hashicorp/terraform-provider-aws/internal/framework/types.ListNestedObjectValueOf[github.com/hashicorp/terraform-provider-aws/internal/framework/flex.tfSingleStringField]"
+  },
+  {
+    "@level": "trace",
+    "@message": "Flattening null value",
+    "@module": "provider.autoflex",
+    "autoflex.source.path": "Field1",
+    "autoflex.source.type": "github.com/hashicorp/terraform-provider-aws/internal/framework/flex.awsInterfaceInterface",
+    "autoflex.target.path": "Field1",
+    "autoflex.target.type": "github.com/hashicorp/terraform-provider-aws/internal/framework/types.ListNestedObjectValueOf[github.com/hashicorp/terraform-provider-aws/internal/framework/flex.tfSingleStringField]"
   }
 ]

--- a/internal/framework/flex/testdata/autoflex/dispatch/flatten_interface/nil_interface_source_and_set_target.golden
+++ b/internal/framework/flex/testdata/autoflex/dispatch/flatten_interface/nil_interface_source_and_set_target.golden
@@ -43,5 +43,14 @@
     "autoflex.source.type": "github.com/hashicorp/terraform-provider-aws/internal/framework/flex.awsInterfaceInterface",
     "autoflex.target.path": "Field1",
     "autoflex.target.type": "github.com/hashicorp/terraform-provider-aws/internal/framework/types.SetNestedObjectValueOf[github.com/hashicorp/terraform-provider-aws/internal/framework/flex.tfInterfaceFlexer]"
+  },
+  {
+    "@level": "trace",
+    "@message": "Flattening null value",
+    "@module": "provider.autoflex",
+    "autoflex.source.path": "Field1",
+    "autoflex.source.type": "github.com/hashicorp/terraform-provider-aws/internal/framework/flex.awsInterfaceInterface",
+    "autoflex.target.path": "Field1",
+    "autoflex.target.type": "github.com/hashicorp/terraform-provider-aws/internal/framework/types.SetNestedObjectValueOf[github.com/hashicorp/terraform-provider-aws/internal/framework/flex.tfInterfaceFlexer]"
   }
 ]

--- a/internal/framework/flex/testdata/autoflex/dispatch/flatten_interface/single_interface_source_and_nonflattener_list_target.golden
+++ b/internal/framework/flex/testdata/autoflex/dispatch/flatten_interface/single_interface_source_and_nonflattener_list_target.golden
@@ -46,7 +46,7 @@
   },
   {
     "@level": "error",
-    "@message": "Source does not implement flex.Flattener",
+    "@message": "Target does not implement flex.Flattener",
     "@module": "provider.autoflex",
     "autoflex.source.path": "Field1",
     "autoflex.source.type": "github.com/hashicorp/terraform-provider-aws/internal/framework/flex.awsInterfaceInterface",

--- a/internal/framework/flex/testdata/autoflex/dispatch/flatten_interface/single_unmapped_interface_source_and_list_target.golden
+++ b/internal/framework/flex/testdata/autoflex/dispatch/flatten_interface/single_unmapped_interface_source_and_list_target.golden
@@ -1,0 +1,65 @@
+[
+  {
+    "@level": "info",
+    "@message": "Flattening",
+    "@module": "provider.autoflex",
+    "autoflex.source.type": "github.com/hashicorp/terraform-provider-aws/internal/framework/flex.awsInterfaceSingle",
+    "autoflex.target.type": "*github.com/hashicorp/terraform-provider-aws/internal/framework/flex.tfListNestedObject[github.com/hashicorp/terraform-provider-aws/internal/framework/flex.tfInterfaceFlexer]"
+  },
+  {
+    "@level": "trace",
+    "@message": "Source is not XML wrapper struct",
+    "@module": "provider.autoflex",
+    "autoflex.source.path": "",
+    "autoflex.source.type": "github.com/hashicorp/terraform-provider-aws/internal/framework/flex.awsInterfaceSingle",
+    "autoflex.target.path": "",
+    "autoflex.target.type": "*github.com/hashicorp/terraform-provider-aws/internal/framework/flex.tfListNestedObject[github.com/hashicorp/terraform-provider-aws/internal/framework/flex.tfInterfaceFlexer]"
+  },
+  {
+    "@level": "info",
+    "@message": "Converting",
+    "@module": "provider.autoflex",
+    "autoflex.source.path": "",
+    "autoflex.source.type": "github.com/hashicorp/terraform-provider-aws/internal/framework/flex.awsInterfaceSingle",
+    "autoflex.target.path": "",
+    "autoflex.target.type": "*github.com/hashicorp/terraform-provider-aws/internal/framework/flex.tfListNestedObject[github.com/hashicorp/terraform-provider-aws/internal/framework/flex.tfInterfaceFlexer]"
+  },
+  {
+    "@level": "trace",
+    "@message": "Matched fields",
+    "@module": "provider.autoflex",
+    "autoflex.source.fieldname": "Field1",
+    "autoflex.source.path": "",
+    "autoflex.source.type": "github.com/hashicorp/terraform-provider-aws/internal/framework/flex.awsInterfaceSingle",
+    "autoflex.target.fieldname": "Field1",
+    "autoflex.target.path": "",
+    "autoflex.target.type": "*github.com/hashicorp/terraform-provider-aws/internal/framework/flex.tfListNestedObject[github.com/hashicorp/terraform-provider-aws/internal/framework/flex.tfInterfaceFlexer]"
+  },
+  {
+    "@level": "info",
+    "@message": "Converting",
+    "@module": "provider.autoflex",
+    "autoflex.source.path": "Field1",
+    "autoflex.source.type": "github.com/hashicorp/terraform-provider-aws/internal/framework/flex.awsInterfaceInterface",
+    "autoflex.target.path": "Field1",
+    "autoflex.target.type": "github.com/hashicorp/terraform-provider-aws/internal/framework/types.ListNestedObjectValueOf[github.com/hashicorp/terraform-provider-aws/internal/framework/flex.tfInterfaceFlexer]"
+  },
+  {
+    "@level": "info",
+    "@message": "Target implements flex.Flattener",
+    "@module": "provider.autoflex",
+    "autoflex.source.path": "Field1",
+    "autoflex.source.type": "github.com/hashicorp/terraform-provider-aws/internal/framework/flex.awsInterfaceInterface",
+    "autoflex.target.path": "Field1",
+    "autoflex.target.type": "github.com/hashicorp/terraform-provider-aws/internal/framework/types.ListNestedObjectValueOf[github.com/hashicorp/terraform-provider-aws/internal/framework/flex.tfInterfaceFlexer]"
+  },
+  {
+    "@level": "warn",
+    "@message": "No values set by Flatten",
+    "@module": "provider.autoflex",
+    "autoflex.source.path": "Field1",
+    "autoflex.source.type": "github.com/hashicorp/terraform-provider-aws/internal/framework/flex.awsInterfaceInterface",
+    "autoflex.target.path": "Field1",
+    "autoflex.target.type": "github.com/hashicorp/terraform-provider-aws/internal/framework/types.ListNestedObjectValueOf[github.com/hashicorp/terraform-provider-aws/internal/framework/flex.tfInterfaceFlexer]"
+  }
+]

--- a/internal/framework/flex/testdata/autoflex/dispatch/flatten_interface/single_unmapped_interface_source_and_set_target.golden
+++ b/internal/framework/flex/testdata/autoflex/dispatch/flatten_interface/single_unmapped_interface_source_and_set_target.golden
@@ -1,0 +1,65 @@
+[
+  {
+    "@level": "info",
+    "@message": "Flattening",
+    "@module": "provider.autoflex",
+    "autoflex.source.type": "github.com/hashicorp/terraform-provider-aws/internal/framework/flex.awsInterfaceSingle",
+    "autoflex.target.type": "*github.com/hashicorp/terraform-provider-aws/internal/framework/flex.tfSetNestedObject[github.com/hashicorp/terraform-provider-aws/internal/framework/flex.tfInterfaceFlexer]"
+  },
+  {
+    "@level": "trace",
+    "@message": "Source is not XML wrapper struct",
+    "@module": "provider.autoflex",
+    "autoflex.source.path": "",
+    "autoflex.source.type": "github.com/hashicorp/terraform-provider-aws/internal/framework/flex.awsInterfaceSingle",
+    "autoflex.target.path": "",
+    "autoflex.target.type": "*github.com/hashicorp/terraform-provider-aws/internal/framework/flex.tfSetNestedObject[github.com/hashicorp/terraform-provider-aws/internal/framework/flex.tfInterfaceFlexer]"
+  },
+  {
+    "@level": "info",
+    "@message": "Converting",
+    "@module": "provider.autoflex",
+    "autoflex.source.path": "",
+    "autoflex.source.type": "github.com/hashicorp/terraform-provider-aws/internal/framework/flex.awsInterfaceSingle",
+    "autoflex.target.path": "",
+    "autoflex.target.type": "*github.com/hashicorp/terraform-provider-aws/internal/framework/flex.tfSetNestedObject[github.com/hashicorp/terraform-provider-aws/internal/framework/flex.tfInterfaceFlexer]"
+  },
+  {
+    "@level": "trace",
+    "@message": "Matched fields",
+    "@module": "provider.autoflex",
+    "autoflex.source.fieldname": "Field1",
+    "autoflex.source.path": "",
+    "autoflex.source.type": "github.com/hashicorp/terraform-provider-aws/internal/framework/flex.awsInterfaceSingle",
+    "autoflex.target.fieldname": "Field1",
+    "autoflex.target.path": "",
+    "autoflex.target.type": "*github.com/hashicorp/terraform-provider-aws/internal/framework/flex.tfSetNestedObject[github.com/hashicorp/terraform-provider-aws/internal/framework/flex.tfInterfaceFlexer]"
+  },
+  {
+    "@level": "info",
+    "@message": "Converting",
+    "@module": "provider.autoflex",
+    "autoflex.source.path": "Field1",
+    "autoflex.source.type": "github.com/hashicorp/terraform-provider-aws/internal/framework/flex.awsInterfaceInterface",
+    "autoflex.target.path": "Field1",
+    "autoflex.target.type": "github.com/hashicorp/terraform-provider-aws/internal/framework/types.SetNestedObjectValueOf[github.com/hashicorp/terraform-provider-aws/internal/framework/flex.tfInterfaceFlexer]"
+  },
+  {
+    "@level": "info",
+    "@message": "Target implements flex.Flattener",
+    "@module": "provider.autoflex",
+    "autoflex.source.path": "Field1",
+    "autoflex.source.type": "github.com/hashicorp/terraform-provider-aws/internal/framework/flex.awsInterfaceInterface",
+    "autoflex.target.path": "Field1",
+    "autoflex.target.type": "github.com/hashicorp/terraform-provider-aws/internal/framework/types.SetNestedObjectValueOf[github.com/hashicorp/terraform-provider-aws/internal/framework/flex.tfInterfaceFlexer]"
+  },
+  {
+    "@level": "warn",
+    "@message": "No values set by Flatten",
+    "@module": "provider.autoflex",
+    "autoflex.source.path": "Field1",
+    "autoflex.source.type": "github.com/hashicorp/terraform-provider-aws/internal/framework/flex.awsInterfaceInterface",
+    "autoflex.target.path": "Field1",
+    "autoflex.target.type": "github.com/hashicorp/terraform-provider-aws/internal/framework/types.SetNestedObjectValueOf[github.com/hashicorp/terraform-provider-aws/internal/framework/flex.tfInterfaceFlexer]"
+  }
+]

--- a/internal/framework/types/list_nested_objectof.go
+++ b/internal/framework/types/list_nested_objectof.go
@@ -260,6 +260,10 @@ func NewListNestedObjectValueOfUnknown[T any](ctx context.Context) ListNestedObj
 	return ListNestedObjectValueOf[T]{ListValue: basetypes.NewListUnknown(NewObjectTypeOf[T](ctx))}
 }
 
+func NewListNestedObjectValueOfEmpty[T any](ctx context.Context, f ...NestedObjectOfOption[T]) ListNestedObjectValueOf[T] {
+	return NewListNestedObjectValueOfSliceMust(ctx, []*T{}, f...)
+}
+
 func NewListNestedObjectValueOfPtr[T any](ctx context.Context, t *T, f ...NestedObjectOfOption[T]) (ListNestedObjectValueOf[T], diag.Diagnostics) {
 	opts := newNestedObjectOfOptions(f...)
 	return newListNestedObjectValueOfPtr(ctx, t, opts.SemanticEqualityFunc)


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Ignores completely unset values returned by custom Flatteners when creating collection. Prevents unconfigured tagged union values when AWS API returns unknown type.

Adds standard warning when AWS API returns unknown type.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>