### PR TITLE
fix(bedrockagentcore): remove provider-level validations on header count

### DIFF
--- a/.changelog/49374.txt
+++ b/.changelog/49374.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_bedrockagentcore_gateway_target: Remove client-side count validation for `metadata_configuration` request and response headers
+```

--- a/internal/service/bedrockagentcore/gateway_target.go
+++ b/internal/service/bedrockagentcore/gateway_target.go
@@ -542,7 +542,6 @@ func (r *gatewayTargetResource) Schema(ctx context.Context, request resource.Sch
 							Optional:    true,
 							Description: "A list of HTTP headers that are allowed to be propagated from incoming client requests to the target.",
 							Validators: []validator.Set{
-								setvalidator.SizeAtMost(10),
 								setvalidator.ValueStringsAre(headerNameValidators()...),
 							},
 						},
@@ -551,7 +550,6 @@ func (r *gatewayTargetResource) Schema(ctx context.Context, request resource.Sch
 							Optional:    true,
 							Description: "A list of HTTP headers that are allowed to be propagated from the target response back to the client.",
 							Validators: []validator.Set{
-								setvalidator.SizeAtMost(10),
 								setvalidator.ValueStringsAre(headerNameValidators()...),
 							},
 						},


### PR DESCRIPTION
## Description

Removes provider-side count validation for `metadata_configuration.allowed_request_headers` and`metadata_configuration.allowed_response_headers` on `aws_bedrockagentcore_gateway_target`.

AgentCore Gateway validates header counts service-side. Maintaining duplicate limits in the provider can reject otherwise valid configurations when service limits or behavior change. This change delegates request and response header count validation to the service.

Relates #49374. This change comes as a direct request of the service team following issue and findings regarding mentioned issue ticket. This change addresses validation concerns listed; does not fully resolve ticket. 

## Testing
No test changes made as this change only relaxes provider-side validations. The existing metadata configuration acceptance test continues to cover creating and updating request and response header configuration.
