### PR TITLE
cloudformation: Add retain except on create

### DIFF
--- a/.changelog/39580.txt
+++ b/.changelog/39580.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_cloudformation_stack: Add `retain_except_on_create` argument
+```

--- a/internal/service/cloudformation/stack.go
+++ b/internal/service/cloudformation/stack.go
@@ -114,6 +114,10 @@ func resourceStack() *schema.Resource {
 					Type:     schema.TypeString,
 					Optional: true,
 				},
+				"retain_except_on_create": {
+					Type:     schema.TypeBool,
+					Optional: true,
+				},
 				names.AttrTags:    tftags.TagsSchema(),
 				names.AttrTagsAll: tftags.TagsSchemaComputed(),
 				"template_body": {
@@ -183,6 +187,9 @@ func resourceStackCreate(ctx context.Context, d *schema.ResourceData, meta any) 
 	}
 	if v, ok := d.GetOk("policy_url"); ok {
 		input.StackPolicyURL = aws.String(v.(string))
+	}
+	if v, ok := d.GetOk("retain_except_on_create"); ok {
+		input.RetainExceptOnCreate = aws.Bool(v.(bool))
 	}
 	if v, ok := d.GetOk("template_body"); ok {
 		template, err := verify.NormalizeJSONOrYAMLString(v)
@@ -312,6 +319,9 @@ func resourceStackUpdate(ctx context.Context, d *schema.ResourceData, meta any) 
 	}
 	if d.HasChange("policy_url") {
 		input.StackPolicyURL = aws.String(d.Get("policy_url").(string))
+	}
+	if d.HasChange("retain_except_on_create") {
+		input.RetainExceptOnCreate = aws.Bool(d.Get("retain_except_on_create").(bool))
 	}
 	// Either TemplateBody, TemplateURL or UsePreviousTemplate are required
 	if v, ok := d.GetOk("template_url"); ok {

--- a/internal/service/cloudformation/stack_test.go
+++ b/internal/service/cloudformation/stack_test.go
@@ -9,7 +9,9 @@ import (
 	"testing"
 
 	"github.com/YakDriver/regexache"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -20,6 +22,23 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
+func TestResourceStack_retainExceptOnCreate(t *testing.T) {
+	t.Parallel()
+
+	s := tfcloudformation.ResourceStack().SchemaFunc()["retain_except_on_create"]
+	if s == nil {
+		t.Fatal("expected retain_except_on_create schema")
+	}
+	if got, want := s.Type, schema.TypeBool; got != want {
+		t.Errorf("Type = %v, want %v", got, want)
+	}
+	if !s.Optional {
+		t.Error("expected retain_except_on_create to be optional")
+	}
+	if s.ForceNew {
+		t.Error("expected retain_except_on_create to be updateable")
+	}
+}
 func TestAccCloudFormationStack_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var stack awstypes.Stack
@@ -65,6 +84,44 @@ func TestAccCloudFormationStack_basic(t *testing.T) {
 						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
 					},
 				},
+			},
+		},
+	})
+}
+
+func TestAccCloudFormationStack_retainExceptOnCreate(t *testing.T) {
+	ctx := acctest.Context(t)
+	var stack awstypes.Stack
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_cloudformation_stack.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CloudFormationServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckStackDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccStackConfig_retainExceptOnCreate(rName, true, "first"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckStackExists(ctx, t, resourceName, &stack),
+					resource.TestCheckResourceAttr(resourceName, "retain_except_on_create", acctest.CtTrue),
+					testAccCheckStackRetainExceptOnCreate(ctx, t, resourceName, false),
+				),
+			},
+			{
+				Config: testAccStackConfig_retainExceptOnCreate(rName, false, "second"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckStackExists(ctx, t, resourceName, &stack),
+					resource.TestCheckResourceAttr(resourceName, "retain_except_on_create", acctest.CtFalse),
+					testAccCheckStackRetainExceptOnCreate(ctx, t, resourceName, false),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"retain_except_on_create"},
 			},
 		},
 	})
@@ -265,6 +322,7 @@ func TestAccCloudFormationStack_allAttributes(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "parameters.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "parameters.VpcCIDR", "10.0.0.0/16"),
 					resource.TestCheckResourceAttr(resourceName, "policy_body", expectedPolicyBody),
+					resource.TestCheckResourceAttr(resourceName, "retain_except_on_create", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.First", "Mickey"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Second", "Mouse"),
@@ -275,7 +333,7 @@ func TestAccCloudFormationStack_allAttributes(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"on_failure", names.AttrParameters, "policy_body"},
+				ImportStateVerifyIgnore: []string{"on_failure", names.AttrParameters, "policy_body", "retain_except_on_create"},
 			},
 			{
 				Config: testAccStackConfig_allAttributesBodiesModified(rName),
@@ -289,6 +347,7 @@ func TestAccCloudFormationStack_allAttributes(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "parameters.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "parameters.VpcCIDR", "10.0.0.0/16"),
 					resource.TestCheckResourceAttr(resourceName, "policy_body", expectedPolicyBody),
+					resource.TestCheckResourceAttr(resourceName, "retain_except_on_create", acctest.CtFalse),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.First", "Mickey"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Second", "Mouse"),
@@ -604,6 +663,27 @@ func testAccCheckStackExists(ctx context.Context, t *testing.T, n string, v *aws
 	}
 }
 
+func testAccCheckStackRetainExceptOnCreate(ctx context.Context, t *testing.T, n string, expected bool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		conn := acctest.ProviderMeta(ctx, t).CloudFormationClient(ctx)
+		stack, err := tfcloudformation.FindStackByName(ctx, conn, rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		if got := aws.ToBool(stack.RetainExceptOnCreate); got != expected {
+			return fmt.Errorf("expected CloudFormation Stack (%s) retain except on create %t, got %t", rs.Primary.ID, expected, got)
+		}
+
+		return nil
+	}
+}
+
 func testAccCheckStackDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.ProviderMeta(ctx, t).CloudFormationClient(ctx)
@@ -662,6 +742,30 @@ resource "aws_cloudformation_stack" "test" {
 STACK
 }
 `, rName)
