### PR TITLE
resource/aws_dx_hosted_private_virtual_interface_accepter: add SiteLink support

### DIFF
--- a/.changelog/49571.txt
+++ b/.changelog/49571.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_dx_hosted_private_virtual_interface_accepter: Add `sitelink_enabled` argument
+```

--- a/internal/service/directconnect/hosted_private_virtual_interface_accepter.go
+++ b/internal/service/directconnect/hosted_private_virtual_interface_accepter.go
@@ -15,6 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/directconnect"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/directconnect/types"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -38,6 +39,8 @@ func resourceHostedPrivateVirtualInterfaceAccepter() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceHostedPrivateVirtualInterfaceAccepterImport,
 		},
+
+		CustomizeDiff: resourceHostedPrivateVirtualInterfaceAccepterCustomizeDiff,
 
 		SchemaFunc: func() map[string]*schema.Schema {
 			return map[string]*schema.Schema{
@@ -63,6 +66,11 @@ func resourceHostedPrivateVirtualInterfaceAccepter() *schema.Resource {
 					Computed:     true,
 					ValidateFunc: validation.IntBetween(0, 1000),
 				},
+				"sitelink_enabled": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Computed: true,
+				},
 				names.AttrTags:    tftags.TagsSchema(),
 				names.AttrTagsAll: tftags.TagsSchemaComputed(),
 				"virtual_interface_id": {
@@ -81,6 +89,7 @@ func resourceHostedPrivateVirtualInterfaceAccepter() *schema.Resource {
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(10 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
 			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
 	}
@@ -89,6 +98,10 @@ func resourceHostedPrivateVirtualInterfaceAccepter() *schema.Resource {
 func resourceHostedPrivateVirtualInterfaceAccepterCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DirectConnectClient(ctx)
+
+	if err := validateHostedPrivateVirtualInterfaceAccepterSiteLink(cty.BoolVal(d.Get("sitelink_enabled").(bool)), cty.StringVal(d.Get("vpn_gateway_id").(string))); err != nil {
+		return sdkdiag.AppendErrorf(diags, "validating Direct Connect Hosted Private Virtual Interface Accepter SiteLink configuration: %s", err)
+	}
 
 	vifID := d.Get("virtual_interface_id").(string)
 	input := &directconnect.ConfirmPrivateVirtualInterfaceInput{
@@ -155,6 +168,7 @@ func resourceHostedPrivateVirtualInterfaceAccepterRead(ctx context.Context, d *s
 	d.Set("dx_gateway_id", vif.DirectConnectGatewayId)
 	d.Set("prefix_pool_allocated_count_ipv4", vif.PrefixPoolAllocatedCountIpv4)
 	d.Set("prefix_pool_allocated_count_ipv6", vif.PrefixPoolAllocatedCountIpv6)
+	d.Set("sitelink_enabled", vif.SiteLinkEnabled)
 	d.Set("virtual_interface_id", vif.VirtualInterfaceId)
 	d.Set("vpn_gateway_id", vif.VirtualGatewayId)
 
@@ -163,13 +177,47 @@ func resourceHostedPrivateVirtualInterfaceAccepterRead(ctx context.Context, d *s
 
 func resourceHostedPrivateVirtualInterfaceAccepterUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
+	siteLinkChanged := d.HasChange("sitelink_enabled")
+
+	if siteLinkChanged {
+		if err := validateHostedPrivateVirtualInterfaceAccepterSiteLink(cty.BoolVal(d.Get("sitelink_enabled").(bool)), cty.StringVal(d.Get("vpn_gateway_id").(string))); err != nil {
+			return sdkdiag.AppendErrorf(diags, "validating Direct Connect Hosted Private Virtual Interface Accepter SiteLink configuration: %s", err)
+		}
+	}
 
 	diags = append(diags, virtualInterfaceUpdate(ctx, d, meta)...)
 	if diags.HasError() {
 		return diags
 	}
 
+	if siteLinkChanged {
+		if _, err := waitHostedPrivateVirtualInterfaceAccepterAvailable(ctx, meta.(*conns.AWSClient).DirectConnectClient(ctx), d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
+			return sdkdiag.AppendErrorf(diags, "waiting for Direct Connect Hosted Private Virtual Interface Accepter (%s) update: %s", d.Id(), err)
+		}
+	}
+
 	return append(diags, resourceHostedPrivateVirtualInterfaceAccepterRead(ctx, d, meta)...)
+}
+
+func resourceHostedPrivateVirtualInterfaceAccepterCustomizeDiff(_ context.Context, diff *schema.ResourceDiff, _ any) error {
+	config := diff.GetRawConfig()
+	if !config.IsKnown() || config.IsNull() {
+		return nil
+	}
+
+	return validateHostedPrivateVirtualInterfaceAccepterSiteLink(config.GetAttr("sitelink_enabled"), config.GetAttr("vpn_gateway_id"))
+}
+
+func validateHostedPrivateVirtualInterfaceAccepterSiteLink(siteLinkEnabled, vpnGatewayID cty.Value) error {
+	if !siteLinkEnabled.IsKnown() || siteLinkEnabled.IsNull() || !siteLinkEnabled.True() {
+		return nil
+	}
+
+	if !vpnGatewayID.IsKnown() || (!vpnGatewayID.IsNull() && vpnGatewayID.AsString() != "") {
+		return fmt.Errorf(`"sitelink_enabled" cannot be enabled with "vpn_gateway_id"; use "dx_gateway_id" instead`)
+	}
+
+	return nil
 }
 
 func resourceHostedPrivateVirtualInterfaceAccepterImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {

--- a/internal/service/directconnect/hosted_private_virtual_interface_accepter.go
+++ b/internal/service/directconnect/hosted_private_virtual_interface_accepter.go
@@ -177,26 +177,30 @@ func resourceHostedPrivateVirtualInterfaceAccepterRead(ctx context.Context, d *s
 
 func resourceHostedPrivateVirtualInterfaceAccepterUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
-	siteLinkChanged := d.HasChange("sitelink_enabled")
+	config := d.GetRawConfig()
+	siteLinkConfigured := config.IsKnown() && !config.IsNull() && isConfiguredValue(config.GetAttr("sitelink_enabled"))
+	siteLinkChanged := siteLinkConfigured && d.HasChange("sitelink_enabled")
 
 	if siteLinkChanged {
 		if err := validateHostedPrivateVirtualInterfaceAccepterSiteLink(cty.BoolVal(d.Get("sitelink_enabled").(bool)), cty.StringVal(d.Get("vpn_gateway_id").(string))); err != nil {
 			return sdkdiag.AppendErrorf(diags, "validating Direct Connect Hosted Private Virtual Interface Accepter SiteLink configuration: %s", err)
 		}
-	}
 
-	diags = append(diags, virtualInterfaceUpdate(ctx, d, meta)...)
-	if diags.HasError() {
-		return diags
-	}
+		diags = append(diags, virtualInterfaceUpdate(ctx, d, meta)...)
+		if diags.HasError() {
+			return diags
+		}
 
-	if siteLinkChanged {
 		if _, err := waitHostedPrivateVirtualInterfaceAccepterAvailable(ctx, meta.(*conns.AWSClient).DirectConnectClient(ctx), d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
 			return sdkdiag.AppendErrorf(diags, "waiting for Direct Connect Hosted Private Virtual Interface Accepter (%s) update: %s", d.Id(), err)
 		}
 	}
 
 	return append(diags, resourceHostedPrivateVirtualInterfaceAccepterRead(ctx, d, meta)...)
+}
+
+func isConfiguredValue(value cty.Value) bool {
+	return value.IsKnown() && !value.IsNull()
 }
 
 func resourceHostedPrivateVirtualInterfaceAccepterCustomizeDiff(_ context.Context, diff *schema.ResourceDiff, _ any) error {

--- a/internal/service/directconnect/hosted_private_virtual_interface_accepter.go
+++ b/internal/service/directconnect/hosted_private_virtual_interface_accepter.go
@@ -180,6 +180,7 @@ func resourceHostedPrivateVirtualInterfaceAccepterUpdate(ctx context.Context, d 
 	config := d.GetRawConfig()
 	siteLinkConfigured := config.IsKnown() && !config.IsNull() && isConfiguredValue(config.GetAttr("sitelink_enabled"))
 	siteLinkChanged := siteLinkConfigured && d.HasChange("sitelink_enabled")
+	prefixPoolChanged := d.HasChanges("prefix_pool_allocated_count_ipv4", "prefix_pool_allocated_count_ipv6")
 
 	if siteLinkChanged {
 		if err := validateHostedPrivateVirtualInterfaceAccepterSiteLink(cty.BoolVal(d.Get("sitelink_enabled").(bool)), cty.StringVal(d.Get("vpn_gateway_id").(string))); err != nil {
@@ -193,6 +194,11 @@ func resourceHostedPrivateVirtualInterfaceAccepterUpdate(ctx context.Context, d 
 
 		if _, err := waitHostedPrivateVirtualInterfaceAccepterAvailable(ctx, meta.(*conns.AWSClient).DirectConnectClient(ctx), d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
 			return sdkdiag.AppendErrorf(diags, "waiting for Direct Connect Hosted Private Virtual Interface Accepter (%s) update: %s", d.Id(), err)
+		}
+	} else if prefixPoolChanged {
+		diags = append(diags, virtualInterfaceUpdatePrefixPool(ctx, d, meta)...)
+		if diags.HasError() {
+			return diags
 		}
 	}
 

--- a/internal/service/directconnect/hosted_private_virtual_interface_accepter_test.go
+++ b/internal/service/directconnect/hosted_private_virtual_interface_accepter_test.go
@@ -1,0 +1,82 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package directconnect
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func TestResourceHostedPrivateVirtualInterfaceAccepterSchema(t *testing.T) {
+	t.Parallel()
+
+	resource := resourceHostedPrivateVirtualInterfaceAccepter()
+	if err := resource.InternalValidate(nil, true); err != nil {
+		t.Fatalf("invalid resource schema: %s", err)
+	}
+
+	attribute, ok := resource.SchemaMap()["sitelink_enabled"]
+	if !ok {
+		t.Fatal("expected sitelink_enabled schema")
+	}
+	if attribute.Type != schema.TypeBool {
+		t.Errorf("expected sitelink_enabled to be TypeBool, got %s", attribute.Type)
+	}
+	if !attribute.Optional {
+		t.Error("expected sitelink_enabled to be optional")
+	}
+	if !attribute.Computed {
+		t.Error("expected sitelink_enabled to be computed")
+	}
+	if resource.Timeouts.Update == nil || *resource.Timeouts.Update != 10*time.Minute {
+		t.Errorf("expected update timeout to be 10m, got %v", resource.Timeouts.Update)
+	}
+}
+
+func TestValidateHostedPrivateVirtualInterfaceAccepterSiteLink(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		siteLinkEnabled cty.Value
+		vpnGatewayID    cty.Value
+		wantErr         bool
+	}{
+		"disabled with virtual private gateway": {
+			siteLinkEnabled: cty.BoolVal(false),
+			vpnGatewayID:    cty.StringVal("vgw-12345678"),
+		},
+		"enabled with direct connect gateway": {
+			siteLinkEnabled: cty.BoolVal(true),
+			vpnGatewayID:    cty.NullVal(cty.String),
+		},
+		"enabled with virtual private gateway": {
+			siteLinkEnabled: cty.BoolVal(true),
+			vpnGatewayID:    cty.StringVal("vgw-12345678"),
+			wantErr:         true,
+		},
+		"unknown SiteLink value": {
+			siteLinkEnabled: cty.UnknownVal(cty.Bool),
+			vpnGatewayID:    cty.StringVal("vgw-12345678"),
+		},
+		"enabled with unknown virtual private gateway": {
+			siteLinkEnabled: cty.BoolVal(true),
+			vpnGatewayID:    cty.UnknownVal(cty.String),
+			wantErr:         true,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateHostedPrivateVirtualInterfaceAccepterSiteLink(testCase.siteLinkEnabled, testCase.vpnGatewayID)
+			if gotErr := err != nil; gotErr != testCase.wantErr {
+				t.Errorf("expected error: %t, got: %v", testCase.wantErr, err)
+			}
+		})
+	}
+}

--- a/internal/service/directconnect/hosted_private_virtual_interface_accepter_test.go
+++ b/internal/service/directconnect/hosted_private_virtual_interface_accepter_test.go
@@ -37,6 +37,29 @@ func TestResourceHostedPrivateVirtualInterfaceAccepterSchema(t *testing.T) {
 	}
 }
 
+func TestIsConfiguredValue(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		value cty.Value
+		want  bool
+	}{
+		"configured true":  {value: cty.BoolVal(true), want: true},
+		"configured false": {value: cty.BoolVal(false), want: true},
+		"omitted":          {value: cty.NullVal(cty.Bool)},
+		"unknown":          {value: cty.UnknownVal(cty.Bool)},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if got := isConfiguredValue(testCase.value); got != testCase.want {
+				t.Errorf("isConfiguredValue() = %t, want %t", got, testCase.want)
+			}
+		})
+	}
+}
+
 func TestValidateHostedPrivateVirtualInterfaceAccepterSiteLink(t *testing.T) {
 	t.Parallel()
 

--- a/internal/service/directconnect/hosted_private_virtual_interface_test.go
+++ b/internal/service/directconnect/hosted_private_virtual_interface_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/directconnect/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -65,6 +66,78 @@ func TestAccDirectConnectHostedPrivateVirtualInterface_basic(t *testing.T) {
 			{
 				Config:            testAccHostedPrivateVirtualInterfaceConfig_basic(connectionID, rName, bgpAsn, vlan),
 				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccDirectConnectHostedPrivateVirtualInterface_siteLink(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+	connectionID := acctest.SkipIfEnvVarNotSet(t, "DX_CONNECTION_ID")
+
+	var vif awstypes.VirtualInterface
+	var vifID string
+	resourceName := "aws_dx_hosted_private_virtual_interface.test"
+	accepterResourceName := "aws_dx_hosted_private_virtual_interface_accepter.test"
+	dxGatewayResourceName := "aws_dx_gateway.test"
+	rName := fmt.Sprintf("tf-testacc-hosted-private-vif-%s", acctest.RandString(t, 9))
+	amazonSideASN := acctest.RandIntRange(t, 64512, 65534)
+	bgpASN := acctest.RandIntRange(t, 64512, 65534)
+	vlan := acctest.RandIntRange(t, 2049, 4094)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckAlternateAccount(t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.DirectConnectServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5FactoriesAlternate(ctx, t),
+		CheckDestroy:             testAccCheckHostedPrivateVirtualInterfaceDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccHostedPrivateVirtualInterfaceConfig_siteLink(connectionID, rName, amazonSideASN, bgpASN, vlan, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckHostedPrivateVirtualInterfaceExists(ctx, t, resourceName, &vif),
+					testAccCheckHostedPrivateVirtualInterfaceID(resourceName, &vifID),
+					resource.TestCheckResourceAttrPair(accepterResourceName, "dx_gateway_id", dxGatewayResourceName, names.AttrID),
+					resource.TestCheckResourceAttr(accepterResourceName, "sitelink_enabled", acctest.CtFalse),
+				),
+			},
+			{
+				Config: testAccHostedPrivateVirtualInterfaceConfig_siteLink(connectionID, rName, amazonSideASN, bgpASN, vlan, true),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(accepterResourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckHostedPrivateVirtualInterfaceExists(ctx, t, resourceName, &vif),
+					testAccCheckHostedPrivateVirtualInterfaceID(resourceName, &vifID),
+					resource.TestCheckResourceAttrPair(accepterResourceName, "dx_gateway_id", dxGatewayResourceName, names.AttrID),
+					resource.TestCheckResourceAttr(accepterResourceName, "sitelink_enabled", acctest.CtTrue),
+				),
+			},
+			{
+				Config: testAccHostedPrivateVirtualInterfaceConfig_siteLink(connectionID, rName, amazonSideASN, bgpASN, vlan, false),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(accepterResourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckHostedPrivateVirtualInterfaceExists(ctx, t, resourceName, &vif),
+					testAccCheckHostedPrivateVirtualInterfaceID(resourceName, &vifID),
+					resource.TestCheckResourceAttrPair(accepterResourceName, "dx_gateway_id", dxGatewayResourceName, names.AttrID),
+					resource.TestCheckResourceAttr(accepterResourceName, "sitelink_enabled", acctest.CtFalse),
+				),
+			},
+			{
+				ResourceName:      accepterResourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -159,6 +232,25 @@ func testAccCheckHostedPrivateVirtualInterfaceExists(ctx context.Context, t *tes
 	return testAccCheckVirtualInterfaceExists(ctx, t, name, vif)
 }
 
+func testAccCheckHostedPrivateVirtualInterfaceID(name string, expectedID *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		resource, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", name)
+		}
+
+		if *expectedID == "" {
+			*expectedID = resource.Primary.ID
+			return nil
+		}
+		if resource.Primary.ID != *expectedID {
+			return fmt.Errorf("expected Direct Connect hosted private virtual interface ID %s, got %s", *expectedID, resource.Primary.ID)
+		}
+
+		return nil
+	}
+}
+
 func testAccHostedPrivateVirtualInterfaceConfig_base(cid, rName string, bgpAsn, vlan int) string {
 	return acctest.ConfigCompose(acctest.ConfigAlternateAccountProvider(), fmt.Sprintf(`
 # Creator
