### PR TITLE
fix(bedrockagentcore): filter policy session header from gateway targ…

### DIFF
--- a/.changelog/49374.txt
+++ b/.changelog/49374.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_bedrockagentcore_gateway_target: Remove client-side count validation for `metadata_configuration` request and response headers
+resource/aws_bedrockagentcore_gateway_target: Remove client-side count validation for `metadata_configuration` request and response headers and prevent state inconsistencies caused by the service-managed policy session header
 ```

--- a/.changelog/49374.txt
+++ b/.changelog/49374.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_bedrockagentcore_gateway_target: Remove client-side count validation for `metadata_configuration` request and response headers and prevent state inconsistencies caused by the service-managed policy session header
+resource/aws_bedrockagentcore_gateway_target: Remove client-side count validation for `metadata_configuration` request and response headers
 ```

--- a/.changelog/49447.txt
+++ b/.changelog/49447.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_bedrockagentcore_gateway_target: Prevent state inconsistencies caused by the service-managed policy session header
+```

--- a/internal/service/bedrockagentcore/exports_test.go
+++ b/internal/service/bedrockagentcore/exports_test.go
@@ -48,6 +48,7 @@ var (
 	FindPolicyEngineByID                 = findPolicyEngineByID
 	FindRegistryByID                     = findRegistryByID
 	FindWorkloadIdentityByName           = findWorkloadIdentityByName
+	NormalizeGatewayTargetOutputForState = normalizeGatewayTargetOutputForState
 )
 
 type (

--- a/internal/service/bedrockagentcore/gateway_target.go
+++ b/internal/service/bedrockagentcore/gateway_target.go
@@ -980,7 +980,7 @@ func (r *gatewayTargetResource) Create(ctx context.Context, request resource.Cre
 	}
 
 	// Set values for unknowns.
-	target = normalizeGatewayTargetOutputForState(target, len(data.MetadataConfiguration.Elements()) > 0)
+	target = normalizeGatewayTargetOutputForState(target, data.MetadataConfiguration.Length(fwtypes.CollectionLengthUnhandledAsZero) > 0)
 	smerr.AddEnrich(ctx, &response.Diagnostics, fwflex.Flatten(ctx, target, &data))
 	if response.Diagnostics.HasError() {
 		return
@@ -1010,7 +1010,7 @@ func (r *gatewayTargetResource) Read(ctx context.Context, request resource.ReadR
 		return
 	}
 
-	out = normalizeGatewayTargetOutputForState(out, len(data.MetadataConfiguration.Elements()) > 0)
+	out = normalizeGatewayTargetOutputForState(out, data.MetadataConfiguration.Length(fwtypes.CollectionLengthUnhandledAsZero) > 0)
 	smerr.AddEnrich(ctx, &response.Diagnostics, fwflex.Flatten(ctx, out, &data, fwflex.WithIgnoredFieldNames([]string{"GatewayArn"})))
 	if response.Diagnostics.HasError() {
 		return

--- a/internal/service/bedrockagentcore/gateway_target.go
+++ b/internal/service/bedrockagentcore/gateway_target.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"iter"
+	"slices"
 	"strings"
 	"time"
 
@@ -52,6 +53,8 @@ import (
 	inttypes "github.com/hashicorp/terraform-provider-aws/internal/types"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
+
+const gatewayTargetPolicySessionIDHeader = "x-amzn-bedrock-agentcore-policy-session-id"
 
 // @FrameworkResource("aws_bedrockagentcore_gateway_target", name="Gateway Target")
 func newGatewayTargetResource(_ context.Context) (resource.ResourceWithConfigure, error) {
@@ -977,6 +980,7 @@ func (r *gatewayTargetResource) Create(ctx context.Context, request resource.Cre
 	}
 
 	// Set values for unknowns.
+	target = normalizeGatewayTargetOutputForState(target, len(data.MetadataConfiguration.Elements()) > 0)
 	smerr.AddEnrich(ctx, &response.Diagnostics, fwflex.Flatten(ctx, target, &data))
 	if response.Diagnostics.HasError() {
 		return
@@ -1006,6 +1010,7 @@ func (r *gatewayTargetResource) Read(ctx context.Context, request resource.ReadR
 		return
 	}
 
+	out = normalizeGatewayTargetOutputForState(out, len(data.MetadataConfiguration.Elements()) > 0)
 	smerr.AddEnrich(ctx, &response.Diagnostics, fwflex.Flatten(ctx, out, &data, fwflex.WithIgnoredFieldNames([]string{"GatewayArn"})))
 	if response.Diagnostics.HasError() {
 		return
@@ -1051,6 +1056,33 @@ func (r *gatewayTargetResource) Update(ctx context.Context, request resource.Upd
 	}
 
 	smerr.AddEnrich(ctx, &response.Diagnostics, response.State.Set(ctx, &new))
+}
+
+func normalizeGatewayTargetOutputForState(out *bedrockagentcorecontrol.GetGatewayTargetOutput, preserveEmptyMetadataConfiguration bool) *bedrockagentcorecontrol.GetGatewayTargetOutput {
+	if out == nil || out.MetadataConfiguration == nil {
+		return out
+	}
+
+	allowedRequestHeaders := slices.DeleteFunc(slices.Clone(out.MetadataConfiguration.AllowedRequestHeaders), func(header string) bool {
+		return strings.EqualFold(header, gatewayTargetPolicySessionIDHeader)
+	})
+	if len(allowedRequestHeaders) == len(out.MetadataConfiguration.AllowedRequestHeaders) {
+		return out
+	}
+
+	normalized := *out
+	metadataConfiguration := *out.MetadataConfiguration
+	metadataConfiguration.AllowedRequestHeaders = allowedRequestHeaders
+	if !preserveEmptyMetadataConfiguration &&
+		len(metadataConfiguration.AllowedRequestHeaders) == 0 &&
+		len(metadataConfiguration.AllowedResponseHeaders) == 0 &&
+		len(metadataConfiguration.AllowedQueryParameters) == 0 {
+		normalized.MetadataConfiguration = nil
+	} else {
+		normalized.MetadataConfiguration = &metadataConfiguration
+	}
+
+	return &normalized
 }
 
 func (r *gatewayTargetResource) Delete(ctx context.Context, request resource.DeleteRequest, response *resource.DeleteResponse) {

--- a/internal/service/bedrockagentcore/gateway_target_test.go
+++ b/internal/service/bedrockagentcore/gateway_target_test.go
@@ -1012,12 +1012,12 @@ func TestNormalizeGatewayTargetOutputForState(t *testing.T) {
 		},
 		"implicit header removed": {
 			metadataConfiguration: &awstypes.MetadataConfiguration{
-				AllowedQueryParameters: []string{"version"},
+				AllowedQueryParameters: []string{names.AttrVersion},
 				AllowedRequestHeaders:  []string{"x-correlation-id", testAccGatewayTargetPolicySessionIDHeader},
 				AllowedResponseHeaders: []string{"x-response-id"},
 			},
 			expectedMetadataConfiguration: &awstypes.MetadataConfiguration{
-				AllowedQueryParameters: []string{"version"},
+				AllowedQueryParameters: []string{names.AttrVersion},
 				AllowedRequestHeaders:  []string{"x-correlation-id"},
 				AllowedResponseHeaders: []string{"x-response-id"},
 			},

--- a/internal/service/bedrockagentcore/gateway_target_test.go
+++ b/internal/service/bedrockagentcore/gateway_target_test.go
@@ -6,6 +6,7 @@ package bedrockagentcore_test
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/YakDriver/regexache"
@@ -26,6 +27,8 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
+
+const testAccGatewayTargetPolicySessionIDHeader = "x-amzn-bedrock-agentcore-policy-session-id"
 
 func testAccGatewayTargetImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
 	return acctest.AttrsImportStateIdFunc(resourceName, ",", "gateway_identifier", "target_id")
@@ -873,6 +876,78 @@ func TestAccBedrockAgentCoreGatewayTarget_metadataConfiguration(t *testing.T) {
 	})
 }
 
+func TestAccBedrockAgentCoreGatewayTarget_metadataConfiguration_policySessionHeader(t *testing.T) {
+	ctx := acctest.Context(t)
+	var gatewayTarget bedrockagentcorecontrol.GetGatewayTargetOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	rNamePolicyEngine := randomWithPrefixAndUnderscore(t)
+	resourceName := "aws_bedrockagentcore_gateway_target.test"
+	metadataConfiguration := `
+  metadata_configuration {
+    allowed_request_headers = ["x-correlation-id", "x-tenant-id"]
+  }
+`
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID)
+			testAccPreCheckGateways(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockAgentCoreServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckGatewayTargetDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGatewayTargetConfig_policySessionHeader(rName, rNamePolicyEngine, ""),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckGatewayTargetExists(ctx, t, resourceName, &gatewayTarget),
+					testAccCheckGatewayTargetHasRequestHeader(&gatewayTarget, testAccGatewayTargetPolicySessionIDHeader),
+					resource.TestCheckResourceAttr(resourceName, "metadata_configuration.#", "0"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+			},
+			{
+				Config: testAccGatewayTargetConfig_policySessionHeader(rName, rNamePolicyEngine, metadataConfiguration),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckGatewayTargetExists(ctx, t, resourceName, &gatewayTarget),
+					testAccCheckGatewayTargetHasRequestHeader(&gatewayTarget, testAccGatewayTargetPolicySessionIDHeader),
+					resource.TestCheckResourceAttr(resourceName, "metadata_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_configuration.0.allowed_request_headers.#", "2"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "metadata_configuration.0.allowed_request_headers.*", "x-correlation-id"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "metadata_configuration.0.allowed_request_headers.*", "x-tenant-id"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateIdFunc:                    testAccGatewayTargetImportStateIDFunc(resourceName),
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "target_id",
+			},
+			{
+				Config: testAccGatewayTargetConfig_policySessionHeaderDetached(rName, rNamePolicyEngine, metadataConfiguration),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckGatewayTargetExists(ctx, t, resourceName, &gatewayTarget),
+					resource.TestCheckResourceAttr(resourceName, "metadata_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_configuration.0.allowed_request_headers.#", "2"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "metadata_configuration.0.allowed_request_headers.*", "x-correlation-id"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "metadata_configuration.0.allowed_request_headers.*", "x-tenant-id"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccBedrockAgentCoreGatewayTarget_metadataConfiguration_invalidHeaders(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
@@ -917,6 +992,110 @@ func TestAccBedrockAgentCoreGatewayTarget_metadataConfiguration_invalidHeaders(t
 			},
 		},
 	})
+}
+
+func TestNormalizeGatewayTargetOutputForState(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		metadataConfiguration         *awstypes.MetadataConfiguration
+		preserveEmptyMetadata         bool
+		expectedMetadataConfiguration *awstypes.MetadataConfiguration
+	}{
+		"no implicit header": {
+			metadataConfiguration: &awstypes.MetadataConfiguration{
+				AllowedRequestHeaders: []string{"x-correlation-id"},
+			},
+			expectedMetadataConfiguration: &awstypes.MetadataConfiguration{
+				AllowedRequestHeaders: []string{"x-correlation-id"},
+			},
+		},
+		"implicit header removed": {
+			metadataConfiguration: &awstypes.MetadataConfiguration{
+				AllowedQueryParameters: []string{"version"},
+				AllowedRequestHeaders:  []string{"x-correlation-id", testAccGatewayTargetPolicySessionIDHeader},
+				AllowedResponseHeaders: []string{"x-response-id"},
+			},
+			expectedMetadataConfiguration: &awstypes.MetadataConfiguration{
+				AllowedQueryParameters: []string{"version"},
+				AllowedRequestHeaders:  []string{"x-correlation-id"},
+				AllowedResponseHeaders: []string{"x-response-id"},
+			},
+		},
+		"all case-insensitive occurrences removed": {
+			metadataConfiguration: &awstypes.MetadataConfiguration{
+				AllowedRequestHeaders: []string{
+					"X-Amzn-Bedrock-AgentCore-Policy-Session-Id",
+					testAccGatewayTargetPolicySessionIDHeader,
+				},
+			},
+			preserveEmptyMetadata: true,
+			expectedMetadataConfiguration: &awstypes.MetadataConfiguration{
+				AllowedRequestHeaders: []string{},
+			},
+		},
+		"service-created metadata removed when empty": {
+			metadataConfiguration: &awstypes.MetadataConfiguration{
+				AllowedRequestHeaders: []string{testAccGatewayTargetPolicySessionIDHeader},
+			},
+			expectedMetadataConfiguration: nil,
+		},
+		"configured empty metadata preserved": {
+			metadataConfiguration: &awstypes.MetadataConfiguration{
+				AllowedRequestHeaders: []string{testAccGatewayTargetPolicySessionIDHeader},
+			},
+			preserveEmptyMetadata: true,
+			expectedMetadataConfiguration: &awstypes.MetadataConfiguration{
+				AllowedRequestHeaders: []string{},
+			},
+		},
+		"other metadata preserves service-created object": {
+			metadataConfiguration: &awstypes.MetadataConfiguration{
+				AllowedRequestHeaders:  []string{testAccGatewayTargetPolicySessionIDHeader},
+				AllowedResponseHeaders: []string{"x-response-id"},
+			},
+			expectedMetadataConfiguration: &awstypes.MetadataConfiguration{
+				AllowedRequestHeaders:  []string{},
+				AllowedResponseHeaders: []string{"x-response-id"},
+			},
+		},
+	}
+
+	if got := tfbedrockagentcore.NormalizeGatewayTargetOutputForState(nil, false); got != nil {
+		t.Fatalf("expected nil output, got %#v", got)
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			originalRequestHeaders := append([]string(nil), testCase.metadataConfiguration.AllowedRequestHeaders...)
+			input := &bedrockagentcorecontrol.GetGatewayTargetOutput{
+				MetadataConfiguration: testCase.metadataConfiguration,
+			}
+
+			got := tfbedrockagentcore.NormalizeGatewayTargetOutputForState(input, testCase.preserveEmptyMetadata)
+
+			if diff := cmp.Diff(originalRequestHeaders, input.MetadataConfiguration.AllowedRequestHeaders); diff != "" {
+				t.Errorf("input mutated (-before, +after):\n%s", diff)
+			}
+			if (got.MetadataConfiguration == nil) != (testCase.expectedMetadataConfiguration == nil) {
+				t.Fatalf("unexpected metadata configuration: got %#v, expected %#v", got.MetadataConfiguration, testCase.expectedMetadataConfiguration)
+			}
+			if got.MetadataConfiguration == nil {
+				return
+			}
+			if diff := cmp.Diff(testCase.expectedMetadataConfiguration.AllowedQueryParameters, got.MetadataConfiguration.AllowedQueryParameters); diff != "" {
+				t.Errorf("unexpected allowed query parameters (-want, +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(testCase.expectedMetadataConfiguration.AllowedRequestHeaders, got.MetadataConfiguration.AllowedRequestHeaders); diff != "" {
+				t.Errorf("unexpected allowed request headers (-want, +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(testCase.expectedMetadataConfiguration.AllowedResponseHeaders, got.MetadataConfiguration.AllowedResponseHeaders); diff != "" {
+				t.Errorf("unexpected allowed response headers (-want, +got):\n%s", diff)
+			}
+		})
+	}
 }
 
 func TestBedrockAgentCoreGatewayTargetPrivateEndpointAutoFlexExpand(t *testing.T) {
@@ -1286,7 +1465,26 @@ func testAccCheckGatewayTargetExists(ctx context.Context, t *testing.T, n string
 	}
 }
 
+func testAccCheckGatewayTargetHasRequestHeader(v *bedrockagentcorecontrol.GetGatewayTargetOutput, expected string) resource.TestCheckFunc {
+	return func(*terraform.State) error {
+		if v.MetadataConfiguration == nil {
+			return fmt.Errorf("expected metadata configuration")
+		}
+		for _, header := range v.MetadataConfiguration.AllowedRequestHeaders {
+			if strings.EqualFold(header, expected) {
+				return nil
+			}
+		}
+
+		return fmt.Errorf("expected request header %q, got %v", expected, v.MetadataConfiguration.AllowedRequestHeaders)
+	}
+}
+
 func testAccGatewayTargetConfig_base(rName string) string {
+	return testAccGatewayTargetConfig_baseWithGatewayConfiguration(rName, "")
+}
+
+func testAccGatewayTargetConfig_baseWithGatewayConfiguration(rName, gatewayConfiguration string) string {
 	return fmt.Sprintf(`
 data "aws_partition" "current" {}
 data "aws_region" "current" {}
