### PR TITLE
td: Skip deleted resources cleanly during List + Add Semgrep rules

### DIFF
--- a/.ci/semgrep/list/finder-notfound-skip.yml
+++ b/.ci/semgrep/list/finder-notfound-skip.yml
@@ -1,0 +1,51 @@
+# Copyright IBM Corp. 2014, 2026
+# "SPDX-License-Identifier: MPL-2.0"
+
+rules:
+  - id: list-resource-finder-inside-setresult
+    languages: [go]
+    message: >-
+      Finder call is inside the SetResult closure: a bare `return` here only
+      exits the closure, so a deleted item can still get yielded with partial
+      data, and any other error here aborts the whole list stream instead of
+      just skipping this item. Move the finder call above SetResult and
+      `continue` on NotFound instead.
+    severity: ERROR
+    paths:
+      include:
+        - "/internal/service/**/*_list.go"
+    patterns:
+      - pattern-inside: |
+          $L.SetResult($CTX, $META, $INCLUDE, $DATA, $RESULT, func() {
+            ...
+          })
+      - pattern: $FIND(...)
+      - metavariable-regex:
+          metavariable: $FIND
+          regex: "^find\\w*$"
+
+  - id: list-resource-notfound-return-not-continue
+    languages: [go]
+    message: >-
+      `return` on NotFound here exits the whole list stream, silently dropping
+      every later item. Use `continue` to skip just this one.
+    severity: ERROR
+    paths:
+      include:
+        - "/internal/service/**/*_list.go"
+    patterns:
+      - pattern-inside: |
+          $STREAM.Results = func(yield func(list.ListResult) bool) {
+            ...
+            for $ITEM, $ERR := range $LISTFN(...) {
+              ...
+            }
+          }
+      - pattern: |
+          if retry.NotFound($ERR) {
+            return
+          }
+      - pattern-not-inside: |
+          $L.SetResult($CTX, $META, $INCLUDE, $DATA, $RESULT, func() {
+            ...
+          })

