### PR TITLE
r/aws_iot_topic_rule: Add headers argument to republish action

### DIFF
--- a/.changelog/49546.txt
+++ b/.changelog/49546.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_iot_topic_rule: Add `headers` argument to `republish` action
+```

--- a/internal/service/iot/topic_rule.go
+++ b/internal/service/iot/topic_rule.go
@@ -705,6 +705,51 @@ func resourceTopicRule() *schema.Resource {
 								MaxItems: 1,
 								Elem: &schema.Resource{
 									Schema: map[string]*schema.Schema{
+										"headers": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													names.AttrContentType: {
+														Type:     schema.TypeString,
+														Optional: true,
+													},
+													"correlation_data": {
+														Type:     schema.TypeString,
+														Optional: true,
+													},
+													"message_expiry": {
+														Type:     schema.TypeString,
+														Optional: true,
+													},
+													"payload_format_indicator": {
+														Type:     schema.TypeString,
+														Optional: true,
+													},
+													"response_topic": {
+														Type:     schema.TypeString,
+														Optional: true,
+													},
+													"user_properties": {
+														Type:     schema.TypeList,
+														Optional: true,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																names.AttrKey: {
+																	Type:     schema.TypeString,
+																	Required: true,
+																},
+																names.AttrValue: {
+																	Type:     schema.TypeString,
+																	Required: true,
+																},
+															},
+														},
+													},
+												},
+											},
+										},
 										"qos": {
 											Type:         schema.TypeInt,
 											Optional:     true,
@@ -1077,6 +1122,51 @@ func resourceTopicRule() *schema.Resource {
 					Optional: true,
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{
+							"headers": {
+								Type:     schema.TypeList,
+								Optional: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										names.AttrContentType: {
+											Type:     schema.TypeString,
+											Optional: true,
+										},
+										"correlation_data": {
+											Type:     schema.TypeString,
+											Optional: true,
+										},
+										"message_expiry": {
+											Type:     schema.TypeString,
+											Optional: true,
+										},
+										"payload_format_indicator": {
+											Type:     schema.TypeString,
+											Optional: true,
+										},
+										"response_topic": {
+											Type:     schema.TypeString,
+											Optional: true,
+										},
+										"user_properties": {
+											Type:     schema.TypeList,
+											Optional: true,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													names.AttrKey: {
+														Type:     schema.TypeString,
+														Required: true,
+													},
+													names.AttrValue: {
+														Type:     schema.TypeString,
+														Required: true,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
 							"qos": {
 								Type:         schema.TypeInt,
 								Optional:     true,
@@ -1890,6 +1980,10 @@ func expandRepublishAction(tfList []any) *awstypes.RepublishAction {
 	apiObject := &awstypes.RepublishAction{}
 	tfMap := tfList[0].(map[string]any)
 
+	if v, ok := tfMap["headers"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.Headers = expandMqttHeaders(v[0].(map[string]any))
+	}
+
 	if v, ok := tfMap["qos"].(int); ok {
 		apiObject.Qos = aws.Int32(int32(v))
 	}
@@ -1900,6 +1994,50 @@ func expandRepublishAction(tfList []any) *awstypes.RepublishAction {
 
 	if v, ok := tfMap["topic"].(string); ok && v != "" {
 		apiObject.Topic = aws.String(v)
+	}
+
+	return apiObject
+}
+
+func expandMqttHeaders(tfMap map[string]any) *awstypes.MqttHeaders {
+	apiObject := &awstypes.MqttHeaders{}
+
+	if v, ok := tfMap[names.AttrContentType].(string); ok && v != "" {
+		apiObject.ContentType = aws.String(v)
+	}
+
+	if v, ok := tfMap["correlation_data"].(string); ok && v != "" {
+		apiObject.CorrelationData = aws.String(v)
+	}
+
+	if v, ok := tfMap["message_expiry"].(string); ok && v != "" {
+		apiObject.MessageExpiry = aws.String(v)
+	}
+
+	if v, ok := tfMap["payload_format_indicator"].(string); ok && v != "" {
+		apiObject.PayloadFormatIndicator = aws.String(v)
+	}
+
+	if v, ok := tfMap["response_topic"].(string); ok && v != "" {
+		apiObject.ResponseTopic = aws.String(v)
+	}
+
+	if v, ok := tfMap["user_properties"].([]any); ok && len(v) > 0 {
+		userProperties := make([]awstypes.UserProperty, 0, len(v))
+
+		for _, tfMapRaw := range v {
+			tfMap, ok := tfMapRaw.(map[string]any)
+			if !ok {
+				continue
+			}
+
+			userProperties = append(userProperties, awstypes.UserProperty{
+				Key:   aws.String(tfMap[names.AttrKey].(string)),
+				Value: aws.String(tfMap[names.AttrValue].(string)),
+			})
+		}
+
+		apiObject.UserProperties = userProperties
 	}
 
 	return apiObject
@@ -3075,6 +3213,10 @@ func flattenRepublishAction(apiObject *awstypes.RepublishAction) []any {
 
 	tfMap := make(map[string]any)
 
+	if v := apiObject.Headers; v != nil {
+		tfMap["headers"] = flattenMqttHeaders(v)
+	}
+
 	if v := apiObject.Qos; v != nil {
 		tfMap["qos"] = aws.ToInt32(v)
 	}
@@ -3085,6 +3227,45 @@ func flattenRepublishAction(apiObject *awstypes.RepublishAction) []any {
 
 	if v := apiObject.Topic; v != nil {
 		tfMap["topic"] = aws.ToString(v)
+	}
+
+	return []any{tfMap}
+}
+
+func flattenMqttHeaders(apiObject *awstypes.MqttHeaders) []any {
+	tfMap := make(map[string]any)
+
+	if v := apiObject.ContentType; v != nil {
+		tfMap[names.AttrContentType] = aws.ToString(v)
+	}
+
+	if v := apiObject.CorrelationData; v != nil {
+		tfMap["correlation_data"] = aws.ToString(v)
+	}
+
+	if v := apiObject.MessageExpiry; v != nil {
+		tfMap["message_expiry"] = aws.ToString(v)
+	}
+
+	if v := apiObject.PayloadFormatIndicator; v != nil {
+		tfMap["payload_format_indicator"] = aws.ToString(v)
+	}
+
+	if v := apiObject.ResponseTopic; v != nil {
+		tfMap["response_topic"] = aws.ToString(v)
+	}
+
+	if v := apiObject.UserProperties; len(v) > 0 {
+		userProperties := make([]any, 0, len(v))
+
+		for _, userProperty := range v {
+			userProperties = append(userProperties, map[string]any{
+				names.AttrKey:   aws.ToString(userProperty.Key),
+				names.AttrValue: aws.ToString(userProperty.Value),
+			})
+		}
+
+		tfMap["user_properties"] = userProperties
 	}
 
 	return []any{tfMap}

--- a/internal/service/iot/topic_rule_test.go
+++ b/internal/service/iot/topic_rule_test.go
@@ -1833,6 +1833,59 @@ func TestAccIoTTopicRule_republishWithQos(t *testing.T) {
 	})
 }
 
+func TestAccIoTTopicRule_republishWithHeaders(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := testAccTopicRuleName(t)
+	resourceName := "aws_iot_topic_rule.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.IoTServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTopicRuleDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTopicRuleConfig_republishHeaders(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTopicRuleExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "republish.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "republish.*", map[string]string{
+						"qos":                                "1",
+						"topic":                              "mytopic",
+						"headers.#":                          "1",
+						"headers.0.content_type":             "application/json",
+						"headers.0.correlation_data":         "cmVxdWVzdC0xMjM=",
+						"headers.0.message_expiry":           "300",
+						"headers.0.payload_format_indicator": "UTF8_DATA",
+						"headers.0.response_topic":           "response/topic",
+						"headers.0.user_properties.#":        "2",
+						"headers.0.user_properties.0.key":    "origin",
+						"headers.0.user_properties.0.value":  "thing-42",
+						"headers.0.user_properties.1.key":    "deployment",
+						"headers.0.user_properties.1.value":  "staging",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccTopicRuleConfig_republish(rName, "mytopic"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTopicRuleExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "republish.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "republish.*", map[string]string{
+						"topic":     "mytopic",
+						"headers.#": "0",
+					}),
+				),
+			},
+		},
+	})
+}
+
 func TestAccIoTTopicRule_s3(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := testAccTopicRuleName(t)
@@ -3056,6 +3109,43 @@ resource "aws_iot_topic_rule" "test" {
   }
 }
 `, rName, topic))
