### PR TITLE
feat: add support for unmanaged_vcpus to aws_batch_compute_environment

### DIFF
--- a/.changelog/49386.txt
+++ b/.changelog/49386.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_batch_compute_environment: Add `unmanaged_vcpus` argument
+```
+
+```release-note:enhancement
+data-source/aws_batch_compute_environment: Add `unmanaged_vcpus` attribute
+```

--- a/internal/service/batch/compute_environment.go
+++ b/internal/service/batch/compute_environment.go
@@ -269,6 +269,11 @@ func resourceComputeEnvironment() *schema.Resource {
 					StateFunc:        sdkv2.ToUpperSchemaStateFunc,
 					ValidateDiagFunc: enum.ValidateIgnoreCase[awstypes.CEType](),
 				},
+				"unmanaged_vcpus": {
+					Type:     schema.TypeInt,
+					Optional: true,
+					Computed: true,
+				},
 				"update_policy": {
 					Type:     schema.TypeList,
 					Optional: true,
@@ -319,6 +324,12 @@ func resourceComputeEnvironmentCreate(ctx context.Context, d *schema.ResourceDat
 
 	if v, ok := d.GetOk(names.AttrState); ok {
 		input.State = awstypes.CEState(v.(string))
+	}
+
+	if computeEnvironmentType == awstypes.CETypeUnmanaged {
+		if v, ok := d.GetOk("unmanaged_vcpus"); ok {
+			input.UnmanagedvCpus = aws.Int32(int32(v.(int)))
+		}
 	}
 
 	output, err := conn.CreateComputeEnvironment(ctx, input)
@@ -393,6 +404,9 @@ func resourceComputeEnvironmentRead(ctx context.Context, d *schema.ResourceData,
 	d.Set(names.AttrStatus, computeEnvironment.Status)
 	d.Set(names.AttrStatusReason, computeEnvironment.StatusReason)
 	d.Set(names.AttrType, computeEnvironment.Type)
+	if computeEnvironment.UnmanagedvCpus != nil {
+		d.Set("unmanaged_vcpus", aws.ToInt32(computeEnvironment.UnmanagedvCpus))
+	}
 	if err := d.Set("update_policy", flattenComputeEnvironmentUpdatePolicy(computeEnvironment.UpdatePolicy)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting update_policy: %s", err)
 	}
@@ -421,6 +435,14 @@ func resourceComputeEnvironmentUpdate(ctx context.Context, d *schema.ResourceDat
 
 		if d.HasChange("update_policy") {
 			input.UpdatePolicy = expandComputeEnvironmentUpdatePolicy(d.Get("update_policy").([]any))
+		}
+
+		if d.HasChange("unmanaged_vcpus") {
+			if awstypes.CEType(strings.ToUpper(d.Get(names.AttrType).(string))) == awstypes.CETypeUnmanaged {
+				if v, ok := d.GetOk("unmanaged_vcpus"); ok {
+					input.UnmanagedvCpus = aws.Int32(int32(v.(int)))
+				}
+			}
 		}
 
 		if computeEnvironmentType := strings.ToUpper(d.Get(names.AttrType).(string)); computeEnvironmentType == string(awstypes.CETypeManaged) {
@@ -589,6 +611,11 @@ func resourceComputeEnvironmentCustomizeDiff(ctx context.Context, diff *schema.R
 		// UNMANAGED compute environments can have no compute_resources configured.
 		if v, ok := diff.GetOk("compute_resources"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
 			return fmt.Errorf("no `compute_resources` can be specified when `type` is %q", computeEnvironmentType)
+		}
+	} else {
+		// Managed types cannot use unmanaged_vcpus
+		if _, ok := diff.GetOk("unmanaged_vcpus"); ok {
+			return fmt.Errorf("`unmanaged_vcpus` can only be specified when `type` is %q", awstypes.CETypeUnmanaged)
 		}
 	}
 

--- a/internal/service/batch/compute_environment.go
+++ b/internal/service/batch/compute_environment.go
@@ -404,9 +404,7 @@ func resourceComputeEnvironmentRead(ctx context.Context, d *schema.ResourceData,
 	d.Set(names.AttrStatus, computeEnvironment.Status)
 	d.Set(names.AttrStatusReason, computeEnvironment.StatusReason)
 	d.Set(names.AttrType, computeEnvironment.Type)
-	if computeEnvironment.UnmanagedvCpus != nil {
-		d.Set("unmanaged_vcpus", computeEnvironment.UnmanagedvCpus)
-	}
+	d.Set("unmanaged_vcpus", computeEnvironment.UnmanagedvCpus)
 	if err := d.Set("update_policy", flattenComputeEnvironmentUpdatePolicy(computeEnvironment.UpdatePolicy)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting update_policy: %s", err)
 	}

--- a/internal/service/batch/compute_environment.go
+++ b/internal/service/batch/compute_environment.go
@@ -405,7 +405,7 @@ func resourceComputeEnvironmentRead(ctx context.Context, d *schema.ResourceData,
 	d.Set(names.AttrStatusReason, computeEnvironment.StatusReason)
 	d.Set(names.AttrType, computeEnvironment.Type)
 	if computeEnvironment.UnmanagedvCpus != nil {
-		d.Set("unmanaged_vcpus", aws.ToInt32(computeEnvironment.UnmanagedvCpus))
+		d.Set("unmanaged_vcpus", computeEnvironment.UnmanagedvCpus)
 	}
 	if err := d.Set("update_policy", flattenComputeEnvironmentUpdatePolicy(computeEnvironment.UpdatePolicy)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting update_policy: %s", err)

--- a/internal/service/batch/compute_environment_data_source.go
+++ b/internal/service/batch/compute_environment_data_source.go
@@ -106,9 +106,7 @@ func dataSourceComputeEnvironmentRead(ctx context.Context, d *schema.ResourceDat
 	d.Set(names.AttrStatus, computeEnvironment.Status)
 	d.Set(names.AttrStatusReason, computeEnvironment.StatusReason)
 	d.Set(names.AttrType, computeEnvironment.Type)
-	if computeEnvironment.UnmanagedvCpus != nil {
-		d.Set("unmanaged_vcpus", computeEnvironment.UnmanagedvCpus)
-	}
+	d.Set("unmanaged_vcpus", computeEnvironment.UnmanagedvCpus)
 	if err := d.Set("update_policy", flattenComputeEnvironmentUpdatePolicy(computeEnvironment.UpdatePolicy)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting update_policy: %s", err)
 	}

--- a/internal/service/batch/compute_environment_data_source.go
+++ b/internal/service/batch/compute_environment_data_source.go
@@ -60,6 +60,10 @@ func dataSourceComputeEnvironment() *schema.Resource {
 					Type:     schema.TypeString,
 					Computed: true,
 				},
+				"unmanaged_vcpus": {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
 				"update_policy": {
 					Type:     schema.TypeList,
 					Computed: true,
@@ -102,6 +106,9 @@ func dataSourceComputeEnvironmentRead(ctx context.Context, d *schema.ResourceDat
 	d.Set(names.AttrStatus, computeEnvironment.Status)
 	d.Set(names.AttrStatusReason, computeEnvironment.StatusReason)
 	d.Set(names.AttrType, computeEnvironment.Type)
+	if computeEnvironment.UnmanagedvCpus != nil {
+		d.Set("unmanaged_vcpus", aws.ToInt32(computeEnvironment.UnmanagedvCpus))
+	}
 	if err := d.Set("update_policy", flattenComputeEnvironmentUpdatePolicy(computeEnvironment.UpdatePolicy)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting update_policy: %s", err)
 	}

--- a/internal/service/batch/compute_environment_data_source.go
+++ b/internal/service/batch/compute_environment_data_source.go
@@ -107,7 +107,7 @@ func dataSourceComputeEnvironmentRead(ctx context.Context, d *schema.ResourceDat
 	d.Set(names.AttrStatusReason, computeEnvironment.StatusReason)
 	d.Set(names.AttrType, computeEnvironment.Type)
 	if computeEnvironment.UnmanagedvCpus != nil {
-		d.Set("unmanaged_vcpus", aws.ToInt32(computeEnvironment.UnmanagedvCpus))
+		d.Set("unmanaged_vcpus", computeEnvironment.UnmanagedvCpus)
 	}
 	if err := d.Set("update_policy", flattenComputeEnvironmentUpdatePolicy(computeEnvironment.UpdatePolicy)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting update_policy: %s", err)

--- a/internal/service/batch/compute_environment_data_source_test.go
+++ b/internal/service/batch/compute_environment_data_source_test.go
@@ -71,7 +71,7 @@ func TestAccBatchComputeEnvironmentDataSource_basicUpdatePolicy(t *testing.T) {
 	})
 }
 
-func TestAccBatchComputeEnvironmentDataSource_unmanagedVCpus(t *testing.T) {
+func TestAccBatchComputeEnvironmentDataSource_unmanagedVCPUs(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_batch_compute_environment.test"
@@ -83,7 +83,7 @@ func TestAccBatchComputeEnvironmentDataSource_unmanagedVCpus(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeEnvironmentDataSourceConfig_unmanagedVCpus(rName, 256),
+				Config: testAccComputeEnvironmentDataSourceConfig_unmanagedVCPUs(rName, 256),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrARN, resourceName, names.AttrARN),
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrName, resourceName, names.AttrName),
@@ -212,7 +212,7 @@ data "aws_batch_compute_environment" "by_name" {
 `, rName, timeout, terminate))
 }
 
