### PR TITLE
r/aws_observabilityadmin_centralization_rule_for_organization: add encryption_scope

### DIFF
--- a/.changelog/49563.txt
+++ b/.changelog/49563.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_observabilityadmin_centralization_rule_for_organization: Add `encryption_scope` argument to the `logs_encryption_configuration` configuration block
+```

--- a/internal/service/observabilityadmin/centralization_rule_for_organization.go
+++ b/internal/service/observabilityadmin/centralization_rule_for_organization.go
@@ -163,6 +163,14 @@ func (r *centralizationRuleForOrganizationResource) Schema(ctx context.Context, 
 																Optional:   true,
 																CustomType: fwtypes.StringEnumType[awstypes.EncryptionConflictResolutionStrategy](),
 															},
+															"encryption_scope": schema.StringAttribute{
+																Optional:   true,
+																Computed:   true,
+																CustomType: fwtypes.StringEnumType[awstypes.EncryptionScope](),
+																PlanModifiers: []planmodifier.String{
+																	stringplanmodifier.UseStateForUnknown(),
+																},
+															},
 															"encryption_strategy": schema.StringAttribute{
 																Required:   true,
 																CustomType: fwtypes.StringEnumType[awstypes.EncryptionStrategy](),
@@ -338,6 +346,19 @@ func (r *centralizationRuleForOrganizationResource) Create(ctx context.Context, 
 
 	if _, err := waitCentralizationRuleForOrganizationHealthy(ctx, conn, ruleName, r.CreateTimeout(ctx, data.Timeouts)); err != nil {
 		smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, ruleName)
+		return
+	}
+
+	// The Create response only returns the rule ARN, so read the rule back to
+	// populate Computed attributes (e.g. encryption_scope) that the service defaults.
+	out, err := findCentralizationRuleForOrganizationByID(ctx, conn, ruleName)
+	if err != nil {
+		smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, ruleName)
+		return
+	}
+
+	smerr.AddEnrich(ctx, &response.Diagnostics, fwflex.Flatten(ctx, out, &data, fwflex.WithFieldNamePrefix("Centralization")))
+	if response.Diagnostics.HasError() {
 		return
 	}
 
@@ -558,6 +579,7 @@ type logGroupNameConfigurationModel struct {
 
 type logsEncryptionConfigurationModel struct {
 	EncryptionConflictResolutionStrategy fwtypes.StringEnum[awstypes.EncryptionConflictResolutionStrategy] `tfsdk:"encryption_conflict_resolution_strategy"`
+	EncryptionScope                      fwtypes.StringEnum[awstypes.EncryptionScope]                      `tfsdk:"encryption_scope"`
 	EncryptionStrategy                   fwtypes.StringEnum[awstypes.EncryptionStrategy]                   `tfsdk:"encryption_strategy"`
 	KMSKeyARN                            fwtypes.ARN                                                       `tfsdk:"kms_key_arn"`
 }

--- a/internal/service/observabilityadmin/centralization_rule_for_organization_flex_test.go
+++ b/internal/service/observabilityadmin/centralization_rule_for_organization_flex_test.go
@@ -1,0 +1,49 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package observabilityadmin
+
+import (
+	"context"
+	"testing"
+
+	awstypes "github.com/aws/aws-sdk-go-v2/service/observabilityadmin/types"
+	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+)
+
+// TestExpandLogsEncryptionConfigurationEncryptionScope validates that the new
+// encryption_scope attribute is carried from the Terraform model into the SDK
+// LogsEncryptionConfiguration input via AutoFlex. This runs fully offline (no AWS).
+func TestExpandLogsEncryptionConfigurationEncryptionScope(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	testCases := map[string]awstypes.EncryptionScope{
+		"new_destination_log_groups": awstypes.EncryptionScopeNewDestinationLogGroups,
+		"encrypted_source_only":      awstypes.EncryptionScopeEncryptedSourceOnly,
+	}
+
+	for name, scope := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			model := logsEncryptionConfigurationModel{
+				EncryptionStrategy: fwtypes.StringEnumValue(awstypes.EncryptionStrategyCustomerManaged),
+				EncryptionScope:    fwtypes.StringEnumValue(scope),
+			}
+
+			var out awstypes.LogsEncryptionConfiguration
+			if diags := fwflex.Expand(ctx, model, &out); diags.HasError() {
+				t.Fatalf("unexpected diags expanding model: %v", diags)
+			}
+
+			if got, want := out.EncryptionScope, scope; got != want {
+				t.Errorf("EncryptionScope = %q, want %q", got, want)
+			}
+			if got, want := out.EncryptionStrategy, awstypes.EncryptionStrategyCustomerManaged; got != want {
+				t.Errorf("EncryptionStrategy = %q, want %q", got, want)
+			}
+		})
+	}
+}

--- a/internal/service/observabilityadmin/centralization_rule_for_organization_test.go
+++ b/internal/service/observabilityadmin/centralization_rule_for_organization_test.go
@@ -226,6 +226,72 @@ func TestAccObservabilityAdminCentralizationRuleForOrganization_update(t *testin
 	})
 }
 
+func TestAccObservabilityAdminCentralizationRuleForOrganization_encryptionScope(t *testing.T) {
+	ctx := acctest.Context(t)
+	var rule observabilityadmin.GetCentralizationRuleForOrganizationOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_observabilityadmin_centralization_rule_for_organization.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckOrganizationManagementAccount(ctx, t)
+			acctest.PreCheckIAMServiceLinkedRole(ctx, t, "/aws-service-role/observabilityadmin.amazonaws.com")
+			acctest.PreCheckOrganizationsEnabledServicePrincipal(ctx, t, "observabilityadmin.amazonaws.com")
+			acctest.PreCheckIAMServiceLinkedRole(ctx, t, "/aws-service-role/logs-centralization.observabilityadmin.amazonaws.com")
+			acctest.PreCheckPartition(t, endpoints.AwsPartitionID)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ObservabilityAdminServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckCentralizationRuleForOrganizationDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCentralizationRuleForOrganizationConfig_encryptionScope(rName, string(awstypes.EncryptionScopeNewDestinationLogGroups), acctest.Region()),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckCentralizationRuleForOrganizationExists(ctx, t, resourceName, &rule),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName,
+						tfjsonpath.New(names.AttrRule).AtSliceIndex(0).
+							AtMapKey(names.AttrDestination).AtSliceIndex(0).
+							AtMapKey("destination_logs_configuration").AtSliceIndex(0).
+							AtMapKey("logs_encryption_configuration").AtSliceIndex(0).
+							AtMapKey("encryption_scope"),
+						tfknownvalue.StringExact(awstypes.EncryptionScopeNewDestinationLogGroups)),
+				},
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, "rule_name"),
+				ImportStateVerifyIdentifierAttribute: "rule_name",
+			},
+			{
+				Config: testAccCentralizationRuleForOrganizationConfig_encryptionScope(rName, string(awstypes.EncryptionScopeEncryptedSourceOnly), acctest.Region()),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckCentralizationRuleForOrganizationExists(ctx, t, resourceName, &rule),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName,
+						tfjsonpath.New(names.AttrRule).AtSliceIndex(0).
+							AtMapKey(names.AttrDestination).AtSliceIndex(0).
+							AtMapKey("destination_logs_configuration").AtSliceIndex(0).
+							AtMapKey("logs_encryption_configuration").AtSliceIndex(0).
+							AtMapKey("encryption_scope"),
+						tfknownvalue.StringExact(awstypes.EncryptionScopeEncryptedSourceOnly)),
+				},
+			},
+		},
+	})
+}
+
 func TestAccObservabilityAdminCentralizationRuleForOrganization_destinationLogGroupNameConfiguration(t *testing.T) {
 	ctx := acctest.Context(t)
 	var rule observabilityadmin.GetCentralizationRuleForOrganizationOutput
@@ -549,6 +615,76 @@ resource "aws_observabilityadmin_centralization_rule_for_organization" "test" {
   }
 }
 `, rName, dstRegion, bkupRegion, acctest.ListOfStrings(srcRegions...))
