### PR TITLE
r/aws_amplify_app: increase token max length to 4096

### DIFF
--- a/.changelog/49642.txt
+++ b/.changelog/49642.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_amplify_app: Fix `access_token` and `oauth_token` maximum length being lower than the AWS API limit
+```

--- a/internal/service/amplify/app.go
+++ b/internal/service/amplify/app.go
@@ -60,7 +60,7 @@ func resourceApp() *schema.Resource {
 					Type:         schema.TypeString,
 					Optional:     true,
 					Sensitive:    true,
-					ValidateFunc: validation.StringLenBetween(1, 255),
+					ValidateFunc: validation.StringLenBetween(1, 4096),
 				},
 				names.AttrARN: {
 					Type:     schema.TypeString,
@@ -293,7 +293,7 @@ func resourceApp() *schema.Resource {
 					Type:         schema.TypeString,
 					Optional:     true,
 					Sensitive:    true,
-					ValidateFunc: validation.StringLenBetween(1, 1000),
+					ValidateFunc: validation.StringLenBetween(1, 4096),
 				},
 				"platform": {
 					Type:             schema.TypeString,


### PR DESCRIPTION


<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
The `access_token` and `oauth_token` on `aws_amplify_app` is validated client-side with `StringLenBetween(1, 255)`, matching AWS's old API limit. AWS has  raised the token limit to `4096` characters, but the validation still rejects anything longer, which blocks newer GitHub App installation tokens, which routinely exceed 255 characters, before the request is sent.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #49565 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
AWS Amplify API [reference](https://docs.aws.amazon.com/amplify/latest/APIReference/API_CreateApp.html) 


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console

```
