### PR TITLE
r/rds_cluster: Fix downgrade error when cluster is auto upgraded

### DIFF
--- a/.changelog/49396.txt
+++ b/.changelog/49396.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_rds_cluster: Fix `InvalidParameterCombination` error when `engine_version` is updated externally
+```

--- a/internal/service/rds/cluster.go
+++ b/internal/service/rds/cluster.go
@@ -1619,10 +1619,16 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta any
 			input.EngineVersion = aws.String(d.Get(names.AttrEngineVersion).(string))
 		}
 
-		// This can happen when updates are deferred (apply_immediately = false), and
-		// multiple applies occur before the maintenance window. In this case,
-		// continue sending the desired engine_version as part of the modify request.
-		if d.Get(names.AttrEngineVersion).(string) != d.Get("engine_version_actual").(string) {
+		// This can happen when updates are deferred (apply_immediately = false) and
+		// multiple applies occur before the maintenance window. Re-send the desired
+		// engine_version so the pending upgrade is not dropped.
+		// Guard: only send when engine_version is newer than engine_version_actual
+		// (the user's desired version is ahead of what is running — a genuine pending
+		// upgrade). If engine_version_actual is newer, the cluster was auto-upgraded
+		// externally (auto_minor_version_upgrade=true or ignore_changes=[engine_version])
+		// and sending the older version would be rejected by AWS as a downgrade.
+		// See: https://github.com/hashicorp/terraform-provider-aws/issues/48936
+		if engineVersionIsNewer(d.Get(names.AttrEngineVersion).(string), d.Get("engine_version_actual").(string)) {
 			input.EngineVersion = aws.String(d.Get(names.AttrEngineVersion).(string))
 		}
 

--- a/internal/service/rds/cluster.go
+++ b/internal/service/rds/cluster.go
@@ -284,6 +284,14 @@ func resourceCluster() *schema.Resource {
 					Type:     schema.TypeString,
 					Optional: true,
 					Computed: true,
+					DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+						// Suppress the diff when the configured version is not newer than
+						// engine_version_actual. This handles the case where the cluster was
+						// auto-upgraded externally (auto_minor_version_upgrade=true or
+						// ignore_changes=[engine_version]): sending the older configured
+						// version would be rejected by AWS as a downgrade.
+						return !engineVersionIsNewer(new, d.Get("engine_version_actual").(string))
+					},
 				},
 				"engine_version_actual": {
 					Type:     schema.TypeString,

--- a/internal/service/rds/cluster_test.go
+++ b/internal/service/rds/cluster_test.go
@@ -4036,6 +4036,9 @@ func TestAccRDSCluster_engineVersion_outOfBand(t *testing.T) {
 	var dbCluster types.DBCluster
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_rds_cluster.test"
+	parameterGroupResourceName := "aws_rds_cluster_parameter_group.test"
+
+	engineVersion, engineVersionUpgrade := "8.0.mysql_aurora.3.90.0", "8.0.mysql_aurora.3.10.0"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -4044,7 +4047,7 @@ func TestAccRDSCluster_engineVersion_outOfBand(t *testing.T) {
 		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterConfig_engineVersion_outOfBand(rName, "STATEMENT"),
+				Config: testAccClusterConfig_engineVersion_outOfBand(rName, engineVersion, "STATEMENT"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, t, resourceName, &dbCluster),
 					acctest.CheckResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "rds", fmt.Sprintf("cluster:%s", rName)),
@@ -4056,8 +4059,8 @@ func TestAccRDSCluster_engineVersion_outOfBand(t *testing.T) {
 
 					id := dbCluster.DBClusterIdentifier
 					_, err := conn.ModifyDBCluster(ctx, &rds.ModifyDBClusterInput{
-						DBClusterIdentifier: dbCluster.DBClusterIdentifier,
-						EngineVersion:       aws.String("8.0.mysql_aurora.3.11.1"),
+						DBClusterIdentifier: id,
+						EngineVersion:       aws.String(engineVersionUpgrade),
 						ApplyImmediately:    aws.Bool(true),
 					})
 
@@ -4065,11 +4068,11 @@ func TestAccRDSCluster_engineVersion_outOfBand(t *testing.T) {
 						t.Fatalf("externally updating RDS Cluster engine version: %s", err)
 					}
 
-					if _, err := tfrds.WaitDBClusterUpdated(ctx, conn, aws.ToString(id), true, time.Duration(15*time.Minute)); err != nil {
+					if _, err := tfrds.WaitDBClusterUpdated(ctx, conn, aws.ToString(id), true, 120*time.Minute); err != nil {
 						t.Fatalf("waiting on external update for RDS Cluster engine version: %s", err)
 					}
 				},
-				Config: testAccClusterConfig_engineVersion_outOfBand(rName, "STATEMENT"),
+				Config: testAccClusterConfig_engineVersion_outOfBand(rName, engineVersion, "STATEMENT"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, t, resourceName, &dbCluster),
 					acctest.CheckResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "rds", fmt.Sprintf("cluster:%s", rName)),
@@ -4077,6 +4080,19 @@ func TestAccRDSCluster_engineVersion_outOfBand(t *testing.T) {
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+			{
+				Config: testAccClusterConfig_engineVersion_outOfBand(rName, engineVersionUpgrade, "ROW"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckClusterExists(ctx, t, resourceName, &dbCluster),
+					acctest.CheckResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "rds", fmt.Sprintf("cluster:%s", rName)),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+						plancheck.ExpectResourceAction(parameterGroupResourceName, plancheck.ResourceActionUpdate),
 					},
 				},
 			},
@@ -7555,10 +7571,10 @@ resource "aws_kms_key" "test" {
 `, rName, tfrds.ClusterEngineMySQL, databaseInsightsMode, performanceInsightsEnabled, performanceInsightsRetentionPeriod))
 }
 
