### PR TITLE
resource/aws_cloudfront_anycast_ip_list: add IPAM CIDR config (BYOIP) support

### DIFF
--- a/.changelog/49595.txt
+++ b/.changelog/49595.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_cloudfront_anycast_ip_list: Add `ipam_cidr_config` argument and `ipam_config` attribute to support bringing your own IP address ranges (BYOIP) from Amazon VPC IPAM pools
+```

--- a/internal/service/cloudfront/anycast_ip_list.go
+++ b/internal/service/cloudfront/anycast_ip_list.go
@@ -8,6 +8,7 @@ package cloudfront
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/YakDriver/regexache"
@@ -82,6 +83,41 @@ func (r *anycastIPListResource) Schema(ctx context.Context, request resource.Sch
 					int32planmodifier.RequiresReplace(),
 				},
 			},
+			"ipam_config": schema.ListNestedAttribute{
+				CustomType: fwtypes.NewListNestedObjectTypeOf[ipamConfigModel](ctx),
+				Computed:   true,
+				PlanModifiers: []planmodifier.List{
+					listplanmodifier.UseStateForUnknown(),
+				},
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"ipam_cidr_configs": schema.ListNestedAttribute{
+							CustomType: fwtypes.NewListNestedObjectTypeOf[ipamCidrConfigStatusModel](ctx),
+							Computed:   true,
+							NestedObject: schema.NestedAttributeObject{
+								Attributes: map[string]schema.Attribute{
+									"anycast_ip": schema.StringAttribute{
+										Computed: true,
+									},
+									"cidr": schema.StringAttribute{
+										Computed: true,
+									},
+									"ipam_pool_arn": schema.StringAttribute{
+										CustomType: fwtypes.ARNType,
+										Computed:   true,
+									},
+									names.AttrStatus: schema.StringAttribute{
+										Computed: true,
+									},
+								},
+							},
+						},
+						"quantity": schema.Int32Attribute{
+							Computed: true,
+						},
+					},
+				},
+			},
 			names.AttrName: schema.StringAttribute{
 				Required: true,
 				Validators: []validator.String{
@@ -95,6 +131,26 @@ func (r *anycastIPListResource) Schema(ctx context.Context, request resource.Sch
 			names.AttrTagsAll: tftags.TagsAttributeComputedOnly(),
 		},
 		Blocks: map[string]schema.Block{
+			"ipam_cidr_config": schema.ListNestedBlock{
+				CustomType: fwtypes.NewListNestedObjectTypeOf[ipamCidrConfigModel](ctx),
+				PlanModifiers: []planmodifier.List{
+					listplanmodifier.RequiresReplace(),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"anycast_ip": schema.StringAttribute{
+							Optional: true,
+						},
+						"cidr": schema.StringAttribute{
+							Required: true,
+						},
+						"ipam_pool_arn": schema.StringAttribute{
+							CustomType: fwtypes.ARNType,
+							Required:   true,
+						},
+					},
+				},
+			},
 			names.AttrTimeouts: timeouts.Block(ctx, timeouts.Opts{
 				Create: true,
 			}),
@@ -136,11 +192,8 @@ func (r *anycastIPListResource) Create(ctx context.Context, request resource.Cre
 		return
 	}
 
-	// Set values for unknowns.
-	anycastIPList := outputCAIL.AnycastIpList
-	data.AnycastIPs = fwflex.FlattenFrameworkStringValueListOfString(ctx, anycastIPList.AnycastIps)
-	data.ARN = fwflex.StringToFramework(ctx, anycastIPList.Arn)
-	data.ID = fwflex.StringToFramework(ctx, anycastIPList.Id)
+	// Set 'id' for the waiter and so as to taint the resource on error.
+	data.ID = fwflex.StringToFramework(ctx, outputCAIL.AnycastIpList.Id)
 
 	outputGAIL, err := waitAnycastIPListDeployed(ctx, conn, data.ID.ValueString(), r.CreateTimeout(ctx, data.Timeouts))
 
@@ -148,6 +201,14 @@ func (r *anycastIPListResource) Create(ctx context.Context, request resource.Cre
 		response.State.SetAttribute(ctx, path.Root(names.AttrID), data.ID) // Set 'id' so as to taint the resource.
 		response.Diagnostics.AddError(fmt.Sprintf("waiting for CloudFront Anycast IP List (%s) create", data.ID.ValueString()), err.Error())
 
+		return
+	}
+
+	// Set values for unknowns. The configured 'ipam_cidr_config' block has no
+	// equivalent on the response (server-assigned values are surfaced via the
+	// computed 'ipam_config' attribute), so AutoFlex leaves it untouched.
+	response.Diagnostics.Append(fwflex.Flatten(ctx, outputGAIL.AnycastIpList, &data)...)
+	if response.Diagnostics.HasError() {
 		return
 	}
 
@@ -281,7 +342,27 @@ func anycastIPListStatus(conn *cloudfront.Client, id string) retry.StateRefreshF
 			return nil, "", err
 		}
 
-		return output, aws.ToString(output.AnycastIpList.Status), nil
+		anycastIPList := output.AnycastIpList
+
+		// When the list is backed by IPAM CIDRs, provisioning is asynchronous and
+		// reported per-CIDR (e.g. "provisioning" -> "provisioned" -> "advertising"
+		// -> "advertised", plus "failed-*" variants). Surface a failure and keep
+		// waiting while any CIDR is still transitioning.
+		if ipamConfig := anycastIPList.IpamConfig; ipamConfig != nil {
+			for _, cidrConfig := range ipamConfig.IpamCidrConfigs {
+				status := string(cidrConfig.Status)
+
+				if strings.HasPrefix(status, "failed-") {
+					return output, status, fmt.Errorf("IPAM CIDR (%s): %s", aws.ToString(cidrConfig.Cidr), status)
+				}
+
+				if strings.HasSuffix(status, "ing") {
+					return output, anycastIPListDeploying, nil
+				}
+			}
+		}
+
+		return output, aws.ToString(anycastIPList.Status), nil
 	}
 }
 
@@ -303,13 +384,37 @@ func waitAnycastIPListDeployed(ctx context.Context, conn *cloudfront.Client, id 
 }
 
 type anycastIPListResourceModel struct {
-	AnycastIPs fwtypes.ListOfString `tfsdk:"anycast_ips"`
-	ARN        types.String         `tfsdk:"arn"`
-	ETag       types.String         `tfsdk:"etag"`
-	ID         types.String         `tfsdk:"id"`
-	IPCount    types.Int32          `tfsdk:"ip_count"`
-	Name       types.String         `tfsdk:"name"`
-	Tags       tftags.Map           `tfsdk:"tags"`
-	TagsAll    tftags.Map           `tfsdk:"tags_all"`
-	Timeouts   timeouts.Value       `tfsdk:"timeouts"`
+	AnycastIPs      fwtypes.ListOfString                                 `tfsdk:"anycast_ips"`
+	ARN             types.String                                         `tfsdk:"arn"`
+	ETag            types.String                                         `tfsdk:"etag"`
+	ID              types.String                                         `tfsdk:"id"`
+	IPCount         types.Int32                                          `tfsdk:"ip_count"`
+	IpamCidrConfigs fwtypes.ListNestedObjectValueOf[ipamCidrConfigModel] `tfsdk:"ipam_cidr_config"`
+	IpamConfig      fwtypes.ListNestedObjectValueOf[ipamConfigModel]     `tfsdk:"ipam_config"`
+	Name            types.String                                         `tfsdk:"name"`
+	Tags            tftags.Map                                           `tfsdk:"tags"`
+	TagsAll         tftags.Map                                           `tfsdk:"tags_all"`
+	Timeouts        timeouts.Value                                       `tfsdk:"timeouts"`
+}
+
+// ipamCidrConfigModel is the configurable 'ipam_cidr_config' block, mapped to
+// the CreateAnycastIpList 'IpamCidrConfigs' input.
+type ipamCidrConfigModel struct {
+	AnycastIP   types.String `tfsdk:"anycast_ip"`
+	Cidr        types.String `tfsdk:"cidr"`
+	IpamPoolARN fwtypes.ARN  `tfsdk:"ipam_pool_arn"`
+}
+
+// ipamConfigModel is the computed 'ipam_config' attribute, mapped from the
+// AnycastIpList 'IpamConfig' response object.
+type ipamConfigModel struct {
+	IpamCidrConfigs fwtypes.ListNestedObjectValueOf[ipamCidrConfigStatusModel] `tfsdk:"ipam_cidr_configs"`
+	Quantity        types.Int32                                                `tfsdk:"quantity"`
+}
+
+type ipamCidrConfigStatusModel struct {
+	AnycastIP   types.String `tfsdk:"anycast_ip"`
+	Cidr        types.String `tfsdk:"cidr"`
+	IpamPoolARN fwtypes.ARN  `tfsdk:"ipam_pool_arn"`
+	Status      types.String `tfsdk:"status"`
 }

--- a/internal/service/cloudfront/anycast_ip_list_test.go
+++ b/internal/service/cloudfront/anycast_ip_list_test.go
@@ -6,6 +6,7 @@ package cloudfront_test
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/YakDriver/regexache"
@@ -30,6 +31,7 @@ func TestAccCloudFrontAnycastIPList_serial(t *testing.T) {
 	testCases := map[string]func(t *testing.T){
 		acctest.CtBasic:      testAccAnycastIPList_basic,
 		acctest.CtDisappears: testAccAnycastIPList_disappears,
+		"ipamCidrConfig":     testAccAnycastIPList_ipamCidrConfig,
 		"tags":               testAccCloudFrontAnycastIPList_tagsSerial,
 	}
 
@@ -108,6 +110,53 @@ func testAccAnycastIPList_disappears(t *testing.T) {
 	})
 }
 
+func testAccAnycastIPList_ipamCidrConfig(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	message := os.Getenv("IPAM_BYOIP_IPV4_MESSAGE")
+	signature := os.Getenv("IPAM_BYOIP_IPV4_SIGNATURE")
+	cidr := os.Getenv("IPAM_BYOIP_IPV4_PROVISIONED_CIDR")
+	if message == "" || signature == "" || cidr == "" {
+		t.Skip("Environment variable IPAM_BYOIP_IPV4_MESSAGE, IPAM_BYOIP_IPV4_SIGNATURE, or IPAM_BYOIP_IPV4_PROVISIONED_CIDR is not set")
+	}
+
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_cloudfront_anycast_ip_list.test"
+
+	acctest.Test(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.CloudFrontEndpointID) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CloudFrontServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckAnycastIPListDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAnycastIPListConfig_ipamCidrConfig(rName, cidr, message, signature),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAnycastIPListExists(ctx, t, resourceName),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("ip_count"), knownvalue.Int32Exact(3)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("ipam_cidr_config"), knownvalue.ListSizeExact(1)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("ipam_cidr_config").AtSliceIndex(0).AtMapKey("cidr"), knownvalue.StringExact(cidr)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("ipam_config"), knownvalue.ListSizeExact(1)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("ipam_config").AtSliceIndex(0).AtMapKey("ipam_cidr_configs").AtSliceIndex(0).AtMapKey(names.AttrStatus), knownvalue.NotNull()),
+				},
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"ipam_cidr_config"},
+			},
+		},
+	})
+}
+
 func testAccCheckAnycastIPListExists(ctx context.Context, t *testing.T, n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -155,4 +204,46 @@ resource "aws_cloudfront_anycast_ip_list" "test" {
   ip_count = 3
 }
 `, rName)
