### PR TITLE
Changie: Add `changelog-entries` workflow, update `readiness_comment` and `maintainer_helpers`

### DIFF
--- a/.github/workflows/changelog-entries.yml
+++ b/.github/workflows/changelog-entries.yml
@@ -1,0 +1,113 @@
+# Copyright IBM Corp. 2014, 2026
+# "SPDX-License-Identifier: MPL-2.0"
+
+name: CHANGELOG Entries
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - ready_for_review
+      - reopened
+
+permissions:
+  pull-requests: read
+
+jobs:
+  missing-fragment:
+    name: Missing Fragment
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          sparse-checkout: .changie.yaml
+
+      - name: Get Changes Directory
+        id: changes-dir
+        shell: bash
+        run: echo "changes_dir=$(yq eval '.changesDir' .changie.yaml)" >> $GITHUB_OUTPUT
+
+      - name: Check File Changes
+        id: filter
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        with:
+          list-files: json
+          predicate-quantifier: 'every'
+          filters: |
+            service_files:
+              - 'internal/service/**/*.go'
+              - '!internal/service/**/*_test.go'
+            changie_fragments:
+              - added:'${{ steps.changes-dir.outputs.changes_dir }}/unreleased/*.yaml'
+
+      - name: Warn of Missing Change Fragment(s)
+        if: |
+          steps.filter.outputs.service_files == 'true'
+          && steps.filter.outputs.changie_fragments != 'true'
+          && !contains(github.event.pull_request.labels.*.name, 'no-changelog-needed')
+        shell: bash
+        run: |
+          FILES=$(echo '${{ steps.filter.outputs.service_files_files }}' | jq -r '.[] | "* `\(.)`"')
+          echo "::error title=CHANGELOG Entry Required::This pull request contains modifications that require a CHANGELOG entry. Please create a change fragment using \`changie new\`.
+
+          Files that require a CHANGELOG entry:
+          $FILES"
+          exit 1
+
+  direct-edits:
+    name: Direct CHANGELOG Edits
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check File Changes
+        id: filter
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        with:
+          filters: |
+            changelog:
+              - 'CHANGELOG.md'
+
+      - name: Warn of Direct CHANGELOG Edits
+        if: steps.filter.outputs.changelog == 'true'
+        shell: bash
+        run: |
+          echo "::error title=Direct CHANGELOG Edits::Direct edits to \`CHANGELOG.md\` are not allowed. The file is regenerated on every PR merge and any manual edits will be overwritten. Refer to the [CHANGELOG Process](https://hashicorp.github.io/terraform-provider-aws/changelog-process/) for more information."
+          exit 1
+
+  go-changelog:
+    name: go-changelog Fragment
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check File Changes
+        id: filter
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        with:
+          list-files: json
+          predicate-quantifier: 'every'
+          filters: |
+            go_changelog_fragments:
+              - added:'.changelog/*.txt'
+
+      - name: Warn of go-changelog Fragment(s)
+        if: steps.filter.outputs.go_changelog_fragments == 'true'
+        shell: bash
+        run: |
+          FILES=$(echo '${{ steps.filter.outputs.go_changelog_fragments_files }}' | jq -r '.[] | "* `\(.)`"')
+          echo "::error title=Old CHANGELOG Format Detected::This pull request includes \`go-changelog\` style change fragments. We have migrated to using Changie for CHANGELOG management.
+
+          To convert your existing fragments, run:
+
+          \`\`\`bash
+          make convert-changelog FILE=.changelog/<pr-number>.txt
+          \`\`\`
+
+          This will automatically convert the \`go-changelog\` change fragment to one compatible with Changie.
+
+          Alternatively:
+          1. Remove the \`go-changelog\` style change fragment file(s)
+          2. Create new change fragment(s) using \`changie new\`
+
+          Files using old format:
+          $FILES"
+          exit 1

--- a/.github/workflows/changelog-entries.yml
+++ b/.github/workflows/changelog-entries.yml
@@ -4,7 +4,7 @@
 name: CHANGELOG Entries
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - synchronize
@@ -47,9 +47,11 @@ jobs:
           steps.filter.outputs.service_files == 'true'
           && steps.filter.outputs.changie_fragments != 'true'
           && !contains(github.event.pull_request.labels.*.name, 'no-changelog-needed')
+        env:
+          SERVICE_FILES_JSON: ${{ steps.filter.outputs.service_files_files }}
         shell: bash
         run: |
-          FILES=$(echo '${{ steps.filter.outputs.service_files_files }}' | jq -r '.[] | "* `\(.)`"')
+          FILES=$(echo "$SERVICE_FILES_JSON" | jq -r '.[] | "* `\(.)`"')
           echo "::error title=CHANGELOG Entry Required::This pull request contains modifications that require a CHANGELOG entry. Please create a change fragment using \`changie new\`.
 
           Files that require a CHANGELOG entry:
@@ -91,9 +93,11 @@ jobs:
 
       - name: Warn of go-changelog Fragment(s)
         if: steps.filter.outputs.go_changelog_fragments == 'true'
+        env:
+          GO_CHANGELOG_FILES_JSON: ${{ steps.filter.outputs.go_changelog_fragments_files }}
         shell: bash
         run: |
-          FILES=$(echo '${{ steps.filter.outputs.go_changelog_fragments_files }}' | jq -r '.[] | "* `\(.)`"')
+          FILES=$(echo "$GO_CHANGELOG_FILES_JSON" | jq -r '.[] | "* `\(.)`"')
           echo "::error title=Old CHANGELOG Format Detected::This pull request includes \`go-changelog\` style change fragments. We have migrated to using Changie for CHANGELOG management.
 
           To convert your existing fragments, run:

--- a/.github/workflows/maintainer_helpers.yml
+++ b/.github/workflows/maintainer_helpers.yml
@@ -109,7 +109,9 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          sparse-checkout: .github/actions/
+          sparse-checkout: |
+            .github/actions/
+            .changie.yaml
 
       - name: Community Check
         id: community_check
@@ -218,6 +220,83 @@ jobs:
                   "text": {
                     "type": "mrkdwn",
                     "text": ${{ toJSON(format(':merged-rounded: <{0}|{1}> merged <{2}|{3}>', env.MERGED_BY_URL, env.MERGED_BY_LOGIN, env.ISSUE_URL, env.ISSUE_TITLE)) }}
+                  }
+                }
+              ]
+            }
+
+      - name: Get Changes Directory
+        id: changes-dir
+        if: github.event.pull_request.merged
+        shell: bash
+        run: echo "changes_dir=$(yq eval '.changesDir' .changie.yaml)" >> $GITHUB_OUTPUT
+
+      - name: Check for Missing CHANGELOG Fragment
+        id: fragment-filter
+        if: github.event.pull_request.merged
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        with:
+          list-files: json
+          predicate-quantifier: 'every'
+          filters: |
+            service_files:
+              - 'internal/service/**/*.go'
+              - '!internal/service/**/*_test.go'
+            changie_fragments:
+              - added:'${{ steps.changes-dir.outputs.changes_dir }}/unreleased/*.yaml'
+
+      - name: Format Missing Fragment File List
+        id: format-files
+        if: |
+          steps.fragment-filter.outputs.service_files == 'true' &&
+          steps.fragment-filter.outputs.changie_fragments != 'true' &&
+          !contains(github.event.pull_request.labels.*.name, 'no-changelog-needed')
+        shell: bash
+        run: |
+          FORMATTED=$(echo '${{ steps.fragment-filter.outputs.service_files_files }}' | jq -r '.[] | "• `\(.)`"')
+          echo "formatted<<EOF" >> $GITHUB_OUTPUT
+          echo "$FORMATTED" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Notify Maintainers of Missing CHANGELOG Entry
+        if: steps.format-files.outcome != 'skipped'
+        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        with:
+          webhook: ${{ secrets.FEED_SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":warning: *Missing CHANGELOG Entry*"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ${{ toJSON(format('Pull request <{0}|#{1}: {2}> was merged but is missing a required CHANGELOG entry.', env.PR_URL, env.PR_NUMBER, env.PR_TITLE)) }}
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Files that require a CHANGELOG entry:*"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ${{ toJSON(steps.format-files.outputs.formatted) }}
                   }
                 }
               ]

--- a/.github/workflows/readiness_comment.yml
+++ b/.github/workflows/readiness_comment.yml
@@ -23,7 +23,7 @@ jobs:
     name: Warn of Potential Issues
     runs-on: ubuntu-latest
     steps:
-      - name: Check for Dependency or Changelog Changes
+      - name: Check for Dependency Changes
         id: filter
         uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         with:
@@ -32,32 +32,12 @@ jobs:
               - '.ci/providerlint/**'
               - 'go.mod'
               - 'go.sum'
-            changelog:
-              - 'CHANGELOG.md'
             new-service:
               - added: 'internal/service/*'
 
-      - name: Determine if Changelog Entry is Needed
-        if: |
-          !github.event.pull_request.draft
-          && !contains(toJSON(github.event.pull_request.labels.*.name), 'no-changelog-needed')
-        id: changelog-update-needed
-        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
-        with:
-          predicate-quantifier: 'every'
-          filters: |
-            needs:
-              - 'internal/service/**'
-              - '!internal/service/**/*_test.go'
-            has:
-              - '.changelog/**'
-
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         id: checkout
-        if: |
-          steps.filter.outputs.changelog == 'true'
-          || (steps.filter.outputs.dependencies == 'true' && steps.filter.outputs.new-service == 'false')
-          || (steps.changelog-update-needed.outputs.needs == 'true' && steps.changelog-update-needed.outputs.has == 'false')
+        if: steps.filter.outputs.dependencies == 'true' && steps.filter.outputs.new-service == 'false'
         with:
           sparse-checkout: .github/actions/community_check
 
@@ -108,44 +88,11 @@ jobs:
           </details>
           ' >> note.md
 
-      - name: Changelog Updated by Non-Maintainers
-        id: changelog
-        if: |
-          steps.filter.outputs.changelog == 'true'
-          && steps.community_check.outputs.maintainer == 'false'
-        shell: bash
-        run: |
-          echo '<details><summary>:x: Unnecessary Changelog Changes (Click to expand)</summary><br>
-
-          The `CHANGELOG.md` file contents are handled by the maintainers during merge. This is to prevent pull request merge conflicts, especially for contributions which may not be merged immediately. Please see the [Changelog Process](https://hashicorp.github.io/terraform-provider-aws/changelog-process/) section of the contributing guide for additional information.
-
-          Remove any changes to the `CHANGELOG.md` file and commit them in this pull request to prevent delays with reviewing and potentially merging it.
-          </details>
-          ' >> note.md
-
-      - name: Needs Changelog Entry
-        id: needs-changelog-entry
-        if: |
-          steps.changelog-update-needed.outputs.needs == 'true'
-          && steps.changelog-update-needed.outputs.has == 'false'
-          && steps.community_check.outputs.maintainer == 'false'
-        shell: bash
-        run: |
-          echo '<details><summary>:x: Changelog Entry Required (Click to expand)</summary><br>
-
-          The proposed change requires a changelog entry. Please see the [Changelog Process](https://hashicorp.github.io/terraform-provider-aws/changelog-process/) section of the contributing guide for information on the changelog generation process.
-
-          **Tip:** This check is not triggered for draft pull requests, since the pull request number is not known until the pull request is opened and is required to create a changelog entry. Opening a pull request first as a draft, adding the requisite changelog entry file, and then marking the pull request as ready for review will prevent future warnings.
-           </details>
-          ' >> note.md
-
       - name: Add Start Message
         id: start
         if: |
           steps.maintainer_editability.outcome != 'skipped'
           || steps.dependencies.outcome != 'skipped'
-          || steps.changelog.outcome != 'skipped'
-          || steps.needs-changelog-entry.outcome != 'skipped'
         shell: bash
         run: |
           { echo $START_TEXT; echo "---"; cat note.md; } > tmpnote && mv tmpnote note.md


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

- Adds a new workflow with 3 jobs, which:
    - Verifies that a change fragment is present if one is needed
    - Prevents direct edits to `CHANGELOG.md` that would be overwritten when the CHANGELOG is regenerated
    - Verifies that `go-changelog` style fragments aren't being added
- Adds a Slack notification to warn maintainers if a merged PR is missing a change fragment when one was expected
- Removes outdated CHANGELOG checks from the "Readiness Comment" workflow

### Relations

Relates #46618