### PR TITLE
F aws eks cluster versions data source control plane customization

### DIFF
--- a/.changelog/49412.txt
+++ b/.changelog/49412.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_eks_cluster: Add `kube_api_server_config`, `kube_controller_manager_config`, and `kube_scheduler_config` arguments
+```

--- a/.changelog/49420.txt
+++ b/.changelog/49420.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data-source/aws_eks_cluster: Add `kube_api_server_config`, `kube_controller_manager_config`, and `kube_scheduler_config` attributes
+```

--- a/.changelog/49421.txt
+++ b/.changelog/49421.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data-source/aws_eks_cluster_versions: Add `control_plane_component_config` and `control_plane_scaling_tiers` attributes
+```

--- a/internal/service/eks/cluster.go
+++ b/internal/service/eks/cluster.go
@@ -256,6 +256,121 @@ func resourceCluster() *schema.Resource {
 						},
 					},
 				},
+				"kube_api_server_config": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Computed: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"event_ttl": {
+								Type:     schema.TypeString,
+								Optional: true,
+								Computed: true,
+							},
+							"service_node_port_range": {
+								Type:     schema.TypeList,
+								Optional: true,
+								Computed: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"max_port": {
+											Type:     schema.TypeInt,
+											Optional: true,
+											Computed: true,
+										},
+										"min_port": {
+											Type:     schema.TypeInt,
+											Optional: true,
+											Computed: true,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				"kube_controller_manager_config": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Computed: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"horizontal_pod_autoscaler_controller_config": {
+								Type:     schema.TypeList,
+								Optional: true,
+								Computed: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"horizontal_pod_autoscaler_sync_period": {
+											Type:     schema.TypeString,
+											Optional: true,
+											Computed: true,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				"kube_scheduler_config": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Computed: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"node_resources_fit": {
+								Type:     schema.TypeList,
+								Optional: true,
+								Computed: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"scoring_strategy": {
+											Type:     schema.TypeList,
+											Optional: true,
+											Computed: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													names.AttrResources: {
+														Type:     schema.TypeList,
+														Optional: true,
+														Computed: true,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																names.AttrName: {
+																	Type:     schema.TypeString,
+																	Optional: true,
+																	Computed: true,
+																},
+																names.AttrWeight: {
+																	Type:     schema.TypeInt,
+																	Optional: true,
+																	Computed: true,
+																},
+															},
+														},
+													},
+													names.AttrType: {
+														Type:             schema.TypeString,
+														Optional:         true,
+														Computed:         true,
+														ValidateDiagFunc: enum.Validate[types.ScoringStrategyType](),
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
 				"kubernetes_network_config": {
 					Type:          schema.TypeList,
 					Optional:      true,
@@ -597,6 +712,18 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta any
 		input.DeletionProtection = aws.Bool(v.(bool))
 	}
 
+	if v, ok := d.GetOk("kube_api_server_config"); ok {
+		input.KubeApiServerConfig = expandKubeAPIServerConfigRequest(v.([]any))
+	}
+
+	if v, ok := d.GetOk("kube_controller_manager_config"); ok {
+		input.KubeControllerManagerConfig = expandKubeControllerManagerConfigRequest(v.([]any))
+	}
+
+	if v, ok := d.GetOk("kube_scheduler_config"); ok {
+		input.KubeSchedulerConfig = expandKubeSchedulerConfigRequest(v.([]any))
+	}
+
 	if v, ok := d.GetOk("outpost_config"); ok {
 		input.OutpostConfig = expandOutpostConfigRequest(v.([]any))
 	}
@@ -778,6 +905,27 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta any
 
 		if _, err := waitClusterUpdateSuccessful(ctx, conn, d.Id(), updateID, d.Timeout(schema.TimeoutUpdate)); err != nil {
 			return sdkdiag.AppendErrorf(diags, "waiting for EKS Cluster (%s) control plane scaling config update (%s): %s", d.Id(), updateID, err)
+		}
+	}
+
+	if d.HasChanges("kube_api_server_config", "kube_controller_manager_config", "kube_scheduler_config") {
+		input := eks.UpdateClusterConfigInput{
+			Name:                        aws.String(d.Id()),
+			KubeApiServerConfig:         expandKubeAPIServerConfigRequest(d.Get("kube_api_server_config").([]any)),
+			KubeControllerManagerConfig: expandKubeControllerManagerConfigRequest(d.Get("kube_controller_manager_config").([]any)),
+			KubeSchedulerConfig:         expandKubeSchedulerConfigRequest(d.Get("kube_scheduler_config").([]any)),
+		}
+
+		output, err := conn.UpdateClusterConfig(ctx, &input)
+
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "updating EKS Cluster (%s) control plane component config: %s", d.Id(), err)
+		}
+
+		updateID := aws.ToString(output.Update.Id)
+
+		if _, err := waitClusterUpdateSuccessful(ctx, conn, d.Id(), updateID, d.Timeout(schema.TimeoutUpdate)); err != nil {
+			return sdkdiag.AppendErrorf(diags, "waiting for EKS Cluster (%s) control plane component config update (%s): %s", d.Id(), updateID, err)
 		}
 	}
 
@@ -1022,6 +1170,15 @@ func resourceClusterFlatten(ctx context.Context, cluster *types.Cluster, d *sche
 	d.Set(names.AttrEndpoint, cluster.Endpoint)
 	if err := d.Set("identity", flattenIdentity(cluster.Identity)); err != nil {
 		return fmt.Errorf("setting identity: %w", err)
+	}
+	if err := d.Set("kube_api_server_config", flattenKubeAPIServerConfigResponse(cluster.KubeApiServerConfig)); err != nil {
+		return fmt.Errorf("setting kube_api_server_config: %w", err)
+	}
+	if err := d.Set("kube_controller_manager_config", flattenKubeControllerManagerConfigResponse(cluster.KubeControllerManagerConfig)); err != nil {
+		return fmt.Errorf("setting kube_controller_manager_config: %w", err)
+	}
+	if err := d.Set("kube_scheduler_config", flattenKubeSchedulerConfigResponse(cluster.KubeSchedulerConfig)); err != nil {
+		return fmt.Errorf("setting kube_scheduler_config: %w", err)
 	}
 	if err := d.Set("kubernetes_network_config", flattenKubernetesNetworkConfigResponse(cluster.KubernetesNetworkConfig)); err != nil {
 		return fmt.Errorf("setting kubernetes_network_config: %w", err)
@@ -1340,6 +1497,180 @@ func expandControlPlaneScalingConfig(tfList []any) *types.ControlPlaneScalingCon
 	}
 
 	return apiObject
+}
+
+func expandKubeAPIServerConfigRequest(tfList []any) *types.KubeApiServerConfigRequest {
+	if len(tfList) == 0 {
+		return nil
+	}
+
+	tfMap, ok := tfList[0].(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	apiObject := &types.KubeApiServerConfigRequest{}
+
+	if v, ok := tfMap["event_ttl"].(string); ok && v != "" {
+		apiObject.EventTtl = aws.String(v)
+	}
+
+	if v, ok := tfMap["service_node_port_range"].([]any); ok && len(v) > 0 {
+		apiObject.ServiceNodePortRange = expandServiceNodePortRange(v)
+	}
+
+	return apiObject
+}
+
+func expandServiceNodePortRange(tfList []any) *types.ServiceNodePortRange {
+	if len(tfList) == 0 {
+		return nil
+	}
+
+	tfMap, ok := tfList[0].(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	apiObject := &types.ServiceNodePortRange{}
+
+	if v, ok := tfMap["min_port"].(int); ok && v != 0 {
+		apiObject.MinPort = int32(v)
+	}
+
+	if v, ok := tfMap["max_port"].(int); ok && v != 0 {
+		apiObject.MaxPort = int32(v)
+	}
+
+	return apiObject
+}
+
+func expandKubeControllerManagerConfigRequest(tfList []any) *types.KubeControllerManagerConfigRequest {
+	if len(tfList) == 0 {
+		return nil
+	}
+
+	tfMap, ok := tfList[0].(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	apiObject := &types.KubeControllerManagerConfigRequest{}
+
+	if v, ok := tfMap["horizontal_pod_autoscaler_controller_config"].([]any); ok && len(v) > 0 {
+		apiObject.HorizontalPodAutoscalerControllerConfig = expandHorizontalPodAutoscalerControllerConfigRequest(v)
+	}
+
+	return apiObject
+}
+
+func expandHorizontalPodAutoscalerControllerConfigRequest(tfList []any) *types.HorizontalPodAutoscalerControllerConfigRequest {
+	if len(tfList) == 0 {
+		return nil
+	}
+
+	tfMap, ok := tfList[0].(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	apiObject := &types.HorizontalPodAutoscalerControllerConfigRequest{}
+
+	if v, ok := tfMap["horizontal_pod_autoscaler_sync_period"].(string); ok && v != "" {
+		apiObject.HorizontalPodAutoscalerSyncPeriod = aws.String(v)
+	}
+
+	return apiObject
+}
+
+func expandKubeSchedulerConfigRequest(tfList []any) *types.KubeSchedulerConfigRequest {
+	if len(tfList) == 0 {
+		return nil
+	}
+
+	tfMap, ok := tfList[0].(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	apiObject := &types.KubeSchedulerConfigRequest{}
+
+	if v, ok := tfMap["node_resources_fit"].([]any); ok && len(v) > 0 {
+		apiObject.NodeResourcesFit = expandNodeResourcesFitConfig(v)
+	}
+
+	return apiObject
+}
+
+func expandNodeResourcesFitConfig(tfList []any) *types.NodeResourcesFitConfig {
+	if len(tfList) == 0 {
+		return nil
+	}
+
+	tfMap, ok := tfList[0].(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	apiObject := &types.NodeResourcesFitConfig{}
+
+	if v, ok := tfMap["scoring_strategy"].([]any); ok && len(v) > 0 {
+		apiObject.ScoringStrategy = expandScoringStrategy(v)
+	}
+
+	return apiObject
+}
+
+func expandScoringStrategy(tfList []any) *types.ScoringStrategy {
+	if len(tfList) == 0 {
+		return nil
+	}
+
+	tfMap, ok := tfList[0].(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	apiObject := &types.ScoringStrategy{}
+
+	if v, ok := tfMap[names.AttrType].(string); ok && v != "" {
+		apiObject.Type = types.ScoringStrategyType(v)
+	}
+
+	if v, ok := tfMap[names.AttrResources].([]any); ok && len(v) > 0 {
+		apiObject.Resources = expandResourceWeights(v)
+	}
+
+	return apiObject
+}
+
+func expandResourceWeights(tfList []any) []types.ResourceWeight {
+	if len(tfList) == 0 {
+		return nil
+	}
+
+	var apiObjects []types.ResourceWeight
+
+	for _, tfMapRaw := range tfList {
+		tfMap, ok := tfMapRaw.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		apiObject := types.ResourceWeight{}
+
+		if v, ok := tfMap[names.AttrName].(string); ok && v != "" {
+			apiObject.Name = aws.String(v)
+		}
+
+		if v, ok := tfMap[names.AttrWeight].(int); ok && v != 0 {
+			apiObject.Weight = aws.Int32(int32(v))
+		}
+
+		apiObjects = append(apiObjects, apiObject)
+	}
+
+	return apiObjects
 }
 
 func expandEncryptionConfig(tfList []any) []types.EncryptionConfig {
@@ -1775,6 +2106,133 @@ func flattenControlPlaneScalingConfig(apiObject *types.ControlPlaneScalingConfig
 	}
 
 	return []any{tfMap}
+}
+
+func flattenKubeAPIServerConfigResponse(apiObject *types.KubeApiServerConfigResponse) []any {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]any{}
+
+	if apiObject.EventTtl != nil {
+		tfMap["event_ttl"] = aws.ToString(apiObject.EventTtl)
+	}
+
+	if apiObject.ServiceNodePortRange != nil {
+		tfMap["service_node_port_range"] = flattenServiceNodePortRange(apiObject.ServiceNodePortRange)
+	}
+
+	return []any{tfMap}
+}
+
+func flattenServiceNodePortRange(apiObject *types.ServiceNodePortRange) []any {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]any{
+		"min_port": apiObject.MinPort,
+		"max_port": apiObject.MaxPort,
+	}
+
+	return []any{tfMap}
+}
+
+func flattenKubeControllerManagerConfigResponse(apiObject *types.KubeControllerManagerConfigResponse) []any {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]any{}
+
+	if apiObject.HorizontalPodAutoscalerControllerConfig != nil {
+		tfMap["horizontal_pod_autoscaler_controller_config"] = flattenHorizontalPodAutoscalerControllerConfigResponse(apiObject.HorizontalPodAutoscalerControllerConfig)
+	}
+
+	return []any{tfMap}
+}
+
+func flattenHorizontalPodAutoscalerControllerConfigResponse(apiObject *types.HorizontalPodAutoscalerControllerConfigResponse) []any {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]any{}
+
+	if apiObject.HorizontalPodAutoscalerSyncPeriod != nil {
+		tfMap["horizontal_pod_autoscaler_sync_period"] = aws.ToString(apiObject.HorizontalPodAutoscalerSyncPeriod)
+	}
+
+	return []any{tfMap}
+}
+
+func flattenKubeSchedulerConfigResponse(apiObject *types.KubeSchedulerConfigResponse) []any {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]any{}
+
+	if apiObject.NodeResourcesFit != nil {
+		tfMap["node_resources_fit"] = flattenNodeResourcesFitConfig(apiObject.NodeResourcesFit)
+	}
+
+	return []any{tfMap}
+}
+
+func flattenNodeResourcesFitConfig(apiObject *types.NodeResourcesFitConfig) []any {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]any{}
+
+	if apiObject.ScoringStrategy != nil {
+		tfMap["scoring_strategy"] = flattenScoringStrategy(apiObject.ScoringStrategy)
+	}
+
+	return []any{tfMap}
+}
+
+func flattenScoringStrategy(apiObject *types.ScoringStrategy) []any {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]any{
+		names.AttrType: apiObject.Type,
+	}
+
+	if apiObject.Resources != nil {
+		tfMap[names.AttrResources] = flattenResourceWeights(apiObject.Resources)
+	}
+
+	return []any{tfMap}
+}
+
+func flattenResourceWeights(apiObjects []types.ResourceWeight) []any {
+	if len(apiObjects) == 0 {
+		return nil
+	}
+
+	var tfList []any
+
+	for _, apiObject := range apiObjects {
+		tfMap := map[string]any{}
+
+		if apiObject.Name != nil {
+			tfMap[names.AttrName] = aws.ToString(apiObject.Name)
+		}
+
+		if apiObject.Weight != nil {
+			tfMap[names.AttrWeight] = aws.ToInt32(apiObject.Weight)
+		}
+
+		tfList = append(tfList, tfMap)
+	}
+
+	return tfList
 }
 
 func flattenIdentity(apiObject *types.Identity) []map[string]any {

--- a/internal/service/eks/cluster_data_source.go
+++ b/internal/service/eks/cluster_data_source.go
@@ -134,6 +134,98 @@ func dataSourceCluster() *schema.Resource {
 						},
 					},
 				},
+				"kube_api_server_config": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"event_ttl": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"service_node_port_range": {
+								Type:     schema.TypeList,
+								Computed: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"max_port": {
+											Type:     schema.TypeInt,
+											Computed: true,
+										},
+										"min_port": {
+											Type:     schema.TypeInt,
+											Computed: true,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				"kube_controller_manager_config": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"horizontal_pod_autoscaler_controller_config": {
+								Type:     schema.TypeList,
+								Computed: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"horizontal_pod_autoscaler_sync_period": {
+											Type:     schema.TypeString,
+											Computed: true,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				"kube_scheduler_config": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"node_resources_fit": {
+								Type:     schema.TypeList,
+								Computed: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"scoring_strategy": {
+											Type:     schema.TypeList,
+											Computed: true,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													names.AttrResources: {
+														Type:     schema.TypeList,
+														Computed: true,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																names.AttrName: {
+																	Type:     schema.TypeString,
+																	Computed: true,
+																},
+																names.AttrWeight: {
+																	Type:     schema.TypeInt,
+																	Computed: true,
+																},
+															},
+														},
+													},
+													names.AttrType: {
+														Type:     schema.TypeString,
+														Computed: true,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
 				"kubernetes_network_config": {
 					Type:     schema.TypeList,
 					Computed: true,
@@ -402,6 +494,15 @@ func dataSourceClusterRead(ctx context.Context, d *schema.ResourceData, meta any
 	d.Set(names.AttrEndpoint, cluster.Endpoint)
 	if err := d.Set("identity", flattenIdentity(cluster.Identity)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting identity: %s", err)
+	}
+	if err := d.Set("kube_api_server_config", flattenKubeAPIServerConfigResponse(cluster.KubeApiServerConfig)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting kube_api_server_config: %s", err)
+	}
+	if err := d.Set("kube_controller_manager_config", flattenKubeControllerManagerConfigResponse(cluster.KubeControllerManagerConfig)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting kube_controller_manager_config: %s", err)
+	}
+	if err := d.Set("kube_scheduler_config", flattenKubeSchedulerConfigResponse(cluster.KubeSchedulerConfig)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting kube_scheduler_config: %s", err)
 	}
 	if err := d.Set("kubernetes_network_config", flattenKubernetesNetworkConfigResponse(cluster.KubernetesNetworkConfig)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting kubernetes_network_config: %s", err)

--- a/internal/service/eks/cluster_data_source_test.go
+++ b/internal/service/eks/cluster_data_source_test.go
@@ -244,3 +244,103 @@ data "aws_eks_cluster" "test" {
 }
 `)
 }
