### PR TITLE
Sweeper: `aws_subnet` add dependencies

### DIFF
--- a/internal/service/ec2/sweep.go
+++ b/internal/service/ec2/sweep.go
@@ -229,6 +229,8 @@ func RegisterSweepers() {
 		"aws_appstream_image_builder",
 		"aws_autoscaling_group",
 		"aws_batch_compute_environment",
+		"aws_bedrockagentcore_agent_runtime",
+		"aws_bedrockagentcore_harness",
 		"aws_elastic_beanstalk_environment",
 		"aws_cloud9_environment_ec2",
 		"aws_cloudhsm_v2_cluster",


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Adds `aws_bedrockagentcore_harness` and `aws_bedrockagentcore_agent_runtime` to `aws_subnet` sweeper as dependencies