@@ -188,6 +280,43 @@ resource "aws_vpn_gateway" "test" {
   }
 }
 `, cid, rName, bgpAsn, vlan))
+}
+
+func testAccHostedPrivateVirtualInterfaceConfig_siteLink(cid, rName string, amazonSideASN, bgpASN, vlan int, siteLinkEnabled bool) string {
+	return acctest.ConfigCompose(acctest.ConfigAlternateAccountProvider(), fmt.Sprintf(`
+# Creator
+resource "aws_dx_hosted_private_virtual_interface" "test" {
+  address_family   = "ipv4"
+  bgp_asn          = %[4]d
+  connection_id    = %[1]q
+  name             = %[2]q
+  owner_account_id = data.aws_caller_identity.accepter.account_id
+  vlan             = %[5]d
+
+  # The aws_dx_hosted_private_virtual_interface
+  # must be destroyed before the aws_dx_gateway.
+  depends_on = [aws_dx_gateway.test]
+}
+
+# Accepter
+data "aws_caller_identity" "accepter" {
+  provider = "awsalternate"
+}
+
+resource "aws_dx_gateway" "test" {
+  provider        = "awsalternate"
+  amazon_side_asn = %[3]d
+  name            = %[2]q
+}
+
+resource "aws_dx_hosted_private_virtual_interface_accepter" "test" {
+  provider = "awsalternate"
+
+  dx_gateway_id        = aws_dx_gateway.test.id
+  sitelink_enabled     = %[6]t
+  virtual_interface_id = aws_dx_hosted_private_virtual_interface.test.id
+}
+`, cid, rName, amazonSideASN, bgpASN, vlan, siteLinkEnabled))
 }
 
 func testAccHostedPrivateVirtualInterfaceConfig_basic(cid, rName string, bgpAsn, vlan int) string {

--- a/internal/service/directconnect/vif.go
+++ b/internal/service/directconnect/vif.go
@@ -52,24 +52,9 @@ func virtualInterfaceUpdate(ctx context.Context, d *schema.ResourceData, meta an
 		}
 	}
 
-	if d.HasChanges("prefix_pool_allocated_count_ipv4", "prefix_pool_allocated_count_ipv6") {
-		input := &directconnect.UpdateVirtualInterfaceAttributesInput{
-			VirtualInterfaceId: aws.String(d.Id()),
-		}
-
-		if d.HasChange("prefix_pool_allocated_count_ipv4") {
-			input.PrefixPoolAllocatedCountIpv4 = aws.Int32(int32(d.Get("prefix_pool_allocated_count_ipv4").(int)))
-		}
-
-		if d.HasChange("prefix_pool_allocated_count_ipv6") {
-			input.PrefixPoolAllocatedCountIpv6 = aws.Int32(int32(d.Get("prefix_pool_allocated_count_ipv6").(int)))
-		}
-
-		_, err := conn.UpdateVirtualInterfaceAttributes(ctx, input)
-
-		if err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating Direct Connect Virtual Interface (%s) prefix pool allocation: %s", d.Id(), err)
-		}
+	diags = append(diags, virtualInterfaceUpdatePrefixPool(ctx, d, meta)...)
+	if diags.HasError() {
+		return diags
 	}
 
 	if d.HasChange("rate_limit") {
@@ -83,6 +68,35 @@ func virtualInterfaceUpdate(ctx context.Context, d *schema.ResourceData, meta an
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating Direct Connect Virtual Interface (%s) RateLimit attribute: %s", d.Id(), err)
 		}
+	}
+
+	return diags
+}
+
+func virtualInterfaceUpdatePrefixPool(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	if !d.HasChanges("prefix_pool_allocated_count_ipv4", "prefix_pool_allocated_count_ipv6") {
+		return diags
+	}
+
+	conn := meta.(*conns.AWSClient).DirectConnectClient(ctx)
+	input := &directconnect.UpdateVirtualInterfaceAttributesInput{
+		VirtualInterfaceId: aws.String(d.Id()),
+	}
+
+	if d.HasChange("prefix_pool_allocated_count_ipv4") {
+		input.PrefixPoolAllocatedCountIpv4 = aws.Int32(int32(d.Get("prefix_pool_allocated_count_ipv4").(int)))
+	}
+
+	if d.HasChange("prefix_pool_allocated_count_ipv6") {
+		input.PrefixPoolAllocatedCountIpv6 = aws.Int32(int32(d.Get("prefix_pool_allocated_count_ipv6").(int)))
+	}
+
+	_, err := conn.UpdateVirtualInterfaceAttributes(ctx, input)
+
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "updating Direct Connect Virtual Interface (%s) prefix pool allocation: %s", d.Id(), err)
 	}
 
 	return diags

--- a/website/docs/r/dx_hosted_private_virtual_interface_accepter.html.markdown
+++ b/website/docs/r/dx_hosted_private_virtual_interface_accepter.html.markdown
@@ -68,6 +68,7 @@ This resource supports the following arguments:
 * `dx_gateway_id` - (Optional) The ID of the Direct Connect gateway to which to connect the virtual interface.
 * `prefix_pool_allocated_count_ipv4` - (Optional) The number of inbound IPv4 route prefixes to allocate to the virtual interface. Valid values are `0` to `1000`. If not specified, AWS applies the default allocation of `100`.
 * `prefix_pool_allocated_count_ipv6` - (Optional) The number of inbound IPv6 route prefixes to allocate to the virtual interface. Valid values are `0` to `1000`. If not specified, AWS applies the default allocation of `100`.
+* `sitelink_enabled` - (Optional) Whether to enable SiteLink for the virtual interface. SiteLink is supported only for a virtual interface attached to a Direct Connect gateway: configure `dx_gateway_id`, not `vpn_gateway_id`. The value reported by AWS is stored in state.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `vpn_gateway_id` - (Optional) The ID of the [virtual private gateway](vpn_gateway.html) to which to connect the virtual interface.
 
@@ -92,6 +93,7 @@ This resource exports the following attributes in addition to the arguments abov
 [Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
 
 - `create` - (Default `10m`)
+- `update` - (Default `10m`)
 - `delete` - (Default `10m`)
 
 ## Import


### PR DESCRIPTION
## Description

Adds in-place SiteLink management to `aws_dx_hosted_private_virtual_interface_accepter` through a new optional/computed `sitelink_enabled` argument.

The accepter owns this behavior because hosted allocation APIs do not accept `EnableSiteLink`; the owner account must first confirm the VIF, wait for it to become available, and then call `UpdateVirtualInterfaceAttributes`.

The implementation:

- reads the AWS-reported SiteLink state,
- supports explicit `false → true → false` updates without replacing the VIF,
- waits for the VIF to stabilize after updates,
- rejects SiteLink with a directly attached `vpn_gateway_id`, directing users to `dx_gateway_id`,
- preserves remote state when the optional argument is omitted,
- adds a 10-minute update timeout and documentation.

This is the private-VIF portion of #39191. Hosted transit VIF support will follow in a separate focused PR.

## Relations

Part of #39191.

## Acceptance Testing

```console
$ TF_ACC=1 go test -p=2 -v -count=1 -parallel=1 -timeout=180m ./internal/service/directconnect -run '^TestAccDirectConnectHostedPrivateVirtualInterface_siteLink$'
=== RUN   TestAccDirectConnectHostedPrivateVirtualInterface_siteLink
=== PAUSE TestAccDirectConnectHostedPrivateVirtualInterface_siteLink
=== CONT  TestAccDirectConnectHostedPrivateVirtualInterface_siteLink
--- PASS: TestAccDirectConnectHostedPrivateVirtualInterface_siteLink (1113.66s)
PASS
ok  github.com/hashicorp/terraform-provider-aws/internal/service/directconnect  1113.807s
```