+
+func TestAccEKSClusterDataSource_kubeAPIServerConfig(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	dataSourceResourceName := "data.aws_eks_cluster.test"
+	resourceName := "aws_eks_cluster.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EKSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterDataSourceConfig_kubeAPIServerConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrARN, dataSourceResourceName, names.AttrARN),
+					resource.TestCheckResourceAttr(dataSourceResourceName, "kube_api_server_config.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "kube_api_server_config.0.event_ttl", dataSourceResourceName, "kube_api_server_config.0.event_ttl"),
+					resource.TestCheckResourceAttrPair(resourceName, "kube_api_server_config.0.service_node_port_range.0.min_port", dataSourceResourceName, "kube_api_server_config.0.service_node_port_range.0.min_port"),
+					resource.TestCheckResourceAttrPair(resourceName, "kube_api_server_config.0.service_node_port_range.0.max_port", dataSourceResourceName, "kube_api_server_config.0.service_node_port_range.0.max_port"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccEKSClusterDataSource_kubeSchedulerConfig(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	dataSourceResourceName := "data.aws_eks_cluster.test"
+	resourceName := "aws_eks_cluster.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EKSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterDataSourceConfig_kubeSchedulerConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrARN, dataSourceResourceName, names.AttrARN),
+					resource.TestCheckResourceAttr(dataSourceResourceName, "kube_scheduler_config.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "kube_scheduler_config.0.node_resources_fit.0.scoring_strategy.0.type", dataSourceResourceName, "kube_scheduler_config.0.node_resources_fit.0.scoring_strategy.0.type"),
+					resource.TestCheckResourceAttrPair(resourceName, "kube_scheduler_config.0.node_resources_fit.0.scoring_strategy.0.resources.0.name", dataSourceResourceName, "kube_scheduler_config.0.node_resources_fit.0.scoring_strategy.0.resources.0.name"),
+					resource.TestCheckResourceAttrPair(resourceName, "kube_scheduler_config.0.node_resources_fit.0.scoring_strategy.0.resources.0.weight", dataSourceResourceName, "kube_scheduler_config.0.node_resources_fit.0.scoring_strategy.0.resources.0.weight"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccEKSClusterDataSource_kubeControllerManagerConfig(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	dataSourceResourceName := "data.aws_eks_cluster.test"
+	resourceName := "aws_eks_cluster.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EKSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterDataSourceConfig_kubeControllerManagerConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrARN, dataSourceResourceName, names.AttrARN),
+					resource.TestCheckResourceAttr(dataSourceResourceName, "kube_controller_manager_config.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "kube_controller_manager_config.0.horizontal_pod_autoscaler_controller_config.0.horizontal_pod_autoscaler_sync_period", dataSourceResourceName, "kube_controller_manager_config.0.horizontal_pod_autoscaler_controller_config.0.horizontal_pod_autoscaler_sync_period"),
+				),
+			},
+		},
+	})
+}
+
+func testAccClusterDataSourceConfig_kubeAPIServerConfig(rName string) string {
+	return acctest.ConfigCompose(testAccClusterConfig_kubeAPIServerConfig(rName, "30m", 30000, 32767), `
+data "aws_eks_cluster" "test" {
+  name = aws_eks_cluster.test.name
+}
+`)
+}
+
+func testAccClusterDataSourceConfig_kubeSchedulerConfig(rName string) string {
+	return acctest.ConfigCompose(testAccClusterConfig_kubeSchedulerConfig(rName, "LeastAllocated"), `
+data "aws_eks_cluster" "test" {
+  name = aws_eks_cluster.test.name
+}
+`)
+}
+
+func testAccClusterDataSourceConfig_kubeControllerManagerConfig(rName string) string {
+	return acctest.ConfigCompose(testAccClusterConfig_kubeControllerManagerConfig(rName, "10s"), `
+data "aws_eks_cluster" "test" {
+  name = aws_eks_cluster.test.name
+}
+`)
+}

--- a/internal/service/eks/cluster_test.go
+++ b/internal/service/eks/cluster_test.go
@@ -2963,3 +2963,270 @@ resource "aws_eks_cluster" "test" {
 }
 `, rName, tier))
 }
+
+func TestAccEKSCluster_kubeAPIServerConfig(t *testing.T) {
+	ctx := acctest.Context(t)
+	var cluster types.Cluster
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_eks_cluster.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EKSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterConfig_kubeAPIServerConfig(rName, "30m", 30000, 32767),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckClusterExists(ctx, t, resourceName, &cluster),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("kube_api_server_config"), knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
+						"event_ttl": knownvalue.StringExact("30m"),
+						"service_node_port_range": knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"min_port": knownvalue.Int64Exact(30000),
+							"max_port": knownvalue.Int64Exact(32767),
+						})}),
+					})})),
+				},
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"bootstrap_self_managed_addons"},
+			},
+			{
+				Config: testAccClusterConfig_kubeAPIServerConfig(rName, "45m", 30100, 32767),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckClusterExists(ctx, t, resourceName, &cluster),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("kube_api_server_config"), knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
+						"event_ttl": knownvalue.StringExact("45m"),
+						"service_node_port_range": knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"min_port": knownvalue.Int64Exact(30100),
+							"max_port": knownvalue.Int64Exact(32767),
+						})}),
+					})})),
+				},
+			},
+		},
+	})
+}
+
+func TestAccEKSCluster_kubeSchedulerConfig(t *testing.T) {
+	ctx := acctest.Context(t)
+	var cluster types.Cluster
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_eks_cluster.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EKSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterConfig_kubeSchedulerConfig(rName, "LeastAllocated"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckClusterExists(ctx, t, resourceName, &cluster),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("kube_scheduler_config"), knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
+						"node_resources_fit": knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"scoring_strategy": knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
+								names.AttrType: tfknownvalue.StringExact(types.ScoringStrategyTypeLeastAllocated),
+								names.AttrResources: knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
+									acctest.CtName:   knownvalue.StringExact("cpu"),
+									names.AttrWeight: knownvalue.Int64Exact(1),
+								})}),
+							})}),
+						})}),
+					})})),
+				},
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"bootstrap_self_managed_addons"},
+			},
+			{
+				Config: testAccClusterConfig_kubeSchedulerConfig(rName, "MostAllocated"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckClusterExists(ctx, t, resourceName, &cluster),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("kube_scheduler_config"), knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
+						"node_resources_fit": knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"scoring_strategy": knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
+								names.AttrType: tfknownvalue.StringExact(types.ScoringStrategyTypeMostAllocated),
+								names.AttrResources: knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
+									acctest.CtName:   knownvalue.StringExact("cpu"),
+									names.AttrWeight: knownvalue.Int64Exact(1),
+								})}),
+							})}),
+						})}),
+					})})),
+				},
+			},
+		},
+	})
+}
+
+func TestAccEKSCluster_kubeControllerManagerConfig(t *testing.T) {
+	ctx := acctest.Context(t)
+	var cluster types.Cluster
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_eks_cluster.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EKSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterConfig_kubeControllerManagerConfig(rName, "10s"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckClusterExists(ctx, t, resourceName, &cluster),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("kube_controller_manager_config"), knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
+						"horizontal_pod_autoscaler_controller_config": knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"horizontal_pod_autoscaler_sync_period": knownvalue.StringExact("10s"),
+						})}),
+					})})),
+				},
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"bootstrap_self_managed_addons"},
+			},
+			{
+				Config: testAccClusterConfig_kubeControllerManagerConfig(rName, "13s"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckClusterExists(ctx, t, resourceName, &cluster),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("kube_controller_manager_config"), knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
+						"horizontal_pod_autoscaler_controller_config": knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"horizontal_pod_autoscaler_sync_period": knownvalue.StringExact("13s"),
+						})}),
+					})})),
+				},
+			},
+		},
+	})
+}
+
+func testAccClusterConfig_kubeAPIServerConfig(rName, eventTTL string, minPort, maxPort int) string {
+	return acctest.ConfigCompose(testAccClusterConfig_base(rName), fmt.Sprintf(`
+resource "aws_eks_cluster" "test" {
+  name     = %[1]q
+  role_arn = aws_iam_role.cluster.arn
+
+  vpc_config {
+    subnet_ids = aws_subnet.test[*].id
+  }
+
+  kube_api_server_config {
+    event_ttl = %[2]q
+
+    service_node_port_range {
+      min_port = %[3]d
+      max_port = %[4]d
+    }
+  }
+
+  depends_on = [aws_iam_role_policy_attachment.cluster_AmazonEKSClusterPolicy]
+}
+`, rName, eventTTL, minPort, maxPort))
+}
+
+func testAccClusterConfig_kubeSchedulerConfig(rName, strategyType string) string {
+	return acctest.ConfigCompose(testAccClusterConfig_base(rName), fmt.Sprintf(`
+resource "aws_eks_cluster" "test" {
+  name     = %[1]q
+  role_arn = aws_iam_role.cluster.arn
+
+  vpc_config {
+    subnet_ids = aws_subnet.test[*].id
+  }
+
+  kube_scheduler_config {
+    node_resources_fit {
+      scoring_strategy {
+        type = %[2]q
+
+        resources {
+          name   = "cpu"
+          weight = 1
+        }
+      }
+    }
+  }
+
+  depends_on = [aws_iam_role_policy_attachment.cluster_AmazonEKSClusterPolicy]
+}
+`, rName, strategyType))
+}
+
+func testAccClusterConfig_kubeControllerManagerConfig(rName, syncPeriod string) string {
+	return acctest.ConfigCompose(testAccClusterConfig_base(rName), fmt.Sprintf(`
+resource "aws_eks_cluster" "test" {
+  name     = %[1]q
+  role_arn = aws_iam_role.cluster.arn
+
+  vpc_config {
+    subnet_ids = aws_subnet.test[*].id
+  }
+
+  control_plane_scaling_config {
+    tier = "tier-xl"
+  }
+
+  kube_controller_manager_config {
+    horizontal_pod_autoscaler_controller_config {
+      horizontal_pod_autoscaler_sync_period = %[2]q
+    }
+  }
+
+  depends_on = [aws_iam_role_policy_attachment.cluster_AmazonEKSClusterPolicy]
+}
+`, rName, syncPeriod))
+}

--- a/internal/service/eks/cluster_versions_data_source.go
+++ b/internal/service/eks/cluster_versions_data_source.go
@@ -112,13 +112,109 @@ type clusterVersionsDataSourceModel struct {
 }
 
 type customDataSourceClusterVersion struct {
-	ClusterType              types.String                               `tfsdk:"cluster_type"`
-	ClusterVersion           types.String                               `tfsdk:"cluster_version"`
-	DefaultPlatformVersion   types.String                               `tfsdk:"default_platform_version"`
-	DefaultVersion           types.Bool                                 `tfsdk:"default_version"`
-	EndOfExtendedSupportDate timetypes.RFC3339                          `tfsdk:"end_of_extended_support_date"`
-	EndOfStandardSupportDate timetypes.RFC3339                          `tfsdk:"end_of_standard_support_date"`
-	KubernetesPatchVersion   types.String                               `tfsdk:"kubernetes_patch_version"`
-	ReleaseDate              timetypes.RFC3339                          `tfsdk:"release_date"`
-	VersionStatus            fwtypes.StringEnum[awstypes.VersionStatus] `tfsdk:"version_status"`
+	ClusterType                 types.String                                                      `tfsdk:"cluster_type"`
+	ClusterVersion              types.String                                                      `tfsdk:"cluster_version"`
+	ControlPlaneComponentConfig fwtypes.ListNestedObjectValueOf[controlPlaneConfigInfoModel]      `tfsdk:"control_plane_component_config"`
+	ControlPlaneScalingTiers    fwtypes.ListNestedObjectValueOf[controlPlaneScalingTierInfoModel] `tfsdk:"control_plane_scaling_tiers"`
+	DefaultPlatformVersion      types.String                                                      `tfsdk:"default_platform_version"`
+	DefaultVersion              types.Bool                                                        `tfsdk:"default_version"`
+	EndOfExtendedSupportDate    timetypes.RFC3339                                                 `tfsdk:"end_of_extended_support_date"`
+	EndOfStandardSupportDate    timetypes.RFC3339                                                 `tfsdk:"end_of_standard_support_date"`
+	KubernetesPatchVersion      types.String                                                      `tfsdk:"kubernetes_patch_version"`
+	ReleaseDate                 timetypes.RFC3339                                                 `tfsdk:"release_date"`
+	VersionStatus               fwtypes.StringEnum[awstypes.VersionStatus]                        `tfsdk:"version_status"`
+}
+
+type controlPlaneConfigInfoModel struct {
+	KubeApiServerConfig         fwtypes.ListNestedObjectValueOf[kubeAPIServerVersionConfigModel]         `tfsdk:"kube_api_server_config"`
+	KubeControllerManagerConfig fwtypes.ListNestedObjectValueOf[kubeControllerManagerVersionConfigModel] `tfsdk:"kube_controller_manager_config"`
+	KubeSchedulerConfig         fwtypes.ListNestedObjectValueOf[kubeSchedulerVersionConfigModel]         `tfsdk:"kube_scheduler_config"`
+}
+
+type kubeAPIServerVersionConfigModel struct {
+	EventTtl             fwtypes.ListNestedObjectValueOf[durationParameterConfigModel]  `tfsdk:"event_ttl"`
+	ServiceNodePortRange fwtypes.ListNestedObjectValueOf[portRangeParameterConfigModel] `tfsdk:"service_node_port_range"`
+}
+
+type kubeControllerManagerVersionConfigModel struct {
+	HorizontalPodAutoscalerControllerConfig fwtypes.ListNestedObjectValueOf[horizontalPodAutoscalerControllerVersionConfigModel] `tfsdk:"horizontal_pod_autoscaler_controller_config"`
+}
+
+type horizontalPodAutoscalerControllerVersionConfigModel struct {
+	HorizontalPodAutoscalerSyncPeriod fwtypes.ListNestedObjectValueOf[durationParameterConfigModel] `tfsdk:"horizontal_pod_autoscaler_sync_period"`
+}
+
+type kubeSchedulerVersionConfigModel struct {
+	NodeResourcesFit fwtypes.ListNestedObjectValueOf[nodeResourcesFitVersionConfigModel] `tfsdk:"node_resources_fit"`
+}
+
+type nodeResourcesFitVersionConfigModel struct {
+	ScoringStrategy fwtypes.ListNestedObjectValueOf[scoringStrategyConfigModel] `tfsdk:"scoring_strategy"`
+}
+
+type scoringStrategyConfigModel struct {
+	Constraints  fwtypes.ListNestedObjectValueOf[scoringStrategyConstraintsModel] `tfsdk:"constraints"`
+	DefaultValue fwtypes.ListNestedObjectValueOf[scoringStrategyModel]            `tfsdk:"default_value"`
+}
+
+type scoringStrategyModel struct {
+	Resources fwtypes.ListNestedObjectValueOf[resourceWeightModel] `tfsdk:"resources"`
+	Type      fwtypes.StringEnum[awstypes.ScoringStrategyType]     `tfsdk:"type"`
+}
+
+type resourceWeightModel struct {
+	Name   types.String `tfsdk:"name"`
+	Weight types.Int32  `tfsdk:"weight"`
+}
+
+type scoringStrategyConstraintsModel struct {
+	Resources       fwtypes.ListNestedObjectValueOf[resourceConstraintsModel]     `tfsdk:"resources"`
+	ScoringStrategy fwtypes.ListNestedObjectValueOf[allowedValuesConstraintModel] `tfsdk:"scoring_strategy"`
+}
+
+type resourceConstraintsModel struct {
+	Name   fwtypes.ListNestedObjectValueOf[allowedValuesConstraintModel] `tfsdk:"name"`
+	Weight fwtypes.ListNestedObjectValueOf[integerRangeConstraintModel]  `tfsdk:"weight"`
+}
+
+type allowedValuesConstraintModel struct {
+	AllowedValues fwtypes.ListValueOf[types.String] `tfsdk:"allowed_values"`
+}
+
+type integerRangeConstraintModel struct {
+	Max types.Int32 `tfsdk:"max"`
+	Min types.Int32 `tfsdk:"min"`
+}
+
+type durationParameterConfigModel struct {
+	Constraints  fwtypes.ListNestedObjectValueOf[durationConstraintsModel] `tfsdk:"constraints"`
+	DefaultValue types.String                                              `tfsdk:"default_value"`
+}
+
+type durationConstraintsModel struct {
+	Max types.String `tfsdk:"max"`
+	Min types.String `tfsdk:"min"`
+}
+
+type portRangeParameterConfigModel struct {
+	Constraints  fwtypes.ListNestedObjectValueOf[portRangeConstraintsModel] `tfsdk:"constraints"`
+	DefaultValue fwtypes.ListNestedObjectValueOf[serviceNodePortRangeModel] `tfsdk:"default_value"`
+}
+
+type portRangeConstraintsModel struct {
+	MaxPort fwtypes.ListNestedObjectValueOf[integerRangeConstraintModel] `tfsdk:"max_port"`
+	MinPort fwtypes.ListNestedObjectValueOf[integerRangeConstraintModel] `tfsdk:"min_port"`
+}
+
+type serviceNodePortRangeModel struct {
+	MaxPort types.Int32 `tfsdk:"max_port"`
+	MinPort types.Int32 `tfsdk:"min_port"`
+}
+
+type controlPlaneScalingTierInfoModel struct {
+	ApiRequestConcurrency                types.Int32                                                  `tfsdk:"api_request_concurrency"`
+	ClusterDatabaseSizeGb                types.Int32                                                  `tfsdk:"cluster_database_size_gb"`
+	ControlPlaneComponentConfigOverrides fwtypes.ListNestedObjectValueOf[controlPlaneConfigInfoModel] `tfsdk:"control_plane_component_config_overrides"`
+	PodSchedulingRatePerSecond           types.Int32                                                  `tfsdk:"pod_scheduling_rate_per_second"`
+	TierName                             types.String                                                 `tfsdk:"tier_name"`
 }

--- a/internal/service/eks/cluster_versions_data_source_test.go
+++ b/internal/service/eks/cluster_versions_data_source_test.go
@@ -123,3 +123,36 @@ data "aws_eks_cluster_versions" "test" {
 }
 `
 }
+
+func TestAccEKSClusterVersionsDataSource_controlPlaneComponentConfig(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	dataSourceName := "data.aws_eks_cluster_versions.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EKSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterVersionsDataSourceConfig_controlPlaneComponentConfig(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "cluster_versions.#", 0),
+					resource.TestCheckResourceAttr(dataSourceName, "cluster_versions.0.control_plane_component_config.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "cluster_versions.0.control_plane_component_config.0.kube_api_server_config.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "cluster_versions.0.control_plane_component_config.0.kube_scheduler_config.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "cluster_versions.0.control_plane_component_config.0.kube_controller_manager_config.#", "1"),
+					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "cluster_versions.0.control_plane_scaling_tiers.#", 0),
+				),
+			},
+		},
+	})
+}
+
+func testAccClusterVersionsDataSourceConfig_controlPlaneComponentConfig() string {
+	return `
+data "aws_eks_cluster_versions" "test" {
+  cluster_versions_only = ["1.32"]
+}
+`
+}

