### PR TITLE
🤖🤖🤖 resource/aws_dx_transit_virtual_interface: support long BGP ASN

### DIFF
--- a/.changelog/49518.txt
+++ b/.changelog/49518.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_dx_private_virtual_interface: Add `bgp_asn_long` argument
+```

--- a/.changelog/49519.txt
+++ b/.changelog/49519.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_dx_transit_virtual_interface: Add `bgp_asn_long` argument
+```

--- a/internal/service/directconnect/bgp_asn.go
+++ b/internal/service/directconnect/bgp_asn.go
@@ -1,0 +1,90 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package directconnect
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+const (
+	bgpASNAttributeName     = "bgp_asn"
+	bgpASNLongAttributeName = "bgp_asn_long"
+	maxBGPASN               = 2147483646
+	maxBGPASNLong           = 4294967294
+)
+
+func bgpASNAttributeSchema(long bool) *schema.Schema {
+	exactlyOneOf := []string{bgpASNAttributeName, bgpASNLongAttributeName}
+
+	if long {
+		return &schema.Schema{
+			Type:         schema.TypeString,
+			Optional:     true,
+			ForceNew:     true,
+			ExactlyOneOf: exactlyOneOf,
+			ValidateFunc: validateBGPASNLong,
+		}
+	}
+
+	return &schema.Schema{
+		Type:         schema.TypeInt,
+		Optional:     true,
+		ForceNew:     true,
+		ExactlyOneOf: exactlyOneOf,
+		ValidateFunc: validation.IntBetween(1, maxBGPASN),
+	}
+}
+
+func validateBGPASNLong(v any, k string) ([]string, []error) {
+	value := v.(string)
+
+	if value == "" || value[0] == '0' {
+		return nil, []error{fmt.Errorf("%q must be an ASN in asplain format between 1 and %d", k, maxBGPASNLong)}
+	}
+
+	for _, r := range value {
+		if r < '0' || r > '9' {
+			return nil, []error{fmt.Errorf("%q must be an ASN in asplain format between 1 and %d", k, maxBGPASNLong)}
+		}
+	}
+
+	asn, err := strconv.ParseInt(value, 10, 64)
+	if err != nil || asn < 1 || asn > maxBGPASNLong {
+		return nil, []error{fmt.Errorf("%q must be an ASN in asplain format between 1 and %d", k, maxBGPASNLong)}
+	}
+
+	return nil, nil
+}
+
+func expandBGPASN(d *schema.ResourceData) (int32, *int64) {
+	if v, ok := d.GetOk(bgpASNLongAttributeName); ok {
+		asnLong, _ := strconv.ParseInt(v.(string), 10, 64)
+		return 0, aws.Int64(asnLong)
+	}
+
+	return int32(d.Get(bgpASNAttributeName).(int)), nil
+}
+
+func effectiveBGPASN(asn int32, asnLong *int64) int64 {
+	if asnLong != nil {
+		return aws.ToInt64(asnLong)
+	}
+
+	return int64(asn)
+}
+
+func setBGPASN(d *schema.ResourceData, asn int32, asnLong *int64) error {
+	effectiveASN := effectiveBGPASN(asn, asnLong)
+
+	if _, ok := d.GetOk(bgpASNLongAttributeName); ok || asnLong != nil && effectiveASN > maxBGPASN {
+		return d.Set(bgpASNLongAttributeName, strconv.FormatInt(effectiveASN, 10))
+	}
+
+	return d.Set(bgpASNAttributeName, int(effectiveASN))
+}

