### PR TITLE
resource/aws_bedrockagentcore_harness: Handles `memory.managed_memory_configuration`

### DIFF
--- a/.ci/semgrep/smarterr/enforce.yml
+++ b/.ci/semgrep/smarterr/enforce.yml
@@ -155,6 +155,8 @@ rules:
       - pattern-not-inside: |
           return nil, smarterr.NewError(...)
       - pattern-not-inside: |
+          return nil, smarterr.Errorf(...)
+      - pattern-not-inside: |
           func $FUNC(...) (..., diag.Diagnostics) {
             ...
             return nil, $ERR
@@ -183,6 +185,8 @@ rules:
           return $VALUE, nil
       - pattern-not-inside: |
           return $VALUE, smarterr.NewError(...)
+      - pattern-not-inside: |
+          return $VALUE, smarterr.Errorf(...)
       - pattern-not-inside: |
           func $FUNC(...) (..., diag.Diagnostics) {
             ...

--- a/internal/service/bedrockagentcore/harness.go
+++ b/internal/service/bedrockagentcore/harness.go
@@ -1505,7 +1505,7 @@ func (m *harnessMemoryConfigurationModel) Flatten(ctx context.Context, v any) di
 		m.ManagedMemoryConfiguration = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &data)
 
 	case awstypes.UnknownUnionMember:
-		fwflex.HandleFlattenUnkownUnionMember(ctx, t.Tag, &diags)
+		fwflex.HandleFlattenUnknownUnionMember(ctx, t.Tag, &diags)
 
 	default:
 		diags.AddError("Unsupported Type", fmt.Sprintf("memory configuration flatten: %T", v))

--- a/internal/service/bedrockagentcore/harness.go
+++ b/internal/service/bedrockagentcore/harness.go
@@ -725,14 +725,14 @@ func (r *harnessResource) Delete(ctx context.Context, request resource.DeleteReq
 
 func (r *harnessResource) flatten(ctx context.Context, harness *awstypes.Harness, data *harnessResourceModel) diag.Diagnostics {
 	var diags diag.Diagnostics
-	if v := harness.Memory; v != nil {
-		switch v.(type) {
-		case *awstypes.HarnessMemoryConfigurationMemberAgentCoreMemoryConfiguration:
-		default:
-			harness.Memory = nil
-		}
-	}
+
 	diags.Append(fwflex.Flatten(ctx, harness, data)...)
+	if diags.HasError() {
+		return diags
+	}
+
+	diags.Append(fwflex.Flatten(ctx, harness.Memory, &data.Memory)...)
+
 	return diags
 }
 
@@ -851,7 +851,7 @@ type harnessResourceModel struct {
 	HarnessName             types.String                                                         `tfsdk:"harness_name"`
 	MaxIterations           types.Int32                                                          `tfsdk:"max_iterations"`
 	MaxTokens               types.Int32                                                          `tfsdk:"max_tokens"`
-	Memory                  fwtypes.ListNestedObjectValueOf[harnessMemoryConfigurationModel]     `tfsdk:"memory"`
+	Memory                  fwtypes.ListNestedObjectValueOf[harnessMemoryConfigurationModel]     `tfsdk:"memory" autoflex:",noflatten"`
 	Model                   fwtypes.ListNestedObjectValueOf[harnessModelConfigurationModel]      `tfsdk:"model"`
 	Skills                  fwtypes.ListNestedObjectValueOf[harnessSkillModel]                   `tfsdk:"skill"`
 	SystemPrompt            fwtypes.ListNestedObjectValueOf[harnessSystemContentBlockModel]      `tfsdk:"system_prompt"`

--- a/internal/service/bedrockagentcore/harness.go
+++ b/internal/service/bedrockagentcore/harness.go
@@ -32,6 +32,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
@@ -55,6 +56,7 @@ import (
 // @Testing(tagsTest=false)
 // @Testing(hasNoPreExistingResource=true)
 // @Testing(importStateIdAttribute="harness_id")
+// @Testing(importIgnore="memory")
 func newHarnessResource(_ context.Context) (resource.ResourceWithConfigure, error) {
 	r := &harnessResource{}
 
@@ -539,11 +541,14 @@ func (r *harnessResource) Schema(ctx context.Context, request resource.SchemaReq
 }
 
 func (r *harnessResource) Create(ctx context.Context, request resource.CreateRequest, response *resource.CreateResponse) {
-	var data harnessResourceModel
+	var config, data harnessResourceModel
+	smerr.AddEnrich(ctx, &response.Diagnostics, request.Config.Get(ctx, &config))
 	smerr.AddEnrich(ctx, &response.Diagnostics, request.Plan.Get(ctx, &data))
 	if response.Diagnostics.HasError() {
 		return
 	}
+
+	memoryIsConfigured := config.Memory.Length(basetypes.CollectionLengthOptions{UnhandledNullAsZero: true, UnhandledUnknownAsZero: true}) > 0
 
 	conn := r.Meta().BedrockAgentCoreClient(ctx)
 
@@ -595,7 +600,7 @@ func (r *harnessResource) Create(ctx context.Context, request resource.CreateReq
 	// Set values for unknowns. Capture the configured authorizer first so the API-omitted
 	// private_endpoint_overrides can be restored after Flatten.
 	plannedAuthorizerConfiguration := data.AuthorizerConfiguration
-	smerr.AddEnrich(ctx, &response.Diagnostics, r.flatten(ctx, harness, &data))
+	smerr.AddEnrich(ctx, &response.Diagnostics, r.flatten(ctx, harness, &data, memoryIsConfigured))
 	if response.Diagnostics.HasError() {
 		return
 	}
@@ -617,6 +622,12 @@ func (r *harnessResource) Read(ctx context.Context, request resource.ReadRequest
 		return
 	}
 
+	// When importing, all attributes other than `harness_id` will be null.
+	// During a read of an existing resource, `harness_name` will be set as it is a required attribute.
+	isImport := data.HarnessName.IsNull()
+
+	memoryIsConfigured := data.Memory.Length(basetypes.CollectionLengthOptions{UnhandledNullAsZero: true, UnhandledUnknownAsZero: true}) > 0
+
 	conn := r.Meta().BedrockAgentCoreClient(ctx)
 
 	harnessID := fwflex.StringValueFromFramework(ctx, data.HarnessID)
@@ -632,7 +643,7 @@ func (r *harnessResource) Read(ctx context.Context, request resource.ReadRequest
 	}
 
 	priorAuthorizerConfiguration := data.AuthorizerConfiguration
-	smerr.AddEnrich(ctx, &response.Diagnostics, r.flatten(ctx, harness, &data))
+	smerr.AddEnrich(ctx, &response.Diagnostics, r.flatten(ctx, harness, &data, memoryIsConfigured || isImport))
 	if response.Diagnostics.HasError() {
 		return
 	}
@@ -718,7 +729,7 @@ func (r *harnessResource) Delete(ctx context.Context, request resource.DeleteReq
 	}
 }
 
-func (r *harnessResource) flatten(ctx context.Context, harness *awstypes.Harness, data *harnessResourceModel) diag.Diagnostics {
+func (r *harnessResource) flatten(ctx context.Context, harness *awstypes.Harness, data *harnessResourceModel, populateMemory bool) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	diags.Append(fwflex.Flatten(ctx, harness, data)...)
@@ -726,7 +737,9 @@ func (r *harnessResource) flatten(ctx context.Context, harness *awstypes.Harness
 		return diags
 	}
 
-	diags.Append(fwflex.Flatten(ctx, harness.Memory, &data.Memory)...)
+	if populateMemory {
+		diags.Append(fwflex.Flatten(ctx, harness.Memory, &data.Memory)...)
+	}
 
 	return diags
 }

--- a/internal/service/bedrockagentcore/harness.go
+++ b/internal/service/bedrockagentcore/harness.go
@@ -584,15 +584,10 @@ func (r *harnessResource) Create(ctx context.Context, request resource.CreateReq
 
 	harnessID := aws.ToString(out.Harness.HarnessId)
 
-	if _, err := waitHarnessCreated(ctx, conn, harnessID, r.CreateTimeout(ctx, data.Timeouts)); err != nil {
+	harness, err := waitHarnessCreated(ctx, conn, harnessID, r.CreateTimeout(ctx, data.Timeouts))
+	if err != nil {
 		// Taint the resource.
 		response.State.SetAttribute(ctx, path.Root("harness_id"), harnessID)
-		smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, harnessID)
-		return
-	}
-
-	harness, err := findHarnessByID(ctx, conn, harnessID)
-	if err != nil {
 		smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, harnessID)
 		return
 	}

--- a/internal/service/bedrockagentcore/harness.go
+++ b/internal/service/bedrockagentcore/harness.go
@@ -214,7 +214,10 @@ func (r *harnessResource) Schema(ctx context.Context, request resource.SchemaReq
 								Attributes: map[string]schema.Attribute{
 									names.AttrARN: schema.StringAttribute{
 										CustomType: fwtypes.ARNType,
-										Required:   true,
+										Computed:   true,
+										PlanModifiers: []planmodifier.String{
+											stringplanmodifier.UseStateForUnknown(),
+										},
 									},
 									"encryption_key_arn": schema.StringAttribute{
 										CustomType: fwtypes.ARNType,
@@ -223,9 +226,9 @@ func (r *harnessResource) Schema(ctx context.Context, request resource.SchemaReq
 									"event_expiry_duration": schema.Int32Attribute{
 										Optional: true,
 									},
-									"strategies": schema.ListAttribute{
+									"strategies": schema.SetAttribute{
 										Optional:    true,
-										CustomType:  fwtypes.ListOfStringEnumType[awstypes.HarnessManagedMemoryStrategyType](),
+										CustomType:  fwtypes.SetOfStringEnumType[awstypes.HarnessManagedMemoryStrategyType](),
 										ElementType: types.StringType,
 									},
 								},
@@ -1506,12 +1509,30 @@ func (m harnessMemoryConfigurationModel) expandToHarnessMemoryConfiguration(ctx 
 		smerr.AddEnrich(ctx, &diags, fwflex.Expand(ctx, data, &r.Value))
 		return &r, diags
 	}
+	if !m.ManagedMemoryConfiguration.IsNull() {
+		data, d := m.ManagedMemoryConfiguration.ToPtr(ctx)
+		smerr.AddEnrich(ctx, &diags, d)
+		if diags.HasError() {
+			return nil, diags
+		}
+		var r awstypes.HarnessMemoryConfigurationMemberManagedMemoryConfiguration
+		smerr.AddEnrich(ctx, &diags, fwflex.Expand(ctx, data, &r.Value))
+		return &r, diags
+	}
 	return nil, diags
 }
 
 func (m harnessMemoryConfigurationModel) expandToUpdatedHarnessMemoryConfiguration(ctx context.Context) (*awstypes.UpdatedHarnessMemoryConfiguration, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	if !m.AgentCoreMemoryConfiguration.IsNull() {
+		r, d := m.expandToHarnessMemoryConfiguration(ctx)
+		smerr.AddEnrich(ctx, &diags, d)
+		if diags.HasError() {
+			return nil, diags
+		}
+		return &awstypes.UpdatedHarnessMemoryConfiguration{OptionalValue: r}, diags
+	}
+	if !m.ManagedMemoryConfiguration.IsNull() {
 		r, d := m.expandToHarnessMemoryConfiguration(ctx)
 		smerr.AddEnrich(ctx, &diags, d)
 		if diags.HasError() {
@@ -1537,10 +1558,10 @@ type harnessAgentCoreMemoryRetrievalConfigModel struct {
 }
 
 type harnessManagedMemoryConfigurationModel struct {
-	ARN                 fwtypes.ARN                                                         `tfsdk:"arn"`
-	EncryptionKeyARN    fwtypes.ARN                                                         `tfsdk:"encryption_key_arn"`
-	EventExpiryDuration types.Int32                                                         `tfsdk:"event_expiry_duration"`
-	Strategies          fwtypes.ListOfStringEnum[awstypes.HarnessManagedMemoryStrategyType] `tfsdk:"strategies"`
+	ARN                 fwtypes.ARN                                                        `tfsdk:"arn" autoflex:",noexpand"`
+	EncryptionKeyARN    fwtypes.ARN                                                        `tfsdk:"encryption_key_arn"`
+	EventExpiryDuration types.Int32                                                        `tfsdk:"event_expiry_duration"`
+	Strategies          fwtypes.SetOfStringEnum[awstypes.HarnessManagedMemoryStrategyType] `tfsdk:"strategies"`
 }
 
 // HarnessMemoryConfigurationMemberManagedMemoryConfiguration

--- a/internal/service/bedrockagentcore/harness.go
+++ b/internal/service/bedrockagentcore/harness.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/int32validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -225,9 +226,11 @@ func (r *harnessResource) Schema(ctx context.Context, request resource.SchemaReq
 									},
 									"event_expiry_duration": schema.Int32Attribute{
 										Optional: true,
+										Computed: true,
 									},
 									"strategies": schema.SetAttribute{
 										Optional:    true,
+										Computed:    true,
 										CustomType:  fwtypes.SetOfStringEnumType[awstypes.HarnessManagedMemoryStrategyType](),
 										ElementType: types.StringType,
 									},
@@ -741,8 +744,33 @@ func (r *harnessResource) flatten(ctx context.Context, harness *awstypes.Harness
 	}
 
 	if populateMemory {
-		diags.Append(fwflex.Flatten(ctx, harness.Memory, &data.Memory)...)
+		conn := r.Meta().BedrockAgentCoreClient(ctx)
+		diags.Append(r.flattenMemory(ctx, conn, harness, data)...)
 	}
+
+	return diags
+}
+
+func (r *harnessResource) flattenMemory(ctx context.Context, conn *bedrockagentcorecontrol.Client, harness *awstypes.Harness, data *harnessResourceModel) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	diags.Append(fwflex.Flatten(ctx, harness.Memory, &data.Memory)...)
+	if diags.HasError() {
+		return diags
+	}
+
+	memoryBlock, d := data.Memory.ToPtr(ctx)
+	diags.Append(d...)
+	if diags.HasError() || memoryBlock == nil {
+		return diags
+	}
+
+	diags.Append(memoryBlock.flattenEnriched(ctx, conn)...)
+	if diags.HasError() {
+		return diags
+	}
+
+	data.Memory = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, memoryBlock)
 
 	return diags
 }
@@ -1543,6 +1571,27 @@ func (m harnessMemoryConfigurationModel) expandToUpdatedHarnessMemoryConfigurati
 	return &awstypes.UpdatedHarnessMemoryConfiguration{}, diags
 }
 
+func (m *harnessMemoryConfigurationModel) flattenEnriched(ctx context.Context, conn *bedrockagentcorecontrol.Client) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	if !m.ManagedMemoryConfiguration.IsNull() {
+		managedMemory, d := m.ManagedMemoryConfiguration.ToPtr(ctx)
+		diags.Append(d...)
+		if diags.HasError() || managedMemory == nil {
+			return diags
+		}
+
+		diags.Append(managedMemory.flattenEnriched(ctx, conn)...)
+		if diags.HasError() {
+			return diags
+		}
+
+		m.ManagedMemoryConfiguration = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, managedMemory)
+	}
+
+	return diags
+}
+
 type harnessAgentCoreMemoryConfigurationModel struct {
 	ARN             fwtypes.ARN                                                                 `tfsdk:"arn"`
 	ActorID         types.String                                                                `tfsdk:"actor_id"`
@@ -1564,4 +1613,33 @@ type harnessManagedMemoryConfigurationModel struct {
 	Strategies          fwtypes.SetOfStringEnum[awstypes.HarnessManagedMemoryStrategyType] `tfsdk:"strategies"`
 }
 
-// HarnessMemoryConfigurationMemberManagedMemoryConfiguration
+func (m *harnessManagedMemoryConfigurationModel) flattenEnriched(ctx context.Context, conn *bedrockagentcorecontrol.Client) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	if m.ARN.IsNull() || m.ARN.IsUnknown() {
+		return diags
+	}
+
+	memory, err := findMemoryByARN(ctx, conn, m.ARN.ValueString())
+	if err != nil {
+		diags.AddError("reading managed memory", err.Error())
+		return diags
+	}
+
+	// Populate fields from the memory resource.
+	if memory.EncryptionKeyArn != nil {
+		m.EncryptionKeyARN = fwtypes.ARNValue(aws.ToString(memory.EncryptionKeyArn))
+	}
+	if memory.EventExpiryDuration != nil {
+		m.EventExpiryDuration = fwflex.Int32ToFramework(ctx, memory.EventExpiryDuration)
+	}
+	if len(memory.Strategies) > 0 {
+		elements := make([]attr.Value, 0, len(memory.Strategies))
+		for _, s := range memory.Strategies {
+			elements = append(elements, fwtypes.StringEnumValue(awstypes.HarnessManagedMemoryStrategyType(s.Type)))
+		}
+		m.Strategies = fwtypes.NewSetValueOfMust[fwtypes.StringEnum[awstypes.HarnessManagedMemoryStrategyType]](ctx, elements)
+	}
+
+	return diags
+}

--- a/internal/service/bedrockagentcore/harness.go
+++ b/internal/service/bedrockagentcore/harness.go
@@ -203,6 +203,32 @@ func (r *harnessResource) Schema(ctx context.Context, request resource.SchemaReq
 								},
 							},
 						},
+						"managed_memory_configuration": schema.ListNestedBlock{
+							CustomType: fwtypes.NewListNestedObjectTypeOf[harnessManagedMemoryConfigurationModel](ctx),
+							Validators: []validator.List{
+								listvalidator.SizeAtMost(1),
+							},
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									names.AttrARN: schema.StringAttribute{
+										CustomType: fwtypes.ARNType,
+										Required:   true,
+									},
+									"encryption_key_arn": schema.StringAttribute{
+										CustomType: fwtypes.ARNType,
+										Optional:   true,
+									},
+									"event_expiry_duration": schema.Int32Attribute{
+										Optional: true,
+									},
+									"strategies": schema.ListAttribute{
+										Optional:    true,
+										CustomType:  fwtypes.ListOfStringEnumType[awstypes.HarnessManagedMemoryStrategyType](),
+										ElementType: types.StringType,
+									},
+								},
+							},
+						},
 					},
 				},
 			},
