### PR TITLE
Fix `Missing Resource Identity After Read` errors for resources that have non-string identity attributes

### DIFF
--- a/.changelog/49470.txt
+++ b/.changelog/49470.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_network_acl_rule: Fix `Missing Resource Identity After Read` errors. This fixes a regression introduced in [v6.59.0](https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md#6590-august-12-2026)
+```

--- a/internal/provider/framework/identity_interceptor.go
+++ b/internal/provider/framework/identity_interceptor.go
@@ -251,14 +251,19 @@ func identityIsFullyNull(ctx context.Context, identity *tfsdk.ResourceIdentity, 
 		return true
 	}
 
-	for _, attr := range attributes {
-		var attrVal types.String
-		if diags := identity.GetAttribute(ctx, path.Root(attr.Name()), &attrVal); diags.HasError() {
+	for _, att := range attributes {
+		var attrVal attr.Value
+		if diags := identity.GetAttribute(ctx, path.Root(att.Name()), &attrVal); diags.HasError() {
 			return false
 		}
-		if !attrVal.IsNull() && attrVal.ValueString() != "" {
-			return false
+		if attrVal == nil || attrVal.IsNull() {
+			continue
 		}
+		// Preserve the historical behavior of treating an empty string as null.
+		if s, ok := attrVal.(types.String); ok && s.ValueString() == "" {
+			continue
+		}
+		return false
 	}
 
 	return true

--- a/internal/provider/framework/identity_interceptor_test.go
+++ b/internal/provider/framework/identity_interceptor_test.go
@@ -397,6 +397,48 @@ func planFromSchema(ctx context.Context, schema schema.Schema, values map[string
 	}
 }
 
+func TestIdentityIsFullyNull_NonStringAttributes(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	attributes := []inttypes.IdentityAttribute{
+		inttypes.BoolIdentityAttribute("egress", true),
+		inttypes.IntIdentityAttribute("rule_number", true),
+	}
+
+	identitySchema := &identityschema.Schema{
+		Attributes: map[string]identityschema.Attribute{
+			"egress":      identityschema.BoolAttribute{},
+			"rule_number": identityschema.Int64Attribute{},
+		},
+	}
+
+	t.Run("all_null", func(t *testing.T) {
+		t.Parallel()
+
+		identity := emtpyIdentityFromSchema(ctx, identitySchema)
+		if got := identityIsFullyNull(ctx, identity, attributes); !got {
+			t.Errorf("expected identityIsFullyNull to return true for a fully-null non-string identity, got %v", got)
+		}
+	})
+
+	t.Run("bool_false_int_set", func(t *testing.T) {
+		t.Parallel()
+
+		identity := emtpyIdentityFromSchema(ctx, identitySchema)
+		if diags := identity.SetAttribute(ctx, path.Root("egress"), false); diags.HasError() {
+			t.Fatalf("unexpected error setting egress: %s", fwdiag.DiagnosticsError(diags))
+		}
+		if diags := identity.SetAttribute(ctx, path.Root("rule_number"), int64(100)); diags.HasError() {
+			t.Fatalf("unexpected error setting rule_number: %s", fwdiag.DiagnosticsError(diags))
+		}
+		if got := identityIsFullyNull(ctx, identity, attributes); got {
+			t.Errorf("expected identityIsFullyNull to return false when non-string attributes are set, got %v", got)
+		}
+	})
+}
+
 func emtpyIdentityFromSchema(ctx context.Context, schema *identityschema.Schema) *tfsdk.ResourceIdentity {
 	return &tfsdk.ResourceIdentity{
 		Raw:    tftypes.NewValue(schema.Type().TerraformType(ctx), nil),

--- a/internal/provider/framework/listresource/identity_interceptor_sdk.go
+++ b/internal/provider/framework/listresource/identity_interceptor_sdk.go
@@ -79,7 +79,7 @@ func (r identityInterceptorSDK) populateSDKIdentity(ctx context.Context, params 
 			}
 
 		default:
-			val, ok := getAttributeOk(params.ResourceData, attr.ResourceAttributeName())
+			val, ok := getAttributeIfSet(params.ResourceData, attr.ResourceAttributeName())
 			if !ok {
 				continue
 			}
@@ -97,7 +97,7 @@ type resourceData interface {
 	GetOk(string) (any, bool)
 }
 
-func getAttributeOk(d resourceData, name string) (any, bool) {
+func getAttributeIfSet(d resourceData, name string) (any, bool) {
 	if name == "id" {
 		return d.Id(), true
 	}

--- a/internal/provider/framework/listresource/identity_interceptor_sdk.go
+++ b/internal/provider/framework/listresource/identity_interceptor_sdk.go
@@ -102,6 +102,10 @@ func getAttributeOk(d resourceData, name string) (any, bool) {
 		return d.Id(), true
 	}
 	if v, ok := d.GetOk(name); !ok {
+		// check for zero value bool (false), which is a valid value
+		if _, okBool := v.(bool); okBool {
+			return v, true
+		}
 		return nil, false
 	} else {
 		return v, true

--- a/internal/provider/framework/listresource/identity_interceptor_sdk_test.go
+++ b/internal/provider/framework/listresource/identity_interceptor_sdk_test.go
@@ -1,0 +1,97 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package listresource
+
+import (
+	"testing"
+)
+
+type mockResourceData struct {
+	id     string
+	values map[string]any
+}
+
+func (d mockResourceData) Id() string {
+	return d.id
+}
+
+func (d mockResourceData) GetOk(name string) (any, bool) {
+	v, ok := d.values[name]
+	if !ok {
+		return nil, false
+	}
+	// Mimic helper/schema.ResourceData.GetOk, which reports zero values as unset.
+	switch tv := v.(type) {
+	case string:
+		return v, tv != ""
+	case bool:
+		return v, tv
+	case int:
+		return v, tv != 0
+	default:
+		return v, true
+	}
+}
+
+func TestGetAttributeOk(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		d         mockResourceData
+		name      string
+		wantValue any
+		wantOk    bool
+	}{
+		"id": {
+			d:         mockResourceData{id: "some-id"},
+			name:      "id",
+			wantValue: "some-id",
+			wantOk:    true,
+		},
+		"set string": {
+			d:         mockResourceData{values: map[string]any{"name": "value"}},
+			name:      "name",
+			wantValue: "value",
+			wantOk:    true,
+		},
+		"unset string": {
+			d:         mockResourceData{values: map[string]any{"name": ""}},
+			name:      "name",
+			wantValue: nil,
+			wantOk:    false,
+		},
+		"zero value bool is valid": {
+			d:         mockResourceData{values: map[string]any{"egress": false}},
+			name:      "egress",
+			wantValue: false,
+			wantOk:    true,
+		},
+		"true bool": {
+			d:         mockResourceData{values: map[string]any{"egress": true}},
+			name:      "egress",
+			wantValue: true,
+			wantOk:    true,
+		},
+		"set int": {
+			d:         mockResourceData{values: map[string]any{"rule_number": 100}},
+			name:      "rule_number",
+			wantValue: 100,
+			wantOk:    true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			gotValue, gotOk := getAttributeOk(tc.d, tc.name)
+			if gotOk != tc.wantOk {
+				t.Errorf("getAttributeOk(%q) ok = %v, want %v", tc.name, gotOk, tc.wantOk)
+			}
+			if gotValue != tc.wantValue {
+				t.Errorf("getAttributeOk(%q) value = %v, want %v", tc.name, gotValue, tc.wantValue)
+			}
+		})
+	}
+}

--- a/internal/provider/framework/listresource/identity_interceptor_sdk_test.go
+++ b/internal/provider/framework/listresource/identity_interceptor_sdk_test.go
@@ -34,7 +34,7 @@ func (d mockResourceData) GetOk(name string) (any, bool) {
 	}
 }
 
-func TestGetAttributeOk(t *testing.T) {
+func TestGetAttributeIfSet(t *testing.T) {
 	t.Parallel()
 
 	testCases := map[string]struct {
@@ -85,12 +85,12 @@ func TestGetAttributeOk(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			gotValue, gotOk := getAttributeOk(tc.d, tc.name)
+			gotValue, gotOk := getAttributeIfSet(tc.d, tc.name)
 			if gotOk != tc.wantOk {
-				t.Errorf("getAttributeOk(%q) ok = %v, want %v", tc.name, gotOk, tc.wantOk)
+				t.Errorf("getAttributeIfSet(%q) ok = %v, want %v", tc.name, gotOk, tc.wantOk)
 			}
 			if gotValue != tc.wantValue {
-				t.Errorf("getAttributeOk(%q) value = %v, want %v", tc.name, gotValue, tc.wantValue)
+				t.Errorf("getAttributeIfSet(%q) value = %v, want %v", tc.name, gotValue, tc.wantValue)
 			}
 		})
 	}

--- a/internal/provider/sdkv2/identity_interceptor.go
+++ b/internal/provider/sdkv2/identity_interceptor.go
@@ -60,7 +60,7 @@ func (r identityInterceptor) run(ctx context.Context, opts crudInterceptorOption
 					}
 
 				default:
-					val, ok := getAttributeOk(d, attr.ResourceAttributeName())
+					val, ok := getAttributeIfSet(d, attr.ResourceAttributeName())
 					if !ok {
 						continue
 					}
@@ -95,7 +95,7 @@ func (r identityInterceptor) run(ctx context.Context, opts crudInterceptorOption
 						}
 
 					default:
-						val, ok := getAttributeOk(d, attr.ResourceAttributeName())
+						val, ok := getAttributeIfSet(d, attr.ResourceAttributeName())
 						if !ok {
 							continue
 						}
@@ -124,7 +124,7 @@ func identityIsFullyNull(identity *schema.IdentityData, identitySpec *inttypes.I
 	return true
 }
 
-func getAttributeOk(d schemaResourceData, name string) (any, bool) {
+func getAttributeIfSet(d schemaResourceData, name string) (any, bool) {
 	if name == "id" {
 		return d.Id(), true
 	}

--- a/internal/provider/sdkv2/identity_interceptor.go
+++ b/internal/provider/sdkv2/identity_interceptor.go
@@ -115,8 +115,8 @@ func (r identityInterceptor) run(ctx context.Context, opts crudInterceptorOption
 // all attributes are set to null values
 func identityIsFullyNull(identity *schema.IdentityData, identitySpec *inttypes.Identity) bool {
 	for _, attr := range identitySpec.Attributes {
-		value := identity.Get(attr.Name())
-		if value != "" {
+		_, ok := identity.GetOk(attr.Name())
+		if ok {
 			return false
 		}
 	}

--- a/internal/provider/sdkv2/identity_interceptor_test.go
+++ b/internal/provider/sdkv2/identity_interceptor_test.go
@@ -467,7 +467,7 @@ func (c mockClient) AwsConfig(context.Context) aws.Config { // nosemgrep:ci.aws-
 func TestIdentityIsFullyNull(t *testing.T) {
 	t.Parallel()
 
-	identitySpec := &inttypes.Identity{
+	defaultIdentitySpec := &inttypes.Identity{
 		Attributes: []inttypes.IdentityAttribute{
 			inttypes.StringIdentityAttribute(names.AttrAccountID, false),
 			inttypes.StringIdentityAttribute(names.AttrRegion, false),
@@ -476,17 +476,30 @@ func TestIdentityIsFullyNull(t *testing.T) {
 	}
 
 	testCases := map[string]struct {
-		identityValues map[string]string
+		identitySpec   *inttypes.Identity
+		identityValues map[string]any
 		expectNull     bool
 		description    string
 	}{
 		"all_null": {
-			identityValues: map[string]string{},
+			identityValues: map[string]any{},
 			expectNull:     true,
 			description:    "All attributes null should return true",
 		},
+		"all_null_non_string_values": {
+			identitySpec: &inttypes.Identity{
+				Attributes: []inttypes.IdentityAttribute{
+					inttypes.BoolIdentityAttribute("bool", false),
+					inttypes.FloatIdentityAttribute("float", false),
+					inttypes.IntIdentityAttribute("int", false),
+				},
+			},
+			identityValues: map[string]any{},
+			expectNull:     true,
+			description:    "Null bool, float, and int values should return true",
+		},
 		"some_null": {
-			identityValues: map[string]string{
+			identityValues: map[string]any{
 				names.AttrAccountID: "123456789012",
 				// region and bucket remain null
 			},
@@ -494,7 +507,7 @@ func TestIdentityIsFullyNull(t *testing.T) {
 			description: "Some attributes set should return false",
 		},
 		"all_set": {
-			identityValues: map[string]string{
+			identityValues: map[string]any{
 				names.AttrAccountID: "123456789012",
 				names.AttrRegion:    "us-west-2", // lintignore:AWSAT003
 				names.AttrBucket:    "test-bucket",
@@ -503,7 +516,7 @@ func TestIdentityIsFullyNull(t *testing.T) {
 			description: "All attributes set should return false",
 		},
 		"empty_string_values": {
-			identityValues: map[string]string{
+			identityValues: map[string]any{
 				names.AttrAccountID: "",
 				names.AttrRegion:    "",
 				names.AttrBucket:    "",
@@ -516,6 +529,11 @@ func TestIdentityIsFullyNull(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
+
+			identitySpec := defaultIdentitySpec
+			if tc.identitySpec != nil {
+				identitySpec = tc.identitySpec
+			}
 
 			resourceSchema := map[string]*schema.Schema{
 				names.AttrBucket: {Type: schema.TypeString, Required: true},

--- a/internal/provider/sdkv2/identity_interceptor_test.go
+++ b/internal/provider/sdkv2/identity_interceptor_test.go
@@ -492,6 +492,7 @@ func TestIdentityIsFullyNull(t *testing.T) {
 					inttypes.BoolIdentityAttribute("bool", false),
 					inttypes.FloatIdentityAttribute("float", false),
 					inttypes.IntIdentityAttribute("int", false),
+					inttypes.StringIdentityAttribute("string", false),
 				},
 			},
 			identityValues: map[string]any{},
@@ -506,11 +507,41 @@ func TestIdentityIsFullyNull(t *testing.T) {
 			expectNull:  false,
 			description: "Some attributes set should return false",
 		},
+		"some_null_non_string_values": {
+			identitySpec: &inttypes.Identity{
+				Attributes: []inttypes.IdentityAttribute{
+					inttypes.BoolIdentityAttribute("bool", false),
+					inttypes.FloatIdentityAttribute("float", false),
+					inttypes.IntIdentityAttribute("int", false),
+				},
+			},
+			identityValues: map[string]any{
+				"int": 42,
+			},
+			expectNull:  false,
+			description: "Null bool, float, and int values should return true",
+		},
 		"all_set": {
 			identityValues: map[string]any{
 				names.AttrAccountID: "123456789012",
 				names.AttrRegion:    "us-west-2", // lintignore:AWSAT003
 				names.AttrBucket:    "test-bucket",
+			},
+			expectNull:  false,
+			description: "All attributes set should return false",
+		},
+		"all_set_non_string_values": {
+			identitySpec: &inttypes.Identity{
+				Attributes: []inttypes.IdentityAttribute{
+					inttypes.BoolIdentityAttribute("bool", false),
+					inttypes.FloatIdentityAttribute("float", false),
+					inttypes.IntIdentityAttribute("int", false),
+				},
+			},
+			identityValues: map[string]any{
+				"bool":  true,
+				"float": 3.14,
+				"int":   42,
 			},
 			expectNull:  false,
 			description: "All attributes set should return false",


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

`identityIsFullyNull` was classifying non-zero `int` and `bool` attribute values as null.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #49448.
Closes #49469.
Relates #49339.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccVPCNetworkACLRule_Identity_' PKG=ec2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     6.162s
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework 6.049s
make: Running acceptance tests on branch: 🌿 b-r/aws_network_acl_rule-RI-regression 🌿...
TF_ACC=1 go1.26.5 test ./internal/service/ec2/... -v -count 1 -parallel 20  -run=TestAccVPCNetworkACLRule_Identity_ -timeout 360m -vet=off -buildvcs=false
2026/08/13 11:05:27 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/13 11:05:27 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccVPCNetworkACLRule_Identity_basic
=== PAUSE TestAccVPCNetworkACLRule_Identity_basic
=== RUN   TestAccVPCNetworkACLRule_Identity_regionOverride
=== PAUSE TestAccVPCNetworkACLRule_Identity_regionOverride
=== RUN   TestAccVPCNetworkACLRule_Identity_ExistingResource_basic
=== PAUSE TestAccVPCNetworkACLRule_Identity_ExistingResource_basic
=== RUN   TestAccVPCNetworkACLRule_Identity_ExistingResource_noRefreshNoChange
=== PAUSE TestAccVPCNetworkACLRule_Identity_ExistingResource_noRefreshNoChange
=== CONT  TestAccVPCNetworkACLRule_Identity_basic
=== CONT  TestAccVPCNetworkACLRule_Identity_ExistingResource_basic
=== CONT  TestAccVPCNetworkACLRule_Identity_regionOverride
=== CONT  TestAccVPCNetworkACLRule_Identity_ExistingResource_noRefreshNoChange
--- PASS: TestAccVPCNetworkACLRule_Identity_regionOverride (31.94s)
--- PASS: TestAccVPCNetworkACLRule_Identity_basic (38.46s)
--- PASS: TestAccVPCNetworkACLRule_Identity_ExistingResource_basic (74.17s)
--- PASS: TestAccVPCNetworkACLRule_Identity_ExistingResource_noRefreshNoChange (76.53s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        82.785s
```

A couple of other SDKv2 resources:

```console
% make testacc TESTARGS='-run=TestAccS3Bucket_Identity_' PKG=s3
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     5.709s
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework (cached)
make: Running acceptance tests on branch: 🌿 b-r/aws_network_acl_rule-RI-regression 🌿...
TF_ACC=1 go1.26.5 test ./internal/service/s3/... -v -count 1 -parallel 20  -run=TestAccS3Bucket_Identity_ -timeout 360m -vet=off -buildvcs=false
2026/08/13 11:20:04 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/13 11:20:04 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccS3Bucket_Identity_basic
=== PAUSE TestAccS3Bucket_Identity_basic
=== RUN   TestAccS3Bucket_Identity_regionOverride
=== PAUSE TestAccS3Bucket_Identity_regionOverride
=== RUN   TestAccS3Bucket_Identity_ExistingResource_basic
=== PAUSE TestAccS3Bucket_Identity_ExistingResource_basic
=== RUN   TestAccS3Bucket_Identity_ExistingResource_noRefreshNoChange
=== PAUSE TestAccS3Bucket_Identity_ExistingResource_noRefreshNoChange
=== CONT  TestAccS3Bucket_Identity_basic
=== CONT  TestAccS3Bucket_Identity_ExistingResource_basic
=== CONT  TestAccS3Bucket_Identity_regionOverride
=== CONT  TestAccS3Bucket_Identity_ExistingResource_noRefreshNoChange
--- PASS: TestAccS3Bucket_Identity_regionOverride (33.36s)
--- PASS: TestAccS3Bucket_Identity_basic (40.59s)
--- PASS: TestAccS3Bucket_Identity_ExistingResource_noRefreshNoChange (66.30s)
--- PASS: TestAccS3Bucket_Identity_ExistingResource_basic (103.22s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/s3 109.283s
```
```console
% make testacc TESTARGS='-run=TestAccIAMPolicy_Identity_' PKG=iam
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework (cached)
make: Running acceptance tests on branch: 🌿 b-r/aws_network_acl_rule-RI-regression 🌿...
TF_ACC=1 go1.26.5 test ./internal/service/iam/... -v -count 1 -parallel 20  -run=TestAccIAMPolicy_Identity_ -timeout 360m -vet=off -buildvcs=false
2026/08/13 11:25:07 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/13 11:25:07 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccIAMPolicy_Identity_basic
=== PAUSE TestAccIAMPolicy_Identity_basic
=== RUN   TestAccIAMPolicy_Identity_ExistingResource_basic
=== PAUSE TestAccIAMPolicy_Identity_ExistingResource_basic
=== RUN   TestAccIAMPolicy_Identity_ExistingResource_noRefreshNoChange
=== PAUSE TestAccIAMPolicy_Identity_ExistingResource_noRefreshNoChange
=== CONT  TestAccIAMPolicy_Identity_basic
=== CONT  TestAccIAMPolicy_Identity_ExistingResource_noRefreshNoChange
=== CONT  TestAccIAMPolicy_Identity_ExistingResource_basic
--- PASS: TestAccIAMPolicy_Identity_basic (29.41s)
--- PASS: TestAccIAMPolicy_Identity_ExistingResource_noRefreshNoChange (53.06s)
--- PASS: TestAccIAMPolicy_Identity_ExistingResource_basic (63.47s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/iam        69.555s
```

#### Smoke

```console
% make sane
make: Sane Smoke Tests (x tests of Top y resources)
make: Like 'sanity' except full output and stops soon after 1st error
make: NOTE: NOT an exhaustive set of tests! Finds big problems only.
2026/08/13 11:38:31 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/13 11:38:31 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccIAMInstanceProfile_tags
=== PAUSE TestAccIAMInstanceProfile_tags
=== RUN   TestAccIAMInstanceProfile_basic
=== PAUSE TestAccIAMInstanceProfile_basic
=== RUN   TestAccIAMPolicyDocumentDataSource_basic
=== PAUSE TestAccIAMPolicyDocumentDataSource_basic
=== RUN   TestAccIAMPolicyDocumentDataSource_sourceConflicting
=== PAUSE TestAccIAMPolicyDocumentDataSource_sourceConflicting
=== RUN   TestAccIAMPolicy_tags
=== PAUSE TestAccIAMPolicy_tags
=== RUN   TestAccIAMPolicy_basic
=== PAUSE TestAccIAMPolicy_basic
=== RUN   TestAccIAMPolicy_policy
=== PAUSE TestAccIAMPolicy_policy
=== RUN   TestAccIAMRolePolicyAttachment_basic
=== PAUSE TestAccIAMRolePolicyAttachment_basic
=== RUN   TestAccIAMRolePolicyAttachment_disappears
=== PAUSE TestAccIAMRolePolicyAttachment_disappears
=== RUN   TestAccIAMRolePolicyAttachment_Disappears_role
=== PAUSE TestAccIAMRolePolicyAttachment_Disappears_role
=== RUN   TestAccIAMRolePolicy_basic
=== PAUSE TestAccIAMRolePolicy_basic
=== RUN   TestAccIAMRolePolicy_unknownsInPolicy
=== PAUSE TestAccIAMRolePolicy_unknownsInPolicy
=== RUN   TestAccIAMRole_basic
=== PAUSE TestAccIAMRole_basic
=== RUN   TestAccIAMRole_namePrefix
=== PAUSE TestAccIAMRole_namePrefix
=== RUN   TestAccIAMRole_disappears
=== PAUSE TestAccIAMRole_disappears
=== RUN   TestAccIAMRole_InlinePolicy_basic
=== PAUSE TestAccIAMRole_InlinePolicy_basic
=== CONT  TestAccIAMInstanceProfile_tags
=== CONT  TestAccIAMRolePolicyAttachment_disappears
=== CONT  TestAccIAMRole_InlinePolicy_basic
=== CONT  TestAccIAMRolePolicy_unknownsInPolicy
=== CONT  TestAccIAMRolePolicy_basic
=== CONT  TestAccIAMRolePolicyAttachment_Disappears_role
=== CONT  TestAccIAMRole_basic
=== CONT  TestAccIAMRole_disappears
=== CONT  TestAccIAMRole_namePrefix
=== CONT  TestAccIAMPolicy_tags
=== CONT  TestAccIAMPolicy_policy
=== CONT  TestAccIAMPolicy_basic
=== CONT  TestAccIAMRolePolicyAttachment_basic
=== CONT  TestAccIAMPolicyDocumentDataSource_basic
=== CONT  TestAccIAMInstanceProfile_basic
=== CONT  TestAccIAMPolicyDocumentDataSource_sourceConflicting
--- PASS: TestAccIAMPolicyDocumentDataSource_sourceConflicting (23.67s)
--- PASS: TestAccIAMPolicyDocumentDataSource_basic (23.85s)
--- PASS: TestAccIAMRole_disappears (31.96s)
--- PASS: TestAccIAMRolePolicyAttachment_Disappears_role (32.10s)
--- PASS: TestAccIAMRolePolicyAttachment_disappears (32.23s)
--- PASS: TestAccIAMRolePolicy_unknownsInPolicy (32.75s)
--- PASS: TestAccIAMRole_basic (33.27s)
--- PASS: TestAccIAMPolicy_basic (34.22s)
--- PASS: TestAccIAMRole_namePrefix (34.32s)
--- PASS: TestAccIAMRolePolicy_basic (34.44s)
--- PASS: TestAccIAMInstanceProfile_basic (37.25s)
--- PASS: TestAccIAMPolicy_policy (45.27s)
--- PASS: TestAccIAMRolePolicyAttachment_basic (45.53s)
--- PASS: TestAccIAMRole_InlinePolicy_basic (55.50s)
--- PASS: TestAccIAMPolicy_tags (82.35s)
--- PASS: TestAccIAMInstanceProfile_tags (100.38s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/iam        106.383s
2026/08/13 11:41:03 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/13 11:41:03 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccLogsLogGroup_basic
=== PAUSE TestAccLogsLogGroup_basic
=== RUN   TestAccLogsLogGroup_multiple
=== PAUSE TestAccLogsLogGroup_multiple
=== CONT  TestAccLogsLogGroup_basic
=== CONT  TestAccLogsLogGroup_multiple
--- PASS: TestAccLogsLogGroup_multiple (18.94s)
--- PASS: TestAccLogsLogGroup_basic (22.67s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/logs       46.437s
2026/08/13 11:41:07 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/13 11:41:07 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccVPCDataSource_basic
=== PAUSE TestAccVPCDataSource_basic
=== RUN   TestAccVPCRouteTableAssociation_Subnet_basic
=== PAUSE TestAccVPCRouteTableAssociation_Subnet_basic
=== RUN   TestAccVPCRouteTable_basic
=== PAUSE TestAccVPCRouteTable_basic
=== RUN   TestAccVPCSecurityGroupRule_race
=== PAUSE TestAccVPCSecurityGroupRule_race
=== RUN   TestAccVPCSecurityGroupRule_protocolChange
=== PAUSE TestAccVPCSecurityGroupRule_protocolChange
=== RUN   TestAccVPCSecurityGroup_basic
=== PAUSE TestAccVPCSecurityGroup_basic
=== RUN   TestAccVPCSecurityGroup_egressMode
=== PAUSE TestAccVPCSecurityGroup_egressMode
=== RUN   TestAccVPCSecurityGroup_vpcAllEgress
=== PAUSE TestAccVPCSecurityGroup_vpcAllEgress
=== RUN   TestAccVPCSubnet_basic
=== PAUSE TestAccVPCSubnet_basic
=== RUN   TestAccVPC_tenancy
=== PAUSE TestAccVPC_tenancy
=== CONT  TestAccVPCDataSource_basic
=== CONT  TestAccVPCSecurityGroup_basic
=== CONT  TestAccVPCSecurityGroupRule_race
=== CONT  TestAccVPCSecurityGroupRule_protocolChange
=== CONT  TestAccVPCRouteTable_basic
=== CONT  TestAccVPCSubnet_basic
=== CONT  TestAccVPCRouteTableAssociation_Subnet_basic
=== CONT  TestAccVPC_tenancy
=== CONT  TestAccVPCSecurityGroup_egressMode
=== CONT  TestAccVPCSecurityGroup_vpcAllEgress
--- PASS: TestAccVPCSubnet_basic (31.25s)
--- PASS: TestAccVPCRouteTable_basic (31.76s)
--- PASS: TestAccVPCSecurityGroup_basic (33.36s)
--- PASS: TestAccVPCSecurityGroup_vpcAllEgress (33.53s)
--- PASS: TestAccVPCRouteTableAssociation_Subnet_basic (34.47s)
--- PASS: TestAccVPCDataSource_basic (37.09s)
--- PASS: TestAccVPCSecurityGroup_egressMode (58.38s)
--- PASS: TestAccVPCSecurityGroupRule_protocolChange (63.91s)
--- PASS: TestAccVPC_tenancy (64.46s)
--- PASS: TestAccVPCSecurityGroupRule_race (163.38s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        191.893s
2026/08/13 11:40:49 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/13 11:40:49 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccECSService_basic
=== PAUSE TestAccECSService_basic
=== RUN   TestAccECSTaskDefinition_basic
=== PAUSE TestAccECSTaskDefinition_basic
=== CONT  TestAccECSService_basic
=== CONT  TestAccECSTaskDefinition_basic
--- PASS: TestAccECSTaskDefinition_basic (35.36s)
--- PASS: TestAccECSService_basic (117.26s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ecs        127.757s
?       github.com/hashicorp/terraform-provider-aws/internal/service/ecs/test-fixtures  [no test files]
2026/08/13 11:40:54 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/13 11:40:54 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccELBV2TargetGroup_basic
=== PAUSE TestAccELBV2TargetGroup_basic
=== CONT  TestAccELBV2TargetGroup_basic
--- PASS: TestAccELBV2TargetGroup_basic (28.05s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elbv2      42.994s
2026/08/13 11:40:45 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/13 11:40:45 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccEventsPutEventsAction_basic
=== PAUSE TestAccEventsPutEventsAction_basic
=== CONT  TestAccEventsPutEventsAction_basic
--- PASS: TestAccEventsPutEventsAction_basic (136.56s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/events     142.704s
2026/08/13 11:40:58 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/13 11:40:58 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccKMSKey_basic
=== PAUSE TestAccKMSKey_basic
=== CONT  TestAccKMSKey_basic
--- PASS: TestAccKMSKey_basic (39.41s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/kms        58.835s
2026/08/13 11:44:27 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/13 11:44:27 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccLambdaFunction_basic
=== PAUSE TestAccLambdaFunction_basic
=== RUN   TestAccLambdaPermission_basic
=== PAUSE TestAccLambdaPermission_basic
=== CONT  TestAccLambdaFunction_basic
=== CONT  TestAccLambdaPermission_basic
--- PASS: TestAccLambdaPermission_basic (41.80s)
--- PASS: TestAccLambdaFunction_basic (50.79s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lambda     65.963s
2026/08/13 11:44:32 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/13 11:44:32 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccMetaPartitionDataSource_basic
=== PAUSE TestAccMetaPartitionDataSource_basic
=== RUN   TestAccMetaRegionDataSource_basic
=== PAUSE TestAccMetaRegionDataSource_basic
=== RUN   TestAccMetaRegionDataSource_endpoint
=== PAUSE TestAccMetaRegionDataSource_endpoint
=== CONT  TestAccMetaPartitionDataSource_basic
=== CONT  TestAccMetaRegionDataSource_endpoint
=== CONT  TestAccMetaRegionDataSource_basic
--- PASS: TestAccMetaRegionDataSource_endpoint (16.40s)
--- PASS: TestAccMetaRegionDataSource_basic (17.61s)
--- PASS: TestAccMetaPartitionDataSource_basic (17.61s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/meta       37.225s
2026/08/13 11:44:18 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/13 11:44:18 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccRoute53Record_Latency_basic
=== PAUSE TestAccRoute53Record_Latency_basic
=== RUN   TestAccRoute53ZoneDataSource_name
=== PAUSE TestAccRoute53ZoneDataSource_name
=== CONT  TestAccRoute53Record_Latency_basic
=== CONT  TestAccRoute53ZoneDataSource_name
--- PASS: TestAccRoute53ZoneDataSource_name (75.77s)
--- PASS: TestAccRoute53Record_Latency_basic (141.61s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/route53    147.801s
2026/08/13 11:44:23 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/13 11:44:23 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccS3BucketACL_updateACL
=== PAUSE TestAccS3BucketACL_updateACL
=== RUN   TestAccS3BucketPolicy_basic
=== PAUSE TestAccS3BucketPolicy_basic
=== RUN   TestAccS3BucketPublicAccessBlock_basic
=== PAUSE TestAccS3BucketPublicAccessBlock_basic
=== RUN   TestAccS3Bucket_Basic_basic
=== PAUSE TestAccS3Bucket_Basic_basic
=== RUN   TestAccS3Bucket_Security_corsUpdate
=== PAUSE TestAccS3Bucket_Security_corsUpdate
=== RUN   TestAccS3Object_basic
=== PAUSE TestAccS3Object_basic
=== CONT  TestAccS3BucketACL_updateACL
=== CONT  TestAccS3Bucket_Basic_basic
=== CONT  TestAccS3BucketPublicAccessBlock_basic
=== CONT  TestAccS3Object_basic
=== CONT  TestAccS3Bucket_Security_corsUpdate
=== CONT  TestAccS3BucketPolicy_basic
--- PASS: TestAccS3BucketPublicAccessBlock_basic (31.46s)
--- PASS: TestAccS3BucketPolicy_basic (31.47s)
--- PASS: TestAccS3Bucket_Basic_basic (32.26s)
--- PASS: TestAccS3Object_basic (34.95s)
--- PASS: TestAccS3BucketACL_updateACL (45.51s)
--- PASS: TestAccS3Bucket_Security_corsUpdate (49.05s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/s3 59.728s
2026/08/13 11:44:41 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/13 11:44:41 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccSSMParameterEphemeral_basic
=== PAUSE TestAccSSMParameterEphemeral_basic
=== CONT  TestAccSSMParameterEphemeral_basic
--- PASS: TestAccSSMParameterEphemeral_basic (19.32s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ssm        46.785s
2026/08/13 11:44:50 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/13 11:44:50 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccSecretsManagerSecret_basic
=== PAUSE TestAccSecretsManagerSecret_basic
=== CONT  TestAccSecretsManagerSecret_basic
--- PASS: TestAccSecretsManagerSecret_basic (19.35s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/secretsmanager     55.798s
2026/08/13 11:44:45 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/13 11:44:45 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccSTSCallerIdentityDataSource_basic
=== PAUSE TestAccSTSCallerIdentityDataSource_basic
=== CONT  TestAccSTSCallerIdentityDataSource_basic
--- PASS: TestAccSTSCallerIdentityDataSource_basic (12.54s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/sts        44.495s
2026/08/13 11:44:36 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/13 11:44:36 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestARNParseFunction_known
=== PAUSE TestARNParseFunction_known
=== CONT  TestARNParseFunction_known
--- PASS: TestARNParseFunction_known (14.09s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/function   37.101s
```