### PR TITLE
New data source: `aws_cognito_user`

### DIFF
--- a/.changelog/49427.txt
+++ b/.changelog/49427.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_cognito_user
+```

--- a/internal/service/cognitoidp/service_package_gen.go
+++ b/internal/service/cognitoidp/service_package_gen.go
@@ -23,6 +23,12 @@ type servicePackage struct{}
 func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*inttypes.ServicePackageFrameworkDataSource {
 	return []*inttypes.ServicePackageFrameworkDataSource{
 		{
+			Factory:  newUserDataSource,
+			TypeName: "aws_cognito_user",
+			Name:     "User",
+			Region:   inttypes.ResourceRegionDefault(),
+		},
+		{
 			Factory:  newUserGroupDataSource,
 			TypeName: "aws_cognito_user_group",
 			Name:     "User Group",

--- a/internal/service/cognitoidp/user.go
+++ b/internal/service/cognitoidp/user.go
@@ -462,8 +462,8 @@ func expandAttributeTypes(tfMap map[string]any) []awstypes.AttributeType {
 	return apiObjects
 }
 
-func flattenAttributeTypes(apiObjects []awstypes.AttributeType) map[string]any {
-	tfMap := make(map[string]any)
+func flattenAttributeTypes(apiObjects []awstypes.AttributeType) map[string]string {
+	tfMap := make(map[string]string)
 
 	for _, apiObject := range apiObjects {
 		if apiObject.Name != nil {

--- a/internal/service/cognitoidp/user_data_source.go
+++ b/internal/service/cognitoidp/user_data_source.go
@@ -1,0 +1,215 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+// DONOTCOPY: Copying old resources spreads bad habits. Use skaff instead.
+
+package cognitoidp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider/types"
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
+	"github.com/hashicorp/terraform-plugin-framework-validators/datasourcevalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkDataSource("aws_cognito_user", name="User")
+func newUserDataSource(context.Context) (datasource.DataSourceWithConfigure, error) {
+	return &userDataSource{}, nil
+}
+
+type userDataSource struct {
+	framework.DataSourceWithModel[userDataSourceModel]
+}
+
+func (d *userDataSource) Schema(ctx context.Context, request datasource.SchemaRequest, response *datasource.SchemaResponse) {
+	response.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			names.AttrAttributes: schema.MapAttribute{
+				CustomType:  fwtypes.MapOfStringType,
+				ElementType: types.StringType,
+				Computed:    true,
+			},
+			names.AttrCreationDate: schema.StringAttribute{
+				CustomType: timetypes.RFC3339Type{},
+				Computed:   true,
+			},
+			names.AttrEnabled: schema.BoolAttribute{
+				Computed: true,
+			},
+			names.AttrEmail: schema.StringAttribute{
+				Optional: true,
+				Validators: []validator.String{
+					stringvalidator.LengthAtLeast(1),
+				},
+			},
+			names.AttrID: framework.IDAttribute(),
+			"last_modified_date": schema.StringAttribute{
+				CustomType: timetypes.RFC3339Type{},
+				Computed:   true,
+			},
+			"mfa_setting_list": schema.SetAttribute{
+				CustomType:  fwtypes.SetOfStringType,
+				ElementType: types.StringType,
+				Computed:    true,
+			},
+			"preferred_mfa_setting": schema.StringAttribute{
+				Computed: true,
+			},
+			names.AttrStatus: schema.StringAttribute{
+				Computed: true,
+			},
+			"sub": schema.StringAttribute{
+				Computed: true,
+			},
+			names.AttrUserPoolID: schema.StringAttribute{
+				Required: true,
+			},
+			names.AttrUsername: schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+				Validators: []validator.String{
+					stringvalidator.LengthBetween(1, 128),
+				},
+			},
+		},
+	}
+}
+
+func (d *userDataSource) ConfigValidators(context.Context) []datasource.ConfigValidator {
+	return []datasource.ConfigValidator{
+		datasourcevalidator.ExactlyOneOf(
+			path.MatchRoot(names.AttrEmail),
+			path.MatchRoot(names.AttrUsername),
+		),
+	}
+}
+
+func (d *userDataSource) Read(ctx context.Context, request datasource.ReadRequest, response *datasource.ReadResponse) {
+	var data userDataSourceModel
+	response.Diagnostics.Append(request.Config.Get(ctx, &data)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	conn := d.Meta().CognitoIDPClient(ctx)
+
+	userPoolID := data.UserPoolID.ValueString()
+	username := data.Username.ValueString()
+
+	if !data.Email.IsNull() {
+		email := data.Email.ValueString()
+		userSummary, err := tfresource.RetryWhenNotFound(ctx, propagationTimeout, func(ctx context.Context) (*awstypes.UserType, error) {
+			return findUserByEmail(ctx, conn, userPoolID, email)
+		})
+
+		if err != nil {
+			title := fmt.Sprintf("reading Cognito User by email (%s)", email)
+			switch {
+			case errors.Is(err, tfresource.ErrTooManyResults):
+				response.Diagnostics.AddError(title, fmt.Sprintf("multiple Cognito Users found with email %q; email must match exactly one user", email))
+			case retry.NotFound(err):
+				response.Diagnostics.AddError(title, fmt.Sprintf("no Cognito User found with email %q", email))
+			default:
+				response.Diagnostics.AddError(title, err.Error())
+			}
+
+			return
+		}
+
+		username = aws.ToString(userSummary.Username)
+		if username == "" {
+			response.Diagnostics.AddError(fmt.Sprintf("reading Cognito User by email (%s)", email), "email lookup returned a Cognito User without a username")
+			return
+		}
+		data.Username = types.StringValue(username)
+	}
+
+	id := userCreateResourceID(userPoolID, username)
+	user, err := findUserByTwoPartKey(ctx, conn, userPoolID, username)
+
+	if err != nil {
+		response.Diagnostics.AddError(fmt.Sprintf("reading Cognito User (%s)", id), err.Error())
+
+		return
+	}
+
+	data.Attributes = fwflex.FlattenFrameworkStringValueMapOfString(ctx, flattenAttributeTypes(user.UserAttributes))
+	data.CreationDate = timetypes.NewRFC3339TimePointerValue(user.UserCreateDate)
+	data.Enabled = types.BoolValue(user.Enabled)
+	data.ID = fwflex.StringValueToFramework(ctx, id)
+	data.LastModifiedDate = timetypes.NewRFC3339TimePointerValue(user.UserLastModifiedDate)
+	data.MFASettingList = fwflex.FlattenFrameworkStringValueSetOfStringLegacy(ctx, user.UserMFASettingList)
+	data.PreferredMFASetting = fwflex.StringToFramework(ctx, user.PreferredMfaSetting)
+	data.Status = fwflex.StringValueToFramework(ctx, user.UserStatus)
+	data.Sub = fwflex.StringToFramework(ctx, flattenUserSub(user.UserAttributes))
+
+	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
+}
+
+func findUserByEmail(ctx context.Context, conn *cognitoidentityprovider.Client, userPoolID, email string) (*awstypes.UserType, error) {
+	input := &cognitoidentityprovider.ListUsersInput{
+		Filter:     aws.String(userEmailFilter(email)),
+		Limit:      aws.Int32(2),
+		UserPoolId: aws.String(userPoolID),
+	}
+	var users []awstypes.UserType
+
+	pages := cognitoidentityprovider.NewListUsersPaginator(conn, input, func(o *cognitoidentityprovider.ListUsersPaginatorOptions) {
+		o.StopOnDuplicateToken = true
+	})
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, user := range page.Users {
+			users = append(users, user)
+			if len(users) == 2 {
+				return nil, tfresource.NewTooManyResultsError(2, input)
+			}
+		}
+	}
+
+	return tfresource.AssertSingleValueResult(users)
+}
+
+func userEmailFilter(email string) string {
+	email = strings.ReplaceAll(email, `\`, `\\`)
+	email = strings.ReplaceAll(email, `"`, `\"`)
+	return fmt.Sprintf(`email = "%s"`, email)
+}
+
+type userDataSourceModel struct {
+	framework.WithRegionModel
+	Attributes          fwtypes.MapOfString `tfsdk:"attributes"`
+	CreationDate        timetypes.RFC3339   `tfsdk:"creation_date"`
+	Enabled             types.Bool          `tfsdk:"enabled"`
+	Email               types.String        `tfsdk:"email"`
+	ID                  types.String        `tfsdk:"id"`
+	LastModifiedDate    timetypes.RFC3339   `tfsdk:"last_modified_date"`
+	MFASettingList      fwtypes.SetOfString `tfsdk:"mfa_setting_list"`
+	PreferredMFASetting types.String        `tfsdk:"preferred_mfa_setting"`
+	Status              types.String        `tfsdk:"status"`
+	Sub                 types.String        `tfsdk:"sub"`
+	UserPoolID          types.String        `tfsdk:"user_pool_id"`
+	Username            types.String        `tfsdk:"username"`
+}

