### PR TITLE
add plan-time validation for elasticache engine and param group versions

### DIFF
--- a/.changelog/00000.txt
+++ b/.changelog/00000.txt
@@ -1,0 +1,6 @@
+```release-note:enhancement
+resource/aws_elasticache_cluster: Add plan-time validation that `engine_version` is available for the configured `engine` in the current Region and is compatible with the family of `parameter_group_name`
+```
+```release-note:enhancement
+resource/aws_elasticache_replication_group: Add plan-time validation that `engine_version` is available for the configured `engine` in the current Region and is compatible with the family of `parameter_group_name`
+```

--- a/internal/service/elasticache/cluster.go
+++ b/internal/service/elasticache/cluster.go
@@ -348,6 +348,7 @@ func resourceCluster() *schema.Resource {
 		CustomizeDiff: customdiff.Sequence(
 			clusterValidateAZMode,
 			customizeDiffValidateClusterEngineVersion,
+			customizeDiffValidateEngineVersion,
 			customizeDiffEngineVersionForceNewOnDowngrade,
 			clusterValidateNumCacheNodes,
 			clusterForceNewOnMemcachedNodeTypeChange,

--- a/internal/service/elasticache/cluster_test.go
+++ b/internal/service/elasticache/cluster_test.go
@@ -295,6 +295,50 @@ func TestAccElastiCacheCluster_ParameterGroupName_default(t *testing.T) {
 	})
 }
 
