### PR TITLE
resource/aws_glue_catalog_table: Fix `View Expanded Text is not supported` error updating ATHENA dialect views

### DIFF
--- a/.changelog/49419.txt
+++ b/.changelog/49419.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_glue_catalog_table: Fix `InvalidInputException: View Expanded Text is not supported` errors when creating or updating `ATHENA` dialect views configured via `view_definition`
+```

--- a/internal/service/glue/catalog_table.go
+++ b/internal/service/glue/catalog_table.go
@@ -1049,7 +1049,7 @@ func expandTableInput(d *schema.ResourceData) *awstypes.TableInput {
 		}
 	}
 
-	if v, ok := d.GetOk("view_expanded_text"); ok {
+	if v, ok := d.GetOk("view_expanded_text"); ok && !viewDefinitionHasDialect(d, awstypes.ViewDialectAthena) {
 		apiObject.ViewExpandedText = aws.String(v.(string))
 	}
 

--- a/internal/service/glue/catalog_table.go
+++ b/internal/service/glue/catalog_table.go
@@ -1910,8 +1910,11 @@ func expandViewRepresentationInputs(tfList []any) []awstypes.ViewRepresentationI
 			apiObject.ValidationConnection = aws.String(v)
 		}
 
-		if v, ok := tfMap["view_expanded_text"].(string); ok && v != "" {
-			apiObject.ViewExpandedText = aws.String(v)
+		// "InvalidInputException: View Expanded Text is not supported".
+		if apiObject.Dialect != awstypes.ViewDialectAthena {
+			if v, ok := tfMap["view_expanded_text"].(string); ok && v != "" {
+				apiObject.ViewExpandedText = aws.String(v)
+			}
 		}
 
 		if v, ok := tfMap["view_original_text"].(string); ok && v != "" {

--- a/internal/service/glue/catalog_table_test.go
+++ b/internal/service/glue/catalog_table_test.go
@@ -223,6 +223,86 @@ func TestFlattenViewRepresentations(t *testing.T) {
 	}
 }
 
+// Reference: https://github.com/hashicorp/terraform-provider-aws/issues/49323
+func TestExpandViewRepresentationInputs(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name   string
+		tfList []any
+		want   []awstypes.ViewRepresentationInput
+	}{
+		{
+			name: "suppresses view_expanded_text for ATHENA dialect",
+			tfList: []any{
+				map[string]any{
+					"dialect":               "ATHENA",
+					"dialect_version":       "3",
+					"validation_connection": "athena-conn",
+					"view_expanded_text":    "/* Presto View */",
+					"view_original_text":    "SELECT 1 AS x",
+				},
+			},
+			want: []awstypes.ViewRepresentationInput{
+				{
+					Dialect:              awstypes.ViewDialectAthena,
+					DialectVersion:       aws.String("3"),
+					ValidationConnection: aws.String("athena-conn"),
+					ViewOriginalText:     aws.String("SELECT 1 AS x"),
+				},
+			},
+		},
+		{
+			name: "sends view_expanded_text for SPARK dialect",
+			tfList: []any{
+				map[string]any{
+					"dialect":            "SPARK",
+					"dialect_version":    "1.0",
+					"view_expanded_text": "SELECT 1 AS x",
+					"view_original_text": "SELECT 1 AS x",
+				},
+			},
+			want: []awstypes.ViewRepresentationInput{
+				{
+					Dialect:          awstypes.ViewDialectSpark,
+					DialectVersion:   aws.String("1.0"),
+					ViewExpandedText: aws.String("SELECT 1 AS x"),
+					ViewOriginalText: aws.String("SELECT 1 AS x"),
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfglue.ExpandViewRepresentationInputs(tc.tfList)
+
+			if len(got) != len(tc.want) {
+				t.Fatalf("len(got) = %d, want %d", len(got), len(tc.want))
+			}
+			for i, want := range tc.want {
+				if got[i].Dialect != want.Dialect {
+					t.Errorf("[%d] Dialect = %v, want %v", i, got[i].Dialect, want.Dialect)
+				}
+				if aws.ToString(got[i].DialectVersion) != aws.ToString(want.DialectVersion) {
+					t.Errorf("[%d] DialectVersion = %v, want %v", i, aws.ToString(got[i].DialectVersion), aws.ToString(want.DialectVersion))
+				}
+				if aws.ToString(got[i].ValidationConnection) != aws.ToString(want.ValidationConnection) {
+					t.Errorf("[%d] ValidationConnection = %v, want %v", i, aws.ToString(got[i].ValidationConnection), aws.ToString(want.ValidationConnection))
+				}
+				if aws.ToString(got[i].ViewExpandedText) != aws.ToString(want.ViewExpandedText) {
+					t.Errorf("[%d] ViewExpandedText = %v, want %v", i, aws.ToString(got[i].ViewExpandedText), aws.ToString(want.ViewExpandedText))
+				}
+				if aws.ToString(got[i].ViewOriginalText) != aws.ToString(want.ViewOriginalText) {
+					t.Errorf("[%d] ViewOriginalText = %v, want %v", i, aws.ToString(got[i].ViewOriginalText), aws.ToString(want.ViewOriginalText))
+				}
+			}
+		})
+	}
+}
+
 func TestAccGlueCatalogTable_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)

--- a/internal/service/glue/exports_test.go
+++ b/internal/service/glue/exports_test.go
@@ -5,8 +5,9 @@ package glue
 
 // Exports for use in tests only.
 var (
-	FlattenViewRepresentation  = flattenViewRepresentation
-	FlattenViewRepresentations = flattenViewRepresentations
+	ExpandViewRepresentationInputs = expandViewRepresentationInputs
+	FlattenViewRepresentation      = flattenViewRepresentation
+	FlattenViewRepresentations     = flattenViewRepresentations
 
 	ResourceCatalog                       = newCatalogResource
 	ResourceCatalogTable                  = resourceCatalogTable

--- a/website/docs/r/glue_catalog_table.html.markdown
+++ b/website/docs/r/glue_catalog_table.html.markdown
@@ -358,7 +358,7 @@ To add an index to an existing table, see the [`glue_partition_index` resource](
 * `dialect` - (Optional) Parameter that specifies the engine type of a specific representation. Valid values are `REDSHIFT`, `ATHENA`, and `SPARK`.
 * `dialect_version` - (Optional) Parameter that specifies the version of the engine of a specific representation.
 * `validation_connection` - (Optional) Name of the connection to be used to validate the specific representation of the view.
-* `view_expanded_text` - (Optional) String that represents the SQL query that describes the view with expanded resource ARNs.
+* `view_expanded_text` - (Optional) String that represents the SQL query that describes the view with expanded resource ARNs. Ignored for `ATHENA` dialect representations, as the Glue API rejects it (`View Expanded Text is not supported`).
 * `view_original_text` - (Optional) String that represents the original SQL query that describes the view.
 
 ## Attribute Reference

--- a/website/docs/r/glue_catalog_table.html.markdown
+++ b/website/docs/r/glue_catalog_table.html.markdown
@@ -195,7 +195,7 @@ The following arguments are optional:
 * `table_type` - (Optional) Type of this table (EXTERNAL_TABLE, VIRTUAL_VIEW, etc.). While optional, some Athena DDL queries such as `ALTER TABLE` and `SHOW CREATE TABLE` will fail if this argument is empty.
 * `target_table` - (Optional) Configuration block of a target table for resource linking. See [`target_table`](#target_table-block) below.
 * `view_definition` - (Optional) Structure that contains all the information that defines the view, including the dialect or dialects for the view, and the query. See [`view_definition`](#view_definition-block) below.
-* `view_expanded_text` - (Optional) If the table is a view, the expanded text of the view; otherwise null.
+* `view_expanded_text` - (Optional) If the table is a view, the expanded text of the view; otherwise null. Ignored when the `view_definition` block contains an `ATHENA` dialect representation, as the Glue API rejects it (`View Expanded Text is not supported`).
 * `view_original_text` - (Optional) If the table is a view, the original text of the view; otherwise null.
 
 ### `open_table_format_input` Block


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls (access controls, encryption, logging).

### Description

`expandViewRepresentationInputs` serializes `view_expanded_text` into `ViewRepresentationInput` whenever it is non-empty, for every dialect:

```go
if v, ok := tfMap["view_expanded_text"].(string); ok && v != "" {
    apiObject.ViewExpandedText = aws.String(v)
}
```

The Glue API rejects `ViewExpandedText` for `ATHENA` dialect representations with `InvalidInputException: View Expanded Text is not supported`. I verified against the live API that this rejection is unconditional for the `ATHENA` dialect: it happens on both `CreateTable` and `UpdateTable`, and both with and without a `ValidationConnection`. The same field is accepted for `SPARK` dialect representations.

The attribute is `Optional` + `Computed`, so the value the provider sends does not have to come from the user's configuration. For existing `ATHENA` views, `GetTable` can return `ViewExpandedText` (e.g. `/* Presto View */`, see the CloudTrail capture in #49323); `resourceCatalogTableRead` then stores it in state, and the next `UpdateTable` sends it back, failing every subsequent update of the view with the error above. Since the value is injected during Read, users cannot work around this from configuration.

This change skips `ViewExpandedText` for `ATHENA` dialect representations in `expandViewRepresentationInputs`, following the same pattern as the existing `ATHENA`-specific suppression of `StorageDescriptor` in `expandTableInput`. The legacy top-level `view_expanded_text` argument populates `TableInput.ViewExpandedText` in the same request (and `resourceCatalogTableRead` also stores the `GetTable` value into that attribute), so `expandTableInput` now skips it under the same condition — a `view_definition` containing an `ATHENA` representation. Both cases are called out in the resource documentation. Because the API rejects the field for `ATHENA` in all cases, there is no configuration that this change stops working. Other dialects (`SPARK`, `REDSHIFT`) are unaffected, and the Read/flatten path is unchanged.

### Relations

Closes #49323

### References

- [ViewRepresentationInput - AWS Glue API Reference](https://docs.aws.amazon.com/glue/latest/webapi/API_ViewRepresentationInput.html)
- In-repo pattern followed (`ATHENA`-specific `StorageDescriptor` suppression): https://github.com/hashicorp/terraform-provider-aws/blob/0d315cdfb087a65e14308f6005d260141ffd6e1f/internal/service/glue/catalog_table.go#L1023-L1028

### Output from Acceptance Testing

A validated `ATHENA` view cannot be provisioned from an acceptance test configuration in a stock AWS account: creating any multi-dialect view fails with `AccessDeniedException: Create Table Default Permissions should be empty, either in the database or settings.` unless the account's Lake Formation settings (or the database, which `aws_glue_catalog_database` cannot express) drop the `IAMAllowedPrincipals` default permissions, and the `ATHENA` dialect additionally requires a `VIEW_VALIDATION_ATHENA` connection plus an IAM role as caller or `definer`. For the same reason I could not run the existing `view_definition` acceptance tests in my account. The regression coverage is therefore a unit test, and the fix was verified against the live API with a locally built binary:

- Reproduced #49323 with a local build of `main`: created a validated `ATHENA` view (`view_definition` with `validation_connection`, empty `CreateTableDefaultPermissions` on the database), then updated `view_original_text` with `view_expanded_text` present in state; `UpdateTable` fails with `InvalidInputException: View Expanded Text is not supported`. I also confirmed the rejection matrix described above directly with the AWS CLI.
- With this fix, the same update succeeds and the view revalidates: `GetTable --include-status-details` reports `Status.State = SUCCESS` and the new SQL under `ViewValidations`.

```console
% go test ./internal/service/glue/ -run 'TestExpandViewRepresentationInputs|TestFlattenViewRepresentation' -v
...
--- PASS: TestExpandViewRepresentationInputs (0.00s)
    --- PASS: TestExpandViewRepresentationInputs/suppresses_view_expanded_text_for_ATHENA_dialect (0.00s)
    --- PASS: TestExpandViewRepresentationInputs/sends_view_expanded_text_for_SPARK_dialect (0.00s)