--- a/internal/service/cognitoidp/user_data_source_internal_test.go
+++ b/internal/service/cognitoidp/user_data_source_internal_test.go
@@ -1,0 +1,30 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package cognitoidp
+
+import "testing"
+
+func TestUserEmailFilter(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		input string
+		want  string
+	}{
+		"plain":               {input: "user@example.com", want: `email = "user@example.com"`},
+		"quotation mark":      {input: `user"tag@example.com`, want: `email = "user\"tag@example.com"`},
+		"backslash":           {input: `user\tag@example.com`, want: `email = "user\\tag@example.com"`},
+		"backslash and quote": {input: `user\"tag@example.com`, want: `email = "user\\\"tag@example.com"`},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := userEmailFilter(testCase.input); got != testCase.want {
+				t.Fatalf("userEmailFilter(%q) = %q, want %q", testCase.input, got, testCase.want)
+			}
+		})
+	}
+}

--- a/internal/service/cognitoidp/user_data_source_test.go
+++ b/internal/service/cognitoidp/user_data_source_test.go
@@ -1,0 +1,83 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package cognitoidp_test
+
+import (
+	"fmt"
+	"testing"
+
+	awstypes "github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider/types"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccCognitoIDPUserDataSource_selectors(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	email := acctest.RandomEmailAddress(acctest.RandomDomainName(t))
+	emailDataSourceName := "data.aws_cognito_user.by_email"
+	usernameDataSourceName := "data.aws_cognito_user.by_username"
+	resourceName := "aws_cognito_user.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckIdentityProvider(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CognitoIDPServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckUserDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserDataSourceConfig_selectors(rName, email),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(emailDataSourceName, names.AttrUserPoolID, resourceName, names.AttrUserPoolID),
+					resource.TestCheckResourceAttrPair(emailDataSourceName, names.AttrEmail, resourceName, "attributes.email"),
+					resource.TestCheckResourceAttrPair(emailDataSourceName, names.AttrUsername, resourceName, names.AttrUsername),
+					resource.TestCheckResourceAttrPair(emailDataSourceName, "attributes.email", resourceName, "attributes.email"),
+					resource.TestCheckResourceAttr(emailDataSourceName, "attributes.email_verified", acctest.CtFalse),
+					resource.TestCheckResourceAttrPair(emailDataSourceName, names.AttrID, resourceName, names.AttrID),
+					resource.TestCheckResourceAttrSet(emailDataSourceName, names.AttrCreationDate),
+					resource.TestCheckResourceAttrSet(emailDataSourceName, "last_modified_date"),
+					resource.TestCheckResourceAttrSet(emailDataSourceName, "sub"),
+					resource.TestCheckResourceAttr(emailDataSourceName, names.AttrEnabled, acctest.CtTrue),
+					resource.TestCheckResourceAttr(emailDataSourceName, "mfa_setting_list.#", "0"),
+					resource.TestCheckResourceAttr(emailDataSourceName, names.AttrStatus, string(awstypes.UserStatusTypeForceChangePassword)),
+					resource.TestCheckResourceAttrPair(usernameDataSourceName, names.AttrUsername, resourceName, names.AttrUsername),
+					resource.TestCheckResourceAttrPair(usernameDataSourceName, names.AttrID, resourceName, names.AttrID),
+					resource.TestCheckResourceAttrPair(usernameDataSourceName, "attributes.email", resourceName, "attributes.email"),
+					resource.TestCheckResourceAttr(usernameDataSourceName, names.AttrStatus, string(awstypes.UserStatusTypeForceChangePassword)),
+				),
+			},
+		},
+	})
+}
+
+func testAccUserDataSourceConfig_selectors(rName, email string) string {
+	return fmt.Sprintf(`
+resource "aws_cognito_user_pool" "test" {
+  name             = %[1]q
+  alias_attributes = ["email"]
+}
+
+resource "aws_cognito_user" "test" {
+  user_pool_id   = aws_cognito_user_pool.test.id
+  username       = %[1]q
+  message_action = "SUPPRESS"
+
+  attributes = {
+    email          = %[2]q
+    email_verified = "false"
+  }
+}
+
+data "aws_cognito_user" "by_email" {
+  user_pool_id = aws_cognito_user.test.user_pool_id
+  email        = aws_cognito_user.test.attributes.email
+}
+
+data "aws_cognito_user" "by_username" {
+  user_pool_id = aws_cognito_user.test.user_pool_id
+  username     = aws_cognito_user.test.username
+}
+`, rName, email)
+}