@@ -1412,6 +1438,7 @@ func (m harnessEnvironmentArtifactModel) expandToUpdatedHarnessEnvironmentArtifa
 
 type harnessMemoryConfigurationModel struct {
 	AgentCoreMemoryConfiguration fwtypes.ListNestedObjectValueOf[harnessAgentCoreMemoryConfigurationModel] `tfsdk:"agentcore_memory_configuration"`
+	ManagedMemoryConfiguration   fwtypes.ListNestedObjectValueOf[harnessManagedMemoryConfigurationModel]   `tfsdk:"managed_memory_configuration"`
 }
 
 var (
@@ -1429,6 +1456,14 @@ func (m *harnessMemoryConfigurationModel) Flatten(ctx context.Context, v any) di
 			return diags
 		}
 		m.AgentCoreMemoryConfiguration = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &data)
+
+	case awstypes.HarnessMemoryConfigurationMemberManagedMemoryConfiguration:
+		var data harnessManagedMemoryConfigurationModel
+		smerr.AddEnrich(ctx, &diags, fwflex.Flatten(ctx, t.Value, &data))
+		if diags.HasError() {
+			return diags
+		}
+		m.ManagedMemoryConfiguration = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &data)
 
 	case awstypes.UnknownUnionMember:
 		fwflex.HandleFlattenUnkownUnionMember(ctx, t.Tag, &diags)
