### PR TITLE
r/aws_quicksight_dashboard: Fix `Invalid address to set` errors when reading line chart `missing_data_configuration`

### DIFF
--- a/.changelog/49301.txt
+++ b/.changelog/49301.txt
@@ -1,0 +1,15 @@
+```release-note:bug
+resource/aws_quicksight_dashboard: Fix `Invalid address to set` errors when reading a `definition` containing `line_chart_visual` `missing_data_configuration` or `contribution_analysis_defaults` `contributor_dimensions`
+```
+
+```release-note:bug
+resource/aws_quicksight_analysis: Fix `Invalid address to set` errors when reading a `definition` containing `line_chart_visual` `missing_data_configuration` or `contribution_analysis_defaults` `contributor_dimensions`
+```
+
+```release-note:bug
+resource/aws_quicksight_template: Fix `Invalid address to set` errors when reading a `definition` containing `line_chart_visual` `missing_data_configuration` or `contribution_analysis_defaults` `contributor_dimensions`
+```
+
+```release-note:bug
+data-source/aws_quicksight_analysis: Fix `Invalid address to set` errors when reading a `definition` containing `line_chart_visual` `missing_data_configuration` or `contribution_analysis_defaults` `contributor_dimensions`
+```

--- a/internal/service/quicksight/dashboard_test.go
+++ b/internal/service/quicksight/dashboard_test.go
@@ -257,7 +257,6 @@ func TestAccQuickSightDashboard_lineChartVisualMissingDataConfiguration(t *testi
 					resource.TestCheckResourceAttr(resourceName, "dashboard_id", rId),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, "definition.0.sheets.0.visuals.0.line_chart_visual.0.chart_configuration.0.primary_y_axis_display_options.0.missing_data_configuration.0.treatment_option", string(awstypes.MissingDataTreatmentOptionShowAsBlank)),
-					resource.TestCheckResourceAttr(resourceName, "definition.0.sheets.0.visuals.0.line_chart_visual.0.chart_configuration.0.secondary_y_axis_display_options.0.missing_data_configuration.0.treatment_option", string(awstypes.MissingDataTreatmentOptionShowAsZero)),
 				),
 			},
 			{
@@ -716,16 +715,31 @@ resource "aws_quicksight_dashboard" "test" {
           }
           chart_configuration {
             field_wells {
-              line_chart_aggregated_field_wells {}
+              line_chart_aggregated_field_wells {
+                category {
+                  categorical_dimension_field {
+                    field_id = "1"
+                    column {
+                      data_set_identifier = "1"
+                      column_name         = "Column1"
+                    }
+                  }
+                }
+                values {
+                  categorical_measure_field {
+                    field_id = "2"
+                    column {
+                      data_set_identifier = "1"
+                      column_name         = "Column1"
+                    }
+                    aggregation_function = "COUNT"
+                  }
+                }
+              }
             }
             primary_y_axis_display_options {
               missing_data_configuration {
                 treatment_option = "SHOW_AS_BLANK"
-              }
-            }
-            secondary_y_axis_display_options {
-              missing_data_configuration {
-                treatment_option = "SHOW_AS_ZERO"
               }
             }
           }

--- a/internal/service/quicksight/dashboard_test.go
+++ b/internal/service/quicksight/dashboard_test.go
@@ -234,6 +234,42 @@ func TestAccQuickSightDashboard_pieChartVisualArcThickness(t *testing.T) {
 	})
 }
 
+func TestAccQuickSightDashboard_lineChartVisualMissingDataConfiguration(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var dashboard awstypes.Dashboard
+	resourceName := "aws_quicksight_dashboard.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	rId := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDashboardDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDashboardConfig_lineChartVisualMissingDataConfiguration(rId, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDashboardExists(ctx, t, resourceName, &dashboard),
+					resource.TestCheckResourceAttr(resourceName, "dashboard_id", rId),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					resource.TestCheckResourceAttr(resourceName, "definition.0.sheets.0.visuals.0.line_chart_visual.0.chart_configuration.0.primary_y_axis_display_options.0.missing_data_configuration.0.treatment_option", string(awstypes.MissingDataTreatmentOptionShowAsBlank)),
+					resource.TestCheckResourceAttr(resourceName, "definition.0.sheets.0.visuals.0.line_chart_visual.0.chart_configuration.0.secondary_y_axis_display_options.0.missing_data_configuration.0.treatment_option", string(awstypes.MissingDataTreatmentOptionShowAsZero)),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{names.AttrParameters},
+			},
+		},
+	})
+}
+
 func testAccCheckDashboardDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.ProviderMeta(ctx, t).QuickSightClient(ctx)
