### PR TITLE
🤖🤖🤖 New resource: aws_ssoadmin_instance

### DIFF
--- a/.changelog/49456.txt
+++ b/.changelog/49456.txt
@@ -1,0 +1,7 @@
+```release-note:new-resource
+aws_ssoadmin_instance
+```
+
+```release-note:new-list-resource
+aws_ssoadmin_instance
+```

--- a/internal/service/ssoadmin/exports_test.go
+++ b/internal/service/ssoadmin/exports_test.go
@@ -13,6 +13,7 @@ var (
 	ResourceCustomerManagedPolicyAttachment           = resourceCustomerManagedPolicyAttachment
 	ResourceCustomerManagedPolicyAttachmentsExclusive = newCustomerManagedPolicyAttachmentsExclusiveResource
 	ResourceInstanceAccessControlAttributes           = resourceInstanceAccessControlAttributes
+	ResourceInstance                                  = newInstanceResource
 	ResourceManagedPolicyAttachment                   = resourceManagedPolicyAttachment
 	ResourceManagedPolicyAttachmentsExclusive         = newManagedPolicyAttachmentsExclusiveResource
 	ResourcePermissionsBoundaryAttachment             = resourcePermissionsBoundaryAttachment
@@ -29,6 +30,7 @@ var (
 	FindCustomerManagedPolicyAttachmentsByTwoPartKey = findCustomerManagedPolicyAttachmentsByTwoPartKey
 	FindCustomerManagedPolicyByFourPartKey           = findCustomerManagedPolicyByFourPartKey
 	FindInstanceAttributeControlAttributesByARN      = findInstanceAttributeControlAttributesByARN
+	FindInstanceByARN                                = findInstanceByARN
 	FindManagedPolicyAttachmentsByTwoPartKey         = findManagedPolicyAttachmentsByTwoPartKey
 	FindManagedPolicyByThreePartKey                  = findManagedPolicyByThreePartKey
 	FindPermissionsBoundaryByTwoPartKey              = findPermissionsBoundaryByTwoPartKey

--- a/internal/service/ssoadmin/instance.go
+++ b/internal/service/ssoadmin/instance.go
@@ -1,0 +1,375 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package ssoadmin
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+	"time"
+
+	"github.com/YakDriver/smarterr"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ssoadmin"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/ssoadmin/types"
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
+	"github.com/hashicorp/terraform-provider-aws/internal/smerr"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkResource("aws_ssoadmin_instance", name="Instance")
+// @ArnIdentity
+// @ArnFormat(global=true)
+// @Tags
+// @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/ssoadmin;ssoadmin.DescribeInstanceOutput")
+// @Testing(serialize=true)
+// @Testing(hasNoPreExistingResource=true)
+// @Testing(generator=false)
+// @Testing(identityTest=false)
+func newInstanceResource(_ context.Context) (resource.ResourceWithConfigure, error) {
+	r := &instanceResource{}
+	r.SetDefaultCreateTimeout(30 * time.Minute)
+	r.SetDefaultUpdateTimeout(30 * time.Minute)
+	r.SetDefaultDeleteTimeout(30 * time.Minute)
+	return r, nil
+}
+
+const ResNameInstance = "Instance"
+
+type instanceResource struct {
+	framework.ResourceWithModel[instanceResourceModel]
+	framework.WithTimeouts
+	framework.WithImportByIdentity
+}
+
+func (r *instanceResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			names.AttrARN: framework.ARNAttributeComputedOnly(),
+			"client_token": schema.StringAttribute{
+				Optional:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
+				Validators:    []validator.String{stringvalidator.LengthBetween(1, 64)},
+			},
+			"created_date":             schema.StringAttribute{CustomType: timetypes.RFC3339Type{}, Computed: true},
+			"encryption_configuration": framework.ResourceOptionalComputedSingleNestedObjectAttribute[encryptionConfigurationModel](ctx),
+			"identity_store_id":        schema.StringAttribute{Computed: true},
+			names.AttrName: schema.StringAttribute{
+				Optional:      true,
+				Computed:      true,
+				Validators:    []validator.String{stringvalidator.LengthBetween(1, 32), stringvalidator.RegexMatches(regexp.MustCompile(`^[\w+=,.@-]+$`), "must contain only alphanumeric characters and +=,.@-_")},
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"owner_account_id": schema.StringAttribute{Computed: true},
+			names.AttrStatus:   schema.StringAttribute{CustomType: fwtypes.StringEnumType[awstypes.InstanceStatus](), Computed: true},
+			"status_reason":    schema.StringAttribute{Computed: true},
+			names.AttrTags:     tftags.TagsAttribute(),
+			names.AttrTagsAll:  tftags.TagsAttributeComputedOnly(),
+		},
+		Blocks: map[string]schema.Block{
+			names.AttrTimeouts: timeouts.Block(ctx, timeouts.Opts{Create: true, Update: true, Delete: true}),
+		},
+	}
+}
+
+func (r *instanceResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var data instanceResourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() || data.EncryptionConfiguration.IsNull() || data.EncryptionConfiguration.IsUnknown() {
+		return
+	}
+	config, diags := data.EncryptionConfiguration.ToPtr(ctx)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() || config == nil || config.KeyType.IsUnknown() {
+		return
+	}
+	hasKeyARN := !config.KMSKeyARN.IsNull() && !config.KMSKeyARN.IsUnknown()
+	switch config.KeyType.ValueEnum() {
+	case awstypes.KmsKeyTypeCustomerManagedKey:
+		if !hasKeyARN {
+			resp.Diagnostics.AddAttributeError(path.Root("encryption_configuration").AtListIndex(0).AtName("kms_key_arn"), "Missing KMS Key ARN", "kms_key_arn is required when key_type is CUSTOMER_MANAGED_KEY.")
+		}
+	case awstypes.KmsKeyTypeAwsOwnedKmsKey:
+		if hasKeyARN {
+			resp.Diagnostics.AddAttributeError(path.Root("encryption_configuration").AtListIndex(0).AtName("kms_key_arn"), "Invalid KMS Key ARN", "kms_key_arn must not be specified when key_type is AWS_OWNED_KMS_KEY.")
+		}
+	}
+}
+
+func (r *instanceResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan instanceResourceModel
+	smerr.AddEnrich(ctx, &resp.Diagnostics, req.Plan.Get(ctx, &plan))
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	conn := r.Meta().SSOAdminClient(ctx)
+	input := ssoadmin.CreateInstanceInput{Tags: getTagsIn(ctx)}
+	if !plan.ClientToken.IsNull() {
+		input.ClientToken = aws.String(plan.ClientToken.ValueString())
+	}
+	if !plan.Name.IsNull() {
+		input.Name = aws.String(plan.Name.ValueString())
+	}
+	output, err := conn.CreateInstance(ctx, &input)
+	if err != nil {
+		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, plan.Name.ValueString())
+		return
+	}
+	plan.ARN = fwtypes.ARNValue(aws.ToString(output.InstanceArn))
+	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, &plan))
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	described, err := waitInstanceActive(ctx, conn, plan.ARN.ValueString(), r.CreateTimeout(ctx, plan.Timeouts))
+	if err != nil {
+		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, plan.ARN.ValueString())
+		return
+	}
+	if !plan.EncryptionConfiguration.IsNull() {
+		if err := updateInstanceEncryption(ctx, conn, plan.ARN.ValueString(), plan.EncryptionConfiguration); err != nil {
+			smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, plan.ARN.ValueString())
+			return
+		}
+		described, err = waitInstanceEncryptionEnabled(ctx, conn, plan.ARN.ValueString(), r.CreateTimeout(ctx, plan.Timeouts))
+		if err != nil {
+			smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, plan.ARN.ValueString())
+			return
+		}
+	}
+	resp.Diagnostics.Append(r.flatten(ctx, described, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, &plan))
+}
+
+func (r *instanceResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state instanceResourceModel
+	smerr.AddEnrich(ctx, &resp.Diagnostics, req.State.Get(ctx, &state))
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	conn := r.Meta().SSOAdminClient(ctx)
+	output, err := findInstanceByARN(ctx, conn, state.ARN.ValueString())
+	if retry.NotFound(err) {
+		resp.Diagnostics.Append(fwdiag.NewResourceNotFoundWarningDiagnostic(err))
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	if err != nil {
+		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, state.ARN.ValueString())
+		return
+	}
+	resp.Diagnostics.Append(r.flatten(ctx, output, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	tags, err := listTags(ctx, conn, state.ARN.ValueString(), state.ARN.ValueString())
+	if err != nil {
+		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, state.ARN.ValueString())
+		return
+	}
+	setTagsOut(ctx, svcTags(tags))
+	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, &state))
+}
+
+func (r *instanceResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var old, plan instanceResourceModel
+	smerr.AddEnrich(ctx, &resp.Diagnostics, req.State.Get(ctx, &old))
+	smerr.AddEnrich(ctx, &resp.Diagnostics, req.Plan.Get(ctx, &plan))
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	conn := r.Meta().SSOAdminClient(ctx)
+	if !old.Name.Equal(plan.Name) {
+		_, err := conn.UpdateInstance(ctx, &ssoadmin.UpdateInstanceInput{InstanceArn: aws.String(plan.ARN.ValueString()), Name: aws.String(plan.Name.ValueString())})
+		if err != nil {
+			smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, plan.ARN.ValueString())
+			return
+		}
+	}
+	if !old.EncryptionConfiguration.Equal(plan.EncryptionConfiguration) {
+		if err := updateInstanceEncryption(ctx, conn, plan.ARN.ValueString(), plan.EncryptionConfiguration); err != nil {
+			smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, plan.ARN.ValueString())
+			return
+		}
+		if _, err := waitInstanceEncryptionEnabled(ctx, conn, plan.ARN.ValueString(), r.UpdateTimeout(ctx, plan.Timeouts)); err != nil {
+			smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, plan.ARN.ValueString())
+			return
+		}
+	}
+	if !old.TagsAll.Equal(plan.TagsAll) {
+		if err := updateTags(ctx, conn, plan.ARN.ValueString(), plan.ARN.ValueString(), old.TagsAll, plan.TagsAll); err != nil {
+			smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, plan.ARN.ValueString())
+			return
+		}
+	}
+	output, err := findInstanceByARN(ctx, conn, plan.ARN.ValueString())
+	if err != nil {
+		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, plan.ARN.ValueString())
+		return
+	}
+	resp.Diagnostics.Append(r.flatten(ctx, output, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, &plan))
+}
+
+func (r *instanceResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state instanceResourceModel
+	smerr.AddEnrich(ctx, &resp.Diagnostics, req.State.Get(ctx, &state))
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	conn := r.Meta().SSOAdminClient(ctx)
+	_, err := conn.DeleteInstance(ctx, &ssoadmin.DeleteInstanceInput{InstanceArn: aws.String(state.ARN.ValueString())})
+	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+		return
+	}
+	if err != nil {
+		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, state.ARN.ValueString())
+		return
+	}
+	if err := waitInstanceDeleted(ctx, conn, state.ARN.ValueString(), r.DeleteTimeout(ctx, state.Timeouts)); err != nil {
+		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, state.ARN.ValueString())
+	}
+}
+
+func updateInstanceEncryption(ctx context.Context, conn *ssoadmin.Client, arn string, value fwtypes.ListNestedObjectValueOf[encryptionConfigurationModel]) error {
+	model, diags := value.ToPtr(ctx)
+	if diags.HasError() {
+		diagnostic := diags.Errors()[0]
+		return fmt.Errorf("%s: %s", diagnostic.Summary(), diagnostic.Detail())
+	}
+	if model == nil {
+		return nil
+	}
+	input := ssoadmin.UpdateInstanceInput{InstanceArn: aws.String(arn), EncryptionConfiguration: &awstypes.EncryptionConfiguration{KeyType: model.KeyType.ValueEnum()}}
+	if !model.KMSKeyARN.IsNull() {
+		input.EncryptionConfiguration.KmsKeyArn = aws.String(model.KMSKeyARN.ValueString())
+	}
+	_, err := conn.UpdateInstance(ctx, &input)
+	return smarterr.NewError(err)
+}
+
+func (r *instanceResource) flatten(ctx context.Context, output *ssoadmin.DescribeInstanceOutput, data *instanceResourceModel) (diags diag.Diagnostics) {
+	diags.Append(fwflex.Flatten(ctx, output, data)...)
+	if output.EncryptionConfigurationDetails != nil {
+		d := output.EncryptionConfigurationDetails
+		data.EncryptionConfiguration = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &encryptionConfigurationModel{EncryptionStatus: fwtypes.StringEnumValue(d.EncryptionStatus), EncryptionStatusReason: fwflex.StringToFramework(ctx, d.EncryptionStatusReason), KeyType: fwtypes.StringEnumValue(d.KeyType), KMSKeyARN: fwtypes.ARNValue(aws.ToString(d.KmsKeyArn))})
+	}
+	return diags
+}
+
+func findInstanceByARN(ctx context.Context, conn *ssoadmin.Client, arn string) (*ssoadmin.DescribeInstanceOutput, error) {
+	output, err := conn.DescribeInstance(ctx, &ssoadmin.DescribeInstanceInput{InstanceArn: aws.String(arn)})
+	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+		return nil, smarterr.NewError(&retry.NotFoundError{LastError: err})
+	}
+	if err != nil {
+		return nil, smarterr.NewError(err)
+	}
+	if output == nil {
+		return nil, smarterr.NewError(tfresource.NewEmptyResultError())
+	}
+	return output, nil
+}
+
+func statusInstance(conn *ssoadmin.Client, arn string) retry.StateRefreshFunc {
+	return func(ctx context.Context) (any, string, error) {
+		output, err := findInstanceByARN(ctx, conn, arn)
+		if retry.NotFound(err) {
+			return nil, "", nil
+		}
+		if err != nil {
+			return nil, "", err
+		}
+		return output, string(output.Status), nil
+	}
+}
+
+func waitInstanceActive(ctx context.Context, conn *ssoadmin.Client, arn string, timeout time.Duration) (*ssoadmin.DescribeInstanceOutput, error) {
+	conf := retry.StateChangeConf{Pending: enum.Slice(awstypes.InstanceStatusCreateInProgress), Target: enum.Slice(awstypes.InstanceStatusActive), Refresh: statusInstance(conn, arn), Timeout: timeout, Delay: 10 * time.Second, NotFoundChecks: 5}
+	output, err := conf.WaitForStateContext(ctx)
+	if out, ok := output.(*ssoadmin.DescribeInstanceOutput); ok && out.Status == awstypes.InstanceStatusCreateFailed {
+		tfresource.SetLastError(err, errors.New(aws.ToString(out.StatusReason)))
+		return out, err
+	}
+	if err != nil {
+		return nil, err
+	}
+	return output.(*ssoadmin.DescribeInstanceOutput), nil
+}
+
+func waitInstanceEncryptionEnabled(ctx context.Context, conn *ssoadmin.Client, arn string, timeout time.Duration) (*ssoadmin.DescribeInstanceOutput, error) {
+	conf := retry.StateChangeConf{Pending: []string{"", string(awstypes.KmsKeyStatusUpdating)}, Target: enum.Slice(awstypes.KmsKeyStatusEnabled), Refresh: func(ctx context.Context) (any, string, error) {
+		output, err := findInstanceByARN(ctx, conn, arn)
+		if err != nil {
+			return nil, "", err
+		}
+		if output.EncryptionConfigurationDetails == nil {
+			return output, "", nil
+		}
+		return output, string(output.EncryptionConfigurationDetails.EncryptionStatus), nil
+	}, Timeout: timeout, Delay: 10 * time.Second}
+	output, err := conf.WaitForStateContext(ctx)
+	if out, ok := output.(*ssoadmin.DescribeInstanceOutput); ok && out.EncryptionConfigurationDetails != nil && out.EncryptionConfigurationDetails.EncryptionStatus == awstypes.KmsKeyStatusUpdateFailed {
+		tfresource.SetLastError(err, errors.New(aws.ToString(out.EncryptionConfigurationDetails.EncryptionStatusReason)))
+		return out, err
+	}
+	if err != nil {
+		return nil, err
+	}
+	return output.(*ssoadmin.DescribeInstanceOutput), nil
+}
+
+func waitInstanceDeleted(ctx context.Context, conn *ssoadmin.Client, arn string, timeout time.Duration) error {
+	conf := retry.StateChangeConf{Pending: enum.Slice(awstypes.InstanceStatusActive, awstypes.InstanceStatusDeleteInProgress), Target: []string{}, Refresh: statusInstance(conn, arn), Timeout: timeout, Delay: 10 * time.Second}
+	_, err := conf.WaitForStateContext(ctx)
+	return err
+}
+
+type instanceResourceModel struct {
+	framework.WithRegionModel
+	ARN                     fwtypes.ARN                                                   `tfsdk:"arn"`
+	ClientToken             types.String                                                  `tfsdk:"client_token"`
+	CreatedDate             timetypes.RFC3339                                             `tfsdk:"created_date"`
+	EncryptionConfiguration fwtypes.ListNestedObjectValueOf[encryptionConfigurationModel] `tfsdk:"encryption_configuration" autoflex:"-"`
+	IdentityStoreID         types.String                                                  `tfsdk:"identity_store_id"`
+	Name                    types.String                                                  `tfsdk:"name"`
+	OwnerAccountID          types.String                                                  `tfsdk:"owner_account_id"`
+	Status                  fwtypes.StringEnum[awstypes.InstanceStatus]                   `tfsdk:"status"`
+	StatusReason            types.String                                                  `tfsdk:"status_reason"`
+	Tags                    tftags.Map                                                    `tfsdk:"tags"`
+	TagsAll                 tftags.Map                                                    `tfsdk:"tags_all"`
+	Timeouts                timeouts.Value                                                `tfsdk:"timeouts"`
+}
+
+type encryptionConfigurationModel struct {
+	EncryptionStatus       fwtypes.StringEnum[awstypes.KmsKeyStatus] `tfsdk:"encryption_status"`
+	EncryptionStatusReason types.String                              `tfsdk:"encryption_status_reason"`
+	KeyType                fwtypes.StringEnum[awstypes.KmsKeyType]   `tfsdk:"key_type"`
+	KMSKeyARN              fwtypes.ARN                               `tfsdk:"kms_key_arn"`
+}

