### PR TITLE
Add IBM Bob project rules pointing to shared .agents assets

### DIFF
--- a/.bob/rules/00-overview.md
+++ b/.bob/rules/00-overview.md
@@ -1,0 +1,15 @@
+<!-- Copyright IBM Corp. 2014, 2026 -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
+# IBM Bob Project Rules
+
+This repository implements the [Terraform AWS Provider](https://registry.terraform.io/providers/hashicorp/aws/latest/docs): a Go bridge that maps AWS APIs to Terraform resources, data sources, ephemeral resources, and actions using the AWS SDK for Go v2. It is a [muxed](https://developer.hashicorp.com/terraform/plugin/mux) provider using both the Terraform Plugin Framework (new work) and Plugin SDKv2 (legacy).
+
+## Where the guidance lives
+
+Agent guidance is tool-agnostic and shared. Do not duplicate it here.
+
+- [`AGENTS.md`](../../AGENTS.md) — repository overview, stack, conventions, build/test commands, and AI-usage policy. Bob loads this automatically.
+- [`.agents/`](../../.agents) — personas (`contributor`, `maintainer`, `tcm`) and skills (`.agents/skills/`) for scoped tasks such as PR review, changelog entries, and documentation fixes.
+
+Default to the `@contributor` persona unless another is requested, and invoke the relevant skill for the task at hand.

--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,8 @@
 *.test
 *~
 /.kiro
-/.bob
+/.bob/*
+!/.bob/rules/
 /.opencode
 /pkg/
 aws/testdata/service/cloudformation/examplecompany-exampleservice-exampleresource/bin/handler


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