-func testAccComputeEnvironmentDataSourceConfig_unmanagedVCpus(rName string, vcpus int) string {
+func testAccComputeEnvironmentDataSourceConfig_unmanagedVCPUs(rName string, vcpus int) string {
 	return acctest.ConfigCompose(testAccComputeEnvironmentConfig_base(rName), fmt.Sprintf(`
 resource "aws_batch_compute_environment" "test" {
   name = %[1]q

--- a/internal/service/batch/compute_environment_data_source_test.go
+++ b/internal/service/batch/compute_environment_data_source_test.go
@@ -35,6 +35,7 @@ func TestAccBatchComputeEnvironmentDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrServiceRole, resourceName, names.AttrServiceRole),
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrState, resourceName, names.AttrState),
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrType, resourceName, names.AttrType),
+					resource.TestCheckResourceAttrPair(dataSourceName, "unmanaged_vcpus", resourceName, "unmanaged_vcpus"),
 					resource.TestCheckResourceAttr(dataSourceName, "update_policy.#", "0"),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -64,6 +65,31 @@ func TestAccBatchComputeEnvironmentDataSource_basicUpdatePolicy(t *testing.T) {
 					resource.TestCheckResourceAttr(dataSourceName, "update_policy.0.%", "2"),
 					resource.TestCheckResourceAttr(dataSourceName, "update_policy.0.terminate_jobs_on_update", acctest.CtFalse),
 					resource.TestCheckResourceAttr(dataSourceName, "update_policy.0.job_execution_timeout_minutes", "30"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccBatchComputeEnvironmentDataSource_unmanagedVCpus(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_batch_compute_environment.test"
+	dataSourceName := "data.aws_batch_compute_environment.by_name"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeEnvironmentDataSourceConfig_unmanagedVCpus(rName, 256),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrARN, resourceName, names.AttrARN),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrName, resourceName, names.AttrName),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrType, resourceName, names.AttrType),
+					resource.TestCheckResourceAttrPair(dataSourceName, "unmanaged_vcpus", resourceName, "unmanaged_vcpus"),
+					resource.TestCheckResourceAttr(dataSourceName, "unmanaged_vcpus", "256"),
 				),
 			},
 		},
@@ -184,4 +210,21 @@ data "aws_batch_compute_environment" "by_name" {
   name = aws_batch_compute_environment.test.name
 }
 `, rName, timeout, terminate))
+}
+
+func testAccComputeEnvironmentDataSourceConfig_unmanagedVCpus(rName string, vcpus int) string {
+	return acctest.ConfigCompose(testAccComputeEnvironmentConfig_base(rName), fmt.Sprintf(`
+resource "aws_batch_compute_environment" "test" {
+  name = %[1]q
+
+  service_role    = aws_iam_role.batch_service.arn
+  type            = "UNMANAGED"
+  unmanaged_vcpus = %[2]d
+  depends_on      = [aws_iam_role_policy_attachment.batch_service]
+}
+
+data "aws_batch_compute_environment" "by_name" {
+  name = aws_batch_compute_environment.test.name
+}
+`, rName, vcpus))
 }

--- a/internal/service/batch/compute_environment_test.go
+++ b/internal/service/batch/compute_environment_test.go
@@ -1770,7 +1770,7 @@ func TestAccBatchComputeEnvironment_createUnmanagedWithComputeResources(t *testi
 	})
 }
 