--- a/internal/service/ssoadmin/instance.go
+++ b/internal/service/ssoadmin/instance.go
@@ -7,9 +7,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"regexp"
 	"time"
 
+	"github.com/YakDriver/regexache"
 	"github.com/YakDriver/smarterr"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ssoadmin"
@@ -72,20 +72,20 @@ func (r *instanceResource) Schema(ctx context.Context, _ resource.SchemaRequest,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 				Validators:    []validator.String{stringvalidator.LengthBetween(1, 64)},
 			},
-			"created_date":             schema.StringAttribute{CustomType: timetypes.RFC3339Type{}, Computed: true},
-			"encryption_configuration": framework.ResourceOptionalComputedSingleNestedObjectAttribute[encryptionConfigurationModel](ctx),
-			"identity_store_id":        schema.StringAttribute{Computed: true},
+			names.AttrCreatedDate:             schema.StringAttribute{CustomType: timetypes.RFC3339Type{}, Computed: true},
+			names.AttrEncryptionConfiguration: framework.ResourceOptionalComputedSingleNestedObjectAttribute[encryptionConfigurationModel](ctx),
+			"identity_store_id":               schema.StringAttribute{Computed: true},
 			names.AttrName: schema.StringAttribute{
 				Optional:      true,
 				Computed:      true,
-				Validators:    []validator.String{stringvalidator.LengthBetween(1, 32), stringvalidator.RegexMatches(regexp.MustCompile(`^[\w+=,.@-]+$`), "must contain only alphanumeric characters and +=,.@-_")},
+				Validators:    []validator.String{stringvalidator.LengthBetween(1, 32), stringvalidator.RegexMatches(regexache.MustCompile(`^[\w+=,.@-]+$`), "must contain only alphanumeric characters and +=,.@-_")},
 				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
-			"owner_account_id": schema.StringAttribute{Computed: true},
-			names.AttrStatus:   schema.StringAttribute{CustomType: fwtypes.StringEnumType[awstypes.InstanceStatus](), Computed: true},
-			"status_reason":    schema.StringAttribute{Computed: true},
-			names.AttrTags:     tftags.TagsAttribute(),
-			names.AttrTagsAll:  tftags.TagsAttributeComputedOnly(),
+			names.AttrOwnerAccountID: schema.StringAttribute{Computed: true},
+			names.AttrStatus:         schema.StringAttribute{CustomType: fwtypes.StringEnumType[awstypes.InstanceStatus](), Computed: true},
+			names.AttrStatusReason:   schema.StringAttribute{Computed: true},
+			names.AttrTags:           tftags.TagsAttribute(),
+			names.AttrTagsAll:        tftags.TagsAttributeComputedOnly(),
 		},
 		Blocks: map[string]schema.Block{
 			names.AttrTimeouts: timeouts.Block(ctx, timeouts.Opts{Create: true, Update: true, Delete: true}),
@@ -108,11 +108,11 @@ func (r *instanceResource) ValidateConfig(ctx context.Context, req resource.Vali
 	switch config.KeyType.ValueEnum() {
 	case awstypes.KmsKeyTypeCustomerManagedKey:
 		if !hasKeyARN {
-			resp.Diagnostics.AddAttributeError(path.Root("encryption_configuration").AtListIndex(0).AtName("kms_key_arn"), "Missing KMS Key ARN", "kms_key_arn is required when key_type is CUSTOMER_MANAGED_KEY.")
+			resp.Diagnostics.AddAttributeError(path.Root(names.AttrEncryptionConfiguration).AtListIndex(0).AtName(names.AttrKMSKeyARN), "Missing KMS Key ARN", "kms_key_arn is required when key_type is CUSTOMER_MANAGED_KEY.")
 		}
 	case awstypes.KmsKeyTypeAwsOwnedKmsKey:
 		if hasKeyARN {
-			resp.Diagnostics.AddAttributeError(path.Root("encryption_configuration").AtListIndex(0).AtName("kms_key_arn"), "Invalid KMS Key ARN", "kms_key_arn must not be specified when key_type is AWS_OWNED_KMS_KEY.")
+			resp.Diagnostics.AddAttributeError(path.Root(names.AttrEncryptionConfiguration).AtListIndex(0).AtName(names.AttrKMSKeyARN), "Invalid KMS Key ARN", "kms_key_arn must not be specified when key_type is AWS_OWNED_KMS_KEY.")
 		}
 	}
 }
@@ -126,10 +126,10 @@ func (r *instanceResource) Create(ctx context.Context, req resource.CreateReques
 	conn := r.Meta().SSOAdminClient(ctx)
 	input := ssoadmin.CreateInstanceInput{Tags: getTagsIn(ctx)}
 	if !plan.ClientToken.IsNull() {
-		input.ClientToken = aws.String(plan.ClientToken.ValueString())
+		input.ClientToken = plan.ClientToken.ValueStringPointer()
 	}
 	if !plan.Name.IsNull() {
-		input.Name = aws.String(plan.Name.ValueString())
+		input.Name = plan.Name.ValueStringPointer()
 	}
 	output, err := conn.CreateInstance(ctx, &input)
 	if err != nil {
@@ -203,7 +203,7 @@ func (r *instanceResource) Update(ctx context.Context, req resource.UpdateReques
 	}
 	conn := r.Meta().SSOAdminClient(ctx)
 	if !old.Name.Equal(plan.Name) {
-		_, err := conn.UpdateInstance(ctx, &ssoadmin.UpdateInstanceInput{InstanceArn: aws.String(plan.ARN.ValueString()), Name: aws.String(plan.Name.ValueString())})
+		_, err := conn.UpdateInstance(ctx, &ssoadmin.UpdateInstanceInput{InstanceArn: plan.ARN.ValueStringPointer(), Name: plan.Name.ValueStringPointer()})
 		if err != nil {
 			smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, plan.ARN.ValueString())
 			return
@@ -244,7 +244,7 @@ func (r *instanceResource) Delete(ctx context.Context, req resource.DeleteReques
 		return
 	}
 	conn := r.Meta().SSOAdminClient(ctx)
-	_, err := conn.DeleteInstance(ctx, &ssoadmin.DeleteInstanceInput{InstanceArn: aws.String(state.ARN.ValueString())})
+	_, err := conn.DeleteInstance(ctx, &ssoadmin.DeleteInstanceInput{InstanceArn: state.ARN.ValueStringPointer()})
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return
 	}
@@ -268,7 +268,7 @@ func updateInstanceEncryption(ctx context.Context, conn *ssoadmin.Client, arn st
 	}
 	input := ssoadmin.UpdateInstanceInput{InstanceArn: aws.String(arn), EncryptionConfiguration: &awstypes.EncryptionConfiguration{KeyType: model.KeyType.ValueEnum()}}
 	if !model.KMSKeyARN.IsNull() {
-		input.EncryptionConfiguration.KmsKeyArn = aws.String(model.KMSKeyARN.ValueString())
+		input.EncryptionConfiguration.KmsKeyArn = model.KMSKeyARN.ValueStringPointer()
 	}
 	_, err := conn.UpdateInstance(ctx, &input)
 	return smarterr.NewError(err)
@@ -323,7 +323,7 @@ func waitInstanceActive(ctx context.Context, conn *ssoadmin.Client, arn string, 
 	conf := retry.StateChangeConf{Pending: enum.Slice(awstypes.InstanceStatusCreateInProgress), Target: enum.Slice(awstypes.InstanceStatusActive), Refresh: statusInstance(conn, arn), Timeout: timeout, Delay: 10 * time.Second, NotFoundChecks: 5}
 	output, err := conf.WaitForStateContext(ctx)
 	if out, ok := output.(*ssoadmin.DescribeInstanceOutput); ok && out.Status == awstypes.InstanceStatusCreateFailed {
-		tfresource.SetLastError(err, errors.New(aws.ToString(out.StatusReason)))
+		retry.SetLastError(err, errors.New(aws.ToString(out.StatusReason)))
 		return out, err
 	}
 	if err != nil {
@@ -333,7 +333,8 @@ func waitInstanceActive(ctx context.Context, conn *ssoadmin.Client, arn string, 
 }
 
 func waitInstanceEncryptionEnabled(ctx context.Context, conn *ssoadmin.Client, arn string, timeout time.Duration) (*ssoadmin.DescribeInstanceOutput, error) {
-	conf := retry.StateChangeConf{Pending: []string{"", string(awstypes.KmsKeyStatusUpdating)}, Target: enum.Slice(awstypes.KmsKeyStatusEnabled), Refresh: func(ctx context.Context) (any, string, error) {
+	pending := append([]string{""}, enum.Slice(awstypes.KmsKeyStatusUpdating)...)
+	conf := retry.StateChangeConf{Pending: pending, Target: enum.Slice(awstypes.KmsKeyStatusEnabled), Refresh: func(ctx context.Context) (any, string, error) {
 		output, err := findInstanceByARN(ctx, conn, arn)
 		if err != nil {
 			return nil, "", err
@@ -345,7 +346,7 @@ func waitInstanceEncryptionEnabled(ctx context.Context, conn *ssoadmin.Client, a
 	}, Timeout: timeout, Delay: 10 * time.Second}
 	output, err := conf.WaitForStateContext(ctx)
 	if out, ok := output.(*ssoadmin.DescribeInstanceOutput); ok && out.EncryptionConfigurationDetails != nil && out.EncryptionConfigurationDetails.EncryptionStatus == awstypes.KmsKeyStatusUpdateFailed {
-		tfresource.SetLastError(err, errors.New(aws.ToString(out.EncryptionConfigurationDetails.EncryptionStatusReason)))
+		retry.SetLastError(err, errors.New(aws.ToString(out.EncryptionConfigurationDetails.EncryptionStatusReason)))
 		return out, err
 	}
 	if err != nil {

--- a/internal/service/ssoadmin/instance.go
+++ b/internal/service/ssoadmin/instance.go
@@ -146,7 +146,7 @@ func (r *instanceResource) Create(ctx context.Context, req resource.CreateReques
 		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, plan.ARN.ValueString())
 		return
 	}
-	if !plan.EncryptionConfiguration.IsNull() {
+	if !plan.EncryptionConfiguration.IsNull() && !plan.EncryptionConfiguration.IsUnknown() {
 		if err := updateInstanceEncryption(ctx, conn, plan.ARN.ValueString(), plan.EncryptionConfiguration); err != nil {
 			smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, plan.ARN.ValueString())
 			return
@@ -278,7 +278,16 @@ func (r *instanceResource) flatten(ctx context.Context, output *ssoadmin.Describ
 	diags.Append(fwflex.Flatten(ctx, output, data)...)
 	if output.EncryptionConfigurationDetails != nil {
 		d := output.EncryptionConfigurationDetails
-		data.EncryptionConfiguration = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &encryptionConfigurationModel{EncryptionStatus: fwtypes.StringEnumValue(d.EncryptionStatus), EncryptionStatusReason: fwflex.StringToFramework(ctx, d.EncryptionStatusReason), KeyType: fwtypes.StringEnumValue(d.KeyType), KMSKeyARN: fwtypes.ARNValue(aws.ToString(d.KmsKeyArn))})
+		kmsKeyARN := fwtypes.ARNNull()
+		if d.KmsKeyArn != nil {
+			kmsKeyARN = fwtypes.ARNValue(aws.ToString(d.KmsKeyArn))
+		}
+		data.EncryptionConfiguration = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &encryptionConfigurationModel{
+			EncryptionStatus:       fwtypes.StringEnumValue(d.EncryptionStatus),
+			EncryptionStatusReason: fwflex.StringToFramework(ctx, d.EncryptionStatusReason),
+			KeyType:                fwtypes.StringEnumValue(d.KeyType),
+			KMSKeyARN:              kmsKeyARN,
+		})
 	}
 	return diags
 }

--- a/internal/service/ssoadmin/instance_list.go
+++ b/internal/service/ssoadmin/instance_list.go
@@ -1,0 +1,86 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package ssoadmin
+
+import (
+	"context"
+	"fmt"
+	"iter"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ssoadmin"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/ssoadmin/types"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/logging"
+)
+
+// @FrameworkListResource("aws_ssoadmin_instance")
+func newInstanceResourceAsListResource() list.ListResourceWithConfigure {
+	return &instanceListResource{}
+}
+
+var _ list.ListResource = &instanceListResource{}
+
+type instanceListResource struct {
+	instanceResource
+	framework.WithList
+}
+
+func (l *instanceListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
+	conn := l.Meta().SSOAdminClient(ctx)
+	tflog.Info(ctx, "Listing SSO Admin Instances")
+	stream.Results = func(yield func(list.ListResult) bool) {
+		for item, err := range listInstances(ctx, conn, &ssoadmin.ListInstancesInput{}) {
+			if err != nil {
+				yield(fwdiag.NewListResultErrorDiagnostic(err))
+				return
+			}
+			arn := aws.ToString(item.InstanceArn)
+			ctx := tflog.SetField(ctx, logging.ResourceAttributeKey("arn"), arn)
+			result := request.NewListResult(ctx)
+			var data instanceResourceModel
+			l.SetResult(ctx, l.Meta(), request.IncludeResource, &data, &result, func() {
+				data.ARN = fwtypes.ARNValue(arn)
+				if request.IncludeResource {
+					output, err := findInstanceByARN(ctx, conn, arn)
+					if err != nil {
+						result.Diagnostics.AddError("Reading SSO Admin Instance", err.Error())
+						return
+					}
+					result.Diagnostics.Append(l.flatten(ctx, output, &data)...)
+				}
+				result.DisplayName = aws.ToString(item.Name)
+			})
+			if result.Diagnostics.HasError() {
+				yield(list.ListResult{Diagnostics: result.Diagnostics})
+				return
+			}
+			if !yield(result) {
+				return
+			}
+		}
+	}
+}
+
+func listInstances(ctx context.Context, conn *ssoadmin.Client, input *ssoadmin.ListInstancesInput) iter.Seq2[awstypes.InstanceMetadata, error] {
+	return func(yield func(awstypes.InstanceMetadata, error) bool) {
+		pages := ssoadmin.NewListInstancesPaginator(conn, input)
+		for pages.HasMorePages() {
+			page, err := pages.NextPage(ctx)
+			if err != nil {
+				yield(awstypes.InstanceMetadata{}, fmt.Errorf("listing SSO Admin Instance resources: %w", err))
+				return
+			}
+			for _, item := range page.Instances {
+				if !yield(item, nil) {
+					return
+				}
+			}
+		}
+	}
+}

--- a/internal/service/ssoadmin/instance_list.go
+++ b/internal/service/ssoadmin/instance_list.go
@@ -17,6 +17,8 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
 	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/logging"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 // @FrameworkListResource("aws_ssoadmin_instance")
@@ -41,17 +43,23 @@ func (l *instanceListResource) List(ctx context.Context, request list.ListReques
 				return
 			}
 			arn := aws.ToString(item.InstanceArn)
-			ctx := tflog.SetField(ctx, logging.ResourceAttributeKey("arn"), arn)
+			ctx := tflog.SetField(ctx, logging.ResourceAttributeKey(names.AttrARN), arn)
+			var output *ssoadmin.DescribeInstanceOutput
+			if request.IncludeResource {
+				output, err = findInstanceByARN(ctx, conn, arn)
+				if retry.NotFound(err) {
+					continue
+				}
+				if err != nil {
+					yield(fwdiag.NewListResultErrorDiagnostic(err))
+					return
+				}
+			}
 			result := request.NewListResult(ctx)
 			var data instanceResourceModel
 			l.SetResult(ctx, l.Meta(), request.IncludeResource, &data, &result, func() {
 				data.ARN = fwtypes.ARNValue(arn)
 				if request.IncludeResource {
-					output, err := findInstanceByARN(ctx, conn, arn)
-					if err != nil {
-						result.Diagnostics.AddError("Reading SSO Admin Instance", err.Error())
-						return
-					}
 					result.Diagnostics.Append(l.flatten(ctx, output, &data)...)
 				}
 				result.DisplayName = aws.ToString(item.Name)

--- a/internal/service/ssoadmin/instance_test.go
+++ b/internal/service/ssoadmin/instance_test.go
@@ -1,0 +1,181 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package ssoadmin_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/ssoadmin"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
+	tfssoadmin "github.com/hashicorp/terraform-provider-aws/internal/service/ssoadmin"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccSSOAdminInstance_serial(t *testing.T) {
+	t.Parallel()
+	testCases := map[string]func(*testing.T){
+		acctest.CtBasic:      testAccSSOAdminInstance_basic,
+		acctest.CtDisappears: testAccSSOAdminInstance_disappears,
+		"ListBasic":          testAccSSOAdminInstance_listBasic,
+	}
+	acctest.RunSerialTests1Level(t, testCases, 0)
+}
+
+func testAccSSOAdminInstance_listBasic(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_ssoadmin_instance.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	acctest.Test(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.SSOAdminEndpointID)
+			testAccInstancePreCheck(ctx, t)
+		},
+		ErrorCheck: acctest.ErrorCheck(t, names.SSOAdminServiceID), ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy: testAccCheckInstanceDestroy(ctx, t),
+		Steps: []resource.TestStep{{Config: testAccInstanceConfig_list(rName), Check: resource.ComposeAggregateTestCheckFunc(
+			testAccCheckInstanceExists(ctx, t, resourceName), resource.TestCheckResourceAttr("data.aws_ssoadmin_instances.test", "arns.#", "1"),
+			resource.TestCheckResourceAttrPair("data.aws_ssoadmin_instances.test", "arns.0", resourceName, names.AttrARN),
+		)}},
+	})
+}
+
+func testAccSSOAdminInstance_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_ssoadmin_instance.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	acctest.Test(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.SSOAdminEndpointID)
+			testAccInstancePreCheck(ctx, t)
+		},
+		ErrorCheck: acctest.ErrorCheck(t, names.SSOAdminServiceID), ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy: testAccCheckInstanceDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{Config: testAccInstanceConfig_basic(rName), Check: resource.ComposeAggregateTestCheckFunc(
+				testAccCheckInstanceExists(ctx, t, resourceName), resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+				resource.TestCheckResourceAttr(resourceName, "encryption_configuration.0.key_type", "AWS_OWNED_KMS_KEY"),
+				resource.TestCheckResourceAttr(resourceName, names.AttrTags+".%", "1"), resource.TestCheckResourceAttr(resourceName, names.AttrTags+".Name", rName),
+			)},
+			{ResourceName: resourceName, ImportState: true, ImportStateVerify: true, ImportStateVerifyIdentifierAttribute: names.AttrARN, ImportStateVerifyIgnore: []string{"client_token"}},
+			{Config: testAccInstanceConfig_updated(rName), Check: resource.ComposeAggregateTestCheckFunc(
+				resource.TestCheckResourceAttr(resourceName, names.AttrName, rName+"-updated"), resource.TestCheckResourceAttr(resourceName, names.AttrTags+".%", "2"),
+			)},
+		},
+	})
+}
+
+func testAccSSOAdminInstance_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_ssoadmin_instance.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	acctest.Test(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.SSOAdminEndpointID)
+			testAccInstancePreCheck(ctx, t)
+		},
+		ErrorCheck: acctest.ErrorCheck(t, names.SSOAdminServiceID), ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy: testAccCheckInstanceDestroy(ctx, t),
+		Steps: []resource.TestStep{{Config: testAccInstanceConfig_basic(rName), Check: resource.ComposeAggregateTestCheckFunc(
+			testAccCheckInstanceExists(ctx, t, resourceName), acctest.CheckFrameworkResourceDisappears(ctx, t, tfssoadmin.ResourceInstance, resourceName),
+		), ExpectNonEmptyPlan: true}},
+	})
+}
+
+func testAccInstancePreCheck(ctx context.Context, t *testing.T) {
+	output, err := acctest.ProviderMeta(ctx, t).SSOAdminClient(ctx).ListInstances(ctx, &ssoadmin.ListInstancesInput{})
+	if acctest.PreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
+	if len(output.Instances) > 0 {
+		t.Skip("skipping acceptance testing: account already has an IAM Identity Center instance")
+	}
+}
+
+func testAccCheckInstanceExists(ctx context.Context, t *testing.T, name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return create.Error(names.SSOAdmin, create.ErrActionCheckingExistence, tfssoadmin.ResNameInstance, name, errors.New("not found"))
+		}
+		_, err := tfssoadmin.FindInstanceByARN(ctx, acctest.ProviderMeta(ctx, t).SSOAdminClient(ctx), rs.Primary.Attributes[names.AttrARN])
+		return create.Error(names.SSOAdmin, create.ErrActionCheckingExistence, tfssoadmin.ResNameInstance, rs.Primary.Attributes[names.AttrARN], err)
+	}
+}
+
+func testAccCheckInstanceDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_ssoadmin_instance" {
+				continue
+			}
+			_, err := tfssoadmin.FindInstanceByARN(ctx, acctest.ProviderMeta(ctx, t).SSOAdminClient(ctx), rs.Primary.Attributes[names.AttrARN])
+			if retry.NotFound(err) {
+				continue
+			}
+			if err != nil {
+				return err
+			}
+			return errors.New("SSO Admin Instance still exists")
+		}
+		return nil
+	}
+}
+
+func testAccInstanceConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_ssoadmin_instance" "test" {
+  name = %[1]q
+
+  encryption_configuration {
+    key_type = "AWS_OWNED_KMS_KEY"
+  }
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName)
+}
+
+func testAccInstanceConfig_updated(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_ssoadmin_instance" "test" {
+  name = %[2]q
+
+  encryption_configuration {
+    key_type = "AWS_OWNED_KMS_KEY"
+  }
+
+  tags = {
+    Name        = %[1]q
+    Environment = "test"
+  }
+}
+`, rName, rName+"-updated")
+}
+
+func testAccInstanceConfig_list(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_ssoadmin_instance" "test" {
+  name = %[1]q
+}
+
+data "aws_ssoadmin_instances" "test" {
+  depends_on = [aws_ssoadmin_instance.test]
+}
+`, rName)
+}