+}
+
+func testAccAnycastIPListConfig_ipamCidrConfig(rName, cidr, message, signature string) string {
+	return fmt.Sprintf(`
+data "aws_region" "current" {}
+
+resource "aws_vpc_ipam" "test" {
+  operating_regions {
+    region_name = data.aws_region.current.region
+  }
+}
+
+resource "aws_vpc_ipam_pool" "test" {
+  address_family        = "ipv4"
+  ipam_scope_id         = aws_vpc_ipam.test.public_default_scope_id
+  locale                = data.aws_region.current.region
+  publicly_advertisable = true
+  aws_service           = "ec2"
+}
+
+resource "aws_vpc_ipam_pool_cidr" "test" {
+  ipam_pool_id = aws_vpc_ipam_pool.test.id
+  cidr         = %[2]q
+
+  cidr_authorization_context {
+    message   = %[3]q
+    signature = %[4]q
+  }
+}
+
+resource "aws_cloudfront_anycast_ip_list" "test" {
+  name     = %[1]q
+  ip_count = 3
+
+  ipam_cidr_config {
+    cidr          = %[2]q
+    ipam_pool_arn = aws_vpc_ipam_pool.test.arn
+  }
+
+  depends_on = [aws_vpc_ipam_pool_cidr.test]
+}
+`, rName, cidr, message, signature)
 }

