### PR TITLE
r/aws_mailmanager_relay(test): update authenticated relay case 

### DIFF
--- a/internal/service/mailmanager/relay.go
+++ b/internal/service/mailmanager/relay.go
@@ -6,6 +6,7 @@ package mailmanager
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/YakDriver/regexache"
 	"github.com/YakDriver/smarterr"
@@ -133,6 +134,10 @@ func (r *relayResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 	}
 }
 
+const (
+	propagationTimeout = 1 * time.Minute
+)
+
 func (r *relayResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	conn := r.Meta().MailManagerClient(ctx)
 	var plan relayResourceModel
@@ -150,7 +155,12 @@ func (r *relayResource) Create(ctx context.Context, req resource.CreateRequest, 
 	input.ClientToken = aws.String(create.UniqueId(ctx))
 	input.Tags = getTagsIn(ctx)
 
-	out, err := conn.CreateRelay(ctx, &input)
+	// Allow for propagation of secretsmanager credentials
+	// ValidationException: Unable to connect to the relay server, or invalid server name and port, or invalid credentials
+	out, err := tfresource.RetryWhenIsAErrorMessageContains[*mailmanager.CreateRelayOutput, *awstypes.ValidationException](ctx, propagationTimeout, func(ctx context.Context) (*mailmanager.CreateRelayOutput, error) {
+		return conn.CreateRelay(ctx, &input)
+	}, "invalid server name and port, or invalid credentials")
+
 	if err != nil {
 		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, plan.Name.String())
 		return

--- a/internal/service/mailmanager/relay_test.go
+++ b/internal/service/mailmanager/relay_test.go
@@ -7,12 +7,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/YakDriver/regexache"
 	"github.com/YakDriver/smarterr"
 	"github.com/aws/aws-sdk-go-v2/service/mailmanager"
+	"github.com/hashicorp/terraform-plugin-testing/config"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -140,24 +140,12 @@ func TestAccMailManagerRelay_update(t *testing.T) {
 	})
 }
 
