### PR TITLE
resource/aws_bedrockagentcore_harness: Handles `memory.disabled`

### DIFF
--- a/.changelog/49285.txt
+++ b/.changelog/49285.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_bedrockagentcore_harness: Adds support for `memory.managed_memory_configuration`
+```

--- a/.changelog/49334.txt
+++ b/.changelog/49334.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_bedrockagentcore_harness: Adds support for `memory.disabled`
+```

--- a/internal/service/bedrockagentcore/harness.go
+++ b/internal/service/bedrockagentcore/harness.go
@@ -33,7 +33,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
@@ -224,7 +223,7 @@ func (r *harnessResource) Schema(ctx context.Context, request resource.SchemaReq
 										CustomType: fwtypes.ARNType,
 										Computed:   true,
 										PlanModifiers: []planmodifier.String{
-											stringplanmodifier.UseStateForUnknown(),
+											stringplanmodifier.UseNonNullStateForUnknown(),
 										},
 									},
 									"encryption_key_arn": schema.StringAttribute{
@@ -561,7 +560,7 @@ func (r *harnessResource) Create(ctx context.Context, request resource.CreateReq
 		return
 	}
 
-	memoryIsConfigured := config.Memory.Length(basetypes.CollectionLengthOptions{UnhandledNullAsZero: true, UnhandledUnknownAsZero: true}) > 0
+	memoryIsConfigured := config.Memory.Length(fwtypes.CollectionLengthUnhandledAsZero) > 0
 
 	conn := r.Meta().BedrockAgentCoreClient(ctx)
 
@@ -639,7 +638,7 @@ func (r *harnessResource) Read(ctx context.Context, request resource.ReadRequest
 	// During a read of an existing resource, `harness_name` will be set as it is a required attribute.
 	isImport := data.HarnessName.IsNull()
 
-	memoryIsConfigured := data.Memory.Length(basetypes.CollectionLengthOptions{UnhandledNullAsZero: true, UnhandledUnknownAsZero: true}) > 0
+	memoryIsConfigured := data.Memory.Length(fwtypes.CollectionLengthUnhandledAsZero) > 0
 
 	conn := r.Meta().BedrockAgentCoreClient(ctx)
 
@@ -672,25 +671,27 @@ func (r *harnessResource) Read(ctx context.Context, request resource.ReadRequest
 }
 
 func (r *harnessResource) Update(ctx context.Context, request resource.UpdateRequest, response *resource.UpdateResponse) {
-	var new, old harnessResourceModel
-	smerr.AddEnrich(ctx, &response.Diagnostics, request.Plan.Get(ctx, &new))
-	smerr.AddEnrich(ctx, &response.Diagnostics, request.State.Get(ctx, &old))
+	var config harnessResourceModel
+	var plan, state harnessResourceModel
+	smerr.AddEnrich(ctx, &response.Diagnostics, request.Config.Get(ctx, &config))
+	smerr.AddEnrich(ctx, &response.Diagnostics, request.Plan.Get(ctx, &plan))
+	smerr.AddEnrich(ctx, &response.Diagnostics, request.State.Get(ctx, &state))
 	if response.Diagnostics.HasError() {
 		return
 	}
 
 	conn := r.Meta().BedrockAgentCoreClient(ctx)
 
-	diff, d := fwflex.Diff(ctx, new, old)
+	diff, d := fwflex.Diff(ctx, plan, state)
 	smerr.AddEnrich(ctx, &response.Diagnostics, d)
 	if response.Diagnostics.HasError() {
 		return
 	}
 
 	if diff.HasChanges() {
-		harnessID := fwflex.StringValueFromFramework(ctx, new.HarnessID)
+		harnessID := fwflex.StringValueFromFramework(ctx, plan.HarnessID)
 		var input bedrockagentcorecontrol.UpdateHarnessInput
-		smerr.AddEnrich(ctx, &response.Diagnostics, fwflex.Expand(ctx, new, &input))
+		smerr.AddEnrich(ctx, &response.Diagnostics, fwflex.Expand(ctx, plan, &input))
 		if response.Diagnostics.HasError() {
 			return
 		}
@@ -698,19 +699,33 @@ func (r *harnessResource) Update(ctx context.Context, request resource.UpdateReq
 		// Additional fields.
 		input.ClientToken = aws.String(create.UniqueId(ctx))
 
+		if !state.Memory.IsNull() && config.Memory.IsNull() {
+			// Clears configured value for memory
+			input.Memory = &awstypes.UpdatedHarnessMemoryConfiguration{
+				OptionalValue: nil,
+			}
+		}
+
 		_, err := conn.UpdateHarness(ctx, &input)
 		if err != nil {
 			smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, harnessID)
 			return
 		}
 
-		if _, err := waitHarnessUpdated(ctx, conn, harnessID, r.UpdateTimeout(ctx, new.Timeouts)); err != nil {
+		harness, err := waitHarnessUpdated(ctx, conn, harnessID, r.UpdateTimeout(ctx, plan.Timeouts))
+		if err != nil {
 			smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, harnessID)
+			return
+		}
+
+		memoryIsConfigured := config.Memory.Length(fwtypes.CollectionLengthUnhandledAsZero) > 0
+		smerr.AddEnrich(ctx, &response.Diagnostics, r.flatten(ctx, harness, &plan, memoryIsConfigured))
+		if response.Diagnostics.HasError() {
 			return
 		}
 	}
 
-	smerr.AddEnrich(ctx, &response.Diagnostics, response.State.Set(ctx, &new))
+	smerr.AddEnrich(ctx, &response.Diagnostics, response.State.Set(ctx, &plan))
 }
 
 func (r *harnessResource) Delete(ctx context.Context, request resource.DeleteRequest, response *resource.DeleteResponse) {

--- a/internal/service/bedrockagentcore/harness.go
+++ b/internal/service/bedrockagentcore/harness.go
@@ -206,6 +206,13 @@ func (r *harnessResource) Schema(ctx context.Context, request resource.SchemaReq
 								},
 							},
 						},
+						"disabled": schema.ListNestedBlock{
+							CustomType: fwtypes.NewListNestedObjectTypeOf[harnessDisabledMemoryConfigurationModel](ctx),
+							Validators: []validator.List{
+								listvalidator.SizeAtMost(1),
+							},
+							NestedObject: schema.NestedBlockObject{},
+						},
 						"managed_memory_configuration": schema.ListNestedBlock{
 							CustomType: fwtypes.NewListNestedObjectTypeOf[harnessManagedMemoryConfigurationModel](ctx),
 							Validators: []validator.List{
@@ -1477,6 +1484,7 @@ func (m harnessEnvironmentArtifactModel) expandToUpdatedHarnessEnvironmentArtifa
 
 type harnessMemoryConfigurationModel struct {
 	AgentCoreMemoryConfiguration fwtypes.ListNestedObjectValueOf[harnessAgentCoreMemoryConfigurationModel] `tfsdk:"agentcore_memory_configuration"`
+	Disabled                     fwtypes.ListNestedObjectValueOf[harnessDisabledMemoryConfigurationModel]  `tfsdk:"disabled"`
 	ManagedMemoryConfiguration   fwtypes.ListNestedObjectValueOf[harnessManagedMemoryConfigurationModel]   `tfsdk:"managed_memory_configuration"`
 }
 
@@ -1503,6 +1511,9 @@ func (m *harnessMemoryConfigurationModel) Flatten(ctx context.Context, v any) di
 			return diags
 		}
 		m.ManagedMemoryConfiguration = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &data)
+
+	case awstypes.HarnessMemoryConfigurationMemberDisabled:
+		m.Disabled = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &harnessDisabledMemoryConfigurationModel{})
 
 	case awstypes.UnknownUnionMember:
 		fwflex.HandleFlattenUnknownUnionMember(ctx, t.Tag, &diags)
