### PR TITLE
resource/aws_wafv2_web_acl, resource/aws_wafv2_rule_group: add pre_parse_text_transformation to rule match statements

### DIFF
--- a/.changelog/49381.txt
+++ b/.changelog/49381.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_wafv2_web_acl: Add `pre_parse_text_transformation` argument to `byte_match_statement`, `regex_match_statement`, `regex_pattern_set_reference_statement`, `size_constraint_statement`, `sqli_match_statement`, and `xss_match_statement` rule statements
+```
+
+```release-note:enhancement
+resource/aws_wafv2_rule_group: Add `pre_parse_text_transformation` argument to `byte_match_statement`, `regex_match_statement`, `regex_pattern_set_reference_statement`, `size_constraint_statement`, `sqli_match_statement`, and `xss_match_statement` rule statements
+```

--- a/internal/service/wafv2/attr_names.go
+++ b/internal/service/wafv2/attr_names.go
@@ -5,5 +5,6 @@ package wafv2
 
 // Schema attribute name constants used across package
 const (
-	attrTextTransformation = "text_transformation"
+	attrPreParseTextTransformation = "pre_parse_text_transformation"
+	attrTextTransformation         = "text_transformation"
 )

--- a/internal/service/wafv2/flex.go
+++ b/internal/service/wafv2/flex.go
@@ -553,10 +553,11 @@ func expandByteMatchStatement(l []any) *awstypes.ByteMatchStatement {
 	m := l[0].(map[string]any)
 
 	return &awstypes.ByteMatchStatement{
-		FieldToMatch:         expandFieldToMatch(m["field_to_match"].([]any)),
-		PositionalConstraint: awstypes.PositionalConstraint(m["positional_constraint"].(string)),
-		SearchString:         []byte(m["search_string"].(string)),
-		TextTransformations:  expandTextTransformations(m[attrTextTransformation].(*schema.Set).List()),
+		FieldToMatch:                expandFieldToMatch(m["field_to_match"].([]any)),
+		PositionalConstraint:        awstypes.PositionalConstraint(m["positional_constraint"].(string)),
+		PreParseTextTransformations: expandPreParseTextTransformations(m[attrPreParseTextTransformation].(*schema.Set).List()),
+		SearchString:                []byte(m["search_string"].(string)),
+		TextTransformations:         expandTextTransformations(m[attrTextTransformation].(*schema.Set).List()),
 	}
 }
 
@@ -818,6 +819,30 @@ func expandURIFragment(tfList []any) *awstypes.UriFragment {
 	return apiObject
 }
 
+func expandPreParseTextTransformations(l []any) []awstypes.PreParseTextTransformation {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	rules := make([]awstypes.PreParseTextTransformation, 0)
+
+	for _, rule := range l {
+		if rule == nil {
+			continue
+		}
+		rules = append(rules, expandPreParseTextTransformation(rule.(map[string]any)))
+	}
+
+	return rules
+}
+
+func expandPreParseTextTransformation(m map[string]any) awstypes.PreParseTextTransformation {
+	return awstypes.PreParseTextTransformation{
+		Priority: int32(m[names.AttrPriority].(int)),
+		Type:     awstypes.PreParseTextTransformationType(m[names.AttrType].(string)),
+	}
+}
+
 func expandTextTransformations(l []any) []awstypes.TextTransformation {
 	if len(l) == 0 || l[0] == nil {
 		return nil
@@ -932,9 +957,10 @@ func expandRegexMatchStatement(l []any) *awstypes.RegexMatchStatement {
 	m := l[0].(map[string]any)
 
 	return &awstypes.RegexMatchStatement{
-		RegexString:         aws.String(m["regex_string"].(string)),
-		FieldToMatch:        expandFieldToMatch(m["field_to_match"].([]any)),
-		TextTransformations: expandTextTransformations(m[attrTextTransformation].(*schema.Set).List()),
+		RegexString:                 aws.String(m["regex_string"].(string)),
+		FieldToMatch:                expandFieldToMatch(m["field_to_match"].([]any)),
+		PreParseTextTransformations: expandPreParseTextTransformations(m[attrPreParseTextTransformation].(*schema.Set).List()),
+		TextTransformations:         expandTextTransformations(m[attrTextTransformation].(*schema.Set).List()),
 	}
 }
 
@@ -946,9 +972,10 @@ func expandRegexPatternSetReferenceStatement(l []any) *awstypes.RegexPatternSetR
 	m := l[0].(map[string]any)
 
 	return &awstypes.RegexPatternSetReferenceStatement{
-		ARN:                 aws.String(m[names.AttrARN].(string)),
-		FieldToMatch:        expandFieldToMatch(m["field_to_match"].([]any)),
-		TextTransformations: expandTextTransformations(m[attrTextTransformation].(*schema.Set).List()),
+		ARN:                         aws.String(m[names.AttrARN].(string)),
+		FieldToMatch:                expandFieldToMatch(m["field_to_match"].([]any)),
+		PreParseTextTransformations: expandPreParseTextTransformations(m[attrPreParseTextTransformation].(*schema.Set).List()),
+		TextTransformations:         expandTextTransformations(m[attrTextTransformation].(*schema.Set).List()),
 	}
 }
 
@@ -960,10 +987,11 @@ func expandSizeConstraintStatement(l []any) *awstypes.SizeConstraintStatement {
 	m := l[0].(map[string]any)
 
 	return &awstypes.SizeConstraintStatement{
-		ComparisonOperator:  awstypes.ComparisonOperator(m["comparison_operator"].(string)),
-		FieldToMatch:        expandFieldToMatch(m["field_to_match"].([]any)),
-		Size:                int64(m[names.AttrSize].(int)),
-		TextTransformations: expandTextTransformations(m[attrTextTransformation].(*schema.Set).List()),
+		ComparisonOperator:          awstypes.ComparisonOperator(m["comparison_operator"].(string)),
+		FieldToMatch:                expandFieldToMatch(m["field_to_match"].([]any)),
+		PreParseTextTransformations: expandPreParseTextTransformations(m[attrPreParseTextTransformation].(*schema.Set).List()),
+		Size:                        int64(m[names.AttrSize].(int)),
+		TextTransformations:         expandTextTransformations(m[attrTextTransformation].(*schema.Set).List()),
 	}
 }
 
@@ -975,9 +1003,10 @@ func expandSQLiMatchStatement(l []any) *awstypes.SqliMatchStatement {
 	m := l[0].(map[string]any)
 
 	return &awstypes.SqliMatchStatement{
-		FieldToMatch:        expandFieldToMatch(m["field_to_match"].([]any)),
-		SensitivityLevel:    awstypes.SensitivityLevel(m["sensitivity_level"].(string)),
-		TextTransformations: expandTextTransformations(m[attrTextTransformation].(*schema.Set).List()),
+		FieldToMatch:                expandFieldToMatch(m["field_to_match"].([]any)),
+		PreParseTextTransformations: expandPreParseTextTransformations(m[attrPreParseTextTransformation].(*schema.Set).List()),
+		SensitivityLevel:            awstypes.SensitivityLevel(m["sensitivity_level"].(string)),
+		TextTransformations:         expandTextTransformations(m[attrTextTransformation].(*schema.Set).List()),
 	}
 }
 
@@ -989,8 +1018,9 @@ func expandXSSMatchStatement(l []any) *awstypes.XssMatchStatement {
 	m := l[0].(map[string]any)
 
 	return &awstypes.XssMatchStatement{
-		FieldToMatch:        expandFieldToMatch(m["field_to_match"].([]any)),
-		TextTransformations: expandTextTransformations(m[attrTextTransformation].(*schema.Set).List()),
+		FieldToMatch:                expandFieldToMatch(m["field_to_match"].([]any)),
+		PreParseTextTransformations: expandPreParseTextTransformations(m[attrPreParseTextTransformation].(*schema.Set).List()),
+		TextTransformations:         expandTextTransformations(m[attrTextTransformation].(*schema.Set).List()),
 	}
 }
 
@@ -2417,10 +2447,11 @@ func flattenByteMatchStatement(b *awstypes.ByteMatchStatement) any {
 	}
 
 	m := map[string]any{
-		"field_to_match":        flattenFieldToMatch(b.FieldToMatch),
-		"positional_constraint": b.PositionalConstraint,
-		"search_string":         string(b.SearchString),
-		attrTextTransformation:  flattenTextTransformations(b.TextTransformations),
+		"field_to_match":               flattenFieldToMatch(b.FieldToMatch),
+		"positional_constraint":        b.PositionalConstraint,
+		attrPreParseTextTransformation: flattenPreParseTextTransformations(b.PreParseTextTransformations),
+		"search_string":                string(b.SearchString),
+		attrTextTransformation:         flattenTextTransformations(b.TextTransformations),
 	}
 
 	return []any{m}
@@ -2654,6 +2685,17 @@ func flattenURIFragment(apiObject *awstypes.UriFragment) any {
 	return []any{tfMap}
 }
 
+func flattenPreParseTextTransformations(l []awstypes.PreParseTextTransformation) []any {
+	out := make([]any, len(l))
+	for i, t := range l {
+		m := make(map[string]any)
+		m[names.AttrPriority] = t.Priority
+		m[names.AttrType] = t.Type
+		out[i] = m
+	}
+	return out
+}
+
 func flattenTextTransformations(l []awstypes.TextTransformation) []any {
 	out := make([]any, len(l))
 	for i, t := range l {
@@ -2734,9 +2776,10 @@ func flattenRegexMatchStatement(r *awstypes.RegexMatchStatement) any {
 	}
 
 	m := map[string]any{
-		"regex_string":         aws.ToString(r.RegexString),
-		"field_to_match":       flattenFieldToMatch(r.FieldToMatch),
-		attrTextTransformation: flattenTextTransformations(r.TextTransformations),
+		"regex_string":                 aws.ToString(r.RegexString),
+		"field_to_match":               flattenFieldToMatch(r.FieldToMatch),
+		attrPreParseTextTransformation: flattenPreParseTextTransformations(r.PreParseTextTransformations),
+		attrTextTransformation:         flattenTextTransformations(r.TextTransformations),
 	}
 
 	return []any{m}
@@ -2748,9 +2791,10 @@ func flattenRegexPatternSetReferenceStatement(r *awstypes.RegexPatternSetReferen
 	}
 
 	m := map[string]any{
-		names.AttrARN:          aws.ToString(r.ARN),
-		"field_to_match":       flattenFieldToMatch(r.FieldToMatch),
-		attrTextTransformation: flattenTextTransformations(r.TextTransformations),
+		names.AttrARN:                  aws.ToString(r.ARN),
+		"field_to_match":               flattenFieldToMatch(r.FieldToMatch),
+		attrPreParseTextTransformation: flattenPreParseTextTransformations(r.PreParseTextTransformations),
+		attrTextTransformation:         flattenTextTransformations(r.TextTransformations),
 	}
 
 	return []any{m}
@@ -2762,10 +2806,11 @@ func flattenSizeConstraintStatement(s *awstypes.SizeConstraintStatement) any {
 	}
 
 	m := map[string]any{
-		"comparison_operator":  s.ComparisonOperator,
-		"field_to_match":       flattenFieldToMatch(s.FieldToMatch),
-		names.AttrSize:         s.Size,
-		attrTextTransformation: flattenTextTransformations(s.TextTransformations),
+		"comparison_operator":          s.ComparisonOperator,
+		"field_to_match":               flattenFieldToMatch(s.FieldToMatch),
+		attrPreParseTextTransformation: flattenPreParseTextTransformations(s.PreParseTextTransformations),
+		names.AttrSize:                 s.Size,
+		attrTextTransformation:         flattenTextTransformations(s.TextTransformations),
 	}
 
 	return []any{m}
@@ -2777,9 +2822,10 @@ func flattenSQLiMatchStatement(s *awstypes.SqliMatchStatement) any {
 	}
 
 	m := map[string]any{
-		"field_to_match":       flattenFieldToMatch(s.FieldToMatch),
-		"sensitivity_level":    s.SensitivityLevel,
-		attrTextTransformation: flattenTextTransformations(s.TextTransformations),
+		"field_to_match":               flattenFieldToMatch(s.FieldToMatch),
+		attrPreParseTextTransformation: flattenPreParseTextTransformations(s.PreParseTextTransformations),
+		"sensitivity_level":            s.SensitivityLevel,
+		attrTextTransformation:         flattenTextTransformations(s.TextTransformations),
 	}
 
 	return []any{m}
@@ -2791,8 +2837,9 @@ func flattenXSSMatchStatement(s *awstypes.XssMatchStatement) any {
 	}
 
 	m := map[string]any{
-		"field_to_match":       flattenFieldToMatch(s.FieldToMatch),
-		attrTextTransformation: flattenTextTransformations(s.TextTransformations),
+		"field_to_match":               flattenFieldToMatch(s.FieldToMatch),
+		attrPreParseTextTransformation: flattenPreParseTextTransformations(s.PreParseTextTransformations),
+		attrTextTransformation:         flattenTextTransformations(s.TextTransformations),
 	}
 
 	return []any{m}

--- a/internal/service/wafv2/rule_group_test.go
+++ b/internal/service/wafv2/rule_group_test.go
@@ -437,6 +437,62 @@ func TestAccWAFV2RuleGroup_byteMatchStatement(t *testing.T) {
 	})
 }
 
+func TestAccWAFV2RuleGroup_ByteMatchStatement_preParseTextTransformation(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v awstypes.RuleGroup
+	ruleGroupName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_wafv2_rule_group.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckScopeRegional(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.WAFV2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckRuleGroupDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRuleGroupConfig_byteMatchStatementPreParseTextTransformation(ruleGroupName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRuleGroupExists(ctx, t, resourceName, &v),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "wafv2", regexache.MustCompile(`regional/rulegroup/.+$`)),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtRulePound, "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+						"statement.#":                        "1",
+						"statement.0.byte_match_statement.#": "1",
+						"statement.0.byte_match_statement.0.pre_parse_text_transformation.#": "2",
+						"statement.0.byte_match_statement.0.text_transformation.#":           "1",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*.statement.0.byte_match_statement.0.pre_parse_text_transformation.*", map[string]string{
+						names.AttrPriority: "1",
+						names.AttrType:     "URL_DECODE",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*.statement.0.byte_match_statement.0.pre_parse_text_transformation.*", map[string]string{
+						names.AttrPriority: "2",
+						names.AttrType:     "COMBINE_DUPLICATE_QUERY_ARGS_BY_COMMA",
+					}),
+				),
+			},
+			{
+				Config: testAccRuleGroupConfig_byteMatchStatement(ruleGroupName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRuleGroupExists(ctx, t, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtRulePound, "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+						"statement.#":                        "1",
+						"statement.0.byte_match_statement.#": "1",
+						"statement.0.byte_match_statement.0.pre_parse_text_transformation.#": "0",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccRuleGroupImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
 func TestAccWAFV2RuleGroup_ByteMatchStatement_fieldToMatch(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.RuleGroup
@@ -3197,6 +3253,63 @@ resource "aws_wafv2_rule_group" "test" {
     statement {
       geo_match_statement {
         country_codes = ["US", "NL"]
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = false
+      metric_name                = "friendly-rule-metric-name"
+      sampled_requests_enabled   = false
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = false
+    metric_name                = "friendly-metric-name"
+    sampled_requests_enabled   = false
+  }
+}
+`, rName)
+}
+
+func testAccRuleGroupConfig_byteMatchStatementPreParseTextTransformation(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_wafv2_rule_group" "test" {
+  capacity = 300
+  name     = %[1]q
+  scope    = "REGIONAL"
+
+  rule {
+    name     = "rule-1"
+    priority = 1
+
+    action {
+      allow {}
+    }
+
+    statement {
+      byte_match_statement {
+        positional_constraint = "CONTAINS"
+        search_string         = "word"
+
+        field_to_match {
+          all_query_arguments {}
+        }
+
+        pre_parse_text_transformation {
+          priority = 1
+          type     = "URL_DECODE"
+        }
+
+        pre_parse_text_transformation {
+          priority = 2
+          type     = "COMBINE_DUPLICATE_QUERY_ARGS_BY_COMMA"
+        }
+
+        text_transformation {
+          priority = 0
+          type     = "NONE"
+        }
       }
     }
 

--- a/internal/service/wafv2/schemas.go
+++ b/internal/service/wafv2/schemas.go
@@ -182,7 +182,8 @@ var byteMatchStatementSchema = sync.OnceValue(func() *schema.Schema {
 					Required:     true,
 					ValidateFunc: validation.StringLenBetween(1, 200),
 				},
-				attrTextTransformation: textTransformationSchema(),
+				attrPreParseTextTransformation: preParseTextTransformationSchema(),
+				attrTextTransformation:         textTransformationSchema(),
 			},
 		},
 	}
