### PR TITLE
🤖🤖🤖 r/aws_s3_bucket_lifecycle_configuration: Handle third-party S3 APIs that don't round-trip the lifecycle configuration

### DIFF
--- a/.changelog/49547.txt
+++ b/.changelog/49547.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_s3_bucket_lifecycle_configuration: Fix `timeout while waiting for state to become 'true'` errors on create and update against third-party S3 API implementations (e.g. Ceph RADOS Gateway, NetApp StorageGRID) that don't return the `x-amz-transition-default-minimum-object-size` response header or that report an empty `filter` as the deprecated top-level `prefix` element
+```

--- a/internal/service/s3/bucket_lifecycle_configuration.go
+++ b/internal/service/s3/bucket_lifecycle_configuration.go
@@ -433,7 +433,7 @@ func (r *bucketLifecycleConfigurationResource) Create(ctx context.Context, reque
 		return
 	}
 
-	response.Diagnostics.Append(fwflex.Flatten(ctx, output, &data)...)
+	flattenBucketLifecycleConfigurationResource(ctx, output, &data, &response.Diagnostics)
 
 	data.ID = types.StringValue(createResourceID(bucket, expectedBucketOwner))
 	data.ExpectedBucketOwner = types.StringValue(expectedBucketOwner)
@@ -546,7 +546,7 @@ func (r *bucketLifecycleConfigurationResource) Update(ctx context.Context, reque
 		return
 	}
 
-	response.Diagnostics.Append(fwflex.Flatten(ctx, output, &new)...)
+	flattenBucketLifecycleConfigurationResource(ctx, output, &new, &response.Diagnostics)
 
 	new.ID = types.StringValue(createResourceID(bucket, expectedBucketOwner))
 	new.ExpectedBucketOwner = types.StringValue(expectedBucketOwner)
@@ -614,6 +614,19 @@ func (r *bucketLifecycleConfigurationResource) ImportState(ctx context.Context, 
 }
 
 func flattenBucketLifecycleConfigurationResource(ctx context.Context, bucket *s3.GetBucketLifecycleConfigurationOutput, data *bucketLifecycleConfigurationResourceModel, diags *diag.Diagnostics) {
+	// Some third-party S3 API implementations don't return the `x-amz-transition-default-minimum-object-size`
+	// response header. Retain the planned (Create, Update) or prior (Read) value in that case.
+	// Reference: https://github.com/hashicorp/terraform-provider-aws/issues/43333.
+	if bucket.TransitionDefaultMinimumObjectSize == "" {
+		bucket.TransitionDefaultMinimumObjectSize = awstypes.TransitionDefaultMinimumObjectSize(data.TransitionDefaultMinimumObjectSize.ValueString())
+	}
+
+	// Normalize the read-back rules so that a filter reported in the deprecated
+	// form doesn't land in state and produce a perpetual diff.
+	for i, rule := range bucket.Rules {
+		bucket.Rules[i] = normalizeLifecycleRule(rule)
+	}
+
 	diags.Append(fwflex.Flatten(ctx, bucket, data)...)
 }
 
@@ -656,7 +669,11 @@ func findBucketLifecycleConfiguration(ctx context.Context, conn *s3.Client, buck
 }
 
 func lifecycleConfigEqual(transitionMinSize1 awstypes.TransitionDefaultMinimumObjectSize, rules1 []awstypes.LifecycleRule, transitionMinSize2 awstypes.TransitionDefaultMinimumObjectSize, rules2 []awstypes.LifecycleRule) bool {
-	if transitionMinSize1 != transitionMinSize2 {
+	// `transitionMinSize1` is always the value read back from the S3 API.
+	// Some third-party S3 API implementations don't return the `x-amz-transition-default-minimum-object-size`
+	// response header, so there's nothing to compare.
+	// Reference: https://github.com/hashicorp/terraform-provider-aws/issues/43333.
+	if transitionMinSize1 != "" && transitionMinSize1 != transitionMinSize2 {
 		return false
 	}
 
@@ -665,14 +682,34 @@ func lifecycleConfigEqual(transitionMinSize1 awstypes.TransitionDefaultMinimumOb
 	}
 
 	for _, rule1 := range rules1 {
+		rule1 := normalizeLifecycleRule(rule1)
 		if !slices.ContainsFunc(rules2, func(rule2 awstypes.LifecycleRule) bool {
-			return reflect.DeepEqual(rule1, rule2)
+			return reflect.DeepEqual(rule1, normalizeLifecycleRule(rule2))
 		}) {
 			return false
 		}
 	}
 
 	return true
+}
+
+// normalizeLifecycleRule rewrites a rule whose filter is expressed with the
+// deprecated top-level `Prefix` element into the equivalent empty
+// `LifecycleRuleFilter`, which is what the provider sends for an empty `filter`
+// block. Some third-party S3 API implementations (Ceph RADOS Gateway, which is
+// what Hetzner Object Storage runs) report it that way, and the two are
+// semantically identical: an empty prefix matches every object.
+//
+// A non-empty `Prefix` is left alone: it isn't equivalent to an empty filter.
+// On AWS, `Filter` is never nil in a read-back rule, so this is a no-op there.
+// Reference: https://github.com/hashicorp/terraform-provider-aws/issues/43333.
+func normalizeLifecycleRule(rule awstypes.LifecycleRule) awstypes.LifecycleRule {
+	if rule.Filter == nil && aws.ToString(rule.Prefix) == "" {
+		rule.Filter = &awstypes.LifecycleRuleFilter{Prefix: aws.String("")}
+		rule.Prefix = nil
+	}
+
+	return rule
 }
 
 func statusLifecycleConfigEquals(conn *s3.Client, bucket, owner string, transitionMinSize awstypes.TransitionDefaultMinimumObjectSize, rules []awstypes.LifecycleRule) retry.StateRefreshFunc {

--- a/internal/service/s3/bucket_lifecycle_configuration_test.go
+++ b/internal/service/s3/bucket_lifecycle_configuration_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/hashicorp/terraform-plugin-testing/compare"
@@ -27,6 +28,148 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
+
+func TestLifecycleConfigEqual(t *testing.T) {
+	t.Parallel()
+
+	rule := func(id string) types.LifecycleRule {
+		return types.LifecycleRule{
+			Expiration: &types.LifecycleExpiration{Days: aws.Int32(365)},
+			Filter:     &types.LifecycleRuleFilter{Prefix: aws.String("prefix/")},
+			ID:         aws.String(id),
+			Status:     types.ExpirationStatusEnabled,
+		}
+	}
+
+	// What the provider sends for an empty `filter {}` block.
+	emptyFilterRule := func(id string) types.LifecycleRule {
+		return types.LifecycleRule{
+			Expiration: &types.LifecycleExpiration{Days: aws.Int32(365)},
+			Filter:     &types.LifecycleRuleFilter{Prefix: aws.String("")},
+			ID:         aws.String(id),
+			Status:     types.ExpirationStatusEnabled,
+		}
+	}
+
+	// What some third-party implementations read back instead: no `Filter`, and
+	// the deprecated top-level `Prefix` element.
+	legacyPrefixRule := func(id, prefix string) types.LifecycleRule {
+		return types.LifecycleRule{
+			Expiration: &types.LifecycleExpiration{Days: aws.Int32(365)},
+			ID:         aws.String(id),
+			Prefix:     aws.String(prefix),
+			Status:     types.ExpirationStatusEnabled,
+		}
+	}
+
+	testCases := []struct {
+		TestName        string
+		ReadBackMinSize types.TransitionDefaultMinimumObjectSize
+		ReadBackRules   []types.LifecycleRule
+		WantMinSize     types.TransitionDefaultMinimumObjectSize
+		WantRules       []types.LifecycleRule
+		Expected        bool
+	}{
+		{
+			TestName:        "equal",
+			ReadBackMinSize: types.TransitionDefaultMinimumObjectSizeAllStorageClasses128k,
+			ReadBackRules:   []types.LifecycleRule{rule("rule-1")},
+			WantMinSize:     types.TransitionDefaultMinimumObjectSizeAllStorageClasses128k,
+			WantRules:       []types.LifecycleRule{rule("rule-1")},
+			Expected:        true,
+		},
+		{
+			TestName:        "different transition default minimum object size",
+			ReadBackMinSize: types.TransitionDefaultMinimumObjectSizeVariesByStorageClass,
+			ReadBackRules:   []types.LifecycleRule{rule("rule-1")},
+			WantMinSize:     types.TransitionDefaultMinimumObjectSizeAllStorageClasses128k,
+			WantRules:       []types.LifecycleRule{rule("rule-1")},
+			Expected:        false,
+		},
+		{
+			TestName:        "transition default minimum object size not read back",
+			ReadBackMinSize: "",
+			ReadBackRules:   []types.LifecycleRule{rule("rule-1")},
+			WantMinSize:     types.TransitionDefaultMinimumObjectSizeAllStorageClasses128k,
+			WantRules:       []types.LifecycleRule{rule("rule-1")},
+			Expected:        true,
+		},
+		{
+			TestName:        "transition default minimum object size not read back, different rules",
+			ReadBackMinSize: "",
+			ReadBackRules:   []types.LifecycleRule{rule("rule-1")},
+			WantMinSize:     types.TransitionDefaultMinimumObjectSizeAllStorageClasses128k,
+			WantRules:       []types.LifecycleRule{rule("rule-2")},
+			Expected:        false,
+		},
+		{
+			TestName:        "transition default minimum object size not requested",
+			ReadBackMinSize: types.TransitionDefaultMinimumObjectSizeAllStorageClasses128k,
+			ReadBackRules:   []types.LifecycleRule{rule("rule-1")},
+			WantMinSize:     "",
+			WantRules:       []types.LifecycleRule{rule("rule-1")},
+			Expected:        false,
+		},
+		{
+			TestName:        "directory bucket",
+			ReadBackMinSize: "",
+			ReadBackRules:   []types.LifecycleRule{rule("rule-1")},
+			WantMinSize:     "",
+			WantRules:       []types.LifecycleRule{rule("rule-1")},
+			Expected:        true,
+		},
+		{
+			TestName:        "rules in a different order",
+			ReadBackMinSize: types.TransitionDefaultMinimumObjectSizeAllStorageClasses128k,
+			ReadBackRules:   []types.LifecycleRule{rule("rule-1"), rule("rule-2")},
+			WantMinSize:     types.TransitionDefaultMinimumObjectSizeAllStorageClasses128k,
+			WantRules:       []types.LifecycleRule{rule("rule-2"), rule("rule-1")},
+			Expected:        true,
+		},
+		{
+			TestName:        "different number of rules",
+			ReadBackMinSize: types.TransitionDefaultMinimumObjectSizeAllStorageClasses128k,
+			ReadBackRules:   []types.LifecycleRule{rule("rule-1")},
+			WantMinSize:     types.TransitionDefaultMinimumObjectSizeAllStorageClasses128k,
+			WantRules:       []types.LifecycleRule{rule("rule-1"), rule("rule-2")},
+			Expected:        false,
+		},
+		{
+			TestName:        "empty filter read back as the legacy prefix element",
+			ReadBackMinSize: "",
+			ReadBackRules:   []types.LifecycleRule{legacyPrefixRule("rule-1", "")},
+			WantMinSize:     types.TransitionDefaultMinimumObjectSizeAllStorageClasses128k,
+			WantRules:       []types.LifecycleRule{emptyFilterRule("rule-1")},
+			Expected:        true,
+		},
+		{
+			TestName:        "empty filter read back as the legacy prefix element, different rules",
+			ReadBackMinSize: "",
+			ReadBackRules:   []types.LifecycleRule{legacyPrefixRule("rule-1", "")},
+			WantMinSize:     types.TransitionDefaultMinimumObjectSizeAllStorageClasses128k,
+			WantRules:       []types.LifecycleRule{emptyFilterRule("rule-2")},
+			Expected:        false,
+		},
+		{
+			TestName:        "non-empty legacy prefix is not an empty filter",
+			ReadBackMinSize: types.TransitionDefaultMinimumObjectSizeAllStorageClasses128k,
+			ReadBackRules:   []types.LifecycleRule{legacyPrefixRule("rule-1", "prefix/")},
+			WantMinSize:     types.TransitionDefaultMinimumObjectSizeAllStorageClasses128k,
+			WantRules:       []types.LifecycleRule{emptyFilterRule("rule-1")},
+			Expected:        false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.TestName, func(t *testing.T) {
+			t.Parallel()
+
+			if got, want := tfs3.LifecycleConfigEqual(testCase.ReadBackMinSize, testCase.ReadBackRules, testCase.WantMinSize, testCase.WantRules), testCase.Expected; got != want {
+				t.Errorf("LifecycleConfigEqual() = %t, want %t", got, want)
+			}
+		})
+	}
+}
 
 func TestAccS3BucketLifecycleConfiguration_basic(t *testing.T) {
 	ctx := acctest.Context(t)


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls (access controls, encryption, logging) in this pull request.

### Description

`aws_s3_bucket_lifecycle_configuration` hangs in `Creating...`/`Modifying...` and eventually fails with `timeout while waiting for state to become 'true'` when the provider is pointed at a third-party S3 API implementation, even though the lifecycle configuration is written successfully and is readable through the S3 API afterwards.

There are **two independent divergences** behind it, both semantically irrelevant and both fatal to the same `reflect.DeepEqual` comparison. Fixing only the first moves the failure rather than removing it, which is what the version history of this issue shows.

**Root cause, part 1: the transition default minimum object size**

`Create` and `Update` write the configuration and then poll `GetBucketLifecycleConfiguration` until the read-back matches what was sent, via `waitLifecycleConfigEquals` → `lifecycleConfigEqual`. The first statement of the comparator was:

```go
if transitionMinSize1 != transitionMinSize2 {
    return false
}
```

The plan modifier `transitionDefaultMinimumObjectSizeDefault` defaults `transition_default_minimum_object_size` to `all_storage_classes_128K` for every non-directory bucket, so the `PutBucketLifecycleConfiguration` request carries `x-amz-transition-default-minimum-object-size`. Third-party implementations don't return that **response** header on `GetBucketLifecycleConfiguration`, and the SDK field is a non-pointer string type, so the read-back value is `""`.

`"" != "all_storage_classes_128K"` is therefore true on every poll, and the comparator returns before the rules are ever inspected — the rules themselves match perfectly, as the debug output in #43333 shows. `waitLifecycleConfigEquals` sets no `Pending` states, so the state machine has nothing to fail fast on and simply polls until the 3 minute default timeout.

`Read` is unaffected because it compares two `GetBucketLifecycleConfiguration` outputs against each other, both carrying `""`. That is why the workaround reported in #43333 — `terraform import` the already-created resource — unblocks subsequent plans and applies.

**Root cause, part 2: an empty `filter` reported as the deprecated top-level `Prefix`**

With the first half fixed, the comparator reaches the rules and still never converges on the same endpoints. For an empty `filter {}` block, `expandLifecycleRule` sends

```go
r.Filter = &awstypes.LifecycleRuleFilter{Prefix: aws.String("")}
r.Prefix = nil
```

and the endpoint stores it, but reports it back in the deprecated V1 shape. Captured against Hetzner Object Storage (Ceph RADOS Gateway), on a bucket whose rule had just been written by this provider:

```console
$ aws s3api get-bucket-lifecycle-configuration --bucket <redacted> \
    --endpoint-url https://nbg1.your-objectstorage.com --region nbg1
{
    "Rules": [
        {
            "Expiration": {
                "Days": 90
            },
            "ID": "expirar-bundles",
            "Prefix": "",
            "Status": "Enabled",
            "NoncurrentVersionExpiration": {
                "NoncurrentDays": 7
            }
        }
    ]
}
```

No `Filter`, and the deprecated top-level `Prefix` holding `""` instead. The two forms are equivalent, since an empty prefix matches every object, but `reflect.DeepEqual` sees `Filter: &{Prefix: ""}, Prefix: nil` against `Filter: nil, Prefix: &""` and returns false on every poll.

This half is **older than the v5.95.0 regression**: the comparator it replaced, `lifecycleRulesEqual` (pre-d48d93788bb), matched rules with the same `reflect.DeepEqual`, so any version whose waiter compared rules is affected.

**Changes**

1. `lifecycleConfigEqual` skips the `transition_default_minimum_object_size` comparison when the value read back from the API is empty. The guard is deliberately asymmetric: `transitionMinSize1` is the API side at all three call sites, so genuine drift between two reported values (for example `varies_by_storage_class` vs `all_storage_classes_128K`) is still caught.

2. `Create` and `Update` now flatten through the shared `flattenBucketLifecycleConfigurationResource`, which retains the planned (create, update) or prior (read) value when the API reports none.

3. A new `normalizeLifecycleRule` rewrites a rule whose filter is expressed with the deprecated top-level `Prefix` element into the equivalent empty `LifecycleRuleFilter`. It is applied to both sides of the rules comparison and to the read-back rules in the shared flattener. A **non-empty** `Prefix` is left alone, since it is not equivalent to an empty filter.

The second change is needed as well as the first. Fixing only the comparator lets the waiter converge, and then `fwflex.Flatten` writes the endpoint's `""` into state against a plan of `all_storage_classes_128K`. Because the model field is tagged `autoflex:",legacy"`, the empty value flattens to a *known* `""` rather than null, so Terraform raises `Provider produced inconsistent result after apply` — the symptom reported separately in #41603. The apply would fail at a different point rather than succeed.

**Behavior against AWS is unchanged.** Real S3 always returns the header for general purpose buckets, and never returns a rule with a nil `Filter` and an empty top-level `Prefix`, so none of the three branches is taken. Directory buckets are also unaffected: the plan modifier leaves the desired value empty for them too, so `"" == ""` already held, and `TestAccS3BucketLifecycleConfiguration_directoryBucket` continues to assert `transition_default_minimum_object_size` is `""`.

**Affected versions**

The two halves have different ranges, which is worth stating because a partial fix would leave one of them behind.

*Part 1* was introduced in **v5.95.0** by d48d93788bb ("Adds additional waits when reading"), which replaced the rules-only `waitLifecycleRulesEquals` with `waitLifecycleConfigEquals`. It affects v5.95.0 through v6.60.0.

*Part 2* is **older**: the comparator that d48d93788bb replaced already matched rules with `reflect.DeepEqual`, so any version whose create or update waiter compared rules is affected. On endpoints that report an empty filter in the deprecated form, part 1 alone converts the timeout at the transition size check into a timeout at the rules check, with an identical error message.

For completeness, two earlier milestones on the same attribute produce *different* symptoms and are not this bug: v5.70.0 added the argument (waiter still compared rules only), and v5.86.0 started forcing the `all_storage_classes_128K` default, which is where the `Provider produced inconsistent result after apply` symptom of #41603 begins.

**Reported against these backends** across #43333 and its duplicates: Ceph RADOS Gateway (18.2.4, 19.2.2, 19.2.3), NetApp StorageGRID, Cloudian, STACKIT Object Storage, MinIO.

### Relations

Closes #43333
Relates #49019
Relates #41603
Relates #48457

### References

- AWS SDK for Go v2: [`GetBucketLifecycleConfigurationOutput.TransitionDefaultMinimumObjectSize`](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/s3#GetBucketLifecycleConfigurationOutput) — non-pointer `types.TransitionDefaultMinimumObjectSize`, zero value `""` when the header is absent.
- #48457 proposes the comparator half of this fix. This PR adds the flatten half, without which the timeout is replaced by `Provider produced inconsistent result after apply` on the same endpoints.
- #49021 (closed as a duplicate of #48457) proposed both halves using a separate helper applied at each of the three flatten sites; this PR routes `Create` and `Update` through the existing shared flattener instead.

### Output from Acceptance Testing

Unit test for the comparator, covering both divergences:

```console
% go test ./internal/service/s3/ -run TestLifecycleConfigEqual -count=1 -v