@@ -1547,6 +1558,9 @@ func (m harnessMemoryConfigurationModel) expandToHarnessMemoryConfiguration(ctx 
 		smerr.AddEnrich(ctx, &diags, fwflex.Expand(ctx, data, &r.Value))
 		return &r, diags
 	}
+	if !m.Disabled.IsNull() {
+		return &awstypes.HarnessMemoryConfigurationMemberDisabled{}, diags
+	}
 	return nil, diags
 }
 
@@ -1567,6 +1581,9 @@ func (m harnessMemoryConfigurationModel) expandToUpdatedHarnessMemoryConfigurati
 			return nil, diags
 		}
 		return &awstypes.UpdatedHarnessMemoryConfiguration{OptionalValue: r}, diags
+	}
+	if !m.Disabled.IsNull() {
+		return &awstypes.UpdatedHarnessMemoryConfiguration{OptionalValue: &awstypes.HarnessMemoryConfigurationMemberDisabled{}}, diags
 	}
 	return &awstypes.UpdatedHarnessMemoryConfiguration{}, diags
 }
@@ -1605,6 +1622,8 @@ type harnessAgentCoreMemoryRetrievalConfigModel struct {
 	StrategyID     types.String  `tfsdk:"strategy_id"`
 	TopK           types.Int32   `tfsdk:"top_k"`
 }
