### PR TITLE
[Enhancement] rd/aws_fsx_windows_file_system: Add `network_type` argument/attribute

### DIFF
--- a/.changelog/49514.txt
+++ b/.changelog/49514.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_fsx_windows_file_system: Add `network_type` argument
+```
+
+```release-note:enhancement
+data-source/aws_fsx_windows_file_system: Add `network_type` attribute
+```

--- a/internal/service/fsx/windows_file_system.go
+++ b/internal/service/fsx/windows_file_system.go
@@ -186,6 +186,13 @@ func resourceWindowsFileSystem() *schema.Resource {
 					Computed: true,
 					Elem:     &schema.Schema{Type: schema.TypeString},
 				},
+				"network_type": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					Computed:         true,
+					ForceNew:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.NetworkType](),
+				},
 				names.AttrOwnerID: {
 					Type:     schema.TypeString,
 					Computed: true,
@@ -402,6 +409,11 @@ func resourceWindowsFileSystemCreate(ctx context.Context, d *schema.ResourceData
 		inputCFSFB.KmsKeyId = aws.String(v.(string))
 	}
 
+	if v, ok := d.GetOk("network_type"); ok {
+		inputCFS.NetworkType = awstypes.NetworkType(v.(string))
+		inputCFSFB.NetworkType = awstypes.NetworkType(v.(string))
+	}
+
 	if v, ok := d.GetOk("preferred_subnet_id"); ok {
 		inputCFS.WindowsConfiguration.PreferredSubnetId = aws.String(v.(string))
 		inputCFSFB.WindowsConfiguration.PreferredSubnetId = aws.String(v.(string))
@@ -495,6 +507,7 @@ func resourceWindowsFileSystemRead(ctx context.Context, d *schema.ResourceData, 
 	d.Set(names.AttrDNSName, filesystem.DNSName)
 	d.Set(names.AttrKMSKeyID, filesystem.KmsKeyId)
 	d.Set("network_interface_ids", filesystem.NetworkInterfaceIds)
+	d.Set("network_type", filesystem.NetworkType)
 	d.Set(names.AttrOwnerID, filesystem.OwnerId)
 	d.Set("preferred_file_server_ip", windowsConfig.PreferredFileServerIp)
 	d.Set("preferred_subnet_id", windowsConfig.PreferredSubnetId)

--- a/internal/service/fsx/windows_file_system_data_source.go
+++ b/internal/service/fsx/windows_file_system_data_source.go
@@ -115,6 +115,10 @@ func dataSourceWindowsFileSystem() *schema.Resource {
 						Type: schema.TypeString,
 					},
 				},
+				"network_type": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
 				names.AttrOwnerID: {
 					Type:     schema.TypeString,
 					Computed: true,
@@ -201,6 +205,7 @@ func dataSourceWindowsFileSystemRead(ctx context.Context, d *schema.ResourceData
 	d.Set(names.AttrID, filesystem.FileSystemId)
 	d.Set(names.AttrKMSKeyID, filesystem.KmsKeyId)
 	d.Set("network_interface_ids", filesystem.NetworkInterfaceIds)
+	d.Set("network_type", filesystem.NetworkType)
 	d.Set(names.AttrOwnerID, filesystem.OwnerId)
 	d.Set("preferred_file_server_ip", windowsConfig.PreferredFileServerIp)
 	d.Set("preferred_subnet_id", windowsConfig.PreferredSubnetId)

--- a/internal/service/fsx/windows_file_system_data_source_test.go
+++ b/internal/service/fsx/windows_file_system_data_source_test.go
@@ -44,6 +44,7 @@ func TestAccFSxWindowsFileSystemDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(datasourceName, names.AttrID, resourceName, names.AttrID),
 					resource.TestCheckResourceAttrPair(datasourceName, names.AttrKMSKeyID, resourceName, names.AttrKMSKeyID),
 					resource.TestCheckResourceAttrPair(datasourceName, "network_interface_ids.#", resourceName, "network_interface_ids.#"),
+					resource.TestCheckResourceAttrPair(datasourceName, "network_type", resourceName, "network_type"),
 					resource.TestCheckResourceAttrPair(datasourceName, names.AttrOwnerID, resourceName, names.AttrOwnerID),
 					resource.TestCheckResourceAttrPair(datasourceName, "preferred_file_server_ip", resourceName, "preferred_file_server_ip"),
 					resource.TestCheckResourceAttrPair(datasourceName, "preferred_subnet_id", resourceName, "preferred_subnet_id"),

--- a/internal/service/fsx/windows_file_system_test.go
+++ b/internal/service/fsx/windows_file_system_test.go
@@ -52,6 +52,7 @@ func TestAccFSxWindowsFileSystem_basic(t *testing.T) {
 					resource.TestMatchResourceAttr(resourceName, names.AttrDNSName, regexache.MustCompile(`fs-.+\..+`)),
 					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrKMSKeyID, "kms", regexache.MustCompile(`key/.+`)),
 					resource.TestCheckResourceAttr(resourceName, "network_interface_ids.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "network_type", string(awstypes.NetworkTypeIpv4)),
 					acctest.CheckResourceAttrAccountID(ctx, resourceName, names.AttrOwnerID),
 					resource.TestCheckResourceAttr(resourceName, "security_group_ids.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "self_managed_active_directory.#", "0"),
@@ -953,6 +954,40 @@ func TestAccFSxWindowsFileSystem_diskIops(t *testing.T) {
 	})
 }
 
+func TestAccFSxWindowsFileSystem_networkType(t *testing.T) {
+	ctx := acctest.Context(t)
+	var filesystem awstypes.FileSystem
+	resourceName := "aws_fsx_windows_file_system.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	domainName := acctest.RandomDomainName(t)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.FSxEndpointID) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.FSxServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckWindowsFileSystemDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWindowsFileSystemConfig_networkType(rName, domainName, string(awstypes.NetworkTypeDual)),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckWindowsFileSystemExists(ctx, t, resourceName, &filesystem),
+					resource.TestCheckResourceAttr(resourceName, "network_type", string(awstypes.NetworkTypeDual)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"final_backup_tags",
+					names.AttrSecurityGroupIDs,
+					"skip_final_backup",
+				},
+			},
+		},
+	})
+}
+
 func testAccCheckWindowsFileSystemExists(ctx context.Context, t *testing.T, n string, v *awstypes.FileSystem) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -1022,6 +1057,22 @@ func testAccCheckWindowsFileSystemRecreated(i, j *awstypes.FileSystem) resource.
 
 func testAccWindowsFileSystemConfig_base(rName, domain string) string {
 	return acctest.ConfigCompose(acctest.ConfigVPCWithSubnets(rName, 2), fmt.Sprintf(`
