### PR TITLE
r/aws_securityhub_connector_v2: Add Azure connector provider support

### DIFF
--- a/.changelog/49560.txt
+++ b/.changelog/49560.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_securityhub_connector_v2: Add `azure` configuration block to `connector_provider` for Microsoft Azure multi-cloud coverage
+```

--- a/internal/service/securityhub/connector_v2.go
+++ b/internal/service/securityhub/connector_v2.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/securityhub"
@@ -91,6 +92,7 @@ func (r *connectorV2Resource) Schema(ctx context.Context, request resource.Schem
 								listvalidator.ExactlyOneOf(
 									path.MatchRelative().AtParent().AtName("jira_cloud"),
 									path.MatchRelative().AtParent().AtName("service_now"),
+									path.MatchRelative().AtParent().AtName("azure"),
 								),
 							},
 							NestedObject: schema.NestedBlockObject{
@@ -132,6 +134,50 @@ func (r *connectorV2Resource) Schema(ctx context.Context, request resource.Schem
 									"secret_arn": schema.StringAttribute{
 										CustomType: fwtypes.ARNType,
 										Required:   true,
+									},
+								},
+							},
+						},
+						"azure": schema.ListNestedBlock{
+							CustomType: fwtypes.NewListNestedObjectTypeOf[azureDetailModel](ctx),
+							Validators: []validator.List{
+								listvalidator.SizeAtMost(1),
+							},
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									"aws_config_connector_arn": schema.StringAttribute{
+										CustomType: fwtypes.ARNType,
+										Required:   true,
+										PlanModifiers: []planmodifier.String{
+											stringplanmodifier.RequiresReplace(),
+										},
+									},
+									"azure_regions": schema.SetAttribute{
+										CustomType:  fwtypes.SetOfStringType,
+										ElementType: types.StringType,
+										Required:    true,
+									},
+								},
+								Blocks: map[string]schema.Block{
+									"scope_configuration": schema.ListNestedBlock{
+										CustomType: fwtypes.NewListNestedObjectTypeOf[azureScopeConfigurationModel](ctx),
+										Validators: []validator.List{
+											listvalidator.IsRequired(),
+											listvalidator.SizeAtMost(1),
+										},
+										NestedObject: schema.NestedBlockObject{
+											Attributes: map[string]schema.Attribute{
+												"scope_type": schema.StringAttribute{
+													CustomType: fwtypes.StringEnumType[awstypes.ScopeType](),
+													Required:   true,
+												},
+												"scope_values": schema.SetAttribute{
+													CustomType:  fwtypes.SetOfStringType,
+													ElementType: types.StringType,
+													Optional:    true,
+												},
+											},
+										},
 									},
 								},
 							},
@@ -283,7 +329,11 @@ func (r *connectorV2Resource) Delete(ctx context.Context, request resource.Delet
 	input := securityhub.DeleteConnectorV2Input{
 		ConnectorId: aws.String(connectorID),
 	}
-	_, err := conn.DeleteConnectorV2(ctx, &input)
+	// Azure connectors are enabled asynchronously and cannot be deleted while in
+	// the PENDING_ENABLEMENT state, so retry until the connector is deletable.
+	_, err := tfresource.RetryWhenIsAErrorMessageContains[any, *awstypes.ConflictException](ctx, 15*time.Minute, func(ctx context.Context) (any, error) {
+		return conn.DeleteConnectorV2(ctx, &input)
+	}, "cannot be deleted")
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return
@@ -291,6 +341,18 @@ func (r *connectorV2Resource) Delete(ctx context.Context, request resource.Delet
 
 	if err != nil {
 		response.Diagnostics.AddError(fmt.Sprintf("deleting Security Hub V2 Connector (%s)", connectorID), err.Error())
+		return
+	}
+
+	// Wait for the connector to be fully deleted so that any service-linked
+	// configuration recorders it created are removed before dependent resources
+	// (such as aws_config_connector) are deleted.
+	_, err = tfresource.RetryUntilNotFound(ctx, 15*time.Minute, func(ctx context.Context) (any, error) {
+		return findConnectorV2ByID(ctx, conn, connectorID)
+	})
+
+	if err != nil {
+		response.Diagnostics.AddError(fmt.Sprintf("waiting for Security Hub V2 Connector (%s) delete", connectorID), err.Error())
 		return
 	}
 }
@@ -349,6 +411,7 @@ type healthCheckModel struct {
 }
 
 type providerDetailModel struct {
+	Azure      fwtypes.ListNestedObjectValueOf[azureDetailModel]      `tfsdk:"azure"`
 	JiraCloud  fwtypes.ListNestedObjectValueOf[jiraCloudDetailModel]  `tfsdk:"jira_cloud"`
 	ServiceNow fwtypes.ListNestedObjectValueOf[serviceNowDetailModel] `tfsdk:"service_now"`
 }
@@ -372,6 +435,18 @@ func (m providerDetailModel) ExpandTo(ctx context.Context, targetType reflect.Ty
 func (m providerDetailModel) expandToProviderConfiguration(ctx context.Context) (awstypes.ProviderConfiguration, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	switch {
+	case !m.Azure.IsNull():
+		data, d := m.Azure.ToPtr(ctx)
+		diags.Append(d...)
+		if diags.HasError() {
+			return nil, diags
+		}
+		var r awstypes.ProviderConfigurationMemberAzure
+		diags.Append(fwflex.Expand(ctx, data, &r.Value)...)
+		if diags.HasError() {
+			return nil, diags
+		}
+		return &r, diags
 	case !m.JiraCloud.IsNull():
 		data, d := m.JiraCloud.ToPtr(ctx)
 		diags.Append(d...)
@@ -403,6 +478,18 @@ func (m providerDetailModel) expandToProviderConfiguration(ctx context.Context) 
 func (m providerDetailModel) expandToProviderUpdateConfiguration(ctx context.Context) (awstypes.ProviderUpdateConfiguration, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	switch {
+	case !m.Azure.IsNull():
+		data, d := m.Azure.ToPtr(ctx)
+		diags.Append(d...)
+		if diags.HasError() {
+			return nil, diags
+		}
+		var r awstypes.ProviderUpdateConfigurationMemberAzure
+		diags.Append(fwflex.Expand(ctx, data, &r.Value)...)
+		if diags.HasError() {
+			return nil, diags
+		}
+		return &r, diags
 	case !m.JiraCloud.IsNull():
 		data, d := m.JiraCloud.ToPtr(ctx)
 		diags.Append(d...)
@@ -434,6 +521,13 @@ func (m providerDetailModel) expandToProviderUpdateConfiguration(ctx context.Con
 func (m *providerDetailModel) Flatten(ctx context.Context, v any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	switch t := v.(type) {
+	case awstypes.ProviderDetailMemberAzure:
+		var data azureDetailModel
+		diags.Append(fwflex.Flatten(ctx, t.Value, &data)...)
+		if diags.HasError() {
+			return diags
+		}
+		m.Azure = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &data)
 	case awstypes.ProviderDetailMemberJiraCloud:
 		var data jiraCloudDetailModel
 		diags.Append(fwflex.Flatten(ctx, t.Value, &data)...)
@@ -469,4 +563,15 @@ type serviceNowDetailModel struct {
 	AuthStatus   types.String `tfsdk:"auth_status"`
 	InstanceName types.String `tfsdk:"instance_name"`
 	SecretARN    fwtypes.ARN  `tfsdk:"secret_arn"`
+}
+
+type azureDetailModel struct {
+	AWSConfigConnectorARN fwtypes.ARN                                                   `tfsdk:"aws_config_connector_arn"`
+	AzureRegions          fwtypes.SetOfString                                           `tfsdk:"azure_regions"`
+	ScopeConfiguration    fwtypes.ListNestedObjectValueOf[azureScopeConfigurationModel] `tfsdk:"scope_configuration"`
+}
+
+type azureScopeConfigurationModel struct {
+	ScopeType   fwtypes.StringEnum[awstypes.ScopeType] `tfsdk:"scope_type"`
+	ScopeValues fwtypes.SetOfString                    `tfsdk:"scope_values"`
 }

--- a/internal/service/securityhub/connector_v2.go
+++ b/internal/service/securityhub/connector_v2.go
@@ -91,7 +91,6 @@ func (r *connectorV2Resource) Schema(ctx context.Context, request resource.Schem
 								listvalidator.ExactlyOneOf(
 									path.MatchRelative().AtParent().AtName("jira_cloud"),
 									path.MatchRelative().AtParent().AtName("service_now"),
-									path.MatchRelative().AtParent().AtName("azure"),
 								),
 							},
 							NestedObject: schema.NestedBlockObject{
@@ -133,50 +132,6 @@ func (r *connectorV2Resource) Schema(ctx context.Context, request resource.Schem
 									"secret_arn": schema.StringAttribute{
 										CustomType: fwtypes.ARNType,
 										Required:   true,
-									},
-								},
-							},
-						},
-						"azure": schema.ListNestedBlock{
-							CustomType: fwtypes.NewListNestedObjectTypeOf[azureDetailModel](ctx),
-							Validators: []validator.List{
-								listvalidator.SizeAtMost(1),
-							},
-							NestedObject: schema.NestedBlockObject{
-								Attributes: map[string]schema.Attribute{
-									"aws_config_connector_arn": schema.StringAttribute{
-										CustomType: fwtypes.ARNType,
-										Required:   true,
-										PlanModifiers: []planmodifier.String{
-											stringplanmodifier.RequiresReplace(),
-										},
-									},
-									"azure_regions": schema.SetAttribute{
-										CustomType:  fwtypes.SetOfStringType,
-										ElementType: types.StringType,
-										Required:    true,
-									},
-								},
-								Blocks: map[string]schema.Block{
-									"scope_configuration": schema.ListNestedBlock{
-										CustomType: fwtypes.NewListNestedObjectTypeOf[azureScopeConfigurationModel](ctx),
-										Validators: []validator.List{
-											listvalidator.IsRequired(),
-											listvalidator.SizeAtMost(1),
-										},
-										NestedObject: schema.NestedBlockObject{
-											Attributes: map[string]schema.Attribute{
-												"scope_type": schema.StringAttribute{
-													CustomType: fwtypes.StringEnumType[awstypes.ScopeType](),
-													Required:   true,
-												},
-												"scope_values": schema.SetAttribute{
-													CustomType:  fwtypes.SetOfStringType,
-													ElementType: types.StringType,
-													Optional:    true,
-												},
-											},
-										},
 									},
 								},
 							},
@@ -394,7 +349,6 @@ type healthCheckModel struct {
 }
 
 type providerDetailModel struct {
-	Azure      fwtypes.ListNestedObjectValueOf[azureDetailModel]      `tfsdk:"azure"`
 	JiraCloud  fwtypes.ListNestedObjectValueOf[jiraCloudDetailModel]  `tfsdk:"jira_cloud"`
 	ServiceNow fwtypes.ListNestedObjectValueOf[serviceNowDetailModel] `tfsdk:"service_now"`
 }
@@ -418,18 +372,6 @@ func (m providerDetailModel) ExpandTo(ctx context.Context, targetType reflect.Ty
 func (m providerDetailModel) expandToProviderConfiguration(ctx context.Context) (awstypes.ProviderConfiguration, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	switch {
-	case !m.Azure.IsNull():
-		data, d := m.Azure.ToPtr(ctx)
-		diags.Append(d...)
-		if diags.HasError() {
-			return nil, diags
-		}
-		var r awstypes.ProviderConfigurationMemberAzure
-		diags.Append(fwflex.Expand(ctx, data, &r.Value)...)
-		if diags.HasError() {
-			return nil, diags
-		}
-		return &r, diags
 	case !m.JiraCloud.IsNull():
 		data, d := m.JiraCloud.ToPtr(ctx)
 		diags.Append(d...)
@@ -461,18 +403,6 @@ func (m providerDetailModel) expandToProviderConfiguration(ctx context.Context) 
 func (m providerDetailModel) expandToProviderUpdateConfiguration(ctx context.Context) (awstypes.ProviderUpdateConfiguration, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	switch {
-	case !m.Azure.IsNull():
-		data, d := m.Azure.ToPtr(ctx)
-		diags.Append(d...)
-		if diags.HasError() {
-			return nil, diags
-		}
-		var r awstypes.ProviderUpdateConfigurationMemberAzure
-		diags.Append(fwflex.Expand(ctx, data, &r.Value)...)
-		if diags.HasError() {
-			return nil, diags
-		}
-		return &r, diags
 	case !m.JiraCloud.IsNull():
 		data, d := m.JiraCloud.ToPtr(ctx)
 		diags.Append(d...)
@@ -504,13 +434,6 @@ func (m providerDetailModel) expandToProviderUpdateConfiguration(ctx context.Con
 func (m *providerDetailModel) Flatten(ctx context.Context, v any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	switch t := v.(type) {
-	case awstypes.ProviderDetailMemberAzure:
-		var data azureDetailModel
-		diags.Append(fwflex.Flatten(ctx, t.Value, &data)...)
-		if diags.HasError() {
-			return diags
-		}
-		m.Azure = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &data)
 	case awstypes.ProviderDetailMemberJiraCloud:
 		var data jiraCloudDetailModel
 		diags.Append(fwflex.Flatten(ctx, t.Value, &data)...)
@@ -546,15 +469,4 @@ type serviceNowDetailModel struct {
 	AuthStatus   types.String `tfsdk:"auth_status"`
 	InstanceName types.String `tfsdk:"instance_name"`
 	SecretARN    fwtypes.ARN  `tfsdk:"secret_arn"`
-}
-
-type azureDetailModel struct {
-	AWSConfigConnectorARN fwtypes.ARN                                                   `tfsdk:"aws_config_connector_arn"`
-	AzureRegions          fwtypes.SetOfString                                           `tfsdk:"azure_regions"`
-	ScopeConfiguration    fwtypes.ListNestedObjectValueOf[azureScopeConfigurationModel] `tfsdk:"scope_configuration"`
-}
-
-type azureScopeConfigurationModel struct {
-	ScopeType   fwtypes.StringEnum[awstypes.ScopeType] `tfsdk:"scope_type"`
-	ScopeValues fwtypes.SetOfString                    `tfsdk:"scope_values"`
 }

--- a/internal/service/securityhub/connector_v2.go
+++ b/internal/service/securityhub/connector_v2.go
@@ -91,6 +91,7 @@ func (r *connectorV2Resource) Schema(ctx context.Context, request resource.Schem
 								listvalidator.ExactlyOneOf(
 									path.MatchRelative().AtParent().AtName("jira_cloud"),
 									path.MatchRelative().AtParent().AtName("service_now"),
+									path.MatchRelative().AtParent().AtName("azure"),
 								),
 							},
 							NestedObject: schema.NestedBlockObject{
@@ -132,6 +133,50 @@ func (r *connectorV2Resource) Schema(ctx context.Context, request resource.Schem
 									"secret_arn": schema.StringAttribute{
 										CustomType: fwtypes.ARNType,
 										Required:   true,
+									},
+								},
+							},
+						},
+						"azure": schema.ListNestedBlock{
+							CustomType: fwtypes.NewListNestedObjectTypeOf[azureDetailModel](ctx),
+							Validators: []validator.List{
+								listvalidator.SizeAtMost(1),
+							},
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									"aws_config_connector_arn": schema.StringAttribute{
+										CustomType: fwtypes.ARNType,
+										Required:   true,
+										PlanModifiers: []planmodifier.String{
+											stringplanmodifier.RequiresReplace(),
+										},
+									},
+									"azure_regions": schema.SetAttribute{
+										CustomType:  fwtypes.SetOfStringType,
+										ElementType: types.StringType,
+										Required:    true,
+									},
+								},
+								Blocks: map[string]schema.Block{
+									"scope_configuration": schema.ListNestedBlock{
+										CustomType: fwtypes.NewListNestedObjectTypeOf[azureScopeConfigurationModel](ctx),
+										Validators: []validator.List{
+											listvalidator.IsRequired(),
+											listvalidator.SizeAtMost(1),
+										},
+										NestedObject: schema.NestedBlockObject{
+											Attributes: map[string]schema.Attribute{
+												"scope_type": schema.StringAttribute{
+													CustomType: fwtypes.StringEnumType[awstypes.ScopeType](),
+													Required:   true,
+												},
+												"scope_values": schema.SetAttribute{
+													CustomType:  fwtypes.SetOfStringType,
+													ElementType: types.StringType,
+													Optional:    true,
+												},
+											},
+										},
 									},
 								},
 							},
@@ -349,6 +394,7 @@ type healthCheckModel struct {
 }
 
 type providerDetailModel struct {
+	Azure      fwtypes.ListNestedObjectValueOf[azureDetailModel]      `tfsdk:"azure"`
 	JiraCloud  fwtypes.ListNestedObjectValueOf[jiraCloudDetailModel]  `tfsdk:"jira_cloud"`
 	ServiceNow fwtypes.ListNestedObjectValueOf[serviceNowDetailModel] `tfsdk:"service_now"`
 }
@@ -372,6 +418,18 @@ func (m providerDetailModel) ExpandTo(ctx context.Context, targetType reflect.Ty
 func (m providerDetailModel) expandToProviderConfiguration(ctx context.Context) (awstypes.ProviderConfiguration, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	switch {
+	case !m.Azure.IsNull():
+		data, d := m.Azure.ToPtr(ctx)
+		diags.Append(d...)
+		if diags.HasError() {
+			return nil, diags
+		}
+		var r awstypes.ProviderConfigurationMemberAzure
+		diags.Append(fwflex.Expand(ctx, data, &r.Value)...)
+		if diags.HasError() {
+			return nil, diags
+		}
+		return &r, diags
 	case !m.JiraCloud.IsNull():
 		data, d := m.JiraCloud.ToPtr(ctx)
 		diags.Append(d...)
@@ -403,6 +461,18 @@ func (m providerDetailModel) expandToProviderConfiguration(ctx context.Context) 
 func (m providerDetailModel) expandToProviderUpdateConfiguration(ctx context.Context) (awstypes.ProviderUpdateConfiguration, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	switch {
+	case !m.Azure.IsNull():
+		data, d := m.Azure.ToPtr(ctx)
+		diags.Append(d...)
+		if diags.HasError() {
+			return nil, diags
+		}
+		var r awstypes.ProviderUpdateConfigurationMemberAzure
+		diags.Append(fwflex.Expand(ctx, data, &r.Value)...)
+		if diags.HasError() {
+			return nil, diags
+		}
+		return &r, diags
 	case !m.JiraCloud.IsNull():
 		data, d := m.JiraCloud.ToPtr(ctx)
 		diags.Append(d...)
@@ -434,6 +504,13 @@ func (m providerDetailModel) expandToProviderUpdateConfiguration(ctx context.Con
 func (m *providerDetailModel) Flatten(ctx context.Context, v any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	switch t := v.(type) {
+	case awstypes.ProviderDetailMemberAzure:
+		var data azureDetailModel
+		diags.Append(fwflex.Flatten(ctx, t.Value, &data)...)
+		if diags.HasError() {
+			return diags
+		}
+		m.Azure = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &data)
 	case awstypes.ProviderDetailMemberJiraCloud:
 		var data jiraCloudDetailModel
 		diags.Append(fwflex.Flatten(ctx, t.Value, &data)...)
@@ -469,4 +546,15 @@ type serviceNowDetailModel struct {
 	AuthStatus   types.String `tfsdk:"auth_status"`
 	InstanceName types.String `tfsdk:"instance_name"`
 	SecretARN    fwtypes.ARN  `tfsdk:"secret_arn"`
+}
+
+type azureDetailModel struct {
+	AWSConfigConnectorARN fwtypes.ARN                                                   `tfsdk:"aws_config_connector_arn"`
+	AzureRegions          fwtypes.SetOfString                                           `tfsdk:"azure_regions"`
+	ScopeConfiguration    fwtypes.ListNestedObjectValueOf[azureScopeConfigurationModel] `tfsdk:"scope_configuration"`
+}
+
+type azureScopeConfigurationModel struct {
+	ScopeType   fwtypes.StringEnum[awstypes.ScopeType] `tfsdk:"scope_type"`
+	ScopeValues fwtypes.SetOfString                    `tfsdk:"scope_values"`
 }

--- a/internal/service/securityhub/connector_v2.go
+++ b/internal/service/securityhub/connector_v2.go
@@ -46,6 +46,8 @@ func newConnectorV2Resource(_ context.Context) (resource.ResourceWithConfigure, 
 	return &connectorV2Resource{}, nil
 }
 
+const connectorV2DeleteTimeout = 15 * time.Minute
+
 type connectorV2Resource struct {
 	framework.ResourceWithModel[connectorV2ResourceModel]
 	framework.WithImportByIdentity
@@ -331,7 +333,7 @@ func (r *connectorV2Resource) Delete(ctx context.Context, request resource.Delet
 	}
 	// Azure connectors are enabled asynchronously and cannot be deleted while in
 	// the PENDING_ENABLEMENT state, so retry until the connector is deletable.
-	_, err := tfresource.RetryWhenIsAErrorMessageContains[any, *awstypes.ConflictException](ctx, 15*time.Minute, func(ctx context.Context) (any, error) {
+	_, err := tfresource.RetryWhenIsAErrorMessageContains[any, *awstypes.ConflictException](ctx, connectorV2DeleteTimeout, func(ctx context.Context) (any, error) {
 		return conn.DeleteConnectorV2(ctx, &input)
 	}, "cannot be deleted")
 
@@ -347,7 +349,7 @@ func (r *connectorV2Resource) Delete(ctx context.Context, request resource.Delet
 	// Wait for the connector to be fully deleted so that any service-linked
 	// configuration recorders it created are removed before dependent resources
 	// (such as aws_config_connector) are deleted.
-	_, err = tfresource.RetryUntilNotFound(ctx, 15*time.Minute, func(ctx context.Context) (any, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, connectorV2DeleteTimeout, func(ctx context.Context) (any, error) {
 		return findConnectorV2ByID(ctx, conn, connectorID)
 	})
 

--- a/internal/service/securityhub/connector_v2_test.go
+++ b/internal/service/securityhub/connector_v2_test.go
@@ -6,6 +6,7 @@ package securityhub_test
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/YakDriver/regexache"
@@ -454,4 +455,75 @@ resource "aws_securityhub_connector_v2" "test" {
   depends_on = [aws_securityhub_aggregator_v2.test]
 }
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2))
+}
+
+func testAccConnectorV2_azure(t *testing.T) {
+	ctx := acctest.Context(t)
+	var connector securityhub.GetConnectorV2Output
+	resourceName := "aws_securityhub_connector_v2.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	clientID := os.Getenv("AZURE_CLIENT_IDENTIFIER")
+	tenantID := os.Getenv("AZURE_TENANT_IDENTIFIER")
+
+	acctest.Test(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccConnectorV2AzurePreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SecurityHubServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckConnectorV2Destroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConnectorV2Config_azure(rName, clientID, tenantID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConnectorV2Exists(ctx, t, resourceName, &connector),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("connector_provider").AtSliceIndex(0).AtMapKey("azure").AtSliceIndex(0).AtMapKey("azure_regions"), knownvalue.SetSizeExact(1)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("connector_provider").AtSliceIndex(0).AtMapKey("azure").AtSliceIndex(0).AtMapKey("scope_configuration").AtSliceIndex(0).AtMapKey("scope_type"), knownvalue.StringExact("TENANT")),
+				},
+			},
+			{
+				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, "connector_id"),
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "connector_id",
+			},
+		},
+	})
+}
+
+func testAccConnectorV2AzurePreCheck(t *testing.T) {
+	if os.Getenv("AZURE_CLIENT_IDENTIFIER") == "" || os.Getenv("AZURE_TENANT_IDENTIFIER") == "" {
+		t.Skip("AZURE_CLIENT_IDENTIFIER and AZURE_TENANT_IDENTIFIER must be set for Security Hub V2 Azure connector acceptance tests")
+	}
+}
+
+func testAccConnectorV2Config_azure(rName, clientID, tenantID string) string {
+	return fmt.Sprintf(`
+resource "aws_securityhub_account_v2" "test" {}
+
+resource "aws_config_connector" "test" {
+  azure {
+    client_identifier = %[2]q
+    tenant_identifier = %[3]q
+  }
+}
+
+resource "aws_securityhub_connector_v2" "test" {
+  name = %[1]q
+
+  connector_provider {
+    azure {
+      aws_config_connector_arn = aws_config_connector.test.arn
+      azure_regions            = ["eastus"]
+
+      scope_configuration {
+        scope_type = "TENANT"
+      }
+    }
+  }
+
+  depends_on = [aws_securityhub_account_v2.test]
+}
+`, rName, clientID, tenantID)
 }

--- a/internal/service/securityhub/securityhub_test.go
+++ b/internal/service/securityhub/securityhub_test.go
@@ -80,6 +80,7 @@ func TestAccSecurityHub_serial(t *testing.T) {
 			"tags":                    testAccConnectorV2_tags,
 			"KMSKeyARN":               testAccConnectorV2_kmsKeyARN,
 			"ConnectorProviderUpdate": testAccConnectorV2_connectorProviderUpdate,
+			"Azure":                   testAccConnectorV2_azure,
 			"Identity":                testAccSecurityHubConnectorV2_identitySerial,
 			"ListBasic":               testAccConnectorV2_List_basic,
 			"ListIncludeResource":     testAccConnectorV2_List_includeResource,

--- a/website/docs/r/securityhub_connector_v2.html.markdown
+++ b/website/docs/r/securityhub_connector_v2.html.markdown
@@ -77,8 +77,26 @@ This resource supports the following arguments:
 
 The `connector_provider` block supports the following:
 
+* `azure` - (Optional) Details about a Microsoft Azure integration for multi-cloud coverage. See [`azure`](#azure) below.
 * `jira_cloud` - (Optional) Details about a Jira Cloud integration. See [`jira_cloud`](#jira_cloud) below.
 * `service_now` - (Optional) Details about a ServiceNow ITSM integration. See [`service_now`](#service_now) below.
+
+Exactly one of `azure`, `jira_cloud`, or `service_now` must be specified.
+
+### `azure`
+
+The `azure` block supports the following:
+
+* `aws_config_connector_arn` - (Required, Forces new resource) ARN of the AWS Config multi-cloud connector used to establish the connection to Azure. See [`aws_config_connector`](config_connector.html).
+* `azure_regions` - (Required) Set of Azure regions to monitor.
+* `scope_configuration` - (Required) Scope configuration that defines which Azure resources are monitored. See [`scope_configuration`](#scope_configuration) below.
+
+### `scope_configuration`
+
+The `scope_configuration` block supports the following:
+
+* `scope_type` - (Required) Type of scope. Valid values are `TENANT` and `SUBSCRIPTION`.
+* `scope_values` - (Optional) Set of scope values, such as Azure subscription IDs, when `scope_type` is `SUBSCRIPTION`.
 
 ### `jira_cloud`
 


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

This PR adds an `azure` connector provider option to the existing `aws_securityhub_connector_v2` resource, enabling Microsoft Azure multi-cloud coverage in Security Hub. It does not change provider-level access controls, encryption, or logging.

### Description

Adds Microsoft Azure support to `aws_securityhub_connector_v2` via a new `azure` block under `connector_provider`, mapping to the `AzureProviderConfiguration` member of the `CreateConnectorV2` / `UpdateConnectorV2` provider configuration union.

The `azure` block supports:

* `aws_config_connector_arn` - (Required, ForceNew) ARN of the AWS Config multi-cloud connector.
* `azure_regions` - (Required) Azure regions to monitor.
* `scope_configuration { scope_type, scope_values }` - (Required) tenant or subscription scope.

`azure_regions` and `scope_configuration` are updatable in place via `AzureUpdateConfiguration`; `aws_config_connector_arn` forces a new resource. Unlike the ticketing providers, Azure uses federated identity (no OAuth `auth_url` step).

```terraform
resource "aws_securityhub_account_v2" "example" {}

