### PR TITLE
docs/r/efs_file_system: note that AWS recommends elastic throughput mode

### DIFF
--- a/website/docs/r/efs_file_system.html.markdown
+++ b/website/docs/r/efs_file_system.html.markdown
@@ -53,7 +53,7 @@ user guide for more information.
 * `performance_mode` - (Optional) The file system performance mode. Can be either `"generalPurpose"` or `"maxIO"` (Default: `"generalPurpose"`).
 * `provisioned_throughput_in_mibps` - (Optional) The throughput, measured in MiB/s, that you want to provision for the file system. Only applicable with `throughput_mode` set to `provisioned`.
 * `tags` - (Optional) A map of tags to assign to the file system. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
-* `throughput_mode` - (Optional) Throughput mode for the file system. Defaults to `bursting`. Valid values: `bursting`, `provisioned`, or `elastic`. When using `provisioned`, also set `provisioned_throughput_in_mibps`.
+* `throughput_mode` - (Optional) Throughput mode for the file system. Defaults to `bursting`, matching the [`CreateFileSystem`](https://docs.aws.amazon.com/efs/latest/ug/API_CreateFileSystem.html) API default. Note that AWS [recommends `elastic` for most use cases](https://docs.aws.amazon.com/efs/latest/ug/managing-throughput.html), and `elastic` is the default in the Amazon EFS console. Valid values: `bursting`, `provisioned`, or `elastic`. When using `provisioned`, also set `provisioned_throughput_in_mibps`.
 
 ### `lifecycle_policy` Block
 


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

There are no changes to security controls in this pull request. It is a documentation-only change.

### Description

Adds a note to the `throughput_mode` argument reference for `aws_efs_file_system` pointing out that AWS recommends `elastic` for most use cases.

The provider default of `bursting` is correct and this PR does not change it — it mirrors the `CreateFileSystem` API default (`Default is bursting.`). However, that default differs from the Amazon EFS console default, which is `elastic`, and AWS documentation labels Elastic throughput as "(Recommended)". The current wording states the default without that context, so users who omit the argument silently end up on the non-recommended mode.

The consequence is easy to miss: with Bursting, baseline throughput is proportionate to the data stored in the Standard storage class at 50 KiBps per GiB (with a 1 MiBps floor), so a file system that is still being populated has the least throughput available.

Before:

> `throughput_mode` - (Optional) Throughput mode for the file system. Defaults to `bursting`. Valid values: `bursting`, `provisioned`, or `elastic`. When using `provisioned`, also set `provisioned_throughput_in_mibps`.

After:

> `throughput_mode` - (Optional) Throughput mode for the file system. Defaults to `bursting`, matching the [`CreateFileSystem`](https://docs.aws.amazon.com/efs/latest/ug/API_CreateFileSystem.html) API default. Note that AWS [recommends `elastic` for most use cases](https://docs.aws.amazon.com/efs/latest/ug/managing-throughput.html), and `elastic` is the default in the Amazon EFS console. Valid values: `bursting`, `provisioned`, or `elastic`. When using `provisioned`, also set `provisioned_throughput_in_mibps`.

Per [`.changelog/README.md`](https://github.com/hashicorp/terraform-provider-aws/blob/main/.changelog/README.md), no changelog entry is needed for documentation-only changes.

### Relations

Closes #49369

### References

- [Managing file system throughput](https://docs.aws.amazon.com/efs/latest/ug/managing-throughput.html) — *Elastic throughput is the default throughput mode in the Amazon EFS console and is recommended for most use cases.*
- [Throughput modes](https://docs.aws.amazon.com/efs/latest/ug/performance.html#throughput-modes) — "**Elastic throughput** (Recommended)", and the Bursting baseline of 50 KiBps per GiB
- [CreateFileSystem API Reference](https://docs.aws.amazon.com/efs/latest/ug/API_CreateFileSystem.html) — `ThroughputMode` ... `Default is bursting.`

### Output from Acceptance Testing

This is a documentation-only change, so no acceptance tests were run.