--- a/website/docs/d/cognito_user.html.markdown
+++ b/website/docs/d/cognito_user.html.markdown
@@ -1,0 +1,62 @@
+---
+subcategory: "Cognito IDP (Identity Provider)"
+layout: "aws"
+page_title: "AWS: aws_cognito_user"
+description: |-
+  Retrieves an Amazon Cognito user.
+---
+
+# Data Source: aws_cognito_user
+
+Retrieves an Amazon Cognito user by username or exact email address. Both lookup paths use the `AdminGetUser` API operation to return full user details.
+
+~> **Note:** Each read calls `AdminGetUser` and contributes to the user pool's monthly active user (MAU) count for billing purposes. `ListUsers`, used for email lookup, does not contribute to MAU billing. See the [`AdminGetUser` API reference](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminGetUser.html).
+
+## Example Usage
+
+### Username Lookup
+
+```hcl
+data "aws_cognito_user" "example" {
+  user_pool_id = "us-west-2_aaaaaaaaa"
+  username     = "example-user"
+}
+```
+
+### Exact Email Lookup
+
+```hcl
+data "aws_cognito_user" "example" {
+  user_pool_id = "us-west-2_aaaaaaaaa"
+  email        = "user@example.com"
+}
+```
+
+Email lookup first calls the eventually consistent [`ListUsers` API](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_ListUsers.html) with an exact `email` filter. Exactly one user must match. The data source then calls `AdminGetUser` with the matched user's canonical username. Custom attributes cannot be used as lookup selectors.
+
+An active email alias can be supplied with `username`. Use the explicit `email` selector to find users whose stored email is unverified or otherwise not an active alias.
+
+The caller needs `cognito-idp:AdminGetUser` permission for username lookup. Email lookup needs both `cognito-idp:ListUsers` and `cognito-idp:AdminGetUser`.
+
+## Argument Reference
+
+This data source supports the following arguments:
+
+* `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
+* `user_pool_id` - (Required) ID of the user pool containing the user.
+* `email` - (Optional) Exact value of the user's standard `email` attribute. Conflicts with `username`. Exactly one of `email` or `username` must be configured.
+* `username` - (Optional) Username or configured active alias attribute of the user. Length must be between 1 and 128 characters. Conflicts with `email`. Exactly one of `email` or `username` must be configured. When `email` is configured, this attribute exports the resolved canonical username.
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `id` - ID combining `user_pool_id` and the configured `username` selector, or `user_pool_id` and the resolved canonical username for email lookup.
+* `attributes` - Map of user attributes.
+* `creation_date` - Date and time when the user was created in RFC3339 format.
+* `enabled` - Whether the user is enabled.
+* `last_modified_date` - Date and time when the user was last modified in RFC3339 format.
+* `mfa_setting_list` - MFA methods activated for the user.
+* `preferred_mfa_setting` - Preferred MFA method for the user.
+* `status` - User status.
+* `sub` - Unique user identifier.


### PR DESCRIPTION
## Rollback Plan

If this change needs to be reverted, publish an updated provider version without the data source.

## Changes to Security Controls

No changes to security controls.

### Description

Adds the `aws_cognito_user` data source for retrieving an existing Amazon Cognito user by username or exact email address.

The data source accepts `user_pool_id` and exactly one of `username` or `email`. Username lookup calls `AdminGetUser` directly. Email lookup uses an exact `ListUsers` filter, requires exactly one match, then calls `AdminGetUser` with the resolved canonical username. This supports federated users and users whose stored email is unverified or otherwise not an active alias.

The data source exports the user's canonical username, attributes, timestamps, enabled state, MFA settings, status, and `sub`.

Documentation notes required IAM permissions, `ListUsers` eventual consistency, and that `AdminGetUser` contributes to Amazon Cognito monthly active user (MAU) billing.

### Relations

Closes #49426

### References

- https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminGetUser.html
- https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_ListUsers.html
- https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-attributes.html#user-pool-settings-aliases

### Output from Acceptance Testing

Not run locally because AWS test credentials were not provided.

```console
% make testacc TESTS=TestAccCognitoIDPUserDataSource_selectors PKG=cognitoidp

Not run
```

Focused static validation:

```console
% go generate ./internal/service/cognitoidp
% go test ./internal/service/cognitoidp
% terrafmt diff --check --fmtcompat internal/service/cognitoidp/user_data_source_test.go
% terrafmt diff website/docs/d/cognito_user.html.markdown --check

PASS
```
