### PR TITLE
Add control plane customization support

### DIFF
--- a/.changelog/49412.txt
+++ b/.changelog/49412.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_eks_cluster: Add `kube_api_server_config`, `kube_controller_manager_config`, and `kube_scheduler_config` arguments
+```

--- a/internal/service/eks/cluster.go
+++ b/internal/service/eks/cluster.go
@@ -256,6 +256,121 @@ func resourceCluster() *schema.Resource {
 						},
 					},
 				},
+				"kube_api_server_config": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Computed: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"event_ttl": {
+								Type:     schema.TypeString,
+								Optional: true,
+								Computed: true,
+							},
+							"service_node_port_range": {
+								Type:     schema.TypeList,
+								Optional: true,
+								Computed: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"max_port": {
+											Type:     schema.TypeInt,
+											Optional: true,
+											Computed: true,
+										},
+										"min_port": {
+											Type:     schema.TypeInt,
+											Optional: true,
+											Computed: true,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				"kube_controller_manager_config": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Computed: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"horizontal_pod_autoscaler_controller_config": {
+								Type:     schema.TypeList,
+								Optional: true,
+								Computed: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"horizontal_pod_autoscaler_sync_period": {
+											Type:     schema.TypeString,
+											Optional: true,
+											Computed: true,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				"kube_scheduler_config": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Computed: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"node_resources_fit": {
+								Type:     schema.TypeList,
+								Optional: true,
+								Computed: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"scoring_strategy": {
+											Type:     schema.TypeList,
+											Optional: true,
+											Computed: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													names.AttrResources: {
+														Type:     schema.TypeList,
+														Optional: true,
+														Computed: true,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																names.AttrName: {
+																	Type:     schema.TypeString,
+																	Optional: true,
+																	Computed: true,
+																},
+																names.AttrWeight: {
+																	Type:     schema.TypeInt,
+																	Optional: true,
+																	Computed: true,
+																},
+															},
+														},
+													},
+													names.AttrType: {
+														Type:             schema.TypeString,
+														Optional:         true,
+														Computed:         true,
+														ValidateDiagFunc: enum.Validate[types.ScoringStrategyType](),
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
 				"kubernetes_network_config": {
 					Type:          schema.TypeList,
 					Optional:      true,
@@ -597,6 +712,18 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta any
 		input.DeletionProtection = aws.Bool(v.(bool))
 	}
 
+	if v, ok := d.GetOk("kube_api_server_config"); ok {
+		input.KubeApiServerConfig = expandKubeAPIServerConfigRequest(v.([]any))
+	}
+
+	if v, ok := d.GetOk("kube_controller_manager_config"); ok {
+		input.KubeControllerManagerConfig = expandKubeControllerManagerConfigRequest(v.([]any))
+	}
+
+	if v, ok := d.GetOk("kube_scheduler_config"); ok {
+		input.KubeSchedulerConfig = expandKubeSchedulerConfigRequest(v.([]any))
+	}
+
 	if v, ok := d.GetOk("outpost_config"); ok {
 		input.OutpostConfig = expandOutpostConfigRequest(v.([]any))
 	}
@@ -778,6 +905,27 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta any
 
 		if _, err := waitClusterUpdateSuccessful(ctx, conn, d.Id(), updateID, d.Timeout(schema.TimeoutUpdate)); err != nil {
 			return sdkdiag.AppendErrorf(diags, "waiting for EKS Cluster (%s) control plane scaling config update (%s): %s", d.Id(), updateID, err)
+		}
+	}
+
+	if d.HasChanges("kube_api_server_config", "kube_controller_manager_config", "kube_scheduler_config") {
+		input := eks.UpdateClusterConfigInput{
+			Name:                        aws.String(d.Id()),
+			KubeApiServerConfig:         expandKubeAPIServerConfigRequest(d.Get("kube_api_server_config").([]any)),
+			KubeControllerManagerConfig: expandKubeControllerManagerConfigRequest(d.Get("kube_controller_manager_config").([]any)),
+			KubeSchedulerConfig:         expandKubeSchedulerConfigRequest(d.Get("kube_scheduler_config").([]any)),
+		}
+
+		output, err := conn.UpdateClusterConfig(ctx, &input)
+
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "updating EKS Cluster (%s) control plane component config: %s", d.Id(), err)
+		}
+
+		updateID := aws.ToString(output.Update.Id)
+
+		if _, err := waitClusterUpdateSuccessful(ctx, conn, d.Id(), updateID, d.Timeout(schema.TimeoutUpdate)); err != nil {
+			return sdkdiag.AppendErrorf(diags, "waiting for EKS Cluster (%s) control plane component config update (%s): %s", d.Id(), updateID, err)
 		}
 	}
 
@@ -1022,6 +1170,15 @@ func resourceClusterFlatten(ctx context.Context, cluster *types.Cluster, d *sche
 	d.Set(names.AttrEndpoint, cluster.Endpoint)
 	if err := d.Set("identity", flattenIdentity(cluster.Identity)); err != nil {
 		return fmt.Errorf("setting identity: %w", err)
+	}
+	if err := d.Set("kube_api_server_config", flattenKubeAPIServerConfigResponse(cluster.KubeApiServerConfig)); err != nil {
+		return fmt.Errorf("setting kube_api_server_config: %w", err)
+	}
+	if err := d.Set("kube_controller_manager_config", flattenKubeControllerManagerConfigResponse(cluster.KubeControllerManagerConfig)); err != nil {
+		return fmt.Errorf("setting kube_controller_manager_config: %w", err)
+	}
+	if err := d.Set("kube_scheduler_config", flattenKubeSchedulerConfigResponse(cluster.KubeSchedulerConfig)); err != nil {
+		return fmt.Errorf("setting kube_scheduler_config: %w", err)
 	}
 	if err := d.Set("kubernetes_network_config", flattenKubernetesNetworkConfigResponse(cluster.KubernetesNetworkConfig)); err != nil {
 		return fmt.Errorf("setting kubernetes_network_config: %w", err)
@@ -1340,6 +1497,180 @@ func expandControlPlaneScalingConfig(tfList []any) *types.ControlPlaneScalingCon
 	}
 
 	return apiObject
+}
+
+func expandKubeAPIServerConfigRequest(tfList []any) *types.KubeApiServerConfigRequest {
+	if len(tfList) == 0 {
+		return nil
+	}
+
+	tfMap, ok := tfList[0].(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	apiObject := &types.KubeApiServerConfigRequest{}
+
+	if v, ok := tfMap["event_ttl"].(string); ok && v != "" {
+		apiObject.EventTtl = aws.String(v)
+	}
+
+	if v, ok := tfMap["service_node_port_range"].([]any); ok && len(v) > 0 {
+		apiObject.ServiceNodePortRange = expandServiceNodePortRange(v)
+	}
+
+	return apiObject
+}
+
+func expandServiceNodePortRange(tfList []any) *types.ServiceNodePortRange {
+	if len(tfList) == 0 {
+		return nil
+	}
+
+	tfMap, ok := tfList[0].(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	apiObject := &types.ServiceNodePortRange{}
+
+	if v, ok := tfMap["min_port"].(int); ok && v != 0 {
+		apiObject.MinPort = int32(v)
+	}
+
+	if v, ok := tfMap["max_port"].(int); ok && v != 0 {
+		apiObject.MaxPort = int32(v)
+	}
+
+	return apiObject
+}
+
+func expandKubeControllerManagerConfigRequest(tfList []any) *types.KubeControllerManagerConfigRequest {
+	if len(tfList) == 0 {
+		return nil
+	}
+
+	tfMap, ok := tfList[0].(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	apiObject := &types.KubeControllerManagerConfigRequest{}
+
+	if v, ok := tfMap["horizontal_pod_autoscaler_controller_config"].([]any); ok && len(v) > 0 {
+		apiObject.HorizontalPodAutoscalerControllerConfig = expandHorizontalPodAutoscalerControllerConfigRequest(v)
+	}
+
+	return apiObject
+}
+
+func expandHorizontalPodAutoscalerControllerConfigRequest(tfList []any) *types.HorizontalPodAutoscalerControllerConfigRequest {
+	if len(tfList) == 0 {
+		return nil
+	}
+
+	tfMap, ok := tfList[0].(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	apiObject := &types.HorizontalPodAutoscalerControllerConfigRequest{}
+
+	if v, ok := tfMap["horizontal_pod_autoscaler_sync_period"].(string); ok && v != "" {
+		apiObject.HorizontalPodAutoscalerSyncPeriod = aws.String(v)
+	}
+
+	return apiObject
+}
+
+func expandKubeSchedulerConfigRequest(tfList []any) *types.KubeSchedulerConfigRequest {
+	if len(tfList) == 0 {
+		return nil
+	}
+
+	tfMap, ok := tfList[0].(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	apiObject := &types.KubeSchedulerConfigRequest{}
+
+	if v, ok := tfMap["node_resources_fit"].([]any); ok && len(v) > 0 {
+		apiObject.NodeResourcesFit = expandNodeResourcesFitConfig(v)
+	}
+
+	return apiObject
+}
+
+func expandNodeResourcesFitConfig(tfList []any) *types.NodeResourcesFitConfig {
+	if len(tfList) == 0 {
+		return nil
+	}
+
+	tfMap, ok := tfList[0].(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	apiObject := &types.NodeResourcesFitConfig{}
+
+	if v, ok := tfMap["scoring_strategy"].([]any); ok && len(v) > 0 {
+		apiObject.ScoringStrategy = expandScoringStrategy(v)
+	}
+
+	return apiObject
+}
+
+func expandScoringStrategy(tfList []any) *types.ScoringStrategy {
+	if len(tfList) == 0 {
+		return nil
+	}
+
+	tfMap, ok := tfList[0].(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	apiObject := &types.ScoringStrategy{}
+
+	if v, ok := tfMap[names.AttrType].(string); ok && v != "" {
+		apiObject.Type = types.ScoringStrategyType(v)
+	}
+
+	if v, ok := tfMap[names.AttrResources].([]any); ok && len(v) > 0 {
+		apiObject.Resources = expandResourceWeights(v)
+	}
+
+	return apiObject
+}
+
+func expandResourceWeights(tfList []any) []types.ResourceWeight {
+	if len(tfList) == 0 {
+		return nil
+	}
+
+	var apiObjects []types.ResourceWeight
+
+	for _, tfMapRaw := range tfList {
+		tfMap, ok := tfMapRaw.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		apiObject := types.ResourceWeight{}
+
+		if v, ok := tfMap[names.AttrName].(string); ok && v != "" {
+			apiObject.Name = aws.String(v)
+		}
+
+		if v, ok := tfMap[names.AttrWeight].(int); ok && v != 0 {
+			apiObject.Weight = aws.Int32(int32(v))
+		}
+
+		apiObjects = append(apiObjects, apiObject)
+	}
+
+	return apiObjects
 }
 
 func expandEncryptionConfig(tfList []any) []types.EncryptionConfig {
@@ -1775,6 +2106,133 @@ func flattenControlPlaneScalingConfig(apiObject *types.ControlPlaneScalingConfig
 	}
 
 	return []any{tfMap}
+}
+
+func flattenKubeAPIServerConfigResponse(apiObject *types.KubeApiServerConfigResponse) []any {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]any{}
+
+	if apiObject.EventTtl != nil {
+		tfMap["event_ttl"] = aws.ToString(apiObject.EventTtl)
+	}
+
+	if apiObject.ServiceNodePortRange != nil {
+		tfMap["service_node_port_range"] = flattenServiceNodePortRange(apiObject.ServiceNodePortRange)
+	}
+
+	return []any{tfMap}
+}
+
+func flattenServiceNodePortRange(apiObject *types.ServiceNodePortRange) []any {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]any{
+		"min_port": apiObject.MinPort,
+		"max_port": apiObject.MaxPort,
+	}
+
+	return []any{tfMap}
+}
+
+func flattenKubeControllerManagerConfigResponse(apiObject *types.KubeControllerManagerConfigResponse) []any {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]any{}
+
+	if apiObject.HorizontalPodAutoscalerControllerConfig != nil {
+		tfMap["horizontal_pod_autoscaler_controller_config"] = flattenHorizontalPodAutoscalerControllerConfigResponse(apiObject.HorizontalPodAutoscalerControllerConfig)
+	}
+
+	return []any{tfMap}
+}
+
+func flattenHorizontalPodAutoscalerControllerConfigResponse(apiObject *types.HorizontalPodAutoscalerControllerConfigResponse) []any {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]any{}
+
+	if apiObject.HorizontalPodAutoscalerSyncPeriod != nil {
+		tfMap["horizontal_pod_autoscaler_sync_period"] = aws.ToString(apiObject.HorizontalPodAutoscalerSyncPeriod)
+	}
+
+	return []any{tfMap}
+}
+
+func flattenKubeSchedulerConfigResponse(apiObject *types.KubeSchedulerConfigResponse) []any {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]any{}
+
+	if apiObject.NodeResourcesFit != nil {
+		tfMap["node_resources_fit"] = flattenNodeResourcesFitConfig(apiObject.NodeResourcesFit)
+	}
+
+	return []any{tfMap}
+}
+
+func flattenNodeResourcesFitConfig(apiObject *types.NodeResourcesFitConfig) []any {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]any{}
+
+	if apiObject.ScoringStrategy != nil {
+		tfMap["scoring_strategy"] = flattenScoringStrategy(apiObject.ScoringStrategy)
+	}
+
+	return []any{tfMap}
+}
+
+func flattenScoringStrategy(apiObject *types.ScoringStrategy) []any {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]any{
+		names.AttrType: apiObject.Type,
+	}
+
+	if apiObject.Resources != nil {
+		tfMap[names.AttrResources] = flattenResourceWeights(apiObject.Resources)
+	}
+
+	return []any{tfMap}
+}
+
+func flattenResourceWeights(apiObjects []types.ResourceWeight) []any {
+	if len(apiObjects) == 0 {
+		return nil
+	}
+
+	var tfList []any
+
+	for _, apiObject := range apiObjects {
+		tfMap := map[string]any{}
+
+		if apiObject.Name != nil {
+			tfMap[names.AttrName] = aws.ToString(apiObject.Name)
+		}
+
+		if apiObject.Weight != nil {
+			tfMap[names.AttrWeight] = aws.ToInt32(apiObject.Weight)
+		}
+
+		tfList = append(tfList, tfMap)
+	}
+
+	return tfList
 }
 
 func flattenIdentity(apiObject *types.Identity) []map[string]any {

--- a/internal/service/eks/cluster.go
+++ b/internal/service/eks/cluster.go
@@ -337,7 +337,7 @@ func resourceCluster() *schema.Resource {
 											MaxItems: 1,
 											Elem: &schema.Resource{
 												Schema: map[string]*schema.Schema{
-													names.AttrResources: {
+													"resource": {
 														Type:     schema.TypeList,
 														Optional: true,
 														Computed: true,
@@ -1637,7 +1637,7 @@ func expandScoringStrategy(tfList []any) *types.ScoringStrategy {
 		apiObject.Type = types.ScoringStrategyType(v)
 	}
 
-	if v, ok := tfMap[names.AttrResources].([]any); ok && len(v) > 0 {
+	if v, ok := tfMap["resource"].([]any); ok && len(v) > 0 {
 		apiObject.Resources = expandResourceWeights(v)
 	}
 
@@ -2205,7 +2205,7 @@ func flattenScoringStrategy(apiObject *types.ScoringStrategy) []any {
 	}
 
 	if apiObject.Resources != nil {
-		tfMap[names.AttrResources] = flattenResourceWeights(apiObject.Resources)
+		tfMap["resource"] = flattenResourceWeights(apiObject.Resources)
 	}
 
 	return []any{tfMap}
@@ -2323,7 +2323,7 @@ func flattenVPCConfigResponse(apiObject *types.VpcConfigResponse) []map[string]a
 
 	tfMap := map[string]any{
 		"cluster_security_group_id": aws.ToString(apiObject.ClusterSecurityGroupId),
-		"control_plane_egress_mode": string(apiObject.ControlPlaneEgressMode),
+		"control_plane_egress_mode": apiObject.ControlPlaneEgressMode,
 		"endpoint_private_access":   apiObject.EndpointPrivateAccess,
 		"endpoint_public_access":    apiObject.EndpointPublicAccess,
 		names.AttrSecurityGroupIDs:  securityGroupIds,

--- a/internal/service/eks/cluster_test.go
+++ b/internal/service/eks/cluster_test.go
@@ -3053,7 +3053,7 @@ func TestAccEKSCluster_kubeSchedulerConfig(t *testing.T) {
 						"node_resources_fit": knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
 							"scoring_strategy": knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
 								names.AttrType: tfknownvalue.StringExact(types.ScoringStrategyTypeLeastAllocated),
-								names.AttrResources: knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"resource": knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
 									acctest.CtName:   knownvalue.StringExact("cpu"),
 									names.AttrWeight: knownvalue.Int64Exact(1),
 								})}),
@@ -3083,7 +3083,7 @@ func TestAccEKSCluster_kubeSchedulerConfig(t *testing.T) {
 						"node_resources_fit": knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
 							"scoring_strategy": knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
 								names.AttrType: tfknownvalue.StringExact(types.ScoringStrategyTypeMostAllocated),
-								names.AttrResources: knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"resource": knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
 									acctest.CtName:   knownvalue.StringExact("cpu"),
 									names.AttrWeight: knownvalue.Int64Exact(1),
 								})}),
@@ -3193,7 +3193,7 @@ resource "aws_eks_cluster" "test" {
       scoring_strategy {
         type = %[2]q
 
-        resources {
+        resource {
           name   = "cpu"
           weight = 1
         }

--- a/internal/service/eks/cluster_test.go
+++ b/internal/service/eks/cluster_test.go
@@ -2963,3 +2963,270 @@ resource "aws_eks_cluster" "test" {
 }
 `, rName, tier))
 }
