### PR TITLE
🤖🤖🤖 resource/aws_amplify_app: Fix perpetual diff on custom_headers

### DIFF
--- a/.changelog/49452.txt
+++ b/.changelog/49452.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_amplify_app: Fix perpetual diff on `custom_headers`
+```

--- a/internal/service/amplify/app.go
+++ b/internal/service/amplify/app.go
@@ -7,6 +7,7 @@ package amplify
 
 import (
 	"context"
+	"encoding/json"
 	"log"
 	"time"
 
@@ -26,6 +27,7 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	tfyaml "github.com/hashicorp/terraform-provider-aws/internal/yaml"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -194,10 +196,11 @@ func resourceApp() *schema.Resource {
 					ValidateFunc: verify.ValidARN,
 				},
 				"custom_headers": {
-					Type:         schema.TypeString,
-					Optional:     true,
-					Computed:     true,
-					ValidateFunc: validation.StringLenBetween(1, 25000),
+					Type:             schema.TypeString,
+					Optional:         true,
+					Computed:         true,
+					ValidateFunc:     validation.StringLenBetween(1, 25000),
+					DiffSuppressFunc: suppressCustomHeadersDiff,
 				},
 				"custom_rule": {
 					Type:     schema.TypeList,
@@ -940,4 +943,45 @@ func flattenProductionBranch(apiObject *types.ProductionBranch) map[string]any {
 	}
 
 	return tfMap
+}
+
+// suppressCustomHeadersDiff works around GetApp returning custom_headers as a bare rule list while UpdateApp expects a customHeaders-keyed document.
+func suppressCustomHeadersDiff(k, old, new string, d *schema.ResourceData) bool {
+	if old == "" || new == "" {
+		return old == new
+	}
+
+	oldRules, oldErr := normalizeCustomHeaders(old)
+	newRules, newErr := normalizeCustomHeaders(new)
+	if oldErr != nil || newErr != nil {
+		return false
+	}
+
+	oldJSON, err := json.Marshal(oldRules)
+	if err != nil {
+		return false
+	}
+	newJSON, err := json.Marshal(newRules)
+	if err != nil {
+		return false
+	}
+
+	return verify.JSONBytesEqual(oldJSON, newJSON)
+}
+
+// normalizeCustomHeaders unwraps a custom_headers value to its header-rule list, wrapped or bare.
+func normalizeCustomHeaders(s string) (any, error) {
+	var wrapped struct {
+		CustomHeaders any `yaml:"customHeaders" json:"customHeaders"`
+	}
+	if err := tfyaml.DecodeFromString(s, &wrapped); err == nil && wrapped.CustomHeaders != nil {
+		return wrapped.CustomHeaders, nil
+	}
+
+	var bare any
+	if err := tfyaml.DecodeFromString(s, &bare); err != nil {
+		return nil, err
+	}
+
+	return bare, nil
 }

--- a/internal/service/amplify/app_test.go
+++ b/internal/service/amplify/app_test.go
@@ -1098,3 +1098,153 @@ resource "aws_amplify_app" "test" {
 }
 `, rName, buildComputeType)
 }