--- a/internal/service/directconnect/bgp_asn_test.go
+++ b/internal/service/directconnect/bgp_asn_test.go
@@ -1,0 +1,205 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package directconnect
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func TestValidateBGPASNLong(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		value string
+		valid bool
+	}{
+		"minimum":         {value: "1", valid: true},
+		"legacy range":    {value: "65000", valid: true},
+		"four byte range": {value: "4294967294", valid: true},
+		"empty":           {value: "", valid: false},
+		"zero":            {value: "0", valid: false},
+		"leading zero":    {value: "01", valid: false},
+		"sign":            {value: "+1", valid: false},
+		"whitespace":      {value: " 1", valid: false},
+		"asdot":           {value: "1.10", valid: false},
+		"out of range":    {value: "4294967295", valid: false},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			_, errors := validateBGPASNLong(tc.value, bgpASNLongAttributeName)
+			if got := len(errors) == 0; got != tc.valid {
+				t.Fatalf("validateBGPASNLong(%q) valid = %t, want %t: %v", tc.value, got, tc.valid, errors)
+			}
+		})
+	}
+}
+
+func TestBGPASNAttributeSchema(t *testing.T) {
+	t.Parallel()
+
+	expectedExactlyOneOf := []string{bgpASNAttributeName, bgpASNLongAttributeName}
+
+	legacy := bgpASNAttributeSchema(false)
+	if legacy.Type != schema.TypeInt {
+		t.Errorf("legacy Type = %v, want %v", legacy.Type, schema.TypeInt)
+	}
+	if !legacy.Optional || legacy.Required || !legacy.ForceNew {
+		t.Errorf("legacy Optional, Required, ForceNew = %t, %t, %t, want true, false, true", legacy.Optional, legacy.Required, legacy.ForceNew)
+	}
+	if !reflect.DeepEqual(legacy.ExactlyOneOf, expectedExactlyOneOf) {
+		t.Errorf("legacy ExactlyOneOf = %v, want %v", legacy.ExactlyOneOf, expectedExactlyOneOf)
+	}
+	for _, value := range []int{0, maxBGPASN + 1} {
+		if _, errors := legacy.ValidateFunc(value, bgpASNAttributeName); len(errors) == 0 {
+			t.Errorf("legacy validation accepted %d", value)
+		}
+	}
+	if _, errors := legacy.ValidateFunc(maxBGPASN, bgpASNAttributeName); len(errors) != 0 {
+		t.Errorf("legacy validation rejected %d: %v", maxBGPASN, errors)
+	}
+
+	long := bgpASNAttributeSchema(true)
+	if long.Type != schema.TypeString {
+		t.Errorf("long Type = %v, want %v", long.Type, schema.TypeString)
+	}
+	if !long.Optional || long.Required || !long.ForceNew {
+		t.Errorf("long Optional, Required, ForceNew = %t, %t, %t, want true, false, true", long.Optional, long.Required, long.ForceNew)
+	}
+	if !reflect.DeepEqual(long.ExactlyOneOf, expectedExactlyOneOf) {
+		t.Errorf("long ExactlyOneOf = %v, want %v", long.ExactlyOneOf, expectedExactlyOneOf)
+	}
+}
+
+func TestBGPASNPrivateVirtualInterfaceSchema(t *testing.T) {
+	t.Parallel()
+
+	resourceSchema := resourcePrivateVirtualInterface().SchemaFunc()
+
+	if resourceSchema[bgpASNAttributeName].Type != schema.TypeInt {
+		t.Errorf("%s Type = %v, want %v", bgpASNAttributeName, resourceSchema[bgpASNAttributeName].Type, schema.TypeInt)
+	}
+	if resourceSchema[bgpASNLongAttributeName].Type != schema.TypeString {
+		t.Errorf("%s Type = %v, want %v", bgpASNLongAttributeName, resourceSchema[bgpASNLongAttributeName].Type, schema.TypeString)
+	}
+	if !reflect.DeepEqual(resourceSchema[bgpASNAttributeName].ExactlyOneOf, resourceSchema[bgpASNLongAttributeName].ExactlyOneOf) {
+		t.Errorf("BGP ASN attributes have mismatched ExactlyOneOf values")
+	}
+}
+
+func TestExpandBGPASN(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		raw           map[string]any
+		wantASN       int32
+		wantASNLong   int64
+		wantLongIsNil bool
+	}{
+		"legacy": {
+			raw:           map[string]any{bgpASNAttributeName: 65000},
+			wantASN:       65000,
+			wantLongIsNil: true,
+		},
+		"long": {
+			raw:         map[string]any{bgpASNLongAttributeName: "4294967294"},
+			wantASNLong: 4294967294,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			asn, asnLong := expandBGPASN(testBGPASNResourceData(t, tc.raw))
+			if asn != tc.wantASN {
+				t.Errorf("Asn = %d, want %d", asn, tc.wantASN)
+			}
+			if got := asnLong == nil; got != tc.wantLongIsNil {
+				t.Fatalf("AsnLong nil = %t, want %t", got, tc.wantLongIsNil)
+			}
+			if asnLong != nil && aws.ToInt64(asnLong) != tc.wantASNLong {
+				t.Errorf("AsnLong = %d, want %d", aws.ToInt64(asnLong), tc.wantASNLong)
+			}
+		})
+	}
+}
+
+func TestEffectiveBGPASN(t *testing.T) {
+	t.Parallel()
+
+	if got := effectiveBGPASN(65000, nil); got != 65000 {
+		t.Errorf("effective legacy ASN = %d, want 65000", got)
+	}
+	if got := effectiveBGPASN(0, aws.Int64(4294967294)); got != 4294967294 {
+		t.Errorf("effective long ASN = %d, want 4294967294", got)
+	}
+}
+
+func TestSetBGPASN(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		raw           map[string]any
+		asn           int32
+		asnLong       *int64
+		wantLegacy    int
+		wantLong      string
+		wantLongIsSet bool
+	}{
+		"legacy configuration": {
+			raw:        map[string]any{bgpASNAttributeName: 65000},
+			asn:        65000,
+			wantLegacy: 65000,
+		},
+		"long configuration in legacy range": {
+			raw:           map[string]any{bgpASNLongAttributeName: "65000"},
+			asn:           65000,
+			asnLong:       aws.Int64(65000),
+			wantLong:      "65000",
+			wantLongIsSet: true,
+		},
+		"imported long ASN": {
+			asnLong:       aws.Int64(4294967294),
+			wantLong:      "4294967294",
+			wantLongIsSet: true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			d := testBGPASNResourceData(t, tc.raw)
+			if err := setBGPASN(d, tc.asn, tc.asnLong); err != nil {
+				t.Fatalf("setBGPASN returned error: %s", err)
+			}
+			if got := d.Get(bgpASNAttributeName).(int); got != tc.wantLegacy {
+				t.Errorf("%s = %d, want %d", bgpASNAttributeName, got, tc.wantLegacy)
+			}
+			gotLong, longIsSet := d.GetOk(bgpASNLongAttributeName)
+			if longIsSet != tc.wantLongIsSet {
+				t.Fatalf("%s set = %t, want %t", bgpASNLongAttributeName, longIsSet, tc.wantLongIsSet)
+			}
+			if longIsSet && gotLong.(string) != tc.wantLong {
+				t.Errorf("%s = %q, want %q", bgpASNLongAttributeName, gotLong, tc.wantLong)
+			}
+		})
+	}
+}
+
+func testBGPASNResourceData(t *testing.T, raw map[string]any) *schema.ResourceData {
+	t.Helper()
+
+	return schema.TestResourceDataRaw(t, map[string]*schema.Schema{
+		bgpASNAttributeName:     bgpASNAttributeSchema(false),
+		bgpASNLongAttributeName: bgpASNAttributeSchema(true),
+	}, raw)
+}

