### PR TITLE
Replaces `len(val.Elements())` with `val.Length(...)`

### DIFF
--- a/internal/framework/flex/autoflex.go
+++ b/internal/framework/flex/autoflex.go
@@ -12,6 +12,7 @@ import (
 	pluralize "github.com/gertd/go-pluralize"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	tfreflect "github.com/hashicorp/terraform-provider-aws/internal/reflect"
 )
@@ -170,6 +171,7 @@ type valueWithElementsAs interface {
 
 	Elements() []attr.Value
 	ElementsAs(context.Context, any, bool) diag.Diagnostics
+	Length(basetypes.CollectionLengthOptions) int
 }
 
 func diagConvertingTargetIsNil(targetType reflect.Type) diag.ErrorDiagnostic {

--- a/internal/framework/flex/autoflex_expand.go
+++ b/internal/framework/flex/autoflex_expand.go
@@ -730,7 +730,7 @@ func expandListOrSetOfInt64(ctx context.Context, expander *autoExpander, vFrom v
 			// types.List(OfInt64) -> []int64 or []int32
 			//
 			tflog.SubsystemTrace(ctx, subsystemName, "Expanding with ElementsAs", map[string]any{
-				logAttrKeySourceSize: len(vFrom.Elements()),
+				logAttrKeySourceSize: vFrom.Length(fwtypes.CollectionLengthUnhandledAsZero),
 			})
 			var to []int64
 			diags.Append(vFrom.ElementsAs(ctx, &to, false)...)
@@ -752,7 +752,7 @@ func expandListOrSetOfInt64(ctx context.Context, expander *autoExpander, vFrom v
 				// types.List(OfInt64) -> []*int32.
 				//
 				tflog.SubsystemTrace(ctx, subsystemName, "Expanding with ElementsAs", map[string]any{
-					logAttrKeySourceSize: len(vFrom.Elements()),
+					logAttrKeySourceSize: vFrom.Length(fwtypes.CollectionLengthUnhandledAsZero),
 				})
 				var to []*int32
 				diags.Append(vFrom.ElementsAs(ctx, &to, false)...)
@@ -768,7 +768,7 @@ func expandListOrSetOfInt64(ctx context.Context, expander *autoExpander, vFrom v
 				// types.List(OfInt64) -> []*int64.
 				//
 				tflog.SubsystemTrace(ctx, subsystemName, "Expanding with ElementsAs", map[string]any{
-					logAttrKeySourceSize: len(vFrom.Elements()),
+					logAttrKeySourceSize: vFrom.Length(fwtypes.CollectionLengthUnhandledAsZero),
 				})
 				var to []*int64
 				diags.Append(vFrom.ElementsAs(ctx, &to, false)...)
@@ -821,7 +821,7 @@ func expandListOrSetOfString(ctx context.Context, expander *autoExpander, vFrom 
 			// types.List(OfString) -> []string.
 			//
 			tflog.SubsystemTrace(ctx, subsystemName, "Expanding with ElementsAs", map[string]any{
-				logAttrKeySourceSize: len(vFrom.Elements()),
+				logAttrKeySourceSize: vFrom.Length(fwtypes.CollectionLengthUnhandledAsZero),
 			})
 			var to []string
 			diags.Append(vFrom.ElementsAs(ctx, &to, false)...)
@@ -845,7 +845,7 @@ func expandListOrSetOfString(ctx context.Context, expander *autoExpander, vFrom 
 				// types.List(OfString) -> []*string.
 				//
 				tflog.SubsystemTrace(ctx, subsystemName, "Expanding with ElementsAs", map[string]any{
-					logAttrKeySourceSize: len(vFrom.Elements()),
+					logAttrKeySourceSize: vFrom.Length(fwtypes.CollectionLengthUnhandledAsZero),
 				})
 				var to []*string
 				diags.Append(vFrom.ElementsAs(ctx, &to, false)...)
@@ -901,7 +901,7 @@ func expandListOrSetOfInt32(ctx context.Context, expander *autoExpander, vFrom v
 			// types.Set(OfInt32) -> []int32
 			//
 			tflog.SubsystemTrace(ctx, subsystemName, "Expanding with ElementsAs", map[string]any{
-				logAttrKeySourceSize: len(vFrom.Elements()),
+				logAttrKeySourceSize: vFrom.Length(fwtypes.CollectionLengthUnhandledAsZero),
 			})
 			var to []int32
 			diags.Append(vFrom.ElementsAs(ctx, &to, false)...)
@@ -919,7 +919,7 @@ func expandListOrSetOfInt32(ctx context.Context, expander *autoExpander, vFrom v
 				// types.Set(OfInt32) -> []*int32
 				//
 				tflog.SubsystemTrace(ctx, subsystemName, "Expanding with ElementsAs", map[string]any{
-					logAttrKeySourceSize: len(vFrom.Elements()),
+					logAttrKeySourceSize: vFrom.Length(fwtypes.CollectionLengthUnhandledAsZero),
 				})
 				var to []*int32
 				diags.Append(vFrom.ElementsAs(ctx, &to, false)...)
@@ -982,7 +982,7 @@ func expandMap(ctx context.Context, expander *autoExpander, vFrom basetypes.MapV
 			switch k := tMapElem.Elem().Kind(); k {
 			case reflect.String:
 				tflog.SubsystemTrace(ctx, subsystemName, "Expanding with ElementsAs", map[string]any{
-					logAttrKeySourceSize: len(data.Elements()),
+					logAttrKeySourceSize: data.Length(fwtypes.CollectionLengthUnhandledAsZero),
 				})
 				var out map[string][]string
 				diags.Append(data.ElementsAs(ctx, &out, false)...)
@@ -1010,7 +1010,7 @@ func expandMap(ctx context.Context, expander *autoExpander, vFrom basetypes.MapV
 			switch k := tMapElem.Elem().Kind(); k {
 			case reflect.String:
 				tflog.SubsystemTrace(ctx, subsystemName, "Expanding with ElementsAs", map[string]any{
-					logAttrKeySourceSize: len(data.Elements()),
+					logAttrKeySourceSize: data.Length(fwtypes.CollectionLengthUnhandledAsZero),
 				})
 				var out map[string]map[string]string
 				diags.Append(data.ElementsAs(ctx, &out, false)...)
@@ -1029,7 +1029,7 @@ func expandMap(ctx context.Context, expander *autoExpander, vFrom basetypes.MapV
 					// types.Map(OfMap[types.String]) -> map[string]map[string]*string.
 					//
 					tflog.SubsystemTrace(ctx, subsystemName, "Expanding with ElementsAs", map[string]any{
-						logAttrKeySourceSize: len(data.Elements()),
+						logAttrKeySourceSize: data.Length(fwtypes.CollectionLengthUnhandledAsZero),
 					})
 					var to map[string]map[string]*string
 					diags.Append(data.ElementsAs(ctx, &to, false)...)
@@ -1067,7 +1067,7 @@ func expandMapOfString(ctx context.Context, _ *autoExpander, vFrom basetypes.Map
 				// types.Map(OfString) -> map[string]string.
 				//
 				tflog.SubsystemTrace(ctx, subsystemName, "Expanding with ElementsAs", map[string]any{
-					logAttrKeySourceSize: len(vFrom.Elements()),
+					logAttrKeySourceSize: vFrom.Length(fwtypes.CollectionLengthUnhandledAsZero),
 				})
 				var to map[string]string
 				diags.Append(vFrom.ElementsAs(ctx, &to, false)...)
@@ -1085,7 +1085,7 @@ func expandMapOfString(ctx context.Context, _ *autoExpander, vFrom basetypes.Map
 					// types.Map(OfString) -> map[string]*string.
 					//
 					tflog.SubsystemTrace(ctx, subsystemName, "Expanding with ElementsAs", map[string]any{
-						logAttrKeySourceSize: len(vFrom.Elements()),
+						logAttrKeySourceSize: vFrom.Length(fwtypes.CollectionLengthUnhandledAsZero),
 					})
 					var to map[string]*string
 					diags.Append(vFrom.ElementsAs(ctx, &to, false)...)
@@ -1764,7 +1764,7 @@ func expandXMLWrapper(ctx context.Context, expander *autoExpander, vFrom valueWi
 
 	// Set fields
 	itemsField.Set(itemsSlice)
-	if err := setXMLWrapperQuantityField(quantityField, int32(len(vFrom.Elements()))); err != nil {
+	if err := setXMLWrapperQuantityField(quantityField, int32(vFrom.Length(fwtypes.CollectionLengthUnhandledAsZero))); err != nil {
 		diags.Append(diagExpandingIncompatibleTypes(reflect.TypeOf(vFrom), vTo.Type()))
 		return diags
 	}

--- a/internal/framework/types/consts.go
+++ b/internal/framework/types/consts.go
@@ -3,6 +3,15 @@
 
 package types
 
+import "github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+
 // ProviderErrorDetailPrefix contains instructions for reporting provider errors to provider developers
 const ProviderErrorDetailPrefix = "An unexpected error was encountered trying to validate an attribute value. " +
 	"This is always an error in the provider. Please report the following to the provider developer:\n\n"
+
+// CollectionLengthUnhandledAsZero is the standard options to use when calling Length on a
+// framework collection type (List, Set, Map). It treats null and unknown values as zero-length.
+var CollectionLengthUnhandledAsZero = basetypes.CollectionLengthOptions{
+	UnhandledNullAsZero:    true,
+	UnhandledUnknownAsZero: true,
+}

--- a/internal/service/dataexchange/revision_assets.go
+++ b/internal/service/dataexchange/revision_assets.go
@@ -309,8 +309,8 @@ func (r *revisionAssetsResource) Create(ctx context.Context, req resource.Create
 	// The `ImportAssetsFromSignedURL` Job technically requires a `Name` parameter, but I've defaulted to the name of the file.
 	// This should probably be changed to explicitly require the `name`
 	revisionID := aws.ToString(out.Id)
-	assets := make([]assetModel, len(plan.Assets.Elements()))
-	existingAssetIDs := make([]string, 0, len(plan.Assets.Elements()))
+	assets := make([]assetModel, plan.Assets.Length(fwtypes.CollectionLengthUnhandledAsZero))
+	existingAssetIDs := make([]string, 0, plan.Assets.Length(fwtypes.CollectionLengthUnhandledAsZero))
 	for i, asset := range nestedObjectCollectionAllMust[assetModel](ctx, plan.Assets) {
 		switch {
 		case !asset.ImportAssetsFromS3.IsNull():

--- a/internal/service/events/put_events_action.go
+++ b/internal/service/events/put_events_action.go
@@ -101,7 +101,7 @@ func (a *putEventsAction) Invoke(ctx context.Context, req action.InvokeRequest, 
 	conn := a.Meta().EventsClient(ctx)
 
 	tflog.Info(ctx, "Putting events", map[string]any{
-		"entry_count": len(model.Entry.Elements()),
+		"entry_count": model.Entry.Length(fwtypes.CollectionLengthUnhandledAsZero),
 	})
 
 	cb := fwactions.NewSendProgressFunc(resp)

--- a/internal/service/odb/network_peering_connection.go
+++ b/internal/service/odb/network_peering_connection.go
@@ -214,7 +214,7 @@ func (r *resourceNetworkPeeringConnection) Create(ctx context.Context, req resou
 		odbNetwork = plan.OdbNetworkId
 	}
 	//Validation : check is there any peer cidr for removal
-	if len(plan.PeerNetworkCidrs.Elements()) > 0 {
+	if plan.PeerNetworkCidrs.Length(fwtypes.CollectionLengthUnhandledAsZero) > 0 {
 		err := errors.New("during creation add / removal of peer network cidr is not supported")
 		resp.Diagnostics.AddError(
 			create.ProblemStandardMessage(names.ODB, create.ErrActionCreating, ResNameNetworkPeeringConnection, plan.DisplayName.ValueString(), err),

--- a/internal/service/rds/integration.go
+++ b/internal/service/rds/integration.go
@@ -215,7 +215,7 @@ func (r *integrationResource) Read(ctx context.Context, request resource.ReadReq
 	}
 
 	// Null vs. empty map handling.
-	if prevAdditionalEncryptionContext.IsNull() && !data.AdditionalEncryptionContext.IsNull() && len(data.AdditionalEncryptionContext.Elements()) == 0 {
+	if prevAdditionalEncryptionContext.IsNull() && !data.AdditionalEncryptionContext.IsNull() && data.AdditionalEncryptionContext.Length(fwtypes.CollectionLengthUnhandledAsZero) == 0 {
 		data.AdditionalEncryptionContext = prevAdditionalEncryptionContext
 	}
 

--- a/internal/service/redshift/integration.go
+++ b/internal/service/redshift/integration.go
@@ -178,7 +178,7 @@ func (r *integrationResource) Read(ctx context.Context, request resource.ReadReq
 	}
 
 	// Null vs. empty map handling.
-	if prevAdditionalEncryptionContext.IsNull() && !data.AdditionalEncryptionContext.IsNull() && len(data.AdditionalEncryptionContext.Elements()) == 0 {
+	if prevAdditionalEncryptionContext.IsNull() && !data.AdditionalEncryptionContext.IsNull() && data.AdditionalEncryptionContext.Length(fwtypes.CollectionLengthUnhandledAsZero) == 0 {
 		data.AdditionalEncryptionContext = prevAdditionalEncryptionContext
 	}
 

--- a/internal/service/sagemaker/training_job.go
+++ b/internal/service/sagemaker/training_job.go
@@ -1813,7 +1813,7 @@ func normalizeAlgoSpecMetricDefinitions(
 		return
 	}
 
-	if saved.IsNull() || len(saved.Elements()) == 0 {
+	if saved.Length(fwtypes.CollectionLengthUnhandledAsZero) == 0 {
 		flatSpecs[0].MetricDefinitions = fwtypes.NewListNestedObjectValueOfNull[trainingJobMetricDefinitionModel](ctx)
 	} else {
 		savedSpecs, d := saved.ToSlice(ctx)
@@ -1840,7 +1840,7 @@ func normalizeStoppingCondition(
 		return
 	}
 
-	if (saved.IsNull() || len(saved.Elements()) == 0) && !serverlessJobConfig.IsNull() && len(serverlessJobConfig.Elements()) > 0 {
+	if (saved.Length(fwtypes.CollectionLengthUnhandledAsZero) == 0) && !serverlessJobConfig.IsNull() && serverlessJobConfig.Length(fwtypes.CollectionLengthUnhandledAsZero) > 0 {
 		*target = fwtypes.NewListNestedObjectValueOfNull[trainingJobStoppingConditionModel](ctx)
 	}
 }

--- a/internal/service/securitylake/subscriber_notification.go
+++ b/internal/service/securitylake/subscriber_notification.go
@@ -305,13 +305,13 @@ func expandSubscriberNotificationResourceConfiguration(ctx context.Context, subs
 	var diags diag.Diagnostics
 
 	for _, item := range subscriberNotificationResourceConfigurationModels {
-		if !item.SqsNotificationConfiguration.IsNull() && (len(item.SqsNotificationConfiguration.Elements()) > 0) {
+		if item.SqsNotificationConfiguration.Length(fwtypes.CollectionLengthUnhandledAsZero) > 0 {
 			var sqsNotificationConfiguration []sqsNotificationConfigurationModel
 			diags.Append(item.SqsNotificationConfiguration.ElementsAs(ctx, &sqsNotificationConfiguration, false)...)
 			notificationConfiguration := expandSQSNotificationConfigurationModel(sqsNotificationConfiguration)
 			configuration = append(configuration, notificationConfiguration)
 		}
-		if (!item.HTTPSNotificationConfiguration.IsNull()) && (len(item.HTTPSNotificationConfiguration.Elements()) > 0) {
+		if item.HTTPSNotificationConfiguration.Length(fwtypes.CollectionLengthUnhandledAsZero) > 0 {
 			var httpsNotificationConfiguration []httpsNotificationConfigurationModel
 			diags.Append(item.HTTPSNotificationConfiguration.ElementsAs(ctx, &httpsNotificationConfiguration, false)...)
 			notificationConfiguration := expandHTTPSNotificationConfigurationModel(ctx, httpsNotificationConfiguration)

--- a/internal/service/servicequotas/auto_management.go
+++ b/internal/service/servicequotas/auto_management.go
@@ -253,7 +253,7 @@ func expandExclusionList(ctx context.Context, tfMap fwtypes.MapValueOf[fwtypes.L
 		return make(map[string][]string, 0), diags
 	}
 
-	apiMap := make(map[string][]string, len(tfMap.Elements()))
+	apiMap := make(map[string][]string, tfMap.Length(fwtypes.CollectionLengthUnhandledAsZero))
 
 	diags.Append(tfMap.ElementsAs(ctx, &apiMap, false)...)
 

--- a/internal/service/wafv2/web_acl_rule_group_association.go
+++ b/internal/service/wafv2/web_acl_rule_group_association.go
@@ -1923,7 +1923,7 @@ func (m awsManagedRulesACFPRuleSetModel) Expand(ctx context.Context) (result any
 	r.RegistrationPagePath = m.RegistrationPagePath.ValueStringPointer()
 	r.EnableRegexInPath = m.EnableRegexInPath.ValueBool()
 
-	if !m.RequestInspection.IsNull() && len(m.RequestInspection.Elements()) > 0 {
+	if m.RequestInspection.Length(fwtypes.CollectionLengthUnhandledAsZero) > 0 {
 		var reqInspection requestInspectionACFPModel
 		diags.Append(m.RequestInspection.Elements()[0].(fwtypes.ObjectValueOf[requestInspectionACFPModel]).As(ctx, &reqInspection, basetypes.ObjectAsOptions{})...)
 		if diags.HasError() {


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

To get the size of a Framework collection, current code often calls `Elements` and then passes it to the built-in `len`. `Elements` clones the collection.

Framework collection types define a `Length` method that directly returns the length. Calling `Length` avoids unnecessarily cloning the collection.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=dataexchange TESTS=TestAccDataExchangeRevisionAssets_ ACCTEST_PARALLELISM=10

--- PASS: TestAccDataExchangeRevisionAssets_S3Snapshot_Upload (40.57s)
--- PASS: TestAccDataExchangeRevisionAssets_S3DataAccessFromS3Bucket_keys (46.77s)
--- PASS: TestAccDataExchangeRevisionAssets_S3DataAccessFromS3Bucket_basic (47.25s)
--- PASS: TestAccDataExchangeRevisionAssets_S3DataAccessFromS3Bucket_cmk_basic (47.40s)
--- PASS: TestAccDataExchangeRevisionAssets_S3Snapshot_UploadMultiple (62.72s)
--- PASS: TestAccDataExchangeRevisionAssets_Tags_ComputedTag_onCreate (65.92s)
--- PASS: TestAccDataExchangeRevisionAssets_S3DataAccessFromS3Bucket_multiple (66.40s)
--- PASS: TestAccDataExchangeRevisionAssets_S3Snapshot_ImportMultipleFromS3 (66.74s)
--- PASS: TestAccDataExchangeRevisionAssets_S3Snapshot_ImportFromS3 (45.50s)
--- PASS: TestAccDataExchangeRevisionAssets_disappears (48.68s)
--- PASS: TestAccDataExchangeRevisionAssets_S3Snapshot_ImportAndUpload (65.69s)
--- PASS: TestAccDataExchangeRevisionAssets_finalized (73.21s)
--- PASS: TestAccDataExchangeRevisionAssets_Tags_IgnoreTags_Overlap_resourceTag (118.55s)
--- PASS: TestAccDataExchangeRevisionAssets_Tags_DefaultTags_nullNonOverlappingResourceTag (52.76s)
--- PASS: TestAccDataExchangeRevisionAssets_Tags_DefaultTags_emptyProviderOnlyTag (52.07s)
--- PASS: TestAccDataExchangeRevisionAssets_Tags_DefaultTags_nullOverlappingResourceTag (52.58s)
--- PASS: TestAccDataExchangeRevisionAssets_tags (137.60s)
--- PASS: TestAccDataExchangeRevisionAssets_Tags_DefaultTags_emptyResourceTag (50.30s)
--- PASS: TestAccDataExchangeRevisionAssets_Tags_DefaultTags_nonOverlapping (111.68s)
--- PASS: TestAccDataExchangeRevisionAssets_Tags_DefaultTags_updateToResourceOnly (87.14s)
--- PASS: TestAccDataExchangeRevisionAssets_Tags_emptyMap (57.57s)
--- PASS: TestAccDataExchangeRevisionAssets_Tags_DefaultTags_updateToProviderOnly (103.18s)
--- PASS: TestAccDataExchangeRevisionAssets_Tags_EmptyTag_onCreate (108.26s)
--- PASS: TestAccDataExchangeRevisionAssets_Tags_EmptyTag_OnUpdate_replace (108.24s)
--- PASS: TestAccDataExchangeRevisionAssets_Tags_null (72.21s)
--- PASS: TestAccDataExchangeRevisionAssets_Tags_addOnUpdate (108.87s)
--- PASS: TestAccDataExchangeRevisionAssets_Tags_DefaultTags_overlapping (147.65s)
--- PASS: TestAccDataExchangeRevisionAssets_Tags_EmptyTag_OnUpdate_add (146.21s)
--- PASS: TestAccDataExchangeRevisionAssets_Tags_ComputedTag_OnUpdate_replace (104.64s)
--- PASS: TestAccDataExchangeRevisionAssets_Tags_DefaultTags_providerOnly (181.63s)
--- PASS: TestAccDataExchangeRevisionAssets_Tags_ComputedTag_OnUpdate_add (91.45s)
--- PASS: TestAccDataExchangeRevisionAssets_Tags_IgnoreTags_Overlap_defaultTag (120.42s)
```

```console
% make testacc PKG=events TESTS=TestAccEventsPutEventsAction_

--- PASS: TestAccEventsPutEventsAction_customBus (138.88s)
--- PASS: TestAccEventsPutEventsAction_multipleEntries (138.89s)
--- PASS: TestAccEventsPutEventsAction_basic (139.00s)
```

```console
% make testacc PKG=rds TESTS=TestAccRDSIntegration_

--- FAIL: TestAccRDSIntegration_Identity_regionOverride (932.40s)
--- PASS: TestAccRDSIntegration_optional (1466.75s)
--- PASS: TestAccRDSIntegration_disappears (1515.23s)
--- PASS: TestAccRDSIntegration_Identity_basic (1885.36s)
--- PASS: TestAccRDSIntegration_Identity_ExistingResource_basic (1958.58s)
--- PASS: TestAccRDSIntegration_update (3199.44s)
--- PASS: TestAccRDSIntegration_basic (3582.22s)
--- FAIL: TestAccRDSIntegration_Identity_ExistingResource_noRefreshNoChange (3807.11s)
```

`TestAccRDSIntegration_Identity_regionOverride` and `TestAccRDSIntegration_Identity_ExistingResource_noRefreshNoChange` are intermittent failures due to upstream Redshift.

```console
% make testacc PKG=redshift TESTS=TestAccRedshiftIntegration_

--- PASS: TestAccRedshiftIntegration_Identity_basic (306.65s)
--- PASS: TestAccRedshiftIntegration_sourceUsesS3Bucket (311.43s)
--- PASS: TestAccRedshiftIntegration_disappears (337.08s)
--- PASS: TestAccRedshiftIntegration_Tags_DefaultTags_nullOverlappingResourceTag (344.37s)
--- PASS: TestAccRedshiftIntegration_Tags_DefaultTags_emptyResourceTag (441.78s)
--- PASS: TestAccRedshiftIntegration_Tags_IgnoreTags_Overlap_defaultTag (445.23s)
--- PASS: TestAccRedshiftIntegration_optional (452.29s)
--- PASS: TestAccRedshiftIntegration_Identity_ExistingResource_noRefreshNoChange (460.53s)
--- PASS: TestAccRedshiftIntegration_Tags_ComputedTag_OnUpdate_add (467.85s)
--- PASS: TestAccRedshiftIntegration_Tags_DefaultTags_nullNonOverlappingResourceTag (469.82s)
--- PASS: TestAccRedshiftIntegration_Tags_ComputedTag_OnUpdate_replace (474.97s)
--- PASS: TestAccRedshiftIntegration_Tags_DefaultTags_updateToResourceOnly (475.50s)
--- PASS: TestAccRedshiftIntegration_Tags_IgnoreTags_Overlap_resourceTag (485.21s)
--- PASS: TestAccRedshiftIntegration_basic (493.08s)
--- PASS: TestAccRedshiftIntegration_Identity_ExistingResource_basic (493.33s)
--- PASS: TestAccRedshiftIntegration_tags (499.65s)
--- PASS: TestAccRedshiftIntegration_Tags_DefaultTags_emptyProviderOnlyTag (499.70s)
--- PASS: TestAccRedshiftIntegration_Tags_ComputedTag_onCreate (511.64s)
--- PASS: TestAccRedshiftIntegration_Tags_EmptyTag_onCreate (514.65s)
--- PASS: TestAccRedshiftIntegration_Tags_DefaultTags_nonOverlapping (560.81s)
--- PASS: TestAccRedshiftIntegration_Tags_addOnUpdate (332.34s)
--- PASS: TestAccRedshiftIntegration_Tags_emptyMap (366.32s)
--- PASS: TestAccRedshiftIntegration_Tags_EmptyTag_OnUpdate_add (265.29s)
--- PASS: TestAccRedshiftIntegration_Identity_regionOverride (274.60s)
--- PASS: TestAccRedshiftIntegration_Tags_DefaultTags_providerOnly (425.20s)
--- PASS: TestAccRedshiftIntegration_Tags_EmptyTag_OnUpdate_replace (431.81s)
--- PASS: TestAccRedshiftIntegration_Tags_DefaultTags_updateToProviderOnly (346.40s)
--- PASS: TestAccRedshiftIntegration_Tags_null (355.67s)
--- PASS: TestAccRedshiftIntegration_Tags_DefaultTags_overlapping (377.46s)
```

```console
% make testacc PKG=sagemaker TESTS=TestAccSageMakerTrainingJob_serial

--- FAIL: TestAccSageMakerTrainingJob_serial (2589.88s)
    --- PASS: TestAccSageMakerTrainingJob_serial/infraCheckConfig (139.24s)
    --- SKIP: TestAccSageMakerTrainingJob_serial/mlflowConfig (0.00s)
    --- PASS: TestAccSageMakerTrainingJob_serial/vpc (675.38s)
    --- PASS: TestAccSageMakerTrainingJob_serial/environmentAndHyperParameters (129.05s)
    --- PASS: TestAccSageMakerTrainingJob_serial/tensorBoardOutputConfig (128.93s)
    --- PASS: TestAccSageMakerTrainingJob_serial/retryStrategy (129.27s)
    --- PASS: TestAccSageMakerTrainingJob_serial/Identity (179.86s)
        --- PASS: TestAccSageMakerTrainingJob_serial/Identity/basic (73.65s)
        --- PASS: TestAccSageMakerTrainingJob_serial/Identity/RegionOverride (106.21s)
    --- PASS: TestAccSageMakerTrainingJob_serial/outputDataConfig (129.97s)
    --- FAIL: TestAccSageMakerTrainingJob_serial/serverless (18.13s)
    --- SKIP: TestAccSageMakerTrainingJob_serial/remoteDebugConfig (0.00s)
    --- PASS: TestAccSageMakerTrainingJob_serial/debugConfig (140.08s)
    --- PASS: TestAccSageMakerTrainingJob_serial/inputDataConfig (129.19s)
    --- SKIP: TestAccSageMakerTrainingJob_serial/algorithmSpecificationMetrics (0.00s)
    --- PASS: TestAccSageMakerTrainingJob_serial/sessionChainingConfig (141.56s)
    --- PASS: TestAccSageMakerTrainingJob_serial/List (214.92s)
        --- PASS: TestAccSageMakerTrainingJob_serial/List/basic (71.44s)
        --- PASS: TestAccSageMakerTrainingJob_serial/List/includeResource (70.05s)
        --- PASS: TestAccSageMakerTrainingJob_serial/List/regionOverride (73.43s)
    --- PASS: TestAccSageMakerTrainingJob_serial/basic (69.64s)
    --- PASS: TestAccSageMakerTrainingJob_serial/disappears (32.26s)
    --- PASS: TestAccSageMakerTrainingJob_serial/profilerConfig (141.85s)
    --- PASS: TestAccSageMakerTrainingJob_serial/checkpointConfig (127.68s)
    --- PASS: TestAccSageMakerTrainingJob_serial/tags (62.86s)
```

`TestAccSageMakerTrainingJob_serial/serverless` is a pre-existing failure

```console
% make testacc PKG=servicequotas TESTS='TestAccServiceQuotas_serial/AutoManagement'

--- FAIL: TestAccServiceQuotas_serial (191.99s)
    --- FAIL: TestAccServiceQuotas_serial/AutoManagement (191.68s)
        --- PASS: TestAccServiceQuotas_serial/AutoManagement/basic (38.82s)
        --- PASS: TestAccServiceQuotas_serial/AutoManagement/disappears (23.52s)
        --- PASS: TestAccServiceQuotas_serial/AutoManagement/updateExclusionList (60.37s)
        --- FAIL: TestAccServiceQuotas_serial/AutoManagement/updateNotificationARN (7.52s)
        --- PASS: TestAccServiceQuotas_serial/AutoManagement/Identity (61.45s)
            --- PASS: TestAccServiceQuotas_serial/AutoManagement/Identity/basic (26.65s)
            --- PASS: TestAccServiceQuotas_serial/AutoManagement/Identity/RegionOverride (34.81s)
```

`TestAccServiceQuotas_serial/AutoManagement/updateNotificationARN` is a pre-existing failure.

```console
% make testacc PKG=wafv2 TESTS=TestAccWAFV2WebACLRuleGroupAssociation_

--- PASS: TestAccWAFV2WebACLRuleGroupAssociation_withVisibilityConfig (70.33s)
--- PASS: TestAccWAFV2WebACLRuleGroupAssociation_disappears (80.92s)
--- PASS: TestAccWAFV2WebACLRuleGroupAssociation_ManagedRuleGroup_ManagedRuleGroupConfig_BotControl (92.10s)
--- PASS: TestAccWAFV2WebACLRuleGroupAssociation_RuleGroupReference_overrideAction (101.04s)
--- PASS: TestAccWAFV2WebACLRuleGroupAssociation_ManagedRuleGroup_basic (111.54s)
--- PASS: TestAccWAFV2WebACLRuleGroupAssociation_RuleGroupReference_ruleActionOverride (111.79s)
--- PASS: TestAccWAFV2WebACLRuleGroupAssociation_basic (114.92s)
--- PASS: TestAccWAFV2WebACLRuleGroupAssociation_RuleGroupReference_webACLARNRequiresReplace (120.55s)
--- PASS: TestAccWAFV2WebACLRuleGroupAssociation_ManagedRuleGroup_withVersion (122.25s)
--- PASS: TestAccWAFV2WebACLRuleGroupAssociation_RuleGroupReference_ruleActionOverrideUpdate (122.41s)
--- PASS: TestAccWAFV2WebACLRuleGroupAssociation_ManagedRuleGroup_ManagedRuleGroupConfig_ACFPRuleSet (127.01s)
--- PASS: TestAccWAFV2WebACLRuleGroupAssociation_RuleGroupReference_ruleNameRequiresReplace (128.96s)
--- PASS: TestAccWAFV2WebACLRuleGroupAssociation_multipleAssociations (131.73s)
--- PASS: TestAccWAFV2WebACLRuleGroupAssociation_ManagedRuleGroup_ManagedRuleGroupConfig_basic (133.61s)
--- PASS: TestAccWAFV2WebACLRuleGroupAssociation_ManagedRuleGroup_ruleActionOverride (134.50s)
--- PASS: TestAccWAFV2WebACLRuleGroupAssociation_ManagedRuleGroup_ManagedRuleGroupConfig_ATPRuleSet (136.42s)
--- PASS: TestAccWAFV2WebACLRuleGroupAssociation_RuleGroupReference_overrideActionUpdate (137.67s)
--- PASS: TestAccWAFV2WebACLRuleGroupAssociation_ManagedRuleGroup_ManagedRuleGroupConfig_AntiDDoSRuleSet (141.10s)
--- PASS: TestAccWAFV2WebACLRuleGroupAssociation_RuleGroupReference_priorityUpdate (143.30s)
```
