### PR TITLE
r/aws_route53domains_delegation_signer_record: key the record on its DS digest (GetDomainDetail no longer returns flags/public key; Id is registrar-dependent)

### DIFF
--- a/.changelog/49578.txt
+++ b/.changelog/49578.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_route53domains_delegation_signer_record: Fix resource being removed from state or replaced on every refresh, and `empty result` / `Parameters in request are not valid` errors on create, after `GetDomainDetail` stopped returning the key's flags and public key. The record is now keyed on its DS digest (computed from `signing_attributes`); `dnssec_key_id` holds the digest, legacy values are migrated on read, and an imported record is completed in place instead of being replaced
+```

--- a/internal/service/route53domains/delegation_signer_record.go
+++ b/internal/service/route53domains/delegation_signer_record.go
@@ -8,6 +8,7 @@ package route53domains
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -15,9 +16,9 @@ import (
 	awstypes "github.com/aws/aws-sdk-go-v2/service/route53domains/types"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -47,7 +48,6 @@ func newDelegationSignerRecordResource(context.Context) (resource.ResourceWithCo
 
 type delegationSignerRecordResource struct {
 	framework.ResourceWithModel[delegationSignerRecordResourceModel]
-	framework.WithNoUpdate
 	framework.WithTimeouts
 	framework.WithImportByID
 }
@@ -71,26 +71,25 @@ func (r *delegationSignerRecordResource) Schema(ctx context.Context, request res
 					Attributes: map[string]schema.Attribute{
 						"algorithm": schema.Int64Attribute{
 							Required: true,
-							PlanModifiers: []planmodifier.Int64{
-								int64planmodifier.RequiresReplace(),
-							},
 						},
 						"flags": schema.Int64Attribute{
 							Required: true,
-							PlanModifiers: []planmodifier.Int64{
-								int64planmodifier.RequiresReplace(),
-							},
 						},
 						names.AttrPublicKey: schema.StringAttribute{
 							Required: true,
-							PlanModifiers: []planmodifier.String{
-								stringplanmodifier.RequiresReplace(),
-							},
 						},
 					},
 				},
 				PlanModifiers: []planmodifier.List{
-					listplanmodifier.RequiresReplace(),
+					// GetDomainDetail does not return the key's flags or public key, so signing_attributes
+					// cannot be refreshed from the API. Replacement is decided by comparing the DS digest
+					// of the planned key with the digest of the associated key, which also allows an
+					// imported record to be completed in place instead of being destroyed and recreated.
+					listplanmodifier.RequiresReplaceIf(
+						signingAttributesRequiresReplaceIf,
+						"If the value of this attribute changes the DS record digest, Terraform will destroy and recreate the resource.",
+						"If the value of this attribute changes the DS record digest, Terraform will destroy and recreate the resource.",
+					),
 				},
 				Validators: []validator.List{
 					listvalidator.SizeAtLeast(1),
@@ -114,6 +113,13 @@ func (r *delegationSignerRecordResource) Create(ctx context.Context, request res
 
 	conn := r.Meta().Route53DomainsClient(ctx)
 
+	domainName := data.DomainName.ValueString()
+	digests, diags := data.dsDigests(ctx)
+	response.Diagnostics.Append(diags...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
 	input := &route53domains.AssociateDelegationSignerToDomainInput{}
 	response.Diagnostics.Append(fwflex.Expand(ctx, data, input)...)
 	if response.Diagnostics.HasError() {
@@ -129,30 +135,34 @@ func (r *delegationSignerRecordResource) Create(ctx context.Context, request res
 	}
 
 	if _, err := waitOperationSucceeded(ctx, conn, aws.ToString(output.OperationId), r.CreateTimeout(ctx, data.Timeouts)); err != nil {
-		response.Diagnostics.AddError("waiting for Route 53 Domains Delegation Signer Record create", err.Error())
+		detail := err.Error()
+		// Registries reject a DS record that is already associated with the domain.
+		if dnssecKey, findErr := findDNSSECKeyByDigests(ctx, conn, domainName, digests); findErr == nil {
+			detail = fmt.Sprintf("%s. A DS record with digest %s is already associated with domain %s; import it using the ID %q", detail, aws.ToString(dnssecKey.Digest), domainName, domainName+","+aws.ToString(dnssecKey.Digest))
+		}
+		response.Diagnostics.AddError("waiting for Route 53 Domains Delegation Signer Record create", detail)
 
 		return
 	}
 
-	signingAttributes, diags := data.SigningAttributes.ToPtr(ctx)
-	response.Diagnostics.Append(diags...)
-	if response.Diagnostics.HasError() {
-		return
-	}
-
-	dnssecKey, err := findDNSSECKeyByThreePartKey(ctx, conn, data.DomainName.ValueString(), int(signingAttributes.Flags.ValueInt64()), signingAttributes.PublicKey.ValueString())
+	// GetDomainDetail does not return the key's flags or public key, so the associated key
+	// is identified by its DS digest, computed locally from the signing attributes.
+	dnssecKey, err := tfresource.RetryWhenNotFound(ctx, dnssecKeyPropagationTimeout, func(ctx context.Context) (*awstypes.DnssecKey, error) {
+		return findDNSSECKeyByDigests(ctx, conn, domainName, digests)
+	})
 
 	if err != nil {
-		response.Diagnostics.AddError(fmt.Sprintf("reading Route 53 Domains Domain (%s) DNSSEC key", data.DomainName.ValueString()), err.Error())
+		response.Diagnostics.AddError(fmt.Sprintf("reading Route 53 Domains Domain (%s) DNSSEC key", domainName), err.Error())
 
 		return
 	}
 
 	// Set values for unknowns.
-	data.DNSSECKeyID = fwflex.StringToFramework(ctx, dnssecKey.Id)
+	// The DS digest is stable across registrars and API changes, unlike DnssecKey.Id.
+	data.DNSSECKeyID = fwflex.StringToFramework(ctx, dnssecKey.Digest)
 	id, err := data.setID()
 	if err != nil {
-		response.Diagnostics.AddError(fmt.Sprintf("flattening resource ID Route 53 Domains Domain (%s) DNSSEC key", data.DomainName.ValueString()), err.Error())
+		response.Diagnostics.AddError(fmt.Sprintf("flattening resource ID Route 53 Domains Domain (%s) DNSSEC key", domainName), err.Error())
 		return
 	}
 	data.ID = types.StringValue(id)
@@ -190,16 +200,39 @@ func (r *delegationSignerRecordResource) Read(ctx context.Context, request resou
 		return
 	}
 
-	// Set attributes for import.
-	var signingAttributes delegationSignerRecordSigningAttributesModel
-	response.Diagnostics.Append(fwflex.Flatten(ctx, dnssecKey, &signingAttributes)...)
+	// Normalize the key ID to the DS digest. State written by earlier provider versions
+	// holds the registry-assigned DnssecKey.Id instead, whose format varies by registrar.
+	data.DNSSECKeyID = fwflex.StringToFramework(ctx, dnssecKey.Digest)
+	id, err := data.setID()
+	if err != nil {
+		response.Diagnostics.AddError(fmt.Sprintf("flattening resource ID Route 53 Domains Domain (%s) DNSSEC key", data.DomainName.ValueString()), err.Error())
+		return
+	}
+	data.ID = types.StringValue(id)
+
+	// signing_attributes is left untouched: GetDomainDetail does not return the key's flags or
+	// public key, and the DS digest already proves that the associated key matches them.
+
+	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
+}
+
+func (r *delegationSignerRecordResource) Update(ctx context.Context, request resource.UpdateRequest, response *resource.UpdateResponse) {
+	var old, new delegationSignerRecordResourceModel
+	response.Diagnostics.Append(request.State.Get(ctx, &old)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+	response.Diagnostics.Append(request.Plan.Get(ctx, &new)...)
 	if response.Diagnostics.HasError() {
 		return
 	}
 
-	data.SigningAttributes = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &signingAttributes)
+	// The only in-place change is to signing_attributes with an unchanged DS digest
+	// (e.g. completing the configuration after import), which requires no API call.
+	new.DNSSECKeyID = old.DNSSECKeyID
+	new.ID = old.ID
 
-	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
+	response.Diagnostics.Append(response.State.Set(ctx, &new)...)
 }
 
 func (r *delegationSignerRecordResource) Delete(ctx context.Context, request resource.DeleteRequest, response *resource.DeleteResponse) {
@@ -211,9 +244,22 @@ func (r *delegationSignerRecordResource) Delete(ctx context.Context, request res
 
 	conn := r.Meta().Route53DomainsClient(ctx)
 
+	// DisassociateDelegationSignerFromDomain requires the registry-assigned DnssecKey.Id.
+	dnssecKey, err := findDNSSECKeyByTwoPartKey(ctx, conn, data.DomainName.ValueString(), data.DNSSECKeyID.ValueString())
+
+	if retry.NotFound(err) {
+		return
+	}
+
+	if err != nil {
+		response.Diagnostics.AddError(fmt.Sprintf("reading Route 53 Domains Domain (%s) DNSSEC key", data.DomainName.ValueString()), err.Error())
+
+		return
+	}
+
 	output, err := conn.DisassociateDelegationSignerFromDomain(ctx, &route53domains.DisassociateDelegationSignerFromDomainInput{
 		DomainName: data.DomainName.ValueStringPointer(),
-		Id:         data.DNSSECKeyID.ValueStringPointer(),
+		Id:         dnssecKey.Id,
 	})
 
 	if err != nil {
@@ -229,6 +275,33 @@ func (r *delegationSignerRecordResource) Delete(ctx context.Context, request res
 			return
 		}
 	}
+}
+
+// signingAttributesRequiresReplaceIf forces replacement only when the planned signing
+// attributes produce a different DS digest than the associated key's.
+func signingAttributesRequiresReplaceIf(ctx context.Context, request planmodifier.ListRequest, response *listplanmodifier.RequiresReplaceIfFuncResponse) {
+	response.RequiresReplace = true
+
+	var plan, state delegationSignerRecordResourceModel
+	response.Diagnostics.Append(request.Plan.Get(ctx, &plan)...)
+	response.Diagnostics.Append(request.State.Get(ctx, &state)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	if plan.SigningAttributes.IsUnknown() || state.DNSSECKeyID.IsNull() || state.DNSSECKeyID.IsUnknown() {
+		return
+	}
+
+	// domain_name itself requires replacement, so the digest is computed for the associated key's domain.
+	plan.DomainName = state.DomainName
+	digests, diags := plan.dsDigests(ctx)
+	if diags.HasError() {
+		// Invalid or unknown signing attributes; keep the default of replacing the resource.
+		return
+	}
+
+	response.RequiresReplace = !dsDigestMatches(digests, state.DNSSECKeyID.ValueString())
 }
 
 type delegationSignerRecordResourceModel struct {
@@ -247,6 +320,9 @@ type delegationSignerRecordSigningAttributesModel struct {
 
 const (
 	delegationSignerRecordResourceIDPartCount = 2
+
+	// Time to wait for a newly associated key to be returned by GetDomainDetail.
+	dnssecKeyPropagationTimeout = 2 * time.Minute
 )
 
 func (data *delegationSignerRecordResourceModel) InitFromID() error {
@@ -272,6 +348,33 @@ func (data *delegationSignerRecordResourceModel) setID() (string, error) {
 	return flex.FlattenResourceId(parts, delegationSignerRecordResourceIDPartCount, false)
 }
 
+// dsDigests computes the DS record digests (by digest type) of the configured signing attributes.
+func (data *delegationSignerRecordResourceModel) dsDigests(ctx context.Context) (map[int32]string, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	signingAttributes, d := data.SigningAttributes.ToPtr(ctx)
+	diags.Append(d...)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	if signingAttributes == nil || data.DomainName.IsUnknown() || signingAttributes.Algorithm.IsUnknown() || signingAttributes.Flags.IsUnknown() || signingAttributes.PublicKey.IsUnknown() {
+		diags.AddError("computing Route 53 Domains Delegation Signer Record digest", "signing attributes are not known")
+		return nil, diags
+	}
+
+	digests, err := dsDigests(data.DomainName.ValueString(), signingAttributes.Flags.ValueInt64(), signingAttributes.Algorithm.ValueInt64(), signingAttributes.PublicKey.ValueString())
+	if err != nil {
+		diags.AddError("computing Route 53 Domains Delegation Signer Record digest", err.Error())
+		return nil, diags
+	}
+
+	return digests, diags
+}
+
+// findDNSSECKeyByTwoPartKey finds a domain's DNSSEC key by its DS digest.
+// For state written by earlier provider versions, the key ID may instead be the
+// registry-assigned DnssecKey.Id (e.g. a number, or "DS:<keytag>-<algorithm>-<digesttype>-<digest>").
 func findDNSSECKeyByTwoPartKey(ctx context.Context, conn *route53domains.Client, domainName, keyID string) (*awstypes.DnssecKey, error) {
 	output, err := findDomainDetailByName(ctx, conn, domainName)
 
@@ -280,11 +383,14 @@ func findDNSSECKeyByTwoPartKey(ctx context.Context, conn *route53domains.Client,
 	}
 
 	return tfresource.AssertSingleValueResult(tfslices.Filter(output.DnssecKeys, func(v awstypes.DnssecKey) bool {
-		return aws.ToString(v.Id) == keyID
+		digest := aws.ToString(v.Digest)
+
+		return strings.EqualFold(digest, keyID) || aws.ToString(v.Id) == keyID || (digest != "" && strings.HasSuffix(strings.ToUpper(keyID), "-"+strings.ToUpper(digest)))
 	}))
 }
 
-func findDNSSECKeyByThreePartKey(ctx context.Context, conn *route53domains.Client, domainName string, flags int, publicKey string) (*awstypes.DnssecKey, error) {
+// findDNSSECKeyByDigests finds a domain's DNSSEC key whose DS digest matches one of digests.
+func findDNSSECKeyByDigests(ctx context.Context, conn *route53domains.Client, domainName string, digests map[int32]string) (*awstypes.DnssecKey, error) {
 	output, err := findDomainDetailByName(ctx, conn, domainName)
 
 	if err != nil {
@@ -292,6 +398,6 @@ func findDNSSECKeyByThreePartKey(ctx context.Context, conn *route53domains.Clien
 	}
 
 	return tfresource.AssertSingleValueResult(tfslices.Filter(output.DnssecKeys, func(v awstypes.DnssecKey) bool {
-		return int(aws.ToInt32(v.Flags)) == flags && aws.ToString(v.PublicKey) == publicKey
+		return dsDigestMatches(digests, aws.ToString(v.Digest))
 	}))
 }

--- a/internal/service/route53domains/delegation_signer_record_digest.go
+++ b/internal/service/route53domains/delegation_signer_record_digest.go
@@ -1,0 +1,106 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package route53domains
+
+import (
+	"crypto/sha1" // nosemgrep: go/sast/internal/crypto/sha1 -- DS digest type 1 is SHA-1 by specification (RFC 4034), used to match registry-returned digests, not for security
+	"crypto/sha256"
+	"crypto/sha512"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"hash"
+	"strings"
+)
+
+// DS record digest types (IANA "DNSSEC Delegation Signer (DS) Resource Record (RR) Type Digest Algorithms").
+const (
+	dsDigestTypeSHA1   int32 = 1
+	dsDigestTypeSHA256 int32 = 2
+	dsDigestTypeSHA384 int32 = 4
+)
+
+// dnskeyProtocol is the fixed value of the DNSKEY RDATA Protocol field (RFC 4034, section 2.1.2).
+const dnskeyProtocol = 3
+
+// dsDigests computes the Delegation Signer (DS) record digests of a DNSKEY for every
+// digest type that a registry may use, keyed by digest type.
+//
+// Per RFC 4034 section 5.1.4, the digest is calculated over the canonical wire format of
+// the DNSKEY owner name concatenated with the DNSKEY RDATA
+// (Flags | Protocol | Algorithm | Public Key). The result is upper-case hexadecimal,
+// which is how Route 53 Domains returns `DnssecKey.Digest`.
+func dsDigests(domainName string, flags, algorithm int64, publicKey string) (map[int32]string, error) {
+	if flags < 0 || flags > 0xFFFF {
+		return nil, fmt.Errorf("invalid DNSKEY flags: %d", flags)
+	}
+	if algorithm < 0 || algorithm > 0xFF {
+		return nil, fmt.Errorf("invalid DNSKEY algorithm: %d", algorithm)
+	}
+
+	key, err := base64.StdEncoding.DecodeString(strings.Join(strings.Fields(publicKey), ""))
+	if err != nil {
+		return nil, fmt.Errorf("decoding DNSKEY public key: %w", err)
+	}
+
+	owner, err := canonicalOwnerNameWireFormat(domainName)
+	if err != nil {
+		return nil, err
+	}
+
+	// Owner name in canonical wire format followed by the DNSKEY RDATA.
+	data := make([]byte, 0, len(owner)+4+len(key))
+	data = append(data, owner...)
+	data = binary.BigEndian.AppendUint16(data, uint16(flags))
+	data = append(data, dnskeyProtocol, byte(algorithm))
+	data = append(data, key...)
+
+	digests := make(map[int32]string, 3)
+	for digestType, newHash := range map[int32]func() hash.Hash{
+		dsDigestTypeSHA1:   sha1.New, // nosemgrep: go.lang.security.audit.crypto.use_of_weak_crypto.use-of-sha1 -- DS digest type 1 is SHA-1 by specification (RFC 4034)
+		dsDigestTypeSHA256: sha256.New,
+		dsDigestTypeSHA384: sha512.New384,
+	} {
+		h := newHash()
+		h.Write(data)
+		digests[digestType] = strings.ToUpper(hex.EncodeToString(h.Sum(nil)))
+	}
+
+	return digests, nil
+}
+
+// canonicalOwnerNameWireFormat returns the canonical (lower-case, uncompressed) wire
+// format of a DNS owner name (RFC 4034, section 6.2).
+func canonicalOwnerNameWireFormat(name string) ([]byte, error) {
+	name = strings.ToLower(strings.TrimSuffix(name, "."))
+
+	var out []byte
+	if name != "" {
+		for label := range strings.SplitSeq(name, ".") {
+			if len(label) == 0 || len(label) > 63 {
+				return nil, fmt.Errorf("invalid DNS label %q in domain name %q", label, name)
+			}
+			out = append(out, byte(len(label)))
+			out = append(out, label...)
+		}
+	}
+	out = append(out, 0) // root label
+
+	if len(out) > 255 {
+		return nil, fmt.Errorf("domain name %q exceeds 255 octets in wire format", name)
+	}
+
+	return out, nil
+}
+
+// dsDigestMatches reports whether any of the computed digests equals digest.
+func dsDigestMatches(digests map[int32]string, digest string) bool {
+	for _, v := range digests {
+		if strings.EqualFold(v, digest) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/service/route53domains/delegation_signer_record_digest_test.go
+++ b/internal/service/route53domains/delegation_signer_record_digest_test.go
@@ -1,0 +1,129 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package route53domains
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDSDigests(t *testing.T) {
+	t.Parallel()
+
+	// Public KSK shared by all Cloudflare-signed zones; the expected digests are the
+	// values returned by Route 53 Domains GetDomainDetail / published in the parent zones.
+	const cloudflareKSK = "mdsswUyr3DPW132mOi8V9xESWE8jTo0dxCjjnopKl+GqJxpVXckHAeF+KkxLbxILfDLUT0rAK9iUzy1L53eKGQ=="
+
+	testCases := map[string]struct {
+		domainName string
+		flags      int64
+		algorithm  int64
+		publicKey  string
+		digestType int32
+		want       string
+		wantErr    bool
+	}{
+		// RFC 4034, section 5.4 example (SHA-1).
+		"rfc4034 example sha1": {
+			domainName: "dskey.example.com.",
+			flags:      256,
+			algorithm:  5,
+			publicKey: "AQOeiiR0GOMYkDshWoSKz9Xz" +
+				"fwJr1AYtsmx3TGkJaNXVbfi/" +
+				"2pHm822aJ5iI9BMzNXxeYCmZ" +
+				"DRD99WYwYqUSdjMmmAphXdvx" +
+				"egXd/M5+X7OrzKBaMbCVdFLU" +
+				"Uh6DhweJBjEVv5f2wwjM9Xzc" +
+				"nOf+EPbtG9DMBmADjFDc2w/r" +
+				"ljwvFw==",
+			digestType: dsDigestTypeSHA1,
+			want:       "2BB183AF5F22588179A53B0A98631FAD1A292118",
+		},
+		"gandi .com sha256": {
+			domainName: "urbantz.com",
+			flags:      257,
+			algorithm:  13,
+			publicKey:  cloudflareKSK,
+			digestType: dsDigestTypeSHA256,
+			want:       "ABA22F65F11E2D8D43BC95B32BCDB6744AA07C4CE38CE4D3E46189760DE699EB",
+		},
+		"amazon registrar .com sha256": {
+			domainName: "urbantz-legacy.com",
+			flags:      257,
+			algorithm:  13,
+			publicKey:  cloudflareKSK,
+			digestType: dsDigestTypeSHA256,
+			want:       "B8EF62832AA5515654F042AD80B2B5D97EF4D29AA3520333FC4F350FAD01E0B4",
+		},
+		"gandi .eu sha256": {
+			domainName: "urbz.eu",
+			flags:      257,
+			algorithm:  13,
+			publicKey:  cloudflareKSK,
+			digestType: dsDigestTypeSHA256,
+			want:       "4B25E8FA94850AA97B78AB790CBE126A546305ECF3AD5C861A5366FD7FBEEDCB",
+		},
+		"owner name is canonicalized": {
+			domainName: "UrbZ.EU.",
+			flags:      257,
+			algorithm:  13,
+			publicKey:  cloudflareKSK,
+			digestType: dsDigestTypeSHA256,
+			want:       "4B25E8FA94850AA97B78AB790CBE126A546305ECF3AD5C861A5366FD7FBEEDCB",
+		},
+		"invalid public key": {
+			domainName: "example.com",
+			flags:      257,
+			algorithm:  13,
+			publicKey:  "not base64!",
+			wantErr:    true,
+		},
+		"invalid flags": {
+			domainName: "example.com",
+			flags:      70000,
+			algorithm:  13,
+			publicKey:  cloudflareKSK,
+			wantErr:    true,
+		},
+		"invalid domain name": {
+			domainName: "example..com",
+			flags:      257,
+			algorithm:  13,
+			publicKey:  cloudflareKSK,
+			wantErr:    true,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := dsDigests(testCase.domainName, testCase.flags, testCase.algorithm, testCase.publicKey)
+
+			if testCase.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			if got[testCase.digestType] != testCase.want {
+				t.Errorf("digest type %d = %q, want %q", testCase.digestType, got[testCase.digestType], testCase.want)
+			}
+			if !dsDigestMatches(got, testCase.want) {
+				t.Errorf("dsDigestMatches(%q) = false, want true", testCase.want)
+			}
+			// Matching must be case-insensitive and must fail for other values.
+			if !dsDigestMatches(got, strings.ToLower(testCase.want)) {
+				t.Errorf("dsDigestMatches(%q) = false, want true (case-insensitive)", strings.ToLower(testCase.want))
+			}
+			if dsDigestMatches(got, "0000") {
+				t.Errorf("dsDigestMatches(%q) = true, want false", "0000")
+			}
+		})
+	}
+}

--- a/internal/service/route53domains/delegation_signer_record_test.go
+++ b/internal/service/route53domains/delegation_signer_record_test.go
@@ -37,10 +37,22 @@ func testAccDelegationSignerRecord_basic(t *testing.T) {
 				),
 			},
 			{
+				// GetDomainDetail does not return the key's flags or public key. Refresh must still
+				// find the record by its DS digest and must not plan a replacement (#47928).
+				Config: testAccDelegationSignerAssociationConfig_basic(domainName, publicKey),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateIdFunc: testAccDelegationSignerAssociationImportStateIDFunc(ctx, resourceName),
+				// Not returned by the API; completed in place on the next apply after import.
+				ImportStateVerifyIgnore: []string{"signing_attributes"},
 			},
 		},
 	})
@@ -83,7 +95,7 @@ func testAccCheckDelegationSignerAssociationDestroy(ctx context.Context, t *test
 		conn := acctest.ProviderMeta(ctx, t).Route53DomainsClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
-			if rs.Type != "aws_route53domains_ds_association" {
+			if rs.Type != "aws_route53domains_delegation_signer_record" {
 				continue
 			}
 

--- a/website/docs/r/route53domains_delegation_signer_record.html.markdown
+++ b/website/docs/r/route53domains_delegation_signer_record.html.markdown
@@ -118,7 +118,7 @@ This resource supports the following arguments:
 
 This resource exports the following attributes in addition to the arguments above:
 
-* `dnssec_key_id` - An ID assigned to the created DS record.
+* `dnssec_key_id` - Digest of the created DS record (as returned by the registry and published in the parent zone's DS record).
 
 ## Timeouts
 
@@ -129,7 +129,7 @@ This resource exports the following attributes in addition to the arguments abov
 
 ## Import
 
-In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import delegation signer records using the domain name and DNSSEC key ID, separated by a comma (`,`). For example:
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import delegation signer records using the domain name and DS record digest (`dnssec_key_id`), separated by a comma (`,`). The digest is the last field of the domain's DS record in the parent zone (e.g. `dig DS example.com`). After import, `signing_attributes` is not populated (the registry does not return the key's flags or public key); the next apply completes it in place without replacing the record. For example:
 
 ```terraform
 import {
@@ -138,7 +138,7 @@ import {
 }
 ```
 
-Using `terraform import`, import delegation signer records using the domain name and DNSSEC key ID, separated by a comma (`,`). For example:
+Using `terraform import`, import delegation signer records using the domain name and DS record digest, separated by a comma (`,`). For example:
 
 ```console
 % terraform import aws_route53domains_delegation_signer_record.example example.com,40DE3534F5324DBDAC598ACEDB5B1E26A5368732D9C791D1347E4FBDDF6FC343


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No.

### Description

Since roughly mid-May 2026 `aws_route53domains_delegation_signer_record` is unusable: after a successful create, the next refresh either drops the resource from state or plans a **destroy + create of the live DS record**, and the re-create then fails (#47928). I have verified on three real domains at two registrars (AWS account, Gandi .com/.eu and Amazon Registrar .com) what `GetDomainDetail` returns today, and compared it with the same workspace's logs from 2026-05-04 (same provider version `6.43.0`, clean plan) — this is an AWS-side change in the `GetDomainDetail` response, which is why it hits 5.89, 5.100 and 6.x alike:

| | before 2026-05 | now |
|---|---|---|
| `DnssecKey.Flags` / `.PublicKey` | returned | **not returned** (only `Algorithm`, `Digest`, `DigestType`, `KeyTag`, `Id`) |
| `DnssecKey.Id` — Amazon Registrar | bare digest | `DS:<keytag>-<algorithm>-<digesttype>-<digest>` |
| `DnssecKey.Id` — Gandi | numeric (e.g. `1113178`) | numeric (e.g. `1352089`) |

That breaks the resource in three places:

1. **Create** looked the new key up by `Flags` + `PublicKey` (`findDNSSECKeyByThreePartKey`) → `empty result` after a *successful* association, so the record exists at the registry but never reaches state. The next apply re-associates it → `FAILED [Parameters in request are not valid]` (registries that reject duplicates) or a no-op success followed by the same `empty result` again (EURid).
2. **Read** keyed on `DnssecKey.Id` — which changed format for Amazon Registrar domains → `Cannot import non-existent remote object` / resource removed from state.
3. **Read** flattened the (now absent) `Flags`/`PublicKey` into `signing_attributes` as null → `# forces replacement` on every plan; applying it disassociates the DS record and re-associates it (and then hits 1).

The only identifier that is stable across registrars, across the API change, and across both `AssociateDelegationSignerToDomain` and `GetDomainDetail` is the **DS digest**, and it is deterministic: per RFC 4034 §5.1.4 it is the hash of the owner name (canonical wire format) followed by the DNSKEY RDATA (`flags | protocol=3 | algorithm | public key`) — exactly the arguments of `signing_attributes`. So this PR:

- Adds `dsDigests()` (stdlib only; SHA-1 / SHA-256 / SHA-384 for digest types 1/2/4) with unit tests against the RFC 4034 §5.4 vector and three real registry-returned digests.
- **Create**: after the operation succeeds, finds the key by computed digest (with a short not-found retry for propagation) and stores the **digest** in `dnssec_key_id`. If the operation fails and a key with that digest already exists, the error now says so and gives the `import` ID.
- **Read**: finds the key by digest; **also accepts the legacy values** previously stored in state (`DnssecKey.Id` — numeric or `DS:…` — or a bare digest) and rewrites `dnssec_key_id`/`id` to the digest, so existing state migrates on the first refresh with no schema version bump (a pure state upgrader could not convert the numeric Gandi ids offline). `signing_attributes` is no longer overwritten from the API.
- **Delete**: resolves the registry-assigned `DnssecKey.Id` via the digest (the disassociate API needs the registry id); already-gone → no-op.
- **Plan**: the per-attribute `RequiresReplace` on `signing_attributes` is replaced by one list-level `RequiresReplaceIf` that computes the DS digest of the *planned* attributes and only forces replacement when it differs from the associated key's digest. Changing the key still replaces; **completing `signing_attributes` after an import (the API can't return them) is now an in-place no-op `Update` instead of a destroy+create of the live DS record** — this is also the recovery path for everyone bitten by #47928, whose records are orphaned at the registry: `import` with `<domain>,<digest>` (the digest is right there in `dig DS <domain>`).
- Docs: `dnssec_key_id` and the import ID are documented as the DS digest.
- Test: `basic` now asserts an empty plan after create (the regression guard for #47928) and ignores `signing_attributes` on import verify; fixes the `CheckDestroy` resource-type typo (it was checking `aws_route53domains_ds_association`, i.e. nothing).

Earlier attempts (#47932, #48163, #48165) switched Read/Delete to the digest but left Create keyed on `Flags`/`PublicKey`, so Create still fails with `empty result` today; #48165's state upgrader also only recognises the `DS:` prefix (not the numeric ids Gandi returns). This PR supersedes them.

### Relations

Closes #47928
Supersedes #47932
Supersedes #48163
Supersedes #48165

### References

- [`DnssecKey`](https://docs.aws.amazon.com/Route53/latest/APIReference/API_domains_DnssecKey.html), [`GetDomainDetail`](https://docs.aws.amazon.com/Route53/latest/APIReference/API_domains_GetDomainDetail.html), [`DisassociateDelegationSignerFromDomain`](https://docs.aws.amazon.com/Route53/latest/APIReference/API_domains_DisassociateDelegationSignerFromDomain.html)
- [RFC 4034 §5.1.4 (DS digest calculation)](https://www.rfc-editor.org/rfc/rfc4034#section-5.1.4), [§5.4 example](https://www.rfc-editor.org/rfc/rfc4034#section-5.4)

### AI assistance disclosure

Diagnosis, code and tests were drafted with Claude Code (Anthropic) and reviewed, adjusted and verified by me against real domains; I can explain and stand behind every line. Please see the Terraform AI usage policy — the PR is submitted from my own account and I am accountable for it.

### Output from Acceptance Testing

I do not have a Route 53 Domains–registered throwaway domain to run the live acceptance tests (`ROUTE53DOMAINS_DOMAIN_NAME`); a maintainer with one, please run:

```console
% make testacc TESTS=TestAccRoute53Domains_serial/DelegationSignerRecord PKG=route53domains
```

Unit tests:

```console
% go test ./internal/service/route53domains/ -run TestDSDigests -v
--- PASS: TestDSDigests (0.00s)
    --- PASS: TestDSDigests/rfc4034_example_sha1 (0.00s)
    --- PASS: TestDSDigests/gandi_.com_sha256 (0.00s)
    --- PASS: TestDSDigests/amazon_registrar_.com_sha256 (0.00s)
    --- PASS: TestDSDigests/gandi_.eu_sha256 (0.00s)
    --- PASS: TestDSDigests/owner_name_is_canonicalized (0.00s)
    --- PASS: TestDSDigests/invalid_public_key (0.00s)
    --- PASS: TestDSDigests/invalid_flags (0.00s)
    --- PASS: TestDSDigests/invalid_domain_name (0.00s)
PASS
```

Manual verification of the built provider (`dev_overrides`) against three production domains that are in the exact #47928 situation (DS records live at the registry, resources missing from state):

1. **Import by digest, then complete `signing_attributes` in place** (the #47928 recovery path; `import` blocks with `<domain>,<digest>`):

```console
Plan: 3 to import, 0 to add, 3 to change, 0 to destroy.
  # aws_route53domains_delegation_signer_record.urbantz_com will be updated in-place
  # (imported from "urbantz.com,ABA22F65F11E2D8D43BC95B32BCDB6744AA07C4CE38CE4D3E46189760DE699EB")
      + signing_attributes {
          + algorithm  = 13
          + flags      = 257
          + public_key = "mdss…"
        }
Apply complete! Resources: 3 imported, 0 added, 3 changed, 0 destroyed.
No changes. Your infrastructure matches the configuration.
```

2. **Legacy state migration** (hand-written state with `dnssec_key_id` = Gandi numeric `1352089` with full attributes, Amazon Registrar `DS:2371-13-2-B8EF…` with null attributes, Gandi numeric `1352094` with null attributes — the three shapes users can have today):

```console
aws_route53domains_delegation_signer_record.urbantz_com: Refreshing state... [id=urbantz.com,1352089]
aws_route53domains_delegation_signer_record.urbantz_legacy_com: Refreshing state... [id=urbantz-legacy.com,DS:2371-13-2-B8EF62832AA5515654F042AD80B2B5D97EF4D29AA3520333FC4F350FAD01E0B4]
Plan: 0 to add, 2 to change, 0 to destroy.   # urbantz_com: no-op; the two with null attributes: in-place update
Apply complete! Resources: 0 added, 2 changed, 0 destroyed.
# state after: all three dnssec_key_id rewritten to the digest, signing_attributes complete
No changes. Your infrastructure matches the configuration.
```

3. **Key change still replaces** (different `public_key` in config; plan only, not applied):

```console
  # aws_route53domains_delegation_signer_record.urbantz_com must be replaced
      ~ signing_attributes { # forces replacement
Plan: 3 to add, 0 to change, 3 to destroy.
```

Only `GetDomainDetail` was called during 1. and 2. — no registry mutation. `go vet` and `gofmt` are clean on the package (I could not run the full `golangci-lint` matrix locally).
