### PR TITLE
aws_bedrockagentcore_resource_policy: Handles remote resource disappearing during List

### DIFF
--- a/.changelog/49481.txt
+++ b/.changelog/49481.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+list-resource/aws_bedrockagentcore_resource_policy: Prevents error when remote resource disappears during List
+```

--- a/internal/service/bedrockagentcore/resource_policy_list.go
+++ b/internal/service/bedrockagentcore/resource_policy_list.go
@@ -13,6 +13,7 @@ import (
 	awstypes "github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol/types"
 	"github.com/hashicorp/terraform-plugin-framework/list"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
 	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
@@ -63,6 +64,9 @@ func (l *resourcePolicyListResource) List(ctx context.Context, request list.List
 			}
 			for endpoint, err := range listAgentRuntimeEndpointsForPolicies(ctx, conn, &endpointsInput) {
 				if err != nil {
+					if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+						break
+					}
 					yield(fwdiag.NewListResultErrorDiagnostic(err))
 					return
 				}


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
`aws_bedrockagentcore_resource_policy`: Handles remote resource disappearing during List

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=bedrockagentcore TESTS=TestAccBedrockAgentCoreResourcePolicy_List_

--- SKIP: TestAccBedrockAgentCoreResourcePolicy_List_basic (0.00s)
--- SKIP: TestAccBedrockAgentCoreResourcePolicy_List_includeResource (0.00s)
```