### PR TITLE
resource/aws_db_instance: reject blue_green_update when the instance has read replicas

### DIFF
--- a/.changelog/49596.txt
+++ b/.changelog/49596.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_db_instance: Refuse plan when `blue_green_update.enabled` is `true` on an instance that has read replicas, preventing a switchover from silently leaving the sibling replica resources orphaned or promoted to standalone
+```

--- a/internal/service/rds/instance.go
+++ b/internal/service/rds/instance.go
@@ -746,6 +746,81 @@ func resourceInstance() *schema.Resource {
 				}
 				return nil
 			},
+			// Blue/Green deployments on aws_db_instance are not coordinated with
+			// sibling aws_db_instance resources that declare this instance as
+			// their replicate_source_db. If a plan would trigger the Blue/Green
+			// code path in resourceInstanceUpdate while this instance has read
+			// replicas in AWS, the switchover leaves the replicas in one of two
+			// broken states: (1) tracking a "-old<N>" renamed instance, or
+			// (2) auto-promoted to standalone with ReadReplicaSourceDBInstanceIdentifier
+			// cleared to null. In case (2) reads through the replica endpoint
+			// return stale data with no drift signal, until a subsequent apply
+			// touches the replica and fails with "cannot elect new source
+			// database for replication". Recovery requires destroying and
+			// recreating the replica plus manual cleanup of untracked green/old
+			// side resources.
+			//
+			// See hashicorp/terraform-provider-aws#33702 for the underlying
+			// resource-model constraint that prevents coordinating switchover
+			// across sibling resources.
+			func(ctx context.Context, d *schema.ResourceDiff, meta any) error {
+				if !d.Get("blue_green_update.0.enabled").(bool) {
+					return nil
+				}
+				// No existing instance to check on creation.
+				if d.Id() == "" {
+					return nil
+				}
+				// Only check when the planned diff will actually trigger the
+				// Blue/Green code path in resourceInstanceUpdate. This exempt
+				// list mirrors the inner HasChangesExcept in that function.
+				// ResourceDiff does not expose HasChangesExcept, so iterate
+				// GetChangedKeysPrefix and match against the exempt set.
+				bgExempt := map[string]struct{}{
+					names.AttrAllowMajorVersionUpgrade: {},
+					"blue_green_update":                {},
+					"delete_automated_backups":         {},
+					names.AttrFinalSnapshotIdentifier:  {},
+					"replicate_source_db":              {},
+					"skip_final_snapshot":              {},
+					names.AttrTags:                     {},
+					names.AttrTagsAll:                  {},
+					names.AttrDeletionProtection:       {},
+					names.AttrPassword:                 {},
+				}
+				triggersBlueGreen := false
+				for _, changedKey := range d.GetChangedKeysPrefix("") {
+					top := strings.SplitN(changedKey, ".", 2)[0]
+					if _, ok := bgExempt[top]; !ok {
+						triggersBlueGreen = true
+						break
+					}
+				}
+				if !triggersBlueGreen {
+					return nil
+				}
+
+				conn := meta.(*conns.AWSClient).RDSClient(ctx)
+				instance, err := findDBInstanceByID(ctx, conn, d.Id())
+				if err != nil {
+					// Do not block plan on lookup errors; the update path will
+					// surface any genuine problem.
+					return nil //nolint:nilerr // best-effort plan-time check; genuine lookup errors surface during apply
+				}
+				if len(instance.ReadReplicaDBInstanceIdentifiers) == 0 {
+					return nil
+				}
+
+				return fmt.Errorf(
+					`"blue_green_update.enabled" cannot be set to true on an instance with read replicas: %v. `+
+						`Blue/Green deployments on aws_db_instance are not coordinated with sibling replica resources; `+
+						`after switchover the replicas may be orphaned, promoted to standalone, or left tracking a `+
+						`"-old<N>" renamed instance, and read traffic through affected replica endpoints may return `+
+						`stale data. Destroy the replicas before applying this change, or set `+
+						`"blue_green_update.enabled" to false. See hashicorp/terraform-provider-aws#33702.`,
+					instance.ReadReplicaDBInstanceIdentifiers,
+				)
+			},
 		),
 	}
 }

--- a/internal/service/rds/instance_test.go
+++ b/internal/service/rds/instance_test.go
@@ -6888,6 +6888,46 @@ func TestAccRDSInstance_BlueGreenDeployment_updateAndPromoteReplica(t *testing.T
 	})
 }
 
