### PR TITLE
[Enhancement] r/aws_fsx_openzfs_file_system: Add `network_type` argument

### DIFF
--- a/.changelog/49513.txt
+++ b/.changelog/49513.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_fsx_openzfs_file_system: Add `network_type` argument
+```

--- a/internal/service/fsx/openzfs_file_system.go
+++ b/internal/service/fsx/openzfs_file_system.go
@@ -154,6 +154,13 @@ func resourceOpenZFSFileSystem() *schema.Resource {
 					Computed: true,
 					Elem:     &schema.Schema{Type: schema.TypeString},
 				},
+				"network_type": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					Computed:         true,
+					ForceNew:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.NetworkType](),
+				},
 				names.AttrOwnerID: {
 					Type:     schema.TypeString,
 					Computed: true,
@@ -461,6 +468,11 @@ func resourceOpenZFSFileSystemCreate(ctx context.Context, d *schema.ResourceData
 		inputB.KmsKeyId = aws.String(v.(string))
 	}
 
+	if v, ok := d.GetOk("network_type"); ok {
+		inputC.NetworkType = awstypes.NetworkType(v.(string))
+		inputB.NetworkType = awstypes.NetworkType(v.(string))
+	}
+
 	if v, ok := d.GetOk("preferred_subnet_id"); ok {
 		inputC.OpenZFSConfiguration.PreferredSubnetId = aws.String(v.(string))
 		inputB.OpenZFSConfiguration.PreferredSubnetId = aws.String(v.(string))
@@ -556,6 +568,7 @@ func resourceOpenZFSFileSystemRead(ctx context.Context, d *schema.ResourceData, 
 	d.Set("endpoint_ip_address_range", openZFSConfig.EndpointIpAddressRange)
 	d.Set(names.AttrKMSKeyID, filesystem.KmsKeyId)
 	d.Set("network_interface_ids", filesystem.NetworkInterfaceIds)
+	d.Set("network_type", filesystem.NetworkType)
 	d.Set(names.AttrOwnerID, filesystem.OwnerId)
 	d.Set("preferred_subnet_id", openZFSConfig.PreferredSubnetId)
 	if err := d.Set("read_cache_configuration", flattenOpenZFSReadCacheConfiguration(openZFSConfig.ReadCacheConfiguration)); err != nil {

--- a/internal/service/fsx/openzfs_file_system_test.go
+++ b/internal/service/fsx/openzfs_file_system_test.go
@@ -63,6 +63,7 @@ func TestAccFSxOpenZFSFileSystem_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "endpoint_ip_address_range", ""),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrKMSKeyID),
 					resource.TestCheckResourceAttr(resourceName, "network_interface_ids.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "network_type", string(awstypes.NetworkTypeIpv4)),
 					acctest.CheckResourceAttrAccountID(ctx, resourceName, names.AttrOwnerID),
 					resource.TestCheckResourceAttr(resourceName, "preferred_subnet_id", ""),
 					resource.TestCheckResourceAttr(resourceName, "root_volume_configuration.#", "1"),
@@ -1264,6 +1265,39 @@ func TestAccFSxOpenZFSFileSystem_intelligentTiering(t *testing.T) {
 	})
 }
 
+func TestAccFSxOpenZFSFileSystem_networkType(t *testing.T) {
+	ctx := acctest.Context(t)
+	var filesystem awstypes.FileSystem
+	resourceName := "aws_fsx_openzfs_file_system.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.FSxEndpointID) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.FSxServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckOpenZFSFileSystemDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOpenZFSFileSystemConfig_networkType(rName, string(awstypes.NetworkTypeDual)),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckOpenZFSFileSystemExists(ctx, t, resourceName, &filesystem),
+					resource.TestCheckResourceAttr(resourceName, "network_type", string(awstypes.NetworkTypeDual)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"delete_options",
+					"final_backup_tags",
+					"skip_final_backup",
+				},
+			},
+		},
+	})
+}
+
 func testAccCheckOpenZFSFileSystemExists(ctx context.Context, t *testing.T, n string, v *awstypes.FileSystem) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -1333,6 +1367,10 @@ func testAccCheckOpenZFSFileSystemRecreated(i, j *awstypes.FileSystem) resource.
 
 func testAccOpenZFSFileSystemConfig_baseSingleAZ(rName string) string {
 	return acctest.ConfigVPCWithSubnets(rName, 1)
+}
+
+func testAccOpenZFSFileSystemConfig_baseSingleAZIPv6(rName string) string {
+	return acctest.ConfigVPCWithSubnetsIPv6(rName, 1)
 }
 
 func testAccOpenZFSFileSystemConfig_baseMultiAZ(rName string) string {
@@ -2019,4 +2057,18 @@ resource "aws_fsx_openzfs_file_system" "test" {
   }
 }
 `, rName, sizingMode))
