### PR TITLE
service/directconnect: support long BGP ASN for hosted VIFs

### DIFF
--- a/.changelog/49591.txt
+++ b/.changelog/49591.txt
@@ -1,0 +1,11 @@
+```release-note:enhancement
+resource/aws_dx_hosted_private_virtual_interface: Add `bgp_asn_long` argument
+```
+
+```release-note:enhancement
+resource/aws_dx_hosted_public_virtual_interface: Add `bgp_asn_long` argument
+```
+
+```release-note:enhancement
+resource/aws_dx_hosted_transit_virtual_interface: Add `bgp_asn_long` argument
+```

--- a/internal/service/directconnect/bgp_asn_test.go
+++ b/internal/service/directconnect/bgp_asn_test.go
@@ -82,10 +82,13 @@ func TestBGPASNResourceSchemas(t *testing.T) {
 	t.Parallel()
 
 	resourceFactories := map[string]func() *schema.Resource{
-		"BGP peer":    resourceBGPPeer,
-		"private VIF": resourcePrivateVirtualInterface,
-		"transit VIF": resourceTransitVirtualInterface,
-		"public VIF":  resourcePublicVirtualInterface,
+		"BGP peer":           resourceBGPPeer,
+		"private VIF":        resourcePrivateVirtualInterface,
+		"public VIF":         resourcePublicVirtualInterface,
+		"transit VIF":        resourceTransitVirtualInterface,
+		"hosted private VIF": resourceHostedPrivateVirtualInterface,
+		"hosted public VIF":  resourceHostedPublicVirtualInterface,
+		"hosted transit VIF": resourceHostedTransitVirtualInterface,
 	}
 
 	for name, resourceFactory := range resourceFactories {

--- a/internal/service/directconnect/hosted_private_virtual_interface.go
+++ b/internal/service/directconnect/hosted_private_virtual_interface.go
@@ -64,11 +64,8 @@ func resourceHostedPrivateVirtualInterface() *schema.Resource {
 					Type:     schema.TypeString,
 					Computed: true,
 				},
-				"bgp_asn": {
-					Type:     schema.TypeInt,
-					Required: true,
-					ForceNew: true,
-				},
+				"bgp_asn":      bgpASNAttributeSchema(false),
+				"bgp_asn_long": bgpASNAttributeSchema(true),
 				"bgp_auth_key": {
 					Type:     schema.TypeString,
 					Optional: true,
@@ -141,12 +138,14 @@ func resourceHostedPrivateVirtualInterface() *schema.Resource {
 func resourceHostedPrivateVirtualInterfaceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DirectConnectClient(ctx)
+	asn, asnLong := expandBGPASN(d)
 
 	input := &directconnect.AllocatePrivateVirtualInterfaceInput{
 		ConnectionId: aws.String(d.Get(names.AttrConnectionID).(string)),
 		NewPrivateVirtualInterfaceAllocation: &awstypes.NewPrivateVirtualInterfaceAllocation{
 			AddressFamily:        awstypes.AddressFamily(d.Get("address_family").(string)),
-			Asn:                  int32(d.Get("bgp_asn").(int)),
+			Asn:                  asn,
+			AsnLong:              asnLong,
 			Mtu:                  aws.Int32(int32(d.Get("mtu").(int))),
 			VirtualInterfaceName: aws.String(d.Get(names.AttrName).(string)),
 			Vlan:                 int32(d.Get("vlan").(int)),
@@ -217,7 +216,9 @@ func resourceHostedPrivateVirtualInterfaceRead(ctx context.Context, d *schema.Re
 	}.String()
 	d.Set(names.AttrARN, arn)
 	d.Set("aws_device", vif.AwsDeviceV2)
-	d.Set("bgp_asn", vif.Asn)
+	if err := setBGPASN(d, vif.Asn, vif.AsnLong); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting BGP ASN: %s", err)
+	}
 	d.Set("bgp_auth_key", vif.AuthKey)
 	d.Set(names.AttrConnectionID, vif.ConnectionId)
 	d.Set("customer_address", vif.CustomerAddress)
@@ -248,6 +249,10 @@ func resourceHostedPrivateVirtualInterfaceImport(ctx context.Context, d *schema.
 
 	if vifType := aws.ToString(vif.VirtualInterfaceType); vifType != "private" {
 		return nil, fmt.Errorf("virtual interface (%s) has incorrect type: %s", d.Id(), vifType)
+	}
+
+	if err := setBGPASN(d, vif.Asn, vif.AsnLong); err != nil {
+		return nil, fmt.Errorf("setting BGP ASN: %w", err)
 	}
 
 	return []*schema.ResourceData{d}, nil

--- a/internal/service/directconnect/hosted_private_virtual_interface_test.go
+++ b/internal/service/directconnect/hosted_private_virtual_interface_test.go
@@ -310,3 +310,73 @@ resource "aws_dx_hosted_private_virtual_interface_accepter" "test" {
 }
 `, cid, rName, bgpAsn, vlan))
 }
+
+func TestAccDirectConnectHostedPrivateVirtualInterface_bgpASNLong(t *testing.T) {
+	ctx := acctest.Context(t)
+	connectionID := acctest.SkipIfEnvVarNotSet(t, "DX_CONNECTION_ID")
+
+	var vif awstypes.VirtualInterface
+	resourceName := "aws_dx_hosted_private_virtual_interface.test"
+	rName := fmt.Sprintf("tf-testacc-private-vif-%s", acctest.RandString(t, 9))
+	vlan := acctest.RandIntRange(t, 2049, 4094)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckAlternateAccount(t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.DirectConnectServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5FactoriesAlternate(ctx, t),
+		CheckDestroy:             testAccCheckHostedPrivateVirtualInterfaceDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccHostedPrivateVirtualInterfaceConfig_bgpASNLong(connectionID, rName, vlan),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckHostedPrivateVirtualInterfaceExists(ctx, t, resourceName, &vif),
+					resource.TestCheckResourceAttr(resourceName, "bgp_asn_long", "4200012999"),
+				),
+			},
+			{
+				Config:            testAccHostedPrivateVirtualInterfaceConfig_bgpASNLong(connectionID, rName, vlan),
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				// These values are assigned after the accepter confirms the VIF, after the allocation resource state was written.
+				ImportStateVerifyIgnore: []string{"amazon_address", "amazon_side_asn", "customer_address"},
+			},
+		},
+	})
+}
+func testAccHostedPrivateVirtualInterfaceConfig_bgpASNLong(cid, rName string, vlan int) string {
+	return acctest.ConfigCompose(acctest.ConfigAlternateAccountProvider(), fmt.Sprintf(`
+resource "aws_dx_hosted_private_virtual_interface" "test" {
+  address_family   = "ipv4"
+  bgp_asn_long     = "4200012999"
+  connection_id    = %[1]q
+  name             = %[2]q
+  owner_account_id = data.aws_caller_identity.accepter.account_id
+  vlan             = %[3]d
+
+  depends_on = [aws_vpn_gateway.test]
+}
+
+data "aws_caller_identity" "accepter" {
+  provider = "awsalternate"
+}
+
+resource "aws_vpn_gateway" "test" {
+  provider = "awsalternate"
+
+  tags = {
+    Name = %[2]q
+  }
+}
+
+resource "aws_dx_hosted_private_virtual_interface_accepter" "test" {
+  provider = "awsalternate"
+
+  virtual_interface_id = aws_dx_hosted_private_virtual_interface.test.id
+  vpn_gateway_id       = aws_vpn_gateway.test.id
+}
+`, cid, rName, vlan))
+}

--- a/internal/service/directconnect/hosted_public_virtual_interface.go
+++ b/internal/service/directconnect/hosted_public_virtual_interface.go
@@ -66,11 +66,8 @@ func resourceHostedPublicVirtualInterface() *schema.Resource {
 					Type:     schema.TypeString,
 					Computed: true,
 				},
-				"bgp_asn": {
-					Type:     schema.TypeInt,
-					Required: true,
-					ForceNew: true,
-				},
+				"bgp_asn":      bgpASNAttributeSchema(false),
+				"bgp_asn_long": bgpASNAttributeSchema(true),
 				"bgp_auth_key": {
 					Type:     schema.TypeString,
 					Optional: true,
@@ -131,12 +128,14 @@ func resourceHostedPublicVirtualInterface() *schema.Resource {
 func resourceHostedPublicVirtualInterfaceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DirectConnectClient(ctx)
+	asn, asnLong := expandBGPASN(d)
 
 	input := &directconnect.AllocatePublicVirtualInterfaceInput{
 		ConnectionId: aws.String(d.Get(names.AttrConnectionID).(string)),
 		NewPublicVirtualInterfaceAllocation: &awstypes.NewPublicVirtualInterfaceAllocation{
 			AddressFamily:        awstypes.AddressFamily(d.Get("address_family").(string)),
-			Asn:                  int32(d.Get("bgp_asn").(int)),
+			Asn:                  asn,
+			AsnLong:              asnLong,
 			VirtualInterfaceName: aws.String(d.Get(names.AttrName).(string)),
 			Vlan:                 int32(d.Get("vlan").(int)),
 		},
@@ -206,7 +205,9 @@ func resourceHostedPublicVirtualInterfaceRead(ctx context.Context, d *schema.Res
 	}.String()
 	d.Set(names.AttrARN, arn)
 	d.Set("aws_device", vif.AwsDeviceV2)
-	d.Set("bgp_asn", vif.Asn)
+	if err := setBGPASN(d, vif.Asn, vif.AsnLong); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting BGP ASN: %s", err)
+	}
 	d.Set("bgp_auth_key", vif.AuthKey)
 	d.Set(names.AttrConnectionID, vif.ConnectionId)
 	d.Set("customer_address", vif.CustomerAddress)
@@ -236,6 +237,10 @@ func resourceHostedPublicVirtualInterfaceImport(ctx context.Context, d *schema.R
 
 	if vifType := aws.ToString(vif.VirtualInterfaceType); vifType != "public" {
 		return nil, fmt.Errorf("virtual interface (%s) has incorrect type: %s", d.Id(), vifType)
+	}
+
+	if err := setBGPASN(d, vif.Asn, vif.AsnLong); err != nil {
+		return nil, fmt.Errorf("setting BGP ASN: %w", err)
 	}
 
 	return []*schema.ResourceData{d}, nil

--- a/internal/service/directconnect/hosted_public_virtual_interface_test.go
+++ b/internal/service/directconnect/hosted_public_virtual_interface_test.go
@@ -302,3 +302,69 @@ resource "aws_dx_hosted_public_virtual_interface_accepter" "test" {
 }
 `, cid, rName, amzAddr, custAddr, bgpAsn, vlan))
 }
+
+func TestAccDirectConnectHostedPublicVirtualInterface_bgpASNLong(t *testing.T) {
+	ctx := acctest.Context(t)
+	connectionID := acctest.SkipIfEnvVarNotSet(t, "DX_CONNECTION_ID")
+
+	var vif awstypes.VirtualInterface
+	resourceName := "aws_dx_hosted_public_virtual_interface.test"
+	rName := fmt.Sprintf("tf-testacc-public-vif-%s", acctest.RandString(t, 10))
+	amazonAddress := "175.45.176.11/28"
+	customerAddress := "175.45.176.12/28"
+	vlan := acctest.RandIntRange(t, 2049, 4094)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckAlternateAccount(t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.DirectConnectServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5FactoriesAlternate(ctx, t),
+		CheckDestroy:             testAccCheckHostedPublicVirtualInterfaceDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccHostedPublicVirtualInterfaceConfig_bgpASNLong(connectionID, rName, amazonAddress, customerAddress, vlan),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckHostedPublicVirtualInterfaceExists(ctx, t, resourceName, &vif),
+					resource.TestCheckResourceAttr(resourceName, "bgp_asn_long", "4200012999"),
+				),
+			},
+			{
+				Config:            testAccHostedPublicVirtualInterfaceConfig_bgpASNLong(connectionID, rName, amazonAddress, customerAddress, vlan),
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+func testAccHostedPublicVirtualInterfaceConfig_bgpASNLong(cid, rName, amzAddr, custAddr string, vlan int) string {
+	return acctest.ConfigCompose(acctest.ConfigAlternateAccountProvider(), fmt.Sprintf(`
+resource "aws_dx_hosted_public_virtual_interface" "test" {
+  address_family   = "ipv4"
+  amazon_address   = %[3]q
+  bgp_asn_long     = "4200012999"
+  connection_id    = %[1]q
+  customer_address = %[4]q
+  name             = %[2]q
+  owner_account_id = data.aws_caller_identity.accepter.account_id
+  vlan             = %[5]d
+
+  route_filter_prefixes = [
+    "175.45.176.0/22",
+    "210.52.109.0/24",
+  ]
+}
+
+data "aws_caller_identity" "accepter" {
+  provider = "awsalternate"
+}
+
+resource "aws_dx_hosted_public_virtual_interface_accepter" "test" {
+  provider = "awsalternate"
+
+  virtual_interface_id = aws_dx_hosted_public_virtual_interface.test.id
+}
+`, cid, rName, amzAddr, custAddr, vlan))
+}

--- a/internal/service/directconnect/hosted_transit_virtual_interface.go
+++ b/internal/service/directconnect/hosted_transit_virtual_interface.go
@@ -64,11 +64,8 @@ func resourceHostedTransitVirtualInterface() *schema.Resource {
 					Type:     schema.TypeString,
 					Computed: true,
 				},
-				"bgp_asn": {
-					Type:     schema.TypeInt,
-					Required: true,
-					ForceNew: true,
-				},
+				"bgp_asn":      bgpASNAttributeSchema(false),
+				"bgp_asn_long": bgpASNAttributeSchema(true),
 				"bgp_auth_key": {
 					Type:     schema.TypeString,
 					Optional: true,
@@ -141,12 +138,14 @@ func resourceHostedTransitVirtualInterface() *schema.Resource {
 func resourceHostedTransitVirtualInterfaceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DirectConnectClient(ctx)
+	asn, asnLong := expandBGPASN(d)
 
 	input := &directconnect.AllocateTransitVirtualInterfaceInput{
 		ConnectionId: aws.String(d.Get(names.AttrConnectionID).(string)),
 		NewTransitVirtualInterfaceAllocation: &awstypes.NewTransitVirtualInterfaceAllocation{
 			AddressFamily:        awstypes.AddressFamily(d.Get("address_family").(string)),
-			Asn:                  int32(d.Get("bgp_asn").(int)),
+			Asn:                  asn,
+			AsnLong:              asnLong,
 			Mtu:                  aws.Int32(int32(d.Get("mtu").(int))),
 			VirtualInterfaceName: aws.String(d.Get(names.AttrName).(string)),
 			Vlan:                 int32(d.Get("vlan").(int)),
@@ -213,7 +212,9 @@ func resourceHostedTransitVirtualInterfaceRead(ctx context.Context, d *schema.Re
 	}.String()
 	d.Set(names.AttrARN, arn)
 	d.Set("aws_device", vif.AwsDeviceV2)
-	d.Set("bgp_asn", vif.Asn)
+	if err := setBGPASN(d, vif.Asn, vif.AsnLong); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting BGP ASN: %s", err)
+	}
 	d.Set("bgp_auth_key", vif.AuthKey)
 	d.Set(names.AttrConnectionID, vif.ConnectionId)
 	d.Set("customer_address", vif.CustomerAddress)
@@ -244,6 +245,10 @@ func resourceHostedTransitVirtualInterfaceImport(ctx context.Context, d *schema.
 
 	if vifType := aws.ToString(vif.VirtualInterfaceType); vifType != "transit" {
 		return nil, fmt.Errorf("virtual interface (%s) has incorrect type: %s", d.Id(), vifType)
+	}
+
+	if err := setBGPASN(d, vif.Asn, vif.AsnLong); err != nil {
+		return nil, fmt.Errorf("setting BGP ASN: %w", err)
 	}
 
 	return []*schema.ResourceData{d}, nil

--- a/internal/service/directconnect/hosted_transit_virtual_interface_test.go
+++ b/internal/service/directconnect/hosted_transit_virtual_interface_test.go
@@ -25,6 +25,7 @@ func TestAccDirectConnectHostedTransitVirtualInterface_serial(t *testing.T) {
 		acctest.CtBasic: testAccHostedTransitVirtualInterface_basic,
 		"accepterTags":  testAccHostedTransitVirtualInterface_accepterTags,
 		"rateLimit":     testAccHostedTransitVirtualInterface_rateLimit,
+		"bgpASNLong":    testAccHostedTransitVirtualInterface_bgpASNLong,
 	}
 
 	acctest.RunSerialTests1Level(t, testCases, 0)
@@ -322,4 +323,74 @@ resource "aws_dx_hosted_transit_virtual_interface_accepter" "test" {
   virtual_interface_id = aws_dx_hosted_transit_virtual_interface.test.id
 }
 `, cid, rName, amzAsn, bgpAsn, vlan))
+}
+
+func testAccHostedTransitVirtualInterface_bgpASNLong(t *testing.T) {
+	ctx := acctest.Context(t)
+	connectionID := acctest.SkipIfEnvVarNotSet(t, "DX_CONNECTION_ID")
+
+	var vif awstypes.VirtualInterface
+	resourceName := "aws_dx_hosted_transit_virtual_interface.test"
+	rName := fmt.Sprintf("tf-testacc-transit-vif-%s", acctest.RandString(t, 9))
+	amzAsn := acctest.RandIntRange(t, 64512, 65534)
+	vlan := acctest.RandIntRange(t, 2049, 4094)
+
+	acctest.Test(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckAlternateAccount(t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.DirectConnectServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5FactoriesAlternate(ctx, t),
+		CheckDestroy:             testAccCheckHostedTransitVirtualInterfaceDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccHostedTransitVirtualInterfaceConfig_bgpASNLong(connectionID, rName, amzAsn, vlan),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckHostedTransitVirtualInterfaceExists(ctx, t, resourceName, &vif),
+					resource.TestCheckResourceAttr(resourceName, "bgp_asn_long", "4200012999"),
+				),
+			},
+			{
+				Config:            testAccHostedTransitVirtualInterfaceConfig_bgpASNLong(connectionID, rName, amzAsn, vlan),
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				// These values are assigned after the accepter confirms the VIF, after the allocation resource state was written.
+				ImportStateVerifyIgnore: []string{"amazon_address", "amazon_side_asn", "customer_address"},
+			},
+		},
+	})
+}
+func testAccHostedTransitVirtualInterfaceConfig_bgpASNLong(cid, rName string, amzAsn, vlan int) string {
+	return acctest.ConfigCompose(acctest.ConfigAlternateAccountProvider(), fmt.Sprintf(`
+resource "aws_dx_hosted_transit_virtual_interface" "test" {
+  address_family   = "ipv4"
+  bgp_asn_long     = "4200012999"
+  connection_id    = %[1]q
+  name             = %[2]q
+  owner_account_id = data.aws_caller_identity.accepter.account_id
+  vlan             = %[4]d
+
+  depends_on = [aws_dx_gateway.test]
+}
+
+data "aws_caller_identity" "accepter" {
+  provider = "awsalternate"
+}
+
+resource "aws_dx_gateway" "test" {
+  provider = "awsalternate"
+
+  amazon_side_asn = %[3]d
+  name            = %[2]q
+}
+
+resource "aws_dx_hosted_transit_virtual_interface_accepter" "test" {
+  provider = "awsalternate"
+
+  dx_gateway_id        = aws_dx_gateway.test.id
+  virtual_interface_id = aws_dx_hosted_transit_virtual_interface.test.id
+}
+`, cid, rName, amzAsn, vlan))
 }

--- a/website/docs/r/dx_hosted_private_virtual_interface.html.markdown
+++ b/website/docs/r/dx_hosted_private_virtual_interface.html.markdown
@@ -30,7 +30,8 @@ This resource supports the following arguments:
 
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `address_family` - (Required) The address family for the BGP peer. `ipv4 ` or `ipv6`.
-* `bgp_asn` - (Required) The autonomous system (AS) number for Border Gateway Protocol (BGP) configuration.
+* `bgp_asn` - (Optional) BGP autonomous system number as an integer between `1` and `2147483646`. For larger values, use `bgp_asn_long`. Exactly one of `bgp_asn` or `bgp_asn_long` must be specified.
+* `bgp_asn_long` - (Optional) BGP autonomous system number as an asplain decimal string between `1` and `4294967294`. This argument also accepts values in the `bgp_asn` range. Exactly one of `bgp_asn` or `bgp_asn_long` must be specified.
 * `connection_id` - (Required) The ID of the Direct Connect connection (or LAG) on which to create the virtual interface.
 * `name` - (Required) The name for the virtual interface.
 * `owner_account_id` - (Required) The AWS account that will own the new virtual interface.

--- a/website/docs/r/dx_hosted_public_virtual_interface.html.markdown
+++ b/website/docs/r/dx_hosted_public_virtual_interface.html.markdown
@@ -38,7 +38,8 @@ This resource supports the following arguments:
 
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `address_family` - (Required) The address family for the BGP peer. `ipv4 ` or `ipv6`.
-* `bgp_asn` - (Required) The autonomous system (AS) number for Border Gateway Protocol (BGP) configuration.
+* `bgp_asn` - (Optional) BGP autonomous system number as an integer between `1` and `2147483646`. For larger values, use `bgp_asn_long`. Exactly one of `bgp_asn` or `bgp_asn_long` must be specified.
+* `bgp_asn_long` - (Optional) BGP autonomous system number as an asplain decimal string between `1` and `4294967294`. This argument also accepts values in the `bgp_asn` range. Exactly one of `bgp_asn` or `bgp_asn_long` must be specified.
 * `connection_id` - (Required) The ID of the Direct Connect connection (or LAG) on which to create the virtual interface.
 * `name` - (Required) The name for the virtual interface.
 * `owner_account_id` - (Required) The AWS account that will own the new virtual interface.

--- a/website/docs/r/dx_hosted_transit_virtual_interface.html.markdown
+++ b/website/docs/r/dx_hosted_transit_virtual_interface.html.markdown
@@ -31,7 +31,8 @@ This resource supports the following arguments:
 
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `address_family` - (Required) The address family for the BGP peer. `ipv4 ` or `ipv6`.
-* `bgp_asn` - (Required) The autonomous system (AS) number for Border Gateway Protocol (BGP) configuration.
+* `bgp_asn` - (Optional) BGP autonomous system number as an integer between `1` and `2147483646`. For larger values, use `bgp_asn_long`. Exactly one of `bgp_asn` or `bgp_asn_long` must be specified.
+* `bgp_asn_long` - (Optional) BGP autonomous system number as an asplain decimal string between `1` and `4294967294`. This argument also accepts values in the `bgp_asn` range. Exactly one of `bgp_asn` or `bgp_asn_long` must be specified.
 * `connection_id` - (Required) The ID of the Direct Connect connection (or LAG) on which to create the virtual interface.
 * `name` - (Required) The name for the virtual interface.
 * `owner_account_id` - (Required) The AWS account that will own the new virtual interface.


### PR DESCRIPTION
## Description

Adds `bgp_asn_long` to the hosted Direct Connect VIF allocation resources:

- `aws_dx_hosted_private_virtual_interface`
- `aws_dx_hosted_public_virtual_interface`
- `aws_dx_hosted_transit_virtual_interface`

Each resource supports canonical asplain decimal strings through `4294967294`, preserves existing `bgp_asn` behavior, sends the AWS SDK `AsnLong` field, and restores the correct attribute during read and import.

## Relations

Related #40879
Relates #49590

## Acceptance Testing

### Hosted private VIF

```console
=== RUN   TestAccDirectConnectHostedPrivateVirtualInterface_bgpASNLong
=== PAUSE TestAccDirectConnectHostedPrivateVirtualInterface_bgpASNLong
=== CONT  TestAccDirectConnectHostedPrivateVirtualInterface_bgpASNLong
--- PASS: TestAccDirectConnectHostedPrivateVirtualInterface_bgpASNLong (646.06s)
PASS
ok  github.com/hashicorp/terraform-provider-aws/internal/service/directconnect  646.215s
```

### Hosted public VIF

```console
=== RUN   TestAccDirectConnectHostedPublicVirtualInterface_bgpASNLong
=== PAUSE TestAccDirectConnectHostedPublicVirtualInterface_bgpASNLong
=== CONT  TestAccDirectConnectHostedPublicVirtualInterface_bgpASNLong
--- PASS: TestAccDirectConnectHostedPublicVirtualInterface_bgpASNLong (77.12s)
PASS
ok  github.com/hashicorp/terraform-provider-aws/internal/service/directconnect  77.274s
```

### Hosted transit VIF

```console
=== RUN   TestAccDirectConnectHostedTransitVirtualInterface_serial
=== PAUSE TestAccDirectConnectHostedTransitVirtualInterface_serial
=== CONT  TestAccDirectConnectHostedTransitVirtualInterface_serial
=== RUN   TestAccDirectConnectHostedTransitVirtualInterface_serial/bgpASNLong
--- PASS: TestAccDirectConnectHostedTransitVirtualInterface_serial (557.99s)
    --- PASS: TestAccDirectConnectHostedTransitVirtualInterface_serial/bgpASNLong (557.99s)
PASS
ok  github.com/hashicorp/terraform-provider-aws/internal/service/directconnect  558.135s
```