resource "aws_config_connector" "example" {
  azure {
    client_identifier = "00000000-0000-0000-0000-000000000000"
    tenant_identifier = "11111111-1111-1111-1111-111111111111"
  }
}

resource "aws_securityhub_connector_v2" "example" {
  name = "example-azure"

  connector_provider {
    azure {
      aws_config_connector_arn = aws_config_connector.example.arn
      azure_regions            = ["eastus"]

      scope_configuration {
        scope_type = "TENANT"
      }
    }
  }

  depends_on = [aws_securityhub_account_v2.example]
}
```

### Relations

Depends on the new `aws_config_connector` resource (hashicorp/terraform-provider-aws#49559), which provides the required `aws_config_connector_arn`. This PR is a draft until that resource merges.

Relates https://github.com/hashicorp/terraform-provider-aws/issues/49568.

### References

* [Configuring Security Hub to integrate with Microsoft Azure](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-v2-azure-setup-securityhub-v2.html)

### Output from Acceptance Testing

> [!NOTE]
> Acceptance tests require the `aws_config_connector` resource (#49559) and a live Microsoft Azure tenant and application registration (`AZURE_CLIENT_IDENTIFIER` and `AZURE_TENANT_IDENTIFIER` environment variables), and have not yet been run. Draft until the following passes:

```console
% make testacc TESTS='TestAccSecurityHub_serial/ConnectorV2/Azure' PKG=securityhub

...
```