+
+func TestSuppressCustomHeadersDiff(t *testing.T) {
+	t.Parallel()
+
+	// What GetApp actually returns: a bare JSON array, no top-level key.
+	stateValue := `[{"pattern":"/index.html","headers":[{"key":"Cache-Control","value":"public, max-age=0, must-revalidate, s-maxage=31536000"}]},{"pattern":"**/*.{js,css}","headers":[{"key":"Cache-Control","value":"public, max-age=31536000, immutable"}]}]`
+
+	// What .tf config declares: YAML with the customHeaders key UpdateApp requires.
+	configValue := `
+customHeaders:
+  - pattern: '/index.html'
+    headers:
+      - key: 'Cache-Control'
+        value: 'public, max-age=0, must-revalidate, s-maxage=31536000'
+  - pattern: '**/*.{js,css}'
+    headers:
+      - key: 'Cache-Control'
+        value: 'public, max-age=31536000, immutable'
+`
+
+	t.Run("equivalent content across bare-array and keyed-YAML forms suppresses diff", func(t *testing.T) {
+		t.Parallel()
+		if !tfamplify.SuppressCustomHeadersDiff("custom_headers", stateValue, configValue, nil) {
+			t.Fatal("expected diff to be suppressed for semantically identical custom_headers, but it was not")
+		}
+	})
+
+	t.Run("genuinely different content still shows a diff", func(t *testing.T) {
+		t.Parallel()
+		changedConfigValue := `
+customHeaders:
+  - pattern: '/index.html'
+    headers:
+      - key: 'Cache-Control'
+        value: 'no-store'
+`
+		if tfamplify.SuppressCustomHeadersDiff("custom_headers", stateValue, changedConfigValue, nil) {
+			t.Fatal("expected diff to NOT be suppressed when custom_headers content actually changed, but it was suppressed")
+		}
+	})
+
+	t.Run("bare JSON on both sides still compares correctly", func(t *testing.T) {
+		t.Parallel()
+		if !tfamplify.SuppressCustomHeadersDiff("custom_headers", stateValue, stateValue, nil) {
+			t.Fatal("expected diff to be suppressed when both sides are identical")
+		}
+	})
+
+	t.Run("unparseable new value falls back to no suppression", func(t *testing.T) {
+		t.Parallel()
+		if tfamplify.SuppressCustomHeadersDiff("custom_headers", stateValue, "not: [valid: yaml:::", nil) {
+			t.Fatal("expected no suppression when new value fails to parse")
+		}
+	})
+
+	t.Run("unparseable old value falls back to no suppression", func(t *testing.T) {
+		t.Parallel()
+		if tfamplify.SuppressCustomHeadersDiff("custom_headers", "not: [valid: yaml:::", configValue, nil) {
+			t.Fatal("expected no suppression when old value fails to parse")
+		}
+	})
+
+	t.Run("both empty suppresses (nothing to compare)", func(t *testing.T) {
+		t.Parallel()
+		if !tfamplify.SuppressCustomHeadersDiff("custom_headers", "", "", nil) {
+			t.Fatal("expected suppression when both old and new are empty")
+		}
+	})
+
+	t.Run("old empty, new non-empty does not suppress (initial create/config-add)", func(t *testing.T) {
+		t.Parallel()
+		if tfamplify.SuppressCustomHeadersDiff("custom_headers", "", configValue, nil) {
+			t.Fatal("expected no suppression when old is empty and new is not (e.g. first apply)")
+		}
+	})
+
+	t.Run("old non-empty, new empty does not suppress (attribute removed from config)", func(t *testing.T) {
+		t.Parallel()
+		if tfamplify.SuppressCustomHeadersDiff("custom_headers", stateValue, "", nil) {
+			t.Fatal("expected no suppression when new is empty and old is not (e.g. attribute removed)")
+		}
+	})
+
+	t.Run("reordered rule list is currently treated as a diff (documents current behavior)", func(t *testing.T) {
+		t.Parallel()
+		reorderedConfigValue := `
+customHeaders:
+  - pattern: '**/*.{js,css}'
+    headers:
+      - key: 'Cache-Control'
+        value: 'public, max-age=31536000, immutable'
+  - pattern: '/index.html'
+    headers:
+      - key: 'Cache-Control'
+        value: 'public, max-age=0, must-revalidate, s-maxage=31536000'
+`
+		if tfamplify.SuppressCustomHeadersDiff("custom_headers", stateValue, reorderedConfigValue, nil) {
+			t.Fatal("list order-sensitivity assumption changed: reordered-but-equivalent rules are now suppressed; update this test to match the new intended behavior")
+		}
+	})
+
+	t.Run("whitespace/quote-style-only YAML differences still suppress", func(t *testing.T) {
+		t.Parallel()
+		differentlyFormattedConfigValue := "customHeaders:\n" +
+			"    - pattern: \"/index.html\"\n" +
+			"      headers:\n" +
+			"          - key: \"Cache-Control\"\n" +
+			"            value: \"public, max-age=0, must-revalidate, s-maxage=31536000\"\n" +
+			"    - pattern: \"**/*.{js,css}\"\n" +
+			"      headers:\n" +
+			"          - key: \"Cache-Control\"\n" +
+			"            value: \"public, max-age=31536000, immutable\"\n"
+
+		if !tfamplify.SuppressCustomHeadersDiff("custom_headers", stateValue, differentlyFormattedConfigValue, nil) {
+			t.Fatal("expected suppression for a purely cosmetic (indentation/quote-style) YAML formatting difference")
+		}
+	})
+
+	t.Run("config given as a bare array (no customHeaders wrapper) also compares correctly", func(t *testing.T) {
+		t.Parallel()
+		bareConfigValue := `
+- pattern: '/index.html'
+  headers:
+    - key: 'Cache-Control'
+      value: 'public, max-age=0, must-revalidate, s-maxage=31536000'
+- pattern: '**/*.{js,css}'
+  headers:
+    - key: 'Cache-Control'
+      value: 'public, max-age=31536000, immutable'
+`
+		if !tfamplify.SuppressCustomHeadersDiff("custom_headers", stateValue, bareConfigValue, nil) {
+			t.Fatal("expected suppression when config itself uses the bare-array form matching state")
+		}
+	})
+
+	t.Run("numeric-looking values compare equal regardless of int vs float literal form", func(t *testing.T) {
+		t.Parallel()
+		// Not a realistic custom_headers value (key/value are always strings in
+		// practice), but guards against int-vs-float literal mismatches (e.g. 1
+		// vs 1.0) after unmarshaling, which a naive comparison would treat as
+		// different even though they're the same JSON number.
+		oldNumeric := `[{"n":1}]`
+		newNumeric := `customHeaders:
+  - n: 1.0
+`
+		if !tfamplify.SuppressCustomHeadersDiff("custom_headers", oldNumeric, newNumeric, nil) {
+			t.Fatal("expected suppression for numerically-equivalent values (1 vs 1.0) after JSON round-trip normalization")
+		}
+	})
+}

