### PR TITLE
[Enhancement] aws_vpclattice_service: Add `idle_timeout_seconds` argument

### DIFF
--- a/.changelog/49540.txt
+++ b/.changelog/49540.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_vpclattice_service: Add `idle_timeout_seconds` argument
+```
+
+```release-note:enhancement
+data-source/aws_vpclattice_service: Add `idle_timeout_seconds` attribute
+```

--- a/internal/service/vpclattice/service.go
+++ b/internal/service/vpclattice/service.go
@@ -88,6 +88,12 @@ func resourceService() *schema.Resource {
 						},
 					},
 				},
+				"idle_timeout_seconds": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					Computed:     true,
+					ValidateFunc: validation.IntBetween(60, 600),
+				},
 				names.AttrName: {
 					Type:         schema.TypeString,
 					Required:     true,
@@ -129,6 +135,10 @@ func resourceServiceCreate(ctx context.Context, d *schema.ResourceData, meta any
 
 	if v, ok := d.GetOk("custom_domain_name"); ok {
 		in.CustomDomainName = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("idle_timeout_seconds"); ok {
+		in.IdleTimeoutSeconds = aws.Int32(int32(v.(int)))
 	}
 
 	out, err := conn.CreateService(ctx, in)
@@ -173,6 +183,7 @@ func resourceServiceRead(ctx context.Context, d *schema.ResourceData, meta any) 
 	} else {
 		d.Set("dns_entry", nil)
 	}
+	d.Set("idle_timeout_seconds", out.IdleTimeoutSeconds)
 	d.Set(names.AttrName, out.Name)
 	d.Set(names.AttrStatus, out.Status)
 
@@ -194,6 +205,10 @@ func resourceServiceUpdate(ctx context.Context, d *schema.ResourceData, meta any
 
 		if d.HasChanges(names.AttrCertificateARN) {
 			in.CertificateArn = aws.String(d.Get(names.AttrCertificateARN).(string))
+		}
+
+		if d.HasChanges("idle_timeout_seconds") {
+			in.IdleTimeoutSeconds = aws.Int32(int32(d.Get("idle_timeout_seconds").(int)))
 		}
 
 		_, err := conn.UpdateService(ctx, in)

--- a/internal/service/vpclattice/service_data_source.go
+++ b/internal/service/vpclattice/service_data_source.go
@@ -63,6 +63,10 @@ func dataSourceService() *schema.Resource {
 						},
 					},
 				},
+				"idle_timeout_seconds": {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
 				names.AttrName: {
 					Type:         schema.TypeString,
 					Optional:     true,
@@ -131,6 +135,7 @@ func dataSourceServiceRead(ctx context.Context, d *schema.ResourceData, meta any
 	} else {
 		d.Set("dns_entry", nil)
 	}
+	d.Set("idle_timeout_seconds", out.IdleTimeoutSeconds)
 	d.Set(names.AttrName, out.Name)
 	d.Set("service_identifier", out.Id)
 	d.Set(names.AttrStatus, out.Status)

--- a/internal/service/vpclattice/service_data_source_test.go
+++ b/internal/service/vpclattice/service_data_source_test.go
@@ -35,6 +35,7 @@ func TestAccVPCLatticeServiceDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrCertificateARN, dataSourceName, names.AttrCertificateARN),
 					resource.TestCheckResourceAttrPair(resourceName, "custom_domain_name", dataSourceName, "custom_domain_name"),
 					resource.TestCheckResourceAttrPair(resourceName, "dns_entry.#", dataSourceName, "dns_entry.#"),
+					resource.TestCheckResourceAttrPair(resourceName, "idle_timeout_seconds", dataSourceName, "idle_timeout_seconds"),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrName, dataSourceName, names.AttrName),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrStatus, dataSourceName, names.AttrStatus),
 					resource.TestCheckResourceAttrPair(resourceName, acctest.CtTagsPercent, dataSourceName, acctest.CtTagsPercent),

--- a/internal/service/vpclattice/service_test.go
+++ b/internal/service/vpclattice/service_test.go
@@ -116,12 +116,52 @@ func TestAccVPCLatticeService_full(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, "auth_type", "AWS_IAM"),
 					resource.TestCheckResourceAttr(resourceName, "custom_domain_name", "example.com"),
+					resource.TestCheckResourceAttr(resourceName, "idle_timeout_seconds", "120"),
 					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "vpc-lattice", regexache.MustCompile("service/.+$")),
 				),
 			},
 			{
 				ResourceName: resourceName,
 				ImportState:  true,
+			},
+		},
+	})
+}
+
+func TestAccVPCLatticeService_idleTimeoutSeconds(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var service vpclattice.GetServiceOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_vpclattice_service.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.VPCLatticeEndpointID)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.VPCLatticeServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckServiceDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceConfig_idleTimeoutSeconds(rName, 120),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceExists(ctx, t, resourceName, &service),
+					resource.TestCheckResourceAttr(resourceName, "idle_timeout_seconds", "120"),
+				),
+			},
+			{
+				ResourceName: resourceName,
+				ImportState:  true,
+			},
+			{
+				Config: testAccServiceConfig_idleTimeoutSeconds(rName, 300),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceExists(ctx, t, resourceName, &service),
+					resource.TestCheckResourceAttr(resourceName, "idle_timeout_seconds", "300"),
+				),
 			},
 		},
 	})
@@ -259,11 +299,22 @@ resource "aws_vpclattice_service" "test" {
 func testAccServiceConfig_full(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpclattice_service" "test" {
-  name               = %[1]q
-  auth_type          = "AWS_IAM"
-  custom_domain_name = "example.com"
+  name                 = "%[1]s"
+  auth_type            = "AWS_IAM"
+  custom_domain_name   = "example.com"
+  idle_timeout_seconds = 120
 }
 `, rName)