@@ -1492,3 +1527,12 @@ type harnessAgentCoreMemoryRetrievalConfigModel struct {
 	StrategyID     types.String  `tfsdk:"strategy_id"`
 	TopK           types.Int32   `tfsdk:"top_k"`
 }
+
+type harnessManagedMemoryConfigurationModel struct {
+	ARN                 fwtypes.ARN                                                         `tfsdk:"arn"`
+	EncryptionKeyARN    fwtypes.ARN                                                         `tfsdk:"encryption_key_arn"`
+	EventExpiryDuration types.Int32                                                         `tfsdk:"event_expiry_duration"`
+	Strategies          fwtypes.ListOfStringEnum[awstypes.HarnessManagedMemoryStrategyType] `tfsdk:"strategies"`
+}
+
+// HarnessMemoryConfigurationMemberManagedMemoryConfiguration

--- a/internal/service/bedrockagentcore/harness.go
+++ b/internal/service/bedrockagentcore/harness.go
@@ -1429,6 +1429,10 @@ func (m *harnessMemoryConfigurationModel) Flatten(ctx context.Context, v any) di
 			return diags
 		}
 		m.AgentCoreMemoryConfiguration = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &data)
+
+	case awstypes.UnknownUnionMember:
+		fwflex.HandleFlattenUnkownUnionMember(ctx, t.Tag, &diags)
+
 	default:
 		diags.AddError("Unsupported Type", fmt.Sprintf("memory configuration flatten: %T", v))
 	}

--- a/internal/service/bedrockagentcore/harness_identity_gen_test.go
+++ b/internal/service/bedrockagentcore/harness_identity_gen_test.go
@@ -69,6 +69,9 @@ func TestAccBedrockAgentCoreHarness_Identity_basic(t *testing.T) {
 				ImportState:                          true,
 				ImportStateVerify:                    true,
 				ImportStateVerifyIdentifierAttribute: "harness_id",
+				ImportStateVerifyIgnore: []string{
+					"memory",
+				},
 			},
 
 			// Step 3: Import block with Import ID
@@ -83,10 +86,12 @@ func TestAccBedrockAgentCoreHarness_Identity_basic(t *testing.T) {
 				ImportStateIdFunc: acctest.AttrImportStateIdFunc(resourceName, "harness_id"),
 				ImportPlanChecks: resource.ImportPlanChecks{
 					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
 						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New("harness_id"), knownvalue.NotNull()),
 						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.Region())),
 					},
 				},
+				ExpectNonEmptyPlan: true,
 			},
 
 			// Step 4: Import block with Resource Identity
@@ -100,10 +105,12 @@ func TestAccBedrockAgentCoreHarness_Identity_basic(t *testing.T) {
 				ImportStateKind: resource.ImportBlockWithResourceIdentity,
 				ImportPlanChecks: resource.ImportPlanChecks{
 					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
 						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New("harness_id"), knownvalue.NotNull()),
 						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.Region())),
 					},
 				},
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
@@ -155,6 +162,9 @@ func TestAccBedrockAgentCoreHarness_Identity_regionOverride(t *testing.T) {
 				ImportState:                          true,
 				ImportStateVerify:                    true,
 				ImportStateVerifyIdentifierAttribute: "harness_id",
+				ImportStateVerifyIgnore: []string{
+					"memory",
+				},
 			},
 
 			// Step 3: Import block with Import ID
@@ -170,10 +180,12 @@ func TestAccBedrockAgentCoreHarness_Identity_regionOverride(t *testing.T) {
 				ImportStateIdFunc: acctest.CrossRegionAttrImportStateIdFunc(resourceName, "harness_id"),
 				ImportPlanChecks: resource.ImportPlanChecks{
 					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
 						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New("harness_id"), knownvalue.NotNull()),
 						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.AlternateRegion())),
 					},
 				},
+				ExpectNonEmptyPlan: true,
 			},
 
 			// Step 4: Import block with Resource Identity
@@ -188,10 +200,12 @@ func TestAccBedrockAgentCoreHarness_Identity_regionOverride(t *testing.T) {
 				ImportStateKind: resource.ImportBlockWithResourceIdentity,
 				ImportPlanChecks: resource.ImportPlanChecks{
 					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
 						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New("harness_id"), knownvalue.NotNull()),
 						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.AlternateRegion())),
 					},
 				},
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/internal/service/bedrockagentcore/harness_list.go
+++ b/internal/service/bedrockagentcore/harness_list.go
@@ -68,7 +68,7 @@ func (l *harnessListResource) List(ctx context.Context, request list.ListRequest
 
 			var data harnessResourceModel
 			l.SetResult(ctx, l.Meta(), request.IncludeResource, &data, &result, func() {
-				smerr.AddEnrich(ctx, &result.Diagnostics, l.flatten(ctx, output, &data))
+				smerr.AddEnrich(ctx, &result.Diagnostics, l.flatten(ctx, output, &data, true))
 				if result.Diagnostics.HasError() {
 					return
 				}

--- a/internal/service/bedrockagentcore/harness_list_test.go
+++ b/internal/service/bedrockagentcore/harness_list_test.go
@@ -141,8 +141,11 @@ func TestAccBedrockAgentCoreHarness_List_includeResource(t *testing.T) {
 									knownvalue.ObjectExact(map[string]knownvalue.Check{
 										"arn":                   tfknownvalue.RegionalARNRegexp("bedrock-agentcore", regexache.MustCompile(`memory/harness_`+rName+`_0_[a-zA-Z0-9]+-[a-zA-Z0-9]+`)),
 										"encryption_key_arn":    knownvalue.Null(),
-										"event_expiry_duration": knownvalue.Null(),
-										"strategies":            knownvalue.Null(),
+										"event_expiry_duration": knownvalue.Int32Exact(30),
+										"strategies": knownvalue.SetExact([]knownvalue.Check{
+											knownvalue.StringExact("SEMANTIC"),
+											knownvalue.StringExact("SUMMARIZATION"),
+										}),
 									}),
 								}),
 							}),

--- a/internal/service/bedrockagentcore/harness_list_test.go
+++ b/internal/service/bedrockagentcore/harness_list_test.go
@@ -139,7 +139,7 @@ func TestAccBedrockAgentCoreHarness_List_includeResource(t *testing.T) {
 								"agentcore_memory_configuration": knownvalue.ListSizeExact(0),
 								"managed_memory_configuration": knownvalue.ListExact([]knownvalue.Check{
 									knownvalue.ObjectExact(map[string]knownvalue.Check{
-										"arn":                   tfknownvalue.RegionalARNRegexp("bedrock-agentcore", regexache.MustCompile(`memory/harness_`+rName+`_0_[a-zA-Z0-9]+-[a-zA-Z0-9]+`)),
+										names.AttrARN:           tfknownvalue.RegionalARNRegexp("bedrock-agentcore", regexache.MustCompile(`memory/harness_`+rName+`_0_[a-zA-Z0-9]+-[a-zA-Z0-9]+`)),
 										"encryption_key_arn":    knownvalue.Null(),
 										"event_expiry_duration": knownvalue.Int32Exact(30),
 										"strategies": knownvalue.SetExact([]knownvalue.Check{

--- a/internal/service/bedrockagentcore/harness_list_test.go
+++ b/internal/service/bedrockagentcore/harness_list_test.go
@@ -6,6 +6,7 @@ package bedrockagentcore_test
 import (
 	"testing"
 
+	"github.com/YakDriver/regexache"
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
@@ -14,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	tfknownvalue "github.com/hashicorp/terraform-provider-aws/internal/acctest/knownvalue"
 	tfquerycheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/querycheck"
 	tfqueryfilter "github.com/hashicorp/terraform-provider-aws/internal/acctest/queryfilter"
 	tfstatecheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/statecheck"
@@ -123,11 +125,32 @@ func TestAccBedrockAgentCoreHarness_List_includeResource(t *testing.T) {
 					querycheck.ExpectResourceKnownValues("aws_bedrockagentcore_harness.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), []querycheck.KnownValueCheck{
 						tfquerycheck.KnownValueCheck(tfjsonpath.New("allowed_tools"), knownvalue.NotNull()),
 						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrARN), checkHarnessARN(rName+"_0")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("authorizer_configuration"), knownvalue.ListSizeExact(0)),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrEnvironment), knownvalue.NotNull()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("environment_artifact"), knownvalue.ListSizeExact(0)),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("environment_variables"), knownvalue.Null()),
 						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrExecutionRoleARN), knownvalue.NotNull()),
 						tfquerycheck.KnownValueCheck(tfjsonpath.New("harness_id"), knownvalue.NotNull()),
 						tfquerycheck.KnownValueCheck(tfjsonpath.New("harness_name"), knownvalue.StringExact(rName+"_0")),
 						tfquerycheck.KnownValueCheck(tfjsonpath.New("max_iterations"), knownvalue.NotNull()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("max_tokens"), knownvalue.Null()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("memory"), knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"agentcore_memory_configuration": knownvalue.ListSizeExact(0),
+								"managed_memory_configuration": knownvalue.ListExact([]knownvalue.Check{
+									knownvalue.ObjectExact(map[string]knownvalue.Check{
+										"arn":                   tfknownvalue.RegionalARNRegexp("bedrock-agentcore", regexache.MustCompile(`memory/harness_`+rName+`_0_[a-zA-Z0-9]+-[a-zA-Z0-9]+`)),
+										"encryption_key_arn":    knownvalue.Null(),
+										"event_expiry_duration": knownvalue.Null(),
+										"strategies":            knownvalue.Null(),
+									}),
+								}),
+							}),
+						})),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("model"), knownvalue.NotNull()),
 						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.Region())),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("skill"), knownvalue.ListSizeExact(0)),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("system_prompt"), knownvalue.NotNull()),
 						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
 							acctest.CtKey1: knownvalue.StringExact(acctest.CtValue1),
 						})),
