### PR TITLE
resource/aws_quicksight_data_set: Guard empty column_geographic_role before sending to AWS API

### DIFF
--- a/.changelog/38326.txt
+++ b/.changelog/38326.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_quicksight_data_set: Fix `InvalidParameterValueException` when a `tag_column_operation` `tags` block omits `column_geographic_role`
+```

--- a/internal/service/quicksight/schema/data_set.go
+++ b/internal/service/quicksight/schema/data_set.go
@@ -1434,7 +1434,7 @@ func expandColumnTag(tfMap map[string]any) *awstypes.ColumnTag {
 	if v, ok := tfMap["column_description"].([]any); ok {
 		apiObject.ColumnDescription = expandColumnDescription(v)
 	}
-	if v, ok := tfMap["column_geographic_role"].(string); ok {
+	if v, ok := tfMap["column_geographic_role"].(string); ok && v != "" {
 		apiObject.ColumnGeographicRole = awstypes.GeoSpatialDataRole(v)
 	}
 

--- a/internal/service/quicksight/schema/data_set_test.go
+++ b/internal/service/quicksight/schema/data_set_test.go
@@ -6,6 +6,7 @@ package schema
 import (
 	"testing"
 
+	awstypes "github.com/aws/aws-sdk-go-v2/service/quicksight/types"
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-provider-aws/internal/sdkv2"
 )
@@ -111,5 +112,43 @@ func TestDataSetRowLevelPermissionTagConfigurationSchemaDataSourceSchema(t *test
 
 	if diff := cmp.Diff(dataSourceSchema, expectedDataSourceSchema); diff != "" {
 		t.Errorf("unexpected diff (+want, -got): %s", diff)
+	}
+}
+
+func TestExpandColumnTag(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		tfMap    map[string]any
+		expected awstypes.GeoSpatialDataRole
+	}{
+		"column_geographic_role omitted": {
+			tfMap:    map[string]any{},
+			expected: "",
+		},
+		"column_geographic_role empty string": {
+			tfMap:    map[string]any{"column_geographic_role": ""},
+			expected: "",
+		},
+		"column_geographic_role set": {
+			tfMap:    map[string]any{"column_geographic_role": string(awstypes.GeoSpatialDataRoleState)},
+			expected: awstypes.GeoSpatialDataRoleState,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := expandColumnTag(testCase.tfMap)
+
+			if got == nil {
+				t.Fatal("expandColumnTag() returned nil")
+			}
+
+			if got.ColumnGeographicRole != testCase.expected {
+				t.Errorf("ColumnGeographicRole = %q, want %q", got.ColumnGeographicRole, testCase.expected)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Description

`column_geographic_role` on `tag_column_operation.tags` is `Optional`. When a config omits it, the SDKv2 zero-value empty string was still passed through to `awstypes.GeoSpatialDataRole(v)` and sent to the AWS API, which rejects it with:

```
Value '' at 'logicalTableMap.XXX.member.dataTransforms.N.member.tagColumnOperation.tags.M.member.columnGeographicRole' failed to satisfy constraint: Member must satisfy enum value set...
```

This PR only sets `ColumnGeographicRole` when the value is non-empty.

## Relations

Closes #38326

## Output from Acceptance Testing

Not run in this environment (no AWS credentials available). Added a new unit test `TestExpandColumnTag` covering omitted / empty / set cases -- passes. `go vet ./internal/service/quicksight/...` passes cleanly.

The existing acceptance test `TestAccQuickSightDataSet_columnDescriptionText` already exercises a `tags` block with `column_description` only (no `column_geographic_role`), which is the same repro path as the bug.