### PR TITLE
make: auto-detect PKG from T for the `t` target

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -52,9 +52,6 @@ TEST_COUNT                   ?= 1
 # We grep rather than `go test -list` to avoid compiling the whole tree, and
 # scope to the test's own directory so non-service tests (e.g. internal/conns)
 # work too.
-#
-# $(and ...) stands in for the `&&` Make conditionals lack: the guard is
-# non-empty only when PKG and K are undefined and T is defined.
 AUTODETECT_PKG := $(and $(filter undefined,$(origin PKG)),$(filter undefined,$(origin K)),$(filter-out undefined,$(origin T)))
 ifneq ($(AUTODETECT_PKG),)
   AUTO_DIRS := $(shell seg=$$(printf '%s' '$(T)' | cut -d/ -f1); grep -rHE '^func Test' --include='*_test.go' internal 2>/dev/null | awk -F: -v re="$$seg" '{ fn=$$2; sub("^func ","",fn); sub("[^A-Za-z0-9_].*","",fn); if (fn ~ re) { d=$$1; sub("/[^/]*$$","",d); print d } }' | sort -u)

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -41,6 +41,51 @@ TEST_COUNT                   ?= 1
 #   make quick-fix PKG=ses     # Fix code in SES service
 #   make quick-fix K=lambda    # Same as above, but shorter (both work)
 #   make t T=TestAccRole PKG=iam  # Run specific test in IAM service
+#   make t T=TestAccRole          # Same: PKG=iam is auto-detected from the test name
+
+# Auto-discover the package containing a test when neither PKG nor K is
+# provided. This lets `make t T=TestAccExampleThing_basic` work without having
+# to remember and type the (increasingly long) AWS service name.
+#
+# T may be a regular expression (e.g. 'TestAccFooSenderID_(basic|disappears)'),
+# so we emulate `go test -run` matching rather than a literal lookup, but do it
+# cheaply WITHOUT compiling anything (`go test -list` would compile the whole
+# tree, defeating the purpose): read only `_test.go` files under internal/,
+# take the first `/`-separated segment of T (subtest names never appear in func
+# names), and match it, unanchored, against test function names the way
+# `go test` does. The test's own directory is used as the scope, so tests
+# outside internal/service (e.g. internal/conns) resolve correctly too.
+#
+# Scoped to T only (not the legacy TESTS alias) so existing TESTS-based
+# workflows are unaffected. Only runs when T is given and no package was
+# specified, so it adds no overhead to package-scoped or non-test targets.
+# Guard: non-empty only when PKG is undefined AND K is undefined AND T is
+# defined. Make's ifeq/ifneq have no `&&`, but the $(and ...) function does the
+# job, letting us use one conditional instead of three nested ones.
+AUTODETECT_PKG := $(and $(filter undefined,$(origin PKG)),$(filter undefined,$(origin K)),$(filter-out undefined,$(origin T)))
+ifneq ($(AUTODETECT_PKG),)
+  AUTO_DIRS := $(shell seg=$$(printf '%s' '$(T)' | cut -d/ -f1); grep -rHE '^func Test' --include='*_test.go' internal 2>/dev/null | awk -F: -v re="$$seg" '{ fn=$$2; sub("^func ","",fn); sub("[^A-Za-z0-9_].*","",fn); if (fn ~ re) { d=$$1; sub("/[^/]*$$","",d); print d } }' | sort -u)
+  ifeq ($(words $(AUTO_DIRS)),0)
+    $(error make: no test matching T='$(T)' found under internal/ (check the test name/regex). Scope it yourself with PKG=<service> or K=<service>, or use TESTS instead of T to skip autodetection)
+  else
+    AUTO_DIR := $(firstword $(AUTO_DIRS))
+    ifneq ($(words $(AUTO_DIRS)),1)
+      $(warning make: T='$(T)' matches tests in multiple packages ($(AUTO_DIRS)); using $(AUTO_DIR). Set PKG=<service> to choose another, or use TESTS to skip autodetection)
+    endif
+    AUTO_SVC := $(patsubst internal/service/%,%,$(AUTO_DIR))
+    ifeq ($(AUTO_SVC),$(AUTO_DIR))
+      # Not a service package (e.g. internal/conns): scope directly to the directory.
+      PKG_NAME := $(AUTO_DIR)
+      SVC_DIR := ./$(AUTO_DIR)
+      TEST := ./$(AUTO_DIR)/...
+      $(info make: auto-detected package $(AUTO_DIR) from T=$(T))
+    else
+      # Service package: set PKG and let the consolidation below derive the rest.
+      PKG := $(AUTO_SVC)
+      $(info make: auto-detected PKG=$(AUTO_SVC) from T=$(T))
+    endif
+  endif
+endif
 
 # Variable consolidation for backward compatibility and user convenience:
 # - PKG and K both refer to service names (e.g., 'ses', 'lambda')

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -43,25 +43,18 @@ TEST_COUNT                   ?= 1
 #   make t T=TestAccRole PKG=iam  # Run specific test in IAM service
 #   make t T=TestAccRole          # Same: PKG=iam is auto-detected from the test name
 