--- a/internal/service/directconnect/bgp_asn_test.go
+++ b/internal/service/directconnect/bgp_asn_test.go
@@ -78,19 +78,30 @@ func TestBGPASNAttributeSchema(t *testing.T) {
 	}
 }
 
-func TestBGPASNPrivateVirtualInterfaceSchema(t *testing.T) {
+func TestBGPASNResourceSchemas(t *testing.T) {
 	t.Parallel()
 
-	resourceSchema := resourcePrivateVirtualInterface().SchemaFunc()
+	resourceFactories := map[string]func() *schema.Resource{
+		"private VIF": resourcePrivateVirtualInterface,
+		"transit VIF": resourceTransitVirtualInterface,
+	}
 
-	if resourceSchema[bgpASNAttributeName].Type != schema.TypeInt {
-		t.Errorf("%s Type = %v, want %v", bgpASNAttributeName, resourceSchema[bgpASNAttributeName].Type, schema.TypeInt)
-	}
-	if resourceSchema[bgpASNLongAttributeName].Type != schema.TypeString {
-		t.Errorf("%s Type = %v, want %v", bgpASNLongAttributeName, resourceSchema[bgpASNLongAttributeName].Type, schema.TypeString)
-	}
-	if !reflect.DeepEqual(resourceSchema[bgpASNAttributeName].ExactlyOneOf, resourceSchema[bgpASNLongAttributeName].ExactlyOneOf) {
-		t.Errorf("BGP ASN attributes have mismatched ExactlyOneOf values")
+	for name, resourceFactory := range resourceFactories {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			resourceSchema := resourceFactory().SchemaFunc()
+
+			if resourceSchema[bgpASNAttributeName].Type != schema.TypeInt {
+				t.Errorf("%s Type = %v, want %v", bgpASNAttributeName, resourceSchema[bgpASNAttributeName].Type, schema.TypeInt)
+			}
+			if resourceSchema[bgpASNLongAttributeName].Type != schema.TypeString {
+				t.Errorf("%s Type = %v, want %v", bgpASNLongAttributeName, resourceSchema[bgpASNLongAttributeName].Type, schema.TypeString)
+			}
+			if !reflect.DeepEqual(resourceSchema[bgpASNAttributeName].ExactlyOneOf, resourceSchema[bgpASNLongAttributeName].ExactlyOneOf) {
+				t.Errorf("BGP ASN attributes have mismatched ExactlyOneOf values")
+			}
+		})
 	}
 }
 