+
+func TestAccEKSCluster_kubeAPIServerConfig(t *testing.T) {
+	ctx := acctest.Context(t)
+	var cluster types.Cluster
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_eks_cluster.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EKSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterConfig_kubeAPIServerConfig(rName, "30m", 30000, 32767),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckClusterExists(ctx, t, resourceName, &cluster),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("kube_api_server_config"), knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
+						"event_ttl": knownvalue.StringExact("30m"),
+						"service_node_port_range": knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"min_port": knownvalue.Int64Exact(30000),
+							"max_port": knownvalue.Int64Exact(32767),
+						})}),
+					})})),
+				},
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"bootstrap_self_managed_addons"},
+			},
+			{
+				Config: testAccClusterConfig_kubeAPIServerConfig(rName, "45m", 30100, 32767),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckClusterExists(ctx, t, resourceName, &cluster),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("kube_api_server_config"), knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
+						"event_ttl": knownvalue.StringExact("45m"),
+						"service_node_port_range": knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"min_port": knownvalue.Int64Exact(30100),
+							"max_port": knownvalue.Int64Exact(32767),
+						})}),
+					})})),
+				},
+			},
+		},
+	})
+}
+
+func TestAccEKSCluster_kubeSchedulerConfig(t *testing.T) {
+	ctx := acctest.Context(t)
+	var cluster types.Cluster
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_eks_cluster.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EKSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterConfig_kubeSchedulerConfig(rName, "LeastAllocated"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckClusterExists(ctx, t, resourceName, &cluster),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("kube_scheduler_config"), knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
+						"node_resources_fit": knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"scoring_strategy": knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
+								names.AttrType: tfknownvalue.StringExact(types.ScoringStrategyTypeLeastAllocated),
+								names.AttrResources: knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
+									acctest.CtName:   knownvalue.StringExact("cpu"),
+									names.AttrWeight: knownvalue.Int64Exact(1),
+								})}),
+							})}),
+						})}),
+					})})),
+				},
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"bootstrap_self_managed_addons"},
+			},
+			{
+				Config: testAccClusterConfig_kubeSchedulerConfig(rName, "MostAllocated"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckClusterExists(ctx, t, resourceName, &cluster),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("kube_scheduler_config"), knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
+						"node_resources_fit": knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"scoring_strategy": knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
+								names.AttrType: tfknownvalue.StringExact(types.ScoringStrategyTypeMostAllocated),
+								names.AttrResources: knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
+									acctest.CtName:   knownvalue.StringExact("cpu"),
+									names.AttrWeight: knownvalue.Int64Exact(1),
+								})}),
+							})}),
+						})}),
+					})})),
+				},
+			},
+		},
+	})
+}
+
+func TestAccEKSCluster_kubeControllerManagerConfig(t *testing.T) {
+	ctx := acctest.Context(t)
+	var cluster types.Cluster
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_eks_cluster.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EKSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterConfig_kubeControllerManagerConfig(rName, "10s"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckClusterExists(ctx, t, resourceName, &cluster),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("kube_controller_manager_config"), knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
+						"horizontal_pod_autoscaler_controller_config": knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"horizontal_pod_autoscaler_sync_period": knownvalue.StringExact("10s"),
+						})}),
+					})})),
+				},
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"bootstrap_self_managed_addons"},
+			},
+			{
+				Config: testAccClusterConfig_kubeControllerManagerConfig(rName, "13s"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckClusterExists(ctx, t, resourceName, &cluster),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("kube_controller_manager_config"), knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
+						"horizontal_pod_autoscaler_controller_config": knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"horizontal_pod_autoscaler_sync_period": knownvalue.StringExact("13s"),
+						})}),
+					})})),
+				},
+			},
+		},
+	})
+}
+
+func testAccClusterConfig_kubeAPIServerConfig(rName, eventTTL string, minPort, maxPort int) string {
+	return acctest.ConfigCompose(testAccClusterConfig_base(rName), fmt.Sprintf(`
+resource "aws_eks_cluster" "test" {
+  name     = %[1]q
+  role_arn = aws_iam_role.cluster.arn
+
+  vpc_config {
+    subnet_ids = aws_subnet.test[*].id
+  }
+
+  kube_api_server_config {
+    event_ttl = %[2]q
+
+    service_node_port_range {
+      min_port = %[3]d
+      max_port = %[4]d
+    }
+  }
+
+  depends_on = [aws_iam_role_policy_attachment.cluster_AmazonEKSClusterPolicy]
+}
+`, rName, eventTTL, minPort, maxPort))
+}
+
+func testAccClusterConfig_kubeSchedulerConfig(rName, strategyType string) string {
+	return acctest.ConfigCompose(testAccClusterConfig_base(rName), fmt.Sprintf(`
+resource "aws_eks_cluster" "test" {
+  name     = %[1]q
+  role_arn = aws_iam_role.cluster.arn
+
+  vpc_config {
+    subnet_ids = aws_subnet.test[*].id
+  }
+
+  kube_scheduler_config {
+    node_resources_fit {
+      scoring_strategy {
+        type = %[2]q
+
+        resources {
+          name   = "cpu"
+          weight = 1
+        }
+      }
+    }
+  }
+
+  depends_on = [aws_iam_role_policy_attachment.cluster_AmazonEKSClusterPolicy]
+}
+`, rName, strategyType))
+}
+
+func testAccClusterConfig_kubeControllerManagerConfig(rName, syncPeriod string) string {
+	return acctest.ConfigCompose(testAccClusterConfig_base(rName), fmt.Sprintf(`
+resource "aws_eks_cluster" "test" {
+  name     = %[1]q
+  role_arn = aws_iam_role.cluster.arn
+
+  vpc_config {
+    subnet_ids = aws_subnet.test[*].id
+  }
+
+  control_plane_scaling_config {
+    tier = "tier-xl"
+  }
+
+  kube_controller_manager_config {
+    horizontal_pod_autoscaler_controller_config {
+      horizontal_pod_autoscaler_sync_period = %[2]q
+    }
+  }
+
+  depends_on = [aws_iam_role_policy_attachment.cluster_AmazonEKSClusterPolicy]
+}
+`, rName, syncPeriod))
+}

