### PR TITLE
🤖🤖🤖 r/aws_bedrockagentcore_harness: fix inconsistent result after apply for environment.agentcore_runtime_environment (#48159)

### DIFF
--- a/.changelog/48815.txt
+++ b/.changelog/48815.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_bedrockagentcore_harness: Fix `Provider produced inconsistent result after apply` when creating a harness with an `environment` block
+```

--- a/internal/service/bedrockagentcore/harness.go
+++ b/internal/service/bedrockagentcore/harness.go
@@ -85,8 +85,7 @@ func (r *harnessResource) Schema(ctx context.Context, request resource.SchemaReq
 					listplanmodifier.UseStateForUnknown(),
 				},
 			},
-			names.AttrARN:         framework.ARNAttributeComputedOnly(),
-			names.AttrEnvironment: framework.ResourceOptionalComputedSingleNestedObjectAttribute[harnessEnvironmentProviderModel](ctx),
+			names.AttrARN: framework.ARNAttributeComputedOnly(),
 			"environment_variables": schema.MapAttribute{
 				CustomType: fwtypes.MapOfStringType,
 				Optional:   true,
@@ -130,6 +129,105 @@ func (r *harnessResource) Schema(ctx context.Context, request resource.SchemaReq
 		},
 		Blocks: map[string]schema.Block{
 			"authorizer_configuration": authorizerConfigurationSchema(ctx),
+			names.AttrEnvironment: schema.ListNestedBlock{
+				CustomType: fwtypes.NewListNestedObjectTypeOf[harnessEnvironmentProviderModel](ctx),
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Blocks: map[string]schema.Block{
+						"agentcore_runtime_environment": schema.ListNestedBlock{
+							CustomType: fwtypes.NewListNestedObjectTypeOf[harnessAgentCoreRuntimeEnvironmentModel](ctx),
+							Validators: []validator.List{
+								listvalidator.SizeAtMost(1),
+							},
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									// Server-assigned: the API derives these from the harness after
+									// create, so they must be Computed to avoid a post-apply
+									// inconsistency (see hashicorp/terraform-provider-aws#48159).
+									"agent_runtime_arn": schema.StringAttribute{
+										CustomType: fwtypes.ARNType,
+										Computed:   true,
+										PlanModifiers: []planmodifier.String{
+											stringplanmodifier.UseStateForUnknown(),
+										},
+									},
+									"agent_runtime_id": schema.StringAttribute{
+										Computed: true,
+										PlanModifiers: []planmodifier.String{
+											stringplanmodifier.UseStateForUnknown(),
+										},
+									},
+									"agent_runtime_name": schema.StringAttribute{
+										Computed: true,
+										PlanModifiers: []planmodifier.String{
+											stringplanmodifier.UseStateForUnknown(),
+										},
+									},
+									// Optional+Computed list-of-object attribute (not a block): the
+									// API defaults this when not supplied (idle_runtime_session_timeout=900,
+									// max_lifetime=28800), so an unset lifecycle_configuration must be
+									// able to become known after apply. A block cannot be Computed, and
+									// protocol v5 cannot nest attribute metadata inside a block, so this
+									// is modeled as a typed ListAttribute (see #48159).
+									"lifecycle_configuration": schema.ListAttribute{
+										CustomType: fwtypes.NewListNestedObjectTypeOf[lifecycleConfigurationModel](ctx),
+										Optional:   true,
+										Computed:   true,
+										Validators: []validator.List{
+											listvalidator.SizeAtMost(1),
+										},
+										PlanModifiers: []planmodifier.List{
+											listplanmodifier.UseStateForUnknown(),
+										},
+										ElementType: types.ObjectType{
+											AttrTypes: fwtypes.AttributeTypesMust[lifecycleConfigurationModel](ctx),
+										},
+									},
+								},
+								Blocks: map[string]schema.Block{
+									"filesystem_configuration": filesystemConfigurationSchema(ctx),
+									names.AttrNetworkConfiguration: schema.ListNestedBlock{
+										CustomType: fwtypes.NewListNestedObjectTypeOf[harnessNetworkConfigurationModel](ctx),
+										Validators: []validator.List{
+											listvalidator.SizeAtMost(1),
+										},
+										NestedObject: schema.NestedBlockObject{
+											Attributes: map[string]schema.Attribute{
+												"network_mode": schema.StringAttribute{
+													CustomType: fwtypes.StringEnumType[awstypes.NetworkMode](),
+													Required:   true,
+												},
+											},
+											Blocks: map[string]schema.Block{
+												"network_mode_config": schema.ListNestedBlock{
+													CustomType: fwtypes.NewListNestedObjectTypeOf[vpcConfigNoS3EndpointModel](ctx),
+													Validators: []validator.List{
+														listvalidator.SizeAtMost(1),
+													},
+													NestedObject: schema.NestedBlockObject{
+														Attributes: map[string]schema.Attribute{
+															names.AttrSecurityGroups: schema.SetAttribute{
+																CustomType: fwtypes.SetOfStringType,
+																Required:   true,
+															},
+															names.AttrSubnets: schema.SetAttribute{
+																CustomType: fwtypes.SetOfStringType,
+																Required:   true,
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 			"environment_artifact": schema.ListNestedBlock{
 				CustomType: fwtypes.NewListNestedObjectTypeOf[harnessEnvironmentArtifactModel](ctx),
 				Validators: []validator.List{
@@ -1428,12 +1526,20 @@ func (m harnessEnvironmentProviderModel) Expand(ctx context.Context) (any, diag.
 }
 
 type harnessAgentCoreRuntimeEnvironmentModel struct {
-	AgentRuntimeARN          types.String                                                  `tfsdk:"agent_runtime_arn"`
-	AgentRuntimeID           types.String                                                  `tfsdk:"agent_runtime_id"`
-	AgentRuntimeName         types.String                                                  `tfsdk:"agent_runtime_name"`
-	FilesystemConfigurations fwtypes.ListNestedObjectValueOf[filesystemConfigurationModel] `tfsdk:"filesystem_configuration"`
-	LifecycleConfiguration   fwtypes.ListNestedObjectValueOf[lifecycleConfigurationModel]  `tfsdk:"lifecycle_configuration"`
-	NetworkConfiguration     fwtypes.ListNestedObjectValueOf[networkConfigurationModel]    `tfsdk:"network_configuration"`
+	AgentRuntimeARN          types.String                                                      `tfsdk:"agent_runtime_arn"`
+	AgentRuntimeID           types.String                                                      `tfsdk:"agent_runtime_id"`
+	AgentRuntimeName         types.String                                                      `tfsdk:"agent_runtime_name"`
+	FilesystemConfigurations fwtypes.ListNestedObjectValueOf[filesystemConfigurationModel]     `tfsdk:"filesystem_configuration"`
+	LifecycleConfiguration   fwtypes.ListNestedObjectValueOf[lifecycleConfigurationModel]      `tfsdk:"lifecycle_configuration"`
+	NetworkConfiguration     fwtypes.ListNestedObjectValueOf[harnessNetworkConfigurationModel] `tfsdk:"network_configuration"`
+}
+
+// harnessNetworkConfigurationModel is like networkConfigurationModel but uses
+// vpcConfigNoS3EndpointModel because the harness network_mode_config only has
+// security_groups and subnets (no require_service_s3_endpoint).
+type harnessNetworkConfigurationModel struct {
+	NetworkMode       fwtypes.StringEnum[awstypes.NetworkMode]                    `tfsdk:"network_mode"`
+	NetworkModeConfig fwtypes.ListNestedObjectValueOf[vpcConfigNoS3EndpointModel] `tfsdk:"network_mode_config"`
 }
 
 // Environment artifact union.

--- a/internal/service/bedrockagentcore/harness_test.go
+++ b/internal/service/bedrockagentcore/harness_test.go
@@ -1260,6 +1260,92 @@ func TestAccBedrockAgentCoreHarness_environmentArtifact(t *testing.T) {
 	})
 }
 
+func TestAccBedrockAgentCoreHarness_Environment_vpc(t *testing.T) {
+	ctx := acctest.Context(t)
+	var harness awstypes.Harness
+	rName := testAccRandomHarnessName(t)
+	resourceName := "aws_bedrockagentcore_harness.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID)
+			testAccPreCheckHarness(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockAgentCoreServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckHarnessDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccHarnessConfig_Environment_vpc(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckHarnessExists(ctx, t, resourceName, &harness),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					// The API populates these server-side; the create apply must reconcile
+					// them into state without a "inconsistent result after apply" error.
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrEnvironment).AtSliceIndex(0).AtMapKey("agentcore_runtime_environment").AtSliceIndex(0).AtMapKey("agent_runtime_arn"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrEnvironment).AtSliceIndex(0).AtMapKey("agentcore_runtime_environment").AtSliceIndex(0).AtMapKey("agent_runtime_id"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrEnvironment).AtSliceIndex(0).AtMapKey("agentcore_runtime_environment").AtSliceIndex(0).AtMapKey("agent_runtime_name"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrEnvironment).AtSliceIndex(0).AtMapKey("agentcore_runtime_environment").AtSliceIndex(0).AtMapKey("lifecycle_configuration"), knownvalue.ListSizeExact(1)),
+				},
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+					// No perpetual diff / taint loop: a refresh-plan right after apply is empty.
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccBedrockAgentCoreHarness_Environment_public(t *testing.T) {
+	ctx := acctest.Context(t)
+	var harness awstypes.Harness
+	rName := testAccRandomHarnessName(t)
+	resourceName := "aws_bedrockagentcore_harness.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID)
+			testAccPreCheckHarness(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockAgentCoreServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckHarnessDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccHarnessConfig_Environment_public(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckHarnessExists(ctx, t, resourceName, &harness),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					// The API populates these server-side; the create apply must reconcile
+					// them into state without an "inconsistent result after apply" error.
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrEnvironment).AtSliceIndex(0).AtMapKey("agentcore_runtime_environment").AtSliceIndex(0).AtMapKey("agent_runtime_arn"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrEnvironment).AtSliceIndex(0).AtMapKey("agentcore_runtime_environment").AtSliceIndex(0).AtMapKey("agent_runtime_id"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrEnvironment).AtSliceIndex(0).AtMapKey("agentcore_runtime_environment").AtSliceIndex(0).AtMapKey("agent_runtime_name"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrEnvironment).AtSliceIndex(0).AtMapKey("agentcore_runtime_environment").AtSliceIndex(0).AtMapKey("lifecycle_configuration"), knownvalue.ListSizeExact(1)),
+				},
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+					// No perpetual diff / taint loop: a refresh-plan right after apply is empty.
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
 func TestAccBedrockAgentCoreHarness_authorizerConfiguration(t *testing.T) {
 	ctx := acctest.Context(t)
 	var harness awstypes.Harness
@@ -2219,4 +2305,71 @@ resource "aws_bedrockagentcore_harness" "test" {
   depends_on = [aws_iam_role_policy.test]
 }
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2))
+}
+
+func testAccHarnessConfig_Environment_vpc(rName string) string {
+	return acctest.ConfigCompose(testAccHarnessConfig_iamRole(rName), acctest.ConfigVPCWithSubnets(rName, 2), fmt.Sprintf(`
+resource "aws_bedrockagentcore_harness" "test" {
+  harness_name       = %[1]q
+  execution_role_arn = aws_iam_role.test.arn
+
+  model {
+    bedrock_model_config {
+      model_id = "anthropic.claude-sonnet-4-20250514"
+    }
+  }
+
+  system_prompt {
+    text = "You are a coding assistant."
+  }
+
+  environment {
+    agentcore_runtime_environment {
+      network_configuration {
+        network_mode = "VPC"
+        network_mode_config {
+          security_groups = [aws_security_group.test.id]
+          subnets         = aws_subnet.test[*].id
+        }
+      }
+    }
+  }
+}
+
+resource "aws_security_group" "test" {
+  vpc_id = aws_vpc.test.id
+  name   = %[1]q
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName))
+}
+
+func testAccHarnessConfig_Environment_public(rName string) string {
+	return acctest.ConfigCompose(testAccHarnessConfig_iamRole(rName), fmt.Sprintf(`
+resource "aws_bedrockagentcore_harness" "test" {
+  harness_name       = %[1]q
+  execution_role_arn = aws_iam_role.test.arn
+
+  model {
+    bedrock_model_config {
+      model_id = "anthropic.claude-sonnet-4-20250514"
+    }
+  }
+
+  system_prompt {
+    text = "You are a coding assistant."
+  }
+
+  environment {
+    agentcore_runtime_environment {
+      network_configuration {
+        network_mode = "PUBLIC"
+      }
+    }
+  }
+}
+`, rName))
 }


### PR DESCRIPTION
### Description

Fixes the `Provider produced inconsistent result after apply` error reported in #48159 when creating an `aws_bedrockagentcore_harness` with an `environment` block.

This is a rework of #48815 (original author unresponsive) with reviewer feedback from @gdavison addressed:
- Changelog file named for the PR (not the issue)
- Test functions follow `Environment_vpc` / `Environment_public` naming convention
- `network_mode_config` uses `vpcConfigNoS3EndpointModel` (schema only has `security_groups` and `subnets`)
- `names.AttrNetworkConfiguration` constant used (fixes semgrep-constants CI)

Credit to @jesseturner21 for the original fix.

### Changes
- Model `environment` as an explicit nested block so nested attributes can carry Computed metadata
- Mark `agent_runtime_arn`, `agent_runtime_id`, `agent_runtime_name` as Computed
- Model `lifecycle_configuration` as Optional+Computed typed ListAttribute
- Add acceptance tests for VPC and PUBLIC network modes

Closes #48159
Relates #48815

### Output from Acceptance Testing
_Pending — will update after running tests._

### AI Disclosure
This PR was prepared with AI assistance (🤖🤖🤖). Human is fully responsible for the code.