+
+type harnessDisabledMemoryConfigurationModel struct{}
 
 type harnessManagedMemoryConfigurationModel struct {
 	ARN                 fwtypes.ARN                                                        `tfsdk:"arn" autoflex:",noexpand"`

--- a/internal/service/bedrockagentcore/harness_list_test.go
+++ b/internal/service/bedrockagentcore/harness_list_test.go
@@ -137,6 +137,7 @@ func TestAccBedrockAgentCoreHarness_List_includeResource(t *testing.T) {
 						tfquerycheck.KnownValueCheck(tfjsonpath.New("memory"), knownvalue.ListExact([]knownvalue.Check{
 							knownvalue.ObjectExact(map[string]knownvalue.Check{
 								"agentcore_memory_configuration": knownvalue.ListSizeExact(0),
+								"disabled":                       knownvalue.ListSizeExact(0),
 								"managed_memory_configuration": knownvalue.ListExact([]knownvalue.Check{
 									knownvalue.ObjectExact(map[string]knownvalue.Check{
 										names.AttrARN:           tfknownvalue.RegionalARNRegexp("bedrock-agentcore", regexache.MustCompile(`memory/harness_`+rName+`_0_[a-zA-Z0-9]+-[a-zA-Z0-9]+`)),

--- a/internal/service/bedrockagentcore/harness_test.go
+++ b/internal/service/bedrockagentcore/harness_test.go
@@ -28,6 +28,16 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
+type memoryConfigType string
+
+const (
+	memoryNone         memoryConfigType = "none"
+	memoryAgentCore    memoryConfigType = "agentcore"
+	memoryDisabled     memoryConfigType = "disabled"
+	memoryManagedEmpty memoryConfigType = "managed_empty"
+	memoryManaged      memoryConfigType = "managed"
+)
+
 func testAccRandomHarnessName(t *testing.T) string {
 	return strings.ReplaceAll(acctest.RandomWithPrefix(t, acctest.ResourcePrefix), "-", "_")
 }
@@ -1077,6 +1087,79 @@ func TestAccBedrockAgentCoreHarness_Memory_disabled(t *testing.T) {
 	})
 }
 
+func TestAccBedrockAgentCoreHarness_Memory_changeType(t *testing.T) {
+	t.Parallel()
+
+	testcases := []struct {
+		from memoryConfigType
+		to   memoryConfigType
+	}{
+		{memoryNone, memoryAgentCore},
+		{memoryNone, memoryDisabled},
+		{memoryNone, memoryManagedEmpty},
+		{memoryNone, memoryManaged},
+
+		{memoryAgentCore, memoryDisabled},
+		{memoryAgentCore, memoryManagedEmpty},
+		{memoryAgentCore, memoryManaged},
+		// {memoryAgentCore, memoryNone},
+
+		{memoryDisabled, memoryAgentCore},
+		{memoryDisabled, memoryManagedEmpty},
+		{memoryDisabled, memoryManaged},
+		{memoryDisabled, memoryNone},
+
+		{memoryManagedEmpty, memoryAgentCore},
+		{memoryManagedEmpty, memoryDisabled},
+		{memoryManagedEmpty, memoryManaged},
+		{memoryManagedEmpty, memoryNone},
+	}
+
+	for _, tc := range testcases {
+		t.Run(fmt.Sprintf("%s_to_%s", tc.from, tc.to), func(t *testing.T) {
+			ctx := acctest.Context(t)
+			var harness awstypes.Harness
+			rName := testAccRandomHarnessName(t)
+			resourceName := "aws_bedrockagentcore_harness.test"
+
+			fromConfig := testAccHarnessConfig_Memory_byType(rName, tc.from)
+			toConfig := testAccHarnessConfig_Memory_byType(rName, tc.to)
+
+			acctest.ParallelTest(ctx, t, resource.TestCase{
+				PreCheck: func() {
+					acctest.PreCheck(ctx, t)
+					acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID)
+					testAccPreCheckHarness(ctx, t)
+				},
+				ErrorCheck:               acctest.ErrorCheck(t, names.BedrockAgentCoreServiceID),
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				CheckDestroy:             testAccCheckHarnessDestroy(ctx, t),
+				Steps: []resource.TestStep{
+					{
+						Config: fromConfig,
+						Check: resource.ComposeAggregateTestCheckFunc(
+							testAccCheckHarnessExists(ctx, t, resourceName, &harness),
+						),
+						ConfigStateChecks: memoryConfigStateChecks(resourceName, tc.from),
+					},
+					{
+						Config: toConfig,
+						Check: resource.ComposeAggregateTestCheckFunc(
+							testAccCheckHarnessExists(ctx, t, resourceName, &harness),
+						),
+						ConfigPlanChecks: resource.ConfigPlanChecks{
+							PreApply: []plancheck.PlanCheck{
+								plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+							},
+						},
+						ConfigStateChecks: memoryConfigStateChecks(resourceName, tc.to),
+					},
+				},
+			})
+		})
+	}
+}
+
 func TestAccBedrockAgentCoreHarness_environmentArtifact(t *testing.T) {
 	ctx := acctest.Context(t)
 	var harness awstypes.Harness
@@ -1313,6 +1396,78 @@ func testAccPreCheckHarness(ctx context.Context, t *testing.T) {
 	}
 	if err != nil {
 		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
+}
+
+func memoryConfigStateChecks(resourceName string, memType memoryConfigType) []statecheck.StateCheck {
+	memoryPath := tfjsonpath.New("memory")
+	switch memType {
+	case memoryNone:
+		return []statecheck.StateCheck{
+			statecheck.ExpectKnownValue(resourceName, memoryPath, knownvalue.ListSizeExact(0)),
+		}
+	case memoryAgentCore:
+		return []statecheck.StateCheck{
+			statecheck.ExpectKnownValue(resourceName, memoryPath.AtSliceIndex(0), knownvalue.ObjectExact(map[string]knownvalue.Check{
+				"agentcore_memory_configuration": knownvalue.ListExact([]knownvalue.Check{
+					knownvalue.ObjectExact(map[string]knownvalue.Check{
+						names.AttrARN:      knownvalue.NotNull(),
+						"actor_id":         knownvalue.Null(),
+						"messages_count":   knownvalue.Null(),
+						"retrieval_config": knownvalue.ListSizeExact(0),
+					}),
+				}),
+				"disabled":                     knownvalue.ListSizeExact(0),
+				"managed_memory_configuration": knownvalue.ListSizeExact(0),
+			})),
+		}
+	case memoryDisabled:
+		return []statecheck.StateCheck{
+			statecheck.ExpectKnownValue(resourceName, memoryPath.AtSliceIndex(0), knownvalue.ObjectExact(map[string]knownvalue.Check{
+				"agentcore_memory_configuration": knownvalue.ListSizeExact(0),
+				"disabled": knownvalue.ListExact([]knownvalue.Check{
+					knownvalue.ObjectExact(map[string]knownvalue.Check{}),
+				}),
+				"managed_memory_configuration": knownvalue.ListSizeExact(0),
+			})),
+		}
+	case memoryManagedEmpty:
+		return []statecheck.StateCheck{
+			statecheck.ExpectKnownValue(resourceName, memoryPath.AtSliceIndex(0), knownvalue.ObjectExact(map[string]knownvalue.Check{
+				"agentcore_memory_configuration": knownvalue.ListSizeExact(0),
+				"disabled":                       knownvalue.ListSizeExact(0),
+				"managed_memory_configuration": knownvalue.ListExact([]knownvalue.Check{
+					knownvalue.ObjectExact(map[string]knownvalue.Check{
+						names.AttrARN:           knownvalue.NotNull(),
+						"encryption_key_arn":    knownvalue.Null(),
+						"event_expiry_duration": knownvalue.Int32Exact(30),
+						"strategies": knownvalue.SetExact([]knownvalue.Check{
+							knownvalue.StringExact("SEMANTIC"),
+							knownvalue.StringExact("SUMMARIZATION"),
+						}),
+					}),
+				}),
+			})),
+		}
+	case memoryManaged:
+		return []statecheck.StateCheck{
+			statecheck.ExpectKnownValue(resourceName, memoryPath.AtSliceIndex(0), knownvalue.ObjectExact(map[string]knownvalue.Check{
+				"agentcore_memory_configuration": knownvalue.ListSizeExact(0),
+				"disabled":                       knownvalue.ListSizeExact(0),
+				"managed_memory_configuration": knownvalue.ListExact([]knownvalue.Check{
+					knownvalue.ObjectExact(map[string]knownvalue.Check{
+						names.AttrARN:           knownvalue.NotNull(),
+						"encryption_key_arn":    knownvalue.Null(),
+						"event_expiry_duration": knownvalue.Int32Exact(7),
+						"strategies": knownvalue.SetExact([]knownvalue.Check{
+							knownvalue.StringExact("SEMANTIC"),
+						}),
+					}),
+				}),
+			})),
+		}
+	default:
+		panic(fmt.Sprintf("unknown memory config type: %s", memType))
 	}
 }
 
@@ -1786,6 +1941,44 @@ resource "aws_kms_key" "test" {
 `, rName))
 }
 
+func testAccHarnessConfig_Memory_byType(rName string, memType memoryConfigType) string {
+	switch memType {
+	case memoryNone:
+		return testAccHarnessConfig_Memory_byType_none(rName)
+	case memoryAgentCore:
+		return testAccHarnessConfig_Memory_agentCoreMemoryConfiguration_basic(rName)
+	case memoryDisabled:
+		return testAccHarnessConfig_Memory_disabled(rName)
+	case memoryManagedEmpty:
+		return testAccHarnessConfig_Memory_managedMemoryConfiguration_empty(rName)
+	case memoryManaged:
+		return testAccHarnessConfig_Memory_managedMemoryConfiguration_options(rName, 7, `["SEMANTIC"]`)
+	default:
+		panic(fmt.Sprintf("unknown memory config type: %s", memType))
+	}
+}
+
+func testAccHarnessConfig_Memory_byType_none(rName string) string {
+	return acctest.ConfigCompose(testAccHarnessConfig_iamRole(rName), fmt.Sprintf(`
+resource "aws_bedrockagentcore_harness" "test" {
+  harness_name       = %[1]q
+  execution_role_arn = aws_iam_role.test.arn
+
+  model {
+    bedrock_model_config {
+      model_id = "anthropic.claude-sonnet-4-20250514"
+    }
+  }
+
+  system_prompt {
+    text = "You are a helpful assistant."
+  }
+
+  depends_on = [aws_iam_role_policy.test]
+}
+`, rName))
+}
+
 func testAccHarnessConfig_Memory_disabled(rName string) string {
 	return acctest.ConfigCompose(testAccHarnessConfig_iamRole(rName), fmt.Sprintf(`
 resource "aws_bedrockagentcore_harness" "test" {
@@ -1805,6 +1998,8 @@ resource "aws_bedrockagentcore_harness" "test" {
   system_prompt {
     text = "You are a helpful assistant."
   }
+
+  depends_on = [aws_iam_role_policy.test]
 }
 `, rName))
 }
@@ -1888,11 +2083,11 @@ resource "aws_bedrockagentcore_harness" "test" {
     text = "You are a helpful assistant."
   }
 
+  depends_on = [aws_iam_role_policy.test]
+
   tags = {
     %[2]q = %[3]q
   }
-
-  depends_on = [aws_iam_role_policy.test]
 }
 `, rName, tagKey1, tagValue1))
 }

--- a/internal/service/bedrockagentcore/harness_test.go
+++ b/internal/service/bedrockagentcore/harness_test.go
@@ -610,11 +610,17 @@ func TestAccBedrockAgentCoreHarness_Memory_agentCoreMemoryConfiguration_basic(t 
 					},
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("memory").AtSliceIndex(0).AtMapKey("agentcore_memory_configuration").AtSliceIndex(0), knownvalue.ObjectExact(map[string]knownvalue.Check{
-						names.AttrARN:      knownvalue.NotNull(),
-						"actor_id":         knownvalue.Null(),
-						"messages_count":   knownvalue.Null(),
-						"retrieval_config": knownvalue.ListSizeExact(0),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("memory").AtSliceIndex(0), knownvalue.ObjectExact(map[string]knownvalue.Check{
+						"agentcore_memory_configuration": knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								names.AttrARN:      knownvalue.NotNull(),
+								"actor_id":         knownvalue.Null(),
+								"messages_count":   knownvalue.Null(),
+								"retrieval_config": knownvalue.ListSizeExact(0),
+							}),
+						}),
+						"disabled":                     knownvalue.ListSizeExact(0),
+						"managed_memory_configuration": knownvalue.ListSizeExact(0),
 					})),
 					statecheck.CompareValuePairs(resourceName, tfjsonpath.New("memory").AtSliceIndex(0).AtMapKey("agentcore_memory_configuration").AtSliceIndex(0).AtMapKey(names.AttrARN), "aws_bedrockagentcore_memory.test", tfjsonpath.New(names.AttrARN), compare.ValuesSame()),
 				},
@@ -876,13 +882,19 @@ func TestAccBedrockAgentCoreHarness_Memory_managedMemoryConfiguration_empty(t *t
 					},
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("memory").AtSliceIndex(0).AtMapKey("managed_memory_configuration").AtSliceIndex(0), knownvalue.ObjectExact(map[string]knownvalue.Check{
-						names.AttrARN:           tfknownvalue.RegionalARNRegexp("bedrock-agentcore", regexache.MustCompile(`memory/harness_`+rName+`_[a-zA-Z0-9]+-[a-zA-Z0-9]+`)),
-						"encryption_key_arn":    knownvalue.Null(),
-						"event_expiry_duration": knownvalue.Int32Exact(30),
-						"strategies": knownvalue.SetExact([]knownvalue.Check{
-							knownvalue.StringExact("SEMANTIC"),
-							knownvalue.StringExact("SUMMARIZATION"),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("memory").AtSliceIndex(0), knownvalue.ObjectExact(map[string]knownvalue.Check{
+						"agentcore_memory_configuration": knownvalue.ListSizeExact(0),
+						"disabled":                       knownvalue.ListSizeExact(0),
+						"managed_memory_configuration": knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								names.AttrARN:           tfknownvalue.RegionalARNRegexp("bedrock-agentcore", regexache.MustCompile(`memory/harness_`+rName+`_[a-zA-Z0-9]+-[a-zA-Z0-9]+`)),
+								"encryption_key_arn":    knownvalue.Null(),
+								"event_expiry_duration": knownvalue.Int32Exact(30),
+								"strategies": knownvalue.SetExact([]knownvalue.Check{
+									knownvalue.StringExact("SEMANTIC"),
+									knownvalue.StringExact("SUMMARIZATION"),
+								}),
+							}),
 						}),
 					})),
 				},
@@ -1005,6 +1017,53 @@ func TestAccBedrockAgentCoreHarness_Memory_managedMemoryConfiguration_encryption
 						}),
 					})),
 					statecheck.CompareValuePairs(resourceName, tfjsonpath.New("memory").AtSliceIndex(0).AtMapKey("managed_memory_configuration").AtSliceIndex(0).AtMapKey("encryption_key_arn"), "aws_kms_key.test", tfjsonpath.New(names.AttrARN), compare.ValuesSame()),
