### PR TITLE
r/aws_cloudfront_function: Add validation of input variables.

### DIFF
--- a/.changelog/49395.txt
+++ b/.changelog/49395.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_cloudfront_function: Validate `name`, `code`, and `comment` against CloudFront's documented constraints during plan instead of failing at apply time
+```

--- a/internal/service/cloudfront/function.go
+++ b/internal/service/cloudfront/function.go
@@ -9,11 +9,13 @@ import (
 	"context"
 	"log"
 
+	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudfront"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/cloudfront/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
@@ -75,6 +77,10 @@ func resourceFunction() *schema.Resource {
 					Type:     schema.TypeString,
 					Required: true,
 					ForceNew: true,
+					ValidateFunc: validation.All(
+						validation.StringLenBetween(1, 64),
+						validation.StringMatch(regexache.MustCompile(`^[a-zA-Z0-9-_]+$`), "must contain only alphanumeric characters, hyphens, and underscores"),
+					),
 				},
 				"publish": {
 					Type:     schema.TypeBool,

--- a/internal/service/cloudfront/function.go
+++ b/internal/service/cloudfront/function.go
@@ -50,12 +50,14 @@ func resourceFunction() *schema.Resource {
 					Computed: true,
 				},
 				"code": {
-					Type:     schema.TypeString,
-					Required: true,
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringLenBetween(1, 40960),
 				},
 				names.AttrComment: {
-					Type:     schema.TypeString,
-					Optional: true,
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringLenBetween(0, 128),
 				},
 				"etag": {
 					Type:     schema.TypeString,

--- a/internal/service/cloudfront/function_test.go
+++ b/internal/service/cloudfront/function_test.go
@@ -6,8 +6,10 @@ package cloudfront_test
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
+	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go-v2/service/cloudfront"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/cloudfront/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -52,6 +54,39 @@ func TestAccCloudFrontFunction_basic(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"publish"},
+			},
+		},
+	})
+}
+
+func TestAccCloudFrontFunction_validation(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.CloudFrontEndpointID) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CloudFrontServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				// name contains a character outside [a-zA-Z0-9-_].
+				Config:      testAccFunctionConfig_basic(rName + "."),
+				ExpectError: regexache.MustCompile(`must contain only alphanumeric characters, hyphens, and underscores`),
+			},
+			{
+				// name exceeds the 64-character maximum.
+				Config:      testAccFunctionConfig_basic(rName + strings.Repeat("x", 65)),
+				ExpectError: regexache.MustCompile(`expected length of`),
+			},
+			{
+				// code exceeds the 40960-byte maximum.
+				Config:      testAccFunctionConfig_code(rName, strings.Repeat("x", 40961)),
+				ExpectError: regexache.MustCompile(`expected length of`),
+			},
+			{
+				// comment exceeds the 128-character maximum.
+				Config:      testAccFunctionConfig_comment(rName, strings.Repeat("x", 129)),
+				ExpectError: regexache.MustCompile(`expected length of`),
 			},
 		},
 	})
@@ -592,6 +627,16 @@ function handler(event) {
 EOT
 }
 `, rName)
