### PR TITLE
Adds Semgrep rule to prevent `fwflex.StringValueToFramework(ctx, *stringPtr)`

### DIFF
--- a/.ci/semgrep/framework/flex_string_to_framework.fixed.go
+++ b/.ci/semgrep/framework/flex_string_to_framework.fixed.go
@@ -50,12 +50,12 @@ func testStringValueToFrameworkOK(ctx context.Context) types.String {
 
 func testStringValueToFrameworkWithDeref1(ctx context.Context, o output) types.String {
 	// ruleid: string-value-to-framework-with-deref
-	return fwflex.StringValueToFramework(ctx, *o.Name)
+	return fwflex.StringToFramework(ctx, o.Name)
 }
 
 func testStringValueToFrameworkWithDerefVariable(ctx context.Context, ptr *string) types.String {
 	// ruleid: string-value-to-framework-with-deref
-	return fwflex.StringValueToFramework(ctx, *ptr)
+	return fwflex.StringToFramework(ctx, ptr)
 }
 
 func testStringToFrameworkDerefOK(ctx context.Context, o output) types.String {

--- a/.ci/semgrep/framework/flex_string_to_framework.fixed.go
+++ b/.ci/semgrep/framework/flex_string_to_framework.fixed.go
@@ -45,3 +45,20 @@ func testStringValueToFrameworkOK(ctx context.Context) types.String {
 	// ok: string-value-to-framework-with-aws-to-string
 	return fwflex.StringValueToFramework(ctx, "some plain string")
 }
+
+// string-value-to-framework-with-deref tests
+
+func testStringValueToFrameworkWithDeref1(ctx context.Context, o output) types.String {
+	// ruleid: string-value-to-framework-with-deref
+	return fwflex.StringValueToFramework(ctx, *o.Name)
+}
+
+func testStringValueToFrameworkWithDerefVariable(ctx context.Context, ptr *string) types.String {
+	// ruleid: string-value-to-framework-with-deref
+	return fwflex.StringValueToFramework(ctx, *ptr)
+}
+
+func testStringToFrameworkDerefOK(ctx context.Context, o output) types.String {
+	// ok: string-value-to-framework-with-deref
+	return fwflex.StringToFramework(ctx, o.Name)
+}

--- a/.ci/semgrep/framework/flex_string_to_framework.go
+++ b/.ci/semgrep/framework/flex_string_to_framework.go
@@ -45,3 +45,20 @@ func testStringValueToFrameworkOK(ctx context.Context) types.String {
 	// ok: string-value-to-framework-with-aws-to-string
 	return fwflex.StringValueToFramework(ctx, "some plain string")
 }
+
+// string-value-to-framework-with-deref tests
+
+func testStringValueToFrameworkWithDeref1(ctx context.Context, o output) types.String {
+	// ruleid: string-value-to-framework-with-deref
+	return fwflex.StringValueToFramework(ctx, *o.Name)
+}
+
+func testStringValueToFrameworkWithDerefVariable(ctx context.Context, ptr *string) types.String {
+	// ruleid: string-value-to-framework-with-deref
+	return fwflex.StringValueToFramework(ctx, *ptr)
+}
+
+func testStringToFrameworkDerefOK(ctx context.Context, o output) types.String {
+	// ok: string-value-to-framework-with-deref
+	return fwflex.StringToFramework(ctx, o.Name)
+}

--- a/.ci/semgrep/framework/flex_string_to_framework.yml
+++ b/.ci/semgrep/framework/flex_string_to_framework.yml
@@ -17,4 +17,5 @@ rules:
       Prefer `fwflex.StringToFramework(ctx, $PTR)` to
       `fwflex.StringValueToFramework(ctx, *$PTR)`
     pattern: fwflex.StringValueToFramework($CTX, *$PTR)
+    fix: fwflex.StringToFramework($CTX, $PTR)
     severity: ERROR

--- a/.ci/semgrep/framework/flex_string_to_framework.yml
+++ b/.ci/semgrep/framework/flex_string_to_framework.yml
@@ -10,3 +10,11 @@ rules:
     pattern: fwflex.StringValueToFramework($CTX, aws.ToString($PTR))
     fix: fwflex.StringToFramework($CTX, $PTR)
     severity: ERROR
+
+  - id: string-value-to-framework-with-deref
+    languages: [go]
+    message: >-
+      Prefer `fwflex.StringToFramework(ctx, $PTR)` to
+      `fwflex.StringValueToFramework(ctx, *$PTR)`
+    pattern: fwflex.StringValueToFramework($CTX, *$PTR)
+    severity: ERROR

--- a/internal/service/costoptimizationhub/enrollment_status.go
+++ b/internal/service/costoptimizationhub/enrollment_status.go
@@ -196,7 +196,7 @@ func (r *enrollmentStatusResource) Update(ctx context.Context, request resource.
 		}
 
 		old.ID = new.ID
-		old.Status = fwflex.StringValueToFramework(ctx, *out.Status)
+		old.Status = fwflex.StringToFramework(ctx, out.Status)
 	}
 
 	response.Diagnostics.Append(response.State.Set(ctx, &old)...)

--- a/internal/service/lakeformation/opt_in.go
+++ b/internal/service/lakeformation/opt_in.go
@@ -429,7 +429,7 @@ func (r *optInResource) Create(ctx context.Context, req resource.CreateRequest, 
 	}
 
 	plan.LastModified = fwflex.TimeToFramework(ctx, lstrsc.LakeFormationOptInsInfoList[0].LastModified)
-	plan.LastUpdatedBy = fwflex.StringValueToFramework(ctx, *lstrsc.LakeFormationOptInsInfoList[0].LastUpdatedBy)
+	plan.LastUpdatedBy = fwflex.StringToFramework(ctx, lstrsc.LakeFormationOptInsInfoList[0].LastUpdatedBy)
 
 	resp.Diagnostics.Append(fwflex.Flatten(ctx, output, &plan)...)
 	if resp.Diagnostics.HasError() {


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Adds Semgrep rule to prevent `fwflex.StringValueToFramework(ctx, *stringPtr)`. Adds auto-fix to use `fwflex.StringToFramework(ctx, ...)`.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=costoptimizationhub TESTS=TestAccCostOptimizationHub_serial/EnrollmentStatus

--- PASS: TestAccCostOptimizationHub_serial (71.98s)
    --- PASS: TestAccCostOptimizationHub_serial/EnrollmentStatus (71.98s)
        --- PASS: TestAccCostOptimizationHub_serial/EnrollmentStatus/basic (21.14s)
        --- PASS: TestAccCostOptimizationHub_serial/EnrollmentStatus/disappears (21.45s)
        --- PASS: TestAccCostOptimizationHub_serial/EnrollmentStatus/includeMemberAccounts (29.38s)
```

```console
% make testacc PKG=lakeformation TESTS=TestAccLakeFormation_serial/OptIn

--- PASS: TestAccLakeFormation_serial (101.01s)
    --- PASS: TestAccLakeFormation_serial/OptIn (101.01s)
        --- PASS: TestAccLakeFormation_serial/OptIn/table (45.59s)
        --- PASS: TestAccLakeFormation_serial/OptIn/basic (26.83s)
        --- PASS: TestAccLakeFormation_serial/OptIn/disappearsCatalogDatabase (28.59s)
```

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>