### PR TITLE
docs: fix documented type names that do not match registered names (aws_ebs_volume list resource, two page_title fixes)

### DIFF
--- a/.ci/swissshepherd-full.hcl
+++ b/.ci/swissshepherd-full.hcl
@@ -5,9 +5,7 @@ provider_source = "registry.terraform.io/hashicorp/aws"
 provider_dir    = "."
 schema_json     = "terraform-providers-schema/schema.json"
 
-file_aliases = {
-  "list_resource/aws_ebs_volume" = "aws_ec2_ebs_volume"
-}
+file_aliases = {}
 
 ignore_contents_check = [
   "data_source/aws_kms_secret",

--- a/.ci/swissshepherd-weak.hcl
+++ b/.ci/swissshepherd-weak.hcl
@@ -5,9 +5,7 @@ provider_source = "registry.terraform.io/hashicorp/aws"
 provider_dir    = "."
 schema_json     = "terraform-providers-schema/schema.json"
 
-file_aliases = {
-  "list_resource/aws_ebs_volume" = "aws_ec2_ebs_volume"
-}
+file_aliases = {}
 
 ignore_contents_check = [
   "data_source/aws_kms_secret",

--- a/website/docs/list-resources/cloudwatch_log_s3_table_integration_source.html.markdown
+++ b/website/docs/list-resources/cloudwatch_log_s3_table_integration_source.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "CloudWatch Logs"
 layout: "aws"
-page_title: "AWS: aws_logs_s3_table_integration_source"
+page_title: "AWS: aws_cloudwatch_log_s3_table_integration_source"
 description: |-
   Lists CloudWatch Logs S3 Table Integration Source resources.
 ---

--- a/website/docs/list-resources/ebs_volume.html.markdown
+++ b/website/docs/list-resources/ebs_volume.html.markdown
@@ -1,12 +1,12 @@
 ---
 subcategory: "EC2 (Elastic Compute Cloud)"
 layout: "aws"
-page_title: "AWS: aws_ec2_ebs_volume"
+page_title: "AWS: aws_ebs_volume"
 description: |-
   Lists EC2 (Elastic Compute Cloud) EBS Volume resources.
 ---
 
-# List Resource: aws_ec2_ebs_volume
+# List Resource: aws_ebs_volume
 
 Lists EC2 (Elastic Compute Cloud) EBS Volume resources.
 
@@ -15,7 +15,7 @@ Lists EC2 (Elastic Compute Cloud) EBS Volume resources.
 ### Basic Usage
 
 ```terraform
-list "aws_ec2_ebs_volume" "example" {
+list "aws_ebs_volume" "example" {
   provider = aws
 }
 ```
@@ -25,7 +25,7 @@ list "aws_ec2_ebs_volume" "example" {
 This example returns EBS Volumes in a specific Availability Zone.
 
 ```terraform
-list "aws_ec2_ebs_volume" "example" {
+list "aws_ebs_volume" "example" {
   provider = aws
 
   config {
@@ -40,7 +40,7 @@ list "aws_ec2_ebs_volume" "example" {
 This example returns EBS Volumes with a specific tag value.
 
 ```terraform
-list "aws_ec2_ebs_volume" "example" {
+list "aws_ebs_volume" "example" {
   provider = aws
 
   config {

--- a/website/docs/r/drs_replication_configuration_template.html.markdown
+++ b/website/docs/r/drs_replication_configuration_template.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "DRS (Elastic Disaster Recovery)"
 layout: "aws"
-page_title: "AWS: drs_replication_configuration_template"
+page_title: "AWS: aws_drs_replication_configuration_template"
 description: |-
   Provides an Elastic Disaster Recovery replication configuration template resource.
 ---


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

No.

### Description

Documentation-only change. Fixes three pages whose documented type name does not match the name registered in the provider:

- Renames `website/docs/list-resources/ec2_ebs_volume.html.markdown` to `ebs_volume.html.markdown` and replaces `aws_ec2_ebs_volume` with `aws_ebs_volume` throughout (`page_title`, heading, and all three `list` example blocks). The list resource is registered as `aws_ebs_volume` (`internal/service/ec2/ebs_volume_list.go`), matching the `aws_ebs_volume` managed resource, so the examples as documented fail and the filename does not line up with the registered name (all other list resource pages are named after the registered type). The `file_aliases` entry in `.ci/swissshepherd-weak.hcl` / `.ci/swissshepherd-full.hcl` that papered over the filename mismatch is removed, since the renamed file now resolves without it.
- `aws_drs_replication_configuration_template`: adds the missing `aws_` prefix to the `page_title` frontmatter (`"AWS: drs_replication_configuration_template"` → `"AWS: aws_drs_replication_configuration_template"`).
- CloudWatch Logs S3 Table Integration Source list resource page: fixes the `page_title` frontmatter from `aws_logs_s3_table_integration_source` to the registered name `aws_cloudwatch_log_s3_table_integration_source`, matching the page heading and examples.

### Relations

Closes #49459

### References

_None._

### Output from Acceptance Testing

Not applicable — documentation-only change.
