### PR TITLE
Enable `iface` and `mirror` golangci-lint linters

### DIFF
--- a/.ci/.golangci3.yml
+++ b/.ci/.golangci3.yml
@@ -10,9 +10,11 @@ linters:
     - gocritic
     - godox
     - govet
+    - iface
     - importas
     - ineffassign
     - makezero
+    - mirror
     - misspell
     - mnd
   settings:

--- a/internal/dns/normalize.go
+++ b/internal/dns/normalize.go
@@ -46,7 +46,7 @@ func normalizeCasingAndEscapeCodes(input string) string {
 				return b >= '0' && b <= '7' // Octal.
 			}) {
 				output.WriteRune(ch)
-				output.WriteString(string(bytes))
+				output.Write(bytes)
 				_, _ = br.Discard(lenOctalCode)
 				continue
 			}

--- a/internal/service/s3/bucket_lifecycle_configuration_list.go
+++ b/internal/service/s3/bucket_lifecycle_configuration_list.go
@@ -35,7 +35,7 @@ var _ list.ListResource = &bucketLifecycleConfigurationListResource{}
 type bucketLifecycleConfigurationListResource struct {
 	bucketLifecycleConfigurationResource
 	framework.WithList
-	handler bucketPropertyListHandlerFramework
+	handler bucketPropertyListHandler
 }
 
 func (l *bucketLifecycleConfigurationListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
@@ -79,9 +79,9 @@ func (l *bucketLifecycleConfigurationListResource) List(ctx context.Context, req
 	}
 }
 
-var _ bucketPropertyListHandlerFramework = bucketLifecycleConfigurationListHandler{}
+var _ bucketPropertyListHandler = bucketLifecycleConfigurationListHandler{}
 
-func newBucketLifecycleConfigurationListHandler(lister listResourceFramework) bucketPropertyListHandlerFramework {
+func newBucketLifecycleConfigurationListHandler(lister listResourceFramework) bucketPropertyListHandler {
 	return bucketLifecycleConfigurationListHandler{
 		baseBucketPropertyListHandlerFramework: newBaseBucketPropertyListHandlerFramework(lister),
 	}

--- a/internal/service/s3/bucket_ownership_controls_list.go
+++ b/internal/service/s3/bucket_ownership_controls_list.go
@@ -31,9 +31,9 @@ func newBucketOwnershipControlsResourceAsListResource() inttypes.ListResourceFor
 	)
 }
 
-var _ bucketPropertyListHandlerSDK = bucketOwnershipControlsListHandler{}
+var _ bucketPropertyListHandler = bucketOwnershipControlsListHandler{}
 
