### PR TITLE
aws_bedrockagentcore_online_evaluation_config: Handles remote resource disappearing during List

### DIFF
--- a/.changelog/49479.txt
+++ b/.changelog/49479.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_bedrockagentcore_online_evaluation_config: Retries additional IAM propagation errors on creation
+```
+
+```release-note:bug
+list-resource/aws_bedrockagentcore_online_evaluation_config: Prevents error when remote resource disappears during List
+```

--- a/internal/service/bedrockagentcore/online_evaluation_config.go
+++ b/internal/service/bedrockagentcore/online_evaluation_config.go
@@ -286,7 +286,7 @@ func (r *onlineEvaluationConfigResource) Create(ctx context.Context, request res
 	err = tfresource.Retry(ctx, propagationTimeout, func(ctx context.Context) *tfresource.RetryError {
 		out, err = conn.CreateOnlineEvaluationConfig(ctx, &input)
 
-		if tfawserr.ErrMessageContains(err, errCodeValidationException, "The provided execution role cannot be assumed") {
+		if tfawserr.ErrMessageContains(err, errCodeValidationException, "The provided execution role") {
 			return tfresource.RetryableError(err)
 		}
 

--- a/internal/service/bedrockagentcore/online_evaluation_config_list.go
+++ b/internal/service/bedrockagentcore/online_evaluation_config_list.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
 	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/logging"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/smerr"
 	inttypes "github.com/hashicorp/terraform-provider-aws/internal/types"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -58,11 +59,17 @@ func (l *onlineEvaluationConfigListResource) List(ctx context.Context, request l
 			ctx := tflog.SetField(ctx, logging.ResourceAttributeKey(names.AttrARN), arn)
 
 			configID := aws.ToString(item.OnlineEvaluationConfigId)
-			output, err := findOnlineEvaluationConfigByID(ctx, conn, configID)
-			if err != nil {
-				result := fwdiag.NewListResultErrorDiagnostic(err)
-				yield(result)
-				return
+			var output *bedrockagentcorecontrol.GetOnlineEvaluationConfigOutput
+			if request.IncludeResource {
+				var err error
+				output, err = findOnlineEvaluationConfigByID(ctx, conn, configID)
+				if retry.NotFound(err) {
+					continue
+				}
+				if err != nil {
+					yield(fwdiag.NewListResultErrorDiagnostic(err))
+					return
+				}
 			}
 
 			result := request.NewListResult(ctx)
@@ -70,9 +77,13 @@ func (l *onlineEvaluationConfigListResource) List(ctx context.Context, request l
 			var data onlineEvaluationConfigResourceModel
 
 			l.SetResult(ctx, l.Meta(), request.IncludeResource, &data, &result, func() {
-				smerr.AddEnrich(ctx, &result.Diagnostics, fwflex.Flatten(ctx, output, &data))
-				if result.Diagnostics.HasError() {
-					return
+				if request.IncludeResource {
+					smerr.AddEnrich(ctx, &result.Diagnostics, fwflex.Flatten(ctx, output, &data))
+					if result.Diagnostics.HasError() {
+						return
+					}
+				} else {
+					data.OnlineEvaluationConfigID = fwflex.StringValueToFramework(ctx, configID)
 				}
 
 				result.DisplayName = aws.ToString(item.OnlineEvaluationConfigName)

--- a/internal/service/bedrockagentcore/online_evaluation_config_test.go
+++ b/internal/service/bedrockagentcore/online_evaluation_config_test.go
@@ -451,6 +451,8 @@ resource "aws_bedrockagentcore_online_evaluation_config" "test" {
       sampling_percentage = 10.0
     }
   }
+
+  depends_on = [aws_iam_role_policy.test]
 }
 `, rName, executionStatus))
 }
@@ -491,6 +493,8 @@ resource "aws_bedrockagentcore_online_evaluation_config" "test" {
       session_timeout_minutes = 20
     }
   }
