### PR TITLE
resource/aws_autoscaling_schedule: Recalculate start_time when recurrence changes

### DIFF
--- a/.changelog/49465.txt
+++ b/.changelog/49465.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_autoscaling_schedule: Recalculate the start time when updating a recurring schedule that does not configure `start_time`
+```

--- a/internal/service/autoscaling/schedule.go
+++ b/internal/service/autoscaling/schedule.go
@@ -122,8 +122,8 @@ func resourceSchedulePut(ctx context.Context, d *schema.ResourceData, meta any) 
 		input.Recurrence = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk(names.AttrStartTime); ok {
-		v, _ := time.Parse(ScheduleTimeLayout, v.(string))
+	if v := d.GetRawConfig().GetAttr(names.AttrStartTime); v.IsKnown() && !v.IsNull() {
+		v, _ := time.Parse(ScheduleTimeLayout, v.AsString())
 
 		input.StartTime = aws.Time(v)
 	}

--- a/internal/service/autoscaling/schedule_test.go
+++ b/internal/service/autoscaling/schedule_test.go
@@ -115,6 +115,38 @@ func TestAccAutoScalingSchedule_recurrence(t *testing.T) {
 	})
 }
 
+func TestAccAutoScalingSchedule_startTimeRecalculated(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v awstypes.ScheduledUpdateGroupAction
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_autoscaling_schedule.test"
+	startTime1 := time.Now().UTC().Add(2 * time.Hour).Truncate(time.Minute)
+	startTime2 := startTime1.Add(time.Hour)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.AutoScalingServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckScheduleDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccScheduleConfig_recurrenceWithStartTimeUnspecified(rName, startTime1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckScheduleExists(ctx, t, resourceName, &v),
+					testAccCheckScheduleStartTime(ctx, t, resourceName, startTime1),
+				),
+			},
+			{
+				Config: testAccScheduleConfig_recurrenceWithStartTimeUnspecified(rName, startTime2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckScheduleExists(ctx, t, resourceName, &v),
+					testAccCheckScheduleStartTime(ctx, t, resourceName, startTime2),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAutoScalingSchedule_zeroValues(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.ScheduledUpdateGroupAction
@@ -215,6 +247,27 @@ func testAccCheckScheduleExists(ctx context.Context, t *testing.T, n string, v *
 	}
 }
 
+func testAccCheckScheduleStartTime(ctx context.Context, t *testing.T, n string, want time.Time) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		conn := acctest.ProviderMeta(ctx, t).AutoScalingClient(ctx)
+		sa, err := tfautoscaling.FindScheduleByTwoPartKey(ctx, conn, rs.Primary.Attributes["autoscaling_group_name"], rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		if got := aws.ToTime(sa.StartTime); !got.Equal(want) {
+			return fmt.Errorf("expected start_time to be %s, got %s", want, got)
+		}
+
+		return nil
+	}
+}
+
 func testAccCheckScheduleDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.ProviderMeta(ctx, t).AutoScalingClient(ctx)
@@ -277,6 +330,33 @@ resource "aws_autoscaling_group" "test" {
 `, rName))
 }
 
+func testAccScheduleConfig_launchTemplateBase(rName string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigAvailableAZsNoOptInDefaultExclude(),
+		acctest.ConfigLatestAmazonLinux2HVMEBSX8664AMI(),
+		acctest.AvailableEC2InstanceTypeForAvailabilityZone("data.aws_availability_zones.available.names[0]", "t3.micro", "t2.micro"),
+		fmt.Sprintf(`
+resource "aws_launch_template" "test" {
+  name          = %[1]q
+  image_id      = data.aws_ami.amzn2-ami-minimal-hvm-ebs-x86_64.id
+  instance_type = data.aws_ec2_instance_type_offering.available.instance_type
+}
+
+resource "aws_autoscaling_group" "test" {
+  availability_zones = [data.aws_availability_zones.available.names[0]]
+  name               = %[1]q
+  min_size           = 0
+  max_size           = 0
+  force_delete       = true
+
+  launch_template {
+    id      = aws_launch_template.test.id
+    version = "$Latest"
+  }
+}
+`, rName))
+}
+
 func testAccScheduleConfig_basic(rName1, rName2, startTime, endTime string) string {
 	return acctest.ConfigCompose(testAccScheduleConfig_base(rName1), fmt.Sprintf(`
 resource "aws_autoscaling_schedule" "test" {
@@ -302,7 +382,21 @@ resource "aws_autoscaling_schedule" "test" {
   time_zone              = "Pacific/Tahiti"
   autoscaling_group_name = aws_autoscaling_group.test.name
 }
+
 `, rName))
+}
+
+func testAccScheduleConfig_recurrenceWithStartTimeUnspecified(rName string, startTime time.Time) string {
+	return acctest.ConfigCompose(testAccScheduleConfig_launchTemplateBase(rName), fmt.Sprintf(`
+resource "aws_autoscaling_schedule" "test" {
+  scheduled_action_name  = %[1]q
+  min_size               = 0
+  max_size               = 1
+  desired_capacity       = 0
+  recurrence             = %[2]q
+  autoscaling_group_name = aws_autoscaling_group.test.name
+}
+`, rName, fmt.Sprintf("%d %d * * *", startTime.Minute(), startTime.Hour())))
 }
 
 func testAccScheduleConfig_zeroValues(rName, startTime, endTime string) string {


### PR DESCRIPTION
## Summary

Fixes `aws_autoscaling_schedule` reusing the AWS-computed `start_time` when updating `recurrence` without an explicitly configured `start_time`.  

The provider now sends `StartTime` only when it is set in the Terraform configuration, allowing AWS to recalculate it from the new recurrence.

## Testing
- `go test ./internal/service/autoscaling/...`  
- `make testacc TESTS=TestAccAutoScalingSchedule_startTimeRecalculated PKG=autoscaling`  

Regression test behavior:  
- Unfixed provider + regression test: FAIL
- Fixed provider + regression test: PASS

AI was used to assist with implementation, regression-test design, and verification planning. I reviewed the changes and ran the acceptance tests.

Closes [#38983](https://github.com/hashicorp/terraform-provider-aws/issues/38983)