### PR TITLE
r/aws_glue_trigger: stop issuing StartTrigger/StopTrigger calls AWS always rejects for EVENT triggers

### DIFF
--- a/.changelog/49408.txt
+++ b/.changelog/49408.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_glue_trigger: Fix permanent `InvalidInputException` errors when updating `enabled` on `EVENT` type triggers
+```

--- a/internal/service/glue/trigger.go
+++ b/internal/service/glue/trigger.go
@@ -291,7 +291,11 @@ func resourceTriggerCreate(ctx context.Context, d *schema.ResourceData, meta any
 	log.Printf("[DEBUG] Waiting for Glue Trigger (%s) to create", d.Id())
 	if _, err := waitTriggerCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
 		if errs.IsA[*awstypes.EntityNotFoundException](err) {
-			return diags
+			// Read rather than returning bare: it clears the ID if the trigger really is gone,
+			// and otherwise populates attributes that are only ever set on the read path. Of
+			// those, "enabled" cannot recover from being left unset for ON_DEMAND and EVENT
+			// triggers, because it is derived from its own prior value.
+			return append(diags, resourceTriggerRead(ctx, d, meta)...)
 		}
 		return sdkdiag.AppendErrorf(diags, "waiting for Glue Trigger (%s) to be Created: %s", d.Id(), err)
 	}
@@ -414,7 +418,9 @@ func resourceTriggerUpdate(ctx context.Context, d *schema.ResourceData, meta any
 		}
 	}
 
-	if d.HasChange(names.AttrEnabled) {
+	// EVENT triggers cannot be started - AWS rejects StartTrigger on them outright, as the
+	// create path already accounts for. Their enabled value is not actionable either way.
+	if d.HasChange(names.AttrEnabled) && d.Get(names.AttrType).(string) != string(awstypes.TriggerTypeEvent) {
 		if d.Get(names.AttrEnabled).(bool) {
 			input := &glue.StartTriggerInput{
 				Name: aws.String(d.Id()),
@@ -426,8 +432,9 @@ func resourceTriggerUpdate(ctx context.Context, d *schema.ResourceData, meta any
 				return sdkdiag.AppendErrorf(diags, "starting Glue Trigger (%s): %s", d.Id(), err)
 			}
 		} else {
-			//Skip if Trigger is type is ON_DEMAND and is in CREATED state as this means the trigger is not running or has ran already.
-			if !(d.Get(names.AttrType).(string) == string(awstypes.TriggerTypeOnDemand) && d.Get(names.AttrState).(string) == string(awstypes.TriggerStateCreated)) {
+			// AWS refuses StopTrigger in CREATED state for EVERY trigger type, not just
+			// ON_DEMAND: nothing is running yet, or it has already run.
+			if d.Get(names.AttrState).(string) != string(awstypes.TriggerStateCreated) {
 				input := &glue.StopTriggerInput{
 					Name: aws.String(d.Id()),
 				}

--- a/internal/service/glue/trigger_test.go
+++ b/internal/service/glue/trigger_test.go
@@ -535,6 +535,50 @@ func TestAccGlueTrigger_onDemandDisable(t *testing.T) {
 	})
 }
 
+func TestAccGlueTrigger_eventDisable(t *testing.T) {
+	ctx := acctest.Context(t)
+	var trigger awstypes.Trigger
+
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_glue_trigger.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.GlueServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTriggerDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTriggerConfig_eventEnabled(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTriggerExists(ctx, t, resourceName, &trigger),
+					resource.TestCheckResourceAttr(resourceName, names.AttrEnabled, acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, names.AttrType, "EVENT"),
+				),
+			},
+			{
+				// AWS refuses StopTrigger for a trigger in CREATED state, which is the only
+				// state an EVENT trigger ever reaches.
+				Config: testAccTriggerConfig_eventEnabled(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTriggerExists(ctx, t, resourceName, &trigger),
+					resource.TestCheckResourceAttr(resourceName, names.AttrEnabled, acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, names.AttrType, "EVENT"),
+				),
+			},
+			{
+				// AWS rejects StartTrigger for EVENT triggers outright.
+				Config: testAccTriggerConfig_eventEnabled(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTriggerExists(ctx, t, resourceName, &trigger),
+					resource.TestCheckResourceAttr(resourceName, names.AttrEnabled, acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, names.AttrType, "EVENT"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccGlueTrigger_eventBatchingCondition(t *testing.T) {
 	ctx := acctest.Context(t)
 	var trigger awstypes.Trigger

--- a/internal/service/glue/trigger_test.go
+++ b/internal/service/glue/trigger_test.go
@@ -1016,6 +1016,30 @@ resource "aws_glue_trigger" "test" {
 `, rName))
 }
 
