### PR TITLE
aws_bedrockagentcore_harness: Handles remote resource disappearing during List

### DIFF
--- a/.changelog/49446.txt
+++ b/.changelog/49446.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+list-resource/aws_bedrockagentcore_harness: Prevents error when remote resource disappears during List
+```

--- a/internal/service/bedrockagentcore/harness_list.go
+++ b/internal/service/bedrockagentcore/harness_list.go
@@ -15,7 +15,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/logging"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/smerr"
 	inttypes "github.com/hashicorp/terraform-provider-aws/internal/types"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -57,20 +59,30 @@ func (l *harnessListResource) List(ctx context.Context, request list.ListRequest
 			ctx := tflog.SetField(ctx, logging.ResourceAttributeKey(names.AttrARN), arn)
 
 			harnessID := aws.ToString(item.HarnessId)
-			output, err := findHarnessByID(ctx, conn, harnessID)
-			if err != nil {
-				result := fwdiag.NewListResultErrorDiagnostic(err)
-				yield(result)
-				return
+			var output *awstypes.Harness
+			if request.IncludeResource {
+				var err error
+				output, err = findHarnessByID(ctx, conn, harnessID)
+				if retry.NotFound(err) {
+					continue
+				}
+				if err != nil {
+					yield(fwdiag.NewListResultErrorDiagnostic(err))
+					return
+				}
 			}
 
 			result := request.NewListResult(ctx)
 
 			var data harnessResourceModel
 			l.SetResult(ctx, l.Meta(), request.IncludeResource, &data, &result, func() {
-				smerr.AddEnrich(ctx, &result.Diagnostics, l.flatten(ctx, output, &data, true))
-				if result.Diagnostics.HasError() {
-					return
+				if request.IncludeResource {
+					smerr.AddEnrich(ctx, &result.Diagnostics, l.flatten(ctx, output, &data, true))
+					if result.Diagnostics.HasError() {
+						return
+					}
+				} else {
+					data.HarnessID = fwflex.StringValueToFramework(ctx, harnessID)
 				}
 
 				result.DisplayName = aws.ToString(item.HarnessName)


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
`aws_bedrockagentcore_harness`: Handles remote resource disppearing during List

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=bedrockagentcore TESTS=TestAccBedrockAgentCoreHarness_List_

--- PASS: TestAccBedrockAgentCoreHarness_List_basic (361.33s)
--- PASS: TestAccBedrockAgentCoreHarness_List_includeResource (361.92s)
--- PASS: TestAccBedrockAgentCoreHarness_List_regionOverride (395.35s)
```

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>