### PR TITLE
aws_route53domains_registered_domain: Fix privacy HasChanges checking billing_contact instead of billing_privacy

### DIFF
--- a/.changelog/49313.txt
+++ b/.changelog/49313.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_route53domains_registered_domain: Fix `UpdateDomainContactPrivacy` being incorrectly triggered when `billing_contact` changes
+```

--- a/internal/service/route53domains/registered_domain.go
+++ b/internal/service/route53domains/registered_domain.go
@@ -470,7 +470,7 @@ func resourceRegisteredDomainUpdate(ctx context.Context, d *schema.ResourceData,
 		}
 	}
 
-	if d.HasChanges("admin_privacy", "billing_contact", "registrant_privacy", "tech_privacy") {
+	if d.HasChanges("admin_privacy", "billing_privacy", "registrant_privacy", "tech_privacy") {
 		if err := modifyDomainContactPrivacy(ctx, conn, d.Id(), d.Get("admin_privacy").(bool), d.Get("billing_privacy").(bool), d.Get("registrant_privacy").(bool), d.Get("tech_privacy").(bool), d.Timeout(schema.TimeoutUpdate)); err != nil {
 			return sdkdiag.AppendFromErr(diags, err)
 		}


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls (access controls, encryption, logging).

### Description

In `resourceRegisteredDomainUpdate`, the privacy update path incorrectly checked `billing_contact` instead of `billing_privacy`:

```go
// before
if d.HasChanges("admin_privacy", "billing_contact", "registrant_privacy", "tech_privacy") {

// after
if d.HasChanges("admin_privacy", "billing_privacy", "registrant_privacy", "tech_privacy") {
```

This typo was introduced when billing contact/privacy support was added in #36285. As a result, any change to `billing_contact` unconditionally called `UpdateDomainContactPrivacy`.

That fails for TLDs that do not support privacy protection (e.g. `.jp`) with non-`PERSON` contact types, even when:

- privacy attributes are set to `false`
- privacy attributes are listed in `lifecycle.ignore_changes`

### Relations

Closes #49312

Relates #44538 (different root cause: Default=true / unsupported privacy TLDs)

### References

- https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/jp.html
- Typo introduced in https://github.com/hashicorp/terraform-provider-aws/pull/36285

### Output from Acceptance Testing

```console
% make testacc TESTS=TestAccRoute53DomainsRegisteredDomain_ PKG=route53domains

Not run in this environment (requires Route 53 Domains registered domains / long-running acceptance tests).
Change is a one-line HasChanges attribute name correction.
```

Made with [Cursor](https://cursor.com)