### PR TITLE
resource/aws_fms_policy: fix resource_tag_logical_operator silently overwritten with empty value

### DIFF
--- a/.changelog/1.txt
+++ b/.changelog/1.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_fms_policy: Fix `resource_tag_logical_operator` being silently overwritten with an empty value (interpreted by AWS as `AND`) on apply when left unset in configuration
+```

--- a/internal/service/fms/policy.go
+++ b/internal/service/fms/policy.go
@@ -501,8 +501,11 @@ func expandPolicy(d *schema.ResourceData) *awstypes.Policy {
 				Key:   aws.String(k),
 				Value: aws.String(v),
 			})
-			apiObject.ResourceTagLogicalOperator = awstypes.ResourceTagLogicalOperator(d.Get("resource_tag_logical_operator").(string))
 		}
+	}
+
+	if v, ok := d.GetOk("resource_tag_logical_operator"); ok {
+		apiObject.ResourceTagLogicalOperator = awstypes.ResourceTagLogicalOperator(v.(string))
 	}
 
 	tfMap := d.Get("security_service_policy_data").([]any)[0].(map[string]any)


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

None.

### Description

`resource_tag_logical_operator` on `aws_fms_policy` is schema'd `Optional`/`Computed` with no `Default`. When it's left unset in config, `expandPolicy` was unconditionally reading it via `d.Get(...)` inside the `resource_tags` loop, which returns `""` for an unset field. That empty string was sent to the FMS API on every apply/update, and AWS silently interprets an empty `ResourceTagLogicalOperator` as `AND` — flipping the effective value away from whatever `OR`/`AND` was actually configured or previously computed, without Terraform ever showing a diff.

This moves the `resource_tag_logical_operator` handling out of the `resource_tags` loop and guards it with `d.GetOk`, so the field is only sent to the API when the practitioner actually set it, leaving the previously-computed value untouched otherwise.

### Relations

Closes #47771

### References



### Output from Acceptance Testing

No AWS credentials available in this environment, so I was unable to run `make testacc`. Verified with `go build ./internal/service/fms/...` and `go vet ./internal/service/fms/...` (both clean).

```console
% make testacc TESTS=TestAccFMSPolicy PKG=fms

not run — no AWS credentials in this environment
```
