### PR TITLE
dms: fix trim_space_in_char never sent for source Oracle endpoints

### DIFF
--- a/.changelog/49510.txt
+++ b/.changelog/49510.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_dms_endpoint: Fix `oracle_settings.trim_space_in_char` not being sent to the DMS API for source Oracle endpoints
+```

--- a/internal/service/dms/endpoint.go
+++ b/internal/service/dms/endpoint.go
@@ -2531,6 +2531,9 @@ func expandOracleSettings(tfMap map[string]any, endpointType awstypes.Replicatio
 		if v, ok := tfMap["standby_delay_time"].(int); ok {
 			apiObject.StandbyDelayTime = aws.Int32(int32(v))
 		}
+		if v, ok := tfMap["trim_space_in_char"].(bool); ok {
+			apiObject.TrimSpaceInChar = aws.Bool(v)
+		}
 		if v, ok := tfMap["use_alternate_folder_for_online"].(bool); ok {
 			apiObject.UseAlternateFolderForOnline = aws.Bool(v)
 		}

--- a/internal/service/dms/endpoint_internal_test.go
+++ b/internal/service/dms/endpoint_internal_test.go
@@ -1,0 +1,27 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package dms
+
+import (
+	"testing"
+
+	awstypes "github.com/aws/aws-sdk-go-v2/service/databasemigrationservice/types"
+)
+
+func TestExpandOracleSettings_source_trimSpaceInChar(t *testing.T) {
+	t.Parallel()
+
+	tfMap := map[string]any{
+		"trim_space_in_char": false,
+	}
+
+	got := expandOracleSettings(tfMap, awstypes.ReplicationEndpointTypeValueSource)
+
+	if got.TrimSpaceInChar == nil {
+		t.Fatal("expected TrimSpaceInChar to be set, got nil")
+	}
+	if *got.TrimSpaceInChar != false {
+		t.Errorf("expected TrimSpaceInChar = false, got %v", *got.TrimSpaceInChar)
+	}
+}


### PR DESCRIPTION
## What this PR does
Fixes #49468.

`expandOracleSettings`'s `source` case in `internal/service/dms/endpoint.go` maps every other source-only Oracle setting (`use_bfile`, `use_logminer_reader`, etc.) but omits `trim_space_in_char`. As a result, `oracle_settings.trim_space_in_char` configured on an `aws_dms_endpoint` with `endpoint_type = "source"` and `engine_name = "oracle"` is never sent to `CreateEndpoint`/`ModifyEndpoint` — the endpoint is created/updated using AWS's default (`TrimSpaceInChar = true`) regardless of the configured value, with no drift shown in plan or state.

## Fix
Add the missing case, matching the existing pattern for the other source-only boolean settings, in the same position the field already occupies in the schema and in `flattenOracleSettings`.

## Verification
- Added `TestExpandOracleSettings_source_trimSpaceInChar`, a package-internal unit test asserting `expandOracleSettings` sets `TrimSpaceInChar` for the source endpoint type. Passes with the fix.
- `go build ./...` and `go vet ./internal/service/dms/...` clean.
- Acceptance tests for `aws_dms_endpoint` require live AWS credentials, which I don't have access to run here — flagging this so a maintainer can run `TestAccDMSEndpoint_*` as part of review.