@@ -291,8 +292,9 @@ var regexMatchStatementSchema = sync.OnceValue(func() *schema.Schema {
 						validation.StringIsValidRegExp,
 					),
 				},
-				"field_to_match":       fieldToMatchSchema(),
-				attrTextTransformation: textTransformationSchema(),
+				"field_to_match":               fieldToMatchSchema(),
+				attrPreParseTextTransformation: preParseTextTransformationSchema(),
+				attrTextTransformation:         textTransformationSchema(),
 			},
 		},
 	}
@@ -310,8 +312,9 @@ var regexPatternSetReferenceStatementSchema = sync.OnceValue(func() *schema.Sche
 					Required:     true,
 					ValidateFunc: verify.ValidARN,
 				},
-				"field_to_match":       fieldToMatchSchema(),
-				attrTextTransformation: textTransformationSchema(),
+				"field_to_match":               fieldToMatchSchema(),
+				attrPreParseTextTransformation: preParseTextTransformationSchema(),
+				attrTextTransformation:         textTransformationSchema(),
 			},
 		},
 	}
@@ -335,7 +338,8 @@ var sizeConstraintSchema = sync.OnceValue(func() *schema.Schema {
 					Required:     true,
 					ValidateFunc: validation.IntBetween(0, math.MaxInt32),
 				},
-				attrTextTransformation: textTransformationSchema(),
+				attrPreParseTextTransformation: preParseTextTransformationSchema(),
+				attrTextTransformation:         textTransformationSchema(),
 			},
 		},
 	}