-# Auto-discover the package containing a test when neither PKG nor K is
-# provided. This lets `make t T=TestAccExampleThing_basic` work without having
-# to remember and type the (increasingly long) AWS service name.
+# Auto-detect the package from the test name so `make t T=TestAccFoo_basic`
+# works without also typing PKG=<service>. Runs only when T is set and neither
+# PKG nor K is; the legacy TESTS variable is unaffected.
 #
-# T may be a regular expression (e.g. 'TestAccFooSenderID_(basic|disappears)'),
-# so we emulate `go test -run` matching rather than a literal lookup, but do it
-# cheaply WITHOUT compiling anything (`go test -list` would compile the whole
-# tree, defeating the purpose): read only `_test.go` files under internal/,
-# take the first `/`-separated segment of T (subtest names never appear in func
-# names), and match it, unanchored, against test function names the way
-# `go test` does. The test's own directory is used as the scope, so tests
-# outside internal/service (e.g. internal/conns) resolve correctly too.
+# T may be a regex, so we match test function names like `go test -run` does
+# (first `/`-segment, unanchored) by scanning _test.go files under internal/.
+# We grep rather than `go test -list` to avoid compiling the whole tree, and
+# scope to the test's own directory so non-service tests (e.g. internal/conns)
+# work too.
 #
-# Scoped to T only (not the legacy TESTS alias) so existing TESTS-based
-# workflows are unaffected. Only runs when T is given and no package was
-# specified, so it adds no overhead to package-scoped or non-test targets.
-# Guard: non-empty only when PKG is undefined AND K is undefined AND T is
-# defined. Make's ifeq/ifneq have no `&&`, but the $(and ...) function does the
-# job, letting us use one conditional instead of three nested ones.
+# $(and ...) stands in for the `&&` Make conditionals lack: the guard is
+# non-empty only when PKG and K are undefined and T is defined.
 AUTODETECT_PKG := $(and $(filter undefined,$(origin PKG)),$(filter undefined,$(origin K)),$(filter-out undefined,$(origin T)))
 ifneq ($(AUTODETECT_PKG),)
   AUTO_DIRS := $(shell seg=$$(printf '%s' '$(T)' | cut -d/ -f1); grep -rHE '^func Test' --include='*_test.go' internal 2>/dev/null | awk -F: -v re="$$seg" '{ fn=$$2; sub("^func ","",fn); sub("[^A-Za-z0-9_].*","",fn); if (fn ~ re) { d=$$1; sub("/[^/]*$$","",d); print d } }' | sort -u)

--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -36,7 +36,7 @@ Additionally, these tests provide rapid feedback to contributors, enabling them 
 The Makefile included with the Terraform AWS Provider allows you to run many of the CI tests locally before submitting your PR. The file is located in the provider's root directory and is called `GNUmakefile`. You should be able to use `make` with a variety of Linux-type shells that support `bash`, such as a macOS terminal.
 
 !!! tip
-    Most targets scope their work to a single service package via the `PKG` (or `K`) variable, such as `PKG=iam`. When running acceptance tests with the `t` target, you can skip this: set `T` to the test name and omit `PKG`/`K`, and the package containing the test is auto-detected. For example, `make t T=TestAccIAMRole_basic` is equivalent to `make t T=TestAccIAMRole_basic PKG=iam`, and tests outside `internal/service` (such as `make t T=TestAddIsErrorRetryables` in `internal/conns`) resolve too. If nothing matches, `make` stops with an error instead of running the whole codebase. The legacy `TESTS` variable does _not_ auto-detect the package. See the [Makefile Cheat Sheet](makefile-cheat-sheet.md) for details.
+    With the `t` target you can omit `PKG`/`K`: set `T` to the test name and the package is auto-detected, including non-service packages like `internal/conns`. So `make t T=TestAccIAMRole_basic` equals `make t T=TestAccIAMRole_basic PKG=iam`. No match stops with an error; the legacy `TESTS` variable does not auto-detect. See the [Makefile Cheat Sheet](makefile-cheat-sheet.md) for details.
 
 !!! note
     See the [Makefile Cheat Sheet](makefile-cheat-sheet.md) for detailed information about the Makefile.

