### PR TITLE
resource/aws_cloudwatch_log_resource_policy: Updates `basic` tests

### DIFF
--- a/internal/service/logs/resource_policy_test.go
+++ b/internal/service/logs/resource_policy_test.go
@@ -133,7 +133,7 @@ func TestAccLogsResourcePolicy_ignoreEquivalent(t *testing.T) {
 	})
 }
 
-func TestAccLogsResourcePolicy_resourceARN(t *testing.T) {
+func TestAccLogsResourcePolicy_basic_resourceScope(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_cloudwatch_log_resource_policy.test"
@@ -149,8 +149,11 @@ func TestAccLogsResourcePolicy_resourceARN(t *testing.T) {
 				Config: testAccResourcePolicyConfig_resourceARN(rName, "test1", "test1"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckResourcePolicyExists(ctx, t, resourceName, &resourcePolicy),
-					resource.TestCheckResourceAttrPair("aws_cloudwatch_log_group.test1", names.AttrARN, resourceName, names.AttrResourceARN),
+					resource.TestCheckResourceAttrSet(resourceName, "policy_document"),
+					resource.TestCheckNoResourceAttr(resourceName, "policy_name"),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrResourceARN, "aws_cloudwatch_log_group.test1", names.AttrARN),
 					resource.TestCheckResourceAttr(resourceName, "policy_scope", string(types.PolicyScopeResource)),
+					resource.TestCheckResourceAttr(resourceName, "revision_id", "1"),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -168,8 +171,11 @@ func TestAccLogsResourcePolicy_resourceARN(t *testing.T) {
 				Config: testAccResourcePolicyConfig_resourceARN(rName, "test1", "test2"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckResourcePolicyExists(ctx, t, resourceName, &resourcePolicy),
-					resource.TestCheckResourceAttrPair("aws_cloudwatch_log_group.test1", names.AttrARN, resourceName, names.AttrResourceARN),
+					resource.TestCheckResourceAttrSet(resourceName, "policy_document"),
+					resource.TestCheckNoResourceAttr(resourceName, "policy_name"),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrResourceARN, "aws_cloudwatch_log_group.test1", names.AttrARN),
 					resource.TestCheckResourceAttr(resourceName, "policy_scope", string(types.PolicyScopeResource)),
+					resource.TestCheckResourceAttr(resourceName, "revision_id", "2"),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -182,8 +188,11 @@ func TestAccLogsResourcePolicy_resourceARN(t *testing.T) {
 				Config: testAccResourcePolicyConfig_resourceARN(rName, "test2", "test2"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckResourcePolicyExists(ctx, t, resourceName, &resourcePolicy),
-					resource.TestCheckResourceAttrPair("aws_cloudwatch_log_group.test2", names.AttrARN, resourceName, names.AttrResourceARN),
+					resource.TestCheckResourceAttrSet(resourceName, "policy_document"),
+					resource.TestCheckNoResourceAttr(resourceName, "policy_name"),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrResourceARN, "aws_cloudwatch_log_group.test2", names.AttrARN),
 					resource.TestCheckResourceAttr(resourceName, "policy_scope", string(types.PolicyScopeResource)),
+					resource.TestCheckResourceAttr(resourceName, "revision_id", "1"),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{

--- a/internal/service/logs/resource_policy_test.go
+++ b/internal/service/logs/resource_policy_test.go
@@ -33,7 +33,7 @@ func TestAccLogsResourcePolicy_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccResourcePolicyConfig_basic1(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckResourcePolicyExists(ctx, t, resourceName, &resourcePolicy),
 					resource.TestCheckResourceAttr(resourceName, "policy_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "policy_document", fmt.Sprintf("{\"Statement\":[{\"Action\":[\"logs:PutLogEvents\",\"logs:CreateLogStream\"],\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"rds.%s\"},\"Resource\":\"arn:%s:logs:*:*:log-group:/aws/rds/*\"}],\"Version\":\"2012-10-17\"}", acctest.PartitionDNSSuffix(), acctest.Partition())),
@@ -47,7 +47,7 @@ func TestAccLogsResourcePolicy_basic(t *testing.T) {
 			},
 			{
 				Config: testAccResourcePolicyConfig_basic2(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckResourcePolicyExists(ctx, t, resourceName, &resourcePolicy),
 					resource.TestCheckResourceAttr(resourceName, "policy_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "policy_document", fmt.Sprintf("{\"Statement\":[{\"Action\":[\"logs:PutLogEvents\",\"logs:CreateLogStream\"],\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"rds.%s\"},\"Resource\":\"arn:%s:logs:*:*:log-group:/aws/rds/example.com\"}],\"Version\":\"2012-10-17\"}", acctest.PartitionDNSSuffix(), acctest.Partition())),
@@ -72,7 +72,7 @@ func TestAccLogsResourcePolicy_disappears(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccResourcePolicyConfig_basic1(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckResourcePolicyExists(ctx, t, resourceName, &resourcePolicy),
 					acctest.CheckSDKResourceDisappears(ctx, t, tflogs.ResourceResourcePolicy(), resourceName),
 				),
@@ -104,7 +104,7 @@ func TestAccLogsResourcePolicy_ignoreEquivalent(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccResourcePolicyConfig_order(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckResourcePolicyExists(ctx, t, resourceName, &resourcePolicy),
 					resource.TestCheckResourceAttr(resourceName, "policy_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "policy_document", fmt.Sprintf("{\"Statement\":[{\"Action\":[\"logs:CreateLogStream\",\"logs:PutLogEvents\"],\"Effect\":\"Allow\",\"Principal\":{\"Service\":[\"rds.%s\"]},\"Resource\":[\"arn:%s:logs:*:*:log-group:/aws/rds/example.com\"]}],\"Version\":\"2012-10-17\"}", acctest.PartitionDNSSuffix(), acctest.Partition())),
@@ -112,7 +112,7 @@ func TestAccLogsResourcePolicy_ignoreEquivalent(t *testing.T) {
 			},
 			{
 				Config: testAccResourcePolicyConfig_newOrder(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckResourcePolicyExists(ctx, t, resourceName, &resourcePolicy),
 					resource.TestCheckResourceAttr(resourceName, "policy_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "policy_document", fmt.Sprintf("{\"Statement\":[{\"Action\":[\"logs:CreateLogStream\",\"logs:PutLogEvents\"],\"Effect\":\"Allow\",\"Principal\":{\"Service\":[\"rds.%s\"]},\"Resource\":[\"arn:%s:logs:*:*:log-group:/aws/rds/example.com\"]}],\"Version\":\"2012-10-17\"}", acctest.PartitionDNSSuffix(), acctest.Partition())),
@@ -136,7 +136,7 @@ func TestAccLogsResourcePolicy_resourceARN(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccResourcePolicyConfig_resourceARN(rName, "test1", "test1"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckResourcePolicyExists(ctx, t, resourceName, &resourcePolicy),
 					resource.TestCheckResourceAttrPair("aws_cloudwatch_log_group.test1", names.AttrARN, resourceName, names.AttrResourceARN),
 					resource.TestCheckResourceAttr(resourceName, "policy_scope", string(types.PolicyScopeResource)),
@@ -155,7 +155,7 @@ func TestAccLogsResourcePolicy_resourceARN(t *testing.T) {
 			{
 				// Update the resource policy
 				Config: testAccResourcePolicyConfig_resourceARN(rName, "test1", "test2"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckResourcePolicyExists(ctx, t, resourceName, &resourcePolicy),
 					resource.TestCheckResourceAttrPair("aws_cloudwatch_log_group.test1", names.AttrARN, resourceName, names.AttrResourceARN),
 					resource.TestCheckResourceAttr(resourceName, "policy_scope", string(types.PolicyScopeResource)),
@@ -169,7 +169,7 @@ func TestAccLogsResourcePolicy_resourceARN(t *testing.T) {
 			{
 				// Update the resource ARN to a different log group, which requires resource replacement
 				Config: testAccResourcePolicyConfig_resourceARN(rName, "test2", "test2"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckResourcePolicyExists(ctx, t, resourceName, &resourcePolicy),
 					resource.TestCheckResourceAttrPair("aws_cloudwatch_log_group.test2", names.AttrARN, resourceName, names.AttrResourceARN),
 					resource.TestCheckResourceAttr(resourceName, "policy_scope", string(types.PolicyScopeResource)),

--- a/internal/service/logs/resource_policy_test.go
+++ b/internal/service/logs/resource_policy_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccLogsResourcePolicy_basic(t *testing.T) {
+func TestAccLogsResourcePolicy_basic_accountScope(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_cloudwatch_log_resource_policy.test"
@@ -35,9 +35,12 @@ func TestAccLogsResourcePolicy_basic(t *testing.T) {
 				Config: testAccResourcePolicyConfig_basic1(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckResourcePolicyExists(ctx, t, resourceName, &resourcePolicy),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrID, resourceName, "policy_name"),
 					resource.TestCheckResourceAttr(resourceName, "policy_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "policy_document", fmt.Sprintf("{\"Statement\":[{\"Action\":[\"logs:PutLogEvents\",\"logs:CreateLogStream\"],\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"rds.%s\"},\"Resource\":\"arn:%s:logs:*:*:log-group:/aws/rds/*\"}],\"Version\":\"2012-10-17\"}", acctest.PartitionDNSSuffix(), acctest.Partition())),
 					resource.TestCheckResourceAttr(resourceName, "policy_scope", string(types.PolicyScopeAccount)),
+					resource.TestCheckResourceAttr(resourceName, names.AttrResourceARN, ""),
+					resource.TestCheckResourceAttr(resourceName, "revision_id", ""),
 				),
 			},
 			{
@@ -49,10 +52,18 @@ func TestAccLogsResourcePolicy_basic(t *testing.T) {
 				Config: testAccResourcePolicyConfig_basic2(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckResourcePolicyExists(ctx, t, resourceName, &resourcePolicy),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrID, resourceName, "policy_name"),
 					resource.TestCheckResourceAttr(resourceName, "policy_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "policy_document", fmt.Sprintf("{\"Statement\":[{\"Action\":[\"logs:PutLogEvents\",\"logs:CreateLogStream\"],\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"rds.%s\"},\"Resource\":\"arn:%s:logs:*:*:log-group:/aws/rds/example.com\"}],\"Version\":\"2012-10-17\"}", acctest.PartitionDNSSuffix(), acctest.Partition())),
 					resource.TestCheckResourceAttr(resourceName, "policy_scope", string(types.PolicyScopeAccount)),
+					resource.TestCheckResourceAttr(resourceName, names.AttrResourceARN, ""),
+					resource.TestCheckResourceAttr(resourceName, "revision_id", ""),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
 			},
 		},
 	})


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Updates the `basic` tests

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=logs TESTS=TestAccLogsResourcePolicy_

--- PASS: TestAccLogsResourcePolicy_disappears (32.05s)
--- PASS: TestAccLogsResourcePolicy_ignoreEquivalent (45.44s)
--- PASS: TestAccLogsResourcePolicy_Identity_basic (55.67s)
--- PASS: TestAccLogsResourcePolicy_Identity_regionOverride (55.99s)
--- PASS: TestAccLogsResourcePolicy_basic_accountScope (58.06s)
--- PASS: TestAccLogsResourcePolicy_basic_resourceScope (73.33s)
--- PASS: TestAccLogsResourcePolicy_Identity_ExistingResource_basic (74.72s)
--- PASS: TestAccLogsResourcePolicy_Identity_ExistingResource_noRefreshNoChange (78.87s)
```

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>