### PR TITLE
🤖🤖🤖 r/aws_cognito_user_pool: support passwordless invitation templates

### DIFF
--- a/.changelog/49207.txt
+++ b/.changelog/49207.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cognito_user_pool: Fix `InvalidParameterException` when `admin_create_user_config.invite_message_template` omits `email_message`, `email_subject`, or `sms_message`
+```

--- a/.changelog/49294.txt
+++ b/.changelog/49294.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cognito_user_pool: Allow passwordless `admin_create_user_config.invite_message_template` messages without the `{####}` placeholder
+```

--- a/internal/service/cognitoidp/flex_test.go
+++ b/internal/service/cognitoidp/flex_test.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider/types"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -259,6 +261,113 @@ func TestSkipFlatteningStringAttributeContraints(t *testing.T) {
 			got := skipFlatteningStringAttributeContraints(tc.configured, tc.input)
 			if got != tc.want {
 				t.Fatalf("skipFlatteningStringAttributeContraints() got %t, want %t\n\n%#v\n\n", got, tc.want, tc.input)
+			}
+		})
+	}
+}
+
+func TestExpandAdminCreateUserConfigType(t *testing.T) {
+	t.Parallel()
+
+	// The maps below mirror what Terraform Plugin SDKv2 supplies for a nested block:
+	// every declared attribute is present, unset ones holding the zero value.
+	cases := []struct {
+		name  string
+		input map[string]any
+		want  *awstypes.AdminCreateUserConfigType
+	}{
+		{
+			name: "no invite message template",
+			input: map[string]any{
+				"allow_admin_create_user_only": true,
+				"invite_message_template":      []any{},
+			},
+			want: &awstypes.AdminCreateUserConfigType{
+				AllowAdminCreateUserOnly: true,
+			},
+		},
+		{
+			name: "all fields",
+			input: map[string]any{
+				"allow_admin_create_user_only": true,
+				"invite_message_template": []any{
+					map[string]any{
+						"email_message": "Your username is {username} and temporary password is {####}.",
+						"email_subject": "FooBar {####}",
+						"sms_message":   "Your username is {username} and temporary password is {####}.",
+					},
+				},
+			},
+			want: &awstypes.AdminCreateUserConfigType{
+				AllowAdminCreateUserOnly: true,
+				InviteMessageTemplate: &awstypes.MessageTemplateType{
+					EmailMessage: aws.String("Your username is {username} and temporary password is {####}."),
+					EmailSubject: aws.String("FooBar {####}"),
+					SMSMessage:   aws.String("Your username is {username} and temporary password is {####}."),
+				},
+			},
+		},
+		{
+			name: "email only",
+			input: map[string]any{
+				"allow_admin_create_user_only": false,
+				"invite_message_template": []any{
+					map[string]any{
+						"email_message": "Your username is {username} and temporary password is {####}.",
+						"email_subject": "FooBar {####}",
+						"sms_message":   "",
+					},
+				},
+			},
+			want: &awstypes.AdminCreateUserConfigType{
+				InviteMessageTemplate: &awstypes.MessageTemplateType{
+					EmailMessage: aws.String("Your username is {username} and temporary password is {####}."),
+					EmailSubject: aws.String("FooBar {####}"),
+				},
+			},
+		},
+		{
+			name: "SMS only",
+			input: map[string]any{
+				"allow_admin_create_user_only": false,
+				"invite_message_template": []any{
+					map[string]any{
+						"email_message": "",
+						"email_subject": "",
+						"sms_message":   "Your username is {username} and temporary password is {####}.",
+					},
+				},
+			},
+			want: &awstypes.AdminCreateUserConfigType{
+				InviteMessageTemplate: &awstypes.MessageTemplateType{
+					SMSMessage: aws.String("Your username is {username} and temporary password is {####}."),
+				},
+			},
+		},
+		{
+			name: "empty invite message template",
+			input: map[string]any{
+				"allow_admin_create_user_only": false,
+				"invite_message_template": []any{
+					map[string]any{
+						"email_message": "",
+						"email_subject": "",
+						"sms_message":   "",
+					},
+				},
+			},
+			want: &awstypes.AdminCreateUserConfigType{
+				InviteMessageTemplate: &awstypes.MessageTemplateType{},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := expandAdminCreateUserConfigType(tc.input)
+			if diff := cmp.Diff(got, tc.want, cmpopts.IgnoreUnexported(awstypes.AdminCreateUserConfigType{}, awstypes.MessageTemplateType{})); diff != "" {
+				t.Errorf("unexpected diff (+want, -got):\n%s", diff)
 			}
 		})
 	}

--- a/internal/service/cognitoidp/user_pool.go
+++ b/internal/service/cognitoidp/user_pool.go
@@ -1604,15 +1604,15 @@ func expandAdminCreateUserConfigType(tfMap map[string]any) *awstypes.AdminCreate
 			if tfMap, ok := tfList[0].(map[string]any); ok {
 				imt := &awstypes.MessageTemplateType{}
 
-				if v, ok := tfMap["email_message"]; ok {
+				if v, ok := tfMap["email_message"]; ok && v.(string) != "" {
 					imt.EmailMessage = aws.String(v.(string))
 				}
 
-				if v, ok := tfMap["email_subject"]; ok {
+				if v, ok := tfMap["email_subject"]; ok && v.(string) != "" {
 					imt.EmailSubject = aws.String(v.(string))
 				}
 
-				if v, ok := tfMap["sms_message"]; ok {
+				if v, ok := tfMap["sms_message"]; ok && v.(string) != "" {
 					imt.SMSMessage = aws.String(v.(string))
 				}
 

--- a/internal/service/cognitoidp/user_pool_test.go
+++ b/internal/service/cognitoidp/user_pool_test.go
@@ -232,6 +232,68 @@ func TestAccCognitoIDPUserPool_withAdminCreateUser(t *testing.T) {
 	})
 }
 
+// Reference: https://github.com/hashicorp/terraform-provider-aws/issues/49203
+func TestAccCognitoIDPUserPool_withAdminCreateUserEmailOnlyInviteMessageTemplate(t *testing.T) {
+	ctx := acctest.Context(t)
+	var pool awstypes.UserPoolType
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_cognito_user_pool.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckIdentityProvider(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CognitoIDPServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckUserPoolDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserPoolConfig_adminCreateConfigurationEmailOnly(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckUserPoolExists(ctx, t, resourceName, &pool),
+					resource.TestCheckResourceAttr(resourceName, "admin_create_user_config.0.invite_message_template.0.email_message", "Your username is {username} and temporary password is {####}. "),
+					resource.TestCheckResourceAttr(resourceName, "admin_create_user_config.0.invite_message_template.0.email_subject", "FooBar {####}"),
+					resource.TestCheckResourceAttr(resourceName, "admin_create_user_config.0.invite_message_template.0.sms_message", ""),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// Reference: https://github.com/hashicorp/terraform-provider-aws/issues/49203
+func TestAccCognitoIDPUserPool_withAdminCreateUserSMSOnlyInviteMessageTemplate(t *testing.T) {
+	ctx := acctest.Context(t)
+	var pool awstypes.UserPoolType
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_cognito_user_pool.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckIdentityProvider(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CognitoIDPServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckUserPoolDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserPoolConfig_adminCreateConfigurationSMSOnly(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckUserPoolExists(ctx, t, resourceName, &pool),
+					resource.TestCheckResourceAttr(resourceName, "admin_create_user_config.0.invite_message_template.0.email_message", ""),
+					resource.TestCheckResourceAttr(resourceName, "admin_create_user_config.0.invite_message_template.0.email_subject", ""),
+					resource.TestCheckResourceAttr(resourceName, "admin_create_user_config.0.invite_message_template.0.sms_message", "Your username is {username} and temporary password is {####}."),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 // Reference: https://github.com/hashicorp/terraform-provider-aws/issues/11858
 func TestAccCognitoIDPUserPool_withAdminCreateUserAndPasswordPolicy(t *testing.T) {
 	ctx := acctest.Context(t)
@@ -2298,6 +2360,35 @@ resource "aws_cognito_user_pool" "test" {
       email_message = "Your username is {username} and temporary password is {####}. "
       email_subject = "FooBar {####}"
       sms_message   = "Your username is {username} and temporary password is {####}."
+    }
+  }
+}
+`, rName)
+}
+
+func testAccUserPoolConfig_adminCreateConfigurationEmailOnly(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_cognito_user_pool" "test" {
+  name = %[1]q
+
+  admin_create_user_config {
+    invite_message_template {
+      email_message = "Your username is {username} and temporary password is {####}. "
+      email_subject = "FooBar {####}"
+    }
+  }
+}
+`, rName)
+}
+
+func testAccUserPoolConfig_adminCreateConfigurationSMSOnly(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_cognito_user_pool" "test" {
+  name = %[1]q
+
+  admin_create_user_config {
+    invite_message_template {
+      sms_message = "Your username is {username} and temporary password is {####}."
     }
   }
 }

--- a/internal/service/cognitoidp/user_pool_test.go
+++ b/internal/service/cognitoidp/user_pool_test.go
@@ -263,6 +263,38 @@ func TestAccCognitoIDPUserPool_withAdminCreateUserEmailOnlyInviteMessageTemplate
 	})
 }
 
+func TestAccCognitoIDPUserPool_withAdminCreateUserPasswordlessEmailInviteMessageTemplate(t *testing.T) {
+	ctx := acctest.Context(t)
+	var pool awstypes.UserPoolType
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_cognito_user_pool.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckIdentityProvider(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CognitoIDPServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckUserPoolDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserPoolConfig_adminCreateConfigurationPasswordlessEmail(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckUserPoolExists(ctx, t, resourceName, &pool),
+					resource.TestCheckResourceAttr(resourceName, "admin_create_user_config.0.invite_message_template.0.email_message", "Your username is {username}. Sign in at https://example.com/sign-in."),
+					resource.TestCheckResourceAttr(resourceName, "admin_create_user_config.0.invite_message_template.0.email_subject", "Welcome"),
+					resource.TestCheckResourceAttr(resourceName, "admin_create_user_config.0.invite_message_template.0.sms_message", ""),
+					resource.TestCheckResourceAttr(resourceName, "sign_in_policy.0.allowed_first_auth_factors.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "sign_in_policy.0.allowed_first_auth_factors.*", "EMAIL_OTP"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 // Reference: https://github.com/hashicorp/terraform-provider-aws/issues/49203
 func TestAccCognitoIDPUserPool_withAdminCreateUserSMSOnlyInviteMessageTemplate(t *testing.T) {
 	ctx := acctest.Context(t)
@@ -2376,6 +2408,26 @@ resource "aws_cognito_user_pool" "test" {
       email_message = "Your username is {username} and temporary password is {####}. "
       email_subject = "FooBar {####}"
     }
+  }
+}
+`, rName)
+}
+
+func testAccUserPoolConfig_adminCreateConfigurationPasswordlessEmail(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_cognito_user_pool" "test" {
+  name                = %[1]q
+  username_attributes = ["email"]
+
+  admin_create_user_config {
+    invite_message_template {
+      email_message = "Your username is {username}. Sign in at https://example.com/sign-in."
+      email_subject = "Welcome"
+    }
+  }
+
+  sign_in_policy {
+    allowed_first_auth_factors = ["EMAIL_OTP"]
   }
 }
 `, rName)

--- a/internal/service/cognitoidp/validate.go
+++ b/internal/service/cognitoidp/validate.go
@@ -113,10 +113,6 @@ func validUserPoolInviteTemplateEmailMessage(v any, k string) (ws []string, es [
 		es = append(es, fmt.Errorf("%q cannot be longer than 20000 UTF-8 characters", k))
 	}
 
-	if !regexache.MustCompile(`[\p{L}\p{M}\p{S}\p{N}\p{P}\s*]*\{####\}[\p{L}\p{M}\p{S}\p{N}\p{P}\s*]*`).MatchString(value) {
-		es = append(es, fmt.Errorf("%q does not contain {####}", k))
-	}
-
 	if !regexache.MustCompile(`.*\{username\}.*`).MatchString(value) {
 		es = append(es, fmt.Errorf("%q does not contain {username}", k))
 	}