-func newBucketOwnershipControlsListHandler(lister listResourceSDK) bucketPropertyListHandlerSDK {
+func newBucketOwnershipControlsListHandler(lister listResourceSDK) bucketPropertyListHandler {
 	return bucketOwnershipControlsListHandler{
 		baseBucketPropertyListHandlerSDK: newBaseBucketPropertyListHandlerSDK(lister),
 	}

--- a/internal/service/s3/bucket_policy_list.go
+++ b/internal/service/s3/bucket_policy_list.go
@@ -32,9 +32,9 @@ func newBucketPolicyResourceAsListResource() inttypes.ListResourceForSDK {
 	)
 }
 
-var _ bucketPropertyListHandlerSDK = bucketPolicyListHandler{}
+var _ bucketPropertyListHandler = bucketPolicyListHandler{}
 
-func newBucketPolicyListHandler(lister listResourceSDK) bucketPropertyListHandlerSDK {
+func newBucketPolicyListHandler(lister listResourceSDK) bucketPropertyListHandler {
 	return bucketPolicyListHandler{
 		baseBucketPropertyListHandlerSDK: newBaseBucketPropertyListHandlerSDK(lister),
 	}

--- a/internal/service/s3/bucket_property_list_framework.go
+++ b/internal/service/s3/bucket_property_list_framework.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
 )
 
-type bucketPropertyListHandlerFramework interface {
+type bucketPropertyListHandler interface {
 	parseQuery(ctx context.Context, config tfsdk.Config) diag.Diagnostics
 	list(ctx context.Context, request list.ListRequest, conn *s3.Client, buckets iter.Seq2[awstypes.Bucket, error]) iter.Seq[list.ListResult]
 }

--- a/internal/service/s3/bucket_property_list_sdk.go
+++ b/internal/service/s3/bucket_property_list_sdk.go
@@ -5,11 +5,9 @@ package s3
 
 import (
 	"context"
-	"iter"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
-	awstypes "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/list"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
@@ -20,14 +18,9 @@ import (
 	inttypes "github.com/hashicorp/terraform-provider-aws/internal/types"
 )
 
-type bucketPropertyListHandlerSDK interface {
-	parseQuery(ctx context.Context, config tfsdk.Config) diag.Diagnostics
-	list(ctx context.Context, request list.ListRequest, conn *s3.Client, buckets iter.Seq2[awstypes.Bucket, error]) iter.Seq[list.ListResult]
-}
-
 var _ list.ListResource = &listResourceBaseBucketPropertySDK{}
 
-func newListResourceBaseBucketPropertySDK(resource *schema.Resource, f func(listResourceSDK) bucketPropertyListHandlerSDK) inttypes.ListResourceForSDK {
+func newListResourceBaseBucketPropertySDK(resource *schema.Resource, f func(listResourceSDK) bucketPropertyListHandler) inttypes.ListResourceForSDK {
 	l := listResourceBaseBucketPropertySDK{}
 	l.SetResourceSchema(resource)
 	l.handler = f(&l)
@@ -36,7 +29,7 @@ func newListResourceBaseBucketPropertySDK(resource *schema.Resource, f func(list
 
 type listResourceBaseBucketPropertySDK struct {
 	framework.ListResourceWithSDKv2Resource
-	handler bucketPropertyListHandlerSDK
+	handler bucketPropertyListHandler
 }
 
 func (l *listResourceBaseBucketPropertySDK) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {

--- a/internal/service/s3/bucket_server_side_encryption_configuration_list.go
+++ b/internal/service/s3/bucket_server_side_encryption_configuration_list.go
@@ -31,9 +31,9 @@ func newBucketServerSideEncryptionConfigurationResourceAsListResource() inttypes
 	)
 }
 
-var _ bucketPropertyListHandlerSDK = bucketServerSideEncryptionConfigurationListHandler{}
+var _ bucketPropertyListHandler = bucketServerSideEncryptionConfigurationListHandler{}
 
-func newBucketServerSideEncryptionConfigurationListHandler(lister listResourceSDK) bucketPropertyListHandlerSDK {
+func newBucketServerSideEncryptionConfigurationListHandler(lister listResourceSDK) bucketPropertyListHandler {
 	return bucketServerSideEncryptionConfigurationListHandler{
 		baseBucketPropertyListHandlerSDK: newBaseBucketPropertyListHandlerSDK(lister),
 	}

--- a/internal/service/s3/bucket_versioning_list.go
+++ b/internal/service/s3/bucket_versioning_list.go
@@ -31,9 +31,9 @@ func newBucketVersioningResourceAsListResource() inttypes.ListResourceForSDK {
 	)
 }
 
-var _ bucketPropertyListHandlerSDK = bucketVersioningListHandler{}
+var _ bucketPropertyListHandler = bucketVersioningListHandler{}
 
-func newBucketVersioningListHandler(lister listResourceSDK) bucketPropertyListHandlerSDK {
+func newBucketVersioningListHandler(lister listResourceSDK) bucketPropertyListHandler {
 	return bucketVersioningListHandler{
 		baseBucketPropertyListHandlerSDK: newBaseBucketPropertyListHandlerSDK(lister),
 	}


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Enables a couple of additional linters through `golangci-lint`.