@@ -1368,8 +1566,48 @@ resource "aws_bedrockagentcore_gateway" "test" {
   }
 
   protocol_type = "MCP"
+%[2]s
 }
-`, rName)
+`, rName, gatewayConfiguration)
+}
+
+func testAccGatewayTargetConfig_baseWithPolicyEngine(rName, rNamePolicyEngine string) string {
+	return acctest.ConfigCompose(
+		testAccGatewayTargetConfig_baseWithGatewayConfiguration(rName, `
+  policy_engine_configuration {
+    arn  = aws_bedrockagentcore_policy_engine.test.policy_engine_arn
+    mode = "LOG_ONLY"
+  }
+
+  depends_on = [aws_iam_role_policy_attachment.policy_engine]
+`),
+		fmt.Sprintf(`
+resource "aws_bedrockagentcore_policy_engine" "test" {
+  name = %[1]q
+}
+
+resource "aws_iam_role_policy_attachment" "policy_engine" {
+  role       = aws_iam_role.test.name
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/BedrockAgentCoreFullAccess"
+}
+`, rNamePolicyEngine),
+	)
+}
+
+func testAccGatewayTargetConfig_baseWithDetachedPolicyEngine(rName, rNamePolicyEngine string) string {
+	return acctest.ConfigCompose(
+		testAccGatewayTargetConfig_base(rName),
+		fmt.Sprintf(`
+resource "aws_bedrockagentcore_policy_engine" "test" {
+  name = %[1]q
+}
+
+resource "aws_iam_role_policy_attachment" "policy_engine" {
+  role       = aws_iam_role.test.name
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/BedrockAgentCoreFullAccess"
+}
+`, rNamePolicyEngine),
+	)
 }
 
 func testAccGatewayTargetConfig_basic(rName string) string {
@@ -1944,6 +2182,38 @@ resource "aws_bedrockagentcore_gateway_target" "test" {
   }
 }
 `, rName))
+}
+
+func testAccGatewayTargetConfig_policySessionHeader(rName, rNamePolicyEngine, metadataConfiguration string) string {
+	return acctest.ConfigCompose(
+		testAccGatewayTargetConfig_baseWithPolicyEngine(rName, rNamePolicyEngine),
+		testAccGatewayTargetConfig_policySessionHeaderTarget(rName, metadataConfiguration),
+	)
+}
+
+func testAccGatewayTargetConfig_policySessionHeaderDetached(rName, rNamePolicyEngine, metadataConfiguration string) string {
+	return acctest.ConfigCompose(
+		testAccGatewayTargetConfig_baseWithDetachedPolicyEngine(rName, rNamePolicyEngine),
+		testAccGatewayTargetConfig_policySessionHeaderTarget(rName, metadataConfiguration),
+	)
+}
+
+func testAccGatewayTargetConfig_policySessionHeaderTarget(rName, metadataConfiguration string) string {
+	return fmt.Sprintf(`
+resource "aws_bedrockagentcore_gateway_target" "test" {
+  name               = %[1]q
+  gateway_identifier = aws_bedrockagentcore_gateway.test.gateway_id
+
+  target_configuration {
+    mcp {
+      mcp_server {
+        endpoint = "https://docs.mcp.cloudflare.com/mcp"
+      }
+    }
+  }
+%[2]s
+}
+`, rName, metadataConfiguration)
 }
 
 func testAccGatewayTargetConfig_metadataConfigurationInvalidHeader(rName, headerName string) string {


### PR DESCRIPTION
## Description
Fixes metadata header handling for `aws_bedrockagentcore_gateway_target`

A recent update to AgentCore Gateway caused the service to add managed `x-amzn-bedrock-agentcore-policy-session-id` header to `metadata_configuration` implicitly. Since this header is not present in user configurations, terraform validation will reject the header when writing to state.

This change filters the implicit header (case-insensitively) from the metadata configuration block in the gateway response before writing to terraform state. Normalization is done after Create, and during Read. User configured request/response headers and query parameters are preserved. An empty metadata block supplied by the user is preserved as well.

Relates #49374.

## Source
- GitHub issue: https://github.com/hashicorp/terraform-provider-aws/issues/49374
- AgentCore Control API: `GetGatewayTargetOutput.MetadataConfiguration.AllowedRequestHeaders`

## Testing
Unit test:

```console
$ make test PKG=bedrockagentcore T=TestNormalizeGatewayTargetOutputForState
ok  github.com/hashicorp/terraform-provider-aws/internal/service/bedrockagentcore  7.289s
```

Acceptance test:
```
$ make testacc PKG=bedrockagentcore T=TestAccBedrockAgentCoreGatewayTarget_metadataConfiguration_policySessionHeader
=== RUN   TestAccBedrockAgentCoreGatewayTarget_metadataConfiguration_policySessionHeader
=== PAUSE TestAccBedrockAgentCoreGatewayTarget_metadataConfiguration_policySessionHeader
=== CONT  TestAccBedrockAgentCoreGatewayTarget_metadataConfiguration_policySessionHeader
--- PASS: TestAccBedrockAgentCoreGatewayTarget_metadataConfiguration_policySessionHeader (68.14s)
PASS
ok  github.com/hashicorp/terraform-provider-aws/internal/service/bedrockagentcore  74.867s
```