### PR TITLE
r/aws_rds_cluster_instance: patch disabling Performance Insights

### DIFF
--- a/.changelog/49376.txt
+++ b/.changelog/49376.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_rds_cluster_instance: Omit `performance_insights_kms_key_id` and `performance_insights_retention_period` from the update request when `performance_insights_enabled` is `false`, fixing `InvalidParameterCombination: You can't set a Performance Insights retention period without enabling Performance Insights` when disabling Performance Insights
+```

--- a/internal/service/rds/cluster_instance.go
+++ b/internal/service/rds/cluster_instance.go
@@ -484,14 +484,20 @@ func resourceClusterInstanceUpdate(ctx context.Context, d *schema.ResourceData, 
 		}
 
 		if d.HasChanges("performance_insights_enabled", "performance_insights_kms_key_id", "performance_insights_retention_period") {
-			input.EnablePerformanceInsights = aws.Bool(d.Get("performance_insights_enabled").(bool))
+			enabled := d.Get("performance_insights_enabled").(bool)
+			input.EnablePerformanceInsights = aws.Bool(enabled)
 
-			if v, ok := d.GetOk("performance_insights_kms_key_id"); ok {
-				input.PerformanceInsightsKMSKeyId = aws.String(v.(string))
-			}
+			// The API rejects the Performance Insights KMS key and retention period unless
+			// Performance Insights is enabled. Both are Computed, so they retain their prior
+			// values when Performance Insights is disabled and must be omitted here.
+			if enabled {
+				if v, ok := d.GetOk("performance_insights_kms_key_id"); ok {
+					input.PerformanceInsightsKMSKeyId = aws.String(v.(string))
+				}
 
-			if v, ok := d.GetOk("performance_insights_retention_period"); ok {
-				input.PerformanceInsightsRetentionPeriod = aws.Int32(int32(v.(int)))
+				if v, ok := d.GetOk("performance_insights_retention_period"); ok {
+					input.PerformanceInsightsRetentionPeriod = aws.Int32(int32(v.(int)))
+				}
 			}
 		}
 

--- a/internal/service/rds/cluster_instance_test.go
+++ b/internal/service/rds/cluster_instance_test.go
@@ -892,6 +892,14 @@ func TestAccRDSClusterInstance_performanceInsightsRetentionPeriod(t *testing.T) 
 					resource.TestCheckResourceAttr(resourceName, "performance_insights_retention_period", "155"),
 				),
 			},
+			{
+				Config: testAccClusterInstanceConfig_performanceInsightsDisabled(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClusterInstanceExists(ctx, t, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "performance_insights_enabled", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, "performance_insights_retention_period", "0"),
+				),
+			},
 		},
 	})
 }
@@ -1801,4 +1809,28 @@ resource "aws_rds_cluster_instance" "test" {
   performance_insights_retention_period = %[2]d
 }
 `, rName, performanceInsightsRetentionPeriod))
+}
+
+func testAccClusterInstanceConfig_performanceInsightsDisabled(rName string) string {
+	return acctest.ConfigCompose(
+		testAccClusterInstanceConfig_orderableEngineBase("aurora-mysql", true),
+		fmt.Sprintf(`
+resource "aws_rds_cluster" "test" {
+  cluster_identifier  = %[1]q
+  database_name       = "mydb"
+  engine              = data.aws_rds_engine_version.default.engine
+  engine_version      = data.aws_rds_engine_version.default.version
+  master_password     = "mustbeeightcharacters"
+  master_username     = "foo"
+  skip_final_snapshot = true
+}
+
+resource "aws_rds_cluster_instance" "test" {
+  cluster_identifier           = aws_rds_cluster.test.id
+  engine                       = aws_rds_cluster.test.engine
+  identifier                   = %[1]q
+  instance_class               = data.aws_rds_orderable_db_instance.test.instance_class
+  performance_insights_enabled = false
+}
+`, rName))
 }