-func testAccClusterConfig_engineVersion_outOfBand(rName, parameter string) string {
+func testAccClusterConfig_engineVersion_outOfBand(rName, engineVersion, parameter string) string {
 	return fmt.Sprintf(`
 data "aws_rds_engine_version" "default" {
-  engine = local.engine
+  engine = %[3]q
 }
 
 
@@ -7579,7 +7595,7 @@ resource "aws_rds_cluster" "test" {
   db_cluster_parameter_group_name = aws_rds_cluster_parameter_group.test.name
   database_name                   = "test"
   engine                          = %[3]q
-  engine_version                  = "8.0.mysql_aurora.3.10.5" # lower version that is upgradable
+  engine_version                  = %[4]q
   master_username                 = "tfacctest"
   master_password                 = "avoid-plaintext-passwords"
   storage_encrypted               = true
@@ -7606,5 +7622,5 @@ resource "aws_rds_cluster_instance" "test" {
 }
 
 
-`, rName, parameter, tfrds.ClusterEngineAuroraMySQL)
+`, rName, parameter, tfrds.ClusterEngineAuroraMySQL, engineVersion)
 }

--- a/internal/service/rds/cluster_test.go
+++ b/internal/service/rds/cluster_test.go
@@ -4031,6 +4031,59 @@ func TestAccRDSCluster_auroraLimitless(t *testing.T) {
 	})
 }
 
+func TestAccRDSCluster_engineVersion_outOfBand(t *testing.T) {
+	ctx := acctest.Context(t)
+	var dbCluster types.DBCluster
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_rds_cluster.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterConfig_engineVersion_outOfBand(rName, "STATEMENT"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckClusterExists(ctx, t, resourceName, &dbCluster),
+					acctest.CheckResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "rds", fmt.Sprintf("cluster:%s", rName)),
+				),
+			},
+			{
+				PreConfig: func() {
+					conn := acctest.ProviderMeta(ctx, t).RDSClient(ctx)
+
+					id := dbCluster.DBClusterIdentifier
+					_, err := conn.ModifyDBCluster(ctx, &rds.ModifyDBClusterInput{
+						DBClusterIdentifier: dbCluster.DBClusterIdentifier,
+						EngineVersion:       aws.String("8.0.mysql_aurora.3.11.1"),
+						ApplyImmediately:    aws.Bool(true),
+					})
+
+					if err != nil {
+						t.Fatalf("externally updating RDS Cluster engine version: %s", err)
+					}
+
+					if _, err := tfrds.WaitDBClusterUpdated(ctx, conn, aws.ToString(id), true, time.Duration(15*time.Minute)); err != nil {
+						t.Fatalf("waiting on external update for RDS Cluster engine version: %s", err)
+					}
+				},
+				Config: testAccClusterConfig_engineVersion_outOfBand(rName, "STATEMENT"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckClusterExists(ctx, t, resourceName, &dbCluster),
+					acctest.CheckResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "rds", fmt.Sprintf("cluster:%s", rName)),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+		},
+	})
+}
+
 func testAccCheckClusterDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.ProviderMeta(ctx, t).RDSClient(ctx)
@@ -7500,4 +7553,58 @@ resource "aws_kms_key" "test" {
   enable_key_rotation     = true
 }
 `, rName, tfrds.ClusterEngineMySQL, databaseInsightsMode, performanceInsightsEnabled, performanceInsightsRetentionPeriod))
