### PR TITLE
resource/aws_ssm_parameter: Fixes `names` with only leading slash

### DIFF
--- a/.changelog/49339.txt
+++ b/.changelog/49339.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ssm_parameter: Fixes error where `name` with a leading slash and no other slashes was stripping the leading slash.
+```

--- a/internal/provider/sdkv2/identity_interceptor.go
+++ b/internal/provider/sdkv2/identity_interceptor.go
@@ -29,20 +29,22 @@ func (r identityInterceptor) run(ctx context.Context, opts crudInterceptorOption
 	case After:
 		switch why {
 		case Create, Read, Update:
-			if why == Update && !(r.identitySpec.IsMutable && r.identitySpec.IsSetOnUpdate) && !identityIsFullyNull(d, r.identitySpec) {
-				break
-			}
 			// `Id()` is empty when the resource is being removed
 			if d.Id() == "" {
 				break
 			}
-			// Identity is fully-null on Read when Importing or when updating existing resources created without identity.
-			if why == Read && !(r.identitySpec.IsMutable && r.identitySpec.IsSetOnUpdate) && !identityIsFullyNull(d, r.identitySpec) {
-				break
-			}
+
 			identity, err := d.Identity()
 			if err != nil {
 				return sdkdiag.AppendFromErr(diags, err)
+			}
+
+			if why == Update && !(r.identitySpec.IsMutable && r.identitySpec.IsSetOnUpdate) && !identityIsFullyNull(identity, r.identitySpec) {
+				break
+			}
+			// Identity is fully-null on Read when Importing or when updating existing resources created without identity.
+			if why == Read && !(r.identitySpec.IsMutable && r.identitySpec.IsSetOnUpdate) && !identityIsFullyNull(identity, r.identitySpec) {
+				break
 			}
 
 			for _, attr := range r.identitySpec.Attributes {
@@ -71,13 +73,13 @@ func (r identityInterceptor) run(ctx context.Context, opts crudInterceptorOption
 	case OnError:
 		switch why {
 		case Update:
-			if identityIsFullyNull(d, r.identitySpec) {
+			identity, err := d.Identity()
+			if err != nil {
+				return sdkdiag.AppendFromErr(diags, err)
+			}
+			if identityIsFullyNull(identity, r.identitySpec) {
 				if d.Id() == "" {
 					break
-				}
-				identity, err := d.Identity()
-				if err != nil {
-					return sdkdiag.AppendFromErr(diags, err)
 				}
 
 				for _, attr := range r.identitySpec.Attributes {
@@ -111,12 +113,7 @@ func (r identityInterceptor) run(ctx context.Context, opts crudInterceptorOption
 
 // identityIsFullyNull returns true if a resource supports identity and
 // all attributes are set to null values
-func identityIsFullyNull(d schemaResourceData, identitySpec *inttypes.Identity) bool {
-	identity, err := d.Identity()
-	if err != nil {
-		return false
-	}
-
+func identityIsFullyNull(identity *schema.IdentityData, identitySpec *inttypes.Identity) bool {
 	for _, attr := range identitySpec.Attributes {
 		value := identity.Get(attr.Name())
 		if value != "" {

--- a/internal/provider/sdkv2/identity_interceptor.go
+++ b/internal/provider/sdkv2/identity_interceptor.go
@@ -32,7 +32,12 @@ func (r identityInterceptor) run(ctx context.Context, opts crudInterceptorOption
 			if why == Update && !(r.identitySpec.IsMutable && r.identitySpec.IsSetOnUpdate) && !identityIsFullyNull(d, r.identitySpec) {
 				break
 			}
+			// `Id()` is empty when the resource is being removed
 			if d.Id() == "" {
+				break
+			}
+			// Identity is fully-null on Read when Importing or when updating existing resources created without identity.
+			if why == Read && !(r.identitySpec.IsMutable && r.identitySpec.IsSetOnUpdate) && !identityIsFullyNull(d, r.identitySpec) {
 				break
 			}
 			identity, err := d.Identity()

--- a/internal/provider/sdkv2/identity_interceptor_test.go
+++ b/internal/provider/sdkv2/identity_interceptor_test.go
@@ -534,7 +534,7 @@ func TestIdentityIsFullyNull(t *testing.T) {
 				}
 			}
 
-			result := identityIsFullyNull(d, identitySpec)
+			result := identityIsFullyNull(identity, identitySpec)
 			if result != tc.expectNull {
 				t.Errorf("%s: expected identityIsFullyNull to return %v, got %v",
 					tc.description, tc.expectNull, result)

--- a/internal/provider/sdkv2/identity_interceptor_test.go
+++ b/internal/provider/sdkv2/identity_interceptor_test.go
@@ -98,12 +98,13 @@ func TestIdentityInterceptor_Create(t *testing.T) {
 	}
 }
 
-func TestIdentityInterceptor_Read_RemovedFromState(t *testing.T) {
+func TestIdentityInterceptor_Read(t *testing.T) {
 	t.Parallel()
 
 	accountID := "123456789012"
 	region := "us-west-2" //lintignore:AWSAT003
-	name := "a_name"
+	attributeName := "attr_name"
+	identityName := "id_name"
 
 	resourceSchema := map[string]*schema.Schema{
 		"name": {
@@ -117,47 +118,183 @@ func TestIdentityInterceptor_Read_RemovedFromState(t *testing.T) {
 		"region": sdkv2.RegionOptionalComputed(),
 	}
 
-	identitySpec := regionalSingleParameterizedIdentitySpec("name")
-	identitySchema := identity.NewIdentitySchema(identitySpec)
+	client := mockClient{
+		accountID: accountID,
+		region:    region,
+	}
 
-	invocation := newIdentityInterceptor(&identitySpec)
-	interceptor := invocation.interceptor.(identityInterceptor)
+	testCases := map[string]struct {
+		id             string
+		identityValues map[string]string
+		expectedName   string
+	}{
+		"existing resource": {
+			id: "some_id",
+			identityValues: map[string]string{
+				names.AttrAccountID: accountID,
+				names.AttrRegion:    region,
+				"name":              identityName,
+			},
+			expectedName: identityName,
+		},
+		"removed from state": {
+			id: "",
+			identityValues: map[string]string{
+				names.AttrAccountID: accountID,
+				names.AttrRegion:    region,
+				"name":              identityName,
+			},
+			expectedName: identityName,
+		},
+		"for import": {
+			id:             "some_id",
+			identityValues: nil,
+			expectedName:   attributeName,
+		},
+	}
+
+	for tname, tc := range testCases {
+		t.Run(tname, func(t *testing.T) {
+			t.Parallel()
+			ctx := t.Context()
+
+			identitySpec := regionalSingleParameterizedIdentitySpec("name")
+			identitySchema := identity.NewIdentitySchema(identitySpec)
+
+			invocation := newIdentityInterceptor(&identitySpec)
+			interceptor := invocation.interceptor.(identityInterceptor)
+
+			d := schema.TestResourceDataWithIdentityRaw(t, resourceSchema, identitySchema, tc.identityValues)
+			d.SetId(tc.id)
+			d.Set("name", attributeName)
+			d.Set("region", region)
+			d.Set("type", "some_type")
+
+			opts := crudInterceptorOptions{
+				c:    client,
+				d:    d,
+				when: After,
+				why:  Read,
+			}
+
+			interceptor.run(ctx, opts)
+
+			identity, err := d.Identity()
+			if err != nil {
+				t.Fatalf("unexpected error getting identity: %v", err)
+			}
+
+			if e, a := accountID, identity.Get(names.AttrAccountID); e != a {
+				t.Errorf("expected account ID %q, got %q", e, a)
+			}
+			if e, a := region, identity.Get(names.AttrRegion); e != a {
+				t.Errorf("expected region %q, got %q", e, a)
+			}
+			if e, a := tc.expectedName, identity.Get("name"); e != a {
+				t.Errorf("expected name %q, got %q", e, a)
+			}
+		})
+	}
+}
+
+func TestIdentityInterceptor_Read_MutableIdentity(t *testing.T) {
+	t.Parallel()
+
+	accountID := "123456789012"
+	region := "us-west-2" //lintignore:AWSAT003
+	attributeName := "attr_name"
+	identityName := "id_name"
+
+	resourceSchema := map[string]*schema.Schema{
+		"name": {
+			Type:     schema.TypeString,
+			Required: true,
+		},
+		"type": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"region": sdkv2.RegionOptionalComputed(),
+	}
 
 	client := mockClient{
 		accountID: accountID,
 		region:    region,
 	}
 
-	ctx := t.Context()
-
-	d := schema.TestResourceDataWithIdentityRaw(t, resourceSchema, identitySchema, nil)
-	d.SetId("")
-	d.Set("name", name)
-	d.Set("region", region)
-	d.Set("type", "some_type")
-
-	opts := crudInterceptorOptions{
-		c:    client,
-		d:    d,
-		when: After,
-		why:  Read,
+	testCases := map[string]struct {
+		id             string
+		identityValues map[string]string
+		expectedName   string
+	}{
+		"existing resource": {
+			id: "some_id",
+			identityValues: map[string]string{
+				names.AttrAccountID: accountID,
+				names.AttrRegion:    region,
+				"name":              identityName,
+			},
+			expectedName: attributeName,
+		},
+		"removed from state": {
+			id: "",
+			identityValues: map[string]string{
+				names.AttrAccountID: accountID,
+				names.AttrRegion:    region,
+				"name":              identityName,
+			},
+			expectedName: identityName,
+		},
+		"for import": {
+			id:             "some_id",
+			identityValues: nil,
+			expectedName:   attributeName,
+		},
 	}
 
-	interceptor.run(ctx, opts)
+	for tname, tc := range testCases {
+		t.Run(tname, func(t *testing.T) {
+			t.Parallel()
+			ctx := t.Context()
 
-	identity, err := d.Identity()
-	if err != nil {
-		t.Fatalf("unexpected error getting identity: %v", err)
-	}
+			identitySpec := regionalSingleParameterizedIdentitySpec("name",
+				inttypes.WithMutableIdentity(),
+			)
+			identitySchema := identity.NewIdentitySchema(identitySpec)
 
-	if identity.Get(names.AttrAccountID) != "" {
-		t.Errorf("expected no account ID, got %q", identity.Get(names.AttrAccountID))
-	}
-	if identity.Get(names.AttrRegion) != "" {
-		t.Errorf("expected no region, got %q", identity.Get(names.AttrRegion))
-	}
-	if identity.Get("name") != "" {
-		t.Errorf("expected no name, got %q", identity.Get("name"))
+			invocation := newIdentityInterceptor(&identitySpec)
+			interceptor := invocation.interceptor.(identityInterceptor)
+
+			d := schema.TestResourceDataWithIdentityRaw(t, resourceSchema, identitySchema, tc.identityValues)
+			d.SetId(tc.id)
+			d.Set("name", attributeName)
+			d.Set("region", region)
+			d.Set("type", "some_type")
+
+			opts := crudInterceptorOptions{
+				c:    client,
+				d:    d,
+				when: After,
+				why:  Read,
+			}
+
+			interceptor.run(ctx, opts)
+
+			identity, err := d.Identity()
+			if err != nil {
+				t.Fatalf("unexpected error getting identity: %v", err)
+			}
+
+			if e, a := accountID, identity.Get(names.AttrAccountID); e != a {
+				t.Errorf("expected account ID %q, got %q", e, a)
+			}
+			if e, a := region, identity.Get(names.AttrRegion); e != a {
+				t.Errorf("expected region %q, got %q", e, a)
+			}
+			if e, a := tc.expectedName, identity.Get("name"); e != a {
+				t.Errorf("expected name %q, got %q", e, a)
+			}
+		})
 	}
 }
 

--- a/internal/provider/sdkv2/identity_interceptor_test.go
+++ b/internal/provider/sdkv2/identity_interceptor_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestIdentityInterceptor(t *testing.T) {
+func TestIdentityInterceptor_Create(t *testing.T) {
 	t.Parallel()
 
 	accountID := "123456789012"
@@ -98,7 +98,7 @@ func TestIdentityInterceptor(t *testing.T) {
 	}
 }
 
-func TestIdentityInterceptor_Read_Removed(t *testing.T) {
+func TestIdentityInterceptor_Read_RemovedFromState(t *testing.T) {
 	t.Parallel()
 
 	accountID := "123456789012"

--- a/internal/service/ssm/parameter.go
+++ b/internal/service/ssm/parameter.go
@@ -325,7 +325,7 @@ func resourceParameterRead(ctx context.Context, d *schema.ResourceData, meta any
 		return sdkdiag.AppendErrorf(diags, "reading SSM Parameter metadata (%s): %s", d.Id(), err)
 	}
 
-	resourceParameterFlatten(d, paramMetadata)
+	resourceParameterFlatten(d, param, paramMetadata)
 
 	hasWriteOnly := d.Get("has_value_wo").(bool)
 	rawConfig := d.GetRawConfig()
@@ -362,16 +362,17 @@ func resourceParameterRead(ctx context.Context, d *schema.ResourceData, meta any
 	return diags
 }
 
-func resourceParameterFlatten(d *schema.ResourceData, paramMetadata *awstypes.ParameterMetadata) {
+func resourceParameterFlatten(d *schema.ResourceData, param *awstypes.Parameter, paramMetadata *awstypes.ParameterMetadata) {
+	d.Set(names.AttrARN, param.ARN)
+	d.Set(names.AttrName, param.Name)
+	d.Set(names.AttrType, param.Type)
+	d.Set(names.AttrVersion, param.Version)
+
 	d.Set("allowed_pattern", paramMetadata.AllowedPattern)
-	d.Set(names.AttrARN, paramMetadata.ARN)
 	d.Set("data_type", paramMetadata.DataType)
 	d.Set(names.AttrDescription, paramMetadata.Description)
 	d.Set(names.AttrKeyID, paramMetadata.KeyId)
-	d.Set(names.AttrName, paramMetadata.Name)
 	d.Set("tier", paramMetadata.Tier)
-	d.Set(names.AttrType, paramMetadata.Type)
-	d.Set(names.AttrVersion, paramMetadata.Version)
 }
 
 func resourceParameterUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/internal/service/ssm/parameter.go
+++ b/internal/service/ssm/parameter.go
@@ -41,6 +41,7 @@ import (
 // @Testing(preIdentityVersion="v6.7.0")
 // @Testing(plannableImportAction="NoOp")
 // @CustomImport
+// @Testing(identityTestCases="basic;leadingslash;path")
 func resourceParameter() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceParameterCreate,

--- a/internal/service/ssm/parameter_identity_gen_test.go
+++ b/internal/service/ssm/parameter_identity_gen_test.go
@@ -314,3 +314,587 @@ func TestAccSSMParameter_Identity_ExistingResource_noRefreshNoChange(t *testing.
 		},
 	})
 }
+
+func TestAccSSMParameter_Identity_Leadingslash_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var v awstypes.Parameter
+	resourceName := "aws_ssm_parameter.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_12_0),
+		},
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
+		CheckDestroy:             testAccCheckParameterDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Parameter/leadingslash_basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckParameterExists(ctx, t, resourceName, &v),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.CompareValuePairs(resourceName, tfjsonpath.New(names.AttrID), resourceName, tfjsonpath.New(names.AttrName), compare.ValuesSame()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.Region())),
+					statecheck.ExpectIdentity(resourceName, map[string]knownvalue.Check{
+						names.AttrAccountID: tfknownvalue.AccountID(),
+						names.AttrRegion:    knownvalue.StringExact(acctest.Region()),
+						names.AttrName:      knownvalue.NotNull(),
+					}),
+					statecheck.ExpectIdentityValueMatchesState(resourceName, tfjsonpath.New(names.AttrName)),
+				},
+			},
+
+			// Step 2: Import command
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Parameter/leadingslash_basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+				},
+				ImportStateKind:   resource.ImportCommandWithID,
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+
+			// Step 3: Import block with Import ID
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Parameter/leadingslash_basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+				},
+				ResourceName:    resourceName,
+				ImportState:     true,
+				ImportStateKind: resource.ImportBlockWithID,
+				ImportPlanChecks: resource.ImportPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrName), knownvalue.NotNull()),
+						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrID), knownvalue.NotNull()),
+						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.Region())),
+					},
+				},
+			},
+
+			// Step 4: Import block with Resource Identity
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Parameter/leadingslash_basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+				},
+				ResourceName:    resourceName,
+				ImportState:     true,
+				ImportStateKind: resource.ImportBlockWithResourceIdentity,
+				ImportPlanChecks: resource.ImportPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrName), knownvalue.NotNull()),
+						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrID), knownvalue.NotNull()),
+						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.Region())),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccSSMParameter_Identity_Leadingslash_regionOverride(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName := "aws_ssm_parameter.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_12_0),
+		},
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
+		CheckDestroy:             acctest.CheckDestroyNoop,
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Parameter/leadingslash_region_override/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+					"region":        config.StringVariable(acctest.AlternateRegion()),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.CompareValuePairs(resourceName, tfjsonpath.New(names.AttrID), resourceName, tfjsonpath.New(names.AttrName), compare.ValuesSame()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.AlternateRegion())),
+					statecheck.ExpectIdentity(resourceName, map[string]knownvalue.Check{
+						names.AttrAccountID: tfknownvalue.AccountID(),
+						names.AttrRegion:    knownvalue.StringExact(acctest.AlternateRegion()),
+						names.AttrName:      knownvalue.NotNull(),
+					}),
+					statecheck.ExpectIdentityValueMatchesState(resourceName, tfjsonpath.New(names.AttrName)),
+				},
+			},
+
+			// Step 2: Import command
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Parameter/leadingslash_region_override/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+					"region":        config.StringVariable(acctest.AlternateRegion()),
+				},
+				ImportStateKind:   resource.ImportCommandWithID,
+				ImportStateIdFunc: acctest.CrossRegionImportStateIdFunc(resourceName),
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+
+			// Step 3: Import block with Import ID
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Parameter/leadingslash_region_override/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+					"region":        config.StringVariable(acctest.AlternateRegion()),
+				},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateKind:   resource.ImportBlockWithID,
+				ImportStateIdFunc: acctest.CrossRegionImportStateIdFunc(resourceName),
+				ImportPlanChecks: resource.ImportPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrName), knownvalue.NotNull()),
+						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.AlternateRegion())),
+					},
+				},
+			},
+
+			// Step 4: Import block with Resource Identity
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Parameter/leadingslash_region_override/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+					"region":        config.StringVariable(acctest.AlternateRegion()),
+				},
+				ResourceName:    resourceName,
+				ImportState:     true,
+				ImportStateKind: resource.ImportBlockWithResourceIdentity,
+				ImportPlanChecks: resource.ImportPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrName), knownvalue.NotNull()),
+						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.AlternateRegion())),
+					},
+				},
+			},
+		},
+	})
+}
+
+// Resource Identity was added after v6.7.0
+func TestAccSSMParameter_Identity_Leadingslash_ExistingResource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var v awstypes.Parameter
+	resourceName := "aws_ssm_parameter.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_12_0),
+		},
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
+		CheckDestroy: testAccCheckParameterDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			// Step 1: Create pre-Identity
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Parameter/leadingslash_v6.7.0/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckParameterExists(ctx, t, resourceName, &v),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					tfstatecheck.ExpectNoIdentity(resourceName),
+				},
+			},
+
+			// Step 2: Current version
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/Parameter/leadingslash_basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+				},
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectIdentity(resourceName, map[string]knownvalue.Check{
+						names.AttrAccountID: tfknownvalue.AccountID(),
+						names.AttrRegion:    knownvalue.StringExact(acctest.Region()),
+						names.AttrName:      knownvalue.NotNull(),
+					}),
+					statecheck.ExpectIdentityValueMatchesState(resourceName, tfjsonpath.New(names.AttrName)),
+				},
+			},
+		},
+	})
+}
+
+// Resource Identity was added after v6.7.0
+func TestAccSSMParameter_Identity_Leadingslash_ExistingResource_noRefreshNoChange(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var v awstypes.Parameter
+	resourceName := "aws_ssm_parameter.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_12_0),
+		},
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
+		CheckDestroy: testAccCheckParameterDestroy(ctx, t),
+		AdditionalCLIOptions: &resource.AdditionalCLIOptions{
+			Plan: resource.PlanOptions{
+				NoRefresh: true,
+			},
+		},
+		Steps: []resource.TestStep{
+			// Step 1: Create pre-Identity
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Parameter/leadingslash_v6.7.0/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckParameterExists(ctx, t, resourceName, &v),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					tfstatecheck.ExpectNoIdentity(resourceName),
+				},
+			},
+
+			// Step 2: Current version
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/Parameter/leadingslash_basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+				},
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					tfstatecheck.ExpectNoIdentity(resourceName),
+				},
+			},
+		},
+	})
+}
+
+func TestAccSSMParameter_Identity_Path_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var v awstypes.Parameter
+	resourceName := "aws_ssm_parameter.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_12_0),
+		},
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
+		CheckDestroy:             testAccCheckParameterDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Parameter/path_basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckParameterExists(ctx, t, resourceName, &v),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.CompareValuePairs(resourceName, tfjsonpath.New(names.AttrID), resourceName, tfjsonpath.New(names.AttrName), compare.ValuesSame()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.Region())),
+					statecheck.ExpectIdentity(resourceName, map[string]knownvalue.Check{
+						names.AttrAccountID: tfknownvalue.AccountID(),
+						names.AttrRegion:    knownvalue.StringExact(acctest.Region()),
+						names.AttrName:      knownvalue.NotNull(),
+					}),
+					statecheck.ExpectIdentityValueMatchesState(resourceName, tfjsonpath.New(names.AttrName)),
+				},
+			},
+
+			// Step 2: Import command
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Parameter/path_basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+				},
+				ImportStateKind:   resource.ImportCommandWithID,
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+
+			// Step 3: Import block with Import ID
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Parameter/path_basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+				},
+				ResourceName:    resourceName,
+				ImportState:     true,
+				ImportStateKind: resource.ImportBlockWithID,
+				ImportPlanChecks: resource.ImportPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrName), knownvalue.NotNull()),
+						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrID), knownvalue.NotNull()),
+						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.Region())),
+					},
+				},
+			},
+
+			// Step 4: Import block with Resource Identity
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Parameter/path_basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+				},
+				ResourceName:    resourceName,
+				ImportState:     true,
+				ImportStateKind: resource.ImportBlockWithResourceIdentity,
+				ImportPlanChecks: resource.ImportPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrName), knownvalue.NotNull()),
+						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrID), knownvalue.NotNull()),
+						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.Region())),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccSSMParameter_Identity_Path_regionOverride(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName := "aws_ssm_parameter.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_12_0),
+		},
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
+		CheckDestroy:             acctest.CheckDestroyNoop,
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Parameter/path_region_override/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+					"region":        config.StringVariable(acctest.AlternateRegion()),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.CompareValuePairs(resourceName, tfjsonpath.New(names.AttrID), resourceName, tfjsonpath.New(names.AttrName), compare.ValuesSame()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.AlternateRegion())),
+					statecheck.ExpectIdentity(resourceName, map[string]knownvalue.Check{
+						names.AttrAccountID: tfknownvalue.AccountID(),
+						names.AttrRegion:    knownvalue.StringExact(acctest.AlternateRegion()),
+						names.AttrName:      knownvalue.NotNull(),
+					}),
+					statecheck.ExpectIdentityValueMatchesState(resourceName, tfjsonpath.New(names.AttrName)),
+				},
+			},
+
+			// Step 2: Import command
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Parameter/path_region_override/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+					"region":        config.StringVariable(acctest.AlternateRegion()),
+				},
+				ImportStateKind:   resource.ImportCommandWithID,
+				ImportStateIdFunc: acctest.CrossRegionImportStateIdFunc(resourceName),
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+
+			// Step 3: Import block with Import ID
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Parameter/path_region_override/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+					"region":        config.StringVariable(acctest.AlternateRegion()),
+				},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateKind:   resource.ImportBlockWithID,
+				ImportStateIdFunc: acctest.CrossRegionImportStateIdFunc(resourceName),
+				ImportPlanChecks: resource.ImportPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrName), knownvalue.NotNull()),
+						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.AlternateRegion())),
+					},
+				},
+			},
+
+			// Step 4: Import block with Resource Identity
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Parameter/path_region_override/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+					"region":        config.StringVariable(acctest.AlternateRegion()),
+				},
+				ResourceName:    resourceName,
+				ImportState:     true,
+				ImportStateKind: resource.ImportBlockWithResourceIdentity,
+				ImportPlanChecks: resource.ImportPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrName), knownvalue.NotNull()),
+						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.AlternateRegion())),
+					},
+				},
+			},
+		},
+	})
+}
+
+// Resource Identity was added after v6.7.0
+func TestAccSSMParameter_Identity_Path_ExistingResource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var v awstypes.Parameter
+	resourceName := "aws_ssm_parameter.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_12_0),
+		},
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
+		CheckDestroy: testAccCheckParameterDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			// Step 1: Create pre-Identity
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Parameter/path_v6.7.0/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckParameterExists(ctx, t, resourceName, &v),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					tfstatecheck.ExpectNoIdentity(resourceName),
+				},
+			},
+
+			// Step 2: Current version
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/Parameter/path_basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+				},
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectIdentity(resourceName, map[string]knownvalue.Check{
+						names.AttrAccountID: tfknownvalue.AccountID(),
+						names.AttrRegion:    knownvalue.StringExact(acctest.Region()),
+						names.AttrName:      knownvalue.NotNull(),
+					}),
+					statecheck.ExpectIdentityValueMatchesState(resourceName, tfjsonpath.New(names.AttrName)),
+				},
+			},
+		},
+	})
+}
+
+// Resource Identity was added after v6.7.0
+func TestAccSSMParameter_Identity_Path_ExistingResource_noRefreshNoChange(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var v awstypes.Parameter
+	resourceName := "aws_ssm_parameter.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_12_0),
+		},
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
+		CheckDestroy: testAccCheckParameterDestroy(ctx, t),
+		AdditionalCLIOptions: &resource.AdditionalCLIOptions{
+			Plan: resource.PlanOptions{
+				NoRefresh: true,
+			},
+		},
+		Steps: []resource.TestStep{
+			// Step 1: Create pre-Identity
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Parameter/path_v6.7.0/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckParameterExists(ctx, t, resourceName, &v),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					tfstatecheck.ExpectNoIdentity(resourceName),
+				},
+			},
+
+			// Step 2: Current version
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/Parameter/path_basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+				},
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					tfstatecheck.ExpectNoIdentity(resourceName),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/ssm/parameter_list.go
+++ b/internal/service/ssm/parameter_list.go
@@ -77,7 +77,7 @@ func (l *parameterListResource) List(ctx context.Context, request list.ListReque
 					continue
 				}
 
-				resourceParameterFlatten(rd, &paramMetadata)
+				resourceParameterFlatten(rd, param, &paramMetadata)
 
 				rd.Set(names.AttrValue, param.Value)
 			}

--- a/internal/service/ssm/parameter_test.go
+++ b/internal/service/ssm/parameter_test.go
@@ -969,6 +969,37 @@ func TestAccSSMParameter_Name_fullPath(t *testing.T) {
 	})
 }
 
+func TestAccSSMParameter_Name_leadingSlash(t *testing.T) {
+	ctx := acctest.Context(t)
+	var param awstypes.Parameter
+	name := fmt.Sprintf("/%s_%s", t.Name(), acctest.RandString(t, 10))
+	resourceName := "aws_ssm_parameter.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckParameterDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccParameterConfig_basic(name, "String", "test2"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckParameterExists(ctx, t, resourceName, &param),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "ssm", "parameter{name}"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, name),
+					resource.TestCheckResourceAttr(resourceName, names.AttrValue, "test2"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrType, "String"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccSSMParameter_Secure_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var param awstypes.Parameter

--- a/internal/service/ssm/parameter_test.go
+++ b/internal/service/ssm/parameter_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	tfknownvalue "github.com/hashicorp/terraform-provider-aws/internal/acctest/knownvalue"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfssm "github.com/hashicorp/terraform-provider-aws/internal/service/ssm"
 	"github.com/hashicorp/terraform-provider-aws/names"

--- a/internal/service/ssm/parameter_test.go
+++ b/internal/service/ssm/parameter_test.go
@@ -1000,6 +1000,80 @@ func TestAccSSMParameter_Name_singleNameWithLeadingSlash(t *testing.T) {
 	})
 }
 
+func TestAccSSMParameter_Name_migrate_singleNameWithLeadingSlash(t *testing.T) {
+	ctx := acctest.Context(t)
+	var param awstypes.Parameter
+	nameWithoutSlash := fmt.Sprintf("%s_%s", t.Name(), acctest.RandString(t, 10))
+	name := "/" + nameWithoutSlash
+	resourceName := "aws_ssm_parameter.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_12_0),
+		},
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
+		CheckDestroy: testAccCheckParameterDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"aws": {
+						Source:            "hashicorp/aws",
+						VersionConstraint: "6.58.0",
+					},
+				},
+				Config: testAccParameterConfig_basic(name, "String", "test2"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckParameterExists(ctx, t, resourceName, &param),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "ssm", "parameter/{name}"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, nameWithoutSlash),
+					resource.TestCheckResourceAttr(resourceName, names.AttrValue, "test2"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrType, "String"),
+				),
+				ExpectNonEmptyPlan: true,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionReplace),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionReplace),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectIdentity(resourceName, map[string]knownvalue.Check{
+						names.AttrAccountID: tfknownvalue.AccountID(),
+						names.AttrRegion:    knownvalue.StringExact(acctest.Region()),
+						names.AttrName:      knownvalue.StringExact(nameWithoutSlash),
+					}),
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				Config:                   testAccParameterConfig_basic(name, "String", "test2"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckParameterExists(ctx, t, resourceName, &param),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "ssm", "parameter{name}"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, name),
+					resource.TestCheckResourceAttr(resourceName, names.AttrValue, "test2"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrType, "String"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectIdentity(resourceName, map[string]knownvalue.Check{
+						names.AttrAccountID: tfknownvalue.AccountID(),
+						names.AttrRegion:    knownvalue.StringExact(acctest.Region()),
+						names.AttrName:      knownvalue.StringExact(nameWithoutSlash),
+					}),
+				},
+			},
+		},
+	})
+}
+
 func TestAccSSMParameter_Secure_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var param awstypes.Parameter

--- a/internal/service/ssm/parameter_test.go
+++ b/internal/service/ssm/parameter_test.go
@@ -969,7 +969,7 @@ func TestAccSSMParameter_Name_fullPath(t *testing.T) {
 	})
 }
 
-func TestAccSSMParameter_Name_leadingSlash(t *testing.T) {
+func TestAccSSMParameter_Name_singleNameWithLeadingSlash(t *testing.T) {
 	ctx := acctest.Context(t)
 	var param awstypes.Parameter
 	name := fmt.Sprintf("/%s_%s", t.Name(), acctest.RandString(t, 10))

--- a/internal/service/ssm/testdata/Parameter/leadingslash_basic/main_gen.tf
+++ b/internal/service/ssm/testdata/Parameter/leadingslash_basic/main_gen.tf
@@ -1,0 +1,14 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_ssm_parameter" "test" {
+  name  = "/${var.rName}"
+  type  = "String"
+  value = var.rName
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}

--- a/internal/service/ssm/testdata/Parameter/leadingslash_region_override/main_gen.tf
+++ b/internal/service/ssm/testdata/Parameter/leadingslash_region_override/main_gen.tf
@@ -1,0 +1,22 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_ssm_parameter" "test" {
+  region = var.region
+
+  name  = "/${var.rName}"
+  type  = "String"
+  value = var.rName
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "region" {
+  description = "Region to deploy resource in"
+  type        = string
+  nullable    = false
+}

--- a/internal/service/ssm/testdata/Parameter/leadingslash_v6.7.0/main_gen.tf
+++ b/internal/service/ssm/testdata/Parameter/leadingslash_v6.7.0/main_gen.tf
@@ -1,0 +1,24 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_ssm_parameter" "test" {
+  name  = "/${var.rName}"
+  type  = "String"
+  value = var.rName
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "6.7.0"
+    }
+  }
+}
+
+provider "aws" {}

--- a/internal/service/ssm/testdata/Parameter/path_basic/main_gen.tf
+++ b/internal/service/ssm/testdata/Parameter/path_basic/main_gen.tf
@@ -1,0 +1,14 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_ssm_parameter" "test" {
+  name  = "/path/${var.rName}"
+  type  = "String"
+  value = var.rName
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}

--- a/internal/service/ssm/testdata/Parameter/path_region_override/main_gen.tf
+++ b/internal/service/ssm/testdata/Parameter/path_region_override/main_gen.tf
@@ -1,0 +1,22 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_ssm_parameter" "test" {
+  region = var.region
+
+  name  = "/path/${var.rName}"
+  type  = "String"
+  value = var.rName
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "region" {
+  description = "Region to deploy resource in"
+  type        = string
+  nullable    = false
+}

--- a/internal/service/ssm/testdata/Parameter/path_v6.7.0/main_gen.tf
+++ b/internal/service/ssm/testdata/Parameter/path_v6.7.0/main_gen.tf
@@ -1,0 +1,24 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_ssm_parameter" "test" {
+  name  = "/path/${var.rName}"
+  type  = "String"
+  value = var.rName
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "6.7.0"
+    }
+  }
+}
+
+provider "aws" {}

--- a/internal/service/ssm/testdata/tmpl/parameter_leadingslash.gtpl
+++ b/internal/service/ssm/testdata/tmpl/parameter_leadingslash.gtpl
@@ -1,0 +1,8 @@
+resource "aws_ssm_parameter" "test" {
+{{- template "region" }}
+  name  = "/${var.rName}"
+  type  = "String"
+  value = var.rName
+
+{{- template "tags" . }}
+}

--- a/internal/service/ssm/testdata/tmpl/parameter_path.gtpl
+++ b/internal/service/ssm/testdata/tmpl/parameter_path.gtpl
@@ -1,0 +1,8 @@
+resource "aws_ssm_parameter" "test" {
+{{- template "region" }}
+  name  = "/path/${var.rName}"
+  type  = "String"
+  value = var.rName
+
+{{- template "tags" . }}
+}


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

The PR #49098 updated the resource type `aws_ssm_parameter` to read `name` and several other fields from `types.ParameterMetadata` (returned by `DescribeParameters`) instead of `types.Parameter` (returned by `GetParameter`). However, if the name contains only a leading slash and no other slashes, the `Name` on `types.ParameterMetadata` strips the leading slash. The `Name` on `types.Parameter` always preserves the leading slash.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #49304.
Closes https://github.com/hashicorp/terraform-provider-aws/pull/49325.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=ssm TESTS=TestAccSSMParameter_

--- PASS: TestAccSSMParameter_multiple (81.28s)
--- PASS: TestAccSSMParameter_ImportByARN_fullPath (103.99s)
--- PASS: TestAccSSMParameter_ImportByARN_name (104.05s)
--- PASS: TestAccSSMParameter_Overwrite_removeAttribute (112.39s)
--- PASS: TestAccSSMParameter_Overwrite_tags (112.54s)
--- PASS: TestAccSSMParameter_Overwrite_noOverwriteTags (112.77s)
--- PASS: TestAccSSMParameter_DataType_ec2Image (113.03s)
--- PASS: TestAccSSMParameter_Secure_key (122.68s)
--- PASS: TestAccSSMParameter_Tags_DefaultTags_nullNonOverlappingResourceTag (130.40s)
--- PASS: TestAccSSMParameter_basic (139.82s)
--- PASS: TestAccSSMParameter_Tier_intelligentTieringOnUpdate (157.81s)
--- PASS: TestAccSSMParameter_Overwrite_updateDescription (216.31s)
--- PASS: TestAccSSMParameter_Identity_basic (217.75s)
--- PASS: TestAccSSMParameter_Overwrite_updateToTags (218.04s)
--- PASS: TestAccSSMParameter_DataType_update (218.55s)
--- PASS: TestAccSSMParameter_Secure_keyUpdate (219.96s)
--- PASS: TestAccSSMParameter_updateValue (251.23s)
--- PASS: TestAccSSMParameter_DataType_ssmIntegration (170.14s)
--- PASS: TestAccSSMParameter_List_IncludeResource_writeOnly (158.67s)
--- PASS: TestAccSSMParameter_Tags_IgnoreTags_Overlap_defaultTag (324.97s)
--- PASS: TestAccSSMParameter_Secure_basic (123.24s)
--- PASS: TestAccSSMParameter_Name_leadingSlash (126.70s)
--- PASS: TestAccSSMParameter_Tags_emptyMap (226.84s)
--- PASS: TestAccSSMParameter_Tags_ComputedTag_OnUpdate_replace (260.84s)
--- PASS: TestAccSSMParameter_Tags_ComputedTag_OnUpdate_add (261.04s)
--- PASS: TestAccSSMParameter_Tags_IgnoreTags_Overlap_resourceTag (365.45s)
--- PASS: TestAccSSMParameter_Tags_ComputedTag_onCreate (145.89s)
--- PASS: TestAccSSMParameter_disappears (101.24s)
--- PASS: TestAccSSMParameter_Tags_null (239.62s)
--- PASS: TestAccSSMParameter_Tags_EmptyTag_OnUpdate_replace (267.54s)
--- PASS: TestAccSSMParameter_Tags_addOnUpdate (279.80s)
--- PASS: TestAccSSMParameter_Tags_EmptyTag_onCreate (289.95s)
--- PASS: TestAccSSMParameter_Secure_insecure (202.36s)
--- PASS: TestAccSSMParameter_Secure_insecureChangeSecure (231.68s)
--- PASS: TestAccSSMParameter_Overwrite_cascade (224.05s)
--- PASS: TestAccSSMParameter_Tags_DefaultTags_nullOverlappingResourceTag (134.24s)
--- PASS: TestAccSSMParameter_Tags_DefaultTags_emptyProviderOnlyTag (133.67s)
--- PASS: TestAccSSMParameter_List_basic (107.94s)
--- PASS: TestAccSSMParameter_Tier_intelligentTieringOnCreation (129.69s)
--- PASS: TestAccSSMParameter_Tags_DefaultTags_emptyResourceTag (140.59s)
--- PASS: TestAccSSMParameter_Tags_EmptyTag_OnUpdate_add (389.68s)
--- PASS: TestAccSSMParameter_Overwrite_basic (259.89s)
--- PASS: TestAccSSMParameter_List_IncludeResource_basic (115.41s)
--- PASS: TestAccSSMParameter_List_IncludeResource_insecure (126.05s)
--- PASS: TestAccSSMParameter_Tags_DefaultTags_providerOnly (528.93s)
--- PASS: TestAccSSMParameter_List_regionOverride (109.59s)
--- PASS: TestAccSSMParameter_Tags_DefaultTags_updateToResourceOnly (210.35s)
--- PASS: TestAccSSMParameter_Identity_ExistingResource_basic (136.81s)
--- PASS: TestAccSSMParameter_Tags_DefaultTags_updateToProviderOnly (207.22s)
--- PASS: TestAccSSMParameter_Identity_ExistingResource_noRefreshNoChange (111.32s)
--- PASS: TestAccSSMParameter_tier (235.34s)
--- PASS: TestAccSSMParameter_Name_fullPath (89.87s)
--- PASS: TestAccSSMParameter_Tier_intelligentTieringToStandard (245.15s)
--- PASS: TestAccSSMParameter_writeOnly (123.01s)
--- PASS: TestAccSSMParameter_Tier_intelligentTieringToAdvanced (245.66s)
--- PASS: TestAccSSMParameter_Identity_regionOverride (135.40s)
--- PASS: TestAccSSMParameter_tags (463.84s)
--- PASS: TestAccSSMParameter_Name_changeForcesNew (119.24s)
--- PASS: TestAccSSMParameter_updateDescription (129.03s)
--- PASS: TestAccSSMParameter_updateType (108.66s)
--- PASS: TestAccSSMParameter_Tags_DefaultTags_overlapping (262.46s)
--- PASS: TestAccSSMParameter_changeValueToWriteOnly (140.13s)
--- PASS: TestAccSSMParameter_Tags_DefaultTags_nonOverlapping (168.49s)
```
