### PR TITLE
r/aws_mailmanager_relay(test): serialize _Authentication_secretARN 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,9 +54,7 @@ BUG FIXES:
 FEATURES:
 
 * **New List Resource:** `aws_db_parameter_group` ([#49418](https://github.com/hashicorp/terraform-provider-aws/issues/49418))
-* **New List Resource:** `aws_mailmanager_relay` ([#49394](https://github.com/hashicorp/terraform-provider-aws/issues/49394))
 * **New List Resource:** `aws_resiliencehubv2_input_source` ([#48327](https://github.com/hashicorp/terraform-provider-aws/issues/48327))
-* **New Resource:** `aws_mailmanager_relay` ([#49394](https://github.com/hashicorp/terraform-provider-aws/issues/49394))
 * **New Resource:** `aws_resiliencehubv2_input_source` ([#48327](https://github.com/hashicorp/terraform-provider-aws/issues/48327))
 
 ENHANCEMENTS:

--- a/internal/service/mailmanager/ingress_point_test.go
+++ b/internal/service/mailmanager/ingress_point_test.go
@@ -21,27 +21,6 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccMailManagerIngressPoint_serial(t *testing.T) {
-	t.Parallel()
-
-	testCases := map[string]func(t *testing.T){
-		acctest.CtBasic:                testAccMailManagerIngressPoint_basic,
-		acctest.CtDisappears:           testAccMailManagerIngressPoint_disappears,
-		"update":                       testAccMailManagerIngressPoint_update,
-		"tlsPolicy":                    testAccMailManagerIngressPoint_tlsPolicy,
-		"type":                         testAccMailManagerIngressPoint_type,
-		"networkConfiguration_public":  testAccMailManagerIngressPoint_networkConfiguration_public,
-		"networkConfiguration_private": testAccMailManagerIngressPoint_networkConfiguration_private,
-		"ingressPointConfiguration_smtpPasswordWO": testAccMailManagerIngressPoint_ingressPointConfiguration_smtpPasswordWO,
-		"ingressPointConfiguration_tlsAuth":        testAccMailManagerIngressPoint_ingressPointConfiguration_tlsAuth,
-		"Identity":                                 testAccMailManagerIngressPoint_identitySerial,
-		"Tags":                                     testAccMailManagerIngressPoint_tagsSerial,
-		"List":                                     testAccMailManagerIngressPoint_listSerial,
-	}
-
-	acctest.RunSerialTests1Level(t, testCases, 0)
-}
-
 func testAccMailManagerIngressPoint_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 

--- a/internal/service/mailmanager/mailmanager_test.go
+++ b/internal/service/mailmanager/mailmanager_test.go
@@ -1,0 +1,36 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package mailmanager_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccMailManager_serial(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]map[string]func(t *testing.T){
+		"IngressPoint": {
+			acctest.CtBasic:                testAccMailManagerIngressPoint_basic,
+			acctest.CtDisappears:           testAccMailManagerIngressPoint_disappears,
+			"update":                       testAccMailManagerIngressPoint_update,
+			"tlsPolicy":                    testAccMailManagerIngressPoint_tlsPolicy,
+			"type":                         testAccMailManagerIngressPoint_type,
+			"networkConfiguration_public":  testAccMailManagerIngressPoint_networkConfiguration_public,
+			"networkConfiguration_private": testAccMailManagerIngressPoint_networkConfiguration_private,
+			"ingressPointConfiguration_smtpPasswordWO": testAccMailManagerIngressPoint_ingressPointConfiguration_smtpPasswordWO,
+			"ingressPointConfiguration_tlsAuth":        testAccMailManagerIngressPoint_ingressPointConfiguration_tlsAuth,
+			"Identity":                                 testAccMailManagerIngressPoint_identitySerial,
+			"Tags":                                     testAccMailManagerIngressPoint_tagsSerial,
+			"List":                                     testAccMailManagerIngressPoint_listSerial,
+		},
+		"Relay": {
+			"Authentication_secretARN": testAccMailManagerRelay_Authentication_secretARN,
+		},
+	}
+
+	acctest.RunSerialTests2Levels(t, testCases, 0)
+}

--- a/internal/service/mailmanager/relay_test.go
+++ b/internal/service/mailmanager/relay_test.go
@@ -140,14 +140,15 @@ func TestAccMailManagerRelay_update(t *testing.T) {
 	})
 }
 
-func TestAccMailManagerRelay_Authentication_secretARN(t *testing.T) {
+func testAccMailManagerRelay_Authentication_secretARN(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_mailmanager_relay.test"
 	password := "Abcd1234!"
 
-	acctest.ParallelTest(ctx, t, resource.TestCase{
+	// Serialized due to the aws_mailmanager_ingress_point dependency
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccRelayPreCheck(ctx, t)


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
A follow-up to #49394 which serializes the "authentication" acceptance test which depends on a MailManager ingress point resource that has limited capacity in a single account. Also moves the acceptance tests for the ingress point resource into a central `_serial` test for the package now that serialization applies across multiple resource types.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/49394


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->


```console
% make t K=mailmanager T=TestAccMailManager_serial
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 td-relay-serialize 🌿...
TF_ACC=1 go1.26.6 test ./internal/service/mailmanager/... -v -count 1 -parallel 20 -run='TestAccMailManager_serial'  -timeout 360m -vet=off -buildvcs=false
2026/08/18 14:06:44 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/18 14:06:44 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccMailManager_serial (2067.02s)
    --- PASS: TestAccMailManager_serial/IngressPoint (2036.48s)
        --- PASS: TestAccMailManager_serial/IngressPoint/disappears (53.17s)
        --- PASS: TestAccMailManager_serial/IngressPoint/update (69.90s)
        --- PASS: TestAccMailManager_serial/IngressPoint/tlsPolicy (69.69s)
        --- PASS: TestAccMailManager_serial/IngressPoint/networkConfiguration_public (99.78s)
        --- PASS: TestAccMailManager_serial/IngressPoint/networkConfiguration_private (171.45s)
        --- PASS: TestAccMailManager_serial/IngressPoint/ingressPointConfiguration_smtpPasswordWO (33.97s)
        --- PASS: TestAccMailManager_serial/IngressPoint/ingressPointConfiguration_tlsAuth (68.99s)
        --- PASS: TestAccMailManager_serial/IngressPoint/type (69.82s)
        --- PASS: TestAccMailManager_serial/IngressPoint/Identity (129.31s)
            --- PASS: TestAccMailManager_serial/IngressPoint/Identity/basic (66.68s)
            --- PASS: TestAccMailManager_serial/IngressPoint/Identity/RegionOverride (62.64s)
        --- PASS: TestAccMailManager_serial/IngressPoint/Tags (1046.00s)
            --- PASS: TestAccMailManager_serial/IngressPoint/Tags/EmptyMap (57.00s)
            --- PASS: TestAccMailManager_serial/IngressPoint/Tags/ComputedTag_OnUpdate_Add (76.25s)
            --- PASS: TestAccMailManager_serial/IngressPoint/Tags/ComputedTag_OnUpdate_Replace (75.90s)
            --- SKIP: TestAccMailManager_serial/IngressPoint/Tags/null (0.00s)
            --- PASS: TestAccMailManager_serial/IngressPoint/Tags/AddOnUpdate (70.88s)
            --- SKIP: TestAccMailManager_serial/IngressPoint/Tags/EmptyTag_OnUpdate_Add (0.00s)
            --- SKIP: TestAccMailManager_serial/IngressPoint/Tags/EmptyTag_OnUpdate_Replace (0.00s)
            --- PASS: TestAccMailManager_serial/IngressPoint/Tags/DefaultTags_providerOnly (111.93s)
            --- SKIP: TestAccMailManager_serial/IngressPoint/Tags/DefaultTags_emptyResourceTag (0.00s)
            --- SKIP: TestAccMailManager_serial/IngressPoint/Tags/DefaultTags_nullOverlappingResourceTag (0.00s)
            --- PASS: TestAccMailManager_serial/IngressPoint/Tags/ComputedTag_OnCreate (63.04s)
            --- SKIP: TestAccMailManager_serial/IngressPoint/Tags/EmptyTag_OnCreate (0.00s)
            --- PASS: TestAccMailManager_serial/IngressPoint/Tags/DefaultTags_overlapping (94.09s)
            --- PASS: TestAccMailManager_serial/IngressPoint/Tags/DefaultTags_updateToProviderOnly (71.36s)
            --- PASS: TestAccMailManager_serial/IngressPoint/Tags/DefaultTags_updateToResourceOnly (71.26s)
            --- PASS: TestAccMailManager_serial/IngressPoint/Tags/IgnoreTags_Overlap_ResourceTag (70.89s)
            --- PASS: TestAccMailManager_serial/IngressPoint/Tags/DefaultTags_nonOverlapping (93.24s)
            --- SKIP: TestAccMailManager_serial/IngressPoint/Tags/DefaultTags_nullNonOverlappingResourceTag (0.00s)
            --- PASS: TestAccMailManager_serial/IngressPoint/Tags/IgnoreTags_Overlap_DefaultTag (80.57s)
            --- PASS: TestAccMailManager_serial/IngressPoint/Tags/basic (109.58s)
        --- PASS: TestAccMailManager_serial/IngressPoint/List (169.35s)
            --- PASS: TestAccMailManager_serial/IngressPoint/List/basic (65.35s)
            --- PASS: TestAccMailManager_serial/IngressPoint/List/includeResource (53.14s)
            --- PASS: TestAccMailManager_serial/IngressPoint/List/regionOverride (50.86s)
        --- PASS: TestAccMailManager_serial/IngressPoint/basic (55.05s)
    --- PASS: TestAccMailManager_serial/Relay (30.54s)
        --- PASS: TestAccMailManager_serial/Relay/Authentication_secretARN (30.54s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/mailmanager        2075.401s
```
