### PR TITLE
[Enhancement] aws_lb_listener_rule: Add `condition.source_ip.ip_address_type` argument for NLB listener rule

### DIFF
--- a/.changelog/49476.txt
+++ b/.changelog/49476.txt
@@ -1,0 +1,11 @@
+```release-note:enhancement
+resource/aws_lb_listener_rule: Add `condition.source_ip.ip_address_type` argument
+```
+
+```release-note:enhancement
+resource/aws_lb_listener_rule: Change `condition.source_ip.values` to Optional
+```
+
+```release-note:enhancement
+data-source/aws_lb_listener_rule: Add `condition.source_ip.ip_address_type` attribute
+```

--- a/internal/service/elbv2/listener_rule.go
+++ b/internal/service/elbv2/listener_rule.go
@@ -507,13 +507,18 @@ func resourceListenerRule() *schema.Resource {
 								Optional: true,
 								Elem: &schema.Resource{
 									Schema: map[string]*schema.Schema{
+										names.AttrIPAddressType: {
+											Type:             schema.TypeString,
+											Optional:         true,
+											ValidateDiagFunc: enum.Validate[awstypes.SourceIpAddressTypeEnum](),
+										},
 										names.AttrValues: {
 											Type: schema.TypeSet,
 											Elem: &schema.Schema{
 												Type:         schema.TypeString,
 												ValidateFunc: verify.ValidCIDRNetworkAddress,
 											},
-											Required: true,
+											Optional: true,
 										},
 									},
 								},
@@ -756,7 +761,8 @@ func resourceListenerRuleFlatten(_ context.Context, rule *awstypes.Rule, d *sche
 		case "source-ip":
 			conditionMap["source_ip"] = []any{
 				map[string]any{
-					names.AttrValues: flex.FlattenStringValueSet(condition.SourceIpConfig.Values),
+					names.AttrIPAddressType: condition.SourceIpConfig.IpAddressType,
+					names.AttrValues:        flex.FlattenStringValueSet(condition.SourceIpConfig.Values),
 				},
 			}
 		}
@@ -1053,10 +1059,14 @@ func expandRuleConditions(tfList []any) ([]awstypes.RuleCondition, error) {
 		if sourceIp, ok := tfMap["source_ip"].([]any); ok && len(sourceIp) > 0 {
 			field = "source-ip"
 			attrs += 1
-			values := sourceIp[0].(map[string]any)[names.AttrValues].(*schema.Set)
 
-			apiObjects[i].SourceIpConfig = &awstypes.SourceIpConditionConfig{
-				Values: flex.ExpandStringValueSet(values),
+			apiObjects[i].SourceIpConfig = &awstypes.SourceIpConditionConfig{}
+
+			if v, ok := sourceIp[0].(map[string]any)[names.AttrIPAddressType]; ok && v.(string) != "" {
+				apiObjects[i].SourceIpConfig.IpAddressType = awstypes.SourceIpAddressTypeEnum(v.(string))
+			}
+			if v, ok := sourceIp[0].(map[string]any)[names.AttrValues]; ok && v != nil {
+				apiObjects[i].SourceIpConfig.Values = flex.ExpandStringValueSet(v.(*schema.Set))
 			}
 		}
 

--- a/internal/service/elbv2/listener_rule_data_source.go
+++ b/internal/service/elbv2/listener_rule_data_source.go
@@ -337,6 +337,9 @@ func (d *listenerRuleDataSource) Schema(ctx context.Context, req datasource.Sche
 							CustomType: fwtypes.NewListNestedObjectTypeOf[sourceIPConfigModel](ctx),
 							NestedObject: schema.NestedBlockObject{
 								Attributes: map[string]schema.Attribute{
+									names.AttrIPAddressType: schema.StringAttribute{
+										Computed: true,
+									},
 									names.AttrValues: schema.SetAttribute{
 										ElementType: types.StringType,
 										Computed:    true,
@@ -585,7 +588,8 @@ type queryStringKeyValuePairModel struct {
 }
 
 type sourceIPConfigModel struct {
-	Values fwtypes.SetValueOf[types.String] `tfsdk:"values"`
+	IpAddressType fwtypes.StringEnum[awstypes.SourceIpAddressTypeEnum] `tfsdk:"ip_address_type"`
+	Values        fwtypes.SetValueOf[types.String]                     `tfsdk:"values"`
 }
 
 type transformModel struct {

--- a/internal/service/elbv2/listener_rule_data_source_test.go
+++ b/internal/service/elbv2/listener_rule_data_source_test.go
@@ -1006,10 +1006,47 @@ func TestAccELBV2ListenerRuleDataSource_conditionSourceIP(t *testing.T) {
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrCondition), knownvalue.SetExact([]knownvalue.Check{
 						expectKnownCondition("source_ip", knownvalue.ListExact([]knownvalue.Check{
 							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								names.AttrIPAddressType: knownvalue.Null(),
 								names.AttrValues: knownvalue.SetExact([]knownvalue.Check{
 									knownvalue.StringExact("192.168.0.0/16"),
 									knownvalue.StringExact("dead:cafe::/64"),
 								}),
+							}),
+						})),
+					})),
+				},
+			},
+		},
+	})
+}
+
+func TestAccELBV2ListenerRuleDataSource_conditionSourceIPAddressType(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var listenerRule awstypes.Rule
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	dataSourceName := "data.aws_lb_listener_rule.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckListenerRuleDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccListenerRuleDataSourceConfig_conditionSourceIPAddressType(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckListenerRuleExists(ctx, t, dataSourceName, &listenerRule),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrCondition), knownvalue.SetExact([]knownvalue.Check{
+						expectKnownCondition("source_ip", knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								names.AttrIPAddressType: knownvalue.StringExact(string(awstypes.SourceIpAddressTypeEnumIpv6)),
+								names.AttrValues:        knownvalue.SetExact([]knownvalue.Check{}),
 							}),
 						})),
 					})),
@@ -1710,6 +1747,14 @@ resource "aws_lb_listener_rule" "test" {
       ]
     }
   }