+}
+
+func testAccCentralizationRuleForOrganizationConfig_encryptionScope(rName, encryptionScope, region string) string {
+	return fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+data "aws_organizations_organization" "current" {}
+data "aws_partition" "current" {}
+
+resource "aws_kms_key" "test" {
+  description             = %[1]q
+  deletion_window_in_days = 7
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "EnableIAMUserPermissions"
+        Effect    = "Allow"
+        Principal = { AWS = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:root" }
+        Action    = "kms:*"
+        Resource  = "*"
+      },
+      {
+        Sid       = "AllowCloudWatchLogs"
+        Effect    = "Allow"
+        Principal = { Service = "logs.amazonaws.com" }
+        Action = [
+          "kms:Encrypt",
+          "kms:Decrypt",
+          "kms:ReEncrypt*",
+          "kms:GenerateDataKey*",
+          "kms:DescribeKey",
+          "kms:CreateGrant",
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+resource "aws_observabilityadmin_centralization_rule_for_organization" "test" {
+  rule_name = %[1]q
+
+  rule {
+    destination {
+      region  = %[3]q
+      account = data.aws_caller_identity.current.account_id
+
+      destination_logs_configuration {
+        logs_encryption_configuration {
+          encryption_strategy                     = "CUSTOMER_MANAGED"
+          encryption_conflict_resolution_strategy = "ALLOW"
+          kms_key_arn                             = aws_kms_key.test.arn
+          encryption_scope                        = %[2]q
+        }
+      }
+    }
+
+    source {
+      regions = [%[3]q]
+      scope   = "OrganizationId = '${data.aws_organizations_organization.current.id}'"
+
+      source_logs_configuration {
+        encrypted_log_group_strategy = "ALLOW"
+        log_group_selection_criteria = "LogGroupName LIKE '/aws/lambda%%'"
+      }
+    }
+  }
+}
+`, rName, encryptionScope, region)
 }
 
 func testAccCentralizationRuleForOrganizationConfig_destinationLogGroupNameConfiguration(rName, logGroupNamePattern string, dstRegion, bkupRegion string, srcRegions ...string) string {

--- a/website/docs/r/observabilityadmin_centralization_rule_for_organization.html.markdown
+++ b/website/docs/r/observabilityadmin_centralization_rule_for_organization.html.markdown
@@ -206,6 +206,7 @@ The following arguments are optional:
 
 * `encryption_strategy` - (Required) Encryption strategy for logs. Valid values: `AWS_OWNED`, `CUSTOMER_MANAGED`.
 * `encryption_conflict_resolution_strategy` - (Optional) Strategy for resolving encryption conflicts. Valid values: `ALLOW`, `SKIP`.
+* `encryption_scope` - (Optional) Determines which newly created destination log groups are encrypted with `kms_key_arn` when `encryption_strategy` is `CUSTOMER_MANAGED`. Valid values: `ENCRYPTED_SOURCE_ONLY` (default), `NEW_DESTINATION_LOG_GROUPS`. Not valid when `encryption_strategy` is `AWS_OWNED`.
 * `kms_key_arn` - (Optional) ARN of the KMS key to use for encryption when `encryption_strategy` is `CUSTOMER_MANAGED`.
 
 #### destination_metrics_configuration


### PR DESCRIPTION
### Description

Adds the `encryption_scope` argument to the `logs_encryption_configuration` configuration
block of `aws_observabilityadmin_centralization_rule_for_organization`. This was the last
unexposed field on the resource's `LogsEncryptionConfiguration` API surface.

`encryption_scope` controls which newly created destination log groups are encrypted with
the configured `kms_key_arn` when `encryption_strategy = CUSTOMER_MANAGED`:

- `ENCRYPTED_SOURCE_ONLY` (server default) — only destination log groups whose source log
  group is encrypted with a customer managed key use `kms_key_arn`.
- `NEW_DESTINATION_LOG_GROUPS` — every new destination log group created by the rule uses
  `kms_key_arn`, regardless of the source log group's encryption posture.

The field is only valid when `encryption_strategy = CUSTOMER_MANAGED` (the API rejects it
under `AWS_OWNED`). It is modeled as `Optional` + `Computed` with `UseStateForUnknown`
because the service defaults the value, consistent with the other server-defaulted
attributes on this resource. AutoFlex maps it to the SDK `EncryptionScope` field.

This PR also **fixes population of Computed attributes on create**: the
`CreateCentralizationRuleForOrganization` response returns only the rule ARN, so the resource
previously never populated server-computed nested attributes after create. The Create handler
now reads the rule back (after the health wait) and flattens it into state, mirroring the Read
path. Without this, a `logs_encryption_configuration` block created without an explicit
`encryption_scope` would leave the Computed attribute unknown after apply
("Provider returned invalid result object after apply").

### Relations

Relates to the ObservabilityAdmin `CentralizationRule` `LogsEncryptionConfiguration` surface.

### References

* `aws-sdk-go-v2/service/observabilityadmin` `LogsEncryptionConfiguration.EncryptionScope`

### Output from Acceptance Testing

Full `TestAccObservabilityAdminCentralizationRuleForOrganization*` suite (8 tests) run against a
real AWS Organizations management account:

```console
$ make testacc PKG=observabilityadmin TESTS=TestAccObservabilityAdminCentralizationRuleForOrganization

--- PASS: TestAccObservabilityAdminCentralizationRuleForOrganization_disappears (41.06s)
--- PASS: TestAccObservabilityAdminCentralizationRuleForOrganization_basic (50.19s)
--- PASS: TestAccObservabilityAdminCentralizationRuleForOrganization_metricsConfiguration (50.33s)
--- PASS: TestAccObservabilityAdminCentralizationRuleForOrganization_encryptionScope (76.61s)
--- PASS: TestAccObservabilityAdminCentralizationRuleForOrganization_tags (99.24s)
--- PASS: TestAccObservabilityAdminCentralizationRuleForOrganization_dataSourceSelectionCriteria (99.97s)
--- PASS: TestAccObservabilityAdminCentralizationRuleForOrganization_destinationLogGroupNameConfiguration (100.35s)
--- PASS: TestAccObservabilityAdminCentralizationRuleForOrganization_update (100.91s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/observabilityadmin	107.257s
```
