### PR TITLE
aws_bedrockagentcore_policy_engine: Handles remote resource disappearing during List

### DIFF
--- a/.changelog/49478.txt
+++ b/.changelog/49478.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+list-resource/aws_bedrockagentcore_policy_engine: Prevents error when remote resource disappears during List
+```

--- a/internal/service/bedrockagentcore/policy_engine_list.go
+++ b/internal/service/bedrockagentcore/policy_engine_list.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
 	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/logging"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/smerr"
 	inttypes "github.com/hashicorp/terraform-provider-aws/internal/types"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -57,20 +58,30 @@ func (l *policyEngineListResource) List(ctx context.Context, request list.ListRe
 			policyEngineID := aws.ToString(item.PolicyEngineId)
 			ctx := tflog.SetField(ctx, logging.ResourceAttributeKey(names.AttrARN), aws.ToString(item.PolicyEngineArn))
 
-			output, err := findPolicyEngineByID(ctx, conn, policyEngineID)
-			if err != nil {
-				result := fwdiag.NewListResultErrorDiagnostic(err)
-				yield(result)
-				return
+			var output *bedrockagentcorecontrol.GetPolicyEngineOutput
+			if request.IncludeResource {
+				var err error
+				output, err = findPolicyEngineByID(ctx, conn, policyEngineID)
+				if retry.NotFound(err) {
+					continue
+				}
+				if err != nil {
+					yield(fwdiag.NewListResultErrorDiagnostic(err))
+					return
+				}
 			}
 
 			result := request.NewListResult(ctx)
 
 			var data policyEngineResourceModel
 			l.SetResult(ctx, l.Meta(), request.IncludeResource, &data, &result, func() {
-				smerr.AddEnrich(ctx, &result.Diagnostics, fwflex.Flatten(ctx, output, &data))
-				if result.Diagnostics.HasError() {
-					return
+				if request.IncludeResource {
+					smerr.AddEnrich(ctx, &result.Diagnostics, fwflex.Flatten(ctx, output, &data))
+					if result.Diagnostics.HasError() {
+						return
+					}
+				} else {
+					data.PolicyEngineID = fwflex.StringValueToFramework(ctx, policyEngineID)
 				}
 
 				result.DisplayName = aws.ToString(item.Name)


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
`aws_bedrockagentcore_policy_engine`: Handles remote resource disappearing during List

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=bedrockagentcore TESTS=TestAccBedrockAgentCorePolicyEngine_List_

--- PASS: TestAccBedrockAgentCorePolicyEngine_List_regionOverride (42.69s)
--- PASS: TestAccBedrockAgentCorePolicyEngine_List_basic (43.11s)
--- PASS: TestAccBedrockAgentCorePolicyEngine_List_includeResource (43.48s)
```