+func TestAccElastiCacheCluster_EngineVersion_unavailable(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccClusterConfig_parameterGroupName(rName, "redis", "7.9", "default.redis7"),
+				ExpectError: regexache.MustCompile(`engine_version "7.9" is not available for engine "redis"`),
+			},
+		},
+	})
+}
+
+func TestAccElastiCacheCluster_EngineVersion_incompatibleParameterGroup(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccClusterConfig_parameterGroupName(rName, "redis", "7.0", "default.redis6.x"),
+				ExpectError: regexache.MustCompile(`engine_version "7.0" is not compatible with parameter_group_name "default.redis6.x"`),
+			},
+		},
+	})
+}
+
 func TestAccElastiCacheCluster_ipDiscovery(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {

--- a/internal/service/elasticache/engine_version.go
+++ b/internal/service/elasticache/engine_version.go
@@ -9,12 +9,19 @@ import (
 	"fmt"
 	"math"
 	"regexp"
+	"slices"
+	"strings"
 
 	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/elasticache"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
 	gversion "github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -267,4 +274,237 @@ func diffVersion(n, o *gversion.Version) (result versionDiff) {
 	}
 
 	return
+}
+
+// redisMajorVersionWildcardRegexp matches the "<major>.x" convention (e.g. "6.x")
+// that ElastiCache Redis accepts for engine_version to mean "the latest minor of
+// that major version".
+var redisMajorVersionWildcardRegexp = regexache.MustCompile(`^([6-9])\.x$`)
+
+// customizeDiffValidateEngineVersion validates, at plan time, that the configured
+// engine_version:
+//   - is actually available for the engine in the target region, and
+//   - is compatible with the family of the referenced parameter_group_name
+//     (e.g. engine_version "7.0" with parameter_group_name "default.redis6.x").
+//
+// Both checks require calling the ElastiCache API (DescribeCacheEngineVersions,
+// and for custom parameter groups DescribeCacheParameterGroups). To avoid breaking
+// plans for callers that previously planned offline or without
+// elasticache:DescribeCacheEngineVersions / elasticache:DescribeCacheParameterGroups
+// permissions, any API error is treated as "skip" (fail open); only a definitive
+// mismatch produces a plan-time error. Values that are unset or not yet known
+// (e.g. interpolated from another resource) are also skipped.
+func customizeDiffValidateEngineVersion(ctx context.Context, diff *schema.ResourceDiff, meta any) error {
+	engine, engineVersion, ok := configuredEngineVersion(diff)
+	if !ok {
+		return nil
+	}
+
+	conn := meta.(*conns.AWSClient).ElastiCacheClient(ctx)
+
+	available, err := findCacheEngineVersions(ctx, conn, engine)
+	if err != nil {
+		tflog.Debug(ctx, "skipping ElastiCache engine_version validation", map[string]any{
+			names.AttrEngine:        engine,
+			names.AttrEngineVersion: engineVersion,
+			"error":                 err.Error(),
+		})
+		return nil
+	}
+	if len(available) == 0 {
+		return nil
+	}
+
+	matched, found := findAvailableCacheEngineVersion(engine, engineVersion, available)
+	if !found {
+		return fmt.Errorf("engine_version %q is not available for engine %q in this region; available versions: %s",
+			engineVersion, engine, strings.Join(availableEngineVersionStrings(available), ", "))
+	}
+
+	// Parameter group compatibility. Only checked when parameter_group_name is set,
+	// known, and its family can be resolved.
+	parameterGroupName, ok := configuredParameterGroupName(diff)
+	if !ok {
+		return nil
+	}
+
+	family, ok, err := findCacheParameterGroupFamily(ctx, conn, parameterGroupName)
+	if err != nil {
+		tflog.Debug(ctx, "skipping ElastiCache parameter group compatibility validation", map[string]any{
+			names.AttrParameterGroupName: parameterGroupName,
+			"error":                      err.Error(),
+		})
+		return nil
+	}
+	if !ok {
+		return nil
+	}
+
+	if versionFamily := aws.ToString(matched.CacheParameterGroupFamily); !strings.EqualFold(versionFamily, family) {
+		return fmt.Errorf("engine_version %q is not compatible with parameter_group_name %q: engine version family %q does not match parameter group family %q",
+			engineVersion, parameterGroupName, versionFamily, family)
+	}
+
+	return nil
+}
+
+// configuredEngineVersion returns the configured engine and engine_version when
+// both are set and known. It returns ok=false when engine_version is unset, empty,
+// or not yet known (e.g. interpolated from another resource), or when the engine
+// cannot be determined.
+func configuredEngineVersion(diff *schema.ResourceDiff) (engine, engineVersion string, ok bool) {
+	v, exists := diff.GetOk(names.AttrEngineVersion)
+	if !exists {
+		return "", "", false
+	}
+	engineVersion, _ = v.(string)
+	if engineVersion == "" || !rawConfigAttrKnown(diff, names.AttrEngineVersion) {
+		return "", "", false
+	}
+
+	engine, _ = diff.Get(names.AttrEngine).(string)
+	if engine == "" {
+		return "", "", false
+	}
+
+	return engine, engineVersion, true
+}
+
+// configuredParameterGroupName returns the configured parameter_group_name when it
+// is set and known.
+func configuredParameterGroupName(diff *schema.ResourceDiff) (string, bool) {
+	v, exists := diff.GetOk(names.AttrParameterGroupName)
+	if !exists {
+		return "", false
+	}
+	name, _ := v.(string)
+	if name == "" || !rawConfigAttrKnown(diff, names.AttrParameterGroupName) {
+		return "", false
+	}
+
+	return name, true
+}
+
+// rawConfigAttrKnown reports whether the top-level attribute is known in the raw
+// configuration. Unknown values (interpolated from another resource that has not
+// yet been applied) cannot be validated at plan time.
+func rawConfigAttrKnown(diff *schema.ResourceDiff, attr string) bool {
+	rawConfig := diff.GetRawConfig()
+	if rawConfig.IsNull() || !rawConfig.IsKnown() {
+		return false
+	}
+
+	return rawConfig.GetAttr(attr).IsKnown()
+}
+
+// findAvailableCacheEngineVersion returns the CacheEngineVersion matching the
+// configured engine_version, if the version is available.
+func findAvailableCacheEngineVersion(engine, engineVersion string, available []awstypes.CacheEngineVersion) (awstypes.CacheEngineVersion, bool) {
+	for _, v := range available {
+		if engineVersionMatches(engine, engineVersion, aws.ToString(v.EngineVersion)) {
+			return v, true
+		}
+	}
+
+	return awstypes.CacheEngineVersion{}, false
+}
+
+// engineVersionMatches reports whether a configured engine_version matches a
+// version returned by the API, accounting for the Redis "<major>.x" convention.
+func engineVersionMatches(engine, configVersion, apiVersion string) bool {
+	if apiVersion == "" {
+		return false
+	}
+	if configVersion == apiVersion {
+		return true
+	}
+
+	// Redis accepts a "<major>.x" convention (e.g. "6.x") that maps to any minor
+	// version of that major (e.g. the API's "6.0" or "6.2").
+	if engine == engineRedis {
+		if m := redisMajorVersionWildcardRegexp.FindStringSubmatch(configVersion); m != nil {
+			return strings.HasPrefix(apiVersion, m[1]+".")
+		}
+	}
+
+	return false
+}
+
+// availableEngineVersionStrings returns the sorted, de-duplicated set of engine
+// version strings from the supplied CacheEngineVersions, for use in diagnostics.
+func availableEngineVersionStrings(available []awstypes.CacheEngineVersion) []string {
+	seen := make(map[string]struct{}, len(available))
+	versions := make([]string, 0, len(available))
+	for _, v := range available {
+		ev := aws.ToString(v.EngineVersion)
+		if ev == "" {
+			continue
+		}
+		if _, dup := seen[ev]; dup {
+			continue
+		}
+		seen[ev] = struct{}{}
+		versions = append(versions, ev)
+	}
+	slices.Sort(versions)
+
+	return versions
+}
+
+// findCacheParameterGroupFamily resolves the parameter group family for the given
+// parameter group name. For AWS default parameter groups the family is derived from
+// the name without an API call; for custom groups it is looked up via the API.
+// It returns ok=false (without error) when the family cannot be determined, such as
+// when a custom parameter group does not yet exist.
+func findCacheParameterGroupFamily(ctx context.Context, conn *elasticache.Client, name string) (string, bool, error) {
+	if family, ok := defaultCacheParameterGroupFamily(name); ok {
+		return family, true, nil
+	}
+
+	pg, err := findCacheParameterGroupByName(ctx, conn, name)
+	if err != nil {
+		if retry.NotFound(err) {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+
+	return aws.ToString(pg.CacheParameterGroupFamily), true, nil
+}
+
+// defaultCacheParameterGroupFamily derives the family of an AWS-managed default
+// parameter group from its name (e.g. "default.redis6.x" -> "redis6.x",
+// "default.redis7.cluster.on" -> "redis7"). It returns ok=false for names that are
+// not default parameter groups.
+func defaultCacheParameterGroupFamily(name string) (string, bool) {
+	const prefix = "default."
+	if !strings.HasPrefix(name, prefix) {
+		return "", false
+	}
+
+	family := strings.TrimPrefix(name, prefix)
+	family = strings.TrimSuffix(family, ".cluster.on")
+
+	return family, true
+}
+
+// findCacheEngineVersions returns all cache engine versions available for the given
+// engine in the current region.
+func findCacheEngineVersions(ctx context.Context, conn *elasticache.Client, engine string) ([]awstypes.CacheEngineVersion, error) {
+	input := &elasticache.DescribeCacheEngineVersionsInput{
+		Engine: aws.String(engine),
+	}
+
+	var output []awstypes.CacheEngineVersion
+	pages := elasticache.NewDescribeCacheEngineVersionsPaginator(conn, input)
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		output = append(output, page.CacheEngineVersions...)
+	}
+
+	return output, nil
 }

--- a/internal/service/elasticache/engine_version.go
+++ b/internal/service/elasticache/engine_version.go
@@ -309,7 +309,7 @@ func customizeDiffValidateEngineVersion(ctx context.Context, diff *schema.Resour
 			names.AttrEngineVersion: engineVersion,
 			"error":                 err.Error(),
 		})
-		return nil
+		return nil //nolint:nilerr // fail open: skip plan-time validation when the API is unavailable (e.g. missing IAM permissions)
 	}
 	if len(available) == 0 {
 		return nil
@@ -334,7 +334,7 @@ func customizeDiffValidateEngineVersion(ctx context.Context, diff *schema.Resour
 			names.AttrParameterGroupName: parameterGroupName,
 			"error":                      err.Error(),
 		})