+}
+
+func testAccStackConfig_retainExceptOnCreate(rName string, retainExceptOnCreate bool, description string) string {
+	return fmt.Sprintf(`
+resource "aws_cloudformation_stack" "test" {
+  name                    = %[1]q
+  retain_except_on_create = %[2]t
+
+  template_body = <<STACK
+{
+  "Resources": {
+    "Handle": {
+      "Type": "AWS::CloudFormation::WaitConditionHandle"
+    }
+  },
+  "Outputs": {
+    "Marker": {
+      "Value": %[3]q
+    }
+  }
+}
+STACK
+}
+`, rName, retainExceptOnCreate, description)
 }
 
 func testAccStackConfig_creationFailure(rName, onFailure string) string {
@@ -849,13 +953,14 @@ STACK
     VpcCIDR = "10.0.0.0/16"
   }
 
-  policy_body        = <<POLICY
+  policy_body             = <<POLICY
 %[2]s
 POLICY
-  capabilities       = ["CAPABILITY_IAM"]
-  notification_arns  = [aws_sns_topic.test.arn]
-  on_failure         = "DELETE"
-  timeout_in_minutes = 10
+  capabilities            = ["CAPABILITY_IAM"]
+  notification_arns       = [aws_sns_topic.test.arn]
+  retain_except_on_create = %[3]t
+  on_failure              = "DELETE"
+  timeout_in_minutes      = 10
   tags = {
     First  = "Mickey"
     Second = "Mouse"
@@ -890,14 +995,16 @@ func testAccStackConfig_allAttributesBodies(rName string) string {
 	return fmt.Sprintf(
 		testAccStackConfig_allAttributesWithBodies_tpl,
 		rName,
-		policyBody)
+		policyBody,
+		true)
 }
 
 func testAccStackConfig_allAttributesBodiesModified(rName string) string {
 	return fmt.Sprintf(
 		testAccStackConfig_allAttributesWithBodies_tpl,
 		rName,
-		policyBody)
+		policyBody,
+		false)
 }
 
 func testAccStackConfig_params(rName, cidr string) string {

--- a/website/docs/r/cloudformation_stack.html.markdown
+++ b/website/docs/r/cloudformation_stack.html.markdown
@@ -69,6 +69,7 @@ This resource supports the following arguments:
   Conflicts w/ `policy_url`.
 * `policy_url` - (Optional) Location of a file containing the stack policy.
   Conflicts w/ `policy_body`.
+* `retain_except_on_create` - (Optional) Whether to delete newly created resources when a stack operation rolls back, including resources marked with a `Retain` deletion policy. Defaults to `false`.
 * `tags` - (Optional) Map of resource tags to associate with this stack. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `iam_role_arn` - (Optional) The ARN of an IAM role that AWS CloudFormation assumes to create the stack. If you don't specify a value, AWS CloudFormation uses the role that was previously associated with the stack. If no role is available, AWS CloudFormation uses a temporary session that is generated from your user credentials.
 * `timeout_in_minutes` - (Optional) The amount of time that can pass before the stack status becomes `CREATE_FAILED`.


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Adds the optional retain_except_on_create argument to the aws_cloudformation_stack resource.

When enabled, CloudFormation deletes newly created resources if a stack operation rolls back, including resources marked with a Retain deletion policy. The argument is passed to both CreateStack and UpdateStack.

RetainExceptOnCreate is treated as a write-only operation argument - a stack created with RetainExceptOnCreate=true was subsequently described with the value set to false.

AI assistance (Codex) was used to develop code and tests.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #39580

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
[AWS CLI ](https://docs.aws.amazon.com/cli/latest/reference/cloudformation/create-stack.html)[create-stack](https://docs.aws.amazon.com/cli/latest/reference/cloudformation/create-stack.html)[ — ](https://docs.aws.amazon.com/cli/latest/reference/cloudformation/create-stack.html)[--retain-except-on-create](https://docs.aws.amazon.com/cli/latest/reference/cloudformation/create-stack.html)

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% AWS_REGION=eu-north-1 make t GO_VER=go T='^TestAccCloudFormationStack_retainExceptOnCreate$'

=== RUN   TestAccCloudFormationStack_retainExceptOnCreate
=== PAUSE TestAccCloudFormationStack_retainExceptOnCreate
=== CONT  TestAccCloudFormationStack_retainExceptOnCreate
--- PASS: TestAccCloudFormationStack_retainExceptOnCreate (59.35s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudformation	64.200s
...
```
