### PR TITLE
[Enhancement] rd/aws_fsx_ontap_file_system: add `network_type` argument/attribute

### DIFF
--- a/.changelog/49512.txt
+++ b/.changelog/49512.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_fsx_ontap_file_system: Add `network_type` argument
+```
+
+```release-note:enhancement
+data-source/aws_fsx_ontap_file_system: Add `network_type` attribute
+```

--- a/internal/service/fsx/ontap_file_system.go
+++ b/internal/service/fsx/ontap_file_system.go
@@ -178,6 +178,13 @@ func resourceONTAPFileSystem() *schema.Resource {
 					Computed: true,
 					Elem:     &schema.Schema{Type: schema.TypeString},
 				},
+				"network_type": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					Computed:         true,
+					ForceNew:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.NetworkType](),
+				},
 				names.AttrOwnerID: {
 					Type:     schema.TypeString,
 					Computed: true,
@@ -337,6 +344,10 @@ func resourceONTAPFileSystemCreate(ctx context.Context, d *schema.ResourceData, 
 		input.KmsKeyId = aws.String(v.(string))
 	}
 
+	if v, ok := d.GetOk("network_type"); ok {
+		input.NetworkType = awstypes.NetworkType(v.(string))
+	}
+
 	if v, ok := d.GetOk("route_table_ids"); ok {
 		input.OntapConfiguration.RouteTableIds = flex.ExpandStringValueSet(v.(*schema.Set))
 	}
@@ -403,6 +414,7 @@ func resourceONTAPFileSystemRead(ctx context.Context, d *schema.ResourceData, me
 	d.Set("ha_pairs", haPairs)
 	d.Set(names.AttrKMSKeyID, filesystem.KmsKeyId)
 	d.Set("network_interface_ids", filesystem.NetworkInterfaceIds)
+	d.Set("network_type", filesystem.NetworkType)
 	d.Set(names.AttrOwnerID, filesystem.OwnerId)
 	d.Set("preferred_subnet_id", ontapConfig.PreferredSubnetId)
 	d.Set("route_table_ids", ontapConfig.RouteTableIds)

--- a/internal/service/fsx/ontap_file_system_data_source.go
+++ b/internal/service/fsx/ontap_file_system_data_source.go
@@ -125,6 +125,10 @@ func dataSourceONTAPFileSystem() *schema.Resource {
 					Computed: true,
 					Elem:     &schema.Schema{Type: schema.TypeString},
 				},
+				"network_type": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
 				names.AttrOwnerID: {
 					Type:     schema.TypeString,
 					Computed: true,
@@ -205,6 +209,7 @@ func dataSourceONTAPFileSystemRead(ctx context.Context, d *schema.ResourceData, 
 	d.Set("ha_pairs", haPairs)
 	d.Set(names.AttrKMSKeyID, filesystem.KmsKeyId)
 	d.Set("network_interface_ids", filesystem.NetworkInterfaceIds)
+	d.Set("network_type", filesystem.NetworkType)
 	d.Set(names.AttrOwnerID, filesystem.OwnerId)
 	d.Set("preferred_subnet_id", ontapConfig.PreferredSubnetId)
 	d.Set("route_table_ids", ontapConfig.RouteTableIds)

--- a/internal/service/fsx/ontap_file_system_data_source_test.go
+++ b/internal/service/fsx/ontap_file_system_data_source_test.go
@@ -40,6 +40,7 @@ func TestAccFSxONTAPFileSystemDataSource_Id(t *testing.T) {
 					resource.TestCheckResourceAttrPair(datasourceName, "ha_pairs", resourceName, "ha_pairs"),
 					resource.TestCheckResourceAttrPair(datasourceName, names.AttrKMSKeyID, resourceName, names.AttrKMSKeyID),
 					resource.TestCheckResourceAttrPair(datasourceName, "network_interface_ids.#", resourceName, "network_interface_ids.#"),
+					resource.TestCheckResourceAttrPair(datasourceName, "network_type", resourceName, "network_type"),
 					resource.TestCheckResourceAttrPair(datasourceName, names.AttrOwnerID, resourceName, names.AttrOwnerID),
 					resource.TestCheckResourceAttrPair(datasourceName, "preferred_subnet_id", resourceName, "preferred_subnet_id"),
 					resource.TestCheckResourceAttrPair(datasourceName, "route_table_ids.#", resourceName, "route_table_ids.#"),

--- a/internal/service/fsx/ontap_file_system_test.go
+++ b/internal/service/fsx/ontap_file_system_test.go
@@ -1439,7 +1439,7 @@ resource "aws_fsx_ontap_file_system" "test" {
   throughput_capacity = 128
   preferred_subnet_id = aws_subnet.test[0].id
 
-  network_type = %[1]q 
+  network_type = "%[1]s"
 }
 `, networkType))
 }