-		return nil
+		return nil //nolint:nilerr // fail open: skip plan-time validation when the API is unavailable (e.g. missing IAM permissions)
 	}
 	if !ok {
 		return nil

--- a/internal/service/elasticache/engine_version_validate_test.go
+++ b/internal/service/elasticache/engine_version_validate_test.go
@@ -1,0 +1,214 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package elasticache_test
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
+	"github.com/google/go-cmp/cmp"
+	tfelasticache "github.com/hashicorp/terraform-provider-aws/internal/service/elasticache"
+)
+
+func TestEngineVersionMatches(t *testing.T) {
+	t.Parallel()
+
+	testcases := map[string]struct {
+		engine        string
+		configVersion string
+		apiVersion    string
+		expected      bool
+	}{
+		"redis exact minor match": {
+			engine:        tfelasticache.EngineRedis,
+			configVersion: "7.1",
+			apiVersion:    "7.1",
+			expected:      true,
+		},
+		"redis exact minor mismatch": {
+			engine:        tfelasticache.EngineRedis,
+			configVersion: "7.1",
+			apiVersion:    "7.0",
+			expected:      false,
+		},
+		"redis major wildcard matches minor": {
+			engine:        tfelasticache.EngineRedis,
+			configVersion: "6.x",
+			apiVersion:    "6.2",
+			expected:      true,
+		},
+		"redis major wildcard different major": {
+			engine:        tfelasticache.EngineRedis,
+			configVersion: "6.x",
+			apiVersion:    "7.0",
+			expected:      false,
+		},
+		"redis pre-v6 patch match": {
+			engine:        tfelasticache.EngineRedis,
+			configVersion: "5.0.6",
+			apiVersion:    "5.0.6",
+			expected:      true,
+		},
+		"valkey exact match": {
+			engine:        tfelasticache.EngineValkey,
+			configVersion: "7.2",
+			apiVersion:    "7.2",
+			expected:      true,
+		},
+		"valkey does not honor wildcard": {
+			engine:        tfelasticache.EngineValkey,
+			configVersion: "7.x",
+			apiVersion:    "7.2",
+			expected:      false,
+		},
+		"memcached patch match": {
+			engine:        tfelasticache.EngineMemcached,
+			configVersion: "1.6.22",
+			apiVersion:    "1.6.22",
+			expected:      true,
+		},
+		"empty api version": {
+			engine:        tfelasticache.EngineRedis,
+			configVersion: "7.1",
+			apiVersion:    "",
+			expected:      false,
+		},
+	}
+
+	for name, testcase := range testcases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := tfelasticache.EngineVersionMatches(testcase.engine, testcase.configVersion, testcase.apiVersion); got != testcase.expected {
+				t.Errorf("EngineVersionMatches(%q, %q, %q) = %t, want %t", testcase.engine, testcase.configVersion, testcase.apiVersion, got, testcase.expected)
+			}
+		})
+	}
+}
+
+func TestFindAvailableCacheEngineVersion(t *testing.T) {
+	t.Parallel()
+
+	available := []awstypes.CacheEngineVersion{
+		{EngineVersion: aws.String("6.0"), CacheParameterGroupFamily: aws.String("redis6.x")},
+		{EngineVersion: aws.String("6.2"), CacheParameterGroupFamily: aws.String("redis6.x")},
+		{EngineVersion: aws.String("7.0"), CacheParameterGroupFamily: aws.String("redis7")},
+		{EngineVersion: aws.String("7.1"), CacheParameterGroupFamily: aws.String("redis7")},
+	}
+
+	testcases := map[string]struct {
+		engine        string
+		configVersion string
+		wantFound     bool
+		wantFamily    string
+	}{
+		"available exact": {
+			engine:        tfelasticache.EngineRedis,
+			configVersion: "7.0",
+			wantFound:     true,
+			wantFamily:    "redis7",
+		},
+		"available wildcard": {
+			engine:        tfelasticache.EngineRedis,
+			configVersion: "6.x",
+			wantFound:     true,
+			wantFamily:    "redis6.x",
+		},
+		"unavailable": {
+			engine:        tfelasticache.EngineRedis,
+			configVersion: "7.2",
+			wantFound:     false,
+		},
+	}
+
+	for name, testcase := range testcases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			matched, found := tfelasticache.FindAvailableCacheEngineVersion(testcase.engine, testcase.configVersion, available)
+			if found != testcase.wantFound {
+				t.Fatalf("FindAvailableCacheEngineVersion found = %t, want %t", found, testcase.wantFound)
+			}
+			if found {
+				if got := aws.ToString(matched.CacheParameterGroupFamily); got != testcase.wantFamily {
+					t.Errorf("matched family = %q, want %q", got, testcase.wantFamily)
+				}
+			}
+		})
+	}
+}
+
+func TestDefaultCacheParameterGroupFamily(t *testing.T) {
+	t.Parallel()
+
+	testcases := map[string]struct {
+		name       string
+		wantFamily string
+		wantOK     bool
+	}{
+		"default redis 6.x": {
+			name:       "default.redis6.x",
+			wantFamily: "redis6.x",
+			wantOK:     true,
+		},
+		"default redis 7": {
+			name:       "default.redis7",
+			wantFamily: "redis7",
+			wantOK:     true,
+		},
+		"default redis 7 cluster mode": {
+			name:       "default.redis7.cluster.on",
+			wantFamily: "redis7",
+			wantOK:     true,
+		},
+		"default valkey 8": {
+			name:       "default.valkey8",
+			wantFamily: "valkey8",
+			wantOK:     true,
+		},
+		"default memcached": {
+			name:       "default.memcached1.6",
+			wantFamily: "memcached1.6",
+			wantOK:     true,
+		},
+		"custom group": {
+			name:   "my-custom-group",
+			wantOK: false,
+		},
+	}
+
+	for name, testcase := range testcases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			family, ok := tfelasticache.DefaultCacheParameterGroupFamily(testcase.name)
+			if ok != testcase.wantOK {
+				t.Fatalf("DefaultCacheParameterGroupFamily(%q) ok = %t, want %t", testcase.name, ok, testcase.wantOK)
+			}
+			if ok && family != testcase.wantFamily {
+				t.Errorf("DefaultCacheParameterGroupFamily(%q) = %q, want %q", testcase.name, family, testcase.wantFamily)
+			}
+		})
+	}
+}
+
+func TestAvailableEngineVersionStrings(t *testing.T) {
+	t.Parallel()
+
+	available := []awstypes.CacheEngineVersion{
+		{EngineVersion: aws.String("7.1")},
+		{EngineVersion: aws.String("6.0")},
+		{EngineVersion: aws.String("7.1")}, // duplicate
+		{EngineVersion: aws.String("7.0")},
+		{EngineVersion: aws.String("")}, // skipped
+	}
+
+	got := tfelasticache.AvailableEngineVersionStrings(available)
+	want := []string{"6.0", "7.0", "7.1"}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("unexpected result (-want +got):\n%s", diff)
+	}
+}