--- PASS: TestFlattenViewRepresentation (0.00s)
    --- PASS: TestFlattenViewRepresentation/api_values_take_precedence_over_prior_state (0.00s)
    --- PASS: TestFlattenViewRepresentation/empty-string_prior_values_are_not_written_into_flattened_map (0.00s)
    --- PASS: TestFlattenViewRepresentation/nil_prior_does_not_panic_and_omits_empty_optional_fields (0.00s)
    --- PASS: TestFlattenViewRepresentation/falls_back_to_prior_state_when_glue_strips_fields_for_validated_athena_view (0.00s)
--- PASS: TestFlattenViewRepresentations (0.00s)
    --- PASS: TestFlattenViewRepresentations/prior_matched_by_dialect_not_list_position (0.00s)
    --- PASS: TestFlattenViewRepresentations/nil_prior_does_not_panic_and_propagates_api_fields (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/glue	2.012s
```

```console
% make testacc TESTS=TestAccGlueCatalogTable_basic$ PKG=glue
make: Running acceptance tests on branch: 🌿 b-aws_glue_catalog_table-athena-view-expanded-text 🌿...
TF_ACC=1 go test ./internal/service/glue/... -v -count 1 -parallel 20 -run='TestAccGlueCatalogTable_basic$'  -timeout 360m -vet=off -buildvcs=false
2026/08/12 10:55:07 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/12 10:55:07 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccGlueCatalogTable_basic
=== PAUSE TestAccGlueCatalogTable_basic
=== CONT  TestAccGlueCatalogTable_basic
--- PASS: TestAccGlueCatalogTable_basic (75.51s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/glue	76.530s
```

The relevant acceptance tests for reviewers to run are `TestAccGlueCatalogTable_viewDefinition`, `TestAccGlueCatalogTable_Update_viewInPlace` and `TestAccGlueCatalogTable_viewDefinition_noPerpetualDiff` (all pre-existing; this change only removes a field from the request for a dialect that always rejected it).