--- a/internal/service/ssoadmin/instance_test.go
+++ b/internal/service/ssoadmin/instance_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/ssoadmin"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
@@ -86,9 +87,19 @@ func testAccSSOAdminInstance_disappears(t *testing.T) {
 		},
 		ErrorCheck: acctest.ErrorCheck(t, names.SSOAdminServiceID), ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy: testAccCheckInstanceDestroy(ctx, t),
-		Steps: []resource.TestStep{{Config: testAccInstanceConfig_basic(rName), Check: resource.ComposeAggregateTestCheckFunc(
-			testAccCheckInstanceExists(ctx, t, resourceName), acctest.CheckFrameworkResourceDisappears(ctx, t, tfssoadmin.ResourceInstance, resourceName),
-		), ExpectNonEmptyPlan: true}},
+		Steps: []resource.TestStep{{
+			Config: testAccInstanceConfig_basic(rName),
+			Check: resource.ComposeAggregateTestCheckFunc(
+				testAccCheckInstanceExists(ctx, t, resourceName),
+				acctest.CheckFrameworkResourceDisappears(ctx, t, tfssoadmin.ResourceInstance, resourceName),
+			),
+			ExpectNonEmptyPlan: true,
+			ConfigPlanChecks: resource.ConfigPlanChecks{
+				PostApplyPostRefresh: []plancheck.PlanCheck{
+					plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+				},
+			},
+		}},
 	})
 }
 

