### PR TITLE
🤖🤖🤖 resource/aws_dx_private_virtual_interface: support long BGP ASN

### DIFF
--- a/.changelog/49518.txt
+++ b/.changelog/49518.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_dx_private_virtual_interface: Add `bgp_asn_long` argument
+```

--- a/internal/service/directconnect/bgp_asn.go
+++ b/internal/service/directconnect/bgp_asn.go
@@ -1,0 +1,90 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package directconnect
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+const (
+	bgpASNAttributeName     = "bgp_asn"
+	bgpASNLongAttributeName = "bgp_asn_long"
+	maxBGPASN               = 2147483646
+	maxBGPASNLong           = 4294967294
+)
+
+func bgpASNAttributeSchema(long bool) *schema.Schema {
+	exactlyOneOf := []string{bgpASNAttributeName, bgpASNLongAttributeName}
+
+	if long {
+		return &schema.Schema{
+			Type:         schema.TypeString,
+			Optional:     true,
+			ForceNew:     true,
+			ExactlyOneOf: exactlyOneOf,
+			ValidateFunc: validateBGPASNLong,
+		}
+	}
+
+	return &schema.Schema{
+		Type:         schema.TypeInt,
+		Optional:     true,
+		ForceNew:     true,
+		ExactlyOneOf: exactlyOneOf,
+		ValidateFunc: validation.IntBetween(1, maxBGPASN),
+	}
+}
+
+func validateBGPASNLong(v any, k string) ([]string, []error) {
+	value := v.(string)
+
+	if value == "" || value[0] == '0' {
+		return nil, []error{fmt.Errorf("%q must be an ASN in asplain format between 1 and %d", k, maxBGPASNLong)}
+	}
+
+	for _, r := range value {
+		if r < '0' || r > '9' {
+			return nil, []error{fmt.Errorf("%q must be an ASN in asplain format between 1 and %d", k, maxBGPASNLong)}
+		}
+	}
+
+	asn, err := strconv.ParseInt(value, 10, 64)
+	if err != nil || asn < 1 || asn > maxBGPASNLong {
+		return nil, []error{fmt.Errorf("%q must be an ASN in asplain format between 1 and %d", k, maxBGPASNLong)}
+	}
+
+	return nil, nil
+}
+
+func expandBGPASN(d *schema.ResourceData) (int32, *int64) {
+	if v, ok := d.GetOk(bgpASNLongAttributeName); ok {
+		asnLong, _ := strconv.ParseInt(v.(string), 10, 64)
+		return 0, aws.Int64(asnLong)
+	}
+
+	return int32(d.Get(bgpASNAttributeName).(int)), nil
+}
+
+func effectiveBGPASN(asn int32, asnLong *int64) int64 {
+	if asnLong != nil {
+		return aws.ToInt64(asnLong)
+	}
+
+	return int64(asn)
+}
+
+func setBGPASN(d *schema.ResourceData, asn int32, asnLong *int64) error {
+	effectiveASN := effectiveBGPASN(asn, asnLong)
+
+	if _, ok := d.GetOk(bgpASNLongAttributeName); ok || asnLong != nil && effectiveASN > maxBGPASN {
+		return d.Set(bgpASNLongAttributeName, strconv.FormatInt(effectiveASN, 10))
+	}
+
+	return d.Set(bgpASNAttributeName, int(effectiveASN))
+}

--- a/internal/service/directconnect/bgp_asn_test.go
+++ b/internal/service/directconnect/bgp_asn_test.go
@@ -1,0 +1,205 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package directconnect
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func TestValidateBGPASNLong(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		value string
+		valid bool
+	}{
+		"minimum":         {value: "1", valid: true},
+		"legacy range":    {value: "65000", valid: true},
+		"four byte range": {value: "4294967294", valid: true},
+		"empty":           {value: "", valid: false},
+		"zero":            {value: "0", valid: false},
+		"leading zero":    {value: "01", valid: false},
+		"sign":            {value: "+1", valid: false},
+		"whitespace":      {value: " 1", valid: false},
+		"asdot":           {value: "1.10", valid: false},
+		"out of range":    {value: "4294967295", valid: false},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			_, errors := validateBGPASNLong(tc.value, bgpASNLongAttributeName)
+			if got := len(errors) == 0; got != tc.valid {
+				t.Fatalf("validateBGPASNLong(%q) valid = %t, want %t: %v", tc.value, got, tc.valid, errors)
+			}
+		})
+	}
+}
+
+func TestBGPASNAttributeSchema(t *testing.T) {
+	t.Parallel()
+
+	expectedExactlyOneOf := []string{bgpASNAttributeName, bgpASNLongAttributeName}
+
+	legacy := bgpASNAttributeSchema(false)
+	if legacy.Type != schema.TypeInt {
+		t.Errorf("legacy Type = %v, want %v", legacy.Type, schema.TypeInt)
+	}
+	if !legacy.Optional || legacy.Required || !legacy.ForceNew {
+		t.Errorf("legacy Optional, Required, ForceNew = %t, %t, %t, want true, false, true", legacy.Optional, legacy.Required, legacy.ForceNew)
+	}
+	if !reflect.DeepEqual(legacy.ExactlyOneOf, expectedExactlyOneOf) {
+		t.Errorf("legacy ExactlyOneOf = %v, want %v", legacy.ExactlyOneOf, expectedExactlyOneOf)
+	}
+	for _, value := range []int{0, maxBGPASN + 1} {
+		if _, errors := legacy.ValidateFunc(value, bgpASNAttributeName); len(errors) == 0 {
+			t.Errorf("legacy validation accepted %d", value)
+		}
+	}
+	if _, errors := legacy.ValidateFunc(maxBGPASN, bgpASNAttributeName); len(errors) != 0 {
+		t.Errorf("legacy validation rejected %d: %v", maxBGPASN, errors)
+	}
+
+	long := bgpASNAttributeSchema(true)
+	if long.Type != schema.TypeString {
+		t.Errorf("long Type = %v, want %v", long.Type, schema.TypeString)
+	}
+	if !long.Optional || long.Required || !long.ForceNew {
+		t.Errorf("long Optional, Required, ForceNew = %t, %t, %t, want true, false, true", long.Optional, long.Required, long.ForceNew)
+	}
+	if !reflect.DeepEqual(long.ExactlyOneOf, expectedExactlyOneOf) {
+		t.Errorf("long ExactlyOneOf = %v, want %v", long.ExactlyOneOf, expectedExactlyOneOf)
+	}
+}
+
+func TestBGPASNPrivateVirtualInterfaceSchema(t *testing.T) {
+	t.Parallel()
+
+	resourceSchema := resourcePrivateVirtualInterface().SchemaFunc()
+
+	if resourceSchema[bgpASNAttributeName].Type != schema.TypeInt {
+		t.Errorf("%s Type = %v, want %v", bgpASNAttributeName, resourceSchema[bgpASNAttributeName].Type, schema.TypeInt)
+	}
+	if resourceSchema[bgpASNLongAttributeName].Type != schema.TypeString {
+		t.Errorf("%s Type = %v, want %v", bgpASNLongAttributeName, resourceSchema[bgpASNLongAttributeName].Type, schema.TypeString)
+	}
+	if !reflect.DeepEqual(resourceSchema[bgpASNAttributeName].ExactlyOneOf, resourceSchema[bgpASNLongAttributeName].ExactlyOneOf) {
+		t.Errorf("BGP ASN attributes have mismatched ExactlyOneOf values")
+	}
+}
+
+func TestExpandBGPASN(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		raw           map[string]any
+		wantASN       int32
+		wantASNLong   int64
+		wantLongIsNil bool
+	}{
+		"legacy": {
+			raw:           map[string]any{bgpASNAttributeName: 65000},
+			wantASN:       65000,
+			wantLongIsNil: true,
+		},
+		"long": {
+			raw:         map[string]any{bgpASNLongAttributeName: "4294967294"},
+			wantASNLong: 4294967294,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			asn, asnLong := expandBGPASN(testBGPASNResourceData(t, tc.raw))
+			if asn != tc.wantASN {
+				t.Errorf("Asn = %d, want %d", asn, tc.wantASN)
+			}
+			if got := asnLong == nil; got != tc.wantLongIsNil {
+				t.Fatalf("AsnLong nil = %t, want %t", got, tc.wantLongIsNil)
+			}
+			if asnLong != nil && aws.ToInt64(asnLong) != tc.wantASNLong {
+				t.Errorf("AsnLong = %d, want %d", aws.ToInt64(asnLong), tc.wantASNLong)
+			}
+		})
+	}
+}
+
+func TestEffectiveBGPASN(t *testing.T) {
+	t.Parallel()
+
+	if got := effectiveBGPASN(65000, nil); got != 65000 {
+		t.Errorf("effective legacy ASN = %d, want 65000", got)
+	}
+	if got := effectiveBGPASN(0, aws.Int64(4294967294)); got != 4294967294 {
+		t.Errorf("effective long ASN = %d, want 4294967294", got)
+	}
+}
+
+func TestSetBGPASN(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		raw           map[string]any
+		asn           int32
+		asnLong       *int64
+		wantLegacy    int
+		wantLong      string
+		wantLongIsSet bool
+	}{
+		"legacy configuration": {
+			raw:        map[string]any{bgpASNAttributeName: 65000},
+			asn:        65000,
+			wantLegacy: 65000,
+		},
+		"long configuration in legacy range": {
+			raw:           map[string]any{bgpASNLongAttributeName: "65000"},
+			asn:           65000,
+			asnLong:       aws.Int64(65000),
+			wantLong:      "65000",
+			wantLongIsSet: true,
+		},
+		"imported long ASN": {
+			asnLong:       aws.Int64(4294967294),
+			wantLong:      "4294967294",
+			wantLongIsSet: true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			d := testBGPASNResourceData(t, tc.raw)
+			if err := setBGPASN(d, tc.asn, tc.asnLong); err != nil {
+				t.Fatalf("setBGPASN returned error: %s", err)
+			}
+			if got := d.Get(bgpASNAttributeName).(int); got != tc.wantLegacy {
+				t.Errorf("%s = %d, want %d", bgpASNAttributeName, got, tc.wantLegacy)
+			}
+			gotLong, longIsSet := d.GetOk(bgpASNLongAttributeName)
+			if longIsSet != tc.wantLongIsSet {
+				t.Fatalf("%s set = %t, want %t", bgpASNLongAttributeName, longIsSet, tc.wantLongIsSet)
+			}
+			if longIsSet && gotLong.(string) != tc.wantLong {
+				t.Errorf("%s = %q, want %q", bgpASNLongAttributeName, gotLong, tc.wantLong)
+			}
+		})
+	}
+}
+
+func testBGPASNResourceData(t *testing.T, raw map[string]any) *schema.ResourceData {
+	t.Helper()
+
+	return schema.TestResourceDataRaw(t, map[string]*schema.Schema{
+		bgpASNAttributeName:     bgpASNAttributeSchema(false),
+		bgpASNLongAttributeName: bgpASNAttributeSchema(true),
+	}, raw)
+}

--- a/internal/service/directconnect/private_virtual_interface.go
+++ b/internal/service/directconnect/private_virtual_interface.go
@@ -66,11 +66,8 @@ func resourcePrivateVirtualInterface() *schema.Resource {
 					Type:     schema.TypeString,
 					Computed: true,
 				},
-				"bgp_asn": {
-					Type:     schema.TypeInt,
-					Required: true,
-					ForceNew: true,
-				},
+				"bgp_asn":      bgpASNAttributeSchema(false),
+				"bgp_asn_long": bgpASNAttributeSchema(true),
 				"bgp_auth_key": {
 					Type:     schema.TypeString,
 					Optional: true,
@@ -141,12 +138,14 @@ func resourcePrivateVirtualInterface() *schema.Resource {
 func resourcePrivateVirtualInterfaceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DirectConnectClient(ctx)
+	asn, asnLong := expandBGPASN(d)
 
 	input := &directconnect.CreatePrivateVirtualInterfaceInput{
 		ConnectionId: aws.String(d.Get(names.AttrConnectionID).(string)),
 		NewPrivateVirtualInterface: &awstypes.NewPrivateVirtualInterface{
 			AddressFamily:        awstypes.AddressFamily(d.Get("address_family").(string)),
-			Asn:                  int32(d.Get("bgp_asn").(int)),
+			Asn:                  asn,
+			AsnLong:              asnLong,
 			EnableSiteLink:       aws.Bool(d.Get("sitelink_enabled").(bool)),
 			Mtu:                  aws.Int32(int32(d.Get("mtu").(int))),
 			Tags:                 getTagsIn(ctx),
@@ -218,7 +217,9 @@ func resourcePrivateVirtualInterfaceRead(ctx context.Context, d *schema.Resource
 	}.String()
 	d.Set(names.AttrARN, arn)
 	d.Set("aws_device", vif.AwsDeviceV2)
-	d.Set("bgp_asn", vif.Asn)
+	if err := setBGPASN(d, vif.Asn, vif.AsnLong); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting BGP ASN: %s", err)
+	}
 	d.Set("bgp_auth_key", vif.AuthKey)
 	d.Set(names.AttrConnectionID, vif.ConnectionId)
 	d.Set("customer_address", vif.CustomerAddress)
@@ -263,6 +264,10 @@ func resourcePrivateVirtualInterfaceImport(ctx context.Context, d *schema.Resour
 
 	if vifType := aws.ToString(vif.VirtualInterfaceType); vifType != "private" {
 		return nil, fmt.Errorf("virtual interface (%s) has incorrect type: %s", d.Id(), vifType)
+	}
+
+	if err := setBGPASN(d, vif.Asn, vif.AsnLong); err != nil {
+		return nil, fmt.Errorf("setting BGP ASN: %w", err)
 	}
 
 	return []*schema.ResourceData{d}, nil

--- a/internal/service/directconnect/private_virtual_interface_test.go
+++ b/internal/service/directconnect/private_virtual_interface_test.go
@@ -418,3 +418,48 @@ resource "aws_dx_private_virtual_interface" "test" {
 }
 `, cid, rName, amzAsn, bgpAsn, vlan, sitelink_enabled)
 }