+}
+
+func testAccClusterConfig_engineVersion_outOfBand(rName, parameter string) string {
+	return fmt.Sprintf(`
+data "aws_rds_engine_version" "default" {
+  engine = local.engine
+}
+
+
+resource "aws_rds_cluster_parameter_group" "test" {
+  name        = %[1]q
+  family      = data.aws_rds_engine_version.default.parameter_group_family
+  description = "RDS default cluster parameter group"
+
+  parameter {
+    name         = "binlog_format"
+    value        = %[2]q
+    apply_method = "pending-reboot"
+  }
+}
+
+resource "aws_rds_cluster" "test" {
+  cluster_identifier              = %[1]q
+  db_cluster_parameter_group_name = aws_rds_cluster_parameter_group.test.name
+  database_name                   = "test"
+  engine                          = %[3]q
+  engine_version                  = "8.0.mysql_aurora.3.10.5" # lower version that is upgradable
+  master_username                 = "tfacctest"
+  master_password                 = "avoid-plaintext-passwords"
+  storage_encrypted               = true
+  skip_final_snapshot             = true
+
+  allow_major_version_upgrade = true
+  apply_immediately           = false
+
+  serverlessv2_scaling_configuration {
+    min_capacity = 1
+    max_capacity = 2
+  }
+}
+
+resource "aws_rds_cluster_instance" "test" {
+  identifier         = "%[1]s-primary-instance"
+  cluster_identifier = aws_rds_cluster.test.id
+  instance_class     = "db.serverless"
+  engine             = aws_rds_cluster.test.engine
+  engine_version     = aws_rds_cluster.test.engine_version
+
+  auto_minor_version_upgrade = true
+  apply_immediately          = false
+}
+
+
+`, rName, parameter, tfrds.ClusterEngineAuroraMySQL)
 }

--- a/internal/service/rds/cluster_test.go
+++ b/internal/service/rds/cluster_test.go
@@ -4038,7 +4038,7 @@ func TestAccRDSCluster_engineVersion_outOfBand(t *testing.T) {
 	resourceName := "aws_rds_cluster.test"
 	parameterGroupResourceName := "aws_rds_cluster_parameter_group.test"
 
-	engineVersion, engineVersionUpgrade := "8.0.mysql_aurora.3.90.0", "8.0.mysql_aurora.3.10.0"
+	engineVersion, engineVersionUpgrade := "8.0.mysql_aurora.3.09.0", "8.0.mysql_aurora.3.10.0"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },

--- a/internal/service/rds/exports_test.go
+++ b/internal/service/rds/exports_test.go
@@ -103,4 +103,6 @@ var (
 	ValidParamGroupNamePrefix        = validParamGroupNamePrefix
 	ValidSubnetGroupName             = validSubnetGroupName
 	ValidSubnetGroupNamePrefix       = validSubnetGroupNamePrefix
+
+	WaitDBClusterUpdated = waitDBClusterUpdated
 )

--- a/internal/service/rds/exports_test.go
+++ b/internal/service/rds/exports_test.go
@@ -105,4 +105,6 @@ var (
 	ValidSubnetGroupNamePrefix       = validSubnetGroupNamePrefix
 
 	WaitDBClusterUpdated = waitDBClusterUpdated
+
+	EngineVersionIsNewer = engineVersionIsNewer
 )