+}
+
+func testAccOpenZFSFileSystemConfig_networkType(rName, networkType string) string {
+	return acctest.ConfigCompose(testAccOpenZFSFileSystemConfig_baseSingleAZIPv6(rName), fmt.Sprintf(`
+resource "aws_fsx_openzfs_file_system" "test" {
+  skip_final_backup   = true
+  storage_capacity    = 64
+  subnet_ids          = aws_subnet.test[*].id
+  deployment_type     = "SINGLE_AZ_1"
+  throughput_capacity = 64
+
+  network_type = "%[1]s"
+}
+`, networkType))
 }

--- a/website/docs/r/fsx_openzfs_file_system.html.markdown
+++ b/website/docs/r/fsx_openzfs_file_system.html.markdown
@@ -42,6 +42,7 @@ The following arguments are optional:
 * `endpoint_ip_address_range` - (Optional) (Multi-AZ only) Specifies the IP address range in which the endpoints to access your file system will be created.
 * `final_backup_tags` - (Optional) Map of tags to apply to the file system's final backup.
 * `kms_key_id` - (Optional) ARN for the KMS Key to encrypt the file system at rest, Defaults to an AWS managed KMS Key.
+* `network_type` - (Optional) Network type. Valid values are `IPV4` and `DUAL`. Default value is `IPV4`.
 * `preferred_subnet_id` - (Optional) (Multi-AZ only) Required when `deployment_type` is set to `MULTI_AZ_1`. This specifies the subnet in which you want the preferred file server to be located.
 * `read_cache_configuration` - (Optional) Configuration block for optional provisioned SSD read cache on file systems that use the Intelligent-Tiering storage class. Required when `storage_type` is set to `INTELLIGENT_TIERING`. See [`read_cache_configuration` Block](#read_cache_configuration-block) for details.
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
This PR adds `network_type` argument to `aws_fsx_openzfs_file_system` resource to enable IPv6 addressing.
* Note that `aws_fsx_openzfs_file_system` has no data source.

* The newly added `network_type` is marked as `Computed` since the AWS API returns the default value even when it is not specified.
* It is also marked as `ForceNew` since `UpdateFileSystem` API does not support updating it.


### Relations
Relates #49450  
(This issue can be closed once #49512, #49514, and this PR are merged.)

Similar implementations for other FSx resources:
Relates #49512
Relates #49514

### References
https://docs.aws.amazon.com/ja_jp/fsx/latest/APIReference/API_CreateFileSystemFromBackup.html#FSx-CreateFileSystemFromBackup-request-NetworkType
https://docs.aws.amazon.com/ja_jp/fsx/latest/APIReference/API_UpdateFileSystem.html


### Output from Acceptance Testing
```console
$ make testacc TESTS='TestAccFSxOpenZFSFileSystem_(basic|networkType)' PKG=fsx
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework (cached)
make: Running acceptance tests on branch: 🌿 f-aws_fsx_openzfs_file_system-add_network_type 🌿...
TF_ACC=1 go1.26.6 test ./internal/service/fsx/... -v -count 1 -parallel 20 -run='TestAccFSxOpenZFSFileSystem_(basic|networkType)'  -timeout 360m -vet=off -buildvcs=false
2026/08/16 12:31:05 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/16 12:31:05 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccFSxOpenZFSFileSystem_basic
=== PAUSE TestAccFSxOpenZFSFileSystem_basic
=== RUN   TestAccFSxOpenZFSFileSystem_networkType
=== PAUSE TestAccFSxOpenZFSFileSystem_networkType
=== CONT  TestAccFSxOpenZFSFileSystem_basic
=== CONT  TestAccFSxOpenZFSFileSystem_networkType
--- PASS: TestAccFSxOpenZFSFileSystem_basic (960.55s)
--- PASS: TestAccFSxOpenZFSFileSystem_networkType (1044.41s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/fsx        1049.812s

```