--- a/website/docs/d/eks_cluster.html.markdown
+++ b/website/docs/d/eks_cluster.html.markdown
@@ -58,6 +58,21 @@ This data source exports the following attributes in addition to the arguments a
 * `identity` - Nested attribute containing identity provider information for your cluster. Only available on Kubernetes version 1.13 and 1.14 clusters created or upgraded on or after September 3, 2019. For an example using this information to enable IAM Roles for Service Accounts, see the [`aws_eks_cluster` resource documentation](/docs/providers/aws/r/eks_cluster.html).
     * `oidc` - Nested attribute containing [OpenID Connect](https://openid.net/connect/) identity provider information for the cluster.
         * `issuer` - Issuer URL for the OpenID Connect identity provider.
+* `kube_api_server_config` - Configuration for the Kubernetes API server.
+    * `event_ttl` - The duration that Kubernetes events are retained.
+    * `service_node_port_range` - The port range for NodePort services.
+        * `min_port` - The minimum port number in the range.
+        * `max_port` - The maximum port number in the range.
+* `kube_controller_manager_config` - Configuration for the Kubernetes controller manager.
+    * `horizontal_pod_autoscaler_controller_config` - Configuration for the horizontal pod autoscaler controller.
+        * `horizontal_pod_autoscaler_sync_period` - The interval between each sync of the horizontal pod autoscaler.
+* `kube_scheduler_config` - Configuration for the Kubernetes scheduler.
+    * `node_resources_fit` - Configuration for the NodeResourcesFit scheduler plugin.
+        * `scoring_strategy` - The scoring strategy used to rank nodes during scheduling.
+            * `type` - The scoring strategy type (`LeastAllocated` or `MostAllocated`).
+            * `resources` - List of resource weights for scoring nodes.
+                * `name` - The name of the resource (e.g., `cpu`, `memory`).
+                * `weight` - The weight assigned to the resource for scoring (1-100).
 * `kubernetes_network_config` - Nested list containing Kubernetes Network Configuration.
     * `elastic_load_balancing` - Contains Elastic Load Balancing configuration for EKS Auto Mode enabled cluster.
         * `enabled` - Indicates if the load balancing capability is enabled for EKS Auto Mode enabled cluster.

--- a/website/docs/d/eks_cluster_versions.html.markdown
+++ b/website/docs/d/eks_cluster_versions.html.markdown
@@ -65,6 +65,38 @@ This data source exports the following attributes in addition to the arguments a
 * `cluster_versions` - A list of Kubernetes version information.
     * `cluster_type` - Type of cluster that the version belongs to.
     * `cluster_version` - Kubernetes version supported by EKS.
+    * `control_plane_component_config` - Default control plane component configuration and constraints for this version.
+        * `kube_api_server_config` - Kubernetes API server configuration defaults and constraints.
+            * `event_ttl` - Event TTL configuration with default value and constraints.
+                * `default_value` - The default value for the event TTL.
+                * `constraints` - The constraints for the event TTL.
+                    * `min` - The minimum allowed duration.
+                    * `max` - The maximum allowed duration.
+            * `service_node_port_range` - Service node port range configuration with default value and constraints.
+                * `default_value` - The default port range.
+                    * `min_port` - The default minimum port.
+                    * `max_port` - The default maximum port.
+                * `constraints` - The constraints for the port range.
+                    * `min_port` - The allowed range for the minimum port (`min`, `max`).
+                    * `max_port` - The allowed range for the maximum port (`min`, `max`).
+        * `kube_controller_manager_config` - Kubernetes controller manager configuration defaults and constraints.
+            * `horizontal_pod_autoscaler_controller_config` - HPA controller configuration defaults and constraints.
+                * `horizontal_pod_autoscaler_sync_period` - HPA sync period configuration with default value and constraints.
+                    * `default_value` - The default sync period.
+                    * `constraints` - The constraints for the sync period (`min`, `max`).
+        * `kube_scheduler_config` - Kubernetes scheduler configuration defaults and constraints.
+            * `node_resources_fit` - NodeResourcesFit plugin configuration with default value and constraints.
+                * `scoring_strategy` - Scoring strategy configuration.
+                    * `default_value` - Default scoring strategy (`type`, `resources`).
+                    * `constraints` - Scoring strategy constraints.
+                        * `scoring_strategy` - Allowed values for the strategy type.
+                        * `resources` - Constraints for resource names and weights.
+    * `control_plane_scaling_tiers` - Available provisioned control plane scaling tiers and their capabilities.
+        * `tier_name` - The name of the scaling tier.
+        * `api_request_concurrency` - Maximum API request concurrency supported by this tier.
+        * `pod_scheduling_rate_per_second` - Maximum pod scheduling rate per second supported by this tier.
+        * `cluster_database_size_gb` - Maximum cluster database size in GB supported by this tier.
+        * `control_plane_component_config_overrides` - Control plane component configuration overrides specific to this tier (same structure as `control_plane_component_config`).
     * `default_platform_version` - Default eks platform version for the cluster version.
     * `default_version` - Default Kubernetes version for the cluster version.
     * `end_of_extended_support_date` - End of extended support date for the cluster version.

--- a/website/docs/r/eks_cluster.html.markdown
+++ b/website/docs/r/eks_cluster.html.markdown
@@ -353,6 +353,9 @@ The following arguments are optional:
 * `encryption_config` - (Optional) Configuration block with encryption configuration for the cluster. [Detailed](#encryption_config) below.
 * `force_update_version` - (Optional) Force version update by overriding upgrade-blocking readiness checks when updating a cluster.
 * `kubernetes_network_config` - (Optional) Configuration block with kubernetes network configuration for the cluster. [Detailed](#kubernetes_network_config) below. If removed, Terraform will only perform drift detection if a configuration value is provided.
+* `kube_api_server_config` - (Optional) Configuration block for customizing the Kubernetes API server. [Detailed](#kube_api_server_config) below.
+* `kube_controller_manager_config` - (Optional) Configuration block for customizing the Kubernetes controller manager. [Detailed](#kube_controller_manager_config) below.
+* `kube_scheduler_config` - (Optional) Configuration block for customizing the Kubernetes scheduler. [Detailed](#kube_scheduler_config) below.
 * `outpost_config` - (Optional) Configuration block representing the configuration of your local Amazon EKS cluster on an AWS Outpost. This block isn't available for creating Amazon EKS clusters on the AWS cloud.
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `remote_network_config` - (Optional) Configuration block with remote network configuration for EKS Hybrid Nodes. [Detailed](#remote_network_config) below.
@@ -414,6 +417,60 @@ The `remote_node_networks` configuration block supports the following arguments:
 The `remote_pod_networks` configuration block supports the following arguments:
 
 * `cidrs` - (Required) List of network CIDRs that can contain pods that run Kubernetes webhooks on hybrid nodes.
+
+### kube_api_server_config
+
+The `kube_api_server_config` configuration block supports the following arguments:
+
+* `event_ttl` - (Optional) The duration that Kubernetes events are retained. Must be a single-unit duration (e.g., `30m`, `1h`). Valid range: `10m` to `60m`. Default is `1h`.
+* `service_node_port_range` - (Optional) Configuration block for the port range available for NodePort services. [Detailed](#service_node_port_range) below.
+
+#### service_node_port_range
+
+The `service_node_port_range` configuration block supports the following arguments:
+
+* `min_port` - (Optional) The minimum port number in the range. Valid range: `10260` to `32767`. Default is `30000`.
+* `max_port` - (Optional) The maximum port number in the range. Valid range: `10260` to `32767`. Default is `32767`. Must be greater than or equal to `min_port`.
+
+### kube_controller_manager_config
+
+The `kube_controller_manager_config` configuration block supports the following arguments:
+
+* `horizontal_pod_autoscaler_controller_config` - (Optional) Configuration block for the horizontal pod autoscaler controller. [Detailed](#horizontal_pod_autoscaler_controller_config) below.
+
+~> **NOTE:** The `horizontal_pod_autoscaler_controller_config` requires a Provisioned Control Plane scaling tier (e.g., `tier-xl` or higher). It cannot be configured on clusters using the `standard` tier.
+
+#### horizontal_pod_autoscaler_controller_config
+
+The `horizontal_pod_autoscaler_controller_config` configuration block supports the following arguments:
+
+* `horizontal_pod_autoscaler_sync_period` - (Optional) The interval between each sync of the horizontal pod autoscaler. Must be a single-unit duration (e.g., `10s`, `15s`). Valid range: `10s` to `15s`. Default is `15s`.
+
+### kube_scheduler_config
+
+The `kube_scheduler_config` configuration block supports the following arguments:
+
+* `node_resources_fit` - (Optional) Configuration block for the NodeResourcesFit scheduler plugin. [Detailed](#node_resources_fit) below.
+
+#### node_resources_fit
+
+The `node_resources_fit` configuration block supports the following arguments:
+
+* `scoring_strategy` - (Optional) Configuration block for the scoring strategy used to rank nodes during scheduling. [Detailed](#scoring_strategy) below.
+
+#### scoring_strategy
+
+The `scoring_strategy` configuration block supports the following arguments:
+
+* `type` - (Optional) The scoring strategy type. Valid values are `LeastAllocated` and `MostAllocated`. Default is `LeastAllocated`.
+* `resources` - (Optional) List of resource weight configuration blocks for scoring nodes. [Detailed](#resources) below.
+
+#### resources
+
+The `resources` configuration block supports the following arguments:
+
+* `name` - (Optional) The name of the resource (e.g., `cpu`, `memory`, `nvidia.com/gpu`).
+* `weight` - (Optional) The weight assigned to the resource for scoring. Must be between `1` and `100`.
 
 ### vpc_config Arguments
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
Add scaling tiers and component config to aws_eks_cluster_versions data source
Expose control_plane_component_config and control_plane_scaling_tiers
attributes on the aws_eks_cluster_versions data source. These provide
per-version defaults, constraints, and tier capabilities for control
plane component customization parameters.
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Partially addresses https://github.com/hashicorp/terraform-provider-aws/issues/49411

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=eks TESTS="TestAccEKSClusterVersionsDataSource_controlPlaneComponentConfig"
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     6.805s
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework 6.572s
make: Running acceptance tests on branch: 🌿 f_aws_eks_cluster_versions_data_source_control_plane_customization 🌿...
TF_ACC=1 go1.26.5 test ./internal/service/eks/... -v -count 1 -parallel 20 -run='TestAccEKSClusterVersionsDataSource_controlPlaneComponentConfig'  -timeout 360m -vet=off -buildvcs=false
2026/08/12 13:44:01 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/12 13:44:01 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccEKSClusterVersionsDataSource_controlPlaneComponentConfig
=== PAUSE TestAccEKSClusterVersionsDataSource_controlPlaneComponentConfig
=== CONT  TestAccEKSClusterVersionsDataSource_controlPlaneComponentConfig
--- PASS: TestAccEKSClusterVersionsDataSource_controlPlaneComponentConfig (14.45s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/eks        21.291s
```
