### PR TITLE
Add server_side_encryption_configuration to S3 bucket data source

### DIFF
--- a/.changelog/49601.txt
+++ b/.changelog/49601.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data/aws_s3_bucket: Add server_side_encryption_configuration attribute
+```

--- a/internal/service/s3/bucket_data_source.go
+++ b/internal/service/s3/bucket_data_source.go
@@ -59,6 +59,42 @@ func dataSourceBucket() *schema.Resource {
 					Type:     schema.TypeString,
 					Computed: true,
 				},
+				"server_side_encryption_configuration": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"rule": {
+								Type:     schema.TypeList,
+								Computed: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"apply_server_side_encryption_by_default": {
+											Type:     schema.TypeList,
+											Computed: true,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"kms_master_key_id": {
+														Type:     schema.TypeString,
+														Computed: true,
+													},
+													"sse_algorithm": {
+														Type:     schema.TypeString,
+														Computed: true,
+													},
+												},
+											},
+										},
+										"bucket_key_enabled": {
+											Type:     schema.TypeBool,
+											Computed: true,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
 			}
 		},
 	}
@@ -109,6 +145,14 @@ func dataSourceBucketRead(ctx context.Context, d *schema.ResourceData, meta any)
 		d.Set("website_endpoint", endpoint)
 	} else if !retry.NotFound(err) {
 		log.Printf("[WARN] Reading S3 Bucket (%s) Website: %s", bucket, err)
+	}
+
+	encryptionConfig, err := findServerSideEncryptionConfiguration(ctx, conn, bucket, "")
+	if err != nil && !retry.NotFound(err) {
+		log.Printf("[WARN] Reading S3 Bucket (%s) Server Side Encryption Configuration: %s", bucket, err)
+	}
+	if encryptionConfig != nil {
+		d.Set("server_side_encryption_configuration", flattenBucketServerSideEncryptionConfiguration(encryptionConfig))
 	}
 
 	return diags

--- a/internal/service/s3/bucket_data_source.go
+++ b/internal/service/s3/bucket_data_source.go
@@ -64,7 +64,7 @@ func dataSourceBucket() *schema.Resource {
 					Computed: true,
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{
-							"rule": {
+							names.AttrRule: {
 								Type:     schema.TypeList,
 								Computed: true,
 								Elem: &schema.Resource{


### PR DESCRIPTION
## Summary

This PR adds the `server_side_encryption_configuration` attribute to the `aws_s3_bucket` data source, allowing users to read the default encryption configuration of an S3 bucket.

## Problem

Currently, users had to make separate API calls to determine if a bucket had default encryption enabled. This is a common requirement for security compliance checks and infrastructure auditing.

## Solution

Added a new computed attribute `server_side_encryption_configuration` to the `aws_s3_bucket` data source that returns the same structure as the `aws_s3_bucket_server_side_encryption_configuration` resource.

## Changes

- Modified `internal/service/s3/bucket_data_source.go`:
  - Added `server_side_encryption_configuration` schema with nested `rule` and `apply_server_side_encryption_by_default` attributes
  - Updated `dataSourceBucketRead` to fetch and set the encryption configuration using the existing `findServerSideEncryptionConfiguration` function

## Usage Example

```hcl
data "aws_s3_bucket" "example" {
  bucket = "my-bucket"
}

output "encryption_algorithm" {
  value = data.aws_s3_bucket.example.server_side_encryption_configuration[0].rule[0].apply_server_side_encryption_by_default[0].sse_algorithm
}
```

## Testing

The existing data source tests should continue to pass. The new attribute is computed and optional, so it won't break existing configurations.

## Related Issue

Fixes #26054

This is my second contribution to the Terraform AWS Provider. I'm continuing to contribute to this project!