@@ -135,6 +158,8 @@ func TestAccBedrockAgentCoreHarness_List_includeResource(t *testing.T) {
 							acctest.CtKey1: knownvalue.StringExact(acctest.CtValue1),
 						})),
 						tfquerycheck.KnownValueCheck(tfjsonpath.New("timeout_seconds"), knownvalue.NotNull()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("tool"), knownvalue.ListSizeExact(0)),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("truncation"), knownvalue.NotNull()),
 					}),
 				},
 			},

--- a/internal/service/bedrockagentcore/harness_test.go
+++ b/internal/service/bedrockagentcore/harness_test.go
@@ -457,7 +457,7 @@ func TestAccBedrockAgentCoreHarness_environmentVariables(t *testing.T) {
 	})
 }
 
-func TestAccBedrockAgentCoreHarness_memory(t *testing.T) {
+func TestAccBedrockAgentCoreHarness_Memory_agentCoreMemoryConfiguration(t *testing.T) {
 	ctx := acctest.Context(t)
 	var harness awstypes.Harness
 	rName := testAccRandomHarnessName(t)
@@ -474,7 +474,7 @@ func TestAccBedrockAgentCoreHarness_memory(t *testing.T) {
 		CheckDestroy:             testAccCheckHarnessDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccHarnessConfig_memory(rName, 0.25),
+				Config: testAccHarnessConfig_Memory_agentCoreMemoryConfiguration(rName, 0.25),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckHarnessExists(ctx, t, resourceName, &harness),
 				),
@@ -485,7 +485,7 @@ func TestAccBedrockAgentCoreHarness_memory(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccHarnessConfig_memory(rName, 0.35),
+				Config: testAccHarnessConfig_Memory_agentCoreMemoryConfiguration(rName, 0.35),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckHarnessExists(ctx, t, resourceName, &harness),
 				),
@@ -965,7 +965,7 @@ resource "aws_bedrockagentcore_harness" "test" {
 `, rName, key, value))
 }
 
-func testAccHarnessConfig_memory(rName string, relevanceScore float32) string {
+func testAccHarnessConfig_Memory_agentCoreMemoryConfiguration(rName string, relevanceScore float32) string {
 	return acctest.ConfigCompose(testAccHarnessConfig_iamRole(rName), fmt.Sprintf(`
 resource "aws_bedrockagentcore_harness" "test" {
   harness_name       = %[1]q

--- a/internal/service/bedrockagentcore/harness_test.go
+++ b/internal/service/bedrockagentcore/harness_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol/types"
+	"github.com/hashicorp/terraform-plugin-testing/compare"
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
@@ -62,16 +63,44 @@ func TestAccBedrockAgentCoreHarness_basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckHarnessExists(ctx, t, resourceName, &harness),
 				),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
-					},
-				},
 				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("allowed_tools"), knownvalue.NotNull()),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrARN), checkHarnessARN(rName)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("authorizer_configuration"), knownvalue.ListSizeExact(0)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrEnvironment), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("environment_artifact"), knownvalue.ListSizeExact(0)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("environment_variables"), knownvalue.Null()),
+					statecheck.CompareValuePairs(resourceName, tfjsonpath.New(names.AttrExecutionRoleARN), "aws_iam_role.test", tfjsonpath.New(names.AttrARN), compare.ValuesSame()),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("harness_id"), knownvalue.NotNull()),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("harness_name"), knownvalue.StringExact(rName)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("max_iterations"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("max_tokens"), knownvalue.Null()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("memory"), knownvalue.ListSizeExact(0)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("model"), knownvalue.ListExact([]knownvalue.Check{
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"bedrock_model_config": knownvalue.ListExact([]knownvalue.Check{
+								knownvalue.ObjectExact(map[string]knownvalue.Check{
+									"max_tokens":  knownvalue.Null(),
+									"model_id":    knownvalue.StringExact("anthropic.claude-sonnet-4-20250514"),
+									"temperature": knownvalue.Null(),
+									"top_p":       knownvalue.Null(),
+								}),
+							}),
+							"gemini_model_config": knownvalue.ListSizeExact(0),
+							"openai_model_config": knownvalue.ListSizeExact(0),
+						}),
+					})),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("skill"), knownvalue.ListSizeExact(0)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("system_prompt"), knownvalue.ListExact([]knownvalue.Check{
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"text": knownvalue.StringExact("You are a helpful assistant."),
+						}),
+					})),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTagsAll), knownvalue.MapSizeExact(0)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("timeout_seconds"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("tool"), knownvalue.ListSizeExact(0)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("truncation"), knownvalue.NotNull()),
 				},
 			},
 		},

--- a/internal/service/bedrockagentcore/harness_test.go
+++ b/internal/service/bedrockagentcore/harness_test.go
@@ -627,8 +627,11 @@ func TestAccBedrockAgentCoreHarness_Memory_managedMemoryConfiguration_empty(t *t
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("memory").AtSliceIndex(0).AtMapKey("managed_memory_configuration").AtSliceIndex(0), knownvalue.ObjectExact(map[string]knownvalue.Check{
 						names.AttrARN:           tfknownvalue.RegionalARNRegexp("bedrock-agentcore", regexache.MustCompile(`memory/harness_`+rName+`_[a-zA-Z0-9]+-[a-zA-Z0-9]+`)),
 						"encryption_key_arn":    knownvalue.Null(),
-						"event_expiry_duration": knownvalue.Null(),
-						"strategies":            knownvalue.Null(),
+						"event_expiry_duration": knownvalue.Int32Exact(30),
+						"strategies": knownvalue.SetExact([]knownvalue.Check{
+							knownvalue.StringExact("SEMANTIC"),
+							knownvalue.StringExact("SUMMARIZATION"),
+						}),
 					})),
 				},
 			},
@@ -743,8 +746,11 @@ func TestAccBedrockAgentCoreHarness_Memory_managedMemoryConfiguration_encryption
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("memory").AtSliceIndex(0).AtMapKey("managed_memory_configuration").AtSliceIndex(0), knownvalue.ObjectExact(map[string]knownvalue.Check{
 						names.AttrARN:           tfknownvalue.RegionalARNRegexp("bedrock-agentcore", regexache.MustCompile(`memory/harness_`+rName+`_[a-zA-Z0-9]+-[a-zA-Z0-9]+`)),
 						"encryption_key_arn":    knownvalue.NotNull(),
-						"event_expiry_duration": knownvalue.Null(),
-						"strategies":            knownvalue.Null(),
+						"event_expiry_duration": knownvalue.Int32Exact(30),
+						"strategies": knownvalue.SetExact([]knownvalue.Check{
+							knownvalue.StringExact("SEMANTIC"),
+							knownvalue.StringExact("SUMMARIZATION"),
+						}),
 					})),
 					statecheck.CompareValuePairs(resourceName, tfjsonpath.New("memory").AtSliceIndex(0).AtMapKey("managed_memory_configuration").AtSliceIndex(0).AtMapKey("encryption_key_arn"), "aws_kms_key.test", tfjsonpath.New(names.AttrARN), compare.ValuesSame()),
 				},

--- a/internal/service/bedrockagentcore/harness_test.go
+++ b/internal/service/bedrockagentcore/harness_test.go
@@ -103,6 +103,27 @@ func TestAccBedrockAgentCoreHarness_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("truncation"), knownvalue.NotNull()),
 				},
 			},
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Harness/basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+				},
+				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, "harness_id"),
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "harness_id",
+				ImportStateVerifyIgnore:              []string{"memory"},
+				ImportStateCheck: acctest.ComposeAggregateImportStateCheckFunc(
+					acctest.ImportCheckResourceAttr("memory.#", "1"),
+					acctest.ImportCheckResourceAttr("memory.0.agentcore_memory_configuration.#", "0"),
+					acctest.ImportCheckResourceAttr("memory.0.managed_memory_configuration.#", "1"),
+					acctest.ImportMatchResourceAttr("memory.0.managed_memory_configuration.0.arn", regexache.MustCompile(`^arn:[^:]+:bedrock-agentcore:[^:]+:\d{12}:memory/harness_`+rName+`_[a-zA-Z0-9]+-[a-zA-Z0-9]+$`)),
+					acctest.ImportCheckResourceAttr("memory.0.managed_memory_configuration.0.encryption_key_arn", ""),
+					acctest.ImportCheckResourceAttr("memory.0.managed_memory_configuration.0.event_expiry_duration", ""),
+					acctest.ImportCheckResourceAttr("memory.0.managed_memory_configuration.0.strategies.#", ""),
+				),
+			},
 		},
 	})
 }
@@ -184,6 +205,14 @@ func TestAccBedrockAgentCoreHarness_update_systemPrompt(t *testing.T) {
 					},
 				},
 			},
+			{
+				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, "harness_id"),
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "harness_id",
+				ImportStateVerifyIgnore:              []string{"memory"},
+			},
 		},
 	})
 }
@@ -225,6 +254,14 @@ func TestAccBedrockAgentCoreHarness_update_allowedTools(t *testing.T) {
 						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
 					},
 				},
+			},
+			{
+				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, "harness_id"),
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "harness_id",
+				ImportStateVerifyIgnore:              []string{"memory"},
 			},
 		},
 	})
@@ -268,6 +305,14 @@ func TestAccBedrockAgentCoreHarness_update_limits(t *testing.T) {
 					},
 				},
 			},
