### PR TITLE
r/`aws_mailmanager_traffic_policy`: make `policy_statement` optional and send empty slice when omitted

### DIFF
--- a/.changelog/49509.txt
+++ b/.changelog/49509.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_mailmanager_traffic_policy: Allow empty `policy_statement` blocks
+```

--- a/.changelog/49509.txt
+++ b/.changelog/49509.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_mailmanager_traffic_policy: Allow empty `policy_statement` blocks
+resource/aws_mailmanager_traffic_policy: Make `policy_statement` optional
 ```

--- a/internal/service/mailmanager/traffic_policy.go
+++ b/internal/service/mailmanager/traffic_policy.go
@@ -107,9 +107,6 @@ func (r *trafficPolicyResource) Schema(ctx context.Context, _ resource.SchemaReq
 func policyStatementBlock(ctx context.Context) schema.ListNestedBlock {
 	return schema.ListNestedBlock{
 		CustomType: fwtypes.NewListNestedObjectTypeOf[policyStatementModel](ctx),
-		Validators: []validator.List{
-			listvalidator.SizeAtLeast(1),
-		},
 		NestedObject: schema.NestedBlockObject{
 			Attributes: map[string]schema.Attribute{
 				names.AttrAction: schema.StringAttribute{
@@ -408,6 +405,10 @@ func (r *trafficPolicyResource) Create(ctx context.Context, req resource.CreateR
 		return
 	}
 
+	if shouldSendEmptyPolicyStatements(data.PolicyStatements) {
+		input.PolicyStatements = []awstypes.PolicyStatement{}
+	}
+
 	// Additional fields.
 	input.ClientToken = aws.String(create.UniqueId(ctx))
 	input.Tags = getTagsIn(ctx)
@@ -429,6 +430,8 @@ func (r *trafficPolicyResource) Create(ctx context.Context, req resource.CreateR
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	normalizePolicyStatements(ctx, &data, trafficPolicyOut.PolicyStatements)
 
 	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, &data))
 }
@@ -460,6 +463,8 @@ func (r *trafficPolicyResource) Read(ctx context.Context, req resource.ReadReque
 		return
 	}
 
+	normalizePolicyStatements(ctx, &state, out.PolicyStatements)
+
 	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, &state))
 }
 
@@ -485,6 +490,11 @@ func (r *trafficPolicyResource) Update(ctx context.Context, req resource.UpdateR
 		if resp.Diagnostics.HasError() {
 			return
 		}
+
+		if shouldSendEmptyPolicyStatements(plan.PolicyStatements) {
+			input.PolicyStatements = []awstypes.PolicyStatement{}
+		}
+
 		_, err := conn.UpdateTrafficPolicy(ctx, &input)
 		if err != nil {
 			smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, plan.ID.String())
@@ -503,7 +513,19 @@ func (r *trafficPolicyResource) Update(ctx context.Context, req resource.UpdateR
 		return
 	}
 
+	normalizePolicyStatements(ctx, &plan, out.PolicyStatements)
+
 	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, &plan))
