### PR TITLE
Changie: Deprecate `generate-changelog` makefile target

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -420,9 +420,11 @@ gen-check: gen ## [CI] Provider Checks / go_generate
 	@git diff origin/$(BASE_REF) --compact-summary --exit-code || \
 		(echo; echo "Unexpected difference in directories after code generation. Run 'make gen' command and commit."; exit 1)
 
-generate-changelog: ## Generate changelog
-	@echo "make: Generating changelog..."
-	@sh -c "'$(CURDIR)/.ci/scripts/generate-changelog.sh'"
+generate-changelog: ## Legacy target. CHANGELOG generation is now handled by GitHub Actions workflows; see docs/changelog-process.md
+	@echo "make: generate-changelog is deprecated"
+	@echo "make: CHANGELOG generation is now handled by GitHub Actions workflows"
+	@echo "make: See docs/changelog-process.md for current process"
+	@exit 1
 
 gh-workflow-lint: ## [CI] Workflow Linting / actionlint
 	@echo "make: Workflow Linting / actionlint..."

--- a/docs/makefile-cheat-sheet.md
+++ b/docs/makefile-cheat-sheet.md
@@ -129,7 +129,7 @@ Variables are often defined before the `make` call on the same line, such as `MY
 | `gen`<sup>D</sup> | Run Go generators (all provider-wide, or scoped to a service with `PKG`/`K`) |  |  | `GO_VER`, `K`, `PKG`, `SVC_DIR` |
 | `gen-check`<sup>D</sup> | Provider Checks / go_generate | ✔️ |  |  |
 | `gen-raw` | Run all Go generators (without Go version check) |  |  | `GO_VER` |
-| `generate-changelog` | Generate changelog |  |  | `CURDIR` |
+| `generate-changelog` | [DEPRECATED] Generate changelog; use Changie workflows instead |  | ✔️ |  |
 | `gh-workflow-lint` | Workflow Linting / actionlint | ✔️ |  |  |
 | `go-build` | Provider Checks / go-build | ✔️ |  |  |
 | `go-misspell` | Provider Checks / misspell | ✔️ |  |  |


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Deprecates the `generate-changelog` makefile target; unused with Changie

Note: I'm open to the idea that this should instead be updated to wrap Changie commands, but it seemed more trouble than it's worth.

### Relations

Relates #46618