### PR TITLE
resource/aws_ssoadmin_application: Fixes error in no-refresh no-change test case

### DIFF
--- a/internal/service/ssoadmin/application.go
+++ b/internal/service/ssoadmin/application.go
@@ -174,7 +174,7 @@ func (r *applicationResource) Create(ctx context.Context, request resource.Creat
 	app, err := findApplicationByID(ctx, conn, data.ID.ValueString())
 
 	if err != nil {
-		response.Diagnostics.AddError(fmt.Sprintf("reading SSO Application (%s)", data.ID.ValueString()), err.Error())
+		response.Diagnostics.AddError(fmt.Sprintf("reading SSO Application (%s)", data.ID.String()), err.Error())
 
 		return
 	}
@@ -212,7 +212,7 @@ func (r *applicationResource) Read(ctx context.Context, request resource.ReadReq
 	}
 
 	if err != nil {
-		response.Diagnostics.AddError(fmt.Sprintf("reading SSO Application (%s)", data.ID.ValueString()), err.Error())
+		response.Diagnostics.AddError(fmt.Sprintf("reading SSO Application (%s)", data.ID.String()), err.Error())
 
 		return
 	}
@@ -234,7 +234,7 @@ func (r *applicationResource) Read(ctx context.Context, request resource.ReadReq
 	tags, err := listTags(ctx, conn, data.ARN.ValueString(), data.InstanceARN.ValueString())
 
 	if err != nil {
-		response.Diagnostics.AddError(fmt.Sprintf("reading SSO Application (%s) tags", data.ID.ValueString()), err.Error())
+		response.Diagnostics.AddError(fmt.Sprintf("reading SSO Application (%s) tags", data.ID.String()), err.Error())
 
 		return
 	}
@@ -270,7 +270,7 @@ func (r *applicationResource) Update(ctx context.Context, request resource.Updat
 		_, err := conn.UpdateApplication(ctx, &input)
 
 		if err != nil {
-			response.Diagnostics.AddError(fmt.Sprintf("updating SSO Application (%s)", new.ID.ValueString()), err.Error())
+			response.Diagnostics.AddError(fmt.Sprintf("updating SSO Application (%s)", new.ID.String()), err.Error())
 
 			return
 		}
@@ -280,7 +280,7 @@ func (r *applicationResource) Update(ctx context.Context, request resource.Updat
 	// explicitly rather than with transparent tagging.
 	if oldTagsAll, newTagsAll := old.TagsAll, new.TagsAll; !newTagsAll.Equal(oldTagsAll) {
 		if err := updateTags(ctx, conn, new.ARN.ValueString(), new.InstanceARN.ValueString(), oldTagsAll, newTagsAll); err != nil {
-			response.Diagnostics.AddError(fmt.Sprintf("updating SSO Application (%s) tags", new.ID.ValueString()), err.Error())
+			response.Diagnostics.AddError(fmt.Sprintf("updating SSO Application (%s) tags", new.ID.String()), err.Error())
 
 			return
 		}
@@ -308,7 +308,7 @@ func (r *applicationResource) Delete(ctx context.Context, request resource.Delet
 	}
 
 	if err != nil {
-		response.Diagnostics.AddError(fmt.Sprintf("deleting SSO Application (%s)", data.ID.ValueString()), err.Error())
+		response.Diagnostics.AddError(fmt.Sprintf("deleting SSO Application (%s)", data.ID.String()), err.Error())
 
 		return
 	}

--- a/internal/service/ssoadmin/application.go
+++ b/internal/service/ssoadmin/application.go
@@ -299,7 +299,7 @@ func (r *applicationResource) Delete(ctx context.Context, request resource.Delet
 	conn := r.Meta().SSOAdminClient(ctx)
 
 	input := ssoadmin.DeleteApplicationInput{
-		ApplicationArn: fwflex.StringFromFramework(ctx, data.ARN),
+		ApplicationArn: fwflex.StringFromFramework(ctx, data.ID),
 	}
 	_, err := conn.DeleteApplication(ctx, &input)
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Fixes error in deletion after test `TestAccSSOAdminApplication_Identity_ExistingResource_noRefreshNoChange`

Also uses `String` instead of `ValueString` for error messages.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=ssoadmin TESTS=TestAccSSOAdminApplication_

--- SKIP: TestAccSSOAdminApplication_Identity_regionOverride (2.99s)
--- PASS: TestAccSSOAdminApplication_disappears (35.36s)
--- PASS: TestAccSSOAdminApplication_basic (40.42s)
--- PASS: TestAccSSOAdminApplication_Identity_basic (60.56s)
--- PASS: TestAccSSOAdminApplication_description (60.67s)
--- PASS: TestAccSSOAdminApplication_portalOptions (61.51s)
--- PASS: TestAccSSOAdminApplication_Identity_ExistingResource_noRefreshNoChange (74.08s)
--- PASS: TestAccSSOAdminApplication_tags (76.27s)
--- PASS: TestAccSSOAdminApplication_status (76.33s)
--- PASS: TestAccSSOAdminApplication_Identity_ExistingResource_basic (101.32s)
```