+}
+
+func shouldSendEmptyPolicyStatements(v fwtypes.ListNestedObjectValueOf[policyStatementModel]) bool {
+	return v.IsNull() || v.IsUnknown() || len(v.Elements()) == 0
+}
+
+func normalizePolicyStatements(ctx context.Context, data *trafficPolicyResourceModel, policyStatements []awstypes.PolicyStatement) {
+	if len(policyStatements) == 0 {
+		data.PolicyStatements = fwtypes.NewListNestedObjectValueOfEmpty[policyStatementModel](ctx)
+	}
 }
 
 func (r *trafficPolicyResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/internal/service/mailmanager/traffic_policy.go
+++ b/internal/service/mailmanager/traffic_policy.go
@@ -519,7 +519,7 @@ func (r *trafficPolicyResource) Update(ctx context.Context, req resource.UpdateR
 }
 
 func shouldSendEmptyPolicyStatements(v fwtypes.ListNestedObjectValueOf[policyStatementModel]) bool {
-	return v.IsNull() || v.IsUnknown() || len(v.Elements()) == 0
+	return v.IsNull() || v.IsUnknown() || v.Length(fwtypes.CollectionLengthUnhandledAsZero) == 0
 }
 
 func normalizePolicyStatements(ctx context.Context, data *trafficPolicyResourceModel, policyStatements []awstypes.PolicyStatement) {

--- a/internal/service/mailmanager/traffic_policy.go
+++ b/internal/service/mailmanager/traffic_policy.go
@@ -522,7 +522,7 @@ func (r *trafficPolicyResource) Update(ctx context.Context, req resource.UpdateR
 }
 
 // normalizePolicyStatements keeps an empty API result null so an omitted
-// policy_statement block (null in configuration) round-trips without a diff.
+// policy_statement block round-trips without a diff.
 func normalizePolicyStatements(ctx context.Context, data *trafficPolicyResourceModel, policyStatements []awstypes.PolicyStatement) {
 	if len(policyStatements) == 0 {
 		data.PolicyStatements = fwtypes.NewListNestedObjectValueOfNull[policyStatementModel](ctx)

--- a/internal/service/mailmanager/traffic_policy.go
+++ b/internal/service/mailmanager/traffic_policy.go
@@ -405,7 +405,10 @@ func (r *trafficPolicyResource) Create(ctx context.Context, req resource.CreateR
 		return
 	}
 
-	if shouldSendEmptyPolicyStatements(data.PolicyStatements) {
+	// CreateTrafficPolicy requires PolicyStatements but accepts an empty slice.
+	// AutoFlex expands an omitted policy_statement block to nil, so send an
+	// explicit empty slice to allow policies with only a default_action.
+	if input.PolicyStatements == nil {
 		input.PolicyStatements = []awstypes.PolicyStatement{}
 	}
 
@@ -491,7 +494,7 @@ func (r *trafficPolicyResource) Update(ctx context.Context, req resource.UpdateR
 			return
 		}
 
-		if shouldSendEmptyPolicyStatements(plan.PolicyStatements) {
+		if input.PolicyStatements == nil {
 			input.PolicyStatements = []awstypes.PolicyStatement{}
 		}
 
@@ -518,13 +521,11 @@ func (r *trafficPolicyResource) Update(ctx context.Context, req resource.UpdateR
 	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, &plan))
 }
 
-func shouldSendEmptyPolicyStatements(v fwtypes.ListNestedObjectValueOf[policyStatementModel]) bool {
-	return v.IsNull() || v.IsUnknown() || v.Length(fwtypes.CollectionLengthUnhandledAsZero) == 0
-}
-
+// normalizePolicyStatements keeps an empty API result null so an omitted
+// policy_statement block (null in configuration) round-trips without a diff.
 func normalizePolicyStatements(ctx context.Context, data *trafficPolicyResourceModel, policyStatements []awstypes.PolicyStatement) {
 	if len(policyStatements) == 0 {
-		data.PolicyStatements = fwtypes.NewListNestedObjectValueOfEmpty[policyStatementModel](ctx)
+		data.PolicyStatements = fwtypes.NewListNestedObjectValueOfNull[policyStatementModel](ctx)
 	}
 }
 

--- a/internal/service/mailmanager/traffic_policy_test.go
+++ b/internal/service/mailmanager/traffic_policy_test.go
@@ -183,6 +183,71 @@ func TestAccMailManagerTrafficPolicy_conditionTypes(t *testing.T) {
 	})
 }
 
+func TestAccMailManagerTrafficPolicy_emptyPolicyStatements(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_mailmanager_traffic_policy.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheckTrafficPolicy(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.MailManagerServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTrafficPolicyDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTrafficPolicyConfig_emptyPolicyStatements(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckTrafficPolicyExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, names.AttrDefaultAction, "ALLOW"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					resource.TestCheckResourceAttr(resourceName, "policy_statement.#", "0"),
+				),
+			},
+			{
+				Config:   testAccTrafficPolicyConfig_emptyPolicyStatements(rName),
+				PlanOnly: true,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccTrafficPolicyConfig_basic(rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckTrafficPolicyExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "policy_statement.#", "1"),
+				),
+			},
+			{
+				Config: testAccTrafficPolicyConfig_emptyPolicyStatements(rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckTrafficPolicyExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "policy_statement.#", "0"),
+				),
+			},
+			{
+				Config:   testAccTrafficPolicyConfig_emptyPolicyStatements(rName),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 func testAccCheckTrafficPolicyDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.ProviderMeta(ctx, t).MailManagerClient(ctx)
@@ -324,6 +389,15 @@ resource "aws_mailmanager_traffic_policy" "test" {
       }
     }
   }