+}
+`)
+}
+
+func testAccListenerRuleDataSourceConfig_conditionSourceIPAddressType(rName string) string {
+	return acctest.ConfigCompose(testAccListenerRuleConfig_sourceIPAddressType(rName, string(awstypes.SourceIpAddressTypeEnumIpv6)), `
+data "aws_lb_listener_rule" "test" {
+  arn = aws_lb_listener_rule.test.arn
 }
 `)
 }

--- a/internal/service/elbv2/listener_rule_test.go
+++ b/internal/service/elbv2/listener_rule_test.go
@@ -5335,7 +5335,7 @@ resource "aws_lb_listener_rule" "test" {
 
   condition {
     source_ip {
-      ip_address_type = %[2]q 
+      ip_address_type = "%[2]s"
     }
   }
 }

--- a/internal/service/elbv2/listener_rule_test.go
+++ b/internal/service/elbv2/listener_rule_test.go
@@ -5251,8 +5251,7 @@ resource "aws_lb_listener_rule" "test" {
 }
 
 func testAccListenerRuleConfig_sourceIPAddressType(rName string, ipAddressType string) string {
-	return acctest.ConfigCompose(acctest.ConfigVPCWithSubnetsIPv6(rName, 2),
-		fmt.Sprintf(`
+	return acctest.ConfigCompose(acctest.ConfigVPCWithSubnetsIPv6(rName, 2), fmt.Sprintf(`
 resource "aws_security_group" "test" {
   name        = %[1]q
   description = "Used for NLB Testing"

--- a/internal/service/elbv2/listener_rule_test.go
+++ b/internal/service/elbv2/listener_rule_test.go
@@ -2365,6 +2365,40 @@ func TestAccELBV2ListenerRule_transform(t *testing.T) {
 	})
 }
 
+func TestAccELBV2ListenerRule_sourceIPAddressType(t *testing.T) {
+	ctx := acctest.Context(t)
+	var conf awstypes.Rule
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_lb_listener_rule.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckListenerRuleDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccListenerRuleConfig_sourceIPAddressType(rName, string(awstypes.SourceIpAddressTypeEnumIpv4)),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckListenerRuleExists(ctx, t, resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "condition.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "condition.0.source_ip.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "condition.0.source_ip.0.ip_address_type", string(awstypes.SourceIpAddressTypeEnumIpv4)),
+				),
+			},
+			{
+				Config: testAccListenerRuleConfig_sourceIPAddressType(rName, string(awstypes.SourceIpAddressTypeEnumIpv6)),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckListenerRuleExists(ctx, t, resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "condition.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "condition.0.source_ip.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "condition.0.source_ip.0.ip_address_type", string(awstypes.SourceIpAddressTypeEnumIpv6)),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckListenerRuleActionOrderDisappears(ctx context.Context, t *testing.T, rule *awstypes.Rule, actionOrderToDelete int) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		var newActions []awstypes.Action
@@ -5214,4 +5248,97 @@ resource "aws_lb_listener_rule" "test" {
   }
 }
 `)
+}
+
+func testAccListenerRuleConfig_sourceIPAddressType(rName string, ipAddressType string) string {
+	return acctest.ConfigCompose(acctest.ConfigVPCWithSubnetsIPv6(rName, 2),
+		fmt.Sprintf(`
+resource "aws_security_group" "test" {
+  name        = %[1]q
+  description = "Used for NLB Testing"
+  vpc_id      = aws_vpc.test.id
+
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_lb_target_group" "test" {
+  name     = %[1]q
+  port     = 80
+  protocol = "TCP"
+  vpc_id   = aws_vpc.test.id
+
+  deregistration_delay = 200
+  slow_start           = 0
+
+  health_check {
+    interval = 10
+    port     = 81
+    protocol = "TCP"
+    timeout  = 4
+  }
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_lb_listener" "test" {
+  load_balancer_arn = aws_lb.test.arn
+  protocol          = "TCP"
+  port              = "80"
+
+  default_action {
+    target_group_arn = aws_lb_target_group.test.arn
+    type             = "forward"
+  }
+}
+
+resource "aws_lb" "test" {
+  name               = %[1]q
+  load_balancer_type = "network"
+  internal           = true
+  security_groups    = [aws_security_group.test.id]
+  subnets            = aws_subnet.test[*].id
+  ip_address_type    = "dualstack"
+
+  idle_timeout               = 30
+  enable_deletion_protection = false
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_lb_listener_rule" "test" {
+  listener_arn = aws_lb_listener.test.arn
+  priority     = 100
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.test.arn
+  }
+
+  condition {
+    source_ip {
+      ip_address_type = %[2]q 
+    }
+  }
+}
+`, rName, ipAddressType))
 }

