### PR TITLE
r/aws_wafv2_web_acl_rule, r/aws_wafv2_web_acl_rule_group_association: Preserve the parent Web ACL's data_protection_config

### DIFF
--- a/.changelog/49390.txt
+++ b/.changelog/49390.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_wafv2_web_acl_rule: Preserve the parent Web ACL's `data_protection_config`, `monetization_config`, and `on_source_ddos_protection_config`
+```
+
+```release-note:bug
+resource/aws_wafv2_web_acl_rule_group_association: Preserve the parent Web ACL's `data_protection_config`, `monetization_config`, and `on_source_ddos_protection_config`
+```

--- a/internal/service/wafv2/web_acl_rule.go
+++ b/internal/service/wafv2/web_acl_rule.go
@@ -339,24 +339,7 @@ func (r *resourceWebACLRule) Create(ctx context.Context, req resource.CreateRequ
 
 	webACL.WebACL.Rules = append(webACL.WebACL.Rules, newRule)
 
-	updateInput := &wafv2.UpdateWebACLInput{
-		Id:                   aws.String(webACLID),
-		Name:                 aws.String(webACLName),
-		Scope:                awstypes.Scope(webACLScope),
-		DefaultAction:        webACL.WebACL.DefaultAction,
-		Rules:                webACL.WebACL.Rules,
-		VisibilityConfig:     webACL.WebACL.VisibilityConfig,
-		LockToken:            webACL.LockToken,
-		AssociationConfig:    webACL.WebACL.AssociationConfig,
-		CaptchaConfig:        webACL.WebACL.CaptchaConfig,
-		ChallengeConfig:      webACL.WebACL.ChallengeConfig,
-		CustomResponseBodies: webACL.WebACL.CustomResponseBodies,
-		TokenDomains:         webACL.WebACL.TokenDomains,
-	}
-
-	if webACL.WebACL.Description != nil && aws.ToString(webACL.WebACL.Description) != "" {
-		updateInput.Description = webACL.WebACL.Description
-	}
+	updateInput := newUpdateWebACLInput(webACL, webACLID, webACLName, webACLScope, webACL.WebACL.Rules)
 
 	if err = updateWebACLWithRetry(ctx, conn, updateInput, r.CreateTimeout(ctx, plan.Timeouts), func(latest *wafv2.GetWebACLOutput) []awstypes.Rule {
 		// Re-append our rule to the latest rule list (which may have grown since we fetched).
@@ -483,24 +466,7 @@ func (r *resourceWebACLRule) Update(ctx context.Context, req resource.UpdateRequ
 		}
 	}
 
-	updateInput := &wafv2.UpdateWebACLInput{
-		Id:                   aws.String(webACLID),
-		Name:                 aws.String(webACLName),
-		Scope:                awstypes.Scope(webACLScope),
-		DefaultAction:        webACL.WebACL.DefaultAction,
-		Rules:                updatedRules,
-		VisibilityConfig:     webACL.WebACL.VisibilityConfig,
-		LockToken:            webACL.LockToken,
-		AssociationConfig:    webACL.WebACL.AssociationConfig,
-		CaptchaConfig:        webACL.WebACL.CaptchaConfig,
-		ChallengeConfig:      webACL.WebACL.ChallengeConfig,
-		CustomResponseBodies: webACL.WebACL.CustomResponseBodies,
-		TokenDomains:         webACL.WebACL.TokenDomains,
-	}
-
-	if webACL.WebACL.Description != nil && aws.ToString(webACL.WebACL.Description) != "" {
-		updateInput.Description = webACL.WebACL.Description
-	}
+	updateInput := newUpdateWebACLInput(webACL, webACLID, webACLName, webACLScope, updatedRules)
 
 	if err = updateWebACLWithRetry(ctx, conn, updateInput, r.UpdateTimeout(ctx, plan.Timeouts), func(latest *wafv2.GetWebACLOutput) []awstypes.Rule {
 		var rules []awstypes.Rule
@@ -578,24 +544,7 @@ func (r *resourceWebACLRule) Delete(ctx context.Context, req resource.DeleteRequ
 		return
 	}
 
-	updateInput := &wafv2.UpdateWebACLInput{
-		Id:                   aws.String(webACLID),
-		Name:                 aws.String(webACLName),
-		Scope:                awstypes.Scope(webACLScope),
-		DefaultAction:        webACL.WebACL.DefaultAction,
-		Rules:                updatedRules,
-		VisibilityConfig:     webACL.WebACL.VisibilityConfig,
-		LockToken:            webACL.LockToken,
-		AssociationConfig:    webACL.WebACL.AssociationConfig,
-		CaptchaConfig:        webACL.WebACL.CaptchaConfig,
-		ChallengeConfig:      webACL.WebACL.ChallengeConfig,
-		CustomResponseBodies: webACL.WebACL.CustomResponseBodies,
-		TokenDomains:         webACL.WebACL.TokenDomains,
-	}
-
-	if webACL.WebACL.Description != nil && aws.ToString(webACL.WebACL.Description) != "" {
-		updateInput.Description = webACL.WebACL.Description
-	}
+	updateInput := newUpdateWebACLInput(webACL, webACLID, webACLName, webACLScope, updatedRules)
 
 	if err = updateWebACLWithRetry(ctx, conn, updateInput, r.DeleteTimeout(ctx, state.Timeouts), func(latest *wafv2.GetWebACLOutput) []awstypes.Rule {
 		var rules []awstypes.Rule
@@ -609,6 +558,42 @@ func (r *resourceWebACLRule) Delete(ctx context.Context, req resource.DeleteRequ
 		smerr.AddError(ctx, &resp.Diagnostics, smarterr.NewError(err), smerr.ID, state.Name.ValueString())
 		return
 	}
+}
+
+// newUpdateWebACLInput builds the input for UpdateWebACL from the Web ACL as it currently
+// exists in AWS, swapping in a new rule list. UpdateWebACL replaces the whole Web ACL
+// instead of patching it, so every configuration this resource does not manage has to be
+// echoed back or AWS silently drops it. Building the input in one place keeps the three
+// callers from drifting apart as the API grows.
+//
+// ApplicationConfig is deliberately absent. AWS keeps the stored entries when the field is
+// omitted, and rejects the request outright when the entries sent do not match the stored
+// ones exactly, so echoing it back would turn a concurrent change into an error.
+func newUpdateWebACLInput(webACL *wafv2.GetWebACLOutput, id, name, scope string, rules []awstypes.Rule) *wafv2.UpdateWebACLInput {
+	input := &wafv2.UpdateWebACLInput{
+		Id:                           aws.String(id),
+		Name:                         aws.String(name),
+		Scope:                        awstypes.Scope(scope),
+		DefaultAction:                webACL.WebACL.DefaultAction,
+		Rules:                        rules,
+		VisibilityConfig:             webACL.WebACL.VisibilityConfig,
+		LockToken:                    webACL.LockToken,
+		AssociationConfig:            webACL.WebACL.AssociationConfig,
+		CaptchaConfig:                webACL.WebACL.CaptchaConfig,
+		ChallengeConfig:              webACL.WebACL.ChallengeConfig,
+		CustomResponseBodies:         webACL.WebACL.CustomResponseBodies,
+		DataProtectionConfig:         webACL.WebACL.DataProtectionConfig,
+		MonetizationConfig:           webACL.WebACL.MonetizationConfig,
+		OnSourceDDoSProtectionConfig: webACL.WebACL.OnSourceDDoSProtectionConfig,
+		TokenDomains:                 webACL.WebACL.TokenDomains,
+	}
+
+	// An empty description fails validation, so it is only sent when the Web ACL has one.
+	if aws.ToString(webACL.WebACL.Description) != "" {
+		input.Description = webACL.WebACL.Description
+	}
+
+	return input
 }
 
 // updateWebACLWithRetry calls UpdateWebACL, retrying on WAFUnavailableEntityException

--- a/internal/service/wafv2/web_acl_rule_group_association.go
+++ b/internal/service/wafv2/web_acl_rule_group_association.go
@@ -14,7 +14,6 @@ import (
 	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
-	"github.com/aws/aws-sdk-go-v2/service/wafv2"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/wafv2/types"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int32validator"
@@ -1129,25 +1128,7 @@ func (r *resourceWebACLRuleGroupAssociation) Create(ctx context.Context, req res
 	webACL.WebACL.Rules = append(webACL.WebACL.Rules, newRule)
 
 	// Update the Web ACL
-	updateInput := &wafv2.UpdateWebACLInput{
-		Id:                   aws.String(webACLID),
-		Name:                 aws.String(webACLName),
-		Scope:                awstypes.Scope(webACLScope),
-		DefaultAction:        webACL.WebACL.DefaultAction,
-		Rules:                webACL.WebACL.Rules,
-		VisibilityConfig:     webACL.WebACL.VisibilityConfig,
-		LockToken:            webACL.LockToken,
-		AssociationConfig:    webACL.WebACL.AssociationConfig,
-		CaptchaConfig:        webACL.WebACL.CaptchaConfig,
-		ChallengeConfig:      webACL.WebACL.ChallengeConfig,
-		CustomResponseBodies: webACL.WebACL.CustomResponseBodies,
-		TokenDomains:         webACL.WebACL.TokenDomains,
-	}
-
-	// Only set description if it's not empty
-	if webACL.WebACL.Description != nil && aws.ToString(webACL.WebACL.Description) != "" {
-		updateInput.Description = webACL.WebACL.Description
-	}
+	updateInput := newUpdateWebACLInput(webACL, webACLID, webACLName, webACLScope, webACL.WebACL.Rules)
 
 	const timeout = 5 * time.Minute
 	_, err = tfresource.RetryWhenIsA[any, *awstypes.WAFUnavailableEntityException](ctx, timeout, func(ctx context.Context) (any, error) {
@@ -1535,25 +1516,7 @@ func (r *resourceWebACLRuleGroupAssociation) Update(ctx context.Context, req res
 	}
 
 	// Update the Web ACL with the modified rule
-	updateInput := &wafv2.UpdateWebACLInput{
-		Id:                   aws.String(webACLID),
-		Name:                 aws.String(webACLName),
-		Scope:                awstypes.Scope(webACLScope),
-		DefaultAction:        webACL.WebACL.DefaultAction,
-		Rules:                webACL.WebACL.Rules,
-		VisibilityConfig:     webACL.WebACL.VisibilityConfig,
-		LockToken:            webACL.LockToken,
-		AssociationConfig:    webACL.WebACL.AssociationConfig,
-		CaptchaConfig:        webACL.WebACL.CaptchaConfig,
-		ChallengeConfig:      webACL.WebACL.ChallengeConfig,
-		CustomResponseBodies: webACL.WebACL.CustomResponseBodies,
-		TokenDomains:         webACL.WebACL.TokenDomains,
-	}
-
-	// Only set description if it's not empty
-	if webACL.WebACL.Description != nil && aws.ToString(webACL.WebACL.Description) != "" {
-		updateInput.Description = webACL.WebACL.Description
-	}
+	updateInput := newUpdateWebACLInput(webACL, webACLID, webACLName, webACLScope, webACL.WebACL.Rules)
 
 	updateTimeout := r.UpdateTimeout(ctx, plan.Timeouts)
 	_, err = tfresource.RetryWhenIsA[any, *awstypes.WAFUnavailableEntityException](ctx, updateTimeout, func(ctx context.Context) (any, error) {
@@ -1630,25 +1593,7 @@ func (r *resourceWebACLRuleGroupAssociation) Delete(ctx context.Context, req res
 	}
 
 	// Update the Web ACL without the rule
-	updateInput := &wafv2.UpdateWebACLInput{
-		Id:                   aws.String(webACLID),
-		Name:                 aws.String(webACLName),
-		Scope:                awstypes.Scope(webACLScope),
-		DefaultAction:        webACL.WebACL.DefaultAction,
-		Rules:                updatedRules,
-		VisibilityConfig:     webACL.WebACL.VisibilityConfig,
-		LockToken:            webACL.LockToken,
-		AssociationConfig:    webACL.WebACL.AssociationConfig,
-		CaptchaConfig:        webACL.WebACL.CaptchaConfig,
-		ChallengeConfig:      webACL.WebACL.ChallengeConfig,
-		CustomResponseBodies: webACL.WebACL.CustomResponseBodies,
-		TokenDomains:         webACL.WebACL.TokenDomains,
-	}
-
-	// Only set description if it's not empty
-	if webACL.WebACL.Description != nil && aws.ToString(webACL.WebACL.Description) != "" {
-		updateInput.Description = webACL.WebACL.Description
-	}
+	updateInput := newUpdateWebACLInput(webACL, webACLID, webACLName, webACLScope, updatedRules)
 
 	const timeout = 5 * time.Minute
 	_, err = tfresource.RetryWhenIsA[any, *awstypes.WAFUnavailableEntityException](ctx, timeout, func(ctx context.Context) (any, error) {

--- a/internal/service/wafv2/web_acl_rule_group_association_test.go
+++ b/internal/service/wafv2/web_acl_rule_group_association_test.go
@@ -560,6 +560,45 @@ func TestAccWAFV2WebACLRuleGroupAssociation_ManagedRuleGroup_basic(t *testing.T)
 	})
 }
 
+func TestAccWAFV2WebACLRuleGroupAssociation_dataProtectionConfig(t *testing.T) {
+	ctx := acctest.Context(t)
+	var webACL wafv2.GetWebACLOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_wafv2_web_acl_rule_group_association.test"
+	webACLResourceName := "aws_wafv2_web_acl.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.WAFV2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckWebACLRuleGroupAssociationDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			// Create.
+			{
+				Config: testAccWebACLRuleGroupAssociationConfig_dataProtectionConfig(rName, 1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWebACLRuleGroupAssociationExists(ctx, t, resourceName, &webACL),
+					testAccCheckWebACLHasDataProtectionConfig(ctx, t, webACLResourceName),
+				),
+			},
+			// Update. Neither `priority` nor `override_action` forces replacement, so
+			// changing the priority exercises the update path.
+			{
+				Config: testAccWebACLRuleGroupAssociationConfig_dataProtectionConfig(rName, 2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWebACLRuleGroupAssociationExists(ctx, t, resourceName, &webACL),
+					testAccCheckWebACLHasDataProtectionConfig(ctx, t, webACLResourceName),
+				),
+			},
+			// Delete. The association leaves the configuration while the Web ACL stays behind.
+			{
+				Config: testAccWebACLRuleGroupAssociationConfig_dataProtectionConfigWebACLOnly(rName),
+				Check:  testAccCheckWebACLHasDataProtectionConfig(ctx, t, webACLResourceName),
+			},
+		},
+	})
+}
+
 func TestAccWAFV2WebACLRuleGroupAssociation_ManagedRuleGroup_withVersion(t *testing.T) {
 	ctx := acctest.Context(t)
 	var webACL wafv2.GetWebACLOutput
@@ -2489,4 +2528,55 @@ resource "aws_wafv2_web_acl_rule_group_association" "test3" {
   override_action = "none"
 }
 `, rName)