@@ -354,7 +358,8 @@ var sqliMatchStatementSchema = sync.OnceValue(func() *schema.Schema {
 					Optional:         true,
 					ValidateDiagFunc: enum.Validate[awstypes.SensitivityLevel](),
 				},
-				attrTextTransformation: textTransformationSchema(),
+				attrPreParseTextTransformation: preParseTextTransformationSchema(),
+				attrTextTransformation:         textTransformationSchema(),
 			},
 		},
 	}
@@ -367,8 +372,9 @@ var xssMatchStatementSchema = sync.OnceValue(func() *schema.Schema {
 		MaxItems: 1,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
-				"field_to_match":       fieldToMatchSchema(),
-				attrTextTransformation: textTransformationSchema(),
+				"field_to_match":               fieldToMatchSchema(),
+				attrPreParseTextTransformation: preParseTextTransformationSchema(),
+				attrTextTransformation:         textTransformationSchema(),
 			},
 		},
 	}
@@ -534,6 +540,27 @@ var rateLimitJAFingerprintConfigSchema = sync.OnceValue(func() *schema.Schema {
 					Type:             schema.TypeString,
 					Required:         true,
 					ValidateDiagFunc: enum.Validate[awstypes.FallbackBehavior](),
+				},
+			},
+		},
+	}
+})
+
+var preParseTextTransformationSchema = sync.OnceValue(func() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeSet,
+		Optional: true,
+		MaxItems: 10,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				names.AttrPriority: {
+					Type:     schema.TypeInt,
+					Required: true,
+				},
+				names.AttrType: {
+					Type:             schema.TypeString,
+					Required:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.PreParseTextTransformationType](),
 				},
 			},
 		},