--- a/internal/service/rds/verify.go
+++ b/internal/service/rds/verify.go
@@ -4,6 +4,7 @@
 package rds
 
 import (
+	gversion "github.com/YakDriver/go-version"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -34,4 +35,14 @@ func compareActualEngineVersion(d *schema.ResourceData, oldVersion, newVersion, 
 	}
 
 	d.Set(names.AttrEngineVersion, newVersion)
+}
+
+// engineVersionIsNewer returns true when v1 is strictly greater than v2 using
+// numeric-aware version comparison. This handles both plain versions ("16.3")
+// and Aurora-style versions ("8.0.mysql_aurora.3.10.0") correctly, including
+// unpadded minor/patch segments where lexicographic comparison would fail
+// (e.g. "3.9" < "3.10" even though "3.9" > "3.10" as a string).
+// Returns false if either string cannot be parsed as a version.
+func engineVersionIsNewer(v1, v2 string) bool {
+	return !gversion.LessThan(v1, v2) && v1 != v2
 }

--- a/internal/service/rds/verify_test.go
+++ b/internal/service/rds/verify_test.go
@@ -1,0 +1,54 @@
+package rds_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	tfrds "github.com/hashicorp/terraform-provider-aws/internal/service/rds"
+)
+
+func TestEngineVersionIsNewer(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		v1   string
+		v2   string
+		want bool
+	}{
+		"newer plain version": {
+			v1:   "16.3",
+			v2:   "16.2",
+			want: true,
+		},
+		"equal plain version": {
+			v1:   "16.3",
+			v2:   "16.3",
+			want: false,
+		},
+		"older plain version": {
+			v1:   "16.2",
+			v2:   "16.3",
+			want: false,
+		},
+		"newer aurora patch version": {
+			v1:   "8.0.mysql_aurora.3.10.0",
+			v2:   "8.0.mysql_aurora.3.9.0",
+			want: true,
+		},
+		"older aurora patch version": {
+			v1:   "8.0.mysql_aurora.3.9.0",
+			v2:   "8.0.mysql_aurora.3.10.0",
+			want: false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if diff := cmp.Diff(test.want, tfrds.EngineVersionIsNewer(test.v1, test.v2)); diff != "" {
+				t.Errorf("engineVersionIsNewer(%q, %q) mismatch (-want +got):\n%s", test.v1, test.v2, diff)
+			}
+		})
+	}
+}

--- a/internal/service/rds/verify_test.go
+++ b/internal/service/rds/verify_test.go
@@ -1,3 +1,6 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
 package rds_test
 
 import (


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

When `auto_minor_upgrade` is enabled RDS can encounter a `InvalidParameterCombination` error when the configured version is less than the actual version on the database.

- We suppress the diff if the configured version is less than the actual RDS version. RDS cannot be downgraded directly via the API.
- Preserve the behavior that allows multiple updates to be done during a maintenance window when `apply_immediately = false`. `engine_version` will continue to be sent when the configured version is larger than the actual.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

Closes #48936
Closes #48938

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=rds TESTARGS='-run=TestAccRDSCluster_engineVersion_outOfBand'

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2	(cached)
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider/framework	(cached)
make: Running acceptance tests on branch: 🌿 b-rds_cluster_engine_version 🌿...
TF_ACC=1 go1.26.5 test ./internal/service/rds/... -v -count 1 -parallel 20  -run=TestAccRDSCluster_engineVersion_outOfBand -timeout 360m -vet=off -buildvcs=false
2026/08/11 17:11:07 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/11 17:11:07 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccRDSCluster_engineVersion_outOfBand
=== PAUSE TestAccRDSCluster_engineVersion_outOfBand
=== CONT  TestAccRDSCluster_engineVersion_outOfBand
    cluster_test.go:4043: Step 2/3 error: Pre-apply plan check(s) failed:
        'aws_rds_cluster.test' - expected NoOp, got action(s): [update]
--- FAIL: TestAccRDSCluster_engineVersion_outOfBand (1493.07s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/rds	1501.674s
FAIL
make: *** [testacc] Error 1
```