--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -35,6 +35,9 @@ Additionally, these tests provide rapid feedback to contributors, enabling them 
 
 The Makefile included with the Terraform AWS Provider allows you to run many of the CI tests locally before submitting your PR. The file is located in the provider's root directory and is called `GNUmakefile`. You should be able to use `make` with a variety of Linux-type shells that support `bash`, such as a macOS terminal.
 
+!!! tip
+    Most targets scope their work to a single service package via the `PKG` (or `K`) variable, such as `PKG=iam`. When running acceptance tests with the `t` target, you can skip this: set `T` to the test name and omit `PKG`/`K`, and the package containing the test is auto-detected. For example, `make t T=TestAccIAMRole_basic` is equivalent to `make t T=TestAccIAMRole_basic PKG=iam`, and tests outside `internal/service` (such as `make t T=TestAddIsErrorRetryables` in `internal/conns`) resolve too. If nothing matches, `make` stops with an error instead of running the whole codebase. The legacy `TESTS` variable does _not_ auto-detect the package. See the [Makefile Cheat Sheet](makefile-cheat-sheet.md) for details.
+
 !!! note
     See the [Makefile Cheat Sheet](makefile-cheat-sheet.md) for detailed information about the Makefile.
 

--- a/docs/makefile-cheat-sheet.md
+++ b/docs/makefile-cheat-sheet.md
@@ -33,7 +33,7 @@ make testacc TESTS=TestAccIAMRole_basic PKG=iam
 ```
 
 !!! tip
-    The `t` target (a shorthand for acceptance testing) can auto-detect the package containing a test. When you use `T` and omit both `PKG` and `K`, the package is found by scanning `_test.go` files under `internal/`. For example, `make t T=TestAccIAMRole_basic` is equivalent to `make t T=TestAccIAMRole_basic PKG=iam`, but saves you from typing (and remembering) increasingly long service names. See the [`T`](#variables) variable for details.
+    The `t` target can auto-detect the package from the test name: with `T` set and both `PKG` and `K` omitted, `make t T=TestAccIAMRole_basic` scopes to `iam` automatically, so you needn't type long service names. See the [`T`](#variables) variable for details.
 
 ### Meta Targets and Dependent Targets
 
@@ -76,10 +76,10 @@ Variables are often defined before the `make` call on the same line, such as `MY
 * `SWEEP_TIMEOUT` - (Default: `360m`) Time Go will spend sweeping resources before panicking.
 * `SWEEPARGS` - (Default: _None_) Raw arguments that define what to sweep, including dependencies. Similar to `SWEEPERS`. For example, `SWEEPARGS=-sweep-run=aws_example_thing`.
 * `SWEEPERS` - (Default: _None_) Resources to sweep, including dependencies. Similar to `SWEEPARGS`. For example, `SWEEPERS=aws_example_thing`. Assigns a value to `SWEEPARGS` overridding any value set.
-* `T` - (Default: _None_) Names of tests to run; may be a regular expression, just like `go test -run`. Similar to `TESTS`, but with an extra convenience: when neither `PKG` nor `K` is set, the package containing the test is auto-detected by scanning `_test.go` files under `internal/` (no compilation) and matching test function names the same way `go test -run` does. This means `make t T=TestAccIAMRole_basic` scopes to the `iam` package automatically, without typing `PKG=iam`. Tests outside `internal/service` (for example `make t T=TestAddIsErrorRetryables`, which lives in `internal/conns`) resolve to their own directory. If the pattern matches tests in more than one package, the first is used and a warning lists the alternatives; set `PKG` explicitly to choose another. If no matching test is found, `make` stops with an error rather than running the entire codebase; specify `PKG`/`K` or use `TESTS` to skip autodetection. Assigns a value to `RUNARGS` overridding any value set.
+* `T` - (Default: _None_) Names of tests to run; may be a regular expression, like `go test -run`. When neither `PKG` nor `K` is set, the package is auto-detected from the test name (scanning `_test.go` files under `internal/`, including non-service packages), so `make t T=TestAccIAMRole_basic` scopes to `iam` automatically. Multiple matches use the first, with a warning; no match stops with an error. Set `PKG`/`K` or use `TESTS` to skip autodetection. Assigns a value to `RUNARGS` overridding any value set.
 * `TEST` - (Default: `./...`) Limit tests to this directory and dependencies. Overridden if `PKG` or `K` is set.
 * `TEST_COUNT` - (Default: `1`) Number of times to run each acceptance or unit test.
