### PR TITLE
feat: add aws_appstream_usage_report_subscription resource

### DIFF
--- a/.changelog/49545.txt
+++ b/.changelog/49545.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_appstream_usage_report_subscription
+```

--- a/internal/service/appstream/exports_test.go
+++ b/internal/service/appstream/exports_test.go
@@ -11,7 +11,8 @@ var (
 	ResourceImageBuilder          = resourceImageBuilder
 	ResourceStack                 = resourceStack
 	ResourceUser                  = resourceUser
-	ResourceUserStackAssociation  = resourceUserStackAssociation
+	ResourceUsageReportSubscription = resourceUsageReportSubscription
+	ResourceUserStackAssociation    = resourceUserStackAssociation
 
 	FindDirectoryConfigByID                = findDirectoryConfigByID
 	FindFleetByID                          = findFleetByID
@@ -19,5 +20,6 @@ var (
 	FindImageBuilderByID                   = findImageBuilderByID
 	FindStackByID                          = findStackByID
 	FindUserByTwoPartKey                   = findUserByTwoPartKey
+	FindUsageReportSubscription            = findUsageReportSubscription
 	FindUserStackAssociationByThreePartKey = findUserStackAssociationByThreePartKey
 )

--- a/internal/service/appstream/service_package_gen.go
+++ b/internal/service/appstream/service_package_gen.go
@@ -81,6 +81,12 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*inttypes.ServicePa
 			Region: inttypes.ResourceRegionDefault(),
 		},
 		{
+			Factory:  resourceUsageReportSubscription,
+			TypeName: "aws_appstream_usage_report_subscription",
+			Name:     "Usage Report Subscription",
+			Region:   inttypes.ResourceRegionDefault(),
+		},
+		{
 			Factory:  resourceUser,
 			TypeName: "aws_appstream_user",
 			Name:     "User",

--- a/internal/service/appstream/usage_report_subscription.go
+++ b/internal/service/appstream/usage_report_subscription.go
@@ -1,0 +1,117 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package appstream
+
+import (
+	"context"
+	"log"
+
+	"github.com/aws/aws-sdk-go-v2/service/appstream"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/appstream/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+)
+
+// @SDKResource("aws_appstream_usage_report_subscription", name="Usage Report Subscription")
+func resourceUsageReportSubscription() *schema.Resource {
+	return &schema.Resource{
+		CreateWithoutTimeout: resourceUsageReportSubscriptionCreate,
+		ReadWithoutTimeout:   resourceUsageReportSubscriptionRead,
+		DeleteWithoutTimeout: resourceUsageReportSubscriptionDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"s3_bucket_name": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"schedule": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			}
+		},
+	}
+}
+
+func resourceUsageReportSubscriptionCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).AppStreamClient(ctx)
+
+	output, err := conn.CreateUsageReportSubscription(ctx, &appstream.CreateUsageReportSubscriptionInput{})
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "creating AppStream Usage Report Subscription: %s", err)
+	}
+
+	d.SetId(meta.(*conns.AWSClient).AccountID(ctx))
+	d.Set("s3_bucket_name", output.S3BucketName)
+	d.Set("schedule", output.Schedule)
+
+	return append(diags, resourceUsageReportSubscriptionRead(ctx, d, meta)...)
+}
+
+func resourceUsageReportSubscriptionRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).AppStreamClient(ctx)
+
+	subscription, err := findUsageReportSubscription(ctx, conn)
+
+	if !d.IsNewResource() && retry.NotFound(err) {
+		log.Printf("[WARN] AppStream Usage Report Subscription (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return diags
+	}
+
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "reading AppStream Usage Report Subscription (%s): %s", d.Id(), err)
+	}
+
+	d.Set("s3_bucket_name", subscription.S3BucketName)
+	d.Set("schedule", subscription.Schedule)
+
+	return diags
+}
+
+func resourceUsageReportSubscriptionDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).AppStreamClient(ctx)
+
+	log.Printf("[DEBUG] Deleting AppStream Usage Report Subscription: %s", d.Id())
+	_, err := conn.DeleteUsageReportSubscription(ctx, &appstream.DeleteUsageReportSubscriptionInput{})
+
+	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+		return diags
+	}
+
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "deleting AppStream Usage Report Subscription (%s): %s", d.Id(), err)
+	}
+
+	return diags
+}
+
+func findUsageReportSubscription(ctx context.Context, conn *appstream.Client) (*awstypes.UsageReportSubscription, error) {
+	output, err := conn.DescribeUsageReportSubscriptions(ctx, &appstream.DescribeUsageReportSubscriptionsInput{})
+
+	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+		return nil, &retry.NotFoundError{
+			LastError: err,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return tfresource.AssertSingleValueResult(output.UsageReportSubscriptions)
+}

--- a/internal/service/appstream/usage_report_subscription_test.go
+++ b/internal/service/appstream/usage_report_subscription_test.go
@@ -1,0 +1,119 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package appstream_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
+	tfappstream "github.com/hashicorp/terraform-provider-aws/internal/service/appstream"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccAppStreamUsageReportSubscription_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_appstream_usage_report_subscription.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckHasIAMRole(ctx, t, "AmazonAppStreamServiceAccess")
+		},
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckUsageReportSubscriptionDestroy(ctx, t),
+		ErrorCheck:               acctest.ErrorCheck(t, names.AppStreamServiceID),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUsageReportSubscriptionConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUsageReportSubscriptionExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "s3_bucket_name"),
+					resource.TestCheckResourceAttr(resourceName, "schedule", "DAILY"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAppStreamUsageReportSubscription_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_appstream_usage_report_subscription.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckHasIAMRole(ctx, t, "AmazonAppStreamServiceAccess")
+		},
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckUsageReportSubscriptionDestroy(ctx, t),
+		ErrorCheck:               acctest.ErrorCheck(t, names.AppStreamServiceID),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUsageReportSubscriptionConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUsageReportSubscriptionExists(ctx, t, resourceName),
+					acctest.CheckSDKResourceDisappears(ctx, t, tfappstream.ResourceUsageReportSubscription(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckUsageReportSubscriptionExists(ctx context.Context, t *testing.T, n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("not found: %s", n)
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).AppStreamClient(ctx)
+		_, err := tfappstream.FindUsageReportSubscription(ctx, conn)
+
+		return err
+	}
+}
+
+func testAccCheckUsageReportSubscriptionDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).AppStreamClient(ctx)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_appstream_usage_report_subscription" {
+				continue
+			}
+
+			_, err := tfappstream.FindUsageReportSubscription(ctx, conn)
+
+			if retry.NotFound(err) {
+				continue
+			}
+
+			if err != nil {
+				return err
+			}
+
+			return fmt.Errorf("AppStream Usage Report Subscription %s still exists", rs.Primary.ID)
+		}
+
+		return nil
+	}
+}
+
+func testAccUsageReportSubscriptionConfig_basic() string {
+	return `
+resource "aws_appstream_usage_report_subscription" "test" {}
+`
+}

--- a/website/docs/r/appstream_usage_report_subscription.html.markdown
+++ b/website/docs/r/appstream_usage_report_subscription.html.markdown
@@ -1,0 +1,45 @@
+---
+subcategory: "AppStream 2.0"
+layout: "aws"
+page_title: "AWS: aws_appstream_usage_report_subscription"
+description: |-
+  Manages an AppStream 2.0 Usage Report Subscription.
+---
+
+# Resource: aws_appstream_usage_report_subscription
+
+Manages an AppStream 2.0 Usage Report Subscription. Enabling this generates daily usage reports and stores them in an Amazon S3 bucket in your account.
+
+## Example Usage
+
+```terraform
+resource "aws_appstream_usage_report_subscription" "example" {}
+```
+
+## Argument Reference
+
+This resource does not accept any arguments.
+
+## Attribute Reference
+
+This resource exports the following attributes in addition to the arguments above:
+
+* `s3_bucket_name` - The Amazon S3 bucket where generated usage reports are stored.
+* `schedule` - The schedule for generating usage reports (`DAILY`).
+
+## Import
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import AppStream Usage Report Subscriptions using the account ID. For example:
+
+```terraform
+import {
+  to = aws_appstream_usage_report_subscription.example
+  id = "123456789012"
+}
+```
+
+Using `terraform import`, import AppStream Usage Report Subscriptions using the account ID. For example:
+
+```console
+% terraform import aws_appstream_usage_report_subscription.example 123456789012
+```


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

### Description

Adds a new resource `aws_appstream_usage_report_subscription` that manages Amazon AppStream 2.0 Usage Report Subscriptions. This is a singleton resource (one per AWS account/region) that enables daily usage reports delivered to an S3 bucket managed by AWS.

Implements: Create, Read, Delete.

### Relations

Closes #49542
Relates #25363

### References

- AWS API: https://docs.aws.amazon.com/appstream2/latest/APIReference/API_CreateUsageReportSubscription.html
- AWS SDK v2: https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/appstream

### Output from Acceptance Testing

```console
% make testacc TESTS=TestAccAppStreamUsageReportSubscription PKG=appstream

...
```