### PR TITLE
[Enhancement] aws_transfer_web_app: Add `endpoint_details.vpc.ip_address_type`

### DIFF
--- a/.changelog/49579.txt
+++ b/.changelog/49579.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_transfer_web_app: Add `endpoint_details.vpc.ip_address_type` argument
+```

--- a/internal/service/transfer/web_app.go
+++ b/internal/service/transfer/web_app.go
@@ -305,7 +305,7 @@ func (r *webAppResource) Update(ctx context.Context, request resource.UpdateRequ
 	if diff.HasChanges() {
 		webAppID := fwflex.StringValueFromFramework(ctx, new.WebAppID)
 		var input transfer.UpdateWebAppInput
-		response.Diagnostics.Append(fwflex.Expand(ctx, new, &input, fwflex.WithIgnoredFieldNamesAppend("IdentityProviderDetails"), fwflex.WithIgnoredFieldNamesAppend("EndpointDetails"))...)
+		response.Diagnostics.Append(fwflex.Expand(ctx, new, &input, fwflex.WithIgnoredFieldNamesAppend("IdentityProviderDetails"))...)
 		if response.Diagnostics.HasError() {
 			return
 		}
@@ -329,10 +329,13 @@ func (r *webAppResource) Update(ctx context.Context, request resource.UpdateRequ
 			}
 		}
 		if !new.EndpointDetails.Equal(old.EndpointDetails) {
-			response.Diagnostics.Append(expandUpdateWebAppEndpointDetails(ctx, &new, &input)...)
-			if response.Diagnostics.HasError() {
-				return
-			}
+			// Reset AccessEndpoint to null to avoid conflicts.
+			// AccessEndpoint must not be specified when EndpointDetails is set.
+			// Note:
+			// AccessEndpoint is a computed attribute when endpoint_details.vpc is specified,
+			// because endpoint_details.vpc and access_endpoint are defined as conflicting
+			// attributes in the schema.
+			input.AccessEndpoint = nil
 		}
 
 		_, err := tfresource.RetryWhenIsAErrorMessageContains[any, *awstypes.InvalidRequestException](ctx, 1*time.Minute, func(ctx context.Context) (any, error) {
@@ -464,11 +467,11 @@ type webAppEndpointDetailsVPCModel struct {
 }
 
 var (
-	_ fwflex.Expander  = webAppEndpointDetailsModel{}
-	_ fwflex.Flattener = &webAppEndpointDetailsModel{}
+	_ fwflex.TypedExpander = webAppEndpointDetailsModel{}
+	_ fwflex.Flattener     = &webAppEndpointDetailsModel{}
 )
 
-func (m webAppEndpointDetailsModel) Expand(ctx context.Context) (any, diag.Diagnostics) {
+func (m webAppEndpointDetailsModel) ExpandTo(ctx context.Context, targetType reflect.Type) (any, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	switch {
@@ -478,12 +481,27 @@ func (m webAppEndpointDetailsModel) Expand(ctx context.Context) (any, diag.Diagn
 		if diags.HasError() {
 			return nil, diags
 		}
-		var r awstypes.WebAppEndpointDetailsMemberVpc
-		diags.Append(fwflex.Expand(ctx, data, &r.Value)...)
-		if diags.HasError() {
-			return nil, diags
+		switch targetType {
+		case reflect.TypeFor[awstypes.WebAppEndpointDetails]():
+			var r awstypes.WebAppEndpointDetailsMemberVpc
+			diags.Append(fwflex.Expand(ctx, data, &r.Value)...)
+			if diags.HasError() {
+				return nil, diags
+			}
+			return &r, diags
+		case reflect.TypeFor[awstypes.UpdateWebAppEndpointDetails]():
+			var r awstypes.UpdateWebAppEndpointDetailsMemberVpc
+			diags.Append(fwflex.Expand(ctx, data, &r.Value)...)
+			if diags.HasError() {
+				return nil, diags
+			}
+			return &r, diags
+		default:
+			diags.AddError(
+				"Unsupported Type",
+				fmt.Sprintf("web app endpoint details expand: %s", targetType.String()),
+			)
 		}
-		return &r, diags
 	}
 	return nil, diags
 }
@@ -508,49 +526,6 @@ func (m *webAppEndpointDetailsModel) Flatten(ctx context.Context, v any) diag.Di
 			fmt.Sprintf("artifact flatten: %s", reflect.TypeOf(v).String()),
 		)
 	}
-	return diags
-}
-
-func expandUpdateWebAppEndpointDetails(ctx context.Context, data *webAppResourceModel, input *transfer.UpdateWebAppInput) diag.Diagnostics { // nosemgrep:ci.semgrep.framework.manual-expander-functions
-	var diags diag.Diagnostics
-
-	endpointDetails, d := data.EndpointDetails.ToPtr(ctx)
-	diags.Append(d...)
-	if diags.HasError() || endpointDetails == nil {
-		return diags
-	}
-
-	vpc, d := endpointDetails.VPC.ToPtr(ctx)
-	diags.Append(d...)
-	if diags.HasError() || vpc == nil {
-		return diags
-	}
-
-	vpcConfig := awstypes.UpdateWebAppVpcConfig{
-		SubnetIds: fwflex.ExpandFrameworkStringValueSet(ctx, vpc.SubnetIDs),
-	}
-
-	if !vpc.IpAddressType.IsNull() && !vpc.IpAddressType.IsUnknown() {
-		ipAddressType, d := vpc.IpAddressType.ToStringValue(ctx)
-		diags.Append(d...)
-		if diags.HasError() {
-			return diags
-		}
-
-		vpcConfig.IpAddressType = awstypes.WebAppVpcEndpointIpAddressType(fwflex.StringValueFromFramework(ctx, ipAddressType))
-	}
-
-	input.EndpointDetails = &awstypes.UpdateWebAppEndpointDetailsMemberVpc{
-		Value: vpcConfig,
-	}
-	// Reset AccessEndpoint to null to avoid conflicts.
-	// AccessEndpoint must not be specified when EndpointDetails is set.
-	// Note:
-	// AccessEndpoint is a computed attribute when endpoint_details.vpc is specified,
-	// because endpoint_details.vpc and access_endpoint are defined as conflicting
-	// attributes in the schema.
-	input.AccessEndpoint = nil
-
 	return diags
 }
 

--- a/internal/service/transfer/web_app.go
+++ b/internal/service/transfer/web_app.go
@@ -562,6 +562,24 @@ func (m *webAppEndpointDetailsModel) Flatten(ctx context.Context, v any) diag.Di
 	return diags
 }
 
+// The DescribeWebApp API does not return ipAddressType.
+// Instead, retrieve it from the DescribeVpcEndpoints API using the vpcEndpointId returned by DescribeWebApp.
+func webAppVPCEndpointIPAddressType(ctx context.Context, conn *ec2.Client, vpcEndpointID string) (fwtypes.StringEnum[awstypes.IpAddressType], error) {
+	vpcEndpoint, err := tfec2.FindVPCEndpointByID(ctx, conn, vpcEndpointID)
+	if err != nil {
+		return fwtypes.StringEnumNull[awstypes.IpAddressType](), err
+	}
+
+	switch vpcEndpoint.IpAddressType {
+	case ec2types.IpAddressTypeIpv4:
+		return fwtypes.StringEnumValue(awstypes.IpAddressTypeIpv4), nil
+	case ec2types.IpAddressTypeDualstack:
+		return fwtypes.StringEnumValue(awstypes.IpAddressTypeDualstack), nil
+	default:
+		return fwtypes.StringEnumNull[awstypes.IpAddressType](), fmt.Errorf("unsupported IP address type: %s", vpcEndpoint.IpAddressType)
+	}
+}
+
 func setIPAddressTypeInWebAppEndpointDetailsVPC(ctx context.Context, ipAddressType fwtypes.StringEnum[awstypes.IpAddressType], data *webAppResourceModel) diag.Diagnostics {
 	var diags diag.Diagnostics
 
@@ -582,24 +600,6 @@ func setIPAddressTypeInWebAppEndpointDetailsVPC(ctx context.Context, ipAddressTy
 	data.EndpointDetails = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, endpointDetailsData)
 
 	return diags
-}
-
-// The DescribeWebApp API does not return ipAddressType.
-// Instead, retrieve it from the DescribeVpcEndpoints API using the vpcEndpointId returned by DescribeWebApp.
-func webAppVPCEndpointIPAddressType(ctx context.Context, conn *ec2.Client, vpcEndpointID string) (fwtypes.StringEnum[awstypes.IpAddressType], error) {
-	vpcEndpoint, err := tfec2.FindVPCEndpointByID(ctx, conn, vpcEndpointID)
-	if err != nil {
-		return fwtypes.StringEnumNull[awstypes.IpAddressType](), err
-	}
-
-	switch vpcEndpoint.IpAddressType {
-	case ec2types.IpAddressTypeIpv4:
-		return fwtypes.StringEnumValue(awstypes.IpAddressTypeIpv4), nil
-	case ec2types.IpAddressTypeDualstack:
-		return fwtypes.StringEnumValue(awstypes.IpAddressTypeDualstack), nil
-	default:
-		return fwtypes.StringEnumNull[awstypes.IpAddressType](), fmt.Errorf("unsupported IP address type: %s", vpcEndpoint.IpAddressType)
-	}
 }
 
 func setSecurityGroupIDsFromVPCEndpointID(ctx context.Context, conn *ec2.Client, vpcConfig awstypes.DescribedWebAppVpcConfig, new *webAppResourceModel) diag.Diagnostics {

--- a/internal/service/transfer/web_app.go
+++ b/internal/service/transfer/web_app.go
@@ -329,57 +329,8 @@ func (r *webAppResource) Update(ctx context.Context, request resource.UpdateRequ
 			}
 		}
 		if !new.EndpointDetails.Equal(old.EndpointDetails) {
-			if newDetails, diags := new.EndpointDetails.ToPtr(ctx); newDetails != nil && !diags.HasError() {
-				oldDetails, diags := old.EndpointDetails.ToPtr(ctx)
-				if diags.HasError() {
-					response.Diagnostics.Append(diags...)
-					return
-				}
-				if newVPC, diags := newDetails.VPC.ToPtr(ctx); newVPC != nil && !diags.HasError() {
-					var oldVPC *webAppEndpointDetailsVPCModel
-					if oldDetails != nil {
-						oldVPC, diags = oldDetails.VPC.ToPtr(ctx)
-						if diags.HasError() {
-							response.Diagnostics.Append(diags...)
-							return
-						}
-					}
-					vpcConfig := awstypes.UpdateWebAppVpcConfig{}
-					hasVPCConfigChange := false
-					if oldVPC == nil || !newVPC.SubnetIDs.Equal(oldVPC.SubnetIDs) {
-						vpcConfig.SubnetIds = fwflex.ExpandFrameworkStringValueSet(ctx, newVPC.SubnetIDs)
-						hasVPCConfigChange = true
-					}
-					if oldVPC == nil || !newVPC.IpAddressType.Equal(oldVPC.IpAddressType) {
-						ipAddressType, diags := newVPC.IpAddressType.ToStringValue(ctx)
-						if diags.HasError() {
-							response.Diagnostics.Append(diags...)
-							return
-						}
-						if ipAddressType.IsNull() || ipAddressType.IsUnknown() {
-							return
-						}
-						vpcConfig.IpAddressType = awstypes.WebAppVpcEndpointIpAddressType(fwflex.StringValueFromFramework(ctx, ipAddressType))
-						hasVPCConfigChange = true
-					}
-					if hasVPCConfigChange {
-						input.EndpointDetails = &awstypes.UpdateWebAppEndpointDetailsMemberVpc{
-							Value: vpcConfig,
-						}
-						// Reset AccessEndpoint to null to avoid conflicts.
-						// AccessEndpoint must not be specified when EndpointDetails is set.
-						// Note:
-						// AccessEndpoint is a computed attribute when endpoint_details.vpc is specified,
-						// because endpoint_details.vpc and access_endpoint are defined as conflicting
-						// attributes in the schema.
-						input.AccessEndpoint = nil
-					}
-				} else {
-					response.Diagnostics.Append(diags...)
-					return
-				}
-			} else {
-				response.Diagnostics.Append(diags...)
+			response.Diagnostics.Append(expandUpdateWebAppEndpointDetails(ctx, &new, &input)...)
+			if response.Diagnostics.HasError() {
 				return
 			}
 		}
@@ -557,6 +508,49 @@ func (m *webAppEndpointDetailsModel) Flatten(ctx context.Context, v any) diag.Di
 			fmt.Sprintf("artifact flatten: %s", reflect.TypeOf(v).String()),
 		)
 	}
+	return diags
+}
+
+func expandUpdateWebAppEndpointDetails(ctx context.Context, data *webAppResourceModel, input *transfer.UpdateWebAppInput) diag.Diagnostics { // nosemgrep:ci.semgrep.framework.manual-expander-functions
+	var diags diag.Diagnostics
+
+	endpointDetails, d := data.EndpointDetails.ToPtr(ctx)
+	diags.Append(d...)
+	if diags.HasError() || endpointDetails == nil {
+		return diags
+	}
+
+	vpc, d := endpointDetails.VPC.ToPtr(ctx)
+	diags.Append(d...)
+	if diags.HasError() || vpc == nil {
+		return diags
+	}
+
+	vpcConfig := awstypes.UpdateWebAppVpcConfig{
+		SubnetIds: fwflex.ExpandFrameworkStringValueSet(ctx, vpc.SubnetIDs),
+	}
+
+	if !vpc.IpAddressType.IsNull() && !vpc.IpAddressType.IsUnknown() {
+		ipAddressType, d := vpc.IpAddressType.ToStringValue(ctx)
+		diags.Append(d...)
+		if diags.HasError() {
+			return diags
+		}
+
+		vpcConfig.IpAddressType = awstypes.WebAppVpcEndpointIpAddressType(fwflex.StringValueFromFramework(ctx, ipAddressType))
+	}
+
+	input.EndpointDetails = &awstypes.UpdateWebAppEndpointDetailsMemberVpc{
+		Value: vpcConfig,
+	}
+	// Reset AccessEndpoint to null to avoid conflicts.
+	// AccessEndpoint must not be specified when EndpointDetails is set.
+	// Note:
+	// AccessEndpoint is a computed attribute when endpoint_details.vpc is specified,
+	// because endpoint_details.vpc and access_endpoint are defined as conflicting
+	// attributes in the schema.
+	input.AccessEndpoint = nil
+
 	return diags
 }
 

--- a/internal/service/transfer/web_app.go
+++ b/internal/service/transfer/web_app.go
@@ -12,6 +12,7 @@ import ( // nosemgrep:ci.semgrep.aws.multiple-service-imports
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/aws-sdk-go-v2/service/transfer"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/transfer/types"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
@@ -93,6 +94,14 @@ func (r *webAppResource) Schema(ctx context.Context, request resource.SchemaRequ
 							},
 							NestedObject: schema.NestedBlockObject{
 								Attributes: map[string]schema.Attribute{
+									names.AttrIPAddressType: schema.StringAttribute{
+										CustomType: fwtypes.StringEnumType[awstypes.IpAddressType](),
+										Optional:   true,
+										Computed:   true,
+										PlanModifiers: []planmodifier.String{
+											stringplanmodifier.UseStateForUnknown(),
+										},
+									},
 									names.AttrSecurityGroupIDs: schema.SetAttribute{
 										ElementType: types.StringType,
 										Optional:    true,
@@ -201,6 +210,19 @@ func (r *webAppResource) Create(ctx context.Context, request resource.CreateRequ
 	if webApp.DescribedEndpointDetails != nil {
 		switch t := webApp.DescribedEndpointDetails.(type) {
 		case *awstypes.DescribedWebAppEndpointDetailsMemberVpc:
+			vpcEndpointID := aws.ToString(t.Value.VpcEndpointId)
+			ipAddressType, err := webAppVPCEndpointIPAddressType(ctx, r.Meta().EC2Client(ctx), vpcEndpointID)
+			if err != nil {
+				response.Diagnostics.AddError(fmt.Sprintf("reading EC2 VPC Endpoint (%s)", vpcEndpointID), err.Error())
+
+				return
+			}
+
+			response.Diagnostics.Append(setIPAddressTypeInWebAppEndpointDetailsVPC(ctx, ipAddressType, &data)...)
+			if response.Diagnostics.HasError() {
+				return
+			}
+
 			response.Diagnostics.Append(setSecurityGroupIDsFromVPCEndpointID(ctx, r.Meta().EC2Client(ctx), t.Value, &data)...)
 			if response.Diagnostics.HasError() {
 				return
@@ -240,6 +262,19 @@ func (r *webAppResource) Read(ctx context.Context, request resource.ReadRequest,
 	if out.DescribedEndpointDetails != nil {
 		switch t := out.DescribedEndpointDetails.(type) {
 		case *awstypes.DescribedWebAppEndpointDetailsMemberVpc:
+			vpcEndpointID := aws.ToString(t.Value.VpcEndpointId)
+			ipAddressType, err := webAppVPCEndpointIPAddressType(ctx, r.Meta().EC2Client(ctx), vpcEndpointID)
+			if err != nil {
+				response.Diagnostics.AddError(fmt.Sprintf("reading EC2 VPC Endpoint (%s)", vpcEndpointID), err.Error())
+
+				return
+			}
+
+			response.Diagnostics.Append(setIPAddressTypeInWebAppEndpointDetailsVPC(ctx, ipAddressType, &data)...)
+			if response.Diagnostics.HasError() {
+				return
+			}
+
 			response.Diagnostics.Append(setSecurityGroupIDsFromVPCEndpointID(ctx, r.Meta().EC2Client(ctx), t.Value, &data)...)
 			if response.Diagnostics.HasError() {
 				return
@@ -295,20 +330,51 @@ func (r *webAppResource) Update(ctx context.Context, request resource.UpdateRequ
 			}
 		}
 		if !new.EndpointDetails.Equal(old.EndpointDetails) {
-			if v, diags := new.EndpointDetails.ToPtr(ctx); v != nil && !diags.HasError() {
-				if v, diags := v.VPC.ToPtr(ctx); v != nil && !diags.HasError() {
-					input.EndpointDetails = &awstypes.UpdateWebAppEndpointDetailsMemberVpc{
-						Value: awstypes.UpdateWebAppVpcConfig{
-							SubnetIds: fwflex.ExpandFrameworkStringValueSet(ctx, v.SubnetIDs),
-						},
+			if newDetails, diags := new.EndpointDetails.ToPtr(ctx); newDetails != nil && !diags.HasError() {
+				oldDetails, diags := old.EndpointDetails.ToPtr(ctx)
+				if diags.HasError() {
+					response.Diagnostics.Append(diags...)
+					return
+				}
+				if newVPC, diags := newDetails.VPC.ToPtr(ctx); newVPC != nil && !diags.HasError() {
+					var oldVPC *webAppEndpointDetailsVPCModel
+					if oldDetails != nil {
+						oldVPC, diags = oldDetails.VPC.ToPtr(ctx)
+						if diags.HasError() {
+							response.Diagnostics.Append(diags...)
+							return
+						}
 					}
-					// Reset AccessEndpoint to null to avoid conflicts.
-					// AccessEndpoint must not be specified when EndpointDetails is set.
-					// Note:
-					// AccessEndpoint is a computed attribute when endpoint_details.vpc is specified,
-					// because endpoint_details.vpc and access_endpoint are defined as conflicting
-					// attributes in the schema.
-					input.AccessEndpoint = nil
+					vpcConfig := awstypes.UpdateWebAppVpcConfig{}
+					hasVPCConfigChange := false
+					if oldVPC == nil || !newVPC.SubnetIDs.Equal(oldVPC.SubnetIDs) {
+						vpcConfig.SubnetIds = fwflex.ExpandFrameworkStringValueSet(ctx, newVPC.SubnetIDs)
+						hasVPCConfigChange = true
+					}
+					if oldVPC == nil || !newVPC.IpAddressType.Equal(oldVPC.IpAddressType) {
+						ipAddressType, diags := newVPC.IpAddressType.ToStringValue(ctx)
+						if diags.HasError() {
+							response.Diagnostics.Append(diags...)
+							return
+						}
+						if ipAddressType.IsNull() || ipAddressType.IsUnknown() {
+							return
+						}
+						vpcConfig.IpAddressType = awstypes.WebAppVpcEndpointIpAddressType(fwflex.StringValueFromFramework(ctx, ipAddressType))
+						hasVPCConfigChange = true
+					}
+					if hasVPCConfigChange {
+						input.EndpointDetails = &awstypes.UpdateWebAppEndpointDetailsMemberVpc{
+							Value: vpcConfig,
+						}
+						// Reset AccessEndpoint to null to avoid conflicts.
+						// AccessEndpoint must not be specified when EndpointDetails is set.
+						// Note:
+						// AccessEndpoint is a computed attribute when endpoint_details.vpc is specified,
+						// because endpoint_details.vpc and access_endpoint are defined as conflicting
+						// attributes in the schema.
+						input.AccessEndpoint = nil
+					}
 				} else {
 					response.Diagnostics.Append(diags...)
 					return
@@ -341,6 +407,18 @@ func (r *webAppResource) Update(ctx context.Context, request resource.UpdateRequ
 		if webApp.DescribedEndpointDetails != nil {
 			switch t := webApp.DescribedEndpointDetails.(type) {
 			case *awstypes.DescribedWebAppEndpointDetailsMemberVpc:
+				vpcEndpointID := aws.ToString(t.Value.VpcEndpointId)
+				ipAddressType, err := webAppVPCEndpointIPAddressType(ctx, r.Meta().EC2Client(ctx), vpcEndpointID)
+				if err != nil {
+					response.Diagnostics.AddError(fmt.Sprintf("reading EC2 VPC Endpoint (%s)", vpcEndpointID), err.Error())
+					return
+				}
+
+				response.Diagnostics.Append(setIPAddressTypeInWebAppEndpointDetailsVPC(ctx, ipAddressType, &new)...)
+				if response.Diagnostics.HasError() {
+					return
+				}
+
 				response.Diagnostics.Append(setSecurityGroupIDsFromVPCEndpointID(ctx, r.Meta().EC2Client(ctx), t.Value, &new)...)
 				if response.Diagnostics.HasError() {
 					return
@@ -426,10 +504,11 @@ type webAppEndpointDetailsModel struct {
 }
 
 type webAppEndpointDetailsVPCModel struct {
-	SecurityGroupIDs fwtypes.SetValueOf[types.String] `tfsdk:"security_group_ids"`
-	SubnetIDs        fwtypes.SetValueOf[types.String] `tfsdk:"subnet_ids"`
-	VPCEndpointID    types.String                     `tfsdk:"vpc_endpoint_id"`
-	VPCID            types.String                     `tfsdk:"vpc_id"`
+	IpAddressType    fwtypes.StringEnum[awstypes.IpAddressType] `tfsdk:"ip_address_type"`
+	SecurityGroupIDs fwtypes.SetValueOf[types.String]           `tfsdk:"security_group_ids"`
+	SubnetIDs        fwtypes.SetValueOf[types.String]           `tfsdk:"subnet_ids"`
+	VPCEndpointID    types.String                               `tfsdk:"vpc_endpoint_id"`
+	VPCID            types.String                               `tfsdk:"vpc_id"`
 }
 
 var (
@@ -478,6 +557,46 @@ func (m *webAppEndpointDetailsModel) Flatten(ctx context.Context, v any) diag.Di
 		)
 	}
 	return diags
+}
+
+func setIPAddressTypeInWebAppEndpointDetailsVPC(ctx context.Context, ipAddressType fwtypes.StringEnum[awstypes.IpAddressType], data *webAppResourceModel) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	endpointDetailsData, d := data.EndpointDetails.ToPtr(ctx)
+	diags.Append(d...)
+	if diags.HasError() || endpointDetailsData == nil {
+		return diags
+	}
+
+	vpcData, d := endpointDetailsData.VPC.ToPtr(ctx)
+	diags.Append(d...)
+	if diags.HasError() || vpcData == nil {
+		return diags
+	}
+
+	vpcData.IpAddressType = ipAddressType
+	endpointDetailsData.VPC = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, vpcData)
+	data.EndpointDetails = fwtypes.NewListNestedObjectValueOfPtrMust(ctx, endpointDetailsData)
+
+	return diags
+}
+
+// The DescribeWebApp API does not return ipAddressType.
+// Instead, retrieve it from the DescribeVpcEndpoints API using the vpcEndpointId returned by DescribeWebApp.
+func webAppVPCEndpointIPAddressType(ctx context.Context, conn *ec2.Client, vpcEndpointID string) (fwtypes.StringEnum[awstypes.IpAddressType], error) {
+	vpcEndpoint, err := tfec2.FindVPCEndpointByID(ctx, conn, vpcEndpointID)
+	if err != nil {
+		return fwtypes.StringEnumNull[awstypes.IpAddressType](), err
+	}
+
+	switch vpcEndpoint.IpAddressType {
+	case ec2types.IpAddressTypeIpv4:
+		return fwtypes.StringEnumValue(awstypes.IpAddressTypeIpv4), nil
+	case ec2types.IpAddressTypeDualstack:
+		return fwtypes.StringEnumValue(awstypes.IpAddressTypeDualstack), nil
+	default:
+		return fwtypes.StringEnumNull[awstypes.IpAddressType](), fmt.Errorf("unsupported IP address type: %s", vpcEndpoint.IpAddressType)
+	}
 }
 
 func setSecurityGroupIDsFromVPCEndpointID(ctx context.Context, conn *ec2.Client, vpcConfig awstypes.DescribedWebAppVpcConfig, new *webAppResourceModel) diag.Diagnostics {

--- a/internal/service/transfer/web_app.go
+++ b/internal/service/transfer/web_app.go
@@ -215,7 +215,6 @@ func (r *webAppResource) Create(ctx context.Context, request resource.CreateRequ
 			ipAddressType, err := webAppVPCEndpointIPAddressType(ctx, r.Meta().EC2Client(ctx), vpcEndpointID)
 			if err != nil {
 				response.Diagnostics.AddError(fmt.Sprintf("reading EC2 VPC Endpoint (%s)", vpcEndpointID), err.Error())
-
 				return
 			}
 
@@ -267,7 +266,6 @@ func (r *webAppResource) Read(ctx context.Context, request resource.ReadRequest,
 			ipAddressType, err := webAppVPCEndpointIPAddressType(ctx, r.Meta().EC2Client(ctx), vpcEndpointID)
 			if err != nil {
 				response.Diagnostics.AddError(fmt.Sprintf("reading EC2 VPC Endpoint (%s)", vpcEndpointID), err.Error())
-
 				return
 			}
 

--- a/internal/service/transfer/web_app.go
+++ b/internal/service/transfer/web_app.go
@@ -9,6 +9,7 @@ import ( // nosemgrep:ci.semgrep.aws.multiple-service-imports
 	"context"
 	"fmt"
 	"reflect"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -385,7 +386,9 @@ func (r *webAppResource) Update(ctx context.Context, request resource.UpdateRequ
 			}
 		}
 
-		_, err := conn.UpdateWebApp(ctx, &input)
+		_, err := tfresource.RetryWhenIsAErrorMessageContains[any, *awstypes.InvalidRequestException](ctx, 1*time.Minute, func(ctx context.Context) (any, error) {
+			return conn.UpdateWebApp(ctx, &input)
+		}, "VpcEndpoint modify operation in progress")
 		if err != nil {
 			response.Diagnostics.AddError(fmt.Sprintf("updating Transfer Web App (%s)", webAppID), err.Error())
 

--- a/internal/service/transfer/web_app_test.go
+++ b/internal/service/transfer/web_app_test.go
@@ -337,6 +337,11 @@ func TestAccTransferWebApp_VPC(t *testing.T) {
 						tfjsonpath.New(names.AttrID),
 						compare.ValuesSame(),
 					),
+					statecheck.ExpectKnownValue(
+						resourceName,
+						tfjsonpath.New("endpoint_details").AtSliceIndex(0).AtMapKey("vpc").AtSliceIndex(0).AtMapKey(names.AttrIPAddressType),
+						knownvalue.StringExact(string(awstypes.IpAddressTypeDualstack)),
+					),
 				},
 			},
 			{
@@ -363,6 +368,74 @@ func TestAccTransferWebApp_VPC(t *testing.T) {
 						"aws_vpc.test",
 						tfjsonpath.New(names.AttrID),
 						compare.ValuesSame(),
+					),
+					statecheck.ExpectKnownValue(
+						resourceName,
+						tfjsonpath.New("endpoint_details").AtSliceIndex(0).AtMapKey("vpc").AtSliceIndex(0).AtMapKey(names.AttrIPAddressType),
+						knownvalue.StringExact(string(awstypes.IpAddressTypeDualstack)),
+					),
+				},
+			},
+		},
+	})
+}
+
+func TestAccTransferWebApp_VPCIPAddressType(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v awstypes.DescribedWebApp
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_transfer_web_app.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.TransferEndpointID)
+			acctest.PreCheckSSOAdminInstances(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.TransferServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckWebAppDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWebAppConfig_VPCIPAddressType(rName, string(awstypes.IpAddressTypeIpv4)),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckWebAppExists(ctx, t, resourceName, &v),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						resourceName,
+						tfjsonpath.New("endpoint_details").AtSliceIndex(0).AtMapKey("vpc").AtSliceIndex(0).AtMapKey(names.AttrIPAddressType),
+						knownvalue.StringExact(string(awstypes.IpAddressTypeIpv4)),
+					),
+				},
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "web_app_id",
+				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, "web_app_id"),
+			},
+			{
+				Config: testAccWebAppConfig_VPCIPAddressType(rName, string(awstypes.IpAddressTypeDualstack)),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckWebAppExists(ctx, t, resourceName, &v),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						resourceName,
+						tfjsonpath.New("endpoint_details").AtSliceIndex(0).AtMapKey("vpc").AtSliceIndex(0).AtMapKey(names.AttrIPAddressType),
+						knownvalue.StringExact(string(awstypes.IpAddressTypeDualstack)),
 					),
 				},
 			},
@@ -552,6 +625,35 @@ resource "aws_transfer_web_app" "test" {
   }
 }
 `, rName, subnetIndex))