+}
+
+func testAccServiceConfig_idleTimeoutSeconds(rName string, idleTimeoutSeconds int) string {
+	return fmt.Sprintf(`
+resource "aws_vpclattice_service" "test" {
+  name = "%[1]s"
+
+  idle_timeout_seconds = %[2]d
+}
+`, rName, idleTimeoutSeconds)
 }
 
 func testAccServiceConfig_tags1(rName, tagKey1, tagValue1 string) string {

--- a/website/docs/d/vpclattice_service.html.markdown
+++ b/website/docs/d/vpclattice_service.html.markdown
@@ -40,5 +40,6 @@ This data source exports the following attributes in addition to the arguments a
     * `domain_name` - DNS name for the service.
     * `hosted_zone_id` - Hosted zone ID where the DNS name is registered.
 * `id` - Unique identifier for the service.
+* `idle_timeout_seconds` - Amount of time, in seconds, that a connection can remain idle (no data sent) before VPC Lattice closes it.
 * `status` - Status of the service.
 * `tags` - List of tags associated with the service.

--- a/website/docs/r/vpclattice_service.html.markdown
+++ b/website/docs/r/vpclattice_service.html.markdown
@@ -33,6 +33,7 @@ The following arguments are optional:
 * `auth_type` - (Optional) Type of IAM policy. Either `NONE` or `AWS_IAM`.
 * `certificate_arn` - (Optional) Amazon Resource Name (ARN) of the certificate.
 * `custom_domain_name` - (Optional) Custom domain name of the service.
+* `idle_timeout_seconds` - (Optional) Amount of time, in seconds, that a connection can remain idle (no data sent) before VPC Lattice closes it. The valid range is 60 to 600 seconds. Default is 60 seconds.
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `tags` - (Optional) Key-value mapping of resource tags. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
This PR implements `idle_timeout_seconds` argument to `aws_vpclattice_service` resource and data source.

* Since the API API returns the default value (60) even when it is not specified, `idle_timeout_seconds` is marked as `Computed`.

### Relations
Closes #49277

### References
https://docs.aws.amazon.com/vpc-lattice/latest/APIReference/API_CreateService.html#vpclattice-CreateService-request-idleTimeoutSeconds
https://docs.aws.amazon.com/vpc-lattice/latest/APIReference/API_UpdateService.html


### Output from Acceptance Testing
```console
$ make testacc TESTS='TestAccVPCLatticeService(|DataSource)_' PKG=vpclattice
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework (cached)
make: Running acceptance tests on branch: 🌿 f-aws_vpclattice_service-add_idle_timeout_seconds 🌿...
TF_ACC=1 go1.26.6 test ./internal/service/vpclattice/... -v -count 1 -parallel 20 -run='TestAccVPCLatticeService(|DataSource)_'  -timeout 360m -vet=off -buildvcs=false
2026/08/18 08:29:35 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/18 08:29:35 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccVPCLatticeServiceDataSource_basic
=== PAUSE TestAccVPCLatticeServiceDataSource_basic
=== RUN   TestAccVPCLatticeServiceDataSource_byName
=== PAUSE TestAccVPCLatticeServiceDataSource_byName
=== RUN   TestAccVPCLatticeServiceDataSource_shared
=== PAUSE TestAccVPCLatticeServiceDataSource_shared
=== RUN   TestAccVPCLatticeService_basic
=== PAUSE TestAccVPCLatticeService_basic
=== RUN   TestAccVPCLatticeService_disappears
=== PAUSE TestAccVPCLatticeService_disappears
=== RUN   TestAccVPCLatticeService_full
=== PAUSE TestAccVPCLatticeService_full
=== RUN   TestAccVPCLatticeService_idleTimeoutSeconds
=== PAUSE TestAccVPCLatticeService_idleTimeoutSeconds
=== RUN   TestAccVPCLatticeService_tags
=== PAUSE TestAccVPCLatticeService_tags
=== CONT  TestAccVPCLatticeServiceDataSource_basic
=== CONT  TestAccVPCLatticeService_disappears
=== CONT  TestAccVPCLatticeService_idleTimeoutSeconds
=== CONT  TestAccVPCLatticeService_tags
=== CONT  TestAccVPCLatticeServiceDataSource_shared
=== CONT  TestAccVPCLatticeService_basic
=== CONT  TestAccVPCLatticeServiceDataSource_byName
=== CONT  TestAccVPCLatticeService_full
=== NAME  TestAccVPCLatticeServiceDataSource_shared
    service_data_source_test.go:90: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
--- SKIP: TestAccVPCLatticeServiceDataSource_shared (2.07s)
--- PASS: TestAccVPCLatticeServiceDataSource_basic (34.75s)
--- PASS: TestAccVPCLatticeServiceDataSource_byName (34.76s)
--- PASS: TestAccVPCLatticeService_basic (40.57s)
--- PASS: TestAccVPCLatticeService_full (52.19s)
--- PASS: TestAccVPCLatticeService_idleTimeoutSeconds (53.28s)
--- PASS: TestAccVPCLatticeService_tags (65.50s)
--- PASS: TestAccVPCLatticeService_disappears (80.70s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/vpclattice 86.575s

```
