### PR TITLE
Revert Plugin SDK V2 identity interceptor logic changes

### DIFF
--- a/internal/provider/sdkv2/identity_interceptor.go
+++ b/internal/provider/sdkv2/identity_interceptor.go
@@ -32,12 +32,7 @@ func (r identityInterceptor) run(ctx context.Context, opts crudInterceptorOption
 			if why == Update && !(r.identitySpec.IsMutable && r.identitySpec.IsSetOnUpdate) && !identityIsFullyNull(d, r.identitySpec) {
 				break
 			}
-			// `Id()` is empty when the resource is being removed
 			if d.Id() == "" {
-				break
-			}
-			// Identity is fully-null on Read when Importing or when updating existing resources created without identity.
-			if why == Read && !(r.identitySpec.IsMutable && r.identitySpec.IsSetOnUpdate) && !identityIsFullyNull(d, r.identitySpec) {
 				break
 			}
 			identity, err := d.Identity()

--- a/internal/provider/sdkv2/identity_interceptor.go
+++ b/internal/provider/sdkv2/identity_interceptor.go
@@ -29,22 +29,20 @@ func (r identityInterceptor) run(ctx context.Context, opts crudInterceptorOption
 	case After:
 		switch why {
 		case Create, Read, Update:
+			if why == Update && !(r.identitySpec.IsMutable && r.identitySpec.IsSetOnUpdate) && !identityIsFullyNull(d, r.identitySpec) {
+				break
+			}
 			// `Id()` is empty when the resource is being removed
 			if d.Id() == "" {
 				break
 			}
-
+			// Identity is fully-null on Read when Importing or when updating existing resources created without identity.
+			if why == Read && !(r.identitySpec.IsMutable && r.identitySpec.IsSetOnUpdate) && !identityIsFullyNull(d, r.identitySpec) {
+				break
+			}
 			identity, err := d.Identity()
 			if err != nil {
 				return sdkdiag.AppendFromErr(diags, err)
-			}
-
-			if why == Update && !(r.identitySpec.IsMutable && r.identitySpec.IsSetOnUpdate) && !identityIsFullyNull(identity, r.identitySpec) {
-				break
-			}
-			// Identity is fully-null on Read when Importing or when updating existing resources created without identity.
-			if why == Read && !(r.identitySpec.IsMutable && r.identitySpec.IsSetOnUpdate) && !identityIsFullyNull(identity, r.identitySpec) {
-				break
 			}
 
 			for _, attr := range r.identitySpec.Attributes {
@@ -73,13 +71,13 @@ func (r identityInterceptor) run(ctx context.Context, opts crudInterceptorOption
 	case OnError:
 		switch why {
 		case Update:
-			identity, err := d.Identity()
-			if err != nil {
-				return sdkdiag.AppendFromErr(diags, err)
-			}
-			if identityIsFullyNull(identity, r.identitySpec) {
+			if identityIsFullyNull(d, r.identitySpec) {
 				if d.Id() == "" {
 					break
+				}
+				identity, err := d.Identity()
+				if err != nil {
+					return sdkdiag.AppendFromErr(diags, err)
 				}
 
 				for _, attr := range r.identitySpec.Attributes {
@@ -113,7 +111,12 @@ func (r identityInterceptor) run(ctx context.Context, opts crudInterceptorOption
 
 // identityIsFullyNull returns true if a resource supports identity and
 // all attributes are set to null values
-func identityIsFullyNull(identity *schema.IdentityData, identitySpec *inttypes.Identity) bool {
+func identityIsFullyNull(d schemaResourceData, identitySpec *inttypes.Identity) bool {
+	identity, err := d.Identity()
+	if err != nil {
+		return false
+	}
+
 	for _, attr := range identitySpec.Attributes {
 		value := identity.Get(attr.Name())
 		if value != "" {

--- a/internal/provider/sdkv2/identity_interceptor_test.go
+++ b/internal/provider/sdkv2/identity_interceptor_test.go
@@ -534,7 +534,7 @@ func TestIdentityIsFullyNull(t *testing.T) {
 				}
 			}
 
-			result := identityIsFullyNull(identity, identitySpec)
+			result := identityIsFullyNull(d, identitySpec)
 			if result != tc.expectNull {
 				t.Errorf("%s: expected identityIsFullyNull to return %v, got %v",
 					tc.description, tc.expectNull, result)

--- a/internal/provider/sdkv2/identity_interceptor_test.go
+++ b/internal/provider/sdkv2/identity_interceptor_test.go
@@ -98,13 +98,12 @@ func TestIdentityInterceptor_Create(t *testing.T) {
 	}
 }
 
-func TestIdentityInterceptor_Read(t *testing.T) {
+func TestIdentityInterceptor_Read_RemovedFromState(t *testing.T) {
 	t.Parallel()
 
 	accountID := "123456789012"
 	region := "us-west-2" //lintignore:AWSAT003
-	attributeName := "attr_name"
-	identityName := "id_name"
+	name := "a_name"
 
 	resourceSchema := map[string]*schema.Schema{
 		"name": {
@@ -118,183 +117,47 @@ func TestIdentityInterceptor_Read(t *testing.T) {
 		"region": sdkv2.RegionOptionalComputed(),
 	}
 
-	client := mockClient{
-		accountID: accountID,
-		region:    region,
-	}
+	identitySpec := regionalSingleParameterizedIdentitySpec("name")
+	identitySchema := identity.NewIdentitySchema(identitySpec)
 
-	testCases := map[string]struct {
-		id             string
-		identityValues map[string]string
-		expectedName   string
-	}{
-		"existing resource": {
-			id: "some_id",
-			identityValues: map[string]string{
-				names.AttrAccountID: accountID,
-				names.AttrRegion:    region,
-				"name":              identityName,
-			},
-			expectedName: identityName,
-		},
-		"removed from state": {
-			id: "",
-			identityValues: map[string]string{
-				names.AttrAccountID: accountID,
-				names.AttrRegion:    region,
-				"name":              identityName,
-			},
-			expectedName: identityName,
-		},
-		"for import": {
-			id:             "some_id",
-			identityValues: nil,
-			expectedName:   attributeName,
-		},
-	}
-
-	for tname, tc := range testCases {
-		t.Run(tname, func(t *testing.T) {
-			t.Parallel()
-			ctx := t.Context()
-
-			identitySpec := regionalSingleParameterizedIdentitySpec("name")
-			identitySchema := identity.NewIdentitySchema(identitySpec)
-
-			invocation := newIdentityInterceptor(&identitySpec)
-			interceptor := invocation.interceptor.(identityInterceptor)
-
-			d := schema.TestResourceDataWithIdentityRaw(t, resourceSchema, identitySchema, tc.identityValues)
-			d.SetId(tc.id)
-			d.Set("name", attributeName)
-			d.Set("region", region)
-			d.Set("type", "some_type")
-
-			opts := crudInterceptorOptions{
-				c:    client,
-				d:    d,
-				when: After,
-				why:  Read,
-			}
-
-			interceptor.run(ctx, opts)
-
-			identity, err := d.Identity()
-			if err != nil {
-				t.Fatalf("unexpected error getting identity: %v", err)
-			}
-
-			if e, a := accountID, identity.Get(names.AttrAccountID); e != a {
-				t.Errorf("expected account ID %q, got %q", e, a)
-			}
-			if e, a := region, identity.Get(names.AttrRegion); e != a {
-				t.Errorf("expected region %q, got %q", e, a)
-			}
-			if e, a := tc.expectedName, identity.Get("name"); e != a {
-				t.Errorf("expected name %q, got %q", e, a)
-			}
-		})
-	}
-}
-
-func TestIdentityInterceptor_Read_MutableIdentity(t *testing.T) {
-	t.Parallel()
-
-	accountID := "123456789012"
-	region := "us-west-2" //lintignore:AWSAT003
-	attributeName := "attr_name"
-	identityName := "id_name"
-
-	resourceSchema := map[string]*schema.Schema{
-		"name": {
-			Type:     schema.TypeString,
-			Required: true,
-		},
-		"type": {
-			Type:     schema.TypeString,
-			Optional: true,
-		},
-		"region": sdkv2.RegionOptionalComputed(),
-	}
+	invocation := newIdentityInterceptor(&identitySpec)
+	interceptor := invocation.interceptor.(identityInterceptor)
 
 	client := mockClient{
 		accountID: accountID,
 		region:    region,
 	}
 
-	testCases := map[string]struct {
-		id             string
-		identityValues map[string]string
-		expectedName   string
-	}{
-		"existing resource": {
-			id: "some_id",
-			identityValues: map[string]string{
-				names.AttrAccountID: accountID,
-				names.AttrRegion:    region,
-				"name":              identityName,
-			},
-			expectedName: attributeName,
-		},
-		"removed from state": {
-			id: "",
-			identityValues: map[string]string{
-				names.AttrAccountID: accountID,
-				names.AttrRegion:    region,
-				"name":              identityName,
-			},
-			expectedName: identityName,
-		},
-		"for import": {
-			id:             "some_id",
-			identityValues: nil,
-			expectedName:   attributeName,
-		},
+	ctx := t.Context()
+
+	d := schema.TestResourceDataWithIdentityRaw(t, resourceSchema, identitySchema, nil)
+	d.SetId("")
+	d.Set("name", name)
+	d.Set("region", region)
+	d.Set("type", "some_type")
+
+	opts := crudInterceptorOptions{
+		c:    client,
+		d:    d,
+		when: After,
+		why:  Read,
 	}
 
-	for tname, tc := range testCases {
-		t.Run(tname, func(t *testing.T) {
-			t.Parallel()
-			ctx := t.Context()
+	interceptor.run(ctx, opts)
 
-			identitySpec := regionalSingleParameterizedIdentitySpec("name",
-				inttypes.WithMutableIdentity(),
-			)
-			identitySchema := identity.NewIdentitySchema(identitySpec)
+	identity, err := d.Identity()
+	if err != nil {
+		t.Fatalf("unexpected error getting identity: %v", err)
+	}
 
-			invocation := newIdentityInterceptor(&identitySpec)
-			interceptor := invocation.interceptor.(identityInterceptor)
-
-			d := schema.TestResourceDataWithIdentityRaw(t, resourceSchema, identitySchema, tc.identityValues)
-			d.SetId(tc.id)
-			d.Set("name", attributeName)
-			d.Set("region", region)
-			d.Set("type", "some_type")
-
-			opts := crudInterceptorOptions{
-				c:    client,
-				d:    d,
-				when: After,
-				why:  Read,
-			}
-
-			interceptor.run(ctx, opts)
-
-			identity, err := d.Identity()
-			if err != nil {
-				t.Fatalf("unexpected error getting identity: %v", err)
-			}
-
-			if e, a := accountID, identity.Get(names.AttrAccountID); e != a {
-				t.Errorf("expected account ID %q, got %q", e, a)
-			}
-			if e, a := region, identity.Get(names.AttrRegion); e != a {
-				t.Errorf("expected region %q, got %q", e, a)
-			}
-			if e, a := tc.expectedName, identity.Get("name"); e != a {
-				t.Errorf("expected name %q, got %q", e, a)
-			}
-		})
+	if identity.Get(names.AttrAccountID) != "" {
+		t.Errorf("expected no account ID, got %q", identity.Get(names.AttrAccountID))
+	}
+	if identity.Get(names.AttrRegion) != "" {
+		t.Errorf("expected no region, got %q", identity.Get(names.AttrRegion))
+	}
+	if identity.Get("name") != "" {
+		t.Errorf("expected no name, got %q", identity.Get("name"))
 	}
 }
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Reverts a pair of commits to the internal Plugin SDK V2 identity interceptor logic which appear to be the cause of the issue reported in https://github.com/hashicorp/terraform-provider-aws/issues/49448.


Before:

```console
% make t K=vpc T=TestAccVPCNetworkACLRule_Identity_basic
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 td-network-acl-rule-regression 🌿...
TF_ACC=1 go1.26.5 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVPCNetworkACLRule_Identity_basic'  -timeout 360m -vet=off -buildvcs=false
2026/08/13 10:53:48 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/13 10:53:48 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccVPCNetworkACLRule_Identity_basic
=== PAUSE TestAccVPCNetworkACLRule_Identity_basic
=== CONT  TestAccVPCNetworkACLRule_Identity_basic
    vpc_network_acl_rule_identity_gen_test.go:30: Step 2/4 error running import: exit status 1

        Error: Missing Resource Identity After Read: The Terraform provider unexpectedly returned no resource identity after having no errors in the resource read. This is always a problem with the provider and should be reported to the provider developer


--- FAIL: TestAccVPCNetworkACLRule_Identity_basic (25.27s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/ec2        34.183s
```

After:

```console
% make t K=vpc T=TestAccVPCNetworkACLRule_Identity_basic
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 td-network-acl-rule-regression 🌿...
TF_ACC=1 go1.26.5 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVPCNetworkACLRule_Identity_basic'  -timeout 360m -vet=off -buildvcs=false
2026/08/13 10:55:36 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/13 10:55:36 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccVPCNetworkACLRule_Identity_basic
=== PAUSE TestAccVPCNetworkACLRule_Identity_basic
=== CONT  TestAccVPCNetworkACLRule_Identity_basic
--- PASS: TestAccVPCNetworkACLRule_Identity_basic (38.02s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        46.684s
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->
Relates #49448
Relates #49339

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t K=vpc T=TestAccVPCNetworkACLRule_Identity
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 td-network-acl-rule-regression 🌿...
TF_ACC=1 go1.26.5 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVPCNetworkACLRule_Identity'  -timeout 360m -vet=off -buildvcs=false
2026/08/13 11:01:15 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/13 11:01:15 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccVPCNetworkACLRule_Identity_regionOverride (43.77s)
--- PASS: TestAccVPCNetworkACLRule_Identity_basic (49.21s)
--- PASS: TestAccVPCNetworkACLRule_Identity_ExistingResource_noRefreshNoChange (194.57s)
--- PASS: TestAccVPCNetworkACLRule_Identity_ExistingResource_basic (216.19s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        224.867s
```