@@ -643,6 +679,53 @@ resource "aws_quicksight_dashboard" "test" {
             donut_options {
               arc_options {
                 arc_thickness = "WHOLE"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+`, rId, rName))
+}
+
+func testAccDashboardConfig_lineChartVisualMissingDataConfiguration(rId, rName string) string {
+	return acctest.ConfigCompose(
+		testAccDashboardConfig_base(rId, rName),
+		fmt.Sprintf(`
+resource "aws_quicksight_dashboard" "test" {
+  dashboard_id        = %[1]q
+  name                = %[2]q
+  version_description = "test"
+  definition {
+    data_set_identifiers_declarations {
+      data_set_arn = aws_quicksight_data_set.test.arn
+      identifier   = "1"
+    }
+    sheets {
+      title    = "Test"
+      sheet_id = "Test1"
+      visuals {
+        line_chart_visual {
+          visual_id = "LineChart"
+          title {
+            format_text {
+              plain_text = "Line Chart Test"
+            }
+          }
+          chart_configuration {
+            field_wells {
+              line_chart_aggregated_field_wells {}
+            }
+            primary_y_axis_display_options {
+              missing_data_configuration {
+                treatment_option = "SHOW_AS_BLANK"
+              }
+            }
+            secondary_y_axis_display_options {
+              missing_data_configuration {
+                treatment_option = "SHOW_AS_ZERO"
               }
             }
           }

--- a/internal/service/quicksight/schema/visual_chart_configuration.go
+++ b/internal/service/quicksight/schema/visual_chart_configuration.go
@@ -1810,7 +1810,7 @@ func flattenContributionAnalysisDefault(apiObjects []awstypes.ContributionAnalys
 		}
 
 		if apiObject.ContributorDimensions != nil {
-			tfMap["contribution_dimensions"] = flattenColumnIdentifiers(apiObject.ContributorDimensions)
+			tfMap["contributor_dimensions"] = flattenColumnIdentifiers(apiObject.ContributorDimensions)
 		}
 
 		tfList = append(tfList, tfMap)

--- a/internal/service/quicksight/schema/visual_line_chart.go
+++ b/internal/service/quicksight/schema/visual_line_chart.go
@@ -1463,7 +1463,7 @@ func flattenLineSeriesAxisDisplayOptions(apiObject *awstypes.LineSeriesAxisDispl
 		tfMap["axis_options"] = flattenAxisDisplayOptions(apiObject.AxisOptions)
 	}
 	if apiObject.MissingDataConfigurations != nil {
-		tfMap["missing_data_configurations"] = flattenMissingDataConfiguration(apiObject.MissingDataConfigurations)
+		tfMap["missing_data_configuration"] = flattenMissingDataConfiguration(apiObject.MissingDataConfigurations)
 	}
 
 	return []any{tfMap}


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No. This change affects only how QuickSight visual definitions are flattened into
Terraform state; no access controls, encryption, or logging behavior is modified.

### Description

Two flatten functions in the QuickSight schema package write map keys that do not
exist in the corresponding schema, so `d.Set("definition", ...)` rejects the whole
address and any read of an affected definition fails.

**1. `line_chart_visual` missing data configuration**

| Path | Key used |
|---|---|
| Schema (`visual_line_chart.go:156`, `:180`, `:394`, `:414`) | `missing_data_configuration` |
| `expandLineSeriesAxisDisplayOptions` (`:1005`) | `missing_data_configuration` |
| `flattenLineSeriesAxisDisplayOptions` (`:1466`) | `missing_data_configurations` ❌ |

Reading a definition containing a line chart with a Y-axis missing data
configuration fails with:

Error: setting definition: Invalid address to set: []string{"definition", "0",
"sheets", "0", "visuals", "0", "line_chart_visual", "0", "chart_configuration",
"0", "primary_y_axis_display_options", "0", "missing_data_configurations"}



`primary_y_axis_display_options` and `secondary_y_axis_display_options` share the
same schema shape and the same flattener, so both are affected.

Because `definition` is set unconditionally on read (`dashboard.go`,
`analysis.go`, `template.go`), this is not limited to resources that configure
`definition` in HCL. It also breaks `terraform import` and every plan refresh for
dashboards created from a `source_entity` source template, where `definition` is
never present in the configuration — and `ignore_changes = [definition]` is not a
workaround, since the failure happens during read, before any diff. This makes it
impossible to adopt an existing dashboard (for example one previously managed by
an `AWS::QuickSight::Dashboard` CloudFormation stack) whose template contains such
a line chart.

`aws_quicksight_dashboard`, `aws_quicksight_analysis` and `aws_quicksight_template`
are all affected, as they share this flattener.

**2. `contribution_analysis_defaults` contributor dimensions**

The same class of defect: `flattenContributionAnalysisDefault`
(`visual_chart_configuration.go:1813`) wrote `contribution_dimensions`, while the
schema (`:435`, `:459`) and `expandContributionAnalysisDefaults` (`:1179`) use
`contributor_dimensions`.

I scanned every flatten function in `internal/service/quicksight/schema/` against
the declared schema attribute names (including the `attr_names.go` constants);
these two are the only remaining mismatches.

**Fix**

Both are fixed by correcting the flattener to match the schema and expander. Fixing
the read path rather than renaming the schema attributes to the plural/alternate
API spellings keeps this non-breaking for existing configurations.

Verified present in v5.4.0 through v6.57.x and on `main`, so there is no release
that avoids this.

Each fix is a separate commit; happy to split the second one into its own PR if
you'd prefer.

### Relations

Closes #40232

### References

- [`LineSeriesAxisDisplayOptions`](https://docs.aws.amazon.com/quicksight/latest/APIReference/API_LineSeriesAxisDisplayOptions.html)
- [`MissingDataConfiguration`](https://docs.aws.amazon.com/quicksight/latest/APIReference/API_MissingDataConfiguration.html)
- [`ContributionAnalysisDefault`](https://docs.aws.amazon.com/quicksight/latest/APIReference/API_ContributionAnalysisDefault.html)
- #37036 — earlier report of the same error class in this service

### Output from Acceptance Testing Before Changes

```console
% make testacc TESTS=TestAccQuickSightDashboard_lineChartVisualMissingDataConfiguration PKG=quicksight
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     5.948s
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework 5.965s
make: Running acceptance tests on branch: 🌿 main 🌿...
TF_ACC=1 go1.26.5 test ./internal/service/quicksight/... -v -count 1 -parallel 20 -run='TestAccQuickSightDashboard_lineChartVisualMissingDataConfiguration'  -timeout 360m -vet=off -buildvcs=false
2026/08/05 09:58:20 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/05 09:58:20 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccQuickSightDashboard_lineChartVisualMissingDataConfiguration
=== PAUSE TestAccQuickSightDashboard_lineChartVisualMissingDataConfiguration
=== CONT  TestAccQuickSightDashboard_lineChartVisualMissingDataConfiguration
panic: Invalid address to set: []string{"definition", "0", "sheets", "0", "visuals", "0", "line_chart_visual", "0", "chart_configuration", "0", "primary_y_axis_display_options", "0", "missing_data_configurations"}
...
```

### Output from Acceptance Testing After Changes

```console
% make testacc TESTS=TestAccQuickSightDashboard_lineChartVisualMissingDataConfiguration PKG=quicksight
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework (cached)
make: Running acceptance tests on branch: 🌿 b-fix-qs-dashboard-missing-data-configuration 🌿...
TF_ACC=1 go1.26.5 test ./internal/service/quicksight/... -v -count 1 -parallel 20 -run='TestAccQuickSightDashboard_lineChartVisualMissingDataConfiguration'  -timeout 360m -vet=off -buildvcs=false
2026/08/05 09:49:41 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/05 09:49:41 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccQuickSightDashboard_lineChartVisualMissingDataConfiguration
=== PAUSE TestAccQuickSightDashboard_lineChartVisualMissingDataConfiguration
=== CONT  TestAccQuickSightDashboard_lineChartVisualMissingDataConfiguration
--- PASS: TestAccQuickSightDashboard_lineChartVisualMissingDataConfiguration (37.29s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/quicksight 43.475s
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/quicksight/schema  0.553s [no tests to run]
...