-func TestAccBatchComputeEnvironment_unmanagedvCpus(t *testing.T) {
+func TestAccBatchComputeEnvironment_unmanagedVCPUs(t *testing.T) {
 	ctx := acctest.Context(t)
 	var ce awstypes.ComputeEnvironmentDetail
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
@@ -1783,7 +1783,7 @@ func TestAccBatchComputeEnvironment_unmanagedvCpus(t *testing.T) {
 		CheckDestroy:             testAccCheckComputeEnvironmentDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeEnvironmentConfig_unmanagedvCpus(rName, 256),
+				Config: testAccComputeEnvironmentConfig_unmanagedVCPUs(rName, 256),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckComputeEnvironmentExists(ctx, t, resourceName, &ce),
 					acctest.CheckResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "batch", fmt.Sprintf("compute-environment/%s", rName)),
@@ -1801,7 +1801,7 @@ func TestAccBatchComputeEnvironment_unmanagedvCpus(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccComputeEnvironmentConfig_unmanagedvCpus(rName, 512),
+				Config: testAccComputeEnvironmentConfig_unmanagedVCPUs(rName, 512),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckComputeEnvironmentExists(ctx, t, resourceName, &ce),
 					acctest.CheckResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "batch", fmt.Sprintf("compute-environment/%s", rName)),
@@ -1814,7 +1814,7 @@ func TestAccBatchComputeEnvironment_unmanagedvCpus(t *testing.T) {
 	})
 }
 
