### PR TITLE
Adds additional tests for `agentcore_memory_configuration`

### DIFF
--- a/internal/service/bedrockagentcore/harness_test.go
+++ b/internal/service/bedrockagentcore/harness_test.go
@@ -647,7 +647,7 @@ func TestAccBedrockAgentCoreHarness_Memory_agentCoreMemoryConfiguration_options(
 		CheckDestroy:             testAccCheckHarnessDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccHarnessConfig_Memory_agentCoreMemoryConfiguration_options(rName, "actor1", 10, "key1", 0.25, 5),
+				Config: testAccHarnessConfig_Memory_agentCoreMemoryConfiguration_options(rName, "actor1", 10, "/namespace1/{actorId}", 0.25, 5),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckHarnessExists(ctx, t, resourceName, &harness),
 				),
@@ -663,7 +663,7 @@ func TestAccBedrockAgentCoreHarness_Memory_agentCoreMemoryConfiguration_options(
 						"messages_count": knownvalue.Int32Exact(10),
 						"retrieval_config": knownvalue.ListExact([]knownvalue.Check{
 							knownvalue.ObjectExact(map[string]knownvalue.Check{
-								"map_block_key":   knownvalue.StringExact("key1"),
+								"map_block_key":   knownvalue.StringExact("/namespace1/{actorId}"),
 								"relevance_score": knownvalue.Float32Exact(0.25),
 								"strategy_id":     knownvalue.Null(),
 								"top_k":           knownvalue.Int32Exact(5),
@@ -674,7 +674,7 @@ func TestAccBedrockAgentCoreHarness_Memory_agentCoreMemoryConfiguration_options(
 				},
 			},
 			{
-				Config: testAccHarnessConfig_Memory_agentCoreMemoryConfiguration_options(rName, "actor2", 20, "key2", 0.35, 10),
+				Config: testAccHarnessConfig_Memory_agentCoreMemoryConfiguration_options(rName, "actor2", 20, "/namespace2/{actorId}", 0.35, 10),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckHarnessExists(ctx, t, resourceName, &harness),
 				),
@@ -690,7 +690,7 @@ func TestAccBedrockAgentCoreHarness_Memory_agentCoreMemoryConfiguration_options(
 						"messages_count": knownvalue.Int32Exact(20),
 						"retrieval_config": knownvalue.ListExact([]knownvalue.Check{
 							knownvalue.ObjectExact(map[string]knownvalue.Check{
-								"map_block_key":   knownvalue.StringExact("key2"),
+								"map_block_key":   knownvalue.StringExact("/namespace2/{actorId}"),
 								"relevance_score": knownvalue.Float32Exact(0.35),
 								"strategy_id":     knownvalue.Null(),
 								"top_k":           knownvalue.Int32Exact(10),
@@ -749,7 +749,7 @@ func TestAccBedrockAgentCoreHarness_Memory_agentCoreMemoryConfiguration_addRetri
 				},
 			},
 			{
-				Config: testAccHarnessConfig_Memory_agentCoreMemoryConfiguration_retrievalConfig(rName, "key1", 0.25, 5),
+				Config: testAccHarnessConfig_Memory_agentCoreMemoryConfiguration_retrievalConfig(rName, "/namespace1", 0.25, 5),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckHarnessExists(ctx, t, resourceName, &harness),
 				),
@@ -761,7 +761,7 @@ func TestAccBedrockAgentCoreHarness_Memory_agentCoreMemoryConfiguration_addRetri
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("memory").AtSliceIndex(0).AtMapKey("agentcore_memory_configuration").AtSliceIndex(0).AtMapKey("retrieval_config"), knownvalue.ListExact([]knownvalue.Check{
 						knownvalue.ObjectExact(map[string]knownvalue.Check{
-							"map_block_key":   knownvalue.StringExact("key1"),
+							"map_block_key":   knownvalue.StringExact("/namespace1"),
 							"relevance_score": knownvalue.Float32Exact(0.25),
 							"strategy_id":     knownvalue.Null(),
 							"top_k":           knownvalue.Int32Exact(5),
@@ -804,7 +804,7 @@ func TestAccBedrockAgentCoreHarness_Memory_agentCoreMemoryConfiguration_removeRe
 		CheckDestroy:             testAccCheckHarnessDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccHarnessConfig_Memory_agentCoreMemoryConfiguration_retrievalConfig(rName, "key1", 0.25, 5),
+				Config: testAccHarnessConfig_Memory_agentCoreMemoryConfiguration_retrievalConfig(rName, "/namespace1", 0.25, 5),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckHarnessExists(ctx, t, resourceName, &harness),
 				),
@@ -816,7 +816,7 @@ func TestAccBedrockAgentCoreHarness_Memory_agentCoreMemoryConfiguration_removeRe
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("memory").AtSliceIndex(0).AtMapKey("agentcore_memory_configuration").AtSliceIndex(0).AtMapKey("retrieval_config"), knownvalue.ListExact([]knownvalue.Check{
 						knownvalue.ObjectExact(map[string]knownvalue.Check{
-							"map_block_key":   knownvalue.StringExact("key1"),
+							"map_block_key":   knownvalue.StringExact("/namespace1"),
 							"relevance_score": knownvalue.Float32Exact(0.25),
 							"strategy_id":     knownvalue.Null(),
 							"top_k":           knownvalue.Int32Exact(5),
@@ -1547,7 +1547,7 @@ resource "aws_bedrockagentcore_memory" "test" {
 `, rName))
 }
 
-func testAccHarnessConfig_Memory_agentCoreMemoryConfiguration_options(rName, actorID string, messagesCount int, mapBlockKey string, relevanceScore float32, topK int) string {
+func testAccHarnessConfig_Memory_agentCoreMemoryConfiguration_options(rName, actorID string, messagesCount int, namespacePathTemplate string, relevanceScore float32, topK int) string {
 	return acctest.ConfigCompose(testAccHarnessConfig_iamRole(rName), fmt.Sprintf(`
 resource "aws_bedrockagentcore_harness" "test" {
   harness_name       = %[1]q
@@ -1582,10 +1582,10 @@ resource "aws_bedrockagentcore_memory" "test" {
   name                  = %[1]q
   event_expiry_duration = 7
 }
-`, rName, actorID, messagesCount, mapBlockKey, relevanceScore, topK))
+`, rName, actorID, messagesCount, namespacePathTemplate, relevanceScore, topK))
 }
 
-func testAccHarnessConfig_Memory_agentCoreMemoryConfiguration_retrievalConfig(rName, mapBlockKey string, relevanceScore float32, topK int) string {
+func testAccHarnessConfig_Memory_agentCoreMemoryConfiguration_retrievalConfig(rName, namespacePathTemplate string, relevanceScore float32, topK int) string {
 	return acctest.ConfigCompose(testAccHarnessConfig_iamRole(rName), fmt.Sprintf(`
 resource "aws_bedrockagentcore_harness" "test" {
   harness_name       = %[1]q
@@ -1618,7 +1618,7 @@ resource "aws_bedrockagentcore_memory" "test" {
   name                  = %[1]q
   event_expiry_duration = 7
 }
-`, rName, mapBlockKey, relevanceScore, topK))
+`, rName, namespacePathTemplate, relevanceScore, topK))
 }
 
 func testAccHarnessConfig_Memory_managedMemoryConfiguration_empty(rName string) string {

--- a/internal/service/bedrockagentcore/harness_test.go
+++ b/internal/service/bedrockagentcore/harness_test.go
@@ -543,7 +543,7 @@ func TestAccBedrockAgentCoreHarness_environmentVariables(t *testing.T) {
 	})
 }
 
-func TestAccBedrockAgentCoreHarness_Memory_agentCoreMemoryConfiguration(t *testing.T) {
+func TestAccBedrockAgentCoreHarness_Memory_agentCoreMemoryConfiguration_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var harness awstypes.Harness
 	rName := testAccRandomHarnessName(t)
@@ -560,7 +560,7 @@ func TestAccBedrockAgentCoreHarness_Memory_agentCoreMemoryConfiguration(t *testi
 		CheckDestroy:             testAccCheckHarnessDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccHarnessConfig_Memory_agentCoreMemoryConfiguration(rName, 0.25),
+				Config: testAccHarnessConfig_Memory_agentCoreMemoryConfiguration_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckHarnessExists(ctx, t, resourceName, &harness),
 				),
@@ -569,9 +569,72 @@ func TestAccBedrockAgentCoreHarness_Memory_agentCoreMemoryConfiguration(t *testi
 						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
 					},
 				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("memory").AtSliceIndex(0).AtMapKey("agentcore_memory_configuration").AtSliceIndex(0), knownvalue.ObjectExact(map[string]knownvalue.Check{
+						names.AttrARN:      knownvalue.NotNull(),
+						"actor_id":         knownvalue.Null(),
+						"messages_count":   knownvalue.Null(),
+						"retrieval_config": knownvalue.ListSizeExact(0),
+					})),
+					statecheck.CompareValuePairs(resourceName, tfjsonpath.New("memory").AtSliceIndex(0).AtMapKey("agentcore_memory_configuration").AtSliceIndex(0).AtMapKey(names.AttrARN), "aws_bedrockagentcore_memory.test", tfjsonpath.New(names.AttrARN), compare.ValuesSame()),
+				},
 			},
 			{
-				Config: testAccHarnessConfig_Memory_agentCoreMemoryConfiguration(rName, 0.35),
+				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, "harness_id"),
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "harness_id",
+			},
+		},
+	})
+}
+
+func TestAccBedrockAgentCoreHarness_Memory_agentCoreMemoryConfiguration_options(t *testing.T) {
+	ctx := acctest.Context(t)
+	var harness awstypes.Harness
+	rName := testAccRandomHarnessName(t)
+	resourceName := "aws_bedrockagentcore_harness.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID)
+			testAccPreCheckHarness(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockAgentCoreServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckHarnessDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccHarnessConfig_Memory_agentCoreMemoryConfiguration_options(rName, "actor1", 10, "key1", 0.25, 5),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckHarnessExists(ctx, t, resourceName, &harness),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("memory").AtSliceIndex(0).AtMapKey("agentcore_memory_configuration").AtSliceIndex(0), knownvalue.ObjectExact(map[string]knownvalue.Check{
+						names.AttrARN:    knownvalue.NotNull(),
+						"actor_id":       knownvalue.StringExact("actor1"),
+						"messages_count": knownvalue.Int32Exact(10),
+						"retrieval_config": knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"map_block_key":   knownvalue.StringExact("key1"),
+								"relevance_score": knownvalue.Float32Exact(0.25),
+								"strategy_id":     knownvalue.Null(),
+								"top_k":           knownvalue.Int32Exact(5),
+							}),
+						}),
+					})),
+					statecheck.CompareValuePairs(resourceName, tfjsonpath.New("memory").AtSliceIndex(0).AtMapKey("agentcore_memory_configuration").AtSliceIndex(0).AtMapKey(names.AttrARN), "aws_bedrockagentcore_memory.test", tfjsonpath.New(names.AttrARN), compare.ValuesSame()),
+				},
+			},
+			{
+				Config: testAccHarnessConfig_Memory_agentCoreMemoryConfiguration_options(rName, "actor2", 20, "key2", 0.35, 10),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckHarnessExists(ctx, t, resourceName, &harness),
 				),
@@ -579,6 +642,22 @@ func TestAccBedrockAgentCoreHarness_Memory_agentCoreMemoryConfiguration(t *testi
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
 					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("memory").AtSliceIndex(0).AtMapKey("agentcore_memory_configuration").AtSliceIndex(0), knownvalue.ObjectExact(map[string]knownvalue.Check{
+						names.AttrARN:    knownvalue.NotNull(),
+						"actor_id":       knownvalue.StringExact("actor2"),
+						"messages_count": knownvalue.Int32Exact(20),
+						"retrieval_config": knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"map_block_key":   knownvalue.StringExact("key2"),
+								"relevance_score": knownvalue.Float32Exact(0.35),
+								"strategy_id":     knownvalue.Null(),
+								"top_k":           knownvalue.Int32Exact(10),
+							}),
+						}),
+					})),
+					statecheck.CompareValuePairs(resourceName, tfjsonpath.New("memory").AtSliceIndex(0).AtMapKey("agentcore_memory_configuration").AtSliceIndex(0).AtMapKey(names.AttrARN), "aws_bedrockagentcore_memory.test", tfjsonpath.New(names.AttrARN), compare.ValuesSame()),
 				},
 			},
 			{
@@ -594,6 +673,137 @@ func TestAccBedrockAgentCoreHarness_Memory_agentCoreMemoryConfiguration(t *testi
 					// TODO: float32 precision issue
 					acctest.ImportMatchResourceAttr("memory.0.agentcore_memory_configuration.0.retrieval_config.0.relevance_score", regexache.MustCompile(`^0\.34`)),
 				),
+			},
+		},
+	})
+}
+
+func TestAccBedrockAgentCoreHarness_Memory_agentCoreMemoryConfiguration_addRetrievalConfig(t *testing.T) {
+	ctx := acctest.Context(t)
+	var harness awstypes.Harness
+	rName := testAccRandomHarnessName(t)
+	resourceName := "aws_bedrockagentcore_harness.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID)
+			testAccPreCheckHarness(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockAgentCoreServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckHarnessDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccHarnessConfig_Memory_agentCoreMemoryConfiguration_basic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckHarnessExists(ctx, t, resourceName, &harness),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("memory").AtSliceIndex(0).AtMapKey("agentcore_memory_configuration").AtSliceIndex(0).AtMapKey("retrieval_config"), knownvalue.ListSizeExact(0)),
+				},
+			},
+			{
+				Config: testAccHarnessConfig_Memory_agentCoreMemoryConfiguration_retrievalConfig(rName, "key1", 0.25, 5),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckHarnessExists(ctx, t, resourceName, &harness),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("memory").AtSliceIndex(0).AtMapKey("agentcore_memory_configuration").AtSliceIndex(0).AtMapKey("retrieval_config"), knownvalue.ListExact([]knownvalue.Check{
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"map_block_key":   knownvalue.StringExact("key1"),
+							"relevance_score": knownvalue.Float32Exact(0.25),
+							"strategy_id":     knownvalue.Null(),
+							"top_k":           knownvalue.Int32Exact(5),
+						}),
+					})),
+				},
+			},
+			{
+				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, "harness_id"),
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "harness_id",
+				ImportStateVerifyIgnore: []string{
+					"memory.0.agentcore_memory_configuration.0.retrieval_config.0.relevance_score",
+				},
+				ImportStateCheck: acctest.ComposeAggregateImportStateCheckFunc(
+					// TODO: float32 precision issue
+					acctest.ImportMatchResourceAttr("memory.0.agentcore_memory_configuration.0.retrieval_config.0.relevance_score", regexache.MustCompile(`^0\.25`)),
+				),
+			},
+		},
+	})
+}
+
+func TestAccBedrockAgentCoreHarness_Memory_agentCoreMemoryConfiguration_removeRetrievalConfig(t *testing.T) {
+	ctx := acctest.Context(t)
+	var harness awstypes.Harness
+	rName := testAccRandomHarnessName(t)
+	resourceName := "aws_bedrockagentcore_harness.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID)
+			testAccPreCheckHarness(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockAgentCoreServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckHarnessDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccHarnessConfig_Memory_agentCoreMemoryConfiguration_retrievalConfig(rName, "key1", 0.25, 5),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckHarnessExists(ctx, t, resourceName, &harness),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("memory").AtSliceIndex(0).AtMapKey("agentcore_memory_configuration").AtSliceIndex(0).AtMapKey("retrieval_config"), knownvalue.ListExact([]knownvalue.Check{
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"map_block_key":   knownvalue.StringExact("key1"),
+							"relevance_score": knownvalue.Float32Exact(0.25),
+							"strategy_id":     knownvalue.Null(),
+							"top_k":           knownvalue.Int32Exact(5),
+						}),
+					})),
+				},
+			},
+			{
+				Config: testAccHarnessConfig_Memory_agentCoreMemoryConfiguration_basic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckHarnessExists(ctx, t, resourceName, &harness),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("memory").AtSliceIndex(0).AtMapKey("agentcore_memory_configuration").AtSliceIndex(0).AtMapKey("retrieval_config"), knownvalue.ListSizeExact(0)),
+				},
+			},
+			{
+				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, "harness_id"),
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "harness_id",
 			},
 		},
 	})
@@ -1267,7 +1477,7 @@ resource "aws_bedrockagentcore_harness" "test" {
 `, rName, key, value))
 }
 
-func testAccHarnessConfig_Memory_agentCoreMemoryConfiguration(rName string, relevanceScore float32) string {
+func testAccHarnessConfig_Memory_agentCoreMemoryConfiguration_basic(rName string) string {
 	return acctest.ConfigCompose(testAccHarnessConfig_iamRole(rName), fmt.Sprintf(`
 resource "aws_bedrockagentcore_harness" "test" {
   harness_name       = %[1]q
@@ -1276,10 +1486,43 @@ resource "aws_bedrockagentcore_harness" "test" {
   memory {
     agentcore_memory_configuration {
       arn = aws_bedrockagentcore_memory.test.arn
+    }
+  }
+
+  model {
+    bedrock_model_config {
+      model_id = "anthropic.claude-sonnet-4-20250514"
+    }
+  }
+
+  system_prompt {
+    text = "You are a helpful assistant."
+  }
+}
+
+resource "aws_bedrockagentcore_memory" "test" {
+  name                  = %[1]q
+  event_expiry_duration = 7
+}
+`, rName))
+}
+
+func testAccHarnessConfig_Memory_agentCoreMemoryConfiguration_options(rName, actorID string, messagesCount int, mapBlockKey string, relevanceScore float32, topK int) string {
+	return acctest.ConfigCompose(testAccHarnessConfig_iamRole(rName), fmt.Sprintf(`
+resource "aws_bedrockagentcore_harness" "test" {
+  harness_name       = %[1]q
+  execution_role_arn = aws_iam_role.test.arn
+
+  memory {
+    agentcore_memory_configuration {
+      arn            = aws_bedrockagentcore_memory.test.arn
+      actor_id       = %[2]q
+      messages_count = %[3]d
 
       retrieval_config {
-        map_block_key   = "key1"
-        relevance_score = %[2]f
+        map_block_key   = %[4]q
+        relevance_score = %[5]f
+        top_k           = %[6]d
       }
     }
   }
@@ -1299,7 +1542,43 @@ resource "aws_bedrockagentcore_memory" "test" {
   name                  = %[1]q
   event_expiry_duration = 7
 }
-`, rName, relevanceScore))
+`, rName, actorID, messagesCount, mapBlockKey, relevanceScore, topK))
+}
+
+func testAccHarnessConfig_Memory_agentCoreMemoryConfiguration_retrievalConfig(rName, mapBlockKey string, relevanceScore float32, topK int) string {
+	return acctest.ConfigCompose(testAccHarnessConfig_iamRole(rName), fmt.Sprintf(`
+resource "aws_bedrockagentcore_harness" "test" {
+  harness_name       = %[1]q
+  execution_role_arn = aws_iam_role.test.arn
+
+  memory {
+    agentcore_memory_configuration {
+      arn = aws_bedrockagentcore_memory.test.arn
+
+      retrieval_config {
+        map_block_key   = %[2]q
+        relevance_score = %[3]f
+        top_k           = %[4]d
+      }
+    }
+  }
+
+  model {
+    bedrock_model_config {
+      model_id = "anthropic.claude-sonnet-4-20250514"
+    }
+  }
+
+  system_prompt {
+    text = "You are a helpful assistant."
+  }
+}
+
+resource "aws_bedrockagentcore_memory" "test" {
+  name                  = %[1]q
+  event_expiry_duration = 7
+}
+`, rName, mapBlockKey, relevanceScore, topK))
 }
 
 func testAccHarnessConfig_Memory_managedMemoryConfiguration_empty(rName string) string {

--- a/internal/service/bedrockagentcore/harness_test.go
+++ b/internal/service/bedrockagentcore/harness_test.go
@@ -84,7 +84,7 @@ func TestAccBedrockAgentCoreHarness_basic(t *testing.T) {
 											"max_lifetime":                 knownvalue.Int32Exact(28800),
 										}),
 									}),
-									"network_configuration": knownvalue.ListExact([]knownvalue.Check{
+									names.AttrNetworkConfiguration: knownvalue.ListExact([]knownvalue.Check{
 										knownvalue.ObjectExact(map[string]knownvalue.Check{
 											"network_mode":        knownvalue.StringExact("PUBLIC"),
 											"network_mode_config": knownvalue.Null(),

--- a/internal/service/bedrockagentcore/harness_test.go
+++ b/internal/service/bedrockagentcore/harness_test.go
@@ -1328,6 +1328,8 @@ resource "aws_bedrockagentcore_harness" "test" {
   system_prompt {
     text = %[2]q
   }
+
+  depends_on = [aws_iam_role_policy.test]
 }
 `, rName, prompt))
 }
@@ -1348,6 +1350,8 @@ resource "aws_bedrockagentcore_harness" "test" {
   system_prompt {
     text = "You are a helpful assistant."
   }
+
+  depends_on = [aws_iam_role_policy.test]
 }
 `, rName, tools))
 }
@@ -1370,6 +1374,8 @@ resource "aws_bedrockagentcore_harness" "test" {
   system_prompt {
     text = "You are a helpful assistant."
   }
+
+  depends_on = [aws_iam_role_policy.test]
 }
 `, rName, maxIter, maxTokens, timeout))
 }
@@ -1391,6 +1397,8 @@ resource "aws_bedrockagentcore_harness" "test" {
   system_prompt {
     text = "You are a helpful assistant."
   }
+
+  depends_on = [aws_iam_role_policy.test]
 }
 `, rName))
 }
@@ -1420,6 +1428,8 @@ resource "aws_bedrockagentcore_harness" "test" {
       }
     }
   }
+
+  depends_on = [aws_iam_role_policy.test]
 }
 `, rName, messagesCount))
 }
@@ -1450,6 +1460,8 @@ resource "aws_bedrockagentcore_harness" "test" {
       }
     }
   }
+
+  depends_on = [aws_iam_role_policy.test]
 }
 `, rName))
 }
@@ -1490,6 +1502,8 @@ resource "aws_bedrockagentcore_harness" "test" {
       }
     }
   }
+
+  depends_on = [aws_iam_role_policy.test]
 }
 `, rName))
 }
