### PR TITLE
l/`aws_iam_instance_profile`: New List Resource

### DIFF
--- a/.changelog/49576.txt
+++ b/.changelog/49576.txt
@@ -1,0 +1,3 @@
+```release-note:new-list-resource
+aws_iam_instance_profile
+```

--- a/internal/service/iam/instance_profile.go
+++ b/internal/service/iam/instance_profile.go
@@ -190,6 +190,12 @@ func resourceInstanceProfileRead(ctx context.Context, d *schema.ResourceData, me
 		}
 	}
 
+	resourceInstanceProfileFlatten(ctx, instanceProfile, d)
+
+	return diags
+}
+
+func resourceInstanceProfileFlatten(ctx context.Context, instanceProfile *awstypes.InstanceProfile, d *schema.ResourceData) {
 	d.Set(names.AttrARN, instanceProfile.Arn)
 	d.Set("create_date", instanceProfile.CreateDate.Format(time.RFC3339))
 	d.Set(names.AttrName, instanceProfile.InstanceProfileName)
@@ -206,8 +212,6 @@ func resourceInstanceProfileRead(ctx context.Context, d *schema.ResourceData, me
 	d.Set("unique_id", instanceProfile.InstanceProfileId)
 
 	setTagsOut(ctx, instanceProfile.Tags)
-
-	return diags
 }
 
 func resourceInstanceProfileUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/internal/service/iam/instance_profile_list.go
+++ b/internal/service/iam/instance_profile_list.go
@@ -1,0 +1,151 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package iam
+
+import (
+	"context"
+	"fmt"
+	"iter"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	listschema "github.com/hashicorp/terraform-plugin-framework/list/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/logging"
+	inttypes "github.com/hashicorp/terraform-provider-aws/internal/types"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// Function annotations are used for list resource registration to the Provider. DO NOT EDIT.
+// @SDKListResource("aws_iam_instance_profile")
+func newInstanceProfileResourceAsListResource() inttypes.ListResourceForSDK {
+	l := instanceProfileListResource{}
+	l.SetResourceSchema(resourceInstanceProfile())
+
+	return &l
+}
+
+var _ list.ListResource = &instanceProfileListResource{}
+
+type instanceProfileListResource struct {
+	framework.ListResourceWithSDKv2Resource
+}
+
+type instanceProfileListResourceModel struct {
+	PathPrefix types.String `tfsdk:"path_prefix"`
+}
+
+func (l *instanceProfileListResource) ListResourceConfigSchema(_ context.Context, _ list.ListResourceSchemaRequest, response *list.ListResourceSchemaResponse) {
+	response.Schema = listschema.Schema{
+		Attributes: map[string]listschema.Attribute{
+			"path_prefix": listschema.StringAttribute{
+				Optional:    true,
+				Description: "Path prefix on which to filter instance profile names.",
+				Validators: []validator.String{
+					validPolicyPathFramework,
+				},
+			},
+		},
+	}
+}
+
+func (l *instanceProfileListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
+	awsClient := l.Meta()
+	conn := awsClient.IAMClient(ctx)
+
+	var query instanceProfileListResourceModel
+	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
+		if diags := request.Config.Get(ctx, &query); diags.HasError() {
+			stream.Results = list.ListResultsStreamDiagnostics(diags)
+			return
+		}
+	}
+
+	var input iam.ListInstanceProfilesInput
+	if diags := fwflex.Expand(ctx, query, &input); diags.HasError() {
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
+		return
+	}
+
+	tflog.Info(ctx, "Listing IAM Instance Profiles")
+
+	stream.Results = func(yield func(list.ListResult) bool) {
+		for instanceProfile, err := range listInstanceProfiles(ctx, conn, &input) {
+			if err != nil {
+				result := fwdiag.NewListResultErrorDiagnostic(err)
+				yield(result)
+				return
+			}
+
+			name := aws.ToString(instanceProfile.InstanceProfileName)
+			ctx := tflog.SetField(ctx, logging.ResourceAttributeKey(names.AttrName), name)
+			result := request.NewListResult(ctx)
+
+			rd := l.ResourceData()
+			rd.SetId(name)
+			rd.Set(names.AttrName, name)
+
+			if request.IncludeResource {
+				tflog.Info(ctx, "Reading IAM Instance Profile")
+				fullInstanceProfile, err := findInstanceProfileByName(ctx, conn, name)
+				if err != nil {
+					yield(fwdiag.NewListResultErrorDiagnostic(err))
+					return
+				}
+
+				resourceInstanceProfileFlatten(ctx, fullInstanceProfile, rd)
+			}
+
+			result.DisplayName = resourceInstanceProfileDisplayName(instanceProfile)
+
+			l.SetResult(ctx, awsClient, request.IncludeResource, rd, &result)
+			if result.Diagnostics.HasError() {
+				yield(result)
+				return
+			}
+
+			if !yield(result) {
+				return
+			}
+		}
+	}
+}
+
+func resourceInstanceProfileDisplayName(instanceProfile awstypes.InstanceProfile) string {
+	var buf strings.Builder
+
+	path := aws.ToString(instanceProfile.Path)
+	buf.WriteString(strings.TrimPrefix(path, "/"))
+
+	buf.WriteString(aws.ToString(instanceProfile.InstanceProfileName))
+
+	return buf.String()
+}
+
+func listInstanceProfiles(ctx context.Context, conn *iam.Client, input *iam.ListInstanceProfilesInput) iter.Seq2[awstypes.InstanceProfile, error] {
+	return func(yield func(awstypes.InstanceProfile, error) bool) {
+		pages := iam.NewListInstanceProfilesPaginator(conn, input)
+		for pages.HasMorePages() {
+			page, err := pages.NextPage(ctx)
+			if err != nil {
+				yield(awstypes.InstanceProfile{}, fmt.Errorf("listing IAM Instance Profiles: %w", err))
+				return
+			}
+
+			for _, item := range page.InstanceProfiles {
+				if !yield(item, nil) {
+					return
+				}
+			}
+		}
+	}
+}

--- a/internal/service/iam/instance_profile_list_test.go
+++ b/internal/service/iam/instance_profile_list_test.go
@@ -1,0 +1,217 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package iam_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	tfknownvalue "github.com/hashicorp/terraform-provider-aws/internal/acctest/knownvalue"
+	tfquerycheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/querycheck"
+	tfqueryfilter "github.com/hashicorp/terraform-provider-aws/internal/acctest/queryfilter"
+	tfstatecheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/statecheck"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccIAMInstanceProfile_List_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_iam_instance_profile.test[0]"
+	resourceName2 := "aws_iam_instance_profile.test[1]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity1 := tfstatecheck.Identity()
+	identity2 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
+		CheckDestroy:             testAccCheckInstanceProfileDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/InstanceProfile/list_basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+					statecheck.ExpectKnownValue(resourceName1, tfjsonpath.New(names.AttrName), knownvalue.StringExact(rName+"-0")),
+
+					identity2.GetIdentity(resourceName2),
+					statecheck.ExpectKnownValue(resourceName2, tfjsonpath.New(names.AttrName), knownvalue.StringExact(rName+"-1")),
+				},
+			},
+
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/InstanceProfile/list_basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_iam_instance_profile.test", identity1.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_iam_instance_profile.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), knownvalue.StringExact(rName+"-0")),
+					tfquerycheck.ExpectNoResourceObject("aws_iam_instance_profile.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks())),
+
+					tfquerycheck.ExpectIdentityFunc("aws_iam_instance_profile.test", identity2.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_iam_instance_profile.test", tfqueryfilter.ByResourceIdentityFunc(identity2.Checks()), knownvalue.StringExact(rName+"-1")),
+					tfquerycheck.ExpectNoResourceObject("aws_iam_instance_profile.test", tfqueryfilter.ByResourceIdentityFunc(identity2.Checks())),
+				},
+			},
+		},
+	})
+}
+
+func TestAccIAMInstanceProfile_List_includeResource(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_iam_instance_profile.test[0]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity1 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
+		CheckDestroy:             testAccCheckInstanceProfileDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/InstanceProfile/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(1),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
+						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
+					}),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+					statecheck.ExpectKnownValue(resourceName1, tfjsonpath.New(names.AttrName), knownvalue.StringExact(rName+"-0")),
+				},
+			},
+
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/InstanceProfile/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(1),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
+						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
+					}),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_iam_instance_profile.test", identity1.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_iam_instance_profile.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), knownvalue.StringExact(rName+"-0")),
+					querycheck.ExpectResourceKnownValues("aws_iam_instance_profile.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), []querycheck.KnownValueCheck{
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrARN), tfknownvalue.GlobalARNExact("iam", "instance-profile/"+rName+"-0")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("create_date"), knownvalue.NotNull()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrID), knownvalue.StringExact(rName+"-0")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrName), knownvalue.StringExact(rName+"-0")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrPath), knownvalue.StringExact("/")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrRole), knownvalue.Null()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("unique_id"), knownvalue.NotNull()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
+							acctest.CtKey1: knownvalue.StringExact(acctest.CtValue1),
+						})),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrTagsAll), knownvalue.MapExact(map[string]knownvalue.Check{
+							acctest.CtKey1: knownvalue.StringExact(acctest.CtValue1),
+						})),
+					}),
+				},
+			},
+		},
+	})
+}
+
+func TestAccIAMInstanceProfile_List_pathPrefix(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceNameExpected1 := "aws_iam_instance_profile.expected[0]"
+	resourceNameExpected2 := "aws_iam_instance_profile.expected[1]"
+	resourceNameNotExpected1 := "aws_iam_instance_profile.not_expected[0]"
+	resourceNameNotExpected2 := "aws_iam_instance_profile.not_expected[1]"
+
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	rPathName := "/" + acctest.RandomWithPrefix(t, acctest.ResourcePrefix) + "/"
+	rOtherPathName := "/" + acctest.RandomWithPrefix(t, acctest.ResourcePrefix) + "/"
+
+	identityExpected1 := tfstatecheck.Identity()
+	identityExpected2 := tfstatecheck.Identity()
+	identityNotExpected1 := tfstatecheck.Identity()
+	identityNotExpected2 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
+		CheckDestroy:             testAccCheckInstanceProfileDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/InstanceProfile/list_path_prefix/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:      config.StringVariable(rName),
+					"resource_count":     config.IntegerVariable(2),
+					"expected_path_name": config.StringVariable(rPathName),
+					"other_path_name":    config.StringVariable(rOtherPathName),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identityExpected1.GetIdentity(resourceNameExpected1),
+					statecheck.ExpectKnownValue(resourceNameExpected1, tfjsonpath.New(names.AttrName), knownvalue.StringExact(rName+"-0")),
+
+					identityExpected2.GetIdentity(resourceNameExpected2),
+					statecheck.ExpectKnownValue(resourceNameExpected2, tfjsonpath.New(names.AttrName), knownvalue.StringExact(rName+"-1")),
+
+					identityNotExpected1.GetIdentity(resourceNameNotExpected1),
+					statecheck.ExpectKnownValue(resourceNameNotExpected1, tfjsonpath.New(names.AttrName), knownvalue.StringExact(rName+"-other-0")),
+
+					identityNotExpected2.GetIdentity(resourceNameNotExpected2),
+					statecheck.ExpectKnownValue(resourceNameNotExpected2, tfjsonpath.New(names.AttrName), knownvalue.StringExact(rName+"-other-1")),
+				},
+			},
+
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/InstanceProfile/list_path_prefix/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:      config.StringVariable(rName),
+					"resource_count":     config.IntegerVariable(2),
+					"expected_path_name": config.StringVariable(rPathName),
+					"other_path_name":    config.StringVariable(rOtherPathName),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectLength("aws_iam_instance_profile.test", 2),
+					tfquerycheck.ExpectIdentityFunc("aws_iam_instance_profile.test", identityExpected1.Checks()),
+					tfquerycheck.ExpectIdentityFunc("aws_iam_instance_profile.test", identityExpected2.Checks()),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/iam/service_package_gen.go
+++ b/internal/service/iam/service_package_gen.go
@@ -514,6 +514,17 @@ func (p *servicePackage) SDKListResources(ctx context.Context) iter.Seq[*inttype
 			}),
 		},
 		{
+			Factory:  newInstanceProfileResourceAsListResource,
+			TypeName: "aws_iam_instance_profile",
+			Name:     "Instance Profile",
+			Region:   inttypes.ResourceRegionDisabled(),
+			Tags: unique.Make(inttypes.ServicePackageResourceTags{
+				IdentifierAttribute: names.AttrName,
+				ResourceType:        "InstanceProfile",
+			}),
+			Identity: inttypes.GlobalSingleParameterIdentity(inttypes.StringIdentityAttribute(names.AttrName, true)),
+		},
+		{
 			Factory:  newPolicyResourceAsListResource,
 			TypeName: "aws_iam_policy",
 			Name:     "Policy",

--- a/internal/service/iam/testdata/InstanceProfile/list_basic/main.tf
+++ b/internal/service/iam/testdata/InstanceProfile/list_basic/main.tf
@@ -1,0 +1,20 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_iam_instance_profile" "test" {
+  count = var.resource_count
+
+  name = "${var.rName}-${count.index}"
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}

