### PR TITLE
Adds Semgrep rule to prevent `fwflex.StringValueToFramework(ctx, aws.ToString(...))`

### DIFF
--- a/.ci/semgrep/framework/flex_string_to_framework.fixed.go
+++ b/.ci/semgrep/framework/flex_string_to_framework.fixed.go
@@ -1,0 +1,47 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package main
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+)
+
+type output struct {
+	Name   *string
+	Status *string
+}
+
+func testStringValueToFrameworkWithToString1(ctx context.Context, o output) types.String {
+	// ruleid: string-value-to-framework-with-aws-to-string
+	return fwflex.StringToFramework(ctx, o.Name)
+}
+
+func testStringValueToFrameworkWithToString2(ctx context.Context, o output) types.String {
+	// ruleid: string-value-to-framework-with-aws-to-string
+	return fwflex.StringToFramework(ctx, o.Status)
+}
+
+func testStringValueToFrameworkWithToStringVariable(ctx context.Context, ptr *string) types.String {
+	// ruleid: string-value-to-framework-with-aws-to-string
+	return fwflex.StringToFramework(ctx, ptr)
+}
+
+func testStringToFrameworkOK1(ctx context.Context, o output) types.String {
+	// ok: string-value-to-framework-with-aws-to-string
+	return fwflex.StringToFramework(ctx, o.Name)
+}
+
+func testStringToFrameworkOK2(ctx context.Context, ptr *string) types.String {
+	// ok: string-value-to-framework-with-aws-to-string
+	return fwflex.StringToFramework(ctx, ptr)
+}
+
+func testStringValueToFrameworkOK(ctx context.Context) types.String {
+	// ok: string-value-to-framework-with-aws-to-string
+	return fwflex.StringValueToFramework(ctx, "some plain string")
+}

--- a/.ci/semgrep/framework/flex_string_to_framework.go
+++ b/.ci/semgrep/framework/flex_string_to_framework.go
@@ -1,0 +1,47 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package main
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+)
+
+type output struct {
+	Name   *string
+	Status *string
+}
+
+func testStringValueToFrameworkWithToString1(ctx context.Context, o output) types.String {
+	// ruleid: string-value-to-framework-with-aws-to-string
+	return fwflex.StringValueToFramework(ctx, aws.ToString(o.Name))
+}
+
+func testStringValueToFrameworkWithToString2(ctx context.Context, o output) types.String {
+	// ruleid: string-value-to-framework-with-aws-to-string
+	return fwflex.StringValueToFramework(ctx, aws.ToString(o.Status))
+}
+
+func testStringValueToFrameworkWithToStringVariable(ctx context.Context, ptr *string) types.String {
+	// ruleid: string-value-to-framework-with-aws-to-string
+	return fwflex.StringValueToFramework(ctx, aws.ToString(ptr))
+}
+
+func testStringToFrameworkOK1(ctx context.Context, o output) types.String {
+	// ok: string-value-to-framework-with-aws-to-string
+	return fwflex.StringToFramework(ctx, o.Name)
+}
+
+func testStringToFrameworkOK2(ctx context.Context, ptr *string) types.String {
+	// ok: string-value-to-framework-with-aws-to-string
+	return fwflex.StringToFramework(ctx, ptr)
+}
+
+func testStringValueToFrameworkOK(ctx context.Context) types.String {
+	// ok: string-value-to-framework-with-aws-to-string
+	return fwflex.StringValueToFramework(ctx, "some plain string")
+}

--- a/.ci/semgrep/framework/flex_string_to_framework.yml
+++ b/.ci/semgrep/framework/flex_string_to_framework.yml
@@ -8,4 +8,5 @@ rules:
       Prefer `fwflex.StringToFramework(ctx, $PTR)` to
       `fwflex.StringValueToFramework(ctx, aws.ToString($PTR))`
     pattern: fwflex.StringValueToFramework($CTX, aws.ToString($PTR))
+    fix: fwflex.StringToFramework($CTX, $PTR)
     severity: ERROR

--- a/.ci/semgrep/framework/flex_string_to_framework.yml
+++ b/.ci/semgrep/framework/flex_string_to_framework.yml
@@ -1,0 +1,11 @@
+# Copyright IBM Corp. 2014, 2026
+# "SPDX-License-Identifier: MPL-2.0"
+
+rules:
+  - id: string-value-to-framework-with-aws-to-string
+    languages: [go]
+    message: >-
+      Prefer `fwflex.StringToFramework(ctx, $PTR)` to
+      `fwflex.StringValueToFramework(ctx, aws.ToString($PTR))`
+    pattern: fwflex.StringValueToFramework($CTX, aws.ToString($PTR))
+    severity: ERROR

