### PR TITLE
r/aws_cloudwatch_dashboard: retry read-after-create on eventual consistency

### DIFF
--- a/.changelog/49507.txt
+++ b/.changelog/49507.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cloudwatch_dashboard: Retry the read after creation when CloudWatch eventual consistency transiently returns `ResourceNotFound`, preventing intermittent `apply` failures immediately after a successful `PutDashboard`
+```

--- a/internal/service/cloudwatch/dashboard.go
+++ b/internal/service/cloudwatch/dashboard.go
@@ -8,6 +8,7 @@ package cloudwatch
 import (
 	"context"
 	"log"
+	"time"
 
 	"github.com/YakDriver/smarterr"
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -22,6 +23,11 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/smerr"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
+
+// propagationTimeout is the maximum amount of time to wait for CloudWatch
+// read-after-write eventual consistency: a GetDashboard issued immediately after
+// a successful PutDashboard can transiently return ResourceNotFound.
+const propagationTimeout = 2 * time.Minute
 
 // @SDKResource("aws_cloudwatch_dashboard", name="Dashboard")
 // @IdentityAttribute("dashboard_name")
@@ -84,7 +90,13 @@ func resourceDashboardRead(ctx context.Context, d *schema.ResourceData, meta any
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudWatchClient(ctx)
 
-	output, err := findDashboardByName(ctx, conn, d.Id())
+	// A GetDashboard immediately after a successful PutDashboard can transiently
+	// return ResourceNotFound due to CloudWatch read-after-write eventual
+	// consistency. Retry the read for a new resource instead of failing the
+	// apply, matching the standard pattern used elsewhere in the provider.
+	output, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func(ctx context.Context) (*cloudwatch.GetDashboardOutput, error) {
+		return findDashboardByName(ctx, conn, d.Id())
+	}, d.IsNewResource())
 
 	if !d.IsNewResource() && retry.NotFound(err) {
 		smerr.AppendOne(ctx, diags, sdkdiag.NewResourceNotFoundWarningDiagnostic(err), smerr.ID, d.Id())


### PR DESCRIPTION
### Description

A `GetDashboard` issued immediately after a successful `PutDashboard` can transiently return `ResourceNotFound` due to CloudWatch read-after-write eventual consistency. Because `resourceDashboardRead` only tolerates `NotFound` when the resource is **not** new (`!d.IsNewResource() && retry.NotFound(err)`), this surfaced as an intermittent hard failure on `terraform apply` right after create — even though the dashboard demonstrably existed moments later.

This wraps the post-create read in `tfresource.RetryWhenNewResourceNotFound`, the standard pattern already used elsewhere in the provider (e.g. `internal/service/kms/alias.go`), so a new-resource `NotFound` is retried up to `propagationTimeout` instead of failing the apply. Behavior for existing resources (a real deletion → remove from state) is unchanged.

### Relations

Closes #49472

### References

Follows the existing convention, e.g. `resourceAliasRead` in `internal/service/kms/alias.go`, which wraps its post-create find in `tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, ..., d.IsNewResource())`.

### Output from Acceptance Testing

I could **not** run the CloudWatch acceptance tests (`TestAccCloudWatchDashboard_*`) — they require live AWS credentials, and the bug itself is an intermittent timing race that can't be reproduced deterministically without hitting the real API under eventual-consistency conditions. What I verified locally:

```console
$ go build ./internal/service/cloudwatch/     # exit 0
$ gofmt -l internal/service/cloudwatch/dashboard.go   # clean
```

The change is a mechanical application of the provider's own documented retry pattern; a maintainer with the CI acceptance harness can confirm `TestAccCloudWatchDashboard_basic` and friends still pass. Happy to adjust the timeout value or wording.

First-time contributor here.