--- a/internal/service/wafv2/web_acl_test.go
+++ b/internal/service/wafv2/web_acl_test.go
@@ -1337,6 +1337,80 @@ func TestAccWAFV2WebACL_ByteMatchStatement_basic(t *testing.T) {
 	})
 }
 
+func TestAccWAFV2WebACL_ByteMatchStatement_preParseTextTransformation(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v awstypes.WebACL
+	webACLName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_wafv2_web_acl.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckScopeRegional(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.WAFV2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckWebACLDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWebACLConfig_byteMatchStatementPreParseTextTransformation(webACLName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWebACLExists(ctx, t, resourceName, &v),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "wafv2", regexache.MustCompile(`regional/webacl/.+$`)),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtRulePound, "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+						"statement.#":                                         "1",
+						"statement.0.byte_match_statement.#":                  "1",
+						"statement.0.byte_match_statement.0.field_to_match.#": "1",
+						"statement.0.byte_match_statement.0.field_to_match.0.all_query_arguments.#": "1",
+						"statement.0.byte_match_statement.0.pre_parse_text_transformation.#":        "2",
+						"statement.0.byte_match_statement.0.text_transformation.#":                  "1",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*.statement.0.byte_match_statement.0.pre_parse_text_transformation.*", map[string]string{
+						names.AttrPriority: "1",
+						names.AttrType:     "URL_DECODE",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*.statement.0.byte_match_statement.0.pre_parse_text_transformation.*", map[string]string{
+						names.AttrPriority: "2",
+						names.AttrType:     "COMBINE_DUPLICATE_QUERY_ARGS_BY_COMMA",
+					}),
+				),
+			},
+			{
+				Config: testAccWebACLConfig_byteMatchStatementPreParseTextTransformationUpdated(webACLName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWebACLExists(ctx, t, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtRulePound, "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+						"statement.#":                        "1",
+						"statement.0.byte_match_statement.#": "1",
+						"statement.0.byte_match_statement.0.pre_parse_text_transformation.#": "1",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*.statement.0.byte_match_statement.0.pre_parse_text_transformation.*", map[string]string{
+						names.AttrPriority: "0",
+						names.AttrType:     "REPLACE_SEMICOLONS_WITH_AMPERSANDS",
+					}),
+				),
+			},
+			{
+				Config: testAccWebACLConfig_byteMatchStatement(webACLName, string(awstypes.PositionalConstraintContainsWord), acctest.CtValue1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWebACLExists(ctx, t, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtRulePound, "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+						"statement.#":                        "1",
+						"statement.0.byte_match_statement.#": "1",
+						"statement.0.byte_match_statement.0.pre_parse_text_transformation.#": "0",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccWebACLImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
 func TestAccWAFV2WebACL_ByteMatchStatement_ja3fingerprint(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.WebACL
@@ -4182,6 +4256,121 @@ resource "aws_wafv2_web_acl" "test" {
   }
 }
 `, rName, positionalConstraint, searchString)
+}
+
+func testAccWebACLConfig_byteMatchStatementPreParseTextTransformation(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_wafv2_web_acl" "test" {
+  name        = %[1]q
+  description = %[1]q
+  scope       = "REGIONAL"
+
+  default_action {
+    allow {}
+  }
+
+  rule {
+    name     = "rule-1"
+    priority = 1
+
+    action {
+      count {}
+    }
+
+    statement {
+      byte_match_statement {
+        field_to_match {
+          all_query_arguments {}
+        }
+        positional_constraint = "CONTAINS_WORD"
+        search_string         = "value1"
+
+        pre_parse_text_transformation {
+          priority = 1
+          type     = "URL_DECODE"
+        }
+
+        pre_parse_text_transformation {
+          priority = 2
+          type     = "COMBINE_DUPLICATE_QUERY_ARGS_BY_COMMA"
+        }
+
+        text_transformation {
+          priority = 0
+          type     = "NONE"
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = false
+      metric_name                = "friendly-rule-metric-name"
+      sampled_requests_enabled   = false
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = false
+    metric_name                = "friendly-metric-name"
+    sampled_requests_enabled   = false
+  }
+}
+`, rName)
+}
+
+func testAccWebACLConfig_byteMatchStatementPreParseTextTransformationUpdated(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_wafv2_web_acl" "test" {
+  name        = %[1]q
+  description = %[1]q
+  scope       = "REGIONAL"
+
+  default_action {
+    allow {}
+  }
+
+  rule {
+    name     = "rule-1"
+    priority = 1
+
+    action {
+      count {}
+    }
+
+    statement {
+      byte_match_statement {
+        field_to_match {
+          all_query_arguments {}
+        }
+        positional_constraint = "CONTAINS_WORD"
+        search_string         = "value1"
+
+        pre_parse_text_transformation {
+          priority = 0
+          type     = "REPLACE_SEMICOLONS_WITH_AMPERSANDS"
+        }
+
+        text_transformation {
+          priority = 0
+          type     = "NONE"
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = false
+      metric_name                = "friendly-rule-metric-name"
+      sampled_requests_enabled   = false
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = false
+    metric_name                = "friendly-metric-name"
+    sampled_requests_enabled   = false
+  }
+}
+`, rName)
 }
 
 func testAccWebACLConfig_byteMatchStatementJA3Fingerprint(rName, fallbackBehavior string) string {

--- a/website/docs/r/wafv2_rule_group.html.markdown
+++ b/website/docs/r/wafv2_rule_group.html.markdown
@@ -508,6 +508,7 @@ The `byte_match_statement` block supports the following arguments:
 * `field_to_match` - (Required) The part of a web request that you want AWS WAF to inspect. See [Field to Match](#field-to-match) below for details.
 * `positional_constraint` - (Required) The area within the portion of a web request that you want AWS WAF to search for `search_string`. Valid values include the following: `EXACTLY`, `STARTS_WITH`, `ENDS_WITH`, `CONTAINS`, `CONTAINS_WORD`. See the AWS [documentation](https://docs.aws.amazon.com/waf/latest/APIReference/API_ByteMatchStatement.html) for more information.
 * `search_string` - (Required) A string value that you want AWS WAF to search for. AWS WAF searches only in the part of web requests that you designate for inspection in `field_to_match`. The maximum length of the value is 50 bytes.
+* `pre_parse_text_transformation` - (Optional) Text transformations to apply to the raw query string before AWS WAF parses the string into individual query arguments, and before any `text_transformation` is applied. Supported only when `field_to_match` specifies `single_query_argument` or `all_query_arguments`. Maximum of 10. See [Pre-Parse Text Transformation](#pre-parse-text-transformation) below for details.
 * `text_transformation` - (Required) Text transformations eliminate some of the unusual formatting that attackers use in web requests in an effort to bypass detection.
   At least one required.
   See [Text Transformation](#text-transformation) below for details.
@@ -576,6 +577,7 @@ The `regex_match_statement` block supports the following arguments:
 
 * `regex_string` - (Required) The string representing the regular expression. **Note:** The fixed quota for the maximum number of characters in each regex pattern is 200, which can't be changed. See [AWS WAF quotas](https://docs.aws.amazon.com/waf/latest/developerguide/limits.html) for details.
 * `field_to_match` - (Required) The part of a web request that you want AWS WAF to inspect. See [Field to Match](#field-to-match) below for details.
+* `pre_parse_text_transformation` - (Optional) Text transformations to apply to the raw query string before AWS WAF parses the string into individual query arguments, and before any `text_transformation` is applied. Supported only when `field_to_match` specifies `single_query_argument` or `all_query_arguments`. Maximum of 10. See [Pre-Parse Text Transformation](#pre-parse-text-transformation) below for details.
 * `text_transformation` - (Required) Text transformations eliminate some of the unusual formatting that attackers use in web requests in an effort to bypass detection.
   At least one required.
   See [Text Transformation](#text-transformation) below for details.
@@ -588,6 +590,7 @@ The `regex_pattern_set_reference_statement` block supports the following argumen
 
 * `arn` - (Required) The Amazon Resource Name (ARN) of the Regex Pattern Set that this statement references.
 * `field_to_match` - (Required) The part of a web request that you want AWS WAF to inspect. See [Field to Match](#field-to-match) below for details.
+* `pre_parse_text_transformation` - (Optional) Text transformations to apply to the raw query string before AWS WAF parses the string into individual query arguments, and before any `text_transformation` is applied. Supported only when `field_to_match` specifies `single_query_argument` or `all_query_arguments`. Maximum of 10. See [Pre-Parse Text Transformation](#pre-parse-text-transformation) below for details.
 * `text_transformation` - (Required) Text transformations eliminate some of the unusual formatting that attackers use in web requests in an effort to bypass detection.
   At least one required.
   See [Text Transformation](#text-transformation) below for details.
@@ -602,6 +605,7 @@ The `size_constraint_statement` block supports the following arguments:
 * `comparison_operator` - (Required) The operator to use to compare the request part to the size setting. Valid values include: `EQ`, `NE`, `LE`, `LT`, `GE`, or `GT`.
 * `field_to_match` - (Optional) The part of a web request that you want AWS WAF to inspect. See [Field to Match](#field-to-match) below for details.
 * `size` - (Required) The size, in bytes, to compare to the request part, after any transformations. Valid values are integers between 0 and 21474836480, inclusive.
+* `pre_parse_text_transformation` - (Optional) Text transformations to apply to the raw query string before AWS WAF parses the string into individual query arguments, and before any `text_transformation` is applied. Supported only when `field_to_match` specifies `single_query_argument` or `all_query_arguments`. Maximum of 10. See [Pre-Parse Text Transformation](#pre-parse-text-transformation) below for details.
 * `text_transformation` - (Required) Text transformations eliminate some of the unusual formatting that attackers use in web requests in an effort to bypass detection.
   At least one required.
   See [Text Transformation](#text-transformation) below for details.
@@ -614,6 +618,7 @@ The `sqli_match_statement` block supports the following arguments:
 
 * `field_to_match` - (Required) The part of a web request that you want AWS WAF to inspect. See [Field to Match](#field-to-match) below for details.
 * `sensitivity_level` - (Optional) Sensitivity that you want AWS WAF to use to inspect for SQL injection attacks. Valid values include: `LOW`, `HIGH`.
+* `pre_parse_text_transformation` - (Optional) Text transformations to apply to the raw query string before AWS WAF parses the string into individual query arguments, and before any `text_transformation` is applied. Supported only when `field_to_match` specifies `single_query_argument` or `all_query_arguments`. Maximum of 10. See [Pre-Parse Text Transformation](#pre-parse-text-transformation) below for details.
 * `text_transformation` - (Required) Text transformations eliminate some of the unusual formatting that attackers use in web requests in an effort to bypass detection.
   At least one required.
   See [Text Transformation](#text-transformation) below for details.
@@ -625,6 +630,7 @@ The XSS match statement provides the location in requests that you want AWS WAF 
 The `xss_match_statement` block supports the following arguments:
 
 * `field_to_match` - (Required) The part of a web request that you want AWS WAF to inspect. See [Field to Match](#field-to-match) below for details.
+* `pre_parse_text_transformation` - (Optional) Text transformations to apply to the raw query string before AWS WAF parses the string into individual query arguments, and before any `text_transformation` is applied. Supported only when `field_to_match` specifies `single_query_argument` or `all_query_arguments`. Maximum of 10. See [Pre-Parse Text Transformation](#pre-parse-text-transformation) below for details.
 * `text_transformation` - (Required) Text transformations eliminate some of the unusual formatting that attackers use in web requests in an effort to bypass detection.
   At least one required.
   See [Text Transformation](#text-transformation) below for details.
@@ -750,6 +756,15 @@ The `cookies` block supports the following arguments:
 * `match_pattern` - (Required) The filter to use to identify the subset of cookies to inspect in a web request. You must specify exactly one setting: either `all`, `included_cookies` or `excluded_cookies`. More details: [CookieMatchPattern](https://docs.aws.amazon.com/waf/latest/APIReference/API_CookieMatchPattern.html)
 * `match_scope` - (Required) The parts of the cookies to inspect with the rule inspection criteria. If you specify All, AWS WAF inspects both keys and values. Valid values: `ALL`, `KEY`, `VALUE`
 * `oversize_handling` - (Required) What AWS WAF should do if the cookies of the request are larger than AWS WAF can inspect. AWS WAF does not support inspecting the entire contents of request cookies when they exceed 8 KB (8192 bytes) or 200 total cookies. The underlying host service forwards a maximum of 200 cookies and at most 8 KB of cookie contents to AWS WAF. Valid values: `CONTINUE`, `MATCH`, `NO_MATCH`
+
+### Pre-Parse Text Transformation
+
+Pre-parse text transformations normalize the raw query string before AWS WAF parses it into individual query arguments. They are applied before any `text_transformation`. Pre-parse text transformations are supported only when `field_to_match` specifies `single_query_argument` or `all_query_arguments`. You can specify up to 10 pre-parse text transformations per rule statement.
+
+The `pre_parse_text_transformation` block supports the following arguments:
+
+* `priority` - (Required) The relative processing order for the pre-parse text transformations that are defined for a rule statement. AWS WAF processes all transformations, from lowest priority to highest, before parsing the query string.
+* `type` - (Required) The pre-parse text transformation to apply to the raw query string. Valid values are `NONE`, `URL_DECODE`, `URL_DECODE_UNI`, `COMBINE_DUPLICATE_QUERY_ARGS_BY_COMMA`, and `REPLACE_SEMICOLONS_WITH_AMPERSANDS`. See the Pre-Parse Text Transformation [documentation](https://docs.aws.amazon.com/waf/latest/APIReference/API_PreParseTextTransformation.html) for more details.
 
 ### Text Transformation
 

--- a/website/docs/r/wafv2_web_acl.html.markdown
+++ b/website/docs/r/wafv2_web_acl.html.markdown
@@ -675,6 +675,7 @@ The `byte_match_statement` block supports the following arguments:
 * `field_to_match` - (Optional) Part of a web request that you want AWS WAF to inspect. See [`field_to_match`](#field_to_match-block) below for details.
 * `positional_constraint` - (Required) Area within the portion of a web request that you want AWS WAF to search for `search_string`. Valid values include the following: `EXACTLY`, `STARTS_WITH`, `ENDS_WITH`, `CONTAINS`, `CONTAINS_WORD`. See the AWS [documentation](https://docs.aws.amazon.com/waf/latest/APIReference/API_ByteMatchStatement.html) for more information.
 * `search_string` - (Required) String value that you want AWS WAF to search for. AWS WAF searches only in the part of web requests that you designate for inspection in `field_to_match`. The maximum length of the value is 50 bytes.
+* `pre_parse_text_transformation` - (Optional) Text transformations to apply to the raw query string before AWS WAF parses the string into individual query arguments, and before any `text_transformation` is applied. Supported only when `field_to_match` specifies `single_query_argument` or `all_query_arguments`. Maximum of 10. See [`pre_parse_text_transformation`](#pre_parse_text_transformation-block) below for details.
 * `text_transformation` - (Required) Text transformations eliminate some of the unusual formatting that attackers use in web requests in an effort to bypass detection. At least one transformation is required. See [`text_transformation`](#text_transformation-block) below for details.
 
 ### `geo_match_statement` Block
@@ -756,6 +757,7 @@ The `regex_match_statement` block supports the following arguments:
 
 * `regex_string` - (Required) String representing the regular expression. Minimum of `1` and maximum of `512` characters.
 * `field_to_match` - (Required) The part of a web request that you want AWS WAF to inspect. See [`field_to_match`](#field_to_match-block) below for details.
+* `pre_parse_text_transformation` - (Optional) Text transformations to apply to the raw query string before AWS WAF parses the string into individual query arguments, and before any `text_transformation` is applied. Supported only when `field_to_match` specifies `single_query_argument` or `all_query_arguments`. Maximum of 10. See [`pre_parse_text_transformation`](#pre_parse_text_transformation-block) below for details.
 * `text_transformation` - (Required) Text transformations eliminate some of the unusual formatting that attackers use in web requests in an effort to bypass detection. At least one transformation is required. See [`text_transformation`](#text_transformation-block) below for details.
 
 ### `regex_pattern_set_reference_statement` Block
@@ -766,6 +768,7 @@ The `regex_pattern_set_reference_statement` block supports the following argumen
 
 * `arn` - (Required) The Amazon Resource Name (ARN) of the Regex Pattern Set that this statement references.
 * `field_to_match` - (Optional) Part of a web request that you want AWS WAF to inspect. See [`field_to_match`](#field_to_match-block) below for details.
+* `pre_parse_text_transformation` - (Optional) Text transformations to apply to the raw query string before AWS WAF parses the string into individual query arguments, and before any `text_transformation` is applied. Supported only when `field_to_match` specifies `single_query_argument` or `all_query_arguments`. Maximum of 10. See [`pre_parse_text_transformation`](#pre_parse_text_transformation-block) below for details.
 * `text_transformation` - (Required) Text transformations eliminate some of the unusual formatting that attackers use in web requests in an effort to bypass detection. At least one transformation is required. See [`text_transformation`](#text_transformation-block) below for details.
 
 ### `rule_group_reference_statement` Block
@@ -789,6 +792,7 @@ The `size_constraint_statement` block supports the following arguments:
 * `comparison_operator` - (Required) Operator to use to compare the request part to the size setting. Valid values include: `EQ`, `NE`, `LE`, `LT`, `GE`, or `GT`.
 * `field_to_match` - (Optional) Part of a web request that you want AWS WAF to inspect. See [`field_to_match`](#field_to_match-block) below for details.
 * `size` - (Required) Size, in bytes, to compare to the request part, after any transformations. Valid values are integers between 0 and 21474836480, inclusive.
+* `pre_parse_text_transformation` - (Optional) Text transformations to apply to the raw query string before AWS WAF parses the string into individual query arguments, and before any `text_transformation` is applied. Supported only when `field_to_match` specifies `single_query_argument` or `all_query_arguments`. Maximum of 10. See [`pre_parse_text_transformation`](#pre_parse_text_transformation-block) below for details.
 * `text_transformation` - (Required) Text transformations eliminate some of the unusual formatting that attackers use in web requests in an effort to bypass detection. At least one transformation is required. See [`text_transformation`](#text_transformation-block) below for details.
 
 ### `sqli_match_statement` Block
@@ -799,6 +803,7 @@ The `sqli_match_statement` block supports the following arguments:
 
 * `field_to_match` - (Optional) Part of a web request that you want AWS WAF to inspect. See [`field_to_match`](#field_to_match-block) below for details.
 * `sensitivity_level` - (Optional) Sensitivity that you want AWS WAF to use to inspect for SQL injection attacks. Valid values include: `LOW`, `HIGH`.
+* `pre_parse_text_transformation` - (Optional) Text transformations to apply to the raw query string before AWS WAF parses the string into individual query arguments, and before any `text_transformation` is applied. Supported only when `field_to_match` specifies `single_query_argument` or `all_query_arguments`. Maximum of 10. See [`pre_parse_text_transformation`](#pre_parse_text_transformation-block) below for details.
 * `text_transformation` - (Required) Text transformations eliminate some of the unusual formatting that attackers use in web requests in an effort to bypass detection. At least one transformation is required. See [`text_transformation`](#text_transformation-block) below for details.
 
 ### `xss_match_statement` Block
@@ -808,6 +813,7 @@ The XSS match statement provides the location in requests that you want AWS WAF 
 The `xss_match_statement` block supports the following arguments:
 
 * `field_to_match` - (Optional) Part of a web request that you want AWS WAF to inspect. See [`field_to_match`](#field_to_match-block) below for details.
+* `pre_parse_text_transformation` - (Optional) Text transformations to apply to the raw query string before AWS WAF parses the string into individual query arguments, and before any `text_transformation` is applied. Supported only when `field_to_match` specifies `single_query_argument` or `all_query_arguments`. Maximum of 10. See [`pre_parse_text_transformation`](#pre_parse_text_transformation-block) below for details.
 * `text_transformation` - (Required) Text transformations eliminate some of the unusual formatting that attackers use in web requests in an effort to bypass detection. At least one transformation is required. See [`text_transformation`](#text_transformation-block) below for details.
 
 ### `rule_action_override` Block
@@ -1050,6 +1056,15 @@ The `cookies` block supports the following arguments:
 * `match_pattern` - (Required) The filter to use to identify the subset of cookies to inspect in a web request. You must specify exactly one setting: either `all`, `included_cookies` or `excluded_cookies`. More details: [CookieMatchPattern](https://docs.aws.amazon.com/waf/latest/APIReference/API_CookieMatchPattern.html)
 * `match_scope` - (Required) The parts of the cookies to inspect with the rule inspection criteria. If you specify All, AWS WAF inspects both keys and values. Valid values: `ALL`, `KEY`, `VALUE`
 * `oversize_handling` - (Required) What AWS WAF should do if the cookies of the request are larger than AWS WAF can inspect. AWS WAF does not support inspecting the entire contents of request cookies when they exceed 8 KB (8192 bytes) or 200 total cookies. The underlying host service forwards a maximum of 200 cookies and at most 8 KB of cookie contents to AWS WAF. Valid values: `CONTINUE`, `MATCH`, `NO_MATCH`.
+
+### `pre_parse_text_transformation` Block
+
+Pre-parse text transformations normalize the raw query string before AWS WAF parses it into individual query arguments. They are applied before any `text_transformation`. Pre-parse text transformations are supported only when `field_to_match` specifies `single_query_argument` or `all_query_arguments`. You can specify up to 10 pre-parse text transformations per rule statement.
+
+The `pre_parse_text_transformation` block supports the following arguments:
+
+* `priority` - (Required) Relative processing order for the pre-parse text transformations that are defined for a rule statement. AWS WAF processes all transformations, from lowest priority to highest, before parsing the query string.
+* `type` - (Required) Pre-parse text transformation to apply to the raw query string. Valid values are `NONE`, `URL_DECODE`, `URL_DECODE_UNI`, `COMBINE_DUPLICATE_QUERY_ARGS_BY_COMMA`, and `REPLACE_SEMICOLONS_WITH_AMPERSANDS`. See the Pre-Parse Text Transformation [documentation](https://docs.aws.amazon.com/waf/latest/APIReference/API_PreParseTextTransformation.html) for more details.
 
 ### `text_transformation` Block
 


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

No changes to security controls. This adds an optional schema block that surfaces an existing AWS WAF API field.

### Description

Adds support for AWS WAF **pre-parse text transformations**, announced 2026-07-29. A new optional `pre_parse_text_transformation` block is available on the six rule match statements that carry the API field — `byte_match_statement`, `regex_match_statement`, `regex_pattern_set_reference_statement`, `size_constraint_statement`, `sqli_match_statement`, and `xss_match_statement` — in both `aws_wafv2_web_acl` and `aws_wafv2_rule_group` (shared statement schema).

Pre-parse text transformations normalize the raw query string before WAF parses it into individual query arguments (addressing HTTP parameter pollution and parser-differential evasion), run before the standard `text_transformation`s, are supported by the API only when `field_to_match` is `all_query_arguments` or `single_query_argument`, and allow up to 10 entries per statement (`MaxItems: 10` enforced in schema; `type` validated against the SDK's `PreParseTextTransformationType` enum).

No dependency changes: the shapes are present in `aws-sdk-go-v2/service/wafv2` v1.77.0+, already pinned on `main`.

### Relations

Closes #49380

### References

- [AWS What's New announcement (2026-07-29)](https://aws.amazon.com/about-aws/whats-new/2026/07/aws-waf/)
- [Pre-parse text transformations developer guide](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-preparse-transformation.html)
- [PreParseTextTransformation API reference](https://docs.aws.amazon.com/waf/latest/APIReference/API_PreParseTextTransformation.html)

### Output from Acceptance Testing

```console
% make testacc TESTS=TestAccWAFV2WebACL_ByteMatchStatement_preParseTextTransformation\|TestAccWAFV2RuleGroup_ByteMatchStatement_preParseTextTransformation PKG=wafv2

--- PASS: TestAccWAFV2RuleGroup_ByteMatchStatement_preParseTextTransformation (48.42s)
--- PASS: TestAccWAFV2WebACL_ByteMatchStatement_preParseTextTransformation (69.22s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/wafv2     78.059s
```