--- a/internal/service/elasticache/exports_test.go
+++ b/internal/service/elasticache/exports_test.go
@@ -32,6 +32,8 @@ var (
 	WaitCacheClusterAvailable            = waitCacheClusterAvailable
 	WaitReplicationGroupAvailable        = waitReplicationGroupAvailable
 
+	AvailableEngineVersionStrings                     = availableEngineVersionStrings
+	DefaultCacheParameterGroupFamily                  = defaultCacheParameterGroupFamily
 	DeleteCacheCluster                                = deleteCacheCluster
 	DiffVersion                                       = diffVersion
 	EmptyDescription                                  = emptyDescription
@@ -40,6 +42,8 @@ var (
 	EngineValkey                                      = engineValkey
 	EngineVersionForceNewOnDowngrade                  = engineVersionForceNewOnDowngrade
 	EngineVersionIsDowngrade                          = engineVersionIsDowngrade
+	EngineVersionMatches                              = engineVersionMatches
+	FindAvailableCacheEngineVersion                   = findAvailableCacheEngineVersion
 	GlobalReplicationGroupRegionPrefixFormat          = globalReplicationGroupRegionPrefixFormat
 	NormalizeEngineVersion                            = normalizeEngineVersion
 	ParamGroupNameRequiresEngineOrMajorVersionUpgrade = paramGroupNameRequiresEngineOrMajorVersionUpgrade

--- a/internal/service/elasticache/replication_group.go
+++ b/internal/service/elasticache/replication_group.go
@@ -495,6 +495,7 @@ func resourceReplicationGroup() *schema.Resource {
 		CustomizeDiff: customdiff.All(
 			suppressDiffIfBelongsToGlobalReplicationGroup,
 			replicationGroupValidateMultiAZAutomaticFailover,
+			customizeDiffValidateEngineVersion,
 			customizeDiffEngineVersionForceNewOnDowngrade,
 			authTokenUpdateStrategyValidate,
 			customizeDiffEngineForceNewOnDowngrade(),


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

### Description
Currently, there's no plan time validation for elasticache engine updates, and so plans can succeed, but then fail on merge, which isn't the worst thing in the world, but it's annoying and requires another round of PR review/approval.

It would be nicer to get faster feedback so that it's clear what the problem is before merge/apply. 

Even though the initial issue was regarding the engine version, I also added in some checks for whether the parameter group version was available, since I've also seen that pass planning stages and then fail on apply.

### Relations
Closes: https://github.com/hashicorp/terraform-provider-aws/issues/49466

### References
N/A


### Output from Acceptance Testing
I haven't run any acceptance testing, since this is a plan-time validation, but I can try to do that if it would be helpful.

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
