### PR TITLE
resource/aws_bedrockagentcore_harness: Adds `memory_actual`

### DIFF
--- a/.changelog/49383.txt
+++ b/.changelog/49383.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_bedrockagentcore_harness: Adds computed attribute `memory_actual`
+```

--- a/internal/framework/planmodifiers/listplanmodifier/unknown_other_value_changes.go
+++ b/internal/framework/planmodifiers/listplanmodifier/unknown_other_value_changes.go
@@ -1,0 +1,50 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package listplanmodifier
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+func UnknownWhenOtherValueChanges(path path.Path) planmodifier.List {
+	return unknownWhenOtherValueChanges{
+		path: path,
+	}
+}
+
+type unknownWhenOtherValueChanges struct {
+	path path.Path
+}
+
+func (m unknownWhenOtherValueChanges) Description(_ context.Context) string {
+	return fmt.Sprintf("Uses state for unknown when the value at %[1]q does not change.", m.path)
+}
+
+func (m unknownWhenOtherValueChanges) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (m unknownWhenOtherValueChanges) PlanModifyList(ctx context.Context, req planmodifier.ListRequest, resp *planmodifier.ListResponse) {
+	if req.StateValue.IsNull() {
+		return
+	}
+
+	var otherPlanValue, otherStateValue attr.Value
+	resp.Diagnostics.Append(req.Plan.GetAttribute(ctx, m.path, &otherPlanValue)...)
+	resp.Diagnostics.Append(req.State.GetAttribute(ctx, m.path, &otherStateValue)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !otherPlanValue.Equal(otherStateValue) {
+		return
+	}
+
+	resp.PlanValue = req.StateValue
+}

--- a/internal/framework/planmodifiers/listplanmodifier/unknown_other_value_changes_test.go
+++ b/internal/framework/planmodifiers/listplanmodifier/unknown_other_value_changes_test.go
@@ -1,0 +1,144 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package listplanmodifier_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	tflistplanmodifier "github.com/hashicorp/terraform-provider-aws/internal/framework/planmodifiers/listplanmodifier"
+)
+
+func TestUnknownWhenOtherValueChanges(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		request  planmodifier.ListRequest
+		expected planmodifier.ListResponse
+	}
+
+	testSchema := schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"src": schema.StringAttribute{},
+			"dst": schema.ListAttribute{
+				ElementType: types.StringType,
+			},
+		},
+	}
+	nullState := tfsdk.State{
+		Schema: testSchema,
+		Raw: tftypes.NewValue(
+			testSchema.Type().TerraformType(t.Context()),
+			nil,
+		),
+	}
+	testPlan := func(src types.String, dst types.List) tfsdk.Plan {
+		tfSrc, err := src.ToTerraformValue(t.Context())
+
+		if err != nil {
+			panic("ToTerraformValue error: " + err.Error())
+		}
+
+		tfDst, err := dst.ToTerraformValue(t.Context())
+
+		if err != nil {
+			panic("ToTerraformValue error: " + err.Error())
+		}
+
+		return tfsdk.Plan{
+			Schema: testSchema,
+			Raw: tftypes.NewValue(
+				testSchema.Type().TerraformType(t.Context()),
+				map[string]tftypes.Value{
+					"src": tfSrc,
+					"dst": tfDst,
+				},
+			),
+		}
+	}
+	testState := func(src types.String, dst types.List) tfsdk.State {
+		tfSrc, err := src.ToTerraformValue(t.Context())
+
+		if err != nil {
+			panic("ToTerraformValue error: " + err.Error())
+		}
+
+		tfDst, err := dst.ToTerraformValue(t.Context())
+
+		if err != nil {
+			panic("ToTerraformValue error: " + err.Error())
+		}
+
+		return tfsdk.State{
+			Schema: testSchema,
+			Raw: tftypes.NewValue(
+				testSchema.Type().TerraformType(t.Context()),
+				map[string]tftypes.Value{
+					"src": tfSrc,
+					"dst": tfDst,
+				},
+			),
+		}
+	}
+	unknownValue := types.ListUnknown(types.StringType)
+	configuredValue := types.ListValueMust(types.StringType, []attr.Value{types.StringValue("configured-value")})
+
+	tests := map[string]testCase{
+		"on create": {
+			request: planmodifier.ListRequest{
+				State:      nullState,
+				StateValue: types.ListNull(types.StringType),
+				Plan:       testPlan(types.StringValue("test"), unknownValue),
+				PlanValue:  unknownValue,
+			},
+			expected: planmodifier.ListResponse{
+				PlanValue: unknownValue,
+			},
+		},
+		"equal values on update": {
+			request: planmodifier.ListRequest{
+				State:      testState(types.StringValue("test"), configuredValue),
+				StateValue: configuredValue,
+				Plan:       testPlan(types.StringValue("test"), unknownValue),
+				PlanValue:  unknownValue,
+			},
+			expected: planmodifier.ListResponse{
+				PlanValue: configuredValue,
+			},
+		},
+		"different values on update": {
+			request: planmodifier.ListRequest{
+				State:      testState(types.StringValue("old"), configuredValue),
+				StateValue: configuredValue,
+				Plan:       testPlan(types.StringValue("new"), unknownValue),
+				PlanValue:  unknownValue,
+			},
+			expected: planmodifier.ListResponse{
+				PlanValue: unknownValue,
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			response := planmodifier.ListResponse{
+				PlanValue: test.request.PlanValue,
+			}
+			tflistplanmodifier.UnknownWhenOtherValueChanges(path.Root("src")).PlanModifyList(t.Context(), test.request, &response)
+
+			if diff := cmp.Diff(test.expected, response); diff != "" {
+				t.Errorf("unexpected diff (+wanted, -got): %s", diff)
+			}
+		})
+	}
+}

--- a/internal/generate/semgrep/pointer_conversion/main.go
+++ b/internal/generate/semgrep/pointer_conversion/main.go
@@ -58,7 +58,7 @@ func main() {
 			UnwrapFunc: "aws.ToTime",
 		},
 	}
-	for k, _ := range types {
+	for k := range types {
 		typ := types[k]
 		if k == "bool" {
 			typ.Conditionals = []string{"==", "!="}

--- a/internal/service/bedrockagentcore/harness.go
+++ b/internal/service/bedrockagentcore/harness.go
@@ -115,6 +115,7 @@ func (r *harnessResource) Schema(ctx context.Context, request resource.SchemaReq
 			"max_tokens": schema.Int32Attribute{
 				Optional: true,
 			},
+			"memory_actual":   framework.ResourceComputedListOfObjectsAttribute[harnessMemoryConfigurationModel](ctx, unknownWhenValueChanges{path: path.Root("memory")}),
 			names.AttrTags:    tftags.TagsAttribute(),
 			names.AttrTagsAll: tftags.TagsAttributeComputedOnly(),
 			"timeout_seconds": schema.Int32Attribute{
@@ -765,34 +766,39 @@ func (r *harnessResource) flatten(ctx context.Context, harness *awstypes.Harness
 		return diags
 	}
 
-	if populateMemory {
-		conn := r.Meta().BedrockAgentCoreClient(ctx)
-		diags.Append(r.flattenMemory(ctx, conn, harness, data)...)
-	}
+	conn := r.Meta().BedrockAgentCoreClient(ctx)
+	diags.Append(r.flattenMemory(ctx, conn, data, populateMemory)...)
 
 	return diags
 }
 
-func (r *harnessResource) flattenMemory(ctx context.Context, conn *bedrockagentcorecontrol.Client, harness *awstypes.Harness, data *harnessResourceModel) diag.Diagnostics {
+func (r *harnessResource) flattenMemory(ctx context.Context, conn *bedrockagentcorecontrol.Client, data *harnessResourceModel, populateMemory bool) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	diags.Append(fwflex.Flatten(ctx, harness.Memory, &data.Memory)...)
-	if diags.HasError() {
-		return diags
-	}
-
+	// Always flatten into memory (AutoFlex handles this via the Flattener interface since noflatten was removed).
+	// Now enrich and build memory_actual.
 	memoryBlock, d := data.Memory.ToPtr(ctx)
 	diags.Append(d...)
-	if diags.HasError() || memoryBlock == nil {
-		return diags
-	}
-
-	diags.Append(memoryBlock.flattenEnriched(ctx, conn)...)
 	if diags.HasError() {
 		return diags
 	}
 
-	data.Memory = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, memoryBlock)
+	if memoryBlock != nil {
+		diags.Append(memoryBlock.flattenEnriched(ctx, conn)...)
+		if diags.HasError() {
+			return diags
+		}
+
+		data.Memory = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, memoryBlock)
+	}
+
+	// Always populate memory_actual from the current memory state.
+	data.MemoryActual = data.Memory
+
+	// If memory was not configured by the user, null it out.
+	if !populateMemory {
+		data.Memory = fwtypes.NewListNestedObjectValueOfNull[harnessMemoryConfigurationModel](ctx)
+	}
 
 	return diags
 }
@@ -912,7 +918,8 @@ type harnessResourceModel struct {
 	HarnessName             types.String                                                         `tfsdk:"harness_name"`
 	MaxIterations           types.Int32                                                          `tfsdk:"max_iterations"`
 	MaxTokens               types.Int32                                                          `tfsdk:"max_tokens"`
-	Memory                  fwtypes.ListNestedObjectValueOf[harnessMemoryConfigurationModel]     `tfsdk:"memory" autoflex:",noflatten"`
+	Memory                  fwtypes.ListNestedObjectValueOf[harnessMemoryConfigurationModel]     `tfsdk:"memory"`
+	MemoryActual            fwtypes.ListNestedObjectValueOf[harnessMemoryConfigurationModel]     `tfsdk:"memory_actual" autoflex:"-"`
 	Model                   fwtypes.ListNestedObjectValueOf[harnessModelConfigurationModel]      `tfsdk:"model"`
 	Skills                  fwtypes.ListNestedObjectValueOf[harnessSkillModel]                   `tfsdk:"skill"`
 	SystemPrompt            fwtypes.ListNestedObjectValueOf[harnessSystemContentBlockModel]      `tfsdk:"system_prompt"`
@@ -1676,4 +1683,37 @@ func (m *harnessManagedMemoryConfigurationModel) flattenEnriched(ctx context.Con
 	}
 
 	return diags
+}
+
+// memory_actual plan modifier.
+
+type unknownWhenValueChanges struct {
+	path path.Path
+}
+
+func (m unknownWhenValueChanges) Description(_ context.Context) string {
+	return "Uses state for unknown when the value at the given path is not changing."
+}
+
+func (m unknownWhenValueChanges) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (m unknownWhenValueChanges) PlanModifyList(ctx context.Context, req planmodifier.ListRequest, resp *planmodifier.ListResponse) {
+	if req.StateValue.IsNull() {
+		return
+	}
+
+	var configValue, stateValue attr.Value
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, m.path, &configValue)...)
+	resp.Diagnostics.Append(req.State.GetAttribute(ctx, m.path, &stateValue)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !configValue.Equal(stateValue) {
+		return
+	}
+
+	resp.PlanValue = req.StateValue
 }

--- a/internal/service/bedrockagentcore/harness.go
+++ b/internal/service/bedrockagentcore/harness.go
@@ -39,6 +39,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
 	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	tflistplanmodifier "github.com/hashicorp/terraform-provider-aws/internal/framework/planmodifiers/listplanmodifier"
 	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/smerr"
@@ -115,7 +116,7 @@ func (r *harnessResource) Schema(ctx context.Context, request resource.SchemaReq
 			"max_tokens": schema.Int32Attribute{
 				Optional: true,
 			},
-			"memory_actual":   framework.ResourceComputedListOfObjectsAttribute[harnessMemoryConfigurationModel](ctx, unknownWhenValueChanges{path: path.Root("memory")}),
+			"memory_actual":   framework.ResourceComputedListOfObjectsAttribute[harnessMemoryConfigurationModel](ctx, tflistplanmodifier.UnknownWhenOtherValueChanges(path.Root("memory"))),
 			names.AttrTags:    tftags.TagsAttribute(),
 			names.AttrTagsAll: tftags.TagsAttributeComputedOnly(),
 			"timeout_seconds": schema.Int32Attribute{
@@ -1683,37 +1684,4 @@ func (m *harnessManagedMemoryConfigurationModel) flattenEnriched(ctx context.Con
 	}
 
 	return diags
-}
-
-// memory_actual plan modifier.
-
-type unknownWhenValueChanges struct {
-	path path.Path
-}
-
-func (m unknownWhenValueChanges) Description(_ context.Context) string {
-	return "Uses state for unknown when the value at the given path is not changing."
-}
-
-func (m unknownWhenValueChanges) MarkdownDescription(ctx context.Context) string {
-	return m.Description(ctx)
-}
-
-func (m unknownWhenValueChanges) PlanModifyList(ctx context.Context, req planmodifier.ListRequest, resp *planmodifier.ListResponse) {
-	if req.StateValue.IsNull() {
-		return
-	}
-
-	var configValue, stateValue attr.Value
-	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, m.path, &configValue)...)
-	resp.Diagnostics.Append(req.State.GetAttribute(ctx, m.path, &stateValue)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	if !configValue.Equal(stateValue) {
-		return
-	}
-
-	resp.PlanValue = req.StateValue
 }

--- a/internal/service/bedrockagentcore/harness_list_test.go
+++ b/internal/service/bedrockagentcore/harness_list_test.go
@@ -140,7 +140,7 @@ func TestAccBedrockAgentCoreHarness_List_includeResource(t *testing.T) {
 								"disabled":                       knownvalue.ListSizeExact(0),
 								"managed_memory_configuration": knownvalue.ListExact([]knownvalue.Check{
 									knownvalue.ObjectExact(map[string]knownvalue.Check{
-										names.AttrARN:           tfknownvalue.RegionalARNRegexp("bedrock-agentcore", regexache.MustCompile(`memory/harness_`+rName+`_0_[a-zA-Z0-9]+-[a-zA-Z0-9]+`)),
+										names.AttrARN:           tfknownvalue.RegionalARNRegexp("bedrock-agentcore", regexache.MustCompile(`memory/`+rName+`_0-[a-zA-Z0-9]{10}`)),
 										"encryption_key_arn":    knownvalue.Null(),
 										"event_expiry_duration": knownvalue.Int32Exact(30),
 										"strategies": knownvalue.SetExact([]knownvalue.Check{

--- a/internal/service/bedrockagentcore/harness_test.go
+++ b/internal/service/bedrockagentcore/harness_test.go
@@ -112,6 +112,21 @@ func TestAccBedrockAgentCoreHarness_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("max_iterations"), knownvalue.Int32Exact(75)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("max_tokens"), knownvalue.Null()),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("memory"), knownvalue.ListSizeExact(0)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("memory_actual").AtSliceIndex(0), knownvalue.ObjectExact(map[string]knownvalue.Check{
+						"agentcore_memory_configuration": knownvalue.Null(),
+						"disabled":                       knownvalue.Null(),
+						"managed_memory_configuration": knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								names.AttrARN:           tfknownvalue.RegionalARNRegexp("bedrock-agentcore", regexache.MustCompile(`memory/`+rName+`-[a-zA-Z0-9]{10}`)),
+								"encryption_key_arn":    knownvalue.Null(),
+								"event_expiry_duration": knownvalue.Int32Exact(30),
+								"strategies": knownvalue.SetExact([]knownvalue.Check{
+									knownvalue.StringExact("SEMANTIC"),
+									knownvalue.StringExact("SUMMARIZATION"),
+								}),
+							}),
+						}),
+					})),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("model"), knownvalue.ListExact([]knownvalue.Check{
 						knownvalue.ObjectExact(map[string]knownvalue.Check{
 							"bedrock_model_config": knownvalue.ListExact([]knownvalue.Check{
@@ -633,6 +648,19 @@ func TestAccBedrockAgentCoreHarness_Memory_agentCoreMemoryConfiguration_basic(t 
 						"managed_memory_configuration": knownvalue.ListSizeExact(0),
 					})),
 					statecheck.CompareValuePairs(resourceName, tfjsonpath.New("memory").AtSliceIndex(0).AtMapKey("agentcore_memory_configuration").AtSliceIndex(0).AtMapKey(names.AttrARN), "aws_bedrockagentcore_memory.test", tfjsonpath.New(names.AttrARN), compare.ValuesSame()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("memory_actual").AtSliceIndex(0), knownvalue.ObjectExact(map[string]knownvalue.Check{
+						"agentcore_memory_configuration": knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								names.AttrARN:      knownvalue.NotNull(),
+								"actor_id":         knownvalue.Null(),
+								"messages_count":   knownvalue.Null(),
+								"retrieval_config": knownvalue.Null(),
+							}),
+						}),
+						"disabled":                     knownvalue.Null(),
+						"managed_memory_configuration": knownvalue.Null(),
+					})),
+					statecheck.CompareValuePairs(resourceName, tfjsonpath.New("memory_actual").AtSliceIndex(0).AtMapKey("agentcore_memory_configuration").AtSliceIndex(0).AtMapKey(names.AttrARN), "aws_bedrockagentcore_memory.test", tfjsonpath.New(names.AttrARN), compare.ValuesSame()),
 				},
 			},
 			{
@@ -907,6 +935,21 @@ func TestAccBedrockAgentCoreHarness_Memory_managedMemoryConfiguration_empty(t *t
 							}),
 						}),
 					})),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("memory_actual").AtSliceIndex(0), knownvalue.ObjectExact(map[string]knownvalue.Check{
+						"agentcore_memory_configuration": knownvalue.Null(),
+						"disabled":                       knownvalue.Null(),
+						"managed_memory_configuration": knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								names.AttrARN:           tfknownvalue.RegionalARNRegexp("bedrock-agentcore", regexache.MustCompile(`memory/`+rName+`-[a-zA-Z0-9]{10}`)),
+								"encryption_key_arn":    knownvalue.Null(),
+								"event_expiry_duration": knownvalue.Int32Exact(30),
+								"strategies": knownvalue.SetExact([]knownvalue.Check{
+									knownvalue.StringExact("SEMANTIC"),
+									knownvalue.StringExact("SUMMARIZATION"),
+								}),
+							}),
+						}),
+					})),
 				},
 			},
 			{
@@ -1073,6 +1116,13 @@ func TestAccBedrockAgentCoreHarness_Memory_disabled(t *testing.T) {
 							knownvalue.ObjectExact(map[string]knownvalue.Check{}),
 						}),
 						"managed_memory_configuration": knownvalue.ListSizeExact(0),
+					})),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("memory_actual").AtSliceIndex(0), knownvalue.ObjectExact(map[string]knownvalue.Check{
+						"agentcore_memory_configuration": knownvalue.Null(),
+						"disabled": knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectExact(map[string]knownvalue.Check{}),
+						}),
+						"managed_memory_configuration": knownvalue.Null(),
 					})),
 				},
 			},
@@ -1402,6 +1452,7 @@ func testAccPreCheckHarness(ctx context.Context, t *testing.T) {
 func memoryConfigStateChecks(t *testing.T, resourceName string, memType memoryConfigType) []statecheck.StateCheck {
 	t.Helper()
 	memoryPath := tfjsonpath.New("memory")
+	memoryActualPath := tfjsonpath.New("memory_actual")
 	switch memType {
 	case memoryNone:
 		return []statecheck.StateCheck{
@@ -1421,6 +1472,18 @@ func memoryConfigStateChecks(t *testing.T, resourceName string, memType memoryCo
 				"disabled":                     knownvalue.ListSizeExact(0),
 				"managed_memory_configuration": knownvalue.ListSizeExact(0),
 			})),
+			statecheck.ExpectKnownValue(resourceName, memoryActualPath.AtSliceIndex(0), knownvalue.ObjectExact(map[string]knownvalue.Check{
+				"agentcore_memory_configuration": knownvalue.ListExact([]knownvalue.Check{
+					knownvalue.ObjectExact(map[string]knownvalue.Check{
+						names.AttrARN:      knownvalue.NotNull(),
+						"actor_id":         knownvalue.Null(),
+						"messages_count":   knownvalue.Null(),
+						"retrieval_config": knownvalue.Null(),
+					}),
+				}),
+				"disabled":                     knownvalue.Null(),
+				"managed_memory_configuration": knownvalue.Null(),
+			})),
 		}
 	case memoryDisabled:
 		return []statecheck.StateCheck{
@@ -1430,6 +1493,13 @@ func memoryConfigStateChecks(t *testing.T, resourceName string, memType memoryCo
 					knownvalue.ObjectExact(map[string]knownvalue.Check{}),
 				}),
 				"managed_memory_configuration": knownvalue.ListSizeExact(0),
+			})),
+			statecheck.ExpectKnownValue(resourceName, memoryActualPath.AtSliceIndex(0), knownvalue.ObjectExact(map[string]knownvalue.Check{
+				"agentcore_memory_configuration": knownvalue.Null(),
+				"disabled": knownvalue.ListExact([]knownvalue.Check{
+					knownvalue.ObjectExact(map[string]knownvalue.Check{}),
+				}),
+				"managed_memory_configuration": knownvalue.Null(),
 			})),
 		}
 	case memoryManagedEmpty:
@@ -1449,12 +1519,41 @@ func memoryConfigStateChecks(t *testing.T, resourceName string, memType memoryCo
 					}),
 				}),
 			})),
+			statecheck.ExpectKnownValue(resourceName, memoryActualPath.AtSliceIndex(0), knownvalue.ObjectExact(map[string]knownvalue.Check{
+				"agentcore_memory_configuration": knownvalue.Null(),
+				"disabled":                       knownvalue.Null(),
+				"managed_memory_configuration": knownvalue.ListExact([]knownvalue.Check{
+					knownvalue.ObjectExact(map[string]knownvalue.Check{
+						names.AttrARN:           knownvalue.NotNull(),
+						"encryption_key_arn":    knownvalue.Null(),
+						"event_expiry_duration": knownvalue.Int32Exact(30),
+						"strategies": knownvalue.SetExact([]knownvalue.Check{
+							knownvalue.StringExact("SEMANTIC"),
+							knownvalue.StringExact("SUMMARIZATION"),
+						}),
+					}),
+				}),
+			})),
 		}
 	case memoryManaged:
 		return []statecheck.StateCheck{
 			statecheck.ExpectKnownValue(resourceName, memoryPath.AtSliceIndex(0), knownvalue.ObjectExact(map[string]knownvalue.Check{
 				"agentcore_memory_configuration": knownvalue.ListSizeExact(0),
 				"disabled":                       knownvalue.ListSizeExact(0),
+				"managed_memory_configuration": knownvalue.ListExact([]knownvalue.Check{
+					knownvalue.ObjectExact(map[string]knownvalue.Check{
+						names.AttrARN:           knownvalue.NotNull(),
+						"encryption_key_arn":    knownvalue.Null(),
+						"event_expiry_duration": knownvalue.Int32Exact(7),
+						"strategies": knownvalue.SetExact([]knownvalue.Check{
+							knownvalue.StringExact("SEMANTIC"),
+						}),
+					}),
+				}),
+			})),
+			statecheck.ExpectKnownValue(resourceName, memoryActualPath.AtSliceIndex(0), knownvalue.ObjectExact(map[string]knownvalue.Check{
+				"agentcore_memory_configuration": knownvalue.Null(),
+				"disabled":                       knownvalue.Null(),
 				"managed_memory_configuration": knownvalue.ListExact([]knownvalue.Check{
 					knownvalue.ObjectExact(map[string]knownvalue.Check{
 						names.AttrARN:           knownvalue.NotNull(),
@@ -1775,7 +1874,7 @@ resource "aws_bedrockagentcore_harness" "test" {
 }
 
 resource "aws_bedrockagentcore_memory" "test" {
-  name                  = %[1]q
+  name                  = "%[1]s_mem"
   event_expiry_duration = 7
 }
 `, rName))