--- a/website/docs/d/lb_listener_rule.html.markdown
+++ b/website/docs/d/lb_listener_rule.html.markdown
@@ -167,7 +167,8 @@ This data source exports the following attributes in addition to the arguments a
   [Detailed below](#path_pattern).
 * `query_string` - Query string parameters to match.
   [Detailed below](#query_string).
-* `source_ip` - Contains a single attribute `values`, which contains a set of source IPs in CIDR notation.
+* `source_ip` - Source IP address to match.
+  [Detailed below](#source_ip).
 
 #### `host_header`
 
@@ -188,6 +189,11 @@ This data source exports the following attributes in addition to the arguments a
 #### `query_string`
 
 * `values` - Set of `key`-`value` pairs indicating the query string parameters to match.
+
+#### `source_ip`
+
+* `ip_address_type` - IP address type for Network Load Balancers.
+* `values` - Set of source IP addresses in CIDR format for Application Load Balancers
 
 ### `transform`
 

--- a/website/docs/r/lb_listener_rule.html.markdown
+++ b/website/docs/r/lb_listener_rule.html.markdown
@@ -390,7 +390,7 @@ Condition Blocks (for `condition`) support the following:
 * `http_request_method` - (Optional) Contains a single `values` item which is a list of HTTP request methods or verbs to match. Maximum size is 40 characters. Only allowed characters are A-Z, hyphen (-) and underscore (\_). Comparison is case sensitive. Wildcards are not supported. Only one needs to match for the condition to be satisfied. AWS recommends that GET and HEAD requests are routed in the same way because the response to a HEAD request may be cached.
 * `path_pattern` - (Optional) Path patterns to match against the request URL. [Path Pattern block](#path-pattern-blocks) fields documented below.
 * `query_string` - (Optional) Query strings to match. [Query String block](#query-string-blocks) fields documented below.
-* `source_ip` - (Optional) Contains a single `values` item which is a list of source IP CIDR notations to match. You can use both IPv4 and IPv6 addresses. Wildcards are not supported. Condition is satisfied if the source IP address of the request matches one of the CIDR blocks. Condition is not satisfied by the addresses in the `X-Forwarded-For` header, use `http_header` condition instead.
+* `source_ip` - (Optional) Source IP address to match. For ALB, use `values` to specify CIDR ranges. For NLB, use `ip_address_type` to match the IP address type (`ipv4` or `ipv6`). [Source IP block](#source-ip-blocks) fields documented below.
 
 ~> **NOTE::** Exactly one of `host_header`, `http_header`, `http_request_method`, `path_pattern`, `query_string` or `source_ip` must be set per condition.
 
@@ -426,6 +426,13 @@ Query String Value Blocks (for `query_string.values`) support the following:
 
 * `key` - (Optional) Query string key pattern to match.
 * `value` - (Required) Query string value pattern to match.
+
+#### Source IP Blocks
+
+Source IP Blocks (for `source_ip`) support the following:
+
+* `values` - (Optional) List of source IP addresses in CIDR format for Application Load Balancers. Both IPv4 and IPv6 addresses can be used. Wildcards are not supported. Condition is satisfied if the source IP address of the request matches one of the CIDR blocks. Condition is not satisfied by the addresses in the `X-Forwarded-For` header, use `http_header` condition instead.
+* `ip_address_type` - (Optional) IP address type for Network Load Balancers. Valid values are `ipv4` and `ipv6`.
 
 #### Transform Blocks
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
This PR adds `condition.source_ip.ip_address_type` argument/attribute to `aws_lb_listener_rule` resource/data source for recently introduced NLB listener rule.

* The existing `condition.source_ip.ip_address_type` argument is changed to be `Optional`.

### Relations

Closes #49368

### References
https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_SourceIpConditionConfig.html

### Output from Acceptance Testing
One test failed, but it appears not to be related to the fix in this PR.
```console
$ make testacc TESTS='TestAccELBV2ListenerRule_' PKG=elbv2 
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework (cached)
make: Running acceptance tests on branch: 🌿 f-aws_lb_listener_rule-add_ip_address_type_condition_for_nlb 🌿...
TF_ACC=1 go1.26.5 test ./internal/service/elbv2/... -v -count 1 -parallel 20 -run='TestAccELBV2ListenerRule_'  -timeout 360m -vet=off -buildvcs=false
2026/08/14 01:56:48 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/14 01:56:48 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccELBV2ListenerRule_Identity_basic
=== PAUSE TestAccELBV2ListenerRule_Identity_basic
=== RUN   TestAccELBV2ListenerRule_Identity_regionOverride
=== PAUSE TestAccELBV2ListenerRule_Identity_regionOverride
=== RUN   TestAccELBV2ListenerRule_Identity_ExistingResource_basic
=== PAUSE TestAccELBV2ListenerRule_Identity_ExistingResource_basic
=== RUN   TestAccELBV2ListenerRule_Identity_ExistingResource_noRefreshNoChange
=== PAUSE TestAccELBV2ListenerRule_Identity_ExistingResource_noRefreshNoChange
=== RUN   TestAccELBV2ListenerRule_List_basic
=== PAUSE TestAccELBV2ListenerRule_List_basic
=== RUN   TestAccELBV2ListenerRule_List_includeResource
=== PAUSE TestAccELBV2ListenerRule_List_includeResource
=== RUN   TestAccELBV2ListenerRule_List_regionOverride
=== PAUSE TestAccELBV2ListenerRule_List_regionOverride
=== RUN   TestAccELBV2ListenerRule_tags
=== PAUSE TestAccELBV2ListenerRule_tags
=== RUN   TestAccELBV2ListenerRule_Tags_null
=== PAUSE TestAccELBV2ListenerRule_Tags_null
=== RUN   TestAccELBV2ListenerRule_Tags_emptyMap
=== PAUSE TestAccELBV2ListenerRule_Tags_emptyMap
=== RUN   TestAccELBV2ListenerRule_Tags_addOnUpdate
=== PAUSE TestAccELBV2ListenerRule_Tags_addOnUpdate
=== RUN   TestAccELBV2ListenerRule_Tags_EmptyTag_onCreate
=== PAUSE TestAccELBV2ListenerRule_Tags_EmptyTag_onCreate
=== RUN   TestAccELBV2ListenerRule_Tags_EmptyTag_OnUpdate_add
=== PAUSE TestAccELBV2ListenerRule_Tags_EmptyTag_OnUpdate_add
=== RUN   TestAccELBV2ListenerRule_Tags_EmptyTag_OnUpdate_replace
=== PAUSE TestAccELBV2ListenerRule_Tags_EmptyTag_OnUpdate_replace
=== RUN   TestAccELBV2ListenerRule_Tags_DefaultTags_providerOnly
=== PAUSE TestAccELBV2ListenerRule_Tags_DefaultTags_providerOnly
=== RUN   TestAccELBV2ListenerRule_Tags_DefaultTags_nonOverlapping
=== PAUSE TestAccELBV2ListenerRule_Tags_DefaultTags_nonOverlapping
=== RUN   TestAccELBV2ListenerRule_Tags_DefaultTags_overlapping
=== PAUSE TestAccELBV2ListenerRule_Tags_DefaultTags_overlapping
=== RUN   TestAccELBV2ListenerRule_Tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccELBV2ListenerRule_Tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccELBV2ListenerRule_Tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccELBV2ListenerRule_Tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccELBV2ListenerRule_Tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccELBV2ListenerRule_Tags_DefaultTags_emptyResourceTag
=== RUN   TestAccELBV2ListenerRule_Tags_DefaultTags_emptyProviderOnlyTag
=== PAUSE TestAccELBV2ListenerRule_Tags_DefaultTags_emptyProviderOnlyTag
=== RUN   TestAccELBV2ListenerRule_Tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccELBV2ListenerRule_Tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccELBV2ListenerRule_Tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccELBV2ListenerRule_Tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccELBV2ListenerRule_Tags_ComputedTag_onCreate
=== PAUSE TestAccELBV2ListenerRule_Tags_ComputedTag_onCreate
=== RUN   TestAccELBV2ListenerRule_Tags_ComputedTag_OnUpdate_add
=== PAUSE TestAccELBV2ListenerRule_Tags_ComputedTag_OnUpdate_add
=== RUN   TestAccELBV2ListenerRule_Tags_ComputedTag_OnUpdate_replace
=== PAUSE TestAccELBV2ListenerRule_Tags_ComputedTag_OnUpdate_replace
=== RUN   TestAccELBV2ListenerRule_Tags_IgnoreTags_Overlap_defaultTag
=== PAUSE TestAccELBV2ListenerRule_Tags_IgnoreTags_Overlap_defaultTag
=== RUN   TestAccELBV2ListenerRule_Tags_IgnoreTags_Overlap_resourceTag
=== PAUSE TestAccELBV2ListenerRule_Tags_IgnoreTags_Overlap_resourceTag
=== RUN   TestAccELBV2ListenerRule_basic
=== PAUSE TestAccELBV2ListenerRule_basic
=== RUN   TestAccELBV2ListenerRule_disappears
=== PAUSE TestAccELBV2ListenerRule_disappears
=== RUN   TestAccELBV2ListenerRule_updateForwardBasic
=== PAUSE TestAccELBV2ListenerRule_updateForwardBasic
=== RUN   TestAccELBV2ListenerRule_forwardWeighted
=== PAUSE TestAccELBV2ListenerRule_forwardWeighted
=== RUN   TestAccELBV2ListenerRule_ActionForward_TargetGroupARNToForwardBlock_NoChanges
=== PAUSE TestAccELBV2ListenerRule_ActionForward_TargetGroupARNToForwardBlock_NoChanges
=== RUN   TestAccELBV2ListenerRule_ActionForward_ForwardBlock_AddStickiness
=== PAUSE TestAccELBV2ListenerRule_ActionForward_ForwardBlock_AddStickiness
=== RUN   TestAccELBV2ListenerRule_ActionForward_ForwardBlock_RemoveStickiness
=== PAUSE TestAccELBV2ListenerRule_ActionForward_ForwardBlock_RemoveStickiness
=== RUN   TestAccELBV2ListenerRule_ActionForward_TargetGroupARNToForwardBlock_WeightAndStickiness
=== PAUSE TestAccELBV2ListenerRule_ActionForward_TargetGroupARNToForwardBlock_WeightAndStickiness
=== RUN   TestAccELBV2ListenerRule_ActionForward_ForwardBlockToTargetGroupARN_NoChanges
=== PAUSE TestAccELBV2ListenerRule_ActionForward_ForwardBlockToTargetGroupARN_NoChanges
=== RUN   TestAccELBV2ListenerRule_ActionForward_ForwardBlockToTargetGroupARN_WeightAndStickiness
=== PAUSE TestAccELBV2ListenerRule_ActionForward_ForwardBlockToTargetGroupARN_WeightAndStickiness
=== RUN   TestAccELBV2ListenerRule_ActionForward_ForwardBlock_AddAction
=== PAUSE TestAccELBV2ListenerRule_ActionForward_ForwardBlock_AddAction
=== RUN   TestAccELBV2ListenerRule_ActionForward_ForwardBlock_RemoveAction
=== PAUSE TestAccELBV2ListenerRule_ActionForward_ForwardBlock_RemoveAction
=== RUN   TestAccELBV2ListenerRule_ActionForward_IgnoreFields
=== PAUSE TestAccELBV2ListenerRule_ActionForward_IgnoreFields
=== RUN   TestAccELBV2ListenerRule_backwardsCompatibility
=== PAUSE TestAccELBV2ListenerRule_backwardsCompatibility
=== RUN   TestAccELBV2ListenerRule_redirect
=== PAUSE TestAccELBV2ListenerRule_redirect
=== RUN   TestAccELBV2ListenerRule_fixedResponse
=== PAUSE TestAccELBV2ListenerRule_fixedResponse
=== RUN   TestAccELBV2ListenerRule_updateFixedResponse
=== PAUSE TestAccELBV2ListenerRule_updateFixedResponse
=== RUN   TestAccELBV2ListenerRule_updateRulePriority
=== PAUSE TestAccELBV2ListenerRule_updateRulePriority
=== RUN   TestAccELBV2ListenerRule_changeListenerRuleARNForcesNew
=== PAUSE TestAccELBV2ListenerRule_changeListenerRuleARNForcesNew
=== RUN   TestAccELBV2ListenerRule_priority
=== PAUSE TestAccELBV2ListenerRule_priority
=== RUN   TestAccELBV2ListenerRule_cognito
=== PAUSE TestAccELBV2ListenerRule_cognito
=== RUN   TestAccELBV2ListenerRule_oidc
=== PAUSE TestAccELBV2ListenerRule_oidc
=== RUN   TestAccELBV2ListenerRule_jwtValidation
=== PAUSE TestAccELBV2ListenerRule_jwtValidation
=== RUN   TestAccELBV2ListenerRule_Action_defaultOrder
=== PAUSE TestAccELBV2ListenerRule_Action_defaultOrder
=== RUN   TestAccELBV2ListenerRule_Action_specifyOrder
=== PAUSE TestAccELBV2ListenerRule_Action_specifyOrder
=== RUN   TestAccELBV2ListenerRule_Action_actionDisappears
=== PAUSE TestAccELBV2ListenerRule_Action_actionDisappears
=== RUN   TestAccELBV2ListenerRule_EmptyAction
=== PAUSE TestAccELBV2ListenerRule_EmptyAction
=== RUN   TestAccELBV2ListenerRule_redirectWithTargetGroupARN
=== PAUSE TestAccELBV2ListenerRule_redirectWithTargetGroupARN
=== RUN   TestAccELBV2ListenerRule_conditionAttributesCount
=== PAUSE TestAccELBV2ListenerRule_conditionAttributesCount
=== RUN   TestAccELBV2ListenerRule_conditionHostHeader
=== PAUSE TestAccELBV2ListenerRule_conditionHostHeader
=== RUN   TestAccELBV2ListenerRule_conditionHostHeaderRegex
=== PAUSE TestAccELBV2ListenerRule_conditionHostHeaderRegex
=== RUN   TestAccELBV2ListenerRule_conditionHTTPHeader
=== PAUSE TestAccELBV2ListenerRule_conditionHTTPHeader
=== RUN   TestAccELBV2ListenerRule_conditionHTTPHeaderRegex
=== PAUSE TestAccELBV2ListenerRule_conditionHTTPHeaderRegex
=== RUN   TestAccELBV2ListenerRule_ConditionHTTPHeader_invalid
=== PAUSE TestAccELBV2ListenerRule_ConditionHTTPHeader_invalid
=== RUN   TestAccELBV2ListenerRule_conditionHTTPRequestMethod
=== PAUSE TestAccELBV2ListenerRule_conditionHTTPRequestMethod
=== RUN   TestAccELBV2ListenerRule_conditionPathPattern
=== PAUSE TestAccELBV2ListenerRule_conditionPathPattern
=== RUN   TestAccELBV2ListenerRule_conditionPathPatternRegex
=== PAUSE TestAccELBV2ListenerRule_conditionPathPatternRegex
=== RUN   TestAccELBV2ListenerRule_conditionQueryString
=== PAUSE TestAccELBV2ListenerRule_conditionQueryString
=== RUN   TestAccELBV2ListenerRule_conditionSourceIP
=== PAUSE TestAccELBV2ListenerRule_conditionSourceIP
=== RUN   TestAccELBV2ListenerRule_conditionUpdateMixed
=== PAUSE TestAccELBV2ListenerRule_conditionUpdateMixed
=== RUN   TestAccELBV2ListenerRule_conditionMultiple
=== PAUSE TestAccELBV2ListenerRule_conditionMultiple
=== RUN   TestAccELBV2ListenerRule_conditionUpdateMultiple
=== PAUSE TestAccELBV2ListenerRule_conditionUpdateMultiple
=== RUN   TestAccELBV2ListenerRule_transform
=== PAUSE TestAccELBV2ListenerRule_transform
=== RUN   TestAccELBV2ListenerRule_sourceIPAddressType
=== PAUSE TestAccELBV2ListenerRule_sourceIPAddressType
=== CONT  TestAccELBV2ListenerRule_Identity_basic
=== CONT  TestAccELBV2ListenerRule_ActionForward_ForwardBlockToTargetGroupARN_NoChanges
=== CONT  TestAccELBV2ListenerRule_ActionForward_ForwardBlock_AddStickiness
=== CONT  TestAccELBV2ListenerRule_Tags_IgnoreTags_Overlap_defaultTag
=== CONT  TestAccELBV2ListenerRule_Tags_ComputedTag_onCreate
=== CONT  TestAccELBV2ListenerRule_Tags_DefaultTags_nullOverlappingResourceTag
=== CONT  TestAccELBV2ListenerRule_Tags_DefaultTags_nullNonOverlappingResourceTag
=== CONT  TestAccELBV2ListenerRule_EmptyAction
=== CONT  TestAccELBV2ListenerRule_conditionPathPattern
=== RUN   TestAccELBV2ListenerRule_EmptyAction/fixed-response
=== PAUSE TestAccELBV2ListenerRule_EmptyAction/fixed-response
=== RUN   TestAccELBV2ListenerRule_EmptyAction/forward
=== PAUSE TestAccELBV2ListenerRule_EmptyAction/forward
=== RUN   TestAccELBV2ListenerRule_EmptyAction/authenticate-oidc
=== PAUSE TestAccELBV2ListenerRule_EmptyAction/authenticate-oidc
=== RUN   TestAccELBV2ListenerRule_EmptyAction/authenticate-cognito
=== PAUSE TestAccELBV2ListenerRule_EmptyAction/authenticate-cognito
=== RUN   TestAccELBV2ListenerRule_EmptyAction/redirect
=== PAUSE TestAccELBV2ListenerRule_EmptyAction/redirect
=== CONT  TestAccELBV2ListenerRule_EmptyAction/fixed-response
=== CONT  TestAccELBV2ListenerRule_sourceIPAddressType
=== CONT  TestAccELBV2ListenerRule_Tags_DefaultTags_updateToResourceOnly
=== CONT  TestAccELBV2ListenerRule_conditionHTTPRequestMethod
=== CONT  TestAccELBV2ListenerRule_ActionForward_ForwardBlock_RemoveStickiness
=== CONT  TestAccELBV2ListenerRule_Tags_ComputedTag_OnUpdate_add
=== CONT  TestAccELBV2ListenerRule_ConditionHTTPHeader_invalid
=== CONT  TestAccELBV2ListenerRule_conditionHTTPHeaderRegex
=== CONT  TestAccELBV2ListenerRule_Tags_ComputedTag_OnUpdate_replace
=== CONT  TestAccELBV2ListenerRule_conditionHTTPHeader
=== CONT  TestAccELBV2ListenerRule_ActionForward_TargetGroupARNToForwardBlock_WeightAndStickiness
=== CONT  TestAccELBV2ListenerRule_conditionHostHeaderRegex
--- PASS: TestAccELBV2ListenerRule_ConditionHTTPHeader_invalid (8.27s)
=== CONT  TestAccELBV2ListenerRule_conditionHostHeader
=== CONT  TestAccELBV2ListenerRule_conditionAttributesCount
--- PASS: TestAccELBV2ListenerRule_conditionAttributesCount (40.27s)
=== CONT  TestAccELBV2ListenerRule_redirectWithTargetGroupARN
--- PASS: TestAccELBV2ListenerRule_Tags_ComputedTag_onCreate (259.18s)
=== CONT  TestAccELBV2ListenerRule_EmptyAction/redirect
=== CONT  TestAccELBV2ListenerRule_EmptyAction/authenticate-cognito
=== CONT  TestAccELBV2ListenerRule_EmptyAction/authenticate-oidc
=== CONT  TestAccELBV2ListenerRule_EmptyAction/forward
--- PASS: TestAccELBV2ListenerRule_EmptyAction (0.00s)
    --- PASS: TestAccELBV2ListenerRule_EmptyAction/fixed-response (11.46s)
    --- PASS: TestAccELBV2ListenerRule_EmptyAction/redirect (8.23s)
    --- PASS: TestAccELBV2ListenerRule_EmptyAction/authenticate-cognito (5.45s)
    --- PASS: TestAccELBV2ListenerRule_EmptyAction/authenticate-oidc (5.58s)
    --- PASS: TestAccELBV2ListenerRule_EmptyAction/forward (8.46s)
=== CONT  TestAccELBV2ListenerRule_updateRulePriority
--- PASS: TestAccELBV2ListenerRule_conditionPathPattern (290.77s)
=== CONT  TestAccELBV2ListenerRule_Action_actionDisappears
--- PASS: TestAccELBV2ListenerRule_Tags_DefaultTags_nullNonOverlappingResourceTag (295.60s)
=== CONT  TestAccELBV2ListenerRule_Action_specifyOrder
--- PASS: TestAccELBV2ListenerRule_Tags_DefaultTags_nullOverlappingResourceTag (300.06s)
=== CONT  TestAccELBV2ListenerRule_Action_defaultOrder
--- PASS: TestAccELBV2ListenerRule_conditionHostHeaderRegex (310.48s)
=== CONT  TestAccELBV2ListenerRule_jwtValidation
--- PASS: TestAccELBV2ListenerRule_conditionHTTPHeader (312.73s)
=== CONT  TestAccELBV2ListenerRule_oidc
--- PASS: TestAccELBV2ListenerRule_Identity_basic (321.74s)
=== CONT  TestAccELBV2ListenerRule_cognito
--- PASS: TestAccELBV2ListenerRule_conditionHTTPHeaderRegex (323.18s)
=== CONT  TestAccELBV2ListenerRule_priority
--- PASS: TestAccELBV2ListenerRule_conditionHTTPRequestMethod (324.06s)
=== CONT  TestAccELBV2ListenerRule_changeListenerRuleARNForcesNew
--- PASS: TestAccELBV2ListenerRule_sourceIPAddressType (330.91s)
=== CONT  TestAccELBV2ListenerRule_Tags_emptyMap
--- PASS: TestAccELBV2ListenerRule_ActionForward_ForwardBlockToTargetGroupARN_NoChanges (331.60s)
=== CONT  TestAccELBV2ListenerRule_Tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccELBV2ListenerRule_conditionHostHeader (323.85s)
=== CONT  TestAccELBV2ListenerRule_Tags_DefaultTags_overlapping
--- PASS: TestAccELBV2ListenerRule_ActionForward_ForwardBlock_AddStickiness (336.74s)
=== CONT  TestAccELBV2ListenerRule_Tags_DefaultTags_nonOverlapping
--- PASS: TestAccELBV2ListenerRule_Tags_ComputedTag_OnUpdate_add (357.29s)
=== CONT  TestAccELBV2ListenerRule_Tags_DefaultTags_providerOnly
--- PASS: TestAccELBV2ListenerRule_ActionForward_TargetGroupARNToForwardBlock_WeightAndStickiness (358.84s)
=== CONT  TestAccELBV2ListenerRule_Tags_EmptyTag_OnUpdate_replace
--- PASS: TestAccELBV2ListenerRule_ActionForward_ForwardBlock_RemoveStickiness (362.07s)
=== CONT  TestAccELBV2ListenerRule_Tags_EmptyTag_OnUpdate_add
--- PASS: TestAccELBV2ListenerRule_Tags_ComputedTag_OnUpdate_replace (365.07s)
=== CONT  TestAccELBV2ListenerRule_Tags_EmptyTag_onCreate
--- PASS: TestAccELBV2ListenerRule_Tags_DefaultTags_updateToResourceOnly (380.01s)
=== CONT  TestAccELBV2ListenerRule_Tags_addOnUpdate
--- PASS: TestAccELBV2ListenerRule_Tags_IgnoreTags_Overlap_defaultTag (382.34s)
=== CONT  TestAccELBV2ListenerRule_conditionUpdateMixed
--- PASS: TestAccELBV2ListenerRule_redirectWithTargetGroupARN (341.59s)
=== CONT  TestAccELBV2ListenerRule_transform
--- PASS: TestAccELBV2ListenerRule_Action_actionDisappears (255.59s)
=== CONT  TestAccELBV2ListenerRule_conditionUpdateMultiple
--- PASS: TestAccELBV2ListenerRule_updateRulePriority (263.09s)
=== CONT  TestAccELBV2ListenerRule_conditionMultiple
--- PASS: TestAccELBV2ListenerRule_cognito (229.79s)
=== CONT  TestAccELBV2ListenerRule_conditionQueryString
--- PASS: TestAccELBV2ListenerRule_jwtValidation (245.43s)
=== CONT  TestAccELBV2ListenerRule_conditionSourceIP
--- PASS: TestAccELBV2ListenerRule_oidc (268.26s)
=== CONT  TestAccELBV2ListenerRule_ActionForward_IgnoreFields
--- PASS: TestAccELBV2ListenerRule_Action_defaultOrder (285.46s)
=== CONT  TestAccELBV2ListenerRule_updateFixedResponse
--- PASS: TestAccELBV2ListenerRule_Action_specifyOrder (292.81s)
=== CONT  TestAccELBV2ListenerRule_fixedResponse
--- PASS: TestAccELBV2ListenerRule_changeListenerRuleARNForcesNew (296.22s)
=== CONT  TestAccELBV2ListenerRule_redirect
--- PASS: TestAccELBV2ListenerRule_Tags_emptyMap (320.07s)
=== CONT  TestAccELBV2ListenerRule_backwardsCompatibility
--- PASS: TestAccELBV2ListenerRule_Tags_DefaultTags_updateToProviderOnly (337.33s)
=== CONT  TestAccELBV2ListenerRule_List_includeResource
--- PASS: TestAccELBV2ListenerRule_Tags_EmptyTag_onCreate (320.23s)
=== CONT  TestAccELBV2ListenerRule_Tags_null
--- PASS: TestAccELBV2ListenerRule_Tags_addOnUpdate (319.63s)
=== CONT  TestAccELBV2ListenerRule_tags
--- PASS: TestAccELBV2ListenerRule_Tags_EmptyTag_OnUpdate_add (359.45s)
=== CONT  TestAccELBV2ListenerRule_List_regionOverride
--- PASS: TestAccELBV2ListenerRule_conditionUpdateMixed (356.48s)
=== CONT  TestAccELBV2ListenerRule_updateForwardBasic
--- PASS: TestAccELBV2ListenerRule_Tags_EmptyTag_OnUpdate_replace (387.94s)
=== CONT  TestAccELBV2ListenerRule_ActionForward_TargetGroupARNToForwardBlock_NoChanges
--- PASS: TestAccELBV2ListenerRule_transform (356.48s)
=== CONT  TestAccELBV2ListenerRule_forwardWeighted
--- PASS: TestAccELBV2ListenerRule_Tags_DefaultTags_overlapping (448.69s)
=== CONT  TestAccELBV2ListenerRule_basic
--- PASS: TestAccELBV2ListenerRule_Tags_DefaultTags_nonOverlapping (453.80s)
=== CONT  TestAccELBV2ListenerRule_disappears
--- PASS: TestAccELBV2ListenerRule_conditionQueryString (258.25s)
=== CONT  TestAccELBV2ListenerRule_Tags_IgnoreTags_Overlap_resourceTag
--- PASS: TestAccELBV2ListenerRule_conditionSourceIP (261.35s)
=== CONT  TestAccELBV2ListenerRule_ActionForward_ForwardBlock_AddAction
=== NAME  TestAccELBV2ListenerRule_priority
    listener_rule_test.go:1110: Step 8/9, expected an error but got none
--- PASS: TestAccELBV2ListenerRule_conditionUpdateMultiple (304.82s)
=== CONT  TestAccELBV2ListenerRule_ActionForward_ForwardBlock_RemoveAction
--- PASS: TestAccELBV2ListenerRule_fixedResponse (265.81s)
=== CONT  TestAccELBV2ListenerRule_Identity_ExistingResource_noRefreshNoChange
--- FAIL: TestAccELBV2ListenerRule_priority (539.52s)
=== CONT  TestAccELBV2ListenerRule_List_basic
--- PASS: TestAccELBV2ListenerRule_Tags_DefaultTags_providerOnly (514.86s)
=== CONT  TestAccELBV2ListenerRule_Identity_ExistingResource_basic
--- PASS: TestAccELBV2ListenerRule_updateFixedResponse (291.34s)
=== CONT  TestAccELBV2ListenerRule_Identity_regionOverride
--- PASS: TestAccELBV2ListenerRule_conditionMultiple (329.06s)
=== CONT  TestAccELBV2ListenerRule_ActionForward_ForwardBlockToTargetGroupARN_WeightAndStickiness
--- PASS: TestAccELBV2ListenerRule_ActionForward_IgnoreFields (307.69s)
=== CONT  TestAccELBV2ListenerRule_conditionPathPatternRegex
--- PASS: TestAccELBV2ListenerRule_backwardsCompatibility (251.12s)
=== CONT  TestAccELBV2ListenerRule_Tags_DefaultTags_emptyProviderOnlyTag
--- PASS: TestAccELBV2ListenerRule_List_includeResource (248.60s)
=== CONT  TestAccELBV2ListenerRule_Tags_DefaultTags_emptyResourceTag
--- PASS: TestAccELBV2ListenerRule_redirect (321.84s)
--- PASS: TestAccELBV2ListenerRule_Tags_null (278.57s)
--- PASS: TestAccELBV2ListenerRule_List_regionOverride (243.53s)
--- PASS: TestAccELBV2ListenerRule_basic (233.26s)
--- PASS: TestAccELBV2ListenerRule_disappears (238.69s)
--- PASS: TestAccELBV2ListenerRule_updateForwardBasic (296.21s)
--- PASS: TestAccELBV2ListenerRule_ActionForward_TargetGroupARNToForwardBlock_NoChanges (291.25s)
--- PASS: TestAccELBV2ListenerRule_forwardWeighted (314.49s)
--- PASS: TestAccELBV2ListenerRule_tags (378.18s)
--- PASS: TestAccELBV2ListenerRule_ActionForward_ForwardBlock_AddAction (282.20s)
--- PASS: TestAccELBV2ListenerRule_List_basic (260.56s)
--- PASS: TestAccELBV2ListenerRule_Identity_ExistingResource_noRefreshNoChange (272.00s)
--- PASS: TestAccELBV2ListenerRule_Tags_IgnoreTags_Overlap_resourceTag (326.90s)
--- PASS: TestAccELBV2ListenerRule_ActionForward_ForwardBlock_RemoveAction (306.60s)
--- PASS: TestAccELBV2ListenerRule_conditionPathPatternRegex (271.66s)
--- PASS: TestAccELBV2ListenerRule_Tags_DefaultTags_emptyProviderOnlyTag (258.68s)
--- PASS: TestAccELBV2ListenerRule_Tags_DefaultTags_emptyResourceTag (247.69s)
--- PASS: TestAccELBV2ListenerRule_Identity_ExistingResource_basic (295.07s)
--- PASS: TestAccELBV2ListenerRule_ActionForward_ForwardBlockToTargetGroupARN_WeightAndStickiness (296.96s)
--- PASS: TestAccELBV2ListenerRule_Identity_regionOverride (313.08s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/elbv2      1196.946s
FAIL
make: *** [testacc] Error 1
```

```console
$ make testacc TESTS='TestAccELBV2ListenerRuleDataSource_' PKG=elbv2 
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework (cached)
make: Running acceptance tests on branch: 🌿 f-aws_lb_listener_rule-add_ip_address_type_condition_for_nlb 🌿...
TF_ACC=1 go1.26.5 test ./internal/service/elbv2/... -v -count 1 -parallel 20 -run='TestAccELBV2ListenerRuleDataSource_'  -timeout 360m -vet=off -buildvcs=false
2026/08/14 02:56:01 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/14 02:56:01 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccELBV2ListenerRuleDataSource_tags
=== PAUSE TestAccELBV2ListenerRuleDataSource_tags
=== RUN   TestAccELBV2ListenerRuleDataSource_Tags_nullMap
=== PAUSE TestAccELBV2ListenerRuleDataSource_Tags_nullMap
=== RUN   TestAccELBV2ListenerRuleDataSource_Tags_emptyMap
=== PAUSE TestAccELBV2ListenerRuleDataSource_Tags_emptyMap
=== RUN   TestAccELBV2ListenerRuleDataSource_Tags_DefaultTags_nonOverlapping
=== PAUSE TestAccELBV2ListenerRuleDataSource_Tags_DefaultTags_nonOverlapping
=== RUN   TestAccELBV2ListenerRuleDataSource_Tags_IgnoreTags_Overlap_defaultTag
=== PAUSE TestAccELBV2ListenerRuleDataSource_Tags_IgnoreTags_Overlap_defaultTag
=== RUN   TestAccELBV2ListenerRuleDataSource_Tags_IgnoreTags_Overlap_resourceTag
=== PAUSE TestAccELBV2ListenerRuleDataSource_Tags_IgnoreTags_Overlap_resourceTag
=== RUN   TestAccELBV2ListenerRuleDataSource_byARN
=== PAUSE TestAccELBV2ListenerRuleDataSource_byARN
=== RUN   TestAccELBV2ListenerRuleDataSource_byListenerAndPriority
=== PAUSE TestAccELBV2ListenerRuleDataSource_byListenerAndPriority
=== RUN   TestAccELBV2ListenerRuleDataSource_actionAuthenticateCognito
=== PAUSE TestAccELBV2ListenerRuleDataSource_actionAuthenticateCognito
=== RUN   TestAccELBV2ListenerRuleDataSource_actionAuthenticateOIDC
=== PAUSE TestAccELBV2ListenerRuleDataSource_actionAuthenticateOIDC
=== RUN   TestAccELBV2ListenerRuleDataSource_actionAuthenticateJWTValidation
=== PAUSE TestAccELBV2ListenerRuleDataSource_actionAuthenticateJWTValidation
=== RUN   TestAccELBV2ListenerRuleDataSource_actionFixedResponse
=== PAUSE TestAccELBV2ListenerRuleDataSource_actionFixedResponse
=== RUN   TestAccELBV2ListenerRuleDataSource_actionForwardWeightedStickiness
=== PAUSE TestAccELBV2ListenerRuleDataSource_actionForwardWeightedStickiness
=== RUN   TestAccELBV2ListenerRuleDataSource_actionRedirect
=== PAUSE TestAccELBV2ListenerRuleDataSource_actionRedirect
=== RUN   TestAccELBV2ListenerRuleDataSource_conditionHostHeader
=== PAUSE TestAccELBV2ListenerRuleDataSource_conditionHostHeader
=== RUN   TestAccELBV2ListenerRuleDataSource_conditionHostHeaderRegex
=== PAUSE TestAccELBV2ListenerRuleDataSource_conditionHostHeaderRegex
=== RUN   TestAccELBV2ListenerRuleDataSource_conditionHTTPHeader
=== PAUSE TestAccELBV2ListenerRuleDataSource_conditionHTTPHeader
=== RUN   TestAccELBV2ListenerRuleDataSource_conditionHTTPHeaderRegex
=== PAUSE TestAccELBV2ListenerRuleDataSource_conditionHTTPHeaderRegex
=== RUN   TestAccELBV2ListenerRuleDataSource_conditionHTTPRequestMethod
=== PAUSE TestAccELBV2ListenerRuleDataSource_conditionHTTPRequestMethod
=== RUN   TestAccELBV2ListenerRuleDataSource_conditionPathPattern
=== PAUSE TestAccELBV2ListenerRuleDataSource_conditionPathPattern
=== RUN   TestAccELBV2ListenerRuleDataSource_conditionPathPatternRegex
=== PAUSE TestAccELBV2ListenerRuleDataSource_conditionPathPatternRegex
=== RUN   TestAccELBV2ListenerRuleDataSource_conditionQueryString
=== PAUSE TestAccELBV2ListenerRuleDataSource_conditionQueryString
=== RUN   TestAccELBV2ListenerRuleDataSource_conditionSourceIP
=== PAUSE TestAccELBV2ListenerRuleDataSource_conditionSourceIP
=== RUN   TestAccELBV2ListenerRuleDataSource_conditionSourceIPAddressType
=== PAUSE TestAccELBV2ListenerRuleDataSource_conditionSourceIPAddressType
=== RUN   TestAccELBV2ListenerRuleDataSource_transform
=== PAUSE TestAccELBV2ListenerRuleDataSource_transform
=== CONT  TestAccELBV2ListenerRuleDataSource_tags
=== CONT  TestAccELBV2ListenerRuleDataSource_actionRedirect
=== CONT  TestAccELBV2ListenerRuleDataSource_byListenerAndPriority
=== CONT  TestAccELBV2ListenerRuleDataSource_Tags_IgnoreTags_Overlap_defaultTag
=== CONT  TestAccELBV2ListenerRuleDataSource_byARN
=== CONT  TestAccELBV2ListenerRuleDataSource_actionForwardWeightedStickiness
=== CONT  TestAccELBV2ListenerRuleDataSource_conditionPathPattern
=== CONT  TestAccELBV2ListenerRuleDataSource_conditionHTTPHeader
=== CONT  TestAccELBV2ListenerRuleDataSource_transform
=== CONT  TestAccELBV2ListenerRuleDataSource_actionFixedResponse
=== CONT  TestAccELBV2ListenerRuleDataSource_conditionSourceIPAddressType
=== CONT  TestAccELBV2ListenerRuleDataSource_conditionPathPatternRegex
=== CONT  TestAccELBV2ListenerRuleDataSource_Tags_emptyMap
=== CONT  TestAccELBV2ListenerRuleDataSource_Tags_DefaultTags_nonOverlapping
=== CONT  TestAccELBV2ListenerRuleDataSource_actionAuthenticateJWTValidation
=== CONT  TestAccELBV2ListenerRuleDataSource_conditionHostHeaderRegex
=== CONT  TestAccELBV2ListenerRuleDataSource_actionAuthenticateOIDC
=== CONT  TestAccELBV2ListenerRuleDataSource_actionAuthenticateCognito
=== CONT  TestAccELBV2ListenerRuleDataSource_Tags_nullMap
=== CONT  TestAccELBV2ListenerRuleDataSource_conditionQueryString
--- PASS: TestAccELBV2ListenerRuleDataSource_tags (277.76s)
=== CONT  TestAccELBV2ListenerRuleDataSource_Tags_IgnoreTags_Overlap_resourceTag
--- PASS: TestAccELBV2ListenerRuleDataSource_Tags_nullMap (278.02s)
=== CONT  TestAccELBV2ListenerRuleDataSource_conditionHTTPRequestMethod
--- PASS: TestAccELBV2ListenerRuleDataSource_Tags_emptyMap (278.18s)
=== CONT  TestAccELBV2ListenerRuleDataSource_conditionHTTPHeaderRegex
=== CONT  TestAccELBV2ListenerRuleDataSource_conditionSourceIP
--- PASS: TestAccELBV2ListenerRuleDataSource_Tags_DefaultTags_nonOverlapping (278.40s)
--- PASS: TestAccELBV2ListenerRuleDataSource_byListenerAndPriority (280.71s)
=== CONT  TestAccELBV2ListenerRuleDataSource_conditionHostHeader
--- PASS: TestAccELBV2ListenerRuleDataSource_actionForwardWeightedStickiness (281.98s)
--- PASS: TestAccELBV2ListenerRuleDataSource_conditionHTTPHeader (282.72s)
--- PASS: TestAccELBV2ListenerRuleDataSource_conditionPathPattern (283.90s)
--- PASS: TestAccELBV2ListenerRuleDataSource_transform (287.20s)
--- PASS: TestAccELBV2ListenerRuleDataSource_actionAuthenticateJWTValidation (287.75s)
--- PASS: TestAccELBV2ListenerRuleDataSource_conditionHostHeaderRegex (288.08s)
--- PASS: TestAccELBV2ListenerRuleDataSource_Tags_IgnoreTags_Overlap_defaultTag (289.09s)
--- PASS: TestAccELBV2ListenerRuleDataSource_actionFixedResponse (289.95s)
--- PASS: TestAccELBV2ListenerRuleDataSource_conditionPathPatternRegex (290.83s)
--- PASS: TestAccELBV2ListenerRuleDataSource_conditionQueryString (294.16s)
--- PASS: TestAccELBV2ListenerRuleDataSource_actionAuthenticateCognito (297.18s)
--- PASS: TestAccELBV2ListenerRuleDataSource_actionRedirect (300.02s)
--- PASS: TestAccELBV2ListenerRuleDataSource_byARN (305.56s)
--- PASS: TestAccELBV2ListenerRuleDataSource_actionAuthenticateOIDC (318.23s)
--- PASS: TestAccELBV2ListenerRuleDataSource_conditionSourceIPAddressType (328.17s)
--- PASS: TestAccELBV2ListenerRuleDataSource_Tags_IgnoreTags_Overlap_resourceTag (240.57s)
--- PASS: TestAccELBV2ListenerRuleDataSource_conditionSourceIP (241.27s)
--- PASS: TestAccELBV2ListenerRuleDataSource_conditionHTTPHeaderRegex (242.74s)
--- PASS: TestAccELBV2ListenerRuleDataSource_conditionHostHeader (243.89s)
--- PASS: TestAccELBV2ListenerRuleDataSource_conditionHTTPRequestMethod (251.25s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elbv2      535.571s
```