+func TestAccRDSInstance_BlueGreenDeployment_prohibitedOnReadReplicaSource(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	// All RDS Instance tests should skip for testing.Short() except the 20 shortest running tests.
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var v types.DBInstance
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	sourceResourceName := "aws_db_instance.source"
+	replicaResourceName := "aws_db_instance.replica"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_11_0),
+		},
+		CheckDestroy: testAccCheckDBInstanceDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceConfig_BlueGreenDeployment_readReplicaSource(rName, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckDBInstanceExists(ctx, t, sourceResourceName, &v),
+					resource.TestCheckResourceAttrPair(replicaResourceName, "replicate_source_db", sourceResourceName, names.AttrIdentifier),
+				),
+			},
+			{
+				// Enabling blue_green_update on the source while it has a read
+				// replica, together with a triggering change (instance_class),
+				// must be rejected at plan time.
+				Config:      testAccInstanceConfig_BlueGreenDeployment_readReplicaSource(rName, true),
+				ExpectError: regexache.MustCompile(`cannot be set to true on an instance with read replicas`),
+			},
+		},
+	})
+}
+
 func TestAccRDSInstance_BlueGreenDeployment_updateAndEnableBackups(t *testing.T) {
 	ctx := acctest.Context(t)
 
@@ -14406,6 +14446,72 @@ resource "aws_db_instance" "test" {
   }
 }
 `, tfrds.InstanceEngineMySQL, "general-public-license", "gp2", halfMainInstClass, rName))
+}
+
+func testAccInstanceConfig_BlueGreenDeployment_readReplicaSource(rName string, triggerBlueGreen bool) string {
+	// Select a different instance class set on the triggering step so the
+	// source's instance_class actually changes between steps.
+	var halfClasses []string
+	start := 0
+	if triggerBlueGreen {
+		start = 1
+	}
+	for i := start; i < len(instanceClassesSlice); i += 2 {
+		halfClasses = append(halfClasses, instanceClassesSlice[i])
+	}
+	halfMainInstClass := strings.Join(halfClasses, ", ")
+
+	// blue_green_update is only set on the triggering step. Setting it while the
+	// source has a read replica, together with the instance_class change, is what
+	// the guard must reject. It is intentionally absent on the first step so the
+	// source and its replica can be created cleanly.
+	blueGreen := ""
+	if triggerBlueGreen {
+		blueGreen = `
+  blue_green_update {
+    enabled = true
+  }
+`
+	}
+
+	return acctest.ConfigCompose(
+		acctest.ConfigRandomPassword(),
+		fmt.Sprintf(`
+data "aws_rds_engine_version" "default" {
+  engine = %[1]q
+}
+
+data "aws_rds_orderable_db_instance" "test" {
+  engine         = data.aws_rds_engine_version.default.engine
+  engine_version = data.aws_rds_engine_version.default.version
+  license_model  = %[2]q
+  storage_type   = %[3]q
+
+  preferred_instance_classes = [%[4]s]
+}
+
+resource "aws_db_instance" "source" {
+  allocated_storage       = 20
+  backup_retention_period = 1
+  engine                  = data.aws_rds_orderable_db_instance.test.engine
+  engine_version          = data.aws_rds_orderable_db_instance.test.engine_version
+  identifier              = %[5]q
+  instance_class          = data.aws_rds_orderable_db_instance.test.instance_class
+  storage_type            = %[3]q
+  password_wo             = ephemeral.aws_secretsmanager_random_password.test.random_password
+  password_wo_version     = 1
+  username                = "tfacctest"
+  skip_final_snapshot     = true
+%[6]s
+}
+
+resource "aws_db_instance" "replica" {
+  identifier          = "%[5]s-replica"
+  instance_class      = data.aws_rds_orderable_db_instance.test.instance_class
+  replicate_source_db = aws_db_instance.source.identifier
+  skip_final_snapshot = true
+}
+`, tfrds.InstanceEngineMySQL, "general-public-license", "gp2", halfMainInstClass, rName, blueGreen))
 }
 
 func testAccInstanceConfig_BlueGreenDeployment_prePromote(rName string) string {


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

None. This change adds plan-time validation to prevent silent data-integrity failures; it does not affect access controls, encryption, or logging.

### Description

Adds a plan-time check in `aws_db_instance`'s `CustomizeDiff` chain that refuses plans which would trigger a Blue/Green deployment on a primary that currently has read replicas.

**Background.** The AWS provider routes engine-version, instance-class, and storage-type changes through RDS's Blue/Green workflow (`CreateBlueGreenDeployment` → `SwitchoverBlueGreenDeployment` → `DeleteBlueGreenDeployment`) when `blue_green_update { enabled = true }`. That orchestration is per-resource: it operates only on the single `aws_db_instance` resource it's invoked from and does not coordinate with sibling `aws_db_instance` resources that declare the primary as their `replicate_source_db`. This is a documented design constraint of the Terraform resource model (see #33702, closed as "cannot be done from the current-resource-only model").

**Observed failure.** When B/G runs on a primary that has read replicas, the switchover leaves the replicas in one of two broken states:

1. Sibling replica's state ends up tracking the blue-side `-old<N>` renamed instance (the shape described in #33702).
2. Sibling replica retains its original identifier but is auto-promoted to standalone — `DescribeDBInstances` returns `ReadReplicaSourceDBInstanceIdentifier: null`. The green-side replica AWS created is retained under an RDS-generated `-green-<hash>` identifier that Terraform doesn't track.

In case (2), any workload reading through the replica endpoint sees stale data with no drift signal, until the next apply that touches the replica fails with `cannot elect new source database for replication`. Recovery requires destroying and recreating the replica plus manual cleanup of the untracked green/old-side instance — AWS does not permit modifying `ReplicationSourceDBInstanceIdentifier` on an existing DB instance, so `terraform import` and manual state edits do not resolve the drift.

**This change.** Adds a fourth `CustomizeDiff` function to `aws_db_instance` that:

1. Skips unless `blue_green_update.enabled = true`.
2. Skips on create (`d.Id() == ""`).
3. Skips unless the planned diff would actually trigger the Blue/Green code path in `resourceInstanceUpdate`. The exempt list mirrors the inner `HasChangesExcept` in that function; `ResourceDiff` does not expose `HasChangesExcept`, so the check iterates `GetChangedKeysPrefix("")` and filters against the same set. Configurations that have the flag set as a forward-looking guard but are not currently planning a triggering change continue to plan cleanly.
4. Calls `findDBInstanceByID` and refuses the plan with a helpful error if `ReadReplicaDBInstanceIdentifiers` is non-empty.
5. Falls through cleanly on lookup errors (does not block plan on transient API failures).

Since the check queries AWS at plan time rather than trying to look across the plan graph, it sidesteps the resource-model constraint that closed #33702 while still catching the failure before any AWS-side operation commits.

### Testing

Added `TestAccRDSInstance_BlueGreenDeployment_prohibitedOnReadReplicaSource`, which provisions a primary with a read replica, then attempts a Blue/Green update on the primary and asserts the plan is rejected:

```
$ make testacc PKG=rds TESTS='TestAccRDSInstance_BlueGreenDeployment_prohibitedOnReadReplicaSource'
--- PASS: TestAccRDSInstance_BlueGreenDeployment_prohibitedOnReadReplicaSource (1132.83s)
ok  github.com/hashicorp/terraform-provider-aws/internal/service/rds  1139.121s
```

### Relations

Closes #49593
Relates #33702

### References

- Original coordination request: #33702 (closed as design-level won't-fix at the resource-model layer)
- Design decisions doc: [`docs/design-decisions/rds-bluegreen-deployments.md`](https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/design-decisions/rds-bluegreen-deployments.md)

### Output from Acceptance Testing

<!--
No new acceptance tests were added in this initial PR. The existing CustomizeDiff functions in this resource are not covered by dedicated unit tests either (they are exercised via the resource's acceptance suite). Happy to add a dedicated acceptance test if the maintainers would like one — please advise on the preferred pattern. A minimal test would:

1. Create a primary + one replica with default engine version.
2. Change engine_version on the primary to a compatible upgrade target.
3. Expect `terraform plan` to fail with the new "instance has read replicas" error.
4. Also verify that setting `blue_green_update.enabled = false` on the primary allows the same plan to proceed.
-->

I do not have an AWS account to run the acceptance suite against. The change builds cleanly (`go build ./internal/service/rds/...`) and passes `go vet ./internal/service/rds/...` locally. Existing tests in the package were not modified.

If the maintainers can run the following patterns against a test account and share results, or if you'd like me to author a specific acceptance test first, I'll iterate:

```
% make testacc TESTS=TestAccRDSInstance_BlueGreenDeployment PKG=rds
```