+}
+`, rName)
+}
+
+func testAccTrafficPolicyConfig_emptyPolicyStatements(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_mailmanager_traffic_policy" "test" {
+  default_action = "ALLOW"
+  name           = %[1]q
 }
 `, rName)
 }

--- a/internal/service/mailmanager/traffic_policy_test.go
+++ b/internal/service/mailmanager/traffic_policy_test.go
@@ -208,8 +208,12 @@ func TestAccMailManagerTrafficPolicy_emptyPolicyStatements(t *testing.T) {
 				),
 			},
 			{
-				Config:   testAccTrafficPolicyConfig_emptyPolicyStatements(rName),
-				PlanOnly: true,
+				Config: testAccTrafficPolicyConfig_emptyPolicyStatements(rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
 			},
 			{
 				ResourceName:      resourceName,
@@ -232,7 +236,7 @@ func TestAccMailManagerTrafficPolicy_emptyPolicyStatements(t *testing.T) {
 				Config: testAccTrafficPolicyConfig_emptyPolicyStatements(rName),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
 					},
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -241,8 +245,12 @@ func TestAccMailManagerTrafficPolicy_emptyPolicyStatements(t *testing.T) {
 				),
 			},
 			{
-				Config:   testAccTrafficPolicyConfig_emptyPolicyStatements(rName),
-				PlanOnly: true,
+				Config: testAccTrafficPolicyConfig_emptyPolicyStatements(rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
 			},
 		},
 	})

--- a/internal/service/mailmanager/traffic_policy_test.go
+++ b/internal/service/mailmanager/traffic_policy_test.go
@@ -47,14 +47,16 @@ func TestAccMailManagerTrafficPolicy_basic(t *testing.T) {
 					acctest.CheckResourceAttrRFC3339(resourceName, "last_updated_timestamp"),
 					resource.TestCheckNoResourceAttr(resourceName, "max_message_size_bytes"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
-					resource.TestCheckResourceAttr(resourceName, "policy_statement.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "policy_statement.0.action", "DENY"),
-					resource.TestCheckResourceAttr(resourceName, "policy_statement.0.condition.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "policy_statement.0.condition.0.ip_expression.0.evaluate.0.attribute", "SENDER_IP"),
-					resource.TestCheckResourceAttr(resourceName, "policy_statement.0.condition.0.ip_expression.0.operator", "CIDR_MATCHES"),
-					resource.TestCheckResourceAttr(resourceName, "policy_statement.0.condition.0.ip_expression.0.values.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "policy_statement.0.condition.0.ip_expression.0.values.0", "192.0.2.0/24"),
+					resource.TestCheckResourceAttr(resourceName, "policy_statement.#", "0"),
 				),
+			},
+			{
+				Config: testAccTrafficPolicyConfig_basic(rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
 			},
 			{
 				ResourceName:      resourceName,
@@ -183,7 +185,7 @@ func TestAccMailManagerTrafficPolicy_conditionTypes(t *testing.T) {
 	})
 }
 
-func TestAccMailManagerTrafficPolicy_emptyPolicyStatements(t *testing.T) {
+func TestAccMailManagerTrafficPolicy_policyStatement(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
@@ -199,21 +201,34 @@ func TestAccMailManagerTrafficPolicy_emptyPolicyStatements(t *testing.T) {
 		CheckDestroy:             testAccCheckTrafficPolicyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTrafficPolicyConfig_emptyPolicyStatements(rName),
+				Config: testAccTrafficPolicyConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTrafficPolicyExists(ctx, t, resourceName),
-					resource.TestCheckResourceAttr(resourceName, names.AttrDefaultAction, "ALLOW"),
-					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, "policy_statement.#", "0"),
 				),
 			},
 			{
-				Config: testAccTrafficPolicyConfig_emptyPolicyStatements(rName),
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccTrafficPolicyConfig_policyStatement(rName),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
 					},
 				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckTrafficPolicyExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "policy_statement.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "policy_statement.0.action", "DENY"),
+					resource.TestCheckResourceAttr(resourceName, "policy_statement.0.condition.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "policy_statement.0.condition.0.ip_expression.0.evaluate.0.attribute", "SENDER_IP"),
+					resource.TestCheckResourceAttr(resourceName, "policy_statement.0.condition.0.ip_expression.0.operator", "CIDR_MATCHES"),
+					resource.TestCheckResourceAttr(resourceName, "policy_statement.0.condition.0.ip_expression.0.values.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "policy_statement.0.condition.0.ip_expression.0.values.0", "192.0.2.0/24"),
+				),
 			},
 			{
 				ResourceName:      resourceName,
@@ -229,28 +244,8 @@ func TestAccMailManagerTrafficPolicy_emptyPolicyStatements(t *testing.T) {
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTrafficPolicyExists(ctx, t, resourceName),
-					resource.TestCheckResourceAttr(resourceName, "policy_statement.#", "1"),
-				),
-			},
-			{
-				Config: testAccTrafficPolicyConfig_emptyPolicyStatements(rName),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
-					},
-				},
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTrafficPolicyExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "policy_statement.#", "0"),
 				),