--- PASS: TestLifecycleConfigEqual (0.00s)
    --- PASS: TestLifecycleConfigEqual/equal (0.00s)
    --- PASS: TestLifecycleConfigEqual/different_transition_default_minimum_object_size (0.00s)
    --- PASS: TestLifecycleConfigEqual/transition_default_minimum_object_size_not_read_back (0.00s)
    --- PASS: TestLifecycleConfigEqual/transition_default_minimum_object_size_not_read_back,_different_rules (0.00s)
    --- PASS: TestLifecycleConfigEqual/transition_default_minimum_object_size_not_requested (0.00s)
    --- PASS: TestLifecycleConfigEqual/directory_bucket (0.00s)
    --- PASS: TestLifecycleConfigEqual/rules_in_a_different_order (0.00s)
    --- PASS: TestLifecycleConfigEqual/different_number_of_rules (0.00s)
    --- PASS: TestLifecycleConfigEqual/empty_filter_read_back_as_the_legacy_prefix_element (0.00s)
    --- PASS: TestLifecycleConfigEqual/empty_filter_read_back_as_the_legacy_prefix_element,_different_rules (0.00s)
    --- PASS: TestLifecycleConfigEqual/non-empty_legacy_prefix_is_not_an_empty_filter (0.00s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/s3  0.390s
```

Each half was verified by reverting it on its own, so that the tests are shown to cover the bugs rather than the implementation.

Reverting the guard in the transition size comparison:

```console
--- FAIL: TestLifecycleConfigEqual (0.00s)
    --- FAIL: TestLifecycleConfigEqual/transition_default_minimum_object_size_not_read_back (0.00s)
        bucket_lifecycle_configuration_test.go:123: LifecycleConfigEqual() = false, want true
FAIL
```

Reverting only the `normalizeLifecycleRule` calls in the rules comparison:

```console
--- FAIL: TestLifecycleConfigEqual (0.00s)
    --- FAIL: TestLifecycleConfigEqual/empty_filter_read_back_as_the_legacy_prefix_element (0.00s)
        bucket_lifecycle_configuration_test.go:168: LifecycleConfigEqual() = false, want true
FAIL
```

Note that the other two new cases keep passing under that mutation, which is the intent: they assert **inequality**, and exist to catch the opposite mistake of normalizing too aggressively and treating a non-empty prefix as an empty filter.

End to end, against Hetzner Object Storage (Ceph RADOS Gateway, `nbg1`), six `aws_s3_bucket_lifecycle_configuration` resources across three buckets: before the change, every apply failed with `timeout while waiting for state to become 'true'` after 3m0s per resource while the rules were in fact written; the plan is clean afterwards.

### AI Usage

This change was developed with AI assistance (Claude). AI was used to trace the root cause through the waiter and AutoFlex flatten paths, to capture and interpret the `GetBucketLifecycleConfiguration` response from a real Ceph RADOS Gateway endpoint, to draft the table-driven unit tests, and to draft this description. I reviewed every line, verified the root cause against the debug output in #43333 and the AWS SDK type definitions, and confirmed that each half of the fix has a unit test that fails without it and passes with it.