+}
+
+func testAccWebAppConfig_VPCIPAddressType(rName, ipAddressType string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigVPCWithSubnetsIPv6(rName, 2),
+		testAccWebAppConfig_base(rName),
+		fmt.Sprintf(`
+resource "aws_security_group" "test" {
+  name   = %[1]q
+  vpc_id = aws_vpc.test.id
+}
+
+resource "aws_transfer_web_app" "test" {
+  identity_provider_details {
+    identity_center_config {
+      instance_arn = tolist(data.aws_ssoadmin_instances.test.arns)[0]
+      role         = aws_iam_role.test.arn
+    }
+  }
+  endpoint_details {
+    vpc {
+      vpc_id             = aws_vpc.test.id
+      subnet_ids         = aws_subnet.test[*].id
+      security_group_ids = [aws_security_group.test.id]
+      ip_address_type    = "%[2]s"
+    }
+  }
+}
+`, rName, ipAddressType))
 }
 
 func testAccWebAppConfig_tags1(rName, tag1Key, tag1Value string) string {

--- a/website/docs/r/transfer_web_app.html.markdown
+++ b/website/docs/r/transfer_web_app.html.markdown
@@ -128,9 +128,10 @@ The following arguments are optional:
 
 For details about prerequisites to host a web app endpoint within a VPC, see [the AWS documentation](https://docs.aws.amazon.com/transfer/latest/userguide/create-webapp-in-vpc.html).
 
+* `ip_address_type` - (Optional) IP address type for the web app's VPC endpoint. Valid values are: `IPV4` and `DUALSTACK` (default).
 * `security_group_ids` - (Optional) List of security group IDs that control access to the web app endpoint. If not specified, the VPC's default security group is used.
 * `subnet_ids` - (Required) List of subnet IDs within the VPC where the web app endpoint will be deployed. These subnets must be in the same VPC specified in the `vpc_id` parameter.
-* `vpc_id` - (Required) ID of the VPC where the web app endpoint will be hosted. The VPC must be dual-stack, meaning it supports both IPv4 and IPv6 addressing.
+- `vpc_id` - (Required) ID of the VPC where the web app endpoint will be hosted. When the VPC does not have an associated IPv6 CIDR block, `ip_address_type` must be specified as `IPV4`.
 
 ### `web_app_units` Block
 

--- a/website/docs/r/transfer_web_app.html.markdown
+++ b/website/docs/r/transfer_web_app.html.markdown
@@ -131,7 +131,7 @@ For details about prerequisites to host a web app endpoint within a VPC, see [th
 * `ip_address_type` - (Optional) IP address type for the web app's VPC endpoint. Valid values are: `IPV4` and `DUALSTACK` (default).
 * `security_group_ids` - (Optional) List of security group IDs that control access to the web app endpoint. If not specified, the VPC's default security group is used.
 * `subnet_ids` - (Required) List of subnet IDs within the VPC where the web app endpoint will be deployed. These subnets must be in the same VPC specified in the `vpc_id` parameter.
-- `vpc_id` - (Required) ID of the VPC where the web app endpoint will be hosted. When the VPC does not have an associated IPv6 CIDR block, `ip_address_type` must be specified as `IPV4`.
+* `vpc_id` - (Required) ID of the VPC where the web app endpoint will be hosted. When the VPC does not have an associated IPv6 CIDR block, `ip_address_type` must be specified as `IPV4`.
 
 ### `web_app_units` Block
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
This PR adds `endpoint_details.vpc.ip_address_type` to the `aws_transfer_web_app` resource to support IPv4-only addressing in addition to dual-stack addressing.

* Previously, when the `vpc` option was used, the VPC was required to have an IPv6 CIDR block association.

#### AWS API behavior and Provider implementation

* The `DescribeWebApp` API does not return `ip_address_type`. Instead, it is retrieved using the `DescribeVpcEndpoints` API with the `vpcEndpointId` returned by `DescribeWebApp`.
  * When `ip_address_type` is not specified or is set to `DUALSTACK`, the `CreateWebApp` API creates a VPC endpoint with dual-stack addressing.
  * When `ip_address_type` is set to `IPV4`, it creates a VPC endpoint with IPv4-only addressing.

* The `UpdateWebApp` API supports updating `ip_address_type`. Previously, `subnetIds` was the only updatable attribute, and the update logic was implemented based on the assumption that it was the only attribute that could be updated. The update logic has therefore been restructured using auto flex with TypedExpander. 

* Retry `UpdateWebApp` when VPC endpoint update conflicts occurs.

### Relations
Closes #48554

### References
https://docs.aws.amazon.com/ja_jp/transfer/latest/APIReference/API_CreateWebApp.html
https://docs.aws.amazon.com/ja_jp/transfer/latest/APIReference/API_UpdateWebApp.html
https://docs.aws.amazon.com/ja_jp/transfer/latest/APIReference/API_DescribeWebApp.html


### Output from Acceptance Testing

```console
$ AWS_DEFAULT_REGION=ap-northeast-1 make testacc TESTS='TestAccTransferWebApp_' PKG=transfer
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework (cached)
make: Running acceptance tests on branch: 🌿 f-aws_transfer_web_app-add_vpc_ip_address_type 🌿...
TF_ACC=1 go1.26.6 test ./internal/service/transfer/... -v -count 1 -parallel 20 -run='TestAccTransferWebApp_'  -timeout 360m -vet=off -buildvcs=false
2026/08/21 09:54:34 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/21 09:54:34 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccTransferWebApp_basic
=== PAUSE TestAccTransferWebApp_basic
=== RUN   TestAccTransferWebApp_disappears
=== PAUSE TestAccTransferWebApp_disappears
=== RUN   TestAccTransferWebApp_tags
=== PAUSE TestAccTransferWebApp_tags
=== RUN   TestAccTransferWebApp_webAppUnits
=== PAUSE TestAccTransferWebApp_webAppUnits
=== RUN   TestAccTransferWebApp_accessEndpoint
=== PAUSE TestAccTransferWebApp_accessEndpoint
=== RUN   TestAccTransferWebApp_VPC
=== PAUSE TestAccTransferWebApp_VPC
=== RUN   TestAccTransferWebApp_VPCIPAddressType
=== PAUSE TestAccTransferWebApp_VPCIPAddressType
=== CONT  TestAccTransferWebApp_basic
=== CONT  TestAccTransferWebApp_accessEndpoint
=== CONT  TestAccTransferWebApp_tags
=== CONT  TestAccTransferWebApp_disappears
=== CONT  TestAccTransferWebApp_webAppUnits
=== CONT  TestAccTransferWebApp_VPCIPAddressType
=== CONT  TestAccTransferWebApp_VPC
--- PASS: TestAccTransferWebApp_disappears (35.75s)
--- PASS: TestAccTransferWebApp_basic (39.06s)
--- PASS: TestAccTransferWebApp_webAppUnits (60.06s)
--- PASS: TestAccTransferWebApp_accessEndpoint (60.84s)
--- PASS: TestAccTransferWebApp_tags (77.82s)
--- PASS: TestAccTransferWebApp_VPCIPAddressType (181.95s)
--- PASS: TestAccTransferWebApp_VPC (203.00s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/transfer   208.810s


```
