### PR TITLE
r/aws_ssm_parameter: `v6.58.0` regression when `name` starts with `/`

### DIFF
--- a/internal/service/ssm/parameter_test.go
+++ b/internal/service/ssm/parameter_test.go
@@ -1344,6 +1344,14 @@ func TestAccSSMParameter_NameStartsWithForwardSlash_v6571(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckParameterExists(ctx, t, resourceName, &param),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrARN), tfknownvalue.RegionalARNExact("ssm", "parameter/"+rName)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrName), knownvalue.StringExact(name)),
@@ -1359,6 +1367,48 @@ func TestAccSSMParameter_NameStartsWithForwardSlash_v6571(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccSSMParameter_NameStartsWithForwardSlash_v6580(t *testing.T) {
+	ctx := acctest.Context(t)
+	var param awstypes.Parameter
+	rName := fmt.Sprintf("%s_%s", t.Name(), acctest.RandString(t, 10)) // Sans slash.
+	name := fmt.Sprintf("/%s", rName)                                  // With slash.
+	resourceName := "aws_ssm_parameter.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
+		CheckDestroy: testAccCheckParameterDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"aws": {
+						Source:            "hashicorp/aws",
+						VersionConstraint: "6.58.0",
+					},
+				},
+				Config: testAccParameterConfig_basic(name, "String", "test2"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckParameterExists(ctx, t, resourceName, &param),
+				),
+				// name = "TestAccSSMParameter_NameStartsWithForwardSlash_v6580_s7r6g4xunc" -> "/TestAccSSMParameter_NameStartsWithForwardSlash_v6580_s7r6g4xunc" # forces replacement
+				ExpectNonEmptyPlan: true,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionReplace),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrARN), tfknownvalue.RegionalARNExact("ssm", "parameter/"+rName)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrName), knownvalue.StringExact(rName)),
+				},
 			},
 		},
 	})

--- a/internal/service/ssm/parameter_test.go
+++ b/internal/service/ssm/parameter_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	tfknownvalue "github.com/hashicorp/terraform-provider-aws/internal/acctest/knownvalue"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfssm "github.com/hashicorp/terraform-provider-aws/internal/service/ssm"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -1314,6 +1315,50 @@ func TestAccSSMParameter_ImportByARN_fullPath(t *testing.T) {
 				},
 				ImportStateVerify:                    true,
 				ImportStateVerifyIdentifierAttribute: names.AttrName,
+			},
+		},
+	})
+}
+
+// https://github.com/hashicorp/terraform-provider-aws/issues/49304.
+func TestAccSSMParameter_NameStartsWithForwardSlash_v6571(t *testing.T) {
+	ctx := acctest.Context(t)
+	var param awstypes.Parameter
+	rName := fmt.Sprintf("%s_%s", t.Name(), acctest.RandString(t, 10)) // Sans slash.
+	name := fmt.Sprintf("/%s", rName)                                  // With slash.
+	resourceName := "aws_ssm_parameter.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
+		CheckDestroy: testAccCheckParameterDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"aws": {
+						Source:            "hashicorp/aws",
+						VersionConstraint: "6.57.1",
+					},
+				},
+				Config: testAccParameterConfig_basic(name, "String", "test2"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckParameterExists(ctx, t, resourceName, &param),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrARN), tfknownvalue.RegionalARNExact("ssm", "parameter/"+rName)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrName), knownvalue.StringExact(name)),
+				},
+			},
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"aws": {
+						Source:            "hashicorp/aws",
+						VersionConstraint: "6.57.1",
+					},
+				},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

There is a regression for the `aws_ssm_parameter` resource between **v6.57.1** and **v6.58.0** if `name` starts with `/` (as is common: https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-paramstore-hierarchies.html).

* For resources created with a version prior to *v6.58.0* the first `terraform plan` after upgrade reports `Unexpected Identity Change` errors
* For resources created with *v6.58.0* the first `terraform plan` after create reports that the resource needs replacement as the `name` attribute values has changed

If I create via the AWS Console and call the AWS API directly:

```console
% aws ssm get-parameter --name "/Environment/TypeOfComputer/Application/Data"
{
    "Parameter": {
        "Name": "/Environment/TypeOfComputer/Application/Data",
        "Type": "String",
        "Value": "Some stuff",
        "Version": 1,
        "LastModifiedDate": "2026-08-06T10:39:23.215000-04:00",
        "ARN": "arn:aws:ssm:us-west-2:123456789012:parameter/Environment/TypeOfComputer/Application/Data",
        "DataType": "text"
    }
}
% aws ssm describe-parameters
{
    "Parameters": [
        {
            "Name": "/Environment/TypeOfComputer/Application/Data",
            "ARN": "arn:aws:ssm:us-west-2:123456789012:parameter/Environment/TypeOfComputer/Application/Data",
            "Type": "String",
            "LastModifiedDate": "2026-08-06T10:39:23.215000-04:00",
            "LastModifiedUser": "arn:aws:sts::123456789012:assumed-role/terraform_team1_dev-developer/kewbank@hashicorp.com",
            "Version": 1,
            "Tier": "Standard",
            "Policies": [],
            "DataType": "text"
        }
    ]
}
```

##### New acceptance tests

* `TestAccSSMParameter_NameStartsWithForwardSlash_v6571` runs with **v6.57.1** only and verifies that `name` retains the leading `/` in state, but `arn` format does not (which matches the AWS API)
* `TestAccSSMParameter_NameStartsWithForwardSlash_v6580` runs with **v6.58.0** only and shows that both `name` and `arn` format have the leading `/` removed in state. It also shows the _ForceNew_ behavior

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/49304.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