+			{
+				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, "harness_id"),
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "harness_id",
+				ImportStateVerifyIgnore:              []string{"memory"},
+			},
 		},
 	})
 }
@@ -305,7 +350,11 @@ func TestAccBedrockAgentCoreHarness_model_bedrock(t *testing.T) {
 				ImportState:                          true,
 				ImportStateVerify:                    true,
 				ImportStateVerifyIdentifierAttribute: "harness_id",
-				ImportStateVerifyIgnore:              []string{"model.0.bedrock_model_config.0.temperature", "model.0.bedrock_model_config.0.top_p"},
+				ImportStateVerifyIgnore: []string{
+					"memory",
+					"model.0.bedrock_model_config.0.temperature",
+					"model.0.bedrock_model_config.0.top_p",
+				},
 			},
 		},
 	})
@@ -349,6 +398,14 @@ func TestAccBedrockAgentCoreHarness_truncation_slidingWindow(t *testing.T) {
 					},
 				},
 			},
+			{
+				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, "harness_id"),
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "harness_id",
+				ImportStateVerifyIgnore:              []string{"memory"},
+			},
 		},
 	})
 }
@@ -380,6 +437,14 @@ func TestAccBedrockAgentCoreHarness_truncation_summarization(t *testing.T) {
 					},
 				},
 			},
+			{
+				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, "harness_id"),
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "harness_id",
+				ImportStateVerifyIgnore:              []string{"memory"},
+			},
 		},
 	})
 }
@@ -410,6 +475,14 @@ func TestAccBedrockAgentCoreHarness_tools_inlineFunction(t *testing.T) {
 						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
 					},
 				},
+			},
+			{
+				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, "harness_id"),
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "harness_id",
+				ImportStateVerifyIgnore:              []string{"memory"},
 			},
 		},
 	})
@@ -451,6 +524,17 @@ func TestAccBedrockAgentCoreHarness_environmentVariables(t *testing.T) {
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
 					},
+				},
+			},
+			{
+				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, "harness_id"),
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "harness_id",
+				ImportStateVerifyIgnore: []string{
+					"environment_variables",
+					"memory",
 				},
 			},
 		},
@@ -495,6 +579,20 @@ func TestAccBedrockAgentCoreHarness_Memory_agentCoreMemoryConfiguration(t *testi
 					},
 				},
 			},
+			{
+				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, "harness_id"),
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "harness_id",
+				ImportStateVerifyIgnore: []string{
+					"memory.0.agentcore_memory_configuration.0.retrieval_config.0.relevance_score",
+				},
+				ImportStateCheck: acctest.ComposeAggregateImportStateCheckFunc(
+					// TODO: float32 precision issue
+					acctest.ImportMatchResourceAttr("memory.0.agentcore_memory_configuration.0.retrieval_config.0.relevance_score", regexache.MustCompile(`^0\.34`)),
+				),
+			},
 		},
 	})
 }
@@ -536,6 +634,14 @@ func TestAccBedrockAgentCoreHarness_environmentArtifact(t *testing.T) {
 						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
 					},
 				},
+			},
+			{
+				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, "harness_id"),
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "harness_id",
+				ImportStateVerifyIgnore:              []string{"memory"},
 			},
 		},
 	})
@@ -579,6 +685,14 @@ func TestAccBedrockAgentCoreHarness_authorizerConfiguration(t *testing.T) {
 					},
 				},
 			},
+			{
+				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, "harness_id"),
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "harness_id",
+				ImportStateVerifyIgnore:              []string{"memory"},
+			},
 		},
 	})
 }
@@ -621,6 +735,7 @@ func TestAccBedrockAgentCoreHarness_tags(t *testing.T) {
 				ImportState:                          true,
 				ImportStateVerify:                    true,
 				ImportStateVerifyIdentifierAttribute: "harness_id",
+				ImportStateVerifyIgnore:              []string{"memory"},
 			},
 			{
 				Config: testAccHarnessConfig_tags2(rName, acctest.CtKey1, acctest.CtValue1Updated, acctest.CtKey2, acctest.CtValue2),

--- a/internal/service/bedrockagentcore/harness_test.go
+++ b/internal/service/bedrockagentcore/harness_test.go
@@ -597,6 +597,169 @@ func TestAccBedrockAgentCoreHarness_Memory_agentCoreMemoryConfiguration(t *testi
 	})
 }
 