--- a/internal/service/amplify/exports_test.go
+++ b/internal/service/amplify/exports_test.go
@@ -18,4 +18,6 @@ var (
 	FindWebhookByID                    = findWebhookByID
 
 	WaitDomainAssociationAvailable = waitDomainAssociationAvailable
+
+	SuppressCustomHeadersDiff = suppressCustomHeadersDiff
 )


### PR DESCRIPTION
## Description

`custom_headers` on `aws_amplify_app` never converges: `GetApp` returns it as a bare JSON array with no top-level key, while `UpdateApp` requires a YAML/JSON document with a top-level `customHeaders` key. No single config value satisfies both, so `terraform plan` shows a diff on this attribute on every run, even immediately after a successful `apply`.

This adds a `DiffSuppressFunc` that unwraps both the keyed and bare forms and compares the underlying header-rule list structurally (via a JSON round-trip through `verify.JSONBytesEqual`, so int/float literal mismatches don't cause false diffs), suppressing the diff when content is actually unchanged while still catching real changes.

Reproduced the failure mode independently, including the "fix" several commenters on #34318 already suspected and tried (matching the config to state's bare-array form via `jsonencode`) — that doesn't converge either, since `UpdateApp` then rejects it outright:
```
Error: updating Amplify App (...): operation error Amplify: UpdateApp,
https response error StatusCode: 400, BadRequestException: Invalid spec,
yaml parsing error: Invalid spec, top level must be key value pairs
```

## AI Usage

This PR was written by an AI coding agent (Claude, via Claude Code) operating under my direction, not autopiloted. Specifics:

- I asked it to investigate a recurring Terraform plan diff we were hitting on `aws_amplify_app.custom_headers` in a separate, private infrastructure repo. It traced the issue to the `GetApp`/`UpdateApp` format asymmetry described above. Its first attempt at a fix in that private repo was actually applying the config in the state's bare-array form (`jsonencode([...])`) — that got deployed and caused a live `UpdateApp` 400 error (the same error shown above), which we had to revert. That failure is what confirmed a config-only fix isn't possible and this needs a provider-side `DiffSuppressFunc`.
- After that, I asked it to implement the `DiffSuppressFunc` fix in a local clone of this repo, as a trial, not for submission. It iterated on it across two rounds of self-directed multi-pass review (each round running parallel checks for correctness/edge cases, consistency with this codebase's existing helpers and conventions, and test coverage; one pass in the second round used a more capable model specifically for the correctness check), applying the fixes those passes surfaced, and verified the result against unit tests it wrote.
- I directed the search for duplicate issues/PRs before submission (found and cross-referenced #34318, closed my own earlier duplicate issue), and directed opening this PR once that search came back clear.
- Across this process I reviewed AI-generated summaries of each round's findings and directed follow-up scrutiny where those summaries flagged risk, and read the final diff before asking for this PR to be opened. I understand the mechanism: `custom_headers` is genuinely unsatisfiable as written today because Amplify's read and write shapes for it differ, so the fix has to compare content structurally rather than relying on a literal string match.

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

None. This only changes how a Terraform plan diff is computed/suppressed for one attribute; it does not change any AWS API calls, permissions, or data handling.

## Relations

Closes #34318

## References

- https://github.com/hashicorp/terraform-provider-aws/issues/34318
- https://docs.aws.amazon.com/amplify/latest/userguide/custom-header-YAML-format.html

## Output from Acceptance Testing

Unit tests only in this PR (`TestSuppressCustomHeadersDiff` in `internal/service/amplify/app_test.go`, 12 subtests covering equivalence across bare/keyed forms, genuine changes, parse failures, empty-value transitions, list ordering, YAML formatting differences, and numeric-literal equivalence). All pass:

```
$ go test ./internal/service/amplify/ -run TestSuppressCustomHeadersDiff -v
--- PASS: TestSuppressCustomHeadersDiff (0.00s)
    (12 subtests, all PASS)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/amplify	4.85s
```

Acceptance tests (`TestAccAmplifyApp_*`) require AWS credentials I don't have configured for this fork — happy to run them or take feedback if a maintainer can trigger CI.