--- a/internal/service/amp/anomaly_detector_list.go
+++ b/internal/service/amp/anomaly_detector_list.go
@@ -87,6 +87,19 @@ func (l *anomalyDetectorListResource) List(ctx context.Context, request list.Lis
 			id := aws.ToString(item.AnomalyDetectorId)
 			ctx := tflog.SetField(ctx, logging.ResourceAttributeKey(names.AttrARN), aws.ToString(item.Arn))
 
+			var out *awstypes.AnomalyDetectorDescription
+			if request.IncludeResource {
+				var err error
+				out, err = findAnomalyDetectorByID(ctx, conn, id, workspaceID)
+				if retry.NotFound(err) {
+					continue
+				}
+				if err != nil {
+					yield(fwdiag.NewListResultErrorDiagnostic(err))
+					return
+				}
+			}
+
 			result := request.NewListResult(ctx)
 
 			var data anomalyDetectorResourceModel
@@ -94,15 +107,6 @@ func (l *anomalyDetectorListResource) List(ctx context.Context, request list.Lis
 				data.WorkspaceID = types.StringValue(workspaceID)
 
 				if request.IncludeResource {
-					out, err := findAnomalyDetectorByID(ctx, conn, id, workspaceID)
-					if retry.NotFound(err) {
-						return
-					}
-					if err != nil {
-						result = fwdiag.NewListResultErrorDiagnostic(err)
-						return
-					}
-
 					result.Diagnostics.Append(fwflex.Flatten(ctx, out, &data, fwflex.WithFieldNamePrefix("AnomalyDetector"))...)
 					if result.Diagnostics.HasError() {
 						return

--- a/internal/service/amp/scraper_list.go
+++ b/internal/service/amp/scraper_list.go
@@ -75,6 +75,20 @@ func (l *scraperListResource) List(ctx context.Context, request list.ListRequest
 			ctx := tflog.SetField(ctx, logging.ResourceAttributeKey(names.AttrARN), aws.ToString(item.Arn))
 
 			scraperID := aws.ToString(item.ScraperId)
+
+			var scraper *awstypes.ScraperDescription
+			if request.IncludeResource {
+				var err error
+				scraper, err = findScraperByID(ctx, conn, scraperID)
+				if retry.NotFound(err) {
+					continue
+				}
+				if err != nil {
+					yield(fwdiag.NewListResultErrorDiagnostic(err))
+					return
+				}
+			}
+
 			result := request.NewListResult(ctx)
 
 			var data scraperResourceModel
@@ -84,15 +98,6 @@ func (l *scraperListResource) List(ctx context.Context, request list.ListRequest
 				data.ID = fwflex.StringValueToFramework(ctx, scraperID)
 
 				if request.IncludeResource {
-					scraper, err := findScraperByID(ctx, conn, scraperID)
-					if retry.NotFound(err) {
-						return
-					}
-					if err != nil {
-						result = fwdiag.NewListResultErrorDiagnostic(err)
-						return
-					}
-
 					result.Diagnostics.Append(l.flatten(ctx, scraper, &data)...)
 					if result.Diagnostics.HasError() {
 						return

--- a/internal/service/bedrock/evaluation_job_list.go
+++ b/internal/service/bedrock/evaluation_job_list.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
 	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/logging"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -47,17 +48,25 @@ func (l *evaluationJobListResource) List(ctx context.Context, request list.ListR
 			arn := aws.ToString(item.JobArn)
 			ctx := tflog.SetField(ctx, logging.ResourceAttributeKey(names.AttrARN), arn)
 
+			var job *bedrock.GetEvaluationJobOutput
+			if request.IncludeResource {
+				var err error
+				job, err = findEvaluationJobByARN(ctx, conn, arn)
+				if retry.NotFound(err) {
+					continue
+				}
+				if err != nil {
+					yield(fwdiag.NewListResultErrorDiagnostic(err))
+					return
+				}
+			}
+
 			result := request.NewListResult(ctx)
 
 			var data evaluationJobResourceModel
 			l.SetResult(ctx, l.Meta(), request.IncludeResource, &data, &result, func() {
 				data.JobARN = fwflex.StringToFramework(ctx, item.JobArn)
 				if request.IncludeResource {
-					job, err := findEvaluationJobByARN(ctx, conn, arn)
-					if err != nil {
-						result.Diagnostics.Append(fwdiag.NewResourceNotFoundWarningDiagnostic(err))
-						return
-					}
 					result.Diagnostics.Append(fwflex.Flatten(ctx, job, &data)...)
 					if result.Diagnostics.HasError() {
 						return

--- a/internal/service/bedrockagentcore/evaluator_list.go
+++ b/internal/service/bedrockagentcore/evaluator_list.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
 	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/logging"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/smerr"
 	inttypes "github.com/hashicorp/terraform-provider-aws/internal/types"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -66,17 +67,24 @@ func (l *evaluatorListResource) List(ctx context.Context, request list.ListReque
 			arn := aws.ToString(item.EvaluatorArn)
 			ctx := tflog.SetField(ctx, logging.ResourceAttributeKey(names.AttrARN), arn)
 
+			var output *bedrockagentcorecontrol.GetEvaluatorOutput
+			if request.IncludeResource {
+				var err error
+				output, err = findEvaluatorByID(ctx, conn, evaluatorID)
+				if retry.NotFound(err) {
+					continue
+				}
+				if err != nil {
+					yield(fwdiag.NewListResultErrorDiagnostic(err))
+					return
+				}
+			}
+
 			result := request.NewListResult(ctx)
 
 			var data evaluatorResourceModel
 			l.SetResult(ctx, l.Meta(), request.IncludeResource, &data, &result, func() {
 				if request.IncludeResource {
-					output, err := findEvaluatorByID(ctx, conn, evaluatorID)
-					if err != nil {
-						smerr.AddError(ctx, &result.Diagnostics, err, smerr.ID, evaluatorID)
-						return
-					}
-
 					smerr.AddEnrich(ctx, &result.Diagnostics, fwflex.Flatten(ctx, output, &data))
 				} else {
 					smerr.AddEnrich(ctx, &result.Diagnostics, fwflex.Flatten(ctx, &item, &data))

--- a/internal/service/cleanrooms/membership_list.go
+++ b/internal/service/cleanrooms/membership_list.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
 	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/logging"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -58,6 +59,19 @@ func (l *membershipListResource) List(ctx context.Context, request list.ListRequ
 			id := aws.ToString(item.Id)
 			ctx := tflog.SetField(ctx, logging.ResourceAttributeKey(names.AttrID), id)
 
+			var out *cleanrooms.GetMembershipOutput
+			if request.IncludeResource {
+				var err error
+				out, err = findMembershipByID(ctx, conn, id)
+				if retry.NotFound(err) {
+					continue
+				}
+				if err != nil {
+					yield(fwdiag.NewListResultErrorDiagnostic(err))
+					return
+				}
+			}
+
 			result := request.NewListResult(ctx)
 
 			var data membershipResourceModel
@@ -65,12 +79,6 @@ func (l *membershipListResource) List(ctx context.Context, request list.ListRequ
 				data.ID = fwflex.StringValueToFramework(ctx, id)
 
 				if request.IncludeResource {
-					out, err := findMembershipByID(ctx, conn, id)
-					if err != nil {
-						result.Diagnostics.Append(fwdiag.NewListResultErrorDiagnostic(err).Diagnostics...)
-						return
-					}
-
 					result.Diagnostics.Append(fwflex.Flatten(ctx, out.Membership, &data, fwflex.WithIgnoredFieldNamesAppend("PaymentConfiguration"))...)
 					if result.Diagnostics.HasError() {
 						return

--- a/internal/service/codebuild/project_list.go
+++ b/internal/service/codebuild/project_list.go
@@ -100,6 +100,9 @@ func (l *projectListResource) List(ctx context.Context, request list.ListRequest
 						})
 						continue
 					}
+				} else if request.IncludeResource {
+					tflog.Warn(ctx, "Resource disappeared during listing, skipping")
+					continue
 				}
 				result.DisplayName = projectName
 

--- a/internal/service/ecs/daemon_list.go
+++ b/internal/service/ecs/daemon_list.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
 	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	inttypes "github.com/hashicorp/terraform-provider-aws/internal/types"
 )
 
@@ -67,16 +68,19 @@ func (r *listResourceDaemon) List(ctx context.Context, request list.ListRequest,
 				return
 			}
 
+			daemon, err := findDaemonByARN(ctx, conn, aws.ToString(summary.DaemonArn))
+			if retry.NotFound(err) {
+				continue
+			}
+			if err != nil {
+				yield(fwdiag.NewListResultErrorDiagnostic(err))
+				return
+			}
+
 			result := request.NewListResult(ctx)
 
 			var data daemonResourceModel
 			r.SetResult(ctx, awsClient, request.IncludeResource, &data, &result, func() {
-				daemon, err := findDaemonByARN(ctx, conn, aws.ToString(summary.DaemonArn))
-				if err != nil {
-					result.Diagnostics.AddError(fmt.Sprintf("reading ECS Daemon (%s)", aws.ToString(summary.DaemonArn)), err.Error())
-					return
-				}
-
 				data.CapacityProviderArns = fwflex.FlattenFrameworkStringValueSetOfString(ctx, []string{})
 
 				result.Diagnostics.Append(fwflex.Flatten(ctx, daemon, &data)...)

--- a/internal/service/ecs/daemon_task_definition_list.go
+++ b/internal/service/ecs/daemon_task_definition_list.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
 	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	inttypes "github.com/hashicorp/terraform-provider-aws/internal/types"
 )
 
@@ -60,16 +61,19 @@ func (r *listResourceDaemonTaskDefinition) List(ctx context.Context, request lis
 				return
 			}
 
+			outputFind, err := findDaemonTaskDefinitionByARN(ctx, conn, aws.ToString(summary.Arn))
+			if retry.NotFound(err) {
+				continue
+			}
+			if err != nil {
+				yield(fwdiag.NewListResultErrorDiagnostic(err))
+				return
+			}
+
 			result := request.NewListResult(ctx)
 
 			var data daemonTaskDefinitionResourceModel
 			r.SetResult(ctx, awsClient, request.IncludeResource, &data, &result, func() {
-				outputFind, err := findDaemonTaskDefinitionByARN(ctx, conn, aws.ToString(summary.Arn))
-				if err != nil {
-					result.Diagnostics.AddError(fmt.Sprintf("reading ECS Daemon Task Definition (%s)", aws.ToString(summary.Arn)), err.Error())
-					return
-				}
-
 				result.Diagnostics.Append(fwflex.Flatten(ctx, outputFind, &data)...)
 				if result.Diagnostics.HasError() {
 					return

--- a/internal/service/kafka/topic_list.go
+++ b/internal/service/kafka/topic_list.go
@@ -19,6 +19,7 @@ import (
 	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
 	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/logging"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	inttypes "github.com/hashicorp/terraform-provider-aws/internal/types"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -74,17 +75,20 @@ func (l *topicListResource) List(ctx context.Context, request list.ListRequest, 
 			arn := aws.ToString(item.TopicArn)
 			ctx := tflog.SetField(ctx, logging.ResourceAttributeKey(names.AttrARN), arn)
 
+			topicName := aws.ToString(item.TopicName)
+			out, err := findTopicByTwoPartKey(ctx, conn, clusterARN, topicName)
+			if retry.NotFound(err) {
+				continue
+			}
+			if err != nil {
+				yield(fwdiag.NewListResultErrorDiagnostic(err))
+				return
+			}
+
 			result := request.NewListResult(ctx)
 
 			var data topicResourceModel
 			l.SetResult(ctx, l.Meta(), request.IncludeResource, &data, &result, func() {
-				topicName := aws.ToString(item.TopicName)
-				out, err := findTopicByTwoPartKey(ctx, conn, clusterARN, topicName)
-				if err != nil {
-					result.Diagnostics.AddError("Reading MSK Topic", err.Error())
-					return
-				}
-
 				data.ClusterARN = fwtypes.ARNValue(clusterARN)
 				result.Diagnostics.Append(l.flatten(ctx, out, &data, true)...)
 				if result.Diagnostics.HasError() {

--- a/internal/service/networkfirewall/container_association_list.go
+++ b/internal/service/networkfirewall/container_association_list.go
@@ -63,7 +63,7 @@ func (l *containerAssociationListResource) List(ctx context.Context, request lis
 			if request.IncludeResource {
 				out, err = findContainerAssociationByARN(ctx, conn, arn)
 				if retry.NotFound(err) {
-					return
+					continue
 				}
 				if err != nil {
 					yield(fwdiag.NewListResultErrorDiagnostic(err))

--- a/internal/service/opensearchserverless/collection_group_list.go
+++ b/internal/service/opensearchserverless/collection_group_list.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
 	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/logging"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -60,6 +61,21 @@ func (l *collectionGroupListResource) List(ctx context.Context, request list.Lis
 			collectionGroupID := aws.ToString(item.Id)
 			ctx = tflog.SetField(ctx, logging.ResourceAttributeKey(names.AttrID), collectionGroupID)
 
+			var collectionGroup *awstypes.CollectionGroupDetail
+			if request.IncludeResource {
+				var err error
+				collectionGroup, err = findCollectionGroup(ctx, conn, &opensearchserverless.BatchGetCollectionGroupInput{
+					Ids: []string{collectionGroupID},
+				})
+				if retry.NotFound(err) {
+					continue
+				}
+				if err != nil {
+					yield(fwdiag.NewListResultErrorDiagnostic(err))
+					return
+				}
+			}
+
 			result := request.NewListResult(ctx)
 			var data collectionGroupResourceModel
 			data.ID = fwflex.StringToFramework(ctx, item.Id)
@@ -67,14 +83,6 @@ func (l *collectionGroupListResource) List(ctx context.Context, request list.Lis
 
 			l.SetResult(ctx, awsClient, request.IncludeResource, &data, &result, func() {
 				if request.IncludeResource {
-					collectionGroup, err := findCollectionGroup(ctx, conn, &opensearchserverless.BatchGetCollectionGroupInput{
-						Ids: []string{collectionGroupID},
-					})
-					if err != nil {
-						result = fwdiag.NewListResultErrorDiagnostic(err)
-						return
-					}
-
 					result.Diagnostics.Append(fwflex.Flatten(ctx, collectionGroup, &data, fwflex.WithIgnoredFieldNamesAppend("CreatedDate"))...)
 					if result.Diagnostics.HasError() {
 						return

--- a/internal/service/osis/pipeline_list.go
+++ b/internal/service/osis/pipeline_list.go
@@ -57,19 +57,19 @@ func (l *pipelineListResource) List(ctx context.Context, request list.ListReques
 			name := aws.ToString(item.PipelineName)
 			ctx := tflog.SetField(ctx, logging.ResourceAttributeKey(names.AttrName), name)
 
+			pipeline, err := findPipelineByName(ctx, conn, name)
+			if retry.NotFound(err) {
+				continue
+			}
+			if err != nil {
+				yield(fwdiag.NewListResultErrorDiagnostic(err))
+				return
+			}
+
 			result := request.NewListResult(ctx)
 
 			var data pipelineResourceModel
 			l.SetResult(ctx, l.Meta(), request.IncludeResource, &data, &result, func() {
-				pipeline, err := findPipelineByName(ctx, conn, name)
-				if retry.NotFound(err) {
-					return
-				}
-				if err != nil {
-					result.Diagnostics.AddError("reading OpenSearch Ingestion Pipeline", err.Error())
-					return
-				}
-
 				smerr.AddEnrich(ctx, &result.Diagnostics, l.flatten(ctx, pipeline, &data))
 				if result.Diagnostics.HasError() {
 					return

--- a/internal/service/pinpointsmsvoicev2/pool_list.go
+++ b/internal/service/pinpointsmsvoicev2/pool_list.go
@@ -59,33 +59,33 @@ func (l *poolListResource) List(ctx context.Context, request list.ListRequest, s
 
 			ctx := tflog.SetField(ctx, logging.ResourceAttributeKey(names.AttrID), poolID)
 
+			associated, err := findPoolOriginationIdentities(ctx, conn, poolID)
+			if retry.NotFound(err) {
+				tflog.Debug(ctx, "Pool deleted concurrently; skipping in list enumeration")
+				continue
+			}
+			if err != nil {
+				yield(fwdiag.NewListResultErrorDiagnostic(err))
+				return
+			}
+
 			result := request.NewListResult(ctx)
 
 			var data poolResourceModel
-			skipPool := false
 			l.SetResult(ctx, l.Meta(), request.IncludeResource, &data, &result, func() {
 				smerr.AddEnrich(ctx, &result.Diagnostics, fwflex.Flatten(ctx, pool, &data))
 				if result.Diagnostics.HasError() {
 					return
 				}
 
-				associated, err := findPoolOriginationIdentities(ctx, conn, poolID)
-				if retry.NotFound(err) {
-					tflog.Debug(ctx, "Pool deleted concurrently; skipping in list enumeration")
-					skipPool = true
-					return
-				}
-				if err != nil {
-					smerr.AddError(ctx, &result.Diagnostics, err, smerr.ID, poolID)
-					return
-				}
 				data.OriginationIdentities = fwflex.FlattenFrameworkStringValueSetOfString(ctx, associated)
 
 				result.DisplayName = poolID
 			})
 
-			if skipPool {
-				continue
+			if result.Diagnostics.HasError() {
+				yield(list.ListResult{Diagnostics: result.Diagnostics})
+				return
 			}
 			if !yield(result) {
 				return

--- a/internal/service/rekognition/collection_list.go
+++ b/internal/service/rekognition/collection_list.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/logging"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/smerr"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -45,6 +46,19 @@ func (l *collectionListResource) List(ctx context.Context, request list.ListRequ
 
 			ctx := tflog.SetField(ctx, logging.ResourceAttributeKey(names.AttrID), collectionID)
 
+			var out *rekognition.DescribeCollectionOutput
+			if request.IncludeResource {
+				var err error
+				out, err = findCollectionByID(ctx, conn, collectionID)
+				if retry.NotFound(err) {
+					continue
+				}
+				if err != nil {
+					yield(fwdiag.NewListResultErrorDiagnostic(err))
+					return
+				}
+			}
+
 			result := request.NewListResult(ctx)
 
 			var data collectionResourceModel
@@ -53,12 +67,6 @@ func (l *collectionListResource) List(ctx context.Context, request list.ListRequ
 				data.ID = flex.StringToFramework(ctx, &collectionID)
 
 				if request.IncludeResource {
-					out, err := findCollectionByID(ctx, conn, collectionID)
-					if err != nil {
-						result.Diagnostics.Append(fwdiag.NewResourceNotFoundWarningDiagnostic(err))
-						return
-					}
-
 					smerr.AddEnrich(ctx, &result.Diagnostics, flex.Flatten(ctx, out, &data, flex.WithFieldNamePrefix("Collection")))
 					if result.Diagnostics.HasError() {
 						return

--- a/internal/service/resiliencehubv2/policy_list.go
+++ b/internal/service/resiliencehubv2/policy_list.go
@@ -58,6 +58,19 @@ func (l *policyListResource) List(ctx context.Context, request list.ListRequest,
 			arn := aws.ToString(item.PolicyArn)
 			ctx := tflog.SetField(ctx, logging.ResourceAttributeKey(names.AttrARN), arn)
 
+			var output *awstypes.Policy
+			if request.IncludeResource {
+				var err error
+				output, err = findPolicyByARN(ctx, conn, arn)
+				if retry.NotFound(err) {
+					continue
+				}
+				if err != nil {
+					yield(fwdiag.NewListResultErrorDiagnostic(err))
+					return
+				}
+			}
+
 			result := request.NewListResult(ctx)
 
 			var data policyResourceModel
@@ -65,16 +78,6 @@ func (l *policyListResource) List(ctx context.Context, request list.ListRequest,
 				data.PolicyARN = fwflex.StringValueToFramework(ctx, arn)
 
 				if request.IncludeResource {
-					output, err := findPolicyByARN(ctx, conn, arn)
-					if retry.NotFound(err) {
-						return
-					}
-					if err != nil {
-						result := fwdiag.NewListResultErrorDiagnostic(err)
-						yield(result)
-						return
-					}
-
 					smerr.AddEnrich(ctx, &result.Diagnostics, l.flatten(ctx, output, &data))
 					if result.Diagnostics.HasError() {
 						return
@@ -84,6 +87,10 @@ func (l *policyListResource) List(ctx context.Context, request list.ListRequest,
 				result.DisplayName = aws.ToString(item.Name)
 			})
 
+			if result.Diagnostics.HasError() {
+				yield(list.ListResult{Diagnostics: result.Diagnostics})
+				return
+			}
 			if !yield(result) {
 				return
 			}

--- a/internal/service/resiliencehubv2/service_list.go
+++ b/internal/service/resiliencehubv2/service_list.go
@@ -58,6 +58,19 @@ func (l *serviceListResource) List(ctx context.Context, request list.ListRequest
 			arn := aws.ToString(item.ServiceArn)
 			ctx := tflog.SetField(ctx, logging.ResourceAttributeKey(names.AttrARN), arn)
 
+			var output *awstypes.Service
+			if request.IncludeResource {
+				var err error
+				output, err = findServiceByARN(ctx, conn, arn)
+				if retry.NotFound(err) {
+					continue
+				}
+				if err != nil {
+					yield(fwdiag.NewListResultErrorDiagnostic(err))
+					return
+				}
+			}
+
 			result := request.NewListResult(ctx)
 
 			var data serviceResourceModel
@@ -65,16 +78,6 @@ func (l *serviceListResource) List(ctx context.Context, request list.ListRequest
 				data.ServiceARN = fwflex.StringValueToFramework(ctx, arn)
 
 				if request.IncludeResource {
-					output, err := findServiceByARN(ctx, conn, arn)
-					if retry.NotFound(err) {
-						return
-					}
-					if err != nil {
-						result := fwdiag.NewListResultErrorDiagnostic(err)
-						yield(result)
-						return
-					}
-
 					smerr.AddEnrich(ctx, &result.Diagnostics, l.flatten(ctx, output, &data))
 					if result.Diagnostics.HasError() {
 						return
@@ -84,6 +87,10 @@ func (l *serviceListResource) List(ctx context.Context, request list.ListRequest
 				result.DisplayName = aws.ToString(item.Name)
 			})
 
+			if result.Diagnostics.HasError() {
+				yield(list.ListResult{Diagnostics: result.Diagnostics})
+				return
+			}
 			if !yield(result) {
 				return
 			}

--- a/internal/service/resiliencehubv2/system_list.go
+++ b/internal/service/resiliencehubv2/system_list.go
@@ -58,6 +58,19 @@ func (l *systemListResource) List(ctx context.Context, request list.ListRequest,
 			arn := aws.ToString(item.SystemArn)
 			ctx := tflog.SetField(ctx, logging.ResourceAttributeKey(names.AttrARN), arn)
 
+			var output *awstypes.System
+			if request.IncludeResource {
+				var err error
+				output, err = findSystemByARN(ctx, conn, arn)
+				if retry.NotFound(err) {
+					continue
+				}
+				if err != nil {
+					yield(fwdiag.NewListResultErrorDiagnostic(err))
+					return
+				}
+			}
+
 			result := request.NewListResult(ctx)
 
 			var data systemResourceModel
@@ -65,16 +78,6 @@ func (l *systemListResource) List(ctx context.Context, request list.ListRequest,
 				data.SystemARN = fwflex.StringValueToFramework(ctx, arn)
 
 				if request.IncludeResource {
-					output, err := findSystemByARN(ctx, conn, arn)
-					if retry.NotFound(err) {
-						return
-					}
-					if err != nil {
-						result := fwdiag.NewListResultErrorDiagnostic(err)
-						yield(result)
-						return
-					}
-
 					smerr.AddEnrich(ctx, &result.Diagnostics, l.flatten(ctx, output, &data))
 					if result.Diagnostics.HasError() {
 						return
@@ -84,6 +87,10 @@ func (l *systemListResource) List(ctx context.Context, request list.ListRequest,
 				result.DisplayName = aws.ToString(item.Name)
 			})
 
+			if result.Diagnostics.HasError() {
+				yield(list.ListResult{Diagnostics: result.Diagnostics})
+				return
+			}
 			if !yield(result) {
 				return
 			}

--- a/internal/service/s3control/multi_region_access_point_routes_list.go
+++ b/internal/service/s3control/multi_region_access_point_routes_list.go
@@ -5,7 +5,6 @@ package s3control
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3control"
@@ -67,6 +66,22 @@ func (l *multiRegionAccessPointRoutesListResource) List(ctx context.Context, req
 
 			ctx := tflog.SetField(ctx, logging.ResourceAttributeKey("mrap"), mrapARN)
 
+			var output *s3control.GetMultiRegionAccessPointRoutesOutput
+			if request.IncludeResource {
+				var err error
+				output, err = findMultiRegionAccessPointRoutesByTwoPartKey(ctx, conn, accountID, mrapARN)
+				if retry.NotFound(err) {
+					tflog.Warn(ctx, "S3 Multi-Region Access Point Routes not found", map[string]any{
+						logging.ResourceAttributeKey("mrap"): mrapARN,
+					})
+					continue
+				}
+				if err != nil {
+					yield(fwdiag.NewListResultErrorDiagnostic(err))
+					return
+				}
+			}
+
 			result := request.NewListResult(ctx)
 
 			var data multiRegionAccessPointRoutesResourceModel
@@ -75,18 +90,6 @@ func (l *multiRegionAccessPointRoutesListResource) List(ctx context.Context, req
 				data.Mrap = fwflex.StringValueToFramework(ctx, mrapARN)
 
 				if request.IncludeResource {
-					output, err := findMultiRegionAccessPointRoutesByTwoPartKey(ctx, conn, accountID, mrapARN)
-					if retry.NotFound(err) {
-						tflog.Warn(ctx, "S3 Multi-Region Access Point Routes not found", map[string]any{
-							logging.ResourceAttributeKey("mrap"): mrapARN,
-						})
-						return
-					}
-					if err != nil {
-						result.Diagnostics.AddError(fmt.Sprintf("reading S3 Multi-Region Access Point Routes (%s)", mrapARN), err.Error())
-						return
-					}
-
 					result.Diagnostics.Append(fwflex.Flatten(ctx, output, &data)...)
 					if result.Diagnostics.HasError() {
 						return

--- a/internal/service/sagemaker/hub_content_reference_list.go
+++ b/internal/service/sagemaker/hub_content_reference_list.go
@@ -50,24 +50,21 @@ func (l *hubContentReferenceListResource) List(ctx context.Context, request list
 			hubContentName := aws.ToString(item.info.HubContentName)
 			ctx := tflog.SetField(ctx, logging.ResourceAttributeKey("hub_content_name"), hubContentName)
 
+			output, err := findHubContentByName(ctx, conn, hubName, hubContentName, awstypes.HubContentTypeModelReference)
+			if retry.NotFound(err) {
+				tflog.Warn(ctx, "Resource disappeared during listing, skipping")
+				continue
+			}
+			if err != nil {
+				yield(fwdiag.NewListResultErrorDiagnostic(err))
+				return
+			}
+
 			result := request.NewListResult(ctx)
 			result.DisplayName = hubContentName
 
 			var data hubContentReferenceResourceModel
 			l.SetResult(ctx, awsClient, request.IncludeResource, &data, &result, func() {
-				output, err := findHubContentByName(ctx, conn, hubName, hubContentName, awstypes.HubContentTypeModelReference)
-				if retry.NotFound(err) {
-					tflog.Warn(ctx, "Resource disappeared during listing, skipping")
-					return
-				}
-				if err != nil {
-					result.Diagnostics.AddError(
-						"Reading SageMaker Hub Content Reference",
-						fmt.Sprintf("Error reading hub content reference (%s): %s", hubContentName, err),
-					)
-					return
-				}
-
 				result.Diagnostics.Append(l.flatten(ctx, output, &data)...)
 			})
 

--- a/internal/service/sagemaker/hyper_parameter_tuning_job_list.go
+++ b/internal/service/sagemaker/hyper_parameter_tuning_job_list.go
@@ -11,7 +11,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/sagemaker"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/sagemaker/types"
-	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/list"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
@@ -62,6 +61,20 @@ func (l *hyperParameterTuningJobListResource) List(ctx context.Context, request 
 			hyperParameterTuningJobName := aws.ToString(item.HyperParameterTuningJobName)
 			ctx := tflog.SetField(ctx, logging.ResourceAttributeKey(names.AttrName), hyperParameterTuningJobName)
 
+			var output *sagemaker.DescribeHyperParameterTuningJobOutput
+			if request.IncludeResource {
+				var err error
+				output, err = findHyperParameterTuningJobByName(ctx, conn, hyperParameterTuningJobName)
+				if retry.NotFound(err) {
+					tflog.Warn(ctx, "Resource disappeared during listing, skipping")
+					continue
+				}
+				if err != nil {
+					yield(fwdiag.NewListResultErrorDiagnostic(err))
+					return
+				}
+			}
+
 			result := request.NewListResult(ctx)
 
 			var data hyperParameterTuningJobResourceModel
@@ -69,16 +82,6 @@ func (l *hyperParameterTuningJobListResource) List(ctx context.Context, request 
 
 			l.SetResult(ctx, awsClient, request.IncludeResource, &data, &result, func() {
 				if request.IncludeResource {
-					output, err := findHyperParameterTuningJobByName(ctx, conn, hyperParameterTuningJobName)
-					if retry.NotFound(err) {
-						tflog.Warn(ctx, "Resource disappeared during listing, skipping")
-						return
-					}
-					if err != nil {
-						result.Diagnostics.Append(diag.NewErrorDiagnostic("Reading SageMaker Hyper Parameter Tuning Job", err.Error()))
-						return
-					}
-
 					result.Diagnostics.Append(fwflex.Flatten(ctx, output, &data, fwflex.WithFieldNamePrefix("HyperParameterTuningJob"))...)
 				}
 

--- a/internal/service/sagemaker/training_job_list.go
+++ b/internal/service/sagemaker/training_job_list.go
@@ -11,11 +11,11 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/sagemaker"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/sagemaker/types"
-	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/list"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
 	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 )
 
 // Function annotations are used for list resource registration to the Provider. DO NOT EDIT.
@@ -54,6 +54,19 @@ func (l *trainingJobListResource) List(ctx context.Context, request list.ListReq
 
 			trainingJobName := aws.ToString(item.TrainingJobName)
 
+			var trainingJob *sagemaker.DescribeTrainingJobOutput
+			if request.IncludeResource {
+				var err error
+				trainingJob, err = findTrainingJobByName(ctx, conn, trainingJobName)
+				if retry.NotFound(err) {
+					continue
+				}
+				if err != nil {
+					yield(fwdiag.NewListResultErrorDiagnostic(err))
+					return
+				}
+			}
+
 			result := request.NewListResult(ctx)
 
 			var data resourceTrainingJobModel
@@ -61,12 +74,6 @@ func (l *trainingJobListResource) List(ctx context.Context, request list.ListReq
 
 			l.SetResult(ctx, l.Meta(), request.IncludeResource, &data, &result, func() {
 				if request.IncludeResource {
-					trainingJob, err := findTrainingJobByName(ctx, conn, trainingJobName)
-					if err != nil {
-						result.Diagnostics.Append(diag.NewErrorDiagnostic("Reading SageMaker Training Job", err.Error()))
-						return
-					}
-
 					result.Diagnostics.Append(fwflex.Flatten(ctx, trainingJob, &data)...)
 					if result.Diagnostics.HasError() {
 						return

--- a/internal/service/workmail/group_list.go
+++ b/internal/service/workmail/group_list.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/logging"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 )
 
 // @FrameworkListResource("aws_workmail_group")
@@ -81,6 +82,19 @@ func (l *groupListResource) List(ctx context.Context, request list.ListRequest, 
 			groupName := aws.ToString(item.Name)
 			ctx := tflog.SetField(ctx, logging.ResourceAttributeKey("group_id"), groupID)
 
+			var out *workmail.DescribeGroupOutput
+			if request.IncludeResource {
+				var err error
+				out, err = findGroupByTwoPartKey(ctx, conn, organizationID, groupID)
+				if retry.NotFound(err) {
+					continue
+				}
+				if err != nil {
+					yield(fwdiag.NewListResultErrorDiagnostic(err))
+					return
+				}
+			}
+
 			result := request.NewListResult(ctx)
 
 			var data groupResourceModel
@@ -89,12 +103,6 @@ func (l *groupListResource) List(ctx context.Context, request list.ListRequest, 
 				data.GroupId = flex.StringValueToFramework(ctx, groupID)
 
 				if request.IncludeResource {
-					out, err := findGroupByTwoPartKey(ctx, conn, organizationID, groupID)
-					if err != nil {
-						result.Diagnostics.Append(fwdiag.NewListResultErrorDiagnostic(err).Diagnostics...)
-						return
-					}
-
 					result.Diagnostics.Append(flex.Flatten(ctx, out, &data)...)
 					if result.Diagnostics.HasError() {
 						return

--- a/internal/service/workmail/user_list.go
+++ b/internal/service/workmail/user_list.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/logging"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 )
 
 // Function annotations are used for list resource registration to the Provider. DO NOT EDIT.
@@ -82,6 +83,19 @@ func (l *userListResource) List(ctx context.Context, request list.ListRequest, s
 			userName := aws.ToString(item.Name)
 			ctx := tflog.SetField(ctx, logging.ResourceAttributeKey("user_id"), userID)
 
+			var out *workmail.DescribeUserOutput
+			if request.IncludeResource {
+				var err error
+				out, err = findUserByTwoPartKey(ctx, conn, organizationID, userID)
+				if retry.NotFound(err) {
+					continue
+				}
+				if err != nil {
+					yield(fwdiag.NewListResultErrorDiagnostic(err))
+					return
+				}
+			}
+
 			result := request.NewListResult(ctx)
 
 			var data userResourceModel
@@ -90,12 +104,6 @@ func (l *userListResource) List(ctx context.Context, request list.ListRequest, s
 				data.UserId = flex.StringValueToFramework(ctx, userID)
 
 				if request.IncludeResource {
-					out, err := findUserByTwoPartKey(ctx, conn, organizationID, userID)
-					if err != nil {
-						result.Diagnostics.Append(fwdiag.NewListResultErrorDiagnostic(err).Diagnostics...)
-						return
-					}
-
 					result.Diagnostics.Append(flex.Flatten(ctx, out, &data)...)
 					if result.Diagnostics.HasError() {
 						return


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

### Description

Move the Get call outside the closure, into the outer per-item loop, and continue on NotFound instead of return. That skips the item entirely instead of yielding it broken.


### Relations

Closes #49378 


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
make t K=amp T=TestAccAMPAnomalyDetector_List_includeResource
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 td-list-resource-skip-cleanly-when-deleted 🌿...
TF_ACC=1 go1.26.5 test ./internal/service/amp/... -v -count 1 -parallel 20 -run='TestAccAMPAnomalyDetector_List_includeResource'  -timeout 360m -vet=off -buildvcs=false
2026/08/11 16:35:44 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/11 16:35:44 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccAMPAnomalyDetector_List_includeResource
=== PAUSE TestAccAMPAnomalyDetector_List_includeResource
=== CONT  TestAccAMPAnomalyDetector_List_includeResource
--- PASS: TestAccAMPAnomalyDetector_List_includeResource (30.47s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/amp        38.769s
```

```console
make t K=bedrock T=TestAccBedrockEvaluationJob_List_includeResource
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 td-list-resource-skip-cleanly-when-deleted 🌿...
TF_ACC=1 go1.26.5 test ./internal/service/bedrock/... -v -count 1 -parallel 20 -run='TestAccBedrockEvaluationJob_List_includeResource'  -timeout 360m -vet=off -buildvcs=false
2026/08/11 16:47:03 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/11 16:47:03 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccBedrockEvaluationJob_List_includeResource
=== PAUSE TestAccBedrockEvaluationJob_List_includeResource
=== CONT  TestAccBedrockEvaluationJob_List_includeResource
--- PASS: TestAccBedrockEvaluationJob_List_includeResource (57.37s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/bedrock    65.637s[4:49 PM]
```

```console
make t K=bedrockagentcore T=TestAccBedrockAgentCoreEvaluator_List_includeResource
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 td-list-resource-skip-cleanly-when-deleted 🌿...
TF_ACC=1 go1.26.5 test ./internal/service/bedrockagentcore/... -v -count 1 -parallel 20 -run='TestAccBedrockAgentCoreEvaluator_List_includeResource'  -timeout 360m -vet=off -buildvcs=false
2026/08/11 16:48:34 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/11 16:48:34 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccBedrockAgentCoreEvaluator_List_includeResource
=== PAUSE TestAccBedrockAgentCoreEvaluator_List_includeResource
=== CONT  TestAccBedrockAgentCoreEvaluator_List_includeResource
--- PASS: TestAccBedrockAgentCoreEvaluator_List_includeResource (25.67s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/bedrockagentcore   34.031s
```

```console
make t K=cleanrooms T=TestAccCleanRoomsMembership_List_includeResource
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 td-list-resource-skip-cleanly-when-deleted 🌿...
TF_ACC=1 go1.26.5 test ./internal/service/cleanrooms/... -v -count 1 -parallel 20 -run='TestAccCleanRoomsMembership_List_includeResource'  -timeout 360m -vet=off -buildvcs=false
2026/08/11 16:55:28 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/11 16:55:28 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccCleanRoomsMembership_List_includeResource
=== PAUSE TestAccCleanRoomsMembership_List_includeResource
=== CONT  TestAccCleanRoomsMembership_List_includeResource
--- PASS: TestAccCleanRoomsMembership_List_includeResource (28.35s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cleanrooms 36.635s
```

```console
make t K=ecs T=TestAccECSDaemon_List_includeResource
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 td-list-resource-skip-cleanly-when-deleted 🌿...
TF_ACC=1 go1.26.5 test ./internal/service/ecs/... -v -count 1 -parallel 20 -run='TestAccECSDaemon_List_includeResource'  -timeout 360m -vet=off -buildvcs=false
2026/08/11 16:57:20 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/11 16:57:20 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccECSDaemon_List_includeResource
=== PAUSE TestAccECSDaemon_List_includeResource
=== CONT  TestAccECSDaemon_List_includeResource
--- PASS: TestAccECSDaemon_List_includeResource (49.28s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ecs        58.011s
```

```console
make t K=ecs T=TestAccECSDaemonTaskDefinition_List_includeResource
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 td-list-resource-skip-cleanly-when-deleted 🌿...
TF_ACC=1 go1.26.5 test ./internal/service/ecs/... -v -count 1 -parallel 20 -run='TestAccECSDaemonTaskDefinition_List_includeResource'  -timeout 360m -vet=off -buildvcs=false
2026/08/11 16:59:52 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/11 16:59:52 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccECSDaemonTaskDefinition_List_includeResource
=== PAUSE TestAccECSDaemonTaskDefinition_List_includeResource
=== CONT  TestAccECSDaemonTaskDefinition_List_includeResource
--- PASS: TestAccECSDaemonTaskDefinition_List_includeResource (34.16s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ecs        42.226s
```

```console
make t K=amp T=TestAccAMPScraper_List_includeResource
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 td-list-resource-skip-cleanly-when-deleted 🌿...
TF_ACC=1 go1.26.5 test ./internal/service/amp/... -v -count 1 -parallel 20 -run='TestAccAMPScraper_List_includeResource'  -timeout 360m -vet=off -buildvcs=false
2026/08/11 16:43:58 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/11 16:43:58 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccAMPScraper_List_includeResource
=== PAUSE TestAccAMPScraper_List_includeResource
=== CONT  TestAccAMPScraper_List_includeResource
--- PASS: TestAccAMPScraper_List_includeResource (2554.39s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/amp        2562.426s
```

```console
make t K=codebuild T=TestAccCodeBuildProject_List_includeResource
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 td-list-resource-skip-cleanly-when-deleted 🌿...
TF_ACC=1 go1.26.5 test ./internal/service/codebuild/... -v -count 1 -parallel 20 -run='TestAccCodeBuildProject_List_includeResource'  -timeout 360m -vet=off -buildvcs=false
2026/08/11 21:38:42 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/11 21:38:42 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccCodeBuildProject_List_includeResource
=== PAUSE TestAccCodeBuildProject_List_includeResource
=== CONT  TestAccCodeBuildProject_List_includeResource
--- PASS: TestAccCodeBuildProject_List_includeResource (39.40s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/codebuild  47.855s
```

```console
make t K=sagemaker T=TestAccSageMakerTrainingJob_serial/List/includeResource                                 
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 td-list-resource-skip-cleanly-when-deleted 🌿...
TF_ACC=1 go1.26.5 test ./internal/service/sagemaker/... -v -count 1 -parallel 20 -run='TestAccSageMakerTrainingJob_serial/List/includeResource'  -timeout 360m -vet=off -buildvcs=false
2026/08/11 21:46:34 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/11 21:46:34 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccSageMakerTrainingJob_serial
=== PAUSE TestAccSageMakerTrainingJob_serial
=== CONT  TestAccSageMakerTrainingJob_serial
=== RUN   TestAccSageMakerTrainingJob_serial/List
=== RUN   TestAccSageMakerTrainingJob_serial/List/includeResource
--- PASS: TestAccSageMakerTrainingJob_serial (79.74s)
    --- PASS: TestAccSageMakerTrainingJob_serial/List (79.73s)
        --- PASS: TestAccSageMakerTrainingJob_serial/List/includeResource (79.73s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/sagemaker  87.811s
```
