### PR TITLE
r/aws_sesv2_tenant: Fix sweeper

### DIFF
--- a/internal/service/sesv2/sweep.go
+++ b/internal/service/sesv2/sweep.go
@@ -85,7 +85,7 @@ func sweepTenants(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepab
 
 		for _, v := range page.Tenants {
 			sweepResources = append(sweepResources, framework.NewSweepResource(newTenantResource, client,
-				framework.NewAttribute("tenant_id", aws.ToString(v.TenantId))))
+				framework.NewAttribute("tenant_name", aws.ToString(v.TenantName))))
 		}
 	}
 

--- a/internal/service/sesv2/tenant.go
+++ b/internal/service/sesv2/tenant.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
@@ -132,11 +133,12 @@ func (r *tenantResource) Delete(ctx context.Context, req resource.DeleteRequest,
 
 	conn := r.Meta().SESV2Client(ctx)
 
+	tflog.Info(ctx, "Deleting SESv2 Tenant")
+
 	name := fwflex.StringValueFromFramework(ctx, state.TenantName)
 	input := sesv2.DeleteTenantInput{
 		TenantName: aws.String(name),
 	}
-
 	_, err := conn.DeleteTenant(ctx, &input)
 	if errs.IsA[*awstypes.NotFoundException](err) {
 		return


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Set `tenant_name`, not `tenant_id`.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/49525.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% SWEEPERS=aws_sesv2_tenant make sweep
# make sweep SWEEPARGS=-sweep-run=aws_example_thing
# set SWEEPARGS=-sweep-allow-failures to continue after first failure
WARNING: This will destroy infrastructure. Use only in development accounts.
go1.26.6 test ./internal/sweep -v -sweep=us-west-2,us-east-1,us-east-2,us-west-1 -sweep-run='aws_sesv2_tenant' -timeout 360m -vet=off -buildvcs=false
2026/08/17 10:48:36 [DEBUG] Running Sweepers for region (us-west-2):
2026/08/17 10:48:36 [DEBUG] Running Sweeper (aws_sesv2_tenant) in region (us-west-2)
2026/08/17 10:48:36 [DEBUG] sweeper: Configuring Terraform AWS Provider: sweeper_region=us-west-2 tf_resource_type=aws_sesv2_tenant
2026-08-17T10:48:36.329-0400 [DEBUG] sweeper.aws-base: Resolving credentials provider: tf_resource_type=aws_sesv2_tenant sweeper_region=us-west-2
2026-08-17T10:48:36.329-0400 [DEBUG] sweeper.aws-base: Loading configuration: sweeper_region=us-west-2 tf_resource_type=aws_sesv2_tenant
2026-08-17T10:48:36.331-0400 [DEBUG] sweeper.aws-base: Retrieving credentials: tf_resource_type=aws_sesv2_tenant sweeper_region=us-west-2
2026-08-17T10:48:36.331-0400 [INFO]  sweeper.aws-base: Retrieved credentials: tf_aws.credentials_source=EnvConfigCredentials sweeper_region=us-west-2 tf_resource_type=aws_sesv2_tenant
2026-08-17T10:48:36.331-0400 [DEBUG] sweeper.aws-base: Loading configuration: sweeper_region=us-west-2 tf_resource_type=aws_sesv2_tenant
2026/08/17 10:48:36 [DEBUG] sweeper: Retrieving AWS account details: sweeper_region=us-west-2 tf_resource_type=aws_sesv2_tenant
2026-08-17T10:48:36.331-0400 [DEBUG] sweeper.aws-base: Retrieving caller identity from STS: tf_resource_type=aws_sesv2_tenant sweeper_region=us-west-2
2026-08-17T10:48:36.742-0400 [INFO]  sweeper.aws-base: Retrieved caller identity from STS: sweeper_region=us-west-2 tf_resource_type=aws_sesv2_tenant
2026/08/17 10:48:36 [INFO]  sweeper: listing resources: sweeper_region=us-west-2 tf_resource_type=aws_sesv2_tenant
2026/08/17 10:48:37 [INFO]  sweeper: Sweeping resource: tf_resource_type=aws_sesv2_tenant tenant_name=tf-acc-test-7367436310404799570 sweeper_region=us-west-2
2026/08/17 10:48:37 [INFO]  sweeper: Sweeping resource: sweeper_region=us-west-2 tf_resource_type=aws_sesv2_tenant tenant_name=tf-acc-test-3704134050493691608
2026/08/17 10:48:37 [INFO]  sweeper: Sweeping resource: sweeper_region=us-west-2 tf_resource_type=aws_sesv2_tenant tenant_name=tf-acc-test-7075737978302621348
2026/08/17 10:48:37 [INFO]  sweeper: Deleting SESv2 Tenant: tenant_name=tf-acc-test-7367436310404799570 sweeper_region=us-west-2 tf_resource_type=aws_sesv2_tenant tf_aws.resource_attribute.id=tf-acc-test-7367436310404799570
2026/08/17 10:48:37 [INFO]  sweeper: Deleting SESv2 Tenant: tf_aws.resource_attribute.id=tf-acc-test-7075737978302621348 sweeper_region=us-west-2 tf_resource_type=aws_sesv2_tenant tenant_name=tf-acc-test-7075737978302621348
2026/08/17 10:48:37 [INFO]  sweeper: Deleting SESv2 Tenant: tenant_name=tf-acc-test-3704134050493691608 tf_aws.resource_attribute.id=tf-acc-test-3704134050493691608 sweeper_region=us-west-2 tf_resource_type=aws_sesv2_tenant
2026/08/17 10:48:37 [DEBUG] Completed Sweeper (aws_sesv2_tenant) in region (us-west-2) in 1.072533084s
2026/08/17 10:48:37 Completed Sweepers for region (us-west-2) in 1.072706292s
2026/08/17 10:48:37 Sweeper Tests for region (us-west-2) ran successfully:
2026/08/17 10:48:37     - aws_sesv2_tenant
2026/08/17 10:48:37 [DEBUG] Running Sweepers for region (us-east-1):
2026/08/17 10:48:37 [DEBUG] Running Sweeper (aws_sesv2_tenant) in region (us-east-1)
2026/08/17 10:48:37 [DEBUG] sweeper: Configuring Terraform AWS Provider: sweeper_region=us-east-1 tf_resource_type=aws_sesv2_tenant
2026-08-17T10:48:37.401-0400 [DEBUG] sweeper.aws-base: Resolving credentials provider: sweeper_region=us-east-1 tf_resource_type=aws_sesv2_tenant
2026-08-17T10:48:37.401-0400 [DEBUG] sweeper.aws-base: Loading configuration: sweeper_region=us-east-1 tf_resource_type=aws_sesv2_tenant
2026-08-17T10:48:37.401-0400 [DEBUG] sweeper.aws-base: Retrieving credentials: sweeper_region=us-east-1 tf_resource_type=aws_sesv2_tenant
2026-08-17T10:48:37.401-0400 [INFO]  sweeper.aws-base: Retrieved credentials: sweeper_region=us-east-1 tf_resource_type=aws_sesv2_tenant tf_aws.credentials_source=EnvConfigCredentials
2026-08-17T10:48:37.401-0400 [DEBUG] sweeper.aws-base: Loading configuration: sweeper_region=us-east-1 tf_resource_type=aws_sesv2_tenant
2026/08/17 10:48:37 [DEBUG] sweeper: Retrieving AWS account details: tf_resource_type=aws_sesv2_tenant sweeper_region=us-east-1
2026-08-17T10:48:37.401-0400 [DEBUG] sweeper.aws-base: Retrieving caller identity from STS: tf_resource_type=aws_sesv2_tenant sweeper_region=us-east-1
2026-08-17T10:48:37.559-0400 [INFO]  sweeper.aws-base: Retrieved caller identity from STS: sweeper_region=us-east-1 tf_resource_type=aws_sesv2_tenant
2026/08/17 10:48:37 [INFO]  sweeper: listing resources: sweeper_region=us-east-1 tf_resource_type=aws_sesv2_tenant
2026/08/17 10:48:37 [INFO]  sweeper: No resources to sweep: sweeper_region=us-east-1 tf_resource_type=aws_sesv2_tenant
2026/08/17 10:48:37 [DEBUG] Completed Sweeper (aws_sesv2_tenant) in region (us-east-1) in 380.288ms
2026/08/17 10:48:37 Completed Sweepers for region (us-east-1) in 380.406084ms
2026/08/17 10:48:37 Sweeper Tests for region (us-east-1) ran successfully:
2026/08/17 10:48:37     - aws_sesv2_tenant
2026/08/17 10:48:37 [DEBUG] Running Sweepers for region (us-east-2):
2026/08/17 10:48:37 [DEBUG] Running Sweeper (aws_sesv2_tenant) in region (us-east-2)
2026/08/17 10:48:37 [DEBUG] sweeper: Configuring Terraform AWS Provider: tf_resource_type=aws_sesv2_tenant sweeper_region=us-east-2
2026-08-17T10:48:37.781-0400 [DEBUG] sweeper.aws-base: Resolving credentials provider: tf_resource_type=aws_sesv2_tenant sweeper_region=us-east-2
2026-08-17T10:48:37.781-0400 [DEBUG] sweeper.aws-base: Loading configuration: tf_resource_type=aws_sesv2_tenant sweeper_region=us-east-2
2026-08-17T10:48:37.781-0400 [DEBUG] sweeper.aws-base: Retrieving credentials: tf_resource_type=aws_sesv2_tenant sweeper_region=us-east-2
2026-08-17T10:48:37.781-0400 [INFO]  sweeper.aws-base: Retrieved credentials: tf_resource_type=aws_sesv2_tenant sweeper_region=us-east-2 tf_aws.credentials_source=EnvConfigCredentials
2026-08-17T10:48:37.781-0400 [DEBUG] sweeper.aws-base: Loading configuration: tf_resource_type=aws_sesv2_tenant sweeper_region=us-east-2
2026/08/17 10:48:37 [DEBUG] sweeper: Retrieving AWS account details: sweeper_region=us-east-2 tf_resource_type=aws_sesv2_tenant
2026-08-17T10:48:37.781-0400 [DEBUG] sweeper.aws-base: Retrieving caller identity from STS: sweeper_region=us-east-2 tf_resource_type=aws_sesv2_tenant
2026-08-17T10:48:38.034-0400 [INFO]  sweeper.aws-base: Retrieved caller identity from STS: tf_resource_type=aws_sesv2_tenant sweeper_region=us-east-2
2026/08/17 10:48:38 [INFO]  sweeper: listing resources: sweeper_region=us-east-2 tf_resource_type=aws_sesv2_tenant
2026/08/17 10:48:38 [INFO]  sweeper: No resources to sweep: sweeper_region=us-east-2 tf_resource_type=aws_sesv2_tenant
2026/08/17 10:48:38 [DEBUG] Completed Sweeper (aws_sesv2_tenant) in region (us-east-2) in 581.468583ms
2026/08/17 10:48:38 Completed Sweepers for region (us-east-2) in 581.49125ms
2026/08/17 10:48:38 Sweeper Tests for region (us-east-2) ran successfully:
2026/08/17 10:48:38     - aws_sesv2_tenant
2026/08/17 10:48:38 [DEBUG] Running Sweepers for region (us-west-1):
2026/08/17 10:48:38 [DEBUG] Running Sweeper (aws_sesv2_tenant) in region (us-west-1)
2026/08/17 10:48:38 [DEBUG] sweeper: Configuring Terraform AWS Provider: sweeper_region=us-west-1 tf_resource_type=aws_sesv2_tenant
2026-08-17T10:48:38.363-0400 [DEBUG] sweeper.aws-base: Resolving credentials provider: sweeper_region=us-west-1 tf_resource_type=aws_sesv2_tenant
2026-08-17T10:48:38.363-0400 [DEBUG] sweeper.aws-base: Loading configuration: tf_resource_type=aws_sesv2_tenant sweeper_region=us-west-1
2026-08-17T10:48:38.363-0400 [DEBUG] sweeper.aws-base: Retrieving credentials: sweeper_region=us-west-1 tf_resource_type=aws_sesv2_tenant
2026-08-17T10:48:38.363-0400 [INFO]  sweeper.aws-base: Retrieved credentials: sweeper_region=us-west-1 tf_resource_type=aws_sesv2_tenant tf_aws.credentials_source=EnvConfigCredentials
2026-08-17T10:48:38.363-0400 [DEBUG] sweeper.aws-base: Loading configuration: tf_resource_type=aws_sesv2_tenant sweeper_region=us-west-1
2026/08/17 10:48:38 [DEBUG] sweeper: Retrieving AWS account details: sweeper_region=us-west-1 tf_resource_type=aws_sesv2_tenant
2026-08-17T10:48:38.363-0400 [DEBUG] sweeper.aws-base: Retrieving caller identity from STS: sweeper_region=us-west-1 tf_resource_type=aws_sesv2_tenant
2026-08-17T10:48:38.799-0400 [INFO]  sweeper.aws-base: Retrieved caller identity from STS: sweeper_region=us-west-1 tf_resource_type=aws_sesv2_tenant
2026/08/17 10:48:38 [INFO]  sweeper: listing resources: tf_resource_type=aws_sesv2_tenant sweeper_region=us-west-1
2026/08/17 10:48:39 [INFO]  sweeper: No resources to sweep: tf_resource_type=aws_sesv2_tenant sweeper_region=us-west-1
2026/08/17 10:48:39 [DEBUG] Completed Sweeper (aws_sesv2_tenant) in region (us-west-1) in 848.575125ms
2026/08/17 10:48:39 Completed Sweepers for region (us-west-1) in 848.59975ms
2026/08/17 10:48:39 Sweeper Tests for region (us-west-1) ran successfully:
2026/08/17 10:48:39     - aws_sesv2_tenant
ok      github.com/hashicorp/terraform-provider-aws/internal/sweep      9.032s
```
