### PR TITLE
r/aws_emr_cluster: Add monitoring_configuration argument

### DIFF
--- a/.changelog/49318.txt
+++ b/.changelog/49318.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_emr_cluster: Add `monitoring_configuration` argument
+```
+
+```release-note:bug
+resource/aws_emr_cluster: Mark `os_release_label` as `Computed`, preventing spurious resource replacement when the argument is not configured
+```

--- a/internal/service/emr/cluster.go
+++ b/internal/service/emr/cluster.go
@@ -647,6 +647,121 @@ func resourceCluster() *schema.Resource {
 					Type:     schema.TypeString,
 					Computed: true,
 				},
+				"monitoring_configuration": {
+					Type:             schema.TypeList,
+					Optional:         true,
+					ForceNew:         true,
+					MaxItems:         1,
+					DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"cloud_watch_log_configuration": {
+								Type:             schema.TypeList,
+								Optional:         true,
+								ForceNew:         true,
+								MaxItems:         1,
+								DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
+								AtLeastOneOf: []string{
+									"monitoring_configuration.0.cloud_watch_log_configuration",
+									"monitoring_configuration.0.s3_logging_configuration",
+								},
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										names.AttrEnabled: {
+											Type:     schema.TypeBool,
+											Required: true,
+											ForceNew: true,
+										},
+										"encryption_key_arn": {
+											Type:         schema.TypeString,
+											Optional:     true,
+											ForceNew:     true,
+											ValidateFunc: verify.ValidARN,
+										},
+										names.AttrLogGroupName: {
+											Type:         schema.TypeString,
+											Optional:     true,
+											Computed:     true,
+											ForceNew:     true,
+											ValidateFunc: validation.StringLenBetween(1, 512),
+										},
+										"log_stream_name_prefix": {
+											Type:         schema.TypeString,
+											Optional:     true,
+											ForceNew:     true,
+											ValidateFunc: validation.StringLenBetween(1, 512),
+										},
+										"log_types": {
+											Type:     schema.TypeSet,
+											Optional: true,
+											Computed: true,
+											ForceNew: true,
+											Set:      sdkv2.SimpleSchemaSetFunc(names.AttrName),
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													names.AttrName: {
+														Type:         schema.TypeString,
+														Required:     true,
+														ForceNew:     true,
+														ValidateFunc: validation.StringInSlice([]string{"STEP_LOGS", "SPARK_DRIVER", "SPARK_EXECUTOR"}, false),
+													},
+													names.AttrValues: {
+														Type:     schema.TypeSet,
+														Required: true,
+														ForceNew: true,
+														MinItems: 1,
+														Elem: &schema.Schema{
+															Type:         schema.TypeString,
+															ValidateFunc: validation.StringInSlice([]string{"STDOUT", "STDERR"}, false),
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							"s3_logging_configuration": {
+								Type:             schema.TypeList,
+								Optional:         true,
+								ForceNew:         true,
+								MaxItems:         1,
+								DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
+								AtLeastOneOf: []string{
+									"monitoring_configuration.0.cloud_watch_log_configuration",
+									"monitoring_configuration.0.s3_logging_configuration",
+								},
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"log_type_upload_policy": {
+											Type:     schema.TypeSet,
+											Required: true,
+											ForceNew: true,
+											MinItems: 1,
+											Set:      sdkv2.SimpleSchemaSetFunc("log_type"),
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"log_type": {
+														Type:             schema.TypeString,
+														Required:         true,
+														ForceNew:         true,
+														ValidateDiagFunc: enum.Validate[awstypes.LogType](),
+													},
+													"upload_policy": {
+														Type:             schema.TypeString,
+														Required:         true,
+														ForceNew:         true,
+														ValidateDiagFunc: enum.Validate[awstypes.LogUploadPolicyValue](),
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
 				names.AttrName: {
 					Type:     schema.TypeString,
 					ForceNew: true,
@@ -656,6 +771,7 @@ func resourceCluster() *schema.Resource {
 					Type:     schema.TypeString,
 					ForceNew: true,
 					Optional: true,
+					Computed: true,
 				},
 				"placement_group_config": {
 					Type:       schema.TypeList,
@@ -995,6 +1111,10 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta any
 		input.LogUri = aws.String(v.(string))
 	}
 
+	if v, ok := d.GetOk("monitoring_configuration"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.MonitoringConfiguration = expandMonitoringConfiguration(v.([]any)[0].(map[string]any))
+	}
+
 	if v, ok := d.GetOk("os_release_label"); ok {
 		input.OSReleaseLabel = aws.String(v.(string))
 	}
@@ -1215,6 +1335,10 @@ func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta any) 
 		if err := d.Set("auto_termination_policy", flattenAutoTerminationPolicy(autoTerminationPolicy)); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting auto_termination_policy: %s", err)
 		}
+	}
+
+	if err := d.Set("monitoring_configuration", flattenMonitoringConfiguration(cluster.MonitoringConfiguration)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting monitoring_configuration: %s", err)
 	}
 
 	if err := d.Set("placement_group_config", flattenPlacementGroupConfigs(cluster.PlacementGroups)); err != nil {
@@ -2474,6 +2598,222 @@ func flattenPlacementGroupConfigs(apiObjects []awstypes.PlacementGroupConfig) []
 		tfMap["placement_strategy"] = apiObject.PlacementStrategy
 
 		tfList = append(tfList, tfMap)
+	}
+
+	return tfList
+}
+
+func expandMonitoringConfiguration(tfMap map[string]any) *awstypes.MonitoringConfiguration {
+	if tfMap == nil {
+		return nil
+	}
+
+	apiObject := &awstypes.MonitoringConfiguration{}
+
+	if v, ok := tfMap["cloud_watch_log_configuration"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.CloudWatchLogConfiguration = expandCloudWatchLogConfiguration(v[0].(map[string]any))
+	}
+
+	if v, ok := tfMap["s3_logging_configuration"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.S3LoggingConfiguration = expandS3LoggingConfiguration(v[0].(map[string]any))
+	}
+
+	return apiObject
+}
+
+func expandCloudWatchLogConfiguration(tfMap map[string]any) *awstypes.CloudWatchLogConfiguration {
+	if tfMap == nil {
+		return nil
+	}
+
+	// Enabled is required by the API, so it is always sent.
+	apiObject := &awstypes.CloudWatchLogConfiguration{
+		Enabled: aws.Bool(tfMap[names.AttrEnabled].(bool)),
+	}
+
+	if v, ok := tfMap["encryption_key_arn"].(string); ok && v != "" {
+		apiObject.EncryptionKeyArn = aws.String(v)
+	}
+
+	if v, ok := tfMap[names.AttrLogGroupName].(string); ok && v != "" {
+		apiObject.LogGroupName = aws.String(v)
+	}
+
+	if v, ok := tfMap["log_stream_name_prefix"].(string); ok && v != "" {
+		apiObject.LogStreamNamePrefix = aws.String(v)
+	}
+
+	if v, ok := tfMap["log_types"].(*schema.Set); ok && v.Len() > 0 {
+		apiObject.LogTypes = expandLogTypes(v.List())
+	}
+
+	return apiObject
+}
+
+func expandLogTypes(tfList []any) map[string][]string {
+	if len(tfList) == 0 {
+		return nil
+	}
+
+	apiObject := make(map[string][]string, len(tfList))
+
+	for _, tfMapRaw := range tfList {
+		tfMap, ok := tfMapRaw.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		name, ok := tfMap[names.AttrName].(string)
+		if !ok || name == "" {
+			continue
+		}
+
+		if v, ok := tfMap[names.AttrValues].(*schema.Set); ok && v.Len() > 0 {
+			apiObject[name] = flex.ExpandStringValueSet(v)
+		}
+	}
+
+	return apiObject
+}
+
+func expandS3LoggingConfiguration(tfMap map[string]any) *awstypes.S3LoggingConfiguration {
+	if tfMap == nil {
+		return nil
+	}
+
+	apiObject := &awstypes.S3LoggingConfiguration{}
+
+	if v, ok := tfMap["log_type_upload_policy"].(*schema.Set); ok && v.Len() > 0 {
+		apiObject.LogTypeUploadPolicy = expandLogTypeUploadPolicy(v.List())
+	}
+
+	return apiObject
+}
+
+func expandLogTypeUploadPolicy(tfList []any) map[string]awstypes.LogUploadPolicyValue {
+	if len(tfList) == 0 {
+		return nil
+	}
+
+	apiObject := make(map[string]awstypes.LogUploadPolicyValue, len(tfList))
+
+	for _, tfMapRaw := range tfList {
+		tfMap, ok := tfMapRaw.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		logType, ok := tfMap["log_type"].(string)
+		if !ok || logType == "" {
+			continue
+		}
+
+		if v, ok := tfMap["upload_policy"].(string); ok && v != "" {
+			apiObject[logType] = awstypes.LogUploadPolicyValue(v)
+		}
+	}
+
+	return apiObject
+}
+
+func flattenMonitoringConfiguration(apiObject *awstypes.MonitoringConfiguration) []any {
+	if apiObject == nil {
+		return []any{}
+	}
+
+	tfMap := map[string]any{}
+
+	if v := apiObject.CloudWatchLogConfiguration; v != nil {
+		tfMap["cloud_watch_log_configuration"] = []any{flattenCloudWatchLogConfiguration(v)}
+	}
+
+	// Amazon EMR returns an empty S3LoggingConfiguration even when only CloudWatch
+	// logging was configured. Setting it would write a block that is absent from the
+	// configuration into state, causing a perpetual diff, so only set it when upload
+	// policies are actually present.
+	if v := apiObject.S3LoggingConfiguration; v != nil && len(v.LogTypeUploadPolicy) > 0 {
+		tfMap["s3_logging_configuration"] = []any{flattenS3LoggingConfiguration(v)}
+	}
+
+	// Likewise, avoid writing a phantom monitoring_configuration block into state.
+	if len(tfMap) == 0 {
+		return []any{}
+	}
+
+	return []any{tfMap}
+}
+
+func flattenCloudWatchLogConfiguration(apiObject *awstypes.CloudWatchLogConfiguration) map[string]any {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]any{
+		names.AttrEnabled: aws.ToBool(apiObject.Enabled),
+	}
+
+	if v := apiObject.EncryptionKeyArn; v != nil {
+		tfMap["encryption_key_arn"] = aws.ToString(v)
+	}
+
+	if v := apiObject.LogGroupName; v != nil {
+		tfMap[names.AttrLogGroupName] = aws.ToString(v)
+	}
+
+	if v := apiObject.LogStreamNamePrefix; v != nil {
+		tfMap["log_stream_name_prefix"] = aws.ToString(v)
+	}
+
+	if v := apiObject.LogTypes; len(v) > 0 {
+		tfMap["log_types"] = flattenLogTypes(v)
+	}
+
+	return tfMap
+}
+
+func flattenLogTypes(apiObject map[string][]string) []any {
+	if len(apiObject) == 0 {
+		return nil
+	}
+
+	tfList := make([]any, 0, len(apiObject))
+
+	for name, values := range apiObject {
+		tfList = append(tfList, map[string]any{
+			names.AttrName:   name,
+			names.AttrValues: flex.FlattenStringValueSet(values),
+		})
+	}
+
+	return tfList
+}
+
+func flattenS3LoggingConfiguration(apiObject *awstypes.S3LoggingConfiguration) map[string]any {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]any{}
+
+	if v := apiObject.LogTypeUploadPolicy; len(v) > 0 {
+		tfMap["log_type_upload_policy"] = flattenLogTypeUploadPolicy(v)
+	}
+
+	return tfMap
+}
+
+func flattenLogTypeUploadPolicy(apiObject map[string]awstypes.LogUploadPolicyValue) []any {
+	if len(apiObject) == 0 {
+		return nil
+	}
+
+	tfList := make([]any, 0, len(apiObject))
+
+	for logType, uploadPolicy := range apiObject {
+		tfList = append(tfList, map[string]any{
+			"log_type":      logType,
+			"upload_policy": string(uploadPolicy),
+		})
 	}
 
 	return tfList

--- a/internal/service/emr/cluster_schema_test.go
+++ b/internal/service/emr/cluster_schema_test.go
@@ -1,0 +1,131 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package emr_test
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	tfemr "github.com/hashicorp/terraform-provider-aws/internal/service/emr"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func monitoringConfigurationSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"monitoring_configuration": tfemr.ResourceCluster().SchemaMap()["monitoring_configuration"],
+	}
+}
+
+func TestClusterMonitoringConfigurationValidation(t *testing.T) {
+	cloudWatch := []any{map[string]any{names.AttrEnabled: true}}
+	s3 := []any{map[string]any{
+		"log_type_upload_policy": []any{map[string]any{
+			"log_type":      "system-logs",
+			"upload_policy": "emr-managed",
+		}},
+	}}
+
+	testCases := map[string]struct {
+		configuration []any
+		wantError     bool
+	}{
+		"omitted":           {},
+		"empty":             {configuration: []any{map[string]any{}}, wantError: true},
+		"CloudWatch only":   {configuration: []any{map[string]any{"cloud_watch_log_configuration": cloudWatch}}},
+		"S3 only":           {configuration: []any{map[string]any{"s3_logging_configuration": s3}}},
+		"CloudWatch and S3": {configuration: []any{map[string]any{"cloud_watch_log_configuration": cloudWatch, "s3_logging_configuration": s3}}},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			raw := map[string]any{}
+			if testCase.configuration != nil {
+				raw["monitoring_configuration"] = testCase.configuration
+			}
+
+			diags := schema.InternalMap(monitoringConfigurationSchema()).Validate(terraform.NewResourceConfigRaw(raw))
+
+			if got := diags.HasError(); got != testCase.wantError {
+				t.Fatalf("expected error %t, got diagnostics: %#v", testCase.wantError, diags)
+			}
+			if !testCase.wantError {
+				return
+			}
+
+			for _, diag := range diags {
+				if strings.Contains(diag.Detail, "cloud_watch_log_configuration") && strings.Contains(diag.Detail, "s3_logging_configuration") {
+					return
+				}
+			}
+			t.Fatalf("expected an error naming both configuration blocks, got diagnostics: %#v", diags)
+		})
+	}
+}
+
+// Amazon EMR models log types and upload policies as maps, so the key attribute
+// of each block determines set identity.
+func TestClusterMonitoringConfigurationSetIdentity(t *testing.T) {
+	testCases := map[string]struct {
+		configuration map[string]any
+		child         string
+		attribute     string
+		key           string
+		wantKeys      []string
+	}{
+		"log types": {
+			configuration: map[string]any{
+				"cloud_watch_log_configuration": []any{map[string]any{
+					names.AttrEnabled: true,
+					"log_types": []any{
+						map[string]any{names.AttrName: "STEP_LOGS", names.AttrValues: []any{"STDOUT"}},
+						map[string]any{names.AttrName: "STEP_LOGS", names.AttrValues: []any{"STDERR"}},
+						map[string]any{names.AttrName: "SPARK_DRIVER", names.AttrValues: []any{"STDOUT"}},
+					},
+				}},
+			},
+			child:     "cloud_watch_log_configuration",
+			attribute: "log_types",
+			key:       names.AttrName,
+			wantKeys:  []string{"SPARK_DRIVER", "STEP_LOGS"},
+		},
+		"upload policies": {
+			configuration: map[string]any{
+				"s3_logging_configuration": []any{map[string]any{
+					"log_type_upload_policy": []any{
+						map[string]any{"log_type": "system-logs", "upload_policy": "emr-managed"},
+						map[string]any{"log_type": "system-logs", "upload_policy": "disabled"},
+						map[string]any{"log_type": "application-logs", "upload_policy": "disabled"},
+					},
+				}},
+			},
+			child:     "s3_logging_configuration",
+			attribute: "log_type_upload_policy",
+			key:       "log_type",
+			wantKeys:  []string{"application-logs", "system-logs"},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			data := schema.TestResourceDataRaw(t, monitoringConfigurationSchema(), map[string]any{
+				"monitoring_configuration": []any{testCase.configuration},
+			})
+			monitoring := data.Get("monitoring_configuration").([]any)[0].(map[string]any)
+			set := monitoring[testCase.child].([]any)[0].(map[string]any)[testCase.attribute].(*schema.Set)
+
+			got := make([]string, 0, set.Len())
+			for _, raw := range set.List() {
+				got = append(got, raw.(map[string]any)[testCase.key].(string))
+			}
+			slices.Sort(got)
+
+			if !slices.Equal(got, testCase.wantKeys) {
+				t.Errorf("expected identities %v, got %v", testCase.wantKeys, got)
+			}
+		})
+	}
+}

--- a/internal/service/emr/cluster_test.go
+++ b/internal/service/emr/cluster_test.go
@@ -68,6 +68,7 @@ func TestAccEMRCluster_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "bootstrap_action.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "kerberos_attributes.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "auto_termination_policy.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "monitoring_configuration.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "step.#", "0"),
 				),
 			},
@@ -1352,6 +1353,127 @@ func TestAccEMRCluster_s3LogEncryption(t *testing.T) {
 					testAccCheckClusterExists(ctx, t, resourceName, &cluster),
 					resource.TestCheckResourceAttr(resourceName, "log_uri", bucketName),
 					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, "log_encryption_kms_key_id", "kms", regexache.MustCompile(`key/.+`)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"cluster_state", // Ignore RUNNING versus WAITING changes
+					"configurations",
+					"keep_job_flow_alive_when_no_steps",
+				},
+			},
+		},
+	})
+}
+
+func TestAccEMRCluster_MonitoringConfiguration_cloudWatchLogs(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+	var cluster awstypes.Cluster
+
+	resourceName := "aws_emr_cluster.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.EMREndpointID)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.EMRServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterConfig_monitoringConfigurationCloudWatchLogs(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClusterExists(ctx, t, resourceName, &cluster),
+					resource.TestCheckResourceAttr(resourceName, "monitoring_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "monitoring_configuration.0.cloud_watch_log_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "monitoring_configuration.0.cloud_watch_log_configuration.0.enabled", acctest.CtTrue),
+					resource.TestCheckResourceAttrPair(resourceName, "monitoring_configuration.0.cloud_watch_log_configuration.0.log_group_name", "aws_cloudwatch_log_group.test", names.AttrName),
+					resource.TestCheckResourceAttr(resourceName, "monitoring_configuration.0.cloud_watch_log_configuration.0.log_stream_name_prefix", "example"),
+					resource.TestCheckResourceAttr(resourceName, "monitoring_configuration.0.cloud_watch_log_configuration.0.log_types.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "monitoring_configuration.0.cloud_watch_log_configuration.0.log_types.*", map[string]string{
+						names.AttrName: "STEP_LOGS",
+						"values.#":     "2",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "monitoring_configuration.0.cloud_watch_log_configuration.0.log_types.*", map[string]string{
+						names.AttrName: "SPARK_DRIVER",
+						"values.#":     "1",
+					}),
+					resource.TestCheckResourceAttr(resourceName, "monitoring_configuration.0.s3_logging_configuration.#", "0"),
+				),
+			},
+			// Verify replacement without applying another billable EMR cluster.
+			// nosemgrep:ci.semgrep.acctest.checks.replace-planonly-checks
+			{
+				Config:             testAccClusterConfig_monitoringConfigurationCloudWatchLogsRemoved(rName),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionReplace),
+					},
+				},
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"cluster_state", // Ignore RUNNING versus WAITING changes
+					"configurations",
+					"keep_job_flow_alive_when_no_steps",
+				},
+			},
+		},
+	})
+}
+
+func TestAccEMRCluster_MonitoringConfiguration_s3Logging(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+	var cluster awstypes.Cluster
+
+	resourceName := "aws_emr_cluster.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.EMREndpointID)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.EMRServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterConfig_monitoringConfigurationS3Logging(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClusterExists(ctx, t, resourceName, &cluster),
+					resource.TestCheckResourceAttr(resourceName, "monitoring_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "monitoring_configuration.0.cloud_watch_log_configuration.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "monitoring_configuration.0.s3_logging_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "monitoring_configuration.0.s3_logging_configuration.0.log_type_upload_policy.#", "3"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "monitoring_configuration.0.s3_logging_configuration.0.log_type_upload_policy.*", map[string]string{
+						"log_type":      "system-logs",
+						"upload_policy": "emr-managed",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "monitoring_configuration.0.s3_logging_configuration.0.log_type_upload_policy.*", map[string]string{
+						"log_type":      "application-logs",
+						"upload_policy": "on-customer-s3only",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "monitoring_configuration.0.s3_logging_configuration.0.log_type_upload_policy.*", map[string]string{
+						"log_type":      "persistent-ui-logs",
+						"upload_policy": "emr-managed",
+					}),
 				),
 			},
 			{
@@ -4574,4 +4696,180 @@ resource "aws_emr_cluster" "test" {
   ebs_root_volume_size = 21
 }
 `, rName, releaseLabel, osReleaseLabel))