-* `TESTS` - (Default: _None_) Names of tests to run. Similar to `T`, but does _not_ auto-detect the service package; you must still set `PKG` or `K` to scope processing. Use `T` if you want package auto-detection. Assigns a value to `RUNARGS` overridding any value set.
+* `TESTS` - (Default: _None_) Names of tests to run. Like `T` but without package auto-detection; set `PKG` or `K` to scope. Assigns a value to `RUNARGS` overridding any value set.
 * `TESTARGS` - (Default: _None_) Raw arguments passed to Go when running tests. Unlike `RUNARGS`, this is _not_ overridden if `TESTS` or `T` is set.
 
 ## Cheat Sheet

--- a/docs/makefile-cheat-sheet.md
+++ b/docs/makefile-cheat-sheet.md
@@ -32,6 +32,15 @@ For example, `testacc` is a phony target to simplify the command for running acc
 make testacc TESTS=TestAccIAMRole_basic PKG=iam
 ```
 
+!!! tip
+    The `t` target (a shorthand for acceptance testing) can auto-detect the package containing a test. When you use `T` and omit both `PKG` and `K`, the package is found by scanning `_test.go` files under `internal/` for the test:
+
+    ```console
+    make t T=TestAccIAMRole_basic
+    ```
+
+    This is equivalent to `make t T=TestAccIAMRole_basic PKG=iam`, but saves you from typing (and remembering) increasingly long service names. See the [`T`](#variables) variable for details.
+
 ### Meta Targets and Dependent Targets
 
 _Meta_ targets are `make` targets that only run other targets. They aggregate the functionality of other targets for convenience. In the [Cheat Sheet](#cheat-sheet), meta targets are marked with <sup>M</sup>.
@@ -60,8 +69,8 @@ Variables are often defined before the `make` call on the same line, such as `MY
 * `GO_VER` - (Default: Value in `.go-version` file) Version of Go to use. To use the default version on your system, use `GO_VER=go`.
 * `K` - (Default: _None_) Name of the service package you want to use, such as `ec2`, `iam`, or `lambda`, limiting Go processing to that package and dependencies. Equivalent to `PKG` variable. Assigns values to `PKG_NAME`, `SVC_DIR`, and `TEST` overridding any values set.
 * `P` - (Default: `20`) Number of concurrent acceptance tests to run. Assigns a value to `ACCTEST_PARALLELISM` overridding any value set.