+
+func TestAccDirectConnectPrivateVirtualInterface_bgpASNLong(t *testing.T) {
+	ctx := acctest.Context(t)
+	connectionID := acctest.SkipIfEnvVarNotSet(t, "DX_CONNECTION_ID")
+	dxGatewayID := acctest.SkipIfEnvVarNotSet(t, "DX_GATEWAY_ID")
+
+	var vif awstypes.VirtualInterface
+	resourceName := "aws_dx_private_virtual_interface.test"
+	rName := fmt.Sprintf("tf-testacc-private-vif-%s", acctest.RandString(t, 9))
+	vlan := acctest.RandIntRange(t, 2049, 4094)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.DirectConnectServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckPrivateVirtualInterfaceDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPrivateVirtualInterfaceConfig_bgpASNLong(connectionID, dxGatewayID, rName, vlan),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPrivateVirtualInterfaceExists(ctx, t, resourceName, &vif),
+					resource.TestCheckResourceAttr(resourceName, "bgp_asn_long", "4200012999"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccPrivateVirtualInterfaceConfig_bgpASNLong(cid, dxGatewayID, rName string, vlan int) string {
+	return fmt.Sprintf(`
+resource "aws_dx_private_virtual_interface" "test" {
+  address_family = "ipv4"
+  bgp_asn_long   = "4200012999"
+  connection_id  = %[1]q
+  dx_gateway_id  = %[2]q
+  name           = %[3]q
+  vlan           = %[4]d
+}
+`, cid, dxGatewayID, rName, vlan)
+}

--- a/website/docs/r/dx_private_virtual_interface.html.markdown
+++ b/website/docs/r/dx_private_virtual_interface.html.markdown
@@ -29,7 +29,8 @@ This resource supports the following arguments:
 
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `address_family` - (Required) The address family for the BGP peer. `ipv4 ` or `ipv6`.
-* `bgp_asn` - (Required) The autonomous system (AS) number for Border Gateway Protocol (BGP) configuration.
+* `bgp_asn` - (Optional) Autonomous system number for Border Gateway Protocol (BGP) configuration. Valid value is between `1` and `2147483646`. Exactly one of `bgp_asn` or `bgp_asn_long` must be specified.
+* `bgp_asn_long` - (Optional) Long autonomous system number for BGP configuration in asplain decimal notation. Valid value is between `1` and `4294967294`. Exactly one of `bgp_asn` or `bgp_asn_long` must be specified.
 * `connection_id` - (Required) The ID of the Direct Connect connection (or LAG) on which to create the virtual interface.
 * `name` - (Required) The name for the virtual interface.
 * `vlan` - (Required) The VLAN ID.


### PR DESCRIPTION
### Description

Adds long BGP ASN support to `aws_dx_private_virtual_interface` through a new optional `bgp_asn_long` argument.

AWS Direct Connect now models 4-byte ASNs through the SDK `AsnLong` field. The existing provider implementation sends `bgp_asn` through the legacy signed 32-bit `Asn` field, causing valid values such as `4200012999` to overflow before reaching the service.

This change:

- Adds `bgp_asn_long` as an asplain decimal string in the range `1`–`4294967294`.
- Makes `bgp_asn` and `bgp_asn_long` mutually exclusive and requires exactly one.
- Preserves existing `bgp_asn` configuration and import behavior.
- Sends long values through `AsnLong` and retains the configured representation during read/import.
- Introduces the shared ASN schema/state helpers used by the follow-up PRs in this stack.

Asdot notation is intentionally not accepted. The Direct Connect API and AWS SDK for Go v2 model `AsnLong` as a numeric `int64`; this argument accepts canonical asplain decimal notation only.

### Stack

This is **PR 1 of 5** and is independently reviewable against `main`:

1. `aws_dx_private_virtual_interface` + shared ASN helper — this PR
2. `aws_dx_transit_virtual_interface`
3. `aws_dx_public_virtual_interface`
4. `aws_dx_bgp_peer`
5. Hosted private/public/transit VIF allocation resources

Successor PRs remain draft until their predecessor merges, at which point their diffs reduce to their focused resource change.

### Relations

Closes #47658

Supersedes the narrower approach in #47662 by preserving legacy state while providing explicit `AsnLong` support and splitting follow-up resources into focused PRs.

### References

- [AWS Direct Connect `NewPrivateVirtualInterface`](https://docs.aws.amazon.com/directconnect/latest/APIReference/API_NewPrivateVirtualInterface.html)
- [AWS SDK for Go v2 Direct Connect types](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/directconnect/types)

### Testing

Unit, schema, documentation, lint, and live acceptance validation completed.

```console
--- PASS: TestAccDirectConnectPrivateVirtualInterface_bgpASNLong (574.01s)
PASS
ok github.com/hashicorp/terraform-provider-aws/internal/service/directconnect 574.149s
```

The live test created a private VIF with `bgp_asn_long = "4200012999"`, verified read and import state, and deleted it successfully.

### AI Usage Disclosure

An LLM coding agent assisted with code extraction, test authoring, documentation, and validation while splitting a broader implementation into focused contributions. The human author reviewed the resulting changes and is responsible for the submission.
