### PR TITLE
aws_bedrockagentcore_registry: Handles remote resource disappearing during List

### DIFF
--- a/.changelog/49480.txt
+++ b/.changelog/49480.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+list-resource/aws_bedrockagentcore_registry: Prevents error when remote resource disappears during List
+```

--- a/internal/service/bedrockagentcore/registry_list.go
+++ b/internal/service/bedrockagentcore/registry_list.go
@@ -16,7 +16,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/logging"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/smerr"
 	inttypes "github.com/hashicorp/terraform-provider-aws/internal/types"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -63,20 +65,30 @@ func (l *registryListResource) List(ctx context.Context, request list.ListReques
 			registryID := aws.ToString(item.RegistryId)
 			ctx := tflog.SetField(ctx, logging.ResourceAttributeKey(names.AttrARN), aws.ToString(item.RegistryArn))
 
-			output, err := findRegistryByID(ctx, conn, registryID)
-			if err != nil {
-				result := fwdiag.NewListResultErrorDiagnostic(err)
-				yield(result)
-				return
+			var output *bedrockagentcorecontrol.GetRegistryOutput
+			if request.IncludeResource {
+				var err error
+				output, err = findRegistryByID(ctx, conn, registryID)
+				if retry.NotFound(err) {
+					continue
+				}
+				if err != nil {
+					yield(fwdiag.NewListResultErrorDiagnostic(err))
+					return
+				}
 			}
 
 			result := request.NewListResult(ctx)
 
 			var data registryResourceModel
 			l.SetResult(ctx, l.Meta(), request.IncludeResource, &data, &result, func() {
-				smerr.AddEnrich(ctx, &result.Diagnostics, l.flatten(ctx, output, &data))
-				if result.Diagnostics.HasError() {
-					return
+				if request.IncludeResource {
+					smerr.AddEnrich(ctx, &result.Diagnostics, l.flatten(ctx, output, &data))
+					if result.Diagnostics.HasError() {
+						return
+					}
+				} else {
+					data.RegistryID = fwflex.StringValueToFramework(ctx, registryID)
 				}
 
 				result.DisplayName = aws.ToString(item.Name)

--- a/internal/service/bedrockagentcore/registry_list_test.go
+++ b/internal/service/bedrockagentcore/registry_list_test.go
@@ -34,7 +34,10 @@ func TestAccBedrockAgentCoreRegistry_List_basic(t *testing.T) {
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_14_0),
 		},
-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheckRegistries(ctx, t)
+		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockAgentCoreServiceID),
 		CheckDestroy:             testAccCheckRegistryDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -87,7 +90,10 @@ func TestAccBedrockAgentCoreRegistry_List_includeResource(t *testing.T) {
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_14_0),
 		},
-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheckRegistries(ctx, t)
+		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockAgentCoreServiceID),
 		CheckDestroy:             testAccCheckRegistryDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -148,6 +154,7 @@ func TestAccBedrockAgentCoreRegistry_List_regionOverride(t *testing.T) {
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckMultipleRegion(t, 2)
+			testAccPreCheckRegistries(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockAgentCoreServiceID),
 		CheckDestroy:             testAccCheckRegistryDestroy(ctx, t),


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
`aws_bedrockagentcore_registry`: Handles remote resource disappearing during List

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=bedrockagentcore TESTS=TestAccBedrockAgentCoreRegistry_List_

--- SKIP: TestAccBedrockAgentCoreRegistry_List_basic (0.56s)
--- SKIP: TestAccBedrockAgentCoreRegistry_List_includeResource (0.57s)
--- SKIP: TestAccBedrockAgentCoreRegistry_List_regionOverride (0.59s)
```