@@ -1513,6 +1527,8 @@ resource "aws_bedrockagentcore_harness" "test" {
   system_prompt {
     text = "You are a helpful assistant."
   }
+
+  depends_on = [aws_iam_role_policy.test]
 }
 `, rName, key, value))
 }
@@ -1538,6 +1554,8 @@ resource "aws_bedrockagentcore_harness" "test" {
   system_prompt {
     text = "You are a helpful assistant."
   }
+
+  depends_on = [aws_iam_role_policy.test]
 }
 
 resource "aws_bedrockagentcore_memory" "test" {
@@ -1576,6 +1594,8 @@ resource "aws_bedrockagentcore_harness" "test" {
   system_prompt {
     text = "You are a helpful assistant."
   }
+
+  depends_on = [aws_iam_role_policy.test]
 }
 
 resource "aws_bedrockagentcore_memory" "test" {
@@ -1612,6 +1632,8 @@ resource "aws_bedrockagentcore_harness" "test" {
   system_prompt {
     text = "You are a helpful assistant."
   }
+
+  depends_on = [aws_iam_role_policy.test]
 }
 
 resource "aws_bedrockagentcore_memory" "test" {
@@ -1640,6 +1662,8 @@ resource "aws_bedrockagentcore_harness" "test" {
   system_prompt {
     text = "You are a helpful assistant."
   }
+
+  depends_on = [aws_iam_role_policy.test]
 }
 `, rName))
 }
