### PR TITLE
aws_msk_cluster: Add support for MSK authorizer logs

### DIFF
--- a/.changelog/49523.txt
+++ b/.changelog/49523.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_msk_cluster: Add support for authorizer log delivery
+```

--- a/internal/service/kafka/cluster.go
+++ b/internal/service/kafka/cluster.go
@@ -500,9 +500,10 @@ func resourceCluster() *schema.Resource {
 								},
 							},
 							"authorizer_logs": {
-								Type:     schema.TypeList,
-								Optional: true,
-								MaxItems: 1,
+								Type:             schema.TypeList,
+								Optional:         true,
+								DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
+								MaxItems:         1,
 								Elem: &schema.Resource{
 									Schema: map[string]*schema.Schema{
 										names.AttrCloudWatchLogs: {

--- a/internal/service/kafka/cluster.go
+++ b/internal/service/kafka/cluster.go
@@ -499,6 +499,73 @@ func resourceCluster() *schema.Resource {
 									},
 								},
 							},
+							"authorizer_logs": {
+								Type:     schema.TypeList,
+								Optional: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										names.AttrCloudWatchLogs: {
+											Type:             schema.TypeList,
+											Optional:         true,
+											DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
+											MaxItems:         1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													names.AttrEnabled: {
+														Type:     schema.TypeBool,
+														Required: true,
+													},
+													"log_group": {
+														Type:     schema.TypeString,
+														Optional: true,
+													},
+												},
+											},
+										},
+										"firehose": {
+											Type:             schema.TypeList,
+											Optional:         true,
+											DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
+											MaxItems:         1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"delivery_stream": {
+														Type:     schema.TypeString,
+														Optional: true,
+													},
+													names.AttrEnabled: {
+														Type:     schema.TypeBool,
+														Required: true,
+													},
+												},
+											},
+										},
+										"s3": {
+											Type:             schema.TypeList,
+											Optional:         true,
+											DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
+											MaxItems:         1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													names.AttrBucket: {
+														Type:     schema.TypeString,
+														Optional: true,
+													},
+													names.AttrEnabled: {
+														Type:     schema.TypeBool,
+														Required: true,
+													},
+													names.AttrPrefix: {
+														Type:     schema.TypeString,
+														Optional: true,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
 						},
 					},
 				},
@@ -1793,6 +1860,10 @@ func expandLoggingInfo(tfMap map[string]any) *types.LoggingInfo {
 		apiObject.BrokerLogs = expandBrokerLogs(v[0].(map[string]any))
 	}
 
+	if v, ok := tfMap["authorizer_logs"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.AuthorizerLogs = expandAuthorizerLogs(v[0].(map[string]any))
+	}
+
 	return apiObject
 }
 
@@ -1802,6 +1873,28 @@ func expandBrokerLogs(tfMap map[string]any) *types.BrokerLogs {
 	}
 
 	apiObject := &types.BrokerLogs{}
+
+	if v, ok := tfMap[names.AttrCloudWatchLogs].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.CloudWatchLogs = expandCloudWatchLogs(v[0].(map[string]any))
+	}
+
+	if v, ok := tfMap["firehose"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.Firehose = expandFirehose(v[0].(map[string]any))
+	}
+
+	if v, ok := tfMap["s3"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.S3 = expandS3(v[0].(map[string]any))
+	}
+
+	return apiObject
+}
+
+func expandAuthorizerLogs(tfMap map[string]any) *types.AuthorizerLogs {
+	if tfMap == nil {
+		return nil
+	}
+
+	apiObject := &types.AuthorizerLogs{}
 
 	if v, ok := tfMap[names.AttrCloudWatchLogs].([]any); ok && len(v) > 0 && v[0] != nil {
 		apiObject.CloudWatchLogs = expandCloudWatchLogs(v[0].(map[string]any))
@@ -2248,10 +2341,36 @@ func flattenLoggingInfo(apiObject *types.LoggingInfo) map[string]any {
 		tfMap["broker_logs"] = []any{flattenBrokerLogs(v)}
 	}
 
+	if v := apiObject.AuthorizerLogs; v != nil {
+		tfMap["authorizer_logs"] = []any{flattenAuthorizerLogs(v)}
+	}
+
 	return tfMap
 }
 
 func flattenBrokerLogs(apiObject *types.BrokerLogs) map[string]any {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]any{}
+
+	if v := apiObject.CloudWatchLogs; v != nil {
+		tfMap[names.AttrCloudWatchLogs] = []any{flattenCloudWatchLogs(v)}
+	}
+
+	if v := apiObject.Firehose; v != nil {
+		tfMap["firehose"] = []any{flattenFirehose(v)}
+	}
+
+	if v := apiObject.S3; v != nil {
+		tfMap["s3"] = []any{flattenS3(v)}
+	}
+
+	return tfMap
+}
+
+func flattenAuthorizerLogs(apiObject *types.AuthorizerLogs) map[string]any {
 	if apiObject == nil {
 		return nil
 	}

--- a/internal/service/kafka/cluster_test.go
+++ b/internal/service/kafka/cluster_test.go
@@ -1328,6 +1328,13 @@ func TestAccKafkaCluster_loggingInfo(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "logging_info.0.broker_logs.0.firehose.0.enabled", acctest.CtFalse),
 					resource.TestCheckResourceAttr(resourceName, "logging_info.0.broker_logs.0.s3.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "logging_info.0.broker_logs.0.s3.0.enabled", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, "logging_info.0.authorizer_logs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "logging_info.0.authorizer_logs.0.cloudwatch_logs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "logging_info.0.authorizer_logs.0.cloudwatch_logs.0.enabled", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, "logging_info.0.authorizer_logs.0.firehose.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "logging_info.0.authorizer_logs.0.firehose.0.enabled", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, "logging_info.0.authorizer_logs.0.s3.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "logging_info.0.authorizer_logs.0.s3.0.enabled", acctest.CtFalse),
 				),
 			},
 			{
@@ -1351,6 +1358,13 @@ func TestAccKafkaCluster_loggingInfo(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "logging_info.0.broker_logs.0.firehose.0.enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "logging_info.0.broker_logs.0.s3.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "logging_info.0.broker_logs.0.s3.0.enabled", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "logging_info.0.authorizer_logs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "logging_info.0.authorizer_logs.0.cloudwatch_logs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "logging_info.0.authorizer_logs.0.cloudwatch_logs.0.enabled", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "logging_info.0.authorizer_logs.0.firehose.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "logging_info.0.authorizer_logs.0.firehose.0.enabled", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "logging_info.0.authorizer_logs.0.s3.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "logging_info.0.authorizer_logs.0.s3.0.enabled", acctest.CtTrue),
 				),
 			},
 		},
@@ -1382,6 +1396,13 @@ func TestAccKafkaCluster_loggingInfoForExpress(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "logging_info.0.broker_logs.0.firehose.0.enabled", acctest.CtFalse),
 					resource.TestCheckResourceAttr(resourceName, "logging_info.0.broker_logs.0.s3.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "logging_info.0.broker_logs.0.s3.0.enabled", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, "logging_info.0.authorizer_logs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "logging_info.0.authorizer_logs.0.cloudwatch_logs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "logging_info.0.authorizer_logs.0.cloudwatch_logs.0.enabled", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, "logging_info.0.authorizer_logs.0.firehose.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "logging_info.0.authorizer_logs.0.firehose.0.enabled", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, "logging_info.0.authorizer_logs.0.s3.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "logging_info.0.authorizer_logs.0.s3.0.enabled", acctest.CtFalse),
 				),
 			},
 			{
@@ -1405,6 +1426,13 @@ func TestAccKafkaCluster_loggingInfoForExpress(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "logging_info.0.broker_logs.0.firehose.0.enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "logging_info.0.broker_logs.0.s3.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "logging_info.0.broker_logs.0.s3.0.enabled", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "logging_info.0.authorizer_logs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "logging_info.0.authorizer_logs.0.cloudwatch_logs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "logging_info.0.authorizer_logs.0.cloudwatch_logs.0.enabled", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "logging_info.0.authorizer_logs.0.firehose.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "logging_info.0.authorizer_logs.0.firehose.0.enabled", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "logging_info.0.authorizer_logs.0.s3.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "logging_info.0.authorizer_logs.0.s3.0.enabled", acctest.CtTrue),
 				),
 			},
 		},
@@ -2661,7 +2689,7 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
 
   lifecycle {
     ignore_changes = [
-      # Ignore changes to LogDeliveryEnabled tag as API adds this tag when broker log delivery is enabled
+      # Ignore changes to LogDeliveryEnabled tag as API adds this tag when log delivery is enabled
       tags["LogDeliveryEnabled"],
     ]
   }
@@ -2686,6 +2714,24 @@ resource "aws_msk_cluster" "test" {
 
   logging_info {
     broker_logs {
+      cloudwatch_logs {
+        enabled   = %[2]t
+        log_group = %[3]s
+      }
+
+      firehose {
+        enabled         = %[4]t
+        delivery_stream = %[5]s
+      }
+
+      s3 {
+        enabled = %[6]t
+        bucket  = %[7]s
+        prefix  = ""
+      }
+    }
+
+    authorizer_logs {
       cloudwatch_logs {
         enabled   = %[2]t
         log_group = %[3]s
@@ -2767,7 +2813,7 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
 
   lifecycle {
     ignore_changes = [
-      # Ignore changes to LogDeliveryEnabled tag as API adds this tag when broker log delivery is enabled
+      # Ignore changes to LogDeliveryEnabled tag as API adds this tag when log delivery is enabled
       tags["LogDeliveryEnabled"],
     ]
   }
@@ -2786,6 +2832,24 @@ resource "aws_msk_cluster" "test" {
 
   logging_info {
     broker_logs {
+      cloudwatch_logs {
+        enabled   = %[2]t
+        log_group = %[3]s
+      }
+
+      firehose {
+        enabled         = %[4]t
+        delivery_stream = %[5]s
+      }
+
+      s3 {
+        enabled = %[6]t
+        bucket  = %[7]s
+        prefix  = ""
+      }
+    }
+
+    authorizer_logs {
       cloudwatch_logs {
         enabled   = %[2]t
         log_group = %[3]s

--- a/website/docs/r/msk_cluster.html.markdown
+++ b/website/docs/r/msk_cluster.html.markdown
@@ -213,7 +213,7 @@ This resource supports the following arguments:
 * `encryption_info` - (Optional) Configuration block for specifying encryption. See [encryption_info Argument Reference](#encryption_info-argument-reference) below.
 * `enhanced_monitoring` - (Optional) Specify the desired enhanced MSK CloudWatch monitoring level. See [Monitoring Amazon MSK with Amazon CloudWatch](https://docs.aws.amazon.com/msk/latest/developerguide/monitoring.html)
 * `open_monitoring` - (Optional) Configuration block for JMX and Node monitoring for the MSK cluster. See [open_monitoring Argument Reference](#open_monitoring-argument-reference) below.
-* `logging_info` - (Optional) Configuration block for streaming broker logs to Cloudwatch/S3/Kinesis Firehose. See [logging_info Argument Reference](#logging_info-argument-reference) below.
+* `logging_info` - (Optional) Configuration block for streaming broker and authorizer logs to Cloudwatch/S3/Kinesis Firehose. See [logging_info Argument Reference](#logging_info-argument-reference) below.
 * `rebalancing` - (Optional) Configuration block for intelligent rebalancing. See [rebalancing Argument Reference](#rebalancing-argument-reference) below. Only applicable to MSK Provisioned clusters with Express brokers.
 * `storage_mode` - (Optional) Controls storage mode for supported storage tiers. Valid values are: `LOCAL` or `TIERED`.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
@@ -315,6 +315,7 @@ This resource supports the following arguments:
 #### logging_info Argument Reference
 
 * `broker_logs` - (Required) Configuration block for Broker Logs settings for logging info. See [logging_info broker_logs Argument Reference](#logging_info-broker_logs-argument-reference) below.
+* `authorizer_logs` - (Optional) Configuration block for Authorizer Logs settings for logging info. See [logging_info authorizer_logs Argument Reference](#logging_info-authorizer_logs-argument-reference) below.
 
 #### logging_info broker_logs Argument Reference
 
@@ -335,6 +336,28 @@ This resource supports the following arguments:
 #### logging_info broker_logs s3 Argument Reference
 
 * `enabled` - (Optional) Indicates whether you want to enable or disable streaming broker logs to S3.
+* `bucket` - (Optional) Name of the S3 bucket to deliver logs to.
+* `prefix` - (Optional) Prefix to append to the folder name.
+
+#### logging_info authorizer_logs Argument Reference
+
+* `cloudwatch_logs` - (Optional) Configuration block for CloudWatch Logs settings. See [logging_info authorizer_logs cloudwatch_logs Argument Reference](#logging_info-authorizer_logs-cloudwatch_logs-argument-reference) below.
+* `firehose` - (Optional) Configuration block for Kinesis Data Firehose settings. See [logging_info authorizer_logs firehose Argument Reference](#logging_info-authorizer_logs-firehose-argument-reference) below.
+* `s3` - (Optional) Configuration block for S3 settings. See [logging_info authorizer_logs s3 Argument Reference](#logging_info-authorizer_logs-s3-argument-reference) below.
+
+#### logging_info authorizer_logs cloudwatch_logs Argument Reference
+
+* `enabled` - (Optional) Indicates whether you want to enable or disable streaming authorizer logs to CloudWatch Logs.
+* `log_group` - (Optional) Name of the CloudWatch Log Group to deliver logs to.
+
+#### logging_info authorizer_logs firehose Argument Reference
+
+* `enabled` - (Optional) Indicates whether you want to enable or disable streaming authorizer logs to Kinesis Data Firehose.
+* `delivery_stream` - (Optional) Name of the Kinesis Data Firehose delivery stream to deliver logs to.
+
+#### logging_info authorizer_logs s3 Argument Reference
+
+* `enabled` - (Optional) Indicates whether you want to enable or disable streaming authorizer logs to S3.
 * `bucket` - (Optional) Name of the S3 bucket to deliver logs to.
 * `prefix` - (Optional) Prefix to append to the folder name.
 


### PR DESCRIPTION
## Context

Amazon MSK supports authorizer-log delivery to CloudWatch Logs, S3, and Kinesis Data Firehose, but `aws_msk_cluster.logging_info` exposed only broker logs. This prevented declarative management of MSK authorization-decision logs.

Closes #49522

## Summary of changes

- Add optional `logging_info.authorizer_logs` configuration.
- Support CloudWatch Logs, Firehose, and S3 destinations.
- Add expand/flatten handling for Terraform state and MSK API requests.
- Extend Standard and Express MSK acceptance configurations and assertions.
- Document the new configuration block.

Validation:

- `gofmt` completed.
- `git diff --check` passed.
- Non-test Kafka package compilation passed.
- Acceptance tests not run; they require AWS resources and credentials.
