### PR TITLE
docs: fix references to nonexistent resource/data source types across 8 pages

### DIFF
--- a/website/docs/d/ec2_service_link_virtual_interfaces.html.markdown
+++ b/website/docs/d/ec2_service_link_virtual_interfaces.html.markdown
@@ -16,7 +16,7 @@ Provides a list of EC2 Service Link Virtual Interface IDs matching the provided 
 data "aws_ec2_service_link_virtual_interfaces" "example" {
   filter {
     name   = "outpost-arn"
-    values = [aws_outposts_outpost.example.arn]
+    values = [data.aws_outposts_outpost.example.arn]
   }
 }
 ```

--- a/website/docs/r/api_gateway_deployment.html.markdown
+++ b/website/docs/r/api_gateway_deployment.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # Resource: aws_api_gateway_deployment
 
-Manages an API Gateway REST Deployment. A deployment is a snapshot of the REST API configuration. The deployment can then be published to callable endpoints via the [`aws_api_gateway_stage` resource](api_gateway_stage.html) and optionally managed further with the [`aws_api_gateway_base_path_mapping` resource](api_gateway_base_path_mapping.html), [`aws_api_gateway_domain_name` resource](api_gateway_domain_name.html), and [`aws_api_method_settings` resource](api_gateway_method_settings.html). For more information, see the [API Gateway Developer Guide](https://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-deploy-api.html).
+Manages an API Gateway REST Deployment. A deployment is a snapshot of the REST API configuration. The deployment can then be published to callable endpoints via the [`aws_api_gateway_stage` resource](api_gateway_stage.html) and optionally managed further with the [`aws_api_gateway_base_path_mapping` resource](api_gateway_base_path_mapping.html), [`aws_api_gateway_domain_name` resource](api_gateway_domain_name.html), and [`aws_api_gateway_method_settings` resource](api_gateway_method_settings.html). For more information, see the [API Gateway Developer Guide](https://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-deploy-api.html).
 
 To properly capture all REST API configuration in a deployment, this resource must have dependencies on all prior Terraform resources that manage resources/paths, methods, integrations, etc.
 

--- a/website/docs/r/api_gateway_stage.html.markdown
+++ b/website/docs/r/api_gateway_stage.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # Resource: aws_api_gateway_stage
 
-Manages an API Gateway Stage. A stage is a named reference to a deployment, which can be done via the [`aws_api_gateway_deployment` resource](api_gateway_deployment.html). Stages can be optionally managed further with the [`aws_api_gateway_base_path_mapping` resource](api_gateway_base_path_mapping.html), [`aws_api_gateway_domain_name` resource](api_gateway_domain_name.html), and [`aws_api_method_settings` resource](api_gateway_method_settings.html). For more information, see the [API Gateway Developer Guide](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-stages.html).
+Manages an API Gateway Stage. A stage is a named reference to a deployment, which can be done via the [`aws_api_gateway_deployment` resource](api_gateway_deployment.html). Stages can be optionally managed further with the [`aws_api_gateway_base_path_mapping` resource](api_gateway_base_path_mapping.html), [`aws_api_gateway_domain_name` resource](api_gateway_domain_name.html), and [`aws_api_gateway_method_settings` resource](api_gateway_method_settings.html). For more information, see the [API Gateway Developer Guide](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-stages.html).
 
 ## Example Usage
 

--- a/website/docs/r/glue_data_catalog_encryption_settings.html.markdown
+++ b/website/docs/r/glue_data_catalog_encryption_settings.html.markdown
@@ -22,7 +22,7 @@ resource "aws_glue_data_catalog_encryption_settings" "example" {
 
     encryption_at_rest {
       catalog_encryption_mode         = "SSE-KMS"
-      catalog_encryption_service_role = aws_iam.role.test.arn
+      catalog_encryption_service_role = aws_iam_role.test.arn
       sse_aws_kms_key_id              = aws_kms_key.test.arn
     }
   }

--- a/website/docs/r/kendra_query_suggestions_block_list.html.markdown
+++ b/website/docs/r/kendra_query_suggestions_block_list.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # Resource: aws_kendra_query_suggestions_block_list
 
-Use the `aws_kendra_index_block_list` resource to manage an AWS Kendra block list used for query suggestions for an index.
+Use the `aws_kendra_query_suggestions_block_list` resource to manage an AWS Kendra block list used for query suggestions for an index.
 
 ## Example Usage
 

--- a/website/docs/r/prometheus_scraper.html.markdown
+++ b/website/docs/r/prometheus_scraper.html.markdown
@@ -197,7 +197,7 @@ EOT
 
 ### Use default EKS scraper configuration
 
-You can use the data source `aws_prometheus_scraper_configuration` to use a
+You can use the data source `aws_prometheus_default_scraper_configuration` to use a
 service managed scrape configuration.
 
 ```terraform