+				},
+			},
+			{
+				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, "harness_id"),
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "harness_id",
+			},
+		},
+	})
+}
+
+func TestAccBedrockAgentCoreHarness_Memory_disabled(t *testing.T) {
+	ctx := acctest.Context(t)
+	var harness awstypes.Harness
+	rName := testAccRandomHarnessName(t)
+	resourceName := "aws_bedrockagentcore_harness.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID)
+			testAccPreCheckHarness(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockAgentCoreServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckHarnessDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccHarnessConfig_Memory_disabled(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckHarnessExists(ctx, t, resourceName, &harness),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("memory").AtSliceIndex(0), knownvalue.ObjectExact(map[string]knownvalue.Check{
+						"agentcore_memory_configuration": knownvalue.ListSizeExact(0),
+						"disabled": knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectExact(map[string]knownvalue.Check{}),
+						}),
+						"managed_memory_configuration": knownvalue.ListSizeExact(0),
+					})),
 				},
 			},
 			{
@@ -1723,6 +1782,29 @@ resource "aws_bedrockagentcore_harness" "test" {
 
 resource "aws_kms_key" "test" {
   description = %[1]q
+}
+`, rName))
+}
+
+func testAccHarnessConfig_Memory_disabled(rName string) string {
+	return acctest.ConfigCompose(testAccHarnessConfig_iamRole(rName), fmt.Sprintf(`
+resource "aws_bedrockagentcore_harness" "test" {
+  harness_name       = %[1]q
+  execution_role_arn = aws_iam_role.test.arn
+
+  memory {
+    disabled {}
+  }
+
+  model {
+    bedrock_model_config {
+      model_id = "anthropic.claude-sonnet-4-20250514"
+    }
+  }
+
+  system_prompt {
+    text = "You are a helpful assistant."
+  }
 }
 `, rName))
 }

--- a/internal/service/bedrockagentcore/harness_test.go
+++ b/internal/service/bedrockagentcore/harness_test.go
@@ -1115,15 +1115,15 @@ func TestAccBedrockAgentCoreHarness_Memory_changeType(t *testing.T) {
 		{memoryManagedEmpty, memoryNone},
 	}
 
-	for _, tc := range testcases {
+	for _, tc := range testcases { //nolint:paralleltest // false positive
 		t.Run(fmt.Sprintf("%s_to_%s", tc.from, tc.to), func(t *testing.T) {
 			ctx := acctest.Context(t)
 			var harness awstypes.Harness
 			rName := testAccRandomHarnessName(t)
 			resourceName := "aws_bedrockagentcore_harness.test"
 
-			fromConfig := testAccHarnessConfig_Memory_byType(rName, tc.from)
-			toConfig := testAccHarnessConfig_Memory_byType(rName, tc.to)
+			fromConfig := testAccHarnessConfig_Memory_byType(t, rName, tc.from)
+			toConfig := testAccHarnessConfig_Memory_byType(t, rName, tc.to)
 
 			acctest.ParallelTest(ctx, t, resource.TestCase{
 				PreCheck: func() {
@@ -1140,7 +1140,7 @@ func TestAccBedrockAgentCoreHarness_Memory_changeType(t *testing.T) {
 						Check: resource.ComposeAggregateTestCheckFunc(
 							testAccCheckHarnessExists(ctx, t, resourceName, &harness),
 						),
-						ConfigStateChecks: memoryConfigStateChecks(resourceName, tc.from),
+						ConfigStateChecks: memoryConfigStateChecks(t, resourceName, tc.from),
 					},
 					{
 						Config: toConfig,
@@ -1152,7 +1152,7 @@ func TestAccBedrockAgentCoreHarness_Memory_changeType(t *testing.T) {
 								plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
 							},
 						},
-						ConfigStateChecks: memoryConfigStateChecks(resourceName, tc.to),
+						ConfigStateChecks: memoryConfigStateChecks(t, resourceName, tc.to),
 					},
 				},
 			})
@@ -1399,7 +1399,8 @@ func testAccPreCheckHarness(ctx context.Context, t *testing.T) {
 	}
 }
 
-func memoryConfigStateChecks(resourceName string, memType memoryConfigType) []statecheck.StateCheck {
+func memoryConfigStateChecks(t *testing.T, resourceName string, memType memoryConfigType) []statecheck.StateCheck {
+	t.Helper()
 	memoryPath := tfjsonpath.New("memory")
 	switch memType {
 	case memoryNone:
@@ -1467,7 +1468,8 @@ func memoryConfigStateChecks(resourceName string, memType memoryConfigType) []st
 			})),
 		}
 	default:
-		panic(fmt.Sprintf("unknown memory config type: %s", memType))
+		t.Fatalf("unknown memory config type: %s", memType)
+		return nil
 	}
 }
 
@@ -1941,7 +1943,8 @@ resource "aws_kms_key" "test" {
 `, rName))
 }
 