--- a/internal/service/configservice/retention_configuration.go
+++ b/internal/service/configservice/retention_configuration.go
@@ -117,7 +117,7 @@ func (r *retentionConfigurationResource) Read(ctx context.Context, request resou
 		return
 	}
 
-	data.Name = fwflex.StringValueToFramework(ctx, aws.ToString(retentionConfiguration.Name))
+	data.Name = fwflex.StringToFramework(ctx, retentionConfiguration.Name)
 	data.RetentionPeriodInDays = fwflex.Int32ToFrameworkInt64(ctx, retentionConfiguration.RetentionPeriodInDays)
 
 	response.Diagnostics.Append(response.State.Set(ctx, &data)...)

--- a/internal/service/costoptimizationhub/enrollment_status.go
+++ b/internal/service/costoptimizationhub/enrollment_status.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/costoptimizationhub"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/costoptimizationhub/types"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -103,7 +102,7 @@ func (r *enrollmentStatusResource) Create(ctx context.Context, request resource.
 	}
 
 	data.ID = fwflex.StringValueToFramework(ctx, r.Meta().AccountID(ctx))
-	data.Status = fwflex.StringValueToFramework(ctx, aws.ToString(out.Status))
+	data.Status = fwflex.StringToFramework(ctx, out.Status)
 
 	response.Diagnostics.Append(response.State.Set(ctx, data)...)
 }

--- a/internal/service/osis/pipeline_endpoint.go
+++ b/internal/service/osis/pipeline_endpoint.go
@@ -144,7 +144,7 @@ func (r *pipelineEndpointResource) Create(ctx context.Context, request resource.
 		return
 	}
 
-	data.ID = fwflex.StringValueToFramework(ctx, aws.ToString(output.EndpointId))
+	data.ID = fwflex.StringToFramework(ctx, output.EndpointId)
 
 	endpoint, err := waitPipelineEndpointCreated(ctx, conn, aws.ToString(output.EndpointId), r.CreateTimeout(ctx, data.Timeouts))
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Adds Semgrep rule to prevent `fwflex.StringValueToFramework(ctx, aws.ToString(...))`. Adds auto-fix to use `fwflex.StringToFramework(ctx, ...)`

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=configservice TESTS=TestAccConfigService_serial/RetentionConfiguration

--- PASS: TestAccConfigService_serial (262.41s)
    --- PASS: TestAccConfigService_serial/RetentionConfiguration (262.41s)
        --- PASS: TestAccConfigService_serial/RetentionConfiguration/basic (44.56s)
        --- PASS: TestAccConfigService_serial/RetentionConfiguration/disappears (31.23s)
        --- PASS: TestAccConfigService_serial/RetentionConfiguration/Identity (186.61s)
            --- PASS: TestAccConfigService_serial/RetentionConfiguration/Identity/basic (29.33s)
            --- PASS: TestAccConfigService_serial/RetentionConfiguration/Identity/ExistingResource (58.58s)
            --- PASS: TestAccConfigService_serial/RetentionConfiguration/Identity/ExistingResourceNoRefresh (54.38s)
            --- PASS: TestAccConfigService_serial/RetentionConfiguration/Identity/RegionOverride (29.32s)
```

```console
% make testacc PKG=costoptimizationhub TESTS=TestAccCostOptimizationHub_serial/EnrollmentStatus

--- PASS: TestAccCostOptimizationHub_serial (68.84s)
    --- PASS: TestAccCostOptimizationHub_serial/EnrollmentStatus (68.84s)
        --- PASS: TestAccCostOptimizationHub_serial/EnrollmentStatus/basic (18.47s)
        --- PASS: TestAccCostOptimizationHub_serial/EnrollmentStatus/disappears (22.12s)
        --- PASS: TestAccCostOptimizationHub_serial/EnrollmentStatus/includeMemberAccounts (28.25s)
```

```console
% make testacc PKG=osis TESTS=TestAccOpenSearchIngestionPipelineEndpoint

--- SKIP: TestAccOpenSearchIngestionPipelineEndpoint_crossAccount (0.39s)
--- PASS: TestAccOpenSearchIngestionPipelineEndpoint_basic (499.45s)
--- PASS: TestAccOpenSearchIngestionPipelineEndpoint_List_regionOverride (502.49s)
--- PASS: TestAccOpenSearchIngestionPipelineEndpoint_List_includeResource (506.97s)
--- PASS: TestAccOpenSearchIngestionPipelineEndpoint_List_basic (508.34s)
--- PASS: TestAccOpenSearchIngestionPipelineEndpoint_disappears (514.49s)
--- PASS: TestAccOpenSearchIngestionPipelineEndpoint_Identity_basic (522.99s)
--- PASS: TestAccOpenSearchIngestionPipelineEndpoint_Identity_regionOverride (569.65s)

```

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>