### PR TITLE
truncate TeamCity output details

### DIFF
--- a/.teamcity/scripts/pullrequest_tests/test_results.sh
+++ b/.teamcity/scripts/pullrequest_tests/test_results.sh
@@ -26,7 +26,23 @@ done
 
 # Authenticate internally using TeamCity's system-provided tokens
 results=$(echo "${response}" |
-	jq -r '.testOccurrence[] | "\(.name | sub(".*(?<t>TestAcc.*)"; "\(.t)")): [\(.status | if . == "SUCCESS" then "PASS" elif . == "FAILURE" then "FAIL" elif . == "UNKNOWN" then "SKIP" else . end)] \(.duration/1000)s\(if (.status == "FAILURE" or .status == "UNKNOWN") and .details != null then "\n\(.details)" else "" end)"')
+	jq -r '.testOccurrence[] | "\(.name | sub(".*(?<t>TestAcc.*)"; "\(.t)")): [\(.status | if . == "SUCCESS" then "PASS" elif . == "FAILURE" then "FAIL" elif . == "UNKNOWN" then "SKIP" else . end)] \(.duration/1000)s\(if (.status == "FAILURE" or .status == "UNKNOWN") and .details != null then "\n\(.details)" else "" end)"' |
+	sed -E -e '/^[0-9]{4}\/[0-9]{2}\/[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} (Initializing|Creating) Terraform AWS Provider \((Framework|SDKv2)-style\)\.\.\./d' -e '/^=== (RUN|PAUSE|CONT) /d' -e 's/arn:aws:([^:]*):([^:]*):([0-9]{12}):/arn:aws:\1:\2:###:/g' -e 's|test_terraform_path=[^ ]*||g' -e 's|test_working_directory=[^ ]*||g' |
+	awk '
+		/^TestAcc.*: \[(PASS|FAIL|SKIP)\]/ { 
+			if (in_test && line_count > 5) print "    [... truncated ...]"
+			print; 
+			in_test=1; 
+			line_count=0; 
+			next 
+		}
+		in_test { 
+			line_count++; 
+			if (line_count <= 5) print; 
+			next 
+		}
+		{ print }
+	')
 
 echo "${results}"
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Truncates test details for failures 
- Masks any account numbers that exist in ARNs
- Includes the first 5 lines of the error output

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