-* `PKG` - (Default: _None_) Name of the service package you want to use, such as `ec2`, `iam`, or `lambda`, limiting Go processing to that package and dependencies. Equivalent to `K` variable. Assigns values to `PKG_NAME`, `SVC_DIR`, and `TEST` overridding any values set.
-* `PKG_NAME` - (Default: `internal`) Subdirectory (Go package) to use as the basis for Go processing. Overridden if `PKG` or `K` is set.
+* `PKG` - (Default: _None_) Name of the service package you want to use, such as `ec2`, `iam`, or `lambda`, limiting Go processing to that package and dependencies. Equivalent to `K` variable. Assigns values to `PKG_NAME`, `SVC_DIR`, and `TEST` overridding any values set. When neither `PKG` nor `K` is set, `PKG` is auto-detected from `T` (see the `T` variable).
+* `PKG_NAME` - (Default: `internal`) Subdirectory (Go package) to use as the basis for Go processing. Overridden if `PKG` or `K` is set, including when `PKG` is auto-detected from `T`.
 * `RUNARGS` - (Default: _None_) Raw arguments passed to Go when running acceptance tests. For example, `RUNARGS=-run=TestMyTest`. Overridden if `TESTS` or `T` is set.
 * `SEMGREP_ARGS` - (Default: `--error`) Semgrep arguments. See the [Semgrep reference](https://semgrep.dev/docs/cli-reference#semgrep-scan-command-options).
 * `SEMGREP_ENABLE_VERSION_CHECK` - (Default: `false`) Whether to check Semgrep servers to verify you are running the latest Semgrep version.
@@ -73,10 +82,10 @@ Variables are often defined before the `make` call on the same line, such as `MY
 * `SWEEP_TIMEOUT` - (Default: `360m`) Time Go will spend sweeping resources before panicking.
 * `SWEEPARGS` - (Default: _None_) Raw arguments that define what to sweep, including dependencies. Similar to `SWEEPERS`. For example, `SWEEPARGS=-sweep-run=aws_example_thing`.
 * `SWEEPERS` - (Default: _None_) Resources to sweep, including dependencies. Similar to `SWEEPARGS`. For example, `SWEEPERS=aws_example_thing`. Assigns a value to `SWEEPARGS` overridding any value set.
-* `T` - (Default: _None_) Names of tests to run. Equivalent to `TESTS`. Assigns a value to `RUNARGS` overridding any value set.
+* `T` - (Default: _None_) Names of tests to run; may be a regular expression, just like `go test -run`. Similar to `TESTS`, but with an extra convenience: when neither `PKG` nor `K` is set, the package containing the test is auto-detected by scanning `_test.go` files under `internal/` (no compilation) and matching test function names the same way `go test -run` does. This means `make t T=TestAccIAMRole_basic` scopes to the `iam` package automatically, without typing `PKG=iam`. Tests outside `internal/service` (for example `make t T=TestAddIsErrorRetryables`, which lives in `internal/conns`) resolve to their own directory. If the pattern matches tests in more than one package, the first is used and a warning lists the alternatives; set `PKG` explicitly to choose another. If no matching test is found, `make` stops with an error rather than running the entire codebase; specify `PKG`/`K` or use `TESTS` to skip autodetection. Assigns a value to `RUNARGS` overridding any value set.
 * `TEST` - (Default: `./...`) Limit tests to this directory and dependencies. Overridden if `PKG` or `K` is set.
 * `TEST_COUNT` - (Default: `1`) Number of times to run each acceptance or unit test.
-* `TESTS` - (Default: _None_) Names of tests to run. Equivalent to `T`. Assigns a value to `RUNARGS` overridding any value set.
+* `TESTS` - (Default: _None_) Names of tests to run. Similar to `T`, but does _not_ auto-detect the service package; you must still set `PKG` or `K` to scope processing. Use `T` if you want package auto-detection. Assigns a value to `RUNARGS` overridding any value set.
 * `TESTARGS` - (Default: _None_) Raw arguments passed to Go when running tests. Unlike `RUNARGS`, this is _not_ overridden if `TESTS` or `T` is set.
 
 ## Cheat Sheet

--- a/docs/makefile-cheat-sheet.md
+++ b/docs/makefile-cheat-sheet.md
@@ -33,13 +33,7 @@ make testacc TESTS=TestAccIAMRole_basic PKG=iam
 ```
 
 !!! tip
-    The `t` target (a shorthand for acceptance testing) can auto-detect the package containing a test. When you use `T` and omit both `PKG` and `K`, the package is found by scanning `_test.go` files under `internal/` for the test:
-
-    ```console
-    make t T=TestAccIAMRole_basic
-    ```
-
-    This is equivalent to `make t T=TestAccIAMRole_basic PKG=iam`, but saves you from typing (and remembering) increasingly long service names. See the [`T`](#variables) variable for details.
+    The `t` target (a shorthand for acceptance testing) can auto-detect the package containing a test. When you use `T` and omit both `PKG` and `K`, the package is found by scanning `_test.go` files under `internal/`. For example, `make t T=TestAccIAMRole_basic` is equivalent to `make t T=TestAccIAMRole_basic PKG=iam`, but saves you from typing (and remembering) increasingly long service names. See the [`T`](#variables) variable for details.
 
 ### Meta Targets and Dependent Targets
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Running `make t T=TestAccSomeTest` previously required also passing `PKG=<service>` to scope the run; without it, `make t` defaulted to `./internal/...` and effectively ran the whole tree. With AWS service names growing ever longer (_e.g._, `route53recoverycontrolconfig`), typing (and remembering) `PKG=` became a recurring papercut.

Now, when `T` is set but neither `PKG` nor `K` is given, the package is auto-detected and the run is scoped to it. 

Details:

- Emulates `go test -run` matching without compiling anything: only `_test.go` files under `internal/` are scanned. Using `go test -list` would compile the whole tree, defeating the purpose (~1s vs minutes).
- Handles `T` as a regular expression (e.g. `TestAccFoo_(basic|disappears)`): takes the first `/`-separated segment (subtest names never appear in func names) and matches test function names unanchored, the way `go test` does.
- Scopes to the test's own directory, so non-service tests resolve too (e.g. `T=TestAddIsErrorRetryables` -> `internal/conns`).
- If nothing matches, `make` stops with a helpful error instead of running the entire codebase.
- If the pattern spans multiple packages, the first is used with a warning listing the alternatives.

Scoped to `T` only; the legacy `TESTS` variable is unchanged and still requires `PKG`/`K`, so existing workflows are unaffected.

Docs updated in the Makefile cheat sheet and continuous integration guide.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