+func TestAccBedrockAgentCoreHarness_Memory_managedMemoryConfiguration_empty(t *testing.T) {
+	ctx := acctest.Context(t)
+	var harness awstypes.Harness
+	rName := testAccRandomHarnessName(t)
+	resourceName := "aws_bedrockagentcore_harness.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID)
+			testAccPreCheckHarness(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockAgentCoreServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckHarnessDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccHarnessConfig_Memory_managedMemoryConfiguration_empty(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckHarnessExists(ctx, t, resourceName, &harness),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("memory").AtSliceIndex(0).AtMapKey("managed_memory_configuration").AtSliceIndex(0), knownvalue.ObjectExact(map[string]knownvalue.Check{
+						names.AttrARN:           tfknownvalue.RegionalARNRegexp("bedrock-agentcore", regexache.MustCompile(`memory/harness_`+rName+`_[a-zA-Z0-9]+-[a-zA-Z0-9]+`)),
+						"encryption_key_arn":    knownvalue.Null(),
+						"event_expiry_duration": knownvalue.Null(),
+						"strategies":            knownvalue.Null(),
+					})),
+				},
+			},
+			{
+				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, "harness_id"),
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "harness_id",
+			},
+		},
+	})
+}
+
+func TestAccBedrockAgentCoreHarness_Memory_managedMemoryConfiguration_update(t *testing.T) {
+	ctx := acctest.Context(t)
+	var harness awstypes.Harness
+	rName := testAccRandomHarnessName(t)
+	resourceName := "aws_bedrockagentcore_harness.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID)
+			testAccPreCheckHarness(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockAgentCoreServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckHarnessDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccHarnessConfig_Memory_managedMemoryConfiguration_options(rName, 7, `["SEMANTIC"]`),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckHarnessExists(ctx, t, resourceName, &harness),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("memory").AtSliceIndex(0).AtMapKey("managed_memory_configuration").AtSliceIndex(0), knownvalue.ObjectExact(map[string]knownvalue.Check{
+						names.AttrARN:           tfknownvalue.RegionalARNRegexp("bedrock-agentcore", regexache.MustCompile(`memory/harness_`+rName+`_[a-zA-Z0-9]+-[a-zA-Z0-9]+`)),
+						"encryption_key_arn":    knownvalue.Null(),
+						"event_expiry_duration": knownvalue.Int32Exact(7),
+						"strategies": knownvalue.SetExact([]knownvalue.Check{
+							knownvalue.StringExact("SEMANTIC"),
+						}),
+					})),
+				},
+			},
+			{
+				Config: testAccHarnessConfig_Memory_managedMemoryConfiguration_options(rName, 14, `["SEMANTIC", "SUMMARIZATION"]`),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckHarnessExists(ctx, t, resourceName, &harness),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("memory").AtSliceIndex(0).AtMapKey("managed_memory_configuration").AtSliceIndex(0), knownvalue.ObjectExact(map[string]knownvalue.Check{
+						names.AttrARN:           tfknownvalue.RegionalARNRegexp("bedrock-agentcore", regexache.MustCompile(`memory/harness_`+rName+`_[a-zA-Z0-9]+-[a-zA-Z0-9]+`)),
+						"encryption_key_arn":    knownvalue.Null(),
+						"event_expiry_duration": knownvalue.Int32Exact(14),
+						"strategies": knownvalue.SetExact([]knownvalue.Check{
+							knownvalue.StringExact("SEMANTIC"),
+							knownvalue.StringExact("SUMMARIZATION"),
+						}),
+					})),
+				},
+			},
+			{
+				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, "harness_id"),
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "harness_id",
+			},
+		},
+	})
+}
+
+func TestAccBedrockAgentCoreHarness_Memory_managedMemoryConfiguration_encryptionKey(t *testing.T) {
+	ctx := acctest.Context(t)
+	var harness awstypes.Harness
+	rName := testAccRandomHarnessName(t)
+	resourceName := "aws_bedrockagentcore_harness.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID)
+			testAccPreCheckHarness(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockAgentCoreServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckHarnessDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccHarnessConfig_Memory_managedMemoryConfiguration_encryptionKey(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckHarnessExists(ctx, t, resourceName, &harness),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("memory").AtSliceIndex(0).AtMapKey("managed_memory_configuration").AtSliceIndex(0), knownvalue.ObjectExact(map[string]knownvalue.Check{
+						names.AttrARN:           tfknownvalue.RegionalARNRegexp("bedrock-agentcore", regexache.MustCompile(`memory/harness_`+rName+`_[a-zA-Z0-9]+-[a-zA-Z0-9]+`)),
+						"encryption_key_arn":    knownvalue.NotNull(),
+						"event_expiry_duration": knownvalue.Null(),
+						"strategies":            knownvalue.Null(),
+					})),
+					statecheck.CompareValuePairs(resourceName, tfjsonpath.New("memory").AtSliceIndex(0).AtMapKey("managed_memory_configuration").AtSliceIndex(0).AtMapKey("encryption_key_arn"), "aws_kms_key.test", tfjsonpath.New(names.AttrARN), compare.ValuesSame()),
+				},
+			},
+			{
+				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, "harness_id"),
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "harness_id",
+			},
+		},
+	})
+}
+
 func TestAccBedrockAgentCoreHarness_environmentArtifact(t *testing.T) {
 	ctx := acctest.Context(t)
 	var harness awstypes.Harness
@@ -1113,6 +1276,84 @@ resource "aws_bedrockagentcore_memory" "test" {
   event_expiry_duration = 7
 }
 `, rName, relevanceScore))
+}
+
+func testAccHarnessConfig_Memory_managedMemoryConfiguration_empty(rName string) string {
+	return acctest.ConfigCompose(testAccHarnessConfig_iamRole(rName), fmt.Sprintf(`
+resource "aws_bedrockagentcore_harness" "test" {
+  harness_name       = %[1]q
+  execution_role_arn = aws_iam_role.test.arn
+
+  memory {
+    managed_memory_configuration {}
+  }
+
+  model {
+    bedrock_model_config {
+      model_id = "anthropic.claude-sonnet-4-20250514"
+    }
+  }
+
+  system_prompt {
+    text = "You are a helpful assistant."
+  }
+}
+`, rName))
+}
+
+func testAccHarnessConfig_Memory_managedMemoryConfiguration_options(rName string, eventExpiryDuration int, strategies string) string {
+	return acctest.ConfigCompose(testAccHarnessConfig_iamRole(rName), fmt.Sprintf(`
+resource "aws_bedrockagentcore_harness" "test" {
+  harness_name       = %[1]q
+  execution_role_arn = aws_iam_role.test.arn
+
+  memory {
+    managed_memory_configuration {
+      event_expiry_duration = %[2]d
+      strategies            = %[3]s
+    }
+  }
+
+  model {
+    bedrock_model_config {
+      model_id = "anthropic.claude-sonnet-4-20250514"
+    }
+  }
+
+  system_prompt {
+    text = "You are a helpful assistant."
+  }
+}
+`, rName, eventExpiryDuration, strategies))
+}
+
+func testAccHarnessConfig_Memory_managedMemoryConfiguration_encryptionKey(rName string) string {
+	return acctest.ConfigCompose(testAccHarnessConfig_iamRole(rName), fmt.Sprintf(`
+resource "aws_bedrockagentcore_harness" "test" {
+  harness_name       = %[1]q
+  execution_role_arn = aws_iam_role.test.arn
+
+  memory {
+    managed_memory_configuration {
+      encryption_key_arn = aws_kms_key.test.arn
+    }
+  }
+
+  model {
+    bedrock_model_config {
+      model_id = "anthropic.claude-sonnet-4-20250514"
+    }
+  }
+
+  system_prompt {
+    text = "You are a helpful assistant."
+  }
+}
+
+resource "aws_kms_key" "test" {
+  description = %[1]q
+}
+`, rName))
 }
 
 func testAccHarnessConfig_environmentArtifact(rName, imageTag string) string {

--- a/internal/service/bedrockagentcore/harness_test.go
+++ b/internal/service/bedrockagentcore/harness_test.go
@@ -120,8 +120,10 @@ func TestAccBedrockAgentCoreHarness_basic(t *testing.T) {
 					acctest.ImportCheckResourceAttr("memory.0.managed_memory_configuration.#", "1"),
 					acctest.ImportMatchResourceAttr("memory.0.managed_memory_configuration.0.arn", regexache.MustCompile(`^arn:[^:]+:bedrock-agentcore:[^:]+:\d{12}:memory/harness_`+rName+`_[a-zA-Z0-9]+-[a-zA-Z0-9]+$`)),
 					acctest.ImportCheckResourceAttr("memory.0.managed_memory_configuration.0.encryption_key_arn", ""),
-					acctest.ImportCheckResourceAttr("memory.0.managed_memory_configuration.0.event_expiry_duration", ""),
-					acctest.ImportCheckResourceAttr("memory.0.managed_memory_configuration.0.strategies.#", ""),
+					acctest.ImportCheckResourceAttr("memory.0.managed_memory_configuration.0.event_expiry_duration", "30"),
+					acctest.ImportCheckResourceAttr("memory.0.managed_memory_configuration.0.strategies.#", "2"),
+					importCheckSetContains("memory.0.managed_memory_configuration.0.strategies", "SEMANTIC"),
+					importCheckSetContains("memory.0.managed_memory_configuration.0.strategies", "SUMMARIZATION"),
 				),
 			},
 		},
@@ -1002,6 +1004,22 @@ func testAccPreCheckHarness(ctx context.Context, t *testing.T) {
 	}
 	if err != nil {
 		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
+}
+
+func importCheckSetContains(prefix, value string) resource.ImportStateCheckFunc {
+	return func(is []*terraform.InstanceState) error {
+		if len(is) != 1 {
+			return fmt.Errorf("expected 1 instance state, got %d", len(is))
+		}
+
+		rs := is[0]
+		for k, v := range rs.Attributes {
+			if strings.HasPrefix(k, prefix+".") && k != prefix+".#" && v == value {
+				return nil
+			}
+		}
+		return fmt.Errorf("set %q does not contain value %q", prefix, value)
 	}
 }
 

--- a/internal/service/bedrockagentcore/memory.go
+++ b/internal/service/bedrockagentcore/memory.go
@@ -464,7 +464,7 @@ func findMemoryByID(ctx context.Context, conn *bedrockagentcorecontrol.Client, i
 func findMemoryByARN(ctx context.Context, conn *bedrockagentcorecontrol.Client, memoryARN string) (*awstypes.Memory, error) {
 	parsedARN, err := arn.Parse(memoryARN)
 	if err != nil {
-		return nil, fmt.Errorf("parsing memory ARN (%s): %w", memoryARN, err)
+		return nil, smarterr.NewError(fmt.Errorf("parsing memory ARN (%s): %w", memoryARN, err))
 	}
 	memoryID := strings.TrimPrefix(parsedARN.Resource, "memory/")
 

--- a/internal/service/bedrockagentcore/memory.go
+++ b/internal/service/bedrockagentcore/memory.go
@@ -9,11 +9,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/YakDriver/regexache"
 	"github.com/YakDriver/smarterr"
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol/types"
 	"github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
@@ -457,6 +459,16 @@ func findMemoryByID(ctx context.Context, conn *bedrockagentcorecontrol.Client, i
 	}
 
 	return findMemory(ctx, conn, &input)
+}
+
+func findMemoryByARN(ctx context.Context, conn *bedrockagentcorecontrol.Client, memoryARN string) (*awstypes.Memory, error) {
+	parsedARN, err := arn.Parse(memoryARN)
+	if err != nil {
+		return nil, fmt.Errorf("parsing memory ARN (%s): %w", memoryARN, err)
+	}
+	memoryID := strings.TrimPrefix(parsedARN.Resource, "memory/")
+
+	return findMemoryByID(ctx, conn, memoryID)
 }
 
 func findMemory(ctx context.Context, conn *bedrockagentcorecontrol.Client, input *bedrockagentcorecontrol.GetMemoryInput) (*awstypes.Memory, error) {

--- a/website/docs/r/bedrockagentcore_harness.html.markdown
+++ b/website/docs/r/bedrockagentcore_harness.html.markdown
@@ -149,33 +149,33 @@ The following arguments are required:
 
 * `harness_name` - (Required, Forces new resource) Name of the harness. Must be 1-40 characters, alphanumeric and underscores only.
 * `execution_role_arn` - (Required) ARN of the IAM role that the harness assumes to access AWS services.
-* `model` - (Required) Model configuration for the harness. See [`model`](#model) below.
+* `model` - (Required) Model configuration for the harness. See [`model` Block](#model-block) below.
 
 The following arguments are optional:
 
 * `allowed_tools` - (Optional) List of tool names allowed for the harness. Use `["*"]` to allow all tools.
-* `authorizer_configuration` - (Optional) Authorization configuration for authenticating requests. See [`authorizer_configuration`](#authorizer_configuration) below.
-* `environment` - (Optional) Compute environment configuration. See [`environment`](#environment) below.
-* `environment_artifact` - (Optional) Environment artifact configuration. See [`environment_artifact`](#environment_artifact) below.
+* `authorizer_configuration` - (Optional) Authorization configuration for authenticating requests. See [`authorizer_configuration` Block](#authorizer_configuration-block) below.
+* `environment` - (Optional) Compute environment configuration. See [`environment` Block](#environment-block) below.
+* `environment_artifact` - (Optional) Environment artifact configuration. See [`environment_artifact` Block](#environment_artifact-block) below.
 * `environment_variables` - (Optional, Sensitive) Map of environment variables.
 * `max_iterations` - (Optional) Maximum number of iterations the agent loop can perform.
 * `max_tokens` - (Optional) Maximum number of tokens in the model response.
 * `memory` - (Optional) Memory configuration. See [`memory` Block](#memory-block) below.
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
-* `skill` - (Optional) Skill configurations. See [`skill`](#skill) below.
-* `system_prompt` - (Optional) System prompt blocks for the harness. See [`system_prompt`](#system_prompt) below.
+* `skill` - (Optional) Skill configurations. See [`skill` Block](#skill-block) below.
+* `system_prompt` - (Optional) System prompt blocks for the harness. See [`system_prompt` Block](#system_prompt-block) below.
 * `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `timeout_seconds` - (Optional) Timeout in seconds for the harness execution.
-* `tool` - (Optional) Tool configurations. See [`tool`](#tool) below.
-* `truncation` - (Optional) Truncation configuration for conversation history. See [`truncation`](#truncation) below.
+* `tool` - (Optional) Tool configurations. See [`tool` Block](#tool-block) below.
+* `truncation` - (Optional) Truncation configuration for conversation history. See [`truncation` Block](#truncation-block) below.
 
 ### `model` Block
 
 The `model` block supports exactly one of the following:
 
-* `bedrock_model_config` - (Optional) Amazon Bedrock model configuration. See [`bedrock_model_config`](#bedrock_model_config) below.
-* `openai_model_config` - (Optional) OpenAI model configuration. See [`openai_model_config`](#openai_model_config) below.
-* `gemini_model_config` - (Optional) Gemini model configuration. See [`gemini_model_config`](#gemini_model_config) below.
+* `bedrock_model_config` - (Optional) Amazon Bedrock model configuration. See [`bedrock_model_config` Block](#bedrock_model_config-block) below.
+* `openai_model_config` - (Optional) OpenAI model configuration. See [`openai_model_config` Block](#openai_model_config-block) below.
+* `gemini_model_config` - (Optional) Gemini model configuration. See [`gemini_model_config` Block](#gemini_model_config-block) below.
 
 ### `bedrock_model_config` Block
 
@@ -215,11 +215,11 @@ The `model` block supports exactly one of the following:
 
 The `config` block supports exactly one of the following:
 
-* `remote_mcp` - (Optional) Remote MCP server configuration. See [`remote_mcp`](#remote_mcp) below.
-* `agentcore_browser` - (Optional) AgentCore browser configuration. See [`agentcore_browser`](#agentcore_browser) below.
-* `agentcore_gateway` - (Optional) AgentCore gateway configuration. See [`agentcore_gateway`](#agentcore_gateway) below.
-* `inline_function` - (Optional) Inline function configuration. See [`inline_function`](#inline_function) below.
-* `agentcore_code_interpreter` - (Optional) AgentCore code interpreter configuration. See [`agentcore_code_interpreter`](#agentcore_code_interpreter) below.
+* `remote_mcp` - (Optional) Remote MCP server configuration. See [`remote_mcp` Block](#remote_mcp-block) below.
+* `agentcore_browser` - (Optional) AgentCore browser configuration. See [`agentcore_browser` Block](#agentcore_browser-block) below.
+* `agentcore_gateway` - (Optional) AgentCore gateway configuration. See [`agentcore_gateway` Block](#agentcore_gateway-block) below.
+* `inline_function` - (Optional) Inline function configuration. See [`inline_function` Block](#inline_function-block) below.
+* `agentcore_code_interpreter` - (Optional) AgentCore code interpreter configuration. See [`agentcore_code_interpreter` Block](#agentcore_code_interpreter-block) below.
 
 ### `remote_mcp` Block
 
@@ -233,7 +233,7 @@ The `config` block supports exactly one of the following:
 ### `agentcore_gateway` Block
 
 * `gateway_arn` - (Required) ARN of the AgentCore gateway resource.
-* `outbound_auth` - (Optional) Outbound authentication configuration. See [`outbound_auth`](#outbound_auth) below.
+* `outbound_auth` - (Optional) Outbound authentication configuration. See [`outbound_auth` Block](#outbound_auth-block) below.
 
 ### `outbound_auth` Block
 
@@ -241,7 +241,7 @@ Exactly one of the following must be specified:
 
 * `aws_iam` - (Optional) Set to `true` to use AWS IAM authentication.
 * `none` - (Optional) Set to `true` to disable authentication.
-* `oauth` - (Optional) OAuth credential provider configuration. See [`oauth`](#oauth) below.
+* `oauth` - (Optional) OAuth credential provider configuration. See [`oauth` Block](#oauth-block) below.
 
 ### `oauth` Block
 
@@ -273,8 +273,8 @@ Exactly one of the following must be specified:
 
 The `config` block supports exactly one of the following:
 
-* `sliding_window` - (Optional) Sliding window truncation configuration. See [`sliding_window`](#sliding_window) below.
-* `summarization` - (Optional) Summarization truncation configuration. See [`summarization`](#summarization) below.
+* `sliding_window` - (Optional) Sliding window truncation configuration. See [`sliding_window` Block](#sliding_window-block) below.
+* `summarization` - (Optional) Summarization truncation configuration. See [`summarization` Block](#summarization-block) below.
 
 ### `sliding_window` Block
 
@@ -288,13 +288,13 @@ The `config` block supports exactly one of the following:
 
 ### `environment` Block
 
-* `agentcore_runtime_environment` - (Required) AgentCore runtime environment configuration. See [`agentcore_runtime_environment`](#agentcore_runtime_environment) below.
+* `agentcore_runtime_environment` - (Required) AgentCore runtime environment configuration. See [`agentcore_runtime_environment` Block](#agentcore_runtime_environment-block) below.
 
 ### `agentcore_runtime_environment` Block
 
-* `lifecycle_configuration` - (Optional) Lifecycle configuration. See [`lifecycle_configuration`](#lifecycle_configuration) below.
-* `network_configuration` - (Optional) Network configuration. See [`network_configuration`](#network_configuration) below.
-* `filesystem_configuration` - (Optional) Filesystem configurations. See [`filesystem_configuration`](#filesystem_configuration) below.
+* `lifecycle_configuration` - (Optional) Lifecycle configuration. See [`lifecycle_configuration` Block](#lifecycle_configuration-block) below.
+* `network_configuration` - (Optional) Network configuration. See [`network_configuration` Block](#network_configuration-block) below.
+* `filesystem_configuration` - (Optional) Filesystem configurations. See [`filesystem_configuration` Block](#filesystem_configuration-block) below.
 
 ### `lifecycle_configuration` Block
 
@@ -304,7 +304,7 @@ The `config` block supports exactly one of the following:
 ### `network_configuration` Block
 
 * `network_mode` - (Required) Network mode. Valid values: `PUBLIC`, `VPC`.
-* `network_mode_config` - (Optional) VPC configuration. See [`network_mode_config`](#network_mode_config) below.
+* `network_mode_config` - (Optional) VPC configuration. See [`network_mode_config` Block](#network_mode_config-block) below.
 
 ### `network_mode_config` Block
 
@@ -316,9 +316,9 @@ The `config` block supports exactly one of the following:
 
 Each `filesystem_configuration` block describes a single filesystem to mount into the agent runtime. The list can contain up to 5 entries. Each block must specify exactly one of `session_storage`, `s3_files_access_point`, or `efs_access_point`.
 
-* `session_storage` - (Optional) Session storage filesystem providing persistent storage across agent runtime session invocations. Exactly one of `session_storage`, `s3_files_access_point`, or `efs_access_point` must be specified. See [`session_storage`](#session_storage) below.
-* `s3_files_access_point` - (Optional) Amazon S3 Files access point to mount as shared file storage. Exactly one of `session_storage`, `s3_files_access_point`, or `efs_access_point` must be specified. See [`s3_files_access_point`](#s3_files_access_point) below.
-* `efs_access_point` - (Optional) Amazon EFS access point to mount as shared file storage. Exactly one of `session_storage`, `s3_files_access_point`, or `efs_access_point` must be specified. See [`efs_access_point`](#efs_access_point) below.
+* `session_storage` - (Optional) Session storage filesystem providing persistent storage across agent runtime session invocations. Exactly one of `session_storage`, `s3_files_access_point`, or `efs_access_point` must be specified. See [`session_storage` Block](#session_storage-block) below.
+* `s3_files_access_point` - (Optional) Amazon S3 Files access point to mount as shared file storage. Exactly one of `session_storage`, `s3_files_access_point`, or `efs_access_point` must be specified. See [`s3_files_access_point` Block](#s3_files_access_point-block) below.
+* `efs_access_point` - (Optional) Amazon EFS access point to mount as shared file storage. Exactly one of `session_storage`, `s3_files_access_point`, or `efs_access_point` must be specified. See [`efs_access_point` Block](#efs_access_point-block) below.
 
 ### `session_storage` Block
 
@@ -342,7 +342,7 @@ The `efs_access_point` block supports the following:
 
 ### `environment_artifact` Block
 
-* `container_configuration` - (Required) Container configuration. See [`container_configuration`](#container_configuration) below.
+* `container_configuration` - (Required) Container configuration. See [`container_configuration` Block](#container_configuration-block) below.
 
 ### `container_configuration` Block
 
@@ -352,7 +352,7 @@ The `efs_access_point` block supports the following:
 
 The `authorizer_configuration` block supports the following:
 
-* `custom_jwt_authorizer` - (Optional) JWT-based authorization configuration block. See [`custom_jwt_authorizer`](#custom_jwt_authorizer) below.
+* `custom_jwt_authorizer` - (Optional) JWT-based authorization configuration block. See [`custom_jwt_authorizer` Block](#custom_jwt_authorizer-block) below.
 
 ### `custom_jwt_authorizer` Block
 
@@ -362,14 +362,14 @@ The `custom_jwt_authorizer` block supports the following:
 * `allowed_audience` - (Optional) Set of allowed audience values for JWT token validation.
 * `allowed_clients` - (Optional) Set of allowed client IDs for JWT token validation.
 * `allowed_scopes` - (Optional) Set of scopes that are allowed to access the token.
-* `allowed_workload_configuration` - (Optional) Configuration restricting which workloads may use this authorizer. See [`allowed_workload_configuration`](#allowed_workload_configuration) below.
-* `custom_claim` - (Optional) Repeatable block to define a custom claim validation name, value, and operation. See [`custom_claim`](#custom_claim) below.
-* `private_endpoint` - (Optional) Private endpoint used to reach the authorization server. See [`private_endpoint`](#private_endpoint) below.
-* `private_endpoint_overrides` - (Optional) Overrides for the private endpoints used to reach the authorization server. See [`private_endpoint_overrides`](#private_endpoint_overrides) below.
+* `allowed_workload_configuration` - (Optional) Configuration restricting which workloads may use this authorizer. See [`allowed_workload_configuration` Block](#allowed_workload_configuration-block) below.
+* `custom_claim` - (Optional) Repeatable block to define a custom claim validation name, value, and operation. See [`custom_claim` Block](#custom_claim-block) below.
+* `private_endpoint` - (Optional) Private endpoint used to reach the authorization server. See [`private_endpoint` Block](#private_endpoint-block) below.
+* `private_endpoint_overrides` - (Optional) Overrides for the private endpoints used to reach the authorization server. See [`private_endpoint_overrides` Block](#private_endpoint_overrides-block) below.
 
 ### `allowed_workload_configuration` Block
 
-* `hosting_environment` - (Optional) Hosting environments allowed to use the authorizer. Between 1 and 10 entries. See [`hosting_environment`](#hosting_environment) below.
+* `hosting_environment` - (Optional) Hosting environments allowed to use the authorizer. Between 1 and 10 entries. See [`hosting_environment` Block](#hosting_environment-block) below.
 * `workload_identities` - (Optional) List of workload identity names allowed to use the authorizer. Between 1 and 10 entries.
 
 ### `hosting_environment` Block
@@ -379,14 +379,14 @@ The `custom_jwt_authorizer` block supports the following:
 ### `private_endpoint_overrides` Block
 
 * `domain` - (Required) Domain the override applies to.
-* `private_endpoint` - (Required) Private endpoint configuration. See [`private_endpoint`](#private_endpoint) below.
+* `private_endpoint` - (Required) Private endpoint configuration. See [`private_endpoint` Block](#private_endpoint-block) below.
 
 ### `private_endpoint` Block
 
 Exactly one of the following must be specified:
 
-* `managed_vpc_resource` - (Optional) Managed VPC resource configuration. See [`managed_vpc_resource`](#managed_vpc_resource) below.
-* `self_managed_lattice_resource` - (Optional) Self-managed VPC Lattice resource configuration. See [`self_managed_lattice_resource`](#self_managed_lattice_resource) below.
+* `managed_vpc_resource` - (Optional) Managed VPC resource configuration. See [`managed_vpc_resource` Block](#managed_vpc_resource-block) below.
+* `self_managed_lattice_resource` - (Optional) Self-managed VPC Lattice resource configuration. See [`self_managed_lattice_resource` Block](#self_managed_lattice_resource-block) below.
 
 ### `managed_vpc_resource` Block
 
@@ -405,7 +405,7 @@ Exactly one of the following must be specified:
 
 The `custom_claim` block supports the following:
 
-* `authorizing_claim_match_value` - (Required) Configuration block to define the value or values to match for and the relationship of the match. See [`authorizing_claim_match_value`](#authorizing_claim_match_value) below.
+* `authorizing_claim_match_value` - (Required) Configuration block to define the value or values to match for and the relationship of the match. See [`authorizing_claim_match_value` Block](#authorizing_claim_match_value-block) below.
 * `inbound_token_claim_name` - (Required) Name of the custom claim field to check.
 * `inbound_token_claim_value_type` - (Required) Data type of the claim value to check for. Valid values are `STRING` and `STRING_ARRAY`.
 
@@ -414,7 +414,7 @@ The `custom_claim` block supports the following:
 The `authorizing_claim_match_value` block supports the following:
 
 * `claim_match_operator` - (Required) Relationship between the claim field value and the value or values to match for. Valid values are `EQUALS`, `CONTAINS`, and `CONTAINS_ANY`. `EQUALS` can be used only when `inbound_token_claim_value_type` is `STRING`. `CONTAINS` or `CONTAINS_ANY` can be used only when `inbound_token_claim_value_type` is `STRING_ARRAY`.
-* `claim_match_value` - (Required) Value or values to match for. See [`claim_match_value`](#claim_match_value) below.
+* `claim_match_value` - (Required) Value or values to match for. See [`claim_match_value` Block](#claim_match_value-block) below.
 
 ### `claim_match_value` Block
 

--- a/website/docs/r/bedrockagentcore_harness.html.markdown
+++ b/website/docs/r/bedrockagentcore_harness.html.markdown
@@ -117,6 +117,32 @@ resource "aws_bedrockagentcore_harness" "example" {
 }
 ```
 
+### With Managed Memory
+
+```terraform
+resource "aws_bedrockagentcore_harness" "example" {
+  harness_name       = "my_harness"
+  execution_role_arn = aws_iam_role.example.arn
+
+  model {
+    bedrock_model_config {
+      model_id = "anthropic.claude-sonnet-4-20250514"
+    }
+  }
+
+  system_prompt {
+    text = "You are a helpful assistant."
+  }
+
+  memory {
+    managed_memory_configuration {
+      event_expiry_duration = 14
+      strategies            = ["SEMANTIC", "SUMMARIZATION"]
+    }
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are required:
@@ -134,7 +160,7 @@ The following arguments are optional:
 * `environment_variables` - (Optional, Sensitive) Map of environment variables.
 * `max_iterations` - (Optional) Maximum number of iterations the agent loop can perform.
 * `max_tokens` - (Optional) Maximum number of tokens in the model response.
-* `memory` - (Optional) Memory configuration. See [`memory`](#memory) below.
+* `memory` - (Optional) Memory configuration. See [`memory` Block](#memory-block) below.
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `skill` - (Optional) Skill configurations. See [`skill`](#skill) below.
 * `system_prompt` - (Optional) System prompt blocks for the harness. See [`system_prompt`](#system_prompt) below.
@@ -399,14 +425,17 @@ The `claim_match_value` block supports the following:
 
 ### `memory` Block
 
-* `agentcore_memory_configuration` - (Required) AgentCore memory configuration. See [`agentcore_memory_configuration`](#agentcore_memory_configuration) below.
+The `memory` block supports one of the following:
+
+* `agentcore_memory_configuration` - (Optional) AgentCore memory configuration. Use this to connect to an existing AgentCore memory resource. See [`agentcore_memory_configuration` Block](#agentcore_memory_configuration-block) below.
+* `managed_memory_configuration` - (Optional) Managed memory configuration. Creates and manages a memory resource automatically. See [`managed_memory_configuration` Block](#managed_memory_configuration-block) below.
 
 ### `agentcore_memory_configuration` Block
 
 * `arn` - (Required) ARN of the AgentCore memory resource.
 * `actor_id` - (Optional) Actor ID for memory sessions.
 * `messages_count` - (Optional) Number of messages to retrieve from memory.
-* `retrieval_config` - (Optional) Retrieval configuration parameters. See [`retrieval_config`](#retrieval_config) below.
+* `retrieval_config` - (Optional) Retrieval configuration parameters. See [`retrieval_config` Block](#retrieval_config-block) below.
 
 ### `retrieval_config` Block
 
@@ -416,6 +445,16 @@ The `claim_match_value` block supports the following:
 * `relevance_score` - (Optional) Relevance score threshold. Valid value is between `0` and `1`.
 * `strategy_id` - (Optional) ID of the memory strategy.
 * `top_k` - (Optional) Number of top results to retrieve.
+
+### `managed_memory_configuration` Block
+
+* `encryption_key_arn` - (Optional) ARN of a customer-managed KMS key used to encrypt the memory. Defaults to an AWS-owned key. Cannot be changed after creation.
+* `event_expiry_duration` - (Optional, Computed) Event retention in days. Defaults to `30`.
+* `strategies` - (Optional, Computed) Set of strategy types to enable. Valid values are `SEMANTIC`, `SUMMARIZATION`, and `USER_PREFERENCE`. Defaults to `["SEMANTIC", "SUMMARIZATION"]`.
+
+In addition, the following attribute is exported:
+
+* `arn` - ARN of the managed memory resource.
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

The AWS API now returns a default managed memory configuration if no `memory` value is specified. This value is now ignored during Create, Read, and Update.

Adds support for `memory.managed_memory_configuration`.

```console
% make testacc PKG=bedrockagentcore TESTS=TestAccBedrockAgentCoreHarness_

--- PASS: TestAccBedrockAgentCoreHarness_update_limits (296.88s)
--- PASS: TestAccBedrockAgentCoreHarness_update_allowedTools (327.75s)
--- PASS: TestAccBedrockAgentCoreHarness_environmentVariables (328.05s)
--- PASS: TestAccBedrockAgentCoreHarness_environmentArtifact (333.26s)
--- PASS: TestAccBedrockAgentCoreHarness_truncation_slidingWindow (333.30s)
--- PASS: TestAccBedrockAgentCoreHarness_update_systemPrompt (334.47s)
--- PASS: TestAccBedrockAgentCoreHarness_authorizerConfiguration (343.45s)
--- PASS: TestAccBedrockAgentCoreHarness_Memory_agentCoreMemoryConfiguration (356.45s)
--- PASS: TestAccBedrockAgentCoreHarness_List_includeResource (373.84s)
--- PASS: TestAccBedrockAgentCoreHarness_model_bedrock (384.83s)
--- PASS: TestAccBedrockAgentCoreHarness_tools_inlineFunction (385.63s)
--- PASS: TestAccBedrockAgentCoreHarness_Identity_basic (387.30s)
--- PASS: TestAccBedrockAgentCoreHarness_Identity_regionOverride (388.37s)
--- PASS: TestAccBedrockAgentCoreHarness_tags (393.03s)
--- PASS: TestAccBedrockAgentCoreHarness_List_regionOverride (393.77s)
--- PASS: TestAccBedrockAgentCoreHarness_disappears (396.11s)
--- PASS: TestAccBedrockAgentCoreHarness_basic (401.34s)
--- PASS: TestAccBedrockAgentCoreHarness_Memory_managedMemoryConfiguration_empty (401.38s)
--- PASS: TestAccBedrockAgentCoreHarness_List_basic (401.41s)
--- PASS: TestAccBedrockAgentCoreHarness_Memory_managedMemoryConfiguration_update (587.08s)
--- PASS: TestAccBedrockAgentCoreHarness_truncation_summarization (368.08s)
--- PASS: TestAccBedrockAgentCoreHarness_Memory_managedMemoryConfiguration_encryptionKey (358.03s)
```

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>