+}
+
+func testAccWebACLRuleGroupAssociationConfig_dataProtectionConfigWebACLOnly(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_wafv2_web_acl" "test" {
+  name  = %[1]q
+  scope = "REGIONAL"
+
+  default_action {
+    allow {}
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = false
+    metric_name                = %[1]q
+    sampled_requests_enabled   = false
+  }
+
+  data_protection_config {
+    data_protection {
+      action = "HASH"
+
+      field {
+        field_type = "SINGLE_HEADER"
+        field_keys = ["authorization"]
+      }
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [rule]
+  }
+}
+`, rName)
+}
+
+func testAccWebACLRuleGroupAssociationConfig_dataProtectionConfig(rName string, priority int) string {
+	return acctest.ConfigCompose(testAccWebACLRuleGroupAssociationConfig_dataProtectionConfigWebACLOnly(rName), fmt.Sprintf(`
+resource "aws_wafv2_web_acl_rule_group_association" "test" {
+  rule_name   = "test-rule"
+  priority    = %[1]d
+  web_acl_arn = aws_wafv2_web_acl.test.arn
+
+  managed_rule_group {
+    name        = "AWSManagedRulesCommonRuleSet"
+    vendor_name = "AWS"
+  }
+
+  override_action = "none"
+}
+`, priority))
 }

--- a/internal/service/wafv2/web_acl_rule_test.go
+++ b/internal/service/wafv2/web_acl_rule_test.go
@@ -774,6 +774,43 @@ func TestAccWAFV2WebACLRule_migrateInlineToSeparateResource(t *testing.T) {
 		},
 	})
 }
+func TestAccWAFV2WebACLRule_dataProtectionConfig(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_wafv2_web_acl_rule.test"
+	webACLResourceName := "aws_wafv2_web_acl.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.WAFV2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckWebACLRuleDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			// Create.
+			{
+				Config: testAccWebACLRuleConfig_dataProtectionConfig(rName, []string{"CN", "RU"}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWebACLRuleExists(ctx, t, resourceName),
+					testAccCheckWebACLHasDataProtectionConfig(ctx, t, webACLResourceName),
+				),
+			},
+			// Update. Only `name` and `priority` force replacement, so changing the statement
+			// exercises the update path rather than a delete and create cycle.
+			{
+				Config: testAccWebACLRuleConfig_dataProtectionConfig(rName, []string{"CN", "RU", "KP"}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWebACLRuleExists(ctx, t, resourceName),
+					testAccCheckWebACLHasDataProtectionConfig(ctx, t, webACLResourceName),
+				),
+			},
+			// Delete. The rule leaves the configuration while the Web ACL stays behind.
+			{
+				Config: testAccWebACLRuleConfig_dataProtectionConfigWebACLOnly(rName),
+				Check:  testAccCheckWebACLHasDataProtectionConfig(ctx, t, webACLResourceName),
+			},
+		},
+	})
+}
 
 func testAccCheckWebACLRuleDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
@@ -852,6 +889,28 @@ func testAccCheckWebACLRuleExists(ctx context.Context, t *testing.T, n string) r
 		}
 
 		return fmt.Errorf("WAFv2 Web ACL Rule %s not found in Web ACL", ruleName)
+	}
+}
+
+func testAccCheckWebACLHasDataProtectionConfig(ctx context.Context, t *testing.T, n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		conn := acctest.ProviderMeta(ctx, t).WAFV2Client(ctx)
+
+		output, err := tfwafv2.FindWebACLByThreePartKey(ctx, conn, rs.Primary.ID, rs.Primary.Attributes[names.AttrName], rs.Primary.Attributes[names.AttrScope])
+		if err != nil {
+			return err
+		}
+
+		if output.WebACL.DataProtectionConfig == nil || len(output.WebACL.DataProtectionConfig.DataProtections) == 0 {
+			return fmt.Errorf("WAFv2 Web ACL (%s): data protection configuration not found", rs.Primary.ID)
+		}
+
+		return nil
 	}
 }
 
@@ -2351,4 +2410,64 @@ resource "aws_wafv2_web_acl_rule" "test" {
   }
 }
 `, rName)