--- a/internal/service/ssoadmin/service_package_gen.go
+++ b/internal/service/ssoadmin/service_package_gen.go
@@ -109,6 +109,17 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*inttypes.Ser
 			},
 		},
 		{
+			Factory:  newInstanceResource,
+			TypeName: "aws_ssoadmin_instance",
+			Name:     "Instance",
+			Tags:     unique.Make(inttypes.ServicePackageResourceTags{}),
+			Region:   inttypes.ResourceRegionDefault(),
+			Identity: inttypes.RegionalResourceWithGlobalARNFormat(),
+			Import: inttypes.FrameworkImport{
+				WrappedImport: true,
+			},
+		},
+		{
 			Factory:  newManagedPolicyAttachmentsExclusiveResource,
 			TypeName: "aws_ssoadmin_managed_policy_attachments_exclusive",
 			Name:     "Managed Policy Attachments Exclusive",
@@ -152,6 +163,14 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*inttypes.Ser
 
 func (p *servicePackage) FrameworkListResources(ctx context.Context) iter.Seq[*inttypes.ServicePackageFrameworkListResource] {
 	return slices.Values([]*inttypes.ServicePackageFrameworkListResource{
+		{
+			Factory:  newInstanceResourceAsListResource,
+			TypeName: "aws_ssoadmin_instance",
+			Name:     "Instance",
+			Tags:     unique.Make(inttypes.ServicePackageResourceTags{}),
+			Region:   inttypes.ResourceRegionDefault(),
+			Identity: inttypes.RegionalARNIdentity(),
+		},
 		{
 			Factory:  newRegionResourceAsListResource,
 			TypeName: "aws_ssoadmin_region",

--- a/website/docs/list-resources/ssoadmin_instance.html.markdown
+++ b/website/docs/list-resources/ssoadmin_instance.html.markdown
@@ -1,0 +1,25 @@
+---
+subcategory: "SSO Admin"
+layout: "aws"
+page_title: "AWS: aws_ssoadmin_instance"
+description: |-
+  Lists SSO Admin Instance resources.
+---
+
+# List Resource: aws_ssoadmin_instance
+
+Lists SSO Admin Instance resources.
+
+## Example Usage
+
+```terraform
+list "aws_ssoadmin_instance" "example" {
+  provider = aws
+}
+```
+
+## Argument Reference
+
+This list resource supports the following arguments:
+
+* `region` - (Optional) Region to query. Defaults to provider region.

--- a/website/docs/r/ssoadmin_instance.html.markdown
+++ b/website/docs/r/ssoadmin_instance.html.markdown
@@ -35,7 +35,7 @@ resource "aws_ssoadmin_instance" "example" {
   name = "example"
 
   encryption_configuration {
-    key_type   = "CUSTOMER_MANAGED_KEY"
+    key_type    = "CUSTOMER_MANAGED_KEY"
     kms_key_arn = aws_kms_key.example.arn
   }
 }

--- a/website/docs/r/ssoadmin_instance.html.markdown
+++ b/website/docs/r/ssoadmin_instance.html.markdown
@@ -1,0 +1,117 @@
+---
+subcategory: "SSO Admin"
+layout: "aws"
+page_title: "AWS: aws_ssoadmin_instance"
+description: |-
+  Manages an IAM Identity Center instance.
+---
+
+# Resource: aws_ssoadmin_instance
+
+Manages an IAM Identity Center instance (formerly AWS Single Sign-On). IAM Identity Center supports one organization instance or one account instance per AWS account.
+
+~> **NOTE:** Creating an instance fails when the AWS account already has an IAM Identity Center instance. Import an existing instance instead.
+
+~> **WARNING:** Destroying this resource deletes the IAM Identity Center instance and can remove access to assigned AWS accounts and applications.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_ssoadmin_instance" "example" {
+  name = "example"
+
+  tags = {
+    Environment = "production"
+  }
+}
+```
+
+### Customer Managed KMS Key
+
+```terraform
+resource "aws_ssoadmin_instance" "example" {
+  name = "example"
+
+  encryption_configuration {
+    key_type   = "CUSTOMER_MANAGED_KEY"
+    kms_key_arn = aws_kms_key.example.arn
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are optional:
+
+* `client_token` - (Optional, Forces new resource) Unique, case-sensitive identifier to ensure idempotency of the request. Must be between 1 and 64 characters.
+* `encryption_configuration` - (Optional) Encryption configuration for data at rest. See [Encryption Configuration](#encryption-configuration).
+* `name` - (Optional) Name of the IAM Identity Center instance. Must be between 1 and 32 characters.
+* `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
+* `tags` - (Optional) Map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block), tags with matching keys will overwrite those defined at the provider-level.
+
+### `encryption_configuration` Block
+
+* `key_type` - (Required) Type of KMS key. Valid values are `AWS_OWNED_KMS_KEY` and `CUSTOMER_MANAGED_KEY`.
+* `kms_key_arn` - (Optional) ARN of the KMS key. Required when `key_type` is `CUSTOMER_MANAGED_KEY` and must not be specified when `key_type` is `AWS_OWNED_KMS_KEY`.
+
+## Attribute Reference
+
+This resource exports the following attributes in addition to the arguments above:
+
+* `arn` - ARN of the IAM Identity Center instance.
+* `created_date` - Date and time the instance was created.
+* `encryption_configuration.encryption_status` - Current encryption configuration status.
+* `encryption_configuration.encryption_status_reason` - Additional context for the encryption configuration status.
+* `identity_store_id` - Identifier of the connected identity store.
+* `owner_account_id` - AWS account ID of the instance owner.
+* `status` - Current instance status.
+* `status_reason` - Additional context for the instance status.
+* `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
+
+## Timeouts
+
+[Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
+
+* `create` - (Default `30m`)
+* `update` - (Default `30m`)
+* `delete` - (Default `30m`)
+
+## Import
+
+In Terraform v1.12.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `identity` attribute. For example:
+
+```terraform
+import {
+  to = aws_ssoadmin_instance.example
+  identity = {
+    arn = "arn:aws:sso:::instance/ssoins-0123456789abcdef"
+  }
+}
+```
+
+### Identity Schema
+
+#### Required
+
+* `arn` - ARN of the IAM Identity Center instance.
+
+#### Optional
+
+* `region` (String) Region where this resource is managed.
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import an IAM Identity Center instance using its ARN. For example:
+
+```terraform
+import {
+  to = aws_ssoadmin_instance.example
+  id = "arn:aws:sso:::instance/ssoins-0123456789abcdef"
+}
+```
+
+Using `terraform import`, import an IAM Identity Center instance using its ARN. For example:
+
+```console
+% terraform import aws_ssoadmin_instance.example arn:aws:sso:::instance/ssoins-0123456789abcdef
+```


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

This pull request adds management of IAM Identity Center encryption at rest. Users can select the AWS owned KMS key or configure a customer managed KMS key. It does not change existing resources or provider defaults.

### Description

Adds the `aws_ssoadmin_instance` resource using the Terraform Plugin Framework.

The resource supports:

* Creating, reading, updating, deleting, and importing IAM Identity Center instances
* Instance names and tags
* AWS owned and customer managed KMS encryption configurations
* Computed instance, identity store, owner, status, and encryption status metadata
* Terraform resource identity and a List Resource implementation

IAM Identity Center only permits one instance per account, so acceptance tests are serialized and skip accounts that already contain an instance.

AI assistance was used to inspect repository conventions, draft implementation code and documentation, and run local validation. The contributor reviewed and revised the resulting code and documentation.

### Relations

Closes #45878
Closes #49454

### References

* [AWS IAM Identity Center CreateInstance API](https://docs.aws.amazon.com/singlesignon/latest/APIReference/API_CreateInstance.html)
* [AWS IAM Identity Center UpdateInstance API](https://docs.aws.amazon.com/singlesignon/latest/APIReference/API_UpdateInstance.html)

### Output from Acceptance Testing

Acceptance tests were not run because they create and delete an IAM Identity Center instance and require an AWS account without an existing instance.

Local validation:

```console
% make build
success

% go test ./internal/service/ssoadmin -run '^Test[^A]'
ok github.com/hashicorp/terraform-provider-aws/internal/service/ssoadmin

% make swissshepherd
0 error(s), 1 unrelated pre-existing warning

% make ci-quick
All checks before semgrep validation passed; semgrep validation could not run because semgrep is not installed in the local environment.
```