+func testAccTriggerConfig_eventEnabled(rName string, enabled bool) string {
+	return acctest.ConfigCompose(testAccJobConfig_required(rName), fmt.Sprintf(`
+resource "aws_glue_workflow" test {
+  name = %[1]q
+}
+
+resource "aws_glue_trigger" "test" {
+  name              = %[1]q
+  type              = "EVENT"
+  workflow_name     = aws_glue_workflow.test.name
+  start_on_creation = false
+  enabled           = %[2]t
+
+  actions {
+    job_name = aws_glue_job.test.name
+  }
+
+  event_batching_condition {
+    batch_size = 1
+  }
+}
+`, rName, enabled))
+}
+
 func testAccTriggerConfig_actionsNull(rName string) string {
 	return acctest.ConfigCompose(testAccJobConfig_required(rName), fmt.Sprintf(`
 resource "aws_glue_trigger" "test" {


### PR DESCRIPTION
### Description

For an `EVENT`-type Glue trigger, any diff on `enabled` is a permanent hard failure, because AWS refuses both mutations the provider might use to reconcile it:

| desired | observed | provider calls | AWS response |
|---|---|---|---|
| `true` | `false` | `StartTrigger` | `InvalidInputException: Trigger Type EVENT cannot be started` |
| `false` | `true` | `StopTrigger` | `InvalidInputException: The operation is not allowed when trigger is in state: CREATED` |

Both reproduced directly against the API on a live `EVENT` trigger in `CREATED` state. Note the asymmetry: `StopTrigger` is refused because of the **state**, not the type — it is refused for any trigger type in `CREATED`.

This PR makes three changes.

**1. `resourceTriggerCreate` — read before returning when the trigger isn't visible yet.**

On the `waitTriggerCreated` failure path, an `EntityNotFoundException` returned bare, skipping the read that normally closes out create. `enabled` was therefore never set, and reads back as the Go zero value `false`.

That matters because for `ON_DEMAND` and `EVENT` triggers `enabled` is derived from *its own prior value*:

```go
enabled = (state == CREATED || state == CREATING) && d.Get(names.AttrEnabled).(bool)
```

An `EVENT` trigger's state is always `CREATED`, so this reduces to `enabled = d.Get("enabled")`. Once the value is `false` it is absorbing — `false && _ == false` — with no path back to `true`. Calling the read instead lets it clear the ID if the trigger really is gone, and otherwise populate `enabled` correctly, so that state is never reachable.

**2. `resourceTriggerUpdate` — don't call `StartTrigger` for `EVENT`.**

The create path already knows this: it guards `StartTrigger` behind `type == ON_DEMAND` and forces `StartOnCreation = false` for `EVENT`. Update had no type check at all.

**3. `resourceTriggerUpdate` — widen the `StopTrigger` skip to AWS's actual rule.**

The existing skip was `type == ON_DEMAND && state == CREATED`. Its comment — *"this means the trigger is not running or has ran already"* — is correct, but AWS refuses `StopTrigger` in `CREATED` for **every** type, so the `ON_DEMAND` test made the guard narrower than the constraint it enforces. Now keyed on state alone.

(2) and (3) stop the errors for triggers that are already in the mismatched state; (1) prevents them from getting there. `resourceTriggerRead` is deliberately left alone: changing how `enabled` is derived would turn `enabled = false` on an `EVENT` trigger into a permanent non-empty plan, which is worse than the current behaviour.

### Relations

Closes #49407

### References

* [`StartTrigger`](https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-jobs-trigger.html#aws-glue-api-jobs-trigger-StartTrigger) / [`StopTrigger`](https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-jobs-trigger.html#aws-glue-api-jobs-trigger-StopTrigger)
* Related but distinct: #42498 (`ON_DEMAND` firing on creation) touches the same `enabled` / `start_on_creation` handling.

### Output from Acceptance Testing

`TestAccGlueTrigger_eventDisable` is added: it creates an `EVENT` trigger with `enabled = true`, flips it to `false`, then back to `true`, asserting each step applies and leaves an empty plan.

```console
$ TF_ACC=1 AWS_REGION=us-west-2 go test ./internal/service/glue/ -v -run 'TestAccGlueTrigger_eventDisable' -timeout 40m
=== RUN   TestAccGlueTrigger_eventDisable
=== PAUSE TestAccGlueTrigger_eventDisable
=== CONT  TestAccGlueTrigger_eventDisable
--- PASS: TestAccGlueTrigger_eventDisable (500.23s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/glue        506.274s
```

`gofmt` clean on both changed files.

One caveat, stated plainly: I also ran this test once against unpatched `main` expecting it to fail at the `enabled = false` step, but that run failed earlier — at step 1, on `waiting for ... to be Created: timeout ... GetTrigger, request canceled` — which is unrelated to this change (step 1 exercises identical code on both branches) and looks like `GetTrigger` throttling in the account I tested from. So I have **not** cleanly demonstrated the pre-fix failure via this test; I did reproduce both API rejections by hand as shown above, and the code path is deterministic. Someone re-running the negative case on a quieter account would confirm it.
