### PR TITLE
r/aws_dms_endpoint: send oracle_settings.trim_space_in_char for source endpoints

### DIFF
--- a/.changelog/49508.txt
+++ b/.changelog/49508.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_dms_endpoint: Fix `oracle_settings.trim_space_in_char` being silently ignored for source endpoints (the value is now sent to the DMS API on create and update)
+```

--- a/internal/service/dms/endpoint.go
+++ b/internal/service/dms/endpoint.go
@@ -2531,6 +2531,9 @@ func expandOracleSettings(tfMap map[string]any, endpointType awstypes.Replicatio
 		if v, ok := tfMap["standby_delay_time"].(int); ok {
 			apiObject.StandbyDelayTime = aws.Int32(int32(v))
 		}
+		if v, ok := tfMap["trim_space_in_char"].(bool); ok {
+			apiObject.TrimSpaceInChar = aws.Bool(v)
+		}
 		if v, ok := tfMap["use_alternate_folder_for_online"].(bool); ok {
 			apiObject.UseAlternateFolderForOnline = aws.Bool(v)
 		}

--- a/internal/service/dms/endpoint_oracle_settings_test.go
+++ b/internal/service/dms/endpoint_oracle_settings_test.go
@@ -1,0 +1,58 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package dms_test
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/databasemigrationservice/types"
+	tfdms "github.com/hashicorp/terraform-provider-aws/internal/service/dms"
+)
+
+func TestExpandOracleSettings_trimSpaceInChar(t *testing.T) {
+	t.Parallel()
+
+	// trim_space_in_char is a source-only Oracle setting. It must be sent to the
+	// API for source endpoints (regression test for #49468, where it was missing
+	// from the source case of expandOracleSettings and silently dropped), and it
+	// must NOT be sent for target endpoints (it is not valid there).
+	testCases := map[string]struct {
+		endpointType awstypes.ReplicationEndpointTypeValue
+		want         *bool
+	}{
+		"source endpoint sends the configured value": {
+			endpointType: awstypes.ReplicationEndpointTypeValueSource,
+			want:         aws.Bool(false),
+		},
+		"target endpoint does not send it": {
+			endpointType: awstypes.ReplicationEndpointTypeValueTarget,
+			want:         nil,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			tfMap := map[string]any{
+				"trim_space_in_char": false,
+			}
+
+			got := tfdms.ExpandOracleSettings(tfMap, tc.endpointType)
+			if got == nil {
+				t.Fatal("expandOracleSettings returned nil")
+			}
+
+			switch {
+			case tc.want == nil && got.TrimSpaceInChar != nil:
+				t.Fatalf("TrimSpaceInChar = %v, want nil (not valid for %s)", aws.ToBool(got.TrimSpaceInChar), tc.endpointType)
+			case tc.want != nil && got.TrimSpaceInChar == nil:
+				t.Fatalf("TrimSpaceInChar = nil, want %v for %s", aws.ToBool(tc.want), tc.endpointType)
+			case tc.want != nil && aws.ToBool(got.TrimSpaceInChar) != aws.ToBool(tc.want):
+				t.Fatalf("TrimSpaceInChar = %v, want %v", aws.ToBool(got.TrimSpaceInChar), aws.ToBool(tc.want))
+			}
+		})
+	}
+}

--- a/internal/service/dms/exports_test.go
+++ b/internal/service/dms/exports_test.go
@@ -22,6 +22,7 @@ var (
 	FindReplicationSubnetGroupByID = findReplicationSubnetGroupByID
 	FindReplicationTaskByID        = findReplicationTaskByID
 	TaskSettingsEqual              = taskSettingsEqual
+	ExpandOracleSettings           = expandOracleSettings
 	ValidEndpointID                = validEndpointID
 	ValidReplicationInstanceID     = validReplicationInstanceID
 	ValidReplicationSubnetGroupID  = validReplicationSubnetGroupID


### PR DESCRIPTION
### Description

`expandOracleSettings()` maps every other source-only Oracle setting (`use_bfile`, `use_logminer_reader`, `add_supplemental_logging`, `number_datatype_scale`, …) from the config into the API object in its `case ReplicationEndpointTypeValueSource` block — but it omits `trim_space_in_char`. As a result the value is silently never sent to DMS on `CreateEndpoint`/`ModifyEndpoint` for a source Oracle endpoint, so the endpoint always runs with the AWS default (`TrimSpaceInChar = true`) regardless of what is configured.

This is compounded by `flattenOracleSettings()`, which only writes the attribute back to state `if apiObject.TrimSpaceInChar != nil`. Since AWS never receives the setting it never returns one, so refresh never corrects state and `terraform plan` shows zero drift forever — masking the bug.

`TrimSpaceInChar` is documented by AWS as a **source** Oracle endpoint setting, so this maps it in the `Source` case only; the `Target` case correctly continues not to send it. (Distinct from #46676, which removed it from the target path.)

### Relations

Closes #49468

### Change

```go
case awstypes.ReplicationEndpointTypeValueSource:
    ...
    if v, ok := tfMap["standby_delay_time"].(int); ok {
        apiObject.StandbyDelayTime = aws.Int32(int32(v))
    }
+   if v, ok := tfMap["trim_space_in_char"].(bool); ok {
+       apiObject.TrimSpaceInChar = aws.Bool(v)
+   }
    if v, ok := tfMap["use_alternate_folder_for_online"].(bool); ok {
        ...
```

The `trim_space_in_char` schema attribute and its `flattenOracleSettings` read already exist; only the expand mapping was missing.

### Test

Adds `TestExpandOracleSettings_trimSpaceInChar` (exposing `expandOracleSettings` via `exports_test.go`): asserts the value is sent for a source endpoint and left `nil` for a target endpoint.

### Output from Acceptance Testing

`go build ./internal/service/dms/` succeeds and `gofmt` is clean on all three files. I was **not** able to run the DMS test suite in my environment — compiling the provider's test dependency closure repeatedly OOM-killed the Go compiler (`signal: killed` on `service/ec2`, `service/bedrock`, etc., even at `-p 1`), a memory limit of the machine rather than anything in the change. The added test logic was validated in isolation. A maintainer's CI can run `TestExpandOracleSettings_trimSpaceInChar` and `make testacc TESTS=TestAccDMSEndpoint_Oracle PKG=dms`.

First-time contributor here — happy to adjust.
