### PR TITLE
🤖🤖🤖 secretsmanager_secret_version: Clarify write-only version behavior

### DIFF
--- a/website/docs/r/secretsmanager_secret_version.html.markdown
+++ b/website/docs/r/secretsmanager_secret_version.html.markdown
@@ -66,7 +66,7 @@ This resource supports the following arguments:
 * `secret_id` - (Required) Secret to which you want to add a new version. You can specify either the Amazon Resource Name (ARN) or the friendly name of the secret. The secret must already exist.
 * `secret_string` - (Optional) Text data that you want to encrypt and store in this version of the secret. This is required if `secret_binary` or `secret_string_wo` is not set.
 * `secret_string_wo` - (Optional) Text data that you want to encrypt and store in this version of the secret. This is required if `secret_binary` or `secret_string` is not set.
-* `secret_string_wo_version` - (Optional) Used together with `secret_string_wo` to trigger an update. Increment this value when an update to `secret_string_wo` is required.
+* `secret_string_wo_version` - (Optional) Used together with `secret_string_wo` to trigger an update. Change this value when an update to `secret_string_wo` is required.
 * `version_stages` - (Optional) List of staging labels that are attached to this version of the secret. A staging label must be unique to a single version of the secret. If you specify a staging label that's already associated with a different version of the same secret then that staging label is automatically removed from the other version and attached to this version. If you do not specify a value, then AWS Secrets Manager automatically moves the staging label `AWSCURRENT` to this new version on creation.
 
 ~> **NOTE:** If `version_stages` is configured, you must include the `AWSCURRENT` staging label if this secret version is the only version or if the label is currently present on this secret version, otherwise Terraform will show a perpetual difference.


### PR DESCRIPTION
## Rollback Plan

Revert this documentation-only change.

## Changes to Security Controls

None.

### Description

Clarifies that changing `secret_string_wo_version` triggers an update. The provider compares the configured value with the value in state and does not require the new value to be greater.

AI assistance was used to inspect the implementation, update the documentation, and prepare this pull request. I reviewed the resulting change.

### Relations

None.

### References

The `secretVersionForceNewCustomDiffInner` implementation triggers replacement whenever the configured and state values differ.

### Output from Acceptance Testing

Documentation-only change; acceptance testing is not applicable.

```console
% git diff --check
```

`make swissshepherd` could not run locally because the `swissshepherd` binary is unavailable; CI can perform the documentation validation.