+}
+
+func testAccClusterConfig_baseIAMInstanceProfileCloudWatchLogs(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role_policy_attachment" "emr_instance_profile_logs" {
+  role       = aws_iam_role.emr_instance_profile.id
+  policy_arn = aws_iam_policy.emr_instance_profile_logs.arn
+}
+
+resource "aws_iam_policy" "emr_instance_profile_logs" {
+  name = "%[1]s_profile_logs"
+
+  policy = <<EOT
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+      "Sid": "AllowCWACloudWatchLogs",
+      "Effect": "Allow",
+      "Resource": "*",
+      "Action": [
+          "logs:CreateLogStream",
+          "logs:DescribeLogGroups",
+          "logs:DescribeLogStreams",
+          "logs:PutLogEvents"
+      ]
+  }]
+}
+EOT
+}
+`, rName)
+}
+
+func testAccClusterConfig_monitoringConfigurationCloudWatchLogs(rName string) string {
+	return testAccClusterConfig_monitoringConfigurationCloudWatchLogsBase(rName, `
+  monitoring_configuration {
+    cloud_watch_log_configuration {
+      enabled                = true
+      log_group_name         = aws_cloudwatch_log_group.test.name
+      log_stream_name_prefix = "example"
+
+      log_types {
+        name   = "STEP_LOGS"
+        values = ["STDOUT", "STDERR"]
+      }
+
+      log_types {
+        name   = "SPARK_DRIVER"
+        values = ["STDERR"]
+      }
+    }
+  }
+`)
+}
+
+func testAccClusterConfig_monitoringConfigurationCloudWatchLogsRemoved(rName string) string {
+	return testAccClusterConfig_monitoringConfigurationCloudWatchLogsBase(rName, "")
+}
+
+func testAccClusterConfig_monitoringConfigurationCloudWatchLogsBase(rName, monitoringConfiguration string) string {
+	return acctest.ConfigCompose(
+		testAccClusterConfig_baseVPC(rName, false),
+		testAccClusterConfig_baseIAMServiceRole(rName),
+		testAccClusterConfig_baseIAMInstanceProfile(rName),
+		testAccClusterConfig_baseIAMInstanceProfileCloudWatchLogs(rName),
+		fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+resource "aws_cloudwatch_log_group" "test" {
+  name = "/aws/emr/%[1]s"
+}
+
+resource "aws_emr_cluster" "test" {
+  name          = %[1]q
+  release_label = "emr-7.11.0"
+  applications  = ["Spark", "AmazonCloudWatchAgent"]
+
+  keep_job_flow_alive_when_no_steps = true
+  termination_protection            = false
+
+  ec2_attributes {
+    subnet_id                         = aws_subnet.test.id
+    emr_managed_master_security_group = aws_security_group.test.id
+    emr_managed_slave_security_group  = aws_security_group.test.id
+    instance_profile                  = aws_iam_instance_profile.emr_instance_profile.arn
+  }
+
+  master_instance_group {
+    instance_type = "m5.xlarge"
+  }
+
+  core_instance_group {
+    instance_count = 1
+    instance_type  = "m5.xlarge"
+  }
+
+%[2]s
+
+  service_role = aws_iam_role.emr_service.arn
+
+  depends_on = [
+    aws_route_table_association.test,
+    aws_iam_role_policy_attachment.emr_service,
+    aws_iam_role_policy_attachment.emr_instance_profile,
+    aws_iam_role_policy_attachment.emr_instance_profile_logs,
+  ]
+}
+`, rName, monitoringConfiguration))
+}
+
+func testAccClusterConfig_monitoringConfigurationS3Logging(rName string) string {
+	return acctest.ConfigCompose(
+		testAccClusterConfig_baseVPC(rName, false),
+		testAccClusterConfig_baseIAMServiceRole(rName),
+		testAccClusterConfig_baseIAMInstanceProfile(rName),
+		fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+resource "aws_s3_bucket" "test" {
+  bucket        = %[1]q
+  force_destroy = true
+}
+
+resource "aws_emr_cluster" "test" {
+  name          = %[1]q
+  release_label = "emr-7.13.0"
+  applications  = ["Spark"]
+
+  keep_job_flow_alive_when_no_steps = true
+  termination_protection            = false
+
+  log_uri = "s3://${aws_s3_bucket.test.bucket}/"
+
+  ec2_attributes {
+    subnet_id                         = aws_subnet.test.id
+    emr_managed_master_security_group = aws_security_group.test.id
+    emr_managed_slave_security_group  = aws_security_group.test.id
+    instance_profile                  = aws_iam_instance_profile.emr_instance_profile.arn
+  }
+
+  master_instance_group {
+    instance_type = "m5.xlarge"
+  }
+
+  core_instance_group {
+    instance_count = 1
+    instance_type  = "m5.xlarge"
+  }
+
+  monitoring_configuration {
+    s3_logging_configuration {
+      log_type_upload_policy {
+        log_type      = "system-logs"
+        upload_policy = "emr-managed"
+      }
+
+      log_type_upload_policy {
+        log_type      = "application-logs"
+        upload_policy = "on-customer-s3only"
+      }
+
+      log_type_upload_policy {
+        log_type      = "persistent-ui-logs"
+        upload_policy = "emr-managed"
+      }
+    }
+  }
+
+  service_role = aws_iam_role.emr_service.arn
+
+  depends_on = [
+    aws_route_table_association.test,
+    aws_iam_role_policy_attachment.emr_service,
+    aws_iam_role_policy_attachment.emr_instance_profile,
+  ]
+}
+`, rName))
 }

--- a/website/docs/r/emr_cluster.html.markdown
+++ b/website/docs/r/emr_cluster.html.markdown
@@ -257,6 +257,38 @@ resource "aws_emr_cluster" "example" {
 }
 ```
 
+### Publish Logs to CloudWatch Logs
+
+Available in EMR version 7.11.0 and later, an EMR Cluster can stream step and Spark logs directly to CloudWatch Logs. This requires the `AmazonCloudWatchAgent` application, and the EC2 instance profile must be granted the CloudWatch Logs permissions described in the [EMR Management Guide](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-plan-logging-cw.html).
+
+```terraform
+resource "aws_emr_cluster" "example" {
+  name          = "example"
+  release_label = "emr-7.11.0"
+  applications  = ["Spark", "AmazonCloudWatchAgent"]
+
+  # ... other configuration ...
+
+  monitoring_configuration {
+    cloud_watch_log_configuration {
+      enabled                = true
+      log_group_name         = "/aws/emr/example"
+      log_stream_name_prefix = "example"
+
+      log_types {
+        name   = "STEP_LOGS"
+        values = ["STDOUT", "STDERR"]
+      }
+
+      log_types {
+        name   = "SPARK_DRIVER"
+        values = ["STDERR"]
+      }
+    }
+  }
+}
+```
+
 ### Multiple Node Master Instance Group
 
 Available in EMR version 5.23.0 and later, an EMR Cluster can be launched with three master nodes for high availability. Additional information about this functionality and its requirements can be found in the [EMR Management Guide](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-plan-ha.html).
@@ -657,6 +689,7 @@ EOF
 * `log_uri` - (Optional) S3 bucket to write the log files of the job flow. If a value is not provided, logs are not created.
 * `master_instance_fleet` - (Optional) Configuration block to use an [Instance Fleet](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-instance-fleet.html) for the master node type. Cannot be specified if any `master_instance_group` configuration blocks are set. Detailed below.
 * `master_instance_group` - (Optional) Configuration block to use an [Instance Group](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-instance-group-configuration.html#emr-plan-instance-groups) for the [master node type](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-master-core-task-nodes.html#emr-plan-master).
+* `monitoring_configuration` - (Optional) Configuration block for publishing cluster logs to CloudWatch Logs and for controlling how logs are uploaded to S3. Amazon EMR accepts this configuration only when the cluster is created, so changing it forces a new resource to be created. See [`monitoring_configuration` Block](#monitoring_configuration) below.
 * `os_release_label` - (Optional) Amazon Linux release for all nodes in a cluster launch RunJobFlow request. If not specified, Amazon EMR uses the latest validated Amazon Linux release for cluster launch.
 * `placement_group_config` - (Optional) The specified placement group configuration for an Amazon EMR cluster.
 * `scale_down_behavior` - (Optional) Way that individual Amazon EC2 instances terminate when an automatic scale-in activity occurs or an `instance group` is resized.
@@ -795,6 +828,37 @@ Supported nested arguments for the `master_instance_group` configuration block:
 #### ebs_config
 
 See `ebs_config` under `core_instance_group` above.
+
+### monitoring_configuration
+
+At least one of `cloud_watch_log_configuration` or `s3_logging_configuration` must be configured.
+
+* `cloud_watch_log_configuration` - (Optional) Configuration block for publishing cluster logs to CloudWatch Logs. Requires `release_label` 7.11.0 or greater and the `AmazonCloudWatchAgent` application. See [`cloud_watch_log_configuration` Block](#cloud_watch_log_configuration) below.
+* `s3_logging_configuration` - (Optional) Configuration block for controlling how each log type is uploaded to S3. Requires `release_label` 7.13.0 or greater. See [`s3_logging_configuration` Block](#s3_logging_configuration) below.
+
+#### cloud_watch_log_configuration
+
+* `enabled` - (Required) Whether to publish cluster logs to CloudWatch Logs.
+* `encryption_key_arn` - (Optional) ARN of the KMS key used to encrypt the logs. If not specified, logs are encrypted using CloudWatch Logs server-side encryption.
+* `log_group_name` - (Optional) Name of the CloudWatch log group where logs are published. Must be between 1 and 512 characters. Default value: `/aws/emr/{cluster_id}`.
+* `log_stream_name_prefix` - (Optional) Prefix for log stream names. Must be between 1 and 512 characters. Defaults to an empty prefix.
+* `log_types` - (Optional) Configuration block(s) specifying which log types to publish. Defaults to `STEP_LOGS` and `SPARK_DRIVER`, each publishing both `STDOUT` and `STDERR`. See [`log_types` Block](#log_types) below.
+
+~> **NOTE:** The EC2 instance profile configured in `ec2_attributes` must be granted the CloudWatch Logs permissions documented in [Publish Amazon EMR logs to CloudWatch Logs](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-plan-logging-cw.html). For clusters in a private subnet, a CloudWatch Logs VPC endpoint is also required.
+
+##### log_types
+
+* `name` - (Required) Log type to publish. Valid values are `STEP_LOGS`, `SPARK_DRIVER`, and `SPARK_EXECUTOR`.
+* `values` - (Required) Set of streams to publish for this log type. At least one value is required. Valid values are `STDOUT` and `STDERR`.
+
+#### s3_logging_configuration
+
+* `log_type_upload_policy` - (Required) Configuration block(s) specifying the upload policy to apply to each log type. Amazon EMR applies a default policy to every log type, so configure one block per log type to avoid a persistent difference. See [`log_type_upload_policy` Block](#log_type_upload_policy) below.
+
+##### log_type_upload_policy
+
+* `log_type` - (Required) Log type the upload policy applies to. Valid values are `system-logs`, `application-logs`, and `persistent-ui-logs`.
+* `upload_policy` - (Required) Upload policy to apply to the log type. Valid values are `emr-managed`, `on-customer-s3only`, and `disabled`. Using `on-customer-s3only` requires `log_uri` to be set and is not supported for `persistent-ui-logs`.
 
 ### step
 


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

This change exposes optional logging controls for data that may contain sensitive application output. The provider does not add or broaden IAM permissions. CloudWatch Logs can use an optional KMS key. Operators remain responsible for destination permissions, encryption, retention, and access controls for CloudWatch Logs and S3.

### Description

Adds `monitoring_configuration` to `aws_emr_cluster`. The provider sends it in `RunJobFlow` and reads it from `DescribeCluster`. New clusters can publish selected step and Spark logs to CloudWatch Logs and set S3 upload policies by log type.

The configuration is create-only, so changes replace the cluster. The schema models AWS map fields as keyed sets. The read path filters empty S3 logging objects and leaves the argument absent when `DescribeCluster` returns no effective configuration. Amazon EMR returns an upload policy for every log type, so the documentation recommends configuring one block per log type.

This also marks `os_release_label` as `Computed`. Amazon EMR returns a value for releases built on Amazon Linux 2023, so a configuration that omits the argument planned a replacement on every apply. `TestAccEMRManagedScalingPolicy_` configurations already work around this with `ignore_changes`. Acceptance testing on `emr-7.11.0` is not possible without the fix.

### Relations

Closes #49317
Relates #44462

### References

- [RunJobFlow API](https://docs.aws.amazon.com/emr/latest/APIReference/API_RunJobFlow.html)
- [Cluster API response](https://docs.aws.amazon.com/emr/latest/APIReference/API_Cluster.html)
- [Publish Amazon EMR logs to CloudWatch Logs](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-plan-logging-cw.html)
- [Control S3 logging behavior](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-plan-debugging.html#s3-logging-configuration)

### Output from Acceptance Testing

```console
% make testacc TESTS='TestAccEMRCluster_(MonitoringConfiguration_.*|basic|upgradeV5_100_0|osReleaseLabel)$' PKG=emr

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework (cached)
make: Running acceptance tests on branch: 🌿 f-aws_emr_cluster-monitoring_configuration 🌿...
TF_ACC=1 go test ./internal/service/emr/... -v -count 1 -parallel 20 -run='TestAccEMRCluster_(MonitoringConfiguration_.*|basic|upgradeV5_100_0|osReleaseLabel)$'  -timeout 360m -vet=off -buildvcs=false
2026/08/06 09:37:54 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/06 09:37:54 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccEMRCluster_basic
=== PAUSE TestAccEMRCluster_basic
=== RUN   TestAccEMRCluster_MonitoringConfiguration_cloudWatchLogs
=== PAUSE TestAccEMRCluster_MonitoringConfiguration_cloudWatchLogs
=== RUN   TestAccEMRCluster_MonitoringConfiguration_s3Logging
=== PAUSE TestAccEMRCluster_MonitoringConfiguration_s3Logging
=== RUN   TestAccEMRCluster_osReleaseLabel
=== PAUSE TestAccEMRCluster_osReleaseLabel
=== RUN   TestAccEMRCluster_upgradeV5_100_0
=== PAUSE TestAccEMRCluster_upgradeV5_100_0
=== CONT  TestAccEMRCluster_basic
=== CONT  TestAccEMRCluster_osReleaseLabel
=== CONT  TestAccEMRCluster_upgradeV5_100_0
=== CONT  TestAccEMRCluster_MonitoringConfiguration_s3Logging
=== CONT  TestAccEMRCluster_MonitoringConfiguration_cloudWatchLogs
--- PASS: TestAccEMRCluster_MonitoringConfiguration_cloudWatchLogs (356.02s)
--- PASS: TestAccEMRCluster_upgradeV5_100_0 (392.25s)
--- PASS: TestAccEMRCluster_basic (396.50s)
--- PASS: TestAccEMRCluster_MonitoringConfiguration_s3Logging (438.26s)
--- PASS: TestAccEMRCluster_osReleaseLabel (731.55s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/emr        739.150s
```

I also confirmed separately that an `emr-7.11.0` cluster configured with `cloud_watch_log_configuration` but without `log_stream_name_prefix` or `encryption_key_arn` produces an empty plan after apply.

### AI Usage Disclosure

I used AI for schema and API mapping and to draft tests, documentation, and this PR description. I checked API behavior against primary AWS documentation and reviewed the full diff. I ran the acceptance tests above. I understand the implementation and take responsibility for the change.