-func TestAccMailManagerRelay_authenticationTypes(t *testing.T) {
+func TestAccMailManagerRelay_Authentication_secretARN(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_mailmanager_relay.test"
-
-	serverName := os.Getenv("TF_ACC_MAILMANAGER_RELAY_SERVER_NAME")
-	if serverName == "" {
-		t.Skipf("Environment variable %s is not set", "TF_ACC_MAILMANAGER_RELAY_SERVER_NAME")
-	}
-	username := os.Getenv("TF_ACC_MAILMANAGER_RELAY_USERNAME")
-	if username == "" {
-		t.Skipf("Environment variable %s is not set", "TF_ACC_MAILMANAGER_RELAY_USERNAME")
-	}
-	password := os.Getenv("TF_ACC_MAILMANAGER_RELAY_PASSWORD")
-	if password == "" {
-		t.Skipf("Environment variable %s is not set", "TF_ACC_MAILMANAGER_RELAY_PASSWORD")
-	}
+	password := "Abcd1234!"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -169,19 +157,14 @@ func TestAccMailManagerRelay_authenticationTypes(t *testing.T) {
 		CheckDestroy:             testAccCheckRelayDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRelayConfig_basic(rName),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckRelayExists(ctx, t, resourceName),
-					resource.TestCheckResourceAttr(resourceName, "authentication.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "authentication.0.no_authentication.#", "1"),
-					resource.TestCheckNoResourceAttr(resourceName, "authentication.0.secret_arn"),
-				),
-			},
-			{
-				Config: testAccRelayConfig_secretARN(rName, serverName, username, password),
+				ConfigDirectory: config.StaticDirectory("testdata/Relay/authentication/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+					"password":      config.StringVariable(password),
+				},
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
 					},
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -276,27 +259,4 @@ resource "aws_mailmanager_relay" "test" {
   }
 }
 `, rName, serverName, serverPort)
-}
-
-func testAccRelayConfig_secretARN(rName, serverName, username, password string) string {
-	return fmt.Sprintf(`
-resource "aws_secretsmanager_secret" "test" {
-  name = %[1]q
-}
-
-resource "aws_secretsmanager_secret_version" "test" {
-  secret_id     = aws_secretsmanager_secret.test.id
-  secret_string = jsonencode({ username = %[3]q, password = %[4]q })
-}
-
-resource "aws_mailmanager_relay" "test" {
-  name        = %[1]q
-  server_name = %[2]q
-  server_port = 587
-
-  authentication {
-    secret_arn = aws_secretsmanager_secret_version.test.arn
-  }
-}
-`, rName, serverName, username, password)
 }

--- a/internal/service/mailmanager/testdata/Relay/authentication/main.tf
+++ b/internal/service/mailmanager/testdata/Relay/authentication/main.tf
@@ -1,3 +1,6 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
 # Authenticated relays require a MailManager ingress point with SMTP credentials.
 #
 # The configuration below is a port of this guide to Terraform.

--- a/internal/service/mailmanager/testdata/Relay/authentication/main.tf
+++ b/internal/service/mailmanager/testdata/Relay/authentication/main.tf
@@ -1,0 +1,154 @@
+# Authenticated relays require a MailManager ingress point with SMTP credentials.
+#
+# The configuration below is a port of this guide to Terraform.
+# Ref: https://docs.aws.amazon.com/ses/latest/dg/eb-relay.html#eb-relay-create-console.
+
+resource "aws_mailmanager_relay" "test" {
+  name        = var.rName
+  server_name = aws_mailmanager_ingress_point.test.a_record
+  server_port = 587
+
+  authentication {
+    secret_arn = aws_secretsmanager_secret_version.test.secret_arn
+  }
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+data "aws_partition" "current" {}
+
+resource "aws_mailmanager_traffic_policy" "test" {
+  default_action = "ALLOW"
+  name           = var.rName
+
+  policy_statement {
+    action = "DENY"
+
+    condition {
+      ip_expression {
+        operator = "CIDR_MATCHES"
+        values   = ["192.0.2.0/24"]
+
+        evaluate {
+          attribute = "SENDER_IP"
+        }
+      }
+    }
+  }
+}
+
+resource "aws_mailmanager_rule_set" "test" {
+  name = var.rName
+
+  rule {
+    action {
+      add_header {
+        header_name  = "X-Test"
+        header_value = "example"
+      }
+    }
+  }
+}
+
+resource "aws_mailmanager_ingress_point" "test" {
+  name              = var.rName
+  type              = "AUTH"
+  rule_set_id       = aws_mailmanager_rule_set.test.id
+  traffic_policy_id = aws_mailmanager_traffic_policy.test.id
+
+  ingress_point_configuration {
+    smtp_password_wo         = var.password
+    smtp_password_wo_version = 0
+  }
+}
+
+resource "aws_kms_key" "test" {
+  deletion_window_in_days = 7
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Enable IAM User Permissions",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:root"
+      },
+      "Action": "kms:*",
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ses.amazonaws.com"
+      },
+      "Action": [
+        "kms:Decrypt",
+        "kms:DescribeKey"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "kms:ViaService": "secretsmanager.${data.aws_region.current.region}.amazonaws.com",
+          "aws:SourceAccount": "${data.aws_caller_identity.current.account_id}"
+        },
+        "ArnLike": {
+					"aws:SourceArn": "arn:${data.aws_partition.current.partition}:ses:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:mailmanager-smtp-relay/*"
+        }
+      }
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_secretsmanager_secret" "test" {
+  name       = var.rName
+  kms_key_id = aws_kms_key.test.arn
+
+  policy = <<EOF
+{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Effect": "Allow",
+			"Principal": {
+				"Service": "ses.amazonaws.com"
+			},
+			"Action": [
+				"secretsmanager:GetSecretValue",
+				"secretsmanager:DescribeSecret"
+			],
+			"Resource": "*",
+			"Condition": {
+				"StringEquals": {
+					"aws:SourceAccount": "${data.aws_caller_identity.current.account_id}"
+				},
+				"ArnLike": {
+					"aws:SourceArn": "arn:${data.aws_partition.current.partition}:ses:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:mailmanager-smtp-relay/*"
+				}
+			}
+		}
+	]
+}
+EOF
+}
+
+resource "aws_secretsmanager_secret_version" "test" {
+  secret_id     = aws_secretsmanager_secret.test.id
+  secret_string = jsonencode({ username = aws_mailmanager_ingress_point.test.id, password = var.password })
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "password" {
+  description = "SMTP password"
+  type        = string
+  sensitive   = true
+  nullable    = false
+}


### PR DESCRIPTION

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Updates the "authentication" test case such that it no longer requires manual out of band set up. The upstream SMTP server is created via the `aws_mailmanager_ingress_point` resource, and credentials are stored in AWS SecretsManager as recommended by the [Mail Manager documentation](https://docs.aws.amazon.com/ses/latest/dg/eb-relay.html#eb-relay-create-console).

I've also tweaked the Create logic slightly to retry `ValidationException`, as I intermittently observed failures while testing this workflow due to a race between relay creation and propagation of the stored secrets. 

Additional considerations:
- The same propagation retry may need applied to update.
- I left `_Authenticated_secretARN` as a parallel test, but the ingress point tests are all serialized (presumably due to quota limits). It may be necessary to serialize this single case to avoid hitting quotas when tests for the entire service are run together. 

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #49394

### References

Converts the instructions from this guide to an automated Terraform configuration.
https://docs.aws.amazon.com/ses/latest/dg/eb-relay.html#eb-relay-create-console


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t K=mailmanager T=TestAccMailManagerRelay_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-relay 🌿...
TF_ACC=1 go1.26.5 test ./internal/service/mailmanager/... -v -count 1 -parallel 20 -run='TestAccMailManagerRelay_'  -timeout 360m -vet=off -buildvcs=false
2026/08/18 10:08:17 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/18 10:08:17 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccMailManagerRelay_List_basic (66.72s)
=== CONT  TestAccMailManagerRelay_Tags_IgnoreTags_Overlap_defaultTag
--- PASS: TestAccMailManagerRelay_List_regionOverride (66.88s)
=== CONT  TestAccMailManagerRelay_Tags_ComputedTag_OnUpdate_replace
--- PASS: TestAccMailManagerRelay_basic (73.66s)
--- PASS: TestAccMailManagerRelay_disappears (76.34s)
--- PASS: TestAccMailManagerRelay_Authentication_secretARN (77.73s)
--- PASS: TestAccMailManagerRelay_List_includeResource (83.49s)
--- PASS: TestAccMailManagerRelay_Tags_ComputedTag_onCreate (87.78s)
--- PASS: TestAccMailManagerRelay_Tags_emptyMap (87.89s)
--- PASS: TestAccMailManagerRelay_Identity_regionOverride (106.72s)
--- PASS: TestAccMailManagerRelay_Identity_basic (110.81s)
--- PASS: TestAccMailManagerRelay_update (114.04s)
--- PASS: TestAccMailManagerRelay_Tags_DefaultTags_updateToResourceOnly (116.06s)
--- PASS: TestAccMailManagerRelay_Tags_addOnUpdate (118.88s)
--- PASS: TestAccMailManagerRelay_Tags_DefaultTags_updateToProviderOnly (121.76s)
--- PASS: TestAccMailManagerRelay_Tags_ComputedTag_OnUpdate_add (123.36s)
--- PASS: TestAccMailManagerRelay_Tags_IgnoreTags_Overlap_resourceTag (141.05s)
--- PASS: TestAccMailManagerRelay_Tags_ComputedTag_OnUpdate_replace (78.91s)
--- PASS: TestAccMailManagerRelay_Tags_DefaultTags_overlapping (151.54s)
--- PASS: TestAccMailManagerRelay_Tags_DefaultTags_nonOverlapping (153.11s)
--- PASS: TestAccMailManagerRelay_Tags_IgnoreTags_Overlap_defaultTag (86.54s)
--- PASS: TestAccMailManagerRelay_Tags_DefaultTags_providerOnly (168.21s)
--- PASS: TestAccMailManagerRelay_tags (169.21s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/mailmanager        177.839s
```