@@ -211,7 +211,7 @@ resource "aws_prometheus_scraper" "example" {
     }
   }
 
-  scrape_configuration = data.aws_prometheus_scraper_configuration.example.configuration
+  scrape_configuration = data.aws_prometheus_default_scraper_configuration.example.configuration
 
   source {
     eks {

--- a/website/docs/r/storagegateway_gateway.html.markdown
+++ b/website/docs/r/storagegateway_gateway.html.markdown
@@ -24,7 +24,7 @@ resource "aws_volume_attachment" "test" {
 }
 
 data "aws_storagegateway_local_disk" "test" {
-  disk_node   = data.aws_volume_attachment.test.device_name
+  disk_node   = aws_volume_attachment.test.device_name
   gateway_arn = aws_storagegateway_gateway.test.arn
 }
 

--- a/website/docs/r/vpclattice_access_log_subscription.html.markdown
+++ b/website/docs/r/vpclattice_access_log_subscription.html.markdown
@@ -17,7 +17,7 @@ Terraform resource for managing an AWS VPC Lattice Service Network or Service Ac
 ```terraform
 resource "aws_vpclattice_access_log_subscription" "example" {
   resource_identifier = aws_vpclattice_service_network.example.id
-  destination_arn     = aws_s3.bucket.arn
+  destination_arn     = aws_s3_bucket.bucket.arn
 }
 ```
 


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

No.

### Description

Documentation-only change. Fixes eight pages whose examples or prose reference resource/data source types that do not exist in the provider, so copying them fails with `Invalid resource type` / `Invalid data source`:

- `aws_ec2_service_link_virtual_interfaces` (data source): example filter referenced `aws_outposts_outpost.example.arn` as a managed resource; `aws_outposts_outpost` only exists as a data source, so the reference needs the `data.` prefix
- `aws_glue_data_catalog_encryption_settings`: example used `aws_iam.role.test.arn` instead of `aws_iam_role.test.arn`
- `aws_prometheus_scraper`: prose and the `scrape_configuration` expression named the data source `aws_prometheus_scraper_configuration` instead of `aws_prometheus_default_scraper_configuration` (as declared in the same example)
- `aws_storagegateway_gateway`: example read `data.aws_volume_attachment.test.device_name`; `aws_volume_attachment` is a managed resource declared in the same example, not a data source
- `aws_vpclattice_access_log_subscription`: example used `aws_s3.bucket.arn` instead of `aws_s3_bucket.bucket.arn`
- `aws_api_gateway_deployment` / `aws_api_gateway_stage`: intro paragraphs called the linked resource `aws_api_method_settings` instead of `aws_api_gateway_method_settings` (link targets were already correct)
- `aws_kendra_query_suggestions_block_list`: intro referenced a nonexistent `aws_kendra_index_block_list` resource

### Relations

Closes #49457

### References

_None._

### Output from Acceptance Testing

Not applicable — documentation-only change.
