### PR TITLE
List/aws_s3_bucket: Paginate lister

### DIFF
--- a/internal/service/s3/bucket_list.go
+++ b/internal/service/s3/bucket_list.go
@@ -108,15 +108,18 @@ type listBucketModel struct {
 
 func listBuckets(ctx context.Context, conn *s3.Client, input *s3.ListBucketsInput) iter.Seq2[awstypes.Bucket, error] {
 	return func(yield func(awstypes.Bucket, error) bool) {
-		output, err := conn.ListBuckets(ctx, input)
-		if err != nil {
-			yield(awstypes.Bucket{}, fmt.Errorf("listing S3 Bucket resources: %w", err))
-			return
-		}
-
-		for _, item := range output.Buckets {
-			if !yield(item, nil) {
+		pages := s3.NewListBucketsPaginator(conn, input)
+		for pages.HasMorePages() {
+			page, err := pages.NextPage(ctx)
+			if err != nil {
+				yield(awstypes.Bucket{}, fmt.Errorf("listing S3 Bucket resources: %w", err))
 				return
+			}
+
+			for _, item := range page.Buckets {
+				if !yield(item, nil) {
+					return
+				}
 			}
 		}
 	}


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Paginates `aws_s3_bucket` List Resource listing

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=s3 TESTS=TestAccS3Bucket_List_

--- PASS: TestAccS3Bucket_List_regionOverride (23.39s)
--- PASS: TestAccS3Bucket_List_includeResource (24.73s)
--- PASS: TestAccS3Bucket_List_basic (24.78s)
```