--- a/internal/service/iam/testdata/InstanceProfile/list_basic/query.tfquery.hcl
+++ b/internal/service/iam/testdata/InstanceProfile/list_basic/query.tfquery.hcl
@@ -1,0 +1,6 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_iam_instance_profile" "test" {
+  provider = aws
+}

--- a/internal/service/iam/testdata/InstanceProfile/list_include_resource/main.tf
+++ b/internal/service/iam/testdata/InstanceProfile/list_include_resource/main.tf
@@ -1,0 +1,28 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_iam_instance_profile" "test" {
+  count = var.resource_count
+
+  name = "${var.rName}-${count.index}"
+
+  tags = var.resource_tags
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}
+
+variable "resource_tags" {
+  description = "Tags to set on resource"
+  type        = map(string)
+  nullable    = false
+}

--- a/internal/service/iam/testdata/InstanceProfile/list_include_resource/query.tfquery.hcl
+++ b/internal/service/iam/testdata/InstanceProfile/list_include_resource/query.tfquery.hcl
@@ -1,0 +1,8 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_iam_instance_profile" "test" {
+  provider = aws
+
+  include_resource = true
+}

--- a/internal/service/iam/testdata/InstanceProfile/list_path_prefix/main.tf
+++ b/internal/service/iam/testdata/InstanceProfile/list_path_prefix/main.tf
@@ -1,0 +1,40 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_iam_instance_profile" "expected" {
+  count = var.resource_count
+
+  name = "${var.rName}-${count.index}"
+  path = var.expected_path_name
+}
+
+resource "aws_iam_instance_profile" "not_expected" {
+  count = var.resource_count
+
+  name = "${var.rName}-other-${count.index}"
+  path = var.other_path_name
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}
+
+variable "expected_path_name" {
+  description = "Path name for expected resources"
+  type        = string
+  nullable    = false
+}
+
+variable "other_path_name" {
+  description = "Path name for non-expected resources"
+  type        = string
+  nullable    = false
+}

