### PR TITLE
docs: fix references to nonexistent resource types in examples and import sections

### DIFF
--- a/website/docs/d/outposts_outpost_instance_type.html.markdown
+++ b/website/docs/d/outposts_outpost_instance_type.html.markdown
@@ -18,7 +18,7 @@ data "aws_outposts_outpost_instance_type" "example" {
   preferred_instance_types = ["m5.large", "m5.4xlarge"]
 }
 
-resource "aws_ec2_instance" "example" {
+resource "aws_instance" "example" {
   # ... other configuration ...
 
   instance_type = data.aws_outposts_outpost_instance_type.example.instance_type

--- a/website/docs/r/cloudwatch_alarm_mute_rule.html.markdown
+++ b/website/docs/r/cloudwatch_alarm_mute_rule.html.markdown
@@ -30,7 +30,7 @@ resource "aws_cloudwatch_alarm_mute_rule" "example" {
 ### With Start/Expire Dates Option
 
 ```terraform
-resource "aws_cloudwatch_alarm" "example" {
+resource "aws_cloudwatch_metric_alarm" "example" {
   alarm_name          = "example"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 2
@@ -56,7 +56,7 @@ resource "aws_cloudwatch_alarm_mute_rule" "example" {
   }
 
   mute_targets {
-    alarm_names = [aws_cloudwatch_alarm.example.alarm_name]
+    alarm_names = [aws_cloudwatch_metric_alarm.example.alarm_name]
   }
 
   tags = {

--- a/website/docs/r/elasticsearch_vpc_endpoint.html.markdown
+++ b/website/docs/r/elasticsearch_vpc_endpoint.html.markdown
@@ -56,17 +56,17 @@ This resource exports the following attributes in addition to the arguments abov
 
 ## Import
 
-In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import elasticsearch VPC endpoint connections using the `id`. For example:
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import elasticsearch VPC endpoints using the `id`. For example:
 
 ```terraform
 import {
-  to = aws_elasticsearch_vpc_endpoint_connection.example
+  to = aws_elasticsearch_vpc_endpoint.example
   id = "endpoint-id"
 }
 ```
 
-Using `terraform import`, import elasticsearch VPC endpoint connections using the `id`. For example:
+Using `terraform import`, import elasticsearch VPC endpoints using the `id`. For example:
 
 ```console
-% terraform import aws_elasticsearch_vpc_endpoint_connection.example endpoint-id
+% terraform import aws_elasticsearch_vpc_endpoint.example endpoint-id
 ```

--- a/website/docs/r/opensearch_vpc_endpoint.html.markdown
+++ b/website/docs/r/opensearch_vpc_endpoint.html.markdown
@@ -56,17 +56,17 @@ This resource exports the following attributes in addition to the arguments abov
 
 ## Import
 
-In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import OpenSearch VPC endpoint connections using the `id`. For example:
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import OpenSearch VPC endpoints using the `id`. For example:
 
 ```terraform
 import {
-  to = aws_opensearch_vpc_endpoint_connection.example
+  to = aws_opensearch_vpc_endpoint.example
   id = "endpoint-id"
 }
 ```
 
-Using `terraform import`, import OpenSearch VPC endpoint connections using the `id`. For example:
+Using `terraform import`, import OpenSearch VPC endpoints using the `id`. For example:
 
 ```console
-% terraform import aws_opensearch_vpc_endpoint_connection.example endpoint-id
+% terraform import aws_opensearch_vpc_endpoint.example endpoint-id
 ```

--- a/website/docs/r/s3control_access_grant.html.markdown
+++ b/website/docs/r/s3control_access_grant.html.markdown
@@ -88,5 +88,5 @@ import {
 Using `terraform import`, import S3 Access Grants using the `account_id` and `access_grant_id`, separated by a comma (`,`). For example:
 
 ```console
-% terraform import aws_s3control_access_grants_location.example 123456789012,04549c5e-2f3c-4a07-824d-2cafe720aa22
+% terraform import aws_s3control_access_grant.example 123456789012,04549c5e-2f3c-4a07-824d-2cafe720aa22
 ```

--- a/website/docs/r/vpc_route_server_peer.html.markdown
+++ b/website/docs/r/vpc_route_server_peer.html.markdown
@@ -38,7 +38,7 @@ resource "aws_vpc_route_server" "test" {
   }
 }
 
-resource "aws_vpc_route_server_association" "test" {
+resource "aws_vpc_route_server_vpc_association" "test" {
   route_server_id = aws_vpc_route_server.test.route_server_id
   vpc_id          = aws_vpc.test.id
 }
@@ -51,14 +51,14 @@ resource "aws_vpc_route_server_endpoint" "test" {
     Name = "Test Endpoint"
   }
 
-  depends_on = [aws_vpc_route_server_association.test]
+  depends_on = [aws_vpc_route_server_vpc_association.test]
 }
 
 resource "aws_vpc_route_server_propagation" "test" {
   route_server_id = aws_vpc_route_server.test.route_server_id
   route_table_id  = aws_route_table.test.id
 
-  depends_on = [aws_vpc_route_server_association.test]
+  depends_on = [aws_vpc_route_server_vpc_association.test]
 }
 
 resource "aws_vpc_route_server_peer" "test" {


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

No.

### Description

Documentation-only change. Fixes six pages whose examples or import sections reference resource types that do not exist in the provider, so copying them fails with `Invalid resource type`:

- `aws_elasticsearch_vpc_endpoint`: import block and CLI example used `aws_elasticsearch_vpc_endpoint_connection`
- `aws_opensearch_vpc_endpoint`: import block and CLI example used `aws_opensearch_vpc_endpoint_connection`
- `aws_s3control_access_grant`: CLI import example used `aws_s3control_access_grants_location`
- `aws_vpc_route_server_peer`: Complete Configuration example used `aws_vpc_route_server_association` instead of `aws_vpc_route_server_vpc_association`
- `aws_cloudwatch_alarm_mute_rule`: example used `aws_cloudwatch_alarm` instead of `aws_cloudwatch_metric_alarm`
- `aws_outposts_outpost_instance_type` (data source): example used `aws_ec2_instance` instead of `aws_instance`

### Relations

Closes #49413

### References

_None._

### Output from Acceptance Testing

Not applicable — documentation-only change.
