### PR TITLE
r/aws_api_gateway_usage_plan_key: Mark value as sensitive

### DIFF
--- a/.changelog/49462.txt
+++ b/.changelog/49462.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_api_gateway_usage_plan_key: Mark `value` as sensitive
+```

--- a/internal/service/apigateway/usage_plan_key.go
+++ b/internal/service/apigateway/usage_plan_key.go
@@ -68,8 +68,9 @@ func resourceUsagePlanKey() *schema.Resource {
 					ForceNew: true,
 				},
 				names.AttrValue: {
-					Type:     schema.TypeString,
-					Computed: true,
+					Type:      schema.TypeString,
+					Computed:  true,
+					Sensitive: true,
 				},
 			}
 		},


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Yes — this changes secret exposure in provider output.

`aws_api_gateway_usage_plan_key.value` is an API key. Because it is not marked `Sensitive`, Terraform renders it in cleartext in plan output whenever the resource changes, so it can be written to CI logs, artifacts, and terminal scrollback by anyone who can read them. This PR marks it sensitive so it renders as `(sensitive value)`.

No change to access controls or encryption, no change to any AWS API call, and no change to what is persisted in state — the value was and remains stored in plaintext in state, as with all sensitive attributes.

### Description

`value` on `aws_api_gateway_usage_plan_key` is missing `Sensitive: true`, so Terraform prints the API key in cleartext in plan output.

The same attribute on the sibling resource in this package, `aws_api_gateway_api_key`, is already marked sensitive ([`api_key.go`](https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/apigateway/api_key.go)). The result is that the *same secret* is redacted when it comes from one resource and exposed when it comes from the other. A plan that replaces both prints:

```console
# ...aws_api_gateway_api_key.client_api_key must be replaced
      ~ value = (sensitive value) # forces replacement

# ...aws_api_gateway_usage_plan_key.usage_plan_key must be replaced
      ~ value = "<the actual API key>" -> (known after apply)
```

This is not theoretical — it is how we found it. A production plan in CI replaced the usage plan key (a KMS key policy change deferred a `aws_secretsmanager_secret_version` data source read to apply time, which made the API key value unknown and forced replacement) and wrote a live production API key into the workflow log. We rotated the key and deleted the run.

`value` is Computed-only, so this is a one-line schema change with no effect on configuration, state layout, or API calls.

**On categorisation:** filed as `release-note:bug` rather than `breaking-change`, following #48577, which marked three attributes sensitive and shipped in **v6.53.0** — a minor release, under BUG FIXES. Worth flagging the one user-visible consequence for reviewers: a configuration that passes this attribute to an `output` without `sensitive = true` will now error until the output is marked. That is inherent to any sensitivity fix and matches the accepted fallout of #48577.

I also looked at `aws_api_gateway_api_keys` (the plural data source), whose `items[].value` has the same exposure. It builds its schema from a Framework model via `DataSourceComputedListOfObjectAttribute`, so it needs a different mechanism, and it requires opt-in `include_values = true`. Left out to keep this focused — happy to follow up.

*AI usage disclosure: this change was prepared with the assistance of an AI coding agent (Zed). The agent located the issue, made the one-line schema change, verified it, identified the precedent, and helped me draft this description. I have reviewed the change and own it.*

### Relations

Closes #26739

### References

- #48577 — precedent: `Mark sensitive attributes`, released in [v6.53.0](https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md#6530-july-1-2026) under BUG FIXES
- `internal/service/apigateway/api_key.go` — `names.AttrValue` already sets `Sensitive: true`

### Output from Acceptance Testing

```console
% make testacc TESTS=TestAccAPIGatewayUsagePlanKey_ PKG=apigateway
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2	(cached)
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider/framework	(cached)
make: Running acceptance tests on branch: 🌿 b-aws_api_gateway_usage_plan_key-sensitive-value 🌿...
TF_ACC=1 go test ./internal/service/apigateway/... -v -count 1 -parallel 20 -run='TestAccAPIGatewayUsagePlanKey_'  -timeout 360m -vet=off -buildvcs=false
2026/08/13 13:20:28 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/13 13:20:28 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccAPIGatewayUsagePlanKey_basic
=== PAUSE TestAccAPIGatewayUsagePlanKey_basic
=== RUN   TestAccAPIGatewayUsagePlanKey_disappears
=== PAUSE TestAccAPIGatewayUsagePlanKey_disappears
=== RUN   TestAccAPIGatewayUsagePlanKey_KeyID_concurrency
=== PAUSE TestAccAPIGatewayUsagePlanKey_KeyID_concurrency
=== CONT  TestAccAPIGatewayUsagePlanKey_basic
=== CONT  TestAccAPIGatewayUsagePlanKey_KeyID_concurrency
=== CONT  TestAccAPIGatewayUsagePlanKey_disappears
--- PASS: TestAccAPIGatewayUsagePlanKey_basic (42.14s)
--- PASS: TestAccAPIGatewayUsagePlanKey_KeyID_concurrency (75.40s)
--- PASS: TestAccAPIGatewayUsagePlanKey_disappears (105.23s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/apigateway	112.177s
```