### PR TITLE
Move config to new HCP Terraform organization

### DIFF
--- a/infrastructure/repository/main.tf
+++ b/infrastructure/repository/main.tf
@@ -3,7 +3,7 @@
 
 terraform {
   backend "remote" {
-    organization = "hashicorp-v2"
+    organization = "hashicorp-terraform-aws-provider"
 
     workspaces {
       name = "terraform-provider-aws-repository"
@@ -13,11 +13,11 @@ terraform {
   required_providers {
     github = {
       source  = "integrations/github"
-      version = "6.13.0"
+      version = "~> 6"
     }
   }
 
-  required_version = ">= 0.13.5"
+  required_version = "~> 1.15"
 }
 
 provider "github" {


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Updates the Terraform config to point at the new HCP Terraform organization now that `hashicorp-v2` is decommissioned. I've lost access to the existing workspace in the `hashicorp-v2` organization, so we'll either need to find someone who still has access to delete the workspace, or we'll need to delete the webhook config from the repo and leave the workspace abandoned. With that in mind, resources for the config were imported locally and the state pushed to the [new workspace](https://app.terraform.io/app/hashicorp-terraform-aws-provider/workspaces/terraform-provider-aws-repository) after running a plan that showed no changes.

> [!WARNING]
> We'll need to set up [authentication](https://registry.terraform.io/providers/integrations/github/latest/docs#authentication). Previously this was done by setting a `GITHUB_TOKEN` environment variable in the workspace, but I don't currently have the requisite access to grab the token from the vault. Since we're looking at it now, it may be worthwhile to migrate to the app installation option described in the docs. If we want to go that route, I'm happy to add the appropriate arguments into this PR.