-			},
-			{
-				Config: testAccTrafficPolicyConfig_emptyPolicyStatements(rName),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
-					},
-				},
 			},
 		},
 	})
@@ -307,6 +302,15 @@ func testAccPreCheckTrafficPolicy(ctx context.Context, t *testing.T) {
 }
 
 func testAccTrafficPolicyConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_mailmanager_traffic_policy" "test" {
+  default_action = "ALLOW"
+  name           = %[1]q
+}
+`, rName)
+}
+
+func testAccTrafficPolicyConfig_policyStatement(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_mailmanager_traffic_policy" "test" {
   default_action = "ALLOW"
@@ -397,15 +401,6 @@ resource "aws_mailmanager_traffic_policy" "test" {
       }
     }
   }
-}
-`, rName)
-}
-
-func testAccTrafficPolicyConfig_emptyPolicyStatements(rName string) string {
-	return fmt.Sprintf(`
-resource "aws_mailmanager_traffic_policy" "test" {
-  default_action = "ALLOW"
-  name           = %[1]q
 }
 `, rName)
 }

--- a/website/docs/r/mailmanager_traffic_policy.html.markdown
+++ b/website/docs/r/mailmanager_traffic_policy.html.markdown
@@ -42,11 +42,11 @@ The following arguments are required:
 
 * `default_action` - (Required) Default action for traffic that does not match any policy statement. Valid values are `ALLOW` and `DENY`.
 * `name` - (Required) Name of the traffic policy.
-* `policy_statement` - (Required) Traffic policy statements. See [`policy_statement` Block](#policy_statement-block) below.
 
 The following arguments are optional:
 
 * `max_message_size_bytes` - (Optional) Maximum message size, in bytes, allowed by the traffic policy.
+* `policy_statement` - (Optional) Traffic policy statements. See [`policy_statement` Block](#policy_statement-block) below.
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `tags` - (Optional) Map of tags assigned to the resource. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.


### Description

Allow the creation of `aws_mailmanager_traffic_policy` with zero policy statements, includes

- Removal of the `	listvalidator.SizeAtLeast(1),`
- Writing a `[ ]` if no policy statements are provided.


Below an example for creating a traffic policy with zero policy statements:

```shell
$ aws mailmanager create-traffic-policy --region eu-central-1 --traffic-policy-name "Test" --default-action "ALLOW" --policy-statements "[]"
 {
     "TrafficPolicyId": "tp-7zftpdel63rrwt7yahjqppke"
 }

$ aws mailmanager list-traffic-policies --region eu-central-1
 {
     "TrafficPolicies": [
         {
             "TrafficPolicyName": "Test",
             "TrafficPolicyId": "tp-7zftpdel63rrwt7yahjqppke",
             "DefaultAction": "ALLOW"
         }
     ]
 }
```

### Relations

Closes #49366

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing

```console
make testacc T=TestAccMailManagerTrafficPolicy_emptyPolicyStatements K=mailmanager
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     0.225s
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework 0.212s
make: Running acceptance tests on branch: 🌿 f-aws_mailmanager_traffic_policy-update-validation 🌿...
TF_ACC=1 go1.26.5 test ./internal/service/mailmanager/... -v -count 1 -parallel 20 -run='TestAccMailManagerTrafficPolicy_emptyPolicyStatements'  -timeout 360m -vet=off -buildvcs=false
2026/08/16 10:12:00 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/16 10:12:00 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccMailManagerTrafficPolicy_emptyPolicyStatements
=== PAUSE TestAccMailManagerTrafficPolicy_emptyPolicyStatements
=== CONT  TestAccMailManagerTrafficPolicy_emptyPolicyStatements
--- PASS: TestAccMailManagerTrafficPolicy_emptyPolicyStatements (112.20s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/mailmanager        112.374s

```