+}
+
+func testAccWebACLRuleConfig_dataProtectionConfigWebACLOnly(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_wafv2_web_acl" "test" {
+  name  = %[1]q
+  scope = "REGIONAL"
+
+  default_action {
+    allow {}
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = false
+    metric_name                = %[1]q
+    sampled_requests_enabled   = false
+  }
+
+  data_protection_config {
+    data_protection {
+      action = "HASH"
+
+      field {
+        field_type = "SINGLE_HEADER"
+        field_keys = ["authorization"]
+      }
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [rule]
+  }
+}
+`, rName)
+}
+
+func testAccWebACLRuleConfig_dataProtectionConfig(rName string, countryCodes []string) string {
+	return acctest.ConfigCompose(testAccWebACLRuleConfig_dataProtectionConfigWebACLOnly(rName), fmt.Sprintf(`
+resource "aws_wafv2_web_acl_rule" "test" {
+  name        = %[1]q
+  priority    = 1
+  web_acl_arn = aws_wafv2_web_acl.test.arn
+
+  action {
+    block {}
+  }
+
+  statement {
+    geo_match_statement {
+      country_codes = [%[2]s]
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = false
+    metric_name                = %[1]q
+    sampled_requests_enabled   = false
+  }
+}
+`, rName, acctest.ListOfStrings(countryCodes...)))
 }


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Yes, indirectly, and in the direction of restoring one.

`data_protection_config` is a data protection control: it hashes or substitutes sensitive request fields before they reach WAF logging destinations, web ACL request sampling, and Amazon Security Lake. Today the rule resources silently remove it from the parent Web ACL, so a user who configured `HASH` on their `authorization` header is unknowingly logging that header in the clear from the moment a rule is created, updated, or deleted.

This PR stops that removal. It adds no new controls, and changes nothing about access control or encryption.

### Description

`aws_wafv2_web_acl_rule` and `aws_wafv2_web_acl_rule_group_association` silently strip three configurations from the Web ACL they attach to, including `data_protection_config`.

Neither resource maps to a WAFv2 API entity. There is no per-rule API, so every `create`, `update`, and `delete` is a read-modify-write of the whole Web ACL: `GetWebACL`, change the rule list, `UpdateWebACL`. Because `UpdateWebACL` replaces the Web ACL instead of patching it, anything absent from the request is silently dropped.

Rather than echo back what `GetWebACL` returned, both resources rebuilt `UpdateWebACLInput` field by field from a hand maintained list. Three fields present on `WebACL` never made it onto that list:

- `DataProtectionConfig`
- `MonetizationConfig`
- `OnSourceDDoSProtectionConfig`

`UpdateWebACL` succeeds, the rule is created correctly, and Terraform reports no error. 
Because the rule resources reference the Web ACL's ARN they always apply after it, so within a single `apply` the Web ACL writes `data_protection_config` and a rule immediately removes it. 

`ApplicationConfig` is the fourth field absent from the list, and it is left absent deliberately. AWS retains the stored entries when it is omitted and rejects the request when the entries sent do not match the stored ones exactly, so echoing it back would convert a concurrent change into a hard failure, added a comment documenting that behavior.

#### The fix

The root cause is not a missing field, it is six hand-maintained copies of the same field list — `Create`, `Update`, and `Delete` in each of the two resources — which fall behind whenever AWS extends the API. 

All six now call one `newUpdateWebACLInput` builder, which derives the input from the Web ACL as it currently exists and swaps in the new rule list. Adding a field to the API is a one-line change in one place instead of six.

#### GenAI / LLM assisted development

Claude Code (Anthropic) was used throughout: locating the affected call sites, diffing `UpdateWebACLInput` against what the resources send, writing the builder and the acceptance tests, and drafting this description. I directed the work and made the calls on scope — extending the fix to the second resource, excluding `ApplicationConfig`, and leaving the retry race out reviewed every line, and ran the acceptance tests against my own AWS environment.

### Relations
Closes #49388

### References
- [`UpdateWebACLInput`](https://github.com/aws/aws-sdk-go-v2/blob/main/service/wafv2/api_op_UpdateWebACL.go) — the SDK input struct, including the `ApplicationConfig` retention semantics quoted above
- [`UpdateWebACL`](https://docs.aws.amazon.com/waf/latest/APIReference/API_UpdateWebACL.html) — AWS API reference confirming full-replacement behaviour
- [Data protection in WAF](https://docs.aws.amazon.com/waf/latest/developerguide/data-protection-config.html) — what `data_protection_config` affects

### Output from Acceptance Testing

```console
% make testacc TESTS='TestAccWAFV2WebACLRule_dataProtectionConfig|TestAccWAFV2WebACLRuleGroupAssociation_dataProtectionConfig' PKG=wafv2

TF_ACC=1 go1.26.5 test ./internal/service/wafv2/... -v -count 1 -parallel 20 -run='TestAccWAFV2WebACLRule_dataProtectionConfig|TestAccWAFV2WebACLRuleGroupAssociation_dataProtectionConfig'  -timeout 360m -vet=off -buildvcs=false
=== RUN   TestAccWAFV2WebACLRuleGroupAssociation_dataProtectionConfig
=== PAUSE TestAccWAFV2WebACLRuleGroupAssociation_dataProtectionConfig
=== RUN   TestAccWAFV2WebACLRule_dataProtectionConfig
=== PAUSE TestAccWAFV2WebACLRule_dataProtectionConfig
=== CONT  TestAccWAFV2WebACLRuleGroupAssociation_dataProtectionConfig
=== CONT  TestAccWAFV2WebACLRule_dataProtectionConfig
--- PASS: TestAccWAFV2WebACLRuleGroupAssociation_dataProtectionConfig (63.38s)
--- PASS: TestAccWAFV2WebACLRule_dataProtectionConfig (94.12s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/wafv2      100.217s
```