--- a/internal/service/eks/cluster_test.go
+++ b/internal/service/eks/cluster_test.go
@@ -76,6 +76,9 @@ func TestAccEKSCluster_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "identity.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "identity.0.oidc.#", "1"),
 					resource.TestMatchResourceAttr(resourceName, "identity.0.oidc.0.issuer", regexache.MustCompile(`^https://`)),
+					resource.TestCheckResourceAttr(resourceName, "kube_api_server_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "kube_controller_manager_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "kube_scheduler_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "kubernetes_network_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "kubernetes_network_config.0.elastic_load_balancing.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "kubernetes_network_config.0.elastic_load_balancing.0.enabled", acctest.CtFalse),
@@ -1811,6 +1814,196 @@ func TestAccEKSCluster_deletionProtection(t *testing.T) {
 	})
 }
 
+func TestAccEKSCluster_kubeAPIServerConfig(t *testing.T) {
+	ctx := acctest.Context(t)
+	var cluster types.Cluster
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_eks_cluster.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EKSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterConfig_kubeAPIServerConfig(rName, "30m", 30000, 32767),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckClusterExists(ctx, t, resourceName, &cluster),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("kube_api_server_config"), knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
+						"event_ttl": knownvalue.StringExact("30m"),
+						"service_node_port_range": knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"min_port": knownvalue.Int64Exact(30000),
+							"max_port": knownvalue.Int64Exact(32767),
+						})}),
+					})})),
+				},
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"bootstrap_self_managed_addons"},
+			},
+			{
+				Config: testAccClusterConfig_kubeAPIServerConfig(rName, "45m", 30100, 32767),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckClusterExists(ctx, t, resourceName, &cluster),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("kube_api_server_config"), knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
+						"event_ttl": knownvalue.StringExact("45m"),
+						"service_node_port_range": knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"min_port": knownvalue.Int64Exact(30100),
+							"max_port": knownvalue.Int64Exact(32767),
+						})}),
+					})})),
+				},
+			},
+		},
+	})
+}
+
+func TestAccEKSCluster_kubeSchedulerConfig(t *testing.T) {
+	ctx := acctest.Context(t)
+	var cluster types.Cluster
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_eks_cluster.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EKSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterConfig_kubeSchedulerConfig(rName, "LeastAllocated"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckClusterExists(ctx, t, resourceName, &cluster),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("kube_scheduler_config"), knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
+						"node_resources_fit": knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"scoring_strategy": knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
+								names.AttrType: tfknownvalue.StringExact(types.ScoringStrategyTypeLeastAllocated),
+								"resource": knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
+									acctest.CtName:   knownvalue.StringExact("cpu"),
+									names.AttrWeight: knownvalue.Int64Exact(1),
+								})}),
+							})}),
+						})}),
+					})})),
+				},
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"bootstrap_self_managed_addons"},
+			},
+			{
+				Config: testAccClusterConfig_kubeSchedulerConfig(rName, "MostAllocated"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckClusterExists(ctx, t, resourceName, &cluster),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("kube_scheduler_config"), knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
+						"node_resources_fit": knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"scoring_strategy": knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
+								names.AttrType: tfknownvalue.StringExact(types.ScoringStrategyTypeMostAllocated),
+								"resource": knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
+									acctest.CtName:   knownvalue.StringExact("cpu"),
+									names.AttrWeight: knownvalue.Int64Exact(1),
+								})}),
+							})}),
+						})}),
+					})})),
+				},
+			},
+		},
+	})
+}
+
+func TestAccEKSCluster_kubeControllerManagerConfig(t *testing.T) {
+	ctx := acctest.Context(t)
+	var cluster types.Cluster
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_eks_cluster.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EKSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterConfig_kubeControllerManagerConfig(rName, "10s"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckClusterExists(ctx, t, resourceName, &cluster),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("kube_controller_manager_config"), knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
+						"horizontal_pod_autoscaler_controller_config": knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"horizontal_pod_autoscaler_sync_period": knownvalue.StringExact("10s"),
+						})}),
+					})})),
+				},
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"bootstrap_self_managed_addons"},
+			},
+			{
+				Config: testAccClusterConfig_kubeControllerManagerConfig(rName, "13s"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckClusterExists(ctx, t, resourceName, &cluster),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("kube_controller_manager_config"), knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
+						"horizontal_pod_autoscaler_controller_config": knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"horizontal_pod_autoscaler_sync_period": knownvalue.StringExact("13s"),
+						})}),
+					})})),
+				},
+			},
+		},
+	})
+}
+
 func testAccCheckClusterExists(ctx context.Context, t *testing.T, n string, v *types.Cluster) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -2962,196 +3155,6 @@ resource "aws_eks_cluster" "test" {
   depends_on = [aws_iam_role_policy_attachment.cluster_AmazonEKSClusterPolicy]
 }
 `, rName, tier))
-}
-
-func TestAccEKSCluster_kubeAPIServerConfig(t *testing.T) {
-	ctx := acctest.Context(t)
-	var cluster types.Cluster
-	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	resourceName := "aws_eks_cluster.test"
-
-	acctest.ParallelTest(ctx, t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, names.EKSServiceID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccClusterConfig_kubeAPIServerConfig(rName, "30m", 30000, 32767),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClusterExists(ctx, t, resourceName, &cluster),
-				),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
-					},
-				},
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("kube_api_server_config"), knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
-						"event_ttl": knownvalue.StringExact("30m"),
-						"service_node_port_range": knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
-							"min_port": knownvalue.Int64Exact(30000),
-							"max_port": knownvalue.Int64Exact(32767),
-						})}),
-					})})),
-				},
-			},
-			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"bootstrap_self_managed_addons"},
-			},
-			{
-				Config: testAccClusterConfig_kubeAPIServerConfig(rName, "45m", 30100, 32767),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClusterExists(ctx, t, resourceName, &cluster),
-				),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
-					},
-				},
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("kube_api_server_config"), knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
-						"event_ttl": knownvalue.StringExact("45m"),
-						"service_node_port_range": knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
-							"min_port": knownvalue.Int64Exact(30100),
-							"max_port": knownvalue.Int64Exact(32767),
-						})}),
-					})})),
-				},
-			},
-		},
-	})
-}
-
-func TestAccEKSCluster_kubeSchedulerConfig(t *testing.T) {
-	ctx := acctest.Context(t)
-	var cluster types.Cluster
-	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	resourceName := "aws_eks_cluster.test"
-
-	acctest.ParallelTest(ctx, t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, names.EKSServiceID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccClusterConfig_kubeSchedulerConfig(rName, "LeastAllocated"),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClusterExists(ctx, t, resourceName, &cluster),
-				),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
-					},
-				},
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("kube_scheduler_config"), knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
-						"node_resources_fit": knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
-							"scoring_strategy": knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
-								names.AttrType: tfknownvalue.StringExact(types.ScoringStrategyTypeLeastAllocated),
-								"resource": knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
-									acctest.CtName:   knownvalue.StringExact("cpu"),
-									names.AttrWeight: knownvalue.Int64Exact(1),
-								})}),
-							})}),
-						})}),
-					})})),
-				},
-			},
-			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"bootstrap_self_managed_addons"},
-			},
-			{
-				Config: testAccClusterConfig_kubeSchedulerConfig(rName, "MostAllocated"),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClusterExists(ctx, t, resourceName, &cluster),
-				),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
-					},
-				},
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("kube_scheduler_config"), knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
-						"node_resources_fit": knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
-							"scoring_strategy": knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
-								names.AttrType: tfknownvalue.StringExact(types.ScoringStrategyTypeMostAllocated),
-								"resource": knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
-									acctest.CtName:   knownvalue.StringExact("cpu"),
-									names.AttrWeight: knownvalue.Int64Exact(1),
-								})}),
-							})}),
-						})}),
-					})})),
-				},
-			},
-		},
-	})
-}
-
-func TestAccEKSCluster_kubeControllerManagerConfig(t *testing.T) {
-	ctx := acctest.Context(t)
-	var cluster types.Cluster
-	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
-	resourceName := "aws_eks_cluster.test"
-
-	acctest.ParallelTest(ctx, t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, names.EKSServiceID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccClusterConfig_kubeControllerManagerConfig(rName, "10s"),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClusterExists(ctx, t, resourceName, &cluster),
-				),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
-					},
-				},
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("kube_controller_manager_config"), knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
-						"horizontal_pod_autoscaler_controller_config": knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
-							"horizontal_pod_autoscaler_sync_period": knownvalue.StringExact("10s"),
-						})}),
-					})})),
-				},
-			},
-			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"bootstrap_self_managed_addons"},
-			},
-			{
-				Config: testAccClusterConfig_kubeControllerManagerConfig(rName, "13s"),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClusterExists(ctx, t, resourceName, &cluster),
-				),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
-					},
-				},
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("kube_controller_manager_config"), knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
-						"horizontal_pod_autoscaler_controller_config": knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
-							"horizontal_pod_autoscaler_sync_period": knownvalue.StringExact("13s"),
-						})}),
-					})})),
-				},
-			},
-		},
-	})
 }
 
 func testAccClusterConfig_kubeAPIServerConfig(rName, eventTTL string, minPort, maxPort int) string {

--- a/website/docs/r/eks_cluster.html.markdown
+++ b/website/docs/r/eks_cluster.html.markdown
@@ -353,6 +353,9 @@ The following arguments are optional:
 * `encryption_config` - (Optional) Configuration block with encryption configuration for the cluster. [Detailed](#encryption_config) below.
 * `force_update_version` - (Optional) Force version update by overriding upgrade-blocking readiness checks when updating a cluster.
 * `kubernetes_network_config` - (Optional) Configuration block with kubernetes network configuration for the cluster. [Detailed](#kubernetes_network_config) below. If removed, Terraform will only perform drift detection if a configuration value is provided.
+* `kube_api_server_config` - (Optional) Configuration block for customizing the Kubernetes API server. [Detailed](#kube_api_server_config) below.
+* `kube_controller_manager_config` - (Optional) Configuration block for customizing the Kubernetes controller manager. [Detailed](#kube_controller_manager_config) below.
+* `kube_scheduler_config` - (Optional) Configuration block for customizing the Kubernetes scheduler. [Detailed](#kube_scheduler_config) below.
 * `outpost_config` - (Optional) Configuration block representing the configuration of your local Amazon EKS cluster on an AWS Outpost. This block isn't available for creating Amazon EKS clusters on the AWS cloud.
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `remote_network_config` - (Optional) Configuration block with remote network configuration for EKS Hybrid Nodes. [Detailed](#remote_network_config) below.
@@ -414,6 +417,60 @@ The `remote_node_networks` configuration block supports the following arguments:
 The `remote_pod_networks` configuration block supports the following arguments:
 
 * `cidrs` - (Required) List of network CIDRs that can contain pods that run Kubernetes webhooks on hybrid nodes.
+
+### kube_api_server_config
+
+The `kube_api_server_config` configuration block supports the following arguments:
+
+* `event_ttl` - (Optional) The duration that Kubernetes events are retained. Must be a single-unit duration (e.g., `30m`, `1h`). Valid range: `10m` to `60m`. Default is `1h`.
+* `service_node_port_range` - (Optional) Configuration block for the port range available for NodePort services. [Detailed](#service_node_port_range) below.
+
+#### service_node_port_range
+
+The `service_node_port_range` configuration block supports the following arguments:
+
+* `min_port` - (Optional) The minimum port number in the range. Valid range: `10260` to `32767`. Default is `30000`.
+* `max_port` - (Optional) The maximum port number in the range. Valid range: `10260` to `32767`. Default is `32767`. Must be greater than or equal to `min_port`.
+
+### kube_controller_manager_config
+
+The `kube_controller_manager_config` configuration block supports the following arguments:
+
+* `horizontal_pod_autoscaler_controller_config` - (Optional) Configuration block for the horizontal pod autoscaler controller. [Detailed](#horizontal_pod_autoscaler_controller_config) below.
+
+~> **NOTE:** The `horizontal_pod_autoscaler_controller_config` requires a Provisioned Control Plane scaling tier (e.g., `tier-xl` or higher). It cannot be configured on clusters using the `standard` tier.
+
+#### horizontal_pod_autoscaler_controller_config
+
+The `horizontal_pod_autoscaler_controller_config` configuration block supports the following arguments:
+
+* `horizontal_pod_autoscaler_sync_period` - (Optional) The interval between each sync of the horizontal pod autoscaler. Must be a single-unit duration (e.g., `10s`, `15s`). Valid range: `10s` to `15s`. Default is `15s`.
+
+### kube_scheduler_config
+
+The `kube_scheduler_config` configuration block supports the following arguments:
+
+* `node_resources_fit` - (Optional) Configuration block for the NodeResourcesFit scheduler plugin. [Detailed](#node_resources_fit) below.
+
+#### node_resources_fit
+
+The `node_resources_fit` configuration block supports the following arguments:
+
+* `scoring_strategy` - (Optional) Configuration block for the scoring strategy used to rank nodes during scheduling. [Detailed](#scoring_strategy) below.
+
+#### scoring_strategy
+
+The `scoring_strategy` configuration block supports the following arguments:
+
+* `type` - (Optional) The scoring strategy type. Valid values are `LeastAllocated` and `MostAllocated`. Default is `LeastAllocated`.
+* `resources` - (Optional) List of resource weight configuration blocks for scoring nodes. [Detailed](#resources) below.
+
+#### resources
+
+The `resources` configuration block supports the following arguments:
+
+* `name` - (Optional) The name of the resource (e.g., `cpu`, `memory`, `nvidia.com/gpu`).
+* `weight` - (Optional) The weight assigned to the resource for scoring. Must be between `1` and `100`.
 
 ### vpc_config Arguments
 

--- a/website/docs/r/eks_cluster.html.markdown
+++ b/website/docs/r/eks_cluster.html.markdown
@@ -463,11 +463,11 @@ The `node_resources_fit` configuration block supports the following arguments:
 The `scoring_strategy` configuration block supports the following arguments:
 
 * `type` - (Optional) The scoring strategy type. Valid values are `LeastAllocated` and `MostAllocated`. Default is `LeastAllocated`.
-* `resources` - (Optional) List of resource weight configuration blocks for scoring nodes. [Detailed](#resources) below.
+* `resource` - (Optional) List of resource weight configuration blocks for scoring nodes. [Detailed](#resources) below.
 
-#### resources
+#### resource
 
-The `resources` configuration block supports the following arguments:
+The `resource` configuration block supports the following arguments:
 
 * `name` - (Optional) The name of the resource (e.g., `cpu`, `memory`, `nvidia.com/gpu`).
 * `weight` - (Optional) The weight assigned to the resource for scoring. Must be between `1` and `100`.


### PR DESCRIPTION
Add kube_api_server_config, kube_controller_manager_config, and kube_scheduler_config attributes to aws_eks_cluster, enabling Kubernetes control plane component customization.

Includes resource implementation, acceptance tests, and documentation.

<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Partially addresses #49411

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
mvishnub@50f265ecaa4e terraform-provider-aws % make testacc PKG=eks TESTS="TestAccEKSCluster_kubeAPIServerConfig|TestAccEKSCluster_kubeSchedulerConfig|TestAccEKSCluster_kubeControllerManagerConfig"
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
go: downloading github.com/aws/aws-sdk-go-v2 v1.43.5
go: downloading github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.36
go: downloading github.com/aws/aws-sdk-go-v2/config v1.32.36
go: downloading github.com/aws/aws-sdk-go-v2/service/sts v1.45.5
go: downloading github.com/aws/smithy-go v1.27.7
go: downloading github.com/aws/aws-sdk-go-v2/service/accessanalyzer v1.51.5
go: downloading github.com/aws/aws-sdk-go-v2/service/account v1.35.5
go: downloading github.com/aws/aws-sdk-go-v2/service/acm v1.43.5
go: downloading github.com/aws/aws-sdk-go-v2/service/acmpca v1.50.1
go: downloading github.com/aws/aws-sdk-go-v2/service/amp v1.48.2
go: downloading github.com/aws/aws-sdk-go-v2/service/amplify v1.41.5
go: downloading github.com/aws/aws-sdk-go-v2/service/apigateway v1.42.5
go: downloading github.com/aws/aws-sdk-go-v2/service/apigatewayv2 v1.37.5
go: downloading github.com/aws/aws-sdk-go-v2/service/appconfig v1.48.5
go: downloading github.com/aws/aws-sdk-go-v2/service/appfabric v1.19.5
go: downloading github.com/aws/aws-sdk-go-v2/service/appflow v1.54.5
go: downloading github.com/aws/aws-sdk-go-v2/service/appintegrations v1.40.5
go: downloading github.com/aws/aws-sdk-go-v2/service/applicationautoscaling v1.45.5
go: downloading github.com/aws/aws-sdk-go-v2/service/applicationinsights v1.38.5
go: downloading github.com/aws/aws-sdk-go-v2/service/applicationsignals v1.25.5
go: downloading github.com/aws/aws-sdk-go-v2/service/appmesh v1.39.0
go: downloading github.com/aws/aws-sdk-go-v2/service/apprunner v1.42.5
go: downloading github.com/aws/aws-sdk-go-v2/service/appstream v1.64.6
go: downloading github.com/aws/aws-sdk-go-v2/service/appsync v1.56.5
go: downloading github.com/aws/aws-sdk-go-v2/service/arcregionswitch v1.13.4
go: downloading github.com/aws/aws-sdk-go-v2/service/arczonalshift v1.25.5
go: downloading github.com/aws/aws-sdk-go-v2/service/athena v1.60.5
go: downloading github.com/aws/aws-sdk-go-v2/service/auditmanager v1.49.5
go: downloading github.com/aws/aws-sdk-go-v2/service/autoscaling v1.71.1
go: downloading github.com/aws/aws-sdk-go-v2/service/autoscalingplans v1.33.5
go: downloading github.com/aws/aws-sdk-go-v2/service/backup v1.60.1
go: downloading github.com/aws/aws-sdk-go-v2/service/batch v1.68.5
go: downloading github.com/aws/aws-sdk-go-v2/service/bcmdataexports v1.19.5
go: downloading github.com/aws/aws-sdk-go-v2/service/bedrock v1.66.5
go: downloading github.com/aws/aws-sdk-go-v2/service/bedrockagent v1.58.5
go: downloading github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol v1.55.1
go: downloading github.com/aws/aws-sdk-go-v2/service/billing v1.14.2
go: downloading github.com/aws/aws-sdk-go-v2/service/budgets v1.46.5
go: downloading github.com/aws/aws-sdk-go-v2/service/chatbot v1.17.5
go: downloading github.com/aws/aws-sdk-go-v2/service/chime v1.45.0
go: downloading github.com/aws/aws-sdk-go-v2/service/chimesdkmediapipelines v1.30.0
go: downloading github.com/aws/aws-sdk-go-v2/service/chimesdkvoice v1.33.0
go: downloading github.com/aws/aws-sdk-go-v2/service/cleanrooms v1.50.0
go: downloading github.com/aws/aws-sdk-go-v2/service/cloud9 v1.37.0
go: downloading github.com/aws/aws-sdk-go-v2/service/cloudcontrol v1.32.5
go: downloading github.com/aws/aws-sdk-go-v2/service/cloudformation v1.76.2
go: downloading github.com/aws/aws-sdk-go-v2/service/cloudfront v1.67.5
go: downloading github.com/aws/aws-sdk-go-v2/service/cloudfrontkeyvaluestore v1.15.5
go: downloading github.com/aws/aws-sdk-go-v2/service/cloudhsmv2 v1.37.5
go: downloading github.com/aws/aws-sdk-go-v2/service/cloudsearch v1.35.5
go: downloading github.com/aws/aws-sdk-go-v2/service/cloudtrail v1.58.5
go: downloading github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.66.4
go: downloading github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.82.1
go: downloading github.com/aws/aws-sdk-go-v2/service/codeartifact v1.41.5
go: downloading github.com/aws/aws-sdk-go-v2/service/codebuild v1.72.5
go: downloading github.com/aws/aws-sdk-go-v2/service/codecatalyst v1.24.5
go: downloading github.com/aws/aws-sdk-go-v2/service/codecommit v1.37.0
go: downloading github.com/aws/aws-sdk-go-v2/service/codeconnections v1.13.5
go: downloading github.com/aws/aws-sdk-go-v2/service/codedeploy v1.38.5
go: downloading github.com/aws/aws-sdk-go-v2/service/codeguruprofiler v1.33.0
go: downloading github.com/aws/aws-sdk-go-v2/service/codegurureviewer v1.37.5
go: downloading github.com/aws/aws-sdk-go-v2/service/codepipeline v1.49.5
go: downloading github.com/aws/aws-sdk-go-v2/service/codestarconnections v1.39.0
go: downloading github.com/aws/aws-sdk-go-v2/service/codestarnotifications v1.34.5
go: downloading github.com/aws/aws-sdk-go-v2/service/cognitoidentity v1.36.5
go: downloading github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.67.5
go: downloading github.com/aws/aws-sdk-go-v2/service/comprehend v1.43.5
go: downloading github.com/aws/aws-sdk-go-v2/service/computeoptimizer v1.57.6
go: downloading github.com/aws/aws-sdk-go-v2/service/configservice v1.68.5
go: downloading github.com/aws/aws-sdk-go-v2/service/connect v1.187.0
go: downloading github.com/aws/aws-sdk-go-v2/service/connectcases v1.45.0
go: downloading github.com/aws/aws-sdk-go-v2/service/controltower v1.32.0
go: downloading github.com/aws/aws-sdk-go-v2/service/costandusagereportservice v1.37.5
go: downloading github.com/aws/aws-sdk-go-v2/service/costexplorer v1.67.5
go: downloading github.com/aws/aws-sdk-go-v2/service/costoptimizationhub v1.26.6
go: downloading github.com/aws/aws-sdk-go-v2/service/customerprofiles v1.65.5
go: downloading github.com/aws/aws-sdk-go-v2/service/databasemigrationservice v1.66.5
go: downloading github.com/aws/aws-sdk-go-v2/service/databrew v1.42.5
go: downloading github.com/aws/aws-sdk-go-v2/service/dataexchange v1.44.5
go: downloading github.com/aws/aws-sdk-go-v2/service/datapipeline v1.33.5
go: downloading github.com/aws/aws-sdk-go-v2/service/datasync v1.61.5
go: downloading github.com/aws/aws-sdk-go-v2/service/datazone v1.69.0
go: downloading github.com/aws/aws-sdk-go-v2/service/dax v1.33.0
go: downloading github.com/aws/aws-sdk-go-v2/service/detective v1.41.5
go: downloading github.com/aws/aws-sdk-go-v2/service/devicefarm v1.42.1
go: downloading github.com/aws/aws-sdk-go-v2/service/devopsagent v1.10.5
go: downloading github.com/aws/aws-sdk-go-v2/service/devopsguru v1.43.5
go: downloading github.com/aws/aws-sdk-go-v2/service/directconnect v1.44.2
go: downloading github.com/aws/aws-sdk-go-v2/service/directoryservice v1.41.5
go: downloading github.com/aws/aws-sdk-go-v2/service/dlm v1.40.0
go: downloading github.com/aws/aws-sdk-go-v2/service/docdb v1.51.5
go: downloading github.com/aws/aws-sdk-go-v2/service/docdbelastic v1.23.5
go: downloading github.com/aws/aws-sdk-go-v2/service/drs v1.42.6
go: downloading github.com/aws/aws-sdk-go-v2/service/dsql v1.16.6
go: downloading github.com/aws/aws-sdk-go-v2/service/dynamodb v1.63.2
go: downloading github.com/aws/aws-sdk-go-v2/service/ec2 v1.321.1
go: downloading github.com/aws/aws-sdk-go-v2/service/ecr v1.60.5
go: downloading github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.41.5
go: downloading github.com/aws/aws-sdk-go-v2/service/ecs v1.90.1
go: downloading github.com/aws/aws-sdk-go-v2/service/efs v1.44.5
go: downloading github.com/aws/aws-sdk-go-v2/service/eks v1.91.0
go: downloading github.com/aws/aws-sdk-go-v2/service/elasticache v1.56.5
go: downloading github.com/aws/aws-sdk-go-v2/service/elasticbeanstalk v1.37.5
go: downloading github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing v1.36.5
go: downloading github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.58.6
go: downloading github.com/aws/aws-sdk-go-v2/service/elasticsearchservice v1.45.5
go: downloading github.com/aws/aws-sdk-go-v2/service/emr v1.64.5
go: downloading github.com/aws/aws-sdk-go-v2/service/emrcontainers v1.45.5
go: downloading github.com/aws/aws-sdk-go-v2/service/emrserverless v1.44.5
go: downloading github.com/aws/aws-sdk-go-v2/service/eventbridge v1.48.5
go: downloading github.com/aws/aws-sdk-go-v2/service/evs v1.13.5
go: downloading github.com/aws/aws-sdk-go-v2/service/finspace v1.36.5
go: downloading github.com/aws/aws-sdk-go-v2/service/firehose v1.46.5
go: downloading github.com/aws/aws-sdk-go-v2/service/fis v1.40.5
go: downloading github.com/aws/aws-sdk-go-v2/service/fms v1.48.0
go: downloading github.com/aws/aws-sdk-go-v2/service/fsx v1.68.5
go: downloading github.com/aws/aws-sdk-go-v2/service/gamelift v1.61.1
go: downloading github.com/aws/aws-sdk-go-v2/service/glacier v1.35.5
go: downloading github.com/aws/aws-sdk-go-v2/service/globalaccelerator v1.38.5
go: downloading github.com/aws/aws-sdk-go-v2/service/glue v1.152.1
go: downloading github.com/aws/aws-sdk-go-v2/service/grafana v1.38.5
go: downloading github.com/aws/aws-sdk-go-v2/service/greengrass v1.35.5
go: downloading github.com/aws/aws-sdk-go-v2/service/groundstation v1.46.0
go: downloading github.com/aws/aws-sdk-go-v2/service/guardduty v1.85.5
go: downloading github.com/aws/aws-sdk-go-v2/service/healthlake v1.43.1
go: downloading github.com/aws/aws-sdk-go-v2/service/iam v1.58.2
go: downloading github.com/aws/aws-sdk-go-v2/service/identitystore v1.39.5
go: downloading github.com/aws/aws-sdk-go-v2/service/imagebuilder v1.58.5
go: downloading github.com/aws/aws-sdk-go-v2/service/inspector v1.33.5
go: downloading github.com/aws/aws-sdk-go-v2/service/inspector2 v1.54.2
go: downloading github.com/aws/aws-sdk-go-v2/service/interconnect v1.4.4
go: downloading github.com/aws/aws-sdk-go-v2/service/internetmonitor v1.29.5
go: downloading github.com/aws/aws-sdk-go-v2/service/invoicing v1.13.5
go: downloading github.com/aws/aws-sdk-go-v2/service/iot v1.77.5
go: downloading github.com/aws/aws-sdk-go-v2/service/ivs v1.55.5
go: downloading github.com/aws/aws-sdk-go-v2/service/ivschat v1.24.5
go: downloading github.com/aws/aws-sdk-go-v2/service/kafka v1.58.1
go: downloading github.com/aws/aws-sdk-go-v2/service/kafkaconnect v1.33.5
go: downloading github.com/aws/aws-sdk-go-v2/service/kendra v1.64.0
go: downloading github.com/aws/aws-sdk-go-v2/service/keyspaces v1.28.6
go: downloading github.com/aws/aws-sdk-go-v2/service/kinesis v1.46.5
go: downloading github.com/aws/aws-sdk-go-v2/service/kinesisanalytics v1.34.0
go: downloading github.com/aws/aws-sdk-go-v2/service/kinesisanalyticsv2 v1.42.0
go: downloading github.com/aws/aws-sdk-go-v2/service/kinesisvideo v1.36.5
go: downloading github.com/aws/aws-sdk-go-v2/service/kms v1.55.5
go: downloading github.com/aws/aws-sdk-go-v2/service/lakeformation v1.50.5
go: downloading github.com/aws/aws-sdk-go-v2/service/lambda v1.101.3
go: downloading github.com/aws/aws-sdk-go-v2/service/lambdamicrovms v1.2.5
go: downloading github.com/aws/aws-sdk-go-v2/service/launchwizard v1.17.5
go: downloading github.com/aws/aws-sdk-go-v2/service/lexmodelbuildingservice v1.38.5
go: downloading github.com/aws/aws-sdk-go-v2/service/lexmodelsv2 v1.64.5
go: downloading github.com/aws/aws-sdk-go-v2/service/licensemanager v1.41.5
go: downloading github.com/aws/aws-sdk-go-v2/service/lightsail v1.58.5
go: downloading github.com/aws/aws-sdk-go-v2/service/location v1.54.5
go: downloading github.com/aws/aws-sdk-go-v2/service/m2 v1.29.5
go: downloading github.com/aws/aws-sdk-go-v2/service/macie2 v1.54.5
go: downloading github.com/aws/aws-sdk-go-v2/service/mailmanager v1.21.5
go: downloading github.com/aws/aws-sdk-go-v2/service/mediaconnect v1.53.5
go: downloading github.com/aws/aws-sdk-go-v2/service/mediaconvert v1.97.2
go: downloading github.com/aws/aws-sdk-go-v2/service/medialive v1.102.0
go: downloading github.com/aws/aws-sdk-go-v2/service/mediapackage v1.42.5
go: downloading github.com/aws/aws-sdk-go-v2/service/mediapackagev2 v1.44.1
go: downloading github.com/aws/aws-sdk-go-v2/service/mediapackagevod v1.42.5
go: downloading github.com/aws/aws-sdk-go-v2/service/mediastore v1.32.5
go: downloading github.com/aws/aws-sdk-go-v2/service/memorydb v1.37.0
go: downloading github.com/aws/aws-sdk-go-v2/service/mgn v1.49.0
go: downloading github.com/aws/aws-sdk-go-v2/service/mpa v1.10.5
go: downloading github.com/aws/aws-sdk-go-v2/service/mq v1.39.5
go: downloading github.com/aws/aws-sdk-go-v2/service/mwaa v1.43.5
go: downloading github.com/aws/aws-sdk-go-v2/service/mwaaserverless v1.3.5
go: downloading github.com/aws/aws-sdk-go-v2/service/neptune v1.48.5
go: downloading github.com/aws/aws-sdk-go-v2/service/neptunegraph v1.24.5
go: downloading github.com/aws/aws-sdk-go-v2/service/networkfirewall v1.67.2
go: downloading github.com/aws/aws-sdk-go-v2/service/networkflowmonitor v1.14.5
go: downloading github.com/aws/aws-sdk-go-v2/service/networkmanager v1.44.5
go: downloading github.com/aws/aws-sdk-go-v2/service/networkmonitor v1.16.5
go: downloading github.com/aws/aws-sdk-go-v2/service/notifications v1.11.0
go: downloading github.com/aws/aws-sdk-go-v2/service/notificationscontacts v1.9.0
go: downloading github.com/aws/aws-sdk-go-v2/service/oam v1.26.5
go: downloading github.com/aws/aws-sdk-go-v2/service/observabilityadmin v1.22.2
go: downloading github.com/aws/aws-sdk-go-v2/service/odb v1.15.6
go: downloading github.com/aws/aws-sdk-go-v2/service/opensearch v1.75.5
go: downloading github.com/aws/aws-sdk-go-v2/service/opensearchserverless v1.34.5
go: downloading github.com/aws/aws-sdk-go-v2/service/organizations v1.53.7
go: downloading github.com/aws/aws-sdk-go-v2/service/osis v1.24.5
go: downloading github.com/aws/aws-sdk-go-v2/service/outposts v1.66.2
go: downloading github.com/aws/aws-sdk-go-v2/service/paymentcryptography v1.33.5
go: downloading github.com/aws/aws-sdk-go-v2/service/pcaconnectorad v1.18.5
go: downloading github.com/aws/aws-sdk-go-v2/service/pcs v1.24.5
go: downloading github.com/aws/aws-sdk-go-v2/service/pinpoint v1.42.5
go: downloading github.com/aws/aws-sdk-go-v2/service/pinpointsmsvoicev2 v1.33.0
go: downloading github.com/aws/aws-sdk-go-v2/service/pipes v1.26.5
go: downloading github.com/aws/aws-sdk-go-v2/service/polly v1.60.5
go: downloading github.com/aws/aws-sdk-go-v2/service/pricing v1.44.5
go: downloading github.com/aws/aws-sdk-go-v2/service/qbusiness v1.37.5
go: downloading github.com/aws/aws-sdk-go-v2/service/quicksight v1.123.2
go: downloading github.com/aws/aws-sdk-go-v2/service/ram v1.39.5
go: downloading github.com/aws/aws-sdk-go-v2/service/rbin v1.30.5
go: downloading github.com/aws/aws-sdk-go-v2/service/rds v1.124.2
go: downloading github.com/aws/aws-sdk-go-v2/service/rdsdata v1.35.5
go: downloading github.com/aws/aws-sdk-go-v2/service/redshift v1.65.5
go: downloading github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.43.5
go: downloading github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.38.6
go: downloading github.com/aws/aws-sdk-go-v2/service/rekognition v1.54.5
go: downloading github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.38.5
go: downloading github.com/aws/aws-sdk-go-v2/service/resiliencehubv2 v1.4.2
go: downloading github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.27.6
go: downloading github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.37.0
go: downloading github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.36.0
go: downloading github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.26.4
go: downloading github.com/aws/aws-sdk-go-v2/service/route53 v1.65.7
go: downloading github.com/aws/aws-sdk-go-v2/service/route53domains v1.39.0
go: downloading github.com/aws/aws-sdk-go-v2/service/route53profiles v1.12.5
go: downloading github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.35.5
go: downloading github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.29.5
go: downloading github.com/aws/aws-sdk-go-v2/service/route53resolver v1.48.5
go: downloading github.com/aws/aws-sdk-go-v2/service/rum v1.33.5
go: downloading github.com/aws/aws-sdk-go-v2/service/s3 v1.107.1
go: downloading github.com/aws/aws-sdk-go-v2/service/s3control v1.73.5
go: downloading github.com/aws/aws-sdk-go-v2/service/s3files v1.3.5
go: downloading github.com/aws/aws-sdk-go-v2/service/s3outposts v1.37.5
go: downloading github.com/aws/aws-sdk-go-v2/service/s3tables v1.18.5
go: downloading github.com/aws/aws-sdk-go-v2/service/s3vectors v1.10.5
go: downloading github.com/aws/aws-sdk-go-v2/service/sagemaker v1.266.0
go: downloading github.com/aws/aws-sdk-go-v2/service/savingsplans v1.35.5
go: downloading github.com/aws/aws-sdk-go-v2/service/scheduler v1.20.5
go: downloading github.com/aws/aws-sdk-go-v2/service/schemas v1.37.5
go: downloading github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.44.5
go: downloading github.com/aws/aws-sdk-go-v2/service/securityhub v1.76.1
go: downloading github.com/aws/aws-sdk-go-v2/service/securitylake v1.29.0
go: downloading github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.33.5
go: downloading github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.42.5
go: downloading github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry v1.38.5
go: downloading github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.43.5
go: downloading github.com/aws/aws-sdk-go-v2/service/servicequotas v1.37.5
go: downloading github.com/aws/aws-sdk-go-v2/service/ses v1.37.5
go: downloading github.com/aws/aws-sdk-go-v2/service/sesv2 v1.66.5
go: downloading github.com/aws/aws-sdk-go-v2/service/sfn v1.45.5
go: downloading github.com/aws/aws-sdk-go-v2/service/shield v1.37.5
go: downloading github.com/aws/aws-sdk-go-v2/service/signer v1.35.5
go: downloading github.com/aws/aws-sdk-go-v2/service/sns v1.42.5
go: downloading github.com/aws/aws-sdk-go-v2/service/sqs v1.46.5
go: downloading github.com/aws/aws-sdk-go-v2/service/ssm v1.73.5
go: downloading github.com/aws/aws-sdk-go-v2/service/ssmcontacts v1.34.5
go: downloading github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.42.5
go: downloading github.com/aws/aws-sdk-go-v2/service/ssmquicksetup v1.12.0
go: downloading github.com/aws/aws-sdk-go-v2/service/ssmsap v1.30.0
go: downloading github.com/aws/aws-sdk-go-v2/service/sso v1.33.5
go: downloading github.com/aws/aws-sdk-go-v2/service/ssoadmin v1.43.2
go: downloading github.com/aws/aws-sdk-go-v2/service/storagegateway v1.46.5
go: downloading github.com/aws/aws-sdk-go-v2/service/swf v1.37.5
go: downloading github.com/aws/aws-sdk-go-v2/service/synthetics v1.47.5
go: downloading github.com/aws/aws-sdk-go-v2/service/taxsettings v1.21.0
go: downloading github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.23.2
go: downloading github.com/aws/aws-sdk-go-v2/service/timestreamquery v1.39.5
go: downloading github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.38.5
go: downloading github.com/aws/aws-sdk-go-v2/service/transcribe v1.58.5
go: downloading github.com/aws/aws-sdk-go-v2/service/transfer v1.75.5
go: downloading github.com/aws/aws-sdk-go-v2/service/uxc v1.3.5
go: downloading github.com/aws/aws-sdk-go-v2/service/verifiedpermissions v1.36.5
go: downloading github.com/aws/aws-sdk-go-v2/service/vpclattice v1.25.6
go: downloading github.com/aws/aws-sdk-go-v2/service/waf v1.33.5
go: downloading github.com/aws/aws-sdk-go-v2/service/wafregional v1.33.5
go: downloading github.com/aws/aws-sdk-go-v2/service/wafv2 v1.77.4
go: downloading github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.42.5
go: downloading github.com/aws/aws-sdk-go-v2/service/workmail v1.40.0
go: downloading github.com/aws/aws-sdk-go-v2/service/workspaces v1.73.2
go: downloading github.com/aws/aws-sdk-go-v2/service/workspacesweb v1.42.5
go: downloading github.com/aws/aws-sdk-go-v2/service/xray v1.39.5
go: downloading github.com/aws/aws-sdk-go-v2/credentials v1.19.35
go: downloading go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws v0.70.0
go: downloading go.opentelemetry.io/otel v1.45.0
go: downloading github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.22.42
go: downloading github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.36
go: downloading github.com/aws/aws-sdk-go-v2/service/signin v1.5.5
go: downloading github.com/aws/aws-sdk-go-v2/service/ssooidc v1.38.5
go: downloading github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.37
go: downloading github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.16
go: downloading github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.36
go: downloading github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.17
go: downloading github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.12.13
go: downloading github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.29
go: downloading github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.37
go: downloading go.opentelemetry.io/otel/trace v1.45.0
go: downloading github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.36
go: downloading github.com/go-logr/logr v1.4.4
go: downloading go.opentelemetry.io/otel/metric v1.45.0
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     6.998s
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework 5.514s
make: Running acceptance tests on branch: 🌿 f_eks_cluster_control_plane_customization 🌿...
TF_ACC=1 go1.26.5 test ./internal/service/eks/... -v -count 1 -parallel 20 -run='TestAccEKSCluster_kubeAPIServerConfig|TestAccEKSCluster_kubeSchedulerConfig|TestAccEKSCluster_kubeControllerManagerConfig'  -timeout 360m -vet=off -buildvcs=false
2026/08/12 09:08:57 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/12 09:08:57 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccEKSCluster_kubeAPIServerConfig
=== PAUSE TestAccEKSCluster_kubeAPIServerConfig
=== RUN   TestAccEKSCluster_kubeSchedulerConfig
=== PAUSE TestAccEKSCluster_kubeSchedulerConfig
=== RUN   TestAccEKSCluster_kubeControllerManagerConfig
=== PAUSE TestAccEKSCluster_kubeControllerManagerConfig
=== CONT  TestAccEKSCluster_kubeAPIServerConfig
=== CONT  TestAccEKSCluster_kubeControllerManagerConfig
=== CONT  TestAccEKSCluster_kubeSchedulerConfig
--- PASS: TestAccEKSCluster_kubeAPIServerConfig (1155.38s)
--- PASS: TestAccEKSCluster_kubeControllerManagerConfig (1183.56s)
--- PASS: TestAccEKSCluster_kubeSchedulerConfig (1221.48s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/eks        1226.986s
```