+}
+
+func testAccTopicRuleConfig_republishHeaders(rName string) string {
+	return acctest.ConfigCompose(
+		testAccTopicRuleConfig_destinationRole(rName),
+		fmt.Sprintf(`
+resource "aws_iot_topic_rule" "test" {
+  name        = %[1]q
+  enabled     = true
+  sql         = "SELECT * FROM 'topic/test'"
+  sql_version = "2015-10-08"
+
+  republish {
+    role_arn = aws_iam_role.test.arn
+    topic    = "mytopic"
+    qos      = 1
+
+    headers {
+      content_type             = "application/json"
+      correlation_data         = "cmVxdWVzdC0xMjM="
+      message_expiry           = "300"
+      payload_format_indicator = "UTF8_DATA"
+      response_topic           = "response/topic"
+
+      user_properties {
+        key   = "origin"
+        value = "thing-42"
+      }
+
+      user_properties {
+        key   = "deployment"
+        value = "staging"
+      }
+    }
+  }
+}
+`, rName))
 }
 
 func testAccTopicRuleConfig_republishQoS(rName string) string {

--- a/website/docs/r/iot_topic_rule.html.markdown
+++ b/website/docs/r/iot_topic_rule.html.markdown
@@ -195,6 +195,18 @@ The `republish` object takes the following arguments:
 * `role_arn` - (Required) The ARN of the IAM role that grants access.
 * `topic` - (Required) The name of the MQTT topic the message should be republished to.
 * `qos` - (Optional) The Quality of Service (QoS) level to use when republishing messages. Valid values are 0 or 1. The default value is 0.
+* `headers` - (Optional) Configuration block with MQTT Version 5.0 headers information. See below.
+
+The `headers` object takes the following arguments. All arguments support [substitution templates](https://docs.aws.amazon.com/iot/latest/developerguide/iot-substitution-templates.html).
+
+* `content_type` - (Optional) A UTF-8 encoded string that describes the content of the publishing message.
+* `correlation_data` - (Optional) The base64-encoded binary data used by the sender of the request message to identify which request the response message is for when it's received.
+* `message_expiry` - (Optional) The number of seconds before the message expires at the message broker.
+* `payload_format_indicator` - (Optional) Whether the payload is formatted as UTF-8. Valid values are `UNSPECIFIED_BYTES` and `UTF8_DATA`.
+* `response_topic` - (Optional) The topic name of the response message.
+* `user_properties` - (Optional) List of key-value pairs that you define in the MQTT5 header. Each block supports the following:
+    * `key` - (Required) The property key.
+    * `value` - (Required) The property value.
 
 The `s3` object takes the following arguments:
 


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

### Description

AWS IoT rule republish actions support MQTT Version 5.0 headers (content type, correlation data, message expiry, payload format indicator, response topic, and user properties), but `aws_iot_topic_rule` had no way to configure them — the `republish` block only exposed `qos`, `role_arn`, and `topic`. Add an optional `headers` block to the `republish` action (both top-level and in `error_action`), mirroring the AWS API's `MqttHeaders` shape.

### Relations

Closes #43556

### References

- https://docs.aws.amazon.com/iot/latest/developerguide/republish-rule-action.html
- https://docs.aws.amazon.com/iot/latest/apireference/API_MqttHeaders.html

### Output from Acceptance Testing

```console
% TF_ACC=1 go test ./internal/service/iot/ -v -run 'TestAccIoTTopicRule_republishWithHeaders' -timeout 30m

=== RUN   TestAccIoTTopicRule_republishWithHeaders
=== PAUSE TestAccIoTTopicRule_republishWithHeaders
=== CONT  TestAccIoTTopicRule_republishWithHeaders
--- PASS: TestAccIoTTopicRule_republishWithHeaders (51.11s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/iot    56.342s
```