--- a/internal/service/directconnect/private_virtual_interface.go
+++ b/internal/service/directconnect/private_virtual_interface.go
@@ -66,11 +66,8 @@ func resourcePrivateVirtualInterface() *schema.Resource {
 					Type:     schema.TypeString,
 					Computed: true,
 				},
-				"bgp_asn": {
-					Type:     schema.TypeInt,
-					Required: true,
-					ForceNew: true,
-				},
+				"bgp_asn":      bgpASNAttributeSchema(false),
+				"bgp_asn_long": bgpASNAttributeSchema(true),
 				"bgp_auth_key": {
 					Type:     schema.TypeString,
 					Optional: true,
@@ -141,12 +138,14 @@ func resourcePrivateVirtualInterface() *schema.Resource {
 func resourcePrivateVirtualInterfaceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DirectConnectClient(ctx)
+	asn, asnLong := expandBGPASN(d)
 
 	input := &directconnect.CreatePrivateVirtualInterfaceInput{
 		ConnectionId: aws.String(d.Get(names.AttrConnectionID).(string)),
 		NewPrivateVirtualInterface: &awstypes.NewPrivateVirtualInterface{
 			AddressFamily:        awstypes.AddressFamily(d.Get("address_family").(string)),
-			Asn:                  int32(d.Get("bgp_asn").(int)),
+			Asn:                  asn,
+			AsnLong:              asnLong,
 			EnableSiteLink:       aws.Bool(d.Get("sitelink_enabled").(bool)),
 			Mtu:                  aws.Int32(int32(d.Get("mtu").(int))),
 			Tags:                 getTagsIn(ctx),
@@ -218,7 +217,9 @@ func resourcePrivateVirtualInterfaceRead(ctx context.Context, d *schema.Resource
 	}.String()
 	d.Set(names.AttrARN, arn)
 	d.Set("aws_device", vif.AwsDeviceV2)
-	d.Set("bgp_asn", vif.Asn)
+	if err := setBGPASN(d, vif.Asn, vif.AsnLong); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting BGP ASN: %s", err)
+	}
 	d.Set("bgp_auth_key", vif.AuthKey)
 	d.Set(names.AttrConnectionID, vif.ConnectionId)
 	d.Set("customer_address", vif.CustomerAddress)
@@ -263,6 +264,10 @@ func resourcePrivateVirtualInterfaceImport(ctx context.Context, d *schema.Resour
 
 	if vifType := aws.ToString(vif.VirtualInterfaceType); vifType != "private" {
 		return nil, fmt.Errorf("virtual interface (%s) has incorrect type: %s", d.Id(), vifType)
+	}
+
+	if err := setBGPASN(d, vif.Asn, vif.AsnLong); err != nil {
+		return nil, fmt.Errorf("setting BGP ASN: %w", err)
 	}
 
 	return []*schema.ResourceData{d}, nil

--- a/internal/service/directconnect/private_virtual_interface_test.go
+++ b/internal/service/directconnect/private_virtual_interface_test.go
@@ -418,3 +418,48 @@ resource "aws_dx_private_virtual_interface" "test" {
 }
 `, cid, rName, amzAsn, bgpAsn, vlan, sitelink_enabled)
 }
+
+func TestAccDirectConnectPrivateVirtualInterface_bgpASNLong(t *testing.T) {
+	ctx := acctest.Context(t)
+	connectionID := acctest.SkipIfEnvVarNotSet(t, "DX_CONNECTION_ID")
+	dxGatewayID := acctest.SkipIfEnvVarNotSet(t, "DX_GATEWAY_ID")
+
+	var vif awstypes.VirtualInterface
+	resourceName := "aws_dx_private_virtual_interface.test"
+	rName := fmt.Sprintf("tf-testacc-private-vif-%s", acctest.RandString(t, 9))
+	vlan := acctest.RandIntRange(t, 2049, 4094)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.DirectConnectServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckPrivateVirtualInterfaceDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPrivateVirtualInterfaceConfig_bgpASNLong(connectionID, dxGatewayID, rName, vlan),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPrivateVirtualInterfaceExists(ctx, t, resourceName, &vif),
+					resource.TestCheckResourceAttr(resourceName, "bgp_asn_long", "4200012999"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccPrivateVirtualInterfaceConfig_bgpASNLong(cid, dxGatewayID, rName string, vlan int) string {
+	return fmt.Sprintf(`
+resource "aws_dx_private_virtual_interface" "test" {
+  address_family = "ipv4"
+  bgp_asn_long   = "4200012999"
+  connection_id  = %[1]q
+  dx_gateway_id  = %[2]q
+  name           = %[3]q
+  vlan           = %[4]d
+}
+`, cid, dxGatewayID, rName, vlan)
+}

--- a/internal/service/directconnect/transit_virtual_interface.go
+++ b/internal/service/directconnect/transit_virtual_interface.go
@@ -66,11 +66,8 @@ func resourceTransitVirtualInterface() *schema.Resource {
 					Type:     schema.TypeString,
 					Computed: true,
 				},
-				"bgp_asn": {
-					Type:     schema.TypeInt,
-					Required: true,
-					ForceNew: true,
-				},
+				"bgp_asn":      bgpASNAttributeSchema(false),
+				"bgp_asn_long": bgpASNAttributeSchema(true),
 				"bgp_auth_key": {
 					Type:     schema.TypeString,
 					Optional: true,
@@ -134,12 +131,14 @@ func resourceTransitVirtualInterface() *schema.Resource {
 func resourceTransitVirtualInterfaceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DirectConnectClient(ctx)
+	asn, asnLong := expandBGPASN(d)
 
 	input := &directconnect.CreateTransitVirtualInterfaceInput{
 		ConnectionId: aws.String(d.Get(names.AttrConnectionID).(string)),
 		NewTransitVirtualInterface: &awstypes.NewTransitVirtualInterface{
 			AddressFamily:          awstypes.AddressFamily(d.Get("address_family").(string)),
-			Asn:                    int32(d.Get("bgp_asn").(int)),
+			Asn:                    asn,
+			AsnLong:                asnLong,
 			DirectConnectGatewayId: aws.String(d.Get("dx_gateway_id").(string)),
 			EnableSiteLink:         aws.Bool(d.Get("sitelink_enabled").(bool)),
 			Mtu:                    aws.Int32(int32(d.Get("mtu").(int))),
@@ -204,7 +203,9 @@ func resourceTransitVirtualInterfaceRead(ctx context.Context, d *schema.Resource
 	}.String()
 	d.Set(names.AttrARN, arn)
 	d.Set("aws_device", vif.AwsDeviceV2)
-	d.Set("bgp_asn", vif.Asn)
+	if err := setBGPASN(d, vif.Asn, vif.AsnLong); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting BGP ASN: %s", err)
+	}
 	d.Set("bgp_auth_key", vif.AuthKey)
 	d.Set(names.AttrConnectionID, vif.ConnectionId)
 	d.Set("customer_address", vif.CustomerAddress)
@@ -248,6 +249,10 @@ func resourceTransitVirtualInterfaceImport(ctx context.Context, d *schema.Resour
 
 	if vifType := aws.ToString(vif.VirtualInterfaceType); vifType != "transit" {
 		return nil, fmt.Errorf("virtual interface (%s) has incorrect type: %s", d.Id(), vifType)
+	}
+
+	if err := setBGPASN(d, vif.Asn, vif.AsnLong); err != nil {
+		return nil, fmt.Errorf("setting BGP ASN: %w", err)
 	}
 
 	return []*schema.ResourceData{d}, nil

--- a/internal/service/directconnect/transit_virtual_interface_test.go
+++ b/internal/service/directconnect/transit_virtual_interface_test.go
@@ -23,6 +23,7 @@ func TestAccDirectConnectTransitVirtualInterface_serial(t *testing.T) {
 
 	testCases := map[string]func(t *testing.T){
 		acctest.CtBasic: testAccTransitVirtualInterface_basic,
+		"bgpASNLong":    testAccTransitVirtualInterface_bgpASNLong,
 		"tags":          testAccTransitVirtualInterface_tags,
 		"sitelink":      testAccTransitVirtualInterface_siteLink,
 	}
@@ -357,4 +358,49 @@ resource "aws_dx_transit_virtual_interface" "test" {
   vlan             = %[4]d
 }
 `, cid, rName, bgpAsn, vlan, sitelink_enabled))
+}
+
+func testAccTransitVirtualInterface_bgpASNLong(t *testing.T) {
+	ctx := acctest.Context(t)
+	connectionID := acctest.SkipIfEnvVarNotSet(t, "DX_CONNECTION_ID")
+	dxGatewayID := acctest.SkipIfEnvVarNotSet(t, "DX_GATEWAY_ID")
+
+	var vif awstypes.VirtualInterface
+	resourceName := "aws_dx_transit_virtual_interface.test"
+	rName := fmt.Sprintf("tf-testacc-transit-vif-%s", acctest.RandString(t, 9))
+	vlan := acctest.RandIntRange(t, 2049, 4094)
+
+	acctest.Test(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.DirectConnectServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTransitVirtualInterfaceDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTransitVirtualInterfaceConfig_bgpASNLong(connectionID, dxGatewayID, rName, vlan),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTransitVirtualInterfaceExists(ctx, t, resourceName, &vif),
+					resource.TestCheckResourceAttr(resourceName, "bgp_asn_long", "4200012999"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccTransitVirtualInterfaceConfig_bgpASNLong(cid, dxGatewayID, rName string, vlan int) string {
+	return fmt.Sprintf(`
+resource "aws_dx_transit_virtual_interface" "test" {
+  address_family = "ipv4"
+  bgp_asn_long   = "4200012999"
+  connection_id  = %[1]q
+  dx_gateway_id  = %[2]q
+  name           = %[3]q
+  vlan           = %[4]d
+}
+`, cid, dxGatewayID, rName, vlan)
 }

--- a/website/docs/r/dx_private_virtual_interface.html.markdown
+++ b/website/docs/r/dx_private_virtual_interface.html.markdown
@@ -29,7 +29,8 @@ This resource supports the following arguments:
 
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `address_family` - (Required) The address family for the BGP peer. `ipv4 ` or `ipv6`.
-* `bgp_asn` - (Required) The autonomous system (AS) number for Border Gateway Protocol (BGP) configuration.
+* `bgp_asn` - (Optional) Autonomous system number for Border Gateway Protocol (BGP) configuration. Valid value is between `1` and `2147483646`. Exactly one of `bgp_asn` or `bgp_asn_long` must be specified.
+* `bgp_asn_long` - (Optional) Long autonomous system number for BGP configuration in asplain decimal notation. Valid value is between `1` and `4294967294`. Exactly one of `bgp_asn` or `bgp_asn_long` must be specified.
 * `connection_id` - (Required) The ID of the Direct Connect connection (or LAG) on which to create the virtual interface.
 * `name` - (Required) The name for the virtual interface.
 * `vlan` - (Required) The VLAN ID.

--- a/website/docs/r/dx_transit_virtual_interface.html.markdown
+++ b/website/docs/r/dx_transit_virtual_interface.html.markdown
@@ -36,7 +36,8 @@ This resource supports the following arguments:
 
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `address_family` - (Required) The address family for the BGP peer. `ipv4 ` or `ipv6`.
-* `bgp_asn` - (Required) The autonomous system (AS) number for Border Gateway Protocol (BGP) configuration.
+* `bgp_asn` - (Optional) Autonomous system number for Border Gateway Protocol (BGP) configuration. Valid value is between `1` and `2147483646`. Exactly one of `bgp_asn` or `bgp_asn_long` must be specified.
+* `bgp_asn_long` - (Optional) Long autonomous system number for BGP configuration in asplain decimal notation. Valid value is between `1` and `4294967294`. Exactly one of `bgp_asn` or `bgp_asn_long` must be specified.
 * `connection_id` - (Required) The ID of the Direct Connect connection (or LAG) on which to create the virtual interface.
 * `dx_gateway_id` - (Required) The ID of the Direct Connect gateway to which to connect the virtual interface.
 * `name` - (Required) The name for the virtual interface.


### PR DESCRIPTION
### Description

Adds long BGP ASN support to `aws_dx_transit_virtual_interface` through the shared `bgp_asn_long` argument introduced by #49518.

This focused follow-up:

- Sends long ASNs through the Direct Connect SDK `AsnLong` field.
- Preserves existing `bgp_asn` configuration and state behavior.
- Retains the configured ASN representation during read and import.
- Adds create/read/import acceptance coverage using existing Direct Connect fixtures.

`bgp_asn_long` accepts canonical asplain decimal notation from `1` through `4294967294`. Asdot notation is intentionally not accepted because the API and AWS SDK model `AsnLong` numerically.

### Stack

**PR 2 of 5.** Depends on #49518.

1. #49518 — private VIF + shared helper
2. Transit VIF — this PR
3. Public VIF
4. BGP peer
5. Hosted VIF allocation family

This PR is intentionally draft until #49518 merges. Its cumulative diff against `main` will reduce to the four focused transit-VIF files after the predecessor lands.

### Relations

Closes #40879

Relates #47658 and #47662.

### References

- [AWS Direct Connect `NewTransitVirtualInterface`](https://docs.aws.amazon.com/directconnect/latest/APIReference/API_NewTransitVirtualInterface.html)
- [AWS SDK for Go v2 Direct Connect types](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/directconnect/types)

### Testing

Passed:

- Direct Connect unit tests
- Acceptance-test compilation
- Provider schema validation
- `make quick-fix PKG=directconnect`
- Semgrep and documentation checks

Live acceptance was attempted but deferred because the available EMEA lab connections had either reached the transit-VIF quota or the only account-owned DX gateway already had private-VIF attachments. Both API calls failed before resource creation; cleanup verification found no residual test VIFs.

### AI Usage Disclosure

An LLM coding agent assisted with extracting this focused change from a broader implementation, test authoring, documentation, and validation. The human author reviewed the resulting changes and is responsible for the submission.
