### PR TITLE
resource/aws_cloudfront_origin_access_control: support sigv4a signing protocol (S3 Multi-Region Access Point origins)

### DIFF
--- a/.changelog/49652.txt
+++ b/.changelog/49652.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_cloudfront_origin_access_control: Support `sigv4a` as a valid value for `signing_protocol`, for Amazon S3 Multi-Region Access Point origins
+```

--- a/internal/service/cloudfront/origin_access_control_test.go
+++ b/internal/service/cloudfront/origin_access_control_test.go
@@ -225,6 +225,42 @@ func TestAccCloudFrontOriginAccessControl_SigningBehavior(t *testing.T) {
 	})
 }
 
+func TestAccCloudFrontOriginAccessControl_SigningProtocol(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_cloudfront_origin_access_control.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.CloudFrontEndpointID)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.CloudFrontServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckOriginAccessControlDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOriginAccessControlConfig_signingProtocol(rName, "sigv4a"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "signing_protocol", "sigv4a"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccOriginAccessControlConfig_signingProtocol(rName, "sigv4"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "signing_protocol", "sigv4"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccCloudFrontOriginAccessControl_lambdaOriginType(t *testing.T) {
 	ctx := acctest.Context(t)
 	var originaccesscontrol awstypes.OriginAccessControl
@@ -426,6 +462,17 @@ resource "aws_cloudfront_origin_access_control" "test" {
   signing_protocol                  = "sigv4"
 }
 `, rName, signingBehavior)
+}
+
+func testAccOriginAccessControlConfig_signingProtocol(rName, signingProtocol string) string {
+	return fmt.Sprintf(`
+resource "aws_cloudfront_origin_access_control" "test" {
+  name                              = %[1]q
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = %[2]q
+}
+`, rName, signingProtocol)
 }
 
 func testAccOriginAccessControlConfig_originType(rName, originType string) string {

--- a/website/docs/r/cloudfront_origin_access_control.html.markdown
+++ b/website/docs/r/cloudfront_origin_access_control.html.markdown
@@ -26,6 +26,34 @@ resource "aws_cloudfront_origin_access_control" "example" {
 }
 ```
 
+### S3 Multi-Region Access Point Origin
+
+Use `sigv4a` when the origin is an Amazon S3 Multi-Region Access Point, so that CloudFront signs origin requests with Signature Version 4A.
+
+```terraform
+resource "aws_s3_bucket" "example" {
+  bucket = "example"
+}
+
+resource "aws_s3control_multi_region_access_point" "example" {
+  details {
+    name = "example"
+
+    region {
+      bucket = aws_s3_bucket.example.id
+    }
+  }
+}
+
+resource "aws_cloudfront_origin_access_control" "example" {
+  name                              = "example"
+  description                       = "Example Policy"
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4a"
+}
+```
+
 ## Argument Reference
 
 This resource supports the following arguments:
@@ -34,7 +62,7 @@ This resource supports the following arguments:
 * `description` - (Optional) The description of the Origin Access Control. Defaults to "Managed by Terraform" if omitted.
 * `origin_access_control_origin_type` - (Required) The type of origin that this Origin Access Control is for. Valid values are `lambda`, `mediapackagev2`, `mediastore`, and `s3`.
 * `signing_behavior` - (Required) Specifies which requests CloudFront signs. Specify `always` for the most common use case. Allowed values: `always`, `never`, and `no-override`.
-* `signing_protocol` - (Required) Determines how CloudFront signs (authenticates) requests. The only valid value is `sigv4`.
+* `signing_protocol` - (Required) Determines how CloudFront signs (authenticates) requests. Valid values are `sigv4` and `sigv4a`. Use `sigv4a` for Amazon S3 Multi-Region Access Point origins.
 
 ## Attribute Reference
 


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

None. This adds a new accepted value for an existing `signing_protocol` argument; the signing behavior itself is performed by CloudFront.

### Description

CloudFront announced OAC support for Amazon S3 Multi-Region Access Points on 2026-08-20. The only new API surface is a new value in the `OriginAccessControlSigningProtocols` enum, `sigv4a` — MRAP origins keep `OriginAccessControlOriginType = s3`, and `SigningBehavior` is unchanged.

`aws_cloudfront_origin_access_control` validates `signing_protocol` with `enum.Validate[awstypes.OriginAccessControlSigningProtocols]()`, so the accepted set is derived from the pinned SDK enum. That means **no schema, expander, or flattener change is needed** — the value becomes valid as soon as `aws-sdk-go-v2/service/cloudfront` is bumped to `>= v1.68.0`. This PR carries the author-visible remainder:

* `signing_protocol` documentation, which currently states that `sigv4` is the only valid value.
* A new `Example Usage` section showing an S3 Multi-Region Access Point origin.
* `TestAccCloudFrontOriginAccessControl_SigningProtocol`, covering create with `sigv4a`, import, and update to `sigv4`.
* A changelog entry for the new accepted value.

There is deliberately no `go.mod`/`go.sum` change here. `main` now pins `github.com/aws/aws-sdk-go-v2/service/cloudfront v1.70.1`, which carries `OriginAccessControlSigningProtocolsSigv4a`, so the diff is code-only (docs, acceptance test, changelog).

**Ready for review.** The SDK bump this was waiting on (`>= v1.68.0`) has landed on `main`; the branch is rebased onto it and `signing_protocol = "sigv4a"` is accepted by the enum validator with no provider code change.

### Relations

Closes #49650

### References

* What's New: https://aws.amazon.com/about-aws/whats-new/2026/08/amazon-cloudfront-oac-s3-mrap/
* API Reference (`OriginAccessControlConfig`): https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_OriginAccessControlConfig.html
* `aws-sdk-go-v2` changelog: https://github.com/aws/aws-sdk-go-v2/blob/main/service/cloudfront/CHANGELOG.md#v1680-2026-08-20

  > **Feature**: Added SigV4a as a supported signing protocol for Origin Access Control (OAC), enabling CloudFront to sign requests to Amazon S3 Multi-Region Access Point (S3-MRAP) origins.

For what it is worth: CloudFormation has not shipped this — the `AWS::CloudFront::OriginAccessControl` registry schema still constrains `SigningProtocol` to `^(sigv4)$`. That does not affect this provider, which uses the SDK, but it does mean this cannot be cross-checked against Cloud Control.

### Output from Acceptance Testing

Run against the rebased branch (`main` @ `aws-sdk-go-v2/service/cloudfront v1.70.1`), us-east-1:

```console
% go build ./internal/service/cloudfront/
% gofmt -l internal/service/cloudfront/
% go vet ./internal/service/cloudfront/
% go test -run 'xxNoSuchTestxx' ./internal/service/cloudfront/
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudfront	6.621s [no tests to run]

% TF_ACC=1 go test -run '^TestAccCloudFrontOriginAccessControl_SigningProtocol$' -v -timeout 30m ./internal/service/cloudfront/
=== RUN   TestAccCloudFrontOriginAccessControl_SigningProtocol
=== PAUSE TestAccCloudFrontOriginAccessControl_SigningProtocol
=== CONT  TestAccCloudFrontOriginAccessControl_SigningProtocol
--- PASS: TestAccCloudFrontOriginAccessControl_SigningProtocol (29.02s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudfront	35.682s
```

The test creates an OAC with `signing_protocol = "sigv4a"`, imports it, then updates it to `sigv4`.