-func testAccHarnessConfig_Memory_byType(rName string, memType memoryConfigType) string {
+func testAccHarnessConfig_Memory_byType(t *testing.T, rName string, memType memoryConfigType) string {
+	t.Helper()
 	switch memType {
 	case memoryNone:
 		return testAccHarnessConfig_Memory_byType_none(rName)
@@ -1954,7 +1957,8 @@ func testAccHarnessConfig_Memory_byType(rName string, memType memoryConfigType) 
 	case memoryManaged:
 		return testAccHarnessConfig_Memory_managedMemoryConfiguration_options(rName, 7, `["SEMANTIC"]`)
 	default:
-		panic(fmt.Sprintf("unknown memory config type: %s", memType))
+		t.Fatalf("unknown memory config type: %s", memType)
+		return ""
 	}
 }
 

--- a/website/docs/r/bedrockagentcore_harness.html.markdown
+++ b/website/docs/r/bedrockagentcore_harness.html.markdown
@@ -428,6 +428,7 @@ The `claim_match_value` block supports the following:
 The `memory` block supports one of the following:
 
 * `agentcore_memory_configuration` - (Optional) AgentCore memory configuration. Use this to connect to an existing AgentCore memory resource. See [`agentcore_memory_configuration` Block](#agentcore_memory_configuration-block) below.
+* `disabled` - (Optional) Explicitly disable memory for this harness. See [`disabled` Block](#disabled-block) below.
 * `managed_memory_configuration` - (Optional) Managed memory configuration. Creates and manages a memory resource automatically. See [`managed_memory_configuration` Block](#managed_memory_configuration-block) below.
 
 ### `agentcore_memory_configuration` Block
@@ -445,6 +446,10 @@ The `memory` block supports one of the following:
 * `relevance_score` - (Optional) Relevance score threshold. Valid value is between `0` and `1`.
 * `strategy_id` - (Optional) ID of the memory strategy.
 * `top_k` - (Optional) Number of top results to retrieve.
+
+### `disabled` Block
+
+The `disabled` block takes no arguments. Use this to explicitly opt out of memory for the harness.
 
 ### `managed_memory_configuration` Block
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Adds support for `memory.disabled`

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=bedrockagentcore TESTS=TestAccBedrockAgentCoreHarness_

--- PASS: TestAccBedrockAgentCoreHarness_Memory_disabled (116.28s)
--- PASS: TestAccBedrockAgentCoreHarness_update_systemPrompt (303.51s)
--- PASS: TestAccBedrockAgentCoreHarness_update_allowedTools (330.44s)
--- PASS: TestAccBedrockAgentCoreHarness_environmentVariables (330.96s)
--- PASS: TestAccBedrockAgentCoreHarness_environmentArtifact (331.28s)
--- PASS: TestAccBedrockAgentCoreHarness_update_limits (339.31s)
--- PASS: TestAccBedrockAgentCoreHarness_authorizerConfiguration (341.58s)
--- PASS: TestAccBedrockAgentCoreHarness_truncation_slidingWindow (342.97s)
--- PASS: TestAccBedrockAgentCoreHarness_List_regionOverride (387.81s)
--- PASS: TestAccBedrockAgentCoreHarness_Memory_managedMemoryConfiguration_encryptionKey (410.02s)
--- PASS: TestAccBedrockAgentCoreHarness_model_bedrock (410.08s)
--- PASS: TestAccBedrockAgentCoreHarness_tags (418.74s)
--- PASS: TestAccBedrockAgentCoreHarness_Memory_managedMemoryConfiguration_empty (419.57s)
--- PASS: TestAccBedrockAgentCoreHarness_basic (419.84s)
--- PASS: TestAccBedrockAgentCoreHarness_Identity_basic (420.37s)
--- PASS: TestAccBedrockAgentCoreHarness_tools_inlineFunction (420.39s)
--- PASS: TestAccBedrockAgentCoreHarness_disappears (439.35s)
--- PASS: TestAccBedrockAgentCoreHarness_truncation_summarization (445.79s)
--- PASS: TestAccBedrockAgentCoreHarness_List_basic (370.55s)
--- PASS: TestAccBedrockAgentCoreHarness_Memory_agentCoreMemoryConfiguration_removeRetrievalConfig (508.48s)
--- PASS: TestAccBedrockAgentCoreHarness_Memory_managedMemoryConfiguration_update (608.10s)
--- PASS: TestAccBedrockAgentCoreHarness_List_includeResource (368.82s)
--- PASS: TestAccBedrockAgentCoreHarness_Identity_regionOverride (400.69s)
--- PASS: TestAccBedrockAgentCoreHarness_Memory_agentCoreMemoryConfiguration_basic (397.90s)
--- PASS: TestAccBedrockAgentCoreHarness_Memory_agentCoreMemoryConfiguration_addRetrievalConfig (427.53s)
--- PASS: TestAccBedrockAgentCoreHarness_Memory_agentCoreMemoryConfiguration_options (447.84s)
--- PASS: TestAccBedrockAgentCoreHarness_Memory_changeType (0.00s)
    --- PASS: TestAccBedrockAgentCoreHarness_Memory_changeType/disabled_to_none (103.03s)
    --- PASS: TestAccBedrockAgentCoreHarness_Memory_changeType/managed_empty_to_none (265.48s)
    --- PASS: TestAccBedrockAgentCoreHarness_Memory_changeType/managed_empty_to_disabled (245.24s)
    --- PASS: TestAccBedrockAgentCoreHarness_Memory_changeType/none_to_managed_empty (243.25s)
    --- PASS: TestAccBedrockAgentCoreHarness_Memory_changeType/none_to_disabled (250.03s)
    --- PASS: TestAccBedrockAgentCoreHarness_Memory_changeType/disabled_to_managed (406.15s)
    --- PASS: TestAccBedrockAgentCoreHarness_Memory_changeType/disabled_to_managed_empty (406.07s)
    --- PASS: TestAccBedrockAgentCoreHarness_Memory_changeType/agentcore_to_disabled (416.05s)
    --- PASS: TestAccBedrockAgentCoreHarness_Memory_changeType/disabled_to_agentcore (442.78s)
    --- PASS: TestAccBedrockAgentCoreHarness_Memory_changeType/none_to_agentcore (595.73s)
    --- PASS: TestAccBedrockAgentCoreHarness_Memory_changeType/managed_empty_to_managed (550.30s)
    --- PASS: TestAccBedrockAgentCoreHarness_Memory_changeType/managed_empty_to_agentcore (562.31s)
    --- PASS: TestAccBedrockAgentCoreHarness_Memory_changeType/none_to_managed (554.38s)
    --- PASS: TestAccBedrockAgentCoreHarness_Memory_changeType/agentcore_to_managed (697.34s)
    --- PASS: TestAccBedrockAgentCoreHarness_Memory_changeType/agentcore_to_managed_empty (712.23s)
```

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>