+resource "aws_directory_service_directory" "test" {
+  edition  = "Standard"
+  name     = %[1]q
+  password = "SuperSecretPassw0rd"
+  type     = "MicrosoftAD"
+
+  vpc_settings {
+    subnet_ids = aws_subnet.test[*].id
+    vpc_id     = aws_vpc.test.id
+  }
+}
+`, domain))
+}
+
+func testAccWindowsFileSystemConfig_baseIPv6(rName, domain string) string {
+	return acctest.ConfigCompose(acctest.ConfigVPCWithSubnetsIPv6(rName, 2), fmt.Sprintf(`
 resource "aws_directory_service_directory" "test" {
   edition  = "Standard"
   name     = %[1]q
@@ -1714,4 +1765,18 @@ resource "aws_fsx_windows_file_system" "test" {
   depends_on = [aws_secretsmanager_secret_policy.test]
 }
 `, rName))
+}
+
+func testAccWindowsFileSystemConfig_networkType(rName, domain, networkType string) string {
+	return acctest.ConfigCompose(testAccWindowsFileSystemConfig_baseIPv6(rName, domain), fmt.Sprintf(`
+resource "aws_fsx_windows_file_system" "test" {
+  active_directory_id = aws_directory_service_directory.test.id
+  skip_final_backup   = true
+  storage_capacity    = 32
+  subnet_ids          = [aws_subnet.test[0].id]
+  throughput_capacity = 8
+
+  network_type = "%[1]s"
+}
+`, networkType))
 }

--- a/website/docs/d/fsx_windows_file_system.html.markdown
+++ b/website/docs/d/fsx_windows_file_system.html.markdown
@@ -45,6 +45,7 @@ This data source exports the following attributes in addition to the arguments a
 * `id` - Identifier of the file system (e.g. `fs-12345678`).
 * `kms_key_id` - ARN for the KMS Key to encrypt the file system at rest.
 * `network_interface_ids` - Set of network interface identifiers for the file system.
+* `network_type` - Network type (`IPV4` or `DUAL`).
 * `owner_id` - AWS account identifier that created the file system.
 * `preferred_file_server_ip` - IP address of the primary, or preferred, file server.
 * `preferred_subnet_id` - Subnet in which the preferred file server is located.

--- a/website/docs/r/fsx_windows_file_system.html.markdown
+++ b/website/docs/r/fsx_windows_file_system.html.markdown
@@ -85,6 +85,7 @@ The following arguments are optional:
 * `disk_iops_configuration` - (Optional) SSD IOPS configuration for the Amazon FSx for Windows File Server file system. See [`disk_iops_configuration` Block](#disk_iops_configuration-block) for details.
 * `final_backup_tags` - (Optional) Map of tags to apply to the file system's final backup.
 * `kms_key_id` - (Optional) ARN for the KMS Key to encrypt the file system at rest. Defaults to an AWS managed KMS Key.
+* `network_type` - (Optional) Network type. Valid values are `IPV4` and `DUAL`. Default value is `IPV4`.
 * `preferred_subnet_id` - (Optional) Subnet in which you want the preferred file server to be located. Required for when deployment type is `MULTI_AZ_1`.
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `security_group_ids` - (Optional) List of IDs for the security groups that apply to the specified network interfaces created for file system access. These security groups will apply to all network interfaces.


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.


### Description
This PR adds `network_type` argument/attribute to `aws_fsx_windows_file_system` resource/data source to enable IPv6 addressing.

* The newly added `network_type` is marked as `Computed` since the AWS API returns the default value even when it is not specified.
* It is also marked as `ForceNew` since `UpdateFileSystem` API does not support updating it.

### Relations
Closes #49450.

Similar implementations for other FSx resources:
Relates #49512
Relates #49513


### References
https://docs.aws.amazon.com/ja_jp/fsx/latest/APIReference/API_CreateFileSystemFromBackup.html#FSx-CreateFileSystemFromBackup-request-NetworkType
https://docs.aws.amazon.com/ja_jp/fsx/latest/APIReference/API_UpdateFileSystem.html

### Output from Acceptance Testing

```console
$ make testacc TESTS='TestAccFSxWindowsFileSystem(|DataSource)_(basic|networkType)' PKG=fsx
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework (cached)
make: Running acceptance tests on branch: 🌿 f-aws_fsx_windows_file_system-add_network_type 🌿...
TF_ACC=1 go1.26.6 test ./internal/service/fsx/... -v -count 1 -parallel 20 -run='TestAccFSxWindowsFileSystem(|DataSource)_(basic|networkType)'  -timeout 360m -vet=off -buildvcs=false
2026/08/16 15:02:27 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/16 15:02:27 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccFSxWindowsFileSystemDataSource_basic
=== PAUSE TestAccFSxWindowsFileSystemDataSource_basic
=== RUN   TestAccFSxWindowsFileSystem_basic
=== PAUSE TestAccFSxWindowsFileSystem_basic
=== RUN   TestAccFSxWindowsFileSystem_networkType
=== PAUSE TestAccFSxWindowsFileSystem_networkType
=== CONT  TestAccFSxWindowsFileSystemDataSource_basic
=== CONT  TestAccFSxWindowsFileSystem_networkType
=== CONT  TestAccFSxWindowsFileSystem_basic
--- PASS: TestAccFSxWindowsFileSystem_basic (4188.65s)
--- PASS: TestAccFSxWindowsFileSystem_networkType (4230.83s)
--- PASS: TestAccFSxWindowsFileSystemDataSource_basic (5122.36s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/fsx        5128.223s

```