+
+  depends_on = [aws_iam_role_policy.test]
 }
 `, rName))
 }

--- a/internal/service/bedrockagentcore/testdata/OnlineEvaluationConfig/basic/main_gen.tf
+++ b/internal/service/bedrockagentcore/testdata/OnlineEvaluationConfig/basic/main_gen.tf
@@ -22,6 +22,8 @@ resource "aws_bedrockagentcore_online_evaluation_config" "test" {
       sampling_percentage = 10.0
     }
   }
+
+  depends_on = [aws_iam_role_policy.test]
 }
 
 data "aws_partition" "current" {}

--- a/internal/service/bedrockagentcore/testdata/OnlineEvaluationConfig/list_basic/main.tf
+++ b/internal/service/bedrockagentcore/testdata/OnlineEvaluationConfig/list_basic/main.tf
@@ -24,6 +24,8 @@ resource "aws_bedrockagentcore_online_evaluation_config" "test" {
       sampling_percentage = 10.0
     }
   }
+
+  depends_on = [aws_iam_role_policy.test]
 }
 
 data "aws_partition" "current" {}

--- a/internal/service/bedrockagentcore/testdata/OnlineEvaluationConfig/list_include_resource/main.tf
+++ b/internal/service/bedrockagentcore/testdata/OnlineEvaluationConfig/list_include_resource/main.tf
@@ -26,6 +26,8 @@ resource "aws_bedrockagentcore_online_evaluation_config" "test" {
   }
 
   tags = var.resource_tags
+
+  depends_on = [aws_iam_role_policy.test]
 }
 
 data "aws_partition" "current" {}

--- a/internal/service/bedrockagentcore/testdata/OnlineEvaluationConfig/list_region_override/main.tf
+++ b/internal/service/bedrockagentcore/testdata/OnlineEvaluationConfig/list_region_override/main.tf
@@ -28,7 +28,9 @@ resource "aws_bedrockagentcore_online_evaluation_config" "test" {
 }
 
 data "aws_partition" "current" {}
-data "aws_region" "current" {}
+data "aws_region" "current" {
+  region = var.region
+}
 data "aws_caller_identity" "current" {}
 
 data "aws_iam_policy_document" "test" {

--- a/internal/service/bedrockagentcore/testdata/OnlineEvaluationConfig/list_region_override/main.tf
+++ b/internal/service/bedrockagentcore/testdata/OnlineEvaluationConfig/list_region_override/main.tf
@@ -25,6 +25,8 @@ resource "aws_bedrockagentcore_online_evaluation_config" "test" {
       sampling_percentage = 10.0
     }
   }
+
+  depends_on = [aws_iam_role_policy.test]
 }
 
 data "aws_partition" "current" {}

--- a/internal/service/bedrockagentcore/testdata/OnlineEvaluationConfig/region_override/main_gen.tf
+++ b/internal/service/bedrockagentcore/testdata/OnlineEvaluationConfig/region_override/main_gen.tf
@@ -24,6 +24,8 @@ resource "aws_bedrockagentcore_online_evaluation_config" "test" {
       sampling_percentage = 10.0
     }
   }
+
+  depends_on = [aws_iam_role_policy.test]
 }
 
 data "aws_partition" "current" {}

--- a/internal/service/bedrockagentcore/testdata/OnlineEvaluationConfig/region_override/main_gen.tf
+++ b/internal/service/bedrockagentcore/testdata/OnlineEvaluationConfig/region_override/main_gen.tf
@@ -27,7 +27,9 @@ resource "aws_bedrockagentcore_online_evaluation_config" "test" {
 }
 
 data "aws_partition" "current" {}
-data "aws_region" "current" {}
+data "aws_region" "current" {
+  region = var.region
+}
 data "aws_caller_identity" "current" {}
 
 data "aws_iam_policy_document" "test" {

--- a/internal/service/bedrockagentcore/testdata/OnlineEvaluationConfig/tags/main_gen.tf
+++ b/internal/service/bedrockagentcore/testdata/OnlineEvaluationConfig/tags/main_gen.tf
@@ -23,6 +23,8 @@ resource "aws_bedrockagentcore_online_evaluation_config" "test" {
     }
   }
 
+  depends_on = [aws_iam_role_policy.test]
+
   tags = var.resource_tags
 }
 

--- a/internal/service/bedrockagentcore/testdata/OnlineEvaluationConfig/tagsComputed1/main_gen.tf
+++ b/internal/service/bedrockagentcore/testdata/OnlineEvaluationConfig/tagsComputed1/main_gen.tf
@@ -25,6 +25,8 @@ resource "aws_bedrockagentcore_online_evaluation_config" "test" {
     }
   }
 
+  depends_on = [aws_iam_role_policy.test]
+
   tags = {
     (var.unknownTagKey) = null_resource.test.id
   }

--- a/internal/service/bedrockagentcore/testdata/OnlineEvaluationConfig/tagsComputed2/main_gen.tf
+++ b/internal/service/bedrockagentcore/testdata/OnlineEvaluationConfig/tagsComputed2/main_gen.tf
@@ -25,6 +25,8 @@ resource "aws_bedrockagentcore_online_evaluation_config" "test" {
     }
   }
 
+  depends_on = [aws_iam_role_policy.test]
+
   tags = {
     (var.unknownTagKey) = null_resource.test.id
     (var.knownTagKey)   = var.knownTagValue

--- a/internal/service/bedrockagentcore/testdata/OnlineEvaluationConfig/tags_defaults/main_gen.tf
+++ b/internal/service/bedrockagentcore/testdata/OnlineEvaluationConfig/tags_defaults/main_gen.tf
@@ -29,6 +29,8 @@ resource "aws_bedrockagentcore_online_evaluation_config" "test" {
     }
   }
 
+  depends_on = [aws_iam_role_policy.test]
+
   tags = var.resource_tags
 }
 

--- a/internal/service/bedrockagentcore/testdata/OnlineEvaluationConfig/tags_ignore/main_gen.tf
+++ b/internal/service/bedrockagentcore/testdata/OnlineEvaluationConfig/tags_ignore/main_gen.tf
@@ -32,6 +32,8 @@ resource "aws_bedrockagentcore_online_evaluation_config" "test" {
     }
   }
 
+  depends_on = [aws_iam_role_policy.test]
+
   tags = var.resource_tags
 }
 

--- a/internal/service/bedrockagentcore/testdata/OnlineEvaluationConfig/updated/main.tf
+++ b/internal/service/bedrockagentcore/testdata/OnlineEvaluationConfig/updated/main.tf
@@ -31,6 +31,8 @@ resource "aws_bedrockagentcore_online_evaluation_config" "test" {
       session_timeout_minutes = 30
     }
   }
+
+  depends_on = [aws_iam_role_policy.test]
 }
 
 data "aws_partition" "current" {}

--- a/internal/service/bedrockagentcore/testdata/tmpl/online_evaluation_config_basic.gtpl
+++ b/internal/service/bedrockagentcore/testdata/tmpl/online_evaluation_config_basic.gtpl
@@ -21,6 +21,8 @@ resource "aws_bedrockagentcore_online_evaluation_config" "test" {
     }
   }
 
+  depends_on = [aws_iam_role_policy.test]
+
 {{- template "tags" . }}
 }
 

--- a/internal/service/bedrockagentcore/testdata/tmpl/online_evaluation_config_basic.gtpl
+++ b/internal/service/bedrockagentcore/testdata/tmpl/online_evaluation_config_basic.gtpl
@@ -25,7 +25,9 @@ resource "aws_bedrockagentcore_online_evaluation_config" "test" {
 }
 
 data "aws_partition" "current" {}
-data "aws_region" "current" {}
+data "aws_region" "current" {
+{{- template "region" -}}
+}
 data "aws_caller_identity" "current" {}
 
 data "aws_iam_policy_document" "test" {


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
`aws_bedrockagentcore_online_evaluation_config`: Handles remote resource disappearing during List

Fixes IAM propagation errors on create.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=bedrockagentcore TESTS=TestAccBedrockAgentCoreOnlineEvaluationConfig_

--- PASS: TestAccBedrockAgentCoreOnlineEvaluationConfig_List_includeResource (53.96s)
--- PASS: TestAccBedrockAgentCoreOnlineEvaluationConfig_List_basic (55.43s)
--- PASS: TestAccBedrockAgentCoreOnlineEvaluationConfig_filters (59.73s)
--- PASS: TestAccBedrockAgentCoreOnlineEvaluationConfig_disappears (62.16s)
--- PASS: TestAccBedrockAgentCoreOnlineEvaluationConfig_basic (63.92s)
--- PASS: TestAccBedrockAgentCoreOnlineEvaluationConfig_List_regionOverride (64.87s)
--- SKIP: TestAccBedrockAgentCoreOnlineEvaluationConfig_executionStatus (65.30s)
--- SKIP: TestAccBedrockAgentCoreOnlineEvaluationConfig_update (65.73s)
--- PASS: TestAccBedrockAgentCoreOnlineEvaluationConfig_Identity_regionOverride (73.72s)
--- PASS: TestAccBedrockAgentCoreOnlineEvaluationConfig_Identity_basic (81.62s)
--- PASS: TestAccBedrockAgentCoreOnlineEvaluationConfig_tags (92.04s)
```