@@ -1666,6 +1690,8 @@ resource "aws_bedrockagentcore_harness" "test" {
   system_prompt {
     text = "You are a helpful assistant."
   }
+
+  depends_on = [aws_iam_role_policy.test]
 }
 `, rName, eventExpiryDuration, strategies))
 }
@@ -1691,6 +1717,8 @@ resource "aws_bedrockagentcore_harness" "test" {
   system_prompt {
     text = "You are a helpful assistant."
   }
+
+  depends_on = [aws_iam_role_policy.test]
 }
 
 resource "aws_kms_key" "test" {
@@ -1720,6 +1748,8 @@ resource "aws_bedrockagentcore_harness" "test" {
   system_prompt {
     text = "You are a helpful assistant."
   }
+
+  depends_on = [aws_iam_role_policy.test]
 }
 
 data "aws_ecr_image" "test" {
@@ -1754,6 +1784,8 @@ resource "aws_bedrockagentcore_harness" "test" {
   system_prompt {
     text = "You are a helpful assistant."
   }
+
+  depends_on = [aws_iam_role_policy.test]
 }
 `, rName, discoveryUrl, audience1, audience2, client1, client2, scope1, scope2))
 }
@@ -1777,6 +1809,8 @@ resource "aws_bedrockagentcore_harness" "test" {
   tags = {
     %[2]q = %[3]q
   }
+
+  depends_on = [aws_iam_role_policy.test]
 }
 `, rName, tagKey1, tagValue1))
 }
@@ -1801,6 +1835,8 @@ resource "aws_bedrockagentcore_harness" "test" {
     %[2]q = %[3]q
     %[4]q = %[5]q
   }
+
+  depends_on = [aws_iam_role_policy.test]
 }
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2))
 }

--- a/internal/service/bedrockagentcore/harness_test.go
+++ b/internal/service/bedrockagentcore/harness_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	tfknownvalue "github.com/hashicorp/terraform-provider-aws/internal/acctest/knownvalue"
+	tfstatecheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/statecheck"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfbedrockagentcore "github.com/hashicorp/terraform-provider-aws/internal/service/bedrockagentcore"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -64,16 +65,41 @@ func TestAccBedrockAgentCoreHarness_basic(t *testing.T) {
 					testAccCheckHarnessExists(ctx, t, resourceName, &harness),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("allowed_tools"), knownvalue.NotNull()),
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrARN), checkHarnessARN(rName)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("allowed_tools"), knownvalue.ListExact([]knownvalue.Check{
+						knownvalue.StringExact("*"),
+					})),
+					tfstatecheck.ExpectRegionalARNFormat(resourceName, tfjsonpath.New(names.AttrARN), "bedrock-agentcore", "harness/{harness_id}"),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("authorizer_configuration"), knownvalue.ListSizeExact(0)),
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrEnvironment), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrEnvironment), knownvalue.ListExact([]knownvalue.Check{
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"agentcore_runtime_environment": knownvalue.ListExact([]knownvalue.Check{
+								knownvalue.ObjectExact(map[string]knownvalue.Check{
+									"agent_runtime_arn":        tfknownvalue.RegionalARNRegexp("bedrock-agentcore", regexache.MustCompile(`runtime/harness_`+rName+`-[a-zA-Z0-9]+`)),
+									"agent_runtime_id":         knownvalue.StringRegexp(regexache.MustCompile(`^harness_` + rName + `-[a-zA-Z0-9]+$`)),
+									"agent_runtime_name":       knownvalue.StringExact("harness_" + rName),
+									"filesystem_configuration": knownvalue.Null(),
+									"lifecycle_configuration": knownvalue.ListExact([]knownvalue.Check{
+										knownvalue.ObjectExact(map[string]knownvalue.Check{
+											"idle_runtime_session_timeout": knownvalue.Int32Exact(900),
+											"max_lifetime":                 knownvalue.Int32Exact(28800),
+										}),
+									}),
+									"network_configuration": knownvalue.ListExact([]knownvalue.Check{
+										knownvalue.ObjectExact(map[string]knownvalue.Check{
+											"network_mode":        knownvalue.StringExact("PUBLIC"),
+											"network_mode_config": knownvalue.Null(),
+										}),
+									}),
+								}),
+							}),
+						}),
+					})),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("environment_artifact"), knownvalue.ListSizeExact(0)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("environment_variables"), knownvalue.Null()),
 					statecheck.CompareValuePairs(resourceName, tfjsonpath.New(names.AttrExecutionRoleARN), "aws_iam_role.test", tfjsonpath.New(names.AttrARN), compare.ValuesSame()),
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("harness_id"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("harness_id"), knownvalue.StringRegexp(regexache.MustCompile(`^`+rName+`-[a-zA-Z0-9]{10}$`))),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("harness_name"), knownvalue.StringExact(rName)),
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("max_iterations"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("max_iterations"), knownvalue.Int32Exact(75)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("max_tokens"), knownvalue.Null()),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("memory"), knownvalue.ListSizeExact(0)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("model"), knownvalue.ListExact([]knownvalue.Check{
@@ -98,9 +124,23 @@ func TestAccBedrockAgentCoreHarness_basic(t *testing.T) {
 					})),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTagsAll), knownvalue.MapSizeExact(0)),
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("timeout_seconds"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("timeout_seconds"), knownvalue.Int32Exact(3600)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("tool"), knownvalue.ListSizeExact(0)),
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("truncation"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("truncation"), knownvalue.ListExact([]knownvalue.Check{
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"strategy": knownvalue.StringExact("sliding_window"),
+							"config": knownvalue.ListExact([]knownvalue.Check{
+								knownvalue.ObjectExact(map[string]knownvalue.Check{
+									"sliding_window": knownvalue.ListExact([]knownvalue.Check{
+										knownvalue.ObjectExact(map[string]knownvalue.Check{
+											"messages_count": knownvalue.Int32Exact(150),
+										}),
+									}),
+									"summarization": knownvalue.Null(),
+								}),
+							}),
+						}),
+					})),
 				},
 			},
 			{

--- a/internal/service/bedrockagentcore/testdata/Harness/basic/main_gen.tf
+++ b/internal/service/bedrockagentcore/testdata/Harness/basic/main_gen.tf
@@ -14,6 +14,8 @@ resource "aws_bedrockagentcore_harness" "test" {
   system_prompt {
     text = "You are a helpful assistant."
   }
+
+  depends_on = [aws_iam_role_policy.test]
 }
 
 resource "aws_iam_role" "test" {

--- a/internal/service/bedrockagentcore/testdata/Harness/list_basic/main.tf
+++ b/internal/service/bedrockagentcore/testdata/Harness/list_basic/main.tf
@@ -16,6 +16,8 @@ resource "aws_bedrockagentcore_harness" "test" {
   system_prompt {
     text = "You are a helpful assistant."
   }
+
+  depends_on = [aws_iam_role_policy.test]
 }
 
 resource "aws_iam_role" "test" {

--- a/internal/service/bedrockagentcore/testdata/Harness/list_include_resource/main.tf
+++ b/internal/service/bedrockagentcore/testdata/Harness/list_include_resource/main.tf
@@ -17,6 +17,8 @@ resource "aws_bedrockagentcore_harness" "test" {
     text = "You are a helpful assistant."
   }
 
+  depends_on = [aws_iam_role_policy.test]
+
   tags = var.resource_tags
 }
 

--- a/internal/service/bedrockagentcore/testdata/Harness/list_region_override/main.tf
+++ b/internal/service/bedrockagentcore/testdata/Harness/list_region_override/main.tf
@@ -17,6 +17,8 @@ resource "aws_bedrockagentcore_harness" "test" {
   system_prompt {
     text = "You are a helpful assistant."
   }
+
+  depends_on = [aws_iam_role_policy.test]
 }
 
 resource "aws_iam_role" "test" {

--- a/internal/service/bedrockagentcore/testdata/Harness/region_override/main_gen.tf
+++ b/internal/service/bedrockagentcore/testdata/Harness/region_override/main_gen.tf
@@ -16,6 +16,8 @@ resource "aws_bedrockagentcore_harness" "test" {
   system_prompt {
     text = "You are a helpful assistant."
   }
+
+  depends_on = [aws_iam_role_policy.test]
 }
 
 resource "aws_iam_role" "test" {

--- a/internal/service/bedrockagentcore/testdata/tmpl/harness_basic.gtpl
+++ b/internal/service/bedrockagentcore/testdata/tmpl/harness_basic.gtpl
@@ -13,6 +13,8 @@ resource "aws_bedrockagentcore_harness" "test" {
     text = "You are a helpful assistant."
   }
 
+  depends_on = [aws_iam_role_policy.test]
+
 {{- template "tags" . }}
 }
 

--- a/website/docs/r/bedrockagentcore_harness.html.markdown
+++ b/website/docs/r/bedrockagentcore_harness.html.markdown
@@ -441,7 +441,7 @@ The `memory` block supports one of the following:
 
 `retrieval_config` supports the following:
 
-* `map_block_key` - (Required) Key for the retrieval configuration map block.
+* `map_block_key` - (Required) Namespace path template for retrieval settings.
 * `relevance_score` - (Optional) Relevance score threshold. Valid value is between `0` and `1`.
 * `strategy_id` - (Optional) ID of the memory strategy.
 * `top_k` - (Optional) Number of top results to retrieve.


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Adds additional tests for `agentcore_memory_configuration`.

Checks all values in `_basic` test.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=bedrockagentcore TESTS=TestAccBedrockAgentCoreHarness_

--- PASS: TestAccBedrockAgentCoreHarness_update_allowedTools (314.00s)
--- PASS: TestAccBedrockAgentCoreHarness_update_limits (317.49s)
--- PASS: TestAccBedrockAgentCoreHarness_update_systemPrompt (320.93s)
--- PASS: TestAccBedrockAgentCoreHarness_truncation_slidingWindow (336.89s)
--- PASS: TestAccBedrockAgentCoreHarness_List_includeResource (357.69s)
--- PASS: TestAccBedrockAgentCoreHarness_Memory_agentCoreMemoryConfiguration_removeRetrievalConfig (370.13s)
--- PASS: TestAccBedrockAgentCoreHarness_Memory_agentCoreMemoryConfiguration_options (370.13s)
--- PASS: TestAccBedrockAgentCoreHarness_Identity_basic (371.66s)
--- PASS: TestAccBedrockAgentCoreHarness_List_basic (375.41s)
--- PASS: TestAccBedrockAgentCoreHarness_model_bedrock (381.65s)
--- PASS: TestAccBedrockAgentCoreHarness_truncation_summarization (381.68s)
--- PASS: TestAccBedrockAgentCoreHarness_Memory_managedMemoryConfiguration_empty (386.59s)
--- PASS: TestAccBedrockAgentCoreHarness_tools_inlineFunction (387.01s)
--- PASS: TestAccBedrockAgentCoreHarness_basic (387.14s)
--- PASS: TestAccBedrockAgentCoreHarness_tags (390.45s)
--- PASS: TestAccBedrockAgentCoreHarness_disappears (398.18s)
--- PASS: TestAccBedrockAgentCoreHarness_Memory_managedMemoryConfiguration_encryptionKey (401.47s)
--- PASS: TestAccBedrockAgentCoreHarness_Memory_agentCoreMemoryConfiguration_addRetrievalConfig (280.10s)
--- PASS: TestAccBedrockAgentCoreHarness_Memory_agentCoreMemoryConfiguration_basic (248.46s)
--- PASS: TestAccBedrockAgentCoreHarness_environmentVariables (251.93s)
--- PASS: TestAccBedrockAgentCoreHarness_authorizerConfiguration (265.26s)
--- PASS: TestAccBedrockAgentCoreHarness_environmentArtifact (250.62s)
--- PASS: TestAccBedrockAgentCoreHarness_Identity_regionOverride (608.06s)
--- PASS: TestAccBedrockAgentCoreHarness_List_regionOverride (609.48s)
--- PASS: TestAccBedrockAgentCoreHarness_Memory_managedMemoryConfiguration_update (645.29s)
```

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>