@@ -132,10 +128,6 @@ func validUserPoolInviteTemplateSMSMessage(v any, k string) (ws []string, es []e
 
 	if count > 140 {
 		es = append(es, fmt.Errorf("%q cannot be longer than 140 UTF-8 characters", k))
-	}
-
-	if !regexache.MustCompile(`.*\{####\}.*`).MatchString(value) {
-		es = append(es, fmt.Errorf("%q does not contain {####}", k))
 	}
 
 	if !regexache.MustCompile(`.*\{username\}.*`).MatchString(value) {

--- a/internal/service/cognitoidp/validate_test.go
+++ b/internal/service/cognitoidp/validate_test.go
@@ -178,6 +178,72 @@ func TestValidUserPoolID(t *testing.T) {
 	}
 }
 
+func TestValidUserPoolInviteTemplateEmailMessage(t *testing.T) {
+	t.Parallel()
+
+	validValues := []string{
+		"{username}",
+		"Sign in as {username}.",
+		"Your username is {username} and temporary password is {####}.",
+		"{username}" + strings.Repeat("W", 19990), // = 20000
+		"{username}" + strings.Repeat("あ", 19990), // = 20000, multi-byte UTF-8
+	}
+
+	for _, s := range validValues {
+		_, errors := validUserPoolInviteTemplateEmailMessage(s, "email_message")
+		if len(errors) > 0 {
+			t.Fatalf("%q should be a valid Cognito User Pool invite template email message: %v", s, errors)
+		}
+	}
+
+	invalidValues := []string{
+		"short",
+		"Your account is ready.",
+		"{username}" + strings.Repeat("W", 19991), // > 20000
+		"{username}" + strings.Repeat("あ", 19991), // > 20000, multi-byte UTF-8
+	}
+
+	for _, s := range invalidValues {
+		_, errors := validUserPoolInviteTemplateEmailMessage(s, "email_message")
+		if len(errors) == 0 {
+			t.Fatalf("%q should not be a valid Cognito User Pool invite template email message: %v", s, errors)
+		}
+	}
+}
+
+func TestValidUserPoolInviteTemplateSMSMessage(t *testing.T) {
+	t.Parallel()
+
+	validValues := []string{
+		"{username}",
+		"Sign in as {username}.",
+		"Your username is {username} and temporary password is {####}.",
+		"{username}" + strings.Repeat("W", 130), // = 140
+		"{username}" + strings.Repeat("あ", 130), // = 140, multi-byte UTF-8
+	}
+
+	for _, s := range validValues {
+		_, errors := validUserPoolInviteTemplateSMSMessage(s, "sms_message")
+		if len(errors) > 0 {
+			t.Fatalf("%q should be a valid Cognito User Pool invite template SMS message: %v", s, errors)
+		}
+	}
+
+	invalidValues := []string{
+		"short",
+		"Your account is ready.",
+		"{username}" + strings.Repeat("W", 131), // > 140
+		"{username}" + strings.Repeat("あ", 131), // > 140, multi-byte UTF-8
+	}
+
+	for _, s := range invalidValues {
+		_, errors := validUserPoolInviteTemplateSMSMessage(s, "sms_message")
+		if len(errors) == 0 {
+			t.Fatalf("%q should not be a valid Cognito User Pool invite template SMS message: %v", s, errors)
+		}
+	}
+}
+
 func TestValidUserPoolSMSAuthenticationMessage(t *testing.T) {
 	t.Parallel()
 

--- a/website/docs/r/cognito_user_pool.html.markdown
+++ b/website/docs/r/cognito_user_pool.html.markdown
@@ -108,9 +108,9 @@ This resource supports the following arguments:
 
 #### invite_message_template
 
-* `email_message` - (Optional) Message template for email messages. Must contain `{username}` and `{####}` placeholders, for username and temporary password, respectively.
+* `email_message` - (Optional) Message template for email messages. Must contain the `{username}` placeholder. Must also contain the `{####}` placeholder when creating users with passwords; the `{####}` placeholder can be omitted for [passwordless users](https://docs.aws.amazon.com/cognito/latest/developerguide/how-to-create-user-accounts.html).
 * `email_subject` - (Optional) Subject line for email messages.
-* `sms_message` - (Optional) Message template for SMS messages. Must contain `{username}` and `{####}` placeholders, for username and temporary password, respectively.
+* `sms_message` - (Optional) Message template for SMS messages. Must contain the `{username}` placeholder. Must also contain the `{####}` placeholder when creating users with passwords; the `{####}` placeholder can be omitted for [passwordless users](https://docs.aws.amazon.com/cognito/latest/developerguide/how-to-create-user-accounts.html).
 
 ### device_configuration
 


### PR DESCRIPTION
## Rollback Plan

Revert this change to restore the previous validation requirement. If the change has already shipped, publish an updated provider release containing the revert.

## Changes to Security Controls

This does not change Cognito access controls, encryption, or logging. It permits AWS-supported passwordless invitation templates while retaining the username placeholder and message-length validation.

### Description

Amazon Cognito permits invitation templates for passwordless admin-created users to omit the `{####}` temporary-password placeholder. The provider currently rejects those AWS-valid templates during configuration validation.

This change:

* allows email and SMS invitation templates without `{####}`;
* continues to require `{username}` and enforce AWS message-length limits;
* adds unit coverage for passwordless and password-based templates, including length boundaries;
* adds an acceptance test for an email-OTP user pool with a passwordless email invitation; and
* documents when `{####}` is required or may be omitted.

This is intentionally opened as a stacked draft. Its acceptance-test configuration depends on the email-only invitation-template serialization fix in #49207. Until that PR lands, GitHub will show its commits in this PR as well. After #49207 is merged, this PR can be rebased so its standalone diff contains only commit `0501bb71505`.

### Relations

Depends on #49207.

### References

* [AWS AdminCreateUserConfigType API reference](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminCreateUserConfigType.html)
* [AWS: Creating user accounts as administrator](https://docs.aws.amazon.com/cognito/latest/developerguide/how-to-create-user-accounts.html)

### Output from Acceptance Testing

The new AWS acceptance test was not executed because it creates a real Cognito user pool and requires authorized AWS credentials. The following local checks passed:

```console
make build
make ci-quick
make test PKG=cognitoidp
make swissshepherd
```

Focused unit tests also passed for the invitation-template validators and admin-create-user configuration expansion.

### AI Assistance Disclosure

Codex was used to research the documented AWS behavior, prepare the validator, tests, and documentation changes, and run local verification. The contributor reviewed and owns the changes.
