### PR TITLE
sweeper/aws_bedrockagentcore_evaluator: Excludes third-party evaluators when sweeping

### DIFF
--- a/internal/service/bedrockagentcore/sweep.go
+++ b/internal/service/bedrockagentcore/sweep.go
@@ -408,6 +408,13 @@ func sweepEvaluators(ctx context.Context, client *conns.AWSClient) ([]sweep.Swee
 				})
 				continue
 			}
+			if v.EvaluatorType == awstypes.EvaluatorTypeThirdParty {
+				tflog.Info(ctx, "Skipping resource", map[string]any{
+					"skip_reason":  "Third-party evaluator",
+					"evaluator_id": aws.ToString(v.EvaluatorId),
+				})
+				continue
+			}
 
 			sweepResources = append(sweepResources, framework.NewSweepResource(newEvaluatorResource, client,
 				framework.NewAttribute("evaluator_id", aws.ToString(v.EvaluatorId))),

--- a/internal/service/bedrockagentcore/sweep.go
+++ b/internal/service/bedrockagentcore/sweep.go
@@ -5,7 +5,6 @@ package bedrockagentcore
 
 import (
 	"context"
-	"log"
 
 	"github.com/YakDriver/smarterr"
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -294,7 +293,9 @@ func sweepWorkloadIdentities(ctx context.Context, client *conns.AWSClient) ([]sw
 
 func sweepPolicyEngines(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepable, error) {
 	if region := client.Region(ctx); region == endpoints.UsGovEast1RegionID || region == endpoints.UsGovWest1RegionID {
-		log.Printf("[WARN] Skipping Bedrock AgentCore Policy Engine sweep for region: %s", region)
+		tflog.Warn(ctx, "Skipping sweeper", map[string]any{
+			"skip_reason": "Unsupported region",
+		})
 		return nil, nil // nosemgrep:ci.semgrep.smarterr.go-no-bare-return-err
 	}
 	var input bedrockagentcorecontrol.ListPolicyEnginesInput
@@ -320,7 +321,9 @@ func sweepPolicyEngines(ctx context.Context, client *conns.AWSClient) ([]sweep.S
 
 func sweepMemories(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepable, error) {
 	if region := client.Region(ctx); region == endpoints.UsGovEast1RegionID || region == endpoints.UsGovWest1RegionID {
-		log.Printf("[WARN] Skipping Bedrock AgentCore Memory sweep for region: %s", region)
+		tflog.Warn(ctx, "Skipping sweeper", map[string]any{
+			"skip_reason": "Unsupported region",
+		})
 		return nil, nil // nosemgrep:ci.semgrep.smarterr.go-no-bare-return-err
 	}
 	var input bedrockagentcorecontrol.ListMemoriesInput
@@ -427,7 +430,9 @@ func sweepEvaluators(ctx context.Context, client *conns.AWSClient) ([]sweep.Swee
 
 func sweepPolicies(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepable, error) {
 	if region := client.Region(ctx); region == endpoints.UsGovEast1RegionID || region == endpoints.UsGovWest1RegionID {
-		log.Printf("[WARN] Skipping Bedrock AgentCore Policy sweep for region: %s", region)
+		tflog.Warn(ctx, "Skipping sweeper", map[string]any{
+			"skip_reason": "Unsupported region",
+		})
 		return nil, nil // nosemgrep:ci.semgrep.smarterr.go-no-bare-return-err
 	}
 	var input bedrockagentcorecontrol.ListPolicyEnginesInput

--- a/internal/service/bedrockagentcore/sweep.go
+++ b/internal/service/bedrockagentcore/sweep.go
@@ -6,12 +6,13 @@ package bedrockagentcore
 import (
 	"context"
 	"log"
-	"strings"
 
 	"github.com/YakDriver/smarterr"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol/types"
 	"github.com/hashicorp/aws-sdk-go-base/v2/endpoints"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv2"
@@ -400,14 +401,16 @@ func sweepEvaluators(ctx context.Context, client *conns.AWSClient) ([]sweep.Swee
 		}
 
 		for _, v := range page.Evaluators {
-			evaluatorID := aws.ToString(v.EvaluatorId)
-			if strings.HasPrefix(evaluatorID, "Builtin.") {
-				// Skip built-in evaluators, which cannot be deleted.
+			if v.EvaluatorType == awstypes.EvaluatorTypeBuiltin {
+				tflog.Info(ctx, "Skipping resource", map[string]any{
+					"skip_reason":  "Built-in evaluator",
+					"evaluator_id": aws.ToString(v.EvaluatorId),
+				})
 				continue
 			}
 
 			sweepResources = append(sweepResources, framework.NewSweepResource(newEvaluatorResource, client,
-				framework.NewAttribute("evaluator_id", evaluatorID)),
+				framework.NewAttribute("evaluator_id", aws.ToString(v.EvaluatorId))),
 			)
 		}
 	}


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Excludes third-parth evaluators when sweeping. Otherwise gets error message

> ValidationException: Managed third-party evaluator delete is not allowed

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>