--- a/internal/service/iam/testdata/InstanceProfile/list_path_prefix/query.tfquery.hcl
+++ b/internal/service/iam/testdata/InstanceProfile/list_path_prefix/query.tfquery.hcl
@@ -1,0 +1,10 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_iam_instance_profile" "test" {
+  provider = aws
+
+  config {
+    path_prefix = var.expected_path_name
+  }
+}

--- a/website/docs/list-resources/iam_instance_profile.html.markdown
+++ b/website/docs/list-resources/iam_instance_profile.html.markdown
@@ -1,0 +1,41 @@
+---
+subcategory: "IAM (Identity & Access Management)"
+layout: "aws"
+page_title: "AWS: aws_iam_instance_profile"
+description: |-
+  Lists IAM (Identity & Access Management) Instance Profile resources.
+---
+
+# List Resource: aws_iam_instance_profile
+
+Lists IAM (Identity & Access Management) Instance Profile resources.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+list "aws_iam_instance_profile" "example" {
+  provider = aws
+}
+```
+
+### Filter by Path Prefix
+
+This example will return IAM Instance Profiles with a `path` equal to or beginning with `/example/`.
+
+```terraform
+list "aws_iam_instance_profile" "example" {
+  provider = aws
+
+  config {
+    path_prefix = "/example/"
+  }
+}
+```
+
+## Argument Reference
+
+This list resource supports the following arguments:
+
+* `path_prefix` - (Optional) Limits the returned IAM Instance Profiles to those within this path.If `path_prefix` is not specified, or is `"/"`, returns all IAM Instance Profiles.


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

l/aws_iam_instance_profile: New List Resource

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/48581
Relates https://github.com/hashicorp/terraform-provider-aws/issues/47005

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
make t K=iam T=TestAccIAMInstanceProfile_List_                       
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-list-resources-aws_iam_instance_profile 🌿...
TF_ACC=1 go1.26.6 test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMInstanceProfile_List_'  -timeout 360m -vet=off -buildvcs=false
2026/08/19 16:35:00 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/19 16:35:00 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccIAMInstanceProfile_List_basic
=== PAUSE TestAccIAMInstanceProfile_List_basic
=== RUN   TestAccIAMInstanceProfile_List_includeResource
=== PAUSE TestAccIAMInstanceProfile_List_includeResource
=== RUN   TestAccIAMInstanceProfile_List_pathPrefix
=== PAUSE TestAccIAMInstanceProfile_List_pathPrefix
=== CONT  TestAccIAMInstanceProfile_List_basic
=== CONT  TestAccIAMInstanceProfile_List_pathPrefix
=== CONT  TestAccIAMInstanceProfile_List_includeResource
--- PASS: TestAccIAMInstanceProfile_List_basic (31.90s)
--- PASS: TestAccIAMInstanceProfile_List_pathPrefix (32.62s)
--- PASS: TestAccIAMInstanceProfile_List_includeResource (34.91s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/iam        43.199s
```