+}
+
+func testAccFunctionConfig_code(rName, code string) string {
+	return fmt.Sprintf(`
+resource "aws_cloudfront_function" "test" {
+  name    = %[1]q
+  runtime = "cloudfront-js-1.0"
+  code    = %[2]q
+}
+`, rName, code)
 }
 
 func testAccFunctionConfig_comment(rName, comment string) string {

--- a/website/docs/r/cloudfront_function.html.markdown
+++ b/website/docs/r/cloudfront_function.html.markdown
@@ -32,7 +32,7 @@ resource "aws_cloudfront_function" "test" {
 
 The following arguments are required:
 
-* `name` - (Required) Unique name for your CloudFront Function.
+* `name` - (Required) Unique name for your CloudFront Function. Valid names contain only alphanumeric characters, hyphens, and underscores, and must be between 1 and 64 characters.
 * `code` - (Required) Source code of the function
 * `runtime` - (Required) Identifier of the function's runtime. Valid values are `cloudfront-js-1.0` and `cloudfront-js-2.0`.
 

--- a/website/docs/r/cloudfront_function.html.markdown
+++ b/website/docs/r/cloudfront_function.html.markdown
@@ -33,12 +33,12 @@ resource "aws_cloudfront_function" "test" {
 The following arguments are required:
 
 * `name` - (Required) Unique name for your CloudFront Function. Valid names contain only alphanumeric characters, hyphens, and underscores, and must be between 1 and 64 characters.
-* `code` - (Required) Source code of the function
+* `code` - (Required) Source code of the function. Must be between 1 and 40960 bytes.
 * `runtime` - (Required) Identifier of the function's runtime. Valid values are `cloudfront-js-1.0` and `cloudfront-js-2.0`.
 
 The following arguments are optional:
 
-* `comment` - (Optional) Comment.
+* `comment` - (Optional) Comment. Must not exceed 128 characters.
 * `publish` - (Optional) Whether to publish creation/change as Live CloudFront Function Version. Defaults to `true`.
 * `key_value_store_associations` - (Optional) List of `aws_cloudfront_key_value_store` ARNs to be associated to the function. AWS limits associations to one key value store per function.
 * `tags` - (Optional) Map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

None

### Description

Add more validation of input variables for `aws_cloudfront_function`.

A few of these input vars were missing validation, leading to `MalformedXML` errors that would only be caught at apply time.

* Validate regex and length for `name`
* Validate length for `code` and `comment`

### Relations

None

### References

Valid inputs are documented here:
  - https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_CreateFunction.html
  - https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_FunctionConfig.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

New tests:
```console
$ make testacc TESTS=TestAccCloudFrontFunction_validation PKG=cloudfront
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2	6.037s
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider/framework	5.980s
make: Running acceptance tests on branch: 🌿 cf-name-validation 🌿...
TF_ACC=1 go test ./internal/service/cloudfront/... -v -count 1 -parallel 20 -run='TestAccCloudFrontFunction_validation'  -timeout 360m -vet=off -buildvcs=false
2026/08/11 13:48:32 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/11 13:48:32 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccCloudFrontFunction_validation
=== PAUSE TestAccCloudFrontFunction_validation
=== CONT  TestAccCloudFrontFunction_validation
--- PASS: TestAccCloudFrontFunction_validation (4.44s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudfront	10.305s
```

All tests:

```console
$ make testacc TESTS=TestAccCloudFrontFunction PKG=cloudfront
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2	(cached)
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider/framework	(cached)
make: Running acceptance tests on branch: 🌿 cf-name-validation 🌿...
TF_ACC=1 go test ./internal/service/cloudfront/... -v -count 1 -parallel 20 -run='TestAccCloudFrontFunction'  -timeout 360m -vet=off -buildvcs=false
2026/08/11 13:49:21 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/11 13:49:21 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccCloudFrontFunctionDataSource_basic
=== PAUSE TestAccCloudFrontFunctionDataSource_basic
=== RUN   TestAccCloudFrontFunction_tags
=== PAUSE TestAccCloudFrontFunction_tags
=== RUN   TestAccCloudFrontFunction_Tags_null
=== PAUSE TestAccCloudFrontFunction_Tags_null
=== RUN   TestAccCloudFrontFunction_Tags_emptyMap
=== PAUSE TestAccCloudFrontFunction_Tags_emptyMap
=== RUN   TestAccCloudFrontFunction_Tags_addOnUpdate
=== PAUSE TestAccCloudFrontFunction_Tags_addOnUpdate
=== RUN   TestAccCloudFrontFunction_Tags_EmptyTag_onCreate
=== PAUSE TestAccCloudFrontFunction_Tags_EmptyTag_onCreate
=== RUN   TestAccCloudFrontFunction_Tags_EmptyTag_OnUpdate_add
=== PAUSE TestAccCloudFrontFunction_Tags_EmptyTag_OnUpdate_add
=== RUN   TestAccCloudFrontFunction_Tags_EmptyTag_OnUpdate_replace
=== PAUSE TestAccCloudFrontFunction_Tags_EmptyTag_OnUpdate_replace
=== RUN   TestAccCloudFrontFunction_Tags_DefaultTags_providerOnly
=== PAUSE TestAccCloudFrontFunction_Tags_DefaultTags_providerOnly
=== RUN   TestAccCloudFrontFunction_Tags_DefaultTags_nonOverlapping
=== PAUSE TestAccCloudFrontFunction_Tags_DefaultTags_nonOverlapping
=== RUN   TestAccCloudFrontFunction_Tags_DefaultTags_overlapping
=== PAUSE TestAccCloudFrontFunction_Tags_DefaultTags_overlapping
=== RUN   TestAccCloudFrontFunction_Tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccCloudFrontFunction_Tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccCloudFrontFunction_Tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccCloudFrontFunction_Tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccCloudFrontFunction_Tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccCloudFrontFunction_Tags_DefaultTags_emptyResourceTag
=== RUN   TestAccCloudFrontFunction_Tags_DefaultTags_emptyProviderOnlyTag
=== PAUSE TestAccCloudFrontFunction_Tags_DefaultTags_emptyProviderOnlyTag
=== RUN   TestAccCloudFrontFunction_Tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccCloudFrontFunction_Tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccCloudFrontFunction_Tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccCloudFrontFunction_Tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccCloudFrontFunction_Tags_ComputedTag_onCreate
=== PAUSE TestAccCloudFrontFunction_Tags_ComputedTag_onCreate
=== RUN   TestAccCloudFrontFunction_Tags_ComputedTag_OnUpdate_add
=== PAUSE TestAccCloudFrontFunction_Tags_ComputedTag_OnUpdate_add
=== RUN   TestAccCloudFrontFunction_Tags_ComputedTag_OnUpdate_replace
=== PAUSE TestAccCloudFrontFunction_Tags_ComputedTag_OnUpdate_replace
=== RUN   TestAccCloudFrontFunction_Tags_IgnoreTags_Overlap_defaultTag
=== PAUSE TestAccCloudFrontFunction_Tags_IgnoreTags_Overlap_defaultTag
=== RUN   TestAccCloudFrontFunction_Tags_IgnoreTags_Overlap_resourceTag
=== PAUSE TestAccCloudFrontFunction_Tags_IgnoreTags_Overlap_resourceTag
=== RUN   TestAccCloudFrontFunction_basic
=== PAUSE TestAccCloudFrontFunction_basic
=== RUN   TestAccCloudFrontFunction_validation
=== PAUSE TestAccCloudFrontFunction_validation
=== RUN   TestAccCloudFrontFunction_disappears
=== PAUSE TestAccCloudFrontFunction_disappears
=== RUN   TestAccCloudFrontFunction_publish
=== PAUSE TestAccCloudFrontFunction_publish
=== RUN   TestAccCloudFrontFunction_associated
=== PAUSE TestAccCloudFrontFunction_associated
=== RUN   TestAccCloudFrontFunction_Update_code
=== PAUSE TestAccCloudFrontFunction_Update_code
=== RUN   TestAccCloudFrontFunction_UpdateCodeAndPublish
=== PAUSE TestAccCloudFrontFunction_UpdateCodeAndPublish
=== RUN   TestAccCloudFrontFunction_Update_comment
=== PAUSE TestAccCloudFrontFunction_Update_comment
=== RUN   TestAccCloudFrontFunction_KeyValueStoreAssociations
=== PAUSE TestAccCloudFrontFunction_KeyValueStoreAssociations
=== CONT  TestAccCloudFrontFunctionDataSource_basic
=== CONT  TestAccCloudFrontFunction_Tags_DefaultTags_nullNonOverlappingResourceTag
=== CONT  TestAccCloudFrontFunction_disappears
=== CONT  TestAccCloudFrontFunction_UpdateCodeAndPublish
=== CONT  TestAccCloudFrontFunction_Tags_IgnoreTags_Overlap_defaultTag
=== CONT  TestAccCloudFrontFunction_Tags_DefaultTags_providerOnly
=== CONT  TestAccCloudFrontFunction_Tags_DefaultTags_updateToProviderOnly
=== CONT  TestAccCloudFrontFunction_Tags_DefaultTags_overlapping
=== CONT  TestAccCloudFrontFunction_Tags_DefaultTags_nonOverlapping
=== CONT  TestAccCloudFrontFunction_Tags_EmptyTag_OnUpdate_add
=== CONT  TestAccCloudFrontFunction_Tags_EmptyTag_OnUpdate_replace
=== CONT  TestAccCloudFrontFunction_basic
=== CONT  TestAccCloudFrontFunction_validation
=== CONT  TestAccCloudFrontFunction_associated
=== CONT  TestAccCloudFrontFunction_Update_code
=== CONT  TestAccCloudFrontFunction_Tags_EmptyTag_onCreate
=== CONT  TestAccCloudFrontFunction_Tags_ComputedTag_OnUpdate_add
=== CONT  TestAccCloudFrontFunction_KeyValueStoreAssociations
=== CONT  TestAccCloudFrontFunction_Tags_DefaultTags_updateToResourceOnly
=== CONT  TestAccCloudFrontFunction_Tags_addOnUpdate
--- PASS: TestAccCloudFrontFunction_validation (11.89s)
=== CONT  TestAccCloudFrontFunction_Tags_ComputedTag_OnUpdate_replace
--- PASS: TestAccCloudFrontFunction_basic (29.66s)
=== CONT  TestAccCloudFrontFunction_Tags_null
--- PASS: TestAccCloudFrontFunction_Tags_DefaultTags_nullNonOverlappingResourceTag (39.88s)
=== CONT  TestAccCloudFrontFunction_Tags_emptyMap
--- PASS: TestAccCloudFrontFunction_UpdateCodeAndPublish (51.21s)
=== CONT  TestAccCloudFrontFunction_Update_comment
--- PASS: TestAccCloudFrontFunction_Tags_IgnoreTags_Overlap_defaultTag (59.97s)
=== CONT  TestAccCloudFrontFunction_tags
--- PASS: TestAccCloudFrontFunction_Tags_EmptyTag_onCreate (78.55s)
=== CONT  TestAccCloudFrontFunction_Tags_DefaultTags_emptyProviderOnlyTag
--- PASS: TestAccCloudFrontFunction_Tags_DefaultTags_updateToProviderOnly (94.73s)
=== CONT  TestAccCloudFrontFunction_Tags_DefaultTags_nullOverlappingResourceTag
--- PASS: TestAccCloudFrontFunction_Tags_DefaultTags_emptyProviderOnlyTag (24.84s)
=== CONT  TestAccCloudFrontFunction_Tags_DefaultTags_emptyResourceTag
--- PASS: TestAccCloudFrontFunction_Update_comment (58.67s)
=== CONT  TestAccCloudFrontFunction_Tags_IgnoreTags_Overlap_resourceTag
--- PASS: TestAccCloudFrontFunction_Tags_DefaultTags_providerOnly (110.31s)
=== CONT  TestAccCloudFrontFunction_Tags_ComputedTag_onCreate
--- PASS: TestAccCloudFrontFunctionDataSource_basic (110.95s)
=== CONT  TestAccCloudFrontFunction_publish
--- PASS: TestAccCloudFrontFunction_Tags_null (81.48s)
--- PASS: TestAccCloudFrontFunction_Tags_ComputedTag_OnUpdate_add (122.09s)
--- PASS: TestAccCloudFrontFunction_Tags_DefaultTags_nonOverlapping (124.77s)
--- PASS: TestAccCloudFrontFunction_Tags_DefaultTags_nullOverlappingResourceTag (30.97s)
--- PASS: TestAccCloudFrontFunction_Tags_DefaultTags_emptyResourceTag (28.61s)
--- PASS: TestAccCloudFrontFunction_Tags_EmptyTag_OnUpdate_add (138.38s)
--- PASS: TestAccCloudFrontFunction_Tags_ComputedTag_onCreate (30.38s)
--- PASS: TestAccCloudFrontFunction_publish (37.37s)
--- PASS: TestAccCloudFrontFunction_Tags_ComputedTag_OnUpdate_replace (136.66s)
--- PASS: TestAccCloudFrontFunction_Tags_DefaultTags_overlapping (150.82s)
--- PASS: TestAccCloudFrontFunction_KeyValueStoreAssociations (161.86s)
--- PASS: TestAccCloudFrontFunction_Tags_IgnoreTags_Overlap_resourceTag (55.16s)
--- PASS: TestAccCloudFrontFunction_Tags_DefaultTags_updateToResourceOnly (180.62s)
--- PASS: TestAccCloudFrontFunction_Tags_EmptyTag_OnUpdate_replace (181.02s)
--- PASS: TestAccCloudFrontFunction_disappears (206.54s)
--- PASS: TestAccCloudFrontFunction_tags (159.15s)
--- PASS: TestAccCloudFrontFunction_Update_code (263.17s)
--- PASS: TestAccCloudFrontFunction_Tags_emptyMap (225.62s)
--- PASS: TestAccCloudFrontFunction_Tags_addOnUpdate (266.20s)
--- PASS: TestAccCloudFrontFunction_associated (567.45s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudfront	573.328s
```