@@ -1815,7 +1914,7 @@ resource "aws_bedrockagentcore_harness" "test" {
 }
 
 resource "aws_bedrockagentcore_memory" "test" {
-  name                  = %[1]q
+  name                  = "%[1]s_mem"
   event_expiry_duration = 7
 }
 `, rName, actorID, messagesCount, namespacePathTemplate, relevanceScore, topK))
@@ -1853,7 +1952,7 @@ resource "aws_bedrockagentcore_harness" "test" {
 }
 
 resource "aws_bedrockagentcore_memory" "test" {
-  name                  = %[1]q
+  name                  = "%[1]s_mem"
   event_expiry_duration = 7
 }
 `, rName, namespacePathTemplate, relevanceScore, topK))

--- a/internal/service/bedrockagentcore/harness_test.go
+++ b/internal/service/bedrockagentcore/harness_test.go
@@ -168,7 +168,7 @@ func TestAccBedrockAgentCoreHarness_basic(t *testing.T) {
 					acctest.ImportCheckResourceAttr("memory.#", "1"),
 					acctest.ImportCheckResourceAttr("memory.0.agentcore_memory_configuration.#", "0"),
 					acctest.ImportCheckResourceAttr("memory.0.managed_memory_configuration.#", "1"),
-					acctest.ImportMatchResourceAttr("memory.0.managed_memory_configuration.0.arn", regexache.MustCompile(`^arn:[^:]+:bedrock-agentcore:[^:]+:\d{12}:memory/harness_`+rName+`_[a-zA-Z0-9]+-[a-zA-Z0-9]+$`)),
+					acctest.ImportMatchResourceAttr("memory.0.managed_memory_configuration.0.arn", regexache.MustCompile(`^arn:[^:]+:bedrock-agentcore:[^:]+:\d{12}:memory/`+rName+`-[a-zA-Z0-9]{10}$`)),
 					acctest.ImportCheckResourceAttr("memory.0.managed_memory_configuration.0.encryption_key_arn", ""),
 					acctest.ImportCheckResourceAttr("memory.0.managed_memory_configuration.0.event_expiry_duration", "30"),
 					acctest.ImportCheckResourceAttr("memory.0.managed_memory_configuration.0.strategies.#", "2"),
@@ -897,7 +897,7 @@ func TestAccBedrockAgentCoreHarness_Memory_managedMemoryConfiguration_empty(t *t
 						"disabled":                       knownvalue.ListSizeExact(0),
 						"managed_memory_configuration": knownvalue.ListExact([]knownvalue.Check{
 							knownvalue.ObjectExact(map[string]knownvalue.Check{
-								names.AttrARN:           tfknownvalue.RegionalARNRegexp("bedrock-agentcore", regexache.MustCompile(`memory/harness_`+rName+`_[a-zA-Z0-9]+-[a-zA-Z0-9]+`)),
+								names.AttrARN:           tfknownvalue.RegionalARNRegexp("bedrock-agentcore", regexache.MustCompile(`memory/`+rName+`-[a-zA-Z0-9]{10}`)),
 								"encryption_key_arn":    knownvalue.Null(),
 								"event_expiry_duration": knownvalue.Int32Exact(30),
 								"strategies": knownvalue.SetExact([]knownvalue.Check{
@@ -948,7 +948,7 @@ func TestAccBedrockAgentCoreHarness_Memory_managedMemoryConfiguration_update(t *
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("memory").AtSliceIndex(0).AtMapKey("managed_memory_configuration").AtSliceIndex(0), knownvalue.ObjectExact(map[string]knownvalue.Check{
-						names.AttrARN:           tfknownvalue.RegionalARNRegexp("bedrock-agentcore", regexache.MustCompile(`memory/harness_`+rName+`_[a-zA-Z0-9]+-[a-zA-Z0-9]+`)),
+						names.AttrARN:           tfknownvalue.RegionalARNRegexp("bedrock-agentcore", regexache.MustCompile(`memory/`+rName+`-[a-zA-Z0-9]{10}`)),
 						"encryption_key_arn":    knownvalue.Null(),
 						"event_expiry_duration": knownvalue.Int32Exact(7),
 						"strategies": knownvalue.SetExact([]knownvalue.Check{
@@ -969,7 +969,7 @@ func TestAccBedrockAgentCoreHarness_Memory_managedMemoryConfiguration_update(t *
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("memory").AtSliceIndex(0).AtMapKey("managed_memory_configuration").AtSliceIndex(0), knownvalue.ObjectExact(map[string]knownvalue.Check{
-						names.AttrARN:           tfknownvalue.RegionalARNRegexp("bedrock-agentcore", regexache.MustCompile(`memory/harness_`+rName+`_[a-zA-Z0-9]+-[a-zA-Z0-9]+`)),
+						names.AttrARN:           tfknownvalue.RegionalARNRegexp("bedrock-agentcore", regexache.MustCompile(`memory/`+rName+`-[a-zA-Z0-9]{10}`)),
 						"encryption_key_arn":    knownvalue.Null(),
 						"event_expiry_duration": knownvalue.Int32Exact(14),
 						"strategies": knownvalue.SetExact([]knownvalue.Check{
@@ -1018,7 +1018,7 @@ func TestAccBedrockAgentCoreHarness_Memory_managedMemoryConfiguration_encryption
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("memory").AtSliceIndex(0).AtMapKey("managed_memory_configuration").AtSliceIndex(0), knownvalue.ObjectExact(map[string]knownvalue.Check{
-						names.AttrARN:           tfknownvalue.RegionalARNRegexp("bedrock-agentcore", regexache.MustCompile(`memory/harness_`+rName+`_[a-zA-Z0-9]+-[a-zA-Z0-9]+`)),
+						names.AttrARN:           tfknownvalue.RegionalARNRegexp("bedrock-agentcore", regexache.MustCompile(`memory/`+rName+`-[a-zA-Z0-9]{10}`)),
 						"encryption_key_arn":    knownvalue.NotNull(),
 						"event_expiry_duration": knownvalue.Int32Exact(30),
 						"strategies": knownvalue.SetExact([]knownvalue.Check{

--- a/internal/service/bedrockagentcore/memory_test.go
+++ b/internal/service/bedrockagentcore/memory_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	tfknownvalue "github.com/hashicorp/terraform-provider-aws/internal/acctest/knownvalue"
+	tfstatecheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/statecheck"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfbedrockagentcore "github.com/hashicorp/terraform-provider-aws/internal/service/bedrockagentcore"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -52,8 +52,8 @@ func TestAccBedrockAgentCoreMemory_basic(t *testing.T) {
 					},
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrARN), tfknownvalue.RegionalARNRegexp("bedrock-agentcore", regexache.MustCompile(`memory/.+`))),
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrID), knownvalue.NotNull()),
+					tfstatecheck.ExpectRegionalARNFormat(resourceName, tfjsonpath.New(names.AttrARN), "bedrock-agentcore", "memory/{id}"),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrID), knownvalue.StringRegexp(regexache.MustCompile(`^`+rName+`-[a-zA-Z0-9]{10}$`))),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
 				},
 			},

--- a/internal/service/bedrockagentcore/sweep.go
+++ b/internal/service/bedrockagentcore/sweep.go
@@ -31,7 +31,7 @@ func RegisterSweepers() {
 	awsv2.Register("aws_bedrockagentcore_gateway", sweepGateways, "aws_bedrockagentcore_gateway_target")
 	awsv2.Register("aws_bedrockagentcore_gateway_target", sweepGatewayTargets)
 	awsv2.Register("aws_bedrockagentcore_harness", sweepHarnesses)
-	awsv2.Register("aws_bedrockagentcore_memory", sweepMemories)
+	awsv2.Register("aws_bedrockagentcore_memory", sweepMemories, "aws_bedrockagentcore_harness")
 	awsv2.Register("aws_bedrockagentcore_online_evaluation_config", sweepOnlineEvaluationConfigs)
 	awsv2.Register("aws_bedrockagentcore_policy_engine", sweepPolicyEngines, "aws_bedrockagentcore_policy")
 	awsv2.Register("aws_bedrockagentcore_evaluator", sweepEvaluators)

--- a/website/docs/r/bedrockagentcore_harness.html.markdown
+++ b/website/docs/r/bedrockagentcore_harness.html.markdown
@@ -160,7 +160,7 @@ The following arguments are optional:
 * `environment_variables` - (Optional, Sensitive) Map of environment variables.
 * `max_iterations` - (Optional) Maximum number of iterations the agent loop can perform.
 * `max_tokens` - (Optional) Maximum number of tokens in the model response.
-* `memory` - (Optional) Memory configuration. See [`memory` Block](#memory-block) below.
+* `memory` - (Optional) Memory configuration. See [`memory` Block](#memory-block) below. If not specified, configured values can be found in `memory_actual`.
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `skill` - (Optional) Skill configurations. See [`skill` Block](#skill-block) below.
 * `system_prompt` - (Optional) System prompt blocks for the harness. See [`system_prompt` Block](#system_prompt-block) below.
@@ -465,8 +465,9 @@ In addition, the following attribute is exported:
 
 This resource exports the following attributes in addition to the arguments above:
 
-* `harness_id` - Unique identifier of the Harness.
 * `arn` - ARN of the Harness.
+* `harness_id` - Unique identifier of the Harness.
+* `memory_actual` - Actual deployed memory configuration.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 
 ## Timeouts


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Add `memory_actual` `Computed` attribute

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=bedrockagentcore TESTS=TestAccBedrockAgentCoreHarness_

--- PASS: TestAccBedrockAgentCoreHarness_Memory_disabled (113.88s)
--- PASS: TestAccBedrockAgentCoreHarness_truncation_slidingWindow (286.95s)
--- PASS: TestAccBedrockAgentCoreHarness_update_allowedTools (308.81s)
--- PASS: TestAccBedrockAgentCoreHarness_update_systemPrompt (335.47s)
--- PASS: TestAccBedrockAgentCoreHarness_update_limits (337.42s)
--- PASS: TestAccBedrockAgentCoreHarness_environmentArtifact (338.57s)
--- PASS: TestAccBedrockAgentCoreHarness_environmentVariables (340.03s)
--- PASS: TestAccBedrockAgentCoreHarness_authorizerConfiguration (347.27s)
--- PASS: TestAccBedrockAgentCoreHarness_Identity_regionOverride (375.00s)
--- PASS: TestAccBedrockAgentCoreHarness_basic (381.04s)
--- PASS: TestAccBedrockAgentCoreHarness_tags (384.51s)
--- PASS: TestAccBedrockAgentCoreHarness_Identity_basic (387.75s)
--- PASS: TestAccBedrockAgentCoreHarness_List_includeResource (394.45s)
--- PASS: TestAccBedrockAgentCoreHarness_List_regionOverride (396.34s)
--- PASS: TestAccBedrockAgentCoreHarness_truncation_summarization (402.43s)
--- PASS: TestAccBedrockAgentCoreHarness_List_basic (402.52s)
--- PASS: TestAccBedrockAgentCoreHarness_tools_inlineFunction (403.82s)
--- PASS: TestAccBedrockAgentCoreHarness_model_bedrock (405.18s)
--- PASS: TestAccBedrockAgentCoreHarness_Memory_managedMemoryConfiguration_encryptionKey (405.39s)
--- PASS: TestAccBedrockAgentCoreHarness_disappears (418.49s)
--- PASS: TestAccBedrockAgentCoreHarness_Memory_agentCoreMemoryConfiguration_removeRetrievalConfig (429.39s)
--- PASS: TestAccBedrockAgentCoreHarness_Memory_managedMemoryConfiguration_empty (350.85s)
--- PASS: TestAccBedrockAgentCoreHarness_Memory_agentCoreMemoryConfiguration_basic (376.95s)
--- PASS: TestAccBedrockAgentCoreHarness_Memory_managedMemoryConfiguration_update (583.68s)
--- PASS: TestAccBedrockAgentCoreHarness_Memory_agentCoreMemoryConfiguration_options (734.61s)
--- PASS: TestAccBedrockAgentCoreHarness_Memory_agentCoreMemoryConfiguration_addRetrievalConfig (733.54s)
--- PASS: TestAccBedrockAgentCoreHarness_Memory_changeType (0.00s)
    --- PASS: TestAccBedrockAgentCoreHarness_Memory_changeType/disabled_to_none (111.07s)
    --- PASS: TestAccBedrockAgentCoreHarness_Memory_changeType/none_to_managed_empty (342.98s)
    --- PASS: TestAccBedrockAgentCoreHarness_Memory_changeType/disabled_to_managed_empty (413.33s)
    --- PASS: TestAccBedrockAgentCoreHarness_Memory_changeType/none_to_disabled (278.62s)
    --- PASS: TestAccBedrockAgentCoreHarness_Memory_changeType/disabled_to_managed (429.82s)
    --- PASS: TestAccBedrockAgentCoreHarness_Memory_changeType/disabled_to_agentcore (447.28s)
    --- PASS: TestAccBedrockAgentCoreHarness_Memory_changeType/none_to_agentcore (563.70s)
    --- PASS: TestAccBedrockAgentCoreHarness_Memory_changeType/agentcore_to_disabled (514.22s)
    --- PASS: TestAccBedrockAgentCoreHarness_Memory_changeType/managed_empty_to_none (562.11s)
    --- PASS: TestAccBedrockAgentCoreHarness_Memory_changeType/managed_empty_to_managed (584.55s)
    --- PASS: TestAccBedrockAgentCoreHarness_Memory_changeType/managed_empty_to_disabled (593.51s)
    --- PASS: TestAccBedrockAgentCoreHarness_Memory_changeType/none_to_managed (601.74s)
    --- PASS: TestAccBedrockAgentCoreHarness_Memory_changeType/managed_empty_to_agentcore (699.20s)
    --- PASS: TestAccBedrockAgentCoreHarness_Memory_changeType/agentcore_to_managed_empty (767.35s)
    --- PASS: TestAccBedrockAgentCoreHarness_Memory_changeType/agentcore_to_managed (778.65s)
```

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>