-func TestAccBatchComputeEnvironment_unmanagedvCpusInvalidWithManaged(t *testing.T) {
+func TestAccBatchComputeEnvironment_unmanagedVCPUsInvalidWithManaged(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
@@ -1825,7 +1825,7 @@ func TestAccBatchComputeEnvironment_unmanagedvCpusInvalidWithManaged(t *testing.
 		CheckDestroy:             testAccCheckComputeEnvironmentDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccComputeEnvironmentConfig_managedWithUnmanagedvCpus(rName),
+				Config:      testAccComputeEnvironmentConfig_managedWithUnmanagedVCPUs(rName),
 				ExpectError: regexache.MustCompile("`unmanaged_vcpus` can only be specified when `type` is"),
 			},
 		},
@@ -3500,7 +3500,7 @@ resource "aws_batch_compute_environment" "test" {
 `, rName, instanceType))
 }
 
-func testAccComputeEnvironmentConfig_unmanagedvCpus(rName string, vcpus int) string {
+func testAccComputeEnvironmentConfig_unmanagedVCPUs(rName string, vcpus int) string {
 	return acctest.ConfigCompose(testAccComputeEnvironmentConfig_base(rName), fmt.Sprintf(`
 resource "aws_batch_compute_environment" "test" {
   name = %[1]q
@@ -3513,7 +3513,7 @@ resource "aws_batch_compute_environment" "test" {
 `, rName, vcpus))
 }
 
-func testAccComputeEnvironmentConfig_managedWithUnmanagedvCpus(rName string) string {
+func testAccComputeEnvironmentConfig_managedWithUnmanagedVCPUs(rName string) string {
 	return acctest.ConfigCompose(testAccComputeEnvironmentConfig_base(rName), fmt.Sprintf(`
 resource "aws_batch_compute_environment" "test" {
   name = %[1]q

--- a/internal/service/batch/compute_environment_test.go
+++ b/internal/service/batch/compute_environment_test.go
@@ -1770,6 +1770,68 @@ func TestAccBatchComputeEnvironment_createUnmanagedWithComputeResources(t *testi
 	})
 }
 
+func TestAccBatchComputeEnvironment_unmanagedvCpus(t *testing.T) {
+	ctx := acctest.Context(t)
+	var ce awstypes.ComputeEnvironmentDetail
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_batch_compute_environment.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckComputeEnvironmentDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeEnvironmentConfig_unmanagedvCpus(rName, 256),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckComputeEnvironmentExists(ctx, t, resourceName, &ce),
+					acctest.CheckResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "batch", fmt.Sprintf("compute-environment/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					resource.TestCheckResourceAttr(resourceName, names.AttrNamePrefix, ""),
+					resource.TestCheckResourceAttr(resourceName, names.AttrType, "UNMANAGED"),
+					resource.TestCheckResourceAttr(resourceName, "unmanaged_vcpus", "256"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrState, "ENABLED"),
+					resource.TestCheckResourceAttrSet(resourceName, names.AttrStatus),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeEnvironmentConfig_unmanagedvCpus(rName, 512),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckComputeEnvironmentExists(ctx, t, resourceName, &ce),
+					acctest.CheckResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "batch", fmt.Sprintf("compute-environment/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					resource.TestCheckResourceAttr(resourceName, "unmanaged_vcpus", "512"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrType, "UNMANAGED"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccBatchComputeEnvironment_unmanagedvCpusInvalidWithManaged(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckComputeEnvironmentDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccComputeEnvironmentConfig_managedWithUnmanagedvCpus(rName),
+				ExpectError: regexache.MustCompile("`unmanaged_vcpus` can only be specified when `type` is"),
+			},
+		},
+	})
+}
+
 func TestAccBatchComputeEnvironment_updateEC2(t *testing.T) {
 	ctx := acctest.Context(t)
 	var ce awstypes.ComputeEnvironmentDetail
@@ -3436,4 +3498,30 @@ resource "aws_batch_compute_environment" "test" {
   type = "MANAGED"
 }
 `, rName, instanceType))
+}
+
+func testAccComputeEnvironmentConfig_unmanagedvCpus(rName string, vcpus int) string {
+	return acctest.ConfigCompose(testAccComputeEnvironmentConfig_base(rName), fmt.Sprintf(`
+resource "aws_batch_compute_environment" "test" {
+  name = %[1]q
+
+  service_role    = aws_iam_role.batch_service.arn
+  type            = "UNMANAGED"
+  unmanaged_vcpus = %[2]d
+  depends_on      = [aws_iam_role_policy_attachment.batch_service]
+}
+`, rName, vcpus))
+}
+
+func testAccComputeEnvironmentConfig_managedWithUnmanagedvCpus(rName string) string {
+	return acctest.ConfigCompose(testAccComputeEnvironmentConfig_base(rName), fmt.Sprintf(`
+resource "aws_batch_compute_environment" "test" {
+  name = %[1]q
+
+  service_role    = aws_iam_role.batch_service.arn
+  type            = "MANAGED"
+  unmanaged_vcpus = 256
+  depends_on      = [aws_iam_role_policy_attachment.batch_service]
+}
+`, rName))
 }

--- a/website/docs/d/batch_compute_environment.html.markdown
+++ b/website/docs/d/batch_compute_environment.html.markdown
@@ -37,5 +37,6 @@ This data source exports the following attributes in addition to the arguments a
 * `status` - Current status of the compute environment (for example, `CREATING` or `VALID`).
 * `status_reason` - Short, human-readable string to provide additional details about the current status of the compute environment.
 * `state` - State of the compute environment (for example, `ENABLED` or `DISABLED`). If the state is `ENABLED`, then the compute environment accepts jobs from a queue and can scale out automatically based on queues.
+* `unmanaged_vcpus` - Number of vCPUs for an unmanaged compute environment. This parameter is only used for fair-share scheduling to ensure that each compute environment has the correct number of vCPUs when it is used in a fair-share job queue. Only valid when `type` is `UNMANAGED`.
 * `update_policy` - Specifies the infrastructure update policy for the compute environment.
 * `tags` - Key-value map of resource tags

--- a/website/docs/r/batch_compute_environment.html.markdown
+++ b/website/docs/r/batch_compute_environment.html.markdown
@@ -198,6 +198,7 @@ This resource supports the following arguments:
 * `state` - (Optional) The state of the compute environment. If the state is `ENABLED`, then the compute environment accepts jobs from a queue and can scale out automatically based on queues. Valid items are `ENABLED` or `DISABLED`. Defaults to `ENABLED`.
 * `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `type` - (Required) The type of the compute environment. Valid items are `MANAGED` or `UNMANAGED`.
+* `unmanaged_vcpus` - (Optional) Number of vCPUs for an unmanaged compute environment. This parameter is only used for fair-share scheduling to ensure that each compute environment has the correct number of vCPUs when it is used in a fair-share job queue. Only valid when `type` is `UNMANAGED`.
 * `update_policy` - (Optional) Specifies the infrastructure update policy for the compute environment. See details below.
 
 ### compute_resources


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

### Description

- Add support for argument `unmanaged_vcpus` to resource [`aws_batch_compute_environment`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/batch_compute_environment)
- Update data source  [`aws_batch_compute_environment`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/batch_compute_environment) to expose `unmanaged_vcpus`
- Update documentation of resource and data source

### Relations

Closes #49311 

### References

- [AWS API Docs- CreateComputeEnvironment](https://docs.aws.amazon.com/batch/latest/APIReference/API_CreateComputeEnvironment.html#Batch-CreateComputeEnvironment-request-unmanagedvCpus)

- [AWS API Docs- UpdateComputeEnvironment](https://docs.aws.amazon.com/batch/latest/APIReference/API_UpdateComputeEnvironment.html#Batch-UpdateComputeEnvironment-request-unmanagedvCpus)

### Output from Acceptance Testing


```console
make testacc T=TestAccBatchComputeEnvironment_unmanagedVCPUs K=batch
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework (cached)
make: Running acceptance tests on branch: 🌿 f-aws_batch_compute_environment-add-unmanaged_vcpus 🌿...
TF_ACC=1 go1.26.5 test ./internal/service/batch/... -v -count 1 -parallel 20 -run='TestAccBatchComputeEnvironment_unmanagedVCPUs'  -timeout 360m -vet=off -buildvcs=false
2026/08/11 09:58:46 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/11 09:58:46 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccBatchComputeEnvironment_unmanagedVCPUs
=== PAUSE TestAccBatchComputeEnvironment_unmanagedVCPUs
=== RUN   TestAccBatchComputeEnvironment_unmanagedVCPUsInvalidWithManaged
=== PAUSE TestAccBatchComputeEnvironment_unmanagedVCPUsInvalidWithManaged
=== CONT  TestAccBatchComputeEnvironment_unmanagedVCPUs
=== CONT  TestAccBatchComputeEnvironment_unmanagedVCPUsInvalidWithManaged
--- PASS: TestAccBatchComputeEnvironment_unmanagedVCPUsInvalidWithManaged (6.63s)
--- PASS: TestAccBatchComputeEnvironment_unmanagedVCPUs (91.52s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/batch      91.734s
``` 

```console
make testacc T=TestAccBatchComputeEnvironmentDataSource_unmanagedVCPUs K=batch
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework (cached)
make: Running acceptance tests on branch: 🌿 f-aws_batch_compute_environment-add-unmanaged_vcpus 🌿...
TF_ACC=1 go1.26.5 test ./internal/service/batch/... -v -count 1 -parallel 20 -run='TestAccBatchComputeEnvironmentDataSource_unmanagedVCPUs'  -timeout 360m -vet=off -buildvcs=false
2026/08/11 10:01:40 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/11 10:01:40 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccBatchComputeEnvironmentDataSource_unmanagedVCPUs
=== PAUSE TestAccBatchComputeEnvironmentDataSource_unmanagedVCPUs
=== CONT  TestAccBatchComputeEnvironmentDataSource_unmanagedVCPUs
--- PASS: TestAccBatchComputeEnvironmentDataSource_unmanagedVCPUs (58.46s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/batch      58.624s
```
