### PR TITLE
Allow http SQS queue URLs in tests

### DIFF
--- a/internal/service/sqs/queue.go
+++ b/internal/service/sqs/queue.go
@@ -643,7 +643,7 @@ func waitQueueDeleted(ctx context.Context, conn *sqs.Client, url string, timeout
 }
 
 func parseQueueURL(u string) (result inttypes.BaseIdentity, err error) {
-	re := regexache.MustCompile(`^https://sqs\.([a-z0-9-]+)\.[^/]+/([0-9]{12})/.+`)
+	re := regexache.MustCompile(`^https?://sqs\.([a-z0-9-]+)\.[^/]+/([0-9]{12})/.+`)
 	match := re.FindStringSubmatch(u)
 	if match == nil {
 		return inttypes.BaseIdentity{}, fmt.Errorf("could not parse %q as SQS URL", u)


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

### Changes to Security Controls

No

### Description

<!---
Please provide a helpful description of what change this pull request will introduce.
--->

The SQS tests use a regular expression to ensure that [a valid queue URL](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-queue-message-identifiers.html#sqs-general-identifiers) is obtained.

This PR slightly tweaks the regex to allow the 'http' scheme in addition to 'https'.

AWS queue URLs always use the 'https'. But this change is mainly to make it possible to run the test suite against LocalStack.

Given this is a test-related change, I have not updated the changelog; please correct me if I'm wrong.