### PR TITLE
Improve error message for deregistered AMIs

### DIFF
--- a/.changelog/49599.txt
+++ b/.changelog/49599.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_ami: Improve error message when AMI is deregistered
+```

--- a/internal/service/ec2/find.go
+++ b/internal/service/ec2/find.go
@@ -4670,7 +4670,7 @@ func findImageByID(ctx context.Context, conn *ec2.Client, id string) (*awstypes.
 
 	if state := output.State; state == awstypes.ImageStateDeregistered {
 		return nil, &retry.NotFoundError{
-			Message: string(state),
+			Message: fmt.Sprintf("AMI %s is deregistered. The AMI may have been recently deregistered. If this is a new resource, the AMI may not have been available yet when Terraform tried to use it.", id),
 		}
 	}
 


### PR DESCRIPTION
## Summary

This PR improves the error message when an AMI is deregistered or not found. Previously, the error message was just "Deregistered" which wasn't very helpful for users debugging their Terraform configurations.

The new error message provides:
- The specific AMI ID that was deregistered
- An explanation that the AMI may have been recently deregistered
- Guidance that if this is a new resource, the AMI may not have been available yet when Terraform tried to use it

## Changes

- Modified `internal/service/ec2/find.go` in the `findImageByID` function
- Updated the `NotFoundError` message to be more descriptive and helpful

## Testing

The existing acceptance tests for AMI resources should continue to pass. The change only affects the error message content, not the error handling logic.

## Related Issue

Fixes #26046

This is my first contribution to the Terraform AWS Provider. I'm looking forward to contributing more to this project!