--- a/internal/service/fsx/ontap_file_system_test.go
+++ b/internal/service/fsx/ontap_file_system_test.go
@@ -52,6 +52,7 @@ func TestAccFSxONTAPFileSystem_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "ha_pairs", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrKMSKeyID),
 					resource.TestCheckResourceAttr(resourceName, "network_interface_ids.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "network_type", string(awstypes.NetworkTypeIpv4)),
 					acctest.CheckResourceAttrAccountID(ctx, resourceName, names.AttrOwnerID),
 					resource.TestCheckResourceAttrPair(resourceName, "preferred_subnet_id", "aws_subnet.test.0", names.AttrID),
 					resource.TestCheckResourceAttr(resourceName, "route_table_ids.#", "1"),
@@ -840,6 +841,35 @@ func TestAccFSxONTAPFileSystem_storageCapacity(t *testing.T) {
 	})
 }
 
+func TestAccFSxONTAPFileSystem_networkType(t *testing.T) {
+	ctx := acctest.Context(t)
+	var filesystem awstypes.FileSystem
+	resourceName := "aws_fsx_ontap_file_system.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.FSxEndpointID) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.FSxServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckONTAPFileSystemDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccONTAPFileSystemConfig_networkType(rName, string(awstypes.NetworkTypeDual)),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckONTAPFileSystemExists(ctx, t, resourceName, &filesystem),
+					resource.TestCheckResourceAttr(resourceName, "network_type", string(awstypes.NetworkTypeDual)),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{names.AttrSecurityGroupIDs},
+			},
+		},
+	})
+}
+
 func testAccCheckONTAPFileSystemExists(ctx context.Context, t *testing.T, n string, v *awstypes.FileSystem) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -909,6 +939,10 @@ func testAccCheckONTAPFileSystemRecreated(i, j *awstypes.FileSystem) resource.Te
 
 func testAccONTAPFileSystemConfig_base(rName string) string {
 	return acctest.ConfigVPCWithSubnets(rName, 2)
+}
+
+func testAccONTAPFileSystemConfig_baseIPv6(rName string) string {
+	return acctest.ConfigVPCWithSubnetsIPv6(rName, 2)
 }
 
 func testAccONTAPFileSystemConfig_basic(rName string) string {
@@ -1394,4 +1428,18 @@ resource "aws_fsx_ontap_file_system" "test" {
   }
 }
 `, rName))
+}
+
+func testAccONTAPFileSystemConfig_networkType(rName, networkType string) string {
+	return acctest.ConfigCompose(testAccONTAPFileSystemConfig_baseIPv6(rName), fmt.Sprintf(`
+resource "aws_fsx_ontap_file_system" "test" {
+  storage_capacity    = 1024
+  subnet_ids          = aws_subnet.test[*].id
+  deployment_type     = "MULTI_AZ_1"
+  throughput_capacity = 128
+  preferred_subnet_id = aws_subnet.test[0].id
+
+  network_type = %[1]q 
+}
+`, networkType))
 }

--- a/website/docs/d/fsx_ontap_file_system.html.markdown
+++ b/website/docs/d/fsx_ontap_file_system.html.markdown
@@ -45,6 +45,7 @@ This data source exports the following attributes in addition to the arguments a
 * `id` - Identifier of the file system (e.g. `fs-12345678`).
 * `kms_key_id` - ARN for the KMS Key to encrypt the file system at rest.
 * `network_interface_ids` - IDs of the elastic network interfaces from which a specific file system is accessible.
+* `network_type` - Network type (`IPV4` or `DUAL`).
 * `owner_id` - AWS account identifier that created the file system.
 * `preferred_subnet_id` - Subnet in which you want the preferred file server to be located.
 * `route_table_ids` - (Multi-AZ only) VPC route tables in which your file system's endpoints exist.

--- a/website/docs/r/fsx_ontap_file_system.html.markdown
+++ b/website/docs/r/fsx_ontap_file_system.html.markdown
@@ -68,6 +68,7 @@ This resource supports the following arguments:
 * `fsx_admin_password` - (Optional) ONTAP administrative password for the fsxadmin user that you can use to administer your file system using the ONTAP CLI and REST API.
 * `ha_pairs` - (Optional) Number of ha_pairs to deploy for the file system. Valid value is 1 for `SINGLE_AZ_1` or `MULTI_AZ_1` and `MULTI_AZ_2`. Valid values are 1 through 12 for `SINGLE_AZ_2`.
 * `kms_key_id` - (Optional) ARN for the KMS Key to encrypt the file system at rest, Defaults to an AWS managed KMS Key.
+* `network_type` - (Optional) Network type. Valid values are `IPV4` and `DUAL`. Default value is `IPV4`.
 * `preferred_subnet_id` - (Required) ID for a subnet. A subnet is a range of IP addresses in your virtual private cloud (VPC).
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `route_table_ids` - (Optional) VPC route tables in which your file system's endpoints will be created. You should specify all VPC route tables associated with the subnets in which your clients are located. By default, Amazon FSx selects your VPC's default route table.


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
This PR adds `network_type` argument/attribute to `aws_fsx_ontap_file_system` resource/data source to enable IPv6 addressing.

* The newly added `network_type` is marked as `Computed` since the AWS API returns the default value even when it is not specified.
* It is also marked as `ForceNew` since `UpdateFileSystem` API does not support updating it.


### Relations
Relates #49450 
(This issue can be closed once #49513, #49514, and this PR are merged.)

Similar implementations for other FSx resources:
Relates #49513
Relates #49514


### References
https://docs.aws.amazon.com/ja_jp/fsx/latest/APIReference/API_CreateFileSystemFromBackup.html#FSx-CreateFileSystemFromBackup-request-NetworkType
https://docs.aws.amazon.com/ja_jp/fsx/latest/APIReference/API_UpdateFileSystem.html

### Output from Acceptance Testing
#### Resource
```console
$ make testacc TESTS='TestAccFSxONTAPFileSystem_(basic|networkType)' PKG=fsx
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework (cached)
make: Running acceptance tests on branch: 🌿 f-aws_fsx_ontap_file_system-add_network_type 🌿...
TF_ACC=1 go1.26.6 test ./internal/service/fsx/... -v -count 1 -parallel 20 -run='TestAccFSxONTAPFileSystem(|DataSource)_(basic|networkType)'  -timeout 360m -vet=off -buildvcs=false
2026/08/16 16:56:16 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/16 16:56:16 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccFSxONTAPFileSystem_basic
=== PAUSE TestAccFSxONTAPFileSystem_basic
=== RUN   TestAccFSxONTAPFileSystem_networkType
=== PAUSE TestAccFSxONTAPFileSystem_networkType
=== CONT  TestAccFSxONTAPFileSystem_basic
=== CONT  TestAccFSxONTAPFileSystem_networkType
--- PASS: TestAccFSxONTAPFileSystem_networkType (1643.44s)
--- PASS: TestAccFSxONTAPFileSystem_basic (1682.75s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/fsx        1688.436s
```

#### Data Source
```console
$ make testacc TESTS='TestAccFSxONTAPFileSystemDataSource_Id' PKG=fsx
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework (cached)
make: Running acceptance tests on branch: 🌿 f-aws_fsx_ontap_file_system-add_network_type 🌿...
TF_ACC=1 go1.26.6 test ./internal/service/fsx/... -v -count 1 -parallel 20 -run='TestAccFSxONTAPFileSystemDataSource_Id'  -timeout 360m -vet=off -buildvcs=false
2026/08/16 20:13:56 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/16 20:13:56 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccFSxONTAPFileSystemDataSource_Id
=== PAUSE TestAccFSxONTAPFileSystemDataSource_Id
=== CONT  TestAccFSxONTAPFileSystemDataSource_Id
--- PASS: TestAccFSxONTAPFileSystemDataSource_Id (1667.38s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/fsx        1673.173s
```