### PR DESCRIPTION
<!--
Final PR body, narrowed to the one reproduced defect.
Title: r/aws_rds_cluster_instance: Don't send Performance Insights settings when disabling Performance Insights
Before submitting: rename .changelog/00000.txt to the PR number.
-->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No. The Performance Insights KMS key is still sent whenever Performance Insights is enabled; it is only omitted when Performance Insights is being turned off, where the API rejects it.

### Description

Disabling Performance Insights on an existing cluster instance currently fails:

```
Error: updating RDS Cluster Instance: operation error RDS: ModifyDBInstance, https response error StatusCode: 400, api error InvalidParameterCombination: You can't set a Performance Insights retention period without enabling Performance Insights.
```

`resourceClusterInstanceUpdate` enters its Performance Insights block whenever any of the three attributes changes, and then adds `PerformanceInsightsKMSKeyId` / `PerformanceInsightsRetentionPeriod` from `GetOk` regardless of whether Performance Insights is being enabled or disabled. Because both attributes are `Optional + Computed`, they keep their prior state values when the configuration sets them to `null`, so a `true -> false` change on `performance_insights_enabled` still carries a retention period into `ModifyDBInstance`, and the API rejects the combination.

Users cannot work around this in configuration: `null` is ignored for a `Computed` attribute, and `0` fails the schema `ValidateFunc` (`7`, `731`, or a multiple of `31`). The only way out today is to disable Performance Insights out of band and refresh, after which AWS reports a retention period of `0` and the provider stops sending it.

This PR sends the two sub-attributes only when Performance Insights is enabled. `aws_rds_cluster`'s ordinary update path already guards each attribute with its own `d.HasChange` ([cluster.go](https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/rds/cluster.go)), so a disable-only change sends `EnablePerformanceInsights=false` alone; this change brings `aws_rds_cluster_instance` in line with it.

#### Scope

This PR changes `resourceClusterInstanceUpdate` only.

`dbInstancePopulateModify` in `instance.go` has the same shape and also sends the retained retention period, but disabling Performance Insights on a real `aws_db_instance` succeeds on current `main`, so it is left unchanged.

The `database_insights_mode` blocks in `instance.go` and `cluster.go` likewise send the retention period unconditionally. Moving `advanced` -> `standard` while Performance Insights is disabled is covered by `TestAccRDSInstance_PerformanceInsights_databaseInsightsMode` and `TestAccRDSCluster_databaseInsightsMode_defaultKMSKey_create`, so those are left unchanged too.

### Relations

Closes #49348

### References

* #9745 — the same fix previously applied to `performance_insights_kms_key_id` on `aws_db_instance`.
* #42539 — retention period must still be sent when `database_insights_mode` moves to `advanced`. `advanced` requires Performance Insights to be enabled, so the new guard is always open in that direction.
* [ModifyDBInstance API reference](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_ModifyDBInstance.html)

### Output from Acceptance Testing

The failure was reproduced against a real Aurora PostgreSQL cluster as described in #49348. `TestAccRDSClusterInstance_performanceInsightsRetentionPeriod` gains a final step that disables Performance Insights, which is expected to fail on `main` with the `InvalidParameterCombination` error above and to pass with this change. `go build`, `go vet`, `terrafmt` and `golangci-lint` are clean for the changed files.

<!--
Paste the real run below before submitting, then change "is expected to fail ... and to pass"
above to "fails ... and passes".
-->

```console
% make testacc PKG=rds TESTS='TestAccRDSClusterInstance_performanceInsights'

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework (cached)
make: Running acceptance tests on branch: 🌿 b-rds-performance-insights-disable 🌿...
TF_ACC=1 go1.26.5 test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccRDSClusterInstance_performanceInsights'  -timeout 360m -vet=off -buildvcs=false
2026/08/10 16:19:54 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/10 16:19:54 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccRDSClusterInstance_performanceInsightsRetentionPeriod
=== PAUSE TestAccRDSClusterInstance_performanceInsightsRetentionPeriod
=== CONT  TestAccRDSClusterInstance_performanceInsightsRetentionPeriod
--- PASS: TestAccRDSClusterInstance_performanceInsightsRetentionPeriod (1075.87s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/rds        1082.912s
```
