### PR TITLE
Fix aws_db_proxy client_password_auth_type updates

### DIFF
--- a/.changelog/49639.txt
+++ b/.changelog/49639.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_db_proxy: Fix updates to `auth.client_password_auth_type` not being detected or applied
+```

--- a/internal/service/rds/proxy.go
+++ b/internal/service/rds/proxy.go
@@ -38,6 +38,7 @@ func resourceProxy() *schema.Resource {
 		ReadWithoutTimeout:   resourceProxyRead,
 		UpdateWithoutTimeout: resourceProxyUpdate,
 		DeleteWithoutTimeout: resourceProxyDelete,
+		CustomizeDiff:        resourceProxyCustomizeDiff,
 
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -58,6 +59,7 @@ func resourceProxy() *schema.Resource {
 				"auth": {
 					Type:     schema.TypeSet,
 					Optional: true,
+					Computed: true,
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{
 							"auth_scheme": {
@@ -91,7 +93,7 @@ func resourceProxy() *schema.Resource {
 							},
 						},
 					},
-					Set: sdkv2.SimpleSchemaSetFunc("auth_scheme", names.AttrDescription, "iam_auth", "secret_arn", names.AttrUsername),
+					Set: sdkv2.SimpleSchemaSetFunc("auth_scheme", "client_password_auth_type", names.AttrDescription, "iam_auth", "secret_arn", names.AttrUsername),
 				},
 				"debug_logging": {
 					Type:     schema.TypeBool,
@@ -163,6 +165,56 @@ func resourceProxy() *schema.Resource {
 			}
 		},
 	}
+}
+
+func resourceProxyCustomizeDiff(_ context.Context, diff *schema.ResourceDiff, _ any) error {
+	oldAuthRaw, newAuthRaw := diff.GetChange("auth")
+	oldAuth, ok := oldAuthRaw.(*schema.Set)
+	if !ok || oldAuth.Len() == 0 {
+		return nil
+	}
+
+	newAuth, ok := newAuthRaw.(*schema.Set)
+	if !ok || newAuth.Len() == 0 {
+		return nil
+	}
+
+	clientPasswordAuthType := ""
+	for _, authRaw := range oldAuth.List() {
+		auth, ok := authRaw.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		if v, ok := auth["client_password_auth_type"].(string); ok && v != "" {
+			clientPasswordAuthType = v
+			break
+		}
+	}
+
+	if clientPasswordAuthType == "" {
+		return nil
+	}
+
+	authConfigs := newAuth.List()
+	setNew := false
+	for _, authRaw := range authConfigs {
+		auth, ok := authRaw.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		if v, ok := auth["client_password_auth_type"].(string); !ok || v == "" {
+			auth["client_password_auth_type"] = clientPasswordAuthType
+			setNew = true
+		}
+	}
+
+	if !setNew {
+		return nil
+	}
+
+	return diff.SetNew("auth", authConfigs)
 }
 
 func resourceProxyCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/internal/service/rds/proxy_test.go
+++ b/internal/service/rds/proxy_test.go
@@ -690,6 +690,64 @@ func TestAccRDSProxy_disappears(t *testing.T) {
 	})
 }
 
+func TestAccRDSProxy_clientPasswordAuthType_update(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var v types.DBProxy
+	resourceName := "aws_db_proxy.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccDBProxyPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckProxyDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProxyConfig_authClientPasswordType(
+					rName,
+					"MYSQL_NATIVE_PASSWORD",
+				),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckProxyExists(ctx, t, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "auth.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "auth.*", map[string]string{
+						"auth_scheme":               "SECRETS",
+						"client_password_auth_type": "MYSQL_NATIVE_PASSWORD",
+						names.AttrDescription:       "test",
+						"iam_auth":                  "DISABLED",
+					}),
+				),
+			},
+			{
+				Config: testAccProxyConfig_authClientPasswordType(
+					rName,
+					"MYSQL_CACHING_SHA2_PASSWORD",
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckProxyExists(ctx, t, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "auth.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "auth.*", map[string]string{
+						"auth_scheme":               "SECRETS",
+						"client_password_auth_type": "MYSQL_CACHING_SHA2_PASSWORD",
+						names.AttrDescription:       "test",
+						"iam_auth":                  "DISABLED",
+					},
+					),
+				),
+			},
+		},
+	})
+}
+
 // testAccDBProxyPreCheck checks if a call to describe db proxies errors out meaning feature not supported
 func testAccDBProxyPreCheck(ctx context.Context, t *testing.T) {
 	conn := acctest.ProviderMeta(ctx, t).RDSClient(ctx)
@@ -1383,4 +1441,29 @@ resource "aws_db_proxy" "test" {
   }
 }
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2))
+}
+
+func testAccProxyConfig_authClientPasswordType(rName, clientPasswordAuthType string) string {
+	return acctest.ConfigCompose(testAccProxyConfig_base(rName), fmt.Sprintf(`
+resource "aws_db_proxy" "test" {
+  depends_on = [
+    aws_secretsmanager_secret_version.test,
+    aws_iam_role_policy.test
+  ]
+
+  name                   = %[1]q
+  engine_family          = "MYSQL"
+  role_arn               = aws_iam_role.test.arn
+  vpc_security_group_ids = [aws_security_group.test.id]
+  vpc_subnet_ids         = aws_subnet.test[*].id
+
+  auth {
+    auth_scheme               = "SECRETS"
+    client_password_auth_type = %[2]q
+    description               = "test"
+    iam_auth                  = "DISABLED"
+    secret_arn                = aws_secretsmanager_secret.test.arn
+  }
+}
+`, rName, clientPasswordAuthType))
 }


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Fixes detection of updates to client_password_auth_type in the auth block of aws_db_proxy.

The auth TypeSet now accounts for explicitly configured client password authentication types while preserving stable plans when the value is omitted and populated by AWS. A regression acceptance test covers updating from MYSQL_NATIVE_PASSWORD to MYSQL_CACHING_SHA2_PASSWORD.

AI assistance (Codex) was used to develop code.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #49544

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=rds TESTS='^(TestAccRDSProxy_(clientPasswordAuthType_update|authDescription|authIAMAuth|authSecretARN))$'

--- PASS: TestAccRDSProxy_authSecretARN (464.63s)
--- PASS: TestAccRDSProxy_authDescription (514.68s)
--- PASS: TestAccRDSProxy_authIAMAuth (534.25s)
--- PASS: TestAccRDSProxy_clientPasswordAuthType_update (592.35s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/rds        597.316s
```