--- a/internal/service/cloudfront/anycast_ip_list_test.go
+++ b/internal/service/cloudfront/anycast_ip_list_test.go
@@ -217,11 +217,10 @@ resource "aws_vpc_ipam" "test" {
 }
 
 resource "aws_vpc_ipam_pool" "test" {
-  address_family        = "ipv4"
-  ipam_scope_id         = aws_vpc_ipam.test.public_default_scope_id
-  locale                = data.aws_region.current.region
-  publicly_advertisable = true
-  aws_service           = "ec2"
+  address_family = "ipv4"
+  ipam_scope_id  = aws_vpc_ipam.test.public_default_scope_id
+  locale         = data.aws_region.current.region
+  aws_service    = "global-services"
 }
 
 resource "aws_vpc_ipam_pool_cidr" "test" {

--- a/website/docs/r/cloudfront_anycast_ip_list.html.markdown
+++ b/website/docs/r/cloudfront_anycast_ip_list.html.markdown
@@ -47,7 +47,7 @@ The following arguments are required:
 
 The following arguments are optional:
 
-* `ipam_cidr_config` - (Optional, Forces new resource) Configuration block for one or more IPAM CIDRs used to allocate the Anycast static IPs from your own address space (BYOIP). [See below](#ipam_cidr_config).
+* `ipam_cidr_config` - (Optional) Configuration block for one or more IPAM CIDRs used to allocate the Anycast static IPs from your own address space (BYOIP). [See below](#ipam_cidr_config).
 * `tags` - (Optional) Key-value tags for the place index. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ### ipam_cidr_config

--- a/website/docs/r/cloudfront_anycast_ip_list.html.markdown
+++ b/website/docs/r/cloudfront_anycast_ip_list.html.markdown
@@ -21,6 +21,23 @@ resource "aws_cloudfront_anycast_ip_list" "example" {
 }
 ```
 
+### Bring Your Own IP (BYOIP) via IPAM
+
+Allocate the Anycast static IPs from address space you have brought into Amazon VPC IPAM instead of the AWS-owned pool.
+
+```terraform
+resource "aws_cloudfront_anycast_ip_list" "example" {
+  name     = "example-list"
+  ip_count = 3
+
+  ipam_cidr_config {
+    cidr          = "203.0.113.0/24"
+    ipam_pool_arn = aws_vpc_ipam_pool.example.arn
+    anycast_ip    = "203.0.113.10"
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are required:
@@ -30,7 +47,14 @@ The following arguments are required:
 
 The following arguments are optional:
 
+* `ipam_cidr_config` - (Optional, Forces new resource) Configuration block for one or more IPAM CIDRs used to allocate the Anycast static IPs from your own address space (BYOIP). [See below](#ipam_cidr_config).
 * `tags` - (Optional) Key-value tags for the place index. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+### ipam_cidr_config
+
+* `cidr` - (Required, Forces new resource) CIDR that specifies the IP address range for this IPAM configuration.
+* `ipam_pool_arn` - (Required, Forces new resource) Amazon Resource Name (ARN) of the IPAM pool that the CIDR block is assigned to.
+* `anycast_ip` - (Optional, Forces new resource) Specific Anycast IP address to allocate from the IPAM pool for this CIDR configuration.
 
 ## Attribute Reference
 
@@ -40,7 +64,17 @@ This resource exports the following attributes in addition to the arguments abov
 * `arn` - The Anycast IP list ARN.
 * `etag` - The current version of the Anycast IP list.
 * `id` - The Anycast IP list ID.
+* `ipam_config` - IPAM configuration for the Anycast IP list. [See below](#ipam_config).
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
+
+### ipam_config
+
+* `quantity` - Number of IPAM CIDR configurations.
+* `ipam_cidr_configs` - List of IPAM CIDR configurations. Each entry contains:
+    * `cidr` - CIDR for this IPAM configuration.
+    * `ipam_pool_arn` - ARN of the IPAM pool that the CIDR block is assigned to.
+    * `anycast_ip` - Anycast IP address allocated from the IPAM pool for this CIDR configuration.
+    * `status` - Current status of the IPAM CIDR configuration (for example, `provisioning`, `provisioned`, `advertising`, `advertised`).
 
 ## Timeouts
 


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

None.

### Description

Adds the configurable `ipam_cidr_config` block (mapped to the CreateAnycastIpList `IpamCidrConfigs` input) and the computed `ipam_config` attribute (mapped from the `IpamConfig` response object), allowing Anycast static IP lists to be backed by address space brought into Amazon VPC IPAM. The create waiter is IPAM-aware, failing on `failed-*` CIDR statuses and waiting while any CIDR is still transitioning.

### Relations

Closes #49595

### References

* https://github.com/aws/aws-sdk-go-v2/blob/main/service/cloudfront/api_op_CreateAnycastIpList.go
* https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_CreateAnycastIpList.html
* Related enhancement for the same resource: https://github.com/hashicorp/terraform-provider-aws/issues/49129

### Output from Acceptance Testing

```console
% make testacc TESTS=TestAccCloudFrontAnycastIPList_serial PKG=cloudfront
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2	(cached)
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider/framework	(cached)
make: Running acceptance tests on branch: 🌿 f-aws_cloudfront_anycast_ip_list-ipam 🌿...
TF_ACC=1 go1.26.6 test ./internal/service/cloudfront/... -v -count 1 -parallel 20 -run='TestAccCloudFrontAnycastIPList_serial'  -timeout 360m -vet=off -buildvcs=false
2026/08/21 13:34:54 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/21 13:34:54 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccCloudFrontAnycastIPList_serial
=== PAUSE TestAccCloudFrontAnycastIPList_serial
=== CONT  TestAccCloudFrontAnycastIPList_serial
    anycast_ip_list_test.go:29: Amazon CloudFront Anycast static IP lists cost $3000 per list per month
--- SKIP: TestAccCloudFrontAnycastIPList_serial (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudfront	5.439s
```

### AI Disclosure

Claude